### PR TITLE
fix(task): normalize task cwd for source freshness

### DIFF
--- a/e2e/tasks/test_task_source_freshness_with_cwd
+++ b/e2e/tasks/test_task_source_freshness_with_cwd
@@ -38,3 +38,25 @@ pushd b
 assert "mise run -q cwd_task" "running b 2"
 assert_empty "mise run -q cwd_task"
 popd
+
+# A static task dir may use the conventional ./ prefix. Relative sources and
+# outputs should still be matched against the same effective directory.
+cat <<EOF >>mise.toml
+
+[tasks.relative_dir]
+run = "cp input.txt output.txt && cat output.txt"
+dir = "./relative"
+sources = ["input.txt"]
+outputs = ["output.txt"]
+EOF
+
+mkdir relative
+echo "relative 1" >relative/input.txt
+
+assert "mise run -q relative_dir" "relative 1"
+assert_empty "mise run -q relative_dir"
+
+echo "relative 2" >relative/input.txt
+
+assert "mise run -q relative_dir" "relative 2"
+assert_empty "mise run -q relative_dir"

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -16,7 +16,7 @@ use std::collections::BTreeMap;
 use std::fs::{self, File};
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use walkdir::WalkDir;
@@ -365,10 +365,21 @@ fn resolve_task_path(root: &Path, path: impl AsRef<Path>) -> PathBuf {
     }
 }
 
+fn normalize_task_cwd(path: PathBuf) -> PathBuf {
+    let mut normalized: PathBuf = path
+        .components()
+        .filter(|component| !matches!(component, Component::CurDir))
+        .collect();
+    if normalized.as_os_str().is_empty() && !path.as_os_str().is_empty() {
+        normalized.push(".");
+    }
+    normalized
+}
+
 /// Get the working directory for a task
 pub async fn task_cwd(task: &Task, config: &Arc<Config>) -> Result<PathBuf> {
     if let Some(d) = task.dir(config).await? {
-        Ok(d)
+        Ok(normalize_task_cwd(d))
     } else {
         Ok(config
             .project_root
@@ -1665,6 +1676,26 @@ mod tests {
             Path::new("/workspace/lib/worker/src/main.go")
         ));
         assert!(!is_source(&matcher, Path::new("/workspace/src/other.go")));
+    }
+
+    #[test]
+    fn relative_sources_match_when_task_dir_starts_with_dot() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let workspace = temp.path();
+        let task_cwd = normalize_task_cwd(workspace.join("./sub"));
+        let source = workspace.join("sub/input.txt");
+        fs::create_dir_all(source.parent().unwrap())?;
+        fs::write(&source, "source")?;
+
+        let sources = vec!["input.txt".to_string()];
+        let matcher = build_source_matcher(workspace, &task_cwd, &sources);
+        let metadatas = get_file_metadatas(&task_cwd, &sources, &matcher)?;
+
+        assert_eq!(
+            metadatas.into_iter().map(|(path, _)| path).collect_vec(),
+            [source]
+        );
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- normalize current-directory components in the effective task working directory before source freshness checks
- preserve parent-directory components so symlink-sensitive path semantics are unchanged
- add unit and end-to-end regression coverage for tasks using `dir = "./relative"`

## Root cause

The task working directory retained the lexical `./` component, while glob expansion returned normalized source paths. The source matcher therefore filtered out valid task-directory-relative sources, leaving only the task definition in the freshness hash and causing changed inputs to be skipped.

Fixes the bug reported in https://github.com/jdx/mise/discussions/11977.

## Validation

- `cargo test --bin mise task::task_source_checker::tests::relative_sources_match_when_task_dir_starts_with_dot -- --exact`
- `mise run test:e2e e2e/tasks/test_task_source_freshness_with_cwd`
- `mise run lint-fix`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized path normalization in task CWD resolution with targeted tests; no auth, data, or broad API changes.
> 
> **Overview**
> Fixes **source/output freshness** when a task uses a static `dir` with a leading `./` (e.g. `dir = "./relative"`). The effective working directory kept a lexical `.` segment while enumerated source paths were normalized, so the source matcher dropped task-relative files and tasks could stay **skipped** after inputs changed.
> 
> **`task_cwd`** now strips current-directory (`./`) components via `normalize_task_cwd` while leaving `..` and other path semantics unchanged. Regression coverage adds a unit test for `./sub` and an e2e scenario for `relative_dir` with `sources` / `outputs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e187af71cb1965b9824d3badabf3b6ee481a6789. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed task source tracking when static directories use paths beginning with `./`.
  - Relative input sources and outputs now resolve consistently within the task’s working directory.
  - Tasks are correctly skipped when inputs are unchanged and rerun when an input is modified.

- **Tests**
  - Added coverage for relative directory handling and task freshness behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->