### PR TITLE
registry: add knitcalc

### DIFF
--- a/registry/knitcalc.toml
+++ b/registry/knitcalc.toml
@@ -1,0 +1,23 @@
+description = "Knitting calculator: gauge conversion, stitch counts, yarn estimation"
+version_order = "semver"
+
+bins = ["knitcalc"]
+test = { cmd = "knitcalc --version", expected = "knitcalc {{version}}" }
+
+[[backends]]
+full = "github:dmezhnov/knitcalc"
+
+[backends.options.platforms.linux-x64]
+asset_pattern = "knitcalc-linux-x64-*.tar.gz"
+
+[backends.options.platforms.windows-x64]
+asset_pattern = "knitcalc-windows-x64-*.zip"
+
+# The macOS asset is an .app bundle, so the binary sits inside it.
+[backends.options.platforms.macos-arm64]
+asset_pattern = "knitcalc-macos-*.zip"
+bin_path = "knitcalc.app/Contents/MacOS"
+
+[backends.options.platforms.macos-x64]
+asset_pattern = "knitcalc-macos-*.zip"
+bin_path = "knitcalc.app/Contents/MacOS"


### PR DESCRIPTION
Adds a registry entry for [knitcalc](https://github.com/dmezhnov/knitcalc), a cross-platform knitting calculator (gauge conversion, stitch counts, yarn estimation) for Linux, macOS and Windows. I am the upstream author.

The releases are per-platform archives, so each platform pins its own `asset_pattern`; the macOS asset is an `.app` bundle, hence the `bin_path` into `Contents/MacOS`.

`test.cmd` works headless: the native runners answer `--version` before any window is created, so the registry test does not need a display. It does need the GTK 3 runtime the Linux binary links, which the e2e image gained in #12009.

Verified on all three platforms with `mise use -g knitcalc` against the same backend options.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added release configuration for Knitcalc.
  - Enabled version tracking and automated release checks.
  - Added downloadable asset support for Linux, Windows, and macOS, including macOS application bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->