### PR TITLE
fix(activate): stop repeated shims path growth

### DIFF
--- a/e2e/shell/shims_repeated_source.sh
+++ b/e2e/shell/shims_repeated_source.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+mise_bin="$1"
+shell_type="$2"
+
+for _ in 1 2 3; do
+  eval "$("$mise_bin" activate "$shell_type" --shims)"
+done
+
+printf '%s\n' "$PATH"

--- a/e2e/shell/test_shims_activate_additional_slow
+++ b/e2e/shell/test_shims_activate_additional_slow
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Cover the additional repeated-source combinations without making the normal
+# PR regression test exceed the e2e runner's 20-second threshold.
+
+SHIMS_DIR="$MISE_DATA_DIR/shims"
+mkdir -p "$SHIMS_DIR"
+
+MISE_BIN=$(command -v mise)
+BASH_BIN=$(command -v bash)
+EXE_DIR="$(dirname "$MISE_BIN")"
+
+check_repeated_source() {
+  local shell_type="$1"
+  local shell_bin="$2"
+  local initial_path="$3"
+  local expected_count="$4"
+  local result count first
+
+  result="$(env PATH="$initial_path" "$shell_bin" \
+    "$TEST_DIR/shims_repeated_source.sh" "$MISE_BIN" "$shell_type")"
+
+  first="${result%%:*}"
+  if [[ $first != "$SHIMS_DIR" ]]; then
+    echo "FAIL: expected shims first after repeated $shell_type activation"
+    echo "PATH: $result"
+    exit 1
+  fi
+
+  count=0
+  while IFS= read -r entry; do
+    [[ $entry == "$SHIMS_DIR" ]] && count=$((count + 1))
+  done < <(printf '%s' "$result" | tr ':' '\n')
+  if [[ $count != "$expected_count" ]]; then
+    echo "FAIL: expected $expected_count shims entries after repeated $shell_type activation, got $count"
+    echo "PATH: $result"
+    exit 1
+  fi
+}
+
+# Missing shims are added once and remain stable on re-source.
+check_repeated_source bash "$BASH_BIN" "$EXE_DIR:/some/other/bin:/usr/bin" 1
+
+if ZSH_BIN=$(command -v zsh); then
+  check_repeated_source zsh "$ZSH_BIN" "$EXE_DIR:/some/other/bin:/usr/bin" 1
+  check_repeated_source zsh "$ZSH_BIN" "$EXE_DIR:/some/other/bin:$SHIMS_DIR:/usr/bin" 2
+fi
+
+# If activation must add the mise executable directory before shims, shims are
+# prepended again so they remain first. The result is still stable on re-source.
+check_repeated_source bash "$BASH_BIN" "$SHIMS_DIR:/some/other/bin:/usr/bin" 2

--- a/e2e/shell/test_shims_activate_prepend
+++ b/e2e/shell/test_shims_activate_prepend
@@ -1,25 +1,60 @@
 #!/usr/bin/env bash
 
-# Test that `mise activate --shims` always prepends shims to the front of PATH,
-# even when shims is already present (accepting a duplicate entry).
+# Test that `mise activate --shims` keeps shims at the front of PATH without
+# adding another entry on every re-source.
 
 SHIMS_DIR="$MISE_DATA_DIR/shims"
 mkdir -p "$SHIMS_DIR"
 
 MISE_BIN=$(command -v mise)
+BASH_BIN=$(command -v bash)
 CUSTOM_PATH="/some/other/bin:$SHIMS_DIR:/usr/bin"
 
-# Shims already in PATH: should be emitted as a prepend with shims first
+# Shims later in PATH: should be emitted as a prepend with shims first
 assert_contains "env PATH='$CUSTOM_PATH' $MISE_BIN activate bash --shims" "export PATH=\"$SHIMS_DIR:"
 
