### PR TITLE
fix(shim): use snap payload for unix shims

### DIFF
--- a/e2e/cli/test_reshim_with_shims_on_path
+++ b/e2e/cli/test_reshim_with_shims_on_path
@@ -42,3 +42,20 @@ fi
 
 # Doctor should not report missing shims
 assert_not_contains "mise doctor" "shims are missing"
+
+# Simulate Snap's revision-specific payload and refresh-stable `current` link. The public
+# /snap/bin/mise command is a snapd dispatcher and cannot be used as the target of another
+# argv[0]-based symlink shim.
+snap_mount="$(mktemp -d)/mise"
+snap_revision="$snap_mount/189"
+mkdir -p "$snap_revision/bin"
+ln -s "$mise_bin" "$snap_revision/bin/mise"
+ln -s 189 "$snap_mount/current"
+
+SNAP="$snap_revision" __MISE_BIN="$snap_revision/bin/mise" "$mise_bin" reshim --force
+
+# Shims should use the refresh-stable payload path, and doctor must agree with reshim.
+assert "readlink $shimdir/dummy" "$snap_mount/current/bin/mise"
+assert_not_contains \
+  "SNAP=$snap_revision __MISE_BIN=$snap_revision/bin/mise $mise_bin doctor" \
+  "shims are missing"

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -788,7 +788,7 @@ impl Doctor {
     }
 
     async fn analyze_shims(&mut self, config: &Arc<Config>, toolset: &Toolset) -> HashSet<String> {
-        let mise_bin = file::which_no_shims("mise").unwrap_or(env::MISE_BIN.clone());
+        let mise_bin = shims::mise_bin_for_shims();
 
         if let Ok(diffs) = shims::get_shim_diffs(config, mise_bin, toolset).await {
             let cmd = style::nyellow("mise reshim");

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -351,7 +351,15 @@ pub(crate) fn mise_bin_for_shims() -> PathBuf {
 }
 
 fn snap_mise_bin(mise_bin: &Path, snap: &Path) -> Option<PathBuf> {
-    let relative = mise_bin.strip_prefix(snap).ok()?;
+    let relative = mise_bin
+        .strip_prefix(snap)
+        .map(Path::to_path_buf)
+        .or_else(|_| {
+            let mise_bin = file::canonicalize_or_self(mise_bin);
+            let snap = file::canonicalize_or_self(snap);
+            mise_bin.strip_prefix(snap).map(Path::to_path_buf)
+        })
+        .ok()?;
     let snap_mount = snap.parent()?;
     Some(snap_mount.join("current").join(relative))
 }
@@ -963,6 +971,26 @@ mod tests {
                 Path::new("/snap/mise/189")
             ),
             None
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn snap_mise_bin_handles_symlinked_snap_mount() {
+        let temp = tempfile::tempdir().unwrap();
+        let canonical_mount = temp.path().join("var/lib/snapd/snap");
+        let canonical_snap = canonical_mount.join("mise/189");
+        let mise_bin = canonical_snap.join("bin/mise");
+        fs::create_dir_all(mise_bin.parent().unwrap()).unwrap();
+        fs::write(&mise_bin, "").unwrap();
+
+        let snap_mount = temp.path().join("snap");
+        std::os::unix::fs::symlink(&canonical_mount, &snap_mount).unwrap();
+        let snap = snap_mount.join("mise/189");
+
+        assert_eq!(
+            snap_mise_bin(&mise_bin, &snap),
+            Some(snap_mount.join("mise/current/bin/mise"))
         );
     }
 

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -235,7 +235,7 @@ pub async fn reshim(config: &Arc<Config>, ts: &Toolset, force: bool) -> Result<(
         })
         .lock();
 
-    let mise_bin = file::which_no_shims("mise").unwrap_or(env::MISE_BIN.clone());
+    let mise_bin = mise_bin_for_shims();
     let mise_bin = mise_bin.absolutize()?; // relative paths don't work as shims
 
     #[cfg(windows)]
@@ -334,6 +334,26 @@ pub async fn reshim(config: &Arc<Config>, ts: &Toolset, force: bool) -> Result<(
         .collect::<Result<Vec<_>>>()?;
 
     Ok(())
+}
+
+/// Resolve the mise executable that Unix symlink shims should target.
+///
+/// Snap exposes applications through `/snap/bin`, where each command is a symlink to the
+/// `snap` dispatcher. That dispatcher identifies the application from argv[0], so invoking it
+/// through a mise shim named `node`, `python`, etc. runs the snap CLI instead of mise. Point Snap
+/// shims at the payload beneath its refresh-stable `current` symlink instead. For other package
+/// managers, retain the PATH-visible executable so their stable launcher survives upgrades.
+pub(crate) fn mise_bin_for_shims() -> PathBuf {
+    env::var_path("SNAP")
+        .as_deref()
+        .and_then(|snap| snap_mise_bin(&env::MISE_BIN, snap))
+        .unwrap_or_else(|| file::which_no_shims("mise").unwrap_or(env::MISE_BIN.clone()))
+}
+
+fn snap_mise_bin(mise_bin: &Path, snap: &Path) -> Option<PathBuf> {
+    let relative = mise_bin.strip_prefix(snap).ok()?;
+    let snap_mount = snap.parent()?;
+    Some(snap_mount.join("current").join(relative))
 }
 
 /// Remove all shim files from a directory individually, skipping dotfiles like
@@ -923,6 +943,28 @@ mod tests {
     use super::*;
     use crate::cli::args::BackendArg;
     use crate::toolset::{ToolRequest, ToolSource, ToolVersionList};
+
+    #[test]
+    fn snap_mise_bin_uses_refresh_stable_current_path() {
+        assert_eq!(
+            snap_mise_bin(
+                Path::new("/snap/mise/189/bin/mise"),
+                Path::new("/snap/mise/189")
+            ),
+            Some(PathBuf::from("/snap/mise/current/bin/mise"))
+        );
+    }
+
+    #[test]
+    fn snap_mise_bin_rejects_unrelated_executable() {
+        assert_eq!(
+            snap_mise_bin(
+                Path::new("/home/user/.local/bin/mise"),
+                Path::new("/snap/mise/189")
+            ),
+            None
+        );
+    }
 
     #[tokio::test]
     async fn unavailable_tool_message_prefers_matching_configured_tool() {


### PR DESCRIPTION
## Summary

- resolve Snap-installed mise shims to the payload beneath Snap's refresh-stable `current` symlink
- share the target resolver with `mise doctor` so validation matches `reshim`
- add unit and e2e coverage for the Snap revision layout

## Root cause

`/snap/bin/mise` is a symlink to the snap dispatcher, which identifies the application from `argv[0]`. When a mise shim such as `node` points there, snapd sees `node` instead of `mise` and runs the snap CLI rather than mise's shim dispatcher.

The fix bypasses `/snap/bin` only when the running mise executable is beneath `$SNAP`. Other installations retain the PATH-visible executable so package-manager launchers remain stable across upgrades.

Refs https://github.com/jdx/mise/discussions/12027

## Testing

- `cargo test --locked --bin mise shims::tests::snap_mise_bin`
- `mise run test:e2e e2e/cli/test_reshim_with_shims_on_path`
- scoped `hk run check --safe --format json` for the three changed files

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shim target resolution for Snap users and shared doctor validation logic; scope is narrow but affects how every generated shim is validated and created on Unix when SNAP is set.
> 
> **Overview**
> Fixes **Snap** installs where tool shims pointed at the snapd dispatcher (e.g. `/snap/bin/mise`), so `argv[0]` was the shim name (`node`, etc.) and snapd ran the wrong app instead of mise.
> 
> When **`$SNAP`** is set and the running binary lives under that revision, **`reshim`** and **`mise doctor`** now resolve the shim target via **`mise_bin_for_shims()`** to the payload under the refresh-stable **`current`** symlink (e.g. `/snap/mise/current/bin/mise`). Non-Snap installs keep the previous behavior (`which_no_shims` / `MISE_BIN`).
> 
> Adds unit tests for **`snap_mise_bin`** and an e2e scenario that simulates Snap’s revision + **`current`** layout and checks **`doctor`** agrees with **`reshim`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c753f6163895aabe280e80f8f57b4cb2545994fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shim generation for Snap installations so shims consistently point to the stable active version.
  * Improved executable detection during forced reshim operations.
  * Fixed `mise doctor` so it correctly recognizes valid shims in Snap environments.

* **Tests**
  * Added regression coverage for Snap-based installations, including stable path handling and validation of generated shims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->