### PR TITLE
fix(task): find a file task whose shebang follows a byte-order mark

### DIFF
--- a/e2e-win/task_bom.Tests.ps1
+++ b/e2e-win/task_bom.Tests.ps1
@@ -1,0 +1,71 @@
+Describe 'file tasks written with a UTF-8 byte-order mark' {
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        # Saved here, restored in AfterAll: Pester runs every suite in one process, so removing an
+        # inherited value would leave the next suite without it.
+        $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+        $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path (Join-Path $script:TestRoot "mise-tasks") | Out-Null
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:TestRoot
+        "[tools]" | Out-File -Encoding ascii (Join-Path $script:TestRoot "mise.toml")
+
+        # `Out-File -Encoding utf8` in Windows PowerShell 5.1 writes exactly this, which is how a
+        # hand-written task acquires a mark without its author choosing one.
+        function Write-Task {
+            param([string]$Name, [string]$Body, [bool]$Bom)
+            $path = Join-Path $script:TestRoot "mise-tasks\$Name"
+            [System.IO.File]::WriteAllText($path, $Body, (New-Object System.Text.UTF8Encoding $Bom))
+        }
+
+        function Get-Task {
+            param([string]$Name)
+            mise tasks --json | ConvertFrom-Json | Where-Object { $_.name -eq $Name }
+        }
+
+        # A shebang is what makes an extensionless file a task on Windows, so the mark decided
+        # whether these existed at all. `printf` rather than `echo` so the dispatch test below
+        # can only pass through bash: cmd has no `printf`, whereas `echo ran` would print `ran`
+        # if the old `cmd /c` fallback ever ran the file as a batch script.
+        $shebang = "#!/usr/bin/env bash`nprintf 'ran\n'`n"
+        Write-Task -Name "marked" -Body $shebang -Bom $true
+        Write-Task -Name "unmarked" -Body $shebang -Bom $false
+        # `.ps1` is found by its extension either way, so here the mark only reaches the header
+        # on line 1 -- where a task without a shebang naturally puts it.
+        $header = "#MISE description=`"from the header`"`nWrite-Output ran`n"
+        Write-Task -Name "marked_header.ps1" -Body $header -Bom $true
+        Write-Task -Name "unmarked_header.ps1" -Body $header -Bom $false
+
+        Set-Location $script:TestRoot
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        if ($null -eq $script:OriginalTrusted) {
+            Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
+        } else {
+            [Environment]::SetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', $script:OriginalTrusted, 'Process')
+        }
+    }
+
+    It 'finds a marked shebang task' {
+        Get-Task -Name "marked" | Should -Not -BeNullOrEmpty
+    }
+
+    It 'finds the unmarked twin too' {
+        # Control: the two files differ only by the mark, so this pins the fixture itself.
+        Get-Task -Name "unmarked" | Should -Not -BeNullOrEmpty
+    }
+
+    It 'runs a marked shebang task rather than falling back to cmd' {
+        $output = mise run marked | Out-String
+        $output | Should -Match "ran"
+    }
+
+    It 'reads a header on line 1 behind the mark' {
+        (Get-Task -Name "marked_header").description | Should -Be "from the header"
+    }
+
+    It 'reads the unmarked header the same way' {
+        (Get-Task -Name "unmarked_header").description | Should -Be "from the header"
+    }
+}

--- a/src/file.rs
+++ b/src/file.rs
@@ -463,6 +463,20 @@ pub fn read_to_string<P: AsRef<Path>>(path: P) -> Result<String> {
         .wrap_err_with(|| format!("failed read_to_string: {}", path.display_user()))
 }
 
+/// The bytes of a UTF-8 byte-order mark, as [`decode_text`] matches them below.
+#[cfg(windows)]
+pub(crate) const UTF8_BOM_BYTES: [u8; 3] = [0xef, 0xbb, 0xbf];
+
+/// `s` without a leading UTF-8 byte-order mark.
+///
+/// Needed wherever mise matches on the *start* of a line it read from disk. `str::trim` does not
+/// help: U+FEFF does not carry the Unicode `White_Space` property, so a mark left in front of a
+/// `#!` or a `#MISE` defeats every prefix test silently. The writers that leave one there are
+/// ordinary on Windows -- see [`decode_text`], which names them.
+pub fn strip_utf8_bom(s: &str) -> &str {
+    s.strip_prefix('\u{feff}').unwrap_or(s)
+}
+
 /// Decode text that may begin with a byte-order mark.
 ///
 /// `std`'s UTF-8-only readers reject UTF-16 outright, which is how a checksum file sank an install
@@ -976,16 +990,28 @@ pub fn has_known_executable_extension(path: &Path) -> bool {
     )
 }
 
