### PR TITLE
chore(deps): bump aube to 1.41.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,9 +569,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1a6d61ee85662d22660bbf67663a00f3c0e8aaf77f5de7f1bbe06adf6d0313"
+checksum = "96f32e8b165cd44d00394a0ff19f578a92c99b2cc7ca14575df0da2db69f9eef"
 dependencies = [
  "aube-codes",
  "aube-linker",
@@ -626,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20c81d01a7b0f4178ec5f3cfe787fa7a289f801e3eba611263b77cbbad83de8"
+checksum = "7e4970f4e74d441f91ba6a4a0ac8fd6e46658fe65e12ad7ebfe4873b580aff24"
 dependencies = [
  "serde",
  "serde_json",
@@ -636,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac7ae2ec5f5c2849bf9681f24dcc23712c0eed4415d2614c97b1012919af1a4"
+checksum = "162c3a9ff8ee6be148ed9abf3f8b274fe4b2442a54247b258395e69f4a96d7b5"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -664,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65790305a14c71196a2904b47be60e41ce4439fe5c51ca9c93636e69fd04955"
+checksum = "7f0bb9d924f35f07ccb1ead685e7f45f3a6f488df9b03562e5fbb8ec075d6290"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -690,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718cfbee6b95620020176e9c6e1d99e115c577666ad0c401735d7d75ddb11695"
+checksum = "75090ee2a1539bb4130d22f6410c2ab835381dee709913f5fb12c205148a37f0"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -706,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7d9a53b1dbaf6f6f1735abc8949b20fe9b67a7fb2523d5a89a7bb2acc9cb2f"
+checksum = "3f8b7bcdbfde52d4ce96c363b99e577ac73093e82f7ea40a23ed680ffda521ce"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -733,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a4d1a3a039de207eaea6f5688c10817a214fb9ceeac9f3872b82aa2b1ffeaa"
+checksum = "deeda8571e6340e6f9bb8ca3ba39f163463260a8c0e6d8411d84f846fa4101f9"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -763,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "aube-runtime"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cb6591acafea6e9293a6a406a4af84d10a943914bf754b47897788249fbcf1"
+checksum = "70f9172dbd650d35e6a9b54276998179c9b8a776fc11e0696de2b2a6c1f46110"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -788,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe54a641bc3be469fe874890d3bb91dcaab6fb8678323d200502302d970d1d3a"
+checksum = "2526895539b06b2abe99e4e77ed3e37ea54e6aaabf5d3a0d84348ed25d84978e"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -808,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f8feb289ab2a47c73cd2418c6b4cd1346a51cdc27027afe0e600fb197202b7"
+checksum = "5f08726d73039e2fc9407715b3e6c2f97d72a4dbc85256c5ed21fe7b66d0dbaf"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -822,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e00b891cffa36f00b0df810fe9d930537e85ac09060e048fd455b94e7d904bd4"
+checksum = "f40eaeec4efdf07458340bcd405ec9c4f0034d48f6fbd9af765cc1d81aaae3cd"
 dependencies = [
  "aube-util",
  "base64 0.23.1",
@@ -849,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6021a3b376282be63c99ec3507e78a4598415ee58090b1534fab417782659f4f"
+checksum = "ac99c4c1451782b818dbd0f197925352362caded0d798214a0e9dc809a146d3e"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -871,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea67f939ab347d9f23ad467a5f4ef4953b6e542375ff61974c1a245027b6a4c3"
+checksum = "dd585c4e04b176043622fd08a60b3a8f33a0245fa485787d2b01b9747da62d3d"
 dependencies = [
  "aube-codes",
  "aube-manifest",

--- a/mise.lock
+++ b/mise.lock
@@ -117,62 +117,62 @@ url_api = "https://api.github.com/repos/FiloSottile/age/releases/assets/33375267
 provenance = "github-attestations"
 
 [[tools.aube]]
-version = "1.37.0"
+version = "1.41.0"
 backend = "github:endevco/aube"
 
 [tools.aube."platforms.linux-arm64"]
-checksum = "sha256:63488ce5494e80343129e360a59528562a9c5a82d538d10774c3e2f7ae0d8734"
-url = "https://github.com/jdx/aube/releases/download/v1.37.0/aube-v1.37.0-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/496820640"
+checksum = "sha256:012b0da68e9e285aee1564178b2a668f4d79eac9b40868112674ff03c2cdfe22"
+url = "https://github.com/jdx/aube/releases/download/v1.41.0/aube-v1.41.0-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/517186261"
 provenance = "github-attestations"
 
 [tools.aube."platforms.linux-arm64-musl"]
-checksum = "sha256:ebd90cdd570e58af23e31f43b3708be4778505316c8a842ac69929c191361bf3"
-url = "https://github.com/jdx/aube/releases/download/v1.37.0/aube-v1.37.0-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/496788139"
+checksum = "sha256:5a2e5afb02759abad7f56e083c7e2fa2b0ae841f3669cbcf5add42ca5846821f"
+url = "https://github.com/jdx/aube/releases/download/v1.41.0/aube-v1.41.0-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/517161124"
 provenance = "github-attestations"
 
 [tools.aube."platforms.linux-x64"]
-checksum = "sha256:1775b37c4381bff2314c96635cac3eeb90b02bea0f33371e553a4431dc893546"
-url = "https://github.com/jdx/aube/releases/download/v1.37.0/aube-v1.37.0-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/496796145"
+checksum = "sha256:965ae6a487c3e280206afb93649e721387dbbba168567f02e2fa5c797c450c2b"
+url = "https://github.com/jdx/aube/releases/download/v1.41.0/aube-v1.41.0-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/517166989"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools.aube."platforms.linux-x64-baseline"]
-checksum = "sha256:1775b37c4381bff2314c96635cac3eeb90b02bea0f33371e553a4431dc893546"
-url = "https://github.com/jdx/aube/releases/download/v1.37.0/aube-v1.37.0-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/496796145"
+checksum = "sha256:965ae6a487c3e280206afb93649e721387dbbba168567f02e2fa5c797c450c2b"
+url = "https://github.com/jdx/aube/releases/download/v1.41.0/aube-v1.41.0-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/517166989"
 provenance = "github-attestations"
 
 [tools.aube."platforms.linux-x64-musl"]
-checksum = "sha256:56f7b1978e66c6d5a80dc86c38c0b2c83e7019811524b41d941fdbf79b912a4c"
-url = "https://github.com/jdx/aube/releases/download/v1.37.0/aube-v1.37.0-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/496794035"
+checksum = "sha256:7955ddee163f64e9e4348200bb777c0f83fa596410de75e1ea5dd43d4b3fe7f1"
+url = "https://github.com/jdx/aube/releases/download/v1.41.0/aube-v1.41.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/517165326"
 provenance = "github-attestations"
 
 [tools.aube."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:56f7b1978e66c6d5a80dc86c38c0b2c83e7019811524b41d941fdbf79b912a4c"
-url = "https://github.com/jdx/aube/releases/download/v1.37.0/aube-v1.37.0-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/496794035"
+checksum = "sha256:7955ddee163f64e9e4348200bb777c0f83fa596410de75e1ea5dd43d4b3fe7f1"
+url = "https://github.com/jdx/aube/releases/download/v1.41.0/aube-v1.41.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/517165326"
 provenance = "github-attestations"
 
 [tools.aube."platforms.macos-arm64"]
-checksum = "sha256:6fdc27e146e5d6a45abf60ef7cf2e83d5b7284acbba4cecf6237905bd528a916"
-url = "https://github.com/jdx/aube/releases/download/v1.37.0/aube-v1.37.0-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/496852124"
+checksum = "sha256:635720a45125b3cc8afb2979c9a18ed484deecfc91938e9d941e278f529e87e1"
+url = "https://github.com/jdx/aube/releases/download/v1.41.0/aube-v1.41.0-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/517208780"
 provenance = "github-attestations"
 
 [tools.aube."platforms.windows-x64"]
-checksum = "sha256:7a264819a7c05d107ac72916f82209a183bfd26842b9528f1ca281bb32596c5e"
-url = "https://github.com/jdx/aube/releases/download/v1.37.0/aube-v1.37.0-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/496805373"
+checksum = "sha256:03e4d130262219c86d729001c3fc8c502198c60578360a4e8fba29a9564b89a4"
+url = "https://github.com/jdx/aube/releases/download/v1.41.0/aube-v1.41.0-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/517175467"
 provenance = "github-attestations"
 
 [tools.aube."platforms.windows-x64-baseline"]
-checksum = "sha256:7a264819a7c05d107ac72916f82209a183bfd26842b9528f1ca281bb32596c5e"
-url = "https://github.com/jdx/aube/releases/download/v1.37.0/aube-v1.37.0-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/496805373"
+checksum = "sha256:03e4d130262219c86d729001c3fc8c502198c60578360a4e8fba29a9564b89a4"
+url = "https://github.com/jdx/aube/releases/download/v1.41.0/aube-v1.41.0-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/517175467"
 provenance = "github-attestations"
 
 [[tools.bun]]


### PR DESCRIPTION
## Summary

- bump the embedded `aube` and `aube-registry` crates from 1.40.0 to 1.41.0
- refresh all aube workspace crates together in `Cargo.lock`
- bump the standalone aube tool from 1.37.0 to 1.41.0 in `mise.lock`
- refresh standalone checksums, download URLs, and GitHub asset IDs for all nine locked platforms

Upstream's embedder-facing changes only add environment-driven diagnostic initialization and flushing around existing install/add calls. The public API used by mise remains compatible, so no mise integration changes are required.

## Validation

- `cargo check --locked`
- `cargo test --locked --bin mise aube`
- `cargo test --locked --bin mise task::workspace::node::tests`
- `mise run test:e2e e2e/backend/test_npm_aube`
- `mise lock --dry-run --json aube` (no pending metadata changes)
- `git diff --check`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only version bump with no application code changes; main risk is regressions in npm/aube install behavior from the upstream minor release.
> 
> **Overview**
> Bumps embedded **aube** crates from **1.40.0** to **1.41.0** in `Cargo.lock` (all `aube-*` workspace packages refreshed together). Updates the dev-tool pin in `mise.lock` from **1.37.0** to **1.41.0**, including per-platform download URLs, checksums, and GitHub release asset IDs.
> 
> No mise source changes; upstream **1.41.0** is described as adding env-driven diagnostic init/flush around existing install paths while keeping the embedder API compatible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57339884fdd1364228ae41b83c5550c4bf451ad8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->