### PR TITLE
fix(tool): exclude os-inactive inspection versions

### DIFF
--- a/e2e/tools/test_os_arch_filter
+++ b/e2e/tools/test_os_arch_filter
@@ -21,6 +21,18 @@ case "$_os" in
   *) _inactive_os="linux" ;;
 esac
 
+# Commands that report active versions should omit OS-inactive requests.
+mise install dummy@3.0.0
+cat >mise.toml <<EOF
+[tools]
+dummy = { version = "3.0.0", os = ["$_inactive_os"] }
+EOF
+assert "mise current" ""
+assert "mise current dummy" ""
+assert "mise tool dummy --active" ""
+assert "mise tool dummy --json | jq -c .active_versions" "[]"
+assert_fail "mise where dummy" "dummy does not have an active version"
+
 # Unknown tools scoped away from the current OS should be skipped before
 # registry resolution.
 cat >mise.toml <<EOF

--- a/src/cli/current.rs
+++ b/src/cli/current.rs
@@ -49,6 +49,17 @@ impl Current {
             .find(|(p, _)| p.id() == tool.id())
         {
             Some((_, versions)) => {
+                let versions = versions
+                    .iter()
+                    .filter(|v| v.request.is_os_supported())
+                    .collect::<Vec<_>>();
+                if versions.is_empty() {
+                    warn!(
+                        "Plugin {} does not have a version set",
+                        style(tool.id()).blue().for_stderr()
+                    );
+                    return Ok(());
+                }
                 miseprintln!(
                     "{}",
                     versions
@@ -71,10 +82,14 @@ impl Current {
     async fn all(&self, ts: Toolset) -> Result<()> {
         let config = Config::get().await?;
         for (plugin, versions) in ts.list_versions_by_plugin() {
+            let versions = versions
+                .iter()
+                .filter(|v| v.request.is_os_supported())
+                .collect::<Vec<_>>();
             if versions.is_empty() {
                 continue;
             }
-            for tv in versions {
+            for tv in &versions {
                 if !plugin.is_version_installed(&config, tv, true) {
                     let source = ts.versions.get(tv.ba()).unwrap().source.clone();
                     warn!(

--- a/src/cli/current.rs
+++ b/src/cli/current.rs
@@ -48,11 +48,8 @@ impl Current {
             .into_iter()
             .find(|(p, _)| p.id() == tool.id())
         {
-            Some((_, versions)) => {
-                let versions = versions
-                    .iter()
-                    .filter(|v| v.request.is_os_supported())
-                    .collect::<Vec<_>>();
+            Some((_, tvl)) => {
+                let versions = tvl.os_supported_versions().collect::<Vec<_>>();
                 if versions.is_empty() {
                     warn!(
                         "Plugin {} does not have a version set",
@@ -81,11 +78,8 @@ impl Current {
 
     async fn all(&self, ts: Toolset) -> Result<()> {
         let config = Config::get().await?;
-        for (plugin, versions) in ts.list_versions_by_plugin() {
-            let versions = versions
-                .iter()
-                .filter(|v| v.request.is_os_supported())
-                .collect::<Vec<_>>();
+        for (plugin, tvl) in ts.list_versions_by_plugin() {
+            let versions = tvl.os_supported_versions().collect::<Vec<_>>();
             if versions.is_empty() {
                 continue;
             }

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -201,10 +201,9 @@ impl Doctor {
         );
         data.insert("plugins".into(), render_plugins_json());
 
-        let tools = ts.list_versions_by_plugin().into_iter().map(|(f, tv)| {
-            let versions: serde_json::Value = tv
-                .iter()
-                .filter(|tv| tv.request.is_os_supported())
+        let tools = ts.list_versions_by_plugin().into_iter().map(|(f, tvl)| {
+            let versions: serde_json::Value = tvl
+                .os_supported_versions()
                 .map(|tv: &ToolVersion| {
                     let mut tool = serde_json::Map::new();
                     match f.is_version_installed(&config, tv, true) {

--- a/src/cli/tool.rs
+++ b/src/cli/tool.rs
@@ -61,7 +61,7 @@ impl Tool {
         let mut ts = ToolsetBuilder::new().build(&config).await?;
         ts.resolve(&config).await?;
         let tvl = ts.versions.get(&self.tool);
-        let tv = tvl.map(|tvl| tvl.versions.first().unwrap());
+        let tv = tvl.and_then(|tvl| tvl.os_supported_versions().next());
         let ba = tv.map(|tv| tv.ba()).unwrap_or_else(|| &self.tool);
 
         // Check if the backend exists and fail if it doesn't
@@ -93,8 +93,7 @@ impl Tool {
                 .unique()
                 .collect::<Vec<_>>(),
             active_versions: tvl.map(|tvl| {
-                tvl.versions
-                    .iter()
+                tvl.os_supported_versions()
                     .map(|tv| tv.version.clone())
                     .collect::<Vec<_>>()
             }),

--- a/src/cli/where.rs
+++ b/src/cli/where.rs
@@ -35,10 +35,14 @@ impl Where {
                 Some(version) => self.tool.with_version(&version).tvr.unwrap(),
                 None => {
                     let ts = ToolsetBuilder::new().build(&config).await?;
-                    ts.versions
-                        .get(self.tool.ba.as_ref())
-                        .and_then(|tvr| tvr.requests.first().cloned())
-                        .unwrap_or_else(|| self.tool.with_version("latest").tvr.unwrap())
+                    match ts.versions.get(self.tool.ba.as_ref()) {
+                        Some(tvl) => {
+                            tvl.os_supported_requests().next().cloned().ok_or_else(|| {
+                                eyre::eyre!("{} does not have an active version", self.tool.ba)
+                            })?
+                        }
+                        None => self.tool.with_version("latest").tvr.unwrap(),
+                    }
                 }
             },
         };

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -280,10 +280,10 @@ impl Toolset {
             .collect()
     }
 
-    pub fn list_versions_by_plugin(&self) -> Vec<(Arc<dyn Backend>, &Vec<ToolVersion>)> {
+    pub fn list_versions_by_plugin(&self) -> Vec<(Arc<dyn Backend>, &ToolVersionList)> {
         self.versions
             .iter()
-            .flat_map(|(ba, v)| eyre::Ok((ba.backend()?, &v.versions)))
+            .flat_map(|(ba, tvl)| eyre::Ok((ba.backend()?, tvl)))
             .collect()
     }
 
@@ -291,11 +291,7 @@ impl Toolset {
         trace!("list_current_versions");
         self.list_versions_by_plugin()
             .iter()
-            .flat_map(|(p, v)| {
-                v.iter()
-                    .filter(|v| v.request.is_os_supported())
-                    .map(|v| (p.clone(), v.clone()))
-            })
+            .flat_map(|(p, tvl)| tvl.os_supported_versions().map(|v| (p.clone(), v.clone())))
             .collect()
     }
 

--- a/src/toolset/tool_version_list.rs
+++ b/src/toolset/tool_version_list.rs
@@ -63,6 +63,16 @@ impl ToolVersionList {
         }
         Ok(())
     }
+
+    pub fn os_supported_versions(&self) -> impl Iterator<Item = &ToolVersion> {
+        self.versions
+            .iter()
+            .filter(|tv| tv.request.is_os_supported())
+    }
+
+    pub fn os_supported_requests(&self) -> impl Iterator<Item = &ToolRequest> {
+        self.requests.iter().filter(|tvr| tvr.is_os_supported())
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- filter OS-inactive versions from `mise current` and `mise tool --active` output
- make bare `mise where` reject a configured tool with no active version on the current OS
- centralize OS-supported request/version iteration and add cross-platform regression coverage

## Discussion
Follow-up to #10206 and https://github.com/jdx/mise/discussions/6896. The earlier fix covered install-time registry resolution; this covers inspection commands that still consumed unfiltered toolset entries.

## Tests
- `mise run lint-fix`
- `mise run test:e2e e2e/tools/test_os_arch_filter`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Active version listings now exclude tools unsupported by the current operating system.
  * Tool information and lookup commands select only compatible versions.
  * `mise where` reports a clear error when no active version is available for the current operating system.
  * `current` hides unsupported versions and warns when no compatible version exists.
* **Tests**
  * Added end-to-end coverage for operating-system filtering in version reporting and lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->