### PR TITLE
feat(config): support project conf.d fragments

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,9 +10,10 @@ Learn how to configure mise for your project with `mise.toml` files, environment
 - `mise.toml`
 - `mise/config.toml`
 - `.mise/config.toml`
+- `.mise/conf.d/*.toml` - all non-hidden TOML files in this directory will be loaded in alphabetical order
 - `.config/mise.toml` - use this in order to group config files into a common directory
 - `.config/mise/config.toml`
-- `.config/mise/conf.d/*.toml` - all files in this directory will be loaded in alphabetical order
+- `.config/mise/conf.d/*.toml` - all non-hidden TOML files in this directory will be loaded in alphabetical order
 
 ::: tip
 Run [`mise cfg`](/cli/config.html) to figure out what order mise is loading files on your particular setup. This is often
@@ -64,6 +65,9 @@ When mise needs configuration, it follows this process:
         └── myproject/
             ├── mise.local.toml       # Local overrides (git-ignored)
             ├── mise.toml             # Project config
+            ├── .mise/
+            │   ├── config.toml       # Project config grouped under .mise
+            │   └── conf.d/*.toml     # Project fragments, loaded alphabetically
             ├── mise.<env>.toml       # Env-specific project config
             ├── mise.<env>.local.toml # Env-specific project local overrides
             └── backend/

--- a/e2e/config/test_project_config_confd_slow
+++ b/e2e/config/test_project_config_confd_slow
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+mkdir -p .mise/conf.d
+
+cat >.mise/conf.d/01-base.toml <<'EOF'
+[env]
+CONFD_ORDER = "base"
+CONFD_FROM_VAR = "{{ vars.fragment }}"
+
+[vars]
+fragment = "loaded"
+
+[tools]
+dummy = "1.0.0"
+
+[tasks.confd]
+description = "base fragment"
+run = 'echo "$CONFD_ORDER:$CONFD_FROM_VAR"'
+EOF
+
+cat >.mise/conf.d/02-override.toml <<'EOF'
+[env]
+CONFD_ORDER = "override"
+
+[tasks.confd]
+description = "override fragment"
+run = 'echo "$CONFD_ORDER:$CONFD_FROM_VAR"'
+EOF
+
+cat >.mise/conf.d/.hidden.toml <<'EOF'
+[env]
+HIDDEN_FRAGMENT = "unexpected"
+EOF
+
+assert_contains "mise env -s bash" "CONFD_ORDER=override"
+assert_contains "mise env -s bash" "CONFD_FROM_VAR=loaded"
+assert_contains "mise config ls" ".mise/conf.d/01-base.toml"
+assert_contains "mise config ls" ".mise/conf.d/02-override.toml"
+assert_not_contains "mise config ls" ".mise/conf.d/.hidden.toml"
+assert_not_contains "mise env -s bash" "HIDDEN_FRAGMENT"
+assert_contains "mise config ls --tracked-configs" ".mise/conf.d/01-base.toml"
+assert_contains "mise config ls" "dummy"
+assert_contains "mise tasks" "confd  override fragment"
+assert "mise run --skip-tools confd" "override:loaded"
+
+# The regular .mise config has higher precedence than every fragment.
+cat >.mise/config.toml <<'EOF'
+[env]
+CONFD_ORDER = "config"
+EOF
+assert_contains "mise env -s bash" "CONFD_ORDER=config"
+assert "mise run --skip-tools confd" "config:loaded"
+
+# All fragments in .mise/conf.d share the .mise/mise.lock destination.
+export MISE_LOCKFILE=1
+output=$(mise lock --platform linux-x64 --dry-run 2>&1)
+assert_contains "echo '$output'" ".mise/mise.lock"
+assert_not_contains "echo '$output'" ".mise/conf.d/mise.lock"
+
+# Drop-ins are never implicit write targets.
+mkdir -p write-target/.mise/conf.d
+cat >write-target/.mise/conf.d/10-drop-in.toml <<'EOF'
+[env]
+DROP_IN_ONLY = "yes"
+EOF
+mise use --path write-target dummy@system
+assert_contains "cat write-target/mise.toml" 'dummy = "system"'
+assert_not_contains "cat write-target/.mise/conf.d/10-drop-in.toml" 'dummy = "system"'
+
+# Explicit monorepo roots recognize projects whose only config is a fragment.
+mkdir -p monorepo/packages/app/.mise/conf.d
+cat >monorepo/mise.toml <<'EOF'
+min_version = "2026.1.0"
+monorepo_root = true
+
+[monorepo]
+config_roots = ["packages/*"]
+EOF
+cat >monorepo/packages/app/.mise/conf.d/tasks.toml <<'EOF'
+[tasks.hello]
+run = "echo fragment-root"
+EOF
+assert_contains "cd monorepo && mise tasks --all" "app:hello"
+
+# Deprecated automatic discovery uses the same glob-aware root detection.
+cat >monorepo/mise.toml <<'EOF'
+min_version = "2026.1.0"
+monorepo_root = true
+EOF
+assert_contains "cd monorepo && mise tasks --all" "app:hello"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1388,8 +1388,7 @@ fn configs_at_root<'a>(dir: &Path, config_files: &'a ConfigMap) -> Vec<&'a Arc<d
         .flat_map(|f| {
             if f.contains('*') {
                 // Handle glob patterns by matching against actual config file paths
-                glob(dir, f)
-                    .unwrap_or_default()
+                config_glob(dir, f)
                     .into_iter()
                     .rev()
                     .filter_map(|path| config_files.get(&path))
@@ -1581,6 +1580,7 @@ static LOCAL_CONFIG_FILENAMES: Lazy<IndexSet<&'static str>> = Lazy::new(|| {
             ".config/mise/config.toml",
             ".config/mise/mise.toml",
             ".config/mise.toml",
+            ".mise/conf.d/*.toml",
             ".mise/config.toml",
             "mise/config.toml",
             ".rtx.toml",
@@ -1694,10 +1694,25 @@ pub fn glob(dir: &Path, pattern: &str) -> Result<Vec<PathBuf>> {
     Ok(paths)
 }
 
+fn config_glob(dir: &Path, pattern: &str) -> Vec<PathBuf> {
+    // Match global/system conf.d discovery: editor backups and other hidden
+    // files are not configuration fragments.
+    glob(dir, pattern)
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|path| {
+            !is_conf_d_file(path)
+                || !path
+                    .file_name()
+                    .is_some_and(|name| name.to_string_lossy().starts_with('.'))
+        })
+        .collect()
+}
+
 pub fn config_files_in_dir(dir: &Path) -> IndexSet<PathBuf> {
     DEFAULT_CONFIG_FILENAMES
         .iter()
-        .flat_map(|f| glob(dir, f).unwrap_or_default())
+        .flat_map(|f| config_glob(dir, f))
         .collect()
 }
 
@@ -1711,7 +1726,7 @@ fn config_paths_in_dir_with_filenames(dir: &Path, filenames: &[String]) -> Vec<P
         .rev()
         .flat_map(|f| {
             if f.contains('*') {
-                glob(dir, f).unwrap_or_default().into_iter().rev().collect()
+                config_glob(dir, f).into_iter().rev().collect()
             } else {
                 let path = dir.join(f);
                 if path.exists() { vec![path] } else { vec![] }
@@ -1779,7 +1794,7 @@ fn loadable_config_files_in_dir(dir: &Path, filenames: &[String]) -> IndexSet<Pa
     }
     filenames
         .iter()
-        .flat_map(|f| glob(dir, f).unwrap_or_default())
+        .flat_map(|f| config_glob(dir, f))
         .unique_by(|p| file::desymlink_path(p))
         .filter(|p| !config_path_is_ignored(p, false))
         .collect()
@@ -2135,7 +2150,7 @@ pub async fn load_config_hierarchy_from_dir(
                 config_filenames
                     .iter()
                     .rev()
-                    .flat_map(|f| glob(dir, f).unwrap_or_default().into_iter().rev())
+                    .flat_map(|f| config_glob(dir, f).into_iter().rev())
                     .collect()
             }
         })
@@ -3569,14 +3584,19 @@ fn expand_config_roots_inner(
 }
 
 fn has_mise_config_with_filenames(dir: &Path, filenames: &[String]) -> bool {
+    has_config_file_with_filenames(dir, filenames)
+        || dir.join(".mise/tasks").is_dir()
+        || dir.join("mise-tasks").is_dir()
+}
+
+fn has_config_file_with_filenames(dir: &Path, filenames: &[String]) -> bool {
     filenames.iter().any(|f| {
         if f.contains('*') {
-            !glob(dir, f).unwrap_or_default().is_empty()
+            !config_glob(dir, f).is_empty()
         } else {
             dir.join(f).exists()
         }
-    }) || dir.join(".mise/tasks").is_dir()
-        || dir.join("mise-tasks").is_dir()
+    })
 }
 
 fn discover_monorepo_subdirs(
@@ -3651,9 +3671,7 @@ fn discover_monorepo_subdirs(
                 }
 
                 // Check if this directory has a mise config file
-                let has_config = DEFAULT_CONFIG_FILENAMES
-                    .iter()
-                    .any(|f| dir.join(f).exists());
+                let has_config = has_config_file_with_filenames(dir, &DEFAULT_CONFIG_FILENAMES);
                 let has_task_includes = has_task_includes(dir);
                 if has_config || has_task_includes {
                     // Apply context filtering if provided
@@ -3688,9 +3706,7 @@ fn discover_monorepo_subdirs(
             if entry.file_type().is_dir() {
                 let dir = entry.path();
                 // Check if this directory has a mise config file
-                let has_config = DEFAULT_CONFIG_FILENAMES
-                    .iter()
-                    .any(|f| dir.join(f).exists());
+                let has_config = has_config_file_with_filenames(dir, &DEFAULT_CONFIG_FILENAMES);
                 let has_task_includes = has_task_includes(dir);
                 if has_config || has_task_includes {
                     // Apply context filtering if provided
@@ -5085,14 +5101,53 @@ mod tests {
     #[test]
     fn test_has_mise_config_with_glob_filenames() -> Result<()> {
         let tmp = TempDir::new()?;
-        let confd = tmp.path().join(".config/mise/conf.d");
-        fs::create_dir_all(&confd)?;
-        fs::write(confd.join("tools.toml"), "[tools]\n")?;
+        for pattern in [".config/mise/conf.d/*.toml", ".mise/conf.d/*.toml"] {
+            let confd = tmp.path().join(pattern.trim_end_matches("/*.toml"));
+            fs::create_dir_all(&confd)?;
+            fs::write(confd.join("tools.toml"), "[tools]\n")?;
 
-        assert!(has_mise_config_with_filenames(
-            tmp.path(),
-            &[".config/mise/conf.d/*.toml".to_string()]
-        ));
+            assert!(has_mise_config_with_filenames(
+                tmp.path(),
+                &[pattern.to_string()]
+            ));
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_project_mise_conf_d_precedence() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let confd = tmp.path().join(".mise/conf.d");
+        fs::create_dir_all(&confd)?;
+        fs::write(confd.join("01-base.toml"), "[env]\nORDER = 'base'\n")?;
+        fs::write(
+            confd.join("02-override.toml"),
+            "[env]\nORDER = 'override'\n",
+        )?;
+        fs::write(confd.join(".hidden.toml"), "[env]\nORDER = 'hidden'\n")?;
+        fs::write(
+            tmp.path().join(".mise/config.toml"),
+            "[env]\nORDER = 'config'\n",
+        )?;
+
+        let filenames = vec![
+            ".mise/conf.d/*.toml".to_string(),
+            ".mise/config.toml".to_string(),
+        ];
+        let paths = config_paths_in_dir_with_filenames(tmp.path(), &filenames);
+        let relative = paths
+            .iter()
+            .map(|path| path.strip_prefix(tmp.path()).unwrap())
+            .collect_vec();
+        assert_eq!(
+            relative,
+            vec![
+                Path::new(".mise/config.toml"),
+                Path::new(".mise/conf.d/02-override.toml"),
+                Path::new(".mise/conf.d/01-base.toml"),
+            ]
+        );
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

- load non-hidden `.mise/conf.d/*.toml` files as project configuration fragments
- preserve alphabetical fragment precedence while keeping `.mise/config.toml` authoritative
- reuse the existing project trust root, tracking, write-target exclusion, and `.mise/mise.lock` routing
- make deprecated automatic monorepo discovery glob-aware so fragment-only roots are detected consistently with explicit roots

## Details

The project config discovery list already supported `.config/mise/conf.d/*.toml`, while the config-root and lockfile helpers already understood `.mise/conf.d`. The missing piece was the discovery pattern itself. This adds that pattern immediately below `.mise/config.toml` in precedence, filters hidden files consistently with global/system `conf.d`, and routes every downstream feature through the existing config pipeline.

## Verification

- `mise exec -- cargo test --all-features test_project_mise_conf_d_precedence`
- `mise exec -- cargo test --all-features test_has_mise_config_with_glob_filenames`
- `mise run test:e2e e2e/config/test_project_config_confd_slow`
- `mise run test:e2e e2e/cli/test_global_config_confd e2e/tasks/test_task_config_precedence`
- `mise exec -- cargo test --all-features config_root::tests`
- `mise exec -- cargo test --all-features test_lockfile_path_for_config`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shellcheck e2e/config/test_project_config_confd_slow`
- `mise exec -- shfmt -d e2e/config/test_project_config_confd_slow`
- `mise exec -- prettier --check docs/configuration.md`
- `mise run docs:build`

`cargo clippy --workspace --all-features --all-targets -- -D warnings` currently stops on the unchanged latest-main `needless_return` at `src/system/packages/brew/cask.rs:1959`. `mise run lint` also cannot run in this dotgitless Sapling checkout because hk reports `failed to find git repository`.

Addresses https://github.com/jdx/mise/discussions/9909

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*
