### PR TITLE
fix(rust): resolve nightly to dated toolchains

### DIFF
--- a/docs/lang/rust.md
+++ b/docs/lang/rust.md
@@ -41,6 +41,26 @@ mise use -g rust@beta
 cargo build
 ```
 
+Use the rolling nightly channel:
+
+```sh
+mise use -g rust@nightly
+cargo build
+```
+
+The configuration remains `nightly`, while mise resolves the current Rust channel manifest to a concrete
+`nightly-YYYY-MM-DD` toolchain for installation and lockfiles. This keeps the configured channel rolling while making
+locked installs reproducible. Run `mise upgrade rust` or `mise lock --bump` to advance the locked nightly.
+
+To keep a specific nightly instead, configure its date explicitly:
+
+```sh
+mise use -g rust@nightly-2026-08-13
+```
+
+An explicitly dated nightly is an exact pin. Commands using `--bump`, such as `mise upgrade --bump rust`, can replace
+that pin with the current nightly.
+
 Use a specific version of rust:
 
 ```sh

--- a/e2e/core/test_rust_nightly_lock
+++ b/e2e/core/test_rust_nightly_lock
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export MISE_LOCKFILE=1
+export MISE_CARGO_HOME="$PWD/cargo"
+export MISE_RUSTUP_HOME="$PWD/rustup"
+
+SERVER_ROOT="$PWD/server"
+PORT_DIR=$(mktemp -d "${TMPDIR:-/tmp}/mise-rust-nightly.XXXXXX")
+PORT_FILE="$PORT_DIR/port"
+MANIFEST="$SERVER_ROOT/dist/channel-rust-nightly.toml"
+mkdir -p "$SERVER_ROOT/dist" "$SERVER_ROOT/repos/rust-lang/rust" "$MISE_CARGO_HOME/bin" "$MISE_RUSTUP_HOME"
+touch "$MISE_RUSTUP_HOME/settings.toml"
+printf '[]\n' >"$SERVER_ROOT/repos/rust-lang/rust/releases"
+
+write_manifest() {
+  cat >"$MANIFEST" <<EOF
+manifest-version = "2"
+date = "$1"
+EOF
+}
+
+write_manifest 2026-08-12
+
+cat >"$MISE_CARGO_HOME/bin/rustup" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "$*" >>"$CARGO_HOME/rustup.log"
+case "${1:-} ${2:-}" in
+	"toolchain install")
+		mkdir -p "$RUSTUP_HOME/toolchains/$3"
+		;;
+	"toolchain uninstall")
+		;;
+	"component list" | "target list")
+		;;
+	*)
+		echo "unexpected rustup args: $*" >&2
+		exit 1
+		;;
+esac
+EOF
+
+cat >"$MISE_CARGO_HOME/bin/rustc" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+test -d "$RUSTUP_HOME/toolchains/$RUSTUP_TOOLCHAIN"
+echo "rustc $RUSTUP_TOOLCHAIN"
+EOF
+
+cat >"$MISE_CARGO_HOME/bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+echo cargo
+EOF
+
+chmod +x "$MISE_CARGO_HOME/bin/rustup" "$MISE_CARGO_HOME/bin/rustc" "$MISE_CARGO_HOME/bin/cargo"
+
+python3 - "$SERVER_ROOT" "$PORT_FILE" <<'PY' &
+import http.server
+import os
+import socketserver
+import sys
+
+root, port_file = sys.argv[1:]
+os.chdir(root)
+socketserver.TCPServer.allow_reuse_address = True
+with socketserver.TCPServer(("127.0.0.1", 0), http.server.SimpleHTTPRequestHandler) as httpd:
+    with open(port_file, "w") as file:
+        file.write(str(httpd.server_address[1]))
+    httpd.serve_forever()
+PY
+SERVER_PID=$!
+cleanup() {
+  kill "$SERVER_PID" 2>/dev/null || true
+  rm -rf "$PORT_DIR"
+}
+trap cleanup EXIT
+
+wait_for_file "$PORT_FILE" "Rust nightly manifest HTTP server port" 30 "$SERVER_PID"
+SERVER_PORT=$(cat "$PORT_FILE")
+
+cat >mise.toml <<EOF
+[settings]
+lockfile = true
+url_replacements = { "https://static.rust-lang.org" = "http://127.0.0.1:$SERVER_PORT", "https://api.github.com" = "http://127.0.0.1:$SERVER_PORT" }
+
+[tools]
+rust = "dev"
+
+[tool_alias.rust.versions]
+dev = "nightly"
+EOF
+
+# A legacy literal-nightly install is not a reproducible fallback for offline use,
+# including when the rolling channel is reached through an alias.
+mkdir -p "$MISE_DATA_DIR/installs/rust"
+ln -s "$MISE_CARGO_HOME/bin" "$MISE_DATA_DIR/installs/rust/nightly"
+assert_fail_contains "MISE_OFFLINE=1 mise exec -- rustc -V 2>&1" "cannot resolve rolling channel rust@nightly while offline"
+
+cat >mise.toml <<EOF
+[settings]
+lockfile = true
+url_replacements = { "https://static.rust-lang.org" = "http://127.0.0.1:$SERVER_PORT", "https://api.github.com" = "http://127.0.0.1:$SERVER_PORT" }
+
+[tools]
+rust = "nightly"
+
+[tool_alias.rust.versions]
+dev = "nightly"
+EOF
+
+# Locking resolves the rolling channel without installing it or changing config.
+mise lock
+assert_contains "cat mise.lock" 'version = "nightly-2026-08-12"'
+assert_not_contains "cat mise.lock" 'version = "nightly"'
+assert "test ! -e '$MISE_CARGO_HOME/rustup.log'"
+assert_contains "cat mise.toml" 'rust = "nightly"'
+
+# Explicit tool filtering follows the same concrete-resolution path.
+rm mise.lock
+mise lock rust@nightly
+assert_contains "cat mise.lock" 'version = "nightly-2026-08-12"'
+assert_not_contains "cat mise.lock" 'version = "nightly"'
+
+# Explicit aliases are resolved before rolling-channel detection.
+rm mise.lock
+mise lock rust@dev
+assert_contains "cat mise.lock" 'version = "nightly-2026-08-12"'
+assert_not_contains "cat mise.lock" 'version = "dev"'
+
+mise install
+assert_contains "cat '$MISE_CARGO_HOME/rustup.log'" "toolchain install nightly-2026-08-12"
+assert "MISE_OFFLINE=1 mise exec -- rustc -V" "rustc nightly-2026-08-12"
+
+# Advancing the manifest makes the channel outdated and upgrade updates the lock,
+# while the configured selector remains rolling.
+write_manifest 2026-08-13
+assert_contains "mise outdated rust" "nightly-2026-08-13"
+mise upgrade rust --no-prune
+assert_contains "cat mise.lock" 'version = "nightly-2026-08-13"'
+assert_contains "cat mise.toml" 'rust = "nightly"'
+assert_contains "cat '$MISE_CARGO_HOME/rustup.log'" "toolchain install nightly-2026-08-13"
+
+# An explicit dated nightly remains pinned unless --bump is requested.
+cat >mise.toml <<EOF
+[settings]
+lockfile = true
+url_replacements = { "https://static.rust-lang.org" = "http://127.0.0.1:$SERVER_PORT", "https://api.github.com" = "http://127.0.0.1:$SERVER_PORT" }
+
+[tools]
+rust = "nightly-2026-08-12"
+EOF
+write_manifest 2026-08-14
+assert_not_contains "mise outdated rust" "nightly-2026-08-14"
+assert_contains "mise outdated --bump rust" "nightly-2026-08-14"
+mise upgrade --bump rust --no-prune
+assert_contains "cat mise.toml" 'rust = "nightly-2026-08-14"'
+assert_contains "cat '$MISE_CARGO_HOME/rustup.log'" "toolchain install nightly-2026-08-14"
+
+# A malformed manifest must not replace a valid existing lock entry.
+cat >mise.toml <<EOF
+[settings]
+lockfile = true
+url_replacements = { "https://static.rust-lang.org" = "http://127.0.0.1:$SERVER_PORT", "https://api.github.com" = "http://127.0.0.1:$SERVER_PORT" }
+
+[tools]
+rust = "nightly"
+EOF
+cp mise.lock mise.lock.before
+printf 'manifest-version = "2"\ndate = "invalid"\n' >"$MANIFEST"
+assert_fail_contains "mise lock --bump 2>&1" "invalid Rust nightly channel manifest date"
+assert "cmp mise.lock.before mise.lock"
+
+# A broken nightly manifest does not prevent listing stable Rust releases.
+mise cache clear rust
+assert_contains "mise ls-remote --no-versions-host rust" "stable"
+
+write_manifest 2026-08-14
+mise cache clear rust
+assert_contains "mise ls-remote --no-versions-host rust" "nightly-2026-08-14"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2239,6 +2239,12 @@ pub trait Backend: Debug + Send + Sync {
         Ok(None)
     }
 
