### PR TITLE
fix(task): treat a .sh sibling as the POSIX half on Windows

### DIFF
--- a/e2e-win/task.Tests.ps1
+++ b/e2e-win/task.Tests.ps1
@@ -105,6 +105,33 @@ echo "from-bash"
         mise run shebangtask | Select -Last 1 | Should -Be 'from-bash'
     }
 
+    # File tasks cannot branch on platform -- `run_windows` is a TOML-task key and is rejected in a
+    # file-task header -- so writing the task twice, once per platform, is the only option. Both
+    # files reduce to the same task name, and mise used to keep both and run both.
+    #
+    # End to end because the unit tests can only check the preference in isolation: it is the chain
+    # of discovery (shebang admits the `.sh`), naming (the stem, so both become `platpair`) and
+    # preference that produces the collision.
+    It 'prefers the Windows script when a task exists in both forms' {
+        @"
+#!/usr/bin/env bash
+echo "from-posix"
+"@ | Out-File -FilePath "tasks\platpair.sh" -Encoding utf8NoBOM -NoNewline
+        "Write-Output 'from-windows'" | Out-File -FilePath "tasks\platpair.ps1" -Encoding utf8NoBOM -NoNewline
+
+        # One task, not two entries sharing a name.
+        (mise tasks --json | ConvertFrom-Json | Where-Object { $_.name -eq 'platpair' }).Count |
+            Should -Be 1
+
+        # And the POSIX half must not run. Asserting the absence as well as the presence: with both
+        # kept, this printed `from-posix` too and still ended on the Windows line.
+        $out = mise run platpair 2>&1 | Out-String
+        $out | Should -BeLike '*from-windows*'
+        $out | Should -Not -BeLike '*from-posix*'
+
+        Remove-Item "tasks\platpair.sh", "tasks\platpair.ps1" -ErrorAction Ignore
+    }
+
     It 'executes a task in pwsh' {
         $env:MISE_WINDOWS_EXECUTABLE_EXTENSIONS = "ps1"
         $env:MISE_WINDOWS_DEFAULT_FILE_SHELL_ARGS = "pwsh.exe"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3823,62 +3823,77 @@ fn prefer_windows_file_task_siblings(file_tasks: Vec<Task>) -> Vec<Task> {
     prefer_windows_file_task_siblings_inner(file_tasks)
 }
 
+/// On Windows, keep the native script when a task exists in both a POSIX and a Windows form.
+///
+/// File tasks have no way to branch on platform — `run_windows` is a TOML-task key and is rejected
+/// in a file-task header — so writing the task twice, once per platform, is the only option
+/// available. Both files then reduce to the same task name, because the name is the file stem, and
+/// `mise run <name>` would run both.
+///
+/// The POSIX side is anything *not* carrying a Windows-native extension, which includes both
+/// `build` and `build.sh`. Keying on "no extension at all" is what this used to do, and it stopped
+/// being enough once shebang scripts became discoverable (#7941): `build.sh` is the shape people
+/// actually write, and it was passing straight through.
 fn prefer_windows_file_task_siblings_inner(file_tasks: Vec<Task>) -> Vec<Task> {
     let windows_exts = Settings::get()
         .windows_executable_extensions
         .iter()
         .map(|ext| ext.to_lowercase())
         .collect::<IndexSet<_>>();
-    let extensionless_task_keys = file_tasks
-        .iter()
-        .filter(|task| task.config_source.extension().is_none())
-        .map(|task| (task.config_source.clone(), task.name.clone()))
-        .collect::<IndexSet<_>>();
-    let mut windows_native_task_key_counts = IndexMap::new();
-    for task in &file_tasks {
-        let Some(ext) = task
-            .config_source
+    let is_windows_native = |task: &Task| {
+        task.config_source
             .extension()
             .and_then(|ext| ext.to_str())
-            .map(str::to_lowercase)
-        else {
-            continue;
-        };
-        if windows_exts.contains(&ext) {
-            *windows_native_task_key_counts
-                .entry((
-                    task.config_source.with_extension(""),
-                    strip_task_extension(&task.name).to_string(),
-                ))
-                .or_insert(0) += 1;
-        }
+            .is_some_and(|ext| windows_exts.contains(&ext.to_lowercase()))
+    };
+    // Path and name with the extension dropped, so `build.sh` and `build.ps1` land on one key.
+    // `with_extension("")` keeps the directory, which is what confines a pair to a single
+    // task-file family instead of matching same-named tasks from unrelated directories.
+    //
+    // The name has to be stripped too: `name_from_path` keeps the extension, so a file task is
+    // named `build.sh` and only `display_name` drops it. `strip_task_extension` removes just the
+    // last one, so `build.release.sh` keys as `build.release` rather than `build`.
+    let task_key = |task: &Task| {
+        (
+            task.config_source.with_extension(""),
+            strip_task_extension(&task.name).to_string(),
+        )
+    };
+    let posix_task_keys = file_tasks
+        .iter()
+        .filter(|task| !is_windows_native(task))
+        .map(&task_key)
+        .collect::<IndexSet<_>>();
+    let mut windows_native_task_key_counts = IndexMap::new();
+    for task in file_tasks.iter().filter(|task| is_windows_native(task)) {
+        *windows_native_task_key_counts
+            .entry(task_key(task))
+            .or_insert(0) += 1;
     }
-    let windows_takeover_keys = extensionless_task_keys
+    // Exactly one, deliberately: with two Windows siblings there is no basis for choosing between
+    // them, so everything is left alone rather than picking arbitrarily.
+    let windows_takeover_keys = posix_task_keys
         .iter()
         .filter(|key| windows_native_task_key_counts.get(*key) == Some(&1))
         .cloned()
         .collect::<IndexSet<_>>();
 
+    // The POSIX half is dropped and the Windows one is renamed to the bare stem, so `build.ps1`
+    // becomes the `build` the POSIX file used to answer to. Without that the task would only be
+    // reachable as `build.ps1`, which is not a name anyone wrote down.
     file_tasks
         .into_iter()
         .filter_map(|mut task| {
-            if task.config_source.extension().is_none()
-                && windows_takeover_keys.contains(&(task.config_source.clone(), task.name.clone()))
-            {
-                return None;
+            let key = task_key(&task);
+            if !is_windows_native(&task) {
+                return if windows_takeover_keys.contains(&key) {
+                    None
+                } else {
+                    Some(task)
+                };
             }
-            if task
-                .config_source
-                .extension()
-                .and_then(|ext| ext.to_str())
-                .is_some_and(|ext| windows_exts.contains(&ext.to_lowercase()))
-            {
-                let stem = strip_task_extension(&task.name);
-                if windows_takeover_keys
-                    .contains(&(task.config_source.with_extension(""), stem.to_string()))
-                {
-                    task.name = stem.to_string();
-                }
+            if windows_takeover_keys.contains(&key) {
+                task.name = key.1;
             }
             Some(task)
         })
@@ -5058,12 +5073,14 @@ mod tests {
             },
         ];
 
-        let names = prefer_windows_file_task_siblings_inner(file_tasks)
-            .into_iter()
-            .map(|task| task.name)
-            .collect_vec();
+        let tasks = prefer_windows_file_task_siblings_inner(file_tasks);
 
-        assert_eq!(names, vec!["pkl:gen"]);
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].name, "pkl:gen");
+        assert_eq!(
+            tasks[0].config_source,
+            PathBuf::from("mise-tasks/pkl/gen.ps1")
+        );
     }
 
     #[test]
@@ -5227,6 +5244,140 @@ mod tests {
                 Path::new("included-tasks/build"),
                 Path::new("mise-tasks/build.ps1"),
             ]
+        );
+    }
+
+    /// The case this function exists for.
+    ///
+    /// `name_from_path` keeps the extension, so these arrive as `build.sh` and `build.ps1`; both
+    /// reduce to `build` once the extension is stripped, which is why they collide.
+    #[test]
+    fn test_prefer_windows_file_task_siblings_takes_over_a_posix_extension() {
+        let file_tasks = vec![
+            Task {
+                name: "build.sh".to_string(),
+                config_source: PathBuf::from("mise-tasks/build.sh"),
+                ..Default::default()
+            },
+            Task {
+                name: "build.ps1".to_string(),
+                config_source: PathBuf::from("mise-tasks/build.ps1"),
+                ..Default::default()
+            },
+        ];
+
+        let tasks = prefer_windows_file_task_siblings_inner(file_tasks);
+
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].name, "build");
+        assert_eq!(
+            tasks[0].config_source,
+            PathBuf::from("mise-tasks/build.ps1")
+        );
+    }
+
+    /// A dot inside the task name is not the extension.
+    ///
+    /// `build.release.sh` is named `build.release.sh`, and `strip_task_extension` takes off only
+    /// the last extension — so the pair keys as `build.release` and the survivor is renamed to
+    /// `build.release`, not to `build`. Getting that wrong would leave `mise run build.release`
+    /// with nothing to resolve.
+    #[test]
+    fn test_prefer_windows_file_task_siblings_keeps_a_dotted_task_name() {
+        let file_tasks = vec![
+            Task {
+                name: "build.release.sh".to_string(),
+                config_source: PathBuf::from("mise-tasks/build.release.sh"),
+                ..Default::default()
+            },
+            Task {
+                name: "build.release.ps1".to_string(),
+                config_source: PathBuf::from("mise-tasks/build.release.ps1"),
+                ..Default::default()
+            },
+        ];
+
+        let tasks = prefer_windows_file_task_siblings_inner(file_tasks);
+
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].name, "build.release");
+        assert_eq!(
+            tasks[0].config_source,
+            PathBuf::from("mise-tasks/build.release.ps1")
+        );
+    }
+
+    /// A control for the test above: taking over requires something to take over *from*. A `.sh`
+    /// with no Windows sibling is the common shape on a project that never had a Windows script,
+    /// and it has to keep working — dropping it would break every such project on Windows.
+    #[test]
+    fn test_prefer_windows_file_task_siblings_keeps_a_lone_posix_extension() {
+        let file_tasks = vec![Task {
+            name: "build.sh".to_string(),
+            config_source: PathBuf::from("mise-tasks/build.sh"),
+            ..Default::default()
+        }];
+
+        let tasks = prefer_windows_file_task_siblings_inner(file_tasks);
+
+        assert_eq!(tasks.len(), 1);
+        // Name untouched as well as kept: renaming it to `build` here would invent a task the
+        // POSIX-only project never had.
+        assert_eq!(tasks[0].name, "build.sh");
+        assert_eq!(tasks[0].config_source, PathBuf::from("mise-tasks/build.sh"));
+    }
+
+    /// The other control: two POSIX files are not a platform pair, so neither is Windows' to
+    /// prefer. Widening the POSIX side must not turn "same stem" alone into a reason to delete.
+    #[test]
+    fn test_prefer_windows_file_task_siblings_keeps_two_posix_files() {
+        let file_tasks = vec![
+            Task {
+                name: "build".to_string(),
+                config_source: PathBuf::from("mise-tasks/build"),
+                ..Default::default()
+            },
+            Task {
+                name: "build.sh".to_string(),
+                config_source: PathBuf::from("mise-tasks/build.sh"),
+                ..Default::default()
+            },
+        ];
+
+        let tasks = prefer_windows_file_task_siblings_inner(file_tasks);
+
+        assert_eq!(tasks.len(), 2);
+    }
+
+    /// Ambiguity is unchanged by the widening: with two Windows siblings there is no basis for
+    /// choosing, so the `.sh` survives alongside them rather than being deleted for nothing.
+    #[test]
+    fn test_prefer_windows_file_task_siblings_keeps_posix_when_windows_is_ambiguous() {
+        let file_tasks = vec![
+            Task {
+                name: "build.sh".to_string(),
+                config_source: PathBuf::from("mise-tasks/build.sh"),
+                ..Default::default()
+            },
+            Task {
+                name: "build.ps1".to_string(),
+                config_source: PathBuf::from("mise-tasks/build.ps1"),
+                ..Default::default()
+            },
+            Task {
+                name: "build.cmd".to_string(),
+                config_source: PathBuf::from("mise-tasks/build.cmd"),
+                ..Default::default()
+            },
+        ];
+
+        let tasks = prefer_windows_file_task_siblings_inner(file_tasks);
+
+        assert_eq!(tasks.len(), 3);
+        // Names untouched too: nothing was chosen, so nothing should have been renamed.
+        assert_eq!(
+            tasks.iter().map(|task| task.name.as_str()).collect_vec(),
+            vec!["build.sh", "build.ps1", "build.cmd"]
         );
     }
 


