### PR TITLE
feat(dotfiles): create real symlinks on Windows when allowed

### DIFF
--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -299,5 +299,11 @@ fails with an ordinary permission error.
 
 ## Windows
 
-File symlinks require elevation on Windows, so `symlink` and `symlink-each`
-fall back to copying for files there; directory symlinks use junctions.
+`symlink` creates a real file symlink on Windows when it can. Windows allows that
+without elevation once Developer Mode is on — the same privilege
+[`windows_shim_mode`](/configuration/settings.html#windows_shim_mode) relies on for
+its `symlink` option — and mise falls back to copying the file when the privilege
+is not available, so entries keep applying either way.
+`mise bootstrap dotfiles status` reads whichever form is on disk.
+
+`symlink-each` still copies files on Windows. Directory symlinks use junctions.

--- a/e2e-win/dotfiles.Tests.ps1
+++ b/e2e-win/dotfiles.Tests.ps1
@@ -1,0 +1,78 @@
+Describe 'dotfiles' {
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:TestRoot | Out-Null
+
+        # Saved here, restored in AfterAll: Pester runs every suite in one process, so removing
+        # an inherited value would leave the next suite without it.
+        $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:TestRoot
+
+        New-Item -ItemType Directory -Path (Join-Path $script:TestRoot "dotfiles") | Out-Null
+        $script:Source = Join-Path $script:TestRoot "dotfiles\gitconfig"
+        "gitconfig content" | Out-File -FilePath $script:Source -Encoding ascii -NoNewline
+
+        $script:Target = Join-Path $script:TestRoot "applied\.gitconfig"
+        $targetToml = $script:Target -replace '\\', '/'
+        @"
+[dotfiles]
+"$targetToml" = { source = "dotfiles/gitconfig", mode = "symlink" }
+"@ | Out-File (Join-Path $script:TestRoot "mise.toml")
+
+        Set-Location $script:TestRoot
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        Remove-Item -Path $script:TestRoot -Recurse -Force -ErrorAction Ignore
+        if ($null -eq $script:OriginalTrusted) {
+            Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
+        } else {
+            [Environment]::SetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', $script:OriginalTrusted, 'Process')
+        }
+    }
+
+    It 'reports the entry as missing before applying' {
+        $out = mise bootstrap dotfiles status 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -BeLike '*missing*'
+    }
+
+    It 'applies a symlink entry and then reads it back as applied' {
+        # `symlink` mode produces a real symlink when Windows allows one without elevation
+        # (Developer Mode) and a copy otherwise. Which one lands is a property of the runner,
+        # not of mise, so this asserts what has to hold either way: the entry applies, the
+        # content is right, and `status` recognises whichever form is on disk.
+        mise bootstrap dotfiles apply 2>&1 | Out-String | Out-Null
+        $LASTEXITCODE | Should -Be 0
+
+        Test-Path $script:Target | Should -BeTrue
+        (Get-Content $script:Target -Raw) | Should -Be "gitconfig content"
+
+        $out = mise bootstrap dotfiles status 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        # Asserting the positive state, not just the absence of "missing": a row reading
+        # "differs" would satisfy the weaker check while meaning the entry did not converge.
+        $out | Should -BeLike '*applied*'
+
+        # Report which branch the runner took, so a failure elsewhere in this file is readable.
+        $link = (Get-Item $script:Target).LinkType
+        Write-Host "  applied as: $(if ($link) { $link } else { 'copy' })"
+    }
+
+    It 'unapplies without needing --force' {
+        # The regression this guards: a real symlink used to be routed through the content
+        # comparison, which rejects a symlink and demands --force.
+        #
+        # Applied here rather than relying on the previous test, so this one states its own
+        # precondition and does not silently pass if that test stopped applying.
+        mise bootstrap dotfiles apply 2>&1 | Out-String | Out-Null
+        $LASTEXITCODE | Should -Be 0
+        Test-Path $script:Target | Should -BeTrue
+
+        mise bootstrap dotfiles unapply 2>&1 | Out-String | Out-Null
+        $LASTEXITCODE | Should -Be 0
+        Test-Path $script:Target | Should -BeFalse
+    }
+}

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -663,8 +663,10 @@ fn check_rendered(req: &FileRequest, rendered: Option<&str>) -> Result<FileState
 }
 
 fn check_symlink(source: &Path, target: &Path) -> Result<FileState> {
-    // on Windows file "symlinks" are copies (see `link_file`)
-    if cfg!(windows) && source.is_file() {
+    // On Windows a file link is a real symlink when the privilege was available and a copy
+    // otherwise (see `link_path`), so which one is on disk decides how to read it. Only fall
+    // through to the copy comparison when it is not a symlink.
+    if cfg!(windows) && source.is_file() && !target.is_symlink() {
         return check_copy(source, target);
     }
     if target.is_symlink() {
@@ -1392,7 +1394,13 @@ fn plan_unapply_one<'a>(
     let mut conditional = false;
     let mut clear_symlink_each_state = false;
     match req.mode {
-        FileMode::Symlink if !(cfg!(windows) && req.source.is_file()) => {
+        // A Windows file link that came out as a copy is planned by content further down; one
+        // that is a real symlink belongs here, where the link target is what identifies it as
+        // ours. `plan_expected_content` requires a non-symlink, so routing a symlink there
+        // would make unapply demand `--force`.
+        FileMode::Symlink
+            if !(cfg!(windows) && req.source.is_file() && !req.target.is_symlink()) =>
+        {
             if req.target.is_symlink() {
                 let dest = std::fs::read_link(&req.target)?;
                 if opts.force || dest == req.source || points_at_same_file(&req.target, &req.source)
@@ -1832,7 +1840,7 @@ fn apply_one(req: &FileRequest, rendered: Option<&str>) -> Result<()> {
     match req.mode {
         FileMode::Symlink => {
             remove_existing(&req.target)?;
-            link_path(&req.source, &req.target)?;
+            link_path(&req.source, &req.target, true)?;
         }
         FileMode::SymlinkEach => {
             // conflicts were vetted (or --force given): clear anything
@@ -1853,7 +1861,7 @@ fn apply_one(req: &FileRequest, rendered: Option<&str>) -> Result<()> {
                     file::create_dir_all(parent)?;
                 }
                 remove_existing(&target)?;
-                link_path(&source, &target)?;
+                link_path(&source, &target, false)?;
             }
             prune_stale_links(req)?;
         }
@@ -1951,14 +1959,26 @@ fn remove_existing(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn link_path(source: &Path, target: &Path) -> Result<()> {
-    if cfg!(windows) && source.is_file() {
-        // Windows file symlinks require elevation; junctions only work for
-        // directories — fall back to a copy like make_symlink_or_copy does
+/// `allow_windows_symlink` is false for `symlink-each`, which stays on the Windows copy path:
+/// its unapply planner is `#[cfg(not(windows))]`-guarded and falls through to the content
+/// comparison, which rejects a symlink — creating one there would make unapply demand `--force`.
+fn link_path(source: &Path, target: &Path, allow_windows_symlink: bool) -> Result<()> {
+    #[cfg(windows)]
+    if source.is_file() {
+        // Windows grants SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE when Developer Mode is
+        // on, so a file symlink is often creatable without elevation -- `windows_shim_mode`
+        // already relies on that. Try it rather than assume it fails. Junctions only cover
+        // directories, so a copy stays the fallback: it is what this did unconditionally
+        // before, and it keeps working where the privilege really is absent.
+        if allow_windows_symlink && std::os::windows::fs::symlink_file(source, target).is_ok() {
+            return Ok(());
+        }
         file::copy(source, target)?;
-    } else {
-        file::make_symlink(source, target)?;
+        return Ok(());
     }
+    #[cfg(not(windows))]
+    let _ = allow_windows_symlink;
+    file::make_symlink(source, target)?;
     Ok(())
 }
 
@@ -2208,6 +2228,66 @@ mod tests {
             find_conflicts(&symlink_req(&source, &target))?,
             vec![target]
         );
+        Ok(())
+    }
+
+    /// `link_path` produces either a symlink or a copy on Windows depending on a privilege the
+    /// test runner may or may not have, so these assert the property that has to hold for both:
+    /// whichever form lands, `check_symlink` reads it as Applied. Branching on what actually
+    /// happened rather than on an assumed privilege keeps this meaningful on a runner without
+    /// Developer Mode, where only the copy path is exercised.
+    #[test]
+    fn link_path_result_is_recognised_whichever_form_it_takes() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let source = dir.path().join("dotfile");
+        let target = dir.path().join("linked");
+        file::write(&source, "contents")?;
+
+        link_path(&source, &target, true)?;
+
+        assert!(
+            target.exists() || target.is_symlink(),
+            "link_path produced nothing"
+        );
+        assert_eq!(check_symlink(&source, &target)?, FileState::Applied);
+        Ok(())
+    }
+
+    /// `symlink-each` opts out of the Windows symlink attempt, so it keeps producing a copy
+    /// there. Pinned because the two modes share `link_path`: making it symlink for everyone
+    /// would route `symlink-each` unapply through a planner that rejects symlinks.
+    #[cfg(windows)]
+    #[test]
+    fn symlink_each_still_copies_on_windows() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let source = dir.path().join("dotfile");
+        let target = dir.path().join("copied");
+        file::write(&source, "contents")?;
+
+        link_path(&source, &target, false)?;
+
+        assert!(
+            !target.is_symlink(),
+            "symlink-each must not create a symlink"
+        );
+        assert_eq!(file::read_to_string(&target)?, "contents");
+        Ok(())
+    }
+
+    /// The control for the test above: a target that is neither a copy of the source nor a link
+    /// to it must not read as Applied, or the assertion there would hold for the wrong reason.
+    #[test]
+    fn check_symlink_rejects_an_unrelated_file() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let source = dir.path().join("dotfile");
+        let target = dir.path().join("unrelated");
+        file::write(&source, "contents")?;
+        file::write(&target, "something else")?;
+
+        assert!(!matches!(
+            check_symlink(&source, &target)?,
+            FileState::Applied
+        ));
         Ok(())
     }
 }


### PR DESCRIPTION
From [#11431](https://github.com/jdx/mise/discussions/11431), which asks why dotfiles will not
create file symlinks on Windows when `windows_shim_mode` has a `symlink` option. The premise holds
— the two disagree with each other.

## The disagreement

| | |
|---|---|
| `docs/dotfiles.md` | "File symlinks require elevation on Windows, so `symlink` … fall back to copying" |
| `windows_shim_mode` in `settings.toml` | `symlink`: "Requires Windows Vista or later with admin privileges **or enabling Developer Mode**" |

`link_path` matched the docs: `cfg!(windows) && source.is_file()` went straight to `file::copy`,
so a symlink was never attempted.

The settings entry is the accurate one. Since Windows 10 1703, Developer Mode grants
`SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE`. Measured on Windows 11 as a **non-administrator**:

```console
Administrator     : False
Developer Mode    : 1
New-Item -ItemType SymbolicLink …  ->  OK
(Get-Item link.txt).LinkType       ->  SymbolicLink
Get-Content link.txt               ->  hello
```

## The change

Try the symlink; keep the copy as the fallback.

```rust
#[cfg(windows)]
if source.is_file() {
    if std::os::windows::fs::symlink_file(source, target).is_ok() {
        return Ok(());
    }
    file::copy(source, target)?;
    return Ok(());
}
```

Nothing regresses where the privilege is genuinely absent — that path is what the code did
unconditionally before.

### Applying alone would have broken reading

Three other places assumed a Windows file link is *always* a copy. Changing only `link_path` would
have left `status` and `unapply` wrong, so all three now branch on what is on disk:

- **`check_symlink`** sent every Windows file target to the copy comparison, so a symlink would
  never have read as applied.
- **`find_conflicts`** had the same assumption. It was split out into #11981, which has since
  merged, so this branch no longer touches it at all — the predicate here is main's.
- **the `Symlink` arm of the unapply planner** skipped Windows files entirely, so they fell to
  `plan_expected_content`, which requires `!target.is_symlink()`. `unapply` would have failed with
  "differs from its managed source; use --force".

That last one is why this is not a one-line change.

## Not in this PR

**`symlink-each` still copies on Windows** — but it takes an explicit opt-out rather than being
untouched, and the first version of this PR got that wrong.

The two modes share `link_path`, so changing it made `symlink-each` create symlinks on Windows as
well. Review caught it. That is not merely a docs mismatch: its unapply planner is
`FileMode::SymlinkEach if !cfg!(windows)`, so on Windows it falls through to the arm that plans by
content, and `plan_expected_content` requires `!target.is_symlink()` — `unapply` would have begun
demanding `--force`. `link_path` now takes `allow_windows_symlink`, false for `symlink-each`, with
a unit test pinning that it still produces a copy.

Enabling it properly is a separate change: `save_symlink_each_state`, `legacy_stale_links` and
`symlink_each_state_needs_update` all return early on Windows, so its persistent link-ownership
state would have to come with it.

## Split out and already merged: the unmanaged-file overwrite

Review raised that `apply` could replace an unrelated user file without `--force` on Windows.
Measured on the released **2026.8.2**:

```console
$ cat applied/.gitconfig
USER FILE - DO NOT LOSE
$ mise bootstrap dotfiles apply        # mode = "symlink", no --force
$ cat applied/.gitconfig
managed source
```

That predated this branch, so it went out as **#11981**, which has merged. It is a deliberate
behaviour change to `apply` on Windows rather than a regression fix, which is why it needed its own
PR and its own look at unix — where the same situation already *was* a conflict. This branch is
rebased on top of it and no longer touches `find_conflicts`.

## Tests

- **unit** — `link_path` produces *either* form depending on a privilege the runner may not have,
  so the test asserts the property that must hold for both: whatever lands, `check_symlink` reads
  it as `Applied`. It branches on what actually happened rather than on an assumed privilege, so
  it stays meaningful on a runner without Developer Mode, where only the copy path runs. A second
  test is the control: an unrelated file must **not** read as `Applied`, or the first would hold
  for the wrong reason.
- **e2e-win (new)** — `dotfiles.Tests.ps1`. **Windows had no dotfiles coverage at all.** Covers
  status-before-apply, apply (asserting content and that `status` no longer says missing), and
  **unapply without `--force`**, which is the regression described above. It prints which branch
  the runner took so a failure elsewhere in the file is readable.
- **e2e (unix)** — `test_dotfiles_files` is the existing regression guard; unix behaviour is
  untouched.

I could not verify the CI runners have Developer Mode enabled, which is exactly why both the
implementation and the tests are written to work either way rather than assuming it.

### Not run

`cargo fmt --all` only; no local build. The symlink measurement above and the
status → apply → unapply flow were run against a released binary on Windows 11; CI is what
exercises the change itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows dotfile setup now creates file symlinks when permitted and safely falls back to copying when required privileges are unavailable.
  * Status reporting identifies whether each dotfile is represented as a symlink or copy.
  * Directory symlinks continue to use junctions, while `symlink-each` continues copying files.

* **Bug Fixes**
  * Improved detection, conflict handling, and removal of Windows dotfile copies and symlinks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

