### PR TITLE
feat(task): expose prefix color to tasks

### DIFF
--- a/docs/tasks/index.md
+++ b/docs/tasks/index.md
@@ -56,5 +56,11 @@ The following environment variables are passed to the task:
 - `MISE_PROJECT_ROOT`: The root of the project that defines the task. For monorepo subproject tasks this is the subproject's directory and is stable regardless of the directory the task is invoked from.
 - `MISE_MONOREPO_ROOT`: The root of the monorepo (the directory containing the config with `monorepo_root = true`). Only set inside a monorepo.
 - `MISE_TASK_NAME`: The name of the task being run.
+- `MISE_TASK_COLOR`: The ANSI sequence that starts the task's prefix color and emphasis. This is
+  set to an empty string when colors are disabled or the selected output mode does not display a
+  task prefix. Add an ANSI reset after the text, for example
+  `printf '%smessage\033[0m\n' "$MISE_TASK_COLOR"`. Replacing output also provides the value when
+  it uses the text fallback; this describes the task label style and does not imply that every line
+  is automatically prefixed.
 - `MISE_TASK_DIR`: The directory containing the task script.
 - `MISE_TASK_FILE`: The full path to the task script.

--- a/e2e/tasks/test_task_prefix_color
+++ b/e2e/tasks/test_task_prefix_color
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[settings]
+task.output = "interleave"
+
+[tasks.a]
+run = '''printf %s "$MISE_TASK_COLOR" | od -An -tx1 | tr -d ' \n' > a.color'''
+output = "prefix"
+
+[tasks.b]
+run = '''printf %s "$MISE_TASK_COLOR" | od -An -tx1 | tr -d ' \n' > b.color'''
+output = "prefix"
+
+[tasks.disabled]
+run = '''printf %s "$MISE_TASK_COLOR" > disabled.color'''
+output = "prefix"
+
+[tasks.interleave]
+run = '''printf %s "$MISE_TASK_COLOR" > interleave.color'''
+
+[tasks.override]
+run = '''printf %s "$MISE_TASK_COLOR" | od -An -tx1 | tr -d ' \n' > override.color'''
+output = "prefix"
+env = { MISE_TASK_COLOR = "user-value" }
+
+[tasks.keep]
+run = '''printf %s "$MISE_TASK_COLOR" > keep.color'''
+output = "keep-order"
+
+[tasks.timed]
+run = '''printf %s "$MISE_TASK_COLOR" > timed.color'''
+output = "timed"
+
+[tasks.replacing]
+run = '''printf %s "$MISE_TASK_COLOR" > replacing.color'''
+output = "replacing"
+
+[tasks.replacing_fallback]
+run = '''printf %s "$MISE_TASK_COLOR" > replacing-fallback.color'''
+output = "replacing"
+
+[tasks.quiet]
+run = '''printf %s "$MISE_TASK_COLOR" > quiet.color'''
+output = "prefix"
+quiet = true
+
+[tasks.raw]
+run = '''printf %s "$MISE_TASK_COLOR" > raw.color'''
+output = "prefix"
+raw = true
+
+[tasks.parent]
+run = "mise run child"
+output = "prefix"
+
+[tasks.child]
+run = '''printf %s "$MISE_TASK_COLOR" > child.color'''
+output = "interleave"
+EOF
+
+CLICOLOR_FORCE=1 MISE_FORCE_PROGRESS=1 mise run a ::: b ::: override ::: interleave ::: keep ::: timed ::: replacing ::: quiet ::: raw
+assert "cat a.color" "1b5b33356d"
+assert "cat b.color" "1b5b33366d"
+assert "cat override.color" "1b5b33346d"
+assert_empty "cat interleave.color" ""
+assert "od -An -tx1 keep.color | tr -d ' \n' | cut -c1-4" "1b5b"
+assert "od -An -tx1 timed.color | tr -d ' \n' | cut -c1-4" "1b5b"
+assert "od -An -tx1 replacing.color | tr -d ' \n' | cut -c1-4" "1b5b"
+assert_empty "cat quiet.color" ""
+assert_empty "cat raw.color" ""
+
+CI=1 CLICOLOR_FORCE=1 mise run replacing_fallback
+assert "od -An -tx1 replacing-fallback.color | tr -d ' \n' | cut -c1-4" "1b5b"
+
+NO_COLOR=1 mise run disabled
+assert_empty "cat disabled.color" ""
+
+CLICOLOR_FORCE=1 mise run parent
+assert_empty "cat child.color" ""

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -2020,6 +2020,13 @@ impl TaskExecutor {
             "MISE_TASK_NAME",
             task.name.clone(),
         );
