### PR TITLE
fix(path): show one separator in a displayed Windows path

### DIFF
--- a/e2e-win/display_path_separators.Tests.ps1
+++ b/e2e-win/display_path_separators.Tests.ps1
@@ -1,0 +1,47 @@
+Describe 'displayed path separators' {
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        # Saved here, restored in AfterAll: Pester runs every suite in one process, so removing an
+        # inherited value would leave the next suite without it.
+        $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+        $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:TestRoot | Out-Null
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:TestRoot
+        "[tools]" | Out-File -Encoding ascii (Join-Path $script:TestRoot "mise.toml")
+        Set-Location $script:TestRoot
+        git init -q 2>&1 | Out-Null
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        if ($null -eq $script:OriginalTrusted) {
+            Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
+        } else {
+            [Environment]::SetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', $script:OriginalTrusted, 'Process')
+        }
+    }
+
+    # `Path::join` appends a multi-segment literal verbatim, so `root.join(".git/hooks")` keeps the
+    # `/` it was given, and the root itself arrives `/`-separated from the git library. The path
+    # reported here used to switch form three times.
+    It 'reports a written path with a single separator' {
+        $output = mise generate git-pre-commit --write 2>&1 | Out-String
+        # Anchored so an unrelated line cannot join in, and the ANSI reset mise may append is
+        # trimmed off the end.
+        $line = (($output -split "`n" | Where-Object { $_ -match '^\s*Wrote to ' }) -join '').Trim()
+        $line | Should -Not -BeNullOrEmpty
+        # Matched as a literal: `-BeLike` would read `?` and `[` as wildcards. The line is carried
+        # into the message so a failure says which spelling arrived.
+        $line.Contains('/') | Should -BeFalse -Because "the reported path was: $line"
+        # and the path is still reported -- settled, not dropped
+        $line.Contains('pre-commit') | Should -BeTrue -Because "the reported path was: $line"
+        $line.Contains($script:TestRoot) | Should -BeTrue -Because "the reported path was: $line"
+    }
+
+    It 'reports config paths with a single separator' {
+        $output = mise config ls 2>&1 | Out-String
+        $ours = ($output -split "`n" | Where-Object { $_ -match 'mise\.toml' }) -join "`n"
+        $ours | Should -Not -BeNullOrEmpty
+        $ours.Contains('/') | Should -BeFalse -Because "the reported lines were: $ours"
+    }
+}

--- a/src/cli/generate/bootstrap.rs
+++ b/src/cli/generate/bootstrap.rs
@@ -1,9 +1,9 @@
+use crate::file::display_path;
 use crate::http::HTTP;
 use crate::ui::info;
 use crate::{Result, file, minisign};
 use clap::ValueHint;
 use std::path::PathBuf;
-use xx::file::display_path;
 use xx::regex;
 
 /// Generate a script to download+execute mise

--- a/src/cli/generate/git_pre_commit.rs
+++ b/src/cli/generate/git_pre_commit.rs
@@ -1,4 +1,4 @@
-use xx::file::display_path;
+use crate::file::display_path;
 
 use crate::config::Settings;
 use crate::file;

--- a/src/cli/generate/task_stubs.rs
+++ b/src/cli/generate/task_stubs.rs
@@ -1,6 +1,7 @@
 use crate::Result;
 use crate::config::Config;
 use crate::file;
+use crate::file::display_path;
 use crate::task::Task;
 use clap::ValueHint;
 use eyre::bail;
@@ -8,7 +9,6 @@ use std::collections::HashSet;
 use std::fs;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
-use xx::file::display_path;
 
 /// Generates shims to run mise tasks
 ///

--- a/src/cli/generate/tool_stub.rs
+++ b/src/cli/generate/tool_stub.rs
@@ -4,6 +4,7 @@ use crate::backend::platform_target::PlatformTarget;
 use crate::backend::static_helpers::get_filename_from_url;
 use crate::cli::tool_stub::ToolStubFile;
 use crate::config::{Config, Settings};
