### PR TITLE
fix(oci): strip the tag from name:tag@digest references

### DIFF
--- a/src/oci/registry.rs
+++ b/src/oci/registry.rs
@@ -1732,7 +1732,8 @@ mod tests {
         // Tag + digest: the digest wins, and the tag must NOT leak into the
         // repository (it corrupted the auth scope and the manifests URL).
         let digest = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
-        let r = Reference::parse(&format!("cgr.dev/chainguard/wolfi-base:latest@{digest}")).unwrap();
+        let r =
+            Reference::parse(&format!("cgr.dev/chainguard/wolfi-base:latest@{digest}")).unwrap();
         assert_eq!(r.registry, "cgr.dev");
         assert_eq!(r.repository, "chainguard/wolfi-base");
         assert_eq!(r.tag, digest);

--- a/src/oci/registry.rs
+++ b/src/oci/registry.rs
@@ -47,6 +47,15 @@ impl Reference {
         // v2 URL scheme the full `sha256:hex` string takes the place of the
         // tag for GET /v2/<name>/manifests/<reference>.
         let (name, tag) = if let Some((n, digest)) = s.split_once('@') {
+            // `name:tag@digest` is valid reference grammar: the digest is
+            // authoritative and the tag is informational (docker/containerd
+            // accept and ignore it). Strip it, or it stays inside the
+            // repository and corrupts the token scope
+            // (`repository:name:tag:pull`) and the manifests URL.
+            let n = match n.rsplit_once(':') {
+                Some((base, t)) if !t.contains('/') => base,
+                _ => n,
+            };
             (n, digest.to_string())
         } else {
             let (n, t) = match s.rsplit_once(':') {
@@ -1715,6 +1724,28 @@ mod tests {
         let r = Reference::parse(&format!("ubuntu@{digest}")).unwrap();
         assert_eq!(r.registry, "docker.io");
         assert_eq!(r.repository, "library/ubuntu");
+        assert_eq!(r.tag, digest);
+    }
+
+    #[test]
+    fn parses_tag_and_digest_reference() {
+        // Tag + digest: the digest wins, and the tag must NOT leak into the
+        // repository (it corrupted the auth scope and the manifests URL).
+        let digest = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        let r = Reference::parse(&format!("cgr.dev/chainguard/wolfi-base:latest@{digest}")).unwrap();
+        assert_eq!(r.registry, "cgr.dev");
+        assert_eq!(r.repository, "chainguard/wolfi-base");
+        assert_eq!(r.tag, digest);
+    }
+
+    #[test]
+    fn parses_digest_reference_with_registry_port() {
+        // The port's ':' must not be mistaken for a tag separator when
+        // stripping the tag half of a digest reference.
+        let digest = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        let r = Reference::parse(&format!("localhost:5000/img@{digest}")).unwrap();
+        assert_eq!(r.registry, "localhost:5000");
+        assert_eq!(r.repository, "img");
         assert_eq!(r.tag, digest);
     }
 


### PR DESCRIPTION
Pulling a base image by `name:tag@digest` fails: the tag leaks into the repository name, producing a malformed anonymous-token scope and manifest URL.

#### Reproduction

```
MISE_EXPERIMENTAL=1 mise oci build \
  --from cgr.dev/chainguard/wolfi-base:latest@sha256:0a8fd427de5882aed77471b0a432c3675eda6b6a0ae952b5d640b46da628cdbe \
  -o ./oci-layout -y
```

```
mise ERROR fetching anonymous token from https://cgr.dev/token
mise ERROR HTTP status client error (400 Bad Request) for url
  (https://cgr.dev/token?service=cgr.dev&scope=repository%3Achainguard%2Fwolfi-base%3Alatest%3Apull)
```

The scope is `repository:chainguard/wolfi-base:latest:pull` — the tag is inside the repository component. Digest-only references work; docker/containerd accept the combined form (digest authoritative, tag informational).

#### Cause

`Reference::parse` splits on `@` first and keeps the left half whole, so `:tag` stays inside `name` and flows into `repository`, corrupting both `repository:<repo>:<actions>` scopes and `/v2/<repo>/manifests/<digest>`.

#### Fix

Strip a trailing `:tag` from the name half when a digest is present. The `!t.contains('/')` guard mirrors the existing tag-parse branch so a registry port (`localhost:5000/img@sha256:…`) is not mistaken for a tag — both cases covered by new tests (`parses_tag_and_digest_reference`, `parses_digest_reference_with_registry_port`).

`cargo test --bin mise oci::registry::tests`: 20 passed, 0 failed (rustc 1.93.1).

(Filed as a PR directly since issues are disabled on the repo.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of image references that include both a tag and digest.
  * Preserved registry ports when processing digest-based references.
  * Added coverage for these reference formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->