### PR TITLE
fix(vfox): install latest chromedriver on Windows

### DIFF
--- a/crates/vfox/embedded-plugins/vfox-chromedriver/hooks/available.lua
+++ b/crates/vfox/embedded-plugins/vfox-chromedriver/hooks/available.lua
@@ -27,8 +27,11 @@ function PLUGIN:Available(ctx)
         return result
     end
 
-    -- Collect versions that have chromedriver downloads
-    for _, v in ipairs(data.versions) do
+    -- vfox expects the newest available version first. Google's API returns
+    -- versions oldest-first, so preserve its source ordering in reverse rather
+    -- than trying to interpret the version strings.
+    for i = #data.versions, 1, -1 do
+        local v = data.versions[i]
         if v.downloads and v.downloads.chromedriver then
             table.insert(result, {
                 version = v.version,

--- a/crates/vfox/embedded-plugins/vfox-chromedriver/hooks/post_install.lua
+++ b/crates/vfox/embedded-plugins/vfox-chromedriver/hooks/post_install.lua
@@ -2,13 +2,10 @@
 --- @param ctx table Context provided by vfox
 function PLUGIN:PostInstall(ctx)
     local cmd = require("cmd")
+    local file = require("file")
 
     local sdkInfo = ctx.sdkInfo["chromedriver"]
     local path = sdkInfo.path
-    local version = sdkInfo.version
-
-    -- Create bin directory
-    cmd.exec("mkdir -p '" .. path .. "/bin'")
 
     -- Determine platform suffix for the extracted directory using RUNTIME global
     local osType = RUNTIME.osType
@@ -32,31 +29,47 @@ function PLUGIN:PostInstall(ctx)
     end
 
     -- The zip extracts to chromedriver-{platform}/
-    local srcDir = path .. "/chromedriver-" .. platform
+    local binaryName = osType == "windows" and "chromedriver.exe" or "chromedriver"
+    local srcDir = file.join_path(path, "chromedriver-" .. platform)
+    local srcPath = file.join_path(srcDir, binaryName)
 
     -- Check if srcDir exists, if not try without subdirectory
-    local file = io.open(srcDir .. "/chromedriver", "r")
-    if file then
-        file:close()
-    else
+    if not file.exists(srcPath) then
         -- Try direct path (files extracted directly)
-        srcDir = path
+        srcPath = file.join_path(path, binaryName)
     end
 
-    -- Copy chromedriver binary
+    local binDir = file.join_path(path, "bin")
+    local destPath = file.join_path(binDir, binaryName)
+
+    -- Copy chromedriver binary using the platform's native shell. Passing paths
+    -- through environment variables avoids shell-quoting issues.
     if osType == "windows" then
-        cmd.exec("cp -f '" .. srcDir .. "/chromedriver.exe' '" .. path .. "/bin/'")
+        cmd.exec(
+            "powershell.exe -NoLogo -NoProfile -NonInteractive -Command "
+                .. "$null = New-Item -ItemType Directory -Force -Path $env:BIN_DIR; "
+                .. "Copy-Item -LiteralPath $env:SRC_PATH -Destination $env:DEST_PATH -Force",
+            {
+                env = {
+                    BIN_DIR = binDir,
+                    SRC_PATH = srcPath,
+                    DEST_PATH = destPath,
+                },
+            }
+        )
     else
-        cmd.exec("cp -f '" .. srcDir .. "/chromedriver' '" .. path .. "/bin/'")
-        cmd.exec("chmod +x '" .. path .. "/bin/chromedriver'")
+        local env = {
+            BIN_DIR = binDir,
+            SRC_PATH = srcPath,
+            DEST_PATH = destPath,
+        }
+        cmd.exec('mkdir -p "$BIN_DIR"', { env = env })
+        cmd.exec('cp -f "$SRC_PATH" "$DEST_PATH"', { env = env })
+        cmd.exec('chmod +x "$DEST_PATH"', { env = env })
     end
 
     -- Verify installation
-    local binaryName = osType == "windows" and "chromedriver.exe" or "chromedriver"
-    local verifyFile = io.open(path .. "/bin/" .. binaryName, "r")
-    if verifyFile then
-        verifyFile:close()
-    else
-        error("Failed to install chromedriver - binary not found at " .. path .. "/bin/" .. binaryName)
+    if not file.exists(destPath) then
+        error("Failed to install chromedriver - binary not found at " .. destPath)
     end
 end

--- a/crates/vfox/src/hooks/available.rs
+++ b/crates/vfox/src/hooks/available.rs
@@ -60,8 +60,13 @@ impl FromLua for AvailableVersion {
 #[cfg(test)]
 mod tests {
     use crate::Plugin;
+    use crate::embedded_plugins;
     use crate::hooks::available::AvailableVersion;
     use mlua::{FromLua, Lua, Value};
+    use std::sync::Arc;
+    use url::Url;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
     fn test_available_version_rejects_non_table() {
@@ -96,6 +101,38 @@ mod tests {
     async fn test_nodejs_async() {
         let versions = run_async("test-nodejs").await;
         assert!(versions.contains(&"20.0.0".to_string()));
+    }
+
+    #[tokio::test]
+    async fn chromedriver_returns_newest_version_first() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/versions.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "versions": [
+                    {"version": "115.0.5763.0", "downloads": {"chromedriver": [{}]}},
+                    {"version": "152.0.7999.0"},
+                    {"version": "153.0.8009.0", "downloads": {"chromedriver": [{}]}}
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let embedded = embedded_plugins::get_embedded_plugin("chromedriver").unwrap();
+        let plugin = Plugin::from_embedded("chromedriver", embedded).unwrap();
+        let mock_url = Url::parse(&format!("{}/versions.json", server.uri())).unwrap();
+        plugin
+            .set_url_rewriter(Arc::new(move |url| *url = mock_url.clone()))
+            .unwrap();
+
+        let versions = plugin.available_async().await.unwrap();
+        assert_eq!(
+            versions
+                .into_iter()
+                .map(|version| version.version)
+                .collect::<Vec<_>>(),
+            ["153.0.8009.0", "115.0.5763.0"]
+        );
     }
 
     fn run(plugin: &str) -> Vec<String> {

--- a/crates/vfox/src/hooks/post_install.rs
+++ b/crates/vfox/src/hooks/post_install.rs
@@ -34,7 +34,7 @@ impl IntoLua for PostInstallContext {
 
 #[cfg(test)]
 mod tests {
-    use crate::Plugin;
+    use crate::{Plugin, embedded_plugins};
     use tokio::test;
 
     use super::*;
@@ -60,5 +60,38 @@ mod tests {
             "runtime_version"
         );
         assert!(root.join("bin").join("dummy").exists());
+    }
+
+    #[test]
+    async fn embedded_chromedriver() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("O'Brien");
+        std::fs::create_dir_all(&root).unwrap();
+        let binary_name = if cfg!(windows) {
+            "chromedriver.exe"
+        } else {
+            "chromedriver"
+        };
+        std::fs::write(root.join(binary_name), "chromedriver").unwrap();
+
+        let embedded = embedded_plugins::get_embedded_plugin("chromedriver").unwrap();
+        let plugin = Plugin::from_embedded("chromedriver", embedded).unwrap();
+        let sdk_info = SdkInfo::new(
+            "chromedriver".to_string(),
+            "153.0.8009.0".to_string(),
+            root.clone(),
+        );
+        let ctx = PostInstallContext {
+            root_path: root.clone(),
+            runtime_version: "153.0.8009.0".to_string(),
+            sdk_info: BTreeMap::from([("chromedriver".to_string(), sdk_info)]),
+        };
+
+        plugin.post_install(ctx).await.unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(root.join("bin").join(binary_name)).unwrap(),
+            "chromedriver"
+        );
     }
 }

--- a/docs/plugin-lua-modules.md
+++ b/docs/plugin-lua-modules.md
@@ -306,8 +306,14 @@ function PLUGIN:Available(ctx)
         table.insert(result, {version = version})
     end
 
-    -- Sort versions semantically (ascending order - oldest first)
-    return semver.sort_by(result, "version")
+    -- Available() must return newest-first. semver.sort_by() sorts ascending,
+    -- so reverse that result before returning it.
+    local sorted = semver.sort_by(result, "version")
+    local newest_first = {}
+    for i = #sorted, 1, -1 do
+        table.insert(newest_first, sorted[i])
+    end
+    return newest_first
 end
 ```
 
@@ -321,7 +327,7 @@ table.sort(versions, function(a, b)
     return semver.compare(a.version, b.version) > 0
 end)
 
--- Sort ascending (oldest first) - default for Available()
+-- Sort ascending (oldest first); reverse this before returning from Available()
 table.sort(versions, function(a, b)
     return semver.compare(a.version, b.version) < 0
 end)


### PR DESCRIPTION
## Summary

- return embedded chromedriver versions newest-first, preserving Google's source order without assuming semver
- use native PowerShell file operations for the Windows post-install hook and shell-safe environment variables on Unix
- add regression tests for latest-version ordering and cross-platform post-install behavior
- correct the documented ordering contract for traditional vfox `Available()` hooks

## Root cause

Google's Chrome for Testing API returns versions oldest-first, while traditional vfox plugins must return newest-first. Passing the upstream list through unchanged caused mise to resolve `latest` to the oldest available ChromeDriver. The plugin's post-install hook also invoked POSIX `mkdir` and `cp` commands under `cmd.exe` on Windows.

Related: https://github.com/jdx/mise/discussions/12037
Related: https://github.com/mise-plugins/vfox-chromedriver/issues/1

## Validation

- `mise --cd crates/vfox run lint-fix`
- `mise --cd crates/vfox run lint`
- `mise --cd crates/vfox run test` (112 passed, 2 ignored)
- `mise run build`
- fresh-cache `target/debug/mise latest chromedriver` returns `153.0.8009.0`
- fresh-cache `target/debug/mise ls-remote chromedriver` spans `115.0.5763.0` through `153.0.8009.0`
- fresh-data installation places an executable ChromeDriver in `bin/`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tool resolution (`latest`) and install hooks for a bundled plugin; Windows install path is rewritten but scoped to chromedriver with regression tests.
> 
> **Overview**
> **ChromeDriver version ordering** — The embedded `Available()` hook now walks Google's Chrome for Testing JSON **newest-first** (reverse of the API's oldest-first list), so `mise latest chromedriver` picks the current release instead of the oldest entry with a chromedriver download.
> 
> **Post-install on Windows and path safety** — `PostInstall` stops using POSIX `mkdir`/`cp` under `cmd.exe` on Windows; it uses **PowerShell** `New-Item`/`Copy-Item` with paths in `cmd.exec` **environment variables**. Unix still uses `mkdir`/`cp`/`chmod` but also passes paths via env vars (avoids breakage on paths like `O'Brien`). Paths are built with `file.join_path` / `file.exists` instead of string concatenation and `io.open`.
> 
> **Tests and docs** — Adds a wiremock regression for newest-first ordering and an embedded chromedriver post-install test; **plugin-lua-modules** documents that `Available()` must return newest-first (including reversing `semver.sort_by` when needed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c34c2f07ebc7dd901ebabbd01d970f5160436b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Available ChromeDriver versions are now listed newest-first.
  * Only releases that include downloadable ChromeDriver binaries are shown.
  * Installation now supports platform-specific binary extraction and copying, including Windows and Unix-like systems.

* **Bug Fixes**
  * Improved reliability when locating and installing ChromeDriver binaries.

* **Documentation**
  * Updated plugin guidance to explain semantic sorting and newest-first results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->