### PR TITLE
fix(task): parse attached run option values

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -413,6 +413,30 @@ fn get_all_run_flags(cmd: &clap::Command) -> (Vec<String>, Vec<String>) {
     (flags_with_values, boolean_flags)
 }
 
+fn get_value_taking_short_flags(cmd: &clap::Command) -> Vec<(String, String)> {
+    cmd.get_arguments()
+        .filter(|arg| {
+            matches!(
+                arg.get_action(),
+                clap::ArgAction::Set | clap::ArgAction::Append
+            )
+        })
+        .filter_map(|arg| Some((arg.get_short()?, arg.get_long()?)))
+        .map(|(short, long)| (format!("-{short}"), format!("--{long}")))
+        .collect()
+}
+
+fn get_all_run_value_taking_short_flags(cmd: &clap::Command) -> Vec<(String, String)> {
+    let mut flags = get_value_taking_short_flags(cmd);
+    if let Some(run_cmd) = cmd
+        .get_subcommands()
+        .find(|subcommand| subcommand.get_name() == "run")
+    {
+        flags.extend(get_value_taking_short_flags(run_cmd));
+    }
+    flags
+}
+
 /// Prefix used to escape flags that should be passed to tasks, not mise
 const TASK_ARG_ESCAPE_PREFIX: &str = "\x00MISE_TASK_ARG\x00";
 
@@ -568,6 +592,7 @@ fn escape_task_args(cmd: &clap::Command, args: &[String]) -> Vec<String> {
     }
 
     let (flags_with_values, _) = get_all_run_flags(cmd);
+    let short_flags_with_values = get_all_run_value_taking_short_flags(cmd);
 
     // Build result, escaping flags that appear after task names
     let mut result = args[..=run_pos].to_vec(); // Include up to and including "run"
