### PR TITLE
feat(bootstrap): support self-updating and adopted brew casks

### DIFF
--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -89,6 +89,44 @@ relocated into the override directory, preserving any subdirectories the cask
 requests; targets that a cask anchors under `$HOMEBREW_PREFIX/Applications` are
 left in the Homebrew prefix and are never relocated. This mirrors Homebrew's own
 `--appdir` install option.
+To adopt an app that is already installed at the cask's destination, use the
+table form with `adopt = true`:
+
+```toml
+[bootstrap.packages]
+"brew-cask:textmate" = { version = "latest", adopt = true }
+```
+
+To enable adoption for all configured casks, set the Homebrew bootstrap
+default. An individual cask can opt out with `adopt = false`:
+
+```toml
+[bootstrap.brew]
+adopt = true
+
+[bootstrap.packages]
+"brew-cask:textmate" = "latest"
+"brew-cask:replace-me" = { adopt = false }
+```
+
+As with Homebrew's `brew install --cask --adopt`, mise downloads and verifies
+the current cask artifact, then adopts the existing app only when its content
+is identical. A different existing app is left untouched and the install
+fails, except for casks declaring `auto_updates: true`: matching Homebrew,
+those adopt the existing app as-is because it may already have updated itself.
+Adopted apps are tracked by the mise receipt without keeping a duplicate app
+bundle in Caskroom.
+
+Casks declaring `auto_updates: true` in their Homebrew metadata are installed
+at the current version and then left to update themselves. mise does not expose
+an `auto_updates` override: the cask definition remains authoritative. These
+self-updating apps are also tracked by receipt without a duplicate Caskroom app
+bundle, and ordinary mise upgrades skip them.
+
+`mise bootstrap status` marks these entries as `installed (auto-updates)`.
+The `Current` column is the version recorded in the cask receipt; the live app
+may have updated itself to a different version. JSON status keeps the stable
+`"state": "installed"` value and adds `"auto_updates": true`.
 
 On Linux, initial cask support is limited to font-only casks without lifecycle
 hooks or structured `preflight_steps` or `postflight_steps` — concepts from
@@ -237,7 +275,9 @@ This command is mise's declarative cleanup for bootstrap packages, similar to
 config model to direct cask artifacts, with a deliberately narrower ownership
 boundary. A cask is removed only when its install-time `.mise-cask.toml`
 receipt explicitly marks it safe to prune and every recorded target still has
-the exact content fingerprint mise recorded after installation. The command
+the exact content fingerprint mise recorded after installation. Self-updating
+apps are expected to change and are validated by their recorded destination
+instead. The command
 removes those targets and the cask's Caskroom entry; `--dry-run` previews the
 plan and `--yes` skips confirmation.
 

--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -275,11 +275,12 @@ This command is mise's declarative cleanup for bootstrap packages, similar to
 config model to direct cask artifacts, with a deliberately narrower ownership
 boundary. A cask is removed only when its install-time `.mise-cask.toml`
 receipt explicitly marks it safe to prune and every recorded target still has
-the exact content fingerprint mise recorded after installation. Self-updating
-apps are expected to change and are validated by their recorded destination
-instead. The command
+the exact content fingerprint mise recorded after installation. The command
 removes those targets and the cask's Caskroom entry; `--dry-run` previews the
-plan and `--yes` skips confirmation.
+plan and `--yes` skips confirmation. Adopted and self-updating apps are tracked
+without a duplicate Caskroom bundle, so mise cannot prove that a later bundle
+at the same destination is still the one it owns. These metadata-only apps are
+therefore never removed by prune.
 
 Casks installed before their receipt included prune metadata are skipped until
 a later upgrade or reinstall refreshes the receipt. Casks with pkg or command