-# Shims not in PATH: should also be emitted as a prepend with shims first
-assert_contains "env PATH='/some/other/bin:/usr/bin' $MISE_BIN activate bash --shims" "export PATH=\"$SHIMS_DIR:"
+# Shims already first and the mise executable dir already present: no PATH
+# change is needed, so activation emits no prepend.
+EXE_DIR="$(dirname "$MISE_BIN")"
+assert_not_contains "env PATH='$SHIMS_DIR:$EXE_DIR:/usr/bin' $MISE_BIN activate bash --shims" "export PATH="
+
+check_repeated_source() {
+  local shell_type="$1"
+  local shell_bin="$2"
+  local initial_path="$3"
+  local expected_count="$4"
+  local result count first
+
+  result="$(env PATH="$initial_path" "$shell_bin" \
+    "$TEST_DIR/shims_repeated_source.sh" "$MISE_BIN" "$shell_type")"
+
+  first="${result%%:*}"
+  if [[ $first != "$SHIMS_DIR" ]]; then
+    echo "FAIL: expected shims first after repeated $shell_type activation"
+    echo "PATH: $result"
+    exit 1
+  fi
+
+  count=0
+  while IFS= read -r entry; do
+    [[ $entry == "$SHIMS_DIR" ]] && count=$((count + 1))
+  done < <(printf '%s' "$result" | tr ':' '\n')
+  if [[ $count != "$expected_count" ]]; then
+    echo "FAIL: expected $expected_count shims entries after repeated $shell_type activation, got $count"
+    echo "PATH: $result"
+    exit 1
+  fi
+}
+
+# Existing trailing shims are preserved and gain one front entry, but repeated
+# activation must not keep growing PATH. Keep this primary #9994 regression in
+# the normal PR test suite.
+check_repeated_source bash "$BASH_BIN" "$EXE_DIR:/some/other/bin:$SHIMS_DIR:/usr/bin" 2
 
 # Regression #10264: when the dir containing the mise executable is already in
 # PATH (e.g. a deb install at /usr/bin), --shims must NOT re-prepend it, which
 # would reorder PATH (moving /usr/bin ahead of /usr/local/bin). Only the shims
 # dir should be prepended, so exactly one `export PATH=` line is emitted.
-EXE_DIR="$(dirname "$MISE_BIN")"
 if ! out="$(env PATH="$EXE_DIR:/usr/local/bin:/usr/bin" "$MISE_BIN" activate bash --shims 2>&1)"; then
   echo "FAIL: 'mise activate bash --shims' exited non-zero:"
   printf '%s\n' "$out"

--- a/src/cli/activate.rs
+++ b/src/cli/activate.rs
@@ -109,10 +109,13 @@ impl Activate {
         // thereby reordering) a system dir such as /usr/bin that is already in PATH
         // for deb/rpm installs, which would otherwise move it ahead of
         // /usr/local/bin (#10264).
-        if let Some(p) = self.prepend_path(exe_dir) {
+        let prepended_exe_dir = if let Some(p) = self.prepend_path(exe_dir) {
             prelude.push(p);
-        }
-        if let Some(p) = self.shims_prepend_path(shell, &dirs::SHIMS) {
+            true
+        } else {
+            false
+        };
+        if let Some(p) = self.shims_prepend_path(shell, &dirs::SHIMS, prepended_exe_dir) {
             prelude.push(p);
         }
         miseprint!("{}", shell.format_activate_prelude(&prelude))?;
@@ -170,11 +173,17 @@ impl Activate {
         }
     }
 
-    /// Used by activate_shims for the shims directory. Always prepends the path to
-    /// the front, even if already present (accepting a duplicate entry), so the
-    /// shims dir wins on re-source. For shells with native path dedup (fish), uses
-    /// MovePrepend to reorder without duplicating.
-    fn shims_prepend_path(&self, shell: &dyn Shell, p: &Path) -> Option<ActivatePrelude> {
+    /// Used by activate_shims for the shims directory. Shells with native path
+    /// deduplication move the existing entry to the front. Other shells prepend
+    /// only when the shims are not already first, which preserves precedence
+    /// without growing PATH on every re-source. If an earlier prelude changes
+    /// PATH, prepend again so the shims remain first after that change.
+    fn shims_prepend_path(
+        &self,
+        shell: &dyn Shell,
+        p: &Path,
+        path_changed_before: bool,
+    ) -> Option<ActivatePrelude> {
         if !is_dir_not_in_nix(p) || p.is_relative() {
             return None;
         }
@@ -183,11 +192,13 @@ impl Activate {
                 PATH_KEY.to_string(),
                 p.to_string_lossy().to_string(),
             ))
-        } else {
+        } else if should_prepend_shims(&env::PATH, p, path_changed_before) {
             Some(ActivatePrelude::Prepend(
                 PATH_KEY.to_string(),
                 p.to_string_lossy().to_string(),
             ))
+        } else {
+            None
         }
     }
 }
