### PR TITLE
fix(backend): recover when installed metadata names a missing core backend

### DIFF
--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -440,10 +440,28 @@ fn merge_plugin_tools(tools: &mut InstallStateTools, plugins: &InstallStatePlugi
                 opts: BTreeMap::new(),
                 installs_path: None,
             });
-        // Installed metadata describes the versions already on disk. Plugin
-        // discovery should only supply an identity when no metadata exists.
-        tool.full.get_or_insert(full);
+        // Installed metadata describes the versions already on disk, so plugin discovery normally
+        // only supplies an identity when no metadata exists -- a tool installed as
+        // `github:babashka/babashka` must not be claimed by a same-named asdf plugin.
+        //
+        // A recorded `core:<short>` that mise ships no core backend for is the exception. That
+        // value names nothing resolvable, so keeping it leaves the tool unusable: `backend::get`
+        // returns `None` and every command reports "not found in mise tool registry". It reaches
+        // the manifest from a lockfile `backend` field, which is written through verbatim. An
+        // installed plugin is ground truth about what is on disk, so it wins over a name that
+        // cannot resolve.
+        match tool.full.as_deref() {
+            Some(existing) if names_missing_core_backend(existing) => tool.full = Some(full),
+            Some(_) => {}
+            None => tool.full = Some(full),
+        }
     }
+}
+
+/// Whether `full` asks for a core backend that this build does not ship.
+fn names_missing_core_backend(full: &str) -> bool {
+    full.strip_prefix("core:")
+        .is_some_and(|short| !crate::plugins::core::CORE_PLUGINS.contains_key(short))
 }
 
 pub fn list_plugins() -> Arc<BTreeMap<String, PluginType>> {
@@ -742,6 +760,58 @@ mod tests {
             tools["babashka"].full.as_deref(),
             Some("github:babashka/babashka")
         );
+    }
+
+    /// A lockfile `backend` field is written into the manifest verbatim, so it can name a core
+    /// backend this build does not ship. Keeping that value leaves the tool unresolvable, which
+    /// is what broke `mise where` for a plugin-installed tool.
+    #[test]
+    fn plugin_discovery_replaces_a_core_backend_that_does_not_exist() {
+        let mut tools = BTreeMap::from([(
+            "dummy".to_string(),
+            InstallStateTool {
+                short: "dummy".to_string(),
+                full: Some("core:dummy".to_string()),
+                versions: vec!["3.0.0".to_string()],
+                explicit_backend: true,
+                opts: BTreeMap::new(),
+                installs_path: None,
+            },
+        )]);
+        let plugins = BTreeMap::from([("dummy".to_string(), PluginType::Asdf)]);
+
+        merge_plugin_tools(&mut tools, &plugins);
+
+        assert_eq!(tools["dummy"].full.as_deref(), Some("asdf:dummy"));
+        // only the identity is corrected; what is on disk is untouched
+        assert_eq!(tools["dummy"].versions, ["3.0.0"]);
+    }
+
+    /// A core backend mise does ship is real metadata and must survive.
+    #[test]
+    fn plugin_discovery_keeps_a_core_backend_that_exists() {
+        let short = crate::plugins::core::CORE_PLUGINS
+            .keys()
+            .next()
+            .expect("mise ships at least one core plugin")
+            .clone();
+        let full = format!("core:{short}");
+        let mut tools = BTreeMap::from([(
+            short.clone(),
+            InstallStateTool {
+                short: short.clone(),
+                full: Some(full.clone()),
+                versions: vec!["1.0.0".to_string()],
+                explicit_backend: true,
+                opts: BTreeMap::new(),
+                installs_path: None,
+            },
+        )]);
+        let plugins = BTreeMap::from([(short.clone(), PluginType::Asdf)]);
+
+        merge_plugin_tools(&mut tools, &plugins);
+
+        assert_eq!(tools[&short].full.as_deref(), Some(full.as_str()));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

e2e `cli/test_where` has been failing on `main` since #12010 landed. `main`'s own
`test.yml` has not run since 2026-08-08, so the breakage went unnoticed — it only shows
up on PRs, where it looks like the PR's own fault.

```console
$ mise where dummy
0: dummy not found in mise tool registry
```

## Cause

The test writes `backend = "core:dummy"` into `mise.lock`, then runs `mise i`. `dummy` is
an asdf plugin in the e2e fixtures, so `core:dummy` names nothing that exists —
`CORE_PLUGINS` has no `dummy`. The lockfile `backend` field reaches
`.mise.backend.toml` verbatim, measured on CI:

```console
$ cat "$MISE_DATA_DIR"/installs/dummy/.mise.backend.toml
short = "dummy"
full = "core:dummy"
explicit_backend = true
```

#12010 changed `merge_plugin_tools` so plugin discovery no longer overwrites recorded
metadata:

```rust
- tool.full = Some(full);
+ tool.full.get_or_insert(full);
```

That change is right — a tool installed as `github:babashka/babashka` must not be claimed
by a same-named asdf plugin. But the overwrite was also, incidentally, the thing that
repaired an unresolvable `full`. Now the bad value survives, `backend::get` returns
`None`, and every command reports "not found in mise tool registry".

## Fix

Plugin discovery replaces `full` in exactly one case: it names a `core:` backend this
build does not ship. That value cannot resolve to anything, and an installed plugin is
ground truth about what is on disk. Every other recorded identity — core or not — still
wins, as #12010 intended.

## Bisect

Fork CI, one commit per run, checkout SHA verified inside each job with `git rev-parse HEAD`.

| commit | `cli/test_where` |
|---|---|
| `bd7d113b6acf` | PASS |
| `f511491494f6` (#12007) | PASS |
| **`1e6cdb4db002`** — fix(backend): preserve installed backend metadata (#12010) | **FAIL** |
| `d0e63fd057b9` (#12017) | FAIL |

## Tests

- `cli/test_where` is the regression test; no e2e change needed.
- Both unit tests #12010 added are unchanged and still pass.
- Two added: `plugin_discovery_replaces_a_core_backend_that_does_not_exist` and its
  control `plugin_discovery_keeps_a_core_backend_that_exists`.

## Verification

I did not build locally. Verified on fork CI, same harness as the bisect
([run](https://github.com/JamBalaya56562/mise/actions/runs/31877350922)):

```
test toolset::install_state::tests::plugin_discovery_preserves_installed_backend_metadata ... ok
test toolset::install_state::tests::plugin_discovery_adds_missing_tool_metadata ... ok
test toolset::install_state::tests::plugin_discovery_replaces_a_core_backend_that_does_not_exist ... ok
test toolset::install_state::tests::plugin_discovery_keeps_a_core_backend_that_exists ... ok
test result: ok. 17 passed; 0 failed

$ mise where dummy
[mise where dummy] output is equal to '/tmp/test_where.dbuLlY/home/.local/share/mise/installs/dummy/3.0.0'
cli/test_where: 2s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool installation state handling when a core backend is unavailable.
  * Preserved valid existing metadata while filling in missing information.
  * Added safeguards to retain available core backends and replace unavailable ones correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->