### PR TITLE
fix(http): detect archive formats after redirects

### DIFF
--- a/docs/dev-tools/backends/http.md
+++ b/docs/dev-tools/backends/http.md
@@ -295,7 +295,7 @@ format = "tar.xz"  # Explicitly specify the format
 ```
 
 ::: info
-If `format` is not specified, mise will automatically detect the format from the file extension in the URL. Only use `format` when the URL doesn't have a proper extension or when you need to override the detected format.
+If `format` is not specified, mise automatically detects the format from the final URL after HTTP redirects, falling back to the configured URL. This allows an extensionless download endpoint to redirect to an archive such as `.tar.gz`. An explicit `format` always takes precedence, so use it when neither URL has a useful extension or when you need to override the detected format.
 :::
 
 ### Platform-specific Format

--- a/e2e/backend/test_http_redirect_format
+++ b/e2e/backend/test_http_redirect_format
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+FIXTURE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/http-redirect-format.XXXXXX")
+PORT_FILE="$FIXTURE_DIR/port"
+mkdir -p "$FIXTURE_DIR/archive/bin"
+
+cat >"$FIXTURE_DIR/archive/bin/redirect-tool" <<'EOF'
+#!/usr/bin/env sh
+echo redirected archive
+EOF
+chmod +x "$FIXTURE_DIR/archive/bin/redirect-tool"
+tar -C "$FIXTURE_DIR/archive" -czf "$FIXTURE_DIR/artifact.tar.gz" bin
+
+cat >"$FIXTURE_DIR/raw-tool" <<'EOF'
+#!/usr/bin/env sh
+echo redirected raw file
+EOF
+chmod +x "$FIXTURE_DIR/raw-tool"
+
+FIXTURE_DIR="$FIXTURE_DIR" PORT_FILE="$PORT_FILE" python3 - <<'PY' &
+import http.server
+import os
+
+root = os.environ["FIXTURE_DIR"]
+port_file = os.environ["PORT_FILE"]
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        path = self.path.split("?", 1)[0]
+        redirects = {
+            "/download": "/artifact.tar.gz",
+            "/explicit": "/artifact.zip",
+            "/raw": "/raw-tool",
+        }
+        if path in redirects:
+            self.send_response(302)
+            self.send_header("Location", redirects[path])
+            self.end_headers()
+            return
+
+        files = {
+            "/artifact.tar.gz": "artifact.tar.gz",
+            # Deliberately misleading suffix: explicit format must win.
+            "/artifact.zip": "artifact.tar.gz",
+            "/raw-tool": "raw-tool",
+        }
+        filename = files.get(path)
+        if filename is None:
+            self.send_error(404)
+            return
+        with open(os.path.join(root, filename), "rb") as file:
+            body = file.read()
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("ETag", '"redirect-fixture"')
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args):
+        pass
+
+
+server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+with open(port_file, "w", encoding="utf-8") as file:
+    file.write(str(server.server_address[1]))
+server.serve_forever()
+PY
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null || true; rm -rf "$FIXTURE_DIR"' EXIT
+
+while [[ ! -s $PORT_FILE ]]; do
+  sleep 0.05
+done
+PORT=$(cat "$PORT_FILE")
+
+cat >mise.toml <<EOF
+[tools]
+"http:redirect-archive" = { version = "1.0.0", url = "http://127.0.0.1:$PORT/download?arch=x64", bin_path = "bin" }
+EOF
+
+export MISE_EXPERIMENTAL=1
+export MISE_LOCKFILE=1
+touch mise.lock
+mise install
+assert_contains "mise x -- redirect-tool" "redirected archive"
+assert_contains "cat mise.lock" "http://127.0.0.1:$PORT/download?arch=x64"
+assert_not_contains "cat mise.lock" "/artifact.tar.gz"
+
+cat >mise.toml <<EOF
+[tools]
+"http:redirect-explicit" = { version = "1.0.0", url = "http://127.0.0.1:$PORT/explicit", format = "tar.gz", bin_path = "bin" }
+EOF
+
+mise install
+assert_contains "mise x -- redirect-tool" "redirected archive"
+
+cat >mise.toml <<EOF
+[tools]
+"http:redirect-raw" = { version = "1.0.0", url = "http://127.0.0.1:$PORT/raw", bin = "redirect-raw" }
+EOF
+
+mise install
+assert_contains "mise x -- redirect-raw" "redirected raw file"

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -65,6 +65,8 @@ struct FileInfo {
     format: file::ExtractionFormat,
     /// Whether this is a compressed single binary (not a tar archive)
     is_compressed_binary: bool,
+    /// Whether format detection used information other than the original filename
+    format_affects_cache: bool,
 }
 
 struct CachePlan {
@@ -80,9 +82,9 @@ struct CacheTarget<'a> {
 
 impl FileInfo {
     /// Analyze a file path and options to determine format information
-    fn new(file_path: &Path, opts: &HttpOptions<'_>) -> Self {
+    fn new(file_path: &Path, effective_filename: Option<&str>, opts: &HttpOptions<'_>) -> Self {
         // Apply format config to determine effective extension
-        let effective_path = if let Some(added_ext) = opts.format() {
+        let (effective_path, format_affects_cache) = if let Some(added_ext) = opts.format() {
             let mut path = file_path.to_path_buf();
             let current_ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
             let new_ext = if current_ext.is_empty() {
@@ -91,9 +93,15 @@ impl FileInfo {
                 format!("{}.{}", current_ext, added_ext)
             };
             path.set_extension(new_ext);
-            path
+            (path, true)
+        } else if let Some(filename) = effective_filename
+            && file::ExtractionFormat::from_file_name(filename) != file::ExtractionFormat::Raw
+        {
+            let path = PathBuf::from(filename);
+            let affects_cache = path.file_name() != file_path.file_name();
+            (path, affects_cache)
         } else {
-            file_path.to_path_buf()
+            (file_path.to_path_buf(), false)
         };
 
         let file_name = effective_path.file_name().unwrap().to_string_lossy();
@@ -114,6 +122,7 @@ impl FileInfo {
             extension,
             format,
             is_compressed_binary,
+            format_affects_cache,
         }
     }
 
@@ -290,6 +299,7 @@ impl HttpBackend {
         &self,
         file_path: &Path,
         opts: &HttpOptions<'_>,
+        file_info: &FileInfo,
         strip_components: usize,
     ) -> Result<String> {
         let checksum = hash::file_hash_blake3(file_path, None)?;
@@ -297,6 +307,14 @@ impl HttpBackend {
         // Include extraction options that affect output structure
         // Note: bin_path is NOT included - handled at symlink time for deduplication
         let mut parts = vec![checksum];
+
+        if file_info.format_affects_cache {
+            parts.push(format!("format_{}", file_info.format));
+            if file_info.is_compressed_binary {
+                let destination = self.dest_filename(file_path, file_info, opts)?;
+                parts.push(format!("name_{}", hash::hash_blake3_to_str(&destination)));
+            }
+        }
 
         if let Some(strip) = opts.strip_components() {
             parts.push(format!("strip_{strip}"));
@@ -324,10 +342,15 @@ impl HttpBackend {
         Ok(key)
     }
 
-    fn cache_plan(&self, file_path: &Path, opts: &HttpOptions<'_>) -> Result<CachePlan> {
-        let file_info = FileInfo::new(file_path, opts);
+    fn cache_plan(
+        &self,
+        file_path: &Path,
+        effective_filename: Option<&str>,
+        opts: &HttpOptions<'_>,
+    ) -> Result<CachePlan> {
+        let file_info = FileInfo::new(file_path, effective_filename, opts);
         let strip_components = self.effective_strip_components(file_path, &file_info, opts)?;
-        let key = self.cache_key(file_path, opts, strip_components)?;
+        let key = self.cache_key(file_path, opts, &file_info, strip_components)?;
 
         Ok(CachePlan {
             key,
@@ -1119,7 +1142,8 @@ impl Backend for HttpBackend {
             .is_some();
 
         ctx.pr.set_message(format!("download {filename}"));
-        HTTP.download_file(&url, &file_path, Some(ctx.pr.as_ref()))
+        let download = HTTP
+            .download_file_with_metadata(&url, &file_path, Some(ctx.pr.as_ref()))
             .await?;
 
         // Verify artifact (checksum if provided)
@@ -1129,7 +1153,8 @@ impl Backend for HttpBackend {
         verify_artifact(&tv, &file_path, opts.raw(), Some(ctx.pr.as_ref()))?;
 
         // Generate cache key
-        let cache_plan = self.cache_plan(&file_path, &opts)?;
+        let cache_plan =
+            self.cache_plan(&file_path, download.effective_filename.as_deref(), &opts)?;
         ctx.pr.next_operation();
         if tv.install_path_is_explicit {
             ctx.pr.set_message("extracting to install path".into());
@@ -1478,6 +1503,91 @@ mod tests {
     }
 
     #[test]
+    fn file_info_prefers_explicit_then_redirected_then_original_format() {
+        let no_opts = ToolVersionOptions::default();
+        let no_opts = HttpOptions::new(&no_opts);
+
+        let redirected = FileInfo::new(Path::new("download"), Some("tool.tar.gz"), &no_opts);
+        assert_eq!(redirected.format, file::ExtractionFormat::TarGz);
+        assert!(redirected.format_affects_cache);
+
+        let redirected_over_original =
+            FileInfo::new(Path::new("tool.zip"), Some("tool.tar.gz"), &no_opts);
+        assert_eq!(
+            redirected_over_original.format,
+            file::ExtractionFormat::TarGz
+        );
+        assert!(redirected_over_original.format_affects_cache);
+
+        let original = FileInfo::new(Path::new("tool.zip"), Some("download"), &no_opts);
+        assert_eq!(original.format, file::ExtractionFormat::Zip);
+        assert!(!original.format_affects_cache);
+
+        let raw = FileInfo::new(Path::new("download"), Some("artifact"), &no_opts);
+        assert_eq!(raw.format, file::ExtractionFormat::Raw);
+        assert!(!raw.format_affects_cache);
+
+        let explicit_opts = crate::toolset::parse_tool_options("format=tar.xz");
+        let explicit_opts = HttpOptions::new(&explicit_opts);
+        let explicit = FileInfo::new(Path::new("download"), Some("tool.tar.gz"), &explicit_opts);
+        assert_eq!(explicit.format, file::ExtractionFormat::TarXz);
+        assert!(explicit.format_affects_cache);
+    }
+
+    #[test]
+    fn redirected_format_has_a_distinct_cache_identity() {
+        let backend = HttpBackend {
+            ba: Arc::new(BackendArg::new_raw(
+                "http-mytool".to_string(),
+                Some("http:mytool".to_string()),
+                "mytool".to_string(),
+                None,
+                BackendResolution::new(true),
+            )),
+        };
+        let artifact = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(artifact.path(), b"same-content").unwrap();
+        let raw_opts = ToolVersionOptions::default();
+        let opts = HttpOptions::new(&raw_opts);
+        let raw = FileInfo::new(artifact.path(), None, &opts);
+        let redirected = FileInfo::new(artifact.path(), Some("tool.tar.gz"), &opts);
+
+        let raw_key = backend.cache_key(artifact.path(), &opts, &raw, 0).unwrap();
+        let redirected_key = backend
+            .cache_key(artifact.path(), &opts, &redirected, 0)
+            .unwrap();
+
+        assert_ne!(raw_key, redirected_key);
+        assert!(redirected_key.ends_with("format_tar.gz"));
+    }
+
+    #[test]
+    fn redirected_compressed_filenames_have_distinct_cache_identities() {
+        let backend = HttpBackend {
+            ba: Arc::new(BackendArg::new_raw(
+                "http-mytool".to_string(),
+                Some("http:mytool".to_string()),
+                "mytool".to_string(),
+                None,
+                BackendResolution::new(true),
+            )),
+        };
+        let artifact = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(artifact.path(), b"same-content").unwrap();
+        let raw_opts = ToolVersionOptions::default();
+        let opts = HttpOptions::new(&raw_opts);
+        let alpha = FileInfo::new(artifact.path(), Some("alpha.gz"), &opts);
+        let beta = FileInfo::new(artifact.path(), Some("beta.gz"), &opts);
+
+        let alpha_key = backend
+            .cache_key(artifact.path(), &opts, &alpha, 0)
+            .unwrap();
+        let beta_key = backend.cache_key(artifact.path(), &opts, &beta, 0).unwrap();
+
+        assert_ne!(alpha_key, beta_key);
+    }
+
+    #[test]
     fn dest_filename_uses_decompressed_name_for_rename_exe_extension() {
         let backend = HttpBackend {
             ba: Arc::new(BackendArg::new_raw(
@@ -1491,7 +1601,7 @@ mod tests {
         let raw_opts = crate::toolset::parse_tool_options("rename_exe=code2prompt");
         let opts = HttpOptions::new(&raw_opts);
         let file_path = Path::new("code2prompt-x86_64-pc-windows-msvc.exe.gz");
-        let file_info = FileInfo::new(file_path, &opts);
+        let file_info = FileInfo::new(file_path, None, &opts);
 
         assert!(file_info.is_compressed_binary);
         assert_eq!(
@@ -1519,7 +1629,7 @@ mod tests {
         ] {
             let raw_opts = crate::toolset::parse_tool_options(opt);
             let opts = HttpOptions::new(&raw_opts);
-            let file_info = FileInfo::new(file_path, &opts);
+            let file_info = FileInfo::new(file_path, None, &opts);
             let err = backend
                 .dest_filename(file_path, &file_info, &opts)
                 .unwrap_err();
@@ -1531,7 +1641,7 @@ mod tests {
 
         let raw_opts = crate::toolset::parse_tool_options(r#"bin="bin/mytool""#);
         let opts = HttpOptions::new(&raw_opts);
-        let file_info = FileInfo::new(file_path, &opts);
+        let file_info = FileInfo::new(file_path, None, &opts);
         assert_eq!(
             backend.dest_filename(file_path, &file_info, &opts).unwrap(),
             "bin/mytool"
@@ -1559,9 +1669,9 @@ mod tests {
 
         let key_for = |opt: &str| {
             let opts = crate::toolset::parse_tool_options(opt);
-            backend
-                .cache_key(tmp.path(), &HttpOptions::new(&opts), 0)
-                .unwrap()
+            let opts = HttpOptions::new(&opts);
+            let file_info = FileInfo::new(tmp.path(), None, &opts);
+            backend.cache_key(tmp.path(), &opts, &file_info, 0).unwrap()
         };
 
         // Scalar, table, and adversarial values all yield path-safe keys.

--- a/src/http.rs
+++ b/src/http.rs
@@ -116,7 +116,7 @@ impl SendOnceOptions {
     }
 }
 
-const PARTIAL_DOWNLOAD_STATE_VERSION: u8 = 2;
+const PARTIAL_DOWNLOAD_STATE_VERSION: u8 = 3;
 const PARTIAL_DOWNLOAD_MAX_AGE: Duration = Duration::from_secs(30 * 24 * 60 * 60);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -179,6 +179,34 @@ struct PartialDownloadState {
     request_hash: String,
     validator: DownloadValidator,
     total_size: Option<u64>,
+    effective_filename: Option<String>,
+}
+
+/// Safe response metadata exposed to download callers.
+///
+/// This intentionally contains only the final URL's decoded path basename.
+/// Query strings, fragments, credentials, and the complete URL are never
+/// persisted in resumable download state.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct DownloadFileMetadata {
+    pub(crate) effective_filename: Option<String>,
+}
+
+fn download_filename_hint(url: &Url) -> Option<String> {
+    let segment = url.path_segments()?.next_back()?;
+    let filename = urlencoding::decode(segment).ok()?.into_owned();
+    if filename.is_empty()
+        || filename == "."
+        || filename == ".."
+        || filename.ends_with([' ', '.'])
+        || filename.chars().any(|c| {
+            c.is_control() || matches!(c, '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*')
+        })
+    {
+        None
+    } else {
+        Some(filename)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -722,9 +750,20 @@ impl Client {
         path: &Path,
         pr: Option<&dyn SingleReport>,
     ) -> Result<()> {
+        self.download_file_with_metadata(url, path, pr)
+            .await
+            .map(|_| ())
+    }
+
+    pub(crate) async fn download_file_with_metadata<U: IntoUrl>(
+        &self,
+        url: U,
+        path: &Path,
+        pr: Option<&dyn SingleReport>,
+    ) -> Result<DownloadFileMetadata> {
         let url = url.into_url()?;
         let headers = host_auth_headers(&url)?;
-        self.download_file_with_headers(url, path, &headers, pr)
+        self.download_file_with_headers_metadata(url, path, &headers, pr)
             .await
     }
 
@@ -735,6 +774,18 @@ impl Client {
         headers: &HeaderMap,
         pr: Option<&dyn SingleReport>,
     ) -> Result<()> {
+        self.download_file_with_headers_metadata(url, path, headers, pr)
+            .await
+            .map(|_| ())
+    }
+
+    async fn download_file_with_headers_metadata<U: IntoUrl>(
+        &self,
+        url: U,
+        path: &Path,
+        headers: &HeaderMap,
+        pr: Option<&dyn SingleReport>,
+    ) -> Result<DownloadFileMetadata> {
         self.download_file_with_headers_timeout(
             url,
             path,
@@ -752,7 +803,7 @@ impl Client {
         headers: &HeaderMap,
         pr: Option<&dyn SingleReport>,
         total_timeout: Duration,
-    ) -> Result<()> {
+    ) -> Result<DownloadFileMetadata> {
         ensure!(!Settings::get().offline(), "offline mode is enabled");
         let url = url.into_url()?;
         debug!("GET Downloading {} to {}", &url, display_path(path));
@@ -786,7 +837,7 @@ impl Client {
             }
         });
 
-        match tokio::time::timeout(total_timeout, download).await {
+        let metadata = match tokio::time::timeout(total_timeout, download).await {
             Ok(result) => result?,
             Err(_) => {
                 // A timeout cancels the transfer future before its normal cleanup
@@ -803,7 +854,7 @@ impl Client {
                     bytes_received.load(Ordering::Relaxed),
                 )
             }
-        }
+        };
 
         // Complete the atomic rename after the cancellable transfer budget. A
         // blocking task cannot be cancelled once it starts, so keeping it out
@@ -811,7 +862,7 @@ impl Client {
         // install the destination in the background.
         let path = path.to_path_buf();
         tokio::task::spawn_blocking(move || partial.persist(&path)).await??;
-        Ok(())
+        Ok(metadata)
     }
 
     async fn download_file_attempt(
@@ -821,7 +872,7 @@ impl Client {
         partial: &PartialDownload,
         pr: Option<&dyn SingleReport>,
         bytes_received: &AtomicU64,
-    ) -> Result<()> {
+    ) -> Result<DownloadFileMetadata> {
         let mut restarted_without_resume = false;
         loop {
             let resume = if restarted_without_resume {
@@ -836,7 +887,9 @@ impl Client {
                     pr.set_length(*partial_size);
                     pr.set_position(*partial_size);
                 }
-                return Ok(());
+                return Ok(DownloadFileMetadata {
+                    effective_filename: state.effective_filename.clone(),
+                });
             }
 
             let offset = resume.as_ref().map(|(_, size)| *size).unwrap_or(0);
@@ -858,6 +911,7 @@ impl Client {
                     "GET",
                 )
                 .await?;
+            let response_filename = download_filename_hint(resp.url());
 
             if resp.status() == StatusCode::RANGE_NOT_SATISFIABLE {
                 if let Some(ParsedContentRange::Unsatisfied { total }) = resp
@@ -876,64 +930,83 @@ impl Client {
                 resp.error_for_status_ref()?;
             }
 
-            let (write_offset, total_size, validator, resumable) = if resp.status()
-                == StatusCode::PARTIAL_CONTENT
-            {
-                let Some((state, _)) = resume else {
-                    partial.clear()?;
-                    if !restarted_without_resume {
+            let (write_offset, total_size, validator, resumable, effective_filename) =
+                if resp.status() == StatusCode::PARTIAL_CONTENT {
+                    let Some((state, _)) = resume else {
+                        partial.clear()?;
+                        if !restarted_without_resume {
+                            restarted_without_resume = true;
+                            continue;
+                        }
+                        bail!("server returned partial content without a resumable request");
+                    };
+                    let content_range = resp
+                        .headers()
+                        .get(CONTENT_RANGE)
+                        .and_then(|value| value.to_str().ok())
+                        .and_then(parse_content_range);
+                    let Some(ParsedContentRange::Bytes { start, end, total }) = content_range
+                    else {
+                        partial.clear()?;
+                        if restarted_without_resume {
+                            bail!("server returned an invalid Content-Range response");
+                        }
+                        restarted_without_resume = true;
+                        continue;
+                    };
+                    let validator = response_validator(resp.headers());
+                    let response_length_matches = resp
+                        .content_length()
+                        .is_none_or(|length| length == end - start + 1);
+                    if start != offset
+                        || end + 1 != total
+                        || !response_length_matches
+                        || state.total_size.is_some_and(|expected| expected != total)
+                        || validator
+                            .as_ref()
+                            .is_some_and(|value| !value.matches(&state.validator))
+                    {
+                        partial.clear()?;
+                        if restarted_without_resume {
+                            bail!("server returned inconsistent partial content");
+                        }
                         restarted_without_resume = true;
                         continue;
                     }
-                    bail!("server returned partial content without a resumable request");
-                };
-                let content_range = resp
-                    .headers()
-                    .get(CONTENT_RANGE)
-                    .and_then(|value| value.to_str().ok())
-                    .and_then(parse_content_range);
-                let Some(ParsedContentRange::Bytes { start, end, total }) = content_range else {
+                    // Keep the filename associated with the bytes already on disk.
+                    // A redirect target may change between requests even when the
+                    // server accepts the validator and Range header. Replacing the
+                    // stored hint could make the completed bytes use a different
+                    // archive format than the response that started the partial.
+                    let effective_filename = state.effective_filename;
+                    let validator = validator.unwrap_or(state.validator);
+                    (
+                        offset,
+                        Some(total),
+                        Some(validator),
+                        true,
+                        effective_filename,
+                    )
+                } else {
                     partial.clear()?;
-                    if restarted_without_resume {
-                        bail!("server returned an invalid Content-Range response");
-                    }
-                    restarted_without_resume = true;
-                    continue;
+                    let total_size = resp.content_length();
+                    let validator = response_validator(resp.headers());
+                    let resumable = total_size.is_some() && validator.is_some();
+                    (
+                        0,
+                        total_size,
+                        validator.filter(|_| resumable),
+                        resumable,
+                        response_filename,
+                    )
                 };
-                let validator = response_validator(resp.headers());
-                let response_length_matches = resp
-                    .content_length()
-                    .is_none_or(|length| length == end - start + 1);
-                if start != offset
-                    || end + 1 != total
-                    || !response_length_matches
-                    || state.total_size.is_some_and(|expected| expected != total)
-                    || validator
-                        .as_ref()
-                        .is_some_and(|value| !value.matches(&state.validator))
-                {
-                    partial.clear()?;
-                    if restarted_without_resume {
-                        bail!("server returned inconsistent partial content");
-                    }
-                    restarted_without_resume = true;
-                    continue;
-                }
-                let validator = validator.unwrap_or(state.validator);
-                (offset, Some(total), Some(validator), true)
-            } else {
-                partial.clear()?;
-                let total_size = resp.content_length();
-                let validator = response_validator(resp.headers());
-                let resumable = total_size.is_some() && validator.is_some();
-                (0, total_size, validator.filter(|_| resumable), resumable)
-            };
 
             let state = validator.map(|validator| PartialDownloadState {
                 version: PARTIAL_DOWNLOAD_STATE_VERSION,
                 request_hash: partial.request_hash.clone(),
                 validator,
                 total_size,
+                effective_filename: effective_filename.clone(),
             });
             if let Some(state) = &state {
                 partial.write_state(state)?;
@@ -988,7 +1061,7 @@ impl Client {
                     .into());
                 }
             }
-            return Ok(());
+            return Ok(DownloadFileMetadata { effective_filename });
         }
     }
 
@@ -1989,6 +2062,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_download_metadata_uses_redirected_filename() {
+        let mut server = mockito::Server::new_async().await;
+        let location = format!("{}/releases/tool.tar.gz", server.url());
+        let redirect = server
+            .mock("GET", "/download")
+            .with_status(302)
+            .with_header("location", &location)
+            .expect(1)
+            .create_async()
+            .await;
+        let artifact = server
+            .mock("GET", "/releases/tool.tar.gz")
+            .with_status(200)
+            .with_header("content-length", "2")
+            .with_body("OK")
+            .expect(1)
+            .create_async()
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+        let destination = dir.path().join("download");
+        let client = Client::new(Duration::from_secs(3), ClientKind::Http).unwrap();
+
+        let metadata = client
+            .download_file_with_metadata(format!("{}/download", server.url()), &destination, None)
+            .await
+            .unwrap();
+
+        assert_eq!(metadata.effective_filename.as_deref(), Some("tool.tar.gz"));
+        assert_eq!(std::fs::read(&destination).unwrap(), b"OK");
+        redirect.assert();
+        artifact.assert();
+    }
+
+    #[test]
+    fn test_download_filename_hint_excludes_unsafe_or_private_url_parts() {
+        let url: Url =
+            "https://user:pass@example.com/releases/tool%20name.tar.gz?token=secret#fragment"
+                .parse()
+                .unwrap();
+        assert_eq!(
+            download_filename_hint(&url).as_deref(),
+            Some("tool name.tar.gz")
+        );
+
+        let unsafe_url: Url = "https://example.com/releases/%2E%2E%2Fsecret.tar.gz"
+            .parse()
+            .unwrap();
+        assert_eq!(download_filename_hint(&unsafe_url), None);
+
+        for encoded_name in [
+            "tool%3Aname.tar.gz",
+            "tool%2Aname.tar.gz",
+            "tool%00name.tar.gz",
+        ] {
+            let url: Url = format!("https://example.com/releases/{encoded_name}")
+                .parse()
+                .unwrap();
+            assert_eq!(download_filename_hint(&url), None, "{encoded_name}");
+        }
+    }
+
+    #[tokio::test]
     async fn test_get_html_rejects_non_html_content_type() {
         let mut server = mockito::Server::new_async().await;
         let mock = server
@@ -2249,6 +2384,12 @@ mod tests {
             "\r\n",
             "hello"
         )
+    }
+    fn redirect_to_tar_gz_response() -> &'static str {
+        "HTTP/1.1 302 Found\r\nLocation: /tool.tar.gz\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+    }
+    fn redirect_to_zip_response() -> &'static str {
+        "HTTP/1.1 302 Found\r\nLocation: /tool.zip\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
     }
     fn resumed_download_response() -> &'static str {
         concat!(
@@ -3181,7 +3322,7 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
             resumed_download_response(),
         ])
         .await;
-        let url = format!("http://127.0.0.1:{port}/private?token=url-secret");
+        let url = format!("http://127.0.0.1:{port}/private/artifact.tar.gz?token=url-secret");
         let parsed_url: Url = url.parse().unwrap();
         let mut headers = HeaderMap::new();
         headers.insert(
@@ -3197,26 +3338,100 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         let client = Client::new(Duration::from_secs(2), ClientKind::Http).unwrap();
 
         let _err = client
-            .download_file_with_headers(&url, &destination, &headers, None)
+            .download_file_with_headers_metadata(&url, &destination, &headers, None)
             .await
             .unwrap_err();
         assert_eq!(std::fs::read(&partial.path).unwrap(), b"hello");
         let state = std::fs::read_to_string(&partial.state_path).unwrap();
         assert!(!state.contains("url-secret"));
         assert!(!state.contains("header-secret"));
+        assert!(state.contains("artifact.tar.gz"));
         assert_eq!(
             std::fs::read(&destination).unwrap(),
             b"existing destination"
         );
 
-        client
-            .download_file_with_headers(&url, &destination, &headers, None)
+        let metadata = client
+            .download_file_with_headers_metadata(&url, &destination, &headers, None)
             .await
             .unwrap();
+        assert_eq!(
+            metadata.effective_filename.as_deref(),
+            Some("artifact.tar.gz")
+        );
         assert_eq!(std::fs::read(&destination).unwrap(), b"helloworld");
         assert_eq!(count.load(Ordering::SeqCst), 2);
         assert!(
             requests.lock().unwrap()[1]
+                .to_ascii_lowercase()
+                .contains("range: bytes=5-")
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_download_resume_preserves_stored_filename_after_redirect_changes() {
+        let _guard = set_test_http_retries(0);
+        let (port, count, requests) = spawn_recording_server(vec![
+            redirect_to_tar_gz_response(),
+            truncated_download_response(),
+            redirect_to_zip_response(),
+            resumed_download_response(),
+        ])
+        .await;
+        let url = format!("http://127.0.0.1:{port}/download");
+        let dir = tempfile::tempdir().unwrap();
+        let destination = dir.path().join("artifact");
+        let client = Client::new(Duration::from_secs(2), ClientKind::Http).unwrap();
+
+        let _ = client
+            .download_file_with_headers_metadata(&url, &destination, &HeaderMap::new(), None)
+            .await
+            .unwrap_err();
+
+        let metadata = client
+            .download_file_with_headers_metadata(&url, &destination, &HeaderMap::new(), None)
+            .await
+            .unwrap();
+
+        assert_eq!(std::fs::read(&destination).unwrap(), b"helloworld");
+        assert_eq!(metadata.effective_filename.as_deref(), Some("tool.tar.gz"));
+        assert_eq!(count.load(Ordering::SeqCst), 4);
+        assert!(
+            requests.lock().unwrap()[3]
+                .to_ascii_lowercase()
+                .contains("range: bytes=5-")
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_download_resume_does_not_adopt_filename_when_initial_hint_missing() {
+        let _guard = set_test_http_retries(0);
+        let (port, count, requests) = spawn_recording_server(vec![
+            truncated_download_response(),
+            redirect_to_zip_response(),
+            resumed_download_response(),
+        ])
+        .await;
+        let url = format!("http://127.0.0.1:{port}/");
+        let dir = tempfile::tempdir().unwrap();
+        let destination = dir.path().join("artifact");
+        let client = Client::new(Duration::from_secs(2), ClientKind::Http).unwrap();
+
+        let _ = client
+            .download_file_with_headers_metadata(&url, &destination, &HeaderMap::new(), None)
+            .await
+            .unwrap_err();
+
+        let metadata = client
+            .download_file_with_headers_metadata(&url, &destination, &HeaderMap::new(), None)
+            .await
+            .unwrap();
+
+        assert_eq!(std::fs::read(&destination).unwrap(), b"helloworld");
+        assert_eq!(metadata.effective_filename, None);
+        assert_eq!(count.load(Ordering::SeqCst), 3);
+        assert!(
+            requests.lock().unwrap()[2]
                 .to_ascii_lowercase()
                 .contains("range: bytes=5-")
         );


### PR DESCRIPTION
## Summary

- Detect archive formats from the final redirect URL when the configured HTTP URL has no recognizable extension.
- Preserve the original logical URL for downloads, lockfiles, authentication, and destination naming.
- Keep redirect filename hints safe and stable across resumable downloads.

## Implementation

The HTTP downloader now returns only a validated basename hint from the final response URL. The HTTP backend uses that hint after explicit format configuration and before the original URL when selecting an extraction format. Redirect-derived extraction details are included in the cache identity, including a hash of the effective destination name for single-file compression, so equal payloads redirected as different filenames cannot share an incompatible extraction cache.

Resumable download metadata stores only the validated basename, never the full redirect URL, query string, fragment, credentials, or authorization headers. Windows-invalid and control characters are rejected. The redirect E2E uses an isolated temporary directory and port file for each run.

## Verification

- `mise exec -- cargo test --all-features backend::http::tests` — 20 passed
- `mise exec -- cargo test --all-features http::tests::test_download_filename_hint_excludes_unsafe_or_private_url_parts` — passed
- `mise run test:e2e e2e/backend/test_http_redirect_format` — passed
- `mise exec -- cargo check --all-features` — passed
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings` — blocked by the pre-existing `needless_return` in `src/system/packages/brew/cask.rs:1959`, outside this PR

Addresses https://github.com/jdx/mise/discussions/6944

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP tool installation when downloads redirect to different filenames or archive formats.
  * Archive formats are detected from the final download URL when no format is specified.
  * Preserved effective filenames in lockfiles and resumed downloads.
  * Improved compressed binary handling and archive extraction.
  * Added safeguards for unsafe filenames and private URL components.

* **Documentation**
  * Clarified HTTP format detection and precedence rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->