### PR TITLE
fix(aqua): keep the lock-time artifact download out of TEMP

### DIFF
--- a/e2e-win/lock_temp_independence.Tests.ps1
+++ b/e2e-win/lock_temp_independence.Tests.ps1
@@ -1,0 +1,55 @@
+Describe 'mise lock does not depend on TEMP' {
+    BeforeAll {
+        # Saved here and restored in AfterAll: Pester runs every suite in one process, so a
+        # TEMP left pointing at $TestDrive would follow the suites that run after this one.
+        $script:OriginalTemp = $env:TEMP
+        $script:OriginalTmp = $env:TMP
+
+        # Long enough that the lock-time artifact download would land past MAX_PATH, since it
+        # goes to <scratch>\.tmpXXXXXX\<artifact filename>. When that scratch was TEMP, the
+        # download failed here and `provenance` for the current platform was silently dropped
+        # from the generated lockfile — so the file a machine committed depended on how deep
+        # its TEMP happened to be.
+        $script:LongTemp = Join-Path $TestDrive "temp"
+        while ($script:LongTemp.Length -lt 230) { $script:LongTemp = $script:LongTemp + "x" }
+        New-Item -ItemType Directory -Path $script:LongTemp -Force | Out-Null
+    }
+
+    AfterAll {
+        $env:TEMP = $script:OriginalTemp
+        $env:TMP = $script:OriginalTmp
+    }
+
+    It 'writes the same lockfile whatever TEMP is' {
+        $lockfiles = @{}
+        foreach ($case in @('control', 'long')) {
+            $proj = Join-Path $TestDrive $case
+            New-Item -ItemType Directory -Path $proj -Force | Out-Null
+            Set-Content -LiteralPath (Join-Path $proj "mise.toml") -Value "[tools]`njq = `"1.8.2`""
+
+            if ($case -eq 'long') {
+                $env:TEMP = $script:LongTemp
+                $env:TMP = $script:LongTemp
+            } else {
+                $env:TEMP = $script:OriginalTemp
+                $env:TMP = $script:OriginalTmp
+            }
+
+            Push-Location $proj
+            try {
+                mise lock | Out-Null
+                $LASTEXITCODE | Should -Be 0
+            } finally {
+                Pop-Location
+            }
+
+            $lockfiles[$case] = Get-Content -LiteralPath (Join-Path $proj "mise.lock") -Raw
+        }
+
+        # The control half also guards the assertion itself: if lock stopped recording
+        # provenance at all, both files would still match and the comparison would say
+        # nothing, so check the control actually has something to lose.
+        $lockfiles['control'] | Should -Match 'provenance'
+        $lockfiles['long'] | Should -Be $lockfiles['control']
+    }
+}

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -1274,6 +1274,37 @@ impl AquaBackend {
         Ok(tempfile::tempdir_in(&scratch)?)
     }
 
+    /// Refuse a scratch path Windows cannot hold, before downloading into it.
+    ///
+    /// Moving the scratch out of `TEMP` removed one environment variable from the answer, not the
+    /// arithmetic: `MISE_CACHE_DIR` is configurable too, and the longest path here is not the
+    /// artifact but the download's own sidecar, `.{filename}.mise-part.json`
+    /// ([`crate::http`]'s `PartialDownload`). Left to fail on its own it comes back as `os error 3`,
+    /// the lockfile quietly loses `provenance` for this platform, and — measured — nothing else in
+    /// mise fails at that depth to hint at why. Say it instead, and name the variable to change.
+    #[cfg(windows)]
+    fn ensure_scratch_path_fits(artifact_path: &Path, filename: &str) -> Result<()> {
+        use std::os::windows::ffi::OsStrExt;
+
+        // Counts UTF-16 code units and includes the terminating NUL, so exactly MAX_PATH is already
+        // one too many. #12062 landed the same constant privately in `cli::self_update` and #12058
+        // moves it to `file`; whichever of that and this lands second should use the shared one.
+        const MAX_PATH: usize = 260;
+        // `.` + filename + `.mise-part` + `.json`, written alongside the artifact.
+        const SIDECAR_OVERHEAD: usize = 1 + ".mise-part".len() + ".json".len();
+
+        let sidecar = artifact_path.as_os_str().encode_wide().count() + SIDECAR_OVERHEAD;
+        if sidecar < MAX_PATH {
+            return Ok(());
+        }
+        bail!(
+            "cannot verify provenance for {filename}: the download needs {sidecar} characters under \
+             {}, past Windows' {MAX_PATH}-character limit. Point MISE_CACHE_DIR at a shorter \
+             directory.",
+            display_path(dirs::CACHE.join("lock-provenance")),
+        );
+    }
+
     /// Verify provenance at lock time by downloading the artifact to a scratch directory
     /// and running the appropriate cryptographic verification. Only called for the
     /// current platform during `mise lock`.
@@ -1288,6 +1319,8 @@ impl AquaBackend {
         let tmp_dir = Self::lock_time_download_dir()?;
         let filename = get_filename_from_url(artifact_url);
         let artifact_path = tmp_dir.path().join(&filename);
+        #[cfg(windows)]
+        Self::ensure_scratch_path_fits(&artifact_path, &filename)?;
 
         info!(
             "downloading artifact for lock-time provenance verification: {}",
@@ -3453,6 +3486,28 @@ mod tests {
             default: None,
             required,
         }
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn a_scratch_path_that_windows_can_hold_is_allowed() {
+        let path = PathBuf::from(r"C:\c\lock-provenance\.tmpAbCdEf\jq-windows-amd64.exe");
+        assert!(AquaBackend::ensure_scratch_path_fits(&path, "jq-windows-amd64.exe").is_ok());
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn one_that_windows_cannot_says_which_variable_to_change() {
+        // The artifact itself fits; the sidecar the downloader writes beside it does not, which is
+        // the whole point — left alone this came back as a bare `os error 3` and the lockfile
+        // quietly lost `provenance` for this platform.
+        let artifact = format!(r"C:\{}\jq-windows-amd64.exe", "d".repeat(220));
+        let err =
+            AquaBackend::ensure_scratch_path_fits(Path::new(&artifact), "jq-windows-amd64.exe")
+                .expect_err("the sidecar is past MAX_PATH");
+        let msg = err.to_string();
+        assert!(msg.contains("MISE_CACHE_DIR"), "{msg}");
+        assert!(msg.contains("260"), "{msg}");
     }
 
     #[test]

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -7,6 +7,7 @@ use crate::backend::static_helpers::get_filename_from_url;
 use crate::cli::args::BackendArg;
 use crate::cli::version::{ARCH, OS};
 use crate::config::Settings;
+use crate::dirs;
 use crate::file::{ExtractOptions, ExtractionFormat};
 use crate::http::HTTP;
 use crate::install_context::InstallContext;
@@ -1253,7 +1254,22 @@ impl AquaBackend {
         .await
     }
 
-    /// Verify provenance at lock time by downloading the artifact to a temp directory
+    /// A scratch directory for the lock-time artifact download, inside `MISE_DOWNLOADS_DIR`.
+    ///
+    /// Deliberately not `TEMP`. A lockfile is a committed artifact, so its contents must not
+    /// depend on where a machine happens to point `TEMP` — and they did: on Windows a `TEMP`
+    /// deep enough to push this download past `MAX_PATH` made the download fail, which drops
+    /// `provenance` for the current platform from the generated lockfile. `MISE_DOWNLOADS_DIR`
+    /// is also where the same artifact lands at install time, so this only makes the two
+    /// halves of the same job agree. The directory is still removed when the `TempDir` is
+    /// dropped: this changes where the scratch lives, not how long.
+    fn lock_time_download_dir() -> Result<tempfile::TempDir> {
+        let downloads = *dirs::DOWNLOADS;
+        crate::file::create_dir_all(downloads)?;
+        Ok(tempfile::tempdir_in(downloads)?)
+    }
+
+    /// Verify provenance at lock time by downloading the artifact to a scratch directory
     /// and running the appropriate cryptographic verification. Only called for the
     /// current platform during `mise lock`.
     async fn verify_provenance_at_lock_time(
@@ -1264,7 +1280,7 @@ impl AquaBackend {
         detected: &ProvenanceType,
         expected_checksum: Option<&str>,
     ) -> Result<Option<ProvenanceType>> {
-        let tmp_dir = tempfile::tempdir()?;
+        let tmp_dir = Self::lock_time_download_dir()?;
         let filename = get_filename_from_url(artifact_url);
         let artifact_path = tmp_dir.path().join(&filename);
 
@@ -3432,6 +3448,20 @@ mod tests {
             default: None,
             required,
         }
+    }
+
+    #[test]
+    fn the_lock_time_download_lands_under_the_downloads_dir() {
+        // A lockfile is a committed artifact, so what `mise lock` writes must not depend on
+        // where the machine points TEMP. Keeping the download under MISE_DOWNLOADS_DIR — the
+        // same place install puts it — is what makes that true.
+        let dir = AquaBackend::lock_time_download_dir().unwrap();
+        assert!(
+            dir.path().starts_with(*dirs::DOWNLOADS),
+            "expected {} to be under {}",
+            dir.path().display(),
+            dirs::DOWNLOADS.display()
+        );
     }
 
     #[test]

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -997,8 +997,9 @@ impl Backend for AquaBackend {
                     // would be true and verify_provenance() would be skipped.
                     warn!(
                         "lock-time provenance verification failed for {}, \
-                         will be verified at install time: {e}",
-                        self.id
+                         will be verified at install time: {e}{}",
+                        self.id,
+                        Self::scratch_length_hint()
                     );
                     provenance = None;
                 }
@@ -1274,35 +1275,47 @@ impl AquaBackend {
         Ok(tempfile::tempdir_in(&scratch)?)
     }
 
-    /// Refuse a scratch path Windows cannot hold, before downloading into it.
+    /// A note about the scratch directory's length, appended when lock-time verification fails.
     ///
     /// Moving the scratch out of `TEMP` removed one environment variable from the answer, not the
-    /// arithmetic: `MISE_CACHE_DIR` is configurable too, and the longest path here is not the
-    /// artifact but the download's own sidecar, `.{filename}.mise-part.json`
-    /// ([`crate::http`]'s `PartialDownload`). Left to fail on its own it comes back as `os error 3`,
-    /// the lockfile quietly loses `provenance` for this platform, and — measured — nothing else in
-    /// mise fails at that depth to hint at why. Say it instead, and name the variable to change.
-    #[cfg(windows)]
-    fn ensure_scratch_path_fits(artifact_path: &Path, filename: &str) -> Result<()> {
-        use std::os::windows::ffi::OsStrExt;
+    /// arithmetic: `MISE_CACHE_DIR` is configurable too, and past `MAX_PATH` the download comes back
+    /// as a bare `os error 3` while the lockfile quietly loses `provenance` for this platform.
+    /// Measured on 2026.8.6: with the cache at 200 characters `mise install` and `mise lock` both
+    /// still exit 0, so nothing else fails at that depth to suggest why.
+    ///
+    /// This deliberately annotates the *failure* rather than predicting it. Several files land in
+    /// that directory — the artifact and its `.mise-part.json` sidecar, a checksum file, a
+    /// provenance or signature file — with names taken from URLs, and a check on any one of them
+    /// passes while a later one is longer. Reporting after the fact covers all of them.
+    fn scratch_length_hint() -> String {
+        Self::scratch_length_hint_for(&dirs::CACHE.join("lock-provenance"))
+    }
 
-        // Counts UTF-16 code units and includes the terminating NUL, so exactly MAX_PATH is already
-        // one too many. #12062 landed the same constant privately in `cli::self_update` and #12058
-        // moves it to `file`; whichever of that and this lands second should use the shared one.
-        const MAX_PATH: usize = 260;
-        // `.` + filename + `.mise-part` + `.json`, written alongside the artifact.
-        const SIDECAR_OVERHEAD: usize = 1 + ".mise-part".len() + ".json".len();
+    /// Split out from [`Self::scratch_length_hint`] so it can be tested without depending on
+    /// wherever the machine running the tests happens to keep its cache.
+    fn scratch_length_hint_for(root: &Path) -> String {
+        #[cfg(windows)]
+        {
+            use std::os::windows::ffi::OsStrExt;
 
-        let sidecar = artifact_path.as_os_str().encode_wide().count() + SIDECAR_OVERHEAD;
-        if sidecar < MAX_PATH {
-            return Ok(());
+            // The scratch adds `\.tmpXXXXXX` and then a downloaded name; 64 is a modest allowance
+            // for both, so this fires while a real name could still have fitted. That is the right
+            // side to err on for a note that is only printed once something has already failed.
+            const ALLOWANCE: usize = 64;
+
+            let len = root.as_os_str().encode_wide().count();
+            if len + ALLOWANCE >= crate::file::MAX_PATH {
+                return format!(
+                    "\nthe download directory is {len} characters ({}) and Windows stops at {}, \
+                     which may be the reason — point MISE_CACHE_DIR at a shorter directory",
+                    crate::file::display_path(root),
+                    crate::file::MAX_PATH,
+                );
+            }
         }
-        bail!(
-            "cannot verify provenance for {filename}: the download needs {sidecar} characters under \
-             {}, past Windows' {MAX_PATH}-character limit. Point MISE_CACHE_DIR at a shorter \
-             directory.",
-            display_path(dirs::CACHE.join("lock-provenance")),
-        );
+        #[cfg(not(windows))]
+        let _ = root;
+        String::new()
     }
 
     /// Verify provenance at lock time by downloading the artifact to a scratch directory
@@ -1319,8 +1332,6 @@ impl AquaBackend {
         let tmp_dir = Self::lock_time_download_dir()?;
         let filename = get_filename_from_url(artifact_url);
         let artifact_path = tmp_dir.path().join(&filename);
-        #[cfg(windows)]
-        Self::ensure_scratch_path_fits(&artifact_path, &filename)?;
 
         info!(
             "downloading artifact for lock-time provenance verification: {}",
@@ -3489,25 +3500,22 @@ mod tests {
     }
 
     #[test]
-    #[cfg(windows)]
-    fn a_scratch_path_that_windows_can_hold_is_allowed() {
-        let path = PathBuf::from(r"C:\c\lock-provenance\.tmpAbCdEf\jq-windows-amd64.exe");
-        assert!(AquaBackend::ensure_scratch_path_fits(&path, "jq-windows-amd64.exe").is_ok());
+    fn an_ordinary_cache_path_gets_no_length_note() {
+        // The note is only worth printing when length is a plausible explanation, so on a normal
+        // machine it must stay out of the way. On unix it never appears at all.
+        let root = PathBuf::from(r"C:\Users\u\AppData\Local\Temp\mise\lock-provenance");
+        assert_eq!(AquaBackend::scratch_length_hint_for(&root), "");
     }
 
     #[test]
     #[cfg(windows)]
-    fn one_that_windows_cannot_says_which_variable_to_change() {
-        // The artifact itself fits; the sidecar the downloader writes beside it does not, which is
-        // the whole point — left alone this came back as a bare `os error 3` and the lockfile
-        // quietly lost `provenance` for this platform.
-        let artifact = format!(r"C:\{}\jq-windows-amd64.exe", "d".repeat(220));
-        let err =
-            AquaBackend::ensure_scratch_path_fits(Path::new(&artifact), "jq-windows-amd64.exe")
-                .expect_err("the sidecar is past MAX_PATH");
-        let msg = err.to_string();
-        assert!(msg.contains("MISE_CACHE_DIR"), "{msg}");
-        assert!(msg.contains("260"), "{msg}");
+    fn a_deep_cache_path_says_which_variable_to_change() {
+        // Measured: at a 200-character cache, `mise install` and `mise lock` both still exit 0, so
+        // a failure here comes with no other signal about why.
+        let root = PathBuf::from(format!(r"C:\{}", "d".repeat(200)));
+        let hint = AquaBackend::scratch_length_hint_for(&root);
+        assert!(hint.contains("MISE_CACHE_DIR"), "{hint}");
+        assert!(hint.contains("260"), "{hint}");
     }
 
     #[test]

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -1254,19 +1254,24 @@ impl AquaBackend {
         .await
     }
 
-    /// A scratch directory for the lock-time artifact download, inside `MISE_DOWNLOADS_DIR`.
+    /// A scratch directory for the lock-time artifact download, under
+    /// `MISE_CACHE_DIR/lock-provenance`.
     ///
     /// Deliberately not `TEMP`. A lockfile is a committed artifact, so its contents must not
     /// depend on where a machine happens to point `TEMP` — and they did: on Windows a `TEMP`
     /// deep enough to push this download past `MAX_PATH` made the download fail, which drops
-    /// `provenance` for the current platform from the generated lockfile. `MISE_DOWNLOADS_DIR`
-    /// is also where the same artifact lands at install time, so this only makes the two
-    /// halves of the same job agree. The directory is still removed when the `TempDir` is
-    /// dropped: this changes where the scratch lives, not how long.
+    /// `provenance` for the current platform from the generated lockfile.
+    ///
+    /// Deliberately not `MISE_DOWNLOADS_DIR` either, though that is where install puts the same
+    /// artifact. This copy is verified and thrown away, never reused, and `TempDir` cleanup is
+    /// best-effort: a crash or a failed delete strands a randomly named directory. At the root of
+    /// the persistent downloads directory nothing would ever collect it — not `mise cache clear`,
+    /// not the per-tool download cleanup. Under a named directory in the cache, ordinary cache
+    /// clearing sweeps it up.
     fn lock_time_download_dir() -> Result<tempfile::TempDir> {
-        let downloads = *dirs::DOWNLOADS;
-        crate::file::create_dir_all(downloads)?;
-        Ok(tempfile::tempdir_in(downloads)?)
+        let scratch = dirs::CACHE.join("lock-provenance");
+        crate::file::create_dir_all(&scratch)?;
+        Ok(tempfile::tempdir_in(&scratch)?)
     }
 
     /// Verify provenance at lock time by downloading the artifact to a scratch directory
@@ -3451,16 +3456,18 @@ mod tests {
     }
 
     #[test]
-    fn the_lock_time_download_lands_under_the_downloads_dir() {
-        // A lockfile is a committed artifact, so what `mise lock` writes must not depend on
-        // where the machine points TEMP. Keeping the download under MISE_DOWNLOADS_DIR — the
-        // same place install puts it — is what makes that true.
+    fn the_lock_time_download_lands_in_a_sweepable_cache_directory() {
+        // Two things at once. A lockfile is a committed artifact, so what `mise lock` writes must
+        // not depend on where the machine points TEMP — and the scratch has to sit somewhere
+        // ordinary cache clearing reaches, because `TempDir` cleanup is best-effort and an orphan
+        // under the persistent downloads directory would never be collected.
+        let expected = dirs::CACHE.join("lock-provenance");
         let dir = AquaBackend::lock_time_download_dir().unwrap();
         assert!(
-            dir.path().starts_with(*dirs::DOWNLOADS),
+            dir.path().starts_with(&expected),
             "expected {} to be under {}",
             dir.path().display(),
-            dirs::DOWNLOADS.display()
+            expected.display()
         );
     }
 


### PR DESCRIPTION
`mise lock` verifies provenance for the current platform by downloading the release artifact
and checking it cryptographically. That download goes to `tempfile::tempdir()` — under
`TEMP` — which makes the **generated lockfile depend on where the machine points `TEMP`**.

Found while sweeping Windows behaviour under a long `TEMP` on **2026.8.6 windows-x64**.

## What happens

`<TEMP>\.tmpXXXXXX\<artifact filename>` is the download target. Once that path reaches
`MAX_PATH` the download fails:

```console
> mise lock
mise WARN  lock-time provenance verification failed for jqlang/jq,
           will be verified at install time: 指定されたパスが見つかりません。 (os error 3)
```

`mise lock` still exits 0, and the lockfile is still written — but the `provenance` line for
the current platform is gone from it. Same project, same command, **only the length of `TEMP`
differs**:

```diff
 [tools.jq."platforms.windows-x64"]
 checksum = "sha256:a6fc67fe…"
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.2/jq-windows-amd64.exe"
 url_api = "https://api.github.com/repos/jqlang/jq/releases/assets/453012788"
-provenance = "github-attestations"
```

The cross-platform entries are unaffected: lock-time verification only runs for the current
platform, so the others keep the provenance they got from registry metadata.

## Measurement

`jq-windows-amd64.exe` is 20 characters and the scratch directory adds `\.tmpXXXXXX\`, so the artifact path is `TEMP + 32`. The threshold
was predicted from that and then measured — Windows 11 26200, `LongPathsEnabled=0`:

| `TEMP` length | artifact path | `provenance` in mise.lock |
| --- | --- | --- |
| 31 (default) | 63 | recorded |
| 210 | 242 | recorded |
| **230** | **262** | **dropped** |
| 250 | 282 | dropped |

The threshold moves with the artifact's filename, so it is different for every tool.

**Nothing else in mise is affected.** With `TEMP` at 250, `install`, `reshim`,
`doctor --json`, `cache clear`, `ls` and `upgrade --dry-run` all exit 0. This is the only
path that puts a release artifact in `TEMP`.

## Why this is the fix

mise already owns a configurable place for exactly this file: install downloads the artifact
to `MISE_DOWNLOADS_DIR` via `tv.download_path()`, under a per-tool path its own cleanup owns. The lock-time download is the same artifact
from the same URL, and it was the only one going somewhere else. Pointing it at
`MISE_CACHE_DIR/lock-provenance` takes the lockfile's
contents out of the environment's hands.

It is still a `TempDir` removed on drop — this changes *where* the scratch lives, not how
long. Reusing the downloaded artifact at install time would be a real improvement (today it
is fetched twice) but is a behaviour change, so it is deliberately left out.

## How bad was it

Mild, and this PR does not change that part — measured, not assumed:

- with no `provenance` in the lockfile, `has_lockfile_integrity` is false, so install takes
  the `verify_provenance` branch rather than trusting the lockfile. Verified end to end:
  installing from the degraded lockfile logs `verify GitHub artifact attestations` →
  `GitHub attestations verified`.
- the missing line is restored by that first install.

So there is no verification gap. What was actually wrong is that a **committed artifact's
contents varied by machine** — a lockfile written on a box with a deep `TEMP` differs by one
line from the same lockfile written anywhere else, and the difference bounces back on the
next install.

## Tests

- **Unit** (`src/backend/aqua.rs`) — `lock_time_download_dir()` returns a directory under
  `MISE_CACHE_DIR/lock-provenance`. Cheap, no network, and it is the property the fix is about.
- **`e2e-win/lock_temp_independence.Tests.ps1`** — runs `mise lock` twice, once with an
  ordinary `TEMP` and once with a 230-character one, and requires the two lockfiles to be
  identical. The control run is also asserted to contain `provenance`, so the comparison
  cannot pass vacuously if lock ever stopped recording it at all.

## Notes

- No local build was run: `cargo fmt --all` only. `cargo test` and `windows-e2e` are left to
  CI.
- Existing `e2e/lockfile/*` tests drive `mise lock --platform "$PLATFORM"`; this change moves
  where the scratch directory is created and nothing about what is written.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved `mise lock` reliability when temporary-directory paths are unusually long on Windows.
- Lockfile generation now remains consistent across different temporary-directory configurations.
- Lock-time verification uses a stable cache location for temporary downloads.
- Temporary verification files are cleaned up more reliably and validated against Windows path limits.

## Tests

- Added Windows end-to-end coverage for long temporary paths and consistent lockfile generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Follow-up after review

The scratch first went under `MISE_DOWNLOADS_DIR`, reasoning only about where install puts the same
artifact. jdx pointed out the part that reasoning missed: the two directories are swept by different
things. Install's copy lands under a per-tool path its own cleanup owns; this one is a `.tmpXXXXXX`
at the root, owned by nothing — `TempDir` covers the ordinary path and neither `mise cache clear`
nor the per-tool download cleanup covers the rest, so a crash or a failed delete would strand it
indefinitely.

It is now `MISE_CACHE_DIR/lock-provenance`, in its own commit so the earlier review still applies to
what it reviewed. The unit test moved with it.