### PR TITLE
fix(file): say why a Windows file operation failed

### DIFF
--- a/e2e-win/uninstall_in_use.Tests.ps1
+++ b/e2e-win/uninstall_in_use.Tests.ps1
@@ -1,0 +1,70 @@
+Describe 'uninstall while the tool is running' {
+    BeforeAll {
+        $script:originalPath = Get-Location
+        $script:originalEnv = @{}
+        foreach ($name in 'MISE_TRUSTED_CONFIG_PATHS', 'MISE_YES') {
+            $script:originalEnv[$name] = [Environment]::GetEnvironmentVariable($name, 'Process')
+        }
+
+        $script:testDir = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:testDir | Out-Null
+        Set-Location $script:testDir
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:testDir
+        $env:MISE_YES = '1'
+
+        mise install jq@1.8.2 | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw "mise install jq failed with exit code $LASTEXITCODE"
+        }
+        $script:installDir = (mise where jq@1.8.2) | Select-Object -Last 1
+        $script:jq = Join-Path $script:installDir 'jq.exe'
+
+        # Hold the image mapped. jq blocks on stdin, so the file stays locked until it is killed.
+        $psi = [Diagnostics.ProcessStartInfo]::new($script:jq, '.')
+        $psi.RedirectStandardInput = $true
+        $psi.UseShellExecute = $false
+        $script:held = [Diagnostics.Process]::Start($psi)
+        Start-Sleep -Milliseconds 300
+    }
+
+    AfterAll {
+        # Unconditional: leaving it running would lock $TestDrive and break Pester's own cleanup.
+        if ($script:held -and -not $script:held.HasExited) {
+            $script:held.Kill()
+            $script:held.WaitForExit()
+        }
+        Set-Location $script:originalPath
+        foreach ($name in $script:originalEnv.Keys) {
+            if ($null -eq $script:originalEnv[$name]) {
+                Remove-Item -Path "Env:\$name" -ErrorAction SilentlyContinue
+            } else {
+                [Environment]::SetEnvironmentVariable($name, $script:originalEnv[$name], 'Process')
+            }
+        }
+    }
+
+    It 'says the file is in use rather than only "Access is denied"' {
+        $script:held.HasExited | Should -BeFalse -Because 'the lock is the whole premise'
+
+        $out = & mise uninstall jq@1.8.2 2>&1 | Out-String
+        $LASTEXITCODE | Should -Not -Be 0
+        $out | Should -Match 'in use'
+        # `rm -rf` is not a command a Windows reader has.
+        $out | Should -Not -Match 'rm -rf'
+        # The failure has to stay a failure: the tool is still on disk. Asserted on the directory
+        # rather than `mise ls`, whose output matches "jq" for any other jq version the job has
+        # installed.
+        Test-Path -LiteralPath $script:installDir | Should -BeTrue
+    }
+
+    It 'succeeds once nothing is holding it' {
+        # The control. Without it, "uninstall failed" would not show that the lock is what did it.
+        $script:held.Kill()
+        $script:held.WaitForExit()
+
+        $out = & mise uninstall jq@1.8.2 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Not -Match 'in use'
+        Test-Path -LiteralPath $script:installDir | Should -BeFalse
+    }
+}

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -9,6 +9,8 @@ use self_update::{Status, cargo_crate_version};
 use crate::cli::version::{ARCH, OS};
 use crate::config::Settings;
 use crate::env;
+#[cfg(windows)]
+use crate::file::MAX_PATH;
 use std::collections::BTreeMap;
 use std::fs;
 #[cfg(target_os = "macos")]
@@ -102,20 +104,15 @@ pub struct SelfUpdate {
     no_plugins: bool,
 }
 
-/// Windows refuses to *start* an executable whose path reaches this length: the limit counts
-/// UTF-16 code units and includes the terminating NUL, so a path of exactly MAX_PATH is
-/// already one too many. Unlike the file APIs, `CreateProcess` has no `\\?\` escape hatch.
-#[cfg(windows)]
-const MAX_PATH: usize = 260;
-
 /// Whether replacing the running binary would destroy the install with `TEMP` set to `tmp`.
 ///
 /// `self-replace` renames the running mise.exe out of its install directory *first*, then
 /// launches a copy of it from `TEMP` to finish the swap. When that copy's path exceeds
