### PR TITLE
fix(self-update): refuse to update when TEMP would exceed MAX_PATH

### DIFF
--- a/e2e-win/self_update_long_temp.Tests.ps1
+++ b/e2e-win/self_update_long_temp.Tests.ps1
@@ -1,0 +1,54 @@
+Describe 'self-update with a TEMP that is too long' {
+    BeforeAll {
+        # Saved here and restored in AfterAll: Pester runs every suite in one process, so a
+        # TEMP left pointing at $TestDrive would follow the suites that run after this one.
+        $script:OriginalTemp = $env:TEMP
+        $script:OriginalTmp = $env:TMP
+
+        # Replacing the running binary goes through a helper that self-replace drops in TEMP
+        # under a 57-character generated name and then launches. Past 201 characters of TEMP
+        # that helper's path exceeds MAX_PATH, Windows cannot launch it, and the failure
+        # lands after mise.exe has already left its install directory.
+        $script:LongTemp = Join-Path $TestDrive "temp"
+        while ($script:LongTemp.Length -lt 203) { $script:LongTemp = $script:LongTemp + "x" }
+        New-Item -ItemType Directory -Path $script:LongTemp -Force | Out-Null
+
+        # A version that does not exist. If the guard ever stops working, the run fails while
+        # looking up the release instead of replacing the binary, so a regression here cannot
+        # destroy the mise these tests are running against.
+        $script:MissingVersion = "0.0.0-nonexistent"
+        $script:MiseExe = (Get-Command mise).Source
+    }
+
+    AfterAll {
+        $env:TEMP = $script:OriginalTemp
+        $env:TMP = $script:OriginalTmp
+    }
+
+    It 'refuses before touching the binary when TEMP is too long' {
+        $env:TEMP = $script:LongTemp
+        $env:TMP = $script:LongTemp
+
+        $output = mise self-update $script:MissingVersion --force --yes 2>&1 | Out-String
+
+        $LASTEXITCODE | Should -Not -Be 0
+        $output | Should -Match "TEMP is too long"
+        # The update never started: this line is the first thing the update itself prints.
+        $output | Should -Not -Match "Checking target-arch"
+        Test-Path -LiteralPath $script:MiseExe | Should -BeTrue
+    }
+
+    It 'lets the update proceed with an ordinary TEMP' {
+        $env:TEMP = $script:OriginalTemp
+        $env:TMP = $script:OriginalTmp
+
+        $output = mise self-update $script:MissingVersion --force --yes 2>&1 | Out-String
+
+        # Still fails, but on the missing version rather than on TEMP: the guard fires on
+        # length, not on every run.
+        $LASTEXITCODE | Should -Not -Be 0
+        $output | Should -Not -Match "TEMP is too long"
+        $output | Should -Match "Checking target-arch"
+        Test-Path -LiteralPath $script:MiseExe | Should -BeTrue
+    }
+}

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -1,6 +1,8 @@
 use color_eyre::Result;
 use color_eyre::eyre::bail;
 use console::style;
+#[cfg(windows)]
+use indoc::formatdoc;
 use self_update::backends::github::Update;
 use self_update::{Status, cargo_crate_version};
 
@@ -100,6 +102,70 @@ pub struct SelfUpdate {
     no_plugins: bool,
 }
 
