### PR TITLE
fix(task): anchor cache-audit reports and `..` sources at the task directory

### DIFF
--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -414,6 +414,18 @@ outputs = ["target/debug/mycli"]
 Running the above will only execute `cargo build` if `mise.toml`, `Cargo.toml`, or any ".rs" file in the `src` directory
 has changed since the last build.
 
+Relative entries are resolved from the task directory (the task's `dir`, or the project root when it
+has none) and may use `..` to reach files above it, such as a `node_modules` directory shared at the
+root of a monorepo:
+
+```mise-toml
+[tasks.build]
+dir = "packages/web"
+run = "npm run build"
+sources = ["src/**/*.ts", "../../node_modules/**"]
+outputs = ["dist"]
+```
+
 The [`task_source_files`](../templates.md#task-source-files) function can be used to iterate over a task's
 `sources` within its template context.
 
@@ -612,6 +624,9 @@ beneath the task directory that do not match `outputs`. The audit is advisory an
 task or prevent a successful result from being cached. Access outside those roots and directory
 metadata reads are ignored to keep system libraries, executables, and path traversal out of the
 report.
+
+Reported paths are always relative to the task directory, using `..` for the paths above it that a
+read may legitimately touch. A reported read can be added to `sources` exactly as it was printed.
 
 Audit mode requires `strace` on `PATH`. Mise warns and runs the task normally when tracing is not
 available; other platforms are not currently supported. Cached tasks are not executed and therefore

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -398,9 +398,9 @@ cause the task to be run.
 
 This is also used in `mise watch` to know which files/directories to watch.
 
-This can be specified with relative paths to the config file and/or with glob patterns, e.g.:
-`src/**/*.rs`. Brace alternatives such as `src/**/*.{js,ts}` are supported by freshness checks,
-`mise watch`, and `task_source_files()`.
+This can be specified with relative paths and/or with glob patterns, e.g.: `src/**/*.rs`. Brace
+alternatives such as `src/**/*.{js,ts}` are supported by freshness checks, `mise watch`, and
+`task_source_files()`.
 Ensure you don't go crazy with adding a ton of files in a glob though—mise has to scan each and every one to check
 the timestamp.
 

--- a/e2e/tasks/test_task_artifact_cache_audit_anchoring
+++ b/e2e/tasks/test_task_artifact_cache_audit_anchoring
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+mkdir -p bin
+cat <<'EOF' >bin/strace
+#!/usr/bin/env bash
+set -euo pipefail
+
+trace=
+while (($#)); do
+  case $1 in
+  -o)
+    trace=$2
+    shift 2
+    ;;
+  --)
+    shift
+    break
+    ;;
+  *) shift ;;
+  esac
+done
+if [[ -z $trace ]]; then
+  exec "$@"
+fi
+cat <<TRACE >"$trace"
+123 openat(AT_FDCWD<$PWD>, "node_modules/dep.js", O_RDONLY) = 3
+123 openat(AT_FDCWD<$PWD>, "../node_modules/dep.js", O_RDONLY) = 3
+123 openat(AT_FDCWD<$PWD>, "dist/result.txt", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 3
+TRACE
+exec "$@"
+EOF
+chmod +x bin/strace
+
+write_config() {
+  cat <<EOF >mise.toml
+[settings]
+experimental = true
+
+[tasks.build]
+dir = "pkg"
+run = "mkdir -p dist && cat node_modules/dep.js ../node_modules/dep.js >dist/result.txt"
+sources = [$1]
+outputs = ["dist"]
+cache = { enabled = true, audit = true }
+EOF
+}
+
+mkdir -p pkg/node_modules node_modules
+printf 'workspace dep\n' >node_modules/dep.js
+printf 'package dep\n' >pkg/node_modules/dep.js
+
+# Both files are named node_modules/dep.js; only the one inside the task
+# directory is declared, so the report must distinguish them.
+write_config '"node_modules/**"'
+output=$(PATH="$PWD/bin:$PATH" mise run --force build 2>&1)
+assert_contains "echo \"$output\"" "cache audit detected undeclared read: ../node_modules/dep.js"
+assert_not_contains "echo \"$output\"" "undeclared read: node_modules/dep.js"
+
+# The reported path is a usable sources entry: declaring it silences the audit.
+write_config '"node_modules/**", "../node_modules/**"'
+output=$(PATH="$PWD/bin:$PATH" mise run --force build 2>&1)
+assert_not_contains "echo \"$output\"" "cache audit detected undeclared read"

--- a/e2e/tasks/test_task_artifact_cache_audit_symlinked_dir
+++ b/e2e/tasks/test_task_artifact_cache_audit_symlinked_dir
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# A task dir that resolves through a symlink runs in the link's target, and
+# strace reports paths from there. The audit has to work in that same directory
+# or a declared source looks undeclared and the reported path names a file the
+# task never read.
+
+mkdir -p bin
+cat <<'EOF' >bin/strace
+#!/usr/bin/env bash
+set -euo pipefail
+
+trace=
+while (($#)); do
+  case $1 in
+  -o)
+    trace=$2
+    shift 2
+    ;;
+  --)
+    shift
+    break
+    ;;
+  *) shift ;;
+  esac
+done
+if [[ -z $trace ]]; then
+  exec "$@"
+fi
+# `pwd -P` rather than $PWD: real strace annotates the dirfd with the path the
+# kernel resolved, which is the symlink's target.
+cwd=$(pwd -P)
+cat <<TRACE >"$trace"
+123 openat(AT_FDCWD<$cwd>, "input.txt", O_RDONLY) = 3
+123 openat(AT_FDCWD<$cwd>, "secret.txt", O_RDONLY) = 3
+TRACE
+exec "$@"
+EOF
+chmod +x bin/strace
+
+mkdir -p real/inner
+ln -s real/inner link
+printf 'declared\n' >real/inner/input.txt
+printf 'undeclared\n' >real/inner/secret.txt
+
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[tasks.build]
+dir = "link"
+run = "cat input.txt secret.txt"
+sources = ["input.txt"]
+outputs = []
+cache = { enabled = true, audit = true }
+EOF
+
+output=$(PATH="$PWD/bin:$PATH" mise run --force build 2>&1)
+
+# The declared source must be recognised even though it was traced under the
+# link's target rather than the configured dir.
+assert_not_contains "echo \"$output\"" "undeclared read: input.txt"
+
+# The undeclared read is reported relative to the task dir, not climbed out of
+# it and back down through the link target.
+assert_contains "echo \"$output\"" "cache audit detected undeclared read: secret.txt"
+assert_not_contains "echo \"$output\"" "undeclared read: ../real/inner"

