### PR TITLE
fix(tera): quote strings safely for posix shells

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -452,13 +452,22 @@ PROJECT_CONFIG = "{{ [config_root, 'bar.txt'] | join_path }}"
 
 #### String Manipulation
 
-- `str | quote -> String` – Quotes a string. Converts `'` to `\'` and
-  then quotes str, e.g `'it\'s str'`.
+- `str | quote -> String` – Quotes a string for a POSIX shell. Embedded single
+  quotes use the POSIX-safe `'\''` form, e.g. `'it'\''s str'`. This filter does
+  not adapt its output for PowerShell, cmd, or other non-POSIX shells.
 - `str | kebabcase -> String` – Converts a string to kebab-case
 - `str | lowercamelcase -> String` – Converts a string to lowerCamelCase
 - `str | uppercamelcase -> String` – Converts a string to UpperCamelCase
 - `str | snakecase -> String` – Converts a string to snake_case
 - `str | shoutysnakecase -> String` – Converts a string to SHOUTY_SNAKE_CASE
+
+Use `quote` when inserting a template value into a POSIX shell command. Quoted
+and unquoted segments can be concatenated into the same argument:
+
+```toml
+[tasks.create-config]
+run = "touch {{ config_root | quote }}/generated.toml"
+```
 
 ### Tests
 

--- a/e2e/tasks/test_task_tera_quote
+++ b/e2e/tasks/test_task_tera_quote
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Tera's quote filter must preserve paths containing POSIX shell metacharacters.
+project="quote dir ' \$ \\"
+mkdir -p "$project"
+
+cat <<'EOF' >"$project/mise.toml"
+[tasks.quote]
+run = """
+set -eu
+printf '%s\n' {{ config_root | quote }}
+touch {{ config_root | quote }}/created
+"""
+EOF
+
+expected="$PWD/$project"
+output="$(mise --cd "$project" run quote)"
+
+if [ "$output" != "$expected" ]; then
+  echo "expected: $expected" >&2
+  echo "actual:   $output" >&2
+  exit 1
+fi
+
+test -f "$project/created"

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -92,6 +92,10 @@ fn tera_err(message: impl ToString) -> tera::Error {
     tera::Error::message(message)
 }
 
+fn posix_shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
 fn use_tera_v1() -> bool {
     Settings::try_get().is_ok_and(|settings| settings.tera_v1)
 }
@@ -499,9 +503,7 @@ static TERA: Lazy<Tera> = Lazy::new(|| {
     tera.register_filter(
         "quote",
         move |s: &str, _: Kwargs, _: &State| -> TeraResult<Value> {
-            let result = format!("'{}'", s.replace("'", "\\'"));
-
-            Ok(Value::from(result))
+            Ok(Value::from(posix_shell_quote(s)))
         },
     );
     tera.register_filter("as_str", move |value: Value, _: Kwargs, _: &State| {
@@ -1085,10 +1087,7 @@ static TERA1: Lazy<tera1::Tera> = Lazy::new(|| {
     tera.register_filter(
         "quote",
         move |value: &JsonValue, _: &HashMap<String, JsonValue>| {
-            Ok(json!(format!(
-                "'{}'",
-                json_path(value)?.replace("'", "\\'")
-            )))
+            Ok(json!(posix_shell_quote(json_path(value)?)))
         },
     );
     tera.register_filter("kebabcase", tera1_string_filter(|s| s.to_kebab_case()));
@@ -1843,8 +1842,29 @@ mod tests {
     #[tokio::test]
     async fn test_quote() {
         let _config = Config::get().await.unwrap();
-        let s = render("{{ \"quoted'str\" | quote }}");
-        assert_eq!(s, "'quoted\\'str'");
+        let template = "{{ \"quoted'str\" | quote }}";
+        let expected = "'quoted'\\''str'";
+        assert_eq!(render_v2(template), expected);
+        assert_eq!(render_v1(template), expected);
+    }
+
+    #[test]
+    fn test_posix_shell_quote_round_trip() {
+        for value in [
+            "",
+            "plain",
+            "with spaces",
+            "quoted'str",
+            "$HOME",
+            r"a\\backslash",
+            "multiple\nlines",
+        ] {
+            let quoted = posix_shell_quote(value);
+            assert_eq!(shell_words::split(&quoted).unwrap(), [value]);
+        }
+
+        assert_eq!(posix_shell_quote("plain"), "'plain'");
+        assert_eq!(posix_shell_quote("quoted'str"), "'quoted'\\''str'");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- fix the Tera `quote` filter so embedded apostrophes produce valid POSIX shell syntax
- share the same quoting implementation between the current Tera engine and the Tera v1 compatibility path
- document the POSIX-only contract and add a safe task example

The filter previously wrapped values in single quotes but replaced an embedded `'` with `\'`. A backslash does not escape an apostrophe while the shell is inside single quotes, so paths containing an apostrophe produced an unterminated command. The corrected form closes the quoted segment, emits an escaped apostrophe, and reopens it (`'value'\''suffix'`).

This remains an explicit opt-in filter. Template values are not quoted automatically, and the filter does not claim to generate PowerShell, cmd, or other non-POSIX syntax.

Addresses https://github.com/jdx/mise/discussions/9729

## Verification

- `mise exec -- cargo test --all-features tera::tests::test_quote`
- `mise exec -- cargo test --all-features tera::tests::test_posix_shell_quote_round_trip`
- `mise run test:e2e e2e/tasks/test_task_tera_quote`
- POSIX round-trip checks with `sh`, `bash`, and `zsh`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- prettier --check docs/templates.md`
- `mise exec -- markdownlint docs/templates.md`
- `mise exec -- shellcheck -x e2e/tasks/test_task_tera_quote`
- `mise exec -- shfmt -d --apply-ignore e2e/tasks/test_task_tera_quote`
- `mise run docs:build`

The full macOS Clippy command currently stops on an unchanged `needless_return` warning in `src/system/packages/brew/cask.rs`. The repository-wide hk wrappers also require Git metadata and cannot initialize in this Sapling-only working copy; the corresponding format and lint tools for every changed file pass directly.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved the `quote` filter for reliable POSIX shell quoting.
  * Paths and values containing spaces, quotes, dollar signs, backslashes, newlines, and other shell-special characters are now handled safely.
  * Empty values and embedded single quotes are supported correctly.

* **Documentation**
  * Clarified that quoting applies to POSIX shells and not PowerShell or Windows Command Prompt.
  * Added an example showing how to quote a configuration path in a task command.

* **Tests**
  * Added coverage confirming quoted paths work correctly in end-to-end task execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->