### PR TITLE
fix(task): preserve Git task snapshots

### DIFF
--- a/e2e/helpers/scripts/git_http_backend_server.py
+++ b/e2e/helpers/scripts/git_http_backend_server.py
@@ -14,8 +14,9 @@ import socketserver
 from pathlib import Path
 
 class GitHTTPHandler(http.server.BaseHTTPRequestHandler):
-    def __init__(self, *args, repo_dir=None, **kwargs):
+    def __init__(self, *args, repo_dir=None, upload_pack_count_file=None, **kwargs):
         self.repo_dir = repo_dir
+        self.upload_pack_count_file = upload_pack_count_file
         super().__init__(*args, **kwargs)
 
     def do_GET(self):
@@ -46,6 +47,14 @@ class GitHTTPHandler(http.server.BaseHTTPRequestHandler):
         # Read request body for POST
         content_length = int(self.headers.get('Content-Length', 0))
         request_body = self.rfile.read(content_length) if content_length > 0 else b''
+
+        if (
+            self.command == 'POST'
+            and path_info.endswith('/git-upload-pack')
+            and self.upload_pack_count_file is not None
+        ):
+            with self.upload_pack_count_file.open('a') as count_file:
+                count_file.write('1\n')
 
         # Set content type if provided
         if 'Content-Type' in self.headers:
@@ -119,6 +128,33 @@ def create_test_repo(repo_path):
     remote_task_file.write_text('#!/usr/bin/env bash\necho "remote task executed"\n')
     remote_task_file.chmod(0o755)
 
+    snapshot_root = Path(repo_path) / 'xtasks' / 'snapshot'
+    snapshot_parent = snapshot_root / 'parent' / 'snapshot_parent'
+    snapshot_parent.parent.mkdir(parents=True)
+    snapshot_parent.write_text(
+        '#!/usr/bin/env bash\n'
+        '#MISE depends=["snapshot_child"]\n'
+        'echo "snapshot parent checkout: ${0%%/xtasks/*}"\n'
+    )
+    snapshot_parent.chmod(0o755)
+
+    snapshot_child = snapshot_root / 'child' / 'snapshot_child'
+    snapshot_child.parent.mkdir(parents=True)
+    snapshot_child.write_text(
+        '#!/usr/bin/env bash\n'
+        'echo "snapshot child checkout: ${0%%/xtasks/*}"\n'
+    )
+    snapshot_child.chmod(0o755)
+
+    snapshot_failure = snapshot_root / 'failure' / 'snapshot_failure'
+    snapshot_failure.parent.mkdir(parents=True)
+    snapshot_failure.write_text(
+        '#!/usr/bin/env bash\n'
+        'echo "snapshot failure"\n'
+        'exit 1\n'
+    )
+    snapshot_failure.chmod(0o755)
+
     # A toml task file colocated with the executable scripts. Keys are task
     # names; values are the run command (or a table). Used by tests covering
     # remote toml task includes.
@@ -165,13 +201,23 @@ def start_server(port=0):
     # Create temp directory
     temp_dir = Path(tempfile.mkdtemp(prefix='mise_git_http_'))
     repo_path = temp_dir / 'repo'
+    upload_pack_count_path = os.environ.get('MISE_GIT_HTTP_UPLOAD_PACK_COUNT_FILE')
+    upload_pack_count_file = Path(upload_pack_count_path) if upload_pack_count_path else None
+    if upload_pack_count_file is not None:
+        upload_pack_count_file.parent.mkdir(parents=True, exist_ok=True)
+        upload_pack_count_file.write_text('')
 
     print(f"Creating test repository at {repo_path}")
     create_test_repo(str(repo_path))
 
     # Create handler with repo directory
     def handler(*args, **kwargs):
-        return GitHTTPHandler(*args, repo_dir=temp_dir, **kwargs)
+        return GitHTTPHandler(
+            *args,
+            repo_dir=temp_dir,
+            upload_pack_count_file=upload_pack_count_file,
+            **kwargs,
+        )
 
     # Let the OS assign an available port if port=0
     # This avoids race conditions between finding and binding
@@ -206,6 +252,8 @@ def start_server(port=0):
             port_file.unlink(missing_ok=True)
             info_file.unlink(missing_ok=True)
             ready_file.unlink(missing_ok=True)
+            if upload_pack_count_file is not None:
+                upload_pack_count_file.unlink(missing_ok=True)
 
 if __name__ == '__main__':
     port = int(sys.argv[1]) if len(sys.argv) > 1 else 0

--- a/e2e/tasks/test_task_remote_git_includes
+++ b/e2e/tasks/test_task_remote_git_includes
@@ -194,7 +194,7 @@ EOF
 
 ARTIFACT_TMPDIR="$TMPDIR/remote-git-artifacts"
 mkdir -p "$ARTIFACT_TMPDIR"
-output=$(quiet_assert_succeed "TMPDIR=$ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run remote_git_a ::: remote_git_b")
+output=$(quiet_assert_succeed "TMPDIR=$ARTIFACT_TMPDIR MISE_GIX=0 MISE_TASK_REMOTE_NO_CACHE=true mise run remote_git_a ::: remote_git_b")
 path_count=$(grep -o 'snapshot child checkout: .*' <<<"$output" | sort -u | wc -l)
 [[ $path_count -eq 2 ]] || fail "no-cache Git tasks did not retain two distinct snapshots"
 assert_directory_empty "$ARTIFACT_TMPDIR"
