### PR TITLE
docs(config): add vars reference

### DIFF
--- a/docs/.vitepress/sidebar.ts
+++ b/docs/.vitepress/sidebar.ts
@@ -25,6 +25,7 @@ export const sidebar: SidebarItem[] = [
     text: "Configuration",
     items: [
       { text: "mise.toml", link: "/configuration" },
+      { text: "Variables", link: "/configuration/vars" },
       { text: "Settings", link: "/configuration/settings" },
       {
         text: "Configuration Environments",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -218,6 +218,11 @@ root's tools to resolve and install from their lockfiles. See [mise.lock](/dev-t
 
 See [environments](/environments/).
 
+### `[vars]` - Configuration Variables
+
+Define values that can be reused in Tera-rendered configuration without exporting them to child
+processes. See [Variables](/configuration/vars).
+
 ### `[tasks.*]` - Run files or shell scripts
 
 See [Tasks](/tasks/).

--- a/docs/configuration/vars.md
+++ b/docs/configuration/vars.md
@@ -1,0 +1,78 @@
+# Variables
+
+`[vars]` defines values that can be reused in mise configuration templates. Vars are similar to
+environment variables, but mise does not export them to child processes. Reference a var in a
+Tera template with <span v-pre>`{{ vars.NAME }}`</span>.
+
+```mise-toml
+[vars]
+node_version = "24"
+test_mode = "headless"
+
+[tools]
+node = "{{ vars.node_version }}"
+
+[tasks.test]
+run = "./scripts/test-e2e.sh --{{ vars.test_mode }}"
+```
+
+Vars are available to Tera-rendered configuration such as tool versions and options, task
+definitions, hooks, task includes, watch configuration, and dotfile templates. See
+[Templates](/templates) for the complete template syntax and context.
+
+## Value directives
+
+Vars support the same value-producing directives as [`[env]`](/environments/), including defaults,
+required values, redaction, files, sources, and [secrets](/environments/secrets/).
+
+```mise-toml
+[vars]
+test_mode = { default = "headless" }
+api_token = { required = "Set api_token in mise.local.toml" }
+secret_arg = { value = "--token=abc123", redact = true }
+_.file = ".env"
+```
+
+The `default` form uses a process environment variable with the same name when it is set and
+non-empty; values from `[env]` are not used for this lookup. A `required` var must be supplied by the
+process environment or a later config file. Values marked `redact = true` are hidden from task
+output.
+
+See the [`env._` directive reference](/environments/#env-directives) for the available file, source,
+and plugin-provided directive forms. These directives populate `vars` instead of exporting the
+values as environment variables when used under `[vars]`.
+
+## Configuration hierarchy
+
+Vars follow mise's [configuration hierarchy](/configuration.html#configuration-hierarchy). They can
+be defined in the global config and overridden by project or environment-specific config files.
+
+For example, a default can be defined globally:
+
+```mise-toml [~/.config/mise/config.toml]
+[vars]
+test_mode = "headless"
+```
+
+Then overridden for a project:
+
+```mise-toml [mise.local.toml]
+[vars]
+test_mode = "headed"
+```
+
+## Task-local vars
+
+TOML tasks can define their own vars. Task-local values override config vars while that task is
+rendered, but do not change the vars available elsewhere in the configuration.
+
+```mise-toml
+[vars]
+test_mode = "headless"
+
+[tasks.test]
+vars = { test_mode = "headed" }
+run = "./scripts/test-e2e.sh --{{ vars.test_mode }}"
+```
+
+See [Task Configuration](/tasks/task-configuration.html#task-vars) for task-local vars.

--- a/docs/dev-tools/index.md
+++ b/docs/dev-tools/index.md
@@ -22,7 +22,7 @@ with asdf `.tool-versions` files as well as [idiomatic version files](/configura
 `.ruby-version`. See [configuration](/configuration) for more details.
 
 When specifying tool versions and tool options, you can also refer to environment variables or
-[`vars`](/tasks/task-configuration.html#vars) defined in your config hierarchy, including values
+[`vars`](/configuration/vars) defined in your config hierarchy, including values
 produced by directives like `_.source`, `_.file`, or env modules. These are resolved before tool
 version and option templates are rendered.
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -14,6 +14,7 @@
 ## Configuration
 
 - [mise.toml](https://mise.jdx.dev/configuration.html): Learn how to configure mise for your project with mise.toml files, environment variables, and various configuration options to manage your development environment.
+- [Variables](https://mise.jdx.dev/configuration/vars.html): [vars] defines values that can be reused in mise configuration templates. Vars are similar to environment variables, but mise does not export them to child processes.
 - [Settings](https://mise.jdx.dev/configuration/settings.html): The following is a list of all of mise's settings. These can be set via mise settings key=value, by directly modifying the global config file (~/.config/mise/config.toml) or local config, or via…
 - [Configuration Environments](https://mise.jdx.dev/configuration/environments.html): It's possible to have separate mise.toml files in the same directory for different environments like development and production.
 

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -1338,49 +1338,14 @@ mise run deploy secret123
 
 ## Vars
 
-Vars are values that can be shared between TOML tasks and other Tera-rendered config like tool
-versions/options. They are similar to environment variables, but they are not exported to task
-processes. Reference them with <span v-pre>`{{vars.NAME}}`</span>.
-
-```mise-toml
-[vars]
-e2e_args = '--headless'
-
-[tasks.test]
-run = './scripts/test-e2e.sh {{vars.e2e_args}}'
-```
-
-Vars can also use value-producing directive forms from `[env]`:
-
-```mise-toml
-[vars]
-e2e_args = { default = "--headless" }
-api_token = { required = "Set api_token in mise.local.toml" }
-secret_arg = { value = "--token=abc123", redact = true }
-_.file = ".env"
-```
-
-The `default` form reads from a process environment variable with the same name when it is set and
-non-empty; values from `[env]` are not used for this lookup. The `required` form must be satisfied by
-the process environment or by a later config file like `mise.local.toml`. Values marked with
-`redact = true` are hidden from task output. [Secrets](/environments/secrets/) are also supported as
-vars.
-
-Tasks can also define task-local vars that override config vars for that task:
+Top-level [configuration vars](/configuration/vars) are available when rendering TOML tasks. Tasks
+can also define task-local vars that override config vars for that task:
 
 ```mise-toml
 [tasks.test]
 vars = { e2e_args = "--headed" }
 run = './scripts/test-e2e.sh {{vars.e2e_args}}'
 ```
-
-Like most configuration in mise, vars can be defined across several files. So for example, you could
-put some vars in your global mise config `~/.config/mise/config.toml`, use them in a task at
-`~/src/work/myproject/mise.toml`. You can also override those vars in "later" config files such
-as `~/src/work/myproject/mise.local.toml` and they will be used inside tasks of any config file.
-
-As of this writing vars are only supported in TOML tasks. I want to add support for file tasks, but
-I don't want to turn all file tasks into tera templates just for this feature.
 
 ## `[task_config]` options
 
@@ -1657,7 +1622,7 @@ You can also specify these as a glob pattern, e.g.: `redactions = ["SECRETS_*"]`
 
 ## `[vars]` options
 
-See [Vars](#vars).
+See [Variables](/configuration/vars).
 
 ## Task Configuration Settings
 

--- a/docs/tasks/toml-tasks.md
+++ b/docs/tasks/toml-tasks.md
@@ -54,7 +54,7 @@ description = 'Cut a new release'
 file = 'scripts/release.sh' # execute an external script
 ```
 
-You can use [environment variables](/environments/) or [`vars`](/tasks/task-configuration.html#vars) to define common arguments:
+You can use [environment variables](/environments/) or [`vars`](/configuration/vars) to define common arguments:
 
 ```mise-toml [mise.toml]
 [env]

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -182,6 +182,7 @@ These variables offer key information about the current environment:
 
 - `env: HashMap<String, String>` – Accesses current environment variables as
   a key-value map.
+- `vars: HashMap<String, String>` – Accesses user-defined [configuration variables](/configuration/vars).
 - `cwd: PathBuf` – Points to the current working directory.
 - `config_root: PathBuf` – Locates the directory containing your `mise.toml` file, or in the case of something like `~/src/myproj/.config/mise.toml`, it will point to `~/src/myproj`.
 - `mise_bin: String` - Points to the path to the current mise executable


### PR DESCRIPTION
## Summary

- add a standalone Configuration → Variables reference for top-level `[vars]`
- document directives, hierarchy, template availability, and task-local precedence
- replace task-specific canonical links and remove the stale TOML-task-only limitation
- add `vars` to the template context reference and generated documentation index

## Why

Top-level `[vars]` is a cross-cutting configuration feature used by tools, tasks, hooks, includes, watch configuration, and other Tera-rendered fields, but its documentation was buried under task configuration.

Addresses https://github.com/jdx/mise/discussions/12044.

## Validation

- `mise run render:llms`
- `mise run docs:build`
- `hk run --check --safe --format json --unstaged`
- `git diff --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or config behavior impact.
> 
> **Overview**
> Adds a **Configuration → Variables** page that documents top-level `[vars]` as a cross-cutting feature: Tera usage (`{{ vars.NAME }}`), `[env]`-style directives, hierarchy overrides, and task-local precedence.
> 
> The main `configuration.md` page gains a `[vars]` section linking to that reference. **Task configuration** no longer carries the full vars write-up; it defers to the new page and drops the outdated note that vars were TOML-task-only. **Dev tools**, **TOML tasks**, and **templates** now point at `/configuration/vars`, and the template docs list `vars` in the Tera context. Sidebar and `llms.txt` are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f62a2e5ad989a1dcd446f442e59bdd8ce76fd97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for `[vars]` configuration, including reusable template values, supported directives, hierarchy, overrides, and task-local behavior.
  * Added a dedicated Variables page and updated documentation navigation and cross-links.
  * Documented access to user-defined configuration variables in templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->