### PR TITLE
fix(dotfiles): give the test helper the field FileRequest now requires

### DIFF
--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -2111,6 +2111,9 @@ mod tests {
             target_raw: target.to_string_lossy().to_string(),
             target: target.to_path_buf(),
             source: source.to_path_buf(),
+            // These tests are about link and copy modes, which read the file at `source`. Inline
+            // content is the other kind of entry and has nothing to do with what they assert.
+            content: None,
             mode,
             exclude: vec![],
             base: source.parent().expect("source parent").to_path_buf(),


### PR DESCRIPTION
`main` does not compile under `cfg(test)`, so `unit`, `unit-macos`, `windows-unit` and `nightly` are
failing on every open PR:

```
error[E0063]: missing field `content` in initializer of `files::FileRequest`
    --> src/system/files.rs:2110:9
     |
2110 |         FileRequest {
     |         ^^^^^^^^^^^ missing `content`
error: could not compile `mise` (bin "mise" test) due to 1 previous error
```

Confirmed against `main` itself rather than inferred from a branch: the struct at
`src/system/files.rs:100` lists `pub content: Option<String>`, and `link_req` at `:2109` does not
set it.

## How it got there

Two changes landed 24 minutes apart, and neither could see the other:

```
01:28  #11981  added `link_req`, a test helper that builds a FileRequest
01:52  #11983  added `content` as a required field on FileRequest
```

Each was green against the `main` it was cut from. The combination only exists after both merged,
and `link_req` is `cfg(test)`, so the non-test build — which is what most jobs get to first — is
unaffected and the breakage does not look like anything either PR did.

#11981 is mine, so this is half my doing.

## The change

`content: None`, with a comment saying why that is the right value rather than a placeholder: the
field carries a literal whole-file body for inline-content entries, and these tests cover link and
copy modes, which read the file at `source`.

`as_request` in `src/cli/dotfiles/add.rs` already passes `content: None` — this was the one
construction left behind.

## Not run

`cargo fmt --all` only; no local build. The struct now has all seven fields, and CI compiles it —
which is the thing that is currently red, so it is also the check that matters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Clarified test setup for link and copy requests by explicitly marking them as non-inline entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->