### PR TITLE
feat(generate): support checksum algorithm selection

### DIFF
--- a/docs/cli/generate/tool-stub.md
+++ b/docs/cli/generate/tool-stub.md
@@ -45,6 +45,19 @@ Specify mise version for the bootstrap script
 By default, uses the latest version from the install script.
 Use this to pin to a specific version (e.g., "2025.1.0").
 
+### `--checksum-algorithm <CHECKSUM_ALGORITHM>`
+
+Checksum algorithm to use when downloading artifacts
+
+Accepts `blake3` or `sha256` and defaults to `blake3`. Cannot be used with `--lock` or `--skip-download` because those modes do not calculate checksums.
+
+**Choices:**
+
+- `blake3`
+- `sha256`
+
+**Default:** `blake3`
+
 ### `--fetch`
 
 Fetch checksums and sizes for an existing tool stub file

--- a/docs/dev-tools/tool-stubs.md
+++ b/docs/dev-tools/tool-stubs.md
@@ -153,8 +153,21 @@ The generator will preserve existing configuration and merge new platforms into 
 - `--platform-url PLATFORM:URL` - Add platform-specific URL (can be used multiple times)
 - `--platform-url URL` - Add platform-specific URL with auto-detected platform from URL filename
 - `--platform-bin PLATFORM:PATH` - Set platform-specific binary path
+- `--checksum-algorithm ALGORITHM` - Generate `blake3` (default) or `sha256` checksums
 - `--skip-download` - Skip downloading for faster generation (no checksums or binary detection)
 - `--lock` - Resolve and embed lockfile data (pinned version + platform URLs/checksums) into an existing stub
+
+`--checksum-algorithm` cannot be combined with `--lock` or `--skip-download`, because those modes do not calculate checksums.
+
+For consumers such as Bazel that require SHA256 checksums, select it when generating the stub:
+
+```bash
+mise generate tool-stub ./bin/tool \
+  --url "https://example.com/tool.tar.gz" \
+  --checksum-algorithm sha256
+```
+
+The selected algorithm also applies to missing checksums populated by `--fetch`. Existing checksums are preserved.
 
 ### Supported Archive Formats
 
@@ -183,7 +196,7 @@ size = 12345678
 
 The generator automatically:
 
-- Calculates BLAKE3 checksums for integrity verification
+- Calculates BLAKE3 checksums by default, or SHA256 when requested
 - Detects file sizes
 - Identifies the correct binary path within archives
 - Uses the output filename as the tool name

--- a/e2e/generate/test_generate_tool_stub_checksum_algorithm
+++ b/e2e/generate/test_generate_tool_stub_checksum_algorithm
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+export MISE_EXPERIMENTAL=1
+export MISE_GPG_VERIFY=false
+
+SERVER_PORT_FILE="$TMPDIR/tool_stub_checksum_port"
+MISE_TOOL_STUB_TEST_PORT_FILE="$SERVER_PORT_FILE" python3 "${TEST_ROOT}/helpers/scripts/tool_stub_test_server.py" 0 &
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
+wait_for_file "$SERVER_PORT_FILE" "tool stub checksum server port" 30 "$SERVER_PID"
+SERVER_PORT=$(cat "$SERVER_PORT_FILE")
+
+mkdir -p generate_tool_stub_checksum_test
+cd generate_tool_stub_checksum_test
+
+# The default remains BLAKE3.
+mise generate tool-stub checksum-default --url "http://127.0.0.1:$SERVER_PORT/tool"
+assert_contains "cat checksum-default" 'checksum = "blake3:'
+
+# SHA256 can be selected and is accepted by the tool-stub runtime.
+mise generate tool-stub checksum-sha \
+  --url "http://127.0.0.1:$SERVER_PORT/tool" \
+  --checksum-algorithm sha256
+assert_contains "cat checksum-sha" 'checksum = "sha256:6090f722764a96fd596fa91a2d079e98e19f6e5bf945b93ba4209875c01f1c61"'
+assert "./checksum-sha" "tool-stub-checksum"
+
+# Platform checksums use the selected algorithm.
+mise generate tool-stub checksum-platform \
+  --platform-url "linux-x64:http://127.0.0.1:$SERVER_PORT/tool" \
+  --checksum-algorithm sha256
+assert_contains "cat checksum-platform" 'checksum = "sha256:6090f722764a96fd596fa91a2d079e98e19f6e5bf945b93ba4209875c01f1c61"'
+
+# --fetch fills only missing checksums with the selected algorithm.
+cat >checksum-fetch <<EOF
+#!/usr/bin/env -S mise tool-stub
+
+[platforms.macos-arm64]
+url = "http://127.0.0.1:$SERVER_PORT/tool"
+checksum = "blake3:existing_checksum_should_not_change"
+
+[platforms.linux-x64]
+url = "http://127.0.0.1:$SERVER_PORT/tool"
+EOF
+mise generate tool-stub checksum-fetch --fetch --checksum-algorithm sha256
+assert_contains "cat checksum-fetch" 'checksum = "blake3:existing_checksum_should_not_change"'
+assert_contains "cat checksum-fetch" 'checksum = "sha256:6090f722764a96fd596fa91a2d079e98e19f6e5bf945b93ba4209875c01f1c61"'
+
+# Invalid and inapplicable combinations fail during argument parsing.
+assert_fail "mise generate tool-stub checksum-invalid --url 'http://127.0.0.1:$SERVER_PORT/tool' --checksum-algorithm sha512"
+assert_fail "mise generate tool-stub checksum-skip --url 'http://127.0.0.1:$SERVER_PORT/tool' --skip-download --checksum-algorithm sha256"
+assert_fail "mise generate tool-stub checksum-lock --lock --checksum-algorithm sha256"

