### PR TITLE
fix(shell): branch on the exit code in the pwsh command-not-found hook

### DIFF
--- a/e2e-win/pwsh_command_not_found.Tests.ps1
+++ b/e2e-win/pwsh_command_not_found.Tests.ps1
@@ -1,0 +1,121 @@
+Describe 'the pwsh command-not-found hook branches on the exit code' {
+    It 'ships a script that reads $LASTEXITCODE rather than the command output' {
+        $script = mise activate pwsh | Out-String
+
+        # The hook only has meaning when auto-install is on, which is what emits this block.
+        $script | Should -Match 'hook-not-found -s pwsh'
+        $script | Should -Match 'LASTEXITCODE -eq 0'
+
+        # Both halves of the contract: the output has to go to Out-Null for the exit code to be
+        # the thing being read. Dropping the pipe would still satisfy the two lines above.
+        $emitted = 'hook-not-found -s pwsh -- \$Name \| Out-Null'
+        $script | Should -Match $emitted
+
+        # The regression guard. `if (& mise hook-not-found ...)` is the tidier-looking form and the
+        # one somebody will want back, so fail if it returns.
+        $condition = 'if \(& .*hook-not-found'
+        $script | Should -Not -Match $condition
+    }
+
+    It 'because `if (& native)` tests the output, not the code' {
+        # The reason the line above matters, executed rather than asserted in a comment.
+        # `mise hook-not-found` exits 0 when it installed something and writes nothing to stdout,
+        # so the old form took the false branch exactly when it should have taken the true one.
+        $cmd = Join-Path $env:SystemRoot 'System32\cmd.exe'
+
+        $viaOutput = if (& $cmd /c 'exit 0') { 'true' } else { 'false' }
+        $viaOutput | Should -Be 'false' -Because 'exit 0 with no stdout looks false to `if (& ...)`'
+
+        & $cmd /c 'exit 0' | Out-Null
+        $viaCode = if ($LASTEXITCODE -eq 0) { 'true' } else { 'false' }
+        $viaCode | Should -Be 'true' -Because 'the exit code is the answer mise actually gives'
+
+        # And the other direction: a failure that prints looked true to the old form.
+        $viaOutput = if (& $cmd /c 'echo hi & exit 1') { 'true' } else { 'false' }
+        $viaOutput | Should -Be 'true' -Because 'stdout, not the code, is what it was reading'
+
+        & $cmd /c 'echo hi & exit 1' | Out-Null
+        $viaCode = if ($LASTEXITCODE -eq 0) { 'true' } else { 'false' }
+        $viaCode | Should -Be 'false' -Because 'the new form is right in both directions'
+    }
+
+    It 'guards _mise_hook, which --no-hook-env leaves undefined' {
+        # Now that the branch can actually be taken, what it calls has to exist. `--no-hook-env`
+        # suppresses the `_mise_hook` definition while still emitting this block.
+        $script = mise activate pwsh --no-hook-env | Out-String
+
+        $script | Should -Not -Match 'function Global:_mise_hook'
+        $script | Should -Match 'hook-not-found -s pwsh'
+
+        # A `-Not -Match` alone passes on any build that never had the branch, and a positive match
+        # that merely wants `Test-Path` somewhere would accept a guard around nothing. Pin the whole
+        # shape instead.
+        $guardedCall = 'LASTEXITCODE -eq 0\)\{[^}]*if \(Test-Path -Path Function:\\_mise_hook\)\{\s*_mise_hook\s*\}'
+        $script | Should -Match $guardedCall
+
+        # Then require it to be the only call in the branch: a second one, added later and left
+        # unguarded, would still satisfy the shape above.
+        $branch = [regex]::Match($script, '(?s)hook-not-found -s pwsh.*?StopSearch = \$true').Value
+        $branch | Should -Not -BeNullOrEmpty
+        $calls = [regex]::Matches($branch, '(?m)^\s*_mise_hook\s*$').Count
+        $calls | Should -Be 1 -Because 'the guarded one is the only call the branch may make'
+    }
+
+    It 'because an unresolved name inside the handler throws instead of continuing' {
+        # A plain script block carries on past a command it cannot resolve, so the guard only looks
+        # unnecessary until it is run where mise actually runs it: inside a CommandNotFoundAction,
+        # where the same call aborts the handler and takes the $EventArgs handoff with it.
+        function Invoke-MiseHandoffProbe {
+            param([bool] $Guarded)
+
+            $global:__mise_probe_entered = $false
+            $global:__mise_probe_reached = $false
+            $global:__mise_probe_guarded = $Guarded
+            $global:__mise_probe_error = $null
+            $previous = $ExecutionContext.SessionState.InvokeCommand.CommandNotFoundAction
+            try {
+                $ExecutionContext.SessionState.InvokeCommand.CommandNotFoundAction = [EventHandler[System.Management.Automation.CommandLookupEventArgs]] {
+                    param([object] $Name, [System.Management.Automation.CommandLookupEventArgs] $eventArgs)
+                    end {
+                        if ($Name -ne 'mise-probe-missing-tool') { return }
+                        $global:__mise_probe_entered = $true
+                        if ($global:__mise_probe_guarded) {
+                            if (Test-Path -Path Function:\_mise_probe_hook_absent) { _mise_probe_hook_absent }
+                        } else {
+                            _mise_probe_hook_absent
+                        }
+                        $global:__mise_probe_reached = $true
+                        $eventArgs.Command = Get-Command Get-Date
+                        $eventArgs.StopSearch = $true
+                    }
+                }
+                try { mise-probe-missing-tool | Out-Null } catch { $global:__mise_probe_error = $_ }
+                return [pscustomobject]@{
+                    Entered = $global:__mise_probe_entered
+                    Reached = $global:__mise_probe_reached
+                    Error   = $global:__mise_probe_error
+                }
+            } finally {
+                $ExecutionContext.SessionState.InvokeCommand.CommandNotFoundAction = $previous
+                Remove-Variable -Name '__mise_probe_entered' -Scope Global -ErrorAction SilentlyContinue
+                Remove-Variable -Name '__mise_probe_reached' -Scope Global -ErrorAction SilentlyContinue
+                Remove-Variable -Name '__mise_probe_guarded' -Scope Global -ErrorAction SilentlyContinue
+                Remove-Variable -Name '__mise_probe_error' -Scope Global -ErrorAction SilentlyContinue
+            }
+        }
+
+        $unguarded = Invoke-MiseHandoffProbe -Guarded $false
+        # Without this first check the rest proves nothing: a handler that never ran would leave
+        # Reached false too, and the probe would look like it had demonstrated the abort.
+        $unguarded.Entered | Should -BeTrue -Because 'the handler has to run for the rest to mean anything'
+        $unguarded.Reached | Should -BeFalse -Because 'the handoff never runs when the hook is undefined'
+        # The surfaced error names the command the user typed, not the hook that went missing —
+        # so there is nothing in the message to match on, only the type.
+        $unguarded.Error.Exception | Should -BeOfType ([System.Management.Automation.CommandNotFoundException])
+
+        $guarded = Invoke-MiseHandoffProbe -Guarded $true
+        $guarded.Entered | Should -BeTrue
+        $guarded.Reached | Should -BeTrue -Because 'guarding the call lets the installed command be handed back'
+        $guarded.Error | Should -BeNullOrEmpty -Because 'the handoff ran, so nothing propagated out'
+    }
+}

