### PR TITLE
fix(config): write config files atomically

### DIFF
--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -1411,7 +1411,7 @@ impl ConfigFile for MiseToml {
         if let Some(parent) = self.path.parent() {
             create_dir_all(parent)?;
         }
-        file::write(&self.path, contents)?;
+        file::write_atomic(&self.path, contents)?;
         trust(&config_trust_root(&self.path))?;
         Ok(())
     }
@@ -3055,6 +3055,33 @@ mod tests {
         assert_debug_snapshot!(cf.alias);
 
         assert_snapshot!(replace_path(&format!("{:#?}", cf)));
+    }
+
+    /// `save()` has to replace the config file, not rewrite it in place.
+    ///
+    /// An in-place `O_TRUNC` write is not atomic. A second mise process can read the
+    /// file while it is truncated and conclude no tools are configured, and because
+    /// `O_TRUNC` only shortens the file at open time, a shorter write landing on a
+    /// longer one leaves the previous tail attached — which is invalid TOML and breaks
+    /// every later mise command. Replacing through a rename makes the update
+    /// all-or-nothing for concurrent readers, so assert the file is genuinely swapped.
+    #[test]
+    fn save_replaces_the_config_file_rather_than_rewriting_in_place() {
+        use std::os::unix::fs::MetadataExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let p = temp.path().join("config.toml");
+        file::write(&p, "[tools]\nclaude = \"latest\"\n").unwrap();
+        let before = std::fs::metadata(&p).unwrap().ino();
+
+        let cf = MiseToml::from_file(&p).unwrap();
+        cf.save().unwrap();
+
+        let after = std::fs::metadata(&p).unwrap().ino();
+        assert_ne!(
+            before, after,
+            "save() rewrote the config in place, so a concurrent reader can observe a torn file"
+        );
     }
 
     #[tokio::test]

--- a/src/config/config_file/tool_versions.rs
+++ b/src/config/config_file/tool_versions.rs
@@ -182,7 +182,7 @@ impl ConfigFile for ToolVersions {
 
     fn save(&self) -> Result<()> {
         let s = self.dump()?;
-        file::write(&self.path, s)
+        file::write_atomic(&self.path, s)
     }
 
     fn dump(&self) -> eyre::Result<String> {


### PR DESCRIPTION
## Problem

`MiseToml::save()` writes the config with `file::write`, which is `fs::write` — `open(O_WRONLY|O_CREAT|O_TRUNC)` straight into the real file:

```rust
fn save(&self) -> eyre::Result<()> {
    let contents = self.dump()?;
    if let Some(parent) = self.path.parent() {
        create_dir_all(parent)?;
    }
    file::write(&self.path, contents)?;
    trust(&config_trust_root(&self.path))?;
    Ok(())
}
```

Since `mise use -g` is a read-modify-write of the whole global config, two mise processes running at once can interleave inside that window. `O_TRUNC` only shortens the file at *open* time, so a shorter write landing on a file another process has already extended leaves the previous tail attached:

```
A: open(O_TRUNC)               file -> 0 bytes
B: open(O_TRUNC)               file -> 0 bytes
B: write 26 bytes              [tools]\nclaude = "latest"\n
A: write 22 bytes at offset 0  [tools]\ngh = "latest"\n
```

A's 22-byte write cannot shrink a file B already extended to 26 bytes, so bytes 22–25 survive from B. Bytes 22–25 of `[tools]\nclaude = "latest"\n` are `st"\n`, and the config on disk becomes:

```toml
[tools]
gh = "latest"
st"
```

which is invalid TOML. Every subsequent mise command then fails with `key with no value, expected `=``, including the ones you would use to repair it.

The unlocked *read* is what supplies the shorter write: a process can read the config inside another's truncate→write window, observe an empty file, conclude nothing is configured, and write back a config containing only its own tool.

This is not hypothetical — it is being hit in the wild. Downstream report: basecamp/omarchy#6948, where per-tool shell wrappers call `mise use -g` on every launch and a GUI that probes several CLIs concurrently reliably shreds the global config.

## Fix

Use the `write_atomic` that already exists in `src/file.rs` directly below `write` — tempfile → `sync_all` → rename → `sync_dir`. It already resolves symlinks through `atomic_write_target` (so symlinked dotfile configs still write through to the real target), preserves existing Unix permissions, and `persist_atomic` already retries on the Windows sharing-violation errors.

Same change applied to `ToolVersions::save()`, which has the identical `file::write` pattern for `.tool-versions`.

This follows the precedent of #11957, which made install-state manifests atomic for the same reason.

With a rename, a reader sees either the whole old file or the whole new file, and a short write can never leave a stale tail behind.

## Scope

This fixes the file-corrupting half only. Concurrent `mise use -g` calls can still lose each other's updates — a plain lost update, where the slower writer overwrites the tool the faster one just added — because the read-modify-write is not held under a lock. mise takes no cross-process lock anywhere (there is no advisory-locking crate in `Cargo.toml`; the `Mutex`es in `mise_toml.rs` are in-process only). That is a bigger change and a separate discussion; I kept this PR to the part that leaves users with an unparseable config.

## Verification

The non-atomic write is directly observable — the inode is unchanged across a `mise use -g` on 2026.8.3, i.e. the file is rewritten rather than replaced. With a locally built binary, before and after this change:

```
stock   2026.8.3        inode 36154 -> 36154   in-place rewrite
patched 2026.8.6-DEBUG  inode 36155 -> 36156   replaced via rename
```

The regression test added here encodes exactly that property, and fails on `main`.

To be precise about what I have and have not reproduced: I have **not** managed to catch two real mise processes interleaving on demand — the truncate→write window is small, and it needs a slow enough resolve to land inside it. What I can demonstrate is the mechanism and that the resulting byte pattern matches the downstream report exactly. Two interleaved `O_TRUNC` writes of the two strings involved:

```python
fdA = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
fdB = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
os.write(fdB, b'[tools]\nclaude = "latest"\n')   # 26 bytes
os.write(fdA, b'[tools]\ngh = "latest"\n')       # 22 bytes
```

produces:

```
b'[tools]\ngh = "latest"\nst"\n'
```

which is character-for-character the corrupted config reported in basecamp/omarchy#6948, including the otherwise inexplicable `st"` line. That report is a user hitting this repeatedly on a machine that launches several `mise use -g` processes concurrently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration saving reliability by writing files atomically.
  * Reduced the risk of partial or corrupted configuration files during saves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->