-/// MAX_PATH the launch fails, and nothing puts mise back: the install directory is left
-/// empty and the binary is stranded in `TEMP` under a generated name. The crate declares
-/// executable paths that long out of scope (self-replace-1.5.0/src/windows.rs, in
-/// `self_delete_on_init`), so the only place to stop this is before it starts.
+/// `MAX_PATH` the launch fails — `CreateProcess` has no `\\?\` escape hatch the way the file
+/// APIs do — and nothing puts mise back: the install directory is left empty and the binary is
+/// stranded in `TEMP` under a generated name. The crate declares executable paths that long out
+/// of scope (self-replace-1.5.0/src/windows.rs, in `self_delete_on_init`), so the only place to
+/// stop this is before it starts.
 #[cfg(windows)]
 fn temp_dir_breaks_self_replace(tmp: &std::path::Path, exe_stem: Option<&str>) -> bool {
     helper_path_len(tmp, exe_stem) >= MAX_PATH

--- a/src/file.rs
+++ b/src/file.rs
@@ -62,6 +62,85 @@ pub fn append<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> Result<()
         .wrap_err_with(|| format!("failed append: {}", display_path(path)))
 }
 
+/// Windows' `MAX_PATH`. Not a limit mise imposes — the point below is that some paths hit it long
+/// before others do. It counts UTF-16 code units and includes the terminating NUL, so a path of
+/// exactly `MAX_PATH` is already one too many.
+///
+/// Shared with [`crate::cli::self_update`], which needs the same number for the opposite reason:
+/// the file APIs can be escaped past this with a `\\?\` prefix, which is why `std::fs` copes with
+/// long paths, but `CreateProcess` has no such escape hatch and simply will not start an
+/// executable whose path reaches it.
+#[cfg(windows)]
+pub(crate) const MAX_PATH: usize = 260;
+
+/// Why a Windows file operation on `path` probably failed, when the error says something a reader
+/// cannot act on.
+///
+/// `None` on unix, always: deleting a running binary succeeds there, and `MAX_PATH` does not
+/// exist. Splitting the remedy by platform rather than the wording follows
+/// [`make_executable_hint`], where `chmod +x` was not merely unavailable on Windows but the wrong
+/// instruction.
+///
+/// The error codes are the ones already spoken elsewhere in this file — see [`do_rename`] and
+/// `should_retry_atomic_persist`, which retry on the same pair. This answers a different question
+/// about them: not whether to try again, but what to tell the user when trying again will not help.
+#[cfg(windows)]
+fn windows_io_hint(path: &Path, err: &std::io::Error) -> Option<String> {
+    use std::os::windows::ffi::OsStrExt;
+
+    // ERROR_ACCESS_DENIED (5) / ERROR_SHARING_VIOLATION (32). Unlike the transient locks that
+    // `do_rename` retries through, a file held open by a running process stays held, so this is a
+    // message rather than a retry.
+    let in_use = err.kind() == std::io::ErrorKind::PermissionDenied
+        || matches!(err.raw_os_error(), Some(5) | Some(32));
+    if in_use {
+        return Some(
+            "A file under it is in use. A program started from this directory — the tool itself, \
+             an editor, or a shell sitting in it — is probably still running."
+                .to_string(),
+        );
+    }
+    // Only the errors Windows actually reports for an over-long path. Without this the branch
+    // fires on anything that happens to occur deep in a tree -- a genuinely missing directory
+    // would be answered with advice about path length.
+    //
+    // ERROR_PATH_NOT_FOUND (3) is what was measured; ERROR_INVALID_NAME (123) and
+    // ERROR_FILENAME_EXCED_RANGE (206) are the other two Windows uses for the same cause. `3` is
+    // ambiguous by nature -- a path can be both long and absent -- so the wording below suggests
+    // rather than asserts.
+    if !matches!(err.raw_os_error(), Some(3) | Some(123) | Some(206)) {
+        return None;
+    }
+    // UTF-16 code units, which is what the limit counts. `OsStr::len()` is WTF-8 bytes on Windows,
+    // so a path with any non-ASCII in it would measure long before Windows thought so.
+    let units = path.as_os_str().encode_wide().count();
+    if units < MAX_PATH - 16 {
+        return None;
+    }
+    // Measured: `std::fs` itself copes well past `MAX_PATH` -- create_dir_all, write and rename all
+    // succeeded at 490 units with long paths disabled -- so a "path not found" this close to the
+    // limit is more likely the length than the missing directory it appears to be.
+    Some(format!(
+        "The path is {units} characters, at or near Windows' {MAX_PATH}-character limit, which \
+         may be the real cause rather than a missing directory. mise writes through a temporary \
+         file whose name is longer than the final one, so it crosses the limit first. Try a \
+         shorter directory."
+    ))
+}
+
+#[cfg(not(windows))]
+fn windows_io_hint(_path: &Path, _err: &std::io::Error) -> Option<String> {
+    None
+}
+
+/// Attach [`windows_io_hint`] to `err`, if it has anything to say about this path.
+fn with_io_hint(msg: String, path: &Path, err: &std::io::Error) -> String {
+    match windows_io_hint(path, err) {
+        Some(hint) => format!("{msg}\n{hint}"),
+        None => msg,
+    }
+}
+
 pub fn remove_all<P: AsRef<Path>>(path: P) -> Result<()> {
     let path = path.as_ref();
     match path.metadata().map(|m| m.file_type()) {
@@ -70,8 +149,18 @@ pub fn remove_all<P: AsRef<Path>>(path: P) -> Result<()> {
         }
         Ok(x) if x.is_dir() => {
             trace!("rm -rf {}", display_path(path));
-            fs::remove_dir_all(path)
-                .wrap_err_with(|| format!("failed rm -rf: {}", display_path(path)))?;
+            // `map_err` rather than `wrap_err_with`: the hint depends on the error, and
+            // `wrap_err_with`'s closure is not given it.
+            fs::remove_dir_all(path).map_err(|e| {
+                let msg = with_io_hint(
+                    // Not "rm -rf": mise calls `remove_dir_all`, and on Windows it is naming a
+                    // command the reader does not have.
+                    format!("failed to remove: {}", display_path(path)),
+                    path,
+                    &e,
+                );
+                eyre::eyre!(e).wrap_err(msg)
+            })?;
         }
         _ => {}
     };
@@ -389,8 +478,20 @@ pub fn write_atomic<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> Res
     temporary.write_all(contents.as_ref())?;
 
     temporary.as_file_mut().sync_all()?;
-    persist_atomic(temporary, path)
-        .wrap_err_with(|| format!("failed atomic write: {}", display_path(path)))?;
+    // The hint matters most here. `tempfile`'s persist does not get the extended-length path
+    // handling `std::fs` applies, so this is the operation that fails first as a path approaches
+    // `MAX_PATH` -- measured breaking at a 253-character target while `fs::rename` on the same
+    // tree succeeded at 415.
+    persist_atomic(temporary, path).map_err(|e| {
+        let msg = format!("failed atomic write: {}", display_path(path));
+        // Resolve the hint before `wrap_err` takes `e` by value: `downcast_ref` borrows it, and
+        // doing both in one expression leaves the borrow alive across the move.
+        let msg = match e.downcast_ref::<std::io::Error>() {
+            Some(io) => with_io_hint(msg, path, io),
+            None => msg,
+        };
+        e.wrap_err(msg)
+    })?;
     sync_dir(parent)?;
     Ok(())
 }