### PR DESCRIPTION
A task written once per platform becomes two tasks with one name on Windows, and `mise run` runs
both. Measured on **2026.8.2 windows-x64**, with `.mise/tasks/robtest.sh` and `robtest.ps1`:

```console
> mise tasks
robtest  Hello Windows
robtest  Hello World          # same name, twice

> mise run robtest
[robtest] $ ...\.mise/tasks\robtest.sh
[robtest] $ ...\.mise/tasks\robtest.ps1
[robtest] Hello World
[robtest] Hello from PowerShell
```

They collide because a task is addressed by its stem. `name_from_path` keeps the extension — the
tasks are named `robtest.sh` and `robtest.ps1` — and `display_name` drops it, so both answer to
`robtest`:

```rust
/// prints the task name without an extension
pub fn display_name(&self, all_tasks: &BTreeMap<String, Task>) -> String {
```

Not specific to `.ps1`: `.sh` + `.bat` behaves the same. Different stems stay separate, which is the
control.

## Why two files at all

**File tasks cannot branch on platform.** `run_windows` is a TOML-task key; a file-task header
rejects it:

```console
> mise run plat
mise ERROR unknown field(s) ["run_windows"] in task file header: ...\.mise/tasks\plat.sh
```

So writing the task twice is the only option available, and `prefer_windows_file_task_siblings` is
the mechanism meant to make that work.

