### PR TITLE
fix(task): make a trailing `**` enumerate files in sources and outputs

### DIFF
--- a/e2e/tasks/test_task_globstar_enumeration
+++ b/e2e/tasks/test_task_globstar_enumeration
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# A trailing `**` must enumerate files, not just directories. The `glob` crate
+# matches it against directories only, while the matcher built from the same
+# entry matches the files underneath, so enumeration silently skipped every file.
+#
+# The two halves are separate tasks on purpose: each one uses the plain spelling
+# for the field it is not testing, so either defect fails this test on its own
+# rather than being shadowed by the other.
+
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+# sources under test; outputs kept plain
+[tasks.src_build]
+run = '''
+cat $(find src -type f | sort) > bundle.txt
+printf 'ran\n' >> src_runs.txt
+'''
+sources = ["src/**"]
+outputs = ["bundle.txt"]
+cache = { enabled = true }
+
+# outputs under test; sources kept plain
+[tasks.out_build]
+run = '''
+mkdir -p dist/nested
+printf 'top\n' > dist/top.txt
+printf 'nested\n' > dist/nested/n.txt
+printf 'ran\n' >> out_runs.txt
+'''
+sources = ["input.txt"]
+outputs = ["dist/**"]
+cache = { enabled = true }
+EOF
+
+mkdir -p src/sub
+printf 'v1\n' >src/a.txt
+printf 'sub\n' >src/sub/b.txt
+printf 'one\n' >input.txt
+
+# --- sources ------------------------------------------------------------
+# Enumerating only the subdirectories yields a directory mtime, which does not
+# move when a tracked file's contents change, so the task stayed fresh forever.
+assert_contains "mise run src_build 2>&1" "cache miss"
+assert "wc -l < src_runs.txt | tr -d ' '" "1"
+
+printf 'v2\n' >src/a.txt
+mise run src_build
+assert "wc -l < src_runs.txt | tr -d ' '" "2"
+assert "cat bundle.txt" "v2
+sub"
+
+# nothing changed, so it must skip rather than re-run
+assert_contains "mise run src_build 2>&1" "sources up-to-date, skipping"
+assert "wc -l < src_runs.txt | tr -d ' '" "2"
+
+# --- outputs ------------------------------------------------------------
+# `dist/**` enumerated only `dist/nested`, so the archiver was handed a root
+# list that never reached `dist/top.txt`. The restore then reported success
+# over a tree missing a file the task had just produced.
+assert_contains "mise run out_build 2>&1" "cache miss"
+assert "wc -l < out_runs.txt | tr -d ' '" "1"
+
+rm -rf dist
+assert_contains "mise run out_build 2>&1" "restored outputs from cache"
+assert "wc -l < out_runs.txt | tr -d ' '" "1"
+assert "cat dist/top.txt" "top"
+assert "cat dist/nested/n.txt" "nested"

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -8,8 +8,8 @@ use crate::task::task_cache_store::{
     compose_task_cache_stores,
 };
 use crate::task::task_source_checker::{
-    TaskCacheInputs, build_output_matcher, expand_glob_braces, is_output, output_glob_patterns,
-    task_cache_inputs, task_cwd,
+    TaskCacheInputs, build_output_matcher, expand_enumeration_patterns, is_output,
+    output_glob_patterns, task_cache_inputs, task_cwd,
 };
 use crate::task::{RunEntry, Task};
 use crate::toolset::Toolset;
