### PR TITLE
feat(bootstrap): add launchd throttle and queue keys

### DIFF
--- a/docs/bootstrap/launchd.md
+++ b/docs/bootstrap/launchd.md
@@ -32,16 +32,19 @@ numbers, `.`, `_`, and `-`. mise owns only the plist files it creates with the
 | `run_at_load`             | `RunAtLoad`               |
 | `keep_alive`              | `KeepAlive`               |
 | `start_interval`          | `StartInterval`           |
+| `throttle_interval`       | `ThrottleInterval`        |
 | `start_calendar_interval` | `StartCalendarInterval`   |
+| `queue_directories`       | `QueueDirectories`        |
 | `environment`             | `EnvironmentVariables`    |
 | `working_directory`       | `WorkingDirectory`        |
 | `stdout_path`             | `StandardOutPath`         |
 | `stderr_path`             | `StandardErrorPath`       |
 | `kickstart`               | run `launchctl kickstart` |
 
-`program`, `working_directory`, `stdout_path`, and `stderr_path` expand bare
-`~` and `~/` to the current user's home directory before writing the plist.
-`args` are passed through exactly as written.
+`program`, `working_directory`, `stdout_path`, `stderr_path`, and each entry in
+`queue_directories` expand bare `~` and `~/` to the current user's home
+directory before writing the plist. `args` are passed through exactly as
+written.
 `start_calendar_interval` accepts `minute` (0-59), `hour` (0-23), `day`
 (1-31), `weekday` (0-7), and `month` (1-12), and writes the corresponding
 launchd calendar keys. For multiple independent calendar schedules, use an
@@ -53,6 +56,14 @@ start_calendar_interval = [{ hour = 3 }, { hour = 12, weekday = 1 }]
 
 `start_interval` and `start_calendar_interval` are independent launchd
 triggers. If both are set, launchd can start the agent from either schedule.
+
+`throttle_interval` is the minimum number of seconds launchd waits between
+runs of the agent (launchd's default is 10).
+
+`queue_directories` starts the agent whenever any of the listed directories is
+non-empty; launchd expects the agent to drain them. launchd requires absolute
+paths here, so each entry must start with `/`, or be `~` or a `~/` path that
+expands to one.
 
 ## Semantics
 

--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -86,6 +86,11 @@ start_calendar_interval = [
   { minute = 59, hour = 23, day = 31, weekday = 7, month = 12 },
 ]
 
+[bootstrap.macos.launchd.agents.queue]
+program = "/bin/echo"
+throttle_interval = 300
+queue_directories = ["~/Library/Queues/sync", "/var/spool/sync"]
+
 [bootstrap.linux.systemd.units.sync]
 exec_start = "/usr/bin/rsync --archive source/ destination/"
 type = "oneshot"
@@ -212,7 +217,7 @@ strict = true
 
 [[schemas]]
 path = "file://$SCHEMA_PATH"
-include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-env-float.toml", "mise-bad-install-env-float.toml", "mise-bad-postinstall.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-systemd.toml", "mise-bad-oci-copy.toml", "mise-bad-shell-activate.toml"]
+include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-env-float.toml", "mise-bad-install-env-float.toml", "mise-bad-postinstall.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-launchd-queue.toml", "mise-bad-launchd-throttle.toml", "mise-bad-systemd.toml", "mise-bad-oci-copy.toml", "mise-bad-shell-activate.toml"]
 
 [[schemas]]
 path = "file://$TASK_SCHEMA_PATH"
@@ -361,6 +366,32 @@ start_calendar_interval = $interval
 TOML
   assert_fail "$TOMBI_LINT mise-bad-launchd-calendar.toml"
 done
+
+# Verify that launchd queue directories match runtime validation
+for queue_directories in \
+  '[""]' \
+  '["   "]' \
+  '["/var/spool/sync", ""]' \
+  '["queues/sync"]' \
+  '["./queues"]' \
+  '["~user/queues"]' \
+  '["/var/spool/sync", "queues/sync"]'; do
+  cat >"$HOME/workdir/mise-bad-launchd-queue.toml" <<TOML
+[bootstrap.macos.launchd.agents.invalid]
+program = "/bin/echo"
+queue_directories = $queue_directories
+TOML
+  assert_fail "$TOMBI_LINT mise-bad-launchd-queue.toml"
+done
+
+# Verify that a negative launchd throttle interval is rejected, matching the
+# runtime type (u64)
+cat >"$HOME/workdir/mise-bad-launchd-throttle.toml" <<TOML
+[bootstrap.macos.launchd.agents.invalid]
+program = "/bin/echo"
+throttle_interval = -1
+TOML
+assert_fail "$TOMBI_LINT mise-bad-launchd-throttle.toml"
 
 # Verify that systemd service/timer declarations match runtime validation
 for unit in \

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -4119,6 +4119,20 @@
                         "minimum": 0,
                         "description": "write StartInterval in seconds"
                       },
