### PR TITLE
fix(dotfiles): treat an unmanaged file as a conflict on Windows too

### DIFF
--- a/e2e-win/dotfiles_conflicts.Tests.ps1
+++ b/e2e-win/dotfiles_conflicts.Tests.ps1
@@ -1,0 +1,57 @@
+Describe 'dotfiles-conflicts' {
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:TestRoot | Out-Null
+
+        # Saved here, restored in AfterAll: Pester runs every suite in one process, so removing
+        # an inherited value would leave the next suite without it.
+        $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:TestRoot
+
+        New-Item -ItemType Directory -Path (Join-Path $script:TestRoot "dotfiles") | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $script:TestRoot "applied") | Out-Null
+        "managed source" | Out-File -FilePath (Join-Path $script:TestRoot "dotfiles\gitconfig") -Encoding ascii -NoNewline
+
+        $script:Target = Join-Path $script:TestRoot "applied\.gitconfig"
+        $targetToml = $script:Target -replace '\\', '/'
+        @"
+[dotfiles]
+"$targetToml" = { source = "dotfiles/gitconfig", mode = "symlink" }
+"@ | Out-File (Join-Path $script:TestRoot "mise.toml")
+
+        Set-Location $script:TestRoot
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        if ($null -eq $script:OriginalTrusted) {
+            Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
+        } else {
+            [Environment]::SetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', $script:OriginalTrusted, 'Process')
+        }
+    }
+
+    BeforeEach {
+        # Each test starts from an unmanaged file the user wrote.
+        "USER FILE" | Out-File -FilePath $script:Target -Encoding ascii -NoNewline
+    }
+
+    It 'refuses to overwrite an unmanaged file without --force' {
+        $out = mise bootstrap dotfiles apply 2>&1 | Out-String
+        $LASTEXITCODE | Should -Not -Be 0
+        $out | Should -BeLike '*refusing to overwrite*'
+
+        # Asserting the content, not just the exit code: the failure only means anything if the
+        # file the user wrote is still there. Windows used to apply this entry and destroy it.
+        (Get-Content $script:Target -Raw) | Should -Be "USER FILE"
+    }
+
+    It 'applies over it with --force' {
+        # The control: the protection above is a prompt for --force, not a refusal to ever
+        # manage the path.
+        mise bootstrap dotfiles apply --force 2>&1 | Out-String | Out-Null
+        $LASTEXITCODE | Should -Be 0
+        (Get-Content $script:Target -Raw) | Should -Be "managed source"
+    }
+}

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -1601,20 +1601,20 @@ fn unapply_one(plan: &UnapplyPlan<'_>) -> Result<()> {
 /// content overwrites by copy/template (those are the declared intent) or
 /// re-pointing symlinks (always mise-owned territory)
 fn find_conflicts(req: &FileRequest) -> Result<Vec<PathBuf>> {
-    // on Windows, file "symlinks" are applied as copies (see `link_path`),
-    // so existing regular-file targets are routine content updates there,
-    // not conflicts — only a type mismatch blocks
-    let file_link_conflicts = |source: &Path, target: &Path| -> Result<bool> {
-        if cfg!(windows) && source.is_file() {
-            Ok(target.exists() && target.is_dir())
-        } else {
-            Ok(target.exists() && !target.is_symlink())
-        }
-    };
+    // A symlink at the target is one mise made, so it is re-pointable. Anything else that is
+    // there — a regular file or a directory — belongs to someone else and needs `--force`.
+    //
+    // Windows used to exempt regular files here, on the grounds that a file link becomes a copy
+    // on that platform so an existing file is only a content update. That reasoning holds for
+    // `copy` mode, which is declared as overwriting; for a `symlink` entry it meant the copy
+    // silently destroyed a file the user wrote, with no `--force` and no message — while unix
+    // refused the same apply.
+    let file_link_conflicts =
+        |target: &Path| -> Result<bool> { Ok(target.exists() && !target.is_symlink()) };
     let mut out = vec![];
     match req.mode {
         FileMode::Symlink => {
-            if file_link_conflicts(&req.source, &req.target)? {
+            if file_link_conflicts(&req.target)? {
                 out.push(req.target.clone());
             }
         }
@@ -1626,8 +1626,8 @@ fn find_conflicts(req: &FileRequest) -> Result<Vec<PathBuf>> {
                     out.push(dir);
                 }
             }
-            for (source, target) in walk_source_files(req)? {
-                if file_link_conflicts(&source, &target)? {
+            for (_source, target) in walk_source_files(req)? {
+                if file_link_conflicts(&target)? {
                     out.push(target);
                 }
             }
@@ -2010,5 +2010,107 @@ mod tests {
             target,
             PathBuf::from(native_path_separators("C:/Users/me/.config/tool.toml"))
         );
+    }
+
+    fn link_req(source: &Path, target: &Path, mode: FileMode) -> FileRequest {
+        FileRequest {
+            target_raw: target.to_string_lossy().to_string(),
+            target: target.to_path_buf(),
+            source: source.to_path_buf(),
+            mode,
+            exclude: vec![],
+            base: source.parent().expect("source parent").to_path_buf(),
+        }
+    }
+
+    fn symlink_req(source: &Path, target: &Path) -> FileRequest {
+        link_req(source, target, FileMode::Symlink)
+    }
+
+    /// The fix: a file the user wrote is not mise's to replace. This used to pass on Windows,
+    /// where the entry applied and overwrote it with no `--force` and no message.
+    #[test]
+    fn an_unmanaged_file_at_the_target_is_a_conflict() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let source = dir.path().join("source");
+        let target = dir.path().join("target");
+        file::write(&source, "managed")?;
+        file::write(&target, "the user's own file")?;
+
+        assert_eq!(
+            find_conflicts(&symlink_req(&source, &target))?,
+            vec![target]
+        );
+        Ok(())
+    }
+
+    /// The control for the test above: the two cases that must *not* start blocking. A symlink
+    /// is one mise made, so re-pointing it is the normal path and would be a regression to
+    /// refuse; a missing target has nothing to protect.
+    #[test]
+    fn a_managed_symlink_and_a_missing_target_are_not_conflicts() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let source = dir.path().join("source");
+        file::write(&source, "managed")?;
+
+        let absent = dir.path().join("absent");
+        assert!(find_conflicts(&symlink_req(&source, &absent))?.is_empty());
+
+        // Created directly rather than through `link_path`, which copies on Windows: the point
+        // here is what `find_conflicts` does when a symlink *is* present.
+        let link = dir.path().join("link");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&source, &link)?;
+        #[cfg(windows)]
+        let created = std::os::windows::fs::symlink_file(&source, &link).is_ok();
+        #[cfg(unix)]
+        let created = true;
+        if created {
+            assert!(link.is_symlink(), "precondition: target must be a symlink");
+            assert!(find_conflicts(&symlink_req(&source, &link))?.is_empty());
+        }
+        Ok(())
+    }
+
+    /// `symlink-each` shares the predicate, so it gains the same protection: a file the user
+    /// wrote inside the target directory is not mise's to replace either. Asserted separately
+    /// because it reaches `file_link_conflicts` through `walk_source_files` rather than
+    /// directly, and the mode is the half of this change most likely to be overlooked.
+    #[test]
+    fn symlink_each_also_treats_an_unmanaged_file_as_a_conflict() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let source = dir.path().join("source");
+        let target = dir.path().join("target");
+        // `file::write` does not create parents, and the target directory must already exist or
+        // `needed_dirs` would report it as its own conflict and drown the assertion.
+        file::create_dir_all(&source)?;
+        file::create_dir_all(&target)?;
+        file::write(source.join("one"), "managed")?;
+        file::write(source.join("two"), "managed")?;
+        // Only `one` is squatted on; `two` has nothing in its way.
+        file::write(target.join("one"), "the user's own file")?;
+
+        assert_eq!(
+            find_conflicts(&link_req(&source, &target, FileMode::SymlinkEach))?,
+            vec![target.join("one")]
+        );
+        Ok(())
+    }
+
+    /// A directory where a file belongs blocked before this change and still does — the
+    /// type-mismatch case is untouched.
+    #[test]
+    fn a_directory_at_the_target_is_still_a_conflict() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let source = dir.path().join("source");
+        let target = dir.path().join("target");
+        file::write(&source, "managed")?;
+        file::create_dir_all(&target)?;
+
+        assert_eq!(
+            find_conflicts(&symlink_req(&source, &target))?,
+            vec![target]
+        );
+        Ok(())
     }
 }


