### PR TITLE
feat(dotfiles): add inline whole-file content

### DIFF
--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -19,6 +19,7 @@ dotfiles.default_mode = "symlink"
 "~/.gitconfig" = "dotfiles/gitconfig"                                # explicit source
 "~/.config/alacritty.toml" = { mode = "copy" }                       # ~/.dotfiles/.config/alacritty.toml
 "~/.config/starship.toml" = { source = "dotfiles/starship.toml", mode = "copy" }
+"~/.config/tool.conf" = { content = "enabled = true\n" }                # inline whole-file content
 "~/.ssh/config" = { source = "dotfiles/ssh_config.tmpl", mode = "template" }
 "~/.config/nvim" = "dotfiles/nvim"                                   # symlink the directory itself
 "~/.local/bin" = { source = "dotfiles/bin", mode = "symlink-each" }  # symlink each file within
@@ -57,6 +58,15 @@ Relative explicit sources resolve against the directory of the config file
 that declares the entry, so a global `~/.config/mise/config.toml` can manage
 dotfiles kept next to it, and a project config can ship machine setup from
 the repo.
+
+Use `content` to declare a literal whole file inline instead of keeping a
+separate source file. Inline content is written as a regular file and cannot be
+combined with `source`, `mode`, or `exclude`:
+
+```toml
+[dotfiles]
+"~/.config/example.conf" = { content = "enabled = true\n" }
+```
 
 Source paths may contain glob wildcards like `*`, `**`, `?`, or `[ab]`.
 When a wildcard source matches multiple paths, the target path must contain

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -40,8 +40,8 @@ Whole-file entries are keyed by the target path — absolute or starting with
 `~/` — and may point at a source file or directory. If `source` is omitted,
 mise mirrors the home-relative target path under `dotfiles.root`: `~/.zshrc`
 uses `~/.dotfiles/.zshrc`, and `~/.config/foo.toml` uses
-`~/.dotfiles/.config/foo.toml`. Targets outside `$HOME` must specify
-`source`.
+`~/.dotfiles/.config/foo.toml`. Targets outside `$HOME` must specify `source`
+or inline `content`.
 
 String entries are shorthand for an explicit source with
 `dotfiles.default_mode`. `mise bootstrap dotfiles add` omits an implied source
@@ -60,8 +60,8 @@ dotfiles kept next to it, and a project config can ship machine setup from
 the repo.
 
 Use `content` to declare a literal whole file inline instead of keeping a