@@ -255,6 +266,17 @@ fn is_dir_in_path(dir: &Path) -> bool {
         .any(|p| canonicalize_or_self(&p) == dir)
 }
 
+fn should_prepend_shims(paths: &[PathBuf], dir: &Path, path_changed_before: bool) -> bool {
+    path_changed_before || !is_dir_first_in_paths(paths, dir)
+}
+
+fn is_dir_first_in_paths(paths: &[PathBuf], dir: &Path) -> bool {
+    let dir = canonicalize_or_self(dir);
+    paths
+        .first()
+        .is_some_and(|p| canonicalize_or_self(p) == dir)
+}
+
 fn is_dir_not_in_nix(dir: &Path) -> bool {
     !canonicalize_or_self(dir).starts_with("/nix/")
 }
@@ -272,7 +294,8 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
-    use super::forwarded_logging_flags;
+    use super::{forwarded_logging_flags, is_dir_first_in_paths, should_prepend_shims};
+    use std::path::PathBuf;
 
     fn args(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| value.to_string()).collect()
@@ -340,5 +363,28 @@ mod tests {
     #[test]
     fn nothing_is_forwarded_without_a_logging_flag() {
         assert!(forwarded_logging_flags(&args(&["mise", "activate", "bash"])).is_empty());
+    }
+
+    #[test]
+    fn detects_only_a_matching_first_path_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().to_path_buf();
+        let equivalent = target.join(".");
+        let other = PathBuf::from("/other");
+
+        assert!(!is_dir_first_in_paths(&[], &target));
+        assert!(is_dir_first_in_paths(&[equivalent, other.clone()], &target));
+        assert!(!is_dir_first_in_paths(&[other, target.clone()], &target));
+
+        assert!(!should_prepend_shims(
+            std::slice::from_ref(&target),
+            &target,
+            false
+        ));
+        assert!(should_prepend_shims(
+            std::slice::from_ref(&target),
+            &target,
+            true
+        ));
     }
 }


### PR DESCRIPTION
## Summary

- stop non-deduplicating shells from prepending another shims entry when it is already first in PATH
- keep prepending when shims are missing or appear later so command precedence remains correct
- preserve fish native move behavior and the guarded mise executable directory handling

## Details

PR #8757 intentionally made shims prepend unconditional for shells without native PATH movement, ensuring that a trailing shims entry could not remain shadowed. That also made every bash or zsh re-source add another identical entry. This change makes the fallback position-aware: once shims are first and no earlier activation prelude will change PATH, no new prepend is emitted.

The implementation does not rebuild or deduplicate the user's full PATH. If shims originally appears later, one leading entry is added and the original entry is retained, but subsequent activation is stable. When the mise executable directory must first be added, shims is still prepended afterward so #8757 precedence and the #10394 system PATH fix remain intact.

The primary repeated-source regression remains in the normal PR E2E suite. Additional bash/zsh and executable-directory combinations are kept in a separate slow test.

## Verification

- `mise exec -- cargo test --all-features cli::activate::tests`
- `mise run test:e2e e2e/shell/test_shims_activate_prepend`
- `mise run test:e2e e2e/shell/test_shims_activate_additional_slow`
- `mise run test:e2e e2e/cli/test_deactivate_zsh e2e/env/test_path_reorder_after_activate`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shellcheck e2e/shell/shims_repeated_source.sh e2e/shell/test_shims_activate_prepend e2e/shell/test_shims_activate_additional_slow`
- `mise exec -- shfmt -d e2e/shell/shims_repeated_source.sh e2e/shell/test_shims_activate_prepend e2e/shell/test_shims_activate_additional_slow`

The fish-specific E2E could not run locally because fish is not installed; that code path is unchanged. Clippy currently stops on the unchanged latest-main `needless_return` at `src/system/packages/brew/cask.rs:1959`. `mise run lint` also cannot run in this dotgitless Sapling checkout because hk reports `failed to find git repository`.

Addresses https://github.com/jdx/mise/discussions/9994

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell activation so shims are consistently placed first in `PATH`.
  * Prevented repeated activation from adding duplicate shim entries or producing unnecessary `PATH` changes.
  * Added coverage for Bash and Zsh activation, including missing and pre-existing shim scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->