### PR TITLE
fix(erlang): verify precompiled checksums

### DIFF
--- a/e2e/core/test_erlang_lockfile
+++ b/e2e/core/test_erlang_lockfile
@@ -37,9 +37,23 @@ assert_contains "cat mise.lock" 'precompiled_os = "ubuntu-24.04"'
 assert_not_contains "cat mise.lock" 'precompiled = '
 assert_contains "cat mise.lock" "\"platforms.$CURRENT_PLATFORM\""
 assert_matches "cat mise.lock" 'url = "https://builds\.hex\.pm/builds/otp/(amd64|arm64)/ubuntu-24\.04/OTP-28\.3\.tar\.gz"'
+assert_contains "awk '/\[tools.erlang.\"platforms.$CURRENT_PLATFORM\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'checksum = "sha256:'
 assert_not_contains "cat mise.lock" 'install = "source"'
 
-assert "mise install --locked --dry-run"
+assert "mise install --locked"
+assert "mise exec erlang@28.3 -- erl -noshell -eval 'io:format(\"~s\", [erlang:system_info(otp_release)]).' -s init stop" "28"
+
+echo "=== corrupted precompiled checksum fails before extraction ==="
+mise uninstall erlang@28.3
+awk '
+    /^checksum = "sha256:/ {
+        print "checksum = \"sha256:0000000000000000000000000000000000000000000000000000000000000000\""
+        next
+    }
+    { print }
+' mise.lock >mise.lock.tmp && mv mise.lock.tmp mise.lock
+
+assert_fail "mise install --locked" "Checksum mismatch"
 
 echo "=== default fallback records the source artifact ==="
 rm -f mise.lock

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -163,7 +163,7 @@ impl ErlangPlugin {
         format!("otp-source-{}.tar.gz", crate::hash::hash_sha256_to_str(url))
     }
 