+/// Windows refuses to *start* an executable whose path reaches this length: the limit counts
+/// UTF-16 code units and includes the terminating NUL, so a path of exactly MAX_PATH is
+/// already one too many. Unlike the file APIs, `CreateProcess` has no `\\?\` escape hatch.
+#[cfg(windows)]
+const MAX_PATH: usize = 260;
+
+/// Whether replacing the running binary would destroy the install with `TEMP` set to `tmp`.
+///
+/// `self-replace` renames the running mise.exe out of its install directory *first*, then
+/// launches a copy of it from `TEMP` to finish the swap. When that copy's path exceeds
+/// MAX_PATH the launch fails, and nothing puts mise back: the install directory is left
+/// empty and the binary is stranded in `TEMP` under a generated name. The crate declares
+/// executable paths that long out of scope (self-replace-1.5.0/src/windows.rs, in
+/// `self_delete_on_init`), so the only place to stop this is before it starts.
+#[cfg(windows)]
+fn temp_dir_breaks_self_replace(tmp: &std::path::Path, exe_stem: Option<&str>) -> bool {
+    helper_path_len(tmp, exe_stem) >= MAX_PATH
+}
+
+/// Length in UTF-16 code units of the helper's full path. MAX_PATH counts UTF-16 code units
+/// and includes the terminating NUL, so a total of exactly MAX_PATH is already one too many.
+/// `OsStr::len()` would be the wrong unit: it counts WTF-8 bytes.
+#[cfg(windows)]
+fn helper_path_len(tmp: &std::path::Path, exe_stem: Option<&str>) -> usize {
+    use std::os::windows::ffi::OsStrExt;
+
+    // `Path::join` only inserts a separator when there is not one already, and Windows'
+    // `temp_dir()` always comes back with a trailing backslash.
+    let separator = usize::from(!ends_with_separator(tmp));
+    tmp.as_os_str().encode_wide().count() + separator + helper_name_len(exe_stem)
+}
+
+/// Length in UTF-16 code units of the name `self-replace` generates for the helper:
+/// `.` + the running executable's file stem + `.` + 32 random characters +
+/// `.__selfdelete__.exe`, with the stem included only when it is valid UTF-8. Mirrors
+/// `get_temp_executable_name` in self-replace-1.5.0/src/windows.rs. This is 57 for
+/// `mise.exe` and longer whenever the binary has been renamed, so it cannot be a constant.
+#[cfg(windows)]
+fn helper_name_len(exe_stem: Option<&str>) -> usize {
+    const RANDOM_LEN: usize = 32;
+    const SUFFIX_LEN: usize = ".__selfdelete__.exe".len();
+
+    // The stem is followed by a second `.`, and dropped entirely when it is not UTF-8.
+    let stem = exe_stem.map_or(0, |s| s.encode_utf16().count() + 1);
+    1 + stem + RANDOM_LEN + SUFFIX_LEN
+}
+
+#[cfg(windows)]
+fn ends_with_separator(path: &std::path::Path) -> bool {
+    use std::os::windows::ffi::OsStrExt;
+
+    path.as_os_str()
+        .encode_wide()
+        .last()
+        .is_some_and(|c| c == u16::from(b'\\') || c == u16::from(b'/'))
+}
+
+/// The file stem `self-replace` would put in the helper's name: the running executable's.
+#[cfg(windows)]
+fn current_exe_stem() -> Option<String> {
+    let exe = std::env::current_exe().ok()?;
+    exe.file_stem().and_then(|s| s.to_str()).map(str::to_owned)
+}
+
 impl SelfUpdate {
     pub async fn run(self) -> Result<()> {
         if !Self::is_available() && !self.force {
@@ -108,6 +174,8 @@ impl SelfUpdate {
             }
             bail!("mise is installed via a package manager, cannot update");
         }
+        #[cfg(windows)]
+        Self::ensure_temp_dir_can_replace_binary()?;
         let status = self.do_update()?;
 
         if status.updated() {
@@ -137,6 +205,38 @@ impl SelfUpdate {
         }
 
         Ok(())
+    }
+
+    /// Stop before anything is downloaded or moved when `TEMP` is long enough that
+    /// replacing the binary would leave no mise installed at all.
+    #[cfg(windows)]
+    fn ensure_temp_dir_can_replace_binary() -> Result<()> {
+        use std::os::windows::ffi::OsStrExt;
+
+        let tmp = std::env::temp_dir();
+        let stem = current_exe_stem();
+        if !temp_dir_breaks_self_replace(&tmp, stem.as_deref()) {
+            return Ok(());
+        }
+        let msg = formatdoc! {r#"
+            TEMP is too long to replace mise.exe safely ({len} UTF-16 code units)
+
+              TEMP = {tmp}
+
+            Updating moves the running mise.exe aside and then launches a helper from TEMP to
+            put the new one in place. That helper's path would be {helper} UTF-16 code units,
+            and Windows cannot launch an executable whose path reaches {max}. The move happens
+            first, so going ahead would leave no mise installed at all.
+
+            Point TEMP and TMP at a shorter directory and run mise self-update again:
+
+              $env:TEMP = 'C:\Temp'; $env:TMP = 'C:\Temp'"#,
+            len = tmp.as_os_str().encode_wide().count(),
+            tmp = tmp.display(),
+            helper = helper_path_len(&tmp, stem.as_deref()),
+            max = MAX_PATH,
+        };
+        bail!("{msg}");
     }
 
     fn do_update(&self) -> Result<Status> {
@@ -334,5 +434,98 @@ impl SelfUpdate {
 
         debug!("macOS binary signature verified successfully");
         Ok(())
+    }
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+    use std::path::{Path, PathBuf};
+
+    /// What `env::temp_dir()` hands back on Windows: a directory path of exactly `len`
+    /// UTF-16 code units, trailing backslash included.
+    fn temp_dir_of_len(len: usize) -> PathBuf {
+        let mut s = String::from("C:\\");
+        while s.len() < len - 1 {
+            s.push('t');
+        }
+        s.push('\\');
+        assert_eq!(s.len(), len, "test helper built the wrong length");
+        PathBuf::from(s)
+    }
+
+    fn breaks(len: usize) -> bool {
+        temp_dir_breaks_self_replace(&temp_dir_of_len(len), Some("mise"))
+    }
+
+    #[test]
+    fn an_ordinary_temp_dir_is_left_alone() {
+        let tmp = Path::new("C:\\Users\\u\\AppData\\Local\\Temp\\");
+        assert!(!temp_dir_breaks_self_replace(tmp, Some("mise")));
+    }
+
+    #[test]
+    fn the_boundary_matches_what_windows_actually_does() {
+        // Measured on Windows 11 26200 with LongPathsEnabled=0, running self-update against
+        // a copy of mise.exe: with TEMP at 201 it succeeds and the binary survives, at 202 it
+        // fails with `os error 3` and the install directory is left empty. `temp_dir()`
+        // appends a backslash to both, which is why these are 202 and 203 here.
+        assert!(!breaks(202));
+        assert!(breaks(203));
+    }
+
+    #[test]
+    fn temp_dirs_measured_as_destructive_are_rejected() {
+        assert!(breaks(206)); // TEMP=205
+        assert!(breaks(244)); // TEMP=243
+    }
+
+    #[test]
+    fn a_long_temp_dir_that_still_works_is_not_rejected() {
+        // Control: length alone is not the trigger. TEMP=190 was measured as succeeding, so a
+        // guard that fired here would block updates that work.
+        assert!(!breaks(191));
+    }
+
+    #[test]
+    fn a_trailing_separator_is_not_counted_twice() {
+        // `env::temp_dir()` always ends in a separator on Windows and `Path::join` does not
+        // add a second one, so both spellings of the same directory have to agree.
+        assert_eq!(
+            helper_path_len(Path::new("C:\\Temp\\"), Some("mise")),
+            helper_path_len(Path::new("C:\\Temp"), Some("mise"))
+        );
+    }
+
+    #[test]
+    fn the_helper_name_follows_the_running_executable() {
+        // `.` + stem + `.` + 32 random characters + `.__selfdelete__.exe`
+        assert_eq!(helper_name_len(Some("mise")), 57);
+        assert_eq!(helper_name_len(Some("mise-dev")), 61);
+        // self-replace leaves the stem out when it is not valid UTF-8
+        assert_eq!(helper_name_len(None), 52);
+    }
+
+    #[test]
+    fn a_renamed_binary_lowers_the_ceiling() {
+        // A TEMP that is safe for `mise.exe` is not safe once the binary has been renamed to
+        // something longer, so the guard cannot assume the stem.
+        let tmp = temp_dir_of_len(202);
+        assert!(!temp_dir_breaks_self_replace(&tmp, Some("mise")));
+        assert!(temp_dir_breaks_self_replace(&tmp, Some("mise-dev")));
+    }
+
+    #[test]
+    fn the_length_is_counted_in_utf16_code_units() {
+        // Control against the `OsStr::len()` trap: this path is 202 UTF-16 code units, the
+        // longest that works, but 598 WTF-8 bytes. Counting bytes would reject it.
+        let mut s = String::from("C:\\");
+        while s.chars().count() < 201 {
+            s.push('あ');
+        }
+        s.push('\\');
+        let tmp = PathBuf::from(s);
+        assert_eq!(tmp.as_os_str().len(), 598);
+        assert!(!temp_dir_breaks_self_replace(&tmp, Some("mise")));
     }
 }


### PR DESCRIPTION
On Windows, `mise self-update` can finish with **no mise installed at all**. Found while
migrating a machine off a winget-managed install onto a self-managed one, probing on
**2026.8.6 windows-x64**.

## What happens

With `TEMP` pointing at a long directory, run against a copy of `mise.exe` in an isolated
`MISE_*` environment:

```console
> mise self-update --force --yes --no-plugins
Checking target-arch... mise-v2026.8.6-windows-x64.zip
...
Extracting archive... Done
mise ERROR IoError: 指定されたパスが見つかりません。 (os error 3)
exit=1

> Get-ChildItem <install dir>
# nothing
```

The binary is not deleted. It is stranded in `TEMP` as
`.mise.<32 random>.__relocated__.exe` and `.mise.<32 random>.__selfdelete__.exe`, both
byte-identical to the original (145,601,024 bytes, sha256 `9476B556…`). The message says
only that a path was not found, and never mentions that mise has just been moved out of
its install directory.

## Measurement

Same command, same install location, isolated `MISE_*`. **The only variable is the length
of `TEMP`.** Windows 11 26200, `LongPathsEnabled=0`.

| `TEMP` length | exit | `mise.exe` after the run |
| --- | --- | --- |
| 31 (default) | 0 | present |
| 190 | 0 | present |
| 201 | 0 | present |
| **202** | **1** | **install directory empty** |
| 205 | 1 | install directory empty |
| 243 | 1 | install directory empty |

## Why

`do_update_blocking` hands the swap to `self_update`, which calls
`self_replace::self_replace` (self_update-0.44.0/src/update.rs:325). In
self-replace-1.5.0/src/windows.rs:

1. `:285` — the running exe is renamed out of its install directory.
2. `:212`, `:214` — it is moved into `env::temp_dir()` and copied under a
   `__selfdelete__.exe` name. Both succeed even past MAX_PATH, because Rust's std uses the
   `\\?\` form for long absolute paths.
3. `:215` — that helper copy is **launched**. `CreateProcess` has no such escape hatch, so
   a path past MAX_PATH fails with `ERROR_PATH_NOT_FOUND (3)` and `?` propagates.

Step 1 is never undone, which is why the install directory ends up empty.

The helper's name is `.` + the running executable's file stem + `.` + 32 random characters
+ `.__selfdelete__.exe` (windows.rs:236-255) — 57 code units for a binary named `mise.exe`,
longer for anything else. `env::temp_dir()` returns `TEMP` with a trailing backslash, which
`Path::join` does not double, so the swap breaks once `len(TEMP) + 1 + 57 >= 260` — at a
`TEMP` of 202, exactly where the measurement above turns over.

self-replace documents that it deliberately does not support executable paths longer than
MAX_PATH and considers handling them not worth the cost (windows.rs:130-135), so this is
not something that waiting on the crate would fix.

## The change

A Windows-only check in `SelfUpdate::run`, before anything is downloaded or moved:

```
TEMP is too long to replace mise.exe safely (244 UTF-16 code units)

  TEMP = C:\...

Updating moves the running mise.exe aside and then launches a helper from TEMP to
put the new one in place. That helper's path would be 301 UTF-16 code units,
and Windows cannot launch an executable whose path reaches 260. The move happens
first, so going ahead would leave no mise installed at all.

Point TEMP and TMP at a shorter directory and run mise self-update again:

  $env:TEMP = 'C:\Temp'; $env:TMP = 'C:\Temp'
```

The helper name's length is computed from `current_exe()`'s file stem rather than assumed,
because self-replace builds it that way: a binary renamed to something longer than `mise`
lowers the ceiling, and the stem is dropped entirely when it is not valid UTF-8.

Deliberately **not** done, happy to be argued out of any of these:

- **Rewriting `TEMP` for the duration.** `std::env::set_var` is `unsafe` in Rust 2024 and
  mise runs on a multithreaded runtime; mutating the environment mid-run is a worse hazard
  than the one being fixed.
- **Rolling back the relocated binary.** The failure is inside self-replace, and recovering
  would mean reaching into its temp-file naming. That belongs upstream.
- **Recovering binaries stranded by an earlier failure.** Out of scope here.

## Tests

**Unit** (`src/cli/self_update.rs`, `cfg(all(test, windows))`) — the predicate pinned to the
measured numbers, expressed as `env::temp_dir()` hands them back, i.e. with the trailing
backslash: 202 accepted and 203 rejected as the boundary (the measured `TEMP=201` /
`TEMP=202`), 206 and 244 rejected, and 191 accepted as a control that length alone is not
the trigger. Also covered: both spellings of `C:\Temp` produce the same length, the helper
name is 57 for `mise` / 61 for `mise-dev` / 52 with no usable stem, a `TEMP` that is safe
for `mise` is refused for `mise-dev`, and a path of 202 UTF-16 code units but 598 WTF-8
bytes is still accepted (so the count has to be `encode_wide()`).

**`e2e-win/self_update_long_temp.Tests.ps1`** — runs the real command with a long `TEMP` and
asserts it fails, names `TEMP`, never reaches the update itself, and leaves `mise.exe` in
place. The control repeats it with the ordinary `TEMP` and asserts the opposite.

The suite asks for a version that does not exist, so **a regression cannot destroy the
runner's mise**: without the guard the run dies at the release lookup, long before the
binary is touched. Verified by running the suite locally against a release build that has
no guard — the failure is a 404 for `v0.0.0-nonexistent` and `mise.exe` is untouched.

## Notes

- `MAX_PATH` here duplicates the constant #12058 adds to `src/file.rs`. That PR is still in
  draft; whichever lands first, the other should drop the duplicate. Keeping this one cut
  from `main` so a destructive bug does not queue behind an unrelated review.
- No local build was run. Only `cargo fmt --all` and standalone `rustc` probes were done
  locally — one for the length arithmetic, one that measured what `env::temp_dir()` actually
  returns on Windows. `cargo test` and `windows-e2e` are left to CI.