--- a/e2e/tasks/test_task_source_freshness_parent_relative
+++ b/e2e/tasks/test_task_source_freshness_parent_relative
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# A source above the task directory must take part in the freshness decision,
+# not merely match the source matcher: patterns are enumerated by `glob` from
+# the pattern's own literal prefix, so `..` reaches outside the task directory.
+
+mkdir -p shared pkg
+printf 'v1\n' >shared/lib.txt
+
+cat <<'EOF' >mise.toml
+[tasks.build]
+dir = "pkg"
+run = "mkdir -p dist && cat ../shared/lib.txt >dist/out.txt"
+sources = ["../shared/**/*"]
+outputs = ["dist/out.txt"]
+EOF
+
+mise run build
+assert "cat pkg/dist/out.txt" "v1"
+
+# The parent-relative source is in the cache key and unchanged.
+assert_contains "mise run build 2>&1" "sources up-to-date, skipping"
+
+# Editing it must invalidate the task even though it sits above the task
+# directory. A matcher fix that left enumeration blind would skip here.
+printf 'v2\n' >shared/lib.txt
+assert_not_contains "mise run build 2>&1" "sources up-to-date, skipping"
+assert "cat pkg/dist/out.txt" "v2"
+
+# Adding a file under the parent-relative glob invalidates too.
+assert_contains "mise run build 2>&1" "sources up-to-date, skipping"
+printf 'extra\n' >shared/other.txt
+assert_not_contains "mise run build 2>&1" "sources up-to-date, skipping"