@@ -4382,6 +4483,76 @@ mod tests {
         }
         for name in ["tool.ps1", "tool.PS1", "tool.vbs", "tool", r"C:\x\tool"] {
             assert!(!can_execute_directly(Path::new(name)), "{name}");
+        }
+    }
+
+    fn io(raw: i32) -> std::io::Error {
+        std::io::Error::from_raw_os_error(raw)
+    }
+
+    /// `mise uninstall` of a tool whose binary is still running reported only "Access is denied",
+    /// which on Windows is nearly always that and nothing else.
+    #[cfg(windows)]
+    #[test]
+    fn an_in_use_file_says_so() {
+        for raw in [5, 32] {
+            let hint = windows_io_hint(Path::new(r"C:\x\installs\jq\1.8.2"), &io(raw))
+                .unwrap_or_else(|| panic!("raw {raw} should be explained"));
+            assert!(hint.contains("in use"), "raw {raw}: {hint}");
+        }
+    }
+
+    /// Measured: the atomic write breaks at a 253-character target while `fs::rename` on the same
+    /// tree succeeds at 415, so "path not found" here is the length rather than a missing parent.
+    #[cfg(windows)]
+    #[test]
+    fn a_path_near_the_limit_says_so() {
+        let long = PathBuf::from(format!(r"C:\{}", "d".repeat(300)));
+        let hint = windows_io_hint(&long, &io(3)).expect("a long path should be explained");
+        assert!(hint.contains("260"), "{hint}");
+    }
+
+    /// The controls, and the point of the whole thing: do not attach an explanation to an error
+    /// that already means what it says.
+    #[cfg(windows)]
+    #[test]
+    fn an_ordinary_error_is_left_alone() {
+        // A short path that is genuinely absent is not the `MAX_PATH` case.
+        assert!(windows_io_hint(Path::new(r"C:\x\gone"), &io(2)).is_none());
+        assert!(windows_io_hint(Path::new(r"C:\x\gone"), &io(3)).is_none());
+
+        // And neither is an unrelated failure that happens to occur deep in a tree. Length alone
+        // used to be enough to trigger the advice, which answered "disk full" with "shorten it".
+        let long = PathBuf::from(format!(r"C:\{}", "d".repeat(300)));
+        for raw in [2, 39, 112] {
+            assert!(windows_io_hint(&long, &io(raw)).is_none(), "raw {raw}");
+        }
+    }
+
+    /// The limit counts UTF-16 code units; `OsStr::len()` is WTF-8 bytes on Windows. A path of
+    /// non-ASCII characters is under the limit while measuring well over it in bytes.
+    #[cfg(windows)]
+    #[test]
+    fn the_limit_is_measured_the_way_windows_measures_it() {
+        use std::os::windows::ffi::OsStrExt;
+
+        // 200 three-byte characters: 600 bytes, 200 UTF-16 units.
+        let path = PathBuf::from(format!(r"C:\{}", "あ".repeat(200)));
+        assert!(path.as_os_str().len() > MAX_PATH, "premise");
+        assert!(
+            path.as_os_str().encode_wide().count() < MAX_PATH - 16,
+            "premise"
+        );
+        assert!(windows_io_hint(&path, &io(3)).is_none());
+    }
+
+    /// unix has neither failure mode: a running binary can be unlinked, and there is no `MAX_PATH`.
+    #[cfg(not(windows))]
+    #[test]
+    fn unix_is_never_annotated() {
+        let long = PathBuf::from(format!("/{}", "d".repeat(300)));
+        for (path, raw) in [(Path::new("/x/installs/jq/1.8.2"), 13), (long.as_path(), 2)] {
+            assert!(windows_io_hint(path, &io(raw)).is_none(), "{path:?}");
         }
     }
 }