+    /// Whether an opaque version string should use [`Backend::resolve_exact_version`]
+    /// even when it does not have the usual dotted release shape.
+    fn is_exact_version(&self, _version: &str) -> bool {
+        false
+    }
+
     /// Whether `version` names a rolling release channel (e.g. zig's "master")
     /// rather than a concrete version. Cheap (no network). Channels are re-resolved
     /// to a concrete version like "latest" so `mise upgrade`/`outdated` can track
@@ -2268,6 +2274,13 @@ pub trait Backend: Debug + Send + Sync {
         _version: &str,
     ) -> eyre::Result<Option<String>> {
         Ok(None)
+    }
+
+    /// Whether a rolling channel must be resolved to a concrete version before it
+    /// can be used. Backends that opt in fail in offline mode when neither a lock
+    /// entry nor a concrete installed channel build is available.
+    fn requires_concrete_channel_version(&self, _version: &str) -> bool {
+        false
     }
 
     /// Backend opt-in for installing an unresolved `latest` request.
@@ -3858,6 +3871,12 @@ pub trait Backend: Debug + Send + Sync {
         _opts: &ResolveOptions,
     ) -> Result<Option<OutdatedInfo>> {
         Ok(None)
+    }
+
+    /// Whether [`Backend::outdated_info`] fully replaces the generic outdated
+    /// resolver rather than supplementing it.
+    fn uses_custom_outdated_info(&self) -> bool {
+        false
     }
 
     // ========== Lockfile Metadata Fetching Methods ==========

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -400,6 +400,7 @@ impl Install {
             resolve_options: ResolveOptions {
                 use_locked_version: true,
                 latest_versions: true,
+                resolve_rolling_channels: false,
                 prefer_exact_version: false,
                 before_date: self.get_before_date()?,
                 before_date_from_default: false,

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -180,16 +180,11 @@ impl Lock {
             filter_installed_versions_by_release_date: true,
             latest_versions: self.bump,
             use_locked_version: !self.bump,
+            // Lock moving channels to their current concrete value without making
+            // ordinary `latest` requests ignore an installed concrete version.
+            resolve_rolling_channels: true,
             ..Default::default()
         };
-        let has_configured_release_age = settings.minimum_release_age.is_some()
-            || config
-                .get_tool_request_set()
-                .await?
-                .tools
-                .values()
-                .flatten()
-                .any(|request| request.options().minimum_release_age().is_some());
         let monorepo_union = if !self.global && config.monorepo_lockfile_root().is_some() {
             Some(config.monorepo_union().await?)
         } else {
@@ -210,12 +205,10 @@ impl Lock {
                 .await?;
             ts_owned = monorepo_ts;
             &ts_owned
-        } else if self.bump || before_date.is_some() || has_configured_release_age {
+        } else {
             let builder = ToolsetBuilder::new().with_resolve_options(lock_resolve_options.clone());
             ts_owned = builder.build(&config).await?;
             &ts_owned
-        } else {
-            config.get_toolset().await?
         };
 
         let scoped_config_paths = self.config_paths_in_lock_scope(&config, effective_config_files);
@@ -931,7 +924,12 @@ impl Lock {
             }
             // Skip unresolved symbolic versions (e.g., a lockfile poisoned with "latest"
             // as the version). Pass 2's fallback will resolve these to a concrete version.
-            if tv.version == "latest" {
+            if tv.version == "latest"
+                || backend
+                    .ba()
+                    .backend()
+                    .is_ok_and(|backend| backend.is_rolling_channel(&tv.version))
+            {
                 continue;
             }
             push_unique_lock_tool(&mut all_tools, (backend.ba().as_ref().clone(), tv));
@@ -958,6 +956,9 @@ impl Lock {
                                 for tv in &resolved_tv.versions {
                                     if request_matches(&tv.request, request)
                                         && tv.version != "latest"
+                                        && !ba.backend().is_ok_and(|backend| {
+                                            backend.is_rolling_channel(&tv.version)
+                                        })
                                     {
                                         matched_resolved = true;
                                         push_unique_lock_tool(
@@ -1060,9 +1061,14 @@ impl Lock {
             {
                 if let Some(Some(request)) = specified_versions.get(&ba.short) {
                     let version = request.version();
+                    let backend = crate::backend::get(&ba);
+                    let effective_version = match &backend {
+                        Some(backend) => config.resolve_alias(backend, &version).await?,
+                        None => version.clone(),
+                    };
                     let request = ToolRequest::new_opts(
                         Arc::new(ba.clone()),
-                        &version,
+                        &effective_version,
                         tv.request.options(),
                         ToolSource::Argument,
                     );
@@ -1070,13 +1076,20 @@ impl Lock {
                         .as_ref()
                         .ok()
                         .and_then(|request| request.resolve_options(context.resolve_options).ok());
+                    let is_rolling = backend
+                        .is_some_and(|backend| backend.is_rolling_channel(&effective_version));
                     if let (Ok(request), Some(mut resolve_options)) = (request, resolve_options)
-                        && (self.bump || resolve_options.before_date.is_some())
+                        && (self.bump || resolve_options.before_date.is_some() || is_rolling)
                     {
                         resolve_options.use_locked_version = false;
                         resolve_options.latest_versions = true;
                         match request.resolve(config, &resolve_options).await {
                             Ok(resolved_tv) => tv = resolved_tv,
+                            Err(err) if is_rolling => {
+                                return Err(err.wrap_err(format!(
+                                    "failed to resolve specified rolling channel {request}"
+                                )));
+                            }
                             Err(err) => debug!("failed to resolve specified {request}: {err}"),
                         }
                     } else if version == "latest" {

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -176,6 +176,7 @@ impl Upgrade {
         let opts = ResolveOptions {
             use_locked_version: false,
             latest_versions: true,
+            resolve_rolling_channels: false,
             prefer_exact_version: false,
             before_date,
             before_date_from_default: false,
@@ -364,6 +365,7 @@ impl Upgrade {
             resolve_options: ResolveOptions {
                 use_locked_version: false,
                 latest_versions: true,
+                resolve_rolling_channels: false,
                 prefer_exact_version: false,
                 before_date,
                 before_date_from_default: false,

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -152,6 +152,7 @@ impl Use {
         let mut resolve_options = ResolveOptions {
             latest_versions: false,
             use_locked_version: true,
+            resolve_rolling_channels: false,
             prefer_exact_version: pin,
             before_date: self.get_before_date()?,
             before_date_from_default: false,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -15,6 +15,11 @@ pub enum Error {
         ts: ToolSource,
         source: Report,
     },
+    #[error("failed to resolve required rolling channel {backend}@{version}")]
+    RequiredChannelResolution {
+        backend: Box<BackendArg>,
+        version: String,
+    },
     #[error("[{0}] plugin not installed")]
     PluginNotInstalled(String),
     #[error("{0}@{1} not installed")]
@@ -155,6 +160,15 @@ impl Error {
                 )
             })
             .unwrap_or(false)
+    }
+
+    pub fn is_required_channel_resolution_err(err: &Report) -> bool {
+        err.chain().any(|source| {
+            matches!(
+                source.downcast_ref::<Error>(),
+                Some(Error::RequiredChannelResolution { .. })
+            )
+        })
     }
 }
 

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -9,7 +9,7 @@ use crate::build_time::TARGET;
 use crate::cli::args::BackendArg;
 use crate::cmd::{CmdLineRunner, cmd};
 use crate::config::{Config, Settings};
-use crate::http::HTTP;
+use crate::http::{HTTP, HTTP_FETCH};
 use crate::install_context::InstallContext;
 use crate::lock_file::LockFile;
 use crate::toolset::outdated_info::OutdatedInfo;
@@ -17,13 +17,46 @@ use crate::toolset::{ResolveOptions, ToolRequest, ToolVersion, ToolVersionOption
 use crate::ui::progress_report::SingleReport;
 use crate::{dirs, env, file, github, plugins};
 use async_trait::async_trait;
-use eyre::Result;
+use eyre::{Context, Result};
 use indexmap::IndexMap;
 use xx::regex;
 
 #[derive(Debug)]
 pub struct RustPlugin {
     ba: Arc<BackendArg>,
+}
+
+const RUST_NIGHTLY_MANIFEST_URL: &str =
+    "https://static.rust-lang.org/dist/channel-rust-nightly.toml";
+
+fn parse_nightly_manifest(manifest: &str) -> Result<String> {
+    let manifest: toml::Value =
+        toml::from_str(manifest).wrap_err("failed to parse the Rust nightly channel manifest")?;
+    let date = manifest
+        .get("date")
+        .and_then(toml::Value::as_str)
+        .ok_or_else(|| eyre::eyre!("Rust nightly channel manifest is missing its date"))?;
+    date.parse::<jiff::civil::Date>()
+        .wrap_err_with(|| format!("invalid Rust nightly channel manifest date: {date}"))?;
+    Ok(format!("nightly-{date}"))
+}
+
+async fn current_nightly_version() -> Result<String> {
+    let manifest = HTTP_FETCH
+        .get_text_cached(RUST_NIGHTLY_MANIFEST_URL)
+        .await
+        .wrap_err("failed to fetch the Rust nightly channel manifest")?;
+    parse_nightly_manifest(&manifest)
+}
+
+fn is_dated_nightly(version: &str) -> bool {
+    version
+        .strip_prefix("nightly-")
+        .is_some_and(|date| date.parse::<jiff::civil::Date>().is_ok())
+}
+
+fn latest_installed_nightly(versions: impl DoubleEndedIterator<Item = String>) -> Option<String> {
+    versions.rev().find(|version| is_dated_nightly(version))
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -328,7 +361,7 @@ impl Backend for RustPlugin {
     }
 
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> Result<Vec<VersionInfo>> {
-        let versions: Vec<VersionInfo> = github::list_releases("rust-lang/rust")
+        let mut versions: Vec<VersionInfo> = github::list_releases("rust-lang/rust")
             .await?
             .into_iter()
             .map(|r| {
@@ -341,26 +374,70 @@ impl Backend for RustPlugin {
                 }
             })
             .rev()
-            .chain(vec![
-                // Special channels - these are rolling releases that should always be updated
-                VersionInfo {
-                    version: "nightly".into(),
-                    rolling: true,
-                    ..Default::default()
-                },
-                VersionInfo {
-                    version: "beta".into(),
-                    rolling: true,
-                    ..Default::default()
-                },
-                VersionInfo {
-                    version: "stable".into(),
-                    rolling: true,
-                    ..Default::default()
-                },
-            ])
             .collect();
+        if let Ok(current_nightly) = current_nightly_version().await {
+            versions.push(VersionInfo {
+                version: current_nightly,
+                ..Default::default()
+            });
+        }
+        versions.extend([
+            // Special channels - these are rolling releases that should always be updated
+            VersionInfo {
+                version: "nightly".into(),
+                rolling: true,
+                ..Default::default()
+            },
+            VersionInfo {
+                version: "beta".into(),
+                rolling: true,
+                ..Default::default()
+            },
+            VersionInfo {
+                version: "stable".into(),
+                rolling: true,
+                ..Default::default()
+            },
+        ]);
         Ok(versions)
+    }
+
+    fn is_rolling_channel(&self, version: &str) -> bool {
+        version == "nightly"
+    }
+
+    fn latest_installed_channel_version(&self, channel: &str) -> Option<String> {
+        if !self.is_rolling_channel(channel) {
+            return None;
+        }
+        latest_installed_nightly(self.list_installed_versions().into_iter())
+    }
+
+    async fn resolve_channel_version(
+        &self,
+        _config: &Arc<Config>,
+        version: &str,
+    ) -> Result<Option<String>> {
+        if !self.is_rolling_channel(version) {
+            return Ok(None);
+        }
+        current_nightly_version().await.map(Some)
+    }
+
+    fn requires_concrete_channel_version(&self, version: &str) -> bool {
+        self.is_rolling_channel(version)
+    }
+
+    fn is_exact_version(&self, version: &str) -> bool {
+        is_dated_nightly(version)
+    }
+
+    async fn resolve_exact_version(
+        &self,
+        _config: &Arc<Config>,
+        version: &str,
+    ) -> Result<Option<String>> {
+        Ok(is_dated_nightly(version).then(|| version.to_string()))
     }
 
     async fn _parse_idiomatic_file(&self, path: &Path) -> Result<Vec<String>> {
@@ -461,6 +538,34 @@ impl Backend for RustPlugin {
         bump: bool,
         opts: &ResolveOptions,
     ) -> Result<Option<OutdatedInfo>> {
+        let requested = tv.request.version();
+        if requested == "nightly" {
+            if Settings::get().offline() || opts.offline {
+                let oi = OutdatedInfo::new(config, tv.clone(), tv.version.clone())?;
+                return Ok((oi.current.as_ref() != Some(&tv.version)).then_some(oi));
+            }
+            let latest = current_nightly_version().await?;
+            let oi = OutdatedInfo::new(config, tv.clone(), latest.clone())?;
+            return Ok((oi.current.as_ref() != Some(&latest)).then_some(oi));
+        }
+        if is_dated_nightly(&requested) {
+            let latest = if bump && !Settings::get().offline() && !opts.offline {
+                current_nightly_version().await?
+            } else {
+                tv.version.clone()
+            };
+            let mut oi = OutdatedInfo::new(config, tv.clone(), latest.clone())?;
+            if bump && requested != latest {
+                oi.bump = Some(latest.clone());
+                oi.tool_request = ToolRequest::new_opts(
+                    tv.request.ba().clone(),
+                    &latest,
+                    tv.request.options(),
+                    tv.request.source().clone(),
+                )?;
+            }
+            return Ok((oi.current.as_ref() != Some(&latest)).then_some(oi));
+        }
         let v_re = regex!(r#"Update available : (.*) -> (.*)"#);
         if regex!(r"(\d+)\.(\d+)\.(\d+)").is_match(&tv.version) {
             let oi = OutdatedInfo::resolve(config, tv.clone(), bump, opts).await?;
@@ -498,6 +603,10 @@ impl Backend for RustPlugin {
             }
             Ok(None)
         }
+    }
+
+    fn uses_custom_outdated_info(&self) -> bool {
+        true
     }
 }
 
@@ -1008,6 +1117,47 @@ mod tests {
         opts.opts
             .insert(key.to_string(), toml::Value::String(value.to_string()));
         opts
+    }
+
+    #[test]
+    fn parses_nightly_manifest_date() {
+        assert_eq!(
+            parse_nightly_manifest("manifest-version = \"2\"\ndate = \"2026-08-13\"\n").unwrap(),
+            "nightly-2026-08-13"
+        );
+    }
+
+    #[test]
+    fn rejects_missing_or_invalid_nightly_manifest_date() {
+        assert!(parse_nightly_manifest("manifest-version = \"2\"\n").is_err());
+        assert!(parse_nightly_manifest("date = \"2026-13-40\"\n").is_err());
+        assert!(parse_nightly_manifest("not toml").is_err());
+    }
+
+    #[test]
+    fn recognizes_only_valid_dated_nightlies() {
+        assert!(is_dated_nightly("nightly-2026-08-13"));
+        assert!(!is_dated_nightly("nightly"));
+        assert!(!is_dated_nightly("nightly-2026-13-40"));
+        assert!(!is_dated_nightly("1.90.0"));
+    }
+
+    #[test]
+    fn selects_latest_installed_dated_nightly() {
+        let versions = vec![
+            "nightly-2026-08-11".to_string(),
+            "nightly".to_string(),
+            "1.90.0".to_string(),
+            "nightly-2026-08-13".to_string(),
+        ];
+        assert_eq!(
+            latest_installed_nightly(versions.into_iter()).as_deref(),
+            Some("nightly-2026-08-13")
+        );
+        assert_eq!(
+            latest_installed_nightly(["nightly".to_string()].into_iter()),
+            None
+        );
     }
 
     #[test]

--- a/src/toolset/builder.rs
+++ b/src/toolset/builder.rs
@@ -79,7 +79,7 @@ impl ToolsetBuilder {
                 .resolve_with_opts(config, &self.resolve_options)
                 .await
             {
-                if Error::is_argument_err(&err) {
+                if Error::is_argument_err(&err) || Error::is_required_channel_resolution_err(&err) {
                     return Err(err);
                 }
                 warn!("failed to resolve toolset: {err}");

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -4,6 +4,7 @@ use crate::config::Config;
 use crate::config::settings::{Settings, SettingsStatusMissingTools};
 use crate::config::tracking::Tracker;
 use crate::env::TERM_WIDTH;
+use crate::errors::Error;
 use crate::file::display_path;
 use crate::lockfile::{Lockfile, lockfile_path_for_config};
 use crate::registry::REGISTRY;
@@ -139,6 +140,9 @@ impl Toolset {
             .collect::<Vec<_>>();
         let tvls = parallel::parallel(versions, |(config, ba, mut tvl, opts)| async move {
             if let Err(err) = tvl.resolve(&config, &opts).await {
+                if Error::is_required_channel_resolution_err(&err) {
+                    return Err(err);
+                }
                 // warn_once: a command may resolve the same toolset more than
                 // once, and repeating an identical failure adds no information.
                 warn_once!("Failed to resolve tool version list for {ba}: {err}");
@@ -383,6 +387,9 @@ impl Toolset {
             {
                 trace!("skipping symlinked version {tv}");
                 // do not consider symlinked versions to be outdated
+                return Ok(outdated);
+            }
+            if t.uses_custom_outdated_info() {
                 return Ok(outdated);
             }
             match OutdatedInfo::resolve(&config, tv.clone(), bump, &opts).await {

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -291,6 +291,7 @@ impl ToolVersion {
         let opts = ResolveOptions {
             latest_versions: true,
             use_locked_version: false,
+            resolve_rolling_channels: false,
             prefer_exact_version: false,
             before_date: base_opts.before_date,
             before_date_from_default: base_opts.before_date_from_default,
@@ -425,12 +426,6 @@ impl ToolVersion {
             backend.version_order(&request.options())?;
         }
 
-        if let Some(plugin) = backend.plugin()
-            && !plugin.is_installed()
-        {
-            return build(v);
-        }
-
         let settings = Settings::get();
         let is_offline = settings.offline() || opts.offline;
         let prefer_offline =
@@ -440,6 +435,58 @@ impl ToolVersion {
             && !opts.before_date_from_default
             && !is_offline
             && !prefer_offline;
+        // Rolling release channels (e.g. zig's "master") are moving pointers that
+        // mise must resolve before the plugin-installed shortcut can preserve their
+        // symbolic name as an install identity.
+        if backend.is_rolling_channel(&v) {
+            if !opts.latest_versions
+                && !opts.resolve_rolling_channels
+                && !should_filter_installed_versions
+                && let Some(installed) = backend.latest_installed_channel_version(&v)
+            {
+                return build(installed);
+            }
+            if !is_offline {
+                match backend.resolve_channel_version(config, &v).await {
+                    Ok(Some(concrete)) => return build(concrete),
+                    Ok(None) => {}
+                    Err(source) if backend.requires_concrete_channel_version(&v) => {
+                        return Err(source.wrap_err(
+                            crate::errors::Error::RequiredChannelResolution {
+                                backend: Box::new(backend.ba().as_ref().clone()),
+                                version: v.clone(),
+                            },
+                        ));
+                    }
+                    Err(source) => {
+                        debug!(
+                            "{backend}: failed to resolve optional rolling channel {v}: {source:#}"
+                        );
+                    }
+                }
+            }
+            if opts.offline {
+                return build(v);
+            }
+            if is_offline && backend.requires_concrete_channel_version(&v) {
+                let err = crate::errors::Error::RequiredChannelResolution {
+                    backend: Box::new(backend.ba().as_ref().clone()),
+                    version: v.clone(),
+                };
+                return Err(eyre::Report::new(err).wrap_err(format!(
+                    "cannot resolve rolling channel {backend}@{v} while offline; create a lockfile or install a concrete channel version first"
+                )));
+            }
+            // Backends whose channel resolver is best-effort can still fall through
+            // to their legacy symbolic-channel resolution.
+        }
+
+        if let Some(plugin) = backend.plugin()
+            && !plugin.is_installed()
+        {
+            return build(v);
+        }
+
         if v == "latest" {
             if !opts.latest_versions
                 && !should_filter_installed_versions
@@ -477,36 +524,6 @@ impl ToolVersion {
                 return build(v);
             }
             return Err(Self::no_versions_found(&backend, opts.before_date));
-        }
-        // Rolling release channels (e.g. zig's "master") are moving pointers that
-        // mise must re-resolve to a concrete version -- like "latest" -- so they are
-        // not pinned forever. Mirror the "latest" fast paths: prefer an installed
-        // concrete version when not explicitly resolving latest (keeps hook-env /
-        // exec network-free), otherwise re-resolve the channel. (#10251)
-        if backend.is_rolling_channel(&v) {
-            // Reuse an installed build of THIS channel (e.g. a -dev nightly for
-            // zig@master), never an unrelated installed release, so we don't
-            // short-circuit zig@master to a stable version that happens to be
-            // installed.
-            if !opts.latest_versions
-                && !should_filter_installed_versions
-                && let Some(installed) = backend.latest_installed_channel_version(&v)
-            {
-                return build(installed);
-            }
-            if !is_offline
-                && let Some(concrete) = backend.resolve_channel_version(config, &v).await?
-            {
-                return build(concrete);
-            }
-            if opts.offline {
-                return build(v);
-            }
-            // Online but the channel did not resolve to a concrete version --
-            // either the index lacked the channel key, or the fetch failed
-            // transiently (resolve_channel_version maps both to Ok(None)). Fall
-            // through to normal resolution, which still matches the literal
-            // channel name in the backend's version list as before.
         }
         let installed_matches =
             (!opts.latest_versions).then(|| backend.list_installed_versions_matching(&v));
@@ -599,7 +616,7 @@ impl ToolVersion {
         // filtering. If the backend returns None, fall through to normal
         // prefix resolution so requests like "1.2.3" can still resolve to
         // "1.2.3.4" when that is the latest matching version.
-        if v.matches('.').count() >= 2
+        if (v.matches('.').count() >= 2 || backend.is_exact_version(&v))
             && let Some(v) = backend.resolve_exact_version(config, &v).await?
         {
             return build(v);
@@ -817,6 +834,9 @@ impl Hash for ToolVersion {
 pub struct ResolveOptions {
     pub latest_versions: bool,
     pub use_locked_version: bool,
+    /// Resolve rolling channels to their current concrete version even when
+    /// ordinary version requests may reuse installed versions.
+    pub resolve_rolling_channels: bool,
     /// Prefer an exact remote release over a fuzzy installed match.
     pub prefer_exact_version: bool,
     /// Only consider versions released before this timestamp
@@ -845,6 +865,7 @@ impl Default for ResolveOptions {
         Self {
             latest_versions: false,
             use_locked_version: true,
+            resolve_rolling_channels: false,
             prefer_exact_version: false,
             before_date: None,
             before_date_from_default: false,
@@ -945,6 +966,9 @@ impl Display for ResolveOptions {
         }
         if self.use_locked_version {
             opts.push("use_locked_version".to_string());
+        }
+        if self.resolve_rolling_channels {
+            opts.push("resolve_rolling_channels".to_string());
         }
         if self.prefer_exact_version {
             opts.push("prefer_exact_version".to_string());

--- a/src/toolset/tool_version_list.rs
+++ b/src/toolset/tool_version_list.rs
@@ -35,7 +35,12 @@ impl ToolVersionList {
             // explicitly specify "latest". This ensures `mise x node@20 npm@latest` only
             // fetches latest for npm, not node.
             // However, we always respect the caller's use_locked_version setting.
-            let request_opts = if tvr.version() == "latest" {
+            let request_opts = if tvr.version() == "latest"
+                || tvr
+                    .ba()
+                    .backend()
+                    .is_ok_and(|backend| backend.is_rolling_channel(&tvr.version()))
+            {
                 opts.clone()
             } else {
                 ResolveOptions {


### PR DESCRIPTION
## Summary

- resolve the rolling Rust `nightly` channel through the official channel manifest
- store and install concrete `nightly-YYYY-MM-DD` toolchains while leaving `mise.toml` on `nightly`
- make nightly lock, outdated, upgrade, offline reuse, and explicit dated pins reproducible

## Problem

The Rust backend previously treated `nightly` as a concrete version. That allowed the mutable channel name to be written to the lockfile and used as the install identity, so two installs from the same lockfile could select different toolchains.

## Implementation

- Read `channel-rust-nightly.toml` through the shared HTTP client and validate its `date` field.
- Treat `nightly` as a required rolling channel and resolve it to `nightly-YYYY-MM-DD`.
- Reuse only installed dated nightlies when operating without a network; legacy installs named literally `nightly` are not considered concrete.
- Preserve existing lock entries unless `mise lock --bump` is requested, while resolving a first lock to the current manifest date.
- Compare a rolling nightly against the current manifest for `mise outdated` and `mise upgrade`.
- Keep explicitly dated nightlies as exact pins unless a bump operation is requested.
- Include the current dated nightly in backend `ls-remote` results.
- Fail required channel resolution instead of silently continuing with a mutable install identity when the manifest is unavailable or invalid.

This follows the same concrete-version model used by the existing Zig rolling-channel support, while using Rust official distribution metadata as the authoritative source.

Addresses https://github.com/jdx/mise/discussions/4737

## Verification

- `mise exec -- cargo test --all-features plugins::core::rust::tests --no-fail-fast`
- `mise exec -- cargo test --all-features cli::lock::tests --no-fail-fast`
- `mise run test:e2e e2e/core/test_rust_nightly_lock`
- `mise run test:e2e e2e/core/test_rust_config_env_homes e2e/core/test_rust_components_reconcile e2e/core/test_rust_parallel_install e2e/cli/test_lock_latest`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise exec -- shellcheck e2e/core/test_rust_nightly_lock`
- `mise exec -- shfmt -d e2e/core/test_rust_nightly_lock`
- `mise exec -- prettier --check docs/lang/rust.md`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Rust nightly channels now resolve to reproducible, date-specific versions.
  - Added support for dated nightly toolchains, offline resolution, lockfile upgrades, aliases, and accurate outdated-version reporting.
  - Rolling channels can resolve to installed or remotely available concrete versions.

- **Bug Fixes**
  - Required channel-resolution failures are now surfaced instead of silently continuing.
  - Valid nightly locks are preserved when remote manifests are malformed or unavailable.

- **Documentation**
  - Added Rust nightly guidance covering reproducible locking, upgrades, explicit dates, and offline behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->