### PR TITLE
fix(task): warn on an unknown file-task header key instead of failing

### DIFF
--- a/e2e/tasks/test_task_unknown_header_field
+++ b/e2e/tasks/test_task_unknown_header_field
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# An unrecognised key in one file task's header used to abort loading *every* task in the project,
+# so a typo in one script made unrelated tasks — including TOML ones — unrunnable.
+#
+# `run_windows` is the real case: it is a TOML-task key, so a file task header does not know it.
+
+cat <<EOF >mise.toml
+[tasks.good]
+run = "echo GOOD-TOML-TASK"
+EOF
+
+mkdir -p mise-tasks
+cat <<EOF >mise-tasks/badheader
+#!/usr/bin/env bash
+#MISE description="has an unknown key"
+#MISE run_windows="echo nope"
+echo FROM-FILE-TASK
+EOF
+chmod +x mise-tasks/badheader
+
+# The task in the *other* file has to keep working. This is what regressed.
+assert "mise run good" "GOOD-TOML-TASK"
+
+# And the file task itself is still usable, with its known keys applied.
+assert "mise run badheader" "FROM-FILE-TASK"
+assert_contains "mise tasks ls" "has an unknown key"
+
+# Ignored, not silent: the warning names the file so the typo is findable.
+assert_contains "mise tasks ls 2>&1" "run_windows"
+
+# The control: a header that cannot be parsed at all is still an error. Ignoring an unknown key
+# must not turn into ignoring a broken header.
+cat <<EOF >mise-tasks/brokenheader
+#!/usr/bin/env bash
+#MISE env={invalid=toml=here}
+echo unreachable
+EOF
+chmod +x mise-tasks/brokenheader
+assert_fail_contains "mise tasks ls" "task header TOML"

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1448,11 +1448,20 @@ impl Task {
         unparsed.sort();
 
         if !unparsed.is_empty() {
-            return Err(eyre::eyre!(
-                "unknown field(s) {:?} in task file header: {}",
+            // A warning rather than an error, matching how `mise.toml` treats a key it does not
+            // recognise (`MiseToml::from_str` reports one through `serde_ignored` and carries on).
+            // A file task has no reason to be stricter than the config file, and it is in a worse
+            // position to be: this parse runs inside the loop that loads *every* task in the
+            // project, so returning here made one unrecognised key in one file take all of them
+            // down -- `mise run <some other task>` failed too.
+            //
+            // Only genuinely unknown key names reach this point. `TrackingTomlParser` records a key
+            // as parsed when it is looked up, so a known key holding the wrong type is not here.
+            warn!(
+                "unknown field(s) {:?} in task file header, ignoring: {}",
                 unparsed,
                 display_path(path)
-            ));
+            );
         }
 
         #[cfg(test)]
@@ -4359,6 +4368,43 @@ echo "hello world"
                 .to_string()
                 .contains("failed to parse task header TOML")
         );
