### PR TITLE
docs: document devEngines and packageManager config support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -494,7 +494,11 @@ exact binary release. mise treats that value as a normal version request, so a v
 `3.25` selects the latest matching CMake 3.25 release and a GoReleaser config `version: 2` selects
 the latest GoReleaser 2.x release.
 
-For `package.json` (supported by `node`, `deno`, `bun`, `npm`, `pnpm`, and `yarn`), mise reads `devEngines.runtime` for runtime tools (`node`, `bun`, and `deno`), and `devEngines.packageManager` or top-level `packageManager` (e.g. `pnpm@9.1.0` or `npm@10.0.0`) for package managers.
+For `package.json` (supported by `node`, `deno`, `bun`, `npm`, `pnpm`, and `yarn`):
+
+- Runtime tools (`node`, `deno`, and `bun`) read `devEngines.runtime` (both single object and array formats are supported).
+- Package managers (`npm`, `pnpm`, and `yarn`) read `devEngines.packageManager` or top-level `packageManager` (e.g. `pnpm@9.1.0` or `npm@10.0.0`).
+- For `bun`, mise checks `devEngines.runtime` first, falling back to `devEngines.packageManager` and top-level `packageManager` (e.g. `bun@1.2.0`).
 
 For `go.mod`, the `toolchain goX.Y.Z` directive (an exact toolchain pin) is used when present.
 Otherwise the `go X.Y` directive is used; because it declares only the _minimum_ required Go

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -494,6 +494,8 @@ exact binary release. mise treats that value as a normal version request, so a v
 `3.25` selects the latest matching CMake 3.25 release and a GoReleaser config `version: 2` selects
 the latest GoReleaser 2.x release.
 
+For `package.json` (supported by `node`, `deno`, `bun`, `npm`, `pnpm`, and `yarn`), mise reads `devEngines.runtime` for runtime tools (`node`, `bun`, and `deno`), and `devEngines.packageManager` or top-level `packageManager` (e.g. `pnpm@9.1.0` or `npm@10.0.0`) for package managers.
+
 For `go.mod`, the `toolchain goX.Y.Z` directive (an exact toolchain pin) is used when present.
 Otherwise the `go X.Y` directive is used; because it declares only the _minimum_ required Go
 version, mise resolves it to the latest matching patch (e.g. `go 1.22` → latest `1.22.x`).


### PR DESCRIPTION
It's not clear from the docs exactly what fields and files node-related idiomatic file parsers support. This doc improvement makes it clear.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented how runtime and package manager requirements are read from `package.json`.
  * Clarified supported configuration fields for runtime tools and package managers.
  * Explained Bun’s order of precedence when checking runtime and package manager fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->