### PR TITLE
fix(task): refuse a UNC working directory the cmd shell cannot use

### DIFF
--- a/e2e-win/task_unc_dir.Tests.ps1
+++ b/e2e-win/task_unc_dir.Tests.ps1
@@ -1,0 +1,93 @@
+Describe 'a task whose working directory is a UNC path' {
+    BeforeAll {
+        # cmd.exe refuses a UNC working directory: it prints "UNC paths are not supported", starts
+        # in C:\Windows and carries on, so the task used to run somewhere nobody asked for while
+        # mise reported success. The guard fires on the shape of the path, before anything spawns,
+        # so this share does not need to exist and no admin rights are involved.
+        $script:UncDir = "\\example\share"
+        $script:Proj = Join-Path $TestDrive "unc-task"
+        New-Item -ItemType Directory -Path $script:Proj -Force | Out-Null
+    }
+
+    It 'refuses to run it under the default cmd shell' {
+        $config = @"
+[tasks.here]
+run = "cd"
+dir = '$($script:UncDir)'
+"@
+        Set-Content -LiteralPath (Join-Path $script:Proj "mise.toml") -Value $config
+
+        Push-Location $script:Proj
+        try {
+            mise trust | Out-Null
+            $output = mise run here 2>&1 | Out-String
+            $code = $LASTEXITCODE
+        } finally {
+            Pop-Location
+        }
+
+        $code | Should -Not -Be 0
+        $output | Should -Match 'UNC path as a working directory'
+        # Bound first: in argument mode `Should -Match [regex]::Escape($x)` is parsed as the two
+        # arguments `[regex]::Escape` and `$x`, so the pattern becomes the literal method name and
+        # the path silently becomes the -Because text.
+        $escapedDir = [regex]::Escape($script:UncDir)
+        $output | Should -Match $escapedDir
+        # The message is only useful if it says what to do instead.
+        $output | Should -Match 'shell'
+    }
+
+    It 'refuses a cache command input before it can hash the wrong directory' {
+        # These commands feed the artifact cache key, and they run through the same inline shell
+        # from the same task directory. Measured on 2026.8.6 with a real UNC share: an input that
+        # reads a file present in the project failed, because cmd ran it in C:\Windows.
+        $config = @"
+[settings]
+experimental = true
+
+[tasks.build]
+run = "echo built"
+dir = '$($script:UncDir)'
+sources = ["input.txt"]
+outputs = ["out.txt"]
+cache = { enabled = true, command_inputs = ["type marker.txt"] }
+"@
+        Set-Content -LiteralPath (Join-Path $script:Proj "mise.toml") -Value $config
+
+        Push-Location $script:Proj
+        try {
+            mise trust | Out-Null
+            $output = mise run build 2>&1 | Out-String
+            $code = $LASTEXITCODE
+        } finally {
+            Pop-Location
+        }
+
+        $code | Should -Not -Be 0
+        $output | Should -Match 'UNC path as a working directory'
+        # Without the guard this is what came out instead, from a command that had already run.
+        $output | Should -Not -Match 'cache command input failed'
+    }
+
+    It 'leaves a shell that accepts UNC paths alone' {
+        # Control: the guard keys off the shell, not off the path alone. pwsh still fails here
+        # because the share does not exist, but it must fail on that rather than on this check.
+        $config = @"
+[tasks.here]
+run = "Write-Output `$PWD.Path"
+dir = '$($script:UncDir)'
+shell = "pwsh -c"
+"@
+        Set-Content -LiteralPath (Join-Path $script:Proj "mise.toml") -Value $config
+
+        Push-Location $script:Proj
+        try {
+            mise trust | Out-Null
+            $output = mise run here 2>&1 | Out-String
+        } finally {
+            Pop-Location
+        }
+
+        $output | Should -Not -Match 'UNC path as a working directory'
+    }
+}

--- a/src/file.rs
+++ b/src/file.rs
@@ -821,7 +821,7 @@ pub fn make_symlink_or_copy(target: &Path, link: &Path) -> Result<()> {
 }
 
 #[cfg(windows)]