+                      "throttle_interval": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "write ThrottleInterval in seconds"
+                      },
+                      "queue_directories": {
+                        "type": "array",
+                        "description": "write QueueDirectories (absolute paths; `~` and `~/` are expanded)",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1,
+                          "pattern": "^(/|~$|~/)"
+                        }
+                      },
                       "start_calendar_interval": {
                         "description": "write one or more StartCalendarInterval schedules",
                         "oneOf": [

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -3460,7 +3460,9 @@ mod tests {
         args = ["--watch"]
         run_at_load = true
         start_interval = 300
+        throttle_interval = 60
         start_calendar_interval = { hour = 2, minute = 0 }
+        queue_directories = ["~/Library/Queues/my-sync"]
         environment = { PATH = "/usr/bin:/bin" }
         working_directory = "~"
         stdout_path = "~/Library/Logs/my-sync.log"
@@ -3479,6 +3481,8 @@ mod tests {
         assert_eq!(agent.args, vec!["--watch"]);
         assert!(agent.run_at_load);
         assert_eq!(agent.start_interval, Some(300));
+        assert_eq!(agent.throttle_interval, Some(60));
+        assert_eq!(agent.queue_directories, vec!["~/Library/Queues/my-sync"]);
         let crate::system::launchd::LaunchdCalendarIntervals::Single(interval) =
             agent.start_calendar_interval.as_ref().unwrap()
         else {

--- a/src/system/launchd.rs
+++ b/src/system/launchd.rs
@@ -25,7 +25,11 @@ pub struct LaunchdTomlConfig {
     #[serde(default)]
     pub start_interval: Option<u64>,
     #[serde(default)]
+    pub throttle_interval: Option<u64>,
+    #[serde(default)]
     pub start_calendar_interval: Option<LaunchdCalendarIntervals>,
+    #[serde(default)]
+    pub queue_directories: Vec<String>,
     #[serde(default)]
     pub environment: IndexMap<String, String>,
     #[serde(default)]
@@ -68,7 +72,9 @@ pub struct LaunchdRequest {
     pub run_at_load: bool,
     pub keep_alive: bool,
     pub start_interval: Option<u64>,
+    pub throttle_interval: Option<u64>,
     pub start_calendar_interval: Option<LaunchdCalendarIntervals>,
+    pub queue_directories: Vec<String>,
     pub environment: IndexMap<String, String>,
     pub working_directory: Option<String>,
     pub stdout_path: Option<String>,
@@ -106,6 +112,21 @@ impl LaunchdRequest {
         if let Some(interval) = &config.start_calendar_interval {
             interval.validate(&name)?;
         }
+        for dir in &config.queue_directories {
+            if dir.trim().is_empty() {
+                bail!("agent '{name}' `queue_directories` must not contain empty entries");
+            }
+            // checked against the raw string rather than `Path::is_absolute` on the
+            // expanded value: the plist is consumed by macOS launchd, so POSIX rules
+            // apply regardless of the platform parsing the config, and on Windows
+            // `Path::new("/var/spool").is_absolute()` is false (root, but no prefix)
+            if !is_absolute_launchd_path(dir) {
+                bail!(
+                    "agent '{name}' `queue_directories` entry '{dir}' must be an absolute path \
+                     (launchd requires absolute paths; `~` and `~/` are expanded)"
+                );
+            }
+        }
         Ok(Self {
             label: format!("dev.mise.{name}"),
             name,
@@ -114,7 +135,9 @@ impl LaunchdRequest {
             run_at_load: config.run_at_load,
             keep_alive: config.keep_alive,
             start_interval: config.start_interval,
+            throttle_interval: config.throttle_interval,
             start_calendar_interval: config.start_calendar_interval,
+            queue_directories: config.queue_directories,
             environment: config.environment,
             working_directory: config.working_directory,
             stdout_path: config.stdout_path,
@@ -315,10 +338,25 @@ fn plist_value(request: &LaunchdRequest) -> Value {
     if let Some(interval) = request.start_interval {
         dict.insert("StartInterval".into(), Value::Integer(interval.into()));
     }
+    if let Some(interval) = request.throttle_interval {
+        dict.insert("ThrottleInterval".into(), Value::Integer(interval.into()));
+    }
     if let Some(interval) = &request.start_calendar_interval {
         dict.insert(
             "StartCalendarInterval".into(),
             calendar_intervals_value(interval),
+        );
+    }
+    if !request.queue_directories.is_empty() {
+        dict.insert(
+            "QueueDirectories".into(),
+            Value::Array(
+                request
+                    .queue_directories
+                    .iter()
+                    .map(|path| Value::String(expand_path_string(path)))
+                    .collect(),
+            ),
         );
     }
     if !request.environment.is_empty() {
@@ -431,6 +469,14 @@ fn current_uid_from(euid: u32, sudo_uid: Option<&str>) -> u32 {
         return uid;
     }
     euid
+}
+
+/// Whether `path` expands to an absolute path in `expand_path_string`.
+///
+/// `~user/...` is deliberately excluded: `file::replace_path` only rewrites a
+/// `~/` prefix, so a tilde-username path would reach launchd verbatim.
+fn is_absolute_launchd_path(path: &str) -> bool {
+    path == "~" || path.starts_with("~/") || path.starts_with('/')
 }
 
 fn expand_path_string(path: &str) -> String {
@@ -570,6 +616,7 @@ mod tests {
             run_at_load: true,
             keep_alive: true,
             start_interval: Some(60),
+            throttle_interval: Some(300),
             start_calendar_interval: Some(LaunchdCalendarIntervals::Single(
                 LaunchdCalendarInterval {
                     hour: Some(2),
@@ -577,6 +624,7 @@ mod tests {
                     ..Default::default()
                 },
             )),
+            queue_directories: vec!["~/Library/Queues/sync".to_string()],
             environment,
             working_directory: Some("~".to_string()),
             stdout_path: Some("~/Library/Logs/sync.log".to_string()),
@@ -595,6 +643,21 @@ mod tests {
         assert_eq!(dict.get("RunAtLoad"), Some(&Value::Boolean(true)));
         assert_eq!(dict.get("KeepAlive"), Some(&Value::Boolean(true)));
         assert_eq!(dict.get("StartInterval"), Some(&Value::Integer(60.into())));
+        assert_eq!(
+            dict.get("ThrottleInterval"),
+            Some(&Value::Integer(300.into()))
+        );
+        assert_eq!(
+            dict.get("QueueDirectories"),
+            Some(&Value::Array(vec![Value::String(
+                crate::dirs::HOME
+                    .join("Library")
+                    .join("Queues")
+                    .join("sync")
+                    .to_string_lossy()
+                    .to_string()
+            )]))
+        );
         match dict.get("StartCalendarInterval") {
             Some(Value::Dictionary(interval)) => {
                 assert_eq!(interval.get("Hour"), Some(&Value::Integer(2.into())));
@@ -663,6 +726,7 @@ mod tests {
             run_at_load: false,
             keep_alive: false,
             start_interval: None,
+            throttle_interval: None,
             start_calendar_interval: Some(LaunchdCalendarIntervals::Multiple(vec![
                 LaunchdCalendarInterval {
                     hour: Some(3),
@@ -675,6 +739,7 @@ mod tests {
                     ..Default::default()
                 },
             ])),
+            queue_directories: vec![],
             environment: IndexMap::new(),
             working_directory: None,
             stdout_path: None,
@@ -706,6 +771,93 @@ mod tests {
             }
             value => panic!("expected StartCalendarInterval array, got {value:?}"),
         }
+        assert_eq!(dict.get("ThrottleInterval"), None);
+        assert_eq!(dict.get("QueueDirectories"), None);
+    }
+
+    #[test]
+    fn test_render_plist_throttle_and_queue_directories() {
+        let request = LaunchdRequest::from_toml(
+            "sync".to_string(),
+            LaunchdTomlConfig {
+                program: Some("/bin/echo".to_string()),
+                throttle_interval: Some(10),
+                queue_directories: vec![
+                    "~/Library/Queues/sync".to_string(),
+                    "/var/spool/sync".to_string(),
+                ],
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let plist = render_plist(&request).unwrap();
+        let dict = match Value::from_reader_xml(Cursor::new(plist.as_slice())).unwrap() {
+            Value::Dictionary(dict) => dict,
+            value => panic!("expected dictionary, got {value:?}"),
+        };
+        assert_eq!(
+            dict.get("ThrottleInterval"),
+            Some(&Value::Integer(10.into()))
+        );
+        assert_eq!(
+            dict.get("QueueDirectories"),
+            Some(&Value::Array(vec![
+                Value::String(
+                    crate::dirs::HOME
+                        .join("Library")
+                        .join("Queues")
+                        .join("sync")
+                        .to_string_lossy()
+                        .to_string()
+                ),
+                Value::String("/var/spool/sync".to_string()),
+            ]))
+        );
+        assert!(plist_matches(&plist, &request));
+    }
+
+    #[test]
+    fn test_launchd_queue_directories_validation() {
+        for queue_directories in [
+            vec!["".to_string()],
+            vec!["   ".to_string()],
+            vec!["/var/spool/sync".to_string(), "\t".to_string()],
+            vec!["queues/sync".to_string()],
+            vec!["./queues".to_string()],
+            vec!["../queues".to_string()],
+            // `~user` is not expanded by `file::replace_path`
+            vec!["~user/queues".to_string()],
+            vec!["/var/spool/sync".to_string(), "queues/sync".to_string()],
+        ] {
+            assert!(
+                LaunchdRequest::from_toml(
+                    "my-agent".to_string(),
+                    LaunchdTomlConfig {
+                        program: Some("/bin/echo".to_string()),
+                        queue_directories,
+                        ..Default::default()
+                    },
+                )
+                .is_err()
+            );
+        }
+        // `/` and `~`-rooted entries are accepted on every platform: the plist is
+        // consumed by macOS launchd, not by the host parsing the config
+        assert!(
+            LaunchdRequest::from_toml(
+                "my-agent".to_string(),
+                LaunchdTomlConfig {
+                    program: Some("/bin/echo".to_string()),
+                    queue_directories: vec![
+                        "/var/spool/sync".to_string(),
+                        "~/Library/Queues/sync".to_string(),
+                        "~".to_string(),
+                    ],
+                    ..Default::default()
+                },
+            )
+            .is_ok()
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
Adds two additive launchd plist keys to
`[bootstrap.macos.launchd.agents]`:

- `throttle_interval` -> [`ThrottleInterval`](https://keith.github.io/xcode-man-pages/launchd.plist.5.html#ThrottleInterval)
- `queue_directories` -> [`QueueDirectories`](https://keith.github.io/xcode-man-pages/launchd.plist.5.html#QueueDirectories)

`queue_directories` entries expand bare `~`/`~/` like the other path-valued keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added macOS launchd support for throttle intervals and queue-directory triggers.
- Supports configuring one or multiple queue directories.
- Expands queue-directory paths before generating launchd configuration.

## Bug Fixes
- Rejects empty, whitespace-only, relative, or invalid queue-directory entries.
- Validates throttle intervals to prevent negative values.

## Documentation
- Documented supported launchd settings, throttling behavior, path expansion, and queue-directory requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->