### PR TITLE
fix(shell): escape single quotes in pwsh env output

### DIFF
--- a/e2e-win/pwsh_env_quoting.Tests.ps1
+++ b/e2e-win/pwsh_env_quoting.Tests.ps1
@@ -1,0 +1,77 @@
+Describe 'mise env --shell pwsh quoting' {
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        # Saved here, restored in AfterAll: Pester runs every suite in one process, so removing an
+        # inherited value would leave the next suite without it.
+        $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+        $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:TestRoot | Out-Null
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:TestRoot
+        Set-Location $script:TestRoot
+
+        # A unit test can only check the text mise emits. This runs it, which is the thing that
+        # was broken: an apostrophe closed the literal and PowerShell refused to parse the line.
+        function Invoke-MiseEnv {
+            $script = Join-Path $script:TestRoot "env.ps1"
+            $body = mise env --shell pwsh | Out-String
+            $probe = 'Write-Output ("QUOTED=[" + ${Env:QUOTED} + "] PLAIN=[" + ${Env:PLAIN} + "]")'
+            [System.IO.File]::WriteAllText($script, $body + "`n" + $probe + "`n")
+            pwsh -NoProfile -File $script 2>&1 | Out-String
+        }
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        if ($null -eq $script:OriginalTrusted) {
+            Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
+        } else {
+            [Environment]::SetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', $script:OriginalTrusted, 'Process')
+        }
+    }
+
+    It 'emits a value containing an apostrophe that PowerShell can parse' {
+        # `O'Brien` is an ordinary Windows username, so this reaches anyone whose home directory
+        # carries one -- every `hook-env` during `mise activate pwsh`.
+        @"
+[env]
+QUOTED = "C:\\Users\\O'Brien\\tools"
+PLAIN = "no quote here"
+"@ | Out-File -Encoding ascii (Join-Path $script:TestRoot "mise.toml")
+
+        $output = Invoke-MiseEnv
+        $output | Should -Not -BeLike '*ParserError*'
+        # round-tripped exactly, not merely parsed
+        $output.Contains("QUOTED=[C:\Users\O'Brien\tools]") | Should -BeTrue
+        $output.Contains("PLAIN=[no quote here]") | Should -BeTrue
+    }
+
+    It 'still emits a value with no apostrophe correctly' {
+        # Control: pins the fixture, so the test above cannot pass by emitting nothing at all.
+        @"
+[env]
+QUOTED = "plain value"
+PLAIN = "no quote here"
+"@ | Out-File -Encoding ascii (Join-Path $script:TestRoot "mise.toml")
+
+        $output = Invoke-MiseEnv
+        $output | Should -Not -BeLike '*ParserError*'
+        $output.Contains("QUOTED=[plain value]") | Should -BeTrue
+    }
+
+    It 'emits an env name containing a space that PowerShell can parse' {
+        # `$Env:MY VAR=...` is a parse error; the braced form is what accepts it.
+        @"
+[env]
+"MY VAR" = "spaced"
+"@ | Out-File -Encoding ascii (Join-Path $script:TestRoot "mise.toml")
+
+        $script = Join-Path $script:TestRoot "env2.ps1"
+        $body = mise env --shell pwsh | Out-String
+        $probe = 'Write-Output ("SPACED=[" + ${Env:MY VAR} + "]")'
+        [System.IO.File]::WriteAllText($script, $body + "`n" + $probe + "`n")
+        $output = pwsh -NoProfile -File $script 2>&1 | Out-String
+
+        $output | Should -Not -BeLike '*ParserError*'
+        $output.Contains("SPACED=[spaced]") | Should -BeTrue
+    }
+}

--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -17,7 +17,11 @@ impl Shell for Pwsh {
         let exe = opts.exe;
         let flags = opts.flags;
 
-        let exe = exe.to_string_lossy();
+        // Single-quoted rather than double: PowerShell expands `$name` and honours backticks
+        // inside `"..."`, so a mise installed under a directory holding either character was
+        // invoked at a mangled path — `& "C:\...\a$b\mise.exe"` resolves to `C:\...\a\mise.exe`.
+        // A path wants no expansion at all, which is exactly what `'...'` gives.
+        let exe = escape_sq(&exe.to_string_lossy()).into_owned();
         let mut out = String::new();
 
         out.push_str(&shell::build_deactivation_script(self));
@@ -46,11 +50,11 @@ impl Shell for Pwsh {
                 }}
 
                 if ($arguments.count -eq 0) {{
-                    & "{exe}"
+                    & '{exe}'
                     _reset_output_encoding
                     return
                 }} elseif ($arguments -contains '-h' -or $arguments -contains '--help') {{
-                    & "{exe}" @arguments
+                    & '{exe}' @arguments
                     _reset_output_encoding
                     return
                 }}
