### PR TITLE
fix(cli): report a missing shell instead of panicking

### DIFF
--- a/e2e-win/shell_detection.Tests.ps1
+++ b/e2e-win/shell_detection.Tests.ps1
@@ -1,0 +1,59 @@
+Describe 'shell detection' {
+    BeforeAll {
+        $script:originalPath = Get-Location
+        # The workflow sets these for the whole job and Pester runs every suite in one process, so
+        # put back what was there rather than dropping it.
+        $script:originalEnv = @{}
+        foreach ($name in 'MISE_TRUSTED_CONFIG_PATHS', 'MISE_SHELL') {
+            $script:originalEnv[$name] = [Environment]::GetEnvironmentVariable($name, 'Process')
+        }
+
+        $script:testDir = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:testDir | Out-Null
+        Set-Location $script:testDir
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:testDir
+
+        # The whole point is what happens with nothing to detect from. `MISE_SHELL` is what an
+        # activated session sets, so an inherited one would make every case below pass vacuously.
+        Remove-Item -Path Env:\MISE_SHELL -ErrorAction SilentlyContinue
+    }
+
+    AfterAll {
+        Set-Location $script:originalPath
+        foreach ($name in $script:originalEnv.Keys) {
+            if ($null -eq $script:originalEnv[$name]) {
+                Remove-Item -Path "Env:\$name" -ErrorAction SilentlyContinue
+            } else {
+                [Environment]::SetEnvironmentVariable($name, $script:originalEnv[$name], 'Process')
+            }
+        }
+    }
+
+    # Deliberately not a key named `Args` splatted as `@Args`. That is what this was, and mise
+    # received the wrong argv under Pester: once Pester's own state object as an extra argument,
+    # once nothing at all. `Args` is PowerShell's automatic variable for a block's unbound
+    # arguments, so what `@Args` expands to inside a test is not simply what `-ForEach` set. Both
+    # commands take a bare subcommand, so pass it as one argument and do not splat.
+    It 'reports a missing shell for <Command> instead of panicking' -ForEach @(
+        @{ Command = 'activate' }
+        @{ Command = 'hook-env' }
+    ) {
+        # `COMSPEC` is all mise reads on Windows and it names cmd.exe, which is not a shell mise
+        # generates for, so this is the ordinary path here rather than an edge case. It used to
+        # abort: "The application panicked (crashed)."
+        $out = & mise $Command 2>&1 | Out-String
+        $LASTEXITCODE | Should -Not -Be 0
+        $out | Should -Not -Match 'panicked'
+        $out | Should -Match 'could not tell which shell'
+        # The instruction has to name something the reader can actually run on this platform.
+        $out | Should -Match 'pwsh'
+    }
+
+    It 'still generates a script when the shell is named' {
+        # The control. Without it "exited non-zero" above would not distinguish the fix from mise
+        # being broken for every invocation.
+        $out = & mise activate pwsh 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match 'MISE_SHELL'
+    }
+}

--- a/e2e/cli/test_hook_env
+++ b/e2e/cli/test_hook_env
@@ -26,3 +26,26 @@ assert_contains "mise current hyphen-tool" "1.0.0"
 
 mise shell --unset hyphen-tool
 assert "echo ${MISE_HYPHEN_TOOL_VERSION+set}" ""
+
+# With nothing to detect from, mise has to say so rather than abort. `SHELL=""` is the only way
+# to reach that on unix -- unset it and mise falls back to "sh" -- but it is the *default* path on
+# Windows, where the value read is COMSPEC. Unsetting MISE_SHELL too: an activated session sets it,
+# and it would satisfy detection on its own.
+assert_fail "env -u MISE_SHELL SHELL= mise hook-env" "could not tell which shell"
+# The control: the same invocation with a shell named still works, so the assertion above is about
+# detection and not about hook-env being broken.
+assert_succeed "env -u MISE_SHELL SHELL= mise hook-env --shell bash"
+
+# `mise shell` and `mise deactivate` take no shell argument, so detection is all they have. Both
+# check `__MISE_DIFF` first and report "not activated" without it, so reaching the detection error
+# needs a session that looks activated with nothing to detect from. The value does not have to be a
+# real diff -- mise warns that it could not deserialize it and carries on -- which is exactly how
+# these two used to abort rather than report anything.
+assert_fail "env -u MISE_SHELL __MISE_DIFF=x SHELL= mise deactivate" "could not tell which shell"
+assert_fail "env -u MISE_SHELL __MISE_DIFF=x SHELL= mise shell tiny@1" "could not tell which shell"
+# The control for the guard itself: without `__MISE_DIFF` neither reaches detection at all, so the
+# two assertions above would pass for the wrong reason if the guard stopped working. It has to be
+# unset explicitly -- this script activates mise at the top, so the shell running these assertions
+# has one. Asserted on the exit status rather than the message, which goes to stderr and is not
+# what `assert_contains` reads.
+assert_succeed "env -u MISE_SHELL -u __MISE_DIFF SHELL= mise deactivate"

