### PR TITLE
chore(ci): preserve paired e2e tranche failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -369,8 +369,10 @@ jobs:
               retry_wait_seconds: 30
               max_attempts: 2
               command: |
-                MISE_GITHUB_TOKEN="$TOKEN_A" GITHUB_TOKEN="$TOKEN_A" TEST_TRANCHE="$TRANCHE_A" ./e2e/run_all_tests
-                MISE_GITHUB_TOKEN="$TOKEN_B" GITHUB_TOKEN="$TOKEN_B" TEST_TRANCHE="$TRANCHE_B" ./e2e/run_all_tests
+                e2e_status=0
+                MISE_GITHUB_TOKEN="$TOKEN_A" GITHUB_TOKEN="$TOKEN_A" TEST_TRANCHE="$TRANCHE_A" ./e2e/run_all_tests || e2e_status=$?
+                MISE_GITHUB_TOKEN="$TOKEN_B" GITHUB_TOKEN="$TOKEN_B" TEST_TRANCHE="$TRANCHE_B" ./e2e/run_all_tests || e2e_status=$?
+                exit "$e2e_status"
           - name: Test tranches 1 and 5
             uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
             env:


### PR DESCRIPTION
## Summary

- preserve a failure from either e2e tranche in each paired retry command
- continue running the second tranche even when the first one fails
- prevent subsequent successful tranches from masking earlier failures

## Root cause

Each retry command runs two tranches sequentially but previously returned only the second command's exit status. On #12010, `cli/test_where` failed in the first tranche of its pair and the succeeding second tranche made the overall e2e job pass.

## Stack

- stack #12031
- depends on #12030

## Validation

- `actionlint .github/workflows/test.yml`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow shell logic only; no application or runtime behavior changes.
> 
> **Overview**
> Fixes paired e2e retry steps so a failure in **either** tranche fails the job, instead of only reflecting the second command’s exit code.
> 
> Each retry block now tracks `e2e_status`, runs both `./e2e/run_all_tests` invocations with `|| e2e_status=$?` so the second tranche still runs after the first fails, then exits with the accumulated status. This applies to all four parallel tranche pairs via the shared `&e2e-retry` command anchor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 800d0f397795bd048848bab04ff03df4271ee55e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->