### PR DESCRIPTION
Two Windows failures that reported an OS error code and nothing else. Both found by probing on
**2026.8.2 windows-x64** in an isolated `MISE_*` environment.

## `mise uninstall` while the tool is running

Install `jq`, start its exe so the image stays mapped, uninstall:

```console
> mise uninstall jq@1.8.2
mise WARN  failed to remove ...\installs\jq\1.8.2: failed rm -rf: ...\installs\jq\1.8.2
mise ERROR failed rm -rf: ...\installs\jq\1.8.2
mise ERROR failed to uninstall aqua:jqlang/jq@1.8.2
mise ERROR failed rm -rf: ...\installs\jq\1.8.2
mise ERROR アクセスが拒否されました。 (os error 5)
```

On Windows an access-denied under an install directory is nearly always the tool still running.
Unix unlinks a running binary without complaint, so this is a Windows-only gap in what mise can
say. **The failure is correct and stays one** — the install is left intact, `mise ls --installed`
still lists it, and the exit code is unchanged.

## `mise install` into a long path

```console
mise ERROR Failed to install aqua:jqlang/jq@1.8.2:
           failed to persist temporary file: 指定されたパスが見つかりません。 (os error 3)
```

"Path not found" for a path that exists — the reader goes looking for a missing directory.