--- a/src/cli/activate.rs
+++ b/src/cli/activate.rs
@@ -4,7 +4,9 @@ use crate::config::Settings;
 use crate::env::PATH_KEY;
 use crate::file::{canonicalize_cached, canonicalize_or_self, touch_dir};
 use crate::path_env::PathEnv;
-use crate::shell::{ActivateOptions, ActivatePrelude, Shell, ShellType, get_shell};
+use crate::shell::{
+    ActivateOptions, ActivatePrelude, EXAMPLE_SHELL, Shell, ShellType, require_shell,
+};
 use crate::toolset::env_cache::CachedEnv;
 use crate::{dirs, env};
 use eyre::Result;
@@ -67,8 +69,10 @@ pub struct Activate {
 
 impl Activate {
     pub fn run(self) -> Result<()> {
-        let shell = get_shell(self.shell_type.or(self.shell))
-            .expect("no shell provided. Run `mise activate zsh` or similar");
+        let shell = require_shell(
+            self.shell_type.or(self.shell),
+            &format!("Name the shell: `mise activate {EXAMPLE_SHELL}`."),
+        )?;
 
         // touch ROOT to allow hook-env to run
         let _ = touch_dir(&dirs::DATA);

--- a/src/cli/deactivate.rs
+++ b/src/cli/deactivate.rs
@@ -1,7 +1,7 @@
 use eyre::Result;
 
 use crate::env;
-use crate::shell::{build_deactivation_script, get_shell};
+use crate::shell::{EXAMPLE_SHELL, build_deactivation_script, require_shell};
 
 /// Disable mise for current shell session
 ///
@@ -20,7 +20,10 @@ impl Deactivate {
             return Ok(());
         }
 
-        let shell = get_shell(None).expect("no shell detected");
+        let shell = require_shell(
+            None,
+            &format!("Re-run `mise activate {EXAMPLE_SHELL}` in your shell rc file."),
+        )?;
 
         let mut output = build_deactivation_script(&*shell);
         output.push_str(&shell.unset_env("__MISE_ORIG_PATH"));

--- a/src/cli/hook_env.rs
+++ b/src/cli/hook_env.rs
@@ -5,7 +5,7 @@ use crate::env::{join_paths, split_paths};
 use crate::env_diff::{EnvDiff, EnvDiffOperation, EnvMap};
 use crate::file::{canonicalize_cached, display_path, display_rel_path};
 use crate::hook_env::{PREV_SESSION, WatchFilePattern};
-use crate::shell::{ShellType, get_shell};
+use crate::shell::{EXAMPLE_SHELL, ShellType, require_shell};
 use crate::toolset::{ResolveOptions, Toolset, ToolsetBuilder};
 use crate::ui::style;
 use crate::{env, hook_env, hooks, watch_files};
@@ -52,7 +52,10 @@ pub struct HookEnv {
 
 impl HookEnv {
     pub async fn run(self) -> Result<()> {
-        let shell = get_shell(self.shell).expect("no shell provided, use `--shell=zsh`");
+        let shell = require_shell(
+            self.shell,
+            &format!("Name the shell: `mise hook-env --shell {EXAMPLE_SHELL}`."),
+        )?;
         let config = match Config::get().await {
             Ok(config) => config,
             Err(err) => {

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -5,7 +5,7 @@ use indoc::formatdoc;
 use crate::cli::args::ToolArg;
 use crate::config::Config;
 use crate::env;
-use crate::shell::get_shell;
+use crate::shell::{EXAMPLE_SHELL, require_shell};
 use crate::toolset::{InstallOptions, ToolSource, ToolsetBuilder, tool_env_var_name};
 
 /// Sets a tool version for the current session.
@@ -44,7 +44,10 @@ impl Shell {
             err_inactive()?;
         }
 
-        let shell = get_shell(None).expect("no shell detected");
+        let shell = require_shell(
+            None,
+            &format!("Re-run `mise activate {EXAMPLE_SHELL}` in your shell rc file."),
+        )?;
 
         if self.unset {
             for ta in &self.tool {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -1,5 +1,7 @@
 use crate::env;
 use crate::hook_env;
+use clap::ValueEnum;
+use indoc::formatdoc;
 use itertools::Itertools;
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
@@ -163,6 +165,49 @@ pub fn get_shell(shell: Option<ShellType>) -> Option<Box<dyn Shell>> {
     shell.or(*env::MISE_SHELL).map(|st| st.as_shell())
 }
 
+/// A shell to name in an example, chosen so the suggestion is one the reader could actually run.
+///
+/// The old messages said `zsh` on every platform, which on Windows points at something the reader
+/// almost certainly does not have.
+#[cfg(windows)]
+pub const EXAMPLE_SHELL: &str = "pwsh";
+#[cfg(not(windows))]
+pub const EXAMPLE_SHELL: &str = "zsh";
+
+/// The shell mise should generate for, or an error saying how to name one.
+///
+/// Detection is `MISE_SHELL`, falling back to [`env::SHELL`] — which on Windows reads `COMSPEC`,
+/// i.e. `cmd.exe`, a shell mise has no implementation for. So on Windows this resolves only when
+/// the session is already activated or the caller names the shell, which makes the error the
+/// ordinary answer there rather than an edge case. It used to be `.expect()`, so the ordinary
+/// answer was a panic.
+///
+/// `how` is the caller's own instruction, because the commands differ: `mise activate` takes the
+/// shell as an argument, `mise hook-env` takes `--shell`, and `mise shell` takes neither.
+pub fn require_shell(shell: Option<ShellType>, how: &str) -> eyre::Result<Box<dyn Shell>> {
+    get_shell(shell).ok_or_else(|| eyre::eyre!(no_shell_error(how)))
+}
+
+/// Split out from [`require_shell`] so it can be tested: the detection it fails on reads
+/// `MISE_SHELL`, which is a process-wide `Lazy`, so the failing path itself cannot be constructed
+/// from a test.
+fn no_shell_error(how: &str) -> String {
+    // Windows is the only platform where this is reachable without the user having done something
+    // unusual, so it is the only one that needs to explain itself.
+    let why = match cfg!(windows) {
+        true => {
+            "mise cannot detect the shell on Windows: the value it would read, COMSPEC, names cmd.exe.\n"
+        }
+        false => "",
+    };
+    let supported = ShellType::value_variants().iter().join(", ");
+    formatdoc! {r#"
+        mise could not tell which shell to generate for.
+        {why}{how}
+        Supported shells: {supported}"#
+    }
+}
+
 /// Deliberately not `#[cfg(unix)]`: this is string handling, and Windows is the platform whose
 /// paths were not being parsed.
 #[cfg(test)]
@@ -275,5 +320,29 @@ mod tests {
             listed,
             ["bash", "elvish", "fish", "nu", "xonsh", "zsh", "pwsh"]
         );
+    }
+
+    /// The message replaced a `.expect()`, so it is the only thing the user gets. It has to carry
+    /// the caller's instruction and every shell that would have been accepted — the list is built
+    /// from `value_variants()` so that adding a shell cannot leave it stale.
+    #[test]
+    fn the_no_shell_message_says_what_to_do_and_what_is_accepted() {
+        let msg = no_shell_error("Name the shell: `mise activate zsh`.");
+
+        assert!(
+            msg.contains("Name the shell: `mise activate zsh`."),
+            "{msg}"
+        );
+        for shell in ShellType::value_variants() {
+            assert!(msg.contains(&shell.to_string()), "{shell} missing:\n{msg}");
+        }
+    }
+
+    /// On Windows the message is the ordinary answer rather than an edge case, so it also has to
+    /// say why detection cannot work there. Elsewhere that line would be noise.
+    #[test]
+    fn only_windows_explains_why_detection_failed() {
+        let msg = no_shell_error("Name the shell.");
+        assert_eq!(msg.contains("COMSPEC"), cfg!(windows), "{msg}");
     }
 }


### PR DESCRIPTION
## The panic

`mise activate` with no shell argument, and `mise hook-env` with no `--shell`, abort on Windows.
Measured on **2026.8.2 windows-x64**, isolated `MISE_*` dirs:

```console
> mise activate
The application panicked (crashed).
Message:  no shell provided. Run `mise activate zsh` or similar

> mise hook-env
The application panicked (crashed).
Message:  no shell provided, use `--shell=zsh`
Location: src\cli\hook_env.rs:55
```

**This is the ordinary path there, not an edge case.** `MISE_SHELL` falls back to `env::SHELL`,
which on Windows reads `COMSPEC` — always `cmd.exe`, which is not a shell mise generates for — so
`get_shell(None)` is `None` whenever the session is not already activated. **Git Bash panics too**,
`SHELL=/bin/bash.exe` notwithstanding, because that variable is never consulted on Windows.

Unix control, same release in a container:

| `SHELL` | `mise activate` | `mise hook-env` | `mise doctor` shell |
|---|---|---|---|
| `/bin/bash` | exit 0 | exit 0 | `/bin/bash` |
| unset | exit 0 | exit 0 | `bash` (falls back to `sh`) |
| `""` | **exit 134** | **exit 134** | `(unknown)` |

So the abort exists on unix too, but only for a value nobody sets. On Windows it is the default.

## The change

`require_shell` returns an error instead. It names what to pass and which shells are accepted,
with the list built from `ShellType::value_variants()` so it cannot go stale when a shell is added:

```
mise could not tell which shell to generate for.
mise cannot detect the shell on Windows: the value it would read, COMSPEC, names cmd.exe.
Name the shell: `mise activate pwsh`.
Supported shells: bash, elvish, fish, nu, xonsh, zsh, pwsh
```

The example is `pwsh` on Windows and `zsh` elsewhere — the old text said `zsh` on every platform,
which points a Windows reader at something they almost certainly do not have. The "why" line is
Windows-only, because that is the one platform where the message is the ordinary answer rather
than a rare one; elsewhere it would be noise.

`get_shell` still returns `Option` — `mise env` uses that to fall back to bash, which is a real
fallback rather than a failure — so only the callers that turned `None` into a panic changed.

**All four, not the two that panic in practice.** `mise shell` and `mise deactivate` report
cleanly today, but only because `env::is_activated()` runs first; behind that guard they held the
same `.expect()`, reachable when `__MISE_DIFF` is set and `MISE_SHELL` is not. There is now no
`.expect()` on shell detection anywhere.

## Not included

Making Windows honour `SHELL` — Git Bash, MSYS2 and Cygwin all set it, and `ShellType` already
parses a Windows shell path (there is a test for `C:\msys64\usr\bin\bash.exe`). That is a change in
what mise *detects* rather than how it fails, so it belongs on its own. Worth flagging for whoever
picks it up: **do not do it by changing `env::SHELL`** — `src/cli/exec.rs` and `src/cli/en.rs` pair
that value with `SHELL_COMMAND_FLAG`, which is `/c` on Windows, so honouring `SHELL` there would
run `bash.exe /c …`. Only the `MISE_SHELL` detection should consult it.

## Tests

- `e2e-win/shell_detection.Tests.ps1` — on the platform where it happens: both commands exit
  non-zero, print the instruction, and **do not print `panicked`**. The control is `mise activate
  pwsh` still exiting 0 with a script, without which "exited non-zero" would not distinguish the
  fix from mise being broken outright. `MISE_SHELL` is cleared in `BeforeAll`, since an inherited
  one from an activated session would make every case pass vacuously.
- `e2e/cli/test_hook_env` — the unix side, using the `SHELL=""` case from the table above, plus the
  same control with `--shell bash`.
- Unit tests on the message: it carries the caller's instruction and every `value_variants()` entry,
  and the `COMSPEC` explanation appears on Windows only.

I did not build locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell detection for activation, deactivation, shell, and environment-hook commands.
  * Missing shell information now produces clear, actionable errors instead of unexpected crashes.
  * Errors include platform-specific guidance, supported shells, and example shell selections.
  * Windows users can explicitly select `pwsh` when automatic detection is unavailable.

* **Tests**
  * Added coverage for shell detection and missing-shell scenarios across supported command workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->