### PR TITLE
fix(file): stop trusting a configured extension to be OS-launchable

### DIFF
--- a/e2e-win/task_executable_extensions.Tests.ps1
+++ b/e2e-win/task_executable_extensions.Tests.ps1
@@ -1,0 +1,60 @@
+Describe 'windows_executable_extensions and task execution' {
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        # Saved here, restored in AfterAll: Pester runs every suite in one process, so removing an
+        # inherited value would leave the next suite without it.
+        $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+        $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path (Join-Path $script:TestRoot "mise-tasks") | Out-Null
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:TestRoot
+        $script:ConfigPath = Join-Path $script:TestRoot "mise.toml"
+
+        # `printf` rather than `echo` so the assertion can only pass through bash: cmd has no
+        # printf, and the pre-fix failure was mise handing this file straight to CreateProcess.
+        # Written with LF endings, which is what bash wants for the shebang line.
+        [System.IO.File]::WriteAllText(
+            (Join-Path $script:TestRoot "mise-tasks\hello.sh"),
+            "#!/usr/bin/env bash`nprintf 'ran-via-bash\n'`n")
+        "@echo off`r`necho ran-via-cmd`r`n" | ForEach-Object {
+            [System.IO.File]::WriteAllText((Join-Path $script:TestRoot "mise-tasks\native.cmd"), $_)
+        }
+
+        Set-Location $script:TestRoot
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        if ($null -eq $script:OriginalTrusted) {
+            Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
+        } else {
+            [Environment]::SetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', $script:OriginalTrusted, 'Process')
+        }
+    }
+
+    It 'runs a .sh task through its shebang by default' {
+        # Control: `sh` is not in the default list, so nothing claims the OS can start the file
+        # and the shebang decides.
+        "[tools]" | Out-File -Encoding ascii $script:ConfigPath
+        (mise run hello | Out-String) | Should -Match 'ran-via-bash'
+    }
+
+    It 'still runs it after sh is added to windows_executable_extensions' {
+        # The regression. Adding an extension used to make `can_execute_directly` answer yes, so
+        # mise passed the script to CreateProcess and it failed with
+        # "%1 is not a valid Win32 application" (os error 193) without ever reading the shebang.
+        @"
+[settings]
+windows_executable_extensions = ["exe", "bat", "cmd", "com", "ps1", "vbs", "sh"]
+"@ | Out-File -Encoding ascii $script:ConfigPath
+        $output = mise run hello 2>&1 | Out-String
+        $output | Should -Not -Match 'os error 193'
+        $output | Should -Match 'ran-via-bash'
+    }
+
+    It 'still starts a .cmd task directly' {
+        # The other half: narrowing what the OS list allows must not stop mise launching the
+        # extensions it really can launch.
+        "[tools]" | Out-File -Encoding ascii $script:ConfigPath
+        (mise run native | Out-String) | Should -Match 'ran-via-cmd'
+    }
+}

