### PR TITLE
test(brew): take ENV_LOCK without inheriting a poisoned failure

### DIFF
--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -7508,7 +7508,7 @@ mod tests {
 
     #[test]
     fn detects_any_foreign_homebrew_metadata_object() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let metadata = tmp.path().join("Caskroom/example/.metadata");
@@ -7584,7 +7584,7 @@ mod tests {
 
     #[test]
     fn completed_receipt_detects_app_bundle_drift() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let cask = test_cask("example", "1.0.0");
@@ -7671,7 +7671,7 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn stages_command_wrapper_with_args_env_and_expanded_paths() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let prefix = tmp.path().join("homebrew");
         let _guard = BrewPrefixGuard::set(&prefix);
@@ -7718,7 +7718,7 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn stages_command_wrapper_with_literal_content() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let prefix = tmp.path().join("homebrew");
         let _guard = BrewPrefixGuard::set(&prefix);
@@ -7958,7 +7958,7 @@ mod tests {
     fn installer_script_is_made_executable_before_running() -> Result<()> {
         use std::os::unix::fs::PermissionsExt;
 
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let prefix = tmp.path().join("prefix");
         let _guard = BrewPrefixGuard::set(&prefix);
@@ -8024,7 +8024,7 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn installer_script_accepts_preflight_copied_root() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let prefix = tmp.path().join("prefix");
         let _guard = BrewPrefixGuard::set(&prefix);
@@ -8090,7 +8090,7 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn installer_mutations_are_included_in_durable_symlink_sources() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let prefix = tmp.path().join("prefix");
         let _guard = BrewPrefixGuard::set(&prefix);
@@ -8129,7 +8129,7 @@ mod tests {
 
     #[test]
     fn structured_copy_restores_external_target_without_status_tracking() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let prefix = tmp.path().join("prefix");
         let _guard = BrewPrefixGuard::set(&prefix);
@@ -8178,7 +8178,7 @@ mod tests {
 
     #[test]
     fn structured_copy_rollback_removes_target_with_created_parent() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let prefix = tmp.path().join("prefix");
         let _guard = BrewPrefixGuard::set(&prefix);
@@ -9623,7 +9623,7 @@ mod tests {
 
     #[test]
     fn structured_run_expands_paths_args_and_env() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let prefix = tmp.path().join("homebrew");
         let _guard = BrewPrefixGuard::set(&prefix);
@@ -10215,7 +10215,7 @@ end
         // VLC: preflight writes `#{staged_path}/vlc.wrapper.sh` while preflight
         // staged_path is the extract stage, not the temp Caskroom. API binary
         // source is `$HOMEBREW_PREFIX/Caskroom/vlc/<ver>/vlc.wrapper.sh`.
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let prefix = tmp.path().join("homebrew");
         let _guard = BrewPrefixGuard::set(&prefix);
@@ -10241,7 +10241,7 @@ end
 
     #[test]
     fn prefers_temp_caskroom_wrapper_over_extract_stage() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let prefix = tmp.path().join("homebrew");
         let _guard = BrewPrefixGuard::set(&prefix);
@@ -10400,7 +10400,7 @@ end
 
     #[test]
     fn completion_target_paths_match_homebrew_names() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
 
@@ -10426,7 +10426,7 @@ end
 
     #[test]
     fn stages_and_links_declared_completion() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let stage = tmp.path().join("stage");
@@ -10463,7 +10463,7 @@ end
 
     #[test]
     fn declared_completion_source_maps_caskroom_path_to_temp_caskroom() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let stage = tmp.path().join("stage");
@@ -10489,7 +10489,7 @@ end
 
     #[test]
     fn declared_completion_source_maps_caskroom_path_to_extract_stage() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let stage = tmp.path().join("stage");
@@ -10516,7 +10516,7 @@ end
     #[cfg(unix)]
     #[test]
     fn link_completion_adopts_homebrew_app_symlink() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let cask = test_cask("docker-desktop", "2.0.0");
@@ -10557,7 +10557,7 @@ end
     #[cfg(unix)]
     #[test]
     fn link_completion_rejects_other_file_in_declared_app() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let cask = test_cask("foo", "2.0.0");
@@ -10597,7 +10597,7 @@ end
     #[cfg(unix)]
     #[test]
     fn link_completion_rejects_target_owned_by_another_cask() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let cask = test_cask("foo", "2.0.0");
@@ -10624,7 +10624,7 @@ end
     #[cfg(unix)]
     #[test]
     fn stages_generated_completion_output() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let stage = tmp.path().join("stage");
@@ -10656,7 +10656,7 @@ end
 
     #[test]
     fn generated_completion_executable_expands_appdir() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let stage = tmp.path().join("stage");
@@ -10688,7 +10688,7 @@ end
 
     #[test]
     fn appdir_artifact_source_matches_app_case_insensitively() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let prefix_appdir = tmp.path().join("Applications");
@@ -10715,7 +10715,7 @@ end
 
     #[test]
     fn generated_completion_executable_prefers_staged_prefix_binary() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let stage = tmp.path().join("stage");
@@ -10742,7 +10742,7 @@ end
 
     #[test]
     fn rejects_ambiguous_generated_completion_bare_executable() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let stage = tmp.path().join("stage");
@@ -10801,7 +10801,7 @@ end
 
     #[test]
     fn remove_obsolete_completions_removes_only_caskroom_symlinks() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let cask = test_cask("foo", "2.0.0");
@@ -10846,7 +10846,7 @@ end
     #[cfg(unix)]
     #[test]
     fn remove_obsolete_completions_removes_dangling_symlinks_with_symlinked_prefix() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let real_prefix = tmp.path().join("homebrew-real");
         let prefix = tmp.path().join("homebrew");
@@ -10910,7 +10910,7 @@ end
 
     #[test]
     fn maps_generated_caskroom_binary_to_temp_caskroom() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let prefix = tmp.path().join("homebrew");
         let _guard = BrewPrefixGuard::set(&prefix);
@@ -10931,7 +10931,7 @@ end
 
     #[test]
     fn rejects_generated_caskroom_binary_parent_dirs() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let prefix = tmp.path().join("homebrew");
         let _guard = BrewPrefixGuard::set(&prefix);
@@ -10959,7 +10959,7 @@ end
 
     #[test]
     fn parses_and_installs_generic_artifact() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let stage = tmp.path().join("stage");
@@ -11012,7 +11012,7 @@ end
     #[test]
     #[cfg(unix)]
     fn generic_artifact_rejects_extraction_source_symlink_escape() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let stage = tmp.path().join("stage");
@@ -11044,7 +11044,7 @@ end
     #[test]
     #[cfg(unix)]
     fn generic_artifact_rejects_caskroom_source_symlink_escape() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let stage = tmp.path().join("stage");
@@ -11079,7 +11079,7 @@ end
     #[test]
     #[cfg(unix)]
     fn rejects_generic_artifact_target_through_external_symlink() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let prefix = tmp.path().join("homebrew");
         let external = tmp.path().join("external");
@@ -11098,7 +11098,7 @@ end
     #[test]
     #[cfg(unix)]
     fn generic_copy_revalidates_target_after_symlink_swap() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let prefix = tmp.path().join("homebrew");
         let external = tmp.path().join("external");
@@ -11121,7 +11121,7 @@ end
     #[test]
     #[cfg(unix)]
     fn trusted_operation_parent_stays_bound_after_ancestor_swap() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let prefix = tmp.path().join("homebrew");
         let library = prefix.join("lib");
@@ -11156,7 +11156,7 @@ end
     #[test]
     #[cfg(unix)]
     fn trusted_operation_parent_accepts_symlinked_prefix() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let real_prefix = tmp.path().join("real-homebrew");
         file::create_dir_all(real_prefix.join("lib"))?;
@@ -11182,7 +11182,7 @@ end
     #[test]
     #[cfg(unix)]
     fn trusted_operation_parent_creates_missing_directories() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let prefix = tmp.path().join("homebrew");
         file::create_dir_all(&prefix)?;
@@ -11238,7 +11238,7 @@ end
     #[test]
     #[cfg(unix)]
     fn unprivileged_generic_rollback_restores_backup_when_target_is_absent() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let prefix = tmp.path().join("homebrew");
         let target = prefix.join("include/example.h");
@@ -11258,7 +11258,7 @@ end
     #[test]
     #[cfg(unix)]
     fn trusted_generic_rename_rejects_swapped_prefix() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let prefix = tmp.path().join("homebrew");
         let library = prefix.join("lib");
@@ -11300,7 +11300,7 @@ end
     fn private_staging_cleanup_rejects_replaced_directory() -> Result<()> {
         use std::os::unix::fs::PermissionsExt;
 
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let prefix = tmp.path().join("homebrew");
         let library = prefix.join("lib");
@@ -11340,7 +11340,7 @@ end
     fn obsolete_generic_cleanup_skips_mutable_parent_directories() -> Result<()> {
         use std::os::unix::fs::PermissionsExt;
 
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let obsolete = tmp.path().join("lib/obsolete");
@@ -11378,7 +11378,7 @@ end
     fn obsolete_generic_cleanup_allows_owner_group_writable_prefix() -> Result<()> {
         use std::os::unix::fs::PermissionsExt;
 
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let prefix = tmp.path().join("homebrew");
         let library = prefix.join("lib");
@@ -11734,7 +11734,7 @@ end
 
     #[test]
     fn binary_targets_default_to_prefix_bin() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
 
@@ -11755,7 +11755,7 @@ end
 
     #[test]
     fn binary_targets_must_stay_under_an_allowed_root() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
 
@@ -11773,7 +11773,7 @@ end
 
     #[test]
     fn binary_targets_allow_absolute_usr_local() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
 
@@ -11795,7 +11795,7 @@ end
 
     #[test]
     fn appdir_binary_targets_are_contained() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         assert_eq!(
@@ -11823,7 +11823,7 @@ end
 
     #[test]
     fn caskroom_binary_paths_support_contained_appdir_targets() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let caskroom = tmp.path().join("Caskroom/surge/1.0.0");
@@ -11841,7 +11841,7 @@ end
 
     #[test]
     fn caskroom_binary_paths_preserve_prefix_relative_target() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let caskroom = tmp.path().join("Caskroom/example/1.0.0");
@@ -11859,7 +11859,7 @@ end
 
     #[test]
     fn caskroom_binary_paths_strip_usr_local_root() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let caskroom = tmp.path().join("Caskroom/docker-desktop/1.0.0");
@@ -11877,7 +11877,7 @@ end
 
     #[test]
     fn installed_cask_version_uses_only_recorded_legacy_targets() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let cask = test_cask("app-only", "1.0.0");
@@ -11922,7 +11922,7 @@ end
 
     #[test]
     fn installed_cask_version_rejects_unknown_receipt_schema() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let cask = test_cask("future", "1.0.0");
@@ -11956,7 +11956,7 @@ end
 
     #[test]
     fn cask_prune_removes_only_receipt_owned_direct_artifacts() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let state_dir = tmp.path().join("state");
@@ -11998,7 +11998,7 @@ end
 
     #[test]
     fn cask_prune_skips_configured_drifted_and_legacy_casks() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let state_dir = tmp.path().join("state");
@@ -12080,7 +12080,7 @@ end
 
     #[test]
     fn cask_prune_skips_shared_targets_and_pending_transactions() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let state_dir = tmp.path().join("state");
@@ -12122,7 +12122,7 @@ end
 
     #[test]
     fn cask_prune_rechecks_shared_targets_before_removal() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let state_dir = tmp.path().join("state");
@@ -12140,7 +12140,7 @@ end
 
     #[test]
     fn cask_prune_rechecks_homebrew_ownership_before_removal() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let state_dir = tmp.path().join("state");
@@ -12158,7 +12158,7 @@ end
 
     #[test]
     fn cask_prune_fails_closed_when_a_receipt_is_corrupt() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let state_dir = tmp.path().join("state");
@@ -12184,7 +12184,7 @@ end
     fn cask_prune_fails_closed_when_a_token_directory_is_unreadable() -> Result<()> {
         use std::os::unix::fs::PermissionsExt;
 
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let state_dir = tmp.path().join("state");
@@ -12267,7 +12267,7 @@ end
 
     #[test]
     fn installed_cask_version_rejects_binary_state_without_receipt() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let cask = test_cask("binary-only", "1.0.0");
@@ -12307,7 +12307,7 @@ end
 
     #[test]
     fn installed_cask_version_does_not_invent_wrapper_from_current_api() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let cask = test_cask("firefox", "153.0.1");
@@ -12369,7 +12369,7 @@ end
     #[cfg(unix)]
     #[test]
     fn stages_and_links_binary_artifact() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let stage = tmp.path().join("stage");
@@ -12395,7 +12395,7 @@ end
     #[cfg(unix)]
     #[test]
     fn stages_same_basename_binaries_without_collision() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let stage = tmp.path().join("stage");
@@ -12434,7 +12434,7 @@ end
     #[cfg(unix)]
     #[test]
     fn binary_source_prefers_hook_generated_caskroom_file() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let stage = tmp.path().join("stage");
@@ -12461,7 +12461,7 @@ end
     #[cfg(unix)]
     #[test]
     fn stages_absolute_binary_source_from_pkg_install() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let stage = tmp.path().join("stage");
@@ -12495,7 +12495,7 @@ end
     #[cfg(unix)]
     #[test]
     fn reports_missing_target_for_dangling_staged_binary_symlink() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let stage = tmp.path().join("stage");
@@ -12528,7 +12528,7 @@ end
 
     #[test]
     fn cask_appdir_uses_prefix_for_prefix_targeted_apps() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let app = AppArtifact {
@@ -13137,7 +13137,7 @@ end
     #[cfg(unix)]
     #[test]
     fn remove_obsolete_binary_links_removes_only_caskroom_symlinks() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let cask = test_cask("binary-only", "2.0.0");
@@ -13167,7 +13167,7 @@ end
 
     #[test]
     fn installed_cask_version_does_not_invent_pkg_ids_from_current_api() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let cask = test_cask("pkg-only", "1.0.0");
@@ -13210,7 +13210,7 @@ end
 
     #[test]
     fn installed_cask_version_rejects_app_state_without_receipt() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let cask = test_cask("actual-token", "1.0.0");
@@ -13247,7 +13247,7 @@ end
 
     #[test]
     fn installed_cask_version_rejects_completion_state_without_receipt() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let cask = test_cask("completion-only", "1.0.0");
@@ -13273,7 +13273,7 @@ end
 
     #[test]
     fn installed_cask_version_uses_metadata_token() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let cask = test_cask("metadata-token", "2.0.0");
@@ -13335,7 +13335,7 @@ end
 
     #[test]
     fn installed_version_ignores_homebrew_metadata() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let token_dir = caskroom_token_dir("actual-token");
@@ -13349,7 +13349,7 @@ end
 
     #[test]
     fn installed_versions_preserve_conflict_presence_with_multiple_versions() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let token_dir = caskroom_token_dir("conflicting-cask");
@@ -13364,7 +13364,7 @@ end
     #[cfg(unix)]
     #[test]
     fn failed_activation_restores_caskroom_and_external_links() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let cask = test_cask("completion-only", "1.0.0");
@@ -13400,7 +13400,7 @@ end
 
     #[test]
     fn remove_stale_versions_keeps_current_version_and_homebrew_metadata() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let token_dir = caskroom_token_dir("actual-token");
@@ -13423,7 +13423,7 @@ end
 
     #[test]
     fn fetch_git_clone_and_stage_clones_and_restructures_only_path() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
 
         // Create a local git repo to clone from

--- a/src/system/packages/brew/maintenance.rs
+++ b/src/system/packages/brew/maintenance.rs
@@ -376,7 +376,7 @@ mod tests {
 
     #[test]
     fn linked_formulae_default_keeps_only_requested_formulae() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         write_keg(
@@ -407,7 +407,7 @@ mod tests {
 
     #[test]
     fn linked_formulae_infers_tapped_config_entries() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         write_keg(
@@ -441,7 +441,7 @@ mod tests {
 
     #[test]
     fn prune_plan_removes_unconfigured_linked_formulae() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         write_keg(
@@ -473,7 +473,7 @@ mod tests {
 
     #[test]
     fn prune_plan_uses_tap_qualified_keep_keys() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let keep = HashSet::from(["acme/tools/widget".to_string()]);
 
         {
@@ -519,7 +519,7 @@ mod tests {
 
     #[test]
     fn prune_plan_removes_formulae_only_needed_by_unconfigured_roots() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let readline = write_keg(
@@ -568,7 +568,7 @@ mod tests {
 
     #[test]
     fn unlink_and_remove_keg_removes_links_and_keg() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let keg = write_keg(
@@ -605,7 +605,7 @@ mod tests {
     /// symlink chain and must still be removed, not left dangling
     #[test]
     fn unlink_and_remove_keg_removes_dylib_alias_links() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let keg = write_keg(
@@ -644,7 +644,7 @@ mod tests {
 
     #[test]
     fn apply_prune_plan_dry_run_removes_nothing() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let keg = write_keg(


### PR DESCRIPTION
> #12041 has merged, so `crate::test::lock_ignoring_poison` is in `main` and the diff here is now
> only this PR's own change: the two files under `src/system/packages/brew/`.

## Why, measured

#12041 left the brew locks out and said they were the same shape but had never been observed
cascading. They cascade. Three variants of one commit, on a fork, running
`cargo test --all-features system::packages::brew -- --test-threads=1`
([run](https://github.com/JamBalaya56562/mise/actions/runs/31910901964)):

| variant | result | `PoisonError` |
|---|---|---|
| control — no change | `ok. 237 passed; 0 failed` | 0 |
| cascade — one test panics deliberately | `FAILED. 183 passed; **54 failed**` | **53** |
| fixed — same panic, poison tolerated | `FAILED. 236 passed; **1 failed**` | **0** |

One failure is reported as 54. The control is green, so all 54 come from the injection, and the
fixed run keeps exactly one, so this stops the cascade without hiding the real failure. It is 54
rather than 83 only because the injected test sits partway through the run — it can only poison
what comes after it.

## The change

`ENV_LOCK.lock().unwrap()` → `crate::test::lock_ignoring_poison(&ENV_LOCK)`, 83 sites:
75 in `cask.rs`, 8 in `maintenance.rs`. Nothing else — no new abstraction, no change to
`BrewPrefixGuard`, no change to what is locked or for how long.

**None of the care #12041 needed applies here.** That PR had to convert two helpers to RAII first,
because they cleaned up after the callback and the poison flag was accidentally the thing stopping
later tests from seeing leaked state. Checked per function here: 82 of the 83 sites take the lock
and immediately construct `BrewPrefixGuard`, which restores `MISE_SYSTEM_BREW_PREFIX` in `Drop`, so
the state is already back before the lock is released. The one exception,
`fetch_git_clone_and_stage_clones_and_restructures_only_path`, mutates no process-wide state at all
— it takes the lock and never needed it.

## Not included

- **`pour.rs`** — its `ENV_LOCK` is a `tokio::sync::Mutex`, which has no poisoning to tolerate. That
  is why this is 83 sites across two files rather than three.
- **Removing the unnecessary lock** in `fetch_git_clone_and_stage_clones_and_restructures_only_path`.
  Unrelated to poisoning; noted rather than acted on.
- `BrewPrefixGuard` is defined twice, once per file, and the two guard the same environment variable
  behind *different* mutexes. Harmless while unit tests run single-threaded, but it is not what the
  code looks like it is doing. Separate concern.

## Verification

I did not build locally. Same harness, run against this branch's actual content rather than a
sed-patched copy ([run](https://github.com/JamBalaya56562/mise/actions/runs/31911502275)):

```
as-is       test result: ok.     237 passed; 0 failed      PoisonError: 0
injected    test result: FAILED. 236 passed; 1 failed      PoisonError: 0
```

Same one-line injection as the measurement above. With the helper in place the failure stays at one
and no `PoisonError` appears.

No new test: the mechanism is covered by `a_poisoned_lock_is_still_taken` in #12041, and this is a
mechanical swap onto that same helper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability when shared environment locks are affected by previously failed tests.
  * Updated package and maintenance test cases to continue safely when a lock has been left in a poisoned state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