--- a/src/task/task_cache_audit.rs
+++ b/src/task/task_cache_audit.rs
@@ -92,7 +92,13 @@ impl TaskCacheAudit {
             let Some(strace) = usable_strace().await else {
                 return Ok(None);
             };
+            // strace reports paths as the kernel resolved them, so the audit
+            // has to work in the directory the task actually ran in. `task_cwd`
+            // stays lexical because `Command::current_dir` resolves the symlink
+            // itself; resolving it here as well is what keeps the traced paths,
+            // the source matcher, and the reported paths in one namespace.
             let root = task_cwd(task, config).await?;
+            let root = root.canonicalize().unwrap_or(root);
             let source_root = task_source_match_root(&root, config);
             let sources = build_source_matcher(&source_root, &root, &task.sources);
             let outputs = build_output_matcher(&root, &task.outputs.patterns())?;

--- a/src/task/task_cache_audit.rs
+++ b/src/task/task_cache_audit.rs
@@ -2,6 +2,7 @@ use crate::config::{Config, Settings};
 #[cfg(target_os = "linux")]
 use crate::file;
 use crate::task::Task;
+use crate::task::task_source_checker::lexical_normalize;
 #[cfg(target_os = "linux")]
 use crate::task::task_source_checker::{
     build_output_matcher, build_source_matcher, task_cwd, task_source_match_root,
@@ -13,7 +14,7 @@ use std::collections::BTreeSet;
 use std::ffi::OsString;
 use std::fs;
 use std::io::Write;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 #[cfg(target_os = "linux")]
 use std::process::Stdio;
 use std::sync::{Arc, Mutex};
@@ -178,8 +179,7 @@ impl TaskCacheAudit {
                 {
                     continue;
                 }
-                let display_path = path.strip_prefix(&self.root).unwrap_or(relative);
-                undeclared.insert((access.kind, display_path.to_path_buf()));
+                undeclared.insert((access.kind, relative_to(&self.root, &path)));
             }
         }
         let total = undeclared.len();
@@ -439,24 +439,50 @@ fn dirfd_base(input: &str) -> Option<PathBuf> {
     path.is_absolute().then(|| path.to_path_buf())
 }
 
-fn lexical_normalize(path: &Path) -> PathBuf {
-    let mut normalized = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            component => normalized.push(component.as_os_str()),
-        }
+/// Render `path` relative to `base`, climbing with `..` when `path` is not
+/// beneath `base`. Both must be absolute and lexically normalized.
+///
+/// Reads are audited against the workspace root, so one can legitimately sit
+/// above the task directory. Rendering those against a different base than
+/// in-task reads makes two distinct files print the same string, and neither
+/// string is usable as a `sources` entry.
+fn relative_to(base: &Path, path: &Path) -> PathBuf {
+    let base: Vec<_> = base.components().collect();
+    let path: Vec<_> = path.components().collect();
+    let common = base.iter().zip(&path).take_while(|(b, p)| b == p).count();
+    let mut relative = PathBuf::new();
+    for _ in common..base.len() {
+        relative.push("..");
     }
-    normalized
+    relative.extend(&path[common..]);
+    relative
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{AccessKind, TraceAccess, parse_trace_line, quoted_strings};
-    use std::path::PathBuf;
+    use super::{AccessKind, TraceAccess, parse_trace_line, quoted_strings, relative_to};
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn renders_paths_relative_to_the_task_directory() {
+        let base = Path::new("/workspace/pkg");
+        assert_eq!(
+            relative_to(base, Path::new("/workspace/pkg/node_modules/dep.js")),
+            PathBuf::from("node_modules/dep.js")
+        );
+        assert_eq!(
+            relative_to(base, Path::new("/workspace/node_modules/dep.js")),
+            PathBuf::from("../node_modules/dep.js")
+        );
+        assert_eq!(
+            relative_to(base, Path::new("/node_modules/dep.js")),
+            PathBuf::from("../../node_modules/dep.js")
+        );
+        assert_eq!(
+            relative_to(base, Path::new("/workspace/other/dep.js")),
+            PathBuf::from("../other/dep.js")
+        );
+    }
 
     #[test]
     fn parses_strace_file_accesses() {

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -249,6 +249,10 @@ pub(crate) fn build_source_matcher(
 /// A `..` with nothing to collapse is kept in a relative path (`../x` has no
 /// representation without it) and dropped in an absolute one, where `/..` is
 /// `/`.
+///
+/// Only for paths and patterns that are *matched*. A directory the task will
+/// actually run in must keep its `..` for the OS to resolve at `chdir` time, so
+/// [`normalize_task_cwd`] collapses `.` alone.
 pub(crate) fn lexical_normalize(path: &Path) -> PathBuf {
     let absolute = path.is_absolute();
     let mut normalized = PathBuf::new();
@@ -321,14 +325,17 @@ fn normalize_pattern(match_root: &Path, task_cwd: &Path, pattern: &str) -> Strin
         ("", pattern)
     };
     let body_path = Path::new(body);
+    // Inspect the pattern as written: `task_cwd` may legitimately contain a
+    // glob metacharacter as a literal directory name, and folding it in would
+    // make an ordinary `../` entry look like a `..` popping a glob.
+    if parent_dir_pops_glob(body_path) {
+        return pattern.to_string();
+    }
     let body_abs = if body_path.is_absolute() {
         body_path.to_path_buf()
     } else {
         task_cwd.join(body_path)
     };
-    if parent_dir_pops_glob(&body_abs) {
-        return pattern.to_string();
-    }
     let body_abs = lexical_normalize(&body_abs);
     let Ok(rel) = body_abs.strip_prefix(match_root) else {
         return pattern.to_string();
@@ -444,15 +451,11 @@ fn resolve_task_path(root: &Path, path: impl AsRef<Path>) -> PathBuf {
     }
 }
 
-/// Canonicalise a task's working directory before it is used as a matching
-/// base, an enumeration root, and part of [`task_state_key`].
-///
-/// A `dir` of `.` normalizes away to nothing, which is not a usable directory,
-/// so it is restored. Two spellings of the same directory must not produce two
-/// state keys, which is why this runs on the way out of [`task_cwd`] rather
-/// than at each use.
 fn normalize_task_cwd(path: PathBuf) -> PathBuf {
-    let mut normalized = lexical_normalize(&path);
+    let mut normalized: PathBuf = path
+        .components()
+        .filter(|component| !matches!(component, Component::CurDir))
+        .collect();
     if normalized.as_os_str().is_empty() && !path.as_os_str().is_empty() {
         normalized.push(".");
     }
@@ -1838,6 +1841,20 @@ mod tests {
         assert!(!is_source(&matcher, Path::new("/workspace/x")));
     }
 
+    /// The glob guard inspects the pattern as written. A task directory may
+    /// contain a glob metacharacter as a literal name, and folding it into the
+    /// inspected path would make this ordinary `../` entry look like a `..`
+    /// popping a glob, silently leaving the pattern unanchored.
+    #[test]
+    #[cfg(unix)]
+    fn matcher_parent_relative_pattern_from_a_task_dir_containing_a_glob_char() {
+        let match_root = Path::new("/workspace");
+        let task_cwd = Path::new("/workspace/pkg*");
+        let sources = vec!["../shared/**".to_string()];
+        let matcher = build_source_matcher(match_root, task_cwd, &sources);
+        assert!(is_source(&matcher, Path::new("/workspace/shared/util.go")));
+    }
+
     /// `[task_config.input_groups]` anchors a group entry by joining it onto
     /// the defining config's root without normalizing, so absolute patterns
     /// reach the matcher with `..` still in them.
@@ -1884,39 +1901,6 @@ mod tests {
             [source]
         );
         Ok(())
-    }
-
-    /// `..` in a task dir has to collapse for the same reason `.` does: the
-    /// directory is also hashed into `task_state_key`, so two spellings of one
-    /// directory would otherwise keep two independent freshness baselines.
-    #[test]
-    fn relative_sources_match_when_task_dir_contains_parent_dirs() -> Result<()> {
-        let temp = tempfile::tempdir()?;
-        let workspace = temp.path();
-        let task_cwd = normalize_task_cwd(workspace.join("other/../sub"));
-        let source = workspace.join("sub/input.txt");
-        fs::create_dir_all(source.parent().unwrap())?;
-        fs::write(&source, "source")?;
-
-        assert_eq!(task_cwd, workspace.join("sub"));
-
-        let sources = vec!["input.txt".to_string()];
-        let matcher = build_source_matcher(workspace, &task_cwd, &sources);
-        let metadatas = get_file_metadatas(&task_cwd, &sources, &matcher)?;
-
-        assert_eq!(
-            metadatas.into_iter().map(|(path, _)| path).collect_vec(),
-            [source]
-        );
-        Ok(())
-    }
-
-    /// A `dir` of `.` normalizes away to nothing and must be restored, or the
-    /// task would run from an empty path.
-    #[test]
-    fn normalize_task_cwd_keeps_a_bare_current_dir() {
-        assert_eq!(normalize_task_cwd(PathBuf::from(".")), PathBuf::from("."));
-        assert_eq!(normalize_task_cwd(PathBuf::new()), PathBuf::new());
     }
 
     #[test]

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -444,11 +444,15 @@ fn resolve_task_path(root: &Path, path: impl AsRef<Path>) -> PathBuf {
     }
 }
 
+/// Canonicalise a task's working directory before it is used as a matching
+/// base, an enumeration root, and part of [`task_state_key`].
+///
+/// A `dir` of `.` normalizes away to nothing, which is not a usable directory,
+/// so it is restored. Two spellings of the same directory must not produce two
+/// state keys, which is why this runs on the way out of [`task_cwd`] rather
+/// than at each use.
 fn normalize_task_cwd(path: PathBuf) -> PathBuf {
-    let mut normalized: PathBuf = path
-        .components()
-        .filter(|component| !matches!(component, Component::CurDir))
-        .collect();
+    let mut normalized = lexical_normalize(&path);
     if normalized.as_os_str().is_empty() && !path.as_os_str().is_empty() {
         normalized.push(".");
     }
@@ -1880,6 +1884,39 @@ mod tests {
             [source]
         );
         Ok(())
+    }
+
+    /// `..` in a task dir has to collapse for the same reason `.` does: the
+    /// directory is also hashed into `task_state_key`, so two spellings of one
+    /// directory would otherwise keep two independent freshness baselines.
+    #[test]
+    fn relative_sources_match_when_task_dir_contains_parent_dirs() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let workspace = temp.path();
+        let task_cwd = normalize_task_cwd(workspace.join("other/../sub"));
+        let source = workspace.join("sub/input.txt");
+        fs::create_dir_all(source.parent().unwrap())?;
+        fs::write(&source, "source")?;
+
+        assert_eq!(task_cwd, workspace.join("sub"));
+
+        let sources = vec!["input.txt".to_string()];
+        let matcher = build_source_matcher(workspace, &task_cwd, &sources);
+        let metadatas = get_file_metadatas(&task_cwd, &sources, &matcher)?;
+
+        assert_eq!(
+            metadatas.into_iter().map(|(path, _)| path).collect_vec(),
+            [source]
+        );
+        Ok(())
+    }
+
+    /// A `dir` of `.` normalizes away to nothing and must be restored, or the
+    /// task would run from an empty path.
+    #[test]
+    fn normalize_task_cwd_keeps_a_bare_current_dir() {
+        assert_eq!(normalize_task_cwd(PathBuf::from(".")), PathBuf::from("."));
+        assert_eq!(normalize_task_cwd(PathBuf::new()), PathBuf::new());
     }
 
     #[test]

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -303,6 +303,27 @@ fn parent_dir_pops_glob(pattern: &Path) -> bool {
     false
 }
 
+/// Render a relative path as a gitignore pattern body.
+///
+/// Gitignore patterns are always `/`-separated, but `Path` renders the platform
+/// separator, so on Windows a pattern rebuilt from a `PathBuf` arrives as
+/// `dist\**\*.map`. `globset` reads `\` as an escape rather than a separator,
+/// which silently turns the pattern into one that matches something else
+/// entirely — a negated entry then stops excluding and the matcher widens.
+/// Joining the components explicitly keeps the separator independent of the
+/// platform the path was built on.
+fn pattern_from_path(path: &Path) -> Option<String> {
+    let mut pattern = String::new();
+    for component in path.components() {
+        let part = component.as_os_str().to_str()?;
+        if !pattern.is_empty() {
+            pattern.push('/');
+        }
+        pattern.push_str(part);
+    }
+    Some(pattern)
+}
+
 /// Normalise `pattern` so it is always expressed relative to `match_root`.
 ///
 /// A relative body is resolved against `task_cwd` and an absolute one taken as
@@ -340,7 +361,7 @@ fn normalize_pattern(match_root: &Path, task_cwd: &Path, pattern: &str) -> Strin
     let Ok(rel) = body_abs.strip_prefix(match_root) else {
         return pattern.to_string();
     };
-    let Some(rel_str) = rel.to_str() else {
+    let Some(rel_str) = pattern_from_path(rel) else {
         return pattern.to_string();
     };
     if rel_str.is_empty() {
@@ -1246,6 +1267,22 @@ mod tests {
         let root = Path::new(".");
         let matcher = build_source_matcher(root, root, &sources);
         is_source(&matcher, Path::new(path))
+    }
+
+    /// Gitignore patterns are `/`-separated on every platform, but `Path`
+    /// renders `\` on Windows and `globset` reads that as an escape. A pattern
+    /// rebuilt from a `PathBuf` there stops meaning what it says: a negated
+    /// entry no longer excludes, so the matcher widens instead of narrowing.
+    /// This only bites on Windows, so it is asserted rather than left to the
+    /// platform-specific tests that happen to cover it.
+    #[test]
+    fn patterns_stay_slash_separated_on_every_platform() {
+        let joined = Path::new("dist").join("**").join("*.map");
+        assert_eq!(pattern_from_path(&joined).unwrap(), "dist/**/*.map");
+
+        let root = Path::new("/project");
+        let normalized = normalize_pattern(root, root, "!dist/**/*.map");
+        assert_eq!(normalized, "!dist/**/*.map");
     }
 
     #[test]

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -200,10 +200,10 @@ pub(crate) fn expand_glob_braces(pattern: &str) -> Result<Vec<String>> {
 ///
 /// `match_root` is the directory the [`Override`] is anchored at (the workspace
 /// root in workspace setups, otherwise the task CWD). `task_cwd` is the
-/// directory the task actually runs from. When they differ — a subproject task
-/// inside a workspace — relative patterns are prefixed with the
-/// `task_cwd`-relative-to-`match_root` path so they remain correctly anchored.
-/// Absolute patterns are stripped of the `match_root` prefix as before.
+/// directory the task actually runs from. Relative patterns are resolved
+/// against `task_cwd` and absolute ones taken as-is; either way the result is
+/// re-expressed relative to `match_root` so every pattern lives in the same
+/// namespace as the paths the matcher is asked about.
 ///
 /// Patterns use gitignore syntax with `!` inverted (the [`Override`] convention):
 /// a non-negated entry marks a file as a *source*, `!`-prefixed excludes it,
@@ -238,15 +238,80 @@ pub(crate) fn build_source_matcher(
     })
 }
 
+/// Resolve `.` and `..` in `path` without consulting the filesystem.
+///
+/// Being lexical, this disagrees with `canonicalize` whenever a symlink is
+/// involved: `dir/link/..` becomes `dir`, not the parent of the link's target.
+/// Source matching is lexical too — gitignore globs never resolve symlinks —
+/// so both sides of a comparison must be normalized the same way to stay
+/// consistent with each other.
+///
+/// A `..` with nothing to collapse is kept in a relative path (`../x` has no
+/// representation without it) and dropped in an absolute one, where `/..` is
+/// `/`.
+pub(crate) fn lexical_normalize(path: &Path) -> PathBuf {
+    let absolute = path.is_absolute();
+    let mut normalized = PathBuf::new();
+    let mut depth = 0usize;
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if depth > 0 {
+                    normalized.pop();
+                    depth -= 1;
+                } else if !absolute {
+                    normalized.push("..");
+                }
+            }
+            Component::Normal(part) => {
+                normalized.push(part);
+                depth += 1;
+            }
+            component => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}
+
+/// Returns true when resolving `..` in `pattern` would collapse a component
+/// holding a glob metacharacter.
+///
+/// `**/../x` has no well-defined expansion — the `..` would have to apply to
+/// whatever each match of `**` resolved to — so callers leave such a pattern
+/// exactly as written rather than inventing a meaning for it.
+fn parent_dir_pops_glob(pattern: &Path) -> bool {
+    let mut stack: Vec<bool> = Vec::new();
+    for component in pattern.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if stack.pop() == Some(true) {
+                    return true;
+                }
+            }
+            Component::Normal(part) => {
+                stack.push(part.to_string_lossy().contains(['*', '?', '[', '{']));
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
 /// Normalise `pattern` so it is always expressed relative to `match_root`.
 ///
-/// - **Absolute** body under `match_root`: strip the prefix.
-/// - **Relative** body when `task_cwd` is a subdirectory of `match_root`:
-///   prefix with `task_cwd`-relative-to-`match_root` so the pattern is
-///   anchored at the workspace root rather than the subproject CWD.
-///   E.g. `match_root=/ws`, `task_cwd=/ws/lib/worker`, `src/**/*.go`
-///   → `lib/worker/src/**/*.go`.
-/// - Everything else: returned unchanged.
+/// A relative body is resolved against `task_cwd` and an absolute one taken as
+/// written; the result is then lexically normalized and stripped back to a
+/// `match_root`-relative path. Relative entries therefore stay anchored at the
+/// task directory while `..` climbs out of it: `match_root=/ws`,
+/// `task_cwd=/ws/lib/worker`, `src/**/*.go` → `lib/worker/src/**/*.go` and
+/// `../shared/*.go` → `lib/shared/*.go`.
+///
+/// A pattern resolving outside `match_root` is returned unchanged, as is one
+/// whose `..` would collapse a glob component. Gitignore syntax cannot express
+/// a path above the matcher's root; [`is_source`] passes such absolute paths
+/// through without consulting the matcher instead.
 fn normalize_pattern(match_root: &Path, task_cwd: &Path, pattern: &str) -> String {
     let (prefix, body) = if pattern.starts_with("\\!") {
         return pattern.to_string();
@@ -256,32 +321,39 @@ fn normalize_pattern(match_root: &Path, task_cwd: &Path, pattern: &str) -> Strin
         ("", pattern)
     };
     let body_path = Path::new(body);
-    if body_path.is_absolute() {
-        if let Ok(rel) = body_path.strip_prefix(match_root)
-            && let Some(rel_str) = rel.to_str()
-        {
-            let rel_str = if rel_str.starts_with('!') {
-                format!("\\{rel_str}")
-            } else {
-                rel_str.to_string()
-            };
-            return format!("{prefix}{rel_str}");
-        }
+    let body_abs = if body_path.is_absolute() {
+        body_path.to_path_buf()
+    } else {
+        task_cwd.join(body_path)
+    };
+    if parent_dir_pops_glob(&body_abs) {
         return pattern.to_string();
     }
-    // Relative pattern: anchor it at match_root by prepending the subproject path.
-    if let Ok(cwd_rel) = task_cwd.strip_prefix(match_root)
-        && let Some(cwd_rel_str) = cwd_rel.to_str()
-        && !cwd_rel_str.is_empty()
-    {
-        return format!("{prefix}{cwd_rel_str}/{body}");
+    let body_abs = lexical_normalize(&body_abs);
+    let Ok(rel) = body_abs.strip_prefix(match_root) else {
+        return pattern.to_string();
+    };
+    let Some(rel_str) = rel.to_str() else {
+        return pattern.to_string();
+    };
+    if rel_str.is_empty() {
+        return pattern.to_string();
     }
-    pattern.to_string()
+    let rel_str = if rel_str.starts_with('!') {
+        format!("\\{rel_str}")
+    } else {
+        rel_str.to_string()
+    };
+    format!("{prefix}{rel_str}")
 }
 
 /// Returns true iff `path` is selected as a source by `matcher`. With
 /// [`Override`]'s inverted semantics, a non-negated user pattern produces
 /// `Match::Whitelist` for matching paths.
+///
+/// `path` is lexically normalized first: `glob` builds the paths it returns
+/// from the raw pattern, so an enumerated file still carries the `..` that
+/// [`normalize_pattern`] has already resolved out of the matcher's copy.
 ///
 /// Absolute paths that don't fall under the matcher's root are out of
 /// gitignore's domain — `Override::matched` would return `Match::None` and,
@@ -289,10 +361,11 @@ fn normalize_pattern(match_root: &Path, task_cwd: &Path, pattern: &str) -> Strin
 /// silently dropping a file the glob legitimately included. Trust the glob
 /// in that case.
 pub(crate) fn is_source(matcher: &Override, path: &Path) -> bool {
+    let path = lexical_normalize(path);
     if path.is_absolute() && !path.starts_with(matcher.path()) {
         return true;
     }
-    matcher.matched(path, false).is_whitelist()
+    matcher.matched(&path, false).is_whitelist()
 }
 
 /// Returns the include-side glob patterns from `sources`, suitable for file
@@ -349,11 +422,17 @@ pub(crate) fn output_glob_patterns(outputs: &[String]) -> Vec<String> {
 }
 
 /// Returns true when an output path is selected by the ordered matcher.
+///
+/// `path` is lexically normalized to stay in step with [`normalize_pattern`],
+/// which resolves `..` out of the matcher's patterns. Output enumeration
+/// resolves candidates from the raw pattern, so `outputs = ["dist/../x"]`
+/// reaches here still carrying the `..` the matcher no longer holds.
 pub(crate) fn is_output(matcher: &Override, path: &Path, is_dir: bool) -> bool {
+    let path = lexical_normalize(path);
     if path.is_absolute() && !path.starts_with(matcher.path()) {
         return true;
     }
-    matcher.matched(path, is_dir).is_whitelist()
+    matcher.matched(&path, is_dir).is_whitelist()
 }
 
 fn resolve_task_path(root: &Path, path: impl AsRef<Path>) -> PathBuf {
@@ -1188,6 +1267,32 @@ mod tests {
         assert!(is_output(&matcher, &output, false));
     }
 
+    /// Output enumeration resolves candidates from the raw pattern, so the
+    /// `..` the matcher resolved away is still present in the path it is asked
+    /// about. Both sides must normalize or the output never matches and the
+    /// task stays permanently stale.
+    ///
+    /// The pattern has to contain a slash to pin this down: a slashless
+    /// gitignore pattern matches at any depth, so an un-normalized path would
+    /// match on its basename alone and hide the difference.
+    #[test]
+    fn output_matcher_normalizes_parent_traversal() {
+        let root = tempfile::tempdir().unwrap();
+        let patterns = vec!["dist/../out/result.txt".to_string()];
+        let matcher = build_output_matcher(root.path(), &patterns).unwrap();
+
+        assert!(is_output(
+            &matcher,
+            &root.path().join("dist/../out/result.txt"),
+            false
+        ));
+        assert!(is_output(
+            &matcher,
+            &root.path().join("out/result.txt"),
+            false
+        ));
+    }
+
     #[test]
     fn metadata_hash_notices_a_same_size_change_with_an_older_mtime() {
         // https://github.com/jdx/mise/discussions/4209 — restoring an older tree with tar,
@@ -1676,6 +1781,85 @@ mod tests {
             Path::new("/workspace/lib/worker/src/main.go")
         ));
         assert!(!is_source(&matcher, Path::new("/workspace/src/other.go")));
+    }
+
+    /// `..` in a relative pattern climbs out of the task CWD while the pattern
+    /// stays anchored inside the workspace root.
+    #[test]
+    #[cfg(unix)]
+    fn matcher_subproject_parent_relative_pattern() {
+        let match_root = Path::new("/workspace");
+        let task_cwd = Path::new("/workspace/lib/worker");
+        let sources = vec!["../shared/**/*.go".to_string()];
+        let matcher = build_source_matcher(match_root, task_cwd, &sources);
+        assert!(is_source(
+            &matcher,
+            Path::new("/workspace/lib/shared/util.go")
+        ));
+        assert!(!is_source(&matcher, Path::new("/workspace/other.go")));
+    }
+
+    /// `glob` builds its results from the raw pattern, so a `../` source
+    /// enumerates paths that still contain `..`. They must survive the matcher
+    /// that no longer holds one.
+    #[test]
+    #[cfg(unix)]
+    fn matcher_accepts_enumerated_paths_containing_parent_dirs() {
+        let match_root = Path::new("/workspace");
+        let task_cwd = Path::new("/workspace/lib/worker");
+        let sources = vec!["../shared/**/*.go".to_string()];
+        let matcher = build_source_matcher(match_root, task_cwd, &sources);
+        assert!(is_source(
+            &matcher,
+            Path::new("/workspace/lib/worker/../shared/util.go")
+        ));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn matcher_parent_pattern_above_match_root_passes_through() {
+        let match_root = Path::new("/workspace");
+        let task_cwd = Path::new("/workspace/lib");
+        let sources = vec!["../../outside/**".to_string()];
+        let matcher = build_source_matcher(match_root, task_cwd, &sources);
+        assert!(is_source(&matcher, Path::new("/outside/x")));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn matcher_leaves_parent_dirs_that_would_collapse_a_glob() {
+        let root = Path::new("/workspace");
+        let sources = vec!["**/../x".to_string()];
+        let matcher = build_source_matcher(root, root, &sources);
+        assert!(!is_source(&matcher, Path::new("/workspace/x")));
+    }
+
+    /// `[task_config.input_groups]` anchors a group entry by joining it onto
+    /// the defining config's root without normalizing, so absolute patterns
+    /// reach the matcher with `..` still in them.
+    #[test]
+    #[cfg(unix)]
+    fn matcher_normalizes_absolute_pattern_with_parent_dirs() {
+        let root = Path::new("/workspace");
+        let sources = vec!["/workspace/lib/../shared/x".to_string()];
+        let matcher = build_source_matcher(root, root, &sources);
+        assert!(is_source(&matcher, Path::new("/workspace/shared/x")));
+    }
+
+    #[test]
+    fn lexical_normalize_resolves_dot_segments() {
+        assert_eq!(lexical_normalize(Path::new("../x")), PathBuf::from("../x"));
+        assert_eq!(
+            lexical_normalize(Path::new("a/b/../c")),
+            PathBuf::from("a/c")
+        );
+        assert_eq!(lexical_normalize(Path::new("./a")), PathBuf::from("a"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn lexical_normalize_stops_climbing_at_the_root() {
+        assert_eq!(lexical_normalize(Path::new("/a/../..")), PathBuf::from("/"));
     }
 
     #[test]


### PR DESCRIPTION
> Discussion: https://github.com/jdx/mise/discussions/11994

## What

`cache.audit = true` reports undeclared reads using a path string that is not a valid `sources` entry, so adding exactly what the audit printed does not silence it — and neither does the obvious `../`-relative form. Only an absolute `{{ config_root }}` pattern works, which nothing in the message points at, so following the audit's own output does not converge.

Establishes the property: **the string mise prints is a valid `sources` entry that matches the file it was printed for.**

Discussion: <link>

## Reproducing

Linux only — the audit is `#[cfg(target_os = "linux")]` end to end, and needs `strace` on `PATH` (under Docker, `--cap-add=SYS_PTRACE`). It also requires `settings.experimental`, explicit `outputs` (or `outputs = []`), and `mise run --force`, since a cached task does not execute and so emits no report. mise warns in the platform cases, but the report itself is just empty, so a run that never audited anything is easy to mistake for a clean one. A macOS run cannot reproduce this.

## Why it happens

Two symptoms, one gap between the audit's read scope (workspace root) and the directory a task runs from.

**Ambiguous display base.** `report()` renders a read inside the task root relative to the task root, and a read above it relative to the workspace root, indistinguishably. With a `node_modules` at both the repo root and inside a package, a read of either prints the same string — and that string names a path that is already declared.

**`..` is silently inert.** `normalize_pattern` anchors a relative entry by prepending the task-directory-relative prefix as a string, so `../node_modules/**` becomes `apps/ui/../node_modules/**`. globset treats `..` as an ordinary gitignore segment, so the entry can never match, with no diagnostic.

## What changed

- Relative `sources` entries stay task-directory-relative — the documented rule, unchanged, still pinned by `matcher_subproject_relative_pattern`. No new syntax.
- `normalize_pattern` resolves every pattern against the task directory, normalizes it lexically, then strips the match root, so `..` means what it says. A pattern resolving above the match root is returned unchanged; `is_source` already handles those absolute paths without the matcher.
- `is_source` and `is_output` normalize their candidate path in step. `glob` builds returned paths from the raw pattern, so a `../` source enumerates files whose paths still carry `..`; normalizing only the pattern would silently drop every one of them.
- The audit renders every reported path against the task directory, climbing with `..`. One base, always.
- `normalize_task_cwd` from #11987 now delegates to the shared lexical normalizer, keeping its distinct constraint — a `dir` of `.` must not normalize to an empty path.

## Notable consequences

The task dir is hashed into `task_state_key`, so `dir = "a/../b"` and `dir = "b"` previously kept two independent freshness baselines for a single directory. They now share one. This is not visible from the diff.

`[task_config.input_groups]` had the same latent `..` bug — `anchor_task_input` joins the group's root onto the entry without normalizing — and is fixed by the same change.

## Tests

- `e2e/tasks/test_task_artifact_cache_audit_anchoring` — two same-named `node_modules` files now print distinguishably; declaring the reported path silences exactly that read.
- `e2e/tasks/test_task_source_freshness_parent_relative` — a `../`-reaching source participates in freshness: fresh when unchanged, stale on edit, stale when a new file appears under the glob.
- 11 unit tests covering parent-relative anchoring, enumerated paths carrying `..`, patterns above the match root, the `**/../x` guard, absolute patterns with `..`, the display renderer, and the `.`-only task dir.

Both regression tests were verified non-vacuous by removing the fix and confirming they fail. Removing `lexical_normalize` from `is_source` leaves every unit test green while the e2e test fails at the edit step — a declared source changing while the task is skipped.

`#11987`'s `test_task_source_freshness_with_cwd` and `relative_sources_match_when_task_dir_starts_with_dot` pass unchanged.

## Out of scope

Writes above the task directory remain unreported, per the documented write scope. `MAX_REPORTED_PATHS` untouched.

---

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.232.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task source and output matching for relative paths, including parent-directory references such as `..`.
  * Fixed cache-audit reports so undeclared paths are shown relative to the task directory and can be used directly in source declarations.
  * Improved path handling for symlinked task directories and complex glob patterns.
* **Documentation**
  * Clarified relative path behavior and cache-audit reporting, including monorepo examples.
* **Tests**
  * Added coverage for parent-relative source freshness, cache-audit anchoring, and symlinked task directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->