### PR TITLE
fix(current): hide tools for inactive operating systems

### DIFF
--- a/e2e/cli/test_current
+++ b/e2e/cli/test_current
@@ -3,6 +3,16 @@
 mise i dummy@3 tiny@2
 mise use dummy@3
 
+# Configure an uninstalled version for an inactive OS. `mise current` should
+# omit it from both the full listing and the tool-specific output.
+case "$(uname -s)" in
+  Darwin) _inactive_os="linux" ;;
+  *) _inactive_os="macos" ;;
+esac
+cat >>mise.toml <<EOF
+tiny = { version = "1", os = ["$_inactive_os"] }
+EOF
+
 assert "mise current" "dummy 3"
 assert "mise current dummy" "3"
 assert "mise current tiny" ""

--- a/src/cli/current.rs
+++ b/src/cli/current.rs
@@ -53,6 +53,7 @@ impl Current {
                     "{}",
                     versions
                         .iter()
+                        .filter(|v| v.request.is_os_supported())
                         .map(|v| v.version.to_string())
                         .collect::<Vec<_>>()
                         .join(" ")
@@ -71,10 +72,14 @@ impl Current {
     async fn all(&self, ts: Toolset) -> Result<()> {
         let config = Config::get().await?;
         for (plugin, versions) in ts.list_versions_by_plugin() {
+            let versions = versions
+                .iter()
+                .filter(|v| v.request.is_os_supported())
+                .collect::<Vec<_>>();
             if versions.is_empty() {
                 continue;
             }
-            for tv in versions {
+            for tv in &versions {
                 if !plugin.is_version_installed(&config, tv, true) {
                     let source = ts.versions.get(tv.ba()).unwrap().source.clone();
                     warn!(


### PR DESCRIPTION
## Summary
- filter OS-inactive tool versions from `mise current`
- suppress missing-install warnings for inactive versions
- cover both aggregate and tool-specific output

## Root cause

`mise current` read all resolved versions through `list_versions_by_plugin()` without applying `ToolRequest::is_os_supported()`, unlike the active-tool paths elsewhere in the toolset.

Fixes the follow-up reported in https://github.com/jdx/mise/discussions/6896#discussioncomment-18023602.

## Tests
- `mise run test:e2e e2e/cli/test_current`
- hk safe check
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI display/warning change aligned with existing OS filtering elsewhere; no auth or install-path changes.
> 
> **Overview**
> **`mise current`** now skips tool versions whose `os` constraint does not match the current platform, using **`ToolRequest::is_os_supported()`** on both the full listing and single-tool output.
> 
> OS-inactive entries are no longer printed and no longer trigger “specified but not installed” warnings. An e2e case adds a **`tiny`** version pinned to the *other* OS and asserts it stays out of **`mise current`** and **`mise current tiny`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a446a30f7fb12969a493d85c557bab2bec811071. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `mise current` to omit tool versions that aren’t supported by the current operating system.
  * Ensured both general and tool-specific output only show relevant, active versions.
  * Added coverage to verify behavior when configurations target a different operating system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->