--- a/e2e/helpers/scripts/tool_stub_test_server.py
+++ b/e2e/helpers/scripts/tool_stub_test_server.py
@@ -41,6 +41,11 @@ class ToolStubTestHandler(http.server.SimpleHTTPRequestHandler):
                 }
             })
             self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/tool':
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/octet-stream')
+            self.end_headers()
+            self.wfile.write(b'#!/bin/sh\necho tool-stub-checksum\n')
         else:
             super().do_GET()
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2325,6 +2325,14 @@ Specify mise version for the bootstrap script
 By default, uses the latest version from the install script.
 Use this to pin to a specific version (e.g., "2025.1.0").
 .TP
+\fB\-\-checksum\-algorithm\fR \fI<CHECKSUM_ALGORITHM>\fR
+Checksum algorithm to use when downloading artifacts
+
+Accepts `blake3` or `sha256` and defaults to `blake3`. Cannot be used with `\-\-lock` or `\-\-skip\-download` because those modes do not calculate checksums.
+.RS
+\fIDefault: \fRblake3
+.RE
+.TP
 \fB\-\-fetch\fR
 Fetch checksums and sizes for an existing tool stub file
 

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1750,6 +1750,16 @@ Use this to pin to a specific version (e.g., "2025.1.0").
 """#
             arg <BOOTSTRAP_VERSION>
         }
+        flag --checksum-algorithm help="Checksum algorithm to use when downloading artifacts" default=blake3 {
+            long_help #"""
+Checksum algorithm to use when downloading artifacts
+
+Accepts `blake3` or `sha256` and defaults to `blake3`. Cannot be used with `--lock` or `--skip-download` because those modes do not calculate checksums.
+"""#
+            arg <CHECKSUM_ALGORITHM> {
+                choices blake3 sha256
+            }
+        }
         flag --fetch help="Fetch checksums and sizes for an existing tool stub file" {
             long_help #"""
 Fetch checksums and sizes for an existing tool stub file

--- a/src/cli/generate/tool_stub.rs
+++ b/src/cli/generate/tool_stub.rs
@@ -18,6 +18,7 @@ use bytesize::ByteSize;
 use clap::ValueHint;
 use color_eyre::eyre::bail;
 use indexmap::IndexMap;