-separate source file. Inline content is written as a regular file and cannot be
-combined with `source`, `mode`, or `exclude`:
+separate source file. Inline content is written as a private regular file
+(`0600` on Unix) and cannot be combined with `source`, `mode`, or `exclude`:
 
 ```toml
 [dotfiles]

--- a/e2e/cli/test_dotfiles_files
+++ b/e2e/cli/test_dotfiles_files
@@ -52,6 +52,16 @@ assert_contains "mise dotfiles status ~/.config/inline.conf" "content differs"
 assert_succeed "mise dotfiles apply ~/.config/inline.conf --yes"
 assert "cat ~/.config/inline.conf" "inline content"
 
+# A matching symlink was not created by inline content mode and must not be
+# removed without --force.
+echo "linked inline" >linked-inline-source
+ln -s "$PWD/linked-inline-source" ~/.config/linked-inline.conf
+cat <<EOF >>mise.toml
+"~/.config/linked-inline.conf" = { content = "linked inline\n" }
+EOF
+assert_fail "mise dotfiles unapply ~/.config/linked-inline.conf --yes" "target differs from the managed content"
+assert "readlink ~/.config/linked-inline.conf" "$PWD/linked-inline-source"
+
 # Inline content can target any path writable by the current user.
 inline_absolute="$PWD/inline-absolute.conf"
 cat <<EOF >>mise.toml

--- a/e2e/cli/test_dotfiles_files
+++ b/e2e/cli/test_dotfiles_files
@@ -20,6 +20,7 @@ cat <<EOF >mise.toml
 "~/.ssh/config" = { source = "dotfiles/ssh_config.tmpl", mode = "template" }
 "~/.config/nvim" = "dotfiles/nvim"
 "~/.local/mybin" = { source = "dotfiles/bin", mode = "symlink-each" }
+"~/.config/inline.conf" = { content = "inline content\n" }
 EOF
 
 # everything is missing before applying
@@ -42,6 +43,22 @@ assert "cat ~/.ssh/config" "sum = 2"
 assert "readlink ~/.config/nvim" "$PWD/dotfiles/nvim"
 assert "readlink ~/.local/mybin/one" "$PWD/dotfiles/bin/one"
 assert "readlink ~/.local/mybin/two" "$PWD/dotfiles/bin/two"
+assert "cat ~/.config/inline.conf" "inline content"
+
+# Inline content is a whole-file entry and overwrites content drift.
+assert_contains "mise dotfiles status ~/.config/inline.conf --json" '"source": null'
+echo "drifted" >~/.config/inline.conf
+assert_contains "mise dotfiles status ~/.config/inline.conf" "content differs"
+assert_succeed "mise dotfiles apply ~/.config/inline.conf --yes"
+assert "cat ~/.config/inline.conf" "inline content"
+
+# Inline content can target any path writable by the current user.
+inline_absolute="$PWD/inline-absolute.conf"
+cat <<EOF >>mise.toml
+"$inline_absolute" = { content = "absolute inline\n" }
+EOF
+assert_succeed "mise dotfiles apply '$inline_absolute' --yes"
+assert "cat '$inline_absolute'" "absolute inline"
 
 # a table containing only source is a whole-file dotfile entry, not an edit
 echo "source-only table" >dotfiles/source-only
@@ -51,6 +68,13 @@ EOF
 assert_contains "mise dotfiles status ~/.source-only" "symlink"
 assert_succeed "mise dotfiles apply ~/.source-only --yes"
 assert "readlink ~/.source-only" "$PWD/dotfiles/source-only"
+
+# Inline content cannot be combined with source-oriented options.
+cat <<EOF >invalid-inline.toml
+[dotfiles]
+"~/.invalid-inline" = { content = "nope", source = "dotfiles/source-only" }
+EOF
+assert_fail "MISE_CONFIG_FILE=$PWD/invalid-inline.toml mise dotfiles status ~/.invalid-inline" "source and content are mutually exclusive"
 
 # wildcard sources expand to concrete target paths using matching target wildcards
 mkdir -p dotfiles/config dotfiles/question dotfiles/classes dotfiles/tree/nested

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -1771,7 +1771,9 @@ fn config_files_after_dotfiles_dry_run(
     let mut bodies = indexmap::IndexMap::new();
     let mut unavailable_bodies = HashSet::new();
     for file in files {
-        if !is_mise_config_target(&file.target) || !file.source.is_file() {
+        if !is_mise_config_target(&file.target)
+            || (file.mode != system::files::FileMode::Content && !file.source.is_file())
+        {
             continue;
         }
         if file.mode == FileMode::Template {
@@ -1784,7 +1786,12 @@ fn config_files_after_dotfiles_dry_run(
             );
             continue;
         }
-        match crate::file::read_to_string(&file.source) {
+        let contents = if file.mode == system::files::FileMode::Content {
+            Ok(file.content.clone().expect("inline content"))
+        } else {
+            crate::file::read_to_string(&file.source)
+        };
+        match contents {
             Ok(body) => match parse_mise_config_body(&file.target, &body) {
                 Ok(cf) => {
                     bodies.insert(file.target.clone(), body);
@@ -2879,13 +2886,18 @@ impl BootstrapStatus {
             report.row(
                 "dotfiles",
                 req.target_raw.clone(),
-                format!("{} {}", req.mode.name(), req.source.display_user()),
+                if req.mode == system::files::FileMode::Content {
+                    "content inline".to_string()
+                } else {
+                    format!("{} {}", req.mode.name(), req.source.display_user())
+                },
                 state_str,
                 missing,
             );
             json_files.push(json!({
                 "target": req.target_raw,
-                "source": req.source.display_user(),
+                "source": (req.mode != system::files::FileMode::Content)
+                    .then(|| req.source.display_user()),
                 "mode": req.mode.name(),
                 "state": state_json,
             }));

--- a/src/cli/dotfiles/add.rs
+++ b/src/cli/dotfiles/add.rs
@@ -385,6 +385,7 @@ impl PlannedAdd {
             target_raw: self.target_raw.clone(),
             target: self.target.clone(),
             source: self.source.clone(),
+            content: None,
             mode: self.mode,
             exclude: vec![],
             base: config_path
@@ -457,6 +458,7 @@ fn describe_apply(item: &PlannedAdd) -> String {
         FileMode::Copy if item.source.is_dir() => format!("cp -r {source} {target}"),
         FileMode::Copy => format!("cp {source} {target}"),
         FileMode::Template => format!("render {source} -> {target}"),
+        FileMode::Content => unreachable!("dotfiles add always captures a source file"),
     }
 }
 

--- a/src/cli/dotfiles/status.rs
+++ b/src/cli/dotfiles/status.rs
@@ -55,7 +55,8 @@ impl DotfilesStatus {
             if self.json {
                 json_files.push(json!({
                     "target": req.target_raw,
-                    "source": req.source.display_user(),
+                    "source": (req.mode != system::files::FileMode::Content)
+                        .then(|| req.source.display_user()),
                     "mode": req.mode.name(),
                     "state": match &state {
                         FileState::Applied => "applied",
@@ -68,7 +69,11 @@ impl DotfilesStatus {
                 file_rows.push(vec![
                     req.target_raw.clone(),
                     req.mode.name().to_string(),
-                    req.source.display_user(),
+                    if req.mode == system::files::FileMode::Content {
+                        "inline".to_string()
+                    } else {
+                        req.source.display_user()
+                    },
                     state_str,
                 ]);
             }

--- a/src/oci/builder.rs
+++ b/src/oci/builder.rs
@@ -859,7 +859,7 @@ fn build_dotfiles_layer(
     let mut entries = DotfilesLayerEntries::default();
 
     for req in requests {
-        if !req.source.exists() {
+        if req.mode != FileMode::Content && !req.source.exists() {
             bail!(
                 "[dotfiles].\"{}\": source does not exist: {}",
                 req.target_raw,
@@ -905,6 +905,17 @@ fn build_dotfiles_layer(
                     oci_target_path(req)?,
                     rendered.into_bytes(),
                     source_mode(&req.source)?,
+                )?;
+            }
+            FileMode::Content => {
+                entries.add_file(
+                    oci_target_path(req)?,
+                    req.content
+                        .as_deref()
+                        .expect("inline content")
+                        .as_bytes()
+                        .to_vec(),
+                    0o644,
                 )?;
             }
         }

--- a/src/oci/builder.rs
+++ b/src/oci/builder.rs
@@ -915,7 +915,7 @@ fn build_dotfiles_layer(
                         .expect("inline content")
                         .as_bytes()
                         .to_vec(),
-                    0o644,
+                    0o600,
                 )?;
             }
         }

--- a/src/system/edits.rs
+++ b/src/system/edits.rs
@@ -182,7 +182,7 @@ fn edit_entry_from_toml(path_and_id: &str, value: toml::Value) -> Option<EditTom
         toml::Value::Table(table) => {
             let is_whole_file_table = table.is_empty()
                 || table.contains_key("mode")
-                || table.contains_key("source")
+                || (table.contains_key("source") || table.contains_key("content"))
                     && !table.contains_key("block")
                     && !table.contains_key("line")
                     && !table.contains_key("template")

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -47,6 +47,8 @@ pub enum FileMode {
     /// render the source through the mise template engine and write the
     /// result (permissions are taken from the source file)
     Template,
+    /// write literal content declared directly in mise.toml
+    Content,
 }
 
 impl FileMode {
@@ -66,6 +68,7 @@ impl FileMode {
             Self::SymlinkEach => "symlink-each",
             Self::Copy => "copy",
             Self::Template => "template",
+            Self::Content => "content",
         }
     }
 }
@@ -84,6 +87,8 @@ pub enum FileTomlEntry {
         #[serde(default)]
         source: Option<String>,
         #[serde(default)]
+        content: Option<String>,
+        #[serde(default)]
         mode: Option<String>,
         #[serde(default)]
         exclude: Option<Vec<String>>,
@@ -100,6 +105,8 @@ pub struct FileRequest {
     /// absolute source path (relative sources resolve against the config
     /// file's directory; omitted sources resolve under dotfiles.root)
     pub source: PathBuf,
+    /// literal whole-file content; present only for inline content entries
+    pub content: Option<String>,
     pub mode: FileMode,
     /// glob patterns, matched against source-relative paths, for files a
     /// directory-walking mode should skip (see [`is_excluded`])
@@ -177,7 +184,7 @@ fn file_entry_from_toml(target_raw: &str, value: toml::Value) -> Option<FileToml
             if table.is_empty()
                 || table.contains_key("mode")
                 || table.contains_key("exclude")
-                || (table.contains_key("source")
+                || ((table.contains_key("source") || table.contains_key("content"))
                     && !table.contains_key("block")
                     && !table.contains_key("line")
                     && !table.contains_key("template")
@@ -203,14 +210,27 @@ fn merge_file_entry(
     base: &Path,
     merged: &mut IndexMap<PathBuf, FileRequest>,
 ) {
-    let (source, mode, exclude) = match entry {
-        FileTomlEntry::Source(source) => (Some(source), None, None),
+    let (source, content, mode, exclude) = match entry {
+        FileTomlEntry::Source(source) => (Some(source), None, None, None),
         FileTomlEntry::Table {
             source,
+            content,
             mode,
             exclude,
-        } => (source, mode, exclude),
+        } => (source, content, mode, exclude),
     };
+    if source.is_some() && content.is_some() {
+        warn!(
+            "[dotfiles].\"{target_raw}\": source and content are mutually exclusive, ignoring entry"
+        );
+        return;
+    }
+    if content.is_some() && (mode.is_some() || exclude.is_some()) {
+        warn!(
+            "[dotfiles].\"{target_raw}\": inline content does not support mode or exclude, ignoring entry"
+        );
+        return;
+    }
     // compile once here so a typo is reported against the entry that wrote
     // it, not on every walk of the source
     let exclude = exclude
@@ -238,6 +258,21 @@ fn merge_file_entry(
     if target.is_relative() {
         warn!(
             "[dotfiles].\"{target_raw}\": target must be absolute or start with ~/, ignoring entry"
+        );
+        return;
+    }
+    if let Some(content) = content {
+        merged.insert(
+            target.clone(),
+            FileRequest {
+                target_raw,
+                target,
+                source: PathBuf::new(),
+                content: Some(content),
+                mode: FileMode::Content,
+                exclude: vec![],
+                base: base.to_path_buf(),
+            },
         );
         return;
     }
@@ -301,6 +336,9 @@ pub fn implied_source(target: &Path) -> Result<PathBuf> {
 }
 
 pub fn source_is_implied(req: &FileRequest) -> bool {
+    if req.mode == FileMode::Content {
+        return false;
+    }
     match implied_source(&req.target) {
         Ok(source) => source == req.source,
         Err(_) => false,
@@ -367,6 +405,7 @@ fn expand_request(
             target_raw,
             target,
             source,
+            content: None,
             mode,
             exclude,
             base,
@@ -409,6 +448,7 @@ fn expand_request(
             target_raw,
             target,
             source: matches[0].clone(),
+            content: None,
             mode,
             exclude,
             base,
@@ -436,6 +476,7 @@ fn expand_request(
                 target_raw: target_path.display_user().to_string(),
                 target: target_path,
                 source: matched_source,
+                content: None,
                 mode,
                 exclude: exclude.clone(),
                 base: base.clone(),
@@ -576,7 +617,7 @@ where
 /// every command in a trusted config); only `--dry-run` promises to execute
 /// nothing and therefore skips template checks entirely.
 pub fn check(config: &Config, req: &FileRequest) -> Result<FileState> {
-    if !req.source.exists() {
+    if req.mode != FileMode::Content && !req.source.exists() {
         return Ok(FileState::SourceMissing);
     }
     // render at most once per call — templates may use exec()
@@ -596,6 +637,10 @@ fn check_rendered(req: &FileRequest, rendered: Option<&str>) -> Result<FileState
         FileMode::SymlinkEach => check_symlink_each(req),
         FileMode::Copy if req.source.is_dir() => check_copy_dir(req),
         FileMode::Copy => check_copy(&req.source, &req.target),
+        FileMode::Content => check_content(
+            &req.target,
+            req.content.as_deref().expect("inline content").as_bytes(),
+        ),
         FileMode::Template => {
             let state = check_content(
                 &req.target,
@@ -1094,7 +1139,7 @@ pub fn plan_apply<'a>(
     for req in requests {
         // report every problem in one pass instead of fix-and-retry — a
         // render or check failure on one entry must not hide the rest
-        if !req.source.exists() {
+        if req.mode != FileMode::Content && !req.source.exists() {
             missing_sources.push(format!(
                 "  [dotfiles].\"{}\": {}",
                 req.target_raw,
@@ -1402,6 +1447,16 @@ fn plan_unapply_one<'a>(
             }
             plan_single_file(req, opts, &mut paths)?;
         }
+        FileMode::Content => {
+            if !req.target.exists() && !req.target.is_symlink() {
+                return Ok(None);
+            }
+            if opts.force {
+                paths.insert(req.target.clone(), ());
+            } else {
+                plan_inline_file(req, &mut paths)?;
+            }
+        }
         FileMode::Symlink => {
             plan_single_file(req, opts, &mut paths)?;
         }
@@ -1440,6 +1495,17 @@ fn plan_unapply_one<'a>(
             clear_symlink_each_state,
         }))
     }
+}
+
+fn plan_inline_file(req: &FileRequest, paths: &mut IndexMap<PathBuf, ()>) -> Result<()> {
+    if req.target.is_file()
+        && file::read(&req.target)? == req.content.as_deref().expect("inline content").as_bytes()
+    {
+        paths.insert(req.target.clone(), ());
+    } else if req.target.exists() || req.target.is_symlink() {
+        bail!("target differs from the managed content, use --force to remove it");
+    }
+    Ok(())
 }
 
 fn plan_single_file(
@@ -1639,6 +1705,11 @@ fn find_conflicts(req: &FileRequest) -> Result<Vec<PathBuf>> {
                 out.push(req.target.clone());
             }
         }
+        FileMode::Content => {
+            if req.target.is_dir() {
+                out.push(req.target.clone());
+            }
+        }
     }
     Ok(out)
 }
@@ -1662,6 +1733,7 @@ fn describe(req: &FileRequest) -> Result<String> {
         FileMode::Copy if req.source.is_dir() => format!("cp -r {src} {tgt}"),
         FileMode::Copy => format!("cp {src} {tgt}"),
         FileMode::Template => format!("render {src} -> {tgt}"),
+        FileMode::Content => format!("write inline content to {tgt}"),
     })
 }
 
@@ -1676,6 +1748,7 @@ fn describe_applied(req: &FileRequest) -> Result<String> {
         ),
         FileMode::Copy => format!("copied {src} to {tgt}"),
         FileMode::Template => format!("rendered {src} to {tgt}"),
+        FileMode::Content => format!("wrote inline content to {tgt}"),
     })
 }
 
@@ -1734,6 +1807,17 @@ fn print_diff(req: &FileRequest, rendered: Option<&str>) -> Result<()> {
                 req.source.display_user(),
                 req.target.display_user()
             );
+        }
+        FileMode::Content => {
+            let desired = req.content.as_deref().expect("inline content").as_bytes();
+            let current = if req.target.is_file() {
+                file::read(&req.target)?
+            } else {
+                vec![]
+            };
+            if current != desired {
+                miseprintln!("  inline content differs: {}", req.target.display_user());
+            }
         }
     }
     Ok(())
@@ -1805,6 +1889,10 @@ fn apply_one(req: &FileRequest, rendered: Option<&str>) -> Result<()> {
             file::write(&req.target, rendered)?;
             #[cfg(unix)]
             std::fs::set_permissions(&req.target, req.source.metadata()?.permissions())?;
+        }
+        FileMode::Content => {
+            remove_existing(&req.target)?;
+            file::write(&req.target, req.content.as_deref().expect("inline content"))?;
         }
     }
     Ok(())

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -1498,7 +1498,8 @@ fn plan_unapply_one<'a>(
 }
 
 fn plan_inline_file(req: &FileRequest, paths: &mut IndexMap<PathBuf, ()>) -> Result<()> {
-    if req.target.is_file()
+    if !req.target.is_symlink()
+        && req.target.is_file()
         && file::read(&req.target)? == req.content.as_deref().expect("inline content").as_bytes()
     {
         paths.insert(req.target.clone(), ());
@@ -1893,6 +1894,11 @@ fn apply_one(req: &FileRequest, rendered: Option<&str>) -> Result<()> {
         FileMode::Content => {
             remove_existing(&req.target)?;
             file::write(&req.target, req.content.as_deref().expect("inline content"))?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&req.target, std::fs::Permissions::from_mode(0o600))?;
+            }
         }
     }
     Ok(())


### PR DESCRIPTION
## Summary
- add literal `content` entries for whole-file dotfiles
- support inline content in status, apply, unapply, dry-run bootstrap simulation, and OCI layers
- reject combinations with source-oriented `source`, `mode`, or `exclude` options
- document and test user-writable absolute targets and drift repair

## Why
Whole-file dotfile entries previously required a separate source file. This made `[dotfiles]` an awkward workaround for user-writable files declared inline under `[bootstrap.files]`, which always elevated during mutations.

## Validation
- `mise run lint-fix`
- `shellcheck -x e2e/cli/test_dotfiles_files`
- `mise run test:e2e e2e/cli/test_dotfiles_files`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core dotfile apply/unapply and OCI image layers; inline writes can overwrite targets on apply, though validation limits misconfiguration.
> 
> **Overview**
> **Whole-file `[dotfiles]` entries can now declare file bodies inline** with `{ content = "..." }` instead of a separate source file—useful for small configs and paths outside `$HOME` that previously required `source`.
> 
> Inline entries use a new **`content` mode**: mise writes a regular file (mode **`0600`** on Unix), detects **content drift** on status/apply like copy/template, and shows **`source: null`** / **"inline"** in JSON and status output. **`source`**, **`mode`**, and **`exclude`** cannot be combined with `content` (invalid configs are rejected or warned).
> 
> The same behavior is wired through **bootstrap dry-run config simulation**, **OCI dotfiles layers**, and **conservative unapply** (only removes files that still match the managed bytes unless `--force`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7116f2416419b9f3d1b5ea86f2355bb673fd582. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for defining whole-file dotfiles with inline `content`.
  * Inline content supports checking, applying, diffing, conflict detection, and repair.
  * Dry-run and status views identify inline content entries clearly.
* **Bug Fixes**
  * Improved handling of inline dotfiles with absolute targets and editing workflows.
  * Added validation preventing incompatible source, mode, or exclusion settings.
* **Documentation**
  * Documented inline whole-file dotfile configuration and its restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->