### PR TITLE
test(task): re-enable the task_source_files case disabled on Windows

### DIFF
--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -1306,38 +1306,49 @@ mod tests {
 
     #[tokio::test]
     async fn test_task_parse_task_source_files() {
-        let cases: &[(&[&str], &str, &str)] = &[
-            (&[], "echo {{ task_source_files() }}", "echo []"),
+        // A source that reaches the filesystem comes back with the platform separator, so its
+        // expectation has to follow. A source containing template syntax never reaches the
+        // filesystem -- it is passed through verbatim, keeping whatever the user wrote -- so
+        // `native` must not be applied to it, or the expectation rewrites a template instead
+        // of a path.
+        fn native(expected: &str) -> String {
+            match cfg!(windows) {
+                true => expected.replace('/', "\\"),
+                false => expected.to_string(),
+            }
+        }
+
+        let cases: Vec<(&[&str], &str, String)> = vec![
+            (&[], "echo {{ task_source_files() }}", native("echo []")),
             (
                 &["**/filetask"],
                 "echo {{ task_source_files() | first }}",
-                "echo .mise/tasks/filetask", // created by constructor in `src/test.rs`, guaranteed to exist
+                native("echo .mise/tasks/filetask"), // created by constructor in `src/test.rs`, guaranteed to exist
             ),
             (
                 &["nonexistent/*.xyz"],
                 "echo {{ task_source_files() }}",
-                "echo []",
+                native("echo []"),
             ),
             (
                 &["../../Cargo.toml"],
                 "echo {{ task_source_files() | first }}",
-                "echo ../../Cargo.toml",
+                native("echo ../../Cargo.toml"),
             ),
             (
                 &[concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml")],
                 "echo {{ task_source_files() | first }}",
-                concat!("echo ", env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"),
+                native(concat!("echo ", env!("CARGO_MANIFEST_DIR"), "/Cargo.toml")),
             ),
-            #[cfg(not(windows))] // TODO: this cases panics on windows currently
             (
                 &["{{ env.HOME }}/file.txt", "src/*.rs"],
                 "echo {{ task_source_files() | first }}",
-                "echo {{ env.HOME }}/file.txt",
+                "echo {{ env.HOME }}/file.txt".to_string(),
             ),
             (
                 &["[invalid"],
                 "echo {{ task_source_files() | first }}",
-                "echo [invalid",
+                native("echo [invalid"),
             ),
             (
                 &[
@@ -1345,24 +1356,24 @@ mod tests {
                     concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"),
                 ],
                 "{% for file in task_source_files() %}echo {{ file }}; {% endfor %}",
-                concat!(
+                native(concat!(
                     "echo ",
                     env!("CARGO_MANIFEST_DIR"),
                     "/Cargo.toml; echo ",
                     env!("CARGO_MANIFEST_DIR"),
                     "/README.md; ",
-                ),
+                )),
             ),
             // `!` excludes a previously matched file
             (
                 &["**/filetask", "!**/filetask"],
                 "echo {{ task_source_files() }}",
-                "echo []",
+                native("echo []"),
             ),
         ];
 
-        for (sources, template, expected) in cases {
-            let (sources, template, expected) = (*sources, *template, *expected);
+        for (sources, template, expected) in &cases {
+            let (sources, template) = (*sources, *template);
 
             let (mut task, scripts, parser, config) = (
                 Task::default(),
@@ -1378,10 +1389,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            #[cfg(windows)]
-            let expected = expected.replace("/", r"\"); // 🙄
-
-            assert_eq!(parsed, vec![expected]);
+            assert_eq!(parsed, vec![expected.clone()]);
         }
     }
 


### PR DESCRIPTION
## Problem

One case of `test_task_parse_task_source_files` has been skipped on Windows:

```rust
#[cfg(not(windows))] // TODO: this cases panics on windows currently
(
    &["{{ env.HOME }}/file.txt", "src/*.rs"],
    "echo {{ task_source_files() | first }}",
    "echo {{ env.HOME }}/file.txt",
),
```

Nothing panics. The failure is the test's own `assert_eq!`, and the test causes it
itself. It rewrote every `/` to `\` in its expectation on Windows:

```rust
#[cfg(windows)]
let expected = expected.replace("/", r"\"); // 🙄
```

That is right for the cases whose expectation is a path resolved against the
filesystem. It is wrong for this one. A source containing template syntax never
reaches the filesystem — [`register_task_source_files_function`](https://github.com/jdx/mise/blob/main/src/task/task_script_parser.rs#L191-L197)
passes it through verbatim — so `{{ env.HOME }}/file.txt` comes back exactly as
written, and the rewritten expectation could not match:

```
left  (actual)   "echo {{ env.HOME }}/file.txt"
right (expected) "echo {{ env.HOME }}\file.txt"
```

## Fix

Each case carries its own expectation, and the separator conversion is applied only
to the ones that really come back from the filesystem. The skipped case is re-enabled.
No production code changes.

## Verification

I did not build locally; both runs are on fork CI.

**Before** ([run](https://github.com/JamBalaya56562/mise/actions/runs/31878161259)), `windows-latest`,
three variants of the same commit:

| variant | result |
|---|---|
| unchanged (case skipped) | PASS |
| `#[cfg(not(windows))]` removed | **FAIL** — `left "…}}/file.txt"` vs `right "…}}\file.txt"` |
| control: same, expectation deliberately wrong | FAIL — confirms the case really executes |

The control is there because a passing probe would otherwise be indistinguishable from
a case that never ran.

**After** ([run](https://github.com/JamBalaya56562/mise/actions/runs/31878916845)):

```
probe (windows-latest)  test task::task_script_parser::tests::test_task_parse_task_source_files ... ok
probe (ubuntu-latest)   test task::task_script_parser::tests::test_task_parse_task_source_files ... ok
```

`cargo test --bin mise task_source_files` is green on both: 4 passed, 0 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved task source path parsing tests for consistent behavior across operating systems.
  * Preserved template-based paths during normalization.
  * Removed platform-specific test handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->