## Cause

That mechanism's intent is right — on Windows, keep the native script and drop the POSIX one — but
it looked for the POSIX half among files with **no extension**:

```rust
let extensionless_task_keys = file_tasks
    .iter()
    .filter(|task| task.config_source.extension().is_none())
```

That held while the only discoverable POSIX shape *was* extensionless. #7941 made shebang scripts
discoverable, and `build.sh` — the shape people actually write — has an extension, so it never
entered the set and the takeover never fired. The discovery side widened; this side did not.

Measured, same binary, same directory:

| files | before |
|---|---|
| `pairB` + `pairB.ps1` | one task ✔ as intended |
| `pairA.sh` + `pairA.ps1` | two tasks named `pairA`, both run ✘ |

## Change

The POSIX half is now anything **not** carrying a Windows-native extension, which covers `build` and
`build.sh` alike. The key gains `with_extension("")` so the two halves land on one entry while the
directory still scopes a pair to one task-file family.

Ambiguity is deliberately unchanged: with two Windows siblings there is no basis for choosing, so
`== Some(&1)` still declines and everything is kept.

## What does not move

| situation | after |
|---|---|
| **unix, anything** | **unchanged** — `prefer_windows_file_task_siblings` returns before this runs |
| Windows, lone `.sh` | unchanged; no sibling to take over from, still runs via its shebang |
| Windows, extensionless + `.ps1` | unchanged; already worked |
| Windows, two Windows siblings | unchanged; still ambiguous, all kept |
| Windows, two POSIX files | unchanged; not a platform pair |
| **Windows, `.sh` + `.ps1`** | **one task, the Windows one** |

