### PR TITLE
docs(tasks): describe how a file task is detected on Windows

### DIFF
--- a/docs/tasks/file-tasks.md
+++ b/docs/tasks/file-tasks.md
@@ -26,6 +26,8 @@ Ensure that the file is executable, otherwise mise will not be able to detect it
 chmod +x mise-tasks/build
 ```
 
+On Windows there is no permission bit to set, and `chmod` is not the answer there — see
+[Windows](#windows) for what makes a file task detectable instead.
 :::
 
 Having the code in a bash file and not TOML helps make it work
@@ -127,6 +129,54 @@ Write-Host "Hello from PowerShell, current directory is $current_directory"
 ```
 
 :::
+
+## Windows
+
+Windows has no execute permission for mise to look at, so it decides whether a file is a task a
+different way. A file is a task if **either** holds:
+
+- its extension is one of [`windows_executable_extensions`](/configuration/settings.html#windows_executable_extensions)
+  — by default `exe`, `bat`, `cmd`, `com`, `ps1`, `vbs`
+- it starts with a **shebang**
+
+The two answer different questions. The extension means Windows itself can run the file; the shebang
+means mise can work out an interpreter for it. Windows does not implement shebangs — mise reads the
+line and starts the interpreter itself — which is why a `.sh` script, or a file with no extension at
+all, is still a task there as long as it has one.
+
+The practical consequence is that a file with **neither** is invisible on Windows even though it
+works on Linux and macOS:
+
+```bash [mise-tasks/build]
+# no shebang, no extension -> not a task on Windows
+cargo build
+```
+
+Adding `#!/usr/bin/env bash` is usually all it takes, and it costs nothing on the other platforms.
+
+### Writing one task for both platforms
+
+File tasks have no equivalent of a TOML task's
+[`run_windows`](/tasks/task-configuration.html#run-windows) — the script _is_ the command, so there
+is nowhere to put a second one. Write the two scripts side by side instead, giving the Windows one an
+executable extension and the other no extension at all:
+
+```
+mise-tasks/
+  build          # #!/usr/bin/env bash
+  build.ps1      # the Windows version
+```
+
+On Windows mise prefers the native script: `build.ps1` answers to `build`, and the extensionless
+file is dropped. On Linux and macOS the `.ps1` has no execute permission, so only `build` is found.
+`mise run build` does the right thing on each.
+
+Marking the `.ps1` executable on Linux or macOS does not break that — it simply appears there as a
+separate task called `build.ps1`, since the rename to `build` only happens on Windows.
+
+If there is more than one Windows candidate — say `build.ps1` _and_ `build.cmd` — mise cannot choose
+between them, so it leaves everything alone: all three files stay, listed as `build`, `build.ps1`
+and `build.cmd`.
 
 ## Editing tasks
 


### PR DESCRIPTION
`docs/tasks/file-tasks.md` says nothing about Windows. What it does say is:

> Ensure that the file is executable, otherwise mise will not be able to detect it.
> ```shell
> chmod +x mise-tasks/build
> ```

On Windows that instruction cannot work — there is no permission bit for mise to read, and mise's
own error message stopped suggesting `chmod` there in #11923. The page never says what to do
instead.

## What the page now covers

**How a file becomes a task on Windows.** Its extension is in
[`windows_executable_extensions`](/configuration/settings.html#windows_executable_extensions), **or**
it starts with a shebang. The two answer different questions and it is worth saying so: the extension
means Windows itself can run the file, the shebang means *mise* can work out an interpreter.

Windows implements neither `chmod` nor shebangs — mise reads the `#!` line and starts the interpreter
itself — so the consequence readers actually hit is that a script with **neither** is invisible on
Windows while working fine on Linux and macOS. Adding `#!/usr/bin/env bash` is usually the whole fix
and costs nothing elsewhere.

**Writing one task for both platforms**, which had no coverage anywhere. File tasks have no
equivalent of a TOML task's `run_windows` — the script *is* the command — so the mechanism is a pair:

```
mise-tasks/
  build          # #!/usr/bin/env bash
  build.ps1      # the Windows version
```

Windows prefers the native script (`build.ps1` answers to `build`, the extensionless file is
dropped); unix never sees the `.ps1` because it is not executable. `mise run build` does the right
thing on each. The page also notes the two edges: marking the `.ps1` executable on unix is harmless —
it becomes a separate task named `build.ps1`, because the rename only happens on Windows — and two
Windows candidates (`.ps1` **and** `.cmd`) are ambiguous, so mise keeps all three files rather than
picking.

None of that is discoverable from what is currently written down — the preference rule is not
documented at all, so a reader pairing `build.sh` with `build.ps1` has no way to learn that the
extensionless spelling is the one that works.

## Verification

Every claim measured against **2026.8.2 windows-x64**, not reasoned from the source:

```console
> mise tasks
amb
amb.cmd
amb.ps1
build    windows        # `build` + `build.ps1` -> one task, the .ps1's description

> mise run build
FROM-WINDOWS             # and the .ps1 is what runs
```

- `build` + `build.ps1` → one task, and it is the Windows one
- a file with no shebang and no extension → **not listed** at all
- `amb` + `amb.ps1` + `amb.cmd` → all three kept, which is the ambiguity case

The unix half was measured too, in a container on **2026.8.3 linux-x64**, with both files marked
executable — the case a Windows box cannot answer:

```console
$ mise tasks
build
build.ps1

$ mise run build
[build] $ /tmp/p/mise-tasks/build
FROM-POSIX
```

Two tasks with distinct names, and `build` is unambiguous. I first wrote this up as a second task
_named `build`_; both review bots caught it and the container confirmed them.

`prettier --check` and `markdownlint-cli2` both pass. The two links added
(`settings.html#windows_executable_extensions`, `task-configuration.html#run-windows`) were checked
against their targets — the second is a real `### \`run_windows\`` heading; the anchor
`#windows-support` I first reached for does not exist.

## Scope

Docs only. Nothing here describes behaviour that is not already released.

`.sh` deliberately does not appear as the POSIX half of a pair: on current mise a `build.sh` +
`build.ps1` pair produces two tasks with one name and runs both, which is what **#11992** fixes. Once
that lands this page can say `.sh` works too; until then the extensionless spelling is the one worth
recommending, and it stays correct either way.

Found while checking whether file tasks can branch on platform. The other half of that — an unknown
header key taking the whole project's tasks down — is #12007.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Windows-specific guidance for detecting file-based tasks.
  * Clarified how executable extensions and shebangs affect task recognition.
  * Documented recommendations for platform-specific scripts and resolving ambiguous candidates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