+use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 use toml_edit::DocumentMut;
@@ -59,6 +60,19 @@ pub struct ToolStub {
     /// Use this to pin to a specific version (e.g., "2025.1.0").
     #[clap(long, verbatim_doc_comment, requires = "bootstrap")]
     pub bootstrap_version: Option<String>,
+
+    /// Checksum algorithm to use when downloading artifacts
+    ///
+    /// Accepts `blake3` or `sha256` and defaults to `blake3`.
+    /// Cannot be used with `--lock` or `--skip-download` because those modes do not
+    /// calculate checksums.
+    #[clap(
+        long,
+        value_enum,
+        default_value = "blake3",
+        conflicts_with_all = &["lock", "skip_download"]
+    )]
+    pub checksum_algorithm: ChecksumAlgorithm,
 
     /// Fetch checksums and sizes for an existing tool stub file
     ///
@@ -109,6 +123,25 @@ pub struct ToolStub {
     /// Version of the tool
     #[clap(long, default_value = "latest")]
     pub version: String,
+}
+
+#[derive(Debug, Default, Clone, Copy, clap::ValueEnum)]
+pub enum ChecksumAlgorithm {
+    #[default]
+    Blake3,
+    Sha256,
+}
+
+impl ChecksumAlgorithm {
+    fn checksum(self, bytes: &[u8]) -> String {
+        match self {
+            Self::Blake3 => format!("blake3:{}", blake3::hash(bytes).to_hex()),
+            Self::Sha256 => {
+                let hash = Sha256::digest(bytes);
+                format!("sha256:{}", hex::encode(hash))
+            }
+        }
+    }
 }
 
 impl ToolStub {
@@ -468,7 +501,7 @@ exec "$MISE_BIN" tool-stub "$0" "$@"
         // Read the file to calculate checksum and size
         let bytes = file::read(&archive_path)?;
         let size = bytes.len() as u64;
-        let checksum = format!("blake3:{}", blake3::hash(&bytes).to_hex());
+        let checksum = self.checksum_algorithm.checksum(&bytes);
 
         // Detect binary path if this is an archive
         let bin_path = if ExtractionFormat::from_file_name(&filename).is_archive() {
@@ -905,3 +938,24 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     # Resolves the latest node 22.x, pins it, and updates platform URLs/checksums
 "#
 );
+
+#[cfg(test)]
+mod tests {
+    use super::ChecksumAlgorithm;
+
+    #[test]
+    fn checksum_algorithm_formats_blake3() {
+        assert_eq!(
+            ChecksumAlgorithm::Blake3.checksum(b""),
+            "blake3:af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+        );
+    }
+
+    #[test]
+    fn checksum_algorithm_formats_sha256() {
+        assert_eq!(
+            ChecksumAlgorithm::Sha256.checksum(b""),
+            "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add `--checksum-algorithm <blake3|sha256>` to `mise generate tool-stub`
- preserve BLAKE3 as the default while allowing Bazel-compatible SHA256 output
- apply the selected algorithm to normal generation and missing checksums populated by `--fetch`

## Details

The tool-stub runtime already verifies algorithm-prefixed checksums including SHA256, but the generator hard-coded BLAKE3. This change exposes the existing capability at the CLI boundary without changing runtime verification, cache identity, or backend-provided checksums used by `--lock`. Existing checksums remain untouched during `--fetch`.

`--checksum-algorithm` intentionally conflicts with `--lock` and `--skip-download`, where the generator does not calculate a checksum.

## Verification

- `mise exec -- cargo test --all-features cli::generate::tool_stub::tests`
- `mise run test:e2e e2e/generate/test_generate_tool_stub_checksum_algorithm`
- `mise exec -- cargo check --all-features`
- `mise run docs:build`
- Cargo fmt, shfmt, shellcheck, Prettier, and markdownlint on the changed files

Full Clippy currently stops on the unchanged latest-main code at `src/system/packages/brew/cask.rs:1959` (`clippy::needless_return`); the new tool-stub code has no remaining Clippy findings. The native Sapling checkout also cannot run the repository-wide hk wrapper because hk requires Git repository metadata.

Addresses https://github.com/jdx/mise/discussions/9638

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added checksum algorithm selection to `mise generate tool-stub`.
  - Supports BLAKE3 (default) and SHA-256 checksums.
  - Preserves existing checksums when fetching missing values.
  - Validates unsupported and incompatible option combinations.

- **Documentation**
  - Updated command help, manual pages, and tool-stub documentation with the new option and usage details.

- **Tests**
  - Added end-to-end coverage for both algorithms, platform URLs, checksum preservation, and validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->