### PR TITLE
fix(release): push mise tag separately

### DIFF
--- a/xtasks/release-plz
+++ b/xtasks/release-plz
@@ -377,17 +377,18 @@ if [[ $cur_version != "$latest_version" ]]; then
 	mise_tag="v$cur_version"
 	changelog="$(git cliff --tag "$mise_tag" --strip all --unreleased)"
 	changelog="$(echo "$changelog" | tail -n +3)"
-	if git rev-parse -q --verify "refs/tags/$mise_tag" >/dev/null ||
-		git ls-remote --exit-code --tags origin "$mise_tag" >/dev/null 2>&1; then
+	if git ls-remote --exit-code --tags origin "$mise_tag" >/dev/null 2>&1; then
 		echo "Tag $mise_tag already exists, skipping tag creation"
 	else
-		git tag "$mise_tag" -s -m "$changelog"
+		if ! git rev-parse -q --verify "refs/tags/$mise_tag" >/dev/null; then
+			git tag "$mise_tag" -s -m "$changelog"
+		fi
+		git push origin "refs/tags/$mise_tag"
 	fi
 
 	# GitHub does not create push events when more than three tags are pushed at
 	# once. Push the mise tag separately so release and Docker workflows always
 	# receive the event, then publish any subcrate tags in bulk.
-	git push origin "refs/tags/$mise_tag"
 	git push --tags
 	exit 0
 fi

--- a/xtasks/release-plz
+++ b/xtasks/release-plz
@@ -374,16 +374,20 @@ if [[ $cur_version != "$latest_version" ]]; then
 		cargo publish --allow-dirty -p mise
 	fi
 
-	changelog="$(git cliff --tag "v$cur_version" --strip all --unreleased)"
+	mise_tag="v$cur_version"
+	changelog="$(git cliff --tag "$mise_tag" --strip all --unreleased)"
 	changelog="$(echo "$changelog" | tail -n +3)"
-	if git rev-parse -q --verify "refs/tags/v$cur_version" >/dev/null ||
-		git ls-remote --exit-code --tags origin "v$cur_version" >/dev/null 2>&1; then
-		echo "Tag v$cur_version already exists, skipping tag creation"
+	if git rev-parse -q --verify "refs/tags/$mise_tag" >/dev/null ||
+		git ls-remote --exit-code --tags origin "$mise_tag" >/dev/null 2>&1; then
+		echo "Tag $mise_tag already exists, skipping tag creation"
 	else
-		git tag "v$cur_version" -s -m "$changelog"
+		git tag "$mise_tag" -s -m "$changelog"
 	fi
 
-	# Push all tags (mise + any subcrate tags)
+	# GitHub does not create push events when more than three tags are pushed at
+	# once. Push the mise tag separately so release and Docker workflows always
+	# receive the event, then publish any subcrate tags in bulk.
+	git push origin "refs/tags/$mise_tag"
 	git push --tags
 	exit 0
 fi


### PR DESCRIPTION
## Summary

- push the primary mise release tag before the bulk tag push
- preserve the existing bulk push for subcrate tags
- ensure tag-triggered release and Docker workflows receive a push event

## Root cause

The release task pushed the mise tag and all subcrate tags together with git push --tags. Recent releases created more than three tags, and GitHub does not emit tag push events when a single push contains more than three tags. This prevented docker.yml from rebuilding published images and required release.yml to recover through workflow_dispatch.

## Validation

- bash -n xtasks/release-plz
- hk run check --safe --format json scoped to xtasks/release-plz (ShellCheck and shfmt)

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes the release shell script’s git push ordering and tag guards; no runtime product code or security-sensitive paths.
> 
> **Overview**
> Fixes release automation so **tag-triggered `release.yml` and `docker.yml` runs reliably** when many subcrate tags ship in the same release.
> 
> After publishing, the script still builds the signed `v<version>` tag from `git cliff`, but it now **pushes that mise tag alone** (`git push origin refs/tags/$mise_tag`) before the existing **`git push --tags`** for subcrate tags. A comment documents that GitHub often **does not emit tag push events** when more than three tags land in one push— which had left Docker images stale and forced manual `workflow_dispatch` on release.
> 
> Tag handling is tightened slightly: changelog/tag work uses a **`mise_tag` variable**, remote existence is checked with **`git ls-remote`**, and local tag creation is skipped when the tag already exists locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0324c0744177c01e92f5ab5569e7979b6cc4ff97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release automation to consistently use the main release tag when generating changelogs and validating tags.
  * Ensured the primary release tag is pushed explicitly, while preserving subcrate tag publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->