### PR TITLE
fix(lock): include task-specific tools

### DIFF
--- a/docs/cli/lock.md
+++ b/docs/cli/lock.md
@@ -8,7 +8,8 @@
 Update lockfile checksums and URLs for all specified platforms
 
 Updates checksums and download URLs for all platforms already specified in the lockfile.
-If no lockfile exists, shows what would be created based on the current configuration.
+If no lockfile exists, shows what would be created based on the current configuration,
+including tools declared by tasks.
 This allows you to refresh lockfile data for platforms other than the one you're currently on.
 Operates on the lockfile in the current config root. Use TOOL arguments to target specific tools.
 
@@ -18,7 +19,7 @@ Operates on the lockfile in the current config root. Use TOOL arguments to targe
 
 Tool(s) to update in lockfile
 e.g.: node python
-If not specified, all tools in lockfile will be updated
+If not specified, all configured and task-specific tools will be updated
 
 ## Flags
 

--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -30,6 +30,12 @@ lockfile = true
 2. **Version Resolution**: If a `mise.lock` exists, mise will prefer locked versions over version ranges in `mise.toml`
 3. **Checksum Verification**: For supported backends, mise stores and verifies checksums of downloaded tools
 
+`mise lock` resolves both config-level tools and tools declared in individual tasks. It reads task
+definitions—including inherited templates and included task files—but does not run tasks, their
+dependencies, hooks, or tool installers. This lets task-specific tools be locked before the first
+task execution. Their entries use the same `[[tools.*]]` format and are written to the lockfile for
+the config that owns the task.
+
 ## File Format
 
 `mise.lock` is a TOML file with a platform-based format that organizes asset information by platform:

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -267,6 +267,10 @@ tools.rust = "1.50.0"
 run = "cargo build"
 ```
 
+Run [`mise lock`](/dev-tools/mise-lock.html) to resolve task-specific tools into the owning
+config's lockfile before running the task. This reads the task definition without executing the
+task or installing its tools.
+
 ### `dir`
 
 - **Type**: `string`

--- a/e2e/lockfile/test_lockfile_task_tools
+++ b/e2e/lockfile/test_lockfile_task_tools
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+
+export MISE_LOCKFILE=1
+export MISE_EXPERIMENTAL=1
+
+detect_platform
+PLATFORM="$MISE_PLATFORM"
+
+SERVER_ROOT="$TMPDIR/task-tool-lock-server"
+PORT_FILE="$TMPDIR/task-tool-lock-server-port"
+mkdir -p "$SERVER_ROOT/task-only-1.0.0/bin"
+
+cat >"$SERVER_ROOT/task-only-1.0.0/bin/task-only" <<'EOF'
+#!/usr/bin/env bash
+echo task-only-ok
+EOF
+chmod +x "$SERVER_ROOT/task-only-1.0.0/bin/task-only"
+tar -C "$SERVER_ROOT" -czf "$SERVER_ROOT/task-only-1.0.0.tar.gz" task-only-1.0.0
+CHECKSUM=$(shasum -a 256 "$SERVER_ROOT/task-only-1.0.0.tar.gz" | awk '{print $1}')
+printf '1.0.0\n2.0.0\n' >"$SERVER_ROOT/versions.txt"
+
+python3 - "$SERVER_ROOT" "$PORT_FILE" <<'PY' >/dev/null 2>&1 &
+import http.server
+import os
+import socketserver
+import sys
+
+root, port_file = sys.argv[1], sys.argv[2]
+os.chdir(root)
+socketserver.TCPServer.allow_reuse_address = True
+with socketserver.TCPServer(("127.0.0.1", 0), http.server.SimpleHTTPRequestHandler) as server:
+    with open(port_file, "w") as file:
+        file.write(str(server.server_address[1]))
+    server.serve_forever()
+PY
+SERVER_PID=$!
+cleanup() { kill "$SERVER_PID" 2>/dev/null || true; }
+trap cleanup EXIT
+
+wait_for_file "$PORT_FILE" "task tool lock HTTP server port file" 30 "$SERVER_PID"
+PORT=$(cat "$PORT_FILE")
+
+cat >mise.toml <<EOF
+[task_config]
+includes = ["tasks.toml"]
+
+[task_templates.locked]
+tools."http:template-only" = { version = "1.0.0", url = "http://127.0.0.1:${PORT}/task-only-1.0.0.tar.gz", checksum = "sha256:${CHECKSUM}" }
+
+[tasks.from-template]
+extends = "locked"
+run = "true"
+
+[tasks.task-only]
+run = "task-only > task-ran"
+
+[tasks.task-only.tools."http:task-only"]
+version = "1.0.0"
+url = "http://127.0.0.1:${PORT}/task-only-1.0.0.tar.gz"
+checksum = "sha256:${CHECKSUM}"
+bin_path = "task-only-1.0.0/bin"
+postinstall = "chmod +x \$MISE_TOOL_INSTALL_PATH/task-only-1.0.0/bin/task-only"
+EOF
+
+cat >tasks.toml <<EOF
+[included]
+run = "true"
+tools."http:included-only" = { version = "1.0.0", url = "http://127.0.0.1:${PORT}/task-only-1.0.0.tar.gz", checksum = "sha256:${CHECKSUM}" }
+EOF
+
+if ! output=$(mise lock --dry-run --platform "$PLATFORM" 2>&1); then
+  echo "$output" >&2
+  fail "task-only lock dry-run failed"
+fi
+assert_contains "echo '$output'" "http:task-only@1.0.0"
+assert_not_contains "echo '$output'" "No tools configured to lock"
+assert "test ! -e mise.lock"
+assert "test ! -e task-ran"
+assert "test ! -e '$MISE_DATA_DIR/installs/http-task-only/1.0.0'"
+
+mise lock --platform "$PLATFORM"
+assert_contains "cat mise.lock" '[[tools."http:task-only"]]'
+assert_contains "cat mise.lock" 'version = "1.0.0"'
+assert_contains "cat mise.lock" "checksum = \"sha256:${CHECKSUM}\""
+assert_contains "cat mise.lock" '[[tools."http:template-only"]]'
+assert_contains "cat mise.lock" '[[tools."http:included-only"]]'
+
+cp mise.lock mise.lock.before-task
+mise run task-only
+assert_contains "cat task-ran" "task-only-ok"
+assert "cmp mise.lock.before-task mise.lock"
+
+cat >>mise.toml <<EOF
+
+[tasks.latest]
+run = "true"
+
+[tasks.latest.tools."http:task-latest"]
+version = "latest"
+url = "http://127.0.0.1:${PORT}/task-only-1.0.0.tar.gz"
+version_list_url = "http://127.0.0.1:${PORT}/versions.txt"
+
+[tasks.variant-one]
+run = "true"
+
+[tasks.variant-one.tools."http:task-variant"]
+version = "1.0.0"
+url = "http://127.0.0.1:${PORT}/task-only-1.0.0.tar.gz"
+rename_exe = "one"
+
+[tasks.variant-two]
+run = "true"
+
+[tasks.variant-two.tools."http:task-variant"]
+version = "1.0.0"
+url = "http://127.0.0.1:${PORT}/task-only-1.0.0.tar.gz"
+rename_exe = "two"
+EOF
+
+mise lock --platform "$PLATFORM"
+assert_contains "cat mise.lock" '[[tools."http:task-latest"]]'
+assert_contains "cat mise.lock" 'version = "2.0.0"'
+assert "test \"\$(grep -c '\[\[tools.\"http:task-variant\"\]\]' mise.lock)\" -eq 2"
+assert_contains "cat mise.lock" 'rename_exe = "one"'
+assert_contains "cat mise.lock" 'rename_exe = "two"'
+
+mise lock http:task-only --dry-run --platform "$PLATFORM"
+
+cat >mise.toml <<'EOF'
+[tasks.no-tools]
+run = "true"
+EOF
+rm tasks.toml
+
+mise lock --platform "$PLATFORM"
+assert_not_contains "cat mise.lock" 'http:task-only'
+assert_not_contains "cat mise.lock" 'http:task-latest'
+assert_not_contains "cat mise.lock" 'http:task-variant'
+
+cat >mise.test.toml <<EOF
+[tasks.environment-only]
+run = "true"
+tools."http:environment-only" = { version = "1.0.0", url = "http://127.0.0.1:${PORT}/task-only-1.0.0.tar.gz", checksum = "sha256:${CHECKSUM}" }
+EOF
+
+env MISE_ENV=test mise lock --platform "$PLATFORM"
+assert_contains "cat mise.test.lock" '[[tools."http:environment-only"]]'
+assert_not_contains "cat mise.lock" 'http:environment-only'
+
+cat >mise.local.toml <<EOF
+[tasks.local-only]
+run = "true"
+tools."http:local-only" = { version = "1.0.0", url = "http://127.0.0.1:${PORT}/task-only-1.0.0.tar.gz", checksum = "sha256:${CHECKSUM}" }
+EOF
+
+mise lock --local --platform "$PLATFORM"
+assert_contains "cat mise.local.lock" '[[tools."http:local-only"]]'
+assert_not_contains "cat mise.lock" 'http:local-only'
+
+mkdir -p monorepo/packages/app
+cat >monorepo/mise.toml <<'EOF'
+monorepo_root = true
+
+[monorepo]
+lockfile = true
+config_roots = ["packages/*"]
+EOF
+cat >monorepo/packages/app/mise.toml <<EOF
+[tasks.child-only]
+run = "true"
+tools."http:child-only" = { version = "1.0.0", url = "http://127.0.0.1:${PORT}/task-only-1.0.0.tar.gz", checksum = "sha256:${CHECKSUM}" }
+EOF
+
+(cd monorepo && mise lock --platform "$PLATFORM")
+assert_contains "cat monorepo/mise.lock" '[[tools."http:child-only"]]'
+assert "test ! -e monorepo/packages/app/mise.lock"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2541,7 +2541,8 @@ e.g.: ~/.nvm/versions/node/v20.0.0
 Update lockfile checksums and URLs for all specified platforms
 
 Updates checksums and download URLs for all platforms already specified in the lockfile.
-If no lockfile exists, shows what would be created based on the current configuration.
+If no lockfile exists, shows what would be created based on the current configuration,
+including tools declared by tasks.
 This allows you to refresh lockfile data for platforms other than the one you're currently on.
 Operates on the lockfile in the current config root. Use TOOL arguments to target specific tools.
 .PP
@@ -2605,7 +2606,7 @@ Existing matching lockfile entries are preserved and are not downgraded solely b
 \fB<TOOL>\fR
 Tool(s) to update in lockfile
 e.g.: node python
-If not specified, all tools in lockfile will be updated
+If not specified, all configured and task\-specific tools will be updated
 .SH "MISE LS"
 List installed and active tool versions
 

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -2137,7 +2137,8 @@ cmd lock help="Update lockfile checksums and URLs for all specified platforms" e
 Update lockfile checksums and URLs for all specified platforms
 
 Updates checksums and download URLs for all platforms already specified in the lockfile.
-If no lockfile exists, shows what would be created based on the current configuration.
+If no lockfile exists, shows what would be created based on the current configuration,
+including tools declared by tasks.
 This allows you to refresh lockfile data for platforms other than the one you're currently on.
 Operates on the lockfile in the current config root. Use TOOL arguments to target specific tools.
 """#
@@ -2217,7 +2218,7 @@ Existing matching lockfile entries are preserved and are not downgraded solely b
     arg "[TOOL]…" help=#"""
 Tool(s) to update in lockfile
 e.g.: node python
-If not specified, all tools in lockfile will be updated
+If not specified, all configured and task-specific tools will be updated
 """# required=#false var=#true
 }
 cmd ls help="List installed and active tool versions" effect=read {

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -7,6 +7,7 @@ use crate::file::display_path;
 use crate::install_before::resolve_cli_minimum_release_age;
 use crate::lockfile::{self, LockResolutionResult, Lockfile};
 use crate::platform::Platform;
+use crate::task::Task;
 use crate::toolset::{ResolveOptions, ToolRequest, ToolSource, Toolset, ToolsetBuilder};
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::{cli::args::ToolArg, config::Settings};
@@ -20,14 +21,38 @@ use tokio::task::JoinSet;
 type LockTool = (crate::cli::args::BackendArg, crate::toolset::ToolVersion);
 type ToolSelectors = (BTreeSet<String>, BTreeSet<String>);
 
+struct LockCollectionContext<'a> {
+    config: &'a Arc<Config>,
+    toolset: &'a Toolset,
+    config_files: &'a ConfigMap,
+    tasks: &'a BTreeMap<String, Task>,
+    resolve_options: &'a ResolveOptions,
+}
+
 fn request_matches(a: &ToolRequest, b: &ToolRequest) -> bool {
     a.version() == b.version() && a.options() == b.options()
+}
+
+fn lock_tool_matches(a: &LockTool, b: &LockTool) -> bool {
+    a.0.full() == b.0.full()
+        && a.1.version == b.1.version
+        && a.1.request.options() == b.1.request.options()
+}
+
+fn push_unique_lock_tool(tools: &mut Vec<LockTool>, tool: LockTool) {
+    if !tools
+        .iter()
+        .any(|existing| lock_tool_matches(existing, &tool))
+    {
+        tools.push(tool);
+    }
 }
 
 /// Update lockfile checksums and URLs for all specified platforms
 ///
 /// Updates checksums and download URLs for all platforms already specified in the lockfile.
-/// If no lockfile exists, shows what would be created based on the current configuration.
+/// If no lockfile exists, shows what would be created based on the current configuration,
+/// including tools declared by tasks.
 /// This allows you to refresh lockfile data for platforms other than the one you're currently on.
 /// Operates on the lockfile in the current config root. Use TOOL arguments to target specific tools.
 #[derive(Debug, clap::Args)]
@@ -35,7 +60,7 @@ fn request_matches(a: &ToolRequest, b: &ToolRequest) -> bool {
 pub struct Lock {
     /// Tool(s) to update in lockfile
     /// e.g.: node python
-    /// If not specified, all tools in lockfile will be updated
+    /// If not specified, all configured and task-specific tools will be updated
     #[clap(value_name = "TOOL", verbatim_doc_comment)]
     pub tool: Vec<ToolArg>,
 
@@ -174,6 +199,8 @@ impl Lock {
             .as_ref()
             .map(|monorepo_union| &monorepo_union.config_files)
             .unwrap_or(&config.config_files);
+        let task_load_context = crate::task::TaskLoadContext::all();
+        let tasks = config.tasks_with_context(Some(&task_load_context)).await?;
 
         let ts_owned;
         let ts = if let Some(monorepo_union) = &monorepo_union {
@@ -198,17 +225,21 @@ impl Lock {
         let mut all_resolution_errors: Vec<String> = Vec::new();
         let mut all_platform_regressions: Vec<String> = Vec::new();
         let mut all_changes: Vec<LockChange> = Vec::new();
+        let collection_context = LockCollectionContext {
+            config: &config,
+            toolset: ts,
+            config_files: effective_config_files,
+            tasks: &tasks,
+            resolve_options: &lock_resolve_options,
+        };
 
+        // Resolve every target before writing any lockfile. A task tool can fail to
+        // resolve just like a config-level tool, and a later failure must not leave
+        // earlier environment/local/monorepo lockfiles partially updated.
+        let mut prepared_targets = Vec::with_capacity(lockfile_targets.len());
         for (lockfile_path, config_paths) in &lockfile_targets {
             let tools = self
-                .get_tools_to_lock(
-                    &config,
-                    ts,
-                    lockfile_path,
-                    config_paths,
-                    effective_config_files,
-                    &lock_resolve_options,
-                )
+                .get_tools_to_lock(&collection_context, lockfile_path, config_paths)
                 .await?;
             let configured_selectors = self.configured_tool_selectors_for_target(
                 &config,
@@ -217,6 +248,15 @@ impl Lock {
                 config_paths,
                 effective_config_files,
             );
+            prepared_targets.push((
+                lockfile_path.clone(),
+                config_paths.clone(),
+                tools,
+                configured_selectors,
+            ));
+        }
+
+        for (lockfile_path, _config_paths, tools, configured_selectors) in prepared_targets {
             if configured_selectors
                 .as_ref()
                 .is_some_and(|(configured_tools, _)| !configured_tools.is_empty())
@@ -228,30 +268,30 @@ impl Lock {
                 // `tools` can be empty either because config has no tools, or because a filter excludes all.
                 // For unfiltered runs (`mise lock`), this means "prune all stale lockfile entries".
                 if self.dry_run {
-                    let lockfile = Lockfile::read(lockfile_path)?;
+                    let lockfile = Lockfile::read(&lockfile_path)?;
                     if self.json {
                         all_changes.extend(self.compute_version_changes(
                             &lockfile,
                             &tools,
-                            lockfile_path,
+                            &lockfile_path,
                         ));
                     }
                     let stale_tools =
                         self.stale_entries_if_pruned(&lockfile, configured_selectors.as_ref());
-                    self.show_stale_prune_message(lockfile_path, &stale_tools, true)?;
+                    self.show_stale_prune_message(&lockfile_path, &stale_tools, true)?;
                     if !stale_tools.is_empty() {
                         has_lock_targets = true;
                     }
                 } else {
-                    let _lock = crate::lock_file::LockFile::new(lockfile_path)
+                    let _lock = crate::lock_file::LockFile::new(&lockfile_path)
                         .with_callback(|l| debug!("waiting for lock on {}", display_path(l)))
                         .lock()?;
-                    let mut lockfile = Lockfile::read(lockfile_path)?;
+                    let mut lockfile = Lockfile::read(&lockfile_path)?;
                     if self.json {
                         all_changes.extend(self.compute_version_changes(
                             &lockfile,
                             &tools,
-                            lockfile_path,
+                            &lockfile_path,
                         ));
                     }
                     let pruned_tools = self.prune_stale_entries_if_needed(
@@ -259,8 +299,8 @@ impl Lock {
                         configured_selectors.as_ref(),
                     );
                     if !pruned_tools.is_empty() {
-                        lockfile.write(lockfile_path)?;
-                        self.show_stale_prune_message(lockfile_path, &pruned_tools, false)?;
+                        lockfile.write(&lockfile_path)?;
+                        self.show_stale_prune_message(&lockfile_path, &pruned_tools, false)?;
                         has_lock_targets = true;
                     }
                 }
@@ -268,14 +308,14 @@ impl Lock {
             }
             has_lock_targets = true;
 
-            let target_platforms = self.determine_target_platforms(lockfile_path)?;
+            let target_platforms = self.determine_target_platforms(&lockfile_path)?;
 
             if !self.json {
                 miseprintln!(
                     "{} Targeting {} platform(s) for {}: {}",
                     style("→").cyan(),
                     target_platforms.len(),
-                    style(display_path(lockfile_path)).cyan(),
+                    style(display_path(&lockfile_path)).cyan(),
                     target_platforms
                         .iter()
                         .map(|p| p.to_key())
@@ -297,35 +337,35 @@ impl Lock {
 
             if self.dry_run {
                 self.show_dry_run(&tools, &target_platforms)?;
-                let lockfile = Lockfile::read(lockfile_path)?;
+                let lockfile = Lockfile::read(&lockfile_path)?;
                 if self.json {
                     all_changes.extend(self.compute_version_changes(
                         &lockfile,
                         &tools,
-                        lockfile_path,
+                        &lockfile_path,
                     ));
                 }
                 if self.is_unfiltered_lock_run() {
                     let stale_tools =
                         self.stale_entries_if_pruned(&lockfile, configured_selectors.as_ref());
-                    self.show_stale_prune_message(lockfile_path, &stale_tools, true)?;
+                    self.show_stale_prune_message(&lockfile_path, &stale_tools, true)?;
                 }
                 let stale_versions = self.stale_versions_if_pruned(&lockfile, &tools);
-                self.show_stale_version_prune_message(lockfile_path, &stale_versions, true)?;
+                self.show_stale_version_prune_message(&lockfile_path, &stale_versions, true)?;
                 continue;
             }
 
             // Process tools and update lockfile
-            let _lock = crate::lock_file::LockFile::new(lockfile_path)
+            let _lock = crate::lock_file::LockFile::new(&lockfile_path)
                 .with_callback(|l| debug!("waiting for lock on {}", display_path(l)))
                 .lock()?;
-            let mut lockfile = Lockfile::read(lockfile_path)?;
+            let mut lockfile = Lockfile::read(&lockfile_path)?;
             if self.json {
-                all_changes.extend(self.compute_version_changes(&lockfile, &tools, lockfile_path));
+                all_changes.extend(self.compute_version_changes(&lockfile, &tools, &lockfile_path));
             }
             let stale_tools =
                 self.prune_stale_entries_if_needed(&mut lockfile, configured_selectors.as_ref());
-            self.show_stale_prune_message(lockfile_path, &stale_tools, false)?;
+            self.show_stale_prune_message(&lockfile_path, &stale_tools, false)?;
 
             // Compute stale versions BEFORE process_tools so provenance checks can
             // compare against old version entries. Actual pruning happens after.
@@ -345,11 +385,11 @@ impl Lock {
 
             // Prune stale versions AFTER provenance checks complete
             self.prune_stale_versions(&mut lockfile, &tools);
-            self.show_stale_version_prune_message(lockfile_path, &stale_versions, false)?;
+            self.show_stale_version_prune_message(&lockfile_path, &stale_versions, false)?;
 
             // Save lockfile before raising resolution errors so non-regressing
             // tools' entries are preserved
-            lockfile.write(lockfile_path)?;
+            lockfile.write(&lockfile_path)?;
 
             // Print summary
             if !self.json {
@@ -367,7 +407,7 @@ impl Lock {
                 miseprintln!(
                     "{} Lockfile written to {}",
                     style("✓").green(),
-                    style(display_path(lockfile_path)).cyan()
+                    style(display_path(&lockfile_path)).cyan()
                 );
             }
         }
@@ -856,17 +896,15 @@ impl Lock {
     /// Only includes tools whose source config maps to the target lockfile path.
     async fn get_tools_to_lock(
         &self,
-        config: &Arc<Config>,
-        ts: &Toolset,
+        context: &LockCollectionContext<'_>,
         target_lockfile_path: &Path,
         config_paths: &[PathBuf],
-        effective_config_files: &ConfigMap,
-        base_resolve_options: &ResolveOptions,
     ) -> Result<Vec<LockTool>> {
+        let config = context.config;
+        let ts = context.toolset;
         let config_paths_set: BTreeSet<&PathBuf> = config_paths.iter().collect();
 
         let mut all_tools: Vec<LockTool> = Vec::new();
-        let mut seen: BTreeSet<(String, String)> = BTreeSet::new();
 
         // First pass: tools from the resolved toolset whose source maps to this lockfile
         for (backend, tv) in ts.list_current_versions() {
@@ -896,15 +934,12 @@ impl Lock {
             if tv.version == "latest" {
                 continue;
             }
-            let key = (backend.ba().short.clone(), tv.version.clone());
-            if seen.insert(key) {
-                all_tools.push((backend.ba().as_ref().clone(), tv));
-            }
+            push_unique_lock_tool(&mut all_tools, (backend.ba().as_ref().clone(), tv));
         }
 
         // Second pass: iterate config files matching this lockfile to catch
         // tools that were overridden by a higher-priority config
-        for (path, cf) in effective_config_files.iter() {
+        for (path, cf) in context.config_files.iter() {
             let source = cf.source();
             let source_lockfile_matches = lockfile::lockfile_path_for_tool_source(config, &source)
                 .is_some_and(|(source_lockfile, _)| source_lockfile == target_lockfile_path);
@@ -925,10 +960,10 @@ impl Lock {
                                         && tv.version != "latest"
                                     {
                                         matched_resolved = true;
-                                        let key = (ba.short.clone(), tv.version.clone());
-                                        if seen.insert(key) {
-                                            all_tools.push((ba.as_ref().clone(), tv.clone()));
-                                        }
+                                        push_unique_lock_tool(
+                                            &mut all_tools,
+                                            (ba.as_ref().clone(), tv.clone()),
+                                        );
                                     }
                                 }
                             }
@@ -949,7 +984,7 @@ impl Lock {
                                 || source.is_idiomatic_version_file();
                             if !matched_resolved && should_resolve_overridden {
                                 let mut resolve_options = match request
-                                    .resolve_options(base_resolve_options)
+                                    .resolve_options(context.resolve_options)
                                 {
                                     Ok(opts) => opts,
                                     Err(err) => {
@@ -972,10 +1007,10 @@ impl Lock {
                                 }
                                 match request.resolve(config, &resolve_options).await {
                                     Ok(tv) => {
-                                        let key = (ba.short.clone(), tv.version.clone());
-                                        if seen.insert(key) {
-                                            all_tools.push((ba.as_ref().clone(), tv));
-                                        }
+                                        push_unique_lock_tool(
+                                            &mut all_tools,
+                                            (ba.as_ref().clone(), tv),
+                                        );
                                     }
                                     Err(err) => {
                                         if active_unresolved {
@@ -994,6 +1029,16 @@ impl Lock {
                 }
             }
         }
+
+        self.add_task_tools_to_lock(
+            config,
+            context.tasks,
+            target_lockfile_path,
+            config_paths,
+            context,
+            &mut all_tools,
+        )
+        .await?;
 
         if self.tool.is_empty() {
             Ok(all_tools)
@@ -1024,7 +1069,7 @@ impl Lock {
                     let resolve_options = request
                         .as_ref()
                         .ok()
-                        .and_then(|request| request.resolve_options(base_resolve_options).ok());
+                        .and_then(|request| request.resolve_options(context.resolve_options).ok());
                     if let (Ok(request), Some(mut resolve_options)) = (request, resolve_options)
                         && (self.bump || resolve_options.before_date.is_some())
                     {
@@ -1050,10 +1095,128 @@ impl Lock {
                 tools.push((ba, tv));
             }
             // Deduplicate after potential "latest" -> concrete-version resolution.
-            let mut seen_after: BTreeSet<(String, String)> = BTreeSet::new();
-            tools.retain(|(ba, tv)| seen_after.insert((ba.short.clone(), tv.version.clone())));
-            Ok(tools)
+            let mut unique_tools = Vec::with_capacity(tools.len());
+            for tool in tools {
+                push_unique_lock_tool(&mut unique_tools, tool);
+            }
+            Ok(unique_tools)
         }
+    }
+
+    async fn add_task_tools_to_lock(
+        &self,
+        config: &Arc<Config>,
+        tasks: &BTreeMap<String, Task>,
+        target_lockfile_path: &Path,
+        config_paths: &[PathBuf],
+        context: &LockCollectionContext<'_>,
+        all_tools: &mut Vec<LockTool>,
+    ) -> Result<()> {
+        for task in tasks.values() {
+            let Some(config_path) =
+                self.task_config_path(task, config, config_paths, context.config_files)
+            else {
+                continue;
+            };
+            let (task_lockfile_path, _) = lockfile::lockfile_path_for_config(
+                &config_path,
+                config.monorepo_lockfile_root().as_deref(),
+            );
+            if task_lockfile_path != target_lockfile_path {
+                continue;
+            }
+
+            for tool in task.tool_args().map_err(|err| {
+                err.wrap_err(format!("failed to parse tools for task `{}`", task.name))
+            })? {
+                if !self.tool.is_empty()
+                    && !self
+                        .tool
+                        .iter()
+                        .any(|requested| requested.ba.short == tool.ba.short)
+                {
+                    continue;
+                }
+                let Some(request) = tool.tvr else {
+                    continue;
+                };
+                let request = ToolRequest::new_opts(
+                    tool.ba.clone(),
+                    &request.version(),
+                    request.options(),
+                    ToolSource::MiseToml(config_path.clone()),
+                )
+                .map_err(|err| {
+                    err.wrap_err(format!(
+                        "failed to prepare tool `{}` for task `{}`",
+                        tool.ba.short, task.name
+                    ))
+                })?;
+                let mut resolve_options = request
+                    .resolve_options(context.resolve_options)
+                    .map_err(|err| {
+                        err.wrap_err(format!(
+                            "failed to resolve options for task tool `{}` in task `{}`",
+                            tool.ba.short, task.name
+                        ))
+                    })?;
+                if self.bump || resolve_options.before_date.is_some() {
+                    resolve_options.use_locked_version = false;
+                    resolve_options.latest_versions = true;
+                }
+                let tv = request
+                    .resolve(config, &resolve_options)
+                    .await
+                    .map_err(|err| {
+                        err.wrap_err(format!(
+                            "failed to resolve task tool `{}` for task `{}`",
+                            tool.ba.short, task.name
+                        ))
+                    })?;
+                push_unique_lock_tool(all_tools, (tool.ba.as_ref().clone(), tv));
+            }
+        }
+        Ok(())
+    }
+
+    fn task_config_path(
+        &self,
+        task: &Task,
+        config: &Config,
+        config_paths: &[PathBuf],
+        effective_config_files: &ConfigMap,
+    ) -> Option<PathBuf> {
+        if let Some(cf) = task.cf(config) {
+            let path = cf.get_path();
+            return config_paths
+                .iter()
+                .any(|candidate| candidate == path)
+                .then(|| path.to_path_buf());
+        }
+
+        let config_root = task.config_root.as_ref()?;
+        effective_config_files
+            .iter()
+            .filter(|(path, cf)| {
+                config_paths.iter().any(|candidate| candidate == *path)
+                    && cf.source().is_mise_toml()
+                    && cf
+                        .project_root()
+                        .unwrap_or_else(|| cf.config_root())
+                        .as_path()
+                        == config_root
+            })
+            .max_by_key(|(path, _)| {
+                let (lockfile_path, _) = lockfile::lockfile_path_for_config(
+                    path,
+                    config.monorepo_lockfile_root().as_deref(),
+                );
+                let is_base = lockfile_path
+                    .file_name()
+                    .is_some_and(|name| name == "mise.lock");
+                (is_base, path.components().count())
+            })
+            .map(|(path, _)| path.clone())
     }
 
     fn show_dry_run(&self, tools: &[LockTool], platforms: &[Platform]) -> Result<()> {
@@ -1215,11 +1378,13 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
-    use super::{Lock, LockTaskResult, LockTaskStatus, classify_lock_result};
-    use crate::cli::args::ToolArg;
+    use super::{
+        Lock, LockTaskResult, LockTaskStatus, classify_lock_result, push_unique_lock_tool,
+    };
+    use crate::cli::args::{BackendArg, ToolArg};
     use crate::lockfile::{Lockfile, PlatformInfo, apply_lock_result};
     use crate::platform::Platform;
-    use crate::toolset::{ToolRequest, ToolSource, ToolVersion};
+    use crate::toolset::{ToolRequest, ToolSource, ToolVersion, ToolVersionOptions};
     use std::collections::BTreeMap;
     use std::str::FromStr;
     use std::sync::Arc;
@@ -1340,6 +1505,53 @@ mod tests {
             ToolRequest::new(Arc::new(ba.clone()), version, ToolSource::Argument).unwrap();
         let tv = ToolVersion::new(request, version.to_string());
         (ba, tv)
+    }
+
+    fn lock_tool_with_options(
+        short: &str,
+        backend: &str,
+        version: &str,
+        option: Option<(&str, &str)>,
+    ) -> (BackendArg, ToolVersion) {
+        let ba = BackendArg::new(short.to_string(), Some(backend.to_string()));
+        let mut options = ToolVersionOptions::default();
+        if let Some((key, value)) = option {
+            options
+                .insert_option(key.to_string(), toml::Value::String(value.to_string()))
+                .unwrap();
+        }
+        let request =
+            ToolRequest::new_opts(Arc::new(ba.clone()), version, options, ToolSource::Argument)
+                .unwrap();
+        let tv = ToolVersion::new(request, version.to_string());
+        (ba, tv)
+    }
+
+    #[test]
+    fn test_lock_tool_identity_includes_backend_and_options() {
+        let mut tools = Vec::new();
+        push_unique_lock_tool(
+            &mut tools,
+            lock_tool_with_options("dummy", "http:one", "1.0.0", Some(("exe", "one"))),
+        );
+        push_unique_lock_tool(
+            &mut tools,
+            lock_tool_with_options("dummy", "http:one", "1.0.0", Some(("exe", "one"))),
+        );
+        push_unique_lock_tool(
+            &mut tools,
+            lock_tool_with_options("dummy", "http:one", "1.0.0", Some(("exe", "two"))),
+        );
+        push_unique_lock_tool(
+            &mut tools,
+            lock_tool_with_options("dummy", "http:two", "1.0.0", Some(("exe", "one"))),
+        );
+
+        assert_eq!(tools.len(), 3);
+        assert_eq!(tools[0].0.full(), "http:one");
+        assert_eq!(tools[1].0.full(), "http:one");
+        assert_eq!(tools[2].0.full(), "http:two");
+        assert_ne!(tools[0].1.request.options(), tools[1].1.request.options());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- include task-specific tools when `mise lock` resolves configured tool requests
- route inline, inherited-template, included-file, environment, local, and monorepo task tools to their owning lockfiles
- preserve distinct lock entries for the same version when backend or artifact-affecting options differ
- pre-resolve every lockfile target before writing so resolution failures cannot partially update another target
- keep task-only entries during stale pruning and remove them after their task declarations are removed

## Root cause

`mise lock` only collected config-level tool requests from the resolved toolset and config files. Task-specific tools were first resolved when a task ran, which meant that the first execution could unexpectedly update `mise.lock`. Its collection deduplication also used only the short tool name and version, which collapsed requests whose backend or options selected different artifacts.

## Verification

- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- cargo test --all-features cli::lock::tests` (22 passed)
- `mise run test:e2e e2e/lockfile/test_lockfile_task_tools e2e/lockfile/test_lockfile_monorepo e2e/lockfile/test_lockfile_prune_stale_tools`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise run docs:build`

`mise run lint` was also attempted, but the local Sapling-only checkout has no `.git` directory and hk exits before running checks with `failed to find git repository`; CI will run it in a Git checkout.

Addresses https://github.com/jdx/mise/discussions/4782

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `mise lock` now includes tools declared by tasks, inherited templates, and included task files.
  * Task-specific tools are resolved into the appropriate lockfile without running tasks or installing tools.
  * Locking defaults to all configured and task-specific tools when no tools are specified.
  * Supports dry runs, targeted locking, stale-tool removal, and nested configurations.

* **Documentation**
  * Updated CLI help, manuals, and task documentation to describe task tool locking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->