### PR TITLE
feat(task): add task.cache.audit_report for the full audit report

### DIFF
--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -613,6 +613,17 @@ Audit mode requires `strace` on `PATH`. Mise warns and runs the task normally wh
 available; other platforms are not currently supported. Cached tasks are not executed and therefore
 produce no audit report, so use `mise run --force <task>` when checking an existing cache entry.
 
+Console warnings are limited to the first 20 paths per task, which is not enough to classify a task
+that reads thousands of undeclared files. Set
+[`task.cache.audit_report`](/configuration/settings.html#task-cache-audit-report) to also write every
+undeclared path as JSON Lines, one `{"task", "kind", "path"}` object per entry. The first audited
+task to execute truncates the file and later tasks append to it, so it covers every audited task
+that ran.
+
+```shell
+MISE_TASK_CACHE_AUDIT_REPORT=audit.jsonl mise run --force build
+```
+
 ```mise-toml
 [tasks.build]
 run = "npm run build"

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -616,9 +616,10 @@ produce no audit report, so use `mise run --force <task>` when checking an exist
 Console warnings are limited to the first 20 paths per task, which is not enough to classify a task
 that reads thousands of undeclared files. Set
 [`task.cache.audit_report`](/configuration/settings.html#task-cache-audit-report) to also write every
-undeclared path as JSON Lines, one `{"task", "kind", "path"}` object per entry. The first audited
-task to execute truncates the file and later tasks append to it, so it covers every audited task
-that ran.
+undeclared path as JSON Lines, one `{"task", "kind", "path"}` object per entry. Truncation happens
+once per `mise` invocation: the first audited task in each invocation truncates the file and later
+audited tasks in that invocation append to it, so one file holds that run's report for every audited
+task and a later run replaces it rather than adding to it.
 
 ```shell
 MISE_TASK_CACHE_AUDIT_REPORT=audit.jsonl mise run --force build

--- a/e2e/tasks/test_task_artifact_cache_audit_report
+++ b/e2e/tasks/test_task_artifact_cache_audit_report
@@ -54,11 +54,11 @@ cache = { enabled = true, audit = true }
 EOF
 
 for task in alpha beta; do
-	mkdir -p "$task"
-	printf 'declared\n' >"$task/declared.txt"
-	for i in $(seq 1 25); do
-		printf 'undeclared\n' >"$task/undeclared$i.txt"
-	done
+  mkdir -p "$task"
+  printf 'declared\n' >"$task/declared.txt"
+  for i in $(seq 1 25); do
+    printf 'undeclared\n' >"$task/undeclared$i.txt"
+  done
 done
 
 export PATH="$PWD/bin:$PATH"

--- a/e2e/tasks/test_task_artifact_cache_audit_report
+++ b/e2e/tasks/test_task_artifact_cache_audit_report
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
 mkdir -p bin
+# One fake strace serves both tasks; it is spawned in each task's directory, so
+# every task gets its own trace. The write it emits is a plain file so these
+# assertions do not depend on how directory writes are reported.
 cat <<'EOF' >bin/strace
 #!/usr/bin/env bash
 set -euo pipefail
@@ -26,6 +29,7 @@ fi
 for i in $(seq 1 25); do
   echo "123 openat(AT_FDCWD<$PWD>, \"undeclared$i.txt\", O_RDONLY) = 3" >>"$trace"
 done
+echo "123 openat(AT_FDCWD<$PWD>, \"generated.txt\", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 3" >>"$trace"
 exec "$@"
 EOF
 chmod +x bin/strace
@@ -34,29 +38,62 @@ cat <<'EOF' >mise.toml
 [settings]
 experimental = true
 
-[tasks.build]
-run = "mkdir -p dist && cat input.txt >dist/result.txt"
-sources = ["input.txt"]
-outputs = ["dist"]
+[tasks.alpha]
+dir = "alpha"
+run = "cat declared.txt >/dev/null"
+sources = ["declared.txt"]
+outputs = []
+cache = { enabled = true, audit = true }
+
+[tasks.beta]
+dir = "beta"
+run = "cat declared.txt >/dev/null"
+sources = ["declared.txt"]
+outputs = []
 cache = { enabled = true, audit = true }
 EOF
 
-printf 'declared\n' >input.txt
-for i in $(seq 1 25); do
-  printf 'undeclared\n' >"undeclared$i.txt"
+for task in alpha beta; do
+	mkdir -p "$task"
+	printf 'declared\n' >"$task/declared.txt"
+	for i in $(seq 1 25); do
+		printf 'undeclared\n' >"$task/undeclared$i.txt"
+	done
 done
 
-output=$(PATH="$PWD/bin:$PATH" mise run --force build 2>&1)
-count=$(grep -c 'cache audit detected undeclared read:' <<<"$output" || true)
-assert "echo $count" "20"
-assert_contains_text "$output" "cache audit omitted 5 additional paths"
+export PATH="$PWD/bin:$PATH"
+
+# Each task sees 25 undeclared reads and 1 undeclared write. Reads sort ahead of
+# writes, so all 20 console lines per task are reads and the write appears only
+# in the report file.
+output=$(mise run --jobs 2 --force alpha ::: beta 2>&1)
+reads=$(grep -c 'cache audit detected undeclared read:' <<<"$output" || true)
+assert "echo $reads" "40"
+assert_contains_text "$output" "task alpha cache audit omitted 6 additional paths"
+assert_contains_text "$output" "task beta cache audit omitted 6 additional paths"
+assert_not_contains_text "$output" "cache audit detected undeclared write:"
 assert_not_contains_text "$output" "full report written to"
 assert "test -e audit.jsonl && echo exists || echo missing" "missing"
 
-output=$(PATH="$PWD/bin:$PATH" MISE_TASK_CACHE_AUDIT_REPORT=audit.jsonl mise run --force build 2>&1)
-count=$(grep -c 'cache audit detected undeclared read:' <<<"$output" || true)
-assert "echo $count" "20"
-assert_contains_text "$output" "cache audit omitted 5 additional paths; full report written to audit.jsonl"
-assert "grep -c . audit.jsonl" "25"
-assert_contains "cat audit.jsonl" '{"task":"build","kind":"read","path":"undeclared1.txt"}'
-assert_contains "cat audit.jsonl" '{"task":"build","kind":"read","path":"undeclared9.txt"}'
+output=$(MISE_TASK_CACHE_AUDIT_REPORT=audit.jsonl mise run --jobs 2 --force alpha ::: beta 2>&1)
+reads=$(grep -c 'cache audit detected undeclared read:' <<<"$output" || true)
+assert "echo $reads" "40"
+assert_contains_text "$output" "task alpha cache audit omitted 6 additional paths; full report written to audit.jsonl"
+assert_contains_text "$output" "task beta cache audit omitted 6 additional paths; full report written to audit.jsonl"
+assert_not_contains_text "$output" "cache audit detected undeclared write:"
+
+# jq -s parses every line, so this fails if any record is malformed or if the
+# two tasks interleaved their blocks while running concurrently.
+assert "jq -s length audit.jsonl" "52"
+assert "jq -sr '[.[].task] | unique | join(\",\")' audit.jsonl" "alpha,beta"
+assert "jq -sr '[.[].kind] | unique | join(\",\")' audit.jsonl" "read,write"
+assert "jq -s '[.[] | select(.task == \"alpha\")] | length' audit.jsonl" "26"
+assert "jq -s '[.[] | select(.task == \"beta\")] | length' audit.jsonl" "26"
+assert "jq -sr '[.[] | select(.kind == \"write\")] | sort_by(.task) | map(.task + \":\" + .path) | join(\",\")' audit.jsonl" "alpha:generated.txt,beta:generated.txt"
+assert_contains "cat audit.jsonl" '{"task":"alpha","kind":"read","path":"undeclared1.txt"}'
+assert_contains "cat audit.jsonl" '{"task":"beta","kind":"read","path":"undeclared9.txt"}'
+
+# The first audited task of an invocation truncates, so a second run replaces the
+# report rather than appending to it.
+MISE_TASK_CACHE_AUDIT_REPORT=audit.jsonl mise run --jobs 2 --force alpha ::: beta >/dev/null 2>&1
+assert "jq -s length audit.jsonl" "52"

--- a/e2e/tasks/test_task_artifact_cache_audit_report
+++ b/e2e/tasks/test_task_artifact_cache_audit_report
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+mkdir -p bin
+cat <<'EOF' >bin/strace
+#!/usr/bin/env bash
+set -euo pipefail
+
+trace=
+while (($#)); do
+  case $1 in
+  -o)
+    trace=$2
+    shift 2
+    ;;
+  --)
+    shift
+    break
+    ;;
+  *) shift ;;
+  esac
+done
+if [[ -z $trace ]]; then
+  exec "$@"
+fi
+: >"$trace"
+for i in $(seq 1 25); do
+  echo "123 openat(AT_FDCWD<$PWD>, \"undeclared$i.txt\", O_RDONLY) = 3" >>"$trace"
+done
+exec "$@"
+EOF
+chmod +x bin/strace
+
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[tasks.build]
+run = "mkdir -p dist && cat input.txt >dist/result.txt"
+sources = ["input.txt"]
+outputs = ["dist"]
+cache = { enabled = true, audit = true }
+EOF
+
+printf 'declared\n' >input.txt
+for i in $(seq 1 25); do
+  printf 'undeclared\n' >"undeclared$i.txt"
+done
+
+output=$(PATH="$PWD/bin:$PATH" mise run --force build 2>&1)
+count=$(grep -c 'cache audit detected undeclared read:' <<<"$output" || true)
+assert "echo $count" "20"
+assert_contains_text "$output" "cache audit omitted 5 additional paths"
+assert_not_contains_text "$output" "full report written to"
+assert "test -e audit.jsonl && echo exists || echo missing" "missing"
+
+output=$(PATH="$PWD/bin:$PATH" MISE_TASK_CACHE_AUDIT_REPORT=audit.jsonl mise run --force build 2>&1)
+count=$(grep -c 'cache audit detected undeclared read:' <<<"$output" || true)
+assert "echo $count" "20"
+assert_contains_text "$output" "cache audit omitted 5 additional paths; full report written to audit.jsonl"
+assert "grep -c . audit.jsonl" "25"
+assert_contains "cat audit.jsonl" '{"task":"build","kind":"read","path":"undeclared1.txt"}'
+assert_contains "cat audit.jsonl" '{"task":"build","kind":"read","path":"undeclared9.txt"}'

