### PR TITLE
fix(shell): detect the shell from SHELL on Windows

### DIFF
--- a/e2e-win/shell_detection.Tests.ps1
+++ b/e2e-win/shell_detection.Tests.ps1
@@ -4,7 +4,7 @@ Describe 'shell detection' {
         # The workflow sets these for the whole job and Pester runs every suite in one process, so
         # put back what was there rather than dropping it.
         $script:originalEnv = @{}
-        foreach ($name in 'MISE_TRUSTED_CONFIG_PATHS', 'MISE_SHELL') {
+        foreach ($name in 'MISE_TRUSTED_CONFIG_PATHS', 'MISE_SHELL', 'SHELL') {
             $script:originalEnv[$name] = [Environment]::GetEnvironmentVariable($name, 'Process')
         }
 
@@ -14,8 +14,10 @@ Describe 'shell detection' {
         $env:MISE_TRUSTED_CONFIG_PATHS = $script:testDir
 
         # The whole point is what happens with nothing to detect from. `MISE_SHELL` is what an
-        # activated session sets, so an inherited one would make every case below pass vacuously.
+        # activated session sets and `SHELL` is what Git Bash sets, so either one inherited from
+        # the runner would make the cases below pass vacuously.
         Remove-Item -Path Env:\MISE_SHELL -ErrorAction SilentlyContinue
+        Remove-Item -Path Env:\SHELL -ErrorAction SilentlyContinue
     }
 
     AfterAll {
@@ -55,5 +57,35 @@ Describe 'shell detection' {
         $out = & mise activate pwsh 2>&1 | Out-String
         $LASTEXITCODE | Should -Be 0
         $out | Should -Match 'MISE_SHELL'
+    }
+
+    It 'detects the shell from SHELL, the way Git Bash sets it' {
+        # Git Bash, MSYS2 and Cygwin all export SHELL on Windows. mise read COMSPEC and never
+        # looked, so `mise activate` with no argument failed here even though the session had
+        # named its shell. Only the file name is parsed, so the path need not exist.
+        $env:SHELL = 'C:\Program Files\Git\bin\bash.exe'
+        try {
+            $out = & mise activate 2>&1 | Out-String
+            $LASTEXITCODE | Should -Be 0
+            # bash syntax specifically, not just "it printed something".
+            $out | Should -Match 'export MISE_SHELL=bash'
+        } finally {
+            Remove-Item -Path Env:\SHELL -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'prefers MISE_SHELL over SHELL' {
+        # An activated session names its own shell, and that has to win: re-detecting from SHELL
+        # would emit a script for a different shell than the one already activated.
+        $env:SHELL = 'C:\Program Files\Git\bin\bash.exe'
+        $env:MISE_SHELL = 'pwsh'
+        try {
+            $out = & mise activate 2>&1 | Out-String
+            $LASTEXITCODE | Should -Be 0
+            $out | Should -Match "MISE_SHELL = 'pwsh'"
+        } finally {
+            Remove-Item -Path Env:\SHELL -ErrorAction SilentlyContinue
+            Remove-Item -Path Env:\MISE_SHELL -ErrorAction SilentlyContinue
+        }
     }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -30,12 +30,38 @@ pub const NON_TOOL_VERSION_ENV_VARS: &[&str] =
 pub static SHELL: Lazy<String> = Lazy::new(|| var("SHELL").unwrap_or_else(|_| "sh".into()));
 #[cfg(windows)]
 pub static SHELL: Lazy<String> = Lazy::new(|| var("COMSPEC").unwrap_or_else(|_| "cmd.exe".into()));
-pub static MISE_SHELL: Lazy<Option<ShellType>> = Lazy::new(|| {
-    var("MISE_SHELL")
-        .unwrap_or_else(|_| SHELL.clone())
-        .parse()
-        .ok()
-});
+pub static MISE_SHELL: Lazy<Option<ShellType>> =
+    Lazy::new(|| detect_shell(var("MISE_SHELL").ok(), var("SHELL").ok(), &SHELL));
+
+/// Which shell mise should speak, from the environment.
+///
+/// `SHELL` is consulted here but deliberately *not* through [`SHELL`], which on Windows reads
+/// `COMSPEC`. Git Bash, MSYS2 and Cygwin all set `SHELL` to a real shell there, and
+/// [`ShellType::from_str`] already understands the form they use, but nothing ever looked. Reading
+/// it through [`SHELL`] instead would be wrong: [`SHELL_COMMAND_FLAG`] is `/c` on Windows and
+/// `mise exec -c` and `mise en` pair the two, so `bash.exe /c …` is what that would run.
+///
+/// Split out from the `Lazy` because that is process-wide and reads the real environment, so the
+/// precedence below cannot be exercised from a test any other way.
+fn detect_shell(
+    mise_shell: Option<String>,
+    shell_var: Option<String>,
+    fallback: &str,
+) -> Option<ShellType> {
+    // What `mise activate` exports, so it decides on its own. Set but unparseable is an answer,
+    // not a reason to start guessing.
+    if let Some(s) = mise_shell {
+        return s.parse().ok();
+    }
+    // On unix `SHELL` *is* the fallback, so consulting it separately would be the same lookup
+    // twice. On Windows it is the one the fallback cannot reach.
+    if cfg!(windows)
+        && let Some(st) = shell_var.and_then(|s| s.parse().ok())
+    {
+        return Some(st);
+    }
+    fallback.parse().ok()
+}
 #[cfg(unix)]
 pub static SHELL_COMMAND_FLAG: &str = "-c";
 #[cfg(windows)]
@@ -1370,5 +1396,63 @@ mod tests {
         assert!(!is_mise_binary("MISE"));
         assert!(!is_mise_binary("Mise"));
         assert!(!is_mise_binary("MISE-DOCTOR"));
+    }
+
+    fn detect(mise_shell: Option<&str>, shell_var: Option<&str>, fallback: &str) -> String {
+        detect_shell(
+            mise_shell.map(str::to_string),
+            shell_var.map(str::to_string),
+            fallback,
+        )
+        .map(|st| st.to_string())
+        .unwrap_or_else(|| "(none)".to_string())
+    }
+
+    /// `mise activate` exports `MISE_SHELL`, so it decides on its own — including deciding that
+    /// the answer is nothing. Falling back after an unparseable value would start guessing at a
+    /// shell the session has already named.
+    #[test]
+    fn mise_shell_wins_and_an_unparseable_one_is_still_the_answer() {
+        assert_eq!(detect(Some("zsh"), Some("/bin/bash"), "/bin/bash"), "zsh");
+        assert_eq!(
+            detect(Some("nonsense"), Some("/bin/bash"), "/bin/bash"),
+            "(none)"
+        );
+    }
+
+    /// The fix: Git Bash, MSYS2 and Cygwin set `SHELL` on Windows, where the fallback reads
+    /// `COMSPEC` and so can never see it.
+    #[cfg(windows)]
+    #[test]
+    fn shell_is_consulted_on_windows() {
+        for shell_var in [
+            r"C:\Program Files\Git\bin\bash.exe",
+            "/bin/bash.exe",
+            r"C:\msys64\usr\bin\zsh.exe",
+        ] {
+            let expected = match shell_var.contains("zsh") {
+                true => "zsh",
+                false => "bash",
+            };
+            assert_eq!(
+                detect(None, Some(shell_var), r"C:\WINDOWS\system32\cmd.exe"),
+                expected,
+                "{shell_var}"
+            );
+        }
+        // Unchanged where there is nothing to find: cmd.exe is not a shell mise generates for.
+        assert_eq!(detect(None, None, r"C:\WINDOWS\system32\cmd.exe"), "(none)");
+    }
+
+    /// The control. On unix `SHELL` *is* the fallback, so the extra lookup must not exist —
+    /// otherwise this test would pass for the wrong reason on every platform.
+    #[cfg(unix)]
+    #[test]
+    fn the_fallback_is_the_only_second_source_on_unix() {
+        // A `SHELL` that disagrees with the fallback is ignored: unix passes the same value as
+        // both, so anything else would mean the Windows branch had leaked.
+        assert_eq!(detect(None, Some("/bin/zsh"), "/bin/bash"), "bash");
+        assert_eq!(detect(None, None, "/bin/zsh"), "zsh");
+        assert_eq!(detect(None, None, "sh"), "bash");
     }
 }

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -176,11 +176,10 @@ pub const EXAMPLE_SHELL: &str = "zsh";
 
 /// The shell mise should generate for, or an error saying how to name one.
 ///
-/// Detection is `MISE_SHELL`, falling back to [`env::SHELL`] — which on Windows reads `COMSPEC`,
-/// i.e. `cmd.exe`, a shell mise has no implementation for. So on Windows this resolves only when
-/// the session is already activated or the caller names the shell, which makes the error the
-/// ordinary answer there rather than an edge case. It used to be `.expect()`, so the ordinary
-/// answer was a panic.
+/// Detection is `MISE_SHELL`, then `SHELL`. PowerShell and cmd set neither, so on Windows this
+/// resolves only when the session is already activated, the caller names the shell, or the user is
+/// in a shell that sets `SHELL` (Git Bash, MSYS2, Cygwin) — which makes the error an ordinary
+/// answer there rather than an edge case. It used to be `.expect()`, so that answer was a panic.
 ///
 /// `how` is the caller's own instruction, because the commands differ: `mise activate` takes the
 /// shell as an argument, `mise hook-env` takes `--shell`, and `mise shell` takes neither.
@@ -193,10 +192,12 @@ pub fn require_shell(shell: Option<ShellType>, how: &str) -> eyre::Result<Box<dy
 /// from a test.
 fn no_shell_error(how: &str) -> String {
     // Windows is the only platform where this is reachable without the user having done something
-    // unusual, so it is the only one that needs to explain itself.
+    // unusual, so it is the only one that needs to explain itself. Naming the two variables is the
+    // useful part: a Git Bash user can see that mise would have taken `SHELL` and go look at why
+    // theirs is not set, rather than reading this as "Windows is unsupported".
     let why = match cfg!(windows) {
         true => {
-            "mise cannot detect the shell on Windows: the value it would read, COMSPEC, names cmd.exe.\n"
+            "mise reads MISE_SHELL, then SHELL; neither names a shell it supports. PowerShell and cmd set neither.\n"
         }
         false => "",
     };
@@ -339,10 +340,13 @@ mod tests {
     }
 
     /// On Windows the message is the ordinary answer rather than an edge case, so it also has to
-    /// say why detection cannot work there. Elsewhere that line would be noise.
+    /// say which variables were consulted. Elsewhere that line would be noise.
     #[test]
     fn only_windows_explains_why_detection_failed() {
         let msg = no_shell_error("Name the shell.");
-        assert_eq!(msg.contains("COMSPEC"), cfg!(windows), "{msg}");
+        // Both names, because naming only `MISE_SHELL` would read as "activate first" to someone
+        // in Git Bash, where setting `SHELL` is the actual answer.
+        assert_eq!(msg.contains("MISE_SHELL"), cfg!(windows), "{msg}");
+        assert_eq!(msg.contains("SHELL;"), cfg!(windows), "{msg}");
     }
 }


### PR DESCRIPTION
> #12048 has merged and this branch is rebased onto `main`, so the diff is now only what is
> described below. It still rewords a message #12048 introduced — see the last section.

## `SHELL` was never read on Windows

Git Bash, MSYS2 and Cygwin all export `SHELL` there, and `ShellType::from_str` already understands
the form they use — there is a test pinning `C:\msys64\usr\bin\bash.exe`. Nothing looked at it.
`MISE_SHELL` fell back to `env::SHELL`, which on Windows reads `COMSPEC`: always `cmd.exe`, never a
shell mise generates for.

Measured on **2026.8.2 windows-x64**, in Git Bash:

```console
$ echo $SHELL
/bin/bash.exe

$ mise doctor | grep -A1 '^shell:'
shell:
  (unknown)
```

`mise activate` and `mise hook-env` also aborted there — that is #12048, and it is why this is
stacked on it. #12048 makes the failure a clean error; this makes it not fail.

## The change

Detection reads `MISE_SHELL`, then `SHELL`, then the existing fallback.

`MISE_SHELL` still decides on its own, **including deciding the answer is nothing**. An activated
session has already named its shell, so falling through to `SHELL` after an unparseable value would
start guessing at a different one. That behaviour is unchanged and now has a test.

**Deliberately not done by changing `env::SHELL`.** That value is paired with `SHELL_COMMAND_FLAG`
— `/c` on Windows — by `mise exec -c` and `mise en`, so returning `SHELL` from it would run
`bash.exe /c …`. `mise doctor` reads it too. Only the detection reads the variable.

The detection is split into a plain function taking its three inputs, because the `Lazy` is
process-wide and reads the real environment, so precedence cannot be exercised any other way.

## What else changes with it

Three things read `MISE_SHELL`, and all three move toward what unix already does:

| reader | before (Windows) | after |
|---|---|---|
| `get_shell` | `None` | the shell — `activate` / `hook-env` / `shell` / `deactivate` work with no argument in Git Bash |
| `http.rs` user agent | `mise/{v}` | `mise/{v} bash` — an outbound header changes; unix has always sent this |
| `mise doctor` | `shell: (unknown)` | `shell: bash` plus `bash --version` |

One detail on `doctor`: it prefers `env::SHELL` when that value ends with the detected name, which
no longer holds on Windows because the two now come from different variables. It falls through to
running the bare name, which is correct and resolves through PATH. Left alone.

`env::is_activated()` reads `__MISE_DIFF`, so activation detection is untouched. `mise env` output
is unchanged — it already emitted bash syntax on Windows, previously via its hardcoded fallback and
now via detection.

**Plain PowerShell and cmd set neither variable, so nothing changes for them.** They still get
#12048's error. Picking a sensible default for that case is a separate question and not in here.

## The message this makes untrue

#12048 says, on Windows only:

> mise cannot detect the shell on Windows: the value it would read, COMSPEC, names cmd.exe.

That stops being true for a Git Bash user. It now names both variables instead, so someone whose
`SHELL` is unset can see what mise would have taken rather than reading it as "Windows is
unsupported". The test that pinned the old wording is updated with it.

## Tests

- `src/env.rs` — precedence: `MISE_SHELL` wins over `SHELL`; an unparseable `MISE_SHELL` stays the
  answer; `SHELL` resolves on Windows for Git Bash, MSYS2 and Cygwin spellings; nothing set still
  yields nothing. **The control is the unix pair**: there `SHELL` *is* the fallback, so a `SHELL`
  that disagrees with it must be ignored — otherwise the Windows branch has leaked and the tests
  would pass everywhere for the wrong reason.
- `e2e-win/shell_detection.Tests.ps1` (added by #12048) — `mise activate` with no argument, with
  `SHELL` set the way Git Bash sets it, exits 0 and emits **bash** syntax specifically. Plus a case
  pinning that `MISE_SHELL` wins. `BeforeAll` clears both variables, since either inherited from
  the runner would make every case pass vacuously.

I did not build locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shell-dependent commands now show clear error messages and activation guidance when no shell is detected.
  * Improved shell detection across Windows and Unix environments.
  * Explicit shell settings take precedence, including `MISE_SHELL`.
  * Windows detection now recognizes `SHELL`, while platform defaults remain available.
* **Tests**
  * Added coverage for shell detection, precedence rules, invalid configuration, and command behavior across supported environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
