### PR TITLE
fix(age): resolve key paths from config files

### DIFF
--- a/docs/environments/secrets/age.md
+++ b/docs/environments/secrets/age.md
@@ -75,6 +75,12 @@ mise looks for identities in this order:
 4. Default `~/.config/mise/age.txt` if it exists
 5. SSH identities from `settings.age.ssh_identity_files` and common defaults (`~/.ssh/id_ed25519`, `~/.ssh/id_rsa`)
 
+Paths configured in `settings.age.key_file`, `settings.age.identity_files`, and
+`settings.age.ssh_identity_files` are resolved relative to the config root of
+the file that declares them. They also support Tera templates, including
+<span v-pre>`{{ config_root }}`</span> and values from `env`. Absolute paths and paths beginning
+with `~` keep their existing meaning.
+
 Decrypted values are always marked as redacted.
 
 Age decryption is strict by default. If no identities are found, no available identity can decrypt the value, or the age payload is invalid, mise fails instead of continuing with a partially resolved environment.

--- a/e2e/cli/test_age_settings_paths
+++ b/e2e/cli/test_age_settings_paths
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+mkdir -p project/keys project/subdir
+cat >project/keys/age.txt <<'EOF'
+# public key: age1fuvsfq02qr5ju0nhh3rulrwracymjljlr5j49kres24ltd3fjq0s9z9d8l
+AGE-SECRET-KEY-142E7VJ8GUWR94MXDCYQJ7ZTQZRXKQSP9PUJU8HUQJ206QN7QPV4SM5QRL8
+EOF
+cat >project/mise.toml <<'EOF'
+[settings.age]
+key_file = "keys/age.txt"
+identity_files = ["{{ config_root }}/keys/identity.txt"]
+ssh_identity_files = ["keys/id_ed25519"]
+
+[env]
+SECRET = { age = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXS2Jlb0xuZFc5M3BKRGZlWm95MGMyNTM2MHRlbGJ5Y2FsQkdISVRkRFZFCkt5bEFHMFl5ZzMvWWExNVZmeFFEeFcySURFemlrOUhXdmVjY2pyNnArSFUKLT4gXGRBRT4tZ3JlYXNlClk1NS9LNXJSSStOTEF6VlVEYWFwNkwycUlPcGdkdm03Ci0tLSBOVTdVOVA4MElaVG1keGZmM0VsZXpuMHZxQmJaeklOT3lDRkdlS2pHd04wCsEaIzUkHH6t/xRB9eiREl9SlNjBpxtLX3TQGb+zBagRaE4tt143+Wna6va5nLcE9Ydg" }
+EOF
+
+project_root="$PWD/project"
+cd project/subdir
+
+assert "mise settings get age.key_file" "$project_root/keys/age.txt"
+assert "mise settings get age.identity_files" "[\"$project_root/keys/identity.txt\"]"
+assert "mise settings get age.ssh_identity_files" "[\"$project_root/keys/id_ed25519\"]"
+assert_contains "mise env" "SECRET=relative-key-works"
+
+# Environment settings have no declaring config file and retain their existing
+# process-relative behavior.
+MISE_AGE_KEY_FILE=env-key.txt assert "mise settings get age.key_file" "env-key.txt"

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -6,7 +6,7 @@ use crate::{dirs, env, file};
 #[allow(unused_imports)]
 use confique::env::parse::{list_by_colon, list_by_comma};
 use confique::{Config, Layer};
-use eyre::{Result, bail};
+use eyre::{Result, bail, eyre};
 use indexmap::{IndexMap, indexmap};
 use itertools::Itertools;
 use path_absolutize::Absolutize;
@@ -592,6 +592,70 @@ fn resolve_aqua_registry_paths(settings: &mut toml::Table, path: &Path) {
     }
 }
 