--- a/e2e/tasks/test_task_artifact_cache_audit_report
+++ b/e2e/tasks/test_task_artifact_cache_audit_report
@@ -82,8 +82,8 @@ assert_contains_text "$output" "task alpha cache audit omitted 6 additional path
 assert_contains_text "$output" "task beta cache audit omitted 6 additional paths; full report written to audit.jsonl"
 assert_not_contains_text "$output" "cache audit detected undeclared write:"
 
-# jq -s parses every line, so this fails if any record is malformed or if the
-# two tasks interleaved their blocks while running concurrently.
+# jq -s parses every line, so this fails on a torn record. It does not detect
+# whole records from the two tasks alternating; the contiguity check below does.
 assert "jq -s length audit.jsonl" "52"
 assert "jq -sr '[.[].task] | unique | join(\",\")' audit.jsonl" "alpha,beta"
 assert "jq -sr '[.[].kind] | unique | join(\",\")' audit.jsonl" "read,write"
@@ -92,6 +92,18 @@ assert "jq -s '[.[] | select(.task == \"beta\")] | length' audit.jsonl" "26"
 assert "jq -sr '[.[] | select(.kind == \"write\")] | sort_by(.task) | map(.task + \":\" + .path) | join(\",\")' audit.jsonl" "alpha:generated.txt,beta:generated.txt"
 assert_contains "cat audit.jsonl" '{"task":"alpha","kind":"read","path":"undeclared1.txt"}'
 assert_contains "cat audit.jsonl" '{"task":"beta","kind":"read","path":"undeclared9.txt"}'
