### PR TITLE
fix(bootstrap): allow Windows bootstrap without system files

### DIFF
--- a/e2e-win/bootstrap.Tests.ps1
+++ b/e2e-win/bootstrap.Tests.ps1
@@ -13,7 +13,7 @@ Describe 'bootstrap' {
     BeforeEach {
         @"
 [bootstrap.repos]
-"$script:RepoTarget" = "https://example.invalid/repo.git"
+"$script:RepoTarget" = { url = "https://example.invalid/repo.git" }
 "@ | Out-File -FilePath mise.toml -Encoding utf8NoBOM
     }
 

--- a/e2e-win/bootstrap.Tests.ps1
+++ b/e2e-win/bootstrap.Tests.ps1
@@ -1,0 +1,51 @@
+Describe 'bootstrap' {
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        Set-Location TestDrive:
+
+        $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+        $env:MISE_TRUSTED_CONFIG_PATHS = $TestDrive
+
+        $script:RepoTarget = (Join-Path $TestDrive 'repo') -replace '\\', '/'
+        $script:FileTarget = (Join-Path $TestDrive 'managed') -replace '\\', '/'
+    }
+
+    BeforeEach {
+        @"
+[bootstrap.repos]
+"$script:RepoTarget" = "https://example.invalid/repo.git"
+"@ | Out-File -FilePath mise.toml -Encoding utf8NoBOM
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        if ($null -eq $script:OriginalTrusted) {
+            Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
+        } else {
+            [Environment]::SetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', $script:OriginalTrusted, 'Process')
+        }
+    }
+
+    It 'allows aggregate commands when no system files are configured' {
+        mise bootstrap --dry-run 2>&1 | Out-String | Out-Null
+        $LASTEXITCODE | Should -Be 0
+
+        mise bootstrap status 2>&1 | Out-String | Out-Null
+        $LASTEXITCODE | Should -Be 0
+
+        mise bootstrap plan 2>&1 | Out-String | Out-Null
+        $LASTEXITCODE | Should -Be 0
+    }
+
+    It 'still rejects configured system files' {
+        @"
+
+[bootstrap.files."$script:FileTarget"]
+content = "managed"
+"@ | Out-File -FilePath mise.toml -Encoding utf8NoBOM -Append
+
+        $out = mise bootstrap plan 2>&1 | Out-String
+        $LASTEXITCODE | Should -Not -Be 0
+        $out | Should -BeLike '*managed system files are only supported on Unix*'
+    }
+}

--- a/src/system/managed_files.rs
+++ b/src/system/managed_files.rs
@@ -791,11 +791,14 @@ pub fn validate_principals(
 
 #[cfg(not(unix))]
 pub fn validate_principals(
-    _files: &[ManagedFileRequest],
-    _directories: &[ManagedDirectoryRequest],
+    files: &[ManagedFileRequest],
+    directories: &[ManagedDirectoryRequest],
     _accounts: Option<&super::accounts::AccountRequests>,
     _allow_pending_accounts: bool,
 ) -> Result<()> {
+    if files.is_empty() && directories.is_empty() {
+        return Ok(());
+    }
     bail!("managed system files are only supported on Unix")
 }
 


### PR DESCRIPTION
## Summary
- allow Windows bootstrap validation to pass when no managed system files or directories are configured
- preserve the Unix-only error when managed system resources are present
- add Windows regression coverage for aggregate bootstrap, status, and plan with a repo-only configuration

## Root cause
The non-Unix `validate_principals` implementation always returned an error. Aggregate bootstrap paths call it whenever the files phase is enabled, including when the configured file and directory collections are empty. This caused unrelated bootstrap configuration such as `[bootstrap.repos]` to fail on Windows.

Fixes the regression reported in https://github.com/jdx/mise/discussions/12002.

## Verification
- `cargo fmt --all -- --check`
- `cargo test --bin mise system::managed_files` (13 passed)
- `hk run check --safe --format json` scoped to the Rust change (`cargo-fmt`, `cargo-check` passed)
- Windows Pester regression coverage added; local cross-check could not link native dependencies because the Linux host lacks the MSVC/Visual Studio toolchain

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow platform-specific guard change with explicit regression tests; managed system files on Windows remain rejected.
> 
> **Overview**
> **Windows bootstrap** no longer fails when only non-file bootstrap config (e.g. `[bootstrap.repos]`) is present. Non-Unix `validate_principals` used to always error; it now returns success when there are no managed files or directories, and still errors with *managed system files are only supported on Unix* when those resources are configured.
> 
> Adds **Windows Pester coverage** (`e2e-win/bootstrap.Tests.ps1`) for `bootstrap`, `bootstrap status`, and `bootstrap plan` on repo-only config, plus a case that managed `[bootstrap.files]` still fails as expected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56d004d244d11704c488bc452ca03ad20679c751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows bootstrap behavior for aggregate commands when no system-file configuration is provided.
  * Added clear rejection of unsupported managed system-file requests on Windows.
  * Bootstrap operations now correctly succeed when no managed files or directories are requested.
  * Added Windows end-to-end coverage for successful and rejected bootstrap scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->