--- a/src/file.rs
+++ b/src/file.rs
@@ -1023,20 +1023,39 @@ pub fn has_shebang(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
-/// Extensions that `windows_executable_extensions` lists but `CreateProcess` cannot
-/// launch: they need an interpreter (`pwsh -File`, `wscript`/`cscript`). `.bat` and
-/// `.cmd` are not here — std routes those through cmd.exe with escaped arguments.
+/// Extensions `std::process::Command` can start from a path alone on Windows: `exe` and `com`
+/// natively, `bat` and `cmd` because std routes those through cmd.exe with escaped arguments.
+/// Anything else needs an interpreter named for it — `pwsh -File` for a `.ps1`,
+/// `cscript` for a `.vbs`, whatever a shebang asks for.
 ///
-/// `pub(crate)` so `task::task_executor` can assert that its `shell_from_extension` names
-/// an interpreter for every entry. That function is not `cfg(windows)`-gated, so it cannot
-/// match against this list directly; the correspondence is enforced by a test instead.
+/// A fixed list on purpose. It describes what the OS can start, which
+/// `windows_executable_extensions` has no say over: that setting decides what mise *treats* as
+/// executable. Deriving it the other way round — subtracting known interpreter-only extensions
+/// from the setting — happened to be right for the default list and wrong for any other, since a
+/// user who added `sh` or `py` was then answered "yes, `CreateProcess` can start this" and the
+/// task died with "not a valid Win32 application" instead of using its shebang.
+///
+/// `pub(crate)` so `task::task_executor` can assert that `shell_from_extension` names an
+/// interpreter for every default extension this list excludes.
 #[cfg(windows)]
-pub(crate) const INTERPRETER_ONLY_EXTENSIONS: [&str; 2] = ["ps1", "vbs"];
+pub(crate) const OS_LAUNCHABLE_EXTENSIONS: [&str; 4] = ["exe", "com", "bat", "cmd"];
+
+/// Whether the OS can start a file with this extension without an interpreter.
+///
+/// Compared case-insensitively, the way [`has_known_executable_extension`] does: Windows
+/// extensions are not case-sensitive, so `PIPX.PS1` is the same file as `pipx.ps1`.
+#[cfg(windows)]
+pub(crate) fn os_can_launch_extension(ext: &str) -> bool {
+    OS_LAUNCHABLE_EXTENSIONS
+        .iter()
+        .any(|known| ext.eq_ignore_ascii_case(known))
+}
 
 /// Check if a file can be executed directly by the OS without a shell wrapper.
 /// On Unix, this checks the executable permission bit.
-/// On Windows, this checks for a known executable extension (.bat, .cmd, .exe, ...)
-/// minus the ones that only an interpreter can run.
+/// On Windows, it takes both questions in turn: does mise treat this extension as executable
+/// (`windows_executable_extensions`, which a user may narrow), and can the OS actually start it
+/// ([`OS_LAUNCHABLE_EXTENSIONS`], which a user may not widen)?
 ///
 /// Distinct from [`is_executable`], which on Windows deliberately also accepts a
 /// shebang-only file. Callers that hand the path to `Command::new` need this one:
@@ -1050,20 +1069,11 @@ pub(crate) const INTERPRETER_ONLY_EXTENSIONS: [&str; 2] = ["ps1", "vbs"];
 pub fn can_execute_directly(path: &Path) -> bool {
     #[cfg(windows)]
     {
-        // Compared case-insensitively, the way has_known_executable_extension does:
-        // Windows extensions are not case-sensitive, so PIPX.PS1 is the same file.
-        if path
-            .extension()
-            .and_then(|ext| ext.to_str())
-            .is_some_and(|ext| {
-                INTERPRETER_ONLY_EXTENSIONS
-                    .iter()
-                    .any(|only| ext.eq_ignore_ascii_case(only))
-            })
-        {
-            return false;
-        }
         has_known_executable_extension(path)
+            && path
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .is_some_and(os_can_launch_extension)
     }
     #[cfg(not(windows))]
     {
@@ -3888,5 +3898,34 @@ mod tests {
         // A path outside the cwd falls through to `display_path`, which settles separators too.
         let outside = display_rel_path(Path::new("relative-to-nothing"));
         assert!(!outside.starts_with('.'), "{outside}");
+    }
+
+    /// The list answers only "can the OS start this", so it is fixed and does not consult
+    /// settings. Case-insensitive, since Windows extensions are.
+    #[cfg(windows)]
+    #[test]
+    fn os_can_launch_extension_names_only_what_the_os_starts() {
+        for ext in ["exe", "com", "bat", "cmd", "EXE", "Cmd"] {
+            assert!(os_can_launch_extension(ext), "{ext}");
+        }
+        // ps1 and vbs need an interpreter; the rest are extensions a user might add to
+        // `windows_executable_extensions`, which does not make CreateProcess able to start them.
+        for ext in ["ps1", "PS1", "vbs", "sh", "py", "js", ""] {
+            assert!(!os_can_launch_extension(ext), "{ext}");
+        }
+    }
+
+    /// Under the shipped default `windows_executable_extensions` the answers are exactly what
+    /// they were before the whitelist replaced the interpreter-only blacklist -- the two agree on
+    /// that list, which is why the old shape looked correct.
+    #[cfg(windows)]
+    #[test]
+    fn can_execute_directly_is_unchanged_for_the_default_extensions() {
+        for name in [r"C:\x\tool.exe", r"C:\x\tool.com", "tool.bat", "tool.CMD"] {
+            assert!(can_execute_directly(Path::new(name)), "{name}");
+        }
+        for name in ["tool.ps1", "tool.PS1", "tool.vbs", "tool", r"C:\x\tool"] {
+            assert!(!can_execute_directly(Path::new(name)), "{name}");
+        }
     }
 }

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -2370,14 +2370,28 @@ mod tests {
         // the machine's file association points at, where `wscript` writes to message boxes
         // instead of the pipes mise reads.
         //
-        // Iterating the list is the point. `shell_from_extension` cannot match against it
-        // directly because that function is not cfg(windows)-gated while the list is, so
-        // adding an entry there without a mapping here would otherwise go unnoticed.
-        for ext in crate::file::INTERPRETER_ONLY_EXTENSIONS {
+        // Derived from the setting rather than from a hand-kept list of interpreter-only
+        // extensions, so that adding one to the shipped default without a mapping here is caught
+        // too. `shell_from_extension` cannot do the check itself: it is not cfg(windows)-gated
+        // while `os_can_launch_extension` is.
+        let needs_interpreter: Vec<String> = Settings::get()
+            .windows_executable_extensions
+            .iter()
+            .filter(|ext| !crate::file::os_can_launch_extension(ext))
+            .cloned()
+            .collect();
+        // Guards the loop below against passing vacuously if the two lists ever stop overlapping.
+        assert!(
+            !needs_interpreter.is_empty(),
+            "expected the default windows_executable_extensions to include extensions the OS \
+             cannot launch (ps1, vbs)"
+        );
+        for ext in needs_interpreter {
             let path = PathBuf::from(format!("task.{ext}"));
             assert!(
                 shell_from_extension(&path).is_some(),
-                "{ext} is rejected as interpreter-only but has no interpreter mapping"
+                "{ext} is executable per settings but the OS cannot launch it, and it has no \
+                 interpreter mapping"
             );
         }
         // The console host specifically, and case-insensitively.


### PR DESCRIPTION
Using `windows_executable_extensions` the way it is documented breaks a task that worked a moment
earlier. `mise-tasks/hello.sh`, with a shebang:

```console
A) default settings
> mise run hello
ran-via-bash                       # the shebang picks bash

B) "sh" added to windows_executable_extensions, nothing else changed
> mise run hello
[hello] ERROR %1 is not a valid Win32 application. (os error 193)
```

The shebang is never read in B. mise decided the OS could start the file and handed it to
`Command::new`.

## Why

`can_execute_directly` subtracted a fixed interpreter-only list — `["ps1", "vbs"]` — from
`windows_executable_extensions`, and treated whatever remained as something `CreateProcess` can
start. Against the shipped default that leaves `exe`/`bat`/`cmd`/`com`, which is exactly the set
the OS can start, so the shape was right for the default list and wrong for every other one. The
setting is user-editable; the list of what Windows can launch is not.

Two callers depend on that answer, and both are affected:

- `task_executor`'s file-task path — the reproduction above.
- `backend::is_spawnable`, which decides whether a tool's binary can be spawned from a path.

## The change

The two questions are separate, so they are asked separately and ANDed:

- **Does mise treat this extension as executable?** `windows_executable_extensions`, which a user
  may narrow.
- **Can the OS start it?** A new fixed `OS_LAUNCHABLE_EXTENSIONS` — `exe` and `com` natively, `bat`
  and `cmd` because std routes those through cmd.exe with escaped arguments — which a user may not
  widen.

For the default list the answers are identical to before (`exe`/`bat`/`cmd`/`com` yes,
`ps1`/`vbs` no), which is precisely why the old shape looked correct. `INTERPRETER_ONLY_EXTENSIONS`
is gone: `can_execute_directly` was its only non-test use.

A file that is now correctly rejected falls through to `shell_from_shebang`, then
`shell_from_extension`, then `default_file_shell` — the existing chain, which is how the `.sh`
above finds bash again.

## Deliberately unchanged

- **`shell_from_extension` gains no extensions.** Which interpreters mise should know by default is
  a separate call; a user who adds `sh` is served by the shebang.
- **The default `windows_executable_extensions`.**
- **An extension with neither a shebang nor a mapping** — a `.py` with no shebang, say — still
  fails. It reaches `cmd /c` rather than `CreateProcess`, so os error 193 becomes a failure from
  the configured default shell. Better located, still a failure.
- **The whitelist is not configurable.** It describes what the OS can do, not a policy.

## Tests

- `src/file.rs`: `os_can_launch_extension` accepts `exe`/`com`/`bat`/`cmd` case-insensitively and
  rejects `ps1`/`vbs` along with extensions a user might add (`sh`, `py`, `js`) and the empty
  string; `can_execute_directly` gives the same answers as before for the default list.
- `src/task/task_executor.rs`: the `shell_from_extension` invariant now derives its extensions from
  the setting minus the OS-launchable list instead of a hand-kept constant, so a new *default*
  extension without an interpreter mapping is caught too. It asserts the derived set is non-empty
  so the loop cannot pass vacuously.
- `e2e-win/task_executable_extensions.Tests.ps1`: the reproduction above, both halves, plus a
  `.cmd` task to show the whitelist still launches what it should. The script body is `printf`, so
  the assertion can only pass through bash.

No unit test overrides `windows_executable_extensions`: `Settings::override_with` mutates
process-wide state that other tests in the same binary read through `is_executable`. The widened
setting is covered in `e2e-win`, in its own process — which is also how the bug was measured.

## Verification

Measured on 2026.8.2 windows-x64: the A/B pair above. Existing tests were checked against the new
predicate rather than assumed —
`is_spawnable_rejects_interpreter_only_extensions_case_insensitively` asserts `.PS1` is rejected,
which the whitelist still does, and `which_in_dirs_ignores_missing_candidates` uses `tool.exe`.

`cargo fmt` was run locally. **The build, clippy and the test suite were not** — those are left to
CI, so behaviour after the fix rests on the measurement above and on the tests rather than on a
running binary.

Found while auditing Windows behaviour, the same pass that produced #12007, #12008, #12012, #12013,
#12014 and #12016. No existing issue or discussion covers it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Windows task launching with reliable support for `.exe`, `.com`, `.bat`, and `.cmd` files.
  - User-configured executable extensions are now limited to formats Windows can launch directly.
  - Shell scripts continue to use shebang-based execution by default, while explicitly configured shell extensions remain supported.

- **Bug Fixes**
  - Improved case-insensitive extension handling for Windows task execution.
  - Fixed direct execution behavior for command files and other supported Windows executables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->