### PR TITLE
mise: armv7: use hf suffix for gnueabi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           - name: linux-arm64-musl
             target: aarch64-unknown-linux-musl
           - name: linux-armv7
-            target: armv7-unknown-linux-gnueabi
+            target: armv7-unknown-linux-gnueabihf
           - name: linux-armv7-musl
             target: armv7-unknown-linux-musleabi
     steps:

--- a/Cross.toml
+++ b/Cross.toml
@@ -32,8 +32,8 @@ pre-build = [
   "ln -s ~/.cargo/bin/bindgen /usr/local/bin/bindgen",
 ]
 
-[target.armv7-unknown-linux-gnueabi]
-image = "ghcr.io/cross-rs/armv7-unknown-linux-gnueabi:0.2.5"
+[target.armv7-unknown-linux-gnueabihf]
+image = "ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:0.2.5"
 pre-build = [
   "dpkg --add-architecture armhf",
   "apt-get update && apt-get install -y libclang-dev clang llvm-dev pkg-config",


### PR DESCRIPTION
Fixes usage on Debian 11/12 and armhf.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Linux ARMv7 release builds to use the hard-float target.
  * Updated the ARMv7 cross-compilation environment to match, improving compatibility for supported ARMv7 devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->