@@ -589,17 +614,18 @@ fn escape_task_args(cmd: &clap::Command, args: &[String]) -> Vec<String> {
             // Looking for task name - skip any mise flags
             if arg.starts_with('-') {
                 // clap treats attached values for short options as positional
-                // values when the positional allows hyphens. Split them before
-                // parsing so `-j4`, `-Cdir`, and similar forms remain options.
-                let attached_short_value = arg
-                    .get(..2)
-                    .filter(|_| arg.len() > 2)
-                    .filter(|flag| flags_with_values.iter().any(|f| f == flag));
+                // values when the positional allows hyphens. Normalize them to
+                // unambiguous long options before parsing.
+                let attached_short_value =
+                    short_flags_with_values.iter().find_map(|(short, long)| {
+                        arg.strip_prefix(short)
+                            .filter(|value| !value.is_empty())
+                            .map(|value| (long, value))
+                    });
 
-                if let Some(flag) = attached_short_value {
-                    result.push(flag.to_string());
-                    let value = &arg[flag.len()..];
-                    result.push(value.strip_prefix('=').unwrap_or(value).to_string());
+                if let Some((long, value)) = attached_short_value {
+                    let value = value.strip_prefix('=').unwrap_or(value);
+                    result.push(format!("{long}={value}"));
                     i += 1;
                     continue;
                 }
@@ -1181,17 +1207,41 @@ mod tests {
             "run".to_string(),
             "-j1".to_string(),
             "-Ctmp".to_string(),
-            "-o=prefix".to_string(),
+            "-oprefix".to_string(),
             "atask".to_string(),
         ];
 
         assert_eq!(
             escape_task_args(&cmd, &args),
             [
-                "mise", "run", "-j", "1", "-C", "tmp", "-o", "prefix", "atask"
+                "mise",
+                "run",
+                "--jobs=1",
+                "--cd=tmp",
+                "--output=prefix",
+                "atask",
             ]
             .map(str::to_string)
         );
+    }
+
+    #[test]
+    fn test_escape_task_args_preserves_equals_attached_option_values() {
+        let cmd = Cli::command();
+        let args = ["mise", "run", "-C=/tmp", "-o=prefix", "atask"].map(str::to_string);
+        let processed = escape_task_args(&cmd, &args);
+
+        assert_eq!(
+            processed,
+            ["mise", "run", "--cd=/tmp", "--output=prefix", "atask"].map(str::to_string)
+        );
+        let matches = cmd.try_get_matches_from(processed).unwrap();
+        let cli = <Cli as clap::FromArgMatches>::from_arg_matches(&matches).unwrap();
+        assert_eq!(cli.cd, Some(PathBuf::from("/tmp")));
+        let Some(Commands::Run(run)) = cli.command else {
+            panic!("expected run command");
+        };
+        assert_eq!(run.task.as_deref(), Some("atask"));
     }
 
     #[test]
@@ -1202,7 +1252,7 @@ mod tests {
 
         assert_eq!(
             processed,
-            ["mise", "run", "-C", "-dir", "atask"].map(str::to_string)
+            ["mise", "run", "--cd=-dir", "atask"].map(str::to_string)
         );
 
         let matches = cmd.try_get_matches_from(processed).unwrap();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -598,7 +598,8 @@ fn escape_task_args(cmd: &clap::Command, args: &[String]) -> Vec<String> {
 
                 if let Some(flag) = attached_short_value {
                     result.push(flag.to_string());
-                    result.push(arg[flag.len()..].to_string());
+                    let value = &arg[flag.len()..];
+                    result.push(value.strip_prefix('=').unwrap_or(value).to_string());
                     i += 1;
                     continue;
                 }
@@ -1180,7 +1181,7 @@ mod tests {
             "run".to_string(),
             "-j1".to_string(),
             "-Ctmp".to_string(),
-            "-oprefix".to_string(),
+            "-o=prefix".to_string(),
             "atask".to_string(),
         ];
 
@@ -1191,6 +1192,26 @@ mod tests {
             ]
             .map(str::to_string)
         );
+    }
+
+    #[test]
+    fn test_escape_task_args_keeps_hyphen_prefixed_attached_value_bound_to_option() {
+        let cmd = Cli::command();
+        let args = ["mise", "run", "-C-dir", "atask"].map(str::to_string);
+        let processed = escape_task_args(&cmd, &args);
+
+        assert_eq!(
+            processed,
+            ["mise", "run", "-C", "-dir", "atask"].map(str::to_string)
+        );
+
+        let matches = cmd.try_get_matches_from(processed).unwrap();
+        let cli = <Cli as clap::FromArgMatches>::from_arg_matches(&matches).unwrap();
+        assert_eq!(cli.cd, Some(PathBuf::from("-dir")));
+        let Some(Commands::Run(run)) = cli.command else {
+            panic!("expected run command");
+        };
+        assert_eq!(run.task.as_deref(), Some("atask"));
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -588,6 +588,21 @@ fn escape_task_args(cmd: &clap::Command, args: &[String]) -> Vec<String> {
         if !in_task_args {
             // Looking for task name - skip any mise flags
             if arg.starts_with('-') {
+                // clap treats attached values for short options as positional
+                // values when the positional allows hyphens. Split them before
+                // parsing so `-j4`, `-Cdir`, and similar forms remain options.
+                let attached_short_value = arg
+                    .get(..2)
+                    .filter(|_| arg.len() > 2)
+                    .filter(|flag| flags_with_values.iter().any(|f| f == flag));
+
+                if let Some(flag) = attached_short_value {
+                    result.push(flag.to_string());
+                    result.push(arg[flag.len()..].to_string());
+                    i += 1;
+                    continue;
+                }
+
                 // It's a flag - keep it as-is for mise to parse
                 result.push(arg.clone());
 
@@ -1154,6 +1169,27 @@ mod tests {
         assert_eq!(
             unescape_task_args(&escaped[separator_idx + 1..]),
             vec!["--".to_string(), "--help".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_escape_task_args_splits_attached_short_option_values_before_task() {
+        let cmd = Cli::command();
+        let args = vec![
+            "mise".to_string(),
+            "run".to_string(),
+            "-j1".to_string(),
+            "-Ctmp".to_string(),
+            "-oprefix".to_string(),
+            "atask".to_string(),
+        ];
+
+        assert_eq!(
+            escape_task_args(&cmd, &args),
+            [
+                "mise", "run", "-j", "1", "-C", "tmp", "-o", "prefix", "atask"
+            ]
+            .map(str::to_string)
         );
     }
 


### PR DESCRIPTION
## Summary

- normalize attached values for short `mise run` options before clap parses task positionals
- support forms such as `-j1`, `-Cdir`, and `-oquiet`
- add regression coverage for attached short-option values before a task name

## Root cause

The run task positional accepts hyphen-prefixed values so task arguments can be forwarded. In that parsing mode, clap treated short options with attached values as positional task names. Splitting known value-taking short options into their flag and value before parsing removes the ambiguity while preserving task-side arguments.

## Testing

- `cargo test --bin mise cli::tests`
- `hk run check --safe --format json --files0-from -` scoped to `src/cli/mod.rs`
- manual end-to-end checks for `mise run -j1 hello`, `mise run -C<dir> hello`, and `mise run -oquiet hello`

Addresses https://github.com/jdx/mise/discussions/12057

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to CLI argument preprocessing for `run`; behavior change only affects previously broken attached short-option forms, with unit tests covering edge cases.
> 
> **Overview**
> Fixes **`mise run`** so short options with **attached values** (e.g. `-j1`, `-Ctmp`, `-oquiet`) are applied to mise instead of being swallowed as the task name. That failure mode comes from task positionals allowing hyphen-prefixed values while clap still treats glued short flags as positionals.
> 
> **`escape_task_args`** now discovers value-taking short flags from the CLI/`run` definitions and rewrites matching tokens to **`--long=value`** (including `-C=-dir` when the value itself starts with `-`) before clap runs. Regression tests cover split forms, `=` forms, and full parse into `cd` / task name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8146dee0920b1cb9c4221121ece12391559f96a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line option handling for short options with attached values, such as `-j1`, `-Ctmp`, and `-oprefix`.
  * Values beginning with a hyphen are now correctly separated and interpreted during task parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->