### PR TITLE
fix(shims): match mise's own name case-insensitively on Windows

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -471,8 +471,25 @@ pub static IS_RUNNING_AS_SHIM: Lazy<bool> = Lazy::new(|| {
 
 /// Returns true if the given binary name refers to mise itself (not a shim).
 /// Handles "mise", "mise.exe", "mise.bat", "mise.cmd", "mise-doctor", etc.
+///
+/// The comparison ignores case on Windows only. Its filesystem does too, so `MISE.EXE` starts the
+/// same file as `mise.exe` and reaches `argv[0]` with whatever casing the caller wrote — and a
+/// case-sensitive test then sent mise through [`crate::shims::handle_shim`] against itself. On unix
+/// they are two different files, so a shim genuinely named `MISE` has to stay a shim.
 pub fn is_mise_binary(bin_name: &str) -> bool {
-    bin_name == "mise" || bin_name.starts_with("mise.") || bin_name.starts_with("mise-")
+    let is_mise = |s: &str| {
+        if cfg!(windows) {
+            s.eq_ignore_ascii_case("mise")
+        } else {
+            s == "mise"
+        }
+    };
+    // Equivalent to matching "mise" plus the "mise." and "mise-" prefixes, with the case rule
+    // applied in one place rather than three.
+    is_mise(bin_name)
+        || bin_name
+            .split_once(['.', '-'])
+            .is_some_and(|(stem, _)| is_mise(stem))
 }
 
 /// Explicit terminal-width override: `MISE_TERM_WIDTH` takes precedence, then the
@@ -1314,5 +1331,44 @@ mod tests {
                 "argv[0] {argv0:?} should still be a shim"
             );
         }
+    }
+
+    #[test]
+    fn test_is_mise_binary() {
+        // The spellings mise is actually invoked under, on every platform.
+        assert!(is_mise_binary("mise"));
+        assert!(is_mise_binary("mise.exe"));
+        assert!(is_mise_binary("mise.cmd"));
+        assert!(is_mise_binary("mise-doctor"));
+        // The controls. Real shim names must stay shims, or this stops being a test of anything:
+        // a version that always returned true would pass every assertion above.
+        assert!(!is_mise_binary("node"));
+        assert!(!is_mise_binary("node.exe"));
+        assert!(!is_mise_binary("misex"));
+        assert!(!is_mise_binary("misex.exe"));
+    }
+
+    /// Windows resolves `MISE.EXE` to the same file as `mise.exe` and hands the process `argv[0]`
+    /// with the casing the caller wrote, so the test has to ignore case there. See the pair below.
+    #[cfg(windows)]
+    #[test]
+    fn test_is_mise_binary_ignores_case_on_windows() {
+        assert!(is_mise_binary("MISE.EXE"));
+        assert!(is_mise_binary("Mise.exe"));
+        assert!(is_mise_binary("MISE"));
+        assert!(is_mise_binary("MISE-DOCTOR"));
+        // Case-insensitivity must not widen what counts as mise.
+        assert!(!is_mise_binary("NODE.EXE"));
+        assert!(!is_mise_binary("MISEX.EXE"));
+    }
+
+    /// The other half. On unix `MISE` is a different file from `mise`, so a shim by that name has
+    /// to keep being treated as a shim; ignoring case here would make mise run itself instead.
+    #[cfg(unix)]
+    #[test]
+    fn test_is_mise_binary_is_case_sensitive_on_unix() {
+        assert!(!is_mise_binary("MISE"));
+        assert!(!is_mise_binary("Mise"));
+        assert!(!is_mise_binary("MISE-DOCTOR"));
     }
 }


### PR DESCRIPTION
Invoked as `MISE.EXE`, mise treats itself as a shim. Named as a separate fix in #11982, which
handled the other way `argv[0]` could be misread.

## The symptom is not an error

