### PR TITLE
fix(env): default to pwsh on Windows instead of bash

### DIFF
--- a/e2e-win/config_ceiling_paths.Tests.ps1
+++ b/e2e-win/config_ceiling_paths.Tests.ps1
@@ -41,9 +41,12 @@ GRANDCHILD = "true"
         Remove-Item Env:MISE_CEILING_PATHS -ErrorAction Ignore
     }
 
+    # `-s bash` throughout: these assert *which config was loaded*, so they should not also be
+    # asserting which shell `mise env` picks when nothing is named. Left bare, they were pinning
+    # the Windows default as bash and broke when it changed.
     It 'finds all configs without ceiling paths' {
         Remove-Item Env:MISE_CEILING_PATHS -ErrorAction Ignore
-        $output = mise env | Out-String
+        $output = mise env -s bash | Out-String
         $output | Should -Match "export GRANDCHILD=true"
         $output | Should -Match "export CHILD=true"
         $output | Should -Match "export PARENT=true"
@@ -51,7 +54,7 @@ GRANDCHILD = "true"
 
     It 'respects ceiling path at child directory' {
         $env:MISE_CEILING_PATHS = Join-Path $TestRoot "parent\child"
-        $output = mise env | Out-String
+        $output = mise env -s bash | Out-String
         $output | Should -Match "export GRANDCHILD=true"
         $output | Should -Not -Match "export CHILD=true"
         $output | Should -Not -Match "export PARENT=true"
@@ -59,7 +62,7 @@ GRANDCHILD = "true"
 
     It 'respects ceiling path at grandchild directory' {
         $env:MISE_CEILING_PATHS = Join-Path $TestRoot "parent\child\grandchild"
-        $output = mise env | Out-String
+        $output = mise env -s bash | Out-String
         $output | Should -Not -Match "export GRANDCHILD=true"
         $output | Should -Not -Match "export CHILD=true"
         $output | Should -Not -Match "export PARENT=true"
@@ -69,7 +72,7 @@ GRANDCHILD = "true"
         $ChildPath = Join-Path $TestRoot "parent\child"
         $ParentPath = Join-Path $TestRoot "parent"
         $env:MISE_CEILING_PATHS = "$ChildPath;$ParentPath"
-        $output = mise env | Out-String
+        $output = mise env -s bash | Out-String
         $output | Should -Match "export GRANDCHILD=true"
         $output | Should -Not -Match "export CHILD=true"
         $output | Should -Not -Match "export PARENT=true"
@@ -77,7 +80,7 @@ GRANDCHILD = "true"
 
     It 'handles nonexistent ceiling path' {
         $env:MISE_CEILING_PATHS = Join-Path $TestRoot "nonexistent"
-        $output = mise env | Out-String
+        $output = mise env -s bash | Out-String
         $output | Should -Match "export GRANDCHILD=true"
         $output | Should -Match "export CHILD=true"
         $output | Should -Match "export PARENT=true"

--- a/e2e-win/env_default_shell.Tests.ps1
+++ b/e2e-win/env_default_shell.Tests.ps1
@@ -1,0 +1,69 @@
+Describe 'mise env default shell' {
+    BeforeAll {
+        $script:originalPath = Get-Location
+        # The workflow sets these for the whole job and Pester runs every suite in one process, so
+        # put back what was there rather than dropping it.
+        $script:originalEnv = @{}
+        foreach ($name in 'MISE_TRUSTED_CONFIG_PATHS', 'MISE_SHELL', 'SHELL') {
+            $script:originalEnv[$name] = [Environment]::GetEnvironmentVariable($name, 'Process')
+        }
+
+        $script:testDir = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:testDir | Out-Null
+        Set-Location $script:testDir
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:testDir
+        Set-Content -LiteralPath (Join-Path $script:testDir 'mise.toml') -Value @(
+            '[env]'
+            "MISE_E2E_DEFAULT_SHELL = 'probe-value'"
+        )
+
+        # This is about what mise emits with nothing to detect from. `MISE_SHELL` is what an
+        # activated session sets and `SHELL` is what Git Bash sets, so either one inherited from
+        # the runner would make the case below pass vacuously.
+        Remove-Item -Path Env:\MISE_SHELL -ErrorAction SilentlyContinue
+        Remove-Item -Path Env:\SHELL -ErrorAction SilentlyContinue
+    }
+
+    AfterAll {
+        Set-Location $script:originalPath
+        foreach ($name in $script:originalEnv.Keys) {
+            if ($null -eq $script:originalEnv[$name]) {
+                Remove-Item -Path "Env:\$name" -ErrorAction SilentlyContinue
+            } else {
+                [Environment]::SetEnvironmentVariable($name, $script:originalEnv[$name], 'Process')
+            }
+        }
+    }
+
+    It 'emits PowerShell syntax rather than bash' {
+        # `COMSPEC` is all mise reads on Windows without `SHELL`, and it names cmd.exe, which mise
+        # has no implementation for. The fallback used to be bash, so a PowerShell session running
+        # `mise env` was handed `export MISE_E2E_DEFAULT_SHELL='probe-value'`.
+        $out = & mise env 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match 'MISE_E2E_DEFAULT_SHELL'
+        $out | Should -Not -Match 'export '
+        $out | Should -Match '\$\{Env:MISE_E2E_DEFAULT_SHELL\}'
+    }
+
+    It 'still emits bash syntax when bash is named' {
+        # The control. Without it the case above would not distinguish "the default changed" from
+        # "mise stopped being able to emit bash at all".
+        $out = & mise env -s bash 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match 'export MISE_E2E_DEFAULT_SHELL'
+    }
+
+    It 'is only the fallback: a detected shell still wins' {
+        # The fallback must not override detection, or an activated session would get the wrong
+        # syntax back.
+        $env:MISE_SHELL = 'bash'
+        try {
+            $out = & mise env 2>&1 | Out-String
+            $LASTEXITCODE | Should -Be 0
+            $out | Should -Match 'export MISE_E2E_DEFAULT_SHELL'
+        } finally {
+            Remove-Item -Path Env:\MISE_SHELL -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/e2e-win/trusted_config_paths.Tests.ps1
+++ b/e2e-win/trusted_config_paths.Tests.ps1
@@ -38,10 +38,13 @@ PROJECT = "b"
         Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
     }
 
+    # `-s bash` throughout: these assert *whether the config was trusted*, so they should not also
+    # be asserting which shell `mise env` picks when nothing is named. Left bare, they were pinning
+    # the Windows default as bash and broke when it changed.
     It 'trusts a single path set via env var' {
         $env:MISE_TRUSTED_CONFIG_PATHS = $script:DirA
         Set-Location $script:DirA
-        $output = mise env | Out-String
+        $output = mise env -s bash | Out-String
         $output | Should -Match "export PROJECT=a"
     }
 
@@ -50,10 +53,10 @@ PROJECT = "b"
         # contain : in the drive letter (e.g. C:\foo). Using ; avoids ambiguity.
         $env:MISE_TRUSTED_CONFIG_PATHS = "$($script:DirA);$($script:DirB)"
         Set-Location $script:DirA
-        $output = mise env | Out-String
+        $output = mise env -s bash | Out-String
         $output | Should -Match "export PROJECT=a"
         Set-Location $script:DirB
-        $output = mise env | Out-String
+        $output = mise env -s bash | Out-String
         $output | Should -Match "export PROJECT=b"
     }
 }

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -180,7 +180,7 @@ impl Env {
         ts: Toolset,
         redacted_keys: &Option<IndexSet<String>>,
     ) -> Result<()> {
-        let default_shell = get_shell(Some(ShellType::Bash)).unwrap();
+        let default_shell = get_shell(Some(fallback_shell())).unwrap();
         let shell = get_shell(self.shell).unwrap_or(default_shell);
         let mut env = ts.env_with_path(config).await?;
 
@@ -238,6 +238,27 @@ impl Env {
     }
 }
 
+/// The shell to emit for when there is nothing to detect from.
+///
+/// Detection is `MISE_SHELL`, then `SHELL`. On unix that always resolves — an unset `SHELL` falls
+/// back to `sh` — so this is reached only on Windows, where PowerShell and cmd set neither and the
+/// value mise would otherwise read, `COMSPEC`, names cmd.exe. mise has no cmd implementation, so
+/// bash was being printed into a PowerShell session:
+///
+/// ```console
+/// PS> mise env
+/// export MY_PATH='C:\Users\me'
+/// ```
+///
+/// pwsh is the only shell mise can emit for that a Windows user is likely to be in. It is not
+/// right for a cmd user, but neither was bash, and there is no third answer available.
+fn fallback_shell() -> ShellType {
+    match cfg!(windows) {
+        true => ShellType::Pwsh,
+        false => ShellType::Bash,
+    }
+}
+
 static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
 
@@ -247,3 +268,23 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     $ <bold>execx($(mise env -s xonsh))</bold>
 "#
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Asserted on the output rather than on the enum, which would only restate the `cfg!` above.
+    /// What matters is that the syntax is one the platform's shell can run.
+    #[test]
+    fn the_fallback_emits_syntax_this_platform_can_run() {
+        let line = fallback_shell().as_shell().set_env("K", "V");
+
+        if cfg!(windows) {
+            // `export K=V` is what a PowerShell session used to be handed.
+            assert!(!line.starts_with("export "), "{line}");
+            assert!(line.contains("${Env:K}"), "{line}");
+        } else {
+            assert!(line.starts_with("export "), "{line}");
+        }
+    }
+}


### PR DESCRIPTION
> **This one is a question as much as a patch.** The behaviour is clearly wrong; which way to fix it
> is your call, and I have picked the option I think is best rather than the only one. Options at the
> bottom — happy to switch.

## What happens

`mise env` with no `--shell` prints bash into a PowerShell session. Measured on **2026.8.2
windows-x64**, isolated `MISE_*` dirs:

```console
PS> mise env
export MY_PATH='C:\Users\Jam'      # not runnable here

PS> mise env -s pwsh
$Env:MY_PATH='C:\Users\Jam'
```

`mise env` exists to be `eval`'d, so a default the caller's shell cannot run is the whole value of
the command gone.

## Why it is Windows-only

Detection is `MISE_SHELL`, then `SHELL`. On unix that always resolves — an unset `SHELL` falls back
to `sh` — so the hardcoded fallback under it is effectively dead code there. On Windows PowerShell
and cmd set neither variable, and the value mise would otherwise read, `COMSPEC`, names cmd.exe,
which mise has no implementation for. So the fallback is not a corner on Windows: it is the normal
path, and it was bash.

## The change

One line of behaviour in `src/cli/env.rs`: the fallback is `Pwsh` on Windows, `Bash` everywhere
else. Unix is untouched. It is still only a *fallback* — a detected or named shell wins, which the
tests pin in both directions.

## Why pwsh, and where it still does not help

pwsh is the only shell mise can emit for that a Windows user is plausibly in. It is **not** right
for someone in cmd — but neither was bash, and there is no third answer available, because mise has
no cmd shell implementation. Those users want `--json`, `--dotenv` or `--values`, which is what
those flags are for.

## Options

**A — what this PR does.** Fallback to pwsh on Windows.
Smallest change; makes the common Windows case work with no flag. Still silently wrong for cmd.

**B — error instead, like #12048 does for `activate` / `hook-env`.**
More consistent: those four commands now say "name the shell" rather than guessing. But `mise env`
is different in kind — it has shell-independent output modes and a fallback is legitimate — so this
would be a contract change, and on unix it is unreachable, making it a Windows-only breaking change.

**C — leave it; require `--shell` on Windows.**
Status quo. Keeps the asymmetry where mise detects for you on unix and silently guesses wrong on
Windows.

I went with **A** because #12048 already moved the four commands that *cannot* guess toward saying
so, which leaves `mise env` as the one that can guess — and it should guess the shell the platform
actually ships.

## Not included

The `--shell` help text does not mention a default. It never did, so leaving it is status quo rather
than a regression; if you take A I will follow up with the docs, usage spec and man page together.

## Tests

- `e2e-win/env_default_shell.Tests.ps1` — with `MISE_SHELL` and `SHELL` cleared, `mise env` emits
  `${Env:…}` and no `export `. Two controls: `mise env -s bash` still emits bash, so this is about
  the default rather than mise losing the ability to emit bash; and with `MISE_SHELL=bash` set,
  detection still wins over the fallback.
- A unit test on the fallback's *output* rather than the enum — asserting `ShellType::Pwsh` on
  Windows would only restate the `cfg!` beside it. What matters is that the syntax is one the
  platform's shell can run.

## Verification

I did not build locally. I did run the new Pester suite against the released 2026.8.2 binary, which
predates the fix, to check the suite itself is sound rather than passing vacuously:

```
[-] emits PowerShell syntax rather than bash
    'export ' to not match 'export MISE_E2E_DEFAULT_SHELL=probe-value …'
[+] still emits bash syntax when bash is named
[+] is only the fallback: a detected shell still wins
```

The failing case is exactly the defect; the two controls already pass. The rest goes to CI.

Related, but independent of this branch: #12048 (those commands panicked instead of erroring) and
#12050 (Windows never read `SHELL`, so Git Bash was undetectable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved automatic shell detection for environment output.
  * Uses PowerShell by default on Windows and Bash on Unix-like systems.
  * Explicit shell selection remains supported.

* **Bug Fixes**
  * Ensures generated environment commands use syntax compatible with the selected platform shell.
  * Updated Windows environment and configuration checks for more reliable results.
  * Added coverage for shell fallback behavior and environment-state restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->