### PR TITLE
test: stop a poisoned test lock turning one failure into twenty-nine

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -1046,41 +1046,59 @@ mod tests {
         );
     }
 
+    const GITHUB_TOKEN_VARS: [&str; 4] = [
+        "MISE_GITHUB_TOKEN",
+        "GITHUB_API_TOKEN",
+        "GITHUB_TOKEN",
+        "MISE_GITHUB_ENTERPRISE_TOKEN",
+    ];
+
+    /// Holds [`super::TEST_ENV_LOCK`] and puts the token variables back in `Drop`.
+    ///
+    /// Restoring in `Drop` rather than after the callback is what makes the lock's poison flag
+    /// unnecessary: `Drop` runs while unwinding, so a panicking test cannot leave `ghp_test`
+    /// behind for whatever runs next.
+    struct GithubTokenGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        // `var_os`, not `var`: the latter reports a non-Unicode value as `None`, which `Drop`
+        // would then read as "was unset" and delete. Same shape as `crate::test::EnvVarGuard`.
+        prev: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    }
+
+    impl GithubTokenGuard {
+        fn new() -> Self {
+            let lock = crate::test::lock_ignoring_poison(&super::TEST_ENV_LOCK);
+            let prev = GITHUB_TOKEN_VARS
+                .iter()
+                .map(|name| (*name, std::env::var_os(name)))
+                .collect();
+
+            env::remove_var("MISE_GITHUB_TOKEN");
+            env::remove_var("GITHUB_API_TOKEN");
+            env::set_var("GITHUB_TOKEN", "ghp_test");
+            env::remove_var("MISE_GITHUB_ENTERPRISE_TOKEN");
+
+            Self { _lock: lock, prev }
+        }
+    }
+
+    impl Drop for GithubTokenGuard {
+        fn drop(&mut self) {
+            for (name, prev) in self.prev.drain(..) {
+                match prev {
+                    Some(v) => env::set_var(name, v),
+                    None => env::remove_var(name),
+                }
+            }
+        }
+    }
+
     fn with_github_token<F, R>(test_fn: F) -> R
     where
         F: FnOnce() -> R,
     {
-        let _guard = super::TEST_ENV_LOCK.lock().unwrap();
-        let orig_mise = std::env::var("MISE_GITHUB_TOKEN").ok();
-        let orig_api = std::env::var("GITHUB_API_TOKEN").ok();
-        let orig_gh = std::env::var("GITHUB_TOKEN").ok();
-        let orig_enterprise = std::env::var("MISE_GITHUB_ENTERPRISE_TOKEN").ok();
-
-        env::remove_var("MISE_GITHUB_TOKEN");
-        env::remove_var("GITHUB_API_TOKEN");
-        env::set_var("GITHUB_TOKEN", "ghp_test");
-        env::remove_var("MISE_GITHUB_ENTERPRISE_TOKEN");
-
-        let result = test_fn();
-
-        match orig_mise {
-            Some(v) => env::set_var("MISE_GITHUB_TOKEN", v),
-            None => env::remove_var("MISE_GITHUB_TOKEN"),
-        }
-        match orig_api {
-            Some(v) => env::set_var("GITHUB_API_TOKEN", v),
-            None => env::remove_var("GITHUB_API_TOKEN"),
-        }
-        match orig_gh {
-            Some(v) => env::set_var("GITHUB_TOKEN", v),
-            None => env::remove_var("GITHUB_TOKEN"),
-        }
-        match orig_enterprise {
-            Some(v) => env::set_var("MISE_GITHUB_ENTERPRISE_TOKEN", v),
-            None => env::remove_var("MISE_GITHUB_ENTERPRISE_TOKEN"),
-        }
-
-        result
+        let _guard = GithubTokenGuard::new();
+        test_fn()
     }
 
     struct TokensFileOverrideGuard;