+    }
+
+    /// An unrecognised header key is a warning, not an error.
+    ///
+    /// This parse runs for every task file in the project, so failing here took down tasks in
+    /// other files — including TOML ones — over a single typo. `mise.toml` already treats an
+    /// unknown key as a warning; a file task should not be stricter.
+    ///
+    /// `run_windows` is the real case that turned this up: it is a TOML-task key, so a file task
+    /// header does not know it.
+    #[tokio::test]
+    async fn test_from_path_unknown_header_field_is_ignored() {
+        use std::fs;
+        use tempfile::tempdir;
+
+        let config = Config::get().await.unwrap();
+        let temp_dir = tempdir().unwrap();
+        let task_path = temp_dir.path().join("test_task");
+
+        fs::write(
+            &task_path,
+            r#"#!/usr/bin/env bash
+#MISE description="still parsed"
+#MISE run_windows="echo nope"
+echo "hello world"
+"#,
+        )
+        .unwrap();
+
+        let task = Task::from_path(&config, &task_path, temp_dir.path(), temp_dir.path())
+            .await
+            .unwrap();
+
+        // The known key beside it still takes effect: what is dropped is the unknown key alone,
+        // not the whole header and not the task.
+        assert_eq!(task.description, "still parsed");
+        assert!(task.run_windows.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
One unrecognised key in one task file makes **every task in the project** unrunnable — including
tasks defined in `mise.toml`, which the bad file has nothing to do with.

Measured on **2026.8.2**, with a single line added to one script and nothing else changed:

```console
$ cat .mise/tasks/badfile.sh
#!/usr/bin/env bash
#MISE description="bad"
#MISE run_windows="echo X"      # <- the only difference
...

$ mise tasks        exit=1   mise ERROR unknown field(s) ["run_windows"] in task file header: …
$ mise run good     exit=1   the same error          <- a TOML task, in mise.toml
$ mise ls           exit=0
$ mise env          exit=0
$ mise doctor       exit=0
```

The blast radius is task loading; tools and env are unaffected. That is still every task the project
has, over a typo in one file.

## Cause

`Task::from_path…` ends its header parse with:

```rust
if !unparsed.is_empty() {
    return Err(eyre::eyre!("unknown field(s) {:?} in task file header: {}", unparsed, …));
}
```

and the caller in `src/config/mod.rs` runs that inside the loop over `exec_files` with `?`, so the
first bad header ends the loop and the project has no tasks at all.

## Why a warning is the right answer here

**`mise.toml` already treats an unrecognised key as a warning**, and it covers far more ground than
one task file:

```rust
let de_res = serde_ignored::deserialize(des, |p| {
    warn!("unknown field in {}: {p}", display_path(path));
});
```

`system/mod.rs` does the same for a bootstrap block (`… unknown field(s) …, ignoring entry`). The
file-task header was the only place that made it fatal — the strictest treatment applied to the
narrowest input, in the one position where failing takes unrelated files down with it.

**Only genuinely unknown names reach that check.** `TrackingTomlParser::record` marks a key as
parsed when it is *looked up*, so a known key holding the wrong type never lands in `unparsed_keys`.
This is the same category as `mise.toml`'s unknown field, not a parse failure.

## Deliberately unchanged

- **A header that is not valid TOML still errors** (`#MISE env={invalid=toml=here}` →
  `failed to parse task header TOML`). Ignoring an unknown key must not become ignoring a broken
  header; the existing test for this is untouched and the e2e below re-asserts it as a control.
- **`alias` together with `aliases` still errors.** That is a contradiction, not an unknown key.
- **The caller's `?` stays.** Whether a genuinely broken task file should stop the whole load is a
  separate question from whether an unknown key is broken at all. This PR answers only the second.
- **No special-case hint for `run_windows`.** It is the key that turned this up, but singling out one
  name in the message is not justified — that belongs in the file-task docs, which currently say
  nothing about platform handling at all.

## Tests

- **unit** — a header carrying `run_windows` alongside `description` now parses, and the assertion is
  that `description` **still took effect**: what is dropped is the unknown key alone, not the header
  and not the task. Fails on `main`.
- **e2e** (`e2e/tasks/test_task_unknown_header_field`) — the reported symptom, end to end: a file
  task with the bad header sitting beside a TOML task, asserting `mise run good` works. Then that the
  file task itself still runs and its description still shows, that the warning **names the key** so
  the typo is findable, and — as the control — that a header which cannot be parsed at all is still
  an error.

Placed in the unix e2e suite rather than `e2e-win`: this code path has no `cfg`, and nothing about
the defect is platform-specific.

### Not run

`cargo fmt --all`, plus `shellcheck` and `shfmt` on the new e2e script (both clean). No local build —
the transcript above is a released binary run natively; CI compiles the change.

## Origin

Found while checking whether file tasks can branch on platform the way TOML tasks do with
`run_windows`. They cannot — which is worth its own docs change — but the interesting part was what
happened when the header was rejected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File-task headers now tolerate unknown fields and display a warning instead of failing to load.
  * Recognized task metadata remains available, and unrelated tasks continue to run.

* **Bug Fixes**
  * Invalid header syntax continues to be reported when listing tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->