### PR TITLE
test(windows): drop teardown Pester already does

### DIFF
--- a/e2e-win/tool_path.Tests.ps1
+++ b/e2e-win/tool_path.Tests.ps1
@@ -23,7 +23,6 @@ Describe 'tool-path' {
 
     AfterAll {
         Set-Location $script:OriginalDir
-        Remove-Item -Path $script:TestRoot -Recurse -Force -ErrorAction Ignore
         if ($null -eq $script:OriginalTrusted) {
             Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
         } else {

--- a/e2e-win/tool_path_metacharacters.Tests.ps1
+++ b/e2e-win/tool_path_metacharacters.Tests.ps1
@@ -13,7 +13,6 @@ Describe 'tool-path-metacharacters' {
 
     AfterAll {
         Set-Location $script:OriginalDir
-        Remove-Item -Path $script:TestRoot -Recurse -Force -ErrorAction Ignore
         if ($null -eq $script:OriginalTrusted) {
             Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
         } else {

--- a/e2e-win/trusted_config_paths.Tests.ps1
+++ b/e2e-win/trusted_config_paths.Tests.ps1
@@ -27,7 +27,6 @@ PROJECT = "b"
 
     AfterAll {
         Set-Location $script:OriginalDir
-        Remove-Item -Path $script:TestRoot -Recurse -Force -ErrorAction Ignore
         if ($null -eq $script:OriginalTrusted) {
             Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
         } else {


### PR DESCRIPTION
Three `e2e-win` suites remove their own `$TestRoot` in `AfterAll`:

```powershell
AfterAll {
    Set-Location $script:OriginalDir
    Remove-Item -Path $script:TestRoot -Recurse -Force -ErrorAction Ignore   # <- this
    ...
}
```

`$TestRoot` is a GUID directory created **under `$TestDrive`**, which Pester owns and removes on its
own. The line re-did teardown that was already arranged.

## Why this is the right shape and not a preference

The convention is already in the directory, in files neither written nor touched by me:
`task_artifact_cache.Tests.ps1` and `env_cache_venv.Tests.ps1` both build a GUID root under
`$TestDrive`, restore location and environment in `AfterAll`, and leave the removal alone.

The three changed here are all mine — from #11937, #11947 and #11948 — so this is bringing my own
files in line rather than changing anyone's style.

## What stays

`Set-Location $script:OriginalDir` is untouched in all three. That one is not cleanup for its own
sake: Pester cannot remove `TestDrive` while the process is sitting inside it, so dropping it would
break the very cleanup this PR is relying on.

The `MISE_TRUSTED_CONFIG_PATHS` save/restore is untouched too. Pester runs every suite in one
process, so an inherited value has to be put back or the next file runs without it.

## Origin

A review comment on #11981 flagged the same line in the suite added there. It was right, and the
same line was already on `main` in these three. #11981 keeps its own removal; this is the rest of it.

## Not run

No local build — these are Windows e2e suites and `windows-e2e` is what exercises them. The change
is a deletion of three identical lines, and all three files' remaining `AfterAll` bodies are
unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test cleanup behavior.
  * Preserved required environment and location restoration between test runs.
  * Reduced the risk of cleanup-related test failures during tool path and configuration path validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->