### PR TITLE
e2e: install libgtk-3-0t64 so GTK tools can run their registry test

### DIFF
--- a/packaging/e2e/Dockerfile
+++ b/packaging/e2e/Dockerfile
@@ -32,6 +32,7 @@ apt-get update && apt-get install -y --no-install-recommends \
     libffi-dev \
     libgl1 \
     libglib2.0-0 \
+    libgtk-3-0t64 \
     libicu-dev \
     libncurses-dev \
     libreadline-dev \


### PR DESCRIPTION
One package, `libgtk-3-0t64`, so that a registry tool shipping a GTK 3 binary can answer its `test` command inside `ghcr.io/jdx/mise:e2e`.

The image already installs the rest of the desktop runtime — `libgl1`, `libglib2.0-0`, `libsm6`, `libwayland-client0`, `libxkbcommon0`, `libxi6`, `libxfixes3`, `libasound2t64` — but not GTK. For a GTK binary that is fatal before `main` runs, so even a `--version` that deliberately never opens a window cannot be tested:

```console
$ docker run --rm -v /tmp/kc:/kc:ro ghcr.io/jdx/mise:e2e sh -lc '/kc/knitcalc --version'
/kc/knitcalc: error while loading shared libraries: libgtk-3.so.0: cannot open shared object file: No such file or directory
$ echo $?
127
```

With this line added (measured on `ghcr.io/jdx/mise:e2e@sha256:905b8812be0d63aa9858d8f2a343f0f70b5489c0499376f147979fd239201260`, Ubuntu 26.04, plus `apt-get install -y --no-install-recommends libgtk-3-0t64`):

```console
$ docker run --rm -v /tmp/kc:/kc:ro mise-e2e-gtk sh -lc '/kc/knitcalc --version'
knitcalc 1.8.79+102
$ echo $?
0
```

which is what `test = { cmd = "knitcalc --version", expected = "knitcalc {{version}}" }` needs.

I would like to follow this with a `registry/knitcalc.toml` entry (`github:dmezhnov/knitcalc` — a cross-platform desktop app whose native runners answer `--version` headless on Linux, macOS and Windows precisely so that a package manager can test the binary). Since the e2e image is rebuilt only on a mise release tag, that PR cannot be green until this one is merged and a new image is published, so I am sending them in order instead of together.

If you would rather not carry a GTK runtime in the e2e image, say so and I will look for a different arrangement for the entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime compatibility for end-to-end testing by including the required GTK library in the application environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->