### PR TITLE
docs: fix ref link to `env._.path`

### DIFF
--- a/docs/shell-aliases.md
+++ b/docs/shell-aliases.md
@@ -104,7 +104,7 @@ docs = "cd {{config_root}}/docs"
 
 ## Limitations
 
-- **Not available in tasks**: Shell aliases are only active in interactive shells where `mise activate` is running. They are **not** available inside TOML task `run` blocks or file tasks, since tasks run in non-interactive subshells. Use the underlying command directly in tasks, or add wrapper scripts to your `PATH` via [`env._.path`](/environments/#path).
+- **Not available in tasks**: Shell aliases are only active in interactive shells where `mise activate` is running. They are **not** available inside TOML task `run` blocks or file tasks, since tasks run in non-interactive subshells. Use the underlying command directly in tasks, or add wrapper scripts to your `PATH` via [`env._.path`](/environments/#env-path).
 - **Shell support**: Only bash, zsh, fish, and xonsh are supported. See the [shell feature compatibility matrix](/getting-started.html#shell-feature-compatibility) for details.
 
 ## Comparison to Tool Aliases


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the shell alias task limitation link to point to the appropriate environment path documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->