### PR TITLE
fix(release): install newer libclang for armv7 builds

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -36,7 +36,16 @@ pre-build = [
 image = "ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:0.2.5"
 pre-build = [
   "dpkg --add-architecture armhf",
-  "apt-get update && apt-get install -y libclang-dev clang llvm-dev pkg-config",
+  "apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg pkg-config wget",
+  "wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -",
+  "echo 'deb [arch=amd64] https://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main' > /etc/apt/sources.list.d/llvm.list",
+  "apt-get update && apt-get install -y libclang-6.0-dev",
+]
+
+[target.armv7-unknown-linux-gnueabihf.env]
+passthrough = [
+  "BINDGEN_EXTRA_CLANG_ARGS_armv7_unknown_linux_gnueabihf",
+  "LIBCLANG_PATH",
 ]
 
 

--- a/Cross.toml
+++ b/Cross.toml
@@ -37,8 +37,11 @@ image = "ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:0.2.5"
 pre-build = [
   "dpkg --add-architecture armhf",
   "apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg pkg-config wget",
-  "wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -",
-  "echo 'deb [arch=amd64] https://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main' > /etc/apt/sources.list.d/llvm.list",
+  "wget -qO /tmp/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key",
+  "gpg --batch --no-default-keyring --keyring /tmp/apt.llvm.org.gpg --import /tmp/apt.llvm.org.asc",
+  "test \"$(gpg --batch --no-default-keyring --keyring /tmp/apt.llvm.org.gpg --with-colons --fingerprint | awk -F: '$1 == \"fpr\" { print $10; exit }')\" = \"6084F3CF814B57C1CF12EFD515CF4D18AF4F7421\"",
+  "install -m 0644 /tmp/apt.llvm.org.gpg /usr/share/keyrings/apt.llvm.org.gpg",
+  "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/apt.llvm.org.gpg] https://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main' > /etc/apt/sources.list.d/llvm.list",
   "apt-get update && apt-get install -y libclang-6.0-dev",
 ]
 

--- a/scripts/build-tarball.sh
+++ b/scripts/build-tarball.sh
@@ -75,6 +75,13 @@ if [[ $os == "linux" ]] && [[ $arch == "armv7" ]]; then
 	features="$features,aws-lc-rs"
 fi
 
+if [[ $RUST_TRIPLE == "armv7-unknown-linux-gnueabihf" ]]; then
+	# cross 0.2.5 uses Ubuntu 16.04 for this target, whose libclang 3.8 is
+	# too old for aws-lc-sys bindgen. Cross.toml installs libclang 6 here.
+	export LIBCLANG_PATH=/usr/lib/llvm-6.0/lib
+	export BINDGEN_EXTRA_CLANG_ARGS_armv7_unknown_linux_gnueabihf="--sysroot=/usr/arm-linux-gnueabihf -isystem /usr/lib/llvm-6.0/lib/clang/6.0.1/include"
+fi
+
 if [[ $os == "macos" ]]; then
 	# Targeting macOS 12+ makes ld emit chained fixups (LC_DYLD_CHAINED_FIXUPS),
 	# which dyld applies lazily per page instead of eagerly interpreting ~170k


### PR DESCRIPTION
## Summary

- install libclang 6 from the official LLVM Xenial repository in the ARMv7 hard-float cross image
- verify LLVM's published signing-key fingerprint and scope apt trust to that repository
- pass `LIBCLANG_PATH` and the LLVM resource include path into that target's bindgen invocation
- keep the cross 0.2.5 Ubuntu 16.04 image and its existing glibc compatibility floor

## Root cause

The switch to `armv7-unknown-linux-gnueabihf` selected cross's Ubuntu 16.04 image. Its default libclang 3.8 does not provide `clang_getTranslationUnitTargetInfo`, which the `aws-lc-sys 0.44.0` bindgen step calls. The release job therefore panicked on every retry: https://github.com/jdx/mise/actions/runs/31992333725/job/95277969263

libclang 6 also needs its resource include directory supplied explicitly alongside the ARM sysroot so bindgen can resolve builtin headers such as `stddef.h`.

## Validation

- `hk run check --safe --format json` scoped to `Cross.toml` and `scripts/build-tarball.sh` (shellcheck, shfmt, and Taplo passed)
- built the customized ARMv7 hard-float cross image locally
- verified the scoped apt source, signing-key fingerprint, and installed libclang package in the rebuilt image
- completed the exact serious-profile build locally:
  `cargo build --profile=serious --target armv7-unknown-linux-gnueabihf --no-default-features --features rustls-native-roots,self_update,vfox/vendored-lua,openssl/vendored,aws-lc-rs`
- build finished successfully in 11m 09s
- verified the output is a 32-bit ARM EABI5 hard-float ELF using `/lib/ld-linux-armhf.so.3`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect release cross-compilation tooling and CI; no runtime application or auth/data paths.
> 
> **Overview**
> Fixes failing **ARMv7 hard-float** release cross-builds where `aws-lc-sys` bindgen needs a newer libclang than the cross 0.2.5 Ubuntu 16.04 image ships (3.8).
> 
> **Cross.toml** now installs **LLVM 6** from the official Xenial apt repo (with key verification) instead of the default `libclang-dev`, and passes **`LIBCLANG_PATH`** and **`BINDGEN_EXTRA_CLANG_ARGS_armv7_unknown_linux_gnueabihf`** into the container.
> 
> **`scripts/build-tarball.sh`** sets those env vars for `armv7-unknown-linux-gnueabihf` so bindgen finds libclang 6 and the ARM sysroot plus LLVM builtin headers (e.g. `stddef.h`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3fd0234de0286a0129157f69d11d3b54f304c00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the ARMv7 cross-build environment to use LLVM 6.0’s libclang package.
  * Improved ARMv7 build configuration so required compiler libraries and headers are located reliably.
  * Added secure repository signing-key verification for the LLVM package source.
  * Configured target-specific bindgen compiler arguments for ARMv7 builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->