@@ -1275,7 +1275,7 @@ fn resolve_output_roots(task: &Task, root: &Path, require_matches: bool) -> Resu
         ensure_safe_relative(Path::new(&output))?;
         if crate::task::task_source_checker::is_glob_pattern(&output) {
             let mut glob_matched = false;
-            for expanded in expand_glob_braces(&output)? {
+            for expanded in expand_enumeration_patterns(&output)? {
                 ensure_safe_relative(Path::new(&expanded))?;
                 for entry in glob(root.join(expanded).to_str().unwrap_or_default())? {
                     let path = entry?;

--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -197,7 +197,7 @@ impl TaskScriptParser {
                     }
 
                     let expanded_patterns =
-                        crate::task::task_source_checker::expand_glob_braces(pattern);
+                        crate::task::task_source_checker::expand_enumeration_patterns(pattern);
                     match expanded_patterns {
                         Err(error) => {
                             warn!(

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -312,9 +312,11 @@ pub(crate) fn is_source(matcher: &Override, path: &Path) -> bool {
 /// unix that string is an escape and `glob` rejects it outright.
 fn expand_trailing_globstar(pattern: &str) -> String {
     let trailing_globstar = pattern == "**"
-        || pattern
-            .strip_suffix("**")
-            .is_some_and(|head| head.chars().next_back().is_some_and(std::path::is_separator));
+        || pattern.strip_suffix("**").is_some_and(|head| {
+            head.chars()
+                .next_back()
+                .is_some_and(std::path::is_separator)
+        });
     if trailing_globstar {
         format!("{pattern}/*")
     } else {

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -295,10 +295,29 @@ pub(crate) fn is_source(matcher: &Override, path: &Path) -> bool {
     matcher.matched(path, false).is_whitelist()
 }
 
+/// Expands a trailing `**` to `**/*` so enumeration reaches files.
+///
+/// The `glob` crate matches a trailing `**` against directories only, while the
+/// `ignore`/`globset` matcher built from the same entry matches the files
+/// underneath it per gitignore semantics. Enumeration therefore never offers
+/// the files the matcher would have accepted, and because everything it does
+/// offer matches, nothing looks rejected and no diagnostic fires.
+///
+/// A `**` in the interior of a pattern (`src/**/foo.rs`) already spans
+/// directories correctly and is left alone.
+fn expand_trailing_globstar(pattern: &str) -> String {
+    if pattern == "**" || pattern.ends_with("/**") {
+        format!("{pattern}/*")
+    } else {
+        pattern.to_string()
+    }
+}
+
 /// Returns the include-side glob patterns from `sources`, suitable for file
 /// enumeration via `glob`. `!`-prefixed entries are dropped (they only
 /// constrain matching, not enumeration); `\!`-prefixed entries have the
-/// escape removed so they can be globbed as literal `!`-prefixed paths.
+/// escape removed so they can be globbed as literal `!`-prefixed paths; a
+/// trailing `**` is expanded so it enumerates files rather than directories.
 pub(crate) fn source_glob_patterns(sources: &[String]) -> Vec<String> {
     sources
         .iter()
@@ -311,6 +330,7 @@ pub(crate) fn source_glob_patterns(sources: &[String]) -> Vec<String> {
                 Some(s.clone())
             }
         })
+        .map(|pattern| expand_trailing_globstar(&pattern))
         .collect()
 }
 
@@ -1253,6 +1273,38 @@ mod tests {
             ]),
             ["dist", "!important"]
         );
+    }
+
+    /// A trailing `**` must enumerate files. The `glob` crate matches it against
+    /// directories only, so without the expansion `src/**` yields subdirectories
+    /// and no files at all — a `sources` entry that contributes nothing to
+    /// freshness and an `outputs` entry that archives nothing.
+    #[test]
+    fn trailing_globstar_expands_to_reach_files() {
+        assert_eq!(expand_trailing_globstar("src/**"), "src/**/*");
+        assert_eq!(expand_trailing_globstar("**"), "**/*");
+        assert_eq!(
+            source_glob_patterns(&["src/**".to_string(), "dist/**".to_string()]),
+            ["src/**/*", "dist/**/*"]
+        );
+    }
+
+    /// Only a *trailing* `**` is wrong. In the interior it already spans
+    /// directories correctly, and rewriting it would change what the pattern
+    /// selects rather than fixing what it enumerates.
+    #[test]
+    fn interior_globstar_and_other_patterns_are_untouched() {
+        for pattern in [
+            "src/**/foo.rs",
+            "src/**/*.ts",
+            "src/*",
+            "dist",
+            "src/**/*",
+            "**/*",
+            "a**",
+        ] {
+            assert_eq!(expand_trailing_globstar(pattern), pattern);
+        }
     }
 
     #[test]

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -305,19 +305,45 @@ pub(crate) fn is_source(matcher: &Override, path: &Path) -> bool {
 ///
 /// A `**` in the interior of a pattern (`src/**/foo.rs`) already spans
 /// directories correctly and is left alone.
+///
+/// Separators are tested with [`std::path::is_separator`], matching how `glob`
+/// itself decides whether a `**` forms its own path component. `\` is a
+/// separator on Windows, so `src\**` carries the same defect there, while on
+/// unix that string is an escape and `glob` rejects it outright.
 fn expand_trailing_globstar(pattern: &str) -> String {
-    if pattern == "**" || pattern.ends_with("/**") {
+    let trailing_globstar = pattern == "**"
+        || pattern
+            .strip_suffix("**")
+            .is_some_and(|head| head.chars().next_back().is_some_and(std::path::is_separator));
+    if trailing_globstar {
         format!("{pattern}/*")
     } else {
         pattern.to_string()
     }
 }
 
+/// Brace-expands `pattern` for file enumeration, expanding a trailing `**` in
+/// each alternative so enumeration reaches files.
+///
+/// Enumeration callers use this rather than [`expand_glob_braces`] directly,
+/// because the expansion has to happen per alternative: `{src/**,dist}` carries
+/// its `**` inside the braces, where a check on the whole pattern cannot see
+/// it. Matcher construction deliberately keeps calling [`expand_glob_braces`],
+/// since `globset` already matches the files under a trailing `**` and
+/// rewriting there would change what the matcher selects rather than what
+/// enumeration offers.
+pub(crate) fn expand_enumeration_patterns(pattern: &str) -> Result<Vec<String>> {
+    Ok(expand_glob_braces(pattern)?
+        .into_iter()
+        .map(|alternative| expand_trailing_globstar(&alternative))
+        .collect())
+}
+
 /// Returns the include-side glob patterns from `sources`, suitable for file
-/// enumeration via `glob`. `!`-prefixed entries are dropped (they only
-/// constrain matching, not enumeration); `\!`-prefixed entries have the
-/// escape removed so they can be globbed as literal `!`-prefixed paths; a
-/// trailing `**` is expanded so it enumerates files rather than directories.
+/// enumeration via [`expand_enumeration_patterns`]. `!`-prefixed entries are
+/// dropped (they only constrain matching, not enumeration); `\!`-prefixed
+/// entries have the escape removed so they can be globbed as literal
+/// `!`-prefixed paths.
 pub(crate) fn source_glob_patterns(sources: &[String]) -> Vec<String> {
     sources
         .iter()
@@ -330,7 +356,6 @@ pub(crate) fn source_glob_patterns(sources: &[String]) -> Vec<String> {
                 Some(s.clone())
             }
         })
-        .map(|pattern| expand_trailing_globstar(&pattern))
         .collect()
 }
 
@@ -680,7 +705,7 @@ pub async fn save_checksum(task: &Task, config: &Arc<Config>) -> Result<()> {
         // Warn if any explicitly declared output was not generated.
         for output in output_glob_patterns(&task.outputs.paths(task, &root)) {
             let output_exists = if is_glob_pattern(&output) {
-                expand_glob_braces(&output)
+                expand_enumeration_patterns(&output)
                     .map(|patterns| {
                         patterns.into_iter().any(|pattern| {
                             let pattern = resolve_task_path(&root, pattern);
@@ -897,7 +922,7 @@ fn compute_output_hash(task: &Task, root: &Path) -> Result<Option<String>> {
 
     for pattern_str in glob_pats {
         let mut glob_matched = false;
-        for expanded in expand_glob_braces(pattern_str)? {
+        for expanded in expand_enumeration_patterns(pattern_str)? {
             let full = resolve_task_path(root, expanded);
             for entry in glob(full.to_str().unwrap_or_default())? {
                 // Propagate glob resolution errors (OS errors during directory
@@ -958,7 +983,7 @@ fn get_file_metadatas(
 
     let mut metadatas = BTreeMap::new();
     for pattern in patterns {
-        for expanded in expand_glob_braces(pattern)? {
+        for expanded in expand_enumeration_patterns(pattern)? {
             let pattern = resolve_task_path(root, expanded);
             let files = glob(pattern.to_str().unwrap())?;
             for file in files.flatten() {
@@ -1122,7 +1147,7 @@ fn get_last_modified(root: &Path, patterns_or_paths: &[String]) -> Result<Option
         let is_glob = is_glob_pattern(&pattern);
         let candidates = if is_glob {
             let mut candidates = Vec::new();
-            for expanded in expand_glob_braces(&pattern)? {
+            for expanded in expand_enumeration_patterns(&pattern)? {
                 let expanded = resolve_task_path(root, expanded);
                 candidates.extend(
                     glob(expanded.to_str().unwrap_or_default())?.collect::<Result<Vec<_>, _>>()?,
@@ -1283,10 +1308,34 @@ mod tests {
     fn trailing_globstar_expands_to_reach_files() {
         assert_eq!(expand_trailing_globstar("src/**"), "src/**/*");
         assert_eq!(expand_trailing_globstar("**"), "**/*");
+        assert_eq!(expand_enumeration_patterns("src/**").unwrap(), ["src/**/*"]);
+    }
+
+    /// The expansion runs on each brace alternative. `{src/**,dist/**}` ends in
+    /// `}`, so a check against the whole pattern never sees the `**` and every
+    /// alternative would go on enumerating directories only.
+    #[test]
+    fn trailing_globstar_expands_inside_brace_alternatives() {
         assert_eq!(
-            source_glob_patterns(&["src/**".to_string(), "dist/**".to_string()]),
+            expand_enumeration_patterns("{src,dist}/**").unwrap(),
             ["src/**/*", "dist/**/*"]
         );
+        assert_eq!(
+            expand_enumeration_patterns("{src/**,dist/**,docs/*.md}").unwrap(),
+            ["src/**/*", "dist/**/*", "docs/*.md"]
+        );
+    }
+
+    /// `\` is a path separator on Windows, so `src\**` is a trailing globstar
+    /// there and carries the same defect. On unix the same string is an escape
+    /// that `glob` rejects outright, so it must be left alone.
+    #[test]
+    fn trailing_globstar_follows_platform_separators() {
+        if cfg!(windows) {
+            assert_eq!(expand_trailing_globstar(r"src\**"), r"src\**/*");
+        } else {
+            assert_eq!(expand_trailing_globstar(r"src\**"), r"src\**");
+        }
     }
 
     /// Only a *trailing* `**` is wrong. In the interior it already spans


### PR DESCRIPTION
> Discussion: https://github.com/jdx/mise/discussions/11991

## Problem

A trailing `**` in `sources` or `outputs` enumerates **directories only, never files**. Nothing warns.

```console
$ mise run build          # sources = ["src/**"]
$ printf 'v2\n' > src/a.txt
$ mise run build
[build] sources up-to-date, skipping     # wrong — a declared source changed
```

```console
$ mise run build          # outputs = ["dist/**"], dist has a subdirectory
$ rm -rf dist
$ mise run build
[build] restored outputs from cache …    # reports success
$ cat dist/top.txt
cat: dist/top.txt: No such file or directory
```

The second is the serious one: a file the task produced is silently absent after a restore that reported success. Anything downstream either fails confusingly or consumes a stale copy from an earlier run.

This spelling appears **11 times in mise's own docs**, including `outputs = ["dist/**"]` at `docs/tasks/monorepo.md:546` and `sources = ["src/**"]` throughout `docs/tasks/task-configuration.md`. It is also the idiomatic Turborepo spelling, and `turbo.json` `inputs` are imported into `sources` verbatim.

## Root cause

Enumeration globs the pattern as written, and the `glob` crate matches a trailing `**` against directories only:

```
fixture: src/a.rs, src/nested/b.rs

src/**       -> src/nested                          (a directory, no files)
src/**/*     -> src/nested, src/a.rs, src/nested/b.rs
src/*        -> src/nested, src/a.rs
```

The matcher is fine. `build_source_matcher`/`build_output_matcher` compile through `ignore`/`globset`, where `dist/**` correctly matches `dist/top.txt` per gitignore semantics. Only enumeration disagrees — and that mismatch is exactly why it is silent: everything enumeration offers does match, so nothing ever looks rejected. The files are simply never offered.

Consequences differ by field:

- **`sources`** — hashes subdirectory mtimes, which move when an entry is added or removed and *not* when a file's contents change. So the common case, editing a tracked file, never invalidates. With no subdirectory at all it enumerates nothing.
- **`outputs`** — `resolve_output_roots` hands the archiver a root list of just the subdirectories, so `WalkDir` never visits files directly under `dist` and they are never archived.

The existing `bail!("output pattern … matched no files")` guard does not catch this. It fires only when a pattern matches *literally nothing*, and one subdirectory satisfies it while the pattern is still dropping every file.

## Fix

Expand a **trailing** `**` to `**/*` at enumeration. This aligns enumeration with the matcher that already exists rather than introducing a third behavior. `**` in the interior (`src/**/foo.rs`) already spans directories correctly in the `glob` crate and is left alone.

Applied in `source_glob_patterns`, which covers `outputs` too since `output_glob_patterns` delegates to it, and reaches the other enumeration callers for the same reason — output hashing, the output mtime check, and the `task_source_files` template function, all of which glob these patterns.

I considered instead applying the outputs-side "matched nothing" guard to `sources`, and rejected it: that guard is not doing the job on the outputs side either, so copying it across would add a diagnostic that stays quiet in exactly the cases that hurt.

## Compatibility

I don't think there is a behavior anyone relies on here. Nobody writes `sources = ["src/**"]` intending "the mtimes of my subdirectories", and nobody writes `outputs = ["dist/**"]` intending "everything except the files at the top level". The change makes both mean what the docs already show them meaning, so **no documentation changes accompany this** — the 11 existing examples start behaving as written.

Cache keys change for tasks using this spelling, which is the point: those tasks were computing a key that ignored their sources.

## One wart

`resolve_output_roots` reports the expanded pattern, so a user who wrote `dist/**` and matches nothing now sees `output pattern "dist/**/*" matched no files`. Threading the original through would mean changing the helper's signature at eight call sites. The derived form is three characters longer than what they wrote and the guard fires far less often after this change, so I left it — happy to do it properly if you'd rather.

## Tests

`e2e/tasks/test_task_globstar_enumeration` covers both fields as separate tasks, each using the plain spelling for the field it is *not* testing, so either defect fails the test on its own rather than being shadowed by the other. Verified by reverting the one-line change:

- sources half → `sources up-to-date, skipping` after a tracked file changed
- outputs half → `restored outputs from cache`, then `cat dist/top.txt` fails

Unit tests `trailing_globstar_expands_to_reach_files` and `interior_globstar_and_other_patterns_are_untouched` pin the rewrite and the cases it must not touch. `cargo test --bin mise task::` — 385 passed.

---

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.232.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recursive file discovery for task sources and outputs using trailing globstar patterns.
  * Changes to files within recursively matched directories now correctly invalidate cached tasks and refresh bundled content.
  * Restoring cached outputs now recreates nested and top-level files reliably.

* **Tests**
  * Added end-to-end coverage for recursive globstar enumeration, caching, and output restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->