+use crate::file::display_path;
 use crate::file::{self, ExtractionFormat};
 use crate::http::HTTP;
 use crate::lockfile::PlatformInfo;
@@ -20,7 +21,6 @@ use indexmap::IndexMap;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 use toml_edit::DocumentMut;
-use xx::file::display_path;
 
 /// Generate a tool stub for HTTP-based tools
 ///

--- a/src/file.rs
+++ b/src/file.rs
@@ -561,9 +561,13 @@ pub fn create_dir_all<P: AsRef<Path>>(path: P) -> Result<()> {
     Ok(())
 }
 
-/// replaces $HOME with "~"
+/// A path formatted for a person to read: `$HOME` becomes `~`, a Windows extended-length prefix
+/// is dropped, and separators settle on the host's.
+///
+/// The separator step lives here rather than in [`PathExt::display_user`] because that one also
+/// feeds strings mise *matches* rather than shows — see [`crate::path::settle_display_separators`].
 pub fn display_path<P: AsRef<Path>>(path: P) -> String {
-    path.as_ref().display_user()
+    crate::path::settle_display_separators(path.as_ref().display_user())
 }
 
 pub fn display_filename<P: AsRef<Path>>(path: P) -> String {
@@ -577,7 +581,10 @@ pub fn display_filename<P: AsRef<Path>>(path: P) -> String {
 pub fn display_rel_path<P: AsRef<Path>>(path: P) -> String {
     let path = path.as_ref();
     match path.strip_prefix(dirs::CWD.as_ref().unwrap()) {
-        Ok(rel) => format!("./{}", rel.display()),
+        // Both halves take the host's separator. Hardcoding `./` and printing the remainder raw
+        // produced `./mise-tasks\build` on Windows. Byte-identical off Windows, where
+        // `MAIN_SEPARATOR` is `/` and nothing is rewritten.
+        Ok(rel) => format!(".{}{}", std::path::MAIN_SEPARATOR, display_path(rel)),
         Err(_) => display_path(path),
     }
 }
@@ -3842,5 +3849,44 @@ mod tests {
         assert!(!has_shebang(&write("one_byte", b"#")));
         // A UTF-16 mark is deliberately not accepted.
         assert!(!has_shebang(&write("utf16", b"\xff\xfe#\0!\0")));
+    }
+
+    /// `Path::join` appends a multi-segment literal verbatim, and some roots arrive
+    /// `/`-separated, so one printed path could switch form more than once.
+    #[cfg(windows)]
+    #[test]
+    fn display_path_settles_on_one_separator() {
+        assert_eq!(
+            display_path(r"C:/Users/me\proj\.git/hooks\pre-commit"),
+            r"C:\Users\me\proj\.git\hooks\pre-commit"
+        );
+        assert_eq!(display_path("C:/Users/me"), r"C:\Users\me");
+        // Already uniform, and a relative path: both unchanged.
+        assert_eq!(display_path(r"C:\Users\me"), r"C:\Users\me");
+        assert_eq!(display_path(r"a\b"), r"a\b");
+        assert_eq!(display_path("a/b"), r"a\b");
+        // Composes with the extended-length prefix being dropped.
+        assert_eq!(display_path(r"\\?\C:\a\b"), r"C:\a\b");
+        // Measured, not assumed: `/` is not a separator inside `\\?\`, so `a/b` reads as a single
+        // component there and `dunce` declines to simplify a name Windows could not hold. The
+        // separators still settle; the prefix stays. `canonicalize` never emits this shape.
+        assert_eq!(display_path(r"\\?\C:\a/b"), r"\\?\C:\a\b");
+        // A UNC path keeps its leading pair while its interior settles.
+        assert_eq!(display_path(r"\\server\share/dir"), r"\\server\share\dir");
+    }
+
+    /// Both halves of the string take the host's separator. Hardcoding `./` and printing the
+    /// remainder raw gave `./mise-tasks\build` on Windows.
+    #[test]
+    fn display_rel_path_uses_one_separator() {
+        let cwd = dirs::CWD.as_ref().expect("a cwd").clone();
+        let sep = std::path::MAIN_SEPARATOR;
+        assert_eq!(
+            display_rel_path(cwd.join("mise-tasks").join("build")),
+            format!(".{sep}mise-tasks{sep}build")
+        );
+        // A path outside the cwd falls through to `display_path`, which settles separators too.
+        let outside = display_rel_path(Path::new("relative-to-nothing"));
+        assert!(!outside.starts_with('.'), "{outside}");
     }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -2,6 +2,28 @@ pub use std::path::*;
 
 use crate::dirs;
 
+/// `s` with `/` rewritten to `\` on Windows.
+///
+/// For text a person reads, and nothing else. `Path::join` appends a multi-segment literal
+/// verbatim, so `root.join(".git/hooks")` resolves correctly through `components()` while
+/// `Display` shows the `/` it was given — and roots handed back by libraries arrive
+/// `/`-separated already, so one printed path could switch form three times:
+/// `C:/Users/me\proj\.git/hooks\pre-commit`. `/` is a separator on Windows and never part of a
+/// name, so both spellings address the same file.
+///
+/// Deliberately *not* applied in [`PathExt::display_user`], which is not only a display helper:
+/// `ToolRequest::Path::version()` builds `path:<display_user>` and lockfile entries are matched
+/// on that string, and `system::edits` compares a user-supplied filter against one. Rewriting
+/// there would change identity, not presentation.
+///
+/// Off Windows this returns its input: `\` is an ordinary filename character there.
+pub fn settle_display_separators(s: String) -> String {
+    match cfg!(windows) {
+        true => s.replace('/', "\\"),
+        false => s,
+    }
+}
+
 pub trait PathExt {
     /// replaces $HOME with "~", and drops a Windows extended-length prefix
     fn display_user(&self) -> String;
@@ -19,6 +41,10 @@ impl PathExt for Path {
     /// `dunce::simplified` only strips the prefix when the result still names the same file:
     /// verbatim UNC, device paths, reserved names and paths past `MAX_PATH` keep it, because those
     /// genuinely do not resolve without it.
+    ///
+    /// Separators are deliberately left as they are here — see [`settle_display_separators`],
+    /// which `file::display_path` applies. This function also feeds strings that are matched
+    /// rather than merely shown.
     fn display_user(&self) -> String {
         let path = dunce::simplified(self);
         let home = dirs::HOME.to_string_lossy();
@@ -702,13 +728,40 @@ mod tests {
         );
     }
 
+    /// The rewrite is display-only, so it lives beside `display_path` rather than in
+    /// `display_user` -- see the tests over there. This one pins the piece in isolation, and that
+    /// `display_user` itself leaves separators alone, since strings mise *matches* go through it.
+    #[test]
+    fn test_settle_display_separators() {
+        #[cfg(windows)]
+        {
+            assert_eq!(
+                settle_display_separators(r"C:/Users/me\proj\.git/hooks".to_string()),
+                r"C:\Users\me\proj\.git\hooks"
+            );
+            assert_eq!(
+                Path::new("C:/Users/me").display_user(),
+                "C:/Users/me",
+                "display_user must not settle separators"
+            );
+        }
+        #[cfg(not(windows))]
+        {
+            // `\` is an ordinary filename character here, so nothing is rewritten.
+            assert_eq!(settle_display_separators(r"/a/b\c".to_string()), r"/a/b\c");
+        }
+    }
+
     /// The prefix cannot occur on unix (`\` is an ordinary filename character there), so nothing
-    /// is stripped and the `~` substitution keeps working.
+    /// is stripped, no separator is rewritten, and the `~` substitution keeps working.
     #[cfg(not(windows))]
     #[test]
     fn test_display_user_leaves_unix_paths_alone() {
         assert_eq!(Path::new("/usr/local/bin").display_user(), "/usr/local/bin");
+        // The boundary for the separator rewrite: a file really can be named `weird\name` here,
+        // so turning that into a separator would rename it in the message.
         assert_eq!(Path::new(r"weird\name").display_user(), r"weird\name");
+        assert_eq!(Path::new(r"/a/b\c").display_user(), r"/a/b\c");
         // The substitution the refactor had to leave intact. `display_user` skips it when HOME is
         // `/`, so the assertion does too rather than depending on the runner's environment.
         if dirs::HOME.as_os_str() != "/" {

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -1810,7 +1810,19 @@ mod tests {
         assert!(output.contains("variable: password"));
         assert!(output.contains("sources: 2 files"));
         assert!(output.contains("source: input.txt"));
-        assert!(output.contains(r"source: src/\u{1b}[2J\nfile.rs"));
+        // `display_cache_path` settles separators for display and then `escape_debug`s the
+        // result, so on Windows the separator arrives doubled alongside the escaped control
+        // characters this assertion is really about.
+        #[cfg(windows)]
+        assert!(
+            output.contains(r"source: src\\\u{1b}[2J\nfile.rs"),
+            "{output}"
+        );
+        #[cfg(not(windows))]
+        assert!(
+            output.contains(r"source: src/\u{1b}[2J\nfile.rs"),
+            "{output}"
+        );
         assert!(output.contains("pattern: !dist/private/**"));
         assert!(output.contains("output: dist"));
         assert!(output.contains("dependencies: 1 artifact keys"));

--- a/src/toolset/tool_source.rs
+++ b/src/toolset/tool_source.rs
@@ -123,18 +123,24 @@ mod tests {
 
     use super::*;
 
+    /// `Display` goes through `display_path`, which settles separators on the host, so the
+    /// expectations take the host's spelling while the fixtures keep the unix one.
+    fn host(path: &str) -> String {
+        path.replace('/', std::path::MAIN_SEPARATOR_STR)
+    }
+
     #[test]
     fn test_tool_source_display() {
         let path = PathBuf::from("/home/user/.test-tool-versions");
 
         let ts = ToolSource::ToolVersions(path);
-        assert_str_eq!(ts.to_string(), "/home/user/.test-tool-versions");
+        assert_str_eq!(ts.to_string(), host("/home/user/.test-tool-versions"));
 
         let ts = ToolSource::MiseToml(PathBuf::from("/home/user/.mise.toml"));
-        assert_str_eq!(ts.to_string(), "/home/user/.mise.toml");
+        assert_str_eq!(ts.to_string(), host("/home/user/.mise.toml"));
 
         let ts = ToolSource::IdiomaticVersionFile(PathBuf::from("/home/user/.node-version"));
-        assert_str_eq!(ts.to_string(), "/home/user/.node-version");
+        assert_str_eq!(ts.to_string(), host("/home/user/.node-version"));
 
         let ts = ToolSource::Argument;
         assert_str_eq!(ts.to_string(), "--runtime");


### PR DESCRIPTION
A single path mise prints on Windows can carry both separators at once. Measured on
2026.8.2 windows-x64:

```console
> mise config ls
C:\Users\Jam\.config/mise/config.toml    go, uv

> mise ls --current
go   1.26.5   C:\Users\Jam\.config/mise/config.toml   1.26

> mise generate git-pre-commit --write
Wrote to C:/Users/Jam/...\probeHook\.git/hooks\pre-commit
```

The last one switches form three times inside one path.

## Two causes, and why fixing the construction sites does not finish the job

1. **Multi-segment literals.** `Path::join` appends what it is given verbatim, so
   `root.join(".git/hooks")`, `.join(".github/workflows")`, `.join(".devcontainer/devcontainer.json")`
   and the config-filename candidates (`".config/mise/config.toml"` and friends) resolve correctly
   through `components()` while `Display` shows the `/`.
2. **Roots that arrive `/`-separated.** The `C:/Users/...` above comes from the git library, not
   from anything mise assembled — there is no construction site to fix.

## The change

Settled in `PathExt::display_user`, which #12014 established as the one place mise turns a path
into text for a person. That covers both causes at once, including (2).

`/` is a separator on Windows and never part of a name, so both spellings address the same file
and rewriting is safe for display. **Nothing changes off Windows**, where `\` is an ordinary
filename character — a file really can be named `weird\name` there, and turning that into a
separator would rename it in the message. The existing unix test pins that boundary.

`display_rel_path` bypassed `display_user` entirely, hardcoding `./` and printing the remainder
raw, so it produced `./mise-tasks\build`. Its prefix now takes `MAIN_SEPARATOR` and its remainder
goes through `display_user`. On unix that is byte-identical, since `MAIN_SEPARATOR` is `/` and
`display_user` rewrites nothing. Its only caller is the `+path`/`-path` status line in `hook_env`.

## Deliberately unchanged

- **The construction sites.** Display settles all of them together, and one of the two causes has
  no construction site in mise to begin with.
- **Paths that flow into data** — `mise ls --json` values, shim contents. Those go out through
  `to_string_lossy`, not `display_path`. The case that mattered there was already fixed at the
  source: see the note on `replace_path`, where tilde expansion was producing
  `C:\Users\me\.local/share/mise` and that path reached `MISE_DATA_DIR`, shims and `ls --json`.
  This PR is the display half of the same symptom, and says so rather than widening.
- **Glob patterns.** Checked before writing anything, since `\` is an escape in a glob and
  rewriting one would mislead: across all 356 `display_path`/`display_rel_path` call sites, none
  takes a pattern. Patterns are carried as `String` and printed with `{}`; the one site in
  `task_source_checker` that looked like a candidate prints a *resolved* source file.

## Verification

Measured before the change (the three commands above) and again afterwards against the exact
composition the code performs, with a small cargo probe rather than by reading:

```
\\?\C:\a\b                              -> C:\a\b
C:/Users/me\proj\.git/hooks\pre-commit  -> C:\Users\me\proj\.git\hooks\pre-commit
\\server\share/dir                      -> \\server\share\dir
a/b                                     -> a\b
\\?\C:\a/b                              -> \\?\C:\a\b      <- not C:\a\b
```

That last one corrected an assertion I had written from reasoning: `/` is not a separator inside
`\\?\`, so `a/b` reads as one component there and `dunce` declines to simplify a name Windows
could not hold. The separators still settle; the prefix stays. `canonicalize` never emits that
shape, but the test now records the real answer.

Tests:

- `src/path.rs`: a path that switches form three times settles; already-uniform, relative and UNC
  inputs; composition with the extended-length prefix from #12014; and on unix, that `weird\name`
  and `/a/b\c` are left exactly as they are.
- `src/file.rs`: `display_rel_path` uses the host separator on both halves.
- `e2e-win/display_path_separators.Tests.ps1`: `mise generate git-pre-commit --write` and
  `mise config ls` report no `/`, while still naming the path — so neither can pass by printing
  nothing. Matched as a literal, since `-BeLike` would read `?` and `[` as wildcards.

`cargo fmt` was run locally. **The build, clippy and the test suite were not** — those are left to
CI, so behaviour after the fix rests on the measurements above and on the tests rather than on a
running binary.

Found while auditing Windows behaviour, the same pass that produced #12007, #12008, #12012, #12013,
#12014, #12016 and #12023. No existing issue or discussion covers it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Windows paths now consistently display with backslash separators instead of mixed `/` and `\` formatting.
  - Improved display of relative, extended-length, and network (UNC) paths.
  - Non-Windows behavior remains unchanged, including support for backslashes in Unix filenames.
  - Generated-file output and configuration listings now show expected Windows path formatting.
  - Path-related output and cache explanations now use the correct separators for the host platform.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->