--- a/docs/bootstrap/packages/index.md
+++ b/docs/bootstrap/packages/index.md
@@ -35,6 +35,12 @@ aliases as `[tools]` (`linux`, `macos`, `windows`, `linux/x64`,
 "brew-cask:font-jetbrains-mono" = { os = ["linux", "macos"] }
 ```
 
+`brew-cask` entries additionally accept `adopt = true` to adopt an identical
+app already installed at the cask destination. Set `bootstrap.brew.adopt = true`
+to make adoption the default for all casks, with per-cask `adopt = false`
+overrides. See the
+[brew cask documentation](/bootstrap/packages/brew.html#casks).
+
 Host packages are intentionally separate from [`[tools]`](/configuration.html):
 they are not version-pinned per-project, do not get shims, and are managed
 outside the project by the platform's package manager — or, for `brew` and

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -3916,6 +3916,10 @@
                         "minItems": 1
                       }
                     ]
+                  },
+                  "adopt": {
+                    "type": "boolean",
+                    "description": "adopt an existing identical brew-cask app artifact instead of replacing it"
                   }
                 },
                 "additionalProperties": false
@@ -4557,6 +4561,10 @@
           "type": "object",
           "description": "Homebrew-specific bootstrap package config",
           "properties": {
+            "adopt": {
+              "type": "boolean",
+              "description": "adopt existing app artifacts by default for configured brew-cask packages"
+            },
             "taps": {
               "type": "object",
               "description": "Homebrew tap names mapped to custom git URLs",

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -2790,8 +2790,11 @@ impl BootstrapStatus {
             for s in statuses {
                 let auto_updates = s.state.auto_updates();
                 let (installed_version, state, reason, missing) = match &s.state {
-                    PackageState::Installed { version }
-                    | PackageState::InstalledAutoUpdates { version } => {
+                    PackageState::Installed { version } => {
+                        (version.clone(), "installed", None::<&str>, false)
+                    }
+                    #[cfg(unix)]
+                    PackageState::InstalledAutoUpdates { version } => {
                         (version.clone(), "installed", None::<&str>, false)
                     }
                     PackageState::Missing => ("".to_string(), "missing", None, true),

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -2788,8 +2788,10 @@ impl BootstrapStatus {
             let statuses = mp.manager.installed(&mp.requests).await?;
             let mut json_pkgs = vec![];
             for s in statuses {
+                let auto_updates = s.state.auto_updates();
                 let (installed_version, state, reason, missing) = match &s.state {
-                    PackageState::Installed { version } => {
+                    PackageState::Installed { version }
+                    | PackageState::InstalledAutoUpdates { version } => {
                         (version.clone(), "installed", None::<&str>, false)
                     }
                     PackageState::Missing => ("".to_string(), "missing", None, true),
@@ -2808,8 +2810,14 @@ impl BootstrapStatus {
                     "packages",
                     format!("{name}:{}", s.request),
                     installed_version.clone(),
-                    reason
-                        .map_or_else(|| state.to_string(), |reason| format!("{state} ({reason})")),
+                    if auto_updates {
+                        format!("{state} (auto-updates)")
+                    } else {
+                        reason.map_or_else(
+                            || state.to_string(),
+                            |reason| format!("{state} ({reason})"),
+                        )
+                    },
                     missing,
                 );
                 let mut package = json!({
@@ -2820,6 +2828,9 @@ impl BootstrapStatus {
                 });
                 if let Some(reason) = reason {
                     package["reason"] = json!(reason);
+                }
+                if auto_updates {
+                    package["auto_updates"] = json!(true);
                 }
                 json_pkgs.push(package);
             }

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -497,12 +497,7 @@ impl Doctor {
                 Ok(statuses) => {
                     let missing = statuses
                         .iter()
-                        .filter(|s| {
-                            !matches!(
-                                s.state,
-                                crate::system::packages::PackageState::Installed { .. }
-                            ) && !s.state.is_unavailable()
-                        })
+                        .filter(|s| !s.state.is_installed() && !s.state.is_unavailable())
                         .count();
                     total_missing += missing;
                     map.insert(
@@ -728,12 +723,7 @@ impl Doctor {
                 Ok(statuses) => {
                     let missing = statuses
                         .iter()
-                        .filter(|s| {
-                            !matches!(
-                                s.state,
-                                crate::system::packages::PackageState::Installed { .. }
-                            ) && !s.state.is_unavailable()
-                        })
+                        .filter(|s| !s.state.is_installed() && !s.state.is_unavailable())
                         .count();
                     lines.push(format!(
                         "{name}: {} requested, {missing} missing",

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -218,12 +218,7 @@ impl Install {
                 Ok(statuses) => {
                     missing += statuses
                         .iter()
-                        .filter(|s| {
-                            !matches!(
-                                s.state,
-                                crate::system::packages::PackageState::Installed { .. }
-                            ) && !s.state.is_unavailable()
-                        })
+                        .filter(|s| !s.state.is_installed() && !s.state.is_unavailable())
                         .count();
                 }
                 // a transient query failure must not start the 24h throttle

--- a/src/cli/system/driver.rs
+++ b/src/cli/system/driver.rs
@@ -187,9 +187,12 @@ pub(crate) async fn run(mgrs: Vec<ManagerPackages>, action: Action, d: &DriverOp
                     .iter()
                     .filter_map(|s| match &s.state {
                         PackageState::Installed { version }
-                        | PackageState::InstalledAutoUpdates { version }
                         | PackageState::NeedsRepair { installed: version }
                         | PackageState::VersionMismatch { installed: version } => {
+                            Some((s.request.name.clone(), version.clone()))
+                        }
+                        #[cfg(unix)]
+                        PackageState::InstalledAutoUpdates { version } => {
                             Some((s.request.name.clone(), version.clone()))
                         }
                         PackageState::Missing => None,
@@ -204,9 +207,14 @@ pub(crate) async fn run(mgrs: Vec<ManagerPackages>, action: Action, d: &DriverOp
                         .iter()
                         .filter_map(|s| match &s.state {
                             PackageState::Installed { version }
-                            | PackageState::InstalledAutoUpdates { version }
                             | PackageState::NeedsRepair { installed: version }
                             | PackageState::VersionMismatch { installed: version } => {
+                                let old = prior.get(&s.request.name)?;
+                                (old != version)
+                                    .then(|| format!("{} {old} -> {version}", s.request.name))
+                            }
+                            #[cfg(unix)]
+                            PackageState::InstalledAutoUpdates { version } => {
                                 let old = prior.get(&s.request.name)?;
                                 (old != version)
                                     .then(|| format!("{} {old} -> {version}", s.request.name))

--- a/src/cli/system/driver.rs
+++ b/src/cli/system/driver.rs
@@ -113,9 +113,7 @@ pub(crate) async fn run(mgrs: Vec<ManagerPackages>, action: Action, d: &DriverOp
         let mut targets: Vec<_> = statuses
             .iter()
             .filter(|s| match action {
-                Action::Install => {
-                    !matches!(s.state, PackageState::Installed { .. }) && !s.state.is_unavailable()
-                }
+                Action::Install => !s.state.is_installed() && !s.state.is_unavailable(),
                 // upgrade acts on whatever is present (the manager no-ops
                 // already-current packages); missing packages are skipped
                 // below with a pointer at `install`
@@ -153,7 +151,7 @@ pub(crate) async fn run(mgrs: Vec<ManagerPackages>, action: Action, d: &DriverOp
         }
         let installed = statuses
             .iter()
-            .filter(|status| matches!(status.state, PackageState::Installed { .. }))
+            .filter(|status| status.state.is_installed())
             .count();
         if action == Action::Install && installed > 0 {
             info!("{name}: {installed} package(s) already installed");
@@ -175,7 +173,9 @@ pub(crate) async fn run(mgrs: Vec<ManagerPackages>, action: Action, d: &DriverOp
         }
         match action {
             Action::Install => {
-                mp.manager.install(&targets, &opts).await?;
+                mp.manager
+                    .install_with_options(&targets, &opts, &mp.options)
+                    .await?;
                 if !d.dry_run {
                     info!("{name}: installed {}", list.join(", "));
                 }
@@ -187,6 +187,7 @@ pub(crate) async fn run(mgrs: Vec<ManagerPackages>, action: Action, d: &DriverOp
                     .iter()
                     .filter_map(|s| match &s.state {
                         PackageState::Installed { version }
+                        | PackageState::InstalledAutoUpdates { version }
                         | PackageState::NeedsRepair { installed: version }
                         | PackageState::VersionMismatch { installed: version } => {
                             Some((s.request.name.clone(), version.clone()))
@@ -203,6 +204,7 @@ pub(crate) async fn run(mgrs: Vec<ManagerPackages>, action: Action, d: &DriverOp
                         .iter()
                         .filter_map(|s| match &s.state {
                             PackageState::Installed { version }
+                            | PackageState::InstalledAutoUpdates { version }
                             | PackageState::NeedsRepair { installed: version }
                             | PackageState::VersionMismatch { installed: version } => {
                                 let old = prior.get(&s.request.name)?;

--- a/src/cli/system/import.rs
+++ b/src/cli/system/import.rs
@@ -188,7 +188,11 @@ fn imported_package_value(
         Some(PackageTomlConfig::Options(options)) => Some(options),
         Some(PackageTomlConfig::Version(_)) => None,
         None => match configured {
-            Some(PackageTomlConfig::Options(options)) if !options.os.is_empty() => Some(options),
+            Some(PackageTomlConfig::Options(options))
+                if !options.os.is_empty() || options.adopt.is_some() =>
+            {
+                Some(options)
+            }
             _ => None,
         },
     };
@@ -201,6 +205,9 @@ fn imported_package_value(
         let mut os = Array::new();
         os.extend(options.os.clone());
         table.insert("os", Value::Array(os));
+    }
+    if let Some(adopt) = options.adopt {
+        table.insert("adopt", Value::from(adopt));
     }
     Value::InlineTable(table)
 }
@@ -256,10 +263,21 @@ mod tests {
         let inherited = PackageTomlConfig::Options(PackageOptionsTomlConfig {
             version: "1.0.0".to_string(),
             os: vec!["macos".to_string()],
+            adopt: None,
         });
         assert_eq!(
             imported_package_value(None, Some(&inherited)).to_string(),
             r#"{ version = "latest", os = ["macos"] }"#
+        );
+
+        let adopted = PackageTomlConfig::Options(PackageOptionsTomlConfig {
+            version: "1.0.0".to_string(),
+            os: vec![],
+            adopt: Some(true),
+        });
+        assert_eq!(
+            imported_package_value(None, Some(&adopted)).to_string(),
+            r#"{ version = "latest", adopt = true }"#
         );
     }
 }

--- a/src/cli/system/status.rs
+++ b/src/cli/system/status.rs
@@ -56,8 +56,11 @@ impl SystemStatus {
             for s in statuses {
                 let auto_updates = s.state.auto_updates();
                 let (installed_version, state, reason) = match &s.state {
-                    PackageState::Installed { version }
-                    | PackageState::InstalledAutoUpdates { version } => {
+                    PackageState::Installed { version } => {
+                        (version.clone(), "installed", None::<&str>)
+                    }
+                    #[cfg(unix)]
+                    PackageState::InstalledAutoUpdates { version } => {
                         (version.clone(), "installed", None::<&str>)
                     }
                     PackageState::Missing => {

--- a/src/cli/system/status.rs
+++ b/src/cli/system/status.rs
@@ -54,8 +54,10 @@ impl SystemStatus {
             let statuses = mp.manager.installed(&mp.requests).await?;
             let mut json_pkgs = vec![];
             for s in statuses {
+                let auto_updates = s.state.auto_updates();
                 let (installed_version, state, reason) = match &s.state {
-                    PackageState::Installed { version } => {
+                    PackageState::Installed { version }
+                    | PackageState::InstalledAutoUpdates { version } => {
                         (version.clone(), "installed", None::<&str>)
                     }
                     PackageState::Missing => {
@@ -85,16 +87,23 @@ impl SystemStatus {
                     if let Some(reason) = reason {
                         package["reason"] = json!(reason);
                     }
+                    if auto_updates {
+                        package["auto_updates"] = json!(true);
+                    }
                     json_pkgs.push(package);
                 } else {
                     rows.push(vec![
                         name.to_string(),
                         s.request.to_string(),
                         installed_version,
-                        reason.map_or_else(
-                            || state.to_string(),
-                            |reason| format!("{state} ({reason})"),
-                        ),
+                        if auto_updates {
+                            format!("{state} (auto-updates)")
+                        } else {
+                            reason.map_or_else(
+                                || state.to_string(),
+                                |reason| format!("{state} ({reason})"),
+                            )
+                        },
                     ]);
                 }
             }

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -862,7 +862,7 @@ impl MiseToml {
             .is_none_or(|bootstrap| !bootstrap.packages.contains_key(spec));
         if is_missing
             && let Some(PackageTomlConfig::Options(options)) = fallback
-            && !options.os.is_empty()
+            && (!options.os.is_empty() || options.adopt.is_some())
         {
             let mut options = options.clone();
             options.version = version.to_string();
@@ -890,9 +890,14 @@ impl MiseToml {
                 .unwrap();
             let mut value = InlineTable::new();
             value.insert("version", Value::from(version));
-            let mut os = Array::new();
-            os.extend(options.os);
-            value.insert("os", Value::Array(os));
+            if !options.os.is_empty() {
+                let mut os = Array::new();
+                os.extend(options.os);
+                value.insert("os", Value::Array(os));
+            }
+            if let Some(adopt) = options.adopt {
+                value.insert("adopt", Value::from(adopt));
+            }
             packages.insert(spec, Item::Value(Value::InlineTable(value)));
             return Ok(());
         }
@@ -3282,9 +3287,12 @@ mod tests {
         "apt:libssl-dev" = "latest"
         "apt:curl" = "8.5.0-2"
         "brew:postgresql@17" = "latest"
-        "brew-cask:1password" = { version = "latest", os = "macos" }
+        "brew-cask:1password" = { version = "latest", os = "macos", adopt = true }
         "brew-cask:font-example" = { os = ["linux", "macos"] }
         "future-manager:whatever" = "latest"
+
+        [bootstrap.brew]
+        adopt = true
 
         [bootstrap.brew.taps]
         "railwaycat/emacsmacport" = "https://github.com/railwaycat/homebrew-emacsmacport"
@@ -3306,6 +3314,10 @@ mod tests {
             system.packages.get("apt:libssl-dev").unwrap().version(),
             "latest"
         );
+        assert!(matches!(
+            system.packages.get("brew-cask:1password"),
+            Some(crate::system::PackageTomlConfig::Options(options)) if options.adopt == Some(true)
+        ));
         assert_eq!(
             system.packages.get("apt:curl").unwrap().version(),
             "8.5.0-2"
@@ -3334,6 +3346,7 @@ mod tests {
             system.brew.taps.get("railwaycat/emacsmacport").unwrap(),
             "https://github.com/railwaycat/homebrew-emacsmacport"
         );
+        assert_eq!(system.brew.adopt, Some(true));
         let repo = system.repos.get("~/src/dotfiles").unwrap();
         assert_eq!(
             repo.url.as_deref(),
@@ -3358,6 +3371,21 @@ mod tests {
         let cf = MiseToml::from_file(&p).unwrap();
         assert!(cf.bootstrap_config().is_none());
         file::remove_file(&p).unwrap();
+    }
+
+    #[test]
+    fn test_bootstrap_brew_adopt_is_not_reported_as_unknown() {
+        let des = toml::Deserializer::parse(
+            r#"
+            [bootstrap.brew]
+            adopt = true
+            "#,
+        )
+        .unwrap();
+        let mut ignored = Vec::new();
+        let _: MiseToml = serde_ignored::deserialize(des, |path| ignored.push(path.to_string()))
+            .expect("config should deserialize");
+        assert!(ignored.is_empty(), "unexpected ignored fields: {ignored:?}");
     }
 
     #[tokio::test]
@@ -3609,6 +3637,7 @@ mod tests {
                     PackageTomlConfig::Options(crate::system::PackageOptionsTomlConfig {
                         version: "1.0.0".to_string(),
                         os: vec![],
+                        adopt: None,
                     });
                 cf.update_bootstrap_package_with_fallback(
                     "brew:tree",

--- a/src/oci/packages.rs
+++ b/src/oci/packages.rs
@@ -793,6 +793,7 @@ mod tests {
         ManagerPackages {
             manager,
             requests,
+            options: Default::default(),
             disabled: false,
         }
     }

--- a/src/oci/packages.rs
+++ b/src/oci/packages.rs
@@ -536,8 +536,43 @@ fn clean_apt_transients(rootfs: &Path) -> Result<()> {
 }
 
 fn clean_apk_transients(rootfs: &Path) -> Result<()> {
-    remove_dir_children(&rootfs.join("var/cache/apk"))?;
-    remove_path(&rootfs.join("var/log/apk.log"))
+    let cache = rootfs.join("var/cache/apk");
+    let log = rootfs.join("var/log/apk.log");
+    reject_symlink_components(rootfs, &cache)?;
+    reject_symlink_components(rootfs, &log)?;
+    remove_dir_children(&cache)?;
+    remove_path(&log)
+}
+
+/// Reject a cleanup target when it or any path component below `rootfs` is a
+/// symlink. OCI package layers are untrusted, so following one during cleanup
+/// could remove files outside the layer root.
+fn reject_symlink_components(rootfs: &Path, target: &Path) -> Result<()> {
+    let relative = target
+        .strip_prefix(rootfs)
+        .wrap_err_with(|| format!("cleanup target {} is outside rootfs", target.display()))?;
+    let mut current = rootfs.to_path_buf();
+    for component in relative.components() {
+        let std::path::Component::Normal(component) = component else {
+            bail!("invalid cleanup target {}", target.display());
+        };
+        current.push(component);
+        match fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                bail!(
+                    "refusing cleanup through symlink component {}",
+                    current.display()
+                );
+            }
+            Ok(_) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(err) => {
+                return Err(err)
+                    .wrap_err_with(|| format!("reading metadata for {}", current.display()));
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Remove every regular file under `dir` (recursively), leaving the directory
@@ -868,6 +903,41 @@ mod tests {
             fs::read_to_string(rootfs.join("usr/bin/jq")).unwrap(),
             "ELF-payload"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn clean_apk_transients_rejects_symlinked_cache_parent() {
+        let td = TempDir::with_prefix("mise-oci-apk-clean-symlink-parent-").unwrap();
+        let rootfs = td.path().join("rootfs");
+        let outside = td.path().join("outside");
+        write_file(&outside.join("apk/keep"), "outside");
+        file::create_dir_all(rootfs.join("var")).unwrap();
+        symlink(&outside, rootfs.join("var/cache")).unwrap();
+
+        let err = clean_apk_transients(&rootfs).unwrap_err();
+
+        assert!(err.to_string().contains("symlink component"));
+        assert_eq!(
+            fs::read_to_string(outside.join("apk/keep")).unwrap(),
+            "outside"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn clean_apk_transients_rejects_symlinked_cache_directory() {
+        let td = TempDir::with_prefix("mise-oci-apk-clean-symlink-dir-").unwrap();
+        let rootfs = td.path().join("rootfs");
+        let outside = td.path().join("outside");
+        write_file(&outside.join("keep"), "outside");
+        file::create_dir_all(rootfs.join("var/cache")).unwrap();
+        symlink(&outside, rootfs.join("var/cache/apk")).unwrap();
+
+        let err = clean_apk_transients(&rootfs).unwrap_err();
+
+        assert!(err.to_string().contains("symlink component"));
+        assert_eq!(fs::read_to_string(outside.join("keep")).unwrap(), "outside");
     }
 
     #[test]

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -18,6 +18,7 @@
 //! These are intentionally not part of `[tools]`: they're unversioned,
 //! machine-global settings and resources, not mise's per-project toolset.
 
+#[cfg(unix)]
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -332,12 +333,12 @@ pub struct ManagerPackages {
 pub enum ManagerPackageOptions {
     #[default]
     None,
-    BrewCask {
-        adopt: BTreeSet<String>,
-    },
+    #[cfg(unix)]
+    BrewCask { adopt: BTreeSet<String> },
 }
 
 impl ManagerPackageOptions {
+    #[cfg(unix)]
     pub(crate) fn brew_cask_adopt(&self, name: &str) -> bool {
         matches!(self, Self::BrewCask { adopt } if adopt.contains(name))
     }
@@ -582,7 +583,9 @@ fn package_requests_from_config_files(
 ) {
     let merged = package_configs_from_config_files(config_files);
     let mut by_mgr: IndexMap<String, Vec<PackageRequest>> = IndexMap::new();
+    #[cfg(unix)]
     let brew_adopt = brew_adopt_from_config_files(config_files);
+    #[cfg(unix)]
     let mut cask_adopt = BTreeSet::new();
     for (spec, package) in merged {
         if !package.is_os_supported() {
@@ -608,6 +611,7 @@ fn package_requests_from_config_files(
                         "[bootstrap.packages]: adopt is only supported for brew-cask entries; ignoring it for '{spec}'"
                     );
                 }
+                #[cfg(unix)]
                 if mgr == "brew-cask" && adopt_requested.unwrap_or(brew_adopt) {
                     cask_adopt.insert(name.clone());
                 }
@@ -621,6 +625,7 @@ fn package_requests_from_config_files(
         }
     }
     let mut options = IndexMap::new();
+    #[cfg(unix)]
     if !cask_adopt.is_empty() {
         options.insert(
             "brew-cask".to_string(),

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -304,6 +304,7 @@ pub struct BootstrapLinuxSystemdTomlConfig {
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct SystemBrewTomlConfig {
     /// Adopt identical existing app bundles for brew-cask entries by default.
+    #[cfg(unix)]
     #[serde(default)]
     pub adopt: Option<bool>,
     /// `[bootstrap.brew.taps]`: `owner/tap` -> GitHub git URL. Like
@@ -624,14 +625,17 @@ fn package_requests_from_config_files(
             Err(err) => warn!("[bootstrap.packages]: {err}"),
         }
     }
-    let mut options = IndexMap::new();
     #[cfg(unix)]
-    if !cask_adopt.is_empty() {
-        options.insert(
+    let options = if cask_adopt.is_empty() {
+        IndexMap::new()
+    } else {
+        IndexMap::from([(
             "brew-cask".to_string(),
             ManagerPackageOptions::BrewCask { adopt: cask_adopt },
-        );
-    }
+        )])
+    };
+    #[cfg(not(unix))]
+    let options = IndexMap::new();
     (by_mgr, options)
 }
 
@@ -1546,6 +1550,7 @@ fn brew_taps_from_config_files(config_files: &ConfigMap) -> IndexMap<String, Str
     brew_taps
 }
 
+#[cfg(unix)]
 fn brew_adopt_from_config_files(config_files: &ConfigMap) -> bool {
     let mut adopt = false;
     for cf in config_files.values().rev() {

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -18,6 +18,7 @@
 //! These are intentionally not part of `[tools]`: they're unversioned,
 //! machine-global settings and resources, not mise's per-project toolset.
 
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -146,6 +147,9 @@ pub struct PackageOptionsTomlConfig {
     pub version: String,
     #[serde(default, deserialize_with = "deserialize_package_os")]
     pub os: Vec<String>,
+    /// Adopt an identical existing cask artifact instead of replacing it.
+    #[serde(default)]
+    pub adopt: Option<bool>,
 }
 
 impl PackageTomlConfig {
@@ -153,6 +157,13 @@ impl PackageTomlConfig {
         match self {
             Self::Version(version) => version,
             Self::Options(options) => &options.version,
+        }
+    }
+
+    fn adopt(&self) -> Option<bool> {
+        match self {
+            Self::Options(options) => options.adopt,
+            Self::Version(_) => None,
         }
     }
 
@@ -291,6 +302,9 @@ pub struct BootstrapLinuxSystemdTomlConfig {
 
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct SystemBrewTomlConfig {
+    /// Adopt identical existing app bundles for brew-cask entries by default.
+    #[serde(default)]
+    pub adopt: Option<bool>,
     /// `[bootstrap.brew.taps]`: `owner/tap` -> GitHub git URL. Like
     /// `[plugins]`, this lets shared config name tap remotes while package
     /// entries stay focused on formulae/casks.
@@ -307,10 +321,26 @@ pub struct DotfilesTomlConfig(pub IndexMap<String, toml::Value>);
 pub struct ManagerPackages {
     pub manager: Arc<dyn SystemPackageManager>,
     pub requests: Vec<PackageRequest>,
+    pub options: ManagerPackageOptions,
     /// excluded by the `system_packages.managers` setting — surfaced by
     /// status/doctor (nothing is silently invisible), skipped by install
     /// and the missing-packages hint
     pub disabled: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub enum ManagerPackageOptions {
+    #[default]
+    None,
+    BrewCask {
+        adopt: BTreeSet<String>,
+    },
+}
+
+impl ManagerPackageOptions {
+    pub(crate) fn brew_cask_adopt(&self, name: &str) -> bool {
+        matches!(self, Self::BrewCask { adopt } if adopt.contains(name))
+    }
 }
 
 /// Split a `"manager:package"` spec (config key or CLI argument). Only the
@@ -377,7 +407,7 @@ pub fn parse_use_spec(spec: &str) -> eyre::Result<(String, PackageRequest)> {
 pub fn packages_from_requests(
     by_mgr: IndexMap<String, Vec<PackageRequest>>,
 ) -> eyre::Result<Vec<ManagerPackages>> {
-    resolve_managers(by_mgr, true)
+    resolve_managers(by_mgr, IndexMap::new(), true)
 }
 
 pub fn attach_brew_tap_urls(config: &Config, by_mgr: &mut IndexMap<String, Vec<PackageRequest>>) {
@@ -441,6 +471,7 @@ pub(crate) fn pending_plugin_packages_from_config_including_disabled(
         .map(|manager| manager.name().to_string())
         .collect::<std::collections::HashSet<_>>();
     package_requests_from_config_files(&config.config_files, &brew_taps)
+        .0
         .into_iter()
         .filter(|(name, _)| declared.contains_key(name) && !installed.contains(name))
         .collect()
@@ -471,9 +502,11 @@ fn packages_from_config_files_and_tracked_config_files(
     tracked_config_files: &ConfigMap,
 ) -> Result<Vec<ManagerPackages>> {
     let mut by_mgr: IndexMap<String, Vec<PackageRequest>> = IndexMap::new();
+    let mut manager_options = IndexMap::new();
     let current_brew_taps = brew_taps_from_config_files(current_config_files);
     merge_manager_packages(
         &mut by_mgr,
+        &mut manager_options,
         packages_from_config_files_with_brew_taps(current_config_files, &current_brew_taps),
     );
 
@@ -483,20 +516,24 @@ fn packages_from_config_files_and_tracked_config_files(
     }
     merge_manager_packages(
         &mut by_mgr,
+        &mut manager_options,
         packages_from_config_files_with_brew_taps(tracked_config_files, &tracked_brew_taps),
     );
 
-    resolve_managers(by_mgr, false)
+    resolve_managers(by_mgr, manager_options, false)
 }
 
 #[cfg(unix)]
 fn merge_manager_packages(
     by_mgr: &mut IndexMap<String, Vec<PackageRequest>>,
+    manager_options: &mut IndexMap<String, ManagerPackageOptions>,
     manager_packages: Vec<ManagerPackages>,
 ) {
     for mp in manager_packages {
-        let requests = by_mgr.entry(mp.manager.name().to_string()).or_default();
+        let manager_name = mp.manager.name().to_string();
+        let requests = by_mgr.entry(manager_name.clone()).or_default();
         for request in mp.requests {
+            let adopt = mp.options.brew_cask_adopt(&request.name);
             match requests.iter_mut().find(|existing| {
                 existing.name == request.name && existing.version == request.version
             }) {
@@ -504,7 +541,20 @@ fn merge_manager_packages(
                     existing.tap_url = request.tap_url;
                 }
                 Some(_) => {}
-                None => requests.push(request),
+                None => {
+                    if adopt {
+                        let options =
+                            manager_options
+                                .entry(manager_name.clone())
+                                .or_insert_with(|| ManagerPackageOptions::BrewCask {
+                                    adopt: BTreeSet::new(),
+                                });
+                        if let ManagerPackageOptions::BrewCask { adopt } = options {
+                            adopt.insert(request.name.clone());
+                        }
+                    }
+                    requests.push(request);
+                }
             }
         }
     }
@@ -519,19 +569,21 @@ fn packages_from_config_files_with_brew_taps(
     config_files: &ConfigMap,
     brew_taps: &IndexMap<String, String>,
 ) -> Vec<ManagerPackages> {
-    resolve_managers(
-        package_requests_from_config_files(config_files, brew_taps),
-        false,
-    )
-    .expect("non-strict resolve is infallible")
+    let (requests, options) = package_requests_from_config_files(config_files, brew_taps);
+    resolve_managers(requests, options, false).expect("non-strict resolve is infallible")
 }
 
 fn package_requests_from_config_files(
     config_files: &ConfigMap,
     brew_taps: &IndexMap<String, String>,
-) -> IndexMap<String, Vec<PackageRequest>> {
+) -> (
+    IndexMap<String, Vec<PackageRequest>>,
+    IndexMap<String, ManagerPackageOptions>,
+) {
     let merged = package_configs_from_config_files(config_files);
     let mut by_mgr: IndexMap<String, Vec<PackageRequest>> = IndexMap::new();
+    let brew_adopt = brew_adopt_from_config_files(config_files);
+    let mut cask_adopt = BTreeSet::new();
     for (spec, package) in merged {
         if !package.is_os_supported() {
             debug!("[bootstrap.packages]: skipping '{spec}', not enabled for this platform");
@@ -550,6 +602,15 @@ fn package_requests_from_config_files(
                 } else {
                     None
                 };
+                let adopt_requested = package.adopt();
+                if adopt_requested.is_some() && mgr != "brew-cask" {
+                    warn!(
+                        "[bootstrap.packages]: adopt is only supported for brew-cask entries; ignoring it for '{spec}'"
+                    );
+                }
+                if mgr == "brew-cask" && adopt_requested.unwrap_or(brew_adopt) {
+                    cask_adopt.insert(name.clone());
+                }
                 by_mgr.entry(mgr).or_default().push(PackageRequest {
                     name,
                     version,
@@ -559,7 +620,14 @@ fn package_requests_from_config_files(
             Err(err) => warn!("[bootstrap.packages]: {err}"),
         }
     }
-    by_mgr
+    let mut options = IndexMap::new();
+    if !cask_adopt.is_empty() {
+        options.insert(
+            "brew-cask".to_string(),
+            ManagerPackageOptions::BrewCask { adopt: cask_adopt },
+        );
+    }
+    (by_mgr, options)
 }
 
 fn package_configs_from_config_files(
@@ -1412,7 +1480,7 @@ pub fn packages_from_specs_with_config(
             requests.push(request);
         }
     }
-    resolve_managers(by_mgr, true)
+    resolve_managers(by_mgr, IndexMap::new(), true)
 }
 
 pub(crate) fn brew_tap_name(name: &str) -> Option<&str> {
@@ -1473,8 +1541,19 @@ fn brew_taps_from_config_files(config_files: &ConfigMap) -> IndexMap<String, Str
     brew_taps
 }
 
+fn brew_adopt_from_config_files(config_files: &ConfigMap) -> bool {
+    let mut adopt = false;
+    for cf in config_files.values().rev() {
+        if let Some(value) = cf.bootstrap_config().and_then(|system| system.brew.adopt) {
+            adopt = value;
+        }
+    }
+    adopt
+}
+
 fn resolve_managers(
     by_mgr: IndexMap<String, Vec<PackageRequest>>,
+    mut manager_options: IndexMap<String, ManagerPackageOptions>,
     strict: bool,
 ) -> eyre::Result<Vec<ManagerPackages>> {
     let enabled = crate::config::Settings::get()
@@ -1499,6 +1578,7 @@ fn resolve_managers(
             Some(manager) => out.push(ManagerPackages {
                 manager: manager.clone(),
                 requests,
+                options: manager_options.shift_remove(&name).unwrap_or_default(),
                 disabled,
             }),
             None => {
@@ -1641,6 +1721,32 @@ mod tests {
             Some(PackageTomlConfig::Options(options)) if options.os == ["macos"]
         ));
         assert!(!global_packages.contains_key("brew:jq"));
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_brew_cask_adopt_option_reaches_package_request() -> Result<()> {
+        let (_dir, config_files) = config_map_from_toml(&[(
+            "mise.toml",
+            r#"
+                [bootstrap.brew]
+                adopt = true
+
+                [bootstrap.packages]
+                "brew-cask:textmate" = "latest"
+                "brew-cask:replace-me" = { adopt = false }
+            "#,
+        )])?;
+
+        let packages = packages_from_config_files(&config_files);
+        let casks = packages
+            .into_iter()
+            .find(|packages| packages.manager.name() == "brew-cask")
+            .unwrap();
+        assert_eq!(casks.requests.len(), 2);
+        assert!(casks.options.brew_cask_adopt("textmate"));
+        assert!(!casks.options.brew_cask_adopt("replace-me"));
         Ok(())
     }
 

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -7826,8 +7826,8 @@ mod tests {
 
     #[test]
     fn adopts_only_an_identical_existing_app() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let tmp = tempfile::tempdir()?;
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
+        let tmp = trusted_tempdir()?;
         let root = tmp.path().canonicalize()?;
         let _guard = BrewPrefixGuard::set(&root);
         let stage = root.join("stage");
@@ -7854,8 +7854,8 @@ mod tests {
 
     #[test]
     fn self_updating_cask_adopts_a_different_existing_app() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let tmp = tempfile::tempdir()?;
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
+        let tmp = trusted_tempdir()?;
         let root = tmp.path().canonicalize()?;
         let _guard = BrewPrefixGuard::set(&root);
         let stage = root.join("stage");

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -6592,20 +6592,25 @@ fn write_receipt_with_flight_targets(
             })
         })
         .collect::<Result<Vec<_>>>()?;
-    let prune_blocker = cask_prune_blocker(cask, artifacts);
+    let metadata_only_apps = if cask.auto_updates {
+        artifacts
+            .apps
+            .iter()
+            .map(|app| app_target_path(app.target_name()))
+            .collect::<Result<Vec<_>>>()?
+    } else {
+        metadata_only_apps.to_vec()
+    };
+    let prune_blocker = cask_prune_blocker(cask, artifacts).or_else(|| {
+        (!metadata_only_apps.is_empty()).then(|| {
+            "metadata-only app ownership cannot be proven safely during pruning".to_string()
+        })
+    });
     let receipt = CaskReceipt {
         schema_version: 3,
         version: cask.version.clone(),
         auto_updates: cask.auto_updates,
-        metadata_only_apps: if cask.auto_updates {
-            artifacts
-                .apps
-                .iter()
-                .map(|app| app_target_path(app.target_name()))
-                .collect::<Result<Vec<_>>>()?
-        } else {
-            metadata_only_apps.to_vec()
-        },
+        metadata_only_apps,
         apps: artifacts
             .apps
             .iter()
@@ -7135,6 +7140,9 @@ fn validate_cask_prune_candidate(candidate: &CaskPruneCandidate) -> Result<()> {
     if receipt.schema_version != 3 || !receipt.prune_safe || !receipt.pkg_ids.is_empty() {
         bail!("receipt is not marked safe for direct-artifact pruning");
     }
+    if !receipt.metadata_only_apps.is_empty() {
+        bail!("metadata-only app ownership cannot be proven safely during pruning");
+    }
     let records = receipt
         .targets
         .iter()
@@ -7237,14 +7245,7 @@ fn validate_cask_prune_candidate(candidate: &CaskPruneCandidate) -> Result<()> {
         }
     }
     for record in &receipt.targets {
-        if receipt.auto_updates && receipt.apps.contains(&record.path) {
-            if !record.path.is_dir() {
-                bail!(
-                    "self-updating app target is missing: {}",
-                    record.path.display()
-                );
-            }
-        } else if !cask_target_record_matches(record)? {
+        if !cask_target_record_matches(record)? {
             bail!("artifact target has changed: {}", record.path.display());
         }
     }
@@ -7791,8 +7792,35 @@ mod tests {
             installed_cask_version(&cask, &artifacts)?,
             Some("1.0.0".to_string())
         );
-        assert!(read_receipt(&caskroom)?.unwrap().auto_updates);
+        let receipt = read_receipt(&caskroom)?.unwrap();
+        assert!(receipt.auto_updates);
+        assert!(!receipt.prune_safe);
+        assert!(
+            receipt
+                .prune_blocker
+                .as_deref()
+                .is_some_and(|reason| reason.contains("metadata-only app ownership"))
+        );
         assert!(!caskroom.join("Example.app").exists());
+
+        // Fail closed for schema-3 receipts written before metadata-only apps
+        // were marked non-prunable. A replacement bundle at the same path
+        // must never become removable merely because it is a directory.
+        let mut legacy_receipt = receipt;
+        legacy_receipt.prune_safe = true;
+        legacy_receipt.prune_blocker = None;
+        file::write(
+            caskroom.join(".mise-cask.toml"),
+            toml::to_string_pretty(&legacy_receipt)?,
+        )?;
+        let plan = cask_prune_plan_from_tokens(
+            &BTreeSet::new(),
+            &prefix::prefix().join(".mise-test-state"),
+        )?;
+        assert!(plan.remove.is_empty());
+        assert!(plan.skipped.iter().any(|skip| {
+            skip.token == "self-updating" && skip.reason.contains("metadata-only app ownership")
+        }));
         Ok(())
     }
 
@@ -7800,11 +7828,12 @@ mod tests {
     fn adopts_only_an_identical_existing_app() -> Result<()> {
         let _lock = ENV_LOCK.lock().unwrap();
         let tmp = tempfile::tempdir()?;
-        let _guard = BrewPrefixGuard::set(tmp.path());
-        let stage = tmp.path().join("stage");
-        let caskroom = tmp.path().join("Caskroom/example/1.0.0");
+        let root = tmp.path().canonicalize()?;
+        let _guard = BrewPrefixGuard::set(&root);
+        let stage = root.join("stage");
+        let caskroom = root.join("Caskroom/example/1.0.0");
         let source = stage.join("Example.app/Contents");
-        let target = tmp.path().join("Applications/Example.app/Contents");
+        let target = root.join("Applications/Example.app/Contents");
         file::create_dir_all(&source)?;
         file::create_dir_all(&target)?;
         crate::file::write(source.join("app"), "identical")?;
@@ -7827,11 +7856,12 @@ mod tests {
     fn self_updating_cask_adopts_a_different_existing_app() -> Result<()> {
         let _lock = ENV_LOCK.lock().unwrap();
         let tmp = tempfile::tempdir()?;
-        let _guard = BrewPrefixGuard::set(tmp.path());
-        let stage = tmp.path().join("stage");
-        let caskroom = tmp.path().join("Caskroom/example/1.0.0");
+        let root = tmp.path().canonicalize()?;
+        let _guard = BrewPrefixGuard::set(&root);
+        let stage = root.join("stage");
+        let caskroom = root.join("Caskroom/example/1.0.0");
         let source = stage.join("Example.app/Contents");
-        let target = tmp.path().join("Applications/Example.app/Contents");
+        let target = root.join("Applications/Example.app/Contents");
         file::create_dir_all(&source)?;
         file::create_dir_all(&target)?;
         crate::file::write(source.join("app"), "downloaded version")?;

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -23,6 +23,7 @@ use crate::git::{CloneOptions, Git};
 use crate::hash;
 use crate::http::{HTTP, HTTP_FETCH};
 use crate::result::Result;
+use crate::system::ManagerPackageOptions;
 use crate::system::packages::{
     InstallOpts, PackageRequest, PackageState, PackageStatus, SystemPackageManager,
 };
@@ -58,6 +59,8 @@ struct Cask {
     #[serde(default)]
     old_tokens: Vec<String>,
     version: String,
+    #[serde(default)]
+    auto_updates: bool,
     url: String,
     #[serde(default)]
     url_specs: CaskUrlSpecs,
@@ -272,6 +275,15 @@ struct CaskReceipt {
     #[serde(default)]
     schema_version: u8,
     version: String,
+    /// Self-updating apps are allowed to drift from the downloaded cask. For
+    /// these casks the receipt, rather than a stale Caskroom app copy, is the
+    /// durable ownership record.
+    #[serde(default)]
+    auto_updates: bool,
+    /// App bundles owned through metadata only, without a duplicate in the
+    /// versioned Caskroom directory (self-updating or adopted apps).
+    #[serde(default)]
+    metadata_only_apps: Vec<PathBuf>,
     #[serde(default)]
     apps: Vec<PathBuf>,
     #[serde(default)]
@@ -355,13 +367,53 @@ impl BrewCaskManager {
         Self {}
     }
 
+    async fn install_with_manager_options(
+        &self,
+        pkgs: &[PackageRequest],
+        opts: &InstallOpts,
+        manager_options: &ManagerPackageOptions,
+    ) -> Result<()> {
+        if let Some(p) = pkgs.iter().find(|p| p.version.is_some()) {
+            bail!("brew casks are installed at their current version ('{p}')");
+        }
+        if opts.dry_run {
+            prefix::bootstrap(true)?;
+            for pkg in pkgs {
+                self.install_one(pkg, opts, None, manager_options).await?;
+            }
+            return Ok(());
+        }
+        let mpr = MultiProgressReport::get();
+        mpr.init_footer(false, "install", pkgs.len());
+        for pkg in pkgs {
+            let pr: Box<dyn SingleReport> = mpr.add(&format!("brew-cask:{}", pkg.name));
+            match self
+                .install_one(pkg, opts, Some(&*pr), manager_options)
+                .await
+            {
+                Ok(version) => {
+                    pr.finish_with_message(version);
+                    mpr.footer_inc(1);
+                }
+                Err(err) => {
+                    pr.finish_with_icon("failed".to_string(), ProgressIcon::Error);
+                    mpr.footer_finish();
+                    return Err(err);
+                }
+            }
+        }
+        mpr.footer_finish();
+        Ok(())
+    }
+
     async fn install_one(
         &self,
         req: &PackageRequest,
         opts: &InstallOpts,
         pr: Option<&dyn SingleReport>,
+        manager_options: &ManagerPackageOptions,
     ) -> Result<String> {
-        self.install_one_with_ancestors(req, opts, pr, &BTreeSet::new())
+        self.install_one_with_ancestors(req, opts, pr, &BTreeSet::new(), manager_options)
             .await
     }
 
@@ -371,6 +423,7 @@ impl BrewCaskManager {
         opts: &InstallOpts,
         pr: Option<&dyn SingleReport>,
         ancestors: &BTreeSet<String>,
+        manager_options: &ManagerPackageOptions,
     ) -> Result<String> {
         let cask = fetch_cask(req).await?;
         if ancestors.contains(&cask.token) {
@@ -386,9 +439,12 @@ impl BrewCaskManager {
                 cask.token
             );
         }
-        if installed_cask_version(&cask, &artifacts)?.as_deref() == Some(cask.version.as_str()) {
+        let installed_version = installed_cask_version(&cask, &artifacts)?;
+        if let Some(version) = installed_version.as_ref()
+            && (cask.auto_updates || version == &cask.version)
+        {
             info!("brew-cask:{}: already installed", cask.token);
-            return Ok(cask.version);
+            return Ok(version.clone());
         }
         for conflict in &cask.conflicts_with.cask {
             if !installed_versions(conflict).is_empty() {
@@ -420,7 +476,14 @@ impl BrewCaskManager {
                 version: None,
                 tap_url: None,
             };
-            Box::pin(self.install_one_with_ancestors(&request, opts, None, &ancestors)).await?;
+            Box::pin(self.install_one_with_ancestors(
+                &request,
+                opts,
+                None,
+                &ancestors,
+                manager_options,
+            ))
+            .await?;
         }
         if opts.dry_run {
             miseprintln!("install cask {}/{}", cask.token, cask.version);
@@ -459,6 +522,10 @@ impl BrewCaskManager {
         }
         prefix::bootstrap(false)?;
         let stage = fetch_and_stage(&cask, pr).await?;
+        let adopt = manager_options.brew_cask_adopt(&cask.token) && installed_version.is_none();
+        if adopt && !cask.auto_updates {
+            validate_adoptable_apps(&stage, &artifacts.apps)?;
+        }
         let _caskroom_lock = lock_caskroom()?;
         recover_flight_backups()?;
         if homebrew_metadata_present(&cask.token) {
@@ -468,9 +535,11 @@ impl BrewCaskManager {
                 cask.token
             );
         }
-        if installed_cask_version(&cask, &artifacts)?.as_deref() == Some(cask.version.as_str()) {
+        if let Some(version) = installed_cask_version(&cask, &artifacts)?
+            && (cask.auto_updates || version == cask.version)
+        {
             file::remove_all(stage)?;
-            return Ok(cask.version);
+            return Ok(version);
         }
         let previous_binaries = previous_binary_targets(&cask)?;
         let previous_fonts = previous_font_targets(&cask)?;
@@ -528,8 +597,18 @@ impl BrewCaskManager {
             &mut flight_targets,
             |index| record_cask_action(&mut journal, &format!("installer[{index}]")),
         )?;
+        let mut metadata_only_apps = Vec::new();
         for (index, app) in artifacts.apps.iter().enumerate() {
-            install_app(&stage, &tmp_caskroom, app)?;
+            if install_app(
+                &stage,
+                &tmp_caskroom,
+                app,
+                !cask.auto_updates,
+                adopt,
+                !cask.auto_updates,
+            )? {
+                metadata_only_apps.push(app_target_path(app.target_name())?);
+            }
             record_cask_action(&mut journal, &format!("app[{index}]"))?;
         }
         for (index, pkg) in artifacts.pkgs.iter().enumerate() {
@@ -600,6 +679,7 @@ impl BrewCaskManager {
                 flight_targets.installed_targets(),
                 flight_targets.uninstall_targets(),
                 flight_targets.installed_directories(),
+                &metadata_only_apps,
             )?;
             Ok(())
         });
@@ -782,6 +862,7 @@ impl SystemPackageManager for BrewCaskManager {
                     Some(requested) if version != *requested => {
                         PackageState::VersionMismatch { installed: version }
                     }
+                    _ if cask.auto_updates => PackageState::InstalledAutoUpdates { version },
                     _ => PackageState::Installed { version },
                 },
                 None => PackageState::Missing,
@@ -795,34 +876,18 @@ impl SystemPackageManager for BrewCaskManager {
     }
 
     async fn install(&self, pkgs: &[PackageRequest], opts: &InstallOpts) -> Result<()> {
-        if let Some(p) = pkgs.iter().find(|p| p.version.is_some()) {
-            bail!("brew casks are installed at their current version ('{p}')");
-        }
-        if opts.dry_run {
-            prefix::bootstrap(true)?;
-            for pkg in pkgs {
-                self.install_one(pkg, opts, None).await?;
-            }
-            return Ok(());
-        }
-        let mpr = MultiProgressReport::get();
-        mpr.init_footer(false, "install", pkgs.len());
-        for pkg in pkgs {
-            let pr: Box<dyn SingleReport> = mpr.add(&format!("brew-cask:{}", pkg.name));
-            match self.install_one(pkg, opts, Some(&*pr)).await {
-                Ok(version) => {
-                    pr.finish_with_message(version);
-                    mpr.footer_inc(1);
-                }
-                Err(err) => {
-                    pr.finish_with_icon("failed".to_string(), ProgressIcon::Error);
-                    mpr.footer_finish();
-                    return Err(err);
-                }
-            }
-        }
-        mpr.footer_finish();
-        Ok(())
+        self.install_with_manager_options(pkgs, opts, &ManagerPackageOptions::None)
+            .await
+    }
+
+    async fn install_with_options(
+        &self,
+        pkgs: &[PackageRequest],
+        opts: &InstallOpts,
+        manager_options: &ManagerPackageOptions,
+    ) -> Result<()> {
+        self.install_with_manager_options(pkgs, opts, manager_options)
+            .await
     }
 
     async fn upgrade(&self, pkgs: &[PackageRequest], opts: &InstallOpts) -> Result<()> {
@@ -1187,12 +1252,18 @@ fn detect_extraction_format(archive: &Path) -> Result<Option<ExtractionFormat>> 
     Ok(None)
 }
 
-fn install_app(stage: &Path, caskroom: &Path, app: &AppArtifact) -> Result<()> {
+fn install_app(
+    stage: &Path,
+    caskroom: &Path,
+    app: &AppArtifact,
+    keep_caskroom_copy: bool,
+    adopt: bool,
+    verify_adopt: bool,
+) -> Result<bool> {
     let source = find_app(stage, &app.source)
         .ok_or_else(|| eyre!("brew-cask: app artifact '{}' was not found", app.source))?;
     let caskroom_app = caskroom.join(app_bundle_name(app.target_name())?);
     file::remove_all(&caskroom_app)?;
-    ditto(&source, &caskroom_app)?;
     let logical_target = app_target_path(app.target_name())?;
     // Hold the verified appdir open for the whole mutation and address the app
     // only by name relative to that descriptor. Nothing below resolves a
@@ -1208,6 +1279,21 @@ fn install_app(stage: &Path, caskroom: &Path, app: &AppArtifact) -> Result<()> {
         .file_name()
         .ok_or_else(|| eyre!("brew-cask: app target has no filename"))?
         .to_owned();
+    if adopt && exists_at(&parent.fd, &name)? {
+        if verify_adopt {
+            let source_fingerprint = cask_target_fingerprint(&source)?;
+            let target_fingerprint = cask_target_fingerprint(&logical_target)?;
+            if source_fingerprint != target_fingerprint {
+                bail!(
+                    "brew-cask: cannot adopt '{}': existing artifact is not identical to the cask artifact",
+                    logical_target.display()
+                );
+            }
+        }
+        return Ok(true);
+    }
+
+    ditto(&source, &caskroom_app)?;
     // Suffix hashes stay derived from the logical path so temporary and backup
     // names are stable across runs.
     let name_hash = crate::hash::hash_to_str(&logical_target.display().to_string());
@@ -1235,6 +1321,24 @@ fn install_app(stage: &Path, caskroom: &Path, app: &AppArtifact) -> Result<()> {
         ],
         &parent.fd,
     );
+    Ok(!keep_caskroom_copy)
+}
+
+fn validate_adoptable_apps(stage: &Path, apps: &[AppArtifact]) -> Result<()> {
+    for app in apps {
+        let target = app_target_path(app.target_name())?;
+        if target.symlink_metadata().is_err() {
+            continue;
+        }
+        let source = find_app(stage, &app.source)
+            .ok_or_else(|| eyre!("brew-cask: app artifact '{}' was not found", app.source))?;
+        if cask_target_fingerprint(&source)? != cask_target_fingerprint(&target)? {
+            bail!(
+                "brew-cask: cannot adopt '{}': existing artifact is not identical to the cask artifact",
+                target.display()
+            );
+        }
+    }
     Ok(())
 }
 
@@ -6385,7 +6489,15 @@ fn installed_cask_version_in(
                 let targets_match = receipt
                     .targets
                     .iter()
-                    .map(cask_target_record_matches)
+                    .map(|record| {
+                        if (cask.auto_updates || receipt.auto_updates)
+                            && receipt.apps.contains(&record.path)
+                        {
+                            Ok(record.path.is_dir())
+                        } else {
+                            cask_target_record_matches(record)
+                        }
+                    })
                     .collect::<Result<Vec<_>>>()?
                     .into_iter()
                     .all(|matches| matches);
@@ -6451,6 +6563,7 @@ fn write_receipt_with_flight_targets(
     flight_targets: &[PathBuf],
     flight_uninstall_targets: &BTreeMap<PathBuf, bool>,
     flight_directories: &[PathBuf],
+    metadata_only_apps: &[PathBuf],
 ) -> Result<()> {
     let mut target_paths = artifacts
         .apps
@@ -6483,6 +6596,16 @@ fn write_receipt_with_flight_targets(
     let receipt = CaskReceipt {
         schema_version: 3,
         version: cask.version.clone(),
+        auto_updates: cask.auto_updates,
+        metadata_only_apps: if cask.auto_updates {
+            artifacts
+                .apps
+                .iter()
+                .map(|app| app_target_path(app.target_name()))
+                .collect::<Result<Vec<_>>>()?
+        } else {
+            metadata_only_apps.to_vec()
+        },
         apps: artifacts
             .apps
             .iter()
@@ -7028,6 +7151,10 @@ fn validate_cask_prune_candidate(candidate: &CaskPruneCandidate) -> Result<()> {
     if expected.is_empty()
         || records.len() != receipt.targets.len()
         || records.len() != expected.len()
+        || receipt
+            .metadata_only_apps
+            .iter()
+            .any(|path| !receipt.apps.contains(path))
     {
         bail!("receipt target inventory is incomplete or duplicated");
     }
@@ -7110,7 +7237,14 @@ fn validate_cask_prune_candidate(candidate: &CaskPruneCandidate) -> Result<()> {
         }
     }
     for record in &receipt.targets {
-        if !cask_target_record_matches(record)? {
+        if receipt.auto_updates && receipt.apps.contains(&record.path) {
+            if !record.path.is_dir() {
+                bail!(
+                    "self-updating app target is missing: {}",
+                    record.path.display()
+                );
+            }
+        } else if !cask_target_record_matches(record)? {
             bail!("artifact target has changed: {}", record.path.display());
         }
     }
@@ -7446,6 +7580,7 @@ mod tests {
             aliases: Vec::new(),
             old_tokens: Vec::new(),
             version: version.to_string(),
+            auto_updates: false,
             url: "https://example.com/example.zip".to_string(),
             url_specs: CaskUrlSpecs::default(),
             sha256: Some("no_check".to_string()),
@@ -7479,6 +7614,7 @@ mod tests {
             },
             &[],
             &BTreeMap::new(),
+            &[],
             &[],
         )?;
         Ok(target)
@@ -7608,6 +7744,7 @@ mod tests {
             &[],
             &BTreeMap::new(),
             &[],
+            &[],
         )?;
         assert_eq!(
             installed_cask_version(&cask, &artifacts)?,
@@ -7615,6 +7752,101 @@ mod tests {
         );
         crate::file::write(app_target.join("Contents/app"), "changed")?;
         assert_eq!(installed_cask_version(&cask, &artifacts)?, None);
+        Ok(())
+    }
+
+    #[test]
+    fn self_updating_receipt_accepts_app_bundle_drift() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let mut cask = test_cask("self-updating", "1.0.0");
+        cask.auto_updates = true;
+        let app = AppArtifact {
+            source: "Example.app".to_string(),
+            target: Some("$HOMEBREW_PREFIX/Applications/Example.app".to_string()),
+        };
+        let artifacts = CaskArtifacts {
+            apps: vec![app.clone()],
+            ..Default::default()
+        };
+        let app_target = app_target_path(app.target_name())?;
+        file::create_dir_all(app_target.join("Contents"))?;
+        crate::file::write(app_target.join("Contents/app"), "downloaded")?;
+        let caskroom = caskroom_version_dir(&cask.token, &cask.version);
+        file::create_dir_all(&caskroom)?;
+        write_receipt_with_flight_targets(
+            &caskroom,
+            &cask,
+            &artifacts,
+            &[],
+            &BTreeMap::new(),
+            &[],
+            &[],
+        )?;
+
+        crate::file::write(app_target.join("Contents/app"), "updated by app")?;
+        cask.version = "2.0.0".to_string();
+        assert_eq!(
+            installed_cask_version(&cask, &artifacts)?,
+            Some("1.0.0".to_string())
+        );
+        assert!(read_receipt(&caskroom)?.unwrap().auto_updates);
+        assert!(!caskroom.join("Example.app").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn adopts_only_an_identical_existing_app() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let stage = tmp.path().join("stage");
+        let caskroom = tmp.path().join("Caskroom/example/1.0.0");
+        let source = stage.join("Example.app/Contents");
+        let target = tmp.path().join("Applications/Example.app/Contents");
+        file::create_dir_all(&source)?;
+        file::create_dir_all(&target)?;
+        crate::file::write(source.join("app"), "identical")?;
+        crate::file::write(target.join("app"), "identical")?;
+        let app = AppArtifact {
+            source: "Example.app".to_string(),
+            target: Some("$HOMEBREW_PREFIX/Applications/Example.app".to_string()),
+        };
+
+        assert!(install_app(&stage, &caskroom, &app, true, true, true)?);
+        assert!(!caskroom.join("Example.app").exists());
+
+        crate::file::write(target.join("app"), "different")?;
+        let error = install_app(&stage, &caskroom, &app, true, true, true).unwrap_err();
+        assert!(error.to_string().contains("is not identical"));
+        Ok(())
+    }
+
+    #[test]
+    fn self_updating_cask_adopts_a_different_existing_app() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let stage = tmp.path().join("stage");
+        let caskroom = tmp.path().join("Caskroom/example/1.0.0");
+        let source = stage.join("Example.app/Contents");
+        let target = tmp.path().join("Applications/Example.app/Contents");
+        file::create_dir_all(&source)?;
+        file::create_dir_all(&target)?;
+        crate::file::write(source.join("app"), "downloaded version")?;
+        crate::file::write(target.join("app"), "self-updated version")?;
+        let app = AppArtifact {
+            source: "Example.app".to_string(),
+            target: Some("$HOMEBREW_PREFIX/Applications/Example.app".to_string()),
+        };
+
+        assert!(install_app(&stage, &caskroom, &app, false, true, false)?);
+        assert_eq!(
+            std::fs::read_to_string(target.join("app"))?,
+            "self-updated version"
+        );
+        assert!(!caskroom.join("Example.app").exists());
         Ok(())
     }
 
@@ -8236,11 +8468,13 @@ mod tests {
             "token": "example",
             "version": "1.0.0",
             "url": "https://example.com/example.zip",
+            "auto_updates": true,
             "depends_on": null,
             "conflicts_with": null
         }))?;
         assert!(cask.depends_on.formula.is_empty());
         assert!(cask.conflicts_with.cask.is_empty());
+        assert!(cask.auto_updates);
         Ok(())
     }
 
@@ -8891,6 +9125,8 @@ mod tests {
         let receipt = CaskReceipt {
             schema_version: 3,
             version: "1.0.0".to_string(),
+            auto_updates: false,
+            metadata_only_apps: Vec::new(),
             apps: Vec::new(),
             binaries: Vec::new(),
             fonts: Vec::new(),
@@ -9097,6 +9333,8 @@ mod tests {
         let receipt = CaskReceipt {
             schema_version: 3,
             version: "1.0.0".to_string(),
+            auto_updates: false,
+            metadata_only_apps: Vec::new(),
             apps: Vec::new(),
             binaries: vec![binary],
             fonts: Vec::new(),
@@ -11891,6 +12129,8 @@ end
         let receipt = CaskReceipt {
             schema_version: 0,
             version: cask.version.clone(),
+            auto_updates: false,
+            metadata_only_apps: Vec::new(),
             apps: vec![app_target_path(app.target_name())?],
             binaries: vec![],
             fonts: vec![],
@@ -11931,6 +12171,8 @@ end
         let receipt = CaskReceipt {
             schema_version: 4,
             version: cask.version.clone(),
+            auto_updates: false,
+            metadata_only_apps: Vec::new(),
             apps: Vec::new(),
             binaries: Vec::new(),
             fonts: Vec::new(),
@@ -11981,6 +12223,7 @@ end
             &[],
             &BTreeMap::new(),
             &[],
+            &[],
         )?;
 
         let plan = cask_prune_plan_from_tokens(&BTreeSet::new(), &state_dir)?;
@@ -12021,6 +12264,7 @@ end
             &[],
             &BTreeMap::new(),
             &[],
+            &[],
         )?;
 
         let drifted = test_cask("drifted", "1.0.0");
@@ -12041,6 +12285,7 @@ end
             &[],
             &BTreeMap::new(),
             &[],
+            &[],
         )?;
         file::write(drifted_target.join("changed"), "changed")?;
 
@@ -12052,6 +12297,8 @@ end
             toml::to_string_pretty(&CaskReceipt {
                 schema_version: 2,
                 version: legacy.version.clone(),
+                auto_updates: false,
+                metadata_only_apps: Vec::new(),
                 apps: Vec::new(),
                 binaries: Vec::new(),
                 fonts: Vec::new(),
@@ -12330,6 +12577,8 @@ end
         let receipt = CaskReceipt {
             schema_version: 0,
             version: cask.version.clone(),
+            auto_updates: false,
+            metadata_only_apps: Vec::new(),
             apps: vec![app_target],
             binaries: Vec::new(),
             fonts: Vec::new(),
@@ -13176,6 +13425,8 @@ end
         let receipt = CaskReceipt {
             schema_version: 0,
             version: cask.version.clone(),
+            auto_updates: false,
+            metadata_only_apps: Vec::new(),
             apps: vec![],
             binaries: vec![],
             fonts: vec![],
@@ -13300,6 +13551,8 @@ end
         let receipt = CaskReceipt {
             schema_version: 0,
             version: cask.version.clone(),
+            auto_updates: false,
+            metadata_only_apps: Vec::new(),
             apps: vec![app_target_path(
                 "$HOMEBREW_PREFIX/Applications/Example.app",
             )?],
@@ -13498,6 +13751,7 @@ end
             aliases: vec![],
             old_tokens: vec![],
             version: "latest".to_string(),
+            auto_updates: false,
             url,
             url_specs: CaskUrlSpecs {
                 branch: Some("fonts-v2".to_string()),

--- a/src/system/packages/mod.rs
+++ b/src/system/packages/mod.rs
@@ -54,6 +54,7 @@ pub enum PackageState {
     /// Installed cask whose upstream definition declares `auto_updates`.
     /// The version is the cask receipt version, not necessarily the live app
     /// bundle version after it has updated itself.
+    #[cfg(unix)]
     InstalledAutoUpdates {
         version: String,
     },
@@ -77,14 +78,20 @@ pub enum PackageState {
 
 impl PackageState {
     pub fn is_installed(&self) -> bool {
-        matches!(
-            self,
-            Self::Installed { .. } | Self::InstalledAutoUpdates { .. }
-        )
+        match self {
+            Self::Installed { .. } => true,
+            #[cfg(unix)]
+            Self::InstalledAutoUpdates { .. } => true,
+            _ => false,
+        }
     }
 
     pub fn auto_updates(&self) -> bool {
-        matches!(self, Self::InstalledAutoUpdates { .. })
+        match self {
+            #[cfg(unix)]
+            Self::InstalledAutoUpdates { .. } => true,
+            _ => false,
+        }
     }
 
     #[cfg(unix)]

--- a/src/system/packages/mod.rs
+++ b/src/system/packages/mod.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use crate::result::Result;
+use crate::system::ManagerPackageOptions;
 
 pub mod apk;
 pub mod apt;
@@ -50,6 +51,12 @@ pub enum PackageState {
     Installed {
         version: String,
     },
+    /// Installed cask whose upstream definition declares `auto_updates`.
+    /// The version is the cask receipt version, not necessarily the live app
+    /// bundle version after it has updated itself.
+    InstalledAutoUpdates {
+        version: String,
+    },
     Missing,
     /// installed, but a manager-owned record needs local repair
     #[cfg_attr(windows, allow(dead_code))]
@@ -69,6 +76,17 @@ pub enum PackageState {
 }
 
 impl PackageState {
+    pub fn is_installed(&self) -> bool {
+        matches!(
+            self,
+            Self::Installed { .. } | Self::InstalledAutoUpdates { .. }
+        )
+    }
+
+    pub fn auto_updates(&self) -> bool {
+        matches!(self, Self::InstalledAutoUpdates { .. })
+    }
+
     #[cfg(unix)]
     pub fn unavailable(reason: impl Into<String>) -> Self {
         Self::Unavailable {
@@ -138,6 +156,17 @@ pub trait SystemPackageManager: Send + Sync {
 
     /// Install the given packages (already filtered to missing, mismatched, or repairable).
     async fn install(&self, pkgs: &[PackageRequest], opts: &InstallOpts) -> Result<()>;
+
+    /// Install with manager-specific declarative options. Managers without
+    /// additional package options use the ordinary install path unchanged.
+    async fn install_with_options(
+        &self,
+        pkgs: &[PackageRequest],
+        opts: &InstallOpts,
+        _manager_options: &ManagerPackageOptions,
+    ) -> Result<()> {
+        self.install(pkgs, opts).await
+    }
 
     /// Upgrade the given packages (already filtered to installed ones).
     /// Defaults to `install` — for brew that is exactly right (pouring a

--- a/src/system/resources.rs
+++ b/src/system/resources.rs
@@ -647,7 +647,11 @@ fn package_resource_state(
 ) -> (String, ResourceAction) {
     let unsupported_pin = request.version.is_some() && !supports_version_pins;
     match state {
-        PackageState::Installed { version } | PackageState::InstalledAutoUpdates { version } => {
+        PackageState::Installed { version } => {
+            (format!("installed ({version})"), ResourceAction::Noop)
+        }
+        #[cfg(unix)]
+        PackageState::InstalledAutoUpdates { version } => {
             (format!("installed ({version})"), ResourceAction::Noop)
         }
         PackageState::Missing if unsupported_pin => (

--- a/src/system/resources.rs
+++ b/src/system/resources.rs
@@ -647,7 +647,7 @@ fn package_resource_state(
 ) -> (String, ResourceAction) {
     let unsupported_pin = request.version.is_some() && !supports_version_pins;
     match state {
-        PackageState::Installed { version } => {
+        PackageState::Installed { version } | PackageState::InstalledAutoUpdates { version } => {
             (format!("installed ({version})"), ResourceAction::Noop)
         }
         PackageState::Missing if unsupported_pin => (


### PR DESCRIPTION
## Summary

Add Homebrew-compatible handling for self-updating and adopted casks managed through `[bootstrap.packages]`.

This allows mise to install the current cask release, record ownership through metadata, and then leave applications declaring `auto_updates: true` to update themselves.

## Changes

- Read `auto_updates` from the upstream Homebrew cask definition.
- Skip ordinary mise upgrades for self-updating casks.
- Allow self-updating app bundles to drift from the originally installed version without reporting the cask as missing or damaged.
- Avoid retaining a duplicate application bundle under `/opt/homebrew/Caskroom`.
- Add support for adopting an existing application:
  - globally with `[bootstrap.brew].adopt`
  - per cask with `adopt = true` or `adopt = false`
- Keep adoption scoped to the `brew-cask` manager without adding options to unrelated package backends.
- Preserve Homebrew’s adoption behavior:
  - ordinary casks require the existing app to match the staged cask
  - casks declaring `auto_updates: true` adopt the existing app as-is because it may already have updated itself
  - cask resources are still downloaded and staged so auxiliary artifacts such as binaries and completions can be installed
- Store self-updating and adopted application ownership in the mise receipt.
- Annotate self-updating casks in human-readable status output:
  - `installed (auto-updates)`
- Preserve the stable JSON state:
  - `"state": "installed"`
  - add `"auto_updates": true`

## Configuration

Enable adoption for every configured cask:

```toml
[bootstrap.brew]
adopt = true

[bootstrap.packages]
"brew-cask:firefox" = "latest"
"brew-cask:textmate" = "latest"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Homebrew cask adoption with global defaults and per-cask overrides.
  * Added support for tracking self-updating casks while preserving adopted app installations.
  * Package status and JSON output now identify packages with automatic updates enabled.

* **Bug Fixes**
  * Installation, upgrades, diagnostics, rollback, and pruning now correctly recognize automatically updated packages.
  * Package configuration preserves adoption settings during imports and fallback handling.

* **Documentation**
  * Added configuration examples and guidance for cask adoption, validation, receipts, automatic updates, and pruning.
  * Updated configuration schema documentation with adoption settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->