+/// Resolve age identity paths while the settings file that declared them is
+/// still known. Once settings layers are merged, a relative `PathBuf` no
+/// longer carries enough information to distinguish two config roots.
+fn resolve_age_paths(settings: &mut toml::Table, path: &Path) -> Result<()> {
+    let Some(age) = settings.get_mut("age").and_then(toml::Value::as_table_mut) else {
+        return Ok(());
+    };
+    let config_root = crate::config::config_file::config_root::config_root(path);
+    let mut tera = crate::tera::get_miserc_tera();
+    let mut context = tera::Context::new();
+    context.insert("env", &*env::PRISTINE_ENV);
+    context.insert("config_root", &config_root);
+    if let Ok(cwd) = std::env::current_dir() {
+        context.insert("cwd", &cwd);
+    }
+    context.insert("xdg_cache_home", &*env::XDG_CACHE_HOME);
+    context.insert("xdg_config_home", &*env::XDG_CONFIG_HOME);
+    context.insert("xdg_data_home", &*env::XDG_DATA_HOME);
+    context.insert("xdg_state_home", &*env::XDG_STATE_HOME);
+
+    let mut resolve = |setting: &str, target: &mut toml::Value| -> Result<()> {
+        let Some(value) = target.as_str() else {
+            return Ok(());
+        };
+        let rendered = if crate::tera::contains_template_syntax(value) {
+            crate::tera::render_str(&mut tera, value, &context).map_err(|err| {
+                eyre!(
+                    "failed to render settings.age.{setting} in {}: {err}",
+                    file::display_path(path)
+                )
+            })?
+        } else {
+            value.to_string()
+        };
+        let rendered_path = Path::new(&rendered);
+        let resolved = if rendered_path.is_absolute()
+            || rendered_path == Path::new("~")
+            || rendered_path.starts_with("~/")
+        {
+            rendered_path.to_path_buf()
+        } else {
+            let joined = config_root.join(rendered_path);
+            joined
+                .absolutize()
+                .map(|p| p.into_owned())
+                .unwrap_or(joined)
+        };
+        *target = toml::Value::String(resolved.to_string_lossy().into_owned());
+        Ok(())
+    };
+
+    if let Some(key_file) = age.get_mut("key_file") {
+        resolve("key_file", key_file)?;
+    }
+    for setting in ["identity_files", "ssh_identity_files"] {
+        if let Some(values) = age.get_mut(setting).and_then(toml::Value::as_array_mut) {
+            for value in values {
+                resolve(setting, value)?;
+            }
+        }
+    }
+    Ok(())
+}
+
 impl Settings {
     const UNIX_DEFAULT_FILE_SHELL_ARGS: &'static str = "sh";
     const UNIX_DEFAULT_INLINE_SHELL_ARGS: &'static str = "sh -c -o errexit";
@@ -966,6 +1030,7 @@ impl Settings {
             // After the strips, so a setting that will not survive them is
             // never rewritten.
             resolve_aqua_registry_paths(settings, path);
+            resolve_age_paths(settings, path)?;
         }
         let deprecated = deprecated_settings_in_toml_config(&raw);
         let settings_file: SettingsFile = raw.try_into()?;
@@ -2102,6 +2167,87 @@ mod tests {
         let mut settings = toml::from_str::<toml::Table>("offline = true").unwrap();
         resolve_aqua_registry_paths(&mut settings, &dir.path().join(".mise.toml"));
         assert_eq!(settings["offline"].as_bool(), Some(true));
+    }
+
+    #[test]
+    fn age_paths_resolve_against_the_declaring_config_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("mise.toml");
+        let mut settings = toml::from_str::<toml::Table>(
+            r#"
+            [age]
+            key_file = "keys/age.txt"
+            identity_files = ["identities/first.txt", "{{ config_root }}/second.txt"]
+            ssh_identity_files = ["ssh/id_ed25519"]
+            "#,
+        )
+        .unwrap();
+
+        resolve_age_paths(&mut settings, &config_path).unwrap();
+
+        assert_eq!(
+            settings["age"]["key_file"].as_str(),
+            Some(dir.path().join("keys/age.txt").to_str().unwrap())
+        );
+        assert_eq!(
+            settings["age"]["identity_files"][0].as_str(),
+            Some(dir.path().join("identities/first.txt").to_str().unwrap())
+        );
+        assert_eq!(
+            Path::new(settings["age"]["identity_files"][1].as_str().unwrap()),
+            dir.path().join("second.txt")
+        );
+        assert_eq!(
+            settings["age"]["ssh_identity_files"][0].as_str(),
+            Some(dir.path().join("ssh/id_ed25519").to_str().unwrap())
+        );
+    }
+
+    #[test]
+    fn age_paths_preserve_absolute_and_home_relative_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let absolute = dir.path().join("absolute.txt");
+        let mut age = toml::Table::new();
+        age.insert(
+            "key_file".into(),
+            toml::Value::String(absolute.to_string_lossy().into_owned()),
+        );
+        age.insert(
+            "identity_files".into(),
+            toml::Value::Array(vec![toml::Value::String("~/identity.txt".into())]),
+        );
+        let mut settings = toml::Table::new();
+        settings.insert("age".into(), toml::Value::Table(age));
+
+        resolve_age_paths(&mut settings, &dir.path().join("mise.toml")).unwrap();
+
+        assert_eq!(
+            settings["age"]["key_file"].as_str(),
+            Some(absolute.to_str().unwrap())
+        );
+        assert_eq!(
+            settings["age"]["identity_files"][0].as_str(),
+            Some("~/identity.txt")
+        );
+    }
+
+    #[test]
+    fn invalid_age_path_template_names_the_setting_and_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("mise.toml");
+        let mut settings = toml::from_str::<toml::Table>(
+            r#"
+            [age]
+            key_file = "{{ missing_variable }}"
+            "#,
+        )
+        .unwrap();
+
+        let err = resolve_age_paths(&mut settings, &config_path)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("settings.age.key_file"), "{err}");
+        assert!(err.contains("mise.toml"), "{err}");
     }
 
     /// A drive-letter path parses as a URL whose scheme is one character, so it


### PR DESCRIPTION
## Summary

- resolve age key and identity paths relative to the config file that declares them
- render config_root and env Tera values before settings layers lose their source location
- preserve absolute paths, home-relative paths, and environment-provided setting behavior

## Problem

Age path settings were merged before relative paths were interpreted. The later replace_path call only expanded home-relative paths, so project-local keys were resolved from the process working directory and failed when mise ran from a child directory.

## Implementation

Age path-valued settings are now rendered and resolved while each settings file is parsed. This keeps the declaration-specific config root through layered settings and reports invalid templates with the setting name and source file. The runtime decryption and environment-variable override paths are unchanged.

## Verification

- mise exec -- cargo fmt --all -- --check
- mise exec -- cargo test --all-features age_path -- --nocapture
- mise run test:e2e e2e/cli/test_age_settings_paths
- mise exec -- cargo check --all-features
- mise exec -- bun x prettier --check docs/environments/secrets/age.md
- mise exec -- shellcheck e2e/cli/test_age_settings_paths
- mise run docs:build

The new E2E decrypts a fixed age ciphertext from a child directory with a key file declared relative to the project config.

Addresses https://github.com/jdx/mise/discussions/9057

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Age identity and key-file paths now resolve relative to the configuration file that declares them.
  * Path settings support Tera templates, including configuration-root and environment values.
  * Absolute and home-relative paths continue to work as before.
  * Clear errors are reported when a path template cannot be rendered.
  * Encrypted environment loading now reliably finds configured age keys when invoked from subdirectories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->