-/// Check if a file starts with a shebang (#!).
-/// Only reads the first 2 bytes to minimize I/O during task discovery.
+/// Check if a file starts with a shebang (#!), allowing for a leading UTF-8 byte-order mark.
+///
+/// Reads only the first 5 bytes to minimize I/O during task discovery: two for the `#!`, plus
+/// three for a mark in front of it. Reading just the two saw `EF BB` and answered "no shebang",
+/// which on Windows is the whole of [`is_executable`] for an extensionless file -- so a task
+/// written by `Out-File -Encoding utf8` disappeared from `mise tasks` with no diagnostic, while
+/// the same file on unix was a task because there the execute bit decides.
+///
+/// A `read_exact` here would fail outright on a file shorter than the buffer, so read what is
+/// available instead. A UTF-16 mark is deliberately not accepted: no interpreter mise dispatches
+/// to can run a UTF-16 script, so treating one as a task would only trade silence for a
+/// confusing failure at exec time.
 #[cfg(windows)]
 pub fn has_shebang(path: &Path) -> bool {
     std::fs::File::open(path)
-        .and_then(|mut f| {
+        .and_then(|f| {
             use std::io::Read;
-            let mut buf = [0u8; 2];
-            f.read_exact(&mut buf)?;
-            Ok(buf == *b"#!")
+            let mut buf = Vec::with_capacity(UTF8_BOM_BYTES.len() + 2);
+            f.take((UTF8_BOM_BYTES.len() + 2) as u64)
+                .read_to_end(&mut buf)?;
+            let bytes = buf.strip_prefix(UTF8_BOM_BYTES.as_slice()).unwrap_or(&buf);
+            Ok(bytes.starts_with(b"#!"))
         })
         .unwrap_or(false)
 }
@@ -3771,5 +3797,50 @@ mod tests {
         // and it must offer what that branch actually accepts
         assert!(hint.contains("exe"), "{hint}");
         assert!(hint.contains("build"), "{hint}");
+    }
+
+    #[test]
+    fn strip_utf8_bom_removes_only_a_leading_mark() {
+        assert_eq!(
+            strip_utf8_bom("\u{feff}#!/usr/bin/env bash"),
+            "#!/usr/bin/env bash"
+        );
+        assert_eq!(strip_utf8_bom("#!/usr/bin/env bash"), "#!/usr/bin/env bash");
+        assert_eq!(strip_utf8_bom(""), "");
+        // Only the first one, and only at the front: a mark elsewhere is content.
+        assert_eq!(strip_utf8_bom("\u{feff}\u{feff}x"), "\u{feff}x");
+        assert_eq!(strip_utf8_bom("x\u{feff}"), "x\u{feff}");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn has_shebang_looks_past_a_utf8_bom() {
+        let tmp = tempfile::tempdir().unwrap();
+        let write = |name: &str, bytes: &[u8]| {
+            let path = tmp.path().join(name);
+            fs::write(&path, bytes).unwrap();
+            path
+        };
+        const SCRIPT: &[u8] = b"#!/usr/bin/env bash\necho hi\n";
+        let mut marked = UTF8_BOM_BYTES.to_vec();
+        marked.extend_from_slice(SCRIPT);
+
+        // The regression: `Out-File -Encoding utf8` writes this, and reading two bytes saw `EF BB`.
+        let bom = write("bom", &marked);
+        assert!(has_shebang(&bom));
+        // On Windows a shebang is the whole of `is_executable` for a file with no known extension,
+        // so this is what decided whether the task existed at all.
+        assert!(is_executable(&bom));
+
+        // Controls: the unmarked twin, and files that genuinely have no shebang.
+        assert!(has_shebang(&write("plain", SCRIPT)));
+        assert!(!has_shebang(&write("no_shebang", b"echo hi\n")));
+        assert!(!is_executable(&write("no_shebang2", b"echo hi\n")));
+        // Shorter than the buffer: a `read_exact` would error here rather than answer.
+        assert!(!has_shebang(&write("bom_only", &UTF8_BOM_BYTES)));
+        assert!(!has_shebang(&write("empty", b"")));
+        assert!(!has_shebang(&write("one_byte", b"#")));
+        // A UTF-16 mark is deliberately not accepted.
+        assert!(!has_shebang(&write("utf16", b"\xff\xfe#\0!\0")));
     }
 }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1033,6 +1033,11 @@ fn parse_task_dependencies(parser: &mut TrackingTomlParser<'_>, key: &str) -> Re
 /// only part parsed and rendered at load).
 pub(crate) fn file_has_decoded_template(path: &Path, body: &str) -> bool {
     use crate::config::config_file::mise_toml::toml_value_has_template;
+    // Must see exactly what the loader sees. `Task::from_path_unrendered_with_cf` strips a
+    // byte-order mark before scanning headers, so leaving one here would let a `#MISE` on line 1
+    // hide an escaped template from this check and then render it anyway -- the caller runs the
+    // two back to back on the same file.
+    let body = file::strip_utf8_bom(body);
     if path.extension().is_some_and(|e| e == "toml") {
         // Unparseable TOML won't load as a task file (it errors before any
         // render), so it doesn't need trust on this account.
@@ -1049,7 +1054,8 @@ pub(crate) fn file_has_decoded_template(path: &Path, body: &str) -> bool {
 
 fn parse_task_script_usage(file: &Path) -> usage::Result<usage::Spec> {
     let script = std::fs::read_to_string(file)?;
-    let raw = extract_usage_from_comments(&script);
+    // Same reason as the `#MISE` header scan: `#USAGE` on line 1 is invisible behind a mark.
+    let raw = extract_usage_from_comments(crate::file::strip_utf8_bom(&script));
     if raw.trim().is_empty() {
         return usage::Spec::parse_script(file);
     }
@@ -1328,7 +1334,11 @@ impl Task {
     ) -> Result<Task> {
         let mut task = Task::new(path, prefix, config_root)?;
         task.cf = cf;
-        let info = parse_mise_header_toml(&file::read_to_string(path)?)?
+        // Stripped before scanning: the header patterns anchor at the start of a line, so a
+        // byte-order mark would hide a `#MISE` written on line 1 -- which is where a task with
+        // an executable extension rather than a shebang puts it.
+        let body = file::read_to_string(path)?;
+        let info = parse_mise_header_toml(file::strip_utf8_bom(&body))?
             .into_iter()
             .filter_map(|toml| toml.as_table().cloned())
             .flatten()
@@ -3839,6 +3849,23 @@ rust_cache = { unknown = true }
             script,
             "#!/usr/bin/env bash\n#MISE description=\"\\u007b\\u007b exec(command='x') \\u007d\\u007d\"\necho hi\n"
         ));
+
+        // A byte-order mark must not hide the header from this check. The loader strips one
+        // before parsing the same header, so a miss here would mean rendering a template that
+        // was never gated on trust.
+        assert!(file_has_decoded_template(
+            script,
+            "\u{feff}#MISE description=\"\\u007b\\u007b exec(command='x') \\u007d\\u007d\"\necho hi\n"
+        ));
+        assert!(file_has_decoded_template(
+            toml,
+            "\u{feff}[hello]\nrun = \"echo hi\"\ndescription = \"\\u007b\\u007b exec(command='x') \\u007d\\u007d\"\n"
+        ));
+        // and it must not turn a plain file into one that needs trust
+        assert!(!file_has_decoded_template(
+            script,
+            "\u{feff}#MISE description=\"a plain task\"\necho hi\n"
+        ));
     }
 
     #[test]
@@ -3865,6 +3892,27 @@ exec shapeme "$@"
             assert_eq!(spec.cmd.mounts.len(), 1);
             assert_eq!(spec.cmd.mounts[0].run, "shapeme --usage-spec");
             assert!(!spec.cmd.subcommands.contains_key("__mise_task_root_mounts"));
+        }
+    }
+
+    /// A `#USAGE` on line 1 is the case a byte-order mark hides: the extractor anchors at the
+    /// start of a line, and `str::trim` does not remove U+FEFF. Without the mark stripped the
+    /// flag never reaches the spec, so `mise run task -- -f` leaves `usage_force` unset.
+    #[test]
+    fn test_parse_task_script_usage_reads_a_marked_first_line() {
+        use std::io::Write;
+
+        let directives = "#USAGE flag \"-f --force\" help=\"force it\"\nexec tool \"$@\"\n";
+        for (label, body) in [
+            ("marked", format!("\u{feff}{directives}")),
+            ("unmarked", directives.to_string()),
+        ] {
+            let mut tmp = tempfile::NamedTempFile::new().unwrap();
+            tmp.write_all(body.as_bytes()).unwrap();
+
+            let spec = super::parse_task_script_usage(tmp.path()).unwrap();
+            assert_eq!(spec.cmd.flags.len(), 1, "{label}");
+            assert_eq!(&spec.cmd.flags[0].name, "force", "{label}");
         }
     }
 

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -3,7 +3,7 @@ use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings, env_directive::EnvDirective};
 use crate::duration;
 use crate::env_diff::EnvDiff;
-use crate::file::{can_execute_directly, display_path, replace_path};
+use crate::file::{can_execute_directly, display_path, replace_path, strip_utf8_bom};
 use crate::sandbox::SandboxConfig;
 use crate::task::TaskArtifactCache;
 use crate::task::task_cache::{
@@ -2288,13 +2288,17 @@ fn msys_drive_prefix_for(program: &Path, env: &BTreeMap<String, String>) -> Stri
 /// Read the shebang from a file and parse it into a shell command.
 /// e.g. `#!/usr/bin/env bash` → `["bash"]`
 /// e.g. `#!/bin/bash` → `["/bin/bash"]`
+///
+/// A byte-order mark in front of the `#!` is skipped, the same way `crate::file::has_shebang`
+/// skips one when deciding the file is a task at all. Without that, a marked script fell through
+/// to `default_file_shell` -- `cmd /c` on Windows -- not the interpreter its author named.
 fn shell_from_shebang(path: &Path) -> Option<Vec<String>> {
     use std::io::{BufRead, BufReader};
     let f = std::fs::File::open(path).ok()?;
     let mut reader = BufReader::new(f);
     let mut first_line = String::new();
     reader.read_line(&mut first_line).ok()?;
-    let shebang = first_line.strip_prefix("#!")?;
+    let shebang = strip_utf8_bom(&first_line).strip_prefix("#!")?;
     let shebang = shebang.strip_prefix("/usr/bin/env -S").unwrap_or(shebang);
     let shebang = shebang.strip_prefix("/usr/bin/env").unwrap_or(shebang);
     let mut parts = shebang.split_whitespace();
@@ -2331,6 +2335,29 @@ mod tests {
         env.insert((*crate::env::PATH_KEY).to_string(), path.to_string());
         env.insert("OTHER".to_string(), "unchanged".to_string());
         env
+    }
+
+    /// Not gated on Windows: the mark reaches a shared repository from any platform, and the
+    /// fallback it caused -- `default_file_shell` instead of the named interpreter -- is wrong
+    /// everywhere, just most visible where that default is `cmd /c`.
+    #[test]
+    fn shell_from_shebang_looks_past_a_utf8_bom() {
+        let tmp = tempfile::tempdir().unwrap();
+        let write = |name: &str, bytes: &[u8]| {
+            let path = tmp.path().join(name);
+            std::fs::write(&path, bytes).unwrap();
+            path
+        };
+        const SCRIPT: &[u8] = b"#!/usr/bin/env bash\necho hi\n";
+        let mut marked = b"\xef\xbb\xbf".to_vec();
+        marked.extend_from_slice(SCRIPT);
+
+        let expected = Some(vec!["bash".to_string()]);
+        assert_eq!(shell_from_shebang(&write("bom", &marked)), expected);
+        // Control: the unmarked twin resolves the same way, so the mark was the only difference.
+        assert_eq!(shell_from_shebang(&write("plain", SCRIPT)), expected);
+        // A file with no shebang still yields nothing, so callers keep falling back as before.
+        assert_eq!(shell_from_shebang(&write("none", b"echo hi\n")), None);
     }
 
     #[test]


### PR DESCRIPTION
On Windows a file task with no known extension is a task only if it starts with a shebang, and
`has_shebang` read exactly two bytes. A script carrying a UTF-8 BOM shows `EF BB` there, so mise
ruled it not executable and the task disappeared — silently, and only on Windows:

```console
Windows                            Linux (control)
> mise tasks                       $ mise tasks
plain                              plain
                                   withbom          <- the execute bit decides here
> mise run withbom
mise ERROR no task withbom found
```

Both files hold the same bytes apart from the mark.

## Why this is worth fixing rather than documenting

- **Nothing is reported.** `MISE_VERBOSE=1` says nothing about the skipped file; it is simply
  absent from the list.
- **The advice mise gives is already followed.** `make_executable_hint` answers "Add a shebang line
  to …, or give it one of these extensions" — the shebang is right there on line 1.
- **mise is inconsistent with itself.** A `mise.toml` carrying the same mark loads fine.
- **The mark is not something the author opted into.** Measured on this host: Windows PowerShell
  5.1 (`powershell.exe`, the Windows 11 default, 5.1.26100.9168) writes a BOM from both
  `Out-File -Encoding utf8` and `Set-Content -Encoding UTF8`. PowerShell 7 does not. Several
  Windows editors default to it as well.

[#11552](https://github.com/jdx/mise/pull/11552) already taught `src/file.rs` about this exact
writer — its comment names PowerShell 5.1's `Out-File` — but only for checksum files. The file-task
path never got the same treatment.

## The change

A leading UTF-8 BOM should not change how mise reads a task file. One helper,
`file::strip_utf8_bom`, and three places that needed it:

1. **`file::has_shebang`** — reads up to 5 bytes instead of exactly 2 (two for `#!`, three for a
   mark) and skips the mark before comparing. `read_exact` is gone: it errors on a file shorter
   than the buffer rather than answering.
2. **`task_executor::shell_from_shebang`** — skips the mark before `strip_prefix("#!")`. Detection
   alone was not enough: with the shebang unreadable, a marked script fell through to
   `default_file_shell`, which is `cmd /c` on Windows. Measured before the fix, that hung until I
   killed it at five minutes.
3. **`#MISE` and `#USAGE` header scanning** (`Task::from_path_unrendered_with_cf` and
   `parse_task_script_usage`) — both anchor at `^(?:#|//|::)`, and `str::trim` does not help
   because U+FEFF has no Unicode `White_Space` property. A directive on line 1 was therefore
   invisible. That matters for a task found by its extension rather than a shebang — a `.ps1`,
   where line 1 is exactly where the header goes and where a BOM is most likely. Measured:

   ```console
   > mise tasks --json            # .ps1 with #MISE description on line 1
   plain     desc=[from header]
   withbom   desc=[]

   > mise run withbom -- -f       # .ps1 with #USAGE flag on line 1
   force=[]                       # plain gives force=[true]
   ```

   This part is not Windows-specific — a marked file committed from Windows loses its header on
   Linux CI too — so it is not `cfg`-gated.

4. **`file_has_decoded_template`** — the trust gate behind `task_include_requires_trust`, which
   scans the same `#MISE` headers to decide whether a task file may load untrusted. It has to see
   exactly what the loader sees, and `load_task_includes` runs the two back to back on the same
   path. Teaching only the loader about the mark would have let an escaped template on line 1 skip
   the gate and then render anyway. Measured on 2026.8.2 before this PR, with a `.ps1` whose line 1
   carries `description = "{{ exec(...) }}"`:

   ```console
   > mise tasks     # no mark
   mise ERROR Config files in ...\mise-tasks\plain.ps1 are not trusted.

   > mise tasks     # same bytes plus a BOM
   marked           # exit 0
   ```

   Harmless today only because the loader is equally blind; this PR is what would have made them
   disagree. `contains_template_syntax` does not cover it — it scans raw text, and the escaped form
   is precisely what that scan is meant to miss.

## Deliberately unchanged

- **UTF-16 is not accepted.** `decode_text` handles it, but that is for *data* files. No
  interpreter mise dispatches to can run a UTF-16 script, so accepting one would trade silence for
  a confusing failure at exec time.
- **`task_script_parser::shell_from_shebang(&str)`** takes an inline TOML `run` string; a file task
  reaches `exec_file` via `task.file`, so no mark arrives there.
- `decode_text`, `read_to_string_bom`, and the behaviour of `file::read_to_string` generally.
- `docs/tasks/file-tasks.md` — "starts with a shebang" simply becomes true for marked files too, so
  the page stays correct as written.

## Verification

Measured on **2026.8.2 windows-x64**, with a **2026.8.3 linux-x64** container as the control for
every claim about the platform difference. The symptom, the silence at `MISE_VERBOSE=1`, the
misleading hint, the `mise.toml` tolerance, the PowerShell 5.1 writers, the `cmd /c` fallback and
the two header cases above were each measured rather than reasoned about.

Tests:

- `src/file.rs`: `has_shebang` and `is_executable` accept a marked shebang, with the unmarked twin
  as the control and files that genuinely have no shebang as negatives — including a
  shorter-than-the-buffer file, which the old `read_exact` would have errored on, and a UTF-16 mark,
  which must still be rejected. Windows-gated, since the shebang rule is what that branch is for.
- `src/task/task_executor.rs`: `shell_from_shebang` resolves a marked script to `bash`. Not gated —
  the fallback it prevents is wrong on every platform.
- `src/task/mod.rs`: `file_has_decoded_template` catches a marked header in both a script and a
  `.toml` body, and a marked *plain* header still does not require trust — so the gate cannot drift
  into demanding trust for everything. `parse_task_script_usage` resolves a `#USAGE` flag written on
  a marked line 1, with the unmarked twin as the control. Neither is gated: the extractor anchors at
  the start of a line and `str::trim` leaves U+FEFF alone on every platform.
- `e2e-win/task_bom.Tests.ps1`: a marked shebang task is listed and runs, a marked `.ps1` header is
  read, each with its unmarked twin as a control. The script body is `printf` rather than `echo`
  so the dispatch case can only pass through bash — `cmd` has no `printf`, whereas `echo ran` would
  have printed `ran` if the old fallback ever ran the file as a batch script.

`cargo fmt` was run locally. **The build, clippy and the test suite were not** — those are left to
CI, so the behaviour after the fix rests on the measurements above and on the tests rather than on a
running binary.

Found while auditing Windows behaviour, the same pass that produced #12007, #12008 and #12012. No
existing issue or discussion covers it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows task handling for scripts that begin with a UTF-8 byte-order mark (BOM).
  * BOM-prefixed scripts now correctly support interpreter detection, task discovery, and execution.
  * Task metadata and usage headers are recognized even when they appear after a BOM.
  * Added coverage for marked, unmarked, and shebang-less task files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

