### PR TITLE
fix(shims): stop treating a full-path argv[0] as a shim name

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -9,6 +9,7 @@ use indexmap::IndexSet;
 use itertools::Itertools;
 use log::LevelFilter;
 pub use std::env::*;
+use std::process;
 use std::sync::LazyLock as Lazy;
 use std::sync::RwLock;
 use std::{
@@ -16,7 +17,6 @@ use std::{
     ffi::OsStr,
     sync::Mutex,
 };
-use std::{path, process};
 use std::{path::Path, string::ToString};
 use std::{path::PathBuf, sync::atomic::AtomicBool};
 
@@ -920,9 +920,20 @@ fn split_colon_list(value: &str) -> IndexSet<String> {
         .collect()
 }
 
+/// The basename of `path` by the host's path grammar, which on Windows means either separator.
+///
+/// `argv[0]` does not always arrive with `MAIN_SEPARATOR_STR`. libuv hands a Windows process a
+/// forward-slash path, which is how Neovim's `jobstart` spawns mise, and splitting on the platform
+/// separator left the whole path in [`MISE_BIN_NAME`]. [`is_mise_binary`] then said no and mise ran
+/// itself as a shim named after its own path (discussion #11423).
+///
+/// Deferring to [`Path`] rather than splitting on both separators unconditionally is deliberate:
+/// `\` is an ordinary filename character on unix, and splitting there would resolve a shim to a
+/// different tool than the one invoked.
 fn filename(path: &str) -> &str {
-    path.rsplit_once(path::MAIN_SEPARATOR_STR)
-        .map(|(_, file)| file)
+    Path::new(path)
+        .file_name()
+        .and_then(|name| name.to_str())
         .unwrap_or(path)
 }
 
@@ -1233,5 +1244,75 @@ mod tests {
         remove_var("MISE_GITHUB_TOKEN");
         remove_var("GITHUB_TOKEN");
         remove_var("GITHUB_API_TOKEN");
+    }
+
+    #[test]
+    fn test_filename_takes_the_basename() {
+        // The reported case: libuv gives a Windows process a forward-slash argv[0], and splitting
+        // on MAIN_SEPARATOR_STR left the whole path behind. `/` separates on every platform, so
+        // the case the fix is for is pinned everywhere.
+        assert_eq!(filename("C:/Users/alice/.cargo/bin/mise.EXE"), "mise.EXE");
+        // A unix path was equally unhandled on Windows, since the separator there is `\`.
+        assert_eq!(filename("/usr/local/bin/mise"), "mise");
+        // A trailing separator used to yield an empty name.
+        assert_eq!(filename("/usr/local/bin/mise/"), "mise");
+        // Bare names pass through, which is the common case.
+        assert_eq!(filename("mise"), "mise");
+        assert_eq!(filename("mise.exe"), "mise.exe");
+    }
+
+    /// `\` separates path components only on Windows, so the two tests below are a deliberate
+    /// platform split rather than duplicated coverage.
+    ///
+    /// This half is the regression guard: the spelling that always worked has to keep working.
+    #[cfg(windows)]
+    #[test]
+    fn test_filename_splits_on_backslash_on_windows() {
+        assert_eq!(filename(r"C:\Users\alice\.cargo\bin\mise.EXE"), "mise.EXE");
+        assert_eq!(filename(r"C:\tools\mise\"), "mise");
+    }
+
+    /// The other half. On unix `\` is an ordinary filename character, so splitting on it would
+    /// resolve a shim to a different tool than the one invoked. `filename` defers to the host
+    /// path grammar to avoid that, and this pins the choice.
+    #[cfg(unix)]
+    #[test]
+    fn test_filename_keeps_backslashes_on_unix() {
+        assert_eq!(
+            filename(r"C:\Users\alice\.cargo\bin\mise.EXE"),
+            r"C:\Users\alice\.cargo\bin\mise.EXE"
+        );
+        assert_eq!(filename(r"/opt/odd/weird\name"), r"weird\name");
+    }
+
+    #[test]
+    fn test_a_full_path_argv0_is_recognised_as_mise_itself() {
+        // What the fix is actually for: `filename` is only interesting because its result feeds
+        // `is_mise_binary`, and a false there sends mise into shim mode against its own path.
+        for argv0 in [
+            "C:/Users/alice/.cargo/bin/mise.EXE",
+            "/usr/local/bin/mise",
+            "mise",
+        ] {
+            assert!(
+                is_mise_binary(filename(argv0)),
+                "argv[0] {argv0:?} should be recognised as mise, not a shim"
+            );
+        }
+        // The backslash spelling only resolves where `\` is a separator; see the pair of
+        // `filename` tests above.
+        #[cfg(windows)]
+        assert!(
+            is_mise_binary(filename(r"C:\Users\alice\.cargo\bin\mise.exe")),
+            "a backslash argv[0] should be recognised as mise on Windows"
+        );
+        // The control: a real shim invocation must still be treated as one, or this "fix" would
+        // be mise refusing to act as a shim at all.
+        for argv0 in ["/home/alice/.local/share/mise/shims/node", "node.exe"] {
+            assert!(
+                !is_mise_binary(filename(argv0)),
+                "argv[0] {argv0:?} should still be a shim"
+            );
+        }
     }
 }


### PR DESCRIPTION
On Windows, mise invoked through its own full path with forward slashes runs itself as a shim
named after that path. `--version` does not survive it:

```console
> cmd /c "C:/Users/jam/.../argv0/mise.exe --version"
mise ERROR No version is set for shim: C:/Users/jam/.../argv0/mise
Set a global default version with one of the following:
  mise use -g actionlint@1.7.12
  ...
```

Reported in #11423 by @dvnatanael, who found the cause, wrote the fix, and verified it against a
local build before filing. Everything below is a re-verification of that report; the diagnosis is
theirs.

## Cause

`filename` splits on `MAIN_SEPARATOR_STR`, which is `\` on Windows, so a forward-slash path has
nothing to split on and comes back whole:

```rust
fn filename(path: &str) -> &str {
    path.rsplit_once(path::MAIN_SEPARATOR_STR)
        .map(|(_, file)| file)
        .unwrap_or(path)
}
```

Its one caller is `MISE_BIN_NAME`, so the whole path lands there, `is_mise_binary` says no, and
`handle_shim` takes over and treats the path as a tool name. A `rustc` probe over both versions:

```
argv0 = "C:/Users/alice/.cargo/bin/mise.EXE"
  before  bin_name="C:/Users/alice/.cargo/bin/mise.EXE"  is_mise_binary=false  -> shim mode
  after   bin_name="mise.EXE"                            is_mise_binary=true   -> normal
```

`argv[0]` does not always arrive with the platform separator. libuv hands a Windows process a
forward-slash path, which is how Neovim's `jobstart` spawns mise — the reporter's case.

## Change

`Path::file_name`, which takes the basename for either separator:

```rust
fn filename(path: &str) -> &str {
    Path::new(path)
        .file_name()
        .and_then(|name| name.to_str())
        .unwrap_or(path)
}
```

Two more inputs fall out, neither in the report:

| `argv[0]` | before | after |
|---|---|---|
| `/usr/local/bin/mise` (unix-style, on Windows) | whole path | `mise` |
| `C:\tools\mise\` (trailing separator) | **empty string** | `mise` |

## Still broken after this

`is_mise_binary` is `bin_name == "mise" || starts_with("mise.") || starts_with("mise-")`, all
case-sensitive. The probe's `mise.EXE` passes only because the uppercase is in the extension and
the `mise.` prefix still matches literally; `MISE.EXE` is still misread after this fix. Windows
filesystems are case-insensitive but unix ones are not, so a fix needs a platform branch and its
own look at which launchers actually produce a different casing. Separate PR.

## Tests

Added to the existing `mod tests` in `src/env.rs`.

- `filename` over the reported case, the two rows in the table above, and the bare names `mise` /
  `mise.exe` as pass-through controls. No `#[cfg]` on these: `/` separates on every platform, so
  the Windows-only bug is caught by a test a Linux runner executes.
- The backslash spelling is a **platform-split pair** — Windows asserts it splits, unix asserts it
  does not. `\` is an ordinary filename character on unix, so splitting on both separators
  unconditionally would resolve a shim named `weird\name` to the tool `name`; `Path::file_name`
  defers to the host grammar precisely to avoid that. Asserting both directions pins the choice
  rather than leaving it implicit. (The first push asserted the Windows behaviour everywhere and
  `unit-macos` caught it.)
- `is_mise_binary(filename(argv0))` over the full-path spellings. This is the property actually
  worth pinning — the fix exists so mise stops mistaking itself for a shim, not so a string is
  split differently. Two real shim invocations (a `shims/node` path and a bare `node.exe`) are
  asserted to still be shims, so the test fails if the fix were "everything is mise now".

### Not run

`cargo fmt --all` only; no local build. The transcript above is a released binary (2026.8.2) run
natively; the before/after comparison is the `rustc` probe. CI builds the change itself.

### Reproducing

It has to be a launcher that passes `argv[0]` verbatim. PowerShell's `&` rewrites the path to
backslashes before spawning, so the bug is invisible from a PowerShell prompt even though the
command looks right:

```console
> & "C:/Users/jam/.../argv0/mise.exe" --version
2026.8.2 windows-x64 (2026-08-05)              # normalized, so no bug
```

`cmd /c` passes it through, as does libuv. Worth knowing before concluding it does not reproduce.

Closes #11423.
