### PR TITLE
fix(env): redact caller-provided values for required env directives

### DIFF
--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -159,6 +159,20 @@ including patterns inherited from a global config:
 TEST_TOKEN = { value = "not-sensitive", redact = false }
 ```
 
+Redaction also covers values the caller supplies. A variable declared with `required = true` is only
+validated — mise never assigns it — but the value the caller passed in is still redacted when
+`redact = true` or a `redactions` pattern matches its name:
+
+```toml
+redactions = ["*_KEY_*"]
+
+[tasks.deploy]
+env = { ASC_KEY_ID = { required = true, redact = true } }
+run = "./deploy.sh"
+```
+
+The same applies to a `default` whose fallback the caller overrides.
+
 ### Viewing Redacted Environment Variables
 
 The `mise env` command provides flags to work with redacted variables:
@@ -220,6 +234,10 @@ You can mark environment variables as required by setting `required = true`. Thi
 DATABASE_URL = { required = true }
 API_KEY = { required = true }
 ```
+
+A required variable is validated but never assigned by mise. Its value still participates in
+[redactions](#redactions), so `redact = true` or a matching `redactions` pattern masks whatever the
+caller passed in.
 
 You can also provide help text to guide users on how to set the variable:
 

--- a/e2e/tasks/test_task_required_redactions
+++ b/e2e/tasks/test_task_required_redactions
@@ -110,6 +110,26 @@ run = 'echo "value:$DEF_TOKEN"'
 TOML
 assert "DEF_TOKEN=caller_default mise run a" "value:[redacted]"
 
+# the same case on the other task-env path: a config-level [env] table selects
+# TaskContextBuilder::resolve_task_env_with_config instead of Task::render_env
+cat <<'TOML' >mise.toml
+[env]
+UNRELATED = "1"
+[tasks.a]
+env = { DEF_TOKEN = { default = "fallback", redact = true } }
+run = 'echo "value:$DEF_TOKEN"'
+TOML
+assert "DEF_TOKEN=caller_default mise run a" "value:[redacted]"
+
+# a key the config removes must not leave its caller value registered as a
+# redaction pattern; the one-character value would rewrite the whole line
+cat <<'TOML' >mise.toml
+env = [{ SHORT_TOKEN = { required = true, redact = true } }, { SHORT_TOKEN = false }]
+[tasks.a]
+run = 'echo "version 1.2.3"'
+TOML
+assert "SHORT_TOKEN=e mise run a" "version 1.2.3"
+
 # --raw bypasses the output interceptor entirely
 cat <<'TOML' >mise.toml
 redactions = ["*TOKEN*"]

--- a/e2e/tasks/test_task_required_redactions
+++ b/e2e/tasks/test_task_required_redactions
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+
+# A `required` directive never assigns, so the caller's value is not in the task env map
+# that redaction registration consults. Each case is run twice where it matters: without a
+# config-level [env] table (Task::render_env) and with one (TaskContextBuilder).
+
+# global pattern, value supplied only by the caller
+cat <<'TOML' >mise.toml
+redactions = ["*TOKEN*"]
+[tasks.a]
+env = { CALLER_TOKEN = { required = true } }
+run = 'echo "value:$CALLER_TOKEN"'
+TOML
+assert "CALLER_TOKEN=caller_secret mise run a" "value:[redacted]"
+
+cat <<'TOML' >mise.toml
+redactions = ["*TOKEN*"]
+[env]
+UNRELATED = "unrelated_value"
+[tasks.a]
+env = { CALLER_TOKEN = { required = true } }
+run = 'echo "value:$CALLER_TOKEN"'
+TOML
+assert "CALLER_TOKEN=caller_secret mise run a" "value:[redacted]"
+
+# redact = true with no matching global pattern
+cat <<'TOML' >mise.toml
+[tasks.a]
+env = { ASC_KEY_ID = { required = true, redact = true } }
+run = 'echo "value:$ASC_KEY_ID"'
+TOML
+assert "ASC_KEY_ID=caller_key mise run a" "value:[redacted]"
+
+cat <<'TOML' >mise.toml
+[env]
+UNRELATED = "unrelated_value"
+[tasks.a]
+env = { ASC_KEY_ID = { required = true, redact = true } }
+run = 'echo "value:$ASC_KEY_ID"'
+TOML
+assert "ASC_KEY_ID=caller_key mise run a" "value:[redacted]"
+
+# inherited from a task template
+cat <<'TOML' >mise.toml
+[task_templates.secrets]
+env = { TMPL_KEY_ID = { required = true, redact = true } }
+[tasks.a]
+extends = "secrets"
+run = 'echo "value:$TMPL_KEY_ID"'
+TOML
+assert "TMPL_KEY_ID=caller_tmpl mise run a" "value:[redacted]"
+
+# redact = false overrides a global pattern
+cat <<'TOML' >mise.toml
+redactions = ["*TOKEN*"]
+[tasks.a]
+env = { CALLER_TOKEN = { required = true, redact = false } }
+run = 'echo "value:$CALLER_TOKEN"'
+TOML
+assert "CALLER_TOKEN=caller_secret mise run a" "value:caller_secret"
+
+# The same opt-out on the TaskContextBuilder path, which over-redacted instead: that path matches
+# global patterns against the full env, and a required directive recorded no exclusion to honour.
+cat <<'TOML' >mise.toml
+redactions = ["*TOKEN*"]
+[env]
+UNRELATED = "unrelated_value"
+[tasks.a]
+env = { CALLER_TOKEN = { required = true, redact = false } }
+run = 'echo "value:$CALLER_TOKEN"'
+TOML
+assert "CALLER_TOKEN=caller_secret mise run a" "value:caller_secret"
+
+# Redaction is substring replacement with no word boundaries, so a short secret also rewrites
+# unrelated text. A required directive must register its value exactly as an assignment does --
+# no wider, no narrower -- so both spellings mangle `latest` and `contest` the same way.
+cat <<'TOML' >mise.toml
+[tasks.required]
+env = { SHORT = { required = true, redact = true } }
+run = 'echo "latest contest $SHORT"'
+
+[tasks.assigned]
+env = { SHORT2 = { value = "test", redact = true } }
+run = 'echo "latest contest $SHORT2"'
+TOML
+assert "SHORT=test mise run required" "la[redacted] con[redacted] [redacted]"
+assert "mise run assigned" "la[redacted] con[redacted] [redacted]"
+
+# an empty caller value must not become a redaction pattern
+cat <<'TOML' >mise.toml
+[tasks.a]
+env = { ASC_KEY_ID = { required = true, redact = true } }
+run = 'echo "version 1.2.3 value:$ASC_KEY_ID"'
+TOML
+assert "ASC_KEY_ID= mise run a" "version 1.2.3 value:"
+
+# rebinding the caller value explicitly keeps working
+cat <<'TOML' >mise.toml
+[tasks.a]
+env = { REBOUND_TOKEN = { value = "{{env.REBOUND_TOKEN}}", redact = true } }
+run = 'echo "value:$REBOUND_TOKEN"'
+TOML
+assert "REBOUND_TOKEN=caller_rebind mise run a" "value:[redacted]"
+
+# a `default` the caller overrides redacts the caller's value, not just the fallback
+cat <<'TOML' >mise.toml
+[tasks.a]
+env = { DEF_TOKEN = { default = "fallback", redact = true } }
+run = 'echo "value:$DEF_TOKEN"'
+TOML
+assert "DEF_TOKEN=caller_default mise run a" "value:[redacted]"
+
+# --raw bypasses the output interceptor entirely
+cat <<'TOML' >mise.toml
+redactions = ["*TOKEN*"]
+[tasks.a]
+env = { CALLER_TOKEN = { required = true, redact = true } }
+run = 'echo "value:$CALLER_TOKEN"'
+TOML
+assert "CALLER_TOKEN=caller_secret mise run --raw a" "value:caller_secret"
+
+# A `redact = false` exclusion from another config file survives a task that only declares the
+# variable `required`. The exclusion lives in the global config so the task's own config file has
+# no [env] table, which is what selects the Task::render_env path. The one-character value would
+# mangle the whole line if it were registered as a redaction pattern.
+cat <<'TOML' >"$MISE_CONFIG_DIR/config.toml"
+redactions = ["*TOKEN*"]
+[env]
+TEST_TOKEN = { value = "e", redact = false }
+TOML
+cat <<'TOML' >mise.toml
+[tasks.a]
+env = { TEST_TOKEN = { required = true } }
+run = 'echo "version 1.2.3 value:$TEST_TOKEN"'
+TOML
+assert "mise run a" "version 1.2.3 value:e"

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -592,6 +592,10 @@ impl EnvResults {
                 EnvDirective::Rm(k, _opts) => {
                     env.shift_remove(&k);
                     r.redaction_exclusions.remove(&k);
+                    // The key is gone from the environment, so its caller value is no longer
+                    // reachable by the task. Leaving it here would let `redactable_env` resolve
+                    // it anyway and register a pattern that rewrites unrelated output.
+                    r.caller_env_keys.remove(&k);
                     r.env_remove.insert(k);
                 }
                 EnvDirective::Required(k, _opts) => {
@@ -1393,6 +1397,67 @@ mod tests {
             results.redactable_env(&initial).get("ASC_KEY_ID"),
             Some(&"caller_key".to_string())
         );
+    }
+
+    /// A key removed by `_.rm` is unreachable by the task, so its caller value must stop being
+    /// resolvable for redaction. Otherwise `redactable_env` would keep supplying it and register
+    /// a pattern for a variable the config explicitly removed — over-redaction that rewrites
+    /// unrelated output when the value is short.
+    #[tokio::test]
+    async fn test_rm_clears_a_recorded_caller_key() {
+        let initial = EnvMap::from_iter([
+            ("ASC_KEY_ID".to_string(), "caller_key".to_string()),
+            ("DEF_TOKEN".to_string(), "caller_default".to_string()),
+        ]);
+        let config = Config::get().await.unwrap();
+        let redacted = EnvDirectiveOptions {
+            redact: Some(true),
+            required: RequiredValue::True,
+            ..Default::default()
+        };
+        let results = EnvResults::resolve(
+            &config,
+            BASE_CONTEXT.clone(),
+            &initial,
+            vec![
+                (
+                    EnvDirective::Required("ASC_KEY_ID".into(), redacted.clone()),
+                    PathBuf::from("/config"),
+                ),
+                (
+                    EnvDirective::Default(
+                        "DEF_TOKEN".into(),
+                        "fallback".into(),
+                        EnvDirectiveOptions {
+                            redact: Some(true),
+                            ..Default::default()
+                        },
+                    ),
+                    PathBuf::from("/config"),
+                ),
+                (
+                    EnvDirective::Rm("ASC_KEY_ID".into(), Default::default()),
+                    PathBuf::from("/config"),
+                ),
+                (
+                    EnvDirective::Rm("DEF_TOKEN".into(), Default::default()),
+                    PathBuf::from("/config"),
+                ),
+            ],
+            EnvResolveOptions {
+                vars: false,
+                tools: ToolsFilter::Both,
+                warn_on_missing_required: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(!results.caller_env_keys.contains("ASC_KEY_ID"));
+        assert!(!results.caller_env_keys.contains("DEF_TOKEN"));
+        let redactable = results.redactable_env(&initial);
+        assert!(!redactable.contains_key("ASC_KEY_ID"));
+        assert!(!redactable.contains_key("DEF_TOKEN"));
     }
 
     /// `required = true, redact = false` on a directive that assigns nothing must still record

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -322,6 +322,11 @@ pub struct EnvResults {
     pub env_scripts: Vec<PathBuf>,
     pub redactions: Vec<String>,
     pub redaction_exclusions: BTreeSet<String>,
+    /// Keys whose effective value comes from the caller's environment rather than from
+    /// [`Self::env`]: `required` directives validate without assigning, and `default`
+    /// directives yield to a value the caller already set. Redaction resolves these keys
+    /// against the caller environment; only names are recorded, never values.
+    pub caller_env_keys: BTreeSet<String>,
     pub tool_add_paths: Vec<PathBuf>,
     /// Files to watch for cache invalidation (from modules and _.source directives)
     pub watch_files: Vec<PathBuf>,
@@ -387,6 +392,23 @@ impl EnvResults {
                 self.redaction_exclusions.remove(key);
             }
         }
+    }
+
+    /// Value map for [`crate::config::Config::add_redactions_excluding`]: the values this
+    /// resolution assigned, plus caller-supplied values for [`Self::caller_env_keys`], which
+    /// are absent from [`Self::env`] because those directives never assign.
+    pub fn redactable_env(&self, caller_env: &EnvMap) -> EnvMap {
+        let mut out: EnvMap = self
+            .env
+            .iter()
+            .map(|(k, (v, _))| (k.clone(), v.clone()))
+            .collect();
+        for k in &self.caller_env_keys {
+            if let Some(v) = caller_env.get(k) {
+                out.entry(k.clone()).or_insert_with(|| v.clone());
+            }
+        }
+        out
     }
 
     pub async fn resolve(
@@ -547,6 +569,7 @@ impl EnvResults {
                         if redact.unwrap_or(false) {
                             r.redactions.push(k.clone());
                         }
+                        r.caller_env_keys.insert(k.clone());
                         continue;
                     }
 
@@ -572,18 +595,25 @@ impl EnvResults {
                     r.env_remove.insert(k);
                 }
                 EnvDirective::Required(k, _opts) => {
-                    // Env required directives only validate. Var required directives also surface
-                    // process environment values so `{{vars.KEY}}` can render.
-                    if resolve_opts.vars {
-                        if redact.unwrap_or(false) {
-                            r.redactions.push(k.clone());
-                        }
-                        if !vars.contains_key(&k)
-                            && let Some(v) = required_env.get(&k)
-                        {
-                            r.track_redaction_override(&k, redact);
-                            r.vars.insert(k, (v.clone(), source.clone()));
-                        }
+                    // Required directives only validate; they never assign. Record the key so
+                    // redaction can resolve it against the caller environment.
+                    r.caller_env_keys.insert(k.clone());
+                    // A directive that assigns nothing expresses no redaction opinion unless
+                    // `redact` is set explicitly, so an exclusion from an earlier assignment
+                    // survives a later bare `required = true`.
+                    if redact.is_some() {
+                        r.track_redaction_override(&k, redact);
+                    }
+                    if redact == Some(true) {
+                        r.redactions.push(k.clone());
+                    }
+                    // Var required directives also surface process environment values so
+                    // `{{vars.KEY}}` can render.
+                    if resolve_opts.vars
+                        && !vars.contains_key(&k)
+                        && let Some(v) = required_env.get(&k)
+                    {
+                        r.vars.insert(k, (v.clone(), source.clone()));
                     }
                 }
                 EnvDirective::Age {
@@ -1324,5 +1354,186 @@ mod tests {
         .await
         .unwrap();
         assert!(!removed.redaction_exclusions.contains("TOKEN"));
+    }
+
+    /// A `required` directive validates that the caller set a key but must never assign it
+    /// into `env` — otherwise the value would leak into anything that reads `EnvResults::env`
+    /// directly. Redaction instead resolves the value from the caller environment via
+    /// `caller_env_keys` and `redactable_env`.
+    #[tokio::test]
+    async fn test_required_records_caller_key_without_assigning() {
+        let initial = EnvMap::from_iter([("ASC_KEY_ID".to_string(), "caller_key".to_string())]);
+        let config = Config::get().await.unwrap();
+        let options = EnvDirectiveOptions {
+            redact: Some(true),
+            required: RequiredValue::True,
+            ..Default::default()
+        };
+        let results = EnvResults::resolve(
+            &config,
+            BASE_CONTEXT.clone(),
+            &initial,
+            vec![(
+                EnvDirective::Required("ASC_KEY_ID".into(), options),
+                PathBuf::from("/config"),
+            )],
+            EnvResolveOptions {
+                vars: false,
+                tools: ToolsFilter::Both,
+                warn_on_missing_required: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(!results.env.contains_key("ASC_KEY_ID"));
+        assert!(results.caller_env_keys.contains("ASC_KEY_ID"));
+        assert!(results.redactions.contains(&"ASC_KEY_ID".to_string()));
+        assert_eq!(
+            results.redactable_env(&initial).get("ASC_KEY_ID"),
+            Some(&"caller_key".to_string())
+        );
+    }
+
+    /// `required = true, redact = false` on a directive that assigns nothing must still record
+    /// an exclusion, or a global `redactions` pattern would redact the caller's value anyway.
+    #[tokio::test]
+    async fn test_required_redact_false_excludes_key() {
+        let initial = EnvMap::from_iter([("ASC_KEY_ID".to_string(), "caller_key".to_string())]);
+        let config = Config::get().await.unwrap();
+        let options = EnvDirectiveOptions {
+            redact: Some(false),
+            required: RequiredValue::True,
+            ..Default::default()
+        };
+        let results = EnvResults::resolve(
+            &config,
+            BASE_CONTEXT.clone(),
+            &initial,
+            vec![(
+                EnvDirective::Required("ASC_KEY_ID".into(), options),
+                PathBuf::from("/config"),
+            )],
+            EnvResolveOptions {
+                vars: false,
+                tools: ToolsFilter::Both,
+                warn_on_missing_required: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(results.redaction_exclusions.contains("ASC_KEY_ID"));
+        assert!(!results.redactions.contains(&"ASC_KEY_ID".to_string()));
+    }
+
+    /// A bare `required = true` with no `redact` of its own assigns nothing, so it expresses no
+    /// redaction opinion and must not clear an exclusion an earlier directive set. Contrast
+    /// `test_reassignment_and_remove_clear_redaction_exclusion`, where a later *assignment*
+    /// (`Val`) does clear it.
+    #[tokio::test]
+    async fn test_bare_required_preserves_earlier_redaction_exclusion() {
+        let config = Config::get().await.unwrap();
+        let initial = EnvMap::new();
+        let excluded = EnvDirectiveOptions {
+            redact: Some(false),
+            ..Default::default()
+        };
+        let required = EnvDirectiveOptions {
+            required: RequiredValue::True,
+            ..Default::default()
+        };
+        let results = EnvResults::resolve(
+            &config,
+            BASE_CONTEXT.clone(),
+            &initial,
+            vec![
+                (
+                    EnvDirective::Val("TOKEN".into(), "value".into(), excluded),
+                    PathBuf::from("/global"),
+                ),
+                (
+                    EnvDirective::Required("TOKEN".into(), required),
+                    PathBuf::from("/local"),
+                ),
+            ],
+            EnvResolveOptions {
+                vars: false,
+                tools: ToolsFilter::Both,
+                warn_on_missing_required: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(results.redaction_exclusions.contains("TOKEN"));
+    }
+
+    /// `redactable_env` must prefer an assigned value over a caller-supplied one for a key
+    /// present in both `env` and `caller_env_keys`, and must skip caller keys the caller never
+    /// actually set (no `ABSENT` in the caller environment).
+    #[test]
+    fn test_redactable_env_prefers_assigned_value() {
+        let mut results = EnvResults {
+            caller_env_keys: BTreeSet::from([
+                "K".to_string(),
+                "ONLY_CALLER".to_string(),
+                "ABSENT".to_string(),
+            ]),
+            ..Default::default()
+        };
+        results.env.insert(
+            "K".to_string(),
+            ("assigned".to_string(), PathBuf::from("/config")),
+        );
+
+        let caller_env = EnvMap::from_iter([
+            ("K".to_string(), "caller".to_string()),
+            ("ONLY_CALLER".to_string(), "caller_only".to_string()),
+        ]);
+
+        let redactable = results.redactable_env(&caller_env);
+        assert_eq!(redactable.get("K"), Some(&"assigned".to_string()));
+        assert_eq!(
+            redactable.get("ONLY_CALLER"),
+            Some(&"caller_only".to_string())
+        );
+        assert!(!redactable.contains_key("ABSENT"));
+    }
+
+    /// `Default`'s caller-wins branch assigns nothing (the directive's own value is unused), so
+    /// it must record `caller_env_keys` the same way `Required` does, or the caller's value
+    /// would escape redaction.
+    #[tokio::test]
+    async fn test_default_records_caller_key_when_caller_wins() {
+        let initial = EnvMap::from_iter([("DEF_TOKEN".to_string(), "caller_default".to_string())]);
+        let config = Config::get().await.unwrap();
+        let options = EnvDirectiveOptions {
+            redact: Some(true),
+            ..Default::default()
+        };
+        let results = EnvResults::resolve(
+            &config,
+            BASE_CONTEXT.clone(),
+            &initial,
+            vec![(
+                EnvDirective::Default("DEF_TOKEN".into(), "fallback".into(), options),
+                PathBuf::from("/config"),
+            )],
+            EnvResolveOptions {
+                vars: false,
+                tools: ToolsFilter::Both,
+                warn_on_missing_required: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(!results.env.contains_key("DEF_TOKEN"));
+        assert!(results.caller_env_keys.contains("DEF_TOKEN"));
+        assert_eq!(
+            results.redactable_env(&initial).get("DEF_TOKEN"),
+            Some(&"caller_default".to_string())
+        );
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1106,6 +1106,7 @@ impl Config {
                 env_scripts: cached.env_scripts.clone(),
                 redactions: cached.redactions.clone(),
                 redaction_exclusions: cached.redaction_exclusions.clone(),
+                caller_env_keys: cached.caller_env_keys.clone(),
                 tool_add_paths: Vec::new(),
                 watch_files: cached.watch_files.clone(),
                 has_uncacheable: false,
@@ -1117,11 +1118,7 @@ impl Config {
                 .collect_vec();
             self.add_redactions_excluding(
                 redact_keys,
-                &env_results
-                    .env
-                    .iter()
-                    .map(|(k, v)| (k.clone(), v.0.clone()))
-                    .collect(),
+                &env_results.redactable_env(&env::PRISTINE_ENV),
                 &env_results.redaction_exclusions,
             );
             if log::log_enabled!(log::Level::Trace) {
@@ -1184,11 +1181,7 @@ impl Config {
             .collect_vec();
         self.add_redactions_excluding(
             redact_keys,
-            &env_results
-                .env
-                .iter()
-                .map(|(k, v)| (k.clone(), v.0.clone()))
-                .collect(),
+            &env_results.redactable_env(&env::PRISTINE_ENV),
             &env_results.redaction_exclusions,
         );
         if cache_enabled
@@ -1214,6 +1207,7 @@ impl Config {
                 env_scripts: env_results.env_scripts.clone(),
                 redactions: env_results.redactions.clone(),
                 redaction_exclusions: env_results.redaction_exclusions.clone(),
+                caller_env_keys: env_results.caller_env_keys.clone(),
                 watch_files,
                 watch_file_mtimes,
                 created_at: now,

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -2815,15 +2815,18 @@ impl Task {
             .redaction_keys()
             .into_iter()
             .chain(env_results.redactions.iter().cloned());
-        let task_env_map: EnvMap = env_results
-            .env
-            .iter()
-            .map(|(k, (v, _))| (k.clone(), v.clone()))
-            .collect();
+        // Config-level exclusions are resolved separately from task env, so carry them over
+        // here or a `redact = false` variable the task merely declares `required` would be
+        // registered anyway. A task *assignment* still overrides the config-level exclusion.
+        let mut redaction_exclusions = config.env_results().await?.redaction_exclusions.clone();
+        for key in env_results.env.keys() {
+            redaction_exclusions.remove(key);
+        }
+        redaction_exclusions.extend(env_results.redaction_exclusions.iter().cloned());
         config.add_redactions_excluding(
             redact_keys,
-            &task_env_map,
-            &env_results.redaction_exclusions,
+            &env_results.redactable_env(&env),
+            &redaction_exclusions,
         );
 
         let task_env = env_results.env.into_iter().map(|(k, (v, _))| (k, v));

--- a/src/toolset/env_cache.rs
+++ b/src/toolset/env_cache.rs
@@ -123,6 +123,10 @@ pub struct CachedNonToolEnv {
     /// environment keys explicitly excluded from redaction
     #[serde(default)]
     pub redaction_exclusions: BTreeSet<String>,
+    /// keys whose value comes from the caller environment (`required`/`default` directives).
+    /// Names only — caller-supplied values are never cached.
+    #[serde(default)]
+    pub caller_env_keys: BTreeSet<String>,
     /// Files to watch for changes (from modules and _.source directives)
     pub watch_files: Vec<PathBuf>,
     /// mtimes of watch files at cache creation time


### PR DESCRIPTION
> Discussion: https://github.com/jdx/mise/discussions/11998

## Problem

A `required = true` env directive validates that the caller set a variable but never assigns it. Its value therefore never reached the map that redaction registration consults, so `redactions` globs and `redact = true` did nothing for exactly the variables a config declares as secret inputs:

```toml
redactions = ["*KEY*"]

[tasks.probe]
env = { ASC_KEY_ID = { required = true, redact = true } }
run = "printf '%s\n' \"ASC_KEY_ID=$ASC_KEY_ID\""
```

```console
$ mise trust
$ ASC_KEY_ID=caller-key-123 mise run probe
ASC_KEY_ID=caller-key-123     # expected: ASC_KEY_ID=[redacted]
```

Both a global glob and a task-level `redact = true` apply here, and neither takes effect.

## Three defects, one mechanism

**1. Caller-provided values for `required` variables were never redacted.** The `EnvDirective::Required` arm recorded nothing when resolving env: no `redactions` push for `redact = true`, and no exclusion for `redact = false`.

**2. `default` had the same gap in its caller-wins branch** — the more dangerous half of the pair. It pushed the key onto the redaction list but, having assigned nothing, left no value to resolve that key against. The result was backwards: the config fallback was redacted, and the caller's override that actually won was printed in the clear.

```toml
[tasks.a]
env = { DEF_TOKEN = { default = "fallback", redact = true } }
run = 'echo "DEF_TOKEN=$DEF_TOKEN"'
```

```console
$ mise run a                          # fallback used
DEF_TOKEN=[redacted]
$ DEF_TOKEN=caller-secret mise run a  # caller's value wins
DEF_TOKEN=caller-secret               # leaked
```

**3. `redact = false` on a `required` variable was ignored on the `TaskContextBuilder` path.** That path matches global patterns against the full environment, and a required directive recorded no exclusion for it to honour, so an explicit opt-out did nothing and the variable was masked anyway.

This one **over-redacted rather than leaked**, and fixing it is a **visible behavior change**: a variable that previously printed as `[redacted]` on that path now prints its real value, as the config asked. It is called out separately because it moves output in the opposite direction from the rest of this change, and anyone who had come to rely on the incorrect masking will notice.

Underlying all three, the two task-env resolution paths disagreed. `Task::render_env` — taken when the task's own config file has no `[env]` table — passed only the task-declared env map to redaction registration, while `TaskContextBuilder::resolve_task_env_with_config` passed the full environment. The same task config therefore leaked or redacted depending on whether an unrelated `[env]` table happened to exist.

## Fix

Record these keys in `EnvResults::caller_env_keys` (names only, never values) and resolve their values from the caller environment at registration time via the new `EnvResults::redactable_env`. Required directives still never assign — they remain validation-only, and an assigned value always wins over a caller-supplied one.

I rejected the smaller change of simply handing `render_env` the full environment, which would also have covered undeclared caller variables. On that path a config-level `redact = false` exclusion is not visible, so a global config carrying `redactions = ["*TOKEN*"]` and `TEST_TOKEN = { value = "e", redact = false }` would register the single character `e` as a redaction pattern and rewrite every line of task output:

```
v[redacted]rsion 1.2.3 valu[redacted]:[redacted]
```

Scoping registration to keys the config actually declares avoids registering values mise was never told about. `render_env` now also carries over config-level exclusions the way the task-context path already did, so a task that merely declares a variable `required` cannot resurrect an exclusion the config set — a task *assignment* still overrides it, matching existing behavior.

## On over-matching

Redaction is Aho-Corasick substring replacement with no word boundaries, so a short secret rewrites unrelated text. This is pre-existing behavior, and the property worth checking is that `required` does not differ from it. With a caller value of `test` and output `installing latest; contest; value=$X`:

| registered via | output |
| --- | --- |
| `required` (this change) | `installing la[redacted]; con[redacted]; value=[redacted]` |
| config-assigned `redact = true` | `installing la[redacted]; con[redacted]; value=[redacted]` |
| `value = "{{env.X}}"` rebinding | `installing la[redacted]; con[redacted]; value=[redacted]` |

Byte-identical across all three. This change introduces no new over-matching class — it makes `required` behave exactly like every other redacted variable, no wider and no narrower. That equivalence is pinned as a test rather than the current output being pinned, so a future change to how required values are registered breaks loudly. Empty values are the degenerate case of the same concern and were already filtered by `Redactor::new`.

## On the env cache

Only key names enter `CachedNonToolEnv`, never caller-supplied values. The `required` insert is unconditional, so the cached set depends on the config alone — which matters because the non-tool env cache key does not include the caller environment.

`#[serde(default)]` on the new field cannot silently disable the fix across an upgrade. There are two independent guards, both pre-existing: `compute_cache_key` (`src/toolset/env_cache.rs:323`) hashes `CARGO_PKG_VERSION` into the key, so an entry written by an older binary is never looked up; and `load` (`:380-388`) compares the entry's recorded `mise_version` against the running one, deletes the file, and returns `None` on mismatch.

The residual is same-version-string rebuilds with a warm cache — a development scenario, bounded by `env_cache_ttl`, and identical to the exposure the pre-existing `redaction_exclusions` `#[serde(default)]` already carries. The same guards cover the opposite direction, where a stale entry missing exclusions would mask more than the config asked.

## Out of scope

An undeclared caller variable matching a global `redactions` pattern is redacted on the `TaskContextBuilder` path and not on the `render_env` path. This change does not align them.

Aligning them means choosing between removing redaction that users may currently depend on, and registering arbitrary caller environment values as global substring patterns — which is how a one-character value such as `LANG=C` becomes a pattern that rewrites unrelated output. That divergence is a broader defect than this fix and is reported separately.

## Tests

`e2e/tasks/test_task_required_redactions` — 14 assertions covering caller-only values, direct `required` + `redact = true`, inherited task templates via `extends`, explicit `{{env.X}}` rebinding, `redact = false`, empty values, a `default` the caller overrides, `--raw`, the one-character exclusion guard, and the over-matching equivalence. Every case whose behavior differed by path is run on both paths.

Five unit tests in `src/config/env_directive/mod.rs`:

- `test_required_records_caller_key_without_assigning`
- `test_required_redact_false_excludes_key`
- `test_bare_required_preserves_earlier_redaction_exclusion`
- `test_redactable_env_prefers_assigned_value`
- `test_default_records_caller_key_when_caller_wins`

`docs/environments/index.md` is updated in both the Redactions and Required Variables sections.

The `--all-targets` gates were originally run with the one-line fix from https://github.com/jdx/mise/pull/11989 applied locally, since `main` did not compile its own test targets at the time. That fix has since merged, so they now run against `main` unmodified.

---

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.232.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added redaction for caller-supplied values assigned to required environment variables.
  * Added redaction for caller-overridden default values.
  * Preserved redaction behavior across task templates, inherited environments, caching, and environment-rendering modes.
  * Added documentation and examples for required variables, validation, and redacted task environments.

* **Bug Fixes**
  * Improved handling of empty values, explicit rebinding, substring replacement, exclusions, and raw output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->