### PR TITLE
fix(bootstrap): avoid sudo for user-writable files

### DIFF
--- a/docs/bootstrap/files.md
+++ b/docs/bootstrap/files.md
@@ -42,10 +42,14 @@ output.
 
 Mise compares content, type, mode, owner, and group before applying changes.
 Writes use a temporary file in the target directory followed by an atomic
-rename. If the current user cannot inspect a target or search one of its parent
-directories, mise compares its metadata and content in one privileged batch.
-Plans and file content are sent to narrowly scoped mise helpers over stdin, so
-file content does not appear in process arguments or logs.
+rename. Changes are attempted as the current user first. If the filesystem
+rejects an operation with a permission error, mise retries that operation and
+the remaining ordered changes in one privileged batch. User-writable targets
+therefore do not require `sudo`. If the current user cannot inspect a target or
+search one of its parent directories, mise compares its metadata and content in
+one privileged batch. Plans and file content are sent to narrowly scoped mise
+helpers over stdin, so file content does not appear in process arguments or
+logs.
 
 ## Removing resources
 

--- a/e2e/cli/test_bootstrap_system_files_no_sudo
+++ b/e2e/cli/test_bootstrap_system_files_no_sudo
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "skipping: managed system files require Linux"
+  exit 0
+fi
+
+managed_dir="$PWD/user-managed-system"
+managed_file="$managed_dir/example.conf"
+
+cat <<EOF >mise.toml
+[bootstrap.directories."$managed_dir"]
+mode = "0750"
+
+[bootstrap.files."$managed_file"]
+content = "first"
+mode = "0640"
+EOF
+
+# A completely user-writable plan succeeds even when elevation is forbidden.
+assert_succeed "MISE_SYSTEM_PACKAGES_SUDO=0 mise bootstrap files apply --yes"
+assert "cat '$managed_file'" "first"
+assert "stat -c %a '$managed_dir'" "750"
+assert "stat -c %a '$managed_file'" "640"
+
+cat <<EOF >mise.toml
+[bootstrap.files."$managed_file"]
+content = "second"
+mode = "0600"
+EOF
+
+assert_succeed "MISE_SYSTEM_PACKAGES_SUDO=0 mise bootstrap files apply --yes"
+assert "cat '$managed_file'" "second"
+assert "stat -c %a '$managed_file'" "600"
+
+cat <<EOF >mise.toml
+[bootstrap.files."$managed_file"]
+state = "absent"
+
+[bootstrap.directories."$managed_dir"]
+state = "absent"
+EOF
+
+assert_succeed "MISE_SYSTEM_PACKAGES_SUDO=0 mise bootstrap files apply --yes"
+assert_directory_not_exists "$managed_dir"

