### PR TITLE
fix(test): add missing content field to the link_req test helper

### DIFF
--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -2111,6 +2111,7 @@ mod tests {
             target_raw: target.to_string_lossy().to_string(),
             target: target.to_path_buf(),
             source: source.to_path_buf(),
+            content: None,
             mode,
             exclude: vec![],
             base: source.parent().expect("source parent").to_path_buf(),


### PR DESCRIPTION
`FileRequest` gained `content: Option<String>` in d96c3a6db (#11983), but the `link_req` helper in `src/system/files.rs`'s own `mod tests` was not updated, so every test target fails to compile on current `main`:

```
error[E0063]: missing field `content` in initializer of `files::FileRequest`
    --> src/system/files.rs:2110:9
```

Verified on `08cb51e70`, both directions:

| | `cargo check --all-features --all-targets` |
| -- | -- |
| `main` as-is | `error[E0063]` — exit 101 |
| with this one line | clean — exit 0 |

## Why it was not caught

`cargo build` is unaffected, so nothing user-facing broke. `test.yml` runs on `pull_request` into `main`, and on pushes to tags and the `mise`/`release` branches — but not on pushes to `main` itself, so no test target was compiled after the merge. The runs recorded on `main` at `08cb51e70` are `docs`, `release-plz` and `perf`.

The effect is on open pull requests rather than on `main`: `cargo test --all-features`, `cargo clippy --all-features --all-targets -- -D warnings` and `cargo check ... --all-targets` all run in `test.yml`, and all three compile test targets, so any PR opened against `main` currently goes red for a reason unrelated to its own diff.

`None` matches the helper's intent — it builds link and copy requests, which take their content from `source` rather than from an inline literal.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.232.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test setup to correctly handle file requests without content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->