### PR TITLE
fix(use): preserve concurrent global config updates

### DIFF
--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -147,7 +147,7 @@ impl Use {
             .with_scope(scope)
             .build(&config)
             .await?;
-        let cf = self.get_config_file().await?;
+        let mut cf = self.get_config_file().await?;
         let pin = self.pin || !self.fuzzy && (Settings::get().pin || Settings::get().asdf_compat);
         let mut resolve_options = ResolveOptions {
             latest_versions: false,
@@ -198,6 +198,18 @@ impl Use {
             )
             .await?;
 
+        // Installation can take long enough for another `mise use` process to update this file.
+        // Serialize only the read-modify-write phase, then re-read under the lock so we apply our
+        // changes to the latest contents instead of overwriting them with the stale snapshot used
+        // during resolution and installation.
+        let mut config_lock = if self.is_dry_run() {
+            None
+        } else {
+            let (lock, latest_cf) = config_file::lock_and_parse_or_init(cf.get_path()).await?;
+            cf = latest_cf;
+            Some(lock)
+        };
+
         for (ba, tvl) in &versions.iter().chunk_by(|tv| tv.ba()) {
             let versions: Vec<_> = tvl
                 .into_iter()
@@ -233,6 +245,7 @@ impl Use {
 
         if !self.is_dry_run() {
             cf.save()?;
+            drop(config_lock.take());
             for tv in &mut versions {
                 // update the source so the lockfile is updated correctly
                 tv.request.set_source(cf.source());

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -301,10 +301,24 @@ pub async fn parse_or_init(path: &Path) -> eyre::Result<Arc<dyn ConfigFile>> {
 pub async fn lock_and_parse_or_init(
     path: &Path,
 ) -> eyre::Result<(fslock::LockFile, Arc<dyn ConfigFile>)> {
-    let lock = crate::lock_file::LockFile::new(path)
-        .with_callback(|path| {
-            debug!("waiting for config lock on {}", display_path(path));
-        })
+    lock_and_parse_or_init_with_callback(path, |path| {
+        debug!("waiting for config lock on {}", display_path(path));
+    })
+    .await
+}
+
+async fn lock_and_parse_or_init_with_callback<F>(
+    path: &Path,
+    on_locked: F,
+) -> eyre::Result<(fslock::LockFile, Arc<dyn ConfigFile>)>
+where
+    F: Fn(&Path) + 'static,
+{
+    // Use the same target as the atomic writer so a symlink and its real path cannot produce
+    // independent lock identities for the same config file.
+    let target = file::atomic_write_target(path)?;
+    let lock = crate::lock_file::LockFile::new(&target)
+        .with_callback(on_locked)
         .lock()?;
     let cf = parse_or_init(path).await?;
     Ok((lock, cf))
@@ -992,6 +1006,10 @@ mod tests {
 
     #[test]
     fn lock_and_parse_or_init_reads_after_acquiring_lock() -> Result<()> {
+        use std::os::unix::fs::symlink;
+        use std::sync::mpsc;
+        use std::time::Duration;
+
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()?;
@@ -1000,26 +1018,37 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("mise.toml");
         file::write(&path, "[tools]\ndummy = \"1\"\n")?;
+        let alias = dir.path().join("linked.toml");
+        symlink(&path, &alias)?;
 
-        let lock = crate::lock_file::LockFile::new(&path).lock()?;
-        let (started_tx, started_rx) = std::sync::mpsc::channel();
-        let thread_path = path.clone();
+        let target = file::atomic_write_target(&path)?;
+        let lock = crate::lock_file::LockFile::new(&target).lock()?;
+        let (waiting_tx, waiting_rx) = mpsc::channel();
+        let (acquired_tx, acquired_rx) = mpsc::channel();
         let reader = std::thread::spawn(move || -> Result<String> {
-            started_tx.send(()).unwrap();
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()?;
-            let (_lock, cf) = runtime.block_on(lock_and_parse_or_init(&thread_path))?;
+            let (_lock, cf) = runtime
+                .block_on(lock_and_parse_or_init_with_callback(&alias, move |_| {
+                    waiting_tx.send(()).unwrap()
+                }))?;
+            acquired_tx.send(()).unwrap();
             cf.dump()
         });
 
-        // The other read-modify-write transaction is now waiting for this lock. Change the file
-        // before releasing it; the waiter must parse this version, not the snapshot from before
-        // it tried to acquire the lock.
-        started_rx.recv().unwrap();
+        // The callback proves that the symlink spelling reached the contended lock for the real
+        // path. Change the file while the waiter is blocked; it must parse this version only after
+        // acquiring the lock.
+        waiting_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert!(matches!(
+            acquired_rx.try_recv(),
+            Err(mpsc::TryRecvError::Empty)
+        ));
         file::write_atomic(&path, "[tools]\ndummy = \"1\"\ntiny = \"2\"\n")?;
         drop(lock);
 
+        acquired_rx.recv_timeout(Duration::from_secs(5)).unwrap();
         let contents = reader.join().unwrap()?;
         assert_eq!(contents, "[tools]\ndummy = \"1\"\ntiny = \"2\"\n");
         Ok(())

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -293,6 +293,23 @@ pub async fn parse_or_init(path: &Path) -> eyre::Result<Arc<dyn ConfigFile>> {
     Ok(cf)
 }
 
+/// Lock a config file for a read-modify-write operation, then read its latest contents.
+///
+/// Callers must keep the returned lock alive until after [`ConfigFile::save`]. Acquiring the
+/// lock before re-reading is what prevents two mise processes from both modifying the same stale
+/// snapshot and silently overwriting one another's changes.
+pub async fn lock_and_parse_or_init(
+    path: &Path,
+) -> eyre::Result<(fslock::LockFile, Arc<dyn ConfigFile>)> {
+    let lock = crate::lock_file::LockFile::new(path)
+        .with_callback(|path| {
+            debug!("waiting for config lock on {}", display_path(path));
+        })
+        .lock()?;
+    let cf = parse_or_init(path).await?;
+    Ok((lock, cf))
+}
+
 pub async fn parse(path: &Path) -> Result<Arc<dyn ConfigFile>> {
     if let Ok(settings) = Settings::try_get()
         && settings.paranoid
@@ -970,6 +987,41 @@ mod tests {
             .expect("goreleaser should be parsed from its nested idiomatic path");
 
         assert_eq!(versions[0].version(), "2");
+        Ok(())
+    }
+
+    #[test]
+    fn lock_and_parse_or_init_reads_after_acquiring_lock() -> Result<()> {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        runtime.block_on(backend::load_tools())?;
+
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("mise.toml");
+        file::write(&path, "[tools]\ndummy = \"1\"\n")?;
+
+        let lock = crate::lock_file::LockFile::new(&path).lock()?;
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let thread_path = path.clone();
+        let reader = std::thread::spawn(move || -> Result<String> {
+            started_tx.send(()).unwrap();
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?;
+            let (_lock, cf) = runtime.block_on(lock_and_parse_or_init(&thread_path))?;
+            cf.dump()
+        });
+
+        // The other read-modify-write transaction is now waiting for this lock. Change the file
+        // before releasing it; the waiter must parse this version, not the snapshot from before
+        // it tried to acquire the lock.
+        started_rx.recv().unwrap();
+        file::write_atomic(&path, "[tools]\ndummy = \"1\"\ntiny = \"2\"\n")?;
+        drop(lock);
+
+        let contents = reader.join().unwrap()?;
+        assert_eq!(contents, "[tools]\ndummy = \"1\"\ntiny = \"2\"\n");
         Ok(())
     }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -394,7 +394,7 @@ pub fn write_atomic<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> Res
     Ok(())
 }
 
-fn atomic_write_target(path: &Path) -> Result<PathBuf> {
+pub(crate) fn atomic_write_target(path: &Path) -> Result<PathBuf> {
     const MAX_SYMLINKS: usize = 40;
 
     let mut target = path.to_path_buf();


### PR DESCRIPTION
## Summary

- acquire a cross-process config lock for the read-modify-write phase of `mise use`
- re-read the target config after acquiring the lock so concurrent updates are preserved
- release the lock immediately after the atomic save, before config reload and shim rebuilding
- add a deterministic regression test for reading the latest contents after lock acquisition

## Root cause

#12040 made config writes atomic, preventing torn TOML, but each `mise use` process still parsed the config before installation and later saved that stale snapshot. Two concurrent processes could therefore both read the same state and silently overwrite one another's tool additions.

This change uses the existing `fslock` infrastructure to serialize only parse → mutate → save. Installation remains outside the critical section.

Closes the lost-update portion described in https://github.com/jdx/mise/discussions/12067.

## Validation

- `cargo test --bin mise config_file::tests::lock_and_parse_or_init_reads_after_acquiring_lock`
- `mise run test:e2e e2e/cli/test_use` (all matching `test_use*` suites)
- `hk run check --safe --format json` scoped to the changed files
  - `cargo fmt --all -- --check`
  - `cargo check --all-features`
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how global/local config files are written under concurrency; behavior is narrowed to the post-install critical section and reuses existing fslock/atomic-write paths, but incorrect locking could still corrupt or drop config updates.
> 
> **Overview**
> Fixes **lost updates** when two `mise use` runs overlap: each process used to parse the config, install tools, then save an old snapshot and could wipe the other’s tool entries.
> 
> **`mise use`** now locks the target config only for **parse → mutate → save** (after install). It **re-reads** the file under the lock, applies tool add/remove on that copy, saves, then **releases the lock** before config reload and shim rebuild. **Dry-run** skips locking.
> 
> Adds **`config_file::lock_and_parse_or_init`**, using the same resolved path as atomic writes so symlink spellings share one lock. Exposes **`file::atomic_write_target`** for that alignment.
> 
> Includes a **unix regression test** that a waiter sees on-disk changes made while blocked, only after acquiring the lock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7294c65c12f0819e9e0e4d40b78859e6421dd702. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration updates during installation to preserve changes made concurrently.
  * Ensured the latest configuration is used before applying installation changes, preventing stale updates from overwriting newer settings.
  * Improved reliability when initializing or updating configuration files, including when configuration files are accessed through symlinks.
  * Dry-run operations no longer modify or lock configuration files unnecessarily.
  * Reduced the risk of configuration conflicts by coordinating updates safely before changes are saved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->