--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -169,8 +169,23 @@ impl Shell for Pwsh {
                             # `mise` when the user typed `premise`, while matching only
                             # the first token would miss `... | some-missing-tool`
                             if ($lastCommand -and (($lastCommand -split '\s+') -contains $Name)) {{
-                                if (& '{exe}' hook-not-found -s pwsh -- $Name){{
-                                    _mise_hook
+                                # `hook-not-found` answers with an exit code and writes nothing to
+                                # stdout, and `if (& ...)` in PowerShell tests the *output* rather
+                                # than the code: it was false even when a tool had been installed,
+                                # and would have been true for a failure that happened to print.
+                                # bash, zsh and fish put the command straight into the condition
+                                # and get its status; this is the same thing spelled for pwsh.
+                                & '{exe}' hook-not-found -s pwsh -- $Name | Out-Null
+                                if ($LASTEXITCODE -eq 0){{
+                                    # `--no-hook-env` omits the `_mise_hook` definition but still
+                                    # emits this block, and an unresolved name inside a
+                                    # CommandNotFoundAction throws out of the handler instead of
+                                    # continuing: the handoff below would never run, so the tool
+                                    # just installed would still not start. The `mise` wrapper and
+                                    # the prompt function guard the call for the same reason.
+                                    if (Test-Path -Path Function:\_mise_hook){{
+                                        _mise_hook
+                                    }}
                                     if (Get-Command $Name -ErrorAction SilentlyContinue){{
                                         $EventArgs.Command = Get-Command $Name
                                         $EventArgs.StopSearch = $true

--- a/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
@@ -135,8 +135,23 @@ if (-not (Test-Path variable:global:__mise_pwsh_command_not_found)){
                 # `mise` when the user typed `premise`, while matching only
                 # the first token would miss `... | some-missing-tool`
                 if ($lastCommand -and (($lastCommand -split '\s+') -contains $Name)) {
-                    if (& '/some/dir/mise' hook-not-found -s pwsh -- $Name){
-                        _mise_hook
+                    # `hook-not-found` answers with an exit code and writes nothing to
+                    # stdout, and `if (& ...)` in PowerShell tests the *output* rather
+                    # than the code: it was false even when a tool had been installed,
+                    # and would have been true for a failure that happened to print.
+                    # bash, zsh and fish put the command straight into the condition
+                    # and get its status; this is the same thing spelled for pwsh.
+                    & '/some/dir/mise' hook-not-found -s pwsh -- $Name | Out-Null
+                    if ($LASTEXITCODE -eq 0){
+                        # `--no-hook-env` omits the `_mise_hook` definition but still
+                        # emits this block, and an unresolved name inside a
+                        # CommandNotFoundAction throws out of the handler instead of
+                        # continuing: the handoff below would never run, so the tool
+                        # just installed would still not start. The `mise` wrapper and
+                        # the prompt function guard the call for the same reason.
+                        if (Test-Path -Path Function:\_mise_hook){
+                            _mise_hook
+                        }
                         if (Get-Command $Name -ErrorAction SilentlyContinue){
                             $EventArgs.Command = Get-Command $Name
                             $EventArgs.StopSearch = $true


### PR DESCRIPTION
Auto-install on command-not-found has never worked on pwsh. The condition guarding it cannot be
true.

## Why

In PowerShell, `if (& native)` tests the command's **standard output**, not its exit code. Measured
on Windows:

| native command | exit | stdout | `if (& …)` takes |
| --- | --- | --- | --- |
| `cmd /c "exit 0"` | 0 | — | **FALSE** |
| `cmd /c "exit 1"` | 1 | — | FALSE |
| `cmd /c "echo hi"` | 0 | `hi` | TRUE |
| `cmd /c "echo hi & exit 1"` | **1** | `hi` | **TRUE** |

And `mise hook-not-found` answers with an exit code and nothing else — `Ok(())` once it has
installed something, `request_exit(127)` otherwise. Measured for a bin no tool provides: **exit 127,
empty stdout**. Install progress cannot supply any either; that goes through `safe_eprintln!`, to
stderr.

So `if (& '<mise>' hook-not-found -s pwsh -- $Name)` is false whatever happens. `_mise_hook` and the
`$EventArgs.Command` / `StopSearch` handoff inside it have never run. The last row of the table is
the other half of the same bug: a *failed* command that happened to print something would have
looked true.

**The other three shells are the control, and all of them are right.** bash
(`assets/bash/command_not_found.sh`), zsh (`shell/zsh.rs`) and fish (`shell/fish.rs`) each put the
command straight into the condition and get its exit status. Only pwsh wrapped it in `if (& …)`.

## The fix

```powershell
& '<mise>' hook-not-found -s pwsh -- $Name | Out-Null
if ($LASTEXITCODE -eq 0){ … }
```

Measured too, rather than assumed in turn:

- `| Out-Null` **preserves `$LASTEXITCODE`** — 0 stays 0, 127 stays 127.
- exit 0 with no stdout → **TRUE**, where the old form gave FALSE. That is the dead feature.
- exit 127 with stdout → **FALSE**, where the old form gave TRUE. That is the false positive.

So it is correct in both directions, not merely less silent. The comment above it explains why,
because `if (& …)` is the tidier-looking shape and the one a reader will want to restore.

## Tests

**Snapshot** — `test_activate` pinned the old line, so the change shows up in
`mise__shell__pwsh__tests__activate.snap` as a diff rather than silently.

**`e2e-win/pwsh_command_not_found.Tests.ps1`** (new) — the snapshot proves the text changed, not that
it means the right thing:

- the shipped `mise activate pwsh` reads `$LASTEXITCODE` and no longer wraps `hook-not-found` in
  `if (& …)` — the regression guard;
- and, executed rather than asserted in a comment, the four measurements above, so the reason the
  first assertion exists cannot be lost.

## Notes

- Found by a user of this fork, not by probing. Their report — that `if (& native)` is decided by
  stdout — reproduced exactly here, and it also **retired an earlier hypothesis of mine** that had
  blamed the handler registration. The registration is fine; the condition was the whole story.
- **Separate observation, deliberately not fixed here:** pwsh is also missing the `mise` / `mise-*`
  guard its siblings have (`[[ $1 != "mise" && $1 != "mise-"* ]]`). Different bug, and this PR's
  description does not cover it.
- No local build was run: `cargo fmt --all`, the impact grep, and the new Pester suite against a
  release binary — where the shape assertion fails, as it must until a build carries the fix, and
  the semantics assertions pass. `cargo` does not build on that machine at all, so `cargo test` and
  `windows-e2e` are CI's.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PowerShell command-not-found handling by correctly checking command exit status.
  * Prevented silent successes and output-producing failures from being misclassified.
  * Ensured command resolution retries reliably after a command-not-found event.
  * Prevented failures when the command-not-found hook is unavailable.

* **Tests**
  * Added end-to-end coverage for PowerShell command-not-found scenarios, including hook handling and command resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->