-    fn linux_precompiled_url(version: &str, target: &PlatformTarget) -> Result<String> {
+    fn linux_precompiled_base_url(target: &PlatformTarget) -> Result<String> {
         if target.libc() == Some("musl") {
             bail!("precompiled erlang is not supported on musl linux");
         }
@@ -173,10 +173,24 @@ impl ErlangPlugin {
             other => bail!("unsupported architecture: {other}"),
         };
         let os_ver = Self::linux_precompiled_os_version()?;
-        Ok(format!(
-            "https://builds.hex.pm/builds/otp/{arch}/{os_ver}/{}.tar.gz",
-            Self::release_tag(version)
-        ))
+        Ok(format!("https://builds.hex.pm/builds/otp/{arch}/{os_ver}"))
+    }
+
+    async fn linux_precompiled_lock_info(
+        version: &str,
+        target: &PlatformTarget,
+    ) -> Result<PlatformInfo> {
+        let base_url = Self::linux_precompiled_base_url(target)?;
+        let release_tag = Self::release_tag(version);
+        let builds = HTTP_FETCH
+            .get_text_cached(format!("{base_url}/builds.txt"))
+            .await?;
+        let checksum = parse_hex_build_checksum(&builds, &release_tag)?;
+        Ok(PlatformInfo {
+            url: Some(format!("{base_url}/{release_tag}.tar.gz")),
+            checksum: Some(checksum),
+            ..Default::default()
+        })
     }
 
     #[cfg(linux)]
@@ -301,11 +315,19 @@ impl ErlangPlugin {
         if !ctx.locked && Settings::get().erlang_compile(CompilePurpose::Inspect) == Some(true) {
             return Ok(None);
         }
-        let url = if let Some(url) = self.lockfile_url(ctx.locked, &tv) {
-            url
+        let (url, checksum) = if let Some(url) = self.lockfile_url(ctx.locked, &tv) {
+            let checksum = require_locked_precompiled_checksum(
+                &tv.version,
+                tv.lock_platforms
+                    .get(&self.get_platform_key())
+                    .and_then(|info| info.checksum.as_deref()),
+            )?;
+            (url, checksum)
         } else {
-            match Self::linux_precompiled_url(&tv.version, &PlatformTarget::from_current()) {
-                Ok(url) => url,
+            match Self::linux_precompiled_lock_info(&tv.version, &PlatformTarget::from_current())
+                .await
+            {
+                Ok(info) => (info.url.unwrap(), info.checksum.unwrap()),
                 Err(e) => {
                     return self.precompiled_unavailable(e.to_string());
                 }
@@ -322,7 +344,8 @@ impl ErlangPlugin {
             HTTP.download_file(&url, &tarball_path, Some(ctx.pr.as_ref()))
                 .await?;
         }
-        self.set_lockfile_info(&mut tv, None, &url, None, None);
+        self.set_lockfile_info(&mut tv, None, &url, Some(checksum), None);
+        self.verify_checksum(ctx, &mut tv, &tarball_path)?;
         ctx.pr.set_message(format!("Extracting {filename}"));
         file::untar(
             &tarball_path,
@@ -675,11 +698,8 @@ impl Backend for ErlangPlugin {
 
         let release_tag = Self::release_tag(&tv.version);
         match target.os_name() {
-            "linux" => match Self::linux_precompiled_url(&tv.version, target) {
-                Ok(url) => Ok(PlatformInfo {
-                    url: Some(url),
-                    ..Default::default()
-                }),
+            "linux" => match Self::linux_precompiled_lock_info(&tv.version, target).await {
+                Ok(info) => Ok(info),
                 Err(err) if compile == Some(false) => Err(err),
                 Err(_) => self.resolve_source_lock_info(&tv.version).await,
             },
@@ -772,9 +792,94 @@ fn should_install_from_source(
     }
 }
 
+fn parse_hex_build_checksum(builds: &str, release_tag: &str) -> Result<String> {
+    let matching = builds
+        .lines()
+        .filter_map(|line| {
+            let parts = line.split_whitespace().collect::<Vec<_>>();
+            (parts.first() == Some(&release_tag)).then_some(parts)
+        })
+        .collect::<Vec<_>>();
+
+    if matching.len() != 1 {
+        bail!(
+            "expected exactly one Hex OTP build record for {release_tag}, found {}",
+            matching.len()
+        );
+    }
+
+    let checksum = matching[0]
+        .get(3)
+        .ok_or_else(|| eyre::eyre!("Hex OTP build record for {release_tag} has no checksum"))?;
+    if !regex!(r"^[0-9a-f]{64}$").is_match(checksum) {
+        bail!("invalid Hex OTP checksum for {release_tag}: {checksum}");
+    }
+
+    Ok(format!("sha256:{checksum}"))
+}
+
+#[cfg(any(linux, test))]
+fn require_locked_precompiled_checksum(version: &str, checksum: Option<&str>) -> Result<String> {
+    let checksum = checksum.ok_or_else(|| {
+        eyre::eyre!(
+            "No lockfile checksum found for precompiled Erlang/OTP {version}; regenerate mise.lock with `mise lock`"
+        )
+    })?;
+    if !regex!(r"^sha256:[0-9a-f]{64}$").is_match(checksum) {
+        bail!(
+            "Invalid lockfile checksum for precompiled Erlang/OTP {version}; regenerate mise.lock with `mise lock`"
+        );
+    }
+
+    Ok(checksum.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_parse_hex_build_checksum_requires_exact_publisher_record() {
+        let builds = "OTP-28.5.0.4 abc 2026-07-27T13:55:40Z 34498e6287e1fbc31250d36dd88bcdb1d286cedbdd9b1a66bbc4284738d2d2eb\n\
+                      OTP-28.5.0.5 def 2026-08-04T10:35:03Z e3476633cae6fef8e1bb53576832b15823f715e70e3d4d1e66a6be908804f967\n";
+
+        assert_eq!(
+            parse_hex_build_checksum(builds, "OTP-28.5.0.5").unwrap(),
+            "sha256:e3476633cae6fef8e1bb53576832b15823f715e70e3d4d1e66a6be908804f967"
+        );
+        assert!(parse_hex_build_checksum(builds, "OTP-28.5.0.6").is_err());
+    }
+
+    #[test]
+    fn test_parse_hex_build_checksum_rejects_missing_malformed_and_duplicate_evidence() {
+        let missing = "OTP-28.5.0.5 def 2026-08-04T10:35:03Z\n";
+        let malformed = "OTP-28.5.0.5 def 2026-08-04T10:35:03Z abc123\n";
+        let duplicate = "OTP-28.5.0.5 def 2026-08-04T10:35:03Z e3476633cae6fef8e1bb53576832b15823f715e70e3d4d1e66a6be908804f967\n\
+                         OTP-28.5.0.5 def 2026-08-04T10:35:03Z e3476633cae6fef8e1bb53576832b15823f715e70e3d4d1e66a6be908804f967\n";
+
+        assert!(parse_hex_build_checksum(missing, "OTP-28.5.0.5").is_err());
+        assert!(parse_hex_build_checksum(malformed, "OTP-28.5.0.5").is_err());
+        assert!(parse_hex_build_checksum(duplicate, "OTP-28.5.0.5").is_err());
+    }
+
+    #[test]
+    fn test_locked_precompiled_checksum_is_mandatory_and_well_formed() {
+        let valid = "sha256:e3476633cae6fef8e1bb53576832b15823f715e70e3d4d1e66a6be908804f967";
+
+        assert_eq!(
+            require_locked_precompiled_checksum("28.5.0.5", Some(valid)).unwrap(),
+            valid
+        );
+        assert!(require_locked_precompiled_checksum("28.5.0.5", None).is_err());
+        assert!(require_locked_precompiled_checksum("28.5.0.5", Some("sha256:abc123")).is_err());
+        assert!(
+            require_locked_precompiled_checksum(
+                "28.5.0.5",
+                Some("sha512:e3476633cae6fef8e1bb53576832b15823f715e70e3d4d1e66a6be908804f967")
+            )
+            .is_err()
+        );
+    }
 
     #[test]
     fn test_source_build_kerl_env_pins_staged_archive() {


### PR DESCRIPTION
## Summary

- resolve Linux precompiled Erlang/OTP checksums from Hex's platform-specific `builds.txt`
- persist the published SHA-256 digest in `mise.lock`
- verify downloaded and cached archives before extraction
- fail locked precompiled installs without a valid checksum with guidance to regenerate the lockfile

## Why

Linux `core:erlang` precompiled installs currently lock the artifact URL without enforcing Hex's published digest. This change retains the prebuilt installation path while making the lockfile integrity-bearing.

## Compatibility

Existing Linux precompiled lock entries without a valid `sha256:` checksum must be regenerated with `mise lock`. Existing source-build fallback behavior is unchanged.

## Validation

- focused Erlang checksum parsing and lockfile-contract unit tests
- Linux E2E coverage for a locked installation and installed OTP execution
- Linux E2E coverage proving a corrupted checksum is rejected, including for a cached archive

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of precompiled Erlang installations by validating release checksums before extraction.
  * Locked installations now verify recorded checksums and fail safely when lockfile data is missing, malformed, duplicated, or incorrect.
  * Added clearer protection against corrupted lockfiles and prevented installation of artifacts that do not match their expected checksums.
  * Preserved fallback behavior when a precompiled release cannot be resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->