### PR TITLE
chore(ci): enable greptile reviews for draft prs

### DIFF
--- a/greptile.json
+++ b/greptile.json
@@ -1,4 +1,5 @@
 {
+  "triggerOnDrafts": true,
   "disabledLabels": ["release", "autorelease: pending"],
   "ignoreKeywords": "chore: release\nchore(main): release\nThis PR was generated with release-plz\nThis PR was generated with Release Please"
 }


### PR DESCRIPTION
## Summary
- enable automatic Greptile reviews for draft pull requests
- retain the existing release PR exclusions

## Validation
- `jq empty greptile.json`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Greptile reviews can now be triggered for draft pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->