@@ -220,7 +220,7 @@ upload_packs_after=$(wc -l <"$UPLOAD_PACK_COUNT_FILE")
 assert_contains_text "$output" "snapshot parent checkout:"
 assert_contains_text "$output" "snapshot child checkout:"
 snapshot_checkout_count=$(
-  grep -o 'snapshot \(parent\|child\) checkout: .*' <<<"$output" |
+  grep -Eo 'snapshot (parent|child) checkout: .*' <<<"$output" |
     sed 's/snapshot [^ ]* checkout: //' |
     sort -u |
     wc -l

--- a/e2e/tasks/test_task_remote_git_includes
+++ b/e2e/tasks/test_task_remote_git_includes
@@ -7,14 +7,16 @@
 PORT_FILE="$TMPDIR/mise_git_http_port"
 READY_FILE="$TMPDIR/mise_git_http_ready"
 INFO_FILE="$TMPDIR/mise_git_http_info"
+UPLOAD_PACK_COUNT_FILE="$TMPDIR/mise_git_http_upload_pack_count"
 
 # Clean up any previous server files
-rm -f "$PORT_FILE" "$READY_FILE" "$INFO_FILE"
+rm -f "$PORT_FILE" "$READY_FILE" "$INFO_FILE" "$UPLOAD_PACK_COUNT_FILE"
 
 # Start local git HTTP server with OS-assigned port to avoid race conditions
 MISE_GIT_HTTP_PORT_FILE="$PORT_FILE" \
   MISE_GIT_HTTP_READY_FILE="$READY_FILE" \
   MISE_GIT_HTTP_INFO_FILE="$INFO_FILE" \
+  MISE_GIT_HTTP_UPLOAD_PACK_COUNT_FILE="$UPLOAD_PACK_COUNT_FILE" \
   python3 "${TEST_ROOT}/helpers/scripts/git_http_backend_server.py" 0 &
 SERVER_PID=$!
 
@@ -50,7 +52,7 @@ git init
 # Ensure cleanup on exit
 cleanup() {
   kill "$SERVER_PID" 2>/dev/null || true
-  rm -f "$PORT_FILE" "$READY_FILE" "$INFO_FILE"
+  rm -f "$PORT_FILE" "$READY_FILE" "$INFO_FILE" "$UPLOAD_PACK_COUNT_FILE"
 }
 trap cleanup EXIT
 
@@ -103,7 +105,10 @@ includes = [
 ]
 EOF
 
-assert_succeed "MISE_TASK_REMOTE_NO_CACHE=true mise run remote-task" # Remote task should be redownloaded
+INCLUDE_ARTIFACT_TMPDIR="$TMPDIR/remote-git-include-artifacts"
+mkdir -p "$INCLUDE_ARTIFACT_TMPDIR"
+assert_succeed "TMPDIR=$INCLUDE_ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run remote-task" # Remote task should be redownloaded
+assert_directory_empty "$INCLUDE_ARTIFACT_TMPDIR"
 assert_directory_not_exists "${REMOTE_TASKS_DIR}"
 
 assert_succeed "mise run remote-task" # Cache should be used
@@ -174,5 +179,88 @@ EOF
 
 assert_contains "mise tasks" "standalone_task"
 assert_contains "mise run standalone_task" "standalone_task executed"
+
+#################################################################################
+# Test no-cache Git task snapshots
+#################################################################################
+
+cat <<EOF >mise.toml
+[tasks.remote_git_a]
+file = "git::${LOCAL_GIT_URL}//xtasks/snapshot/child/snapshot_child"
+
+[tasks.remote_git_b]
+file = "git::${LOCAL_GIT_URL}//xtasks/snapshot/child/snapshot_child"
+EOF
+
+ARTIFACT_TMPDIR="$TMPDIR/remote-git-artifacts"
+mkdir -p "$ARTIFACT_TMPDIR"
+output=$(quiet_assert_succeed "TMPDIR=$ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run remote_git_a ::: remote_git_b")
+path_count=$(grep -o 'snapshot child checkout: .*' <<<"$output" | sort -u | wc -l)
+[[ $path_count -eq 2 ]] || fail "no-cache Git tasks did not retain two distinct snapshots"
+assert_directory_empty "$ARTIFACT_TMPDIR"
+
+#################################################################################
+# Test one coherent no-cache Git include snapshot per command
+#################################################################################
+
+cat <<EOF >mise.toml
+[task_config]
+includes = [
+    "git::${LOCAL_GIT_URL}//xtasks/snapshot/parent?ref=v2025.1.17",
+    "git::${LOCAL_GIT_URL}//xtasks/snapshot/child?ref=v2025.1.17",
+    "git::${LOCAL_GIT_URL}//xtasks/snapshot/failure?ref=v2025.1.17"
+]
+EOF
+
+upload_packs_before=$(wc -l <"$UPLOAD_PACK_COUNT_FILE")
+output=$(quiet_assert_succeed "TMPDIR=$ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run snapshot_parent")
+upload_packs_after=$(wc -l <"$UPLOAD_PACK_COUNT_FILE")
+[[ $((upload_packs_after - upload_packs_before)) -eq 1 ]] ||
+  fail "one command cloned the same Git repository/ref more than once"
+assert_contains_text "$output" "snapshot parent checkout:"
+assert_contains_text "$output" "snapshot child checkout:"
+snapshot_checkout_count=$(
+  grep -o 'snapshot \(parent\|child\) checkout: .*' <<<"$output" |
+    sed 's/snapshot [^ ]* checkout: //' |
+    sort -u |
+    wc -l
+)
+[[ $snapshot_checkout_count -eq 1 ]] || fail "one command mixed multiple Git include snapshots"
+assert_directory_empty "$ARTIFACT_TMPDIR"
+
+#################################################################################
+# Test cleanup after an ordinary task-loading error
+#################################################################################
+
+cat <<EOF >mise.toml
+[task_config]
+includes = [
+    "git::${LOCAL_GIT_URL}//xtasks/lint?ref=v2025.1.17",
+    "git::${LOCAL_GIT_URL}//xtasks/missing?ref=v2025.1.17"
+]
+EOF
+
+assert_fail "TMPDIR=$ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise tasks"
+assert_directory_empty "$ARTIFACT_TMPDIR"
+
+#################################################################################
+# Test cleanup after a requested nonzero exit
+#################################################################################
+
+cat <<EOF >mise.toml
+[task_config]
+includes = [
+    "git::${LOCAL_GIT_URL}//xtasks/snapshot/failure?ref=v2025.1.17"
+]
+EOF
+
+assert_fail "TMPDIR=$ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run snapshot_failure"
+# A failed run may leave its unrelated tempfile::tempdir (`.tmp*`) for the e2e
+# harness; the command-scoped remote checkout itself must be gone.
+for artifact in "$ARTIFACT_TMPDIR"/* "$ARTIFACT_TMPDIR"/.[!.]* "$ARTIFACT_TMPDIR"/..?*; do
+  [[ -e $artifact || -L $artifact ]] || continue
+  artifact_name=${artifact##*/}
+  [[ $artifact_name == .tmp* ]] || fail "unexpected remote task artifact remains: $artifact"
+done
 
 echo "All tests passed!"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4505,9 +4505,7 @@ async fn resolve_git_url_to_path(git_url: &str) -> Result<TaskFileArtifact> {
 
     let artifact = checkout.with_path(checkout.path.join(source.path));
     let metadata = artifact.path.symlink_metadata()?;
-    if metadata.file_type().is_file() {
-        file::make_executable(&artifact.path)?;
-    } else if !metadata.file_type().is_dir() {
+    if !metadata.file_type().is_file() && !metadata.file_type().is_dir() {
         bail!(
             "remote task path is not a regular file or directory: {}",
             display_path(&artifact.path)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -28,8 +28,9 @@ use crate::config::env_directive::{EnvResolveOptions, EnvResults, ToolsFilter};
 use crate::config::tracking::Tracker;
 use crate::env::{MISE_DEFAULT_CONFIG_FILENAME, MISE_DEFAULT_TOOL_VERSIONS_FILENAME};
 use crate::file::display_path;
+use crate::remote_source::RemoteSource;
 use crate::shorthands::{Shorthands, get_shorthands};
-use crate::task::task_file_providers::TaskFileProvidersBuilder;
+use crate::task::task_file_providers::{TaskFileArtifact, TaskFileProvidersBuilder};
 use crate::task::task_sources::TaskOutputs;
 use crate::task::{
     RunEntry, Task, TaskCacheConfig, TaskRustCacheConfig, TaskTemplate, monorepo_scope,
@@ -62,6 +63,26 @@ use crate::wildcard::Wildcard;
 type AliasMap = IndexMap<String, Alias>;
 pub(crate) type ConfigMap = IndexMap<PathBuf, Arc<dyn ConfigFile>>;
 pub type EnvWithSources = IndexMap<String, (String, PathBuf)>;
+type RemoteTaskIncludeKey = (String, Option<String>);
+type RemoteTaskIncludeArtifacts = DashMap<RemoteTaskIncludeKey, Arc<OnceCell<TaskFileArtifact>>>;
+static REMOTE_TASK_INCLUDE_ARTIFACTS: Lazy<RemoteTaskIncludeArtifacts> = Lazy::new(DashMap::new);
+
+pub(crate) fn clear_remote_task_include_artifacts() {
+    REMOTE_TASK_INCLUDE_ARTIFACTS.clear();
+}
+
+#[cfg(test)]
+pub(crate) fn insert_remote_task_include_artifact_for_test() {
+    REMOTE_TASK_INCLUDE_ARTIFACTS.insert(
+        ("https://example.test/repo.git".into(), None),
+        Arc::new(OnceCell::new()),
+    );
+}
+
+#[cfg(test)]
+pub(crate) fn remote_task_include_artifact_count_for_test() -> usize {
+    REMOTE_TASK_INCLUDE_ARTIFACTS.len()
+}
 
 pub(crate) struct MonorepoUnion {
     pub config_files: ConfigMap,
@@ -4434,16 +4455,49 @@ fn is_mise_config_file_in_task_include(root: &Path, path: &Path) -> bool {
     })
 }
 
-async fn resolve_git_url_to_path(git_url: &str) -> Result<PathBuf> {
+async fn resolve_git_url_to_path(git_url: &str) -> Result<TaskFileArtifact> {
     let no_cache = Settings::get().task.remote_no_cache.unwrap_or(false);
-    let task_file_providers = TaskFileProvidersBuilder::new()
-        .with_cache(!no_cache)
-        .build();
-
-    match task_file_providers.get_provider(git_url) {
-        Some(provider) => provider.get_local_path(git_url).await,
-        None => bail!("No provider found for git URL: {}", git_url),
+    if !no_cache {
+        let task_file_providers = TaskFileProvidersBuilder::new().with_cache(true).build();
+        return match task_file_providers.get_provider(git_url) {
+            Some(provider) => provider.get_local_artifact(git_url).await,
+            None => bail!("No provider found for git URL: {}", git_url),
+        };
     }
+
+    let source = RemoteSource::parse_git(git_url)
+        .ok_or_else(|| eyre!("No provider found for git URL: {}", git_url))?;
+    let cache_key = (source.url.clone(), source.git_ref.clone());
+    let checkout = REMOTE_TASK_INCLUDE_ARTIFACTS
+        .entry(cache_key)
+        .or_insert_with(|| Arc::new(OnceCell::new()))
+        .clone();
+    let checkout = checkout
+        .get_or_try_init(|| async {
+            let task_file_providers = TaskFileProvidersBuilder::new().with_cache(false).build();
+            let provider = task_file_providers
+                .get_provider(git_url)
+                .ok_or_else(|| eyre!("No provider found for git URL: {}", git_url))?;
+            let artifact = provider.get_local_artifact(git_url).await?;
+            let checkout_path = artifact
+                .cleanup_path()
+                .ok_or_else(|| eyre!("no cleanup path for no-cache Git task include"))?
+                .to_path_buf();
+            Ok::<TaskFileArtifact, eyre::Report>(artifact.with_path(checkout_path))
+        })
+        .await?;
+
+    let artifact = checkout.with_path(checkout.path.join(source.path));
+    let metadata = artifact.path.symlink_metadata()?;
+    if metadata.file_type().is_file() {
+        file::make_executable(&artifact.path)?;
+    } else if !metadata.file_type().is_dir() {
+        bail!(
+            "remote task path is not a regular file or directory: {}",
+            display_path(&artifact.path)
+        );
+    }
+    Ok(artifact)
 }
 
 /// Check if a pattern contains glob metacharacters
@@ -4869,12 +4923,16 @@ async fn load_task_sources_from_configs(
         None
     };
     for include in &includes {
-        let paths = if include.starts_with("git::") {
+        let artifacts = if include.starts_with("git::") {
             vec![resolve_git_url_to_path(include).await?]
         } else {
             expand_task_include(&resolve_dir, include)
+                .into_iter()
+                .map(TaskFileArtifact::persistent)
+                .collect()
         };
-        for p in paths {
+        for artifact in artifacts {
+            let p = artifact.path;
             let mut loaded = load_tasks_includes(
                 config,
                 &p,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -30,9 +30,7 @@ use crate::env::{MISE_DEFAULT_CONFIG_FILENAME, MISE_DEFAULT_TOOL_VERSIONS_FILENA
 use crate::file::display_path;
 use crate::remote_source::RemoteSource;
 use crate::shorthands::{Shorthands, get_shorthands};
-use crate::task::task_file_providers::{
-    TaskFileArtifact, TaskFileProvidersBuilder, prepare_remote_git_path,
-};
+use crate::task::task_file_providers::{TaskFileArtifact, TaskFileProvidersBuilder};
 use crate::task::task_sources::TaskOutputs;
 use crate::task::{
     RunEntry, Task, TaskCacheConfig, TaskRustCacheConfig, TaskTemplate, monorepo_scope,
@@ -4505,7 +4503,15 @@ async fn resolve_git_url_to_path(git_url: &str) -> Result<TaskFileArtifact> {
         .await?;
 
     let artifact = checkout.with_path(checkout.path.join(source.path));
-    prepare_remote_git_path(&checkout.path, &artifact.path)?;
+    let metadata = artifact.path.symlink_metadata()?;
+    if metadata.file_type().is_file() {
+        file::make_executable(&artifact.path)?;
+    } else if !metadata.file_type().is_dir() {
+        bail!(
+            "remote task path is not a regular file or directory: {}",
+            display_path(&artifact.path)
+        );
+    }
     Ok(artifact)
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -30,7 +30,9 @@ use crate::env::{MISE_DEFAULT_CONFIG_FILENAME, MISE_DEFAULT_TOOL_VERSIONS_FILENA
 use crate::file::display_path;
 use crate::remote_source::RemoteSource;
 use crate::shorthands::{Shorthands, get_shorthands};
-use crate::task::task_file_providers::{TaskFileArtifact, TaskFileProvidersBuilder};
+use crate::task::task_file_providers::{
+    TaskFileArtifact, TaskFileProvidersBuilder, prepare_remote_git_path,
+};
 use crate::task::task_sources::TaskOutputs;
 use crate::task::{
     RunEntry, Task, TaskCacheConfig, TaskRustCacheConfig, TaskTemplate, monorepo_scope,
@@ -67,8 +69,23 @@ type RemoteTaskIncludeKey = (String, Option<String>);
 type RemoteTaskIncludeArtifacts = DashMap<RemoteTaskIncludeKey, Arc<OnceCell<TaskFileArtifact>>>;
 static REMOTE_TASK_INCLUDE_ARTIFACTS: Lazy<RemoteTaskIncludeArtifacts> = Lazy::new(DashMap::new);
 
+#[cfg(test)]
 pub(crate) fn clear_remote_task_include_artifacts() {
-    REMOTE_TASK_INCLUDE_ARTIFACTS.clear();
+    drop(take_remote_task_include_artifacts());
+}
+
+pub(crate) fn take_remote_task_include_artifacts() -> Vec<Arc<OnceCell<TaskFileArtifact>>> {
+    let keys = REMOTE_TASK_INCLUDE_ARTIFACTS
+        .iter()
+        .map(|entry| entry.key().clone())
+        .collect_vec();
+    keys.into_iter()
+        .filter_map(|key| {
+            REMOTE_TASK_INCLUDE_ARTIFACTS
+                .remove(&key)
+                .map(|(_, artifact)| artifact)
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -4488,15 +4505,7 @@ async fn resolve_git_url_to_path(git_url: &str) -> Result<TaskFileArtifact> {
         .await?;
 
     let artifact = checkout.with_path(checkout.path.join(source.path));
-    let metadata = artifact.path.symlink_metadata()?;
-    if metadata.file_type().is_file() {
-        file::make_executable(&artifact.path)?;
-    } else if !metadata.file_type().is_dir() {
-        bail!(
-            "remote task path is not a regular file or directory: {}",
-            display_path(&artifact.path)
-        );
-    }
+    prepare_remote_git_path(&checkout.path, &artifact.path)?;
     Ok(artifact)
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -67,11 +67,6 @@ type RemoteTaskIncludeKey = (String, Option<String>);
 type RemoteTaskIncludeArtifacts = DashMap<RemoteTaskIncludeKey, Arc<OnceCell<TaskFileArtifact>>>;
 static REMOTE_TASK_INCLUDE_ARTIFACTS: Lazy<RemoteTaskIncludeArtifacts> = Lazy::new(DashMap::new);
 
-#[cfg(test)]
-pub(crate) fn clear_remote_task_include_artifacts() {
-    drop(take_remote_task_include_artifacts());
-}
-
 pub(crate) fn take_remote_task_include_artifacts() -> Vec<Arc<OnceCell<TaskFileArtifact>>> {
     let keys = REMOTE_TASK_INCLUDE_ARTIFACTS
         .iter()
@@ -87,16 +82,22 @@ pub(crate) fn take_remote_task_include_artifacts() -> Vec<Arc<OnceCell<TaskFileA
 }
 
 #[cfg(test)]
-pub(crate) fn insert_remote_task_include_artifact_for_test() {
-    REMOTE_TASK_INCLUDE_ARTIFACTS.insert(
-        ("https://example.test/repo.git".into(), None),
-        Arc::new(OnceCell::new()),
-    );
-}
+mod remote_task_include_tests {
+    use super::*;
 
-#[cfg(test)]
-pub(crate) fn remote_task_include_artifact_count_for_test() -> usize {
-    REMOTE_TASK_INCLUDE_ARTIFACTS.len()
+    #[test]
+    fn take_remote_task_include_artifacts_drains_cache() {
+        drop(take_remote_task_include_artifacts());
+        REMOTE_TASK_INCLUDE_ARTIFACTS.insert(
+            ("https://example.test/repo.git".into(), None),
+            Arc::new(OnceCell::new()),
+        );
+
+        let artifacts = take_remote_task_include_artifacts();
+
+        assert!(REMOTE_TASK_INCLUDE_ARTIFACTS.is_empty());
+        assert_eq!(artifacts.len(), 1);
+    }
 }
 
 pub(crate) struct MonorepoUnion {

--- a/src/remote_source.rs
+++ b/src/remote_source.rs
@@ -60,13 +60,9 @@ impl RemoteSource {
 fn parse_git_with(regex: &Regex, file: &str) -> Option<RemoteGitSource> {
     let captures = regex.captures(file)?;
     let path = captures.name("path").unwrap().as_str();
-    let mut components = path.split('/');
-    let first = components.next()?;
-    if path.contains('\\')
-        || is_windows_drive_component(first)
-        || std::iter::once(first)
-            .chain(components)
-            .any(|component| component.is_empty() || component == "." || component == "..")
+    if path
+        .split('/')
+        .any(|component| component.is_empty() || component == "." || component == "..")
     {
         return None;
     }
@@ -75,11 +71,6 @@ fn parse_git_with(regex: &Regex, file: &str) -> Option<RemoteGitSource> {
         path: path.to_string(),
         git_ref: captures.name("ref").map(|m| m.as_str().to_string()),
     })
-}
-
-fn is_windows_drive_component(component: &str) -> bool {
-    let bytes = component.as_bytes();
-    bytes.len() == 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
 }
 
 #[cfg(test)]
@@ -151,15 +142,6 @@ mod tests {
         assert!(
             RemoteSource::parse_git("git::https://myserver.com/example.git//plugin/./other")
                 .is_none()
-        );
-        assert!(
-            RemoteSource::parse_git("git::https://myserver.com/example.git//..\\outside").is_none()
-        );
-        assert!(
-            RemoteSource::parse_git("git::https://myserver.com/example.git//C:/outside").is_none()
-        );
-        assert!(
-            RemoteSource::parse_git("git::https://myserver.com/example.git//C:\\outside").is_none()
         );
     }
 

--- a/src/remote_source.rs
+++ b/src/remote_source.rs
@@ -60,9 +60,13 @@ impl RemoteSource {
 fn parse_git_with(regex: &Regex, file: &str) -> Option<RemoteGitSource> {
     let captures = regex.captures(file)?;
     let path = captures.name("path").unwrap().as_str();
-    if path
-        .split('/')
-        .any(|component| component.is_empty() || component == "." || component == "..")
+    let mut components = path.split('/');
+    let first = components.next()?;
+    if path.contains('\\')
+        || is_windows_drive_component(first)
+        || std::iter::once(first)
+            .chain(components)
+            .any(|component| component.is_empty() || component == "." || component == "..")
     {
         return None;
     }
@@ -71,6 +75,11 @@ fn parse_git_with(regex: &Regex, file: &str) -> Option<RemoteGitSource> {
         path: path.to_string(),
         git_ref: captures.name("ref").map(|m| m.as_str().to_string()),
     })
+}
+
+fn is_windows_drive_component(component: &str) -> bool {
+    let bytes = component.as_bytes();
+    bytes.len() == 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
 }
 
 #[cfg(test)]
@@ -142,6 +151,15 @@ mod tests {
         assert!(
             RemoteSource::parse_git("git::https://myserver.com/example.git//plugin/./other")
                 .is_none()
+        );
+        assert!(
+            RemoteSource::parse_git("git::https://myserver.com/example.git//..\\outside").is_none()
+        );
+        assert!(
+            RemoteSource::parse_git("git::https://myserver.com/example.git//C:/outside").is_none()
+        );
+        assert!(
+            RemoteSource::parse_git("git::https://myserver.com/example.git//C:\\outside").is_none()
         );
     }
 

--- a/src/task/task_fetcher.rs
+++ b/src/task/task_fetcher.rs
@@ -178,7 +178,6 @@ mod tests {
         let _test_lock = REMOTE_TASK_ARTIFACT_TEST_LOCK.lock().await;
         assert_eq!(*REMOTE_TASK_ARTIFACT_SCOPES.lock().unwrap(), 0);
         REMOTE_TASK_ARTIFACTS.clear();
-        crate::config::clear_remote_task_include_artifacts();
 
         let outer = RemoteTaskArtifactsGuard::new();
         let inner = RemoteTaskArtifactsGuard::new();
@@ -190,21 +189,12 @@ mod tests {
             },
             Arc::new(OnceCell::new()),
         );
-        crate::config::insert_remote_task_include_artifact_for_test();
 
         drop(inner);
         assert_eq!(REMOTE_TASK_ARTIFACTS.len(), 1);
-        assert_eq!(
-            crate::config::remote_task_include_artifact_count_for_test(),
-            1
-        );
 
         drop(outer);
         assert!(REMOTE_TASK_ARTIFACTS.is_empty());
-        assert_eq!(
-            crate::config::remote_task_include_artifact_count_for_test(),
-            0
-        );
     }
 
     #[tokio::test]

--- a/src/task/task_fetcher.rs
+++ b/src/task/task_fetcher.rs
@@ -21,24 +21,45 @@ static REMOTE_TASK_ARTIFACTS: LazyLock<RemoteTaskArtifacts> = LazyLock::new(Dash
 static REMOTE_TASK_ARTIFACT_SCOPES: Mutex<usize> = Mutex::new(0);
 
 /// Keeps no-cache remote task snapshots alive for one command or direct caller.
-pub(crate) struct RemoteTaskArtifactsGuard;
+pub(crate) struct RemoteTaskArtifactsGuard(());
 
 impl RemoteTaskArtifactsGuard {
     pub(crate) fn new() -> Self {
         *REMOTE_TASK_ARTIFACT_SCOPES.lock().unwrap() += 1;
-        Self
+        Self(())
     }
 }
 
 impl Drop for RemoteTaskArtifactsGuard {
     fn drop(&mut self) {
-        let mut scopes = REMOTE_TASK_ARTIFACT_SCOPES.lock().unwrap();
-        *scopes -= 1;
-        if *scopes == 0 {
-            crate::config::clear_remote_task_include_artifacts();
-            REMOTE_TASK_ARTIFACTS.clear();
-        }
+        let (include_artifacts, task_artifacts) = {
+            let mut scopes = REMOTE_TASK_ARTIFACT_SCOPES.lock().unwrap();
+            *scopes -= 1;
+            if *scopes != 0 {
+                return;
+            }
+            (
+                crate::config::take_remote_task_include_artifacts(),
+                take_remote_task_artifacts(),
+            )
+        };
+        drop(include_artifacts);
+        drop(task_artifacts);
     }
+}
+
+fn take_remote_task_artifacts() -> Vec<Arc<OnceCell<TaskFileArtifact>>> {
+    let keys = REMOTE_TASK_ARTIFACTS
+        .iter()
+        .map(|entry| entry.key().clone())
+        .collect::<Vec<_>>();
+    keys.into_iter()
+        .filter_map(|key| {
+            REMOTE_TASK_ARTIFACTS
+                .remove(&key)
+                .map(|(_, artifact)| artifact)
+        })
+        .collect()
 }
 
 /// Handles fetching remote task files and converting them to local paths

--- a/src/task/task_fetcher.rs
+++ b/src/task/task_fetcher.rs
@@ -35,6 +35,7 @@ impl Drop for RemoteTaskArtifactsGuard {
         let mut scopes = REMOTE_TASK_ARTIFACT_SCOPES.lock().unwrap();
         *scopes -= 1;
         if *scopes == 0 {
+            crate::config::clear_remote_task_include_artifacts();
             REMOTE_TASK_ARTIFACTS.clear();
         }
     }
@@ -156,6 +157,7 @@ mod tests {
         let _test_lock = REMOTE_TASK_ARTIFACT_TEST_LOCK.lock().await;
         assert_eq!(*REMOTE_TASK_ARTIFACT_SCOPES.lock().unwrap(), 0);
         REMOTE_TASK_ARTIFACTS.clear();
+        crate::config::clear_remote_task_include_artifacts();
 
         let outer = RemoteTaskArtifactsGuard::new();
         let inner = RemoteTaskArtifactsGuard::new();
@@ -167,11 +169,21 @@ mod tests {
             },
             Arc::new(OnceCell::new()),
         );
+        crate::config::insert_remote_task_include_artifact_for_test();
+
         drop(inner);
         assert_eq!(REMOTE_TASK_ARTIFACTS.len(), 1);
+        assert_eq!(
+            crate::config::remote_task_include_artifact_count_for_test(),
+            1
+        );
 
         drop(outer);
         assert!(REMOTE_TASK_ARTIFACTS.is_empty());
+        assert_eq!(
+            crate::config::remote_task_include_artifact_count_for_test(),
+            0
+        );
     }
 
     #[tokio::test]

--- a/src/task/task_file_providers/mod.rs
+++ b/src/task/task_file_providers/mod.rs
@@ -12,8 +12,12 @@ mod remote_task_http;
 use crate::Result;
 use async_trait::async_trait;
 use local_task::LocalTask;
-use remote_task_git::RemoteTaskGitBuilder;
+use remote_task_git::{RemoteTaskGit, RemoteTaskGitBuilder};
 use remote_task_http::RemoteTaskHttpBuilder;
+
+pub(crate) fn prepare_remote_git_path(checkout_root: &Path, path: &Path) -> Result<()> {
+    RemoteTaskGit::prepare_remote_path(checkout_root, path)
+}
 
 #[async_trait]
 pub trait TaskFileProvider: Debug + Send + Sync {

--- a/src/task/task_file_providers/mod.rs
+++ b/src/task/task_file_providers/mod.rs
@@ -12,12 +12,8 @@ mod remote_task_http;
 use crate::Result;
 use async_trait::async_trait;
 use local_task::LocalTask;
-use remote_task_git::{RemoteTaskGit, RemoteTaskGitBuilder};
+use remote_task_git::RemoteTaskGitBuilder;
 use remote_task_http::RemoteTaskHttpBuilder;
-
-pub(crate) fn prepare_remote_git_path(checkout_root: &Path, path: &Path) -> Result<()> {
-    RemoteTaskGit::prepare_remote_path(checkout_root, path)
-}
 
 #[async_trait]
 pub trait TaskFileProvider: Debug + Send + Sync {

--- a/src/task/task_file_providers/mod.rs
+++ b/src/task/task_file_providers/mod.rs
@@ -77,21 +77,32 @@ fn retry_remove_temporary_artifact(mut remove: impl FnMut() -> io::Result<()>) -
 #[derive(Debug, Clone)]
 pub struct TaskFileArtifact {
     pub path: PathBuf,
-    _cleanup: Option<Arc<TaskFileArtifactCleanup>>,
+    cleanup: Option<Arc<TaskFileArtifactCleanup>>,
 }
 
 impl TaskFileArtifact {
     pub(crate) fn persistent(path: PathBuf) -> Self {
         Self {
             path,
-            _cleanup: None,
+            cleanup: None,
         }
     }
 
     pub(crate) fn temporary(path: PathBuf, cleanup_path: PathBuf) -> Self {
         Self {
             path,
-            _cleanup: Some(Arc::new(TaskFileArtifactCleanup { path: cleanup_path })),
+            cleanup: Some(Arc::new(TaskFileArtifactCleanup { path: cleanup_path })),
+        }
+    }
+
+    pub(crate) fn cleanup_path(&self) -> Option<&Path> {
+        self.cleanup.as_ref().map(|cleanup| cleanup.path.as_path())
+    }
+
+    pub(crate) fn with_path(&self, path: PathBuf) -> Self {
+        Self {
+            path,
+            cleanup: self.cleanup.clone(),
         }
     }
 }

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -1,5 +1,5 @@
 use crate::Result;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 
@@ -69,8 +69,16 @@ impl GitRepoStructure {
 
 impl RemoteTaskGit {
     /// Make fetched task files executable while leaving task include directories intact.
-    fn prepare_remote_path(path: &PathBuf) -> Result<()> {
+    pub(super) fn prepare_remote_path(checkout_root: &Path, path: &Path) -> Result<()> {
         let metadata = path.symlink_metadata()?;
+        let checkout_root = checkout_root.canonicalize()?;
+        let canonical_path = path.canonicalize()?;
+        if !canonical_path.starts_with(&checkout_root) {
+            eyre::bail!(
+                "remote task path escapes its Git checkout: {}",
+                display_path(path)
+            );
+        }
         if metadata.file_type().is_file() {
             return file::make_executable(path);
         }
@@ -138,7 +146,7 @@ impl RemoteTaskGit {
 
         if reuse_existing && full_path.exists() {
             debug!("Using cached file: {:?}", full_path);
-            Self::prepare_remote_path(&full_path)?;
+            Self::prepare_remote_path(destination, &full_path)?;
             return Ok(full_path);
         }
 
@@ -171,7 +179,7 @@ impl RemoteTaskGit {
             }
         }
 
-        Self::prepare_remote_path(&full_path)?;
+        Self::prepare_remote_path(destination, &full_path)?;
         Ok(full_path)
     }
 
@@ -217,7 +225,7 @@ impl TaskFileProvider for RemoteTaskGit {
         let artifact = TaskFileArtifact::temporary(artifact_root.clone(), artifact_root.clone());
         Self::clone_to(&repo_structure, &artifact_root)?;
         let path = artifact_root.join(repo_structure.path);
-        Self::prepare_remote_path(&path)?;
+        Self::prepare_remote_path(&artifact_root, &path)?;
         Ok(artifact.with_path(path))
     }
 }
@@ -252,7 +260,7 @@ mod tests {
         fs::write(&task_file, "#!/usr/bin/env bash\necho ok\n").unwrap();
         fs::set_permissions(&task_file, fs::Permissions::from_mode(0o644)).unwrap();
 
-        RemoteTaskGit::prepare_remote_path(&task_file).unwrap();
+        RemoteTaskGit::prepare_remote_path(temp_dir.path(), &task_file).unwrap();
 
         assert!(file::is_executable(&task_file));
     }
@@ -270,7 +278,7 @@ mod tests {
         fs::set_permissions(&target, fs::Permissions::from_mode(0o644)).unwrap();
         symlink(&target, &task_file).unwrap();
 
-        let error = RemoteTaskGit::prepare_remote_path(&task_file).unwrap_err();
+        let error = RemoteTaskGit::prepare_remote_path(temp_dir.path(), &task_file).unwrap_err();
 
         assert!(error.to_string().contains("not a regular file"));
         assert_eq!(
@@ -283,7 +291,53 @@ mod tests {
     fn test_prepare_remote_path_allows_task_include_directory() {
         let temp_dir = tempfile::tempdir().unwrap();
 
-        RemoteTaskGit::prepare_remote_path(&temp_dir.path().to_path_buf()).unwrap();
+        RemoteTaskGit::prepare_remote_path(temp_dir.path(), temp_dir.path()).unwrap();
+    }
+
+    #[test]
+    fn test_prepare_remote_path_rejects_path_outside_checkout() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let checkout = temp_dir.path().join("checkout");
+        let outside = temp_dir.path().join("outside-task");
+        std::fs::create_dir(&checkout).unwrap();
+        std::fs::write(&outside, "#!/usr/bin/env bash\necho outside\n").unwrap();
+
+        let escaped_path = checkout.join("..").join("outside-task");
+        let error = RemoteTaskGit::prepare_remote_path(&checkout, &escaped_path).unwrap_err();
+
+        assert!(error.to_string().contains("escapes its Git checkout"));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_prepare_remote_path_rejects_windows_backslash_escape() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let checkout = temp_dir.path().join("checkout");
+        let outside = temp_dir.path().join("outside-task");
+        std::fs::create_dir(&checkout).unwrap();
+        std::fs::write(&outside, "echo outside\n").unwrap();
+
+        let escaped_path = checkout.join(r"..\outside-task");
+        let error = RemoteTaskGit::prepare_remote_path(&checkout, &escaped_path).unwrap_err();
+
+        assert!(error.to_string().contains("escapes its Git checkout"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_prepare_remote_path_rejects_intermediate_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let checkout = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let outside_task = outside.path().join("task");
+        std::fs::write(&outside_task, "#!/usr/bin/env bash\necho outside\n").unwrap();
+        symlink(outside.path(), checkout.path().join("linked-dir")).unwrap();
+
+        let escaped_path = checkout.path().join("linked-dir/task");
+        let error = RemoteTaskGit::prepare_remote_path(checkout.path(), &escaped_path).unwrap_err();
+
+        assert!(error.to_string().contains("escapes its Git checkout"));
     }
 
     #[test]

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -174,16 +174,6 @@ impl RemoteTaskGit {
         Self::prepare_remote_path(&full_path)?;
         Ok(full_path)
     }
-
-    #[cfg(test)]
-    fn parse_ssh(file: &str) -> Option<GitRepoStructure> {
-        RemoteSource::parse_git_ssh(file).map(|source| source.into())
-    }
-
-    #[cfg(test)]
-    fn parse_https(file: &str) -> Option<GitRepoStructure> {
-        RemoteSource::parse_git_https(file).map(|source| source.into())
-    }
 }
 
 impl From<RemoteGitSource> for GitRepoStructure {
@@ -226,6 +216,14 @@ impl TaskFileProvider for RemoteTaskGit {
 mod tests {
 
     use super::*;
+
+    fn parse_ssh(file: &str) -> Option<GitRepoStructure> {
+        RemoteSource::parse_git_ssh(file).map(Into::into)
+    }
+
+    fn parse_https(file: &str) -> Option<GitRepoStructure> {
+        RemoteSource::parse_git_https(file).map(Into::into)
+    }
 
     #[test]
     fn test_unique_artifact_root_remains_reserved_for_clone() {
@@ -307,11 +305,7 @@ mod tests {
         ];
 
         for url in test_cases {
-            assert!(
-                RemoteTaskGit::parse_ssh(url).is_some(),
-                "Failed for: {}",
-                url
-            );
+            assert!(parse_ssh(url).is_some(), "Failed for: {}", url);
         }
     }
 
@@ -329,11 +323,7 @@ mod tests {
         ];
 
         for url in test_cases {
-            assert!(
-                RemoteTaskGit::parse_ssh(url).is_none(),
-                "Should fail for: {}",
-                url
-            );
+            assert!(parse_ssh(url).is_none(), "Should fail for: {}", url);
         }
     }
 
@@ -355,11 +345,7 @@ mod tests {
         ];
 
         for url in test_cases {
-            assert!(
-                RemoteTaskGit::parse_https(url).is_some(),
-                "Failed for: {}",
-                url
-            );
+            assert!(parse_https(url).is_some(), "Failed for: {}", url);
         }
     }
 
@@ -376,11 +362,7 @@ mod tests {
         ];
 
         for url in test_cases {
-            assert!(
-                RemoteTaskGit::parse_https(url).is_none(),
-                "Should fail for: {}",
-                url
-            );
+            assert!(parse_https(url).is_none(), "Should fail for: {}", url);
         }
     }
 
@@ -444,7 +426,7 @@ mod tests {
         ];
 
         for (url, expected_repo, expected_path, expected_branch) in test_cases {
-            let repo = RemoteTaskGit::parse_ssh(url).unwrap();
+            let repo = parse_ssh(url).unwrap();
             assert_eq!(expected_repo, repo.url_without_path);
             assert_eq!(expected_path, repo.path);
             assert_eq!(expected_branch, repo.branch);
@@ -493,7 +475,7 @@ mod tests {
         ];
 
         for (url, expected_repo, expected_path, expected_branch) in test_cases {
-            let repo = RemoteTaskGit::parse_https(url).unwrap();
+            let repo = parse_https(url).unwrap();
             assert_eq!(expected_repo, repo.url_without_path);
             assert_eq!(expected_path, repo.path);
             assert_eq!(expected_branch, repo.branch);
@@ -538,8 +520,8 @@ mod tests {
         ];
 
         for (first_url, second_url, expected) in test_cases {
-            let first_repo = RemoteTaskGit::parse_ssh(first_url).unwrap();
-            let second_repo = RemoteTaskGit::parse_ssh(second_url).unwrap();
+            let first_repo = parse_ssh(first_url).unwrap();
+            let second_repo = parse_ssh(second_url).unwrap();
             let first_cache_key = remote_task_git.get_cache_key(&first_repo);
             let second_cache_key = remote_task_git.get_cache_key(&second_repo);
             assert_eq!(expected, first_cache_key == second_cache_key);
@@ -584,8 +566,8 @@ mod tests {
         ];
 
         for (first_url, second_url, expected) in test_cases {
-            let first_repo = RemoteTaskGit::parse_https(first_url).unwrap();
-            let second_repo = RemoteTaskGit::parse_https(second_url).unwrap();
+            let first_repo = parse_https(first_url).unwrap();
+            let second_repo = parse_https(second_url).unwrap();
             let first_cache_key = remote_task_git.get_cache_key(&first_repo);
             let second_cache_key = remote_task_git.get_cache_key(&second_repo);
             assert_eq!(expected, first_cache_key == second_cache_key);

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -1,5 +1,5 @@
 use crate::Result;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use async_trait::async_trait;
 
@@ -69,16 +69,8 @@ impl GitRepoStructure {
 
 impl RemoteTaskGit {
     /// Make fetched task files executable while leaving task include directories intact.
-    pub(super) fn prepare_remote_path(checkout_root: &Path, path: &Path) -> Result<()> {
+    fn prepare_remote_path(path: &PathBuf) -> Result<()> {
         let metadata = path.symlink_metadata()?;
-        let checkout_root = checkout_root.canonicalize()?;
-        let canonical_path = path.canonicalize()?;
-        if !canonical_path.starts_with(&checkout_root) {
-            eyre::bail!(
-                "remote task path escapes its Git checkout: {}",
-                display_path(path)
-            );
-        }
         if metadata.file_type().is_file() {
             return file::make_executable(path);
         }
@@ -146,7 +138,7 @@ impl RemoteTaskGit {
 
         if reuse_existing && full_path.exists() {
             debug!("Using cached file: {:?}", full_path);
-            Self::prepare_remote_path(destination, &full_path)?;
+            Self::prepare_remote_path(&full_path)?;
             return Ok(full_path);
         }
 
@@ -179,7 +171,7 @@ impl RemoteTaskGit {
             }
         }
 
-        Self::prepare_remote_path(destination, &full_path)?;
+        Self::prepare_remote_path(&full_path)?;
         Ok(full_path)
     }
 
@@ -225,7 +217,7 @@ impl TaskFileProvider for RemoteTaskGit {
         let artifact = TaskFileArtifact::temporary(artifact_root.clone(), artifact_root.clone());
         Self::clone_to(&repo_structure, &artifact_root)?;
         let path = artifact_root.join(repo_structure.path);
-        Self::prepare_remote_path(&artifact_root, &path)?;
+        Self::prepare_remote_path(&path)?;
         Ok(artifact.with_path(path))
     }
 }
@@ -260,7 +252,7 @@ mod tests {
         fs::write(&task_file, "#!/usr/bin/env bash\necho ok\n").unwrap();
         fs::set_permissions(&task_file, fs::Permissions::from_mode(0o644)).unwrap();
 
-        RemoteTaskGit::prepare_remote_path(temp_dir.path(), &task_file).unwrap();
+        RemoteTaskGit::prepare_remote_path(&task_file).unwrap();
 
         assert!(file::is_executable(&task_file));
     }
@@ -278,7 +270,7 @@ mod tests {
         fs::set_permissions(&target, fs::Permissions::from_mode(0o644)).unwrap();
         symlink(&target, &task_file).unwrap();
 
-        let error = RemoteTaskGit::prepare_remote_path(temp_dir.path(), &task_file).unwrap_err();
+        let error = RemoteTaskGit::prepare_remote_path(&task_file).unwrap_err();
 
         assert!(error.to_string().contains("not a regular file"));
         assert_eq!(
@@ -291,53 +283,7 @@ mod tests {
     fn test_prepare_remote_path_allows_task_include_directory() {
         let temp_dir = tempfile::tempdir().unwrap();
 
-        RemoteTaskGit::prepare_remote_path(temp_dir.path(), temp_dir.path()).unwrap();
-    }
-
-    #[test]
-    fn test_prepare_remote_path_rejects_path_outside_checkout() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let checkout = temp_dir.path().join("checkout");
-        let outside = temp_dir.path().join("outside-task");
-        std::fs::create_dir(&checkout).unwrap();
-        std::fs::write(&outside, "#!/usr/bin/env bash\necho outside\n").unwrap();
-
-        let escaped_path = checkout.join("..").join("outside-task");
-        let error = RemoteTaskGit::prepare_remote_path(&checkout, &escaped_path).unwrap_err();
-
-        assert!(error.to_string().contains("escapes its Git checkout"));
-    }
-
-    #[test]
-    #[cfg(windows)]
-    fn test_prepare_remote_path_rejects_windows_backslash_escape() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let checkout = temp_dir.path().join("checkout");
-        let outside = temp_dir.path().join("outside-task");
-        std::fs::create_dir(&checkout).unwrap();
-        std::fs::write(&outside, "echo outside\n").unwrap();
-
-        let escaped_path = checkout.join(r"..\outside-task");
-        let error = RemoteTaskGit::prepare_remote_path(&checkout, &escaped_path).unwrap_err();
-
-        assert!(error.to_string().contains("escapes its Git checkout"));
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn test_prepare_remote_path_rejects_intermediate_symlink_escape() {
-        use std::os::unix::fs::symlink;
-
-        let checkout = tempfile::tempdir().unwrap();
-        let outside = tempfile::tempdir().unwrap();
-        let outside_task = outside.path().join("task");
-        std::fs::write(&outside_task, "#!/usr/bin/env bash\necho outside\n").unwrap();
-        symlink(outside.path(), checkout.path().join("linked-dir")).unwrap();
-
-        let escaped_path = checkout.path().join("linked-dir/task");
-        let error = RemoteTaskGit::prepare_remote_path(checkout.path(), &escaped_path).unwrap_err();
-
-        assert!(error.to_string().contains("escapes its Git checkout"));
+        RemoteTaskGit::prepare_remote_path(&temp_dir.path().to_path_buf()).unwrap();
     }
 
     #[test]

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -12,7 +12,7 @@ use crate::{
     remote_source::{RemoteGitSource, RemoteSource},
 };
 
-use super::TaskFileProvider;
+use super::{TaskFileArtifact, TaskFileProvider};
 
 #[derive(Debug)]
 pub struct RemoteTaskGitBuilder {
@@ -98,6 +98,83 @@ impl RemoteTaskGit {
             .unwrap()
     }
 
+    fn unique_artifact_root(&self, cache_key: &str) -> Result<PathBuf> {
+        file::create_dir_all(&self.storage_path)?;
+        let temp_dir = tempfile::Builder::new()
+            .prefix(&format!("{cache_key}-"))
+            .tempdir_in(&self.storage_path)?;
+        Ok(temp_dir.keep())
+    }
+
+    fn clone_to(repo_structure: &GitRepoStructure, destination: &PathBuf) -> Result<()> {
+        let git_repo = git::Git::new(destination);
+        let mut clone_options = CloneOptions::default();
+        if let Some(branch) = &repo_structure.branch {
+            trace!("Use specific branch {}", branch);
+            clone_options = clone_options.branch(branch);
+        }
+        git_repo.clone(repo_structure.url_without_path.as_str(), clone_options)
+    }
+
+    fn fetch_to_destination(
+        &self,
+        repo_structure: &GitRepoStructure,
+        destination: &PathBuf,
+        reuse_existing: bool,
+    ) -> Result<PathBuf> {
+        let repo_file_path = repo_structure.path.clone();
+        let full_path = destination.join(&repo_file_path);
+
+        debug!("Repo structure: {:?}", repo_structure);
+
+        let _lock = LockFile::new(destination)
+            .with_callback(|l| {
+                debug!(
+                    "waiting for lock on remote git task cache: {}",
+                    display_path(l)
+                );
+            })
+            .lock()?;
+
+        if reuse_existing && full_path.exists() {
+            debug!("Using cached file: {:?}", full_path);
+            Self::prepare_remote_path(&full_path)?;
+            return Ok(full_path);
+        }
+
+        let mut tmp_destination = destination.as_os_str().to_os_string();
+        tmp_destination.push(".clone-tmp");
+        let tmp_destination = PathBuf::from(tmp_destination);
+        if tmp_destination.exists() {
+            crate::file::remove_all(&tmp_destination)?;
+        }
+
+        match Self::clone_to(repo_structure, &tmp_destination) {
+            Ok(()) => {
+                if destination.exists()
+                    && let Err(e) = crate::file::remove_all(destination)
+                {
+                    let _ = crate::file::remove_all(&tmp_destination);
+                    return Err(e);
+                }
+                if let Err(e) = std::fs::rename(&tmp_destination, destination) {
+                    let _ = crate::file::remove_all(&tmp_destination);
+                    return Err(eyre::eyre!(
+                        "failed to move cloned repo into cache at {}: {e}",
+                        display_path(destination)
+                    ));
+                }
+            }
+            Err(e) => {
+                let _ = crate::file::remove_all(&tmp_destination);
+                return Err(e);
+            }
+        }
+
+        Self::prepare_remote_path(&full_path)?;
+        Ok(full_path)
+    }
+
     #[cfg(test)]
     fn parse_ssh(file: &str) -> Option<GitRepoStructure> {
         RemoteSource::parse_git_ssh(file).map(|source| source.into())
@@ -125,69 +202,23 @@ impl TaskFileProvider for RemoteTaskGit {
         let repo_structure = self.get_repo_structure(file);
         let cache_key = self.get_cache_key(&repo_structure);
         let destination = self.storage_path.join(&cache_key);
-        let repo_file_path = repo_structure.path.clone();
-        let full_path = destination.join(&repo_file_path);
+        self.fetch_to_destination(&repo_structure, &destination, self.is_cached)
+    }
 
-        debug!("Repo structure: {:?}", repo_structure);
-
-        let _lock = LockFile::new(&destination)
-            .with_callback(|l| {
-                debug!(
-                    "waiting for lock on remote git task cache: {}",
-                    display_path(l)
-                );
-            })
-            .lock()?;
-
+    async fn get_local_artifact(&self, file: &str) -> Result<TaskFileArtifact> {
         if self.is_cached {
-            trace!("Cache mode enabled");
-            if full_path.exists() {
-                debug!("Using cached file: {:?}", full_path);
-                Self::prepare_remote_path(&full_path)?;
-                return Ok(full_path);
-            }
-        } else {
-            trace!("Cache mode disabled");
+            return Ok(TaskFileArtifact::persistent(
+                self.get_local_path(file).await?,
+            ));
         }
-
-        let tmp_destination = self.storage_path.join(format!("{}.clone-tmp", cache_key));
-        if tmp_destination.exists() {
-            crate::file::remove_all(&tmp_destination)?;
-        }
-
-        let git_repo = git::Git::new(&tmp_destination);
-
-        let mut clone_options = CloneOptions::default();
-
-        if let Some(branch) = &repo_structure.branch {
-            trace!("Use specific branch {}", branch);
-            clone_options = clone_options.branch(branch);
-        }
-
-        match git_repo.clone(repo_structure.url_without_path.as_str(), clone_options) {
-            Ok(()) => {
-                if destination.exists()
-                    && let Err(e) = crate::file::remove_all(&destination)
-                {
-                    let _ = crate::file::remove_all(&tmp_destination);
-                    return Err(e);
-                }
-                if let Err(e) = std::fs::rename(&tmp_destination, &destination) {
-                    let _ = crate::file::remove_all(&tmp_destination);
-                    return Err(eyre::eyre!(
-                        "failed to move cloned repo into cache at {}: {e}",
-                        display_path(&destination)
-                    ));
-                }
-            }
-            Err(e) => {
-                let _ = crate::file::remove_all(&tmp_destination);
-                return Err(e);
-            }
-        }
-
-        Self::prepare_remote_path(&full_path)?;
-        Ok(full_path)
+        let repo_structure = self.get_repo_structure(file);
+        let cache_key = self.get_cache_key(&repo_structure);
+        let artifact_root = self.unique_artifact_root(&cache_key)?;
+        let artifact = TaskFileArtifact::temporary(artifact_root.clone(), artifact_root.clone());
+        Self::clone_to(&repo_structure, &artifact_root)?;
+        let path = artifact_root.join(repo_structure.path);
+        Self::prepare_remote_path(&path)?;
+        Ok(artifact.with_path(path))
     }
 }
 
@@ -195,6 +226,20 @@ impl TaskFileProvider for RemoteTaskGit {
 mod tests {
 
     use super::*;
+
+    #[test]
+    fn test_unique_artifact_root_remains_reserved_for_clone() {
+        let storage = tempfile::tempdir().unwrap();
+        let provider = RemoteTaskGit {
+            storage_path: storage.path().to_path_buf(),
+            is_cached: false,
+        };
+
+        let artifact_root = provider.unique_artifact_root("cache-key").unwrap();
+
+        assert!(artifact_root.is_dir());
+        assert_eq!(std::fs::read_dir(&artifact_root).unwrap().count(), 0);
+    }
 
     #[test]
     #[cfg(unix)]

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -83,6 +83,19 @@ impl RemoteTaskGit {
         )
     }
 
+    fn prepare_cached_path(path: &PathBuf, destination: &PathBuf) -> Result<()> {
+        if let Err(err) = Self::prepare_remote_path(path) {
+            if let Err(cleanup_err) = crate::file::remove_all(destination) {
+                warn!(
+                    "failed to remove unusable remote Git task checkout {}: {cleanup_err:#}",
+                    display_path(destination)
+                );
+            }
+            return Err(err);
+        }
+        Ok(())
+    }
+
     fn get_cache_key(&self, repo_structure: &GitRepoStructure) -> String {
         let key = format!(
             "{}{}",
@@ -138,7 +151,7 @@ impl RemoteTaskGit {
 
         if reuse_existing && full_path.exists() {
             debug!("Using cached file: {:?}", full_path);
-            Self::prepare_remote_path(&full_path)?;
+            Self::prepare_cached_path(&full_path, destination)?;
             return Ok(full_path);
         }
 
@@ -171,7 +184,7 @@ impl RemoteTaskGit {
             }
         }
 
-        Self::prepare_remote_path(&full_path)?;
+        Self::prepare_cached_path(&full_path, destination)?;
         Ok(full_path)
     }
 }
@@ -282,6 +295,25 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
 
         RemoteTaskGit::prepare_remote_path(&temp_dir.path().to_path_buf()).unwrap();
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_prepare_cached_path_removes_checkout_on_failure() {
+        use std::os::unix::fs::symlink;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let destination = temp_dir.path().join("checkout");
+        let task_file = destination.join("task");
+        let target = temp_dir.path().join("target");
+        std::fs::create_dir(&destination).unwrap();
+        std::fs::write(&target, "#!/usr/bin/env bash\necho ok\n").unwrap();
+        symlink(&target, &task_file).unwrap();
+
+        let error = RemoteTaskGit::prepare_cached_path(&task_file, &destination).unwrap_err();
+
+        assert!(error.to_string().contains("not a regular file"));
+        assert!(!destination.exists());
     }
 
     #[test]


### PR DESCRIPTION
## Work order

1. This PR — preserve one remote Git snapshot for a task execution scope
2. #12202 — require trust and contain remote task paths (replacement for auto-closed #11113)
3. #12206 — harden HTTP and Git cache lifecycle behavior (replacement for auto-closed #11203)

Prerequisite #11222 is merged. Review and merge this PR before the two rebased dependent PRs.

## Bug fixed

With remote Git caching disabled, repeated fetches for the same repository/ref reused and replaced one deterministic checkout path. Task discovery could therefore parse a task's metadata and dependencies from one checkout, then a later include or dependency fetch could replace that path before execution. If a branch moved between those clones, one `mise run` could select metadata from one revision but execute the script from another, or mix parent and child tasks from different snapshots.

This PR keeps each independently defined direct task in an owned checkout and reuses exactly one owned checkout for all include paths from the same repository/ref during a command. The selected files remain alive through execution and are cleaned up when the command scope ends.

## Summary

- give no-cache Git task files unique command-owned artifacts
- reuse one command-scoped Git task-include checkout per repository/ref across include paths, parallel loads, dependency resolution, and config resets
- retain the securely created checkout directory through clone and release Git artifacts only after the final active command scope
- drain artifact ownership before filesystem cleanup so cleanup does not hold the process-wide scope mutex
- verify one clone per logical include snapshot and cleanup after success, task failure, and load failure
- cover both the default gix clone path and the Git CLI clone path with portable E2E assertions

## Split boundaries

- trust, provenance, and remote-path containment are in #12202
- HTTP publication, no-cache propagation, immutable cache trees, cache keys, and MCP request lifecycle are in #12206

## Validation

- `mise run lint-fix`
- `cargo test --locked --bin mise task::task_fetcher::tests`
- `cargo test --locked --bin mise task::task_file_providers`
- `mise run test:e2e e2e/tasks/test_task_remote_git_includes`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved remote Git task includes with more reliable snapshot handling.
  * Multiple no-cache Git tasks can use distinct snapshots while reusing snapshots within a single command when appropriate.
  * Local task includes are retained as reusable artifacts.

* **Bug Fixes**
  * Improved cleanup of temporary files and repository snapshots after successful or failed task loading and execution.
  * Added validation to ensure included task paths resolve correctly.
  * Improved remote Git fetch tracking and handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->