### PR TITLE
feat(task): support generated usage specs

### DIFF
--- a/docs/.vitepress/cli_commands.ts
+++ b/docs/.vitepress/cli_commands.ts
@@ -614,6 +614,9 @@ export const commands: { [key: string]: Command } = {
   tasks: {
     hide: false,
     subcommands: {
+      __usage: {
+        hide: true,
+      },
       add: {
         hide: false,
       },

--- a/docs/cli/tasks.md
+++ b/docs/cli/tasks.md
@@ -68,9 +68,6 @@ Sort order. Default is asc.
 
 - `asc`
 - `desc`
-
-## Subcommands
-
 - [`mise tasks add [FLAGS] <TASK> [-- RUN]…`](/cli/tasks/add.md)
 - [`mise tasks deps [FLAGS] [TASKS]…`](/cli/tasks/deps.md)
 - [`mise tasks edit [-p --path] <TASK>`](/cli/tasks/edit.md)

--- a/docs/tasks/task-arguments.md
+++ b/docs/tasks/task-arguments.md
@@ -151,6 +151,34 @@ The mount command runs when shell completion asks for the task spec, so it must
 work outside the task's final process. Calling the task itself, as shown above,
 lets mise apply task configuration before forwarding `--usage-spec`.
 
+#### Generating a File Task Spec
+
+When a file task's own argument parser can output a usage KDL spec, declare a
+`usage_command` instead of duplicating the arguments in comments:
+
+```python [.mise/tasks/my-task.py]
+#!/usr/bin/env python3
+#MISE description="Run my Python command"
+#MISE usage_command=".mise/tasks/my-task.py --usage-spec"
+
+# Print the KDL spec and exit when --usage-spec is passed.
+# Run the normal command for all other arguments.
+```
+
+The command runs lazily when mise needs the selected task's complete spec, such
+as for task help, argument parsing, validation, documentation, or shell
+completion. Listing all task specs only emits a lazy mount and does not run
+every generator. Generated specs are cached only within the current mise
+process; mise does not persist them between invocations.
+
+The generator runs with the task's configured shell, directory, environment,
+installed tool paths, sandbox, and timeout. Metadata-only commands such as
+completion do not install missing task tools or run task dependencies. Keep the
+generator fast, non-interactive, and free of side effects, and ensure its
+dependencies are already available. Because it executes code, an untrusted task
+file cannot run its generator. `usage_command` cannot be combined with embedded
+`#MISE` or `#USAGE` usage declarations in the same file.
+
 ## Complete Usage Specification Reference
 
 ### Positional Arguments (`arg`)

--- a/e2e/tasks/test_task_usage_command
+++ b/e2e/tasks/test_task_usage_command
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+mkdir -p .mise/tasks
+cat <<'EOF' >.mise/tasks/dynamic
+#!/usr/bin/env bash
+#MISE description="Dynamic usage task"
+#MISE usage_command=".mise/tasks/dynamic --usage-spec"
+
+if [[ ${1:-} == --usage-spec ]]; then
+  echo run >>.usage-runs
+  cat <<'KDL'
+arg "<name>" help="Name to greet"
+flag "--mode <mode>" help="Greeting mode" {
+  choices "fast" "slow"
+}
+KDL
+  exit 0
+fi
+
+echo "name=$usage_name mode=$usage_mode"
+EOF
+chmod +x .mise/tasks/dynamic
+
+# Extension-qualified siblings share a display name, so aggregate usage must
+# retain both under their canonical names instead of overwriting one mount.
+cat <<'EOF' >.mise/tasks/build.sh
+#!/usr/bin/env bash
+#MISE usage_command="printf 'flag \"--shell\"\n'"
+echo shell
+EOF
+cat <<'EOF' >.mise/tasks/build.bash
+#!/usr/bin/env bash
+#MISE usage_command="printf 'flag \"--bash\"\n'"
+echo bash
+EOF
+chmod +x .mise/tasks/build.sh .mise/tasks/build.bash
+
+# Listing the aggregate usage spec must stay lazy. It exposes an internal mount
+# but does not execute the task's generator.
+assert_contains "mise tasks ls --usage" 'cmd dynamic help="Dynamic usage task"'
+assert_contains "mise tasks ls --usage" 'mount run="mise tasks __usage dynamic"'
+assert_contains "mise tasks ls --usage" 'cmd build.sh'
+assert_contains "mise tasks ls --usage" 'mount run="mise tasks __usage build.sh"'
+assert_contains "mise tasks ls --usage" 'cmd build.bash'
+assert_contains "mise tasks ls --usage" 'mount run="mise tasks __usage build.bash"'
+[[ ! -e .usage-runs ]] || fail "usage_command ran while listing tasks"
+
+# Explicit help resolves the generated spec.
+assert_contains "mise run dynamic --help" "<name>"
+assert_contains "mise run dynamic --help" "--mode <mode>"
+
+# Normal task parsing consumes the same generated spec.
+assert "mise run dynamic Alice --mode fast" "name=Alice mode=fast"
+
+# Completion resolves only the selected task mount and sees generated choices.
+# Completion is delegated to the external usage CLI. Configure it explicitly
+# here so the test does not depend on the developer checkout's tool environment
+# while the earlier metadata-only paths remain free of tool installation.
+cat <<'EOF' >mise.toml
+[tools]
+"usage" = { version = "5.0.0", os = ["linux", "macos"] }
+EOF
+mise usage >mise.usage.kdl
+assert "mise exec -- usage complete-word --shell bash -f ./mise.usage.kdl -- mise run dynamic --mode ''" "fast
+slow"
+assert "mise exec -- usage complete-word --shell bash -f ./mise.usage.kdl -- mise run build.sh --sh" "--shell"
+assert "mise exec -- usage complete-word --shell bash -f ./mise.usage.kdl -- mise run build.bash --ba" "--bash"
+# The two help commands, task run, and completion each start a separate mise
+# process, so the per-process cache intentionally results in four executions.
+[[ $(wc -l <.usage-runs) -eq 4 ]] || fail "usage_command was evaluated more than once in one mise invocation"
+
+# Generator failures include the task and command context and never execute the
+# task body.
+cat <<'EOF' >.mise/tasks/bad
+#!/usr/bin/env bash
+#MISE usage_command="exit 17"
+touch .bad-task-body
+EOF
+chmod +x .mise/tasks/bad
+if output=$(mise run bad --help 2>&1); then
+  fail "failing usage_command unexpectedly succeeded"
+fi
+[[ $output == *"usage command failed for task bad"* ]] || fail "missing task context: $output"
+[[ $output == *"exit 17"* ]] || fail "missing command context: $output"
+[[ ! -e .bad-task-body ]] || fail "task body ran after usage_command failed"
+
+# A generator may not be combined with embedded usage declarations.
+cat <<'EOF' >.mise/tasks/conflict
+#!/usr/bin/env bash
+#MISE usage_command="echo 'arg \"<name>\"'"
+#USAGE flag "--verbose"
+echo conflict
+EOF
+chmod +x .mise/tasks/conflict
+assert_fail "mise tasks ls"

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3847,6 +3847,14 @@ By default, only tasks from the current directory hierarchy are loaded.
     }
     flag --usage hide=#true
     arg "[TASK]" help="Task name to get info of" required=#false
+    cmd __usage hide=#true help="Resolve a file task's generated usage specification" {
+        long_help #"""
+Resolve a file task's generated usage specification.
+
+This is an internal target for usage mounts. Keeping the raw generator command behind mise preserves the task's config root, environment, trust, and sandbox behavior without eagerly running every generator in `tasks ls`.
+"""#
+        arg <TASK> help="Canonical task name to resolve"
+    }
     cmd add help="Create a new task" effect=write {
         long_help #"""
 Create a new task

--- a/src/cli/command_effects.rs
+++ b/src/cli/command_effects.rs
@@ -300,6 +300,10 @@ pub const UNCLASSIFIED: &[(&str, &str)] = &[
     ("mcp", "serves tools that run tasks on request"),
     ("oci run", "runs an arbitrary command in a container"),
     ("run", "runs project tasks"),
+    (
+        "tasks __usage",
+        "runs a task-supplied usage specification generator",
+    ),
     ("tasks run", "runs project tasks"),
     ("test-tool", "installs and executes a tool"),
     ("tool-stub", "executes the tool a stub points at"),

--- a/src/cli/tasks/ls.rs
+++ b/src/cli/tasks/ls.rs
@@ -222,8 +222,9 @@ impl TasksLs {
 
     async fn display_usage(&self, config: &Arc<Config>, tasks: Vec<Task>) -> Result<()> {
         let mut usage = usage::Spec::default();
+        let display_name_counts = tasks.iter().map(|task| task.display_name.clone()).counts();
         for task in tasks {
-            let mut task_spec = task.parse_usage_spec_for_display(config).await?;
+            let mut task_spec = task.parse_usage_spec_for_listing(config).await?;
             for (name, complete) in task_spec.complete {
                 task_spec.cmd.complete.insert(name, complete);
             }
@@ -252,10 +253,14 @@ impl TasksLs {
                     .collect();
                 task_spec.cmd.aliases.extend(prefixed_aliases);
             }
-            usage
-                .cmd
-                .subcommands
-                .insert(task.display_name.clone(), task_spec.cmd);
+            let usage_name = if display_name_counts[&task.display_name] > 1 {
+                task.name.clone()
+            } else {
+                task.display_name.clone()
+            };
+            task_spec.cmd.name = usage_name.clone();
+            task_spec.cmd.usage = task_spec.cmd.usage();
+            usage.cmd.subcommands.insert(usage_name, task_spec.cmd);
         }
         miseprintln!("{}", usage.to_string());
         Ok(())

--- a/src/cli/tasks/mod.rs
+++ b/src/cli/tasks/mod.rs
@@ -9,6 +9,7 @@ mod edit;
 mod graph;
 mod info;
 mod ls;
+mod usage;
 mod validate;
 
 /// Manage tasks
@@ -27,6 +28,8 @@ pub struct Tasks {
 
 #[derive(Subcommand)]
 enum Commands {
+    #[clap(name = "__usage", hide = true)]
+    Usage(usage::TasksUsage),
     Add(Box<add::TasksAdd>),
     Deps(deps::TasksDeps),
     Edit(edit::TasksEdit),
@@ -40,6 +43,7 @@ enum Commands {
 impl Commands {
     pub async fn run(self) -> Result<()> {
         match self {
+            Self::Usage(cmd) => cmd.run().await,
             Self::Add(cmd) => (*cmd).run().await,
             Self::Deps(cmd) => cmd.run().await,
             Self::Edit(cmd) => cmd.run().await,

--- a/src/cli/tasks/usage.rs
+++ b/src/cli/tasks/usage.rs
@@ -1,0 +1,51 @@
+use crate::config::Config;
+use crate::task::TaskLoadContext;
+use crate::task::task_fetcher::TaskFetcher;
+use eyre::{Result, eyre};
+
+/// Resolve a file task's generated usage specification.
+///
+/// This is an internal target for usage mounts. Keeping the raw generator
+/// command behind mise preserves the task's config root, environment, trust,
+/// and sandbox behavior without eagerly running every generator in `tasks ls`.
+#[derive(Debug, clap::Args)]
+pub struct TasksUsage {
+    /// Canonical task name to resolve
+    task: String,
+}
+
+impl TasksUsage {
+    pub async fn run(self) -> Result<()> {
+        let config = Config::get().await?;
+        let context = TaskLoadContext::all();
+        let tasks = config.tasks_with_context(Some(&context)).await?;
+        let task = tasks
+            .get(&self.task)
+            .cloned()
+            .ok_or_else(|| eyre!("task not found: {}", self.task))?;
+        let requires_canonical_name = tasks
+            .values()
+            .filter(|candidate| candidate.display_name == task.display_name)
+            .count()
+            > 1;
+        let mut tasks = vec![task];
+        TaskFetcher::new(false)
+            .fetch_tasks(&config, &mut tasks)
+            .await?;
+        let task = tasks
+            .pop()
+            .ok_or_else(|| eyre!("task disappeared while resolving usage: {}", self.task))?;
+        if task.usage_command.is_none() {
+            return Err(eyre!("task {} has no usage_command", task.display_name));
+        }
+        let mut spec = task.parse_usage_spec_for_display(&config).await?;
+        if requires_canonical_name {
+            spec.name = task.name.clone();
+            spec.bin = task.name.clone();
+            spec.cmd.name = task.name.clone();
+            spec.cmd.usage = spec.cmd.usage();
+        }
+        miseprintln!("{spec}");
+        Ok(())
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3087,7 +3087,7 @@ fn default_task_includes() -> Vec<String> {
     ]
 }
 
-fn is_global_task_include_path(path: &Path) -> bool {
+pub(crate) fn is_global_task_include_path(path: &Path) -> bool {
     [
         dirs::CONFIG.join("tasks"),
         dirs::SYSTEM_CONFIG.join("tasks"),
@@ -4110,6 +4110,9 @@ async fn load_tasks_includes(
                 &config_root,
                 monorepo_cf.cloned(),
             )?;
+            task.usage_command_requires_trust = require_trust
+                && !is_global_task_include_path(&path)
+                && task.usage_command.is_some();
             if let Err(err) = resolve_task_template(&mut task, templates) {
                 if monorepo_cf.is_some() {
                     warn!(

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -9,7 +9,7 @@ use crate::tera::{TeraEngine, contains_template_syntax, get_tera, render_str};
 use crate::ui::tree::TreeItem;
 use crate::{dirs, env, file};
 use console::{measure_text_width, truncate_str};
-use eyre::{Result, bail, eyre};
+use eyre::{Context, Result, bail, eyre};
 use globset::{GlobBuilder, GlobMatcher};
 use indexmap::IndexMap;
 use itertools::Itertools;
@@ -33,9 +33,14 @@ static TASK_VARS_CACHE: Lazy<std::sync::Mutex<IndexMap<PathBuf, IndexMap<String,
 static TASK_ENV_CACHE: Lazy<std::sync::Mutex<IndexMap<PathBuf, EnvMap>>> =
     Lazy::new(|| std::sync::Mutex::new(IndexMap::new()));
 
+type GeneratedUsageCell = Arc<tokio::sync::OnceCell<usage::Spec>>;
+static GENERATED_USAGE_CACHE: Lazy<dashmap::DashMap<String, GeneratedUsageCell>> =
+    Lazy::new(dashmap::DashMap::new);
+
 pub(crate) fn reset() {
     TASK_VARS_CACHE.lock().unwrap().clear();
     TASK_ENV_CACHE.lock().unwrap().clear();
+    GENERATED_USAGE_CACHE.clear();
 }
 
 /// Type alias for tracking failed tasks with their exit codes
@@ -740,6 +745,12 @@ pub struct Task {
     pub tools: IndexMap<String, TaskToolValue>,
     #[serde(default)]
     pub usage: String,
+    /// A file-task-only command that prints a usage KDL specification.
+    #[serde(skip)]
+    pub usage_command: Option<String>,
+    /// Whether the task file must be trusted before `usage_command` may run.
+    #[serde(skip)]
+    pub(crate) usage_command_requires_trust: bool,
     #[serde(default)]
     pub timeout: Option<String>,
 
@@ -1453,6 +1464,13 @@ impl Task {
             })
             .transpose()?
             .unwrap_or_default();
+        task.usage_command = p.parse_str("usage_command");
+        if task.usage_command.is_some() && !extract_usage_from_comments(&body).trim().is_empty() {
+            bail!(
+                "task {} cannot combine usage_command with embedded usage declarations",
+                display_path(path)
+            );
+        }
 
         let mut unparsed = p.unparsed_keys();
         unparsed.sort();
@@ -1958,6 +1976,204 @@ impl Task {
             }
         }
     }
+
+    fn usage_mount_command(&self) -> String {
+        shell_words::join([
+            "mise".to_string(),
+            "tasks".to_string(),
+            "__usage".to_string(),
+            self.name.clone(),
+        ])
+    }
+
+    async fn usage_command_env(&self, config: &Arc<Config>) -> Result<EnvMap> {
+        let context_builder = task_context_builder::TaskContextBuilder::new();
+        let tools = self.tool_args()?;
+        let task_cf = if self.is_remote() {
+            None
+        } else {
+            self.cf(config)
+        };
+        let toolset = context_builder
+            .build_toolset_for_task(config, self, task_cf, &tools)
+            .await?;
+        let (mut env, _, _) = if let Some(task_cf) = task_cf {
+            context_builder
+                .resolve_task_env_with_config(config, self, task_cf, &toolset)
+                .await?
+        } else {
+            let (env, task_env) = self.render_env(config, &toolset).await?;
+            (env, task_env, None)
+        };
+        env.insert("MISE_TASK_NAME".into(), self.name.clone());
+        env.insert(
+            "MISE_TASK_FILE".into(),
+            self.file_path(config)
+                .await?
+                .unwrap_or_else(|| self.config_source.clone())
+                .display()
+                .to_string(),
+        );
+        if let Some(root) = &self.config_root {
+            env.insert("MISE_CONFIG_ROOT".into(), root.display().to_string());
+        }
+        Ok(env)
+    }
+
+    async fn usage_command_sandbox(
+        &self,
+        config: &Arc<Config>,
+    ) -> Result<crate::sandbox::SandboxConfig> {
+        let task_base = self.dir(config).await?;
+        let resolve = |path: &PathBuf| {
+            if path.as_os_str().is_empty() {
+                return PathBuf::new();
+            }
+            let path = file::replace_path(path);
+            if path.is_absolute() {
+                path
+            } else if let Some(base) = &task_base {
+                base.join(path)
+            } else {
+                path
+            }
+        };
+        let mut sandbox = crate::sandbox::SandboxConfig {
+            deny_read: self.deny_all || self.deny_read,
+            deny_write: self.deny_all || self.deny_write,
+            deny_net: self.deny_all || self.deny_net,
+            deny_env: self.deny_all || self.deny_env,
+            allow_read: self.allow_read.iter().map(&resolve).collect(),
+            allow_write: self.allow_write.iter().map(&resolve).collect(),
+            allow_net: self.allow_net.clone(),
+            allow_env: self.allow_env.clone(),
+            pass_through_env: self.pass_through_env.clone(),
+            cache_env: self
+                .cache
+                .iter()
+                .filter(|cache| cache.enabled)
+                .flat_map(|cache| cache.env.iter().cloned())
+                .collect(),
+        };
+        sandbox.resolve_paths();
+        Ok(sandbox)
+    }
+
+    fn generated_usage_cache_key(
+        &self,
+        command: &str,
+        cwd: &Path,
+        sandbox: &crate::sandbox::SandboxConfig,
+        env: &EnvMap,
+    ) -> String {
+        crate::hash::hash_to_str(&(
+            &self.config_source,
+            &self.name,
+            command,
+            cwd,
+            env,
+            format!("{sandbox:?}"),
+            &self.shell,
+            &self.timeout,
+        ))
+    }
+
+    async fn resolve_generated_usage_spec(
+        &self,
+        config: &Arc<Config>,
+        cwd: Option<PathBuf>,
+    ) -> Result<usage::Spec> {
+        let Some(command) = self.usage_command.as_deref() else {
+            return Ok(usage::Spec::default());
+        };
+        if self.usage_command_requires_trust {
+            crate::config::config_file::trust_check(&self.config_source)?;
+        }
+        // Generate the environment independently of an invocation's parsed
+        // arguments and dependency results. The generated spec is task
+        // metadata, so every resolution path must use the same task/config
+        // environment and therefore the same cache identity.
+        let env = self.usage_command_env(config).await?;
+        let cwd = match cwd {
+            Some(cwd) => cwd,
+            None => task_source_checker::task_cwd(self, config).await?,
+        };
+        let sandbox = self.usage_command_sandbox(config).await?;
+        let filtered_env = if sandbox.is_active() {
+            sandbox.filter_env(&env)
+        } else {
+            env
+        };
+        let cache_key = self.generated_usage_cache_key(command, &cwd, &sandbox, &filtered_env);
+        let cell = GENERATED_USAGE_CACHE
+            .entry(cache_key)
+            .or_insert_with(|| Arc::new(tokio::sync::OnceCell::new()))
+            .clone();
+        let spec = cell
+            .get_or_try_init(|| async {
+                let (program, args, cmd_verbatim) =
+                    task_executor::task_inline_command(self, command, &[], None)?;
+                #[cfg(windows)]
+                let program = {
+                    let program = PathBuf::from(program);
+                    crate::path::resolve_posix_shell_program_path(
+                        program.as_os_str(),
+                        &filtered_env,
+                    )
+                    .map(PathBuf::from)
+                    .unwrap_or(program)
+                };
+                #[cfg(not(windows))]
+                let program = PathBuf::from(&program);
+                let env = task_executor::maybe_convert_env_for_msys_shell(&program, &filtered_env);
+                let runner = crate::cmd::CmdLineRunner::new(&program);
+                #[cfg(windows)]
+                let runner = if cmd_verbatim {
+                    args.iter().fold(runner, |runner, arg| runner.raw_arg(arg))
+                } else {
+                    runner.args(&args)
+                };
+                #[cfg(not(windows))]
+                let runner = {
+                    let _ = cmd_verbatim;
+                    runner.args(&args)
+                };
+                let mut runner = runner
+                    .current_dir(cwd)
+                    .envs(env.as_ref())
+                    .redact(config.redactions().iter().cloned())
+                    .with_sandbox(sandbox);
+                if let Some(timeout) = self
+                    .timeout
+                    .as_ref()
+                    .map(|timeout| crate::duration::parse_duration(timeout))
+                    .transpose()?
+                {
+                    runner = runner.with_timeout(timeout);
+                }
+                runner.apply_sandbox().await?;
+                let output = runner.read().await.wrap_err_with(|| {
+                    format!(
+                        "usage command failed for task {} from {}: {command}",
+                        self.name,
+                        display_path(&self.config_source)
+                    )
+                })?;
+                let mut spec: usage::Spec = output.parse().wrap_err_with(|| {
+                    format!(
+                        "invalid usage spec generated for task {} from {}: {command}",
+                        self.name,
+                        display_path(&self.config_source)
+                    )
+                })?;
+                self.populate_spec_metadata(&mut spec);
+                self.populate_usage_about(&mut spec);
+                Ok::<_, eyre::Report>(spec)
+            })
+            .await?;
+        Ok(spec.clone())
+    }
+
     pub async fn parse_usage_spec_with_vars(
         &self,
         config: &Arc<Config>,
@@ -1970,14 +2186,19 @@ impl Task {
             clear_usage_env(&mut env);
         }
         let (mut spec, scripts) = if let Some(file) = self.file_path(config).await? {
-            let spec = parse_task_script_usage(&file)
-                .inspect_err(|e| {
-                    warn!(
-                        "failed to parse task file {} with usage: {e:?}",
-                        file::display_path(&file)
-                    )
-                })
-                .unwrap_or_default();
+            let spec = if self.usage_command.is_some() {
+                self.resolve_generated_usage_spec(config, cwd.clone())
+                    .await?
+            } else {
+                parse_task_script_usage(&file)
+                    .inspect_err(|e| {
+                        warn!(
+                            "failed to parse task file {} with usage: {e:?}",
+                            file::display_path(&file)
+                        )
+                    })
+                    .unwrap_or_default()
+            };
             (spec, vec![])
         } else {
             let scripts_only = self.run_script_strings();
@@ -2008,6 +2229,9 @@ impl Task {
 
     /// Parse usage spec for display purposes without expensive environment rendering
     pub async fn parse_usage_spec_for_display(&self, config: &Arc<Config>) -> Result<usage::Spec> {
+        if self.usage_command.is_some() {
+            return self.resolve_generated_usage_spec(config, None).await;
+        }
         let dir = self.dir(config).await?;
         let mut spec = if let Some(file) = self.file_path(config).await? {
             parse_task_script_usage(&file)
@@ -2029,6 +2253,25 @@ impl Task {
         Ok(spec)
     }
 
+    /// Parse a task spec without executing a dynamic generator. Dynamic file
+    /// tasks expose an internal usage mount which is resolved only when usage
+    /// selects that task for help or completion.
+    pub(crate) async fn parse_usage_spec_for_listing(
+        &self,
+        config: &Arc<Config>,
+    ) -> Result<usage::Spec> {
+        if self.usage_command.is_none() {
+            return self.parse_usage_spec_for_display(config).await;
+        }
+        let mut spec = usage::Spec::default();
+        spec.cmd
+            .mounts
+            .push(usage::SpecMount::new(self.usage_mount_command()));
+        self.populate_spec_metadata(&mut spec);
+        self.populate_usage_about(&mut spec);
+        Ok(spec)
+    }
+
     /// Parse usage metadata without resolving task- or subproject-specific
     /// environment directives. This is used before the scheduler starts, where
     /// source/module hooks must not run ahead of task dependencies.
@@ -2036,6 +2279,9 @@ impl Task {
         &self,
         config: &Arc<Config>,
     ) -> Result<usage::Spec> {
+        if self.usage_command.is_some() {
+            return self.resolve_generated_usage_spec(config, None).await;
+        }
         let mut spec = if let Some(file) = self.file_path_raw() {
             parse_task_script_usage(&file)
                 .inspect_err(|e| {
@@ -2631,6 +2877,10 @@ impl Task {
                 .timeout
                 .as_ref()
                 .is_some_and(|s| contains_template_syntax(s))
+            || self
+                .usage_command
+                .as_ref()
+                .is_some_and(|s| contains_template_syntax(s))
             || self.allow_read.iter().any(|p| path_contains_template(p))
             || self.allow_write.iter().any(|p| path_contains_template(p))
             || tools_have_template
@@ -2706,6 +2956,11 @@ impl Task {
             && contains_template_syntax(timeout)
         {
             *timeout = render_str(&mut tera, timeout, &tera_ctx)?;
+        }
+        if let Some(usage_command) = &mut self.usage_command
+            && contains_template_syntax(usage_command)
+        {
+            *usage_command = render_str(&mut tera, usage_command, &tera_ctx)?;
         }
         let mut render_sandbox_paths = |paths: &mut Vec<PathBuf>| -> Result<()> {
             let mut rendered = Vec::with_capacity(paths.len());
@@ -3145,6 +3400,8 @@ impl Default for Task {
             quiet: false,
             tools: Default::default(),
             usage: "".to_string(),
+            usage_command: None,
+            usage_command_requires_trust: false,
             timeout: None,
             remote_file_source: None,
             deny_all: false,
@@ -3601,12 +3858,12 @@ mod tests {
 
     #[cfg(unix)]
     use super::TaskConfirm;
-    #[cfg(unix)]
-    use super::{TaskCacheConfig, TaskOutput};
     use super::{
-        clear_usage_env, env_contains_key, name_from_path, tera_tag_has_usage_ref,
+        EnvMap, clear_usage_env, env_contains_key, name_from_path, tera_tag_has_usage_ref,
         tera_template_has_usage_ref,
     };
+    #[cfg(unix)]
+    use super::{TaskCacheConfig, TaskOutput};
 
     #[derive(Debug)]
     struct BrokenWorkspaceProvider;
@@ -4143,6 +4400,38 @@ exec proxy "$@"
         }
     }
 
+    #[test]
+    fn generated_usage_mount_uses_canonical_task_name() {
+        let task = Task {
+            name: "build.py".into(),
+            display_name: "build".into(),
+            usage_command: Some("echo spec".into()),
+            ..Default::default()
+        };
+
+        assert_eq!(task.usage_mount_command(), "mise tasks __usage build.py");
+    }
+
+    #[test]
+    fn generated_usage_cache_key_includes_environment() {
+        let task = Task {
+            name: "build".into(),
+            config_source: "/project/mise.toml".into(),
+            usage_command: Some("echo spec".into()),
+            ..Default::default()
+        };
+        let mut first = EnvMap::new();
+        first.insert("PROFILE".into(), "debug".into());
+        let mut second = first.clone();
+        second.insert("PROFILE".into(), "release".into());
+        let sandbox = crate::sandbox::SandboxConfig::default();
+
+        assert_ne!(
+            task.generated_usage_cache_key("echo spec", Path::new("/project"), &sandbox, &first),
+            task.generated_usage_cache_key("echo spec", Path::new("/project"), &sandbox, &second)
+        );
+    }
+
     #[tokio::test]
     async fn test_render_sandbox_allow_paths() {
         let config = Config::get().await.unwrap();
@@ -4357,6 +4646,67 @@ echo "hello world"
         expected.aliases = vec!["b".to_string()];
         expected.sources = vec!["Cargo.toml".to_string(), "src/**/*.rs".to_string()];
         assert_eq!(result.unwrap(), expected);
+    }
+
+    #[tokio::test]
+    async fn test_from_path_usage_command_header() {
+        use std::fs;
+        use tempfile::tempdir;
+
+        let config = Config::get().await.unwrap();
+        let temp_dir = tempdir().unwrap();
+        let task_path = temp_dir.path().join("generated-usage");
+        fs::write(
+            &task_path,
+            r#"#!/usr/bin/env bash
+# [MISE] usage_command="printf 'arg \"<name>\" help=\"Name\"'"
+echo "$@"
+"#,
+        )
+        .unwrap();
+
+        let task = Task::from_path(&config, &task_path, temp_dir.path(), temp_dir.path())
+            .await
+            .unwrap();
+        assert_eq!(
+            task.usage_command.as_deref(),
+            Some("printf 'arg \"<name>\" help=\"Name\"'")
+        );
+
+        let listing = task.parse_usage_spec_for_listing(&config).await.unwrap();
+        assert_eq!(listing.cmd.mounts.len(), 1);
+        assert!(listing.cmd.args.is_empty());
+
+        let generated = task.parse_usage_spec_for_display(&config).await.unwrap();
+        assert_eq!(generated.cmd.args.len(), 1);
+        assert_eq!(generated.cmd.args[0].name, "name");
+    }
+
+    #[tokio::test]
+    async fn test_usage_command_conflicts_with_embedded_usage() {
+        use std::fs;
+        use tempfile::tempdir;
+
+        let config = Config::get().await.unwrap();
+        let temp_dir = tempdir().unwrap();
+        let task_path = temp_dir.path().join("conflicting-usage");
+        fs::write(
+            &task_path,
+            r#"#!/usr/bin/env bash
+#MISE usage_command="echo 'arg \"<name>\"'"
+#USAGE flag "--verbose"
+echo "$@"
+"#,
+        )
+        .unwrap();
+
+        let err = Task::from_path(&config, &task_path, temp_dir.path(), temp_dir.path())
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("cannot combine usage_command with embedded usage declarations")
+        );
     }
 
     #[tokio::test]
@@ -5081,6 +5431,7 @@ echo "hello world"
 #MISE silent=true
 #MISE output="prefix"
 #MISE tools={node={prefix="20"}, python="3.11"}
+#MISE usage_command="echo 'arg \"<name>\"'"
 #MISE confirm="Are you sure?"
 echo "test"
 "#;
@@ -5124,6 +5475,7 @@ echo "test"
         assert_eq!(task.quiet, true);
         assert_eq!(task.output, Some(TaskOutput::Prefix));
         assert!(!task.tools.is_empty());
+        assert_eq!(task.usage_command.as_deref(), Some("echo 'arg \"<name>\"'"));
         assert_eq!(
             task.tools.get("node"),
             Some(&super::TaskToolValue::Map(super::TaskToolValueMap {

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -1213,51 +1213,7 @@ impl TaskExecutor {
         task: &Task,
         args: &[String],
     ) -> Result<(String, Vec<String>, bool)> {
-        let shell = task.shell()?.unwrap_or(self.clone_default_inline_shell()?);
-        let (program, _shell_args) = task_shell_parts(&shell, "inline shell")?;
-        trace!("using shell: {}", shell.join(" "));
-        let mut full_args = shell.clone();
-
-        #[cfg(windows)]
-        {
-            // When the inline shell is cmd.exe, hand the script to cmd verbatim
-            // instead of letting std::process::Command apply MSVCRT-style
-            // quoting. std would wrap the script in quotes and escape any inner
-            // `"` as `\"`, but cmd.exe does not understand that escaping, so
-            // commands like `python -c "import x"` get mangled (the child sees
-            // `\"import`). We assemble the whole command into one body, wrap it
-            // in a single outer quote pair, and use `/s` so cmd strips exactly
-            // that pair and runs the rest — inner quotes included — verbatim.
-            // See discussion #9355.
-            match inline_args_style(program, _shell_args) {
-                InlineArgsStyle::CmdCommandText => {
-                    let cmd_args = crate::path::cmd_verbatim_args(_shell_args, script, args);
-                    return Ok((program.to_string(), cmd_args, true));
-                }
-                InlineArgsStyle::SeparateArgv => {
-                    // Non-POSIX, non-cmd shells (e.g. `pwsh -Command`) use a
-                    // different quoting convention than `shell_words` (which is
-                    // POSIX), so keep passing forwarded args as separate argv.
-                    full_args.push(script.to_string());
-                    full_args.extend(args.iter().cloned());
-                    return Ok((program.to_string(), full_args[1..].to_vec(), false));
-                }
-                InlineArgsStyle::PosixCommandText => {}
-            }
-        }
-
-        // Shared (Unix, and Windows POSIX shells like `bash -c`): append the
-        // forwarded args to the command string so they reach an inline `-c` shell
-        // as part of the command — the documented behavior for inline TOML
-        // scripts — rather than as positional parameters. Passing them as separate
-        // argv to `bash -c` on Windows shifted the user's first arg into `$0`.
-        // See #9355.
-        let mut script = script.to_string();
-        if !args.is_empty() {
-            script = format!("{script} {}", shell_words::join(args));
-        }
-        full_args.push(script);
-        Ok((program.to_string(), full_args[1..].to_vec(), false))
+        task_inline_command(task, script, args, self.shell.as_deref())
     }
 
     fn clone_default_inline_shell(&self) -> Result<Vec<String>> {
@@ -2199,6 +2155,53 @@ fn task_shell_parts<'a>(shell: &'a [String], shell_kind: &str) -> Result<(&'a st
         })
 }
 
+/// Build an inline task command without constructing a full [`TaskExecutor`].
+///
+/// Dynamic usage generators use this so their shell behavior stays identical
+/// to ordinary inline task commands, including Windows `cmd.exe` quoting.
+pub(crate) fn task_inline_command(
+    task: &Task,
+    script: &str,
+    args: &[String],
+    shell_override: Option<&str>,
+) -> Result<(String, Vec<String>, bool)> {
+    let default_shell = || -> Result<Vec<String>> {
+        if let Some(shell) = shell_override {
+            let mut shell = crate::path::split_shell_command(shell)?;
+            Settings::get().maybe_no_profile(&mut shell);
+            Ok(shell)
+        } else {
+            Settings::get().default_inline_shell()
+        }
+    };
+    let shell = task.shell()?.unwrap_or(default_shell()?);
+    let (program, shell_args) = task_shell_parts(&shell, "inline shell")?;
+    trace!("using shell: {}", shell.join(" "));
+    let mut full_args = shell.clone();
+
+    #[cfg(windows)]
+    {
+        match inline_args_style(program, shell_args) {
+            InlineArgsStyle::CmdCommandText => {
+                let cmd_args = crate::path::cmd_verbatim_args(shell_args, script, args);
+                return Ok((program.to_string(), cmd_args, true));
+            }
+            InlineArgsStyle::SeparateArgv => {
+                full_args.push(script.to_string());
+                full_args.extend(args.iter().cloned());
+                return Ok((program.to_string(), full_args[1..].to_vec(), false));
+            }
+            InlineArgsStyle::PosixCommandText => {}
+        }
+    }
+
+    #[cfg(not(windows))]
+    let _ = shell_args;
+    let script = append_inline_args(script, args, InlineArgsStyle::PosixCommandText);
+    full_args.push(script);
+    Ok((program.to_string(), full_args[1..].to_vec(), false))
+}
+
 /// On Windows, when spawning a POSIX-style shell (bash/sh/zsh/...) for a task, the
 /// child needs PATH in MSYS Unix format — `/c/foo:/d/bar` rather than `C:\foo;D:\bar`.
 /// PowerShell-launched mise inherits no `MSYSTEM`, so the conversion has to happen
@@ -2206,7 +2209,7 @@ fn task_shell_parts<'a>(shell: &'a [String], shell_kind: &str) -> Result<(&'a st
 ///
 /// The cfg-attribute pattern keeps the call site OS-agnostic and avoids cloning the
 /// env on the common path (Windows + non-POSIX-shell, or any non-Windows host).
-fn maybe_convert_env_for_msys_shell<'a>(
+pub(crate) fn maybe_convert_env_for_msys_shell<'a>(
     program: &Path,
     env: &'a BTreeMap<String, String>,
 ) -> std::borrow::Cow<'a, BTreeMap<String, String>> {

--- a/src/task/task_fetcher.rs
+++ b/src/task/task_fetcher.rs
@@ -72,6 +72,7 @@ impl TaskFetcher {
                 // Preserve runtime state that is not task metadata and therefore is
                 // intentionally not handled by merge_toml_overlay().
                 remote.global = original.global;
+                remote.usage_command_requires_trust = original.usage_command_requires_trust;
                 remote.remote_file_source = Some(source);
                 *t = remote;
             }
@@ -107,6 +108,7 @@ mod tests {
 #MISE hide=true
 #MISE quiet=true
 #MISE tools={node="24", python="3.12"}
+#MISE usage_command="echo 'arg \"<name>\"'"
 echo ok
 "#,
             )
@@ -125,6 +127,7 @@ echo ok
             config_root: Some(config_root.path().to_path_buf()),
             file: Some(PathBuf::from(&source)),
             args: vec!["--fix".into()],
+            usage_command_requires_trust: true,
             tools: [("python".into(), TaskToolValue::String("3.13".into()))]
                 .into_iter()
                 .collect(),
@@ -148,6 +151,7 @@ echo ok
         assert_eq!(task.config_root.as_deref(), Some(config_root.path()));
         assert_eq!(task.remote_file_source.as_deref(), Some(source.as_str()));
         assert!(task.is_remote());
+        assert!(task.usage_command_requires_trust);
         assert_eq!(
             task.tools.get("node"),
             Some(&TaskToolValue::String("24".into()))

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -502,7 +502,10 @@ pub async fn get_task_lists(
                     .clone()
                     .or_else(|| dirs::CWD.clone())
                     .unwrap_or_default();
-                let task = Task::from_path(config, &path, &PathBuf::new(), &config_root).await?;
+                let mut task =
+                    Task::from_path(config, &path, &PathBuf::new(), &config_root).await?;
+                task.usage_command_requires_trust = task.usage_command.is_some()
+                    && !crate::config::is_global_task_include_path(&path);
                 return Ok(vec![task.with_args(args)]);
             }
         }


### PR DESCRIPTION

## Summary

- add file-task `usage_command` metadata for commands that generate KDL usage specs
- keep aggregate task listing lazy by mounting a hidden per-task resolver
- run generators with the task shell, cwd, environment, installed tool paths, sandbox, timeout, redaction, and trust boundary
- reuse generated specs within one mise process without adding a persistent cache

## Why

File tasks that already define their own CLI currently have to duplicate the same argument definition in static `#MISE` or `#USAGE` comments. This change lets the task generate the canonical usage spec itself while avoiding eager execution of every generator during completion setup.

Static embedded usage and `usage_command` are intentionally mutually exclusive, so there is no ambiguous merge order. Metadata-only resolution does not install missing tools, run dependencies, hooks, or the task body. Untrusted generators are checked immediately before execution, and completion keeps the existing non-interactive trust behavior.

Addresses https://github.com/jdx/mise/discussions/7217

## Verification

- `mise exec -- cargo test --all-features usage_command`
- `mise run test:e2e e2e/tasks/test_task_usage_command`
- `mise run test:e2e e2e/tasks/test_task_ls_usage e2e/tasks/test_task_help e2e/tasks/test_task_completion`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shellcheck e2e/tasks/test_task_usage_command`
- `bunx prettier --check docs/tasks/task-arguments.md`
- `mise run docs:build`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` reaches only an unrelated existing warning in `src/system/packages/brew/cask.rs:1959` on this macOS toolchain; no warning remains in this change

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - File-based tasks can dynamically generate argument usage specifications through a configured command.
  - Generated specifications support task-aware settings, caching, lazy evaluation, help output, completion choices, and argument parsing.
  - Added a hidden command for resolving generated task usage specifications.

- **Bug Fixes**
  - Improved generation errors with task and command context.
  - Enforced trust requirements, including for remotely fetched tasks.
  - Prevented conflicts between generated and embedded usage declarations.

- **Documentation**
  - Documented configuration, execution behavior, restrictions, caching, and compatibility rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->