`build.py` + `build.ps1` is now covered too. Worth stating plainly rather than burying: those
already collide today and already both run, so there is no working configuration for this to break —
choosing the Windows one is strictly better than running both.

## Tests

Every fixture names a task the way `name_from_path` does — after the file, extension included — so
`build.sh` is `build.sh`, not `build`.

- **the fix**: `build.sh` + `build.ps1` → one task named `build`, source `.ps1`. Fails on `main`.
- **dotted names**: `build.release.sh` + `build.release.ps1` → one task still named
  `build.release`, not `build`. `strip_task_extension` takes off only the last extension, and this
  pins that.
- **controls**, because widening the POSIX side is the risky half: a lone `.sh` survives with its
  name untouched (dropping or renaming it would break every project that never had a Windows
  script); two POSIX files stay two (same stem is not by itself a reason to delete); a `.sh` with
  *two* Windows siblings stays put, and nothing is renamed there either, since nothing was chosen.
- **e2e-win**, in `task.Tests.ps1`: real files on disk, asserting `mise tasks --json` has one
  `platpair` and that `mise run` prints the Windows line **and not** the POSIX one. The absence
  matters — with both kept, the run still ended on the Windows line and looked correct.
- The six existing tests are unchanged and still pass.

### Not run

`cargo fmt --all` only; no local build. The transcripts are a released binary run natively, and the
before/after comparison is a `rustc` probe over both implementations — all six existing expectations
plus the four new ones, zero failures, and the reported case going from two tasks to one. CI
compiles it: `windows-unit` for the unit tests, `windows-e2e` for the suite above.

## Scope

From [#7507](https://github.com/jdx/mise/discussions/7507). Deliberately not `Closes` — that thread
raised a second problem (a Windows path losing its backslashes on the way to bash) which no longer
reproduces on 2026.8.2, and answering it belongs in the thread rather than here.

`docs/tasks/file-tasks.md` says nothing about any of this — not the sibling rule, not that a
Windows-native extension wins. That is a real gap and worth its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Improved task discovery on Windows when POSIX and Windows task files share the same name.
- Windows-native task implementations are now selected correctly, while ambiguous or POSIX-only task sets remain unchanged.
- Improved recognition of POSIX task files with different script extensions.
- Preserved task names that contain dots.

## Tests
- Added end-to-end coverage verifying that the Windows task runs and its POSIX counterpart is not executed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