### PR DESCRIPTION
`mise bootstrap dotfiles apply` destroys a file the user wrote — on Windows only, with no
`--force` and no message. Found while reviewing [#11978](https://github.com/jdx/mise/pull/11978)
and split out of it, since that PR is about *creating* symlinks rather than about what may be
replaced.

## The inconsistency

Same config, same `symlink` entry, both platforms measured:

```console
# unix — jdxcode/mise:latest, 2026.8.3
$ cat applied/.gitconfig
USER FILE - DO NOT LOSE
$ mise bootstrap dotfiles apply                    # no --force
mise ERROR files: refusing to overwrite existing files (use --force):
  ~/applied/.gitconfig
$ cat applied/.gitconfig
USER FILE - DO NOT LOSE                            # protected

# Windows — 2026.8.2
$ cat applied\.gitconfig
USER FILE - DO NOT LOSE
$ mise bootstrap dotfiles apply                    # no --force
mise files: applied ...\applied\.gitconfig
$ cat applied\.gitconfig
managed source                                     # gone
```

`find_conflicts` exempted regular files on Windows:

```rust
if cfg!(windows) && source.is_file() {
    Ok(target.exists() && target.is_dir())     // a regular file is never a conflict
} else {
    Ok(target.exists() && !target.is_symlink())
}
```

The reasoning was that a file link becomes a copy on Windows, so an existing file is only a
content update. That is true of `copy` mode. For a `symlink` entry it converted a refusal into
silent data loss.

## The change

Drop the branch, leaving what unix already did:

```rust
let file_link_conflicts =
    |target: &Path| -> Result<bool> { Ok(target.exists() && !target.is_symlink()) };
```

A symlink at the target is one mise made and stays re-pointable; anything else that exists needs
`--force`.

### What each case does, before and after

Every row measured rather than reasoned about:

| entry / target | unix | Windows before | Windows after |
|---|---|---|---|
| `symlink` / unmanaged regular file | conflict | **applied, file destroyed** | conflict |
| `symlink` / symlink | not a conflict | not a conflict | unchanged |
| `symlink` / directory | conflict | conflict | unchanged |
| `symlink` + `--force` | applies | applies | unchanged |
| `copy` / existing file | **overwrites** | overwrites | unchanged |

That last row is the reason this is narrow. `copy` overwrites on unix too, and the docs say so —
"matching files are overwritten". Only the `symlink` path was inconsistent.

## Behaviour change

This is a behaviour change to `apply` on Windows. Anyone whose workflow relied on a `symlink`
entry quietly replacing an existing file now needs `--force`. That seems clearly right — the
alternative is losing a file you wrote with no prompt — but it is a change, not a bug fix that
restores documented behaviour, so it should be a deliberate choice rather than a footnote.

`symlink-each` shares the predicate and gains the same protection on Windows, which likewise
matches unix.

## Tests

- **unit** — an unmanaged file at the target is a conflict (the fix itself), with the two cases
  that must **not** start blocking as controls: a symlink (re-pointing is the normal path, and
  refusing it would be a regression) and a missing target. A third pins that a directory still
  blocks, so the type-mismatch case is visibly untouched. No `#[cfg]` — the platform branch is
  gone, so these run everywhere.

  A fourth covers `symlink-each`, added in review: the description claims it gains the same
  protection, and nothing was asserting that. It uses two source files and squats on only one,
  asserting the exact conflict list, so it also fails if the predicate started reporting every
  path it walks rather than only the occupied one.
- **e2e-win (new)** — `dotfiles_conflicts.Tests.ps1`: apply without `--force` fails **and the
  user's content is still there**, then `--force` applies. Asserting the content matters — an
  exit code alone would not show the file survived, which is the whole point.
- **e2e (unix)** — `test_dotfiles_files` already covers the conflict and `--force` paths; unix
  behaviour is unchanged, so it is the regression guard.

### Not run

`cargo fmt --all` only; no local build. The transcripts above are from released binaries — the
unix one in a container, the Windows one natively. CI exercises the change itself.

## Conflicts

#11978 touches the same predicate — it adds `&& !target.is_symlink()` to the Windows arm, which
this PR replaces outright. Whichever lands second should rebase; the result is the single-line
predicate above either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved dotfile conflict detection on Windows and other platforms.
- Existing unmanaged files are now protected from accidental replacement when applying symlink-based dotfiles.
- `mise bootstrap dotfiles apply` clearly reports conflicts and requires `--force` to overwrite existing files.
- Forced application correctly replaces conflicting files with managed content.
- Existing symlinks and missing targets continue to work as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
