### PR TITLE
test(cli): use actual dummy backend in where fixture

### DIFF
--- a/e2e/cli/test_where
+++ b/e2e/cli/test_where
@@ -17,7 +17,7 @@ echo 'tools.dummy = "latest"' >mise.toml
 cat <<EOF >mise.lock
 [[tools.dummy]]
 version = "3.0.0"
-backend = "core:dummy"
+backend = "asdf:dummy"
 EOF
 assert "mise i"
 assert "mise where dummy" "$MISE_DATA_DIR/installs/dummy/3.0.0"


### PR DESCRIPTION
## Summary

- update the `test_where` lockfile fixture to record the asdf backend that provides the dummy tool
- restore the focused e2e test after installed backend metadata began being preserved

## Root cause

The fixture recorded `core:dummy`, but the e2e harness provides `dummy` through an asdf plugin. Preserving installed backend metadata exposed that mismatch and made `mise where dummy` attempt to resolve a nonexistent core tool.

## Validation

- `mise run test:e2e e2e/cli/test_where`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only lockfile fixture change with no production code impact.
> 
> **Overview**
> Updates the **`test_where`** lockfile snippet so **`dummy@3.0.0`** is locked with **`backend = "asdf:dummy"`** instead of **`core:dummy`**.
> 
> That aligns the fixture with the e2e harness, which provides **`dummy`** via an asdf plugin. After installed backend metadata started being honored, the old value made **`mise where dummy`** try to resolve a nonexistent core backend and the test failed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ce78833de9847f5a7c27a7655552e3a5db3368f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the lockfile fixture to correctly identify the dummy tool using the `asdf:dummy` backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->