### PR TITLE
docs(deps): preserve tera examples in rendered page

### DIFF
--- a/docs/dev-tools/deps.md
+++ b/docs/dev-tools/deps.md
@@ -185,7 +185,8 @@ outputs = ["packages/app/node_modules"]
 ### Templates and Environment Variables
 
 String values in provider configuration support Tera templates such as
-`{{ config_root }}`, `{{ env.NAME }}`, and `{{ vars.name }}`. Shell-style environment variables
+<span v-pre>`{{ config_root }}`</span>, <span v-pre>`{{ env.NAME }}`</span>, and
+<span v-pre>`{{ vars.name }}`</span>. Shell-style environment variables
 such as `$NAME` and `${NAME:-default}` are expanded after Tera templates, using the same
 `env_shell_expand` setting as `[env]` values.
 


### PR DESCRIPTION
## Summary

- mark inline Tera examples as preformatted Vue content
- restore the full rendered Deps documentation page

## Root cause

VitePress interpreted the inline `{{ ... }}` Tera examples as Vue expressions. The docs build succeeded, but server rendering emitted an effectively empty page after the heading.

## Stack

- depends on #12029
- targets `agent/fix-test-where-lock-backend`

## Validation

- `mise run docs:build`
- confirmed the generated `dev-tools/deps.html` contains the full page sections
- `git diff --check`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only markup change with no runtime or configuration behavior impact.
> 
> **Overview**
> Fixes the **Templates and Environment Variables** section on the Deps docs page so inline Tera examples render as literal text instead of breaking VitePress SSR.
> 
> The prose that lists `{{ config_root }}`, `{{ env.NAME }}`, and `{{ vars.name }}` now wraps each example in `<span v-pre>`, matching the pattern used elsewhere in the docs (e.g. bootstrap files, aqua backends). Without this, Vue treated the double braces as expressions and the built page was effectively empty after the heading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef0612c06efc4801283f3a16445500c081b52ba7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed template and environment variable examples so Tera syntax displays correctly without being processed by Vue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->