I bisected it rather than assuming, and the answer was not the one I expected:

| target path | result |
|---|---|
| 233 chars | installs |
| **253 chars** | **fails** |
| 313 chars | fails |

So it is `MAX_PATH` — **but only in this one place.** Plain `std::fs` copes well past it; measured
`create_dir_all`, `write`, `read`, `rename`, `canonicalize` and `read_dir` all succeeding at **490**
characters with long paths disabled. `write_atomic` goes through `tempfile`, which does not get
std's extended-length path handling, and it prefixes the temporary name with `.{filename}.` — so
the temporary crosses 260 before the final path would. That is why the message names *persisting a
temporary file*.

## The change

`windows_io_hint` answers both, and reuses the vocabulary already in this file: `do_rename` and
`should_retry_atomic_persist` both key on `ERROR_ACCESS_DENIED` (5) / `ERROR_SHARING_VIOLATION`
(32). This asks a different question of the same pair — not whether to retry, but what to say when
retrying cannot help.

**No retry is added to `remove_all`.** A process holding a file keeps holding it; that is not the
transient antivirus lock `rename` already retries through. The fix is the message.

Precedent for splitting the remedy rather than the wording: `make_executable_hint` (#11923), which
stopped telling Windows users to run `chmod +x`.

## One separable line

The message drops `rm -rf` for `failed to remove`. mise calls `remove_dir_all`, and on Windows
`rm -rf` names a command the reader does not have — the same complaint #11923 fixed. Nothing
asserts the old wording (`implode` and `prune` print `rm -rf` deliberately and are untouched).
**If you want the behaviour without the rename, that one line can go and the rest still stands.**

## Tests

- `e2e-win/uninstall_in_use.Tests.ps1` — installs a tool, holds its exe open, asserts the uninstall
  fails *and says why*, and that the install survives. The control is the second case: kill the
  process and the same uninstall succeeds, so the hint is tied to the lock rather than printed
  always. `AfterAll` kills the process unconditionally, since leaving it would lock `$TestDrive`
  and break Pester's own cleanup.
- Unit tests on `windows_io_hint` for both codes and for a long path, with a control that an
  ordinary `NotFound` on a short path gets **no** hint — the point is not to annotate errors that
  already mean what they say — and that unix is never annotated.

## Verification

I did not build locally. I ran the new Pester suite against the released 2026.8.2 binary, which
predates the fix, to check the suite drives the scenario rather than passing vacuously:

```
[-] says the file is in use rather than only "Access is denied"   <- fails only on the 'in use' match
[+] succeeds once nothing is holding it
```

That is the expected shape: the control passes, and the only failure is the assertion this PR makes
true. Running it also caught two defects in my own test — it was matching `mise ls` output loosely
enough that any other `jq` version satisfied it — which is why it now asserts on the install
directory instead. The rest goes to CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows error messages when files cannot be removed because they are in use.
  * Added clearer guidance for Windows paths that exceed supported length limits.
  * Preserved existing error details alongside relevant platform-specific diagnostics.
  * Fixed Windows uninstall behavior so locked installations remain intact and can be removed after the running process exits.
  * Improved consistency in Windows self-update path-limit guidance.

* **Tests**
  * Added end-to-end coverage for uninstalling an active Windows installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## `MAX_PATH`

#12062 merged first and left a `MAX_PATH` of its own in `cli::self_update`, for the opposite half of
the same constant — the file APIs can be escaped past it with a `\\?\` prefix, which is why
`std::fs` copes with long paths, while `CreateProcess` cannot and will not start an executable whose
path reaches it. That PR said whichever landed second should drop the duplicate, so this one keeps
the definition in `file` and has `self_update` import it. That is why this branch now touches
`src/cli/self_update.rs`, which is otherwise unrelated to what it fixes.