### PR TITLE
fix(path): stop printing the extended-length prefix on UNC paths

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -24,6 +24,49 @@ pub fn settle_display_separators(s: String) -> String {
     }
 }
 
+/// `\\?\UNC\server\share\x` shown as `\\server\share\x`.
+///
+/// The half of the extended-length prefix `dunce::simplified` leaves behind: its
+/// `is_safe_to_strip_unc` accepts `Prefix::VerbatimDisk` and nothing else, so a UNC path keeps a
+/// prefix mise itself rejects as input. Verified reachable on `\\wsl.localhost\<distro>\…`, which
+/// resolves perfectly well without it.
+///
+/// Declines in the three cases where the plain form would not name the same file:
+///
+/// - **a `/` in the remainder.** Inside `\\?\` a `/` is an ordinary character, so `a/b` is one
+///   component; `\\server\share\a/b` is two. `display_path`'s tests already pin the same trap for
+///   the disk prefix.
+/// - **past `MAX_PATH`.** There the prefix is load-bearing after all.
+/// - **a component ending in `.` or a space.** Those only resolve through the verbatim form.
+///
+/// Reserved names are *not* checked, though `dunce` declines them. It is handing back paths to open;
+/// this is text to read, and a directory named `con` is addressable by its plain path — measured,
+/// along with a task whose `dir` was `con` running in the right place. The disk-prefix case is
+/// unaffected either way, since `dunce` has already declined it before this sees it.
+#[cfg(windows)]
+fn simplify_verbatim_unc(shown: String) -> String {
+    const VERBATIM_UNC: &str = r"\\?\UNC\";
+
+    let Some(rest) = shown.strip_prefix(VERBATIM_UNC) else {
+        return shown;
+    };
+    let plain_len = 2 + rest.encode_utf16().count();
+    if rest.contains('/')
+        || plain_len >= crate::file::MAX_PATH
+        || rest
+            .split('\\')
+            .any(|c| c.ends_with('.') || c.ends_with(' '))
+    {
+        return shown;
+    }
+    format!(r"\\{rest}")
+}
+
+#[cfg(not(windows))]
+fn simplify_verbatim_unc(shown: String) -> String {
+    shown
+}
+
 pub trait PathExt {
     /// replaces $HOME with "~", and drops a Windows extended-length prefix
     fn display_user(&self) -> String;
@@ -38,9 +81,12 @@ impl PathExt for Path {
     /// which calls extended-length and device paths unsupported — so handing one back in a message
     /// offers a path mise would not accept.
     ///
-    /// `dunce::simplified` only strips the prefix when the result still names the same file:
-    /// verbatim UNC, device paths, reserved names and paths past `MAX_PATH` keep it, because those
-    /// genuinely do not resolve without it.
+    /// `dunce::simplified` only strips the prefix from `\\?\C:\…` — `Prefix::VerbatimDisk` is the
+    /// one kind its `is_safe_to_strip_unc` accepts, and every other verbatim form comes back
+    /// untouched. Device paths, reserved names and paths past `MAX_PATH` should come back untouched,
+    /// because those genuinely do not resolve without the prefix. A verbatim **UNC** path should
+    /// not: `\\?\UNC\server\share\x` and `\\server\share\x` name the same file, and only the second
+    /// is one mise would accept back — so [`simplify_verbatim_unc`] finishes the job.
     ///
     /// Separators are deliberately left as they are here — see [`settle_display_separators`],
     /// which `file::display_path` applies. This function also feeds strings that are matched
@@ -49,10 +95,11 @@ impl PathExt for Path {
         let path = dunce::simplified(self);
         let home = dirs::HOME.to_string_lossy();
         let home_str: &str = home.as_ref();
-        match cfg!(unix) && path.starts_with(home_str) && home != "/" {
+        let shown = match cfg!(unix) && path.starts_with(home_str) && home != "/" {
             true => path.to_string_lossy().replacen(home_str, "~", 1),
             false => path.to_string_lossy().to_string(),
-        }
+        };
+        simplify_verbatim_unc(shown)
     }
 
     fn mount(&self, on: &Path) -> PathBuf {
@@ -715,16 +762,49 @@ mod tests {
             Path::new(r"\\server\share\proj").display_user(),
             r"\\server\share\proj"
         );
-        // Verbatim UNC and device paths have no plain equivalent, so they keep the prefix.
+        // A verbatim UNC path does have a plain equivalent, and it is the only form mise accepts
+        // back as input, so the prefix goes. `dunce` leaves this one alone: `is_safe_to_strip_unc`
+        // takes `Prefix::VerbatimDisk` and nothing else.
         assert_eq!(
             Path::new(r"\\?\UNC\server\share").display_user(),
-            r"\\?\UNC\server\share"
+            r"\\server\share"
         );
+        // The shape this was found on, from a project reached through WSL.
+        assert_eq!(
+            Path::new(r"\\?\UNC\wsl.localhost\Ubuntu\home\me\proj").display_user(),
+            r"\\wsl.localhost\Ubuntu\home\me\proj"
+        );
+        // A device path has no plain equivalent and keeps its prefix.
         assert_eq!(Path::new(r"\\.\COM1").display_user(), r"\\.\COM1");
         // A reserved name only resolves through the verbatim form.
         assert_eq!(
             Path::new(r"\\?\C:\proj\CON").display_user(),
             r"\\?\C:\proj\CON"
+        );
+    }
+
+    /// The three shapes where `\\?\UNC\…` has to keep its prefix, because the plain form would not
+    /// name the same file. Each is a way the shorter answer would be wrong rather than merely ugly.
+    #[cfg(windows)]
+    #[test]
+    fn test_display_user_keeps_the_prefix_when_unc_needs_it() {
+        // `/` is an ordinary character inside `\\?\`, so `a/b` is one component here and two in the
+        // plain form. `display_path`'s tests pin the same trap for the disk prefix.
+        assert_eq!(
+            Path::new(r"\\?\UNC\server\share\a/b").display_user(),
+            r"\\?\UNC\server\share\a/b"
+        );
+        // Past MAX_PATH the prefix is what makes the path work.
+        let long = format!(r"\\?\UNC\server\share\{}", "d".repeat(260));
+        assert_eq!(Path::new(&long).display_user(), long);
+        // A trailing dot or space only survives the verbatim form.
+        assert_eq!(
+            Path::new(r"\\?\UNC\server\share\proj.").display_user(),
+            r"\\?\UNC\server\share\proj."
+        );
+        assert_eq!(
+            Path::new(r"\\?\UNC\server\share\proj ").display_user(),
+            r"\\?\UNC\server\share\proj "
         );
     }
 


### PR DESCRIPTION
#12014 stopped `\\?\C:\…` reaching the user. The UNC half survived it, and is still in `main`.

## What happens

A project on a UNC share, measured on **2026.8.6 windows-x64**:

```console
> mise trust --all
mise trusted \\?\UNC\wsl.localhost\Ubuntu-Preview\home\jam\unctest\proj
```

**Control** — the same command from an ordinary local directory:

```console
> mise trust --all
mise trusted C:\Users\Jam\...\unc-local\proj
```

That one is clean because #12014 fixed it. The difference is not the formatter, it is
[`dunce::simplified`](https://docs.rs/dunce), which `PathExt::display_user` delegates to: its
`is_safe_to_strip_unc` returns true for **`Prefix::VerbatimDisk` and nothing else**, so every other
verbatim form — UNC included — comes back untouched. No amount of care in #12014 would have caught
this; it is a different branch of the same helper.

This is worth fixing for the reason #12014 gave in the first place: mise **refuses `\\?\` as input**
— `validate_path_string` calls extended-length and device paths unsupported — so printing one hands
the user back a path mise itself would reject.

> Reproduced with `\\wsl.localhost\<distro>\…`, a real UNC path served by the WSL redirector, which
> needs no administrator. `subst` only ever covered the drive-letter half, which is why this had not
> come up before.

## The comment being corrected was wrong, and it was mine

`src/path.rs` said verbatim UNC paths keep the prefix "because those genuinely do not resolve without
it". They do resolve — `\\wsl.localhost\Ubuntu-Preview\home\jam\unctest\proj` was reachable by
`Test-Path` and `Get-Item` throughout. I wrote that sentence in #12014 and it justified leaving this
alone, so it is corrected here rather than left to justify it again.

## Where the change goes

In `display_user`, not `display_path`. `display_path` is the display-only layer and looks safer, but
`dotfiles/add`, `dotfiles/status` and several `file` error messages call `display_user` directly and
would have kept the prefix.

`display_user` also feeds two strings mise **matches** rather than shows. Both were checked, not
assumed:

- `tool_request.rs` builds `path:{display_user}` and lockfiles match on it — but
  `validate_path_string` rejects `\` outright on Windows before a `path:` value gets that far, so a
  verbatim path can never reach it. No persisted string can change.
- `system/edits.rs` compares a user filter against `{display_user}/{id}` — both sides come from
  `display_user`, so they move together.

## When it declines

Three shapes, each one where the plain form would name something else:

| shape | why |
| --- | --- |
| a `/` in the remainder | inside `\\?\` a `/` is an ordinary character, so `a/b` is **one** component and `\\server\share\a/b` is two. `display_path`'s tests already pin the same trap for the disk prefix |
| the result reaches `MAX_PATH` | there the prefix is load-bearing after all |
| a component ending in `.` or a space | those only resolve through the verbatim form |

**Reserved names are deliberately not checked**, though `dunce` declines them. `dunce` is handing
back paths to open; this is text to read, and a directory named `con` is addressable by its plain
path — measured, along with a task whose `dir` was `con` running in the right place. The disk-prefix
case is unaffected either way, since `dunce` has already declined it before this sees it.

## Tests

Extending the block in `src/path.rs` that already pins this behaviour:

- **Changed:** `\\?\UNC\server\share` → `\\server\share`, and the comment that claimed it had no
  plain equivalent.
- **Added:** the shape this was found on, `\\?\UNC\wsl.localhost\Ubuntu\home\me\proj`.
- **Added:** one test per decline — the `/` case, past `MAX_PATH`, and trailing `.` and space.
- **Kept as controls, unchanged:** a plain `\\server\share\proj` (not verbatim), `\\.\COM1` (a device
  path), and `\\?\C:\proj\CON` (dunce's reserved-name case on the disk prefix).

No e2e test: reproducing it needs a real UNC share, and a CI runner has none. The measurement above
is the end-to-end evidence.

## Notes

- No local build was run. `cargo fmt --all`, plus a standalone `rustc` probe of the transformation
  over all ten shapes above — including the boundary, where a plain form of 259 code units is
  shortened and 260 is not. `cargo test` and `windows-unit` are left to CI.
- `MAX_PATH` is `file::MAX_PATH`, which #12058 landed as `pub(crate)`; this adds no second copy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Windows path display by simplifying safe verbatim UNC paths for readability.
  * Preserves required path prefixes when separators, length limits, or trailing characters could affect safety.

* **Bug Fixes**
  * Maintains existing path display behavior on non-Windows systems.
  * Added coverage for simplified and preserved Windows UNC path cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->