### PR TITLE
fix(backend): preserve installed backend metadata

### DIFF
--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -413,7 +413,17 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
         }
     }
 
-    for (short, pt) in init_plugins().await?.iter() {
+    let plugins = init_plugins().await?;
+    merge_plugin_tools(&mut tools, plugins.as_ref());
+    let tools = Arc::new(tools);
+    *INSTALL_STATE_TOOLS
+        .lock()
+        .expect("INSTALL_STATE_TOOLS lock failed") = Some(tools.clone());
+    Ok(tools)
+}
+
+fn merge_plugin_tools(tools: &mut InstallStateTools, plugins: &InstallStatePlugins) {
+    for (short, pt) in plugins {
         let full = match pt {
             PluginType::Asdf => format!("asdf:{short}"),
             PluginType::Vfox => format!("vfox:{short}"),
@@ -430,13 +440,10 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
                 opts: BTreeMap::new(),
                 installs_path: None,
             });
-        tool.full = Some(full);
+        // Installed metadata describes the versions already on disk. Plugin
+        // discovery should only supply an identity when no metadata exists.
+        tool.full.get_or_insert(full);
     }
-    let tools = Arc::new(tools);
-    *INSTALL_STATE_TOOLS
-        .lock()
-        .expect("INSTALL_STATE_TOOLS lock failed") = Some(tools.clone());
-    Ok(tools)
 }
 
 pub fn list_plugins() -> Arc<BTreeMap<String, PluginType>> {
@@ -695,8 +702,10 @@ pub fn reset() {
 #[cfg(test)]
 mod tests {
     use super::{
-        lock_tool_version, normalize_version_for_sort, read_tool_manifest_from, tool_version_lock,
+        InstallStateTool, lock_tool_version, merge_plugin_tools, normalize_version_for_sort,
+        read_tool_manifest_from, tool_version_lock,
     };
+    use crate::plugins::PluginType;
     use itertools::Itertools;
     use std::collections::BTreeMap;
     use std::sync::mpsc;
@@ -710,6 +719,40 @@ mod tests {
         std::fs::write(&path, "").unwrap();
 
         assert!(read_tool_manifest_from(&path).is_none());
+    }
+
+    #[test]
+    fn plugin_discovery_preserves_installed_backend_metadata() {
+        let mut tools = BTreeMap::from([(
+            "babashka".to_string(),
+            InstallStateTool {
+                short: "babashka".to_string(),
+                full: Some("github:babashka/babashka".to_string()),
+                versions: vec!["1.13.219".to_string()],
+                explicit_backend: false,
+                opts: BTreeMap::new(),
+                installs_path: None,
+            },
+        )]);
+        let plugins = BTreeMap::from([("babashka".to_string(), PluginType::Asdf)]);
+
+        merge_plugin_tools(&mut tools, &plugins);
+
+        assert_eq!(
+            tools["babashka"].full.as_deref(),
+            Some("github:babashka/babashka")
+        );
+    }
+
+    #[test]
+    fn plugin_discovery_adds_missing_tool_metadata() {
+        let mut tools = BTreeMap::new();
+        let plugins = BTreeMap::from([("babashka".to_string(), PluginType::Asdf)]);
+
+        merge_plugin_tools(&mut tools, &plugins);
+
+        assert_eq!(tools["babashka"].full.as_deref(), Some("asdf:babashka"));
+        assert!(tools["babashka"].explicit_backend);
     }
 
     #[test]

--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -746,13 +746,29 @@ mod tests {
 
     #[test]
     fn plugin_discovery_adds_missing_tool_metadata() {
-        let mut tools = BTreeMap::new();
+        let installs_path = std::path::PathBuf::from("installs/babashka");
+        let mut tools = BTreeMap::from([(
+            "babashka".to_string(),
+            InstallStateTool {
+                short: "babashka".to_string(),
+                full: None,
+                versions: vec!["1.13.219".to_string()],
+                explicit_backend: false,
+                opts: BTreeMap::new(),
+                installs_path: Some(installs_path.clone()),
+            },
+        )]);
         let plugins = BTreeMap::from([("babashka".to_string(), PluginType::Asdf)]);
 
         merge_plugin_tools(&mut tools, &plugins);
 
         assert_eq!(tools["babashka"].full.as_deref(), Some("asdf:babashka"));
-        assert!(tools["babashka"].explicit_backend);
+        assert_eq!(tools["babashka"].versions, ["1.13.219"]);
+        assert_eq!(
+            tools["babashka"].installs_path.as_ref(),
+            Some(&installs_path)
+        );
+        assert!(!tools["babashka"].explicit_backend);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve backend identity loaded from installed tool metadata when a same-named plugin is discovered
- retain plugin discovery as a fallback when no installed metadata exists
- add regression coverage for both precedence paths

## Root cause

Plugin discovery unconditionally replaced the backend recorded in `.mise.backend.toml`. When a GitHub-backed tool shared a shorthand with an installed asdf plugin, mise interpreted the existing install through the plugin and could add `<install>/bin` to `PATH` instead of the install root.

Related: https://github.com/jdx/mise/discussions/12005

## Validation

- `cargo test --bin mise toolset::install_state::tests::plugin_discovery`
- `cargo fmt --all -- --check`
- scoped `hk run fix --safe` (`cargo-fmt`, `cargo-check --all-features`)

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install-state backend resolution used for PATH and backend selection; behavior is narrowed to fix incorrect overwrites, with targeted tests.
> 
> **Overview**
> Fixes a bug where **plugin discovery overwrote** the backend identity already loaded from installed tool metadata (`.mise.backend.toml` / manifest). A GitHub-backed install that shared a shorthand with an asdf plugin could be treated as the plugin backend, which led to wrong **PATH** layout (e.g. `<install>/bin` vs install root).
> 
> Plugin merging is moved into **`merge_plugin_tools`**, which only sets `tool.full` when it is still missing (`get_or_insert`), so on-disk metadata wins and plugin IDs remain a fallback for tools without installed metadata. **Regression tests** cover both precedence paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f45dc944154b109c12b87342b4920d9f0c3cb778. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved plugin tool discovery and initialization for more reliable availability.
  - Preserved existing installed tool metadata when plugin information is also available.
  - Added missing metadata for plugin-provided tools when no existing information is present.
  - Ensured the combined tool list is consistently cached and returned after initialization, providing stable results across subsequent use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->