@@ -64,11 +68,11 @@ impl Shell for Pwsh {
 
                 switch ($command) {{
                     {{ $_ -in 'deactivate', 'shell', 'sh' }} {{
-                        & "{exe}" $command @remainingArgs | Out-String | Invoke-Expression -ErrorAction SilentlyContinue
+                        & '{exe}' $command @remainingArgs | Out-String | Invoke-Expression -ErrorAction SilentlyContinue
                         _reset_output_encoding
                     }}
                     default {{
-                        & "{exe}" $command @remainingArgs
+                        & '{exe}' $command @remainingArgs
                         if ($(Test-Path -Path Function:\_mise_hook)){{
                             _mise_hook
                         }}
@@ -84,7 +88,7 @@ impl Shell for Pwsh {
             function Global:_mise_hook {{
                 if ($env:MISE_SHELL -eq "pwsh"){{
                     $status = $global:LASTEXITCODE
-                    $output = & "{exe}" hook-env{flags} $args -s pwsh | Out-String
+                    $output = & '{exe}' hook-env{flags} $args -s pwsh | Out-String
                     if ($output -and $output.Trim()) {{
                         $output | Invoke-Expression
                     }}
@@ -165,7 +169,7 @@ impl Shell for Pwsh {
                             # `mise` when the user typed `premise`, while matching only
                             # the first token would miss `... | some-missing-tool`
                             if ($lastCommand -and (($lastCommand -split '\s+') -contains $Name)) {{
-                                if (& "{exe}" hook-not-found -s pwsh -- $Name){{
+                                if (& '{exe}' hook-not-found -s pwsh -- $Name){{
                                     _mise_hook
                                     if (Get-Command $Name -ErrorAction SilentlyContinue){{
                                         $EventArgs.Command = Get-Command $Name
@@ -201,20 +205,24 @@ impl Shell for Pwsh {
     }
 
     fn set_env(&self, k: &str, v: &str) -> String {
-        let k = powershell_escape(k.into());
-        let v = powershell_escape(v.into());
-        format!("$Env:{k}='{v}'\n")
+        let k = escape_env_name(k);
+        let v = escape_sq(v);
+        format!("${{Env:{k}}}='{v}'\n")
     }
 
     fn prepend_env(&self, k: &str, v: &str) -> String {
-        let k = powershell_escape(k.into());
-        let v = powershell_escape(v.into());
-        format!("$Env:{k}='{v}'+[IO.Path]::PathSeparator+$env:{k}\n")
+        let k = escape_env_name(k);
+        let v = escape_sq(v);
+        format!("${{Env:{k}}}='{v}'+[IO.Path]::PathSeparator+${{env:{k}}}\n")
     }
 
     fn unset_env(&self, k: &str) -> String {
-        let k = powershell_escape(k.into());
-        format!("Remove-Item -ErrorAction SilentlyContinue -Path Env:/{k}\n")
+        // A cmdlet argument rather than a variable reference, so this one is an ordinary
+        // single-quoted string. `-LiteralPath` rather than `-Path` because quoting only settles
+        // how PowerShell *parses* the argument -- `Remove-Item` still globs `*`, `?` and `[...]`
+        // in a `-Path`, so removing a variable named `*` would take every other one with it.
+        let k = escape_sq(k);
+        format!("Remove-Item -ErrorAction SilentlyContinue -LiteralPath 'Env:/{k}'\n")
     }
 }
 
@@ -224,41 +232,33 @@ impl Display for Pwsh {
     }
 }
 
-fn powershell_escape(s: Cow<str>) -> Cow<str> {
-    let needs_escape = s.is_empty();
-
-    if !needs_escape {
-        return s;
+/// Quote `input` for a PowerShell single-quoted string literal, without the surrounding quotes.
+///
+/// Inside `'...'` every character is literal except `'`, which is written by doubling it. A
+/// backtick is *not* an escape there — that is only true inside `"..."` — so emitting `` `' ``
+/// left the quote closing the literal, and the line failed to parse rather than carrying an
+/// apostrophe. Allocates only when there is a quote to double, the way `xonsh_escape_sq` in the
+/// xonsh backend does for Python's rules.
+fn escape_sq(input: &str) -> Cow<'_, str> {
+    if input.contains('\'') {
+        Cow::Owned(input.replace('\'', "''"))
+    } else {
+        Cow::Borrowed(input)
     }
+}
 
-    let mut es = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-    loop {
-        match chars.next() {
-            Some('\t') => {
-                es.push_str("`t");
-            }
-            Some('\n') => {
-                es.push_str("`n");
-            }
-            Some('\r') => {
-                es.push_str("`r");
-            }
-            Some('\'') => {
-                es.push_str("`'");
-            }
-            Some('`') => {
-                es.push_str("``");
-            }
-            Some(c) => {
-                es.push(c);
-            }
-            None => {
-                break;
-            }
-        }
+/// Quote an environment variable name for the `${Env:NAME}` form.
+///
+/// The braces are what let a name through that bare `$Env:NAME` cannot parse — anything holding
+/// a space, say, which `[env]` in a config accepts. Inside them a backtick escapes the next
+/// character, so a backtick and the closing brace are the two that have to be escaped;
+/// everything else, apostrophes included, is literal.
+fn escape_env_name(name: &str) -> Cow<'_, str> {
+    if name.contains(['`', '}']) {
+        Cow::Owned(name.replace('`', "``").replace('}', "`}"))
+    } else {
+        Cow::Borrowed(name)
     }
-    es.into()
 }
 
 #[cfg(test)]
@@ -299,6 +299,93 @@ mod tests {
     fn test_prepend_env() {
         let pwsh = Pwsh::default();
         assert_snapshot!(replace_path(&pwsh.prepend_env("PATH", "/some/dir:/2/dir")));
+    }
+
+    /// The defect: an apostrophe closed the literal, so the line did not parse. Only `'` is
+    /// special inside `'...'` -- escaping anything else would be the same mistake in reverse,
+    /// turning a literal backtick or `$` into something PowerShell acts on.
+    #[test]
+    fn test_set_env_escapes_single_quotes_only() {
+        let pwsh = Pwsh::default();
+        assert_eq!(
+            pwsh.set_env("HOME_ISH", r"C:\Users\O'Brien\tools"),
+            "${Env:HOME_ISH}='C:\\Users\\O''Brien\\tools'\n"
+        );
+        // literal inside a single-quoted string, so they pass through untouched
+        assert_eq!(
+            pwsh.set_env("RAW", "a`b $c \"d\" e\\f"),
+            "${Env:RAW}='a`b $c \"d\" e\\f'\n"
+        );
+        assert_eq!(pwsh.set_env("EMPTY", ""), "${Env:EMPTY}=''\n");
+        // two apostrophes in one value, and one at each edge
+        assert_eq!(pwsh.set_env("K", "'a'b'"), "${Env:K}='''a''b'''\n");
+    }
+
+    /// PATH is the value that matters most here: it carries the user's home directory, so an
+    /// apostrophe in a Windows username reached every `hook-env`.
+    #[test]
+    fn test_prepend_env_escapes_single_quotes() {
+        assert_eq!(
+            Pwsh::default().prepend_env("PATH", r"C:\Users\O'Brien\bin"),
+            "${Env:PATH}='C:\\Users\\O''Brien\\bin'+[IO.Path]::PathSeparator+${env:PATH}\n"
+        );
+    }
+
+    /// `$Env:NAME` cannot parse a name with a space, which `[env]` in a config accepts; the
+    /// braced form can. Inside the braces a backtick escapes the next character, so it and the
+    /// closing brace are escaped and an apostrophe is left alone.
+    #[test]
+    fn test_env_names_use_the_braced_form() {
+        let pwsh = Pwsh::default();
+        assert_eq!(pwsh.set_env("MY VAR", "x"), "${Env:MY VAR}='x'\n");
+        assert_eq!(pwsh.set_env("WEIRD'KEY", "x"), "${Env:WEIRD'KEY}='x'\n");
+        assert_eq!(pwsh.set_env("A}B", "x"), "${Env:A`}B}='x'\n");
+        assert_eq!(pwsh.set_env("A`B", "x"), "${Env:A``B}='x'\n");
+    }
+
+    /// `unset_env` builds a `-Path` argument rather than a variable reference, so it is an
+    /// ordinary single-quoted string and takes the value rule, not the name rule.
+    #[test]
+    fn test_unset_env_quotes_the_path() {
+        assert_eq!(
+            Pwsh::default().unset_env("MY VAR"),
+            "Remove-Item -ErrorAction SilentlyContinue -LiteralPath 'Env:/MY VAR'\n"
+        );
+        assert_eq!(
+            Pwsh::default().unset_env("WEIRD'KEY"),
+            "Remove-Item -ErrorAction SilentlyContinue -LiteralPath 'Env:/WEIRD''KEY'\n"
+        );
+    }
+
+    /// Quoting settles parsing, not globbing: `Remove-Item -Path 'Env:/*'` still matches every
+    /// variable and removes them all. Measured -- with `-Path` two unrelated probe variables were
+    /// wiped, with `-LiteralPath` they survived and only the one named `*` went.
+    #[test]
+    fn test_unset_env_does_not_glob_the_name() {
+        for name in ["*", "?", "PRE[FIX]"] {
+            let out = Pwsh::default().unset_env(name);
+            assert!(out.contains("-LiteralPath"), "{out}");
+            assert!(!out.contains(" -Path "), "{out}");
+            assert!(out.contains(&format!("'Env:/{name}'")), "{out}");
+        }
+    }
+
+    /// A `$` is legal in a Windows directory name, and the exe path used to be interpolated
+    /// into a double-quoted string, where PowerShell expanded it away.
+    #[test]
+    fn test_activate_invokes_the_exe_through_a_single_quoted_path() {
+        unsafe {
+            std::env::remove_var("__MISE_ORIG_PATH");
+            std::env::remove_var("__MISE_DIFF");
+        }
+        let out = Pwsh::default().activate(ActivateOptions {
+            exe: Path::new(r"C:\Users\me\a$b\mise.exe").to_path_buf(),
+            flags: "".into(),
+            no_hook_env: false,
+            prelude: vec![],
+        });
+        assert!(out.contains(r"& 'C:\Users\me\a$b\mise.exe'"), "{out}");
+        assert!(!out.contains(r#"& "C:\Users\me\a$b\mise.exe""#), "{out}");
     }
 
     #[test]

--- a/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
@@ -24,11 +24,11 @@ function mise {
     }
 
     if ($arguments.count -eq 0) {
-        & "/some/dir/mise"
+        & '/some/dir/mise'
         _reset_output_encoding
         return
     } elseif ($arguments -contains '-h' -or $arguments -contains '--help') {
-        & "/some/dir/mise" @arguments
+        & '/some/dir/mise' @arguments
         _reset_output_encoding
         return
     }
@@ -42,11 +42,11 @@ function mise {
 
     switch ($command) {
         { $_ -in 'deactivate', 'shell', 'sh' } {
-            & "/some/dir/mise" $command @remainingArgs | Out-String | Invoke-Expression -ErrorAction SilentlyContinue
+            & '/some/dir/mise' $command @remainingArgs | Out-String | Invoke-Expression -ErrorAction SilentlyContinue
             _reset_output_encoding
         }
         default {
-            & "/some/dir/mise" $command @remainingArgs
+            & '/some/dir/mise' $command @remainingArgs
             if ($(Test-Path -Path Function:\_mise_hook)){
                 _mise_hook
             }
@@ -58,7 +58,7 @@ function mise {
 function Global:_mise_hook {
     if ($env:MISE_SHELL -eq "pwsh"){
         $status = $global:LASTEXITCODE
-        $output = & "/some/dir/mise" hook-env --status $args -s pwsh | Out-String
+        $output = & '/some/dir/mise' hook-env --status $args -s pwsh | Out-String
         if ($output -and $output.Trim()) {
             $output | Invoke-Expression
         }
@@ -135,7 +135,7 @@ if (-not (Test-Path variable:global:__mise_pwsh_command_not_found)){
                 # `mise` when the user typed `premise`, while matching only
                 # the first token would miss `... | some-missing-tool`
                 if ($lastCommand -and (($lastCommand -split '\s+') -contains $Name)) {
-                    if (& "/some/dir/mise" hook-not-found -s pwsh -- $Name){
+                    if (& '/some/dir/mise' hook-not-found -s pwsh -- $Name){
                         _mise_hook
                         if (Get-Command $Name -ErrorAction SilentlyContinue){
                             $EventArgs.Command = Get-Command $Name

--- a/src/shell/snapshots/mise__shell__pwsh__tests__prepend_env.snap
+++ b/src/shell/snapshots/mise__shell__pwsh__tests__prepend_env.snap
@@ -4,4 +4,4 @@ assertion_line: 173
 expression: "replace_path(&pwsh.prepend_env(\"PATH\", \"/some/dir:/2/dir\"))"
 snapshot_kind: text
 ---
-$Env:PATH='/some/dir:/2/dir'+[IO.Path]::PathSeparator+$env:PATH
+${Env:PATH}='/some/dir:/2/dir'+[IO.Path]::PathSeparator+${env:PATH}

--- a/src/shell/snapshots/mise__shell__pwsh__tests__set_env.snap
+++ b/src/shell/snapshots/mise__shell__pwsh__tests__set_env.snap
@@ -4,4 +4,4 @@ assertion_line: 167
 expression: "Pwsh::default().set_env(\"FOO\", \"1\")"
 snapshot_kind: text
 ---
-$Env:FOO='1'
+${Env:FOO}='1'

--- a/src/shell/snapshots/mise__shell__pwsh__tests__unset_env.snap
+++ b/src/shell/snapshots/mise__shell__pwsh__tests__unset_env.snap
@@ -3,4 +3,4 @@ source: src/shell/pwsh.rs
 expression: "Pwsh::default().unset_env(\"FOO\")"
 snapshot_kind: text
 ---
-Remove-Item -ErrorAction SilentlyContinue -Path Env:/FOO
+Remove-Item -ErrorAction SilentlyContinue -LiteralPath 'Env:/FOO'


### PR DESCRIPTION
`powershell_escape` never escaped anything:

```rust
let needs_escape = s.is_empty();
if !needs_escape { return s; }
```

Only an empty string reached the body, where it produced the same empty string back — so the whole
escaping loop was unreachable. Its rule was wrong in any case: it emitted `` `' `` for a quote, but
a backtick is not an escape character inside a PowerShell `'...'` literal (that is only true inside
`"..."`), so the quote simply closed the string.

An apostrophe in any value therefore produced a line PowerShell refuses to parse:

```console
> mise env --shell pwsh
$Env:HOMEISH='C:\Users\O'Brien\tools'
$Env:PATH='C:\Users\O'Brien\bin;...'

> pwsh -NoProfile -File block.ps1
ParserError: ... $Env:HOMEISH='C:\Users\O'Brien\tools'
```

`O'Brien` is an ordinary Windows username, and a home directory feeds `PATH`. Under
`mise activate pwsh` — the documented Windows setup — the activation script itself loads, but every
`_mise_hook` pipes `hook-env -s pwsh` into `Invoke-Expression`, so each one hits a ParserError and
the environment is never applied.

## Control

bash is correct — `export V='it'\''s here'` via `shell_escape::unix::escape` — as are fish
(`shell_escape`), nushell (CSV `"` doubling) and xonsh (`xonsh_escape_sq`). **pwsh was the only
backend whose escaper was inert.** The one case that worked was an empty value, `$Env:EMPTY=''`,
which is exactly the branch that `is_empty()` gate admitted.

The existing tests use `set_env("FOO", "1")`, `prepend_env("PATH", "/some/dir:/2/dir")` and
`unset_env("FOO")` — no special characters anywhere, which is why the dead code went unnoticed.

## The change

Three interpolation contexts, each with its own rule. All four forms below were measured against
real `pwsh` before being written:

| emitted | result |
|---|---|
| `$Env:MY VAR='x'` (before) | ParserError |
| `${Env:MY VAR}='x'` | ok |
| ``${Env:A`}B}='x'`` | ok |
| `-Path Env:/MY VAR` (before) | Remove-Item error |
| `-Path 'Env:/MY VAR'` | ok |

1. **Values** (`set_env`, `prepend_env`) double the quote: `'` → `''`. Nothing else is touched —
   escaping a backtick or `$` inside `'...'` would be the same mistake in reverse, turning a
   literal into something PowerShell acts on.
2. **Names** move to `${Env:NAME}`. Bare `$Env:NAME` cannot parse a name holding a space, which
   `[env]` in a config accepts; the braced form can. Inside the braces a backtick escapes the next
   character, so a backtick and the closing brace are escaped there and an apostrophe is left alone.
3. **`unset_env`** builds a cmdlet argument rather than a variable reference, so it is an ordinary
   single-quoted string and takes the value rule. It also moves from `-Path` to `-LiteralPath`:
   quoting settles how PowerShell *parses* the argument, but `Remove-Item` still globs `*`, `?` and
   `[...]` inside a `-Path`. Measured, with two unrelated probe variables and one named `*`:

   ```console
   before             : A=[a] B=[b] star=[star]
   after -Path        : A=[]  B=[]              # both unrelated variables wiped
   after -LiteralPath : A=[a] B=[b]             # only the variable named `*` went
   ```

   That globbing is not new — the previous `-Path Env:/{k}` was unquoted and globbed identically —
   but quoting the argument without this would have left the line looking safe while it was not.
   `-LiteralPath` has existed since PowerShell 2.0, so Windows PowerShell 5.1 is covered too.

Both helpers allocate only when there is something to escape, the way `xonsh_escape_sq` does for
Python's rules.

## The exe path, same bug in the other direction

The activation script invoked mise as `& "{exe}"` — a *double*-quoted string, where PowerShell does
expand `$name` and honour backticks. A `$` is legal in a Windows directory name, so that path was
mangled. Measured with a real directory and a real executable:

```console
& "...\dollar$dir\fake.cmd"   ->  fails; $dir expands away, leaving ...\dollar\fake.cmd
& '...\dollar$dir\fake.cmd'   ->  REAL-EXE-RAN
```

An apostrophe was harmless there, which is why this is a separate reproduction rather than part of
the one above. All six invocation sites move to `'...'` through the same value escaper — a path
wants no expansion at all.

## Verification

Measured on 2026.8.2 windows-x64 throughout: the ParserError above, the bash control, the empty-value
case, the four name/path forms in the table, and the exe path with a real `$` directory. After
writing the fix I fed the exact strings it emits to `pwsh` rather than only reading them:

```
HOME_ISH=[C:\Users\O'Brien\tools]        PATH_ISH=[C:\Users\O'Brien\bin;]
MYVAR=[spaced]      A-brace-B=[braced]   K=['a'b']
```

Tests:

- `src/shell/pwsh.rs`: quotes doubled; backtick, `$`, `"` and `\` left alone; empty value; quotes at
  both edges; the braced-name forms; `unset_env`'s path, including that a name of `*`, `?` or
  `PRE[FIX]` is not globbed; and the activation script invoking a `$` path through single quotes.
- `e2e-win/pwsh_env_quoting.Tests.ps1`: runs what mise emits through `pwsh` and asserts the value
  round-trips **exactly**, which is the part a unit test cannot reach. A no-apostrophe case is the
  control, so the test cannot pass by emitting nothing.

The four snapshots are updated for the new `${Env:...}` and `& '...'` shapes.

`cargo fmt` was run locally. **The build, clippy and the test suite were not** — those are left to
CI, so behaviour after the fix rests on the measurements above and on the tests rather than on a
running binary. In particular the snapshots were edited by hand rather than regenerated with insta.

Found while auditing Windows behaviour, the same pass that produced #12007, #12008, #12012, #12013
and #12014. No existing issue or discussion covers it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PowerShell environment script generation for values containing apostrophes, dollar signs, backticks, spaces, and other special characters.
  - Corrected handling of environment variable names with spaces or closing braces.
  - Ensured executable and unset paths are emitted safely without causing parsing or expansion errors.

- **Tests**
  - Added coverage for PowerShell quoting, environment round-tripping, and executable invocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