-fn is_unc_path(path: &Path) -> bool {
+pub(crate) fn is_unc_path(path: &Path) -> bool {
     matches!(
         path.components().next(),
         Some(std::path::Component::Prefix(prefix))

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -29,6 +29,8 @@ use crate::ui::{style, time};
 use duct::IntoExecutablePath;
 use eyre::{Context, Report, Result, ensure, eyre};
 use indexmap::IndexMap;
+#[cfg(windows)]
+use indoc::formatdoc;
 use itertools::Itertools;
 #[cfg(unix)]
 use nix::errno::Errno;
@@ -173,6 +175,41 @@ enum InlineArgsStyle {
     PosixCommandText,
     CmdCommandText,
     SeparateArgv,
+}
+
+/// Whether the shell mise is about to spawn cannot use `dir` as its working directory.
+///
+/// cmd.exe refuses a UNC working directory. It says so on stderr, starts in `C:\Windows` instead,
+/// and carries on — so the task runs somewhere the user never asked for while mise reports success.
+/// Reuses [`crate::path::is_cmd_shell_program`] and [`crate::file::is_unc_path`]; both already know
+/// the shapes involved, including `cmd`/`cmd.exe`/`CMD.EXE` and the verbatim `\\?\UNC\` form.
+#[cfg(windows)]
+fn cmd_shell_cannot_use_dir(program: &str, dir: &Path) -> bool {
+    crate::path::is_cmd_shell_program(Path::new(program)) && crate::file::is_unc_path(dir)
+}
+
+/// What to say when it cannot. Names both ways out, because neither setting is guessable.
+#[cfg(windows)]
+fn unc_working_dir_error(dir: &Path) -> String {
+    formatdoc! {r#"
+        cmd.exe cannot use a UNC path as a working directory
+
+          working directory: {dir}
+
+        It would start in C:\Windows instead and run the command there, so mise stops rather
+        than running it somewhere you did not ask for.
+
+        Use a shell that accepts UNC paths, either for this task:
+
+          shell = "pwsh -c"
+
+        or for every task:
+
+          mise settings windows_default_inline_shell_args="pwsh -c"
+
+        A file task takes its shell from windows_default_file_shell_args instead."#,
+        dir = display_path(dir),
+    }
 }
 
 fn inline_args_style(program: &str, shell_args: &[String]) -> InlineArgsStyle {
@@ -1308,6 +1345,16 @@ impl TaskExecutor {
             }
             let (program, args, cmd_verbatim) =
                 self.get_cmd_program_and_args(command, task, &[])?;
+            // The same refusal as in `exec_program`, and it matters more here: these commands feed
+            // the cache key, so running them from C:\Windows would hash the wrong directory's
+            // answer. Measured on 2026.8.6 with the project on a UNC share — a `command_inputs`
+            // entry reading a file that exists in the project fails, while the same config on a
+            // local path succeeds. `--dry-run` does not reach here (see the cache branch in
+            // `run_task`), so there is nothing to exempt.
+            #[cfg(windows)]
+            if cmd_shell_cannot_use_dir(&program, &root) {
+                eyre::bail!("{}", unc_working_dir_error(&root));
+            }
             #[cfg(not(windows))]
             let _ = cmd_verbatim;
             let program = program.to_executable();
@@ -1423,6 +1470,12 @@ impl TaskExecutor {
         } = ctx;
         #[cfg(not(windows))]
         let _ = cmd_verbatim;
+        // `program` is shadowed several times below — `to_executable`, POSIX-shell resolution,
+        // audit wrapping — so keep the shell mise was asked to spawn for the working-directory
+        // check further down. `cmd_verbatim` is not a substitute: it is only set for inline
+        // scripts, and a file task can reach cmd.exe through windows_default_file_shell_args.
+        #[cfg(windows)]
+        let requested_program = program.to_string();
         let config = Config::get().await?;
         let program = program.to_executable();
         let redactions = config.redactions();
@@ -1671,6 +1724,12 @@ impl TaskExecutor {
                     display_path(&dir)
                 ),
             );
+        }
+        // Not under `--dry-run`: nothing is spawned there, so a preview of what *would* run has no
+        // reason to fail on where it would have run.
+        #[cfg(windows)]
+        if !self.dry_run && cmd_shell_cannot_use_dir(&requested_program, &dir) {
+            eyre::bail!("{}", unc_working_dir_error(&dir));
         }
         cmd = cmd.current_dir(dir);
         if self.dry_run {
@@ -2678,5 +2737,47 @@ mod tests {
         let env = env_with_path("/usr/bin:/bin");
         let out = maybe_convert_env_for_msys_shell(Path::new("bash"), &env);
         assert_eq!(out.get(&*crate::env::PATH_KEY).unwrap(), "/usr/bin:/bin");
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn cmd_will_not_take_a_unc_working_directory() {
+        // Measured on 2026.8.6 against \\wsl.localhost\<distro>\...: `cmd /c cd` printed
+        // C:\Windows and the task still reported success, so the spawn has to be refused.
+        assert!(cmd_shell_cannot_use_dir(
+            "cmd.exe",
+            Path::new(r"\\server\share\proj")
+        ));
+        // The verbatim form std hands back from canonicalize names the same directory.
+        assert!(cmd_shell_cannot_use_dir(
+            "cmd.exe",
+            Path::new(r"\\?\UNC\server\share\proj")
+        ));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn another_shell_on_the_same_unc_directory_is_left_alone() {
+        // Control: pwsh runs in that directory correctly, so the shell is half of the decision.
+        assert!(!cmd_shell_cannot_use_dir(
+            "pwsh",
+            Path::new(r"\\server\share\proj")
+        ));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn cmd_on_an_ordinary_directory_is_left_alone() {
+        // Control: the UNC shape is the other half. cmd is fine everywhere else.
+        assert!(!cmd_shell_cannot_use_dir("cmd.exe", Path::new(r"C:\proj")));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn the_error_names_the_directory_and_a_way_out() {
+        let msg = unc_working_dir_error(Path::new(r"\\server\share\proj"));
+        assert!(msg.contains(r"\\server\share\proj"), "{msg}");
+        assert!(msg.contains("pwsh -c"), "{msg}");
+        assert!(msg.contains("windows_default_inline_shell_args"), "{msg}");
     }
 }


### PR DESCRIPTION
`cmd.exe` does not accept a UNC path as its working directory. It says so on stderr, starts in
`C:\Windows` instead, and carries on. Since `cmd /c` is mise's default inline shell on Windows, a
task in a project on a UNC share **runs somewhere the user never asked for, and mise reports
success**.

## What happens

Project at `\\wsl.localhost\Ubuntu-Preview\home\jam\unctest\proj`, isolated `MISE_*`,
**2026.8.6 windows-x64**:

```console
> mise run wherecmd
[wherecmd] $ cd
'\\wsl.localhost\Ubuntu-Preview\home\jam\unctest\proj'
CMD.EXE was started with the above path as the current directory.
UNC paths are not supported.  Defaulting to Windows directory.
C:\Windows
```

mise passes cmd's warning through and ignores it. Exit code 0.

| task | result |
| --- | --- |
| `run = "cd"` — default `cmd /c` | prints **`C:\Windows`**, **exit 0** |
| `run = "Write-Output $PWD.Path"`, `shell = "pwsh -c"` | prints the UNC project dir, exit 0 |
| `run = "echo ROOT=%MISE_PROJECT_ROOT%"` | prints the **UNC** path |
| `run = "echo hello> made-by-task.txt"` | `Access is denied.`, exit 1, file never created |

The third row is the sharpest: the task's **environment** says the project root is the UNC path
while its **working directory** is `C:\Windows`. The fourth is the reachable harm — a relative write
lands in `C:\Windows`, fails on permissions, and nothing connects "Access is denied" to a working
directory that moved. Where the process *can* write, it writes to the wrong place and the task
passes.

**Measured as unaffected on the same UNC tree:** config discovery across three levels, `mise trust`,
`mise env`, and `pwsh` tasks, which run in the right directory.

> Reproduced without any administrator rights by using `\\wsl.localhost\<distro>\...`, which is a
> genuine UNC path served by the WSL redirector. `subst` only ever covered the drive-letter half of
> this, which is why it had not been caught before.

## The change

Refuse before spawning, and name the shells that do accept a UNC working directory:

```
cmd.exe cannot use a UNC path as a working directory

  working directory: \\server\share\proj

It would start in C:\Windows instead and run the task there, so mise stops rather than
running it somewhere you did not ask for.

Use a shell that accepts UNC paths, either for this task:

  shell = "pwsh -c"

or for every task:

  mise settings windows_default_inline_shell_args="pwsh -c"

A file task takes its shell from windows_default_file_shell_args instead.
```

Both predicates already existed and are reused rather than rewritten:

- `path::is_cmd_shell_program` — already knows `cmd`, `cmd.exe`, `CMD.EXE` and full paths, and is
  already used this way by `cmd.rs`, `hooks.rs` and `inline_args_style`.
- `file::is_unc_path` — already matches both `Prefix::UNC` and `Prefix::VerbatimUNC`. Only widened
  from private to `pub(crate)`.

Not keyed off the existing `cmd_verbatim` flag, which would have been the shorter route: it is only
set for inline scripts, so a file task reaching `cmd.exe` through `windows_default_file_shell_args`
would slip past it.

## The judgement call — happy to flip this

**Error or warning?** This errors. The reasoning: the neighbouring "task directory does not exist"
check only warns, but that case then fails loudly at the spawn anyway, whereas this one *succeeds*
in the wrong directory. Silent success in a directory the user did not choose seemed worse than a
refusal with a remedy.

The counter-argument is real, though: a task that never touches a relative path works today and
would start failing. If you would rather it warned and carried on, that is a one-line change from
`bail!` to `warn!` — say the word.

Two things deliberately not done:

- **Wrapping the script in `pushd`/`popd`.** cmd's `pushd` maps a UNC to a temporary drive letter
  and would make this genuinely work. But mise hands the script to `cmd /c` as a single command
  line, so wrapping it changes quoting and exit-code propagation, and it fails when no drive letter
  is free. Worth doing as its own change if you want UNC to actually work rather than be refused.
- **Silently switching to pwsh.** Running a different shell than the one configured is worse than
  saying no.

## Tests

**Unit** (`src/task/task_executor.rs`) — the predicate pinned in both directions: `cmd.exe` on
`\\server\share\proj` and on the verbatim `\\?\UNC\...` form are refused; `pwsh` on the same
directory is not (the shell is half the decision); `cmd.exe` on `C:\proj` is not (the path shape is
the other half). One more checks the message names the directory, `pwsh -c` and the setting.

**`e2e-win/task_unc_dir.Tests.ps1`** — a task with a UNC `dir` under the default shell must fail and
say so, and the same task with `shell = "pwsh -c"` must not produce that message. The share does not
need to exist, because the guard fires on the shape of the path before anything spawns, which keeps
the suite free of admin rights and of a real share. The silent-relocation case above was measured by
hand rather than in CI for the same reason.

## Notes

- No local build was run: `cargo fmt --all` only, plus the new Pester suite against a release binary
  — where, as expected, the control half passes and the guard half fails because the guard is not in
  that build. `cargo test` and `windows-e2e` are left to CI.
- Independent of #12062 and #12064; different files, different concerns.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Windows tasks using UNC working directories now show a clear error with the default command shell.
  * Prevented the shell from silently switching to `C:\Windows`, including during cached command execution.
  * Tasks configured to use PowerShell continue to work with UNC working directories.
  * Dry runs remain unaffected.

* **Tests**
  * Added Windows end-to-end coverage for UNC path handling, cache behavior, diagnostics, and remediation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->