+
+# Each task writes its records as one block under a lock, so a task's records
+# must be contiguous. uniq collapses consecutive runs, leaving one line per
+# block: two blocks for two tasks, however the two happened to be ordered.
+assert "jq -r .task audit.jsonl | uniq | wc -l | tr -d ' '" "2"
+
+# That check is only meaningful if it can fail, so run it against a file that is
+# interleaved on purpose. Alternating every record leaves uniq nothing to
+# collapse, so a broken lock would report 52 blocks rather than 2.
+paste -d '\n' <(jq -c 'select(.task == "alpha")' audit.jsonl) <(jq -c 'select(.task == "beta")' audit.jsonl) >interleaved.jsonl
+assert "jq -s length interleaved.jsonl" "52"
+assert "jq -r .task interleaved.jsonl | uniq | wc -l | tr -d ' '" "52"
 
 # The first audited task of an invocation truncates, so a second run replaces the
 # report rather than appending to it.

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1813,6 +1813,10 @@
               "type": "object",
               "unevaluatedProperties": false,
               "properties": {
+                "audit_report": {
+                  "description": "[experimental] File to write the complete task cache audit report to.",
+                  "type": "string"
+                },
                 "remote_mode": {
                   "default": "read-write",
                   "description": "[experimental] Remote task and action cache access mode.",

--- a/settings.toml
+++ b/settings.toml
@@ -2733,9 +2733,11 @@ Write the complete report produced by [`cache.audit`](/tasks/task-configuration.
 file as JSON Lines, one `{"task", "kind", "path"}` object per undeclared path. Console warnings
 remain limited to the first 20 paths per task.
 
-The first audited task to execute truncates the file and later tasks append to it, so a single file
-covers every audited task that ran. Cached tasks do not execute and write nothing, leaving an
-earlier report in place. Relative paths resolve against mise's working directory.
+Truncation happens once per `mise` invocation: the first audited task in each invocation truncates
+the file and later audited tasks in that invocation append to it, so one file holds that run's
+report for every audited task and a later run replaces it rather than adding to it. Cached tasks do
+not execute and write nothing, leaving an earlier report in place. Relative paths resolve against
+mise's working directory.
 """
 env = "MISE_TASK_CACHE_AUDIT_REPORT"
 optional = true

--- a/settings.toml
+++ b/settings.toml
@@ -2726,6 +2726,21 @@ parse_env = "set_by_comma"
 rust_type = "BTreeSet<String>"
 type = "SetString"
 
+[task.cache.audit_report]
+description = "[experimental] File to write the complete task cache audit report to."
+docs = """
+Write the complete report produced by [`cache.audit`](/tasks/task-configuration.html#cache) to this
+file as JSON Lines, one `{"task", "kind", "path"}` object per undeclared path. Console warnings
+remain limited to the first 20 paths per task.
+
+The first audited task to execute truncates the file and later tasks append to it, so a single file
+covers every audited task that ran. Cached tasks do not execute and write nothing, leaving an
+earlier report in place. Relative paths resolve against mise's working directory.
+"""
+env = "MISE_TASK_CACHE_AUDIT_REPORT"
+optional = true
+type = "Path"
+
 [task.cache.remote_mode]
 default = "read-write"
 description = "[experimental] Remote task and action cache access mode."

--- a/src/task/task_cache_audit.rs
+++ b/src/task/task_cache_audit.rs
@@ -1,4 +1,4 @@
-use crate::config::Config;
+use crate::config::{Config, Settings};
 #[cfg(target_os = "linux")]
 use crate::file;
 use crate::task::Task;
@@ -8,13 +8,15 @@ use crate::task::task_source_checker::{
 };
 use eyre::Result;
 use ignore::overrides::Override;
+use serde::Serialize;
 use std::collections::BTreeSet;
 use std::ffi::OsString;
 use std::fs;
+use std::io::Write;
 use std::path::{Component, Path, PathBuf};
 #[cfg(target_os = "linux")]
 use std::process::Stdio;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tempfile::NamedTempFile;
 #[cfg(target_os = "linux")]
 use tokio::sync::OnceCell;
@@ -24,10 +26,31 @@ const MAX_REPORTED_PATHS: usize = 20;
 #[cfg(target_os = "linux")]
 static STRACE: OnceCell<Option<PathBuf>> = OnceCell::const_new();
 
+/// `true` once the report file has been truncated by this process: the first writer replaces a
+/// report left by an earlier run, every later writer appends to it. Audited tasks run in parallel
+/// and share one file, so each task's block is written under this lock to keep blocks intact.
+static REPORT_FILE: Mutex<bool> = Mutex::new(false);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum AccessKind {
     Read,
     Write,
+}
+
+impl AccessKind {
+    fn as_str(&self) -> &'static str {
+        match self {
+            AccessKind::Read => "read",
+            AccessKind::Write => "write",
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct ReportEntry<'a> {
+    task: &'a str,
+    kind: &'a str,
+    path: &'a str,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -160,23 +183,38 @@ impl TaskCacheAudit {
             }
         }
         let total = undeclared.len();
-        for (kind, path) in undeclared.into_iter().take(MAX_REPORTED_PATHS) {
-            let kind = match kind {
-                AccessKind::Read => "read",
-                AccessKind::Write => "write",
-            };
+        let mut report = Settings::get().task.cache.audit_report.clone();
+        if let Some(path) = &report
+            && let Err(err) = write_report(path, task, &undeclared)
+        {
             warn!(
-                "task {} cache audit detected undeclared {kind}: {}",
+                "task {} cache audit could not write its report to {}: {err}",
                 task.name,
+                path.display()
+            );
+            report = None;
+        }
+        for (kind, path) in undeclared.into_iter().take(MAX_REPORTED_PATHS) {
+            warn!(
+                "task {} cache audit detected undeclared {}: {}",
+                task.name,
+                kind.as_str(),
                 path.display()
             );
         }
         if total > MAX_REPORTED_PATHS {
-            warn!(
-                "task {} cache audit omitted {} additional paths",
-                task.name,
-                total - MAX_REPORTED_PATHS
-            );
+            let omitted = total - MAX_REPORTED_PATHS;
+            match &report {
+                Some(path) => warn!(
+                    "task {} cache audit omitted {omitted} additional paths; full report written to {}",
+                    task.name,
+                    path.display()
+                ),
+                None => warn!(
+                    "task {} cache audit omitted {omitted} additional paths",
+                    task.name
+                ),
+            }
         }
     }
 
@@ -194,6 +232,40 @@ impl TaskCacheAudit {
                 .strip_prefix(&self.source_root)
                 .is_ok_and(|relative| matches_override(&self.sources, relative))
     }
+}
+
+fn write_report(
+    path: &Path,
+    task: &Task,
+    undeclared: &BTreeSet<(AccessKind, PathBuf)>,
+) -> Result<()> {
+    let mut block = String::new();
+    for (kind, undeclared_path) in undeclared {
+        let undeclared_path = undeclared_path.to_string_lossy();
+        let entry = ReportEntry {
+            task: &task.name,
+            kind: kind.as_str(),
+            path: &undeclared_path,
+        };
+        block.push_str(&serde_json::to_string(&entry)?);
+        block.push('\n');
+    }
+    let mut truncated = REPORT_FILE.lock().unwrap_or_else(|err| err.into_inner());
+    let mut file = if *truncated {
+        fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)?
+    } else {
+        fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(path)?
+    };
+    file.write_all(block.as_bytes())?;
+    *truncated = true;
+    Ok(())
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
> Discussion: https://github.com/jdx/mise/discussions/11996

Adds `task.cache.audit_report`, an optional path that receives the complete cache-audit
report. Default behavior is unchanged.

## Problem

`cache.audit = true` reports filesystem accesses a task performs that aren't covered by its
`sources`/`outputs`. The reporter caps console output at 20 paths per task and then prints
only a count of the remainder:

```
mise WARN  task build cache audit detected undeclared read: data/file1.txt
... 19 more ...
mise WARN  task build cache audit omitted 80 additional paths
```

There is no way to see the omitted paths — no flag, no setting, no file. That makes the
audit unusable for the tasks that need it most. A Jest run over `node_modules` reports on
the order of 40,000 undeclared paths; enumerating them 20 at a time would take ~2,000 runs
with a declare-and-rerun loop between each.

What the cap drops is not a random sample. `undeclared` is a
`BTreeSet<(AccessKind, PathBuf)>` and `AccessKind::Read` orders before `Write`, so every
undeclared read sorts ahead of every undeclared write and `take(MAX_REPORTED_PATHS)` yields
reads first. A task with 20 or more undeclared reads shows **no undeclared writes at all**.
On a 100-file repro the console prints 20 lines, none of them writes, and reports `omitted 81
additional paths` — the one undeclared write is inside that remainder. Writes are the more
consequential half of a cache contract: an undeclared write makes a cached result wrong for
the next consumer, whereas an undeclared read mostly makes the key incomplete.

This PR mitigates that rather than fixing it. The report file contains every entry, so the
writes are recoverable — but the console is untouched and still shows zero writes by default
for such a task. Reserving part of the console budget for writes, or reporting the two kinds
separately, is a separate change and deliberately not made here.

## Change

Set `task.cache.audit_report` (env `MISE_TASK_CACHE_AUDIT_REPORT`) to a file path and mise
writes every undeclared path there as JSON Lines:

```
{"task":"build","kind":"read","path":"data/file1.txt"}
{"task":"build","kind":"write","path":"dist/out.txt"}
```

`path` is the same rendered string the console warning uses, so the file needs no separate
path convention and stays in step with however the audit chooses to render paths. A
companion change adjusts that rendering for accesses above the task directory; the two
compose with no changes here.

```shell
MISE_TASK_CACHE_AUDIT_REPORT=audit.jsonl mise run --force build
```

Console output stays capped at 20. The only console change is that the omitted-count
warning names the report file:

```
mise WARN  task build cache audit omitted 80 additional paths; full report written to audit.jsonl
```

## Default behavior is unchanged

Not asserted — measured. A binary was built from `main` and confirmed to predate the change
by the fact that it rejects the new key outright:

```
main:        $ mise settings get task.cache.audit_report
             Error: Unknown setting: task.cache.audit_report
this branch: $ mise settings get task.cache.audit_report
             Error: Setting [task.cache.audit_report] is not set
```

Both binaries were then run against the same 100-file repro with the setting unset, and
their audit output diffed:

```
$ diff base.log new-default.log
$                       # empty — byte-identical, 20 warnings then "omitted 80 additional paths"
```

## Semantics

**One file per invocation.** The first audited task to execute truncates the file; later
tasks append. A run therefore replaces any earlier run's report rather than growing one
without bound. Cached tasks do not execute and write nothing, so a cache-hit run leaves the
previous report in place — consistent with the existing rule that cached tasks produce no
audit report at all.

**Every entry is tagged by task**, so one file covers all audited tasks in a run and stays
attributable. Concurrency is safe: each task serializes its whole block through one lock, so
blocks from tasks running in parallel cannot interleave.

**Writing is advisory.** A write failure warns and continues, and clears the report path so
the omitted-count warning cannot name a file that was not written. The audit must never fail
the task.

## Design notes

**A report file rather than a higher cap.** The obvious alternative is a
`task.cache.audit_max_paths` knob. It answers the title but not the problem: 40k lines
through `warn!` interleave with the task's own output and force the user to strip the
`mise WARN ` prefix back off before the list is usable. A file supersedes it — anyone who
wants more than 20 lines can read the file — so shipping both would be two knobs for one job.

**JSON Lines rather than a delimited format.** Paths can contain tabs, newlines and quotes;
this module has a test (`parses_escaped_quoted_paths`) for exactly the `a"b` case. Any
delimiter is lossy on the inputs the parser is built to handle. JSONL is the smallest
lossless option, and the file exists to be machine-consumed — the point is turning 40k
entries into `sources` declarations.

**A setting rather than a `mise run` flag.** A setting gets the env var for free, which is
what CI wants, and it still works when `mise run` is invoked indirectly.

**Non-UTF-8 paths are rendered lossily**, with invalid sequences replaced by U+FFFD, so such
a path will not round-trip back to a real file. This matches the existing console output,
which formats the same path with `Path::display()` and is lossy in exactly the same way — the
file is no less faithful than the warnings it replaces, and diverging here would mean two
renderings of the same path in the same run.

**Dotted `[task.cache.audit_report]`, with no flat `task.cache_audit_report` alias.** The
flat `task.cache_*` family is not a parallel form new settings are expected to appear in.
All six `task.cache_remote_*` entries are back-compat shims for settings that used to be
flat — each carries `deprecated = "Use task.cache.<x> instead."`, `hide = true`,
`deprecated_warn_at = "2027.2.0"` and `deprecated_remove_at = "2027.8.0"`, with migration
glue in `src/config/settings.rs` and a test named
`test_task_cache_hidden_aliases_map_to_nested_settings`. The flat entries that are canonical
(`task.cache_dir`, `task.cache_max_age`, `task.cache_max_size`) simply have no dotted twin
and were never migrated. Adding a flat alias for a brand-new setting would mean shipping a
pre-deprecated alias for a name that never existed.

## Testing

New e2e test `e2e/tasks/test_task_artifact_cache_audit_report`, following the existing
`test_task_artifact_cache_audit` pattern (fake `strace` on `PATH` emitting a synthetic
trace, so it needs no real strace). It emits 25 undeclared reads and asserts that the
default run prints exactly 20 lines plus `omitted 5 additional paths` and creates no file,
and that with the setting the console is still exactly 20 lines while the file holds all 25
entries.

Also verified by hand against real `strace` on Linux: 100 undeclared reads produce 20
console lines and a 100-entry report; two audited tasks in one invocation land in one file
correctly tagged; a re-run truncates rather than appends; four tasks at `--jobs 4` produce
800 entries with no interleaving; an unwritable report path warns and the task still exits
0; and relative paths resolve against mise's working directory, including under `--cd`.

`cargo clippy --workspace --all-features --all-targets -- -D warnings` passes with no
`#[allow]`/`#[expect]`/`-A` exclusions. `schema/mise.json` regenerated with
`mise run render:schema`.

The single undeclared write in that 100-file run turned out to be a genuine false positive in
the audit — a task's own declared output *directory*, reported on the run that creates it,
because the reporter skips directory reads but has no equivalent skip for directory writes.
It is reported separately and not addressed here; it is noted only because it had been sitting
inside the truncated remainder, invisible on the console, since the audit was introduced.

---

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.232.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `task.cache.audit_report` setting to write complete cache-audit results to a JSON Lines file.
  * Reports include the task, access type, and path for all undeclared accesses.
  * Supports configuration files or the `MISE_TASK_CACHE_AUDIT_REPORT` environment variable.
  * Reports accumulate results across audited tasks, while cached tasks leave the file unchanged.
  * Console warnings continue to be truncated when a full report is enabled.

* **Documentation**
  * Added configuration guidance and usage examples for audit reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->