### PR TITLE
fix(settings): split path lists on the OS separator in the CLI

### DIFF
--- a/e2e-win/settings_set_path_list.Tests.ps1
+++ b/e2e-win/settings_set_path_list.Tests.ps1
@@ -1,0 +1,62 @@
+Describe 'mise settings set with a path list' {
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        # Saved here, restored in AfterAll: Pester runs every suite in one process, so removing an
+        # inherited value would leave the next suite without it.
+        $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+        $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:TestRoot | Out-Null
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:TestRoot
+        $script:ConfigPath = Join-Path $script:TestRoot "mise.toml"
+
+        # Counting `C:\` distinguishes the two behaviours without depending on how toml_edit
+        # quotes a string: the colon split severed every drive letter from its path, so the
+        # broken output held a bare `C` entry and no `C:\` at all.
+        function Get-DriveRootedCount {
+            $written = Get-Content $script:ConfigPath | Out-String
+            ([regex]::Matches($written, [regex]::Escape('C:\'))).Count
+        }
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        if ($null -eq $script:OriginalTrusted) {
+            Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
+        } else {
+            [Environment]::SetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', $script:OriginalTrusted, 'Process')
+        }
+    }
+
+    BeforeEach {
+        # `task.disable_paths` rather than `trusted_config_paths`, which is global_only: --local
+        # would not apply to it and the write would land in the real user config.
+        Set-Location $script:TestRoot
+        "[tools]" | Out-File -Encoding ascii $script:ConfigPath
+    }
+
+    It 'keeps a lone path whole' {
+        # No list separator anywhere, and it still came apart before: the drive letter's colon
+        # is not a separator.
+        mise settings set --local task.disable_paths 'C:\one'
+        Get-DriveRootedCount | Should -Be 1
+        (mise settings get task.disable_paths | Out-String) | Should -Match ([regex]::Escape('C:\one'))
+    }
+
+    It 'splits on the semicolon rather than the drive letter' {
+        mise settings set --local task.disable_paths 'C:\one;C:\two'
+        Get-DriveRootedCount | Should -Be 2
+        $got = mise settings get task.disable_paths | Out-String
+        $got | Should -Match ([regex]::Escape('C:\one'))
+        $got | Should -Match ([regex]::Escape('C:\two'))
+    }
+
+    It 'appends without severing the path when adding' {
+        # `mise settings add` reaches the same parser, so it carried the same defect.
+        mise settings set --local task.disable_paths 'C:\one'
+        mise settings add --local task.disable_paths 'C:\two'
+        Get-DriveRootedCount | Should -Be 2
+        $got = mise settings get task.disable_paths | Out-String
+        $got | Should -Match ([regex]::Escape('C:\one'))
+        $got | Should -Match ([regex]::Escape('C:\two'))
+    }
+}

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2045,7 +2045,7 @@
         },
         "trusted_config_paths": {
           "default": [],
-          "description": "This is a list of config paths that mise will automatically mark as trusted. Any config files under these paths will be trusted without prompting. Set to `[\"/\"]` to trust all config files, effectively disabling the trust mechanism. Paths are separated by the OS path separator when using the environment variable (`:` on Unix, `;` on Windows).",
+          "description": "This is a list of config paths that mise will automatically mark as trusted. Any config files under these paths will be trusted without prompting. Set to `[\"/\"]` to trust all config files, effectively disabling the trust mechanism. Paths are separated by the OS path separator when using the environment variable, `mise settings set`, or `mise settings add` (`:` on Unix, `;` on Windows).",
           "type": "array",
           "items": {
             "type": "string"

--- a/settings.toml
+++ b/settings.toml
@@ -406,8 +406,8 @@ This is an early-init setting: it must be set in `.miserc.toml`, environment
 variables, or CLI flags. Setting it in `mise.toml` will have no effect because
 config file discovery has already occurred by the time `mise.toml` is read.
 
-Paths are separated by the OS path separator when using the environment variable
-(`:` on Unix, `;` on Windows).
+Paths are separated by the OS path separator when using the environment variable,
+`mise settings set`, or `mise settings add` (`:` on Unix, `;` on Windows).
 """
 env = "MISE_CEILING_PATHS"
 parse_env = "list_by_os_path_separator"
@@ -1333,8 +1333,8 @@ This is an early-init setting: it must be set in `.miserc.toml`, environment
 variables, or CLI flags. Setting it in `mise.toml` will have no effect because
 config file discovery has already occurred by the time `mise.toml` is read.
 
-Paths are separated by the OS path separator when using the environment variable
-(`:` on Unix, `;` on Windows).
+Paths are separated by the OS path separator when using the environment variable,
+`mise settings set`, or `mise settings add` (`:` on Unix, `;` on Windows).
 """
 env = "MISE_IGNORED_CONFIG_PATHS"
 parse_env = "list_by_os_path_separator"
@@ -2494,8 +2494,8 @@ This is useful for shared environments like Docker containers or bastion hosts w
 base set of tools is pre-installed in a shared location, and users can install additional
 tools in their own directory.
 
-Paths are separated by the OS path separator when using the environment variable
-(`:` on Unix, `;` on Windows).
+Paths are separated by the OS path separator when using the environment variable,
+`mise settings set`, or `mise settings add` (`:` on Unix, `;` on Windows).
 """
 env = "MISE_SHARED_INSTALL_DIRS"
 optional = true
@@ -2919,8 +2919,8 @@ description = "Paths that mise will not look for tasks in."
 docs = """
 Paths that mise will not look for tasks in.
 
-Paths are separated by the OS path separator when using the environment variable
-(`:` on Unix, `;` on Windows).
+Paths are separated by the OS path separator when using the environment variable,
+`mise settings set`, or `mise settings add` (`:` on Unix, `;` on Windows).
 """
 env = "MISE_TASK_DISABLE_PATHS"
 parse_env = "list_by_os_path_separator"
@@ -3220,8 +3220,8 @@ default = []
 description = """This is a list of config paths that mise will automatically mark as \
 trusted. Any config files under these paths will be trusted without prompting. \
 Set to `["/"]` to trust all config files, effectively disabling the trust mechanism. \
-Paths are separated by the OS path separator when using the environment variable \
-(`:` on Unix, `;` on Windows)."""
+Paths are separated by the OS path separator when using the environment variable, \
+`mise settings set`, or `mise settings add` (`:` on Unix, `;` on Windows)."""
 env = "MISE_TRUSTED_CONFIG_PATHS"
 global_only = true
 parse_env = "list_by_os_path_separator"

--- a/src/cli/settings/set.rs
+++ b/src/cli/settings/set.rs
@@ -64,7 +64,7 @@ pub fn set(mut key: &str, value: &str, add: bool, local: bool) -> Result<()> {
         SettingsType::Duration => parse_duration(value)?,
         SettingsType::Url | SettingsType::Path | SettingsType::String => value.into(),
         SettingsType::ListString => parse_list_by_comma(value)?,
-        SettingsType::ListPath => parse_list_by_colon(value)?,
+        SettingsType::ListPath => parse_list_by_os_path_separator(value)?,
         SettingsType::SetString => parse_set_by_comma(value)?,
         SettingsType::IndexMap => parse_indexmap_by_json(value)?,
         SettingsType::BoolOrString => parse_bool(value).unwrap_or_else(|_| value.into()),
@@ -129,11 +129,26 @@ fn parse_list_by_comma(value: &str) -> Result<toml_edit::Value> {
     Ok(value.split(',').map(|s| s.trim().to_string()).collect())
 }
 
-fn parse_list_by_colon(value: &str) -> Result<toml_edit::Value> {
+/// Split a path list the way the host does: `;` on Windows, `:` on Unix.
+///
+/// Splitting on `:` unconditionally made `mise settings set trusted_config_paths 'C:\proj'`
+/// store `["C", "\proj"]`. A Windows drive letter's colon is not a separator, so even a lone
+/// path with no list separator in it came apart, leaving no way to write one from the CLI.
+/// #9058 gave the environment-variable route the OS separator; this is the CLI route it missed.
+///
+/// Deliberately the same `std::env::split_paths` that `list_by_os_path_separator` in
+/// `config::settings` uses for `parse_env = "list_by_os_path_separator"`, so the two entry
+/// points to the same settings cannot drift apart again. On Windows it also strips surrounding
+/// double quotes, matching how the OS itself reads a path list.
+fn parse_list_by_os_path_separator(value: &str) -> Result<toml_edit::Value> {
     if value.is_empty() || value == "[]" {
         return Ok(toml_edit::Array::new().into());
     }
-    Ok(value.split(':').map(|s| s.trim().to_string()).collect())
+    // `std::env` rather than `crate::env`, which is what `env` resolves to elsewhere in mise.
+    Ok(std::env::split_paths(value)
+        .map(|p| p.to_string_lossy().trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect())
 }
 
 fn parse_set_by_comma(value: &str) -> Result<toml_edit::Value> {
@@ -188,3 +203,89 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     $ <bold>mise settings idiomatic_version_file=true</bold>
 "#
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    fn entries(value: toml_edit::Value) -> Vec<String> {
+        value
+            .as_array()
+            .expect("a path list parses to an array")
+            .iter()
+            .map(|v| v.as_str().expect("array of strings").to_string())
+            .collect()
+    }
+
+    fn parse(value: &str) -> Vec<String> {
+        entries(parse_list_by_os_path_separator(value).unwrap())
+    }
+
+    fn expect(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// The defect this function exists for: a drive letter's colon is not a separator, so a
+    /// path list splits on `;` here. Asserted only on Windows -- `\` and `;` are ordinary
+    /// filename characters on unix, where `C:\a` really is one relative path named `C:\a`.
+    #[cfg(windows)]
+    #[test]
+    fn windows_drive_letter_is_not_a_separator() {
+        // The sharpest form: no list separator anywhere, and it still came apart before.
+        assert_eq!(parse(r"C:\a"), expect(&[r"C:\a"]));
+        assert_eq!(
+            parse(r"C:\a\one;C:\b\two"),
+            expect(&[r"C:\a\one", r"C:\b\two"])
+        );
+    }
+
+    /// `split_paths` unquotes on Windows, the way the OS reads a path list -- which is the only
+    /// way to spell a path containing the separator. Asserted so that swapping the split for a
+    /// hand-rolled one would fail here rather than quietly drop the quotes into the config.
+    #[cfg(windows)]
+    #[test]
+    fn windows_quoted_paths_are_unquoted() {
+        assert_eq!(
+            parse(r#""C:\Program Files\one";"C:\Program Files\two""#),
+            expect(&[r"C:\Program Files\one", r"C:\Program Files\two"])
+        );
+        // Quoting is per entry, not all-or-nothing.
+        assert_eq!(parse(r#""C:\a b";C:\c"#), expect(&[r"C:\a b", r"C:\c"]));
+    }
+
+    /// Unix keeps the colon it always had. This is the control for the change above: the
+    /// separator moved with the platform rather than everywhere.
+    #[cfg(not(windows))]
+    #[test]
+    fn unix_still_splits_on_colon() {
+        assert_eq!(parse("/a/one:/b/two"), expect(&["/a/one", "/b/two"]));
+        assert_eq!(parse("/a"), expect(&["/a"]));
+    }
+
+    #[test]
+    fn empty_input_parses_to_an_empty_array() {
+        assert!(parse("").is_empty());
+        assert!(parse("[]").is_empty());
+    }
+
+    #[test]
+    fn surrounding_whitespace_is_trimmed() {
+        #[cfg(windows)]
+        let (input, expected) = (r"  C:\a ; C:\b  ", expect(&[r"C:\a", r"C:\b"]));
+        #[cfg(not(windows))]
+        let (input, expected) = ("  /a : /b  ", expect(&["/a", "/b"]));
+        assert_eq!(parse(input), expected);
+    }
+
+    /// An empty segment is not a path. `list_by_os_path_separator` and `env::split_colon_list`
+    /// both drop them; writing one into the config would only be dropped again on read.
+    #[test]
+    fn empty_segments_are_dropped() {
+        #[cfg(windows)]
+        let (input, expected) = (r";C:\a;;C:\b;", expect(&[r"C:\a", r"C:\b"]));
+        #[cfg(not(windows))]
+        let (input, expected) = (":/a::/b:", expect(&["/a", "/b"]));
+        assert_eq!(parse(input), expected);
+    }
+}


### PR DESCRIPTION
`mise settings set` splits a `ListPath` value on `:`. On Windows that is the drive letter, so the
value comes apart — and it does so even when the input contains no list separator at all, which
leaves no way to spell one of these settings from the CLI:

```console
> mise settings set --local task.disable_paths "C:\a"
> mise settings get task.disable_paths
['\a', "C"]
```

## Why only the CLI

[#9058](https://github.com/jdx/mise/pull/9058) fixed exactly this for the environment-variable route
in April, adding `parse_env = "list_by_os_path_separator"` and `e2e-win/trusted_config_paths.Tests.ps1`.
It touched `src/env.rs`, `src/config/settings.rs` and `settings.toml` — but not
`src/cli/settings/set.rs`, which kept its own `parse_list_by_colon`. The two entry points to the
same setting have disagreed since:

```console
> $env:MISE_TASK_DISABLE_PATHS = "C:\a\one;C:\b\two"
> mise settings get task.disable_paths
['C:\a\one', 'C:\b\two']                      # env var: correct since #9058

> mise settings set --local task.disable_paths "C:\a\one;C:\b\two"
> mise settings get task.disable_paths
['\a\one;C', '\b\two', "C"]                   # CLI: same setting, same value
```

The docs said the OS separator applied "when using the environment variable", which described the
gap rather than closing it. They now name `mise settings set` and `mise settings add` alongside it,
because all three behave that way now.

## What it actually costs

Less than it looks, which is probably why it has gone unreported. A drive-less `\a\one` still
resolves against the *current* drive, so a single path on `C:` survives by accident. Two paths do
not — the first entry keeps the `;` and can never resolve. Measured against `trusted_config_paths`,
with the env var as the control:

```console
> mise settings set trusted_config_paths "<projA>;<projB>"
projA -> NOT trusted
projB -> TRUSTED

> $env:MISE_TRUSTED_CONFIG_PATHS = "<projA>;<projB>"     # control
projA -> TRUSTED
projB -> TRUSTED
```

So the config file is mangled in every case, and trust silently half-applies once there is more than
one path.

## The change

`parse_list_by_colon` becomes `parse_list_by_os_path_separator` and defers to
`std::env::split_paths` — deliberately the same function `list_by_os_path_separator` uses for the
env route, so the two cannot drift apart again. One call site.

Affects every `ListPath` setting — `trusted_config_paths`, `ceiling_paths`,
`ignored_config_paths`, `shared_install_dirs`, `task.disable_paths`, `age.identity_files`,
`age.ssh_identity_files` (and the deprecated `task_disable_paths`) — through both
`mise settings set` and `mise settings add`, which reach the same parser via `set()`.

Two smaller behaviour notes:

- **Trimming is kept.** `"/a : /b"` still yields `["/a", "/b"]` on unix, unchanged.
- **Empty segments are now dropped** (`"a::b"` → `["a", "b"]`). `list_by_os_path_separator` and
  `env::split_colon_list` already drop them and `Settings::trusted_config_paths()` filters empties
  on read, so this only stops writing something the reader discards.

`split_paths` also strips surrounding double quotes on Windows, the way the OS reads a path list, so
`'"C:\a b";C:\c'` now works — quoting being the only way to spell a path that contains the
separator. A test pins that, so a later hand-rolled split cannot quietly write the quotes into the
config file.

## Deliberately unchanged

- **`:` is not kept as a Windows fallback.** It is the defect: for an absolute path it produces
  garbage today, so nothing that works is lost by dropping it.
- **`mise config set`** splits `ListPath` on a comma (`src/cli/config/set.rs`). A Windows path has no
  comma, so it is not broken — a separate inconsistency, not this bug.
- `parse_list_by_comma` / `parse_set_by_comma` and the `set()` signature.

## Verification

Measured on **2026.8.2 windows-x64** before the change, with four controls:

| | result |
|---|---|
| lone path `C:\a`, no separator anywhere | `["C", '\a']` — no workaround exists |
| env var, same value | `['C:\a\one', 'C:\b\two']` — already correct |
| unix-shaped `/a/one:/b/two` | `["/a/one", "/b/two"]` — the split was live, not dead code |
| a comma-typed setting (`disable_tools`) | unaffected — specific to `ListPath` |

`std::env::split_paths` was measured on this host with a standalone `rustc` probe rather than
assumed, since the fix rests on it: `C:\a` → 1 entry, `C:\a\one;C:\b\two` → 2, surrounding quotes
stripped, empty segments dropped, and `/a/one:/b/two` → 1 entry (a colon is not a separator there).
Those are the cases the new unit tests assert.

Tests:

- unit tests in `src/cli/settings/set.rs`, which had none, split by platform — Windows asserts the
  drive letter is not a separator, unix asserts the colon still is. Asserting the Windows shape
  unconditionally is what broke `unit-macos` in #11982; `\` and `;` are ordinary filename characters
  on unix.
- `e2e-win/settings_set_path_list.Tests.ps1`, covering a lone path, a `;`-separated pair, and
  `settings add`. It uses `--local` with `task.disable_paths` rather than `trusted_config_paths`,
  which is `global_only` and would write to the real user config.

`cargo fmt`, `taplo fmt --check settings.toml` and `mise run render:schema` were run locally; the
schema regeneration changed exactly the one description string. **The build, clippy and the test
suite were not run locally** — those are left to CI, so the behaviour after the fix rests on the
`split_paths` probe and the tests rather than on a running binary.

Found while auditing Windows behaviour, the same pass that produced #12007 and #12008. No existing
issue or discussion covers it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path-list parsing for settings across operating systems.
  * Windows drive-letter colons are preserved, while platform-specific separators correctly separate multiple paths.
  * Empty entries are ignored, surrounding whitespace is trimmed, and quoted paths are handled correctly.
  * Applies consistently when setting, replacing, or adding path values.

* **Documentation**
  * Clarified path-separator behavior for list-based settings configured through environment variables, `mise settings set`, or `mise settings add`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