That is the part worth leading with. `handle_shim` resolves the name and
[`shims.rs`](https://github.com/jdx/mise/blob/main/src/shims.rs) does `args[0] = bin`, so mise
re-executes a *different* binary and carries on. Measured on **2026.8.2 windows-x64**, one binary,
one directory, only the casing of the name changed:

```console
> mise.exe --trace --version
DEBUG ARGS: ...\argv0\mise.exe --trace --version                        # argv[0] intact

> MISE.EXE --trace --version
DEBUG ARGS: C:\Users\...\WinGet\Links\mise.exe --trace --version        # replaced
```

What that round trip costs, even when it "works": an extra process, an extra config load and tool
resolution, `PREFER_OFFLINE` forced on, `__MISE_SHIM=1` exported to the child, and on Windows the
`__MISE_SHIM_PATH` recursion guard written. Where mise is *not* resolvable as a tool it is instead
the hard `No version is set for shim:` failure from #11423.

It is also not a stable failure. The same command produced a working `--version` through `cmd` and
help text with exit 1 through PowerShell. A bug that sometimes returns the right answer is worse to
find than one that always fails.

## Cause

Windows filesystems are case-insensitive, so `MISE.EXE` starts the same file as `mise.exe`, and
`argv[0]` arrives with whatever casing the caller wrote. `is_mise_binary` compared exactly:

```rust
bin_name == "mise" || bin_name.starts_with("mise.") || bin_name.starts_with("mise-")
```

Its two callers are `IS_RUNNING_AS_SHIM` and `handle_shim`. Nothing else in the tree compares an
`argv[0]` basename against `"mise"`.

## Change

Ignore case on Windows only:

```rust
let is_mise = |s: &str| {
    if cfg!(windows) { s.eq_ignore_ascii_case("mise") } else { s == "mise" }
};
is_mise(bin_name) || bin_name.split_once(['.', '-']).is_some_and(|(stem, _)| is_mise(stem))
```

**This is the convention already in the tree, not a new one.** `BackendArg::matches_bin_name`
(`src/cli/args/backend_arg.rs`) compares executable names with `eq_ignore_ascii_case` under
`cfg!(windows)` and exactly otherwise. On unix `MISE` is a genuinely different file from `mise`, so
a shim by that name must keep being treated as one.

The `split_once` form is equivalent to the two `starts_with` arms and puts the case rule in one
place instead of three. Verified rather than asserted: a `rustc` probe ran both implementations over
a 24-input corpus — including `""`, `"."`, `"-"`, `".mise"`, `"mise."`, `"mise-"`, `"mise.foo.bar"`,
`"mise_x"`, `"misex.exe"` — and the unix branch **diverges on none of them**. The only behaviour that
changes is the Windows casing:

```
MISE.EXE   before=false   after(windows)=true   after(unix)=false
```

## Tests

In the existing `mod tests` in `src/env.rs`, following the platform-split pair already there
(`test_path_key_from_env_uses_uppercase_path_on_unix` / `..._preserves_windows_path_casing`).

- **Ungated** — `mise`, `mise.exe`, `mise.cmd`, `mise-doctor` are mise; `node`, `node.exe`, `misex`,
  `misex.exe` are not. The negative half is the control: a version that always returned true would
  satisfy every positive assertion.
- **`#[cfg(windows)]`** — `MISE.EXE`, `Mise.exe`, `MISE`, `MISE-DOCTOR` are mise. **These fail on
  `main` today**, which is the point. `NODE.EXE` and `MISEX.EXE` pin that ignoring case did not
  widen what counts as mise.
- **`#[cfg(unix)]`** — the same inputs are **not** mise. Asserting both directions makes the split
  deliberate rather than incidental, so a later "unify these" change fails instead of silently
  making a unix shim named `MISE` unreachable.

An `e2e-win` test was considered and dropped. Windows would let one invoke `MISE.EXE` with no
fixture at all, but the pre-fix symptom is the unstable one described above, so any assertion about
it would be flaky. The unit test fails on `main` today, which is what the coverage needs to do.

### Not run

`cargo fmt --all` only; no local build. The transcripts are from a released binary run natively, and
the before/after comparison is the `rustc` probe. CI builds the change — `windows-unit` covers the
Windows-gated test and `unit-macos`/`nightly` the unix-gated one.

## Relation to #11982

#11982 landed first and this is rebased on top of it. The two are independent halves of the same
report: that one is about which separator `argv[0]` arrives with, this one about its casing. Their
tests sit in the same `mod tests`, which is the only reason they touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of `mise`, `mise.*`, and `mise-*` executable names on Windows, regardless of capitalization.
  * Preserved case-sensitive name matching on Unix-based systems.
  * Corrected inconsistent handling across supported executable naming patterns, improving reliable executable detection across platforms.

* **Tests**
  * Added coverage for standard names, invalid matches, Windows casing variations, and Unix case sensitivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