@@ -1118,7 +1136,7 @@ mod tests {
 
     #[test]
     fn test_get_headers_remembers_tokens_file_source() {
-        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&TEST_ENV_LOCK);
         let host = "github-tokens-file-test.example.com";
         let _tokens_file = TokensFileOverrideGuard::set(host, "ghp_from_tokens_file");
 

--- a/src/github/oauth.rs
+++ b/src/github/oauth.rs
@@ -664,7 +664,7 @@ mod tests {
 
     impl OAuthEnvGuard {
         fn new(auth_url: String, cache_path: PathBuf) -> Self {
-            let lock = crate::github::TEST_ENV_LOCK.lock().unwrap();
+            let lock = crate::test::lock_ignoring_poison(&crate::github::TEST_ENV_LOCK);
             let vars = vec![
                 (
                     "MISE_GITHUB_OAUTH_CLIENT_ID",

--- a/src/github/sigstore.rs
+++ b/src/github/sigstore.rs
@@ -418,7 +418,7 @@ mod tests {
             replacements: Option<indexmap::IndexMap<String, String>>,
             use_versions_host: Option<bool>,
         ) -> Self {
-            let lock = TEST_SETTINGS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let lock = crate::test::lock_ignoring_poison(&TEST_SETTINGS_LOCK);
             let mut settings = crate::config::settings::SettingsPartial::empty();
             settings.url_replacements = replacements;
             settings.use_versions_host = use_versions_host;
@@ -465,7 +465,7 @@ mod tests {
 
     #[test]
     fn test_resolve_token_wrapper_uses_env_var_with_default_url() {
-        let _lock = crate::github::TEST_ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&crate::github::TEST_ENV_LOCK);
         let _env = TokenEnvGuard::new();
         mise_env::set_var("GITHUB_TOKEN", "ghp_wrapper_default");
 
@@ -479,7 +479,7 @@ mod tests {
 
     #[test]
     fn test_resolve_token_wrapper_uses_env_var_with_explicit_api_url() {
-        let _lock = crate::github::TEST_ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&crate::github::TEST_ENV_LOCK);
         let _env = TokenEnvGuard::new();
         mise_env::set_var("MISE_GITHUB_TOKEN", "ghp_explicit_api");
 
@@ -493,7 +493,7 @@ mod tests {
 
     #[test]
     fn test_resolve_token_wrapper_respects_enterprise_api_url() {
-        let _lock = crate::github::TEST_ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&crate::github::TEST_ENV_LOCK);
         let _env = TokenEnvGuard::new();
         mise_env::set_var("GITHUB_TOKEN", "ghp_public_only");
         mise_env::set_var("MISE_GITHUB_ENTERPRISE_TOKEN", "ghp_enterprise_only");
@@ -545,7 +545,7 @@ mod tests {
         // non-env-var sources — here, the `github_tokens.toml` path (source #4). Without
         // this, a future regression could short-circuit on env vars and silently pass all
         // prior tests.
-        let _lock = crate::github::TEST_ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&crate::github::TEST_ENV_LOCK);
         let _env = TokenEnvGuard::new();
         let _tokens_file = TokensFileOverrideGuard::set("github.com", "ghp_from_tokens_file");
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -1981,8 +1981,13 @@ mod tests {
     where
         F: FnOnce() -> R,
     {
-        // Lock to prevent parallel tests from interfering with global settings
-        let _guard = TEST_SETTINGS_LOCK.lock().unwrap();
+        // `SettingsGuard` holds the lock and calls `Settings::reset(None)` in `Drop`, which runs
+        // while unwinding. Resetting after `test_fn` instead would leave the replacements behind
+        // for the next test whenever this one panics -- previously the lock's poison flag hid
+        // that by failing every later test outright.
+        let _guard = SettingsGuard {
+            _lock: crate::test::lock_ignoring_poison(&TEST_SETTINGS_LOCK),
+        };
 
         // Create settings with custom URL replacements
         let mut settings = crate::config::settings::SettingsPartial::empty();
@@ -1991,13 +1996,7 @@ mod tests {
         // Set settings for this test
         crate::config::Settings::reset(Some(settings));
 
-        // Run test
-        let result = test_fn();
-
-        // Clean up after test
-        crate::config::Settings::reset(None);
-
-        result
+        test_fn()
     }
 
     #[test]
@@ -2157,14 +2156,14 @@ mod tests {
         }
     }
     fn set_test_http_retries(retries: i64) -> SettingsGuard {
-        let lock = TEST_SETTINGS_LOCK.lock().unwrap();
+        let lock = crate::test::lock_ignoring_poison(&TEST_SETTINGS_LOCK);
         let mut settings = crate::config::settings::SettingsPartial::empty();
         settings.http_retries = Some(retries);
         crate::config::Settings::reset(Some(settings));
         SettingsGuard { _lock: lock }
     }
     fn set_test_prefer_offline(http_retries: i64) -> SettingsGuard {
-        let lock = TEST_SETTINGS_LOCK.lock().unwrap();
+        let lock = crate::test::lock_ignoring_poison(&TEST_SETTINGS_LOCK);
         let mut settings = crate::config::settings::SettingsPartial::empty();
         settings.prefer_offline = Some(true);
         settings.http_retries = Some(http_retries);
@@ -2172,7 +2171,7 @@ mod tests {
         SettingsGuard { _lock: lock }
     }
     fn set_test_offline() -> SettingsGuard {
-        let lock = TEST_SETTINGS_LOCK.lock().unwrap();
+        let lock = crate::test::lock_ignoring_poison(&TEST_SETTINGS_LOCK);
         let mut settings = crate::config::settings::SettingsPartial::empty();
         settings.offline = Some(true);
         crate::config::Settings::reset(Some(settings));
@@ -2240,8 +2239,8 @@ mod tests {
     }
 
     fn set_test_github_oauth(server_url: &str, cache_path: PathBuf) -> GithubOauthSettingsGuard {
-        let settings_lock = TEST_SETTINGS_LOCK.lock().unwrap();
-        let github_env_lock = crate::github::TEST_ENV_LOCK.lock().unwrap();
+        let settings_lock = crate::test::lock_ignoring_poison(&TEST_SETTINGS_LOCK);
+        let github_env_lock = crate::test::lock_ignoring_poison(&crate::github::TEST_ENV_LOCK);
         let vars = vec![
             ("MISE_EXPERIMENTAL", std::env::var("MISE_EXPERIMENTAL").ok()),
             (
@@ -3913,7 +3912,7 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
     #[test]
     fn test_no_settings_configured() {
         // Test the real apply_url_replacements function with no settings override
-        let _guard = TEST_SETTINGS_LOCK.lock().unwrap();
+        let _guard = crate::test::lock_ignoring_poison(&TEST_SETTINGS_LOCK);
         crate::config::Settings::reset(None);
 
         let mut url = Url::parse("https://github.com/owner/repo").unwrap();

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -1284,7 +1284,7 @@ mod tests {
     fn resolve_node_lockfile_options(
         configure_settings: impl FnOnce(&mut SettingsPartial),
     ) -> BTreeMap<String, String> {
-        let lock = TEST_SETTINGS_LOCK.lock().unwrap();
+        let lock = crate::test::lock_ignoring_poison(&TEST_SETTINGS_LOCK);
         let _guard = SettingsResetGuard { _lock: lock };
         let _env_guard = NodeEnvResetGuard::clear();
         let mut settings = SettingsPartial::empty();
@@ -1383,7 +1383,7 @@ mod tests {
 
     #[test]
     fn test_node_flavor_not_found_message_is_flavor_specific() {
-        let lock = TEST_SETTINGS_LOCK.lock().unwrap();
+        let lock = crate::test::lock_ignoring_poison(&TEST_SETTINGS_LOCK);
         let _guard = SettingsResetGuard { _lock: lock };
         let mut settings = SettingsPartial::empty();
         settings.node.flavor = Some("glibc-217".to_string());
@@ -1539,7 +1539,7 @@ mod tests {
 
     #[test]
     fn test_node_lockfile_options_include_legacy_source_build_env() {
-        let lock = TEST_SETTINGS_LOCK.lock().unwrap();
+        let lock = crate::test::lock_ignoring_poison(&TEST_SETTINGS_LOCK);
         let _guard = SettingsResetGuard { _lock: lock };
         let _env_guard = NodeEnvResetGuard::clear();
         env::set_var("NODE_CONFIGURE_OPTS", "--openssl-no-asm");

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -1302,9 +1302,7 @@ mod tests {
         configure_settings: impl FnOnce(&mut SettingsPartial),
         target: PlatformTarget,
     ) -> BTreeMap<String, String> {
-        let lock = TEST_SETTINGS_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let lock = crate::test::lock_ignoring_poison(&TEST_SETTINGS_LOCK);
         let mut settings = SettingsPartial::empty();
         configure_settings(&mut settings);
         Settings::reset(Some(settings));
@@ -1319,9 +1317,7 @@ mod tests {
         configure_settings: impl FnOnce(&mut SettingsPartial),
         f: impl FnOnce(&RubyPlugin) -> T,
     ) -> T {
-        let lock = TEST_SETTINGS_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let lock = crate::test::lock_ignoring_poison(&TEST_SETTINGS_LOCK);
         let mut settings = SettingsPartial::empty();
         configure_settings(&mut settings);
         Settings::reset(Some(settings));
@@ -1633,9 +1629,7 @@ mod tests {
 
     #[test]
     fn test_ruby_lock_info_url_uses_precompiled_overrides() {
-        let lock = TEST_SETTINGS_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let lock = crate::test::lock_ignoring_poison(&TEST_SETTINGS_LOCK);
         let mut settings = SettingsPartial::empty();
         settings.ruby.compile = Some(false);
         settings.ruby.precompiled_url =

--- a/src/plugins/core/swift.rs
+++ b/src/plugins/core/swift.rs
@@ -448,7 +448,7 @@ mod lockfile_tests {
     /// Pin `swift.platform` so the assertions don't depend on the distro the
     /// tests happen to run on.
     fn pin_platform(platform: Option<&str>) -> SettingsResetGuard {
-        let lock = TEST_SETTINGS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let lock = crate::test::lock_ignoring_poison(&TEST_SETTINGS_LOCK);
         let guard = SettingsResetGuard { _lock: lock };
         let mut settings = SettingsPartial::empty();
         settings.swift.platform = platform.map(str::to_string);

--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -993,7 +993,7 @@ mod tests {
 
     impl TeraV1Guard {
         fn new() -> Self {
-            let lock = TEST_SETTINGS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let lock = crate::test::lock_ignoring_poison(&TEST_SETTINGS_LOCK);
             Settings::override_with(|settings| settings.tera_v1 = Some(true));
             Self { _lock: lock }
         }

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -1652,7 +1652,7 @@ mod tests {
 
     impl SettingsGuard {
         fn tera_v1() -> Self {
-            let lock = TEST_SETTINGS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let lock = crate::test::lock_ignoring_poison(&TEST_SETTINGS_LOCK);
             Settings::override_with(|settings| settings.tera_v1 = Some(true));
             Self { _lock: lock }
         }

--- a/src/test.rs
+++ b/src/test.rs
@@ -2,6 +2,7 @@ use std::env::join_paths;
 #[cfg(unix)]
 use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
+use std::sync::{Mutex, MutexGuard};
 
 use indoc::indoc;
 
@@ -143,6 +144,23 @@ impl Drop for EnvVarGuard {
     }
 }
 
+/// Take a test-only global lock, ignoring poisoning.
+///
+/// These locks are `Mutex<()>`: they guard no data, only the order in which tests reach
+/// process-wide state such as `Settings` or environment variables. Restoring that state is the
+/// job of each guard's `Drop`, and `Drop` runs while unwinding, so by the time a panicking test
+/// releases the lock the state is already back. The poison flag left behind therefore records
+/// nothing about correctness — all it does is fail every later test that wanted the same lock.
+///
+/// Measured once: a single failed assertion in `http::tests` was reported as **29** failures,
+/// 28 of them `PoisonError` from tests that had nothing to do with it. Triage cost more than the
+/// bug did.
+pub fn lock_ignoring_poison<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 pub fn replace_path(input: &str) -> String {
     let path = join_paths(&*env::PATH)
         .unwrap()
@@ -163,4 +181,31 @@ macro_rules! with_settings {
             (home.as_str(), "~"),
         ]}, {$body})
     }}
+}
+
+// Last in the file: `clippy::items_after_test_module` rejects anything declared after it.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_poisoned_lock_is_still_taken() {
+        static LOCK: Mutex<()> = Mutex::new(());
+
+        // Poison it for real first. Without this the call below would only show that an
+        // unpoisoned mutex can be locked, which is true of `.lock().unwrap()` as well and so
+        // proves nothing. The panic message says it is deliberate because it reaches the log.
+        let poisoner = std::thread::spawn(|| {
+            let _guard = LOCK.lock().unwrap();
+            panic!("deliberate panic: poisoning the lock for a_poisoned_lock_is_still_taken");
+        });
+        assert!(
+            poisoner.join().is_err(),
+            "the thread had to panic for the lock to be poisoned"
+        );
+        assert!(LOCK.lock().is_err(), "the lock should now be poisoned");
+
+        // The property: a later test still gets the lock rather than inheriting the failure.
+        let _guard = lock_ignoring_poison(&LOCK);
+    }
 }


### PR DESCRIPTION
## What happened

`cargo test --all-features` reported **29 failures** on a PR that touches none of the code
involved. One was real; the other 28 were collateral
([run](https://github.com/jdx/mise/actions/runs/31881711049), counted from the `panicked at` lines):

| site | count | what |
|---|---|---|
| `src/http.rs:3344` | 1 | **the real failure** — a flaky `assert_eq!` in `test_download_resumes_across_calls_without_storing_secrets`, `left: []` against `b"hello"` |
| `src/http.rs:1985` | 11 | `PoisonError` |
| `src/http.rs:2160` | 9 | `PoisonError` |
| `src/http.rs:2167` | 4 | `PoisonError` |
| `src/http.rs:2243` | 2 | `PoisonError` |
| `src/http.rs:2175` | 1 | `PoisonError` |
| `src/http.rs:3916` | 1 | `PoisonError` |

The first test panicked while holding `TEST_SETTINGS_LOCK`. Every later test took it with
`.lock().unwrap()`, and unit tests run single-threaded, so all of them inherited the failure.

The cost is triage, not correctness: a one-line flake is reported as a systemic break, and telling
the two apart takes a round trip. That is what happened here — the PR was suspected before the log
showed every failing test was in a file it never touched.

## Why poisoning means nothing here

These locks are `Mutex<()>`. They guard no data, only the order in which tests reach process-wide
`Settings` and environment variables. Restoring that is each guard's `Drop` — `SettingsGuard::drop`
calls `Settings::reset(None)` — and `Drop` runs while unwinding. So by the time a panicking test
releases the lock, the state it was protecting is already back. The flag left behind records
nothing; it only fails the next twenty-eight tests.

Parts of the codebase had already reached that conclusion and written
`unwrap_or_else(|e| e.into_inner())` by hand — `github/sigstore.rs`, `tera.rs`,
`plugins/core/swift.rs`, `plugins/core/ruby.rs`, `task/task_script_parser.rs`. It just was not
applied everywhere, and the reasoning was not written down anywhere.

## The change

`crate::test::lock_ignoring_poison` in `src/test.rs`, beside the existing `EnvVarGuard`. It replaces
both spellings, so there is one way to take these locks and one place that says why. Every
acquisition of `TEST_SETTINGS_LOCK` and `TEST_ENV_LOCK` now goes through it — 17 that used
`.unwrap()` and 7 that already ignored poisoning.

Ordering is unchanged: the same locks are taken and held for the same scopes.

## Deliberately not included

- **`ENV_LOCK` in `system/packages/brew/{cask,maintenance,pour}.rs` — 83 sites.** Same shape, but
  unrelated to this failure and never observed cascading. Including it would triple the diff. Happy
  to send it as a follow-up if you want the codebase uniform.
- `MUTEX` in `src/env.rs` — same, 2 sites.
- **Production locks are untouched** (`cmd.rs`, `ui/prompt.rs`, `toolset/install_state.rs`,
  `sops.rs`, `config/config_file/mod.rs`). Poisoning can mean something there.
- The `http.rs:3344` flake itself. That is a separate bug; this PR only stops it taking 28 other
  tests with it.

## Verification

I did not build locally. Run on a fork with the same command CI uses:

```
test result: ok. 2867 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out

$ cargo test --all-features a_poisoned_lock_is_still_taken -- --nocapture
deliberate panic: poisoning the lock for a_poisoned_lock_is_still_taken
test test::tests::a_poisoned_lock_is_still_taken ... ok
```

The new test poisons a mutex for real first — a thread that takes it and panics, with `join()`
asserted to be `Err` and `lock()` asserted to be `Err` — before checking the helper still returns a
guard. Without that control it would only show that an unpoisoned mutex can be locked, which
`.lock().unwrap()` does too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability when shared settings or authentication environment state is interrupted.
  * Tests now recover safely from disrupted synchronization state instead of failing unexpectedly.
  * Added coverage confirming interrupted test locks can be reacquired.
  * Standardized synchronization across authentication, HTTP, plugin, task, and template test suites.
  * Ensured temporary test configuration is restored reliably, including after unexpected test termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->