+        let task_color = self.output_handler.task_prefix_color(task);
+        Self::insert_env_excluded_from_nested_mise_diff(
+            &mut env,
+            &mut nested_mise_diff_exclude_keys,
+            "MISE_TASK_COLOR",
+            task_color,
+        );
         let task_file = task
             .file_path(config)
             .await?

--- a/src/task/task_output_handler.rs
+++ b/src/task/task_output_handler.rs
@@ -4,6 +4,7 @@ use crate::task::task_output::TaskOutput;
 use crate::task::{Task, TaskCacheOutput};
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::progress_report::SingleReport;
+use crate::ui::style;
 use indexmap::IndexMap;
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
@@ -224,6 +225,30 @@ impl OutputHandler {
             pr
         }
     }
+
+    /// Return the task prefix's ANSI opening sequence when the selected output
+    /// path actually preserves the styled prefix.
+    pub fn task_prefix_color(&self, task: &Task) -> String {
+        if self.quiet(Some(task)) {
+            return String::new();
+        }
+
+        let output = self.output(Some(task));
+        if console::colors_enabled_stderr() && displays_colored_task_prefix(output) {
+            style::prefix_ansi(&task.display_name)
+        } else {
+            String::new()
+        }
+    }
+}
+
+// This reports whether the mode renders a styled task label, not whether every
+// output line is prefixed. Replacing's text fallback still renders that label.
+fn displays_colored_task_prefix(output: TaskOutput) -> bool {
+    matches!(
+        output,
+        TaskOutput::Prefix | TaskOutput::KeepOrder | TaskOutput::Replacing | TaskOutput::Timed
+    )
 }
 
 impl OutputHandler {
@@ -450,6 +475,25 @@ impl OutputHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn colored_prefix_modes_require_a_rendered_style() {
+        for output in [
+            TaskOutput::Prefix,
+            TaskOutput::KeepOrder,
+            TaskOutput::Replacing,
+            TaskOutput::Timed,
+        ] {
+            assert!(displays_colored_task_prefix(output));
+        }
+        for output in [
+            TaskOutput::Interleave,
+            TaskOutput::Quiet,
+            TaskOutput::Silent,
+        ] {
+            assert!(!displays_colored_task_prefix(output));
+        }
+    }
 
     #[test]
     fn cached_timed_output_preserves_all_stdout_lines() {

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::sync::LazyLock;
 
 use crate::file::display_path;
-use console::{Color, StyledObject, style};
+use console::{Color, Style, StyledObject, style};
 
 pub fn estyle<D>(val: D) -> StyledObject<D> {
     style(val).for_stderr()
@@ -84,13 +84,12 @@ pub fn nbright<D>(val: D) -> StyledObject<D> {
     nstyle(val).bright()
 }
 
-pub fn prefix(label: impl Into<String>, hash_key: impl AsRef<str>, stderr: bool) -> String {
+fn prefix_style(hash_key: impl AsRef<str>, stderr: bool) -> Style {
     static COLORS: LazyLock<Vec<Color>> =
         LazyLock::new(|| vec![Color::Blue, Color::Magenta, Color::Cyan, Color::Green]);
 
-    let label = label.into();
     let hash = hash_key.as_ref().chars().map(|c| c as usize).sum::<usize>();
-    let styled = style(label).fg(COLORS[hash % COLORS.len()]);
+    let styled = Style::new().fg(COLORS[hash % COLORS.len()]);
     let mut styled = if stderr {
         styled.for_stderr()
     } else {
@@ -103,5 +102,55 @@ pub fn prefix(label: impl Into<String>, hash_key: impl AsRef<str>, stderr: bool)
         _ => {}
     }
 
-    styled.to_string()
+    styled
+}
+
+pub fn prefix(label: impl Into<String>, hash_key: impl AsRef<str>, stderr: bool) -> String {
+    prefix_style(hash_key, stderr)
+        .apply_to(label.into())
+        .to_string()
+}
+
+/// Return the ANSI sequence that starts the style used for a task prefix.
+///
+/// Styling is forced here because the caller separately decides whether color
+/// is enabled for the selected output mode. The trailing reset emitted by
+/// `console` is removed so tasks can apply the style to their own output.
+pub fn prefix_ansi(hash_key: impl AsRef<str>) -> String {
+    let rendered = prefix_style(hash_key, false)
+        .force_styling(true)
+        .apply_to("")
+        .to_string();
+    rendered
+        .strip_suffix("\x1b[0m")
+        .expect("forced prefix style should end with an ANSI reset")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefix_ansi_matches_rendered_prefix_style() {
+        for name in ["a", "b", "c", "d", "alpha", "bravo", "charlie", "echo"] {
+            let ansi = prefix_ansi(name);
+            let rendered = prefix_style(name, false)
+                .force_styling(true)
+                .apply_to("label")
+                .to_string();
+            assert_eq!(rendered, format!("{ansi}label\x1b[0m"));
+        }
+    }
+
+    #[test]
+    fn prefix_ansi_includes_color_and_emphasis() {
+        assert_eq!(prefix_ansi("p"), "\x1b[34m");
+        assert_eq!(prefix_ansi("a"), "\x1b[35m");
+        assert_eq!(prefix_ansi("b"), "\x1b[36m");
+        assert_eq!(prefix_ansi("c"), "\x1b[32m");
+        assert_eq!(prefix_ansi("alpha"), "\x1b[36m\x1b[1m");
+        assert_eq!(prefix_ansi("bravo"), "\x1b[36m\x1b[2m");
+        assert_eq!(prefix_ansi("echo"), "\x1b[38;5;10m");
+    }
 }


### PR DESCRIPTION
## Summary

- expose the resolved task prefix style as `MISE_TASK_COLOR`
- share one color/style resolver between prefix rendering and task environments
- keep the value empty when colors or prefix-style output are disabled

## Context

Task prefix colors were deterministic, but the resolved style was internal to mise. Task scripts that wanted matching output had to duplicate the display-name hash, palette, and emphasis rules.

`MISE_TASK_COLOR` now contains the complete ANSI opening sequence used by the task label, including bold, dim, or bright styling. It is injected per task occurrence as a reserved runtime value, so ambient or configured values cannot make it disagree with the rendered label and a parent task's color does not leak into nested tasks. The value is empty for interleaved, quiet, silent, or raw output and when color is disabled. Replacing output also provides the value through its text fallback because the variable describes the rendered task-label style rather than promising that every output line is prefixed.

## Verification

- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- cargo test --all-features ui::style::tests`
- `mise exec -- cargo test --all-features task::task_output_handler::tests`
- `mise run test:e2e e2e/tasks/test_task_prefix_color e2e/tasks/test_task_run_output e2e/tasks/test_task_output_style_decoupling e2e/tasks/test_task_prefix_args_disambiguation`
- `mise exec -- cargo check --all-features`
- `mise exec -- shellcheck e2e/tasks/test_task_prefix_color`
- `mise exec -- prettier --check docs/tasks/index.md`
- `mise exec npm:markdownlint-cli -- markdownlint docs/tasks/index.md`
- `mise run docs:build`

Full workspace Clippy currently stops in unchanged upstream code at `src/system/packages/brew/cask.rs:1959` (`clippy::needless_return`). `mise run lint` also cannot discover a Git repository in this Sapling checkout; the focused format, ShellCheck, Prettier, and Markdownlint checks above pass.

Addresses https://github.com/jdx/mise/discussions/9598

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added colored task prefixes through the `MISE_TASK_COLOR` environment variable.
  - Supports forced colors, output-mode-specific behavior, fallback styling, and ANSI reset handling.
  - Preserves expected behavior for quiet, raw, disabled, nested, timed, and replacing output modes.

- **Documentation**
  - Documented `MISE_TASK_COLOR`, including empty values, text fallback, and line-prefix behavior.

- **Tests**
  - Added comprehensive end-to-end coverage for task prefix coloring and suppression scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->