--- a/src/system/managed_files.rs
+++ b/src/system/managed_files.rs
@@ -584,12 +584,17 @@ impl ManagedDirectoryRequest {
 }
 
 impl PrivilegedPlan {
-    /// Apply actions as the current user until the filesystem says elevation
-    /// is required. The failed action and everything after it stay ordered in
-    /// the returned plan for one privileged retry.
+    /// Apply actions as the current user until elevation is required. Actions
+    /// that could mutate state before reporting a permission error are sent to
+    /// the privileged helper without first attempting them.
     fn apply_until_elevation_required(self) -> Result<Self> {
         let mut actions = self.actions.into_iter();
         while let Some(action) = actions.next() {
+            if action.requires_preemptive_elevation()? {
+                return Ok(Self {
+                    actions: std::iter::once(action).chain(actions).collect(),
+                });
+            }
             match action.apply() {
                 Ok(()) => {}
                 Err(error) if is_permission_denied(&error) => {
@@ -795,6 +800,37 @@ pub fn validate_principals(
 }
 
 impl PrivilegedAction {
+    fn requires_preemptive_elevation(&self) -> Result<bool> {
+        match self {
+            // Ownership changes normally require privilege. Avoid creating or
+            // replacing a path before discovering that at set_metadata().
+            Self::WriteFile {
+                path,
+                owner,
+                group,
+                replace,
+                ..
+            } => Ok(owner.is_some()
+                || group.is_some()
+                || (*replace && replacement_is_not(path, ManagedPathKind::File)?)),
+            Self::CreateDirectory {
+                path,
+                owner,
+                group,
+                replace,
+                ..
+            } => Ok(owner.is_some()
+                || group.is_some()
+                || (*replace && replacement_is_not(path, ManagedPathKind::Directory)?)),
+            // Recursive removal can delete writable descendants before an
+            // inaccessible one fails. Run it once with the required access.
+            Self::RemoveDirectory {
+                recursive: true, ..
+            } => Ok(true),
+            Self::RemoveFile { .. } | Self::RemoveDirectory { .. } => Ok(false),
+        }
+    }
+
     fn description(&self) -> String {
         match self {
             Self::WriteFile { path, .. } => format!("write file {}", path.display()),
@@ -806,6 +842,15 @@ impl PrivilegedAction {
                 if *recursive { " recursively" } else { "" }
             ),
         }
+    }
+}
+
+fn replacement_is_not(path: &Path, expected: ManagedPathKind) -> Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(ManagedPathKind::from_metadata(&metadata) != expected),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => Ok(true),
+        Err(error) => Err(error.into()),
     }
 }
 
@@ -1106,14 +1151,19 @@ fn inspect_path(request: PrivilegedPathInspection) -> Result<PathInspection> {
 
 fn is_permission_denied(error: &eyre::Report) -> bool {
     error.chain().any(|error| {
-        error
+        let io_permission_denied = error
             .downcast_ref::<std::io::Error>()
-            .is_some_and(|error| error.kind() == std::io::ErrorKind::PermissionDenied)
-            || error
+            .is_some_and(|error| error.kind() == std::io::ErrorKind::PermissionDenied);
+        #[cfg(unix)]
+        let platform_permission_denied =
+            error
                 .downcast_ref::<nix::errno::Errno>()
                 .is_some_and(|error| {
                     matches!(error, nix::errno::Errno::EACCES | nix::errno::Errno::EPERM)
-                })
+                });
+        #[cfg(not(unix))]
+        let platform_permission_denied = false;
+        io_permission_denied || platform_permission_denied
     })
 }
 
@@ -1298,9 +1348,23 @@ fn write_file(
     let parent = path
         .parent()
         .ok_or_else(|| eyre!("managed file has no parent: {}", path.display()))?;
-    if !parent.is_dir() {
-        bail!("managed file parent does not exist: {}", parent.display());
+    match fs::metadata(parent) {
+        Ok(metadata) if metadata.is_dir() => {}
+        Ok(_) => bail!(
+            "managed file parent is not a directory: {}",
+            parent.display()
+        ),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            bail!("managed file parent does not exist: {}", parent.display())
+        }
+        Err(error) => return Err(error.into()),
     }
+    // Prepare the complete replacement before mutating the destination. In
+    // particular, a metadata permission error must leave the old path intact.
+    let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
+    temporary.write_all(content)?;
+    temporary.as_file_mut().sync_all()?;
+    set_metadata(temporary.path(), owner, group, mode)?;
     match fs::symlink_metadata(path) {
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
         Err(error) => return Err(error.into()),
@@ -1318,10 +1382,6 @@ fn write_file(
         }
         Ok(_) => fs::remove_file(path)?,
     }
-    let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
-    temporary.write_all(content)?;
-    temporary.as_file_mut().sync_all()?;
-    set_metadata(temporary.path(), owner, group, mode)?;
     temporary
         .persist(path)
         .map_err(|error| error.error)
@@ -1429,10 +1489,65 @@ mod tests {
             .unwrap_err();
         assert!(is_permission_denied(&io_error));
 
-        let nix_error: eyre::Report = nix::errno::Errno::EPERM.into();
-        assert!(is_permission_denied(&nix_error));
+        #[cfg(unix)]
+        {
+            let nix_error: eyre::Report = nix::errno::Errno::EPERM.into();
+            assert!(is_permission_denied(&nix_error));
+        }
         let other_error: eyre::Report = std::io::Error::from(std::io::ErrorKind::NotFound).into();
         assert!(!is_permission_denied(&other_error));
+    }
+
+    #[test]
+    fn elevates_before_destructive_composite_actions() {
+        let temp = tempfile::tempdir().unwrap();
+        let file_path = temp.path().join("file");
+        fs::write(&file_path, "content").unwrap();
+        let directory_path = temp.path().join("directory");
+        fs::create_dir(&directory_path).unwrap();
+
+        let replace_file_with_directory = PrivilegedAction::CreateDirectory {
+            path: file_path,
+            owner: None,
+            group: None,
+            mode: 0o755,
+            replace: true,
+        };
+        assert!(
+            replace_file_with_directory
+                .requires_preemptive_elevation()
+                .unwrap()
+        );
+
+        let replace_directory_with_file = PrivilegedAction::WriteFile {
+            path: directory_path,
+            content: "content".to_string(),
+            owner: None,
+            group: None,
+            mode: 0o644,
+            replace: true,
+        };
+        assert!(
+            replace_directory_with_file
+                .requires_preemptive_elevation()
+                .unwrap()
+        );
+
+        let recursive_removal = PrivilegedAction::RemoveDirectory {
+            path: temp.path().join("tree"),
+            recursive: true,
+        };
+        assert!(recursive_removal.requires_preemptive_elevation().unwrap());
+
+        let ordinary_write = PrivilegedAction::WriteFile {
+            path: temp.path().join("ordinary"),
+            content: "content".to_string(),
+            owner: None,
+            group: None,
+            mode: 0o644,
+            replace: false,
+        };
+        assert!(!ordinary_write.requires_preemptive_elevation().unwrap());
     }
 
     #[cfg(unix)]

--- a/src/system/managed_files.rs
+++ b/src/system/managed_files.rs
@@ -583,6 +583,27 @@ impl ManagedDirectoryRequest {
     }
 }
 
+impl PrivilegedPlan {
+    /// Apply actions as the current user until the filesystem says elevation
+    /// is required. The failed action and everything after it stay ordered in
+    /// the returned plan for one privileged retry.
+    fn apply_until_elevation_required(self) -> Result<Self> {
+        let mut actions = self.actions.into_iter();
+        while let Some(action) = actions.next() {
+            match action.apply() {
+                Ok(()) => {}
+                Err(error) if is_permission_denied(&error) => {
+                    return Ok(Self {
+                        actions: std::iter::once(action).chain(actions).collect(),
+                    });
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(Self::default())
+    }
+}
+
 pub fn apply_with_accounts(
     files: &[ManagedFileRequest],
     directories: &[ManagedDirectoryRequest],
@@ -678,20 +699,24 @@ pub fn apply_with_accounts(
         info!("system files: skipped");
         return Ok(ApplyReport::default());
     }
-    let input = serde_json::to_vec(&plan)?;
-    let executable = std::env::current_exe()?.to_string_lossy().to_string();
-    crate::system::sudo::run_with_input(
-        &executable,
-        &[
-            "--no-config".to_string(),
-            "--no-env".to_string(),
-            "--no-hooks".to_string(),
-            "bootstrap".to_string(),
-            "__apply-system-plan".to_string(),
-        ],
-        &input,
-    )?;
-    info!("system files: applied {} change(s)", plan.actions.len());
+    let change_count = plan.actions.len();
+    let privileged_plan = plan.apply_until_elevation_required()?;
+    if !privileged_plan.actions.is_empty() {
+        let input = serde_json::to_vec(&privileged_plan)?;
+        let executable = std::env::current_exe()?.to_string_lossy().to_string();
+        crate::system::sudo::run_with_input(
+            &executable,
+            &[
+                "--no-config".to_string(),
+                "--no-env".to_string(),
+                "--no-hooks".to_string(),
+                "bootstrap".to_string(),
+                "__apply-system-plan".to_string(),
+            ],
+            &input,
+        )?;
+    }
+    info!("system files: applied {change_count} change(s)");
     Ok(report)
 }
 
@@ -804,7 +829,7 @@ pub fn inspect_privileged_files_from_stdin() -> Result<()> {
 }
 
 impl PrivilegedAction {
-    fn apply(self) -> Result<()> {
+    fn apply(&self) -> Result<()> {
         match self {
             Self::WriteFile {
                 path,
@@ -814,14 +839,14 @@ impl PrivilegedAction {
                 mode,
                 replace,
             } => write_file(
-                &validate_privileged_target(&path)?,
+                &validate_privileged_target(path)?,
                 content.as_bytes(),
                 owner.as_deref(),
                 group.as_deref(),
-                mode,
-                replace,
+                *mode,
+                *replace,
             ),
-            Self::RemoveFile { path } => remove_file(&validate_privileged_target(&path)?),
+            Self::RemoveFile { path } => remove_file(&validate_privileged_target(path)?),
             Self::CreateDirectory {
                 path,
                 owner,
@@ -829,14 +854,14 @@ impl PrivilegedAction {
                 mode,
                 replace,
             } => create_directory(
-                &validate_privileged_target(&path)?,
+                &validate_privileged_target(path)?,
                 owner.as_deref(),
                 group.as_deref(),
-                mode,
-                replace,
+                *mode,
+                *replace,
             ),
             Self::RemoveDirectory { path, recursive } => {
-                remove_directory(&validate_privileged_target(&path)?, recursive)
+                remove_directory(&validate_privileged_target(path)?, *recursive)
             }
         }
     }
@@ -1080,9 +1105,16 @@ fn inspect_path(request: PrivilegedPathInspection) -> Result<PathInspection> {
 }
 
 fn is_permission_denied(error: &eyre::Report) -> bool {
-    error
-        .downcast_ref::<std::io::Error>()
-        .is_some_and(|error| error.kind() == std::io::ErrorKind::PermissionDenied)
+    error.chain().any(|error| {
+        error
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|error| error.kind() == std::io::ErrorKind::PermissionDenied)
+            || error
+                .downcast_ref::<nix::errno::Errno>()
+                .is_some_and(|error| {
+                    matches!(error, nix::errno::Errno::EACCES | nix::errno::Errno::EPERM)
+                })
+    })
 }
 
 impl ManagedPathKind {
@@ -1388,6 +1420,19 @@ mod tests {
         assert_eq!(parse_mode(Some("0600"), 0).unwrap(), 0o600);
         assert_eq!(parse_mode(Some("0o1750"), 0).unwrap(), 0o1750);
         assert!(parse_mode(Some("888"), 0).is_err());
+    }
+
+    #[test]
+    fn detects_permission_errors_through_context() {
+        let io_error = Err::<(), _>(std::io::Error::from(std::io::ErrorKind::PermissionDenied))
+            .wrap_err("wrapped permission error")
+            .unwrap_err();
+        assert!(is_permission_denied(&io_error));
+
+        let nix_error: eyre::Report = nix::errno::Errno::EPERM.into();
+        assert!(is_permission_denied(&nix_error));
+        let other_error: eyre::Report = std::io::Error::from(std::io::ErrorKind::NotFound).into();
+        assert!(!is_permission_denied(&other_error));
     }
 
     #[cfg(unix)]

--- a/src/system/managed_files.rs
+++ b/src/system/managed_files.rs
@@ -1363,8 +1363,8 @@ fn write_file(
     // particular, a metadata permission error must leave the old path intact.
     let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
     temporary.write_all(content)?;
-    temporary.as_file_mut().sync_all()?;
     set_metadata(temporary.path(), owner, group, mode)?;
+    temporary.as_file_mut().sync_all()?;
     match fs::symlink_metadata(path) {
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
         Err(error) => return Err(error.into()),

--- a/src/system/managed_files.rs
+++ b/src/system/managed_files.rs
@@ -1552,6 +1552,58 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn permission_failure_preserves_remaining_action_order() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // Root can write through the mode restriction used to induce EACCES.
+        if nix::unistd::geteuid().is_root() {
+            return;
+        }
+
+        let temp = tempfile::tempdir().unwrap();
+        let first = temp.path().join("first");
+        let blocked_parent = temp.path().join("blocked");
+        let blocked = blocked_parent.join("second");
+        let remaining = temp.path().join("third");
+        fs::create_dir(&blocked_parent).unwrap();
+        fs::set_permissions(&blocked_parent, fs::Permissions::from_mode(0o555)).unwrap();
+
+        let write = |path: PathBuf| PrivilegedAction::WriteFile {
+            path,
+            content: "content".to_string(),
+            owner: None,
+            group: None,
+            mode: 0o644,
+            replace: false,
+        };
+        let pending = PrivilegedPlan {
+            actions: vec![
+                write(first.clone()),
+                write(blocked.clone()),
+                write(remaining.clone()),
+            ],
+        }
+        .apply_until_elevation_required()
+        .unwrap();
+
+        // Let TempDir clean up even if an assertion below fails.
+        fs::set_permissions(&blocked_parent, fs::Permissions::from_mode(0o755)).unwrap();
+        assert!(first.is_file());
+        assert!(!blocked.exists());
+        assert!(!remaining.exists());
+        assert_eq!(pending.actions.len(), 2);
+        assert!(matches!(
+            &pending.actions[0],
+            PrivilegedAction::WriteFile { path, .. } if path == &blocked
+        ));
+        assert!(matches!(
+            &pending.actions[1],
+            PrivilegedAction::WriteFile { path, .. } if path == &remaining
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn atomically_writes_and_updates_files() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("config");


### PR DESCRIPTION
## Summary
- attempt ordered `[bootstrap.files]` and `[bootstrap.directories]` mutations as the invoking user
- retry the first `EACCES`/`EPERM` action and the remaining ordered plan through one privileged helper
- preserve privileged inspection and root-owned file behavior
- document the fallback and add no-sudo create, update, mode, removal, and directory coverage

## Root cause
Every non-empty system-files mutation plan was unconditionally serialized to the sudo helper, even when all target paths were writable by the current user.

## User impact
User-writable plans no longer prompt for or require sudo. Protected paths and ownership changes continue to elevate when the operating system rejects the unprivileged attempt.

## Validation
- `mise run lint-fix`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --quiet --bin mise detects_permission_errors_through_context`
- `mise run test:e2e e2e/cli/test_bootstrap_system_files_no_sudo e2e/cli/test_bootstrap_system_files`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core bootstrap filesystem apply ordering and elevation boundaries; mistakes could partially apply plans or elevate too late, though new unit and e2e tests cover permission fallback and preemptive elevation.
> 
> **Overview**
> **Bootstrap managed files and directories** no longer send every apply plan through `sudo`. `apply_with_accounts` runs the ordered plan as the current user via `apply_until_elevation_required`, and only invokes the privileged helper for actions that still need elevation (or when the first `EACCES`/`EPERM` occurs, retrying that action and all remaining steps in one batch).
> 
> Elevation is skipped up front for actions that could mutate state before a permission error surfaces: owner/group changes, `replace` when the path is the wrong type (or unreadable), and recursive directory removal. `write_file` now builds and sets metadata on a temp file before touching the destination so a failed metadata step does not leave a half-updated path. Permission detection walks the error chain and treats `nix` `EACCES`/`EPERM` like I/O permission denied.
> 
> Docs in `docs/bootstrap/files.md` describe the try-unprivileged-then-elevate behavior. A Linux e2e test asserts full create/update/mode/remove cycles succeed with `MISE_SYSTEM_PACKAGES_SUDO=0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29b00fae964f082a9fe941493a542525de955239. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System-managed files can now be created, updated, and removed without `sudo` when the current user has sufficient permissions.
  * Operations requiring elevated access automatically retry with the necessary privileges while preserving their order.
  * Directory and file permissions are respected during no-`sudo` system-file management.

* **Bug Fixes**
  * Improved detection of permission-denied errors across common filesystem error formats.
  * File contents, metadata, and permissions are handled more reliably during updates and replacements.
  * Added safer handling for replacing files and removing directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->