### PR TITLE
chore: release 2026.8.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,114 @@
 # Changelog
 
+## [2026.8.9](https://github.com/jdx/mise/compare/v2026.8.8..v2026.8.9) - 2026-08-19
+
+### 🚀 Features
+
+- **(bootstrap)** expose resource provenance by @jdx in [#12100](https://github.com/jdx/mise/pull/12100)
+- **(bootstrap)** support self-updating and adopted brew casks by @ascarter in [#12074](https://github.com/jdx/mise/pull/12074)
+- **(bootstrap)** compose config roots by @jdx in [#12105](https://github.com/jdx/mise/pull/12105)
+- **(bootstrap)** compose services and compose projects by @jdx in [#12132](https://github.com/jdx/mise/pull/12132)
+- **(bootstrap)** add symlink copy controls by @jdx in [#12121](https://github.com/jdx/mise/pull/12121)
+- **(config)** implicitly trust config for execution commands by @jdx in [#12107](https://github.com/jdx/mise/pull/12107)
+- **(config)** support environment-specific conf.d files by @jdx in [#12151](https://github.com/jdx/mise/pull/12151)
+- **(config)** support relative ignored config globs by @jdx in [#12169](https://github.com/jdx/mise/pull/12169)
+- **(system)** let plugins declare candidate package names by @jdx in [#12149](https://github.com/jdx/mise/pull/12149)
+- **(vfox)** pass tool options in hook contexts by @jdx in [#12174](https://github.com/jdx/mise/pull/12174)
+
+### 🐛 Bug Fixes
+
+- **(aqua)** prefer glibc assets with musl fallback by @jdx in [#12093](https://github.com/jdx/mise/pull/12093)
+- **(backend)** keep flavour queries from crossing a '+' by @Marukome0743 in [#12118](https://github.com/jdx/mise/pull/12118)
+- **(backend)** key the remote version cache by listing tool options by @JamBalaya56562 in [#12164](https://github.com/jdx/mise/pull/12164)
+- **(bootstrap)** create missing directory parents by @jdx in [#12096](https://github.com/jdx/mise/pull/12096)
+- **(docs)** route tool search results to mise-versions by @jdx in [#12097](https://github.com/jdx/mise/pull/12097)
+- **(github)** match arm assets on arm64 by @jdx in [#12098](https://github.com/jdx/mise/pull/12098)
+- **(hook-env)** preserve runtime environment overrides by @jdx in [#12094](https://github.com/jdx/mise/pull/12094)
+- **(http)** order remote versions consistently by @jdx in [#12170](https://github.com/jdx/mise/pull/12170)
+- **(python)** resolve configured uv for automatic venv by @jdx in [#12177](https://github.com/jdx/mise/pull/12177)
+- **(shell)** branch on the exit code in the pwsh command-not-found hook by @JamBalaya56562 in [#12089](https://github.com/jdx/mise/pull/12089)
+- **(shell)** skip mise's own commands in the pwsh command-not-found hook by @JamBalaya56562 in [#12131](https://github.com/jdx/mise/pull/12131)
+- **(shell)** refresh the environment on auto-install when --no-hook-env omits the hook by @JamBalaya56562 in [#12117](https://github.com/jdx/mise/pull/12117)
+- **(system)** resolve dependency executables on Windows by @jdx in [#12178](https://github.com/jdx/mise/pull/12178)
+- **(task)** support azure devops cloud ssh urls (remote git sources) by @cheesemans in [#12102](https://github.com/jdx/mise/pull/12102)
+- **(task)** normalize Windows task environment paths by @jdx in [#12173](https://github.com/jdx/mise/pull/12173)
+- **(use)** scope global install hooks by @jdx in [#12101](https://github.com/jdx/mise/pull/12101)
+- **(vfox)** follow symlinks when fingerprinting plugin sources by @jdx in [#12155](https://github.com/jdx/mise/pull/12155)
+- **(vfox)** honor systemDependencies in embedded plugins by @jdx in [#12152](https://github.com/jdx/mise/pull/12152)
+- **(vfox)** apply netrc credentials to HTTP requests by @jdx in [#12168](https://github.com/jdx/mise/pull/12168)
+- **(which)** report uninstalled --tool version instead of "not active" by @TrevorBurnham in [#12106](https://github.com/jdx/mise/pull/12106)
+- asset selection for non-gz tar variants by @sgammon in [#12156](https://github.com/jdx/mise/pull/12156)
+
+### 🚜 Refactor
+
+- **(backend)** remove legacy RTX environment variables by @jdx in [#12172](https://github.com/jdx/mise/pull/12172)
+
+### 📚 Documentation
+
+- fix installing mise links by @jdx in [#12104](https://github.com/jdx/mise/pull/12104)
+
+### ⚡ Performance
+
+- **(activate)** stop pwsh running hook-env twice per directory change by @jdx in [#12147](https://github.com/jdx/mise/pull/12147)
+- **(cache)** batch remote blob prefetch by @jdx in [#12103](https://github.com/jdx/mise/pull/12103)
+- **(config)** gate idiomatic file detection on idiomatic_version_file_enable_tools by @jdx in [#12143](https://github.com/jdx/mise/pull/12143)
+- **(release)** build windows with the serious profile and one TLS stack by @jdx in [#12146](https://github.com/jdx/mise/pull/12146)
+- **(vfox)** cache plugin metadata on disk by @jdx in [#12145](https://github.com/jdx/mise/pull/12145)
+
+### 🧪 Testing
+
+- **(java)** cover version matching with unit tests instead of live metadata by @Marukome0743 in [#12116](https://github.com/jdx/mise/pull/12116)
+
+### 📦️ Dependency Updates
+
+- update h2 to 0.4.16 for RUSTSEC-2026-0258 by @Marukome0743 in [#12119](https://github.com/jdx/mise/pull/12119)
+- update ghcr.io/jdx/mise:rpm docker digest to 50e4032 by @renovate[bot] in [#12124](https://github.com/jdx/mise/pull/12124)
+- update swatinem/rust-cache digest to 6323deb by @renovate[bot] in [#12125](https://github.com/jdx/mise/pull/12125)
+- update ghcr.io/jdx/mise:deb docker digest to bf1cd85 by @renovate[bot] in [#12123](https://github.com/jdx/mise/pull/12123)
+- update rust crate async-trait to v0.1.92 by @renovate[bot] in [#12128](https://github.com/jdx/mise/pull/12128)
+- update ghcr.io/jdx/mise:alpine docker digest to d21f898 by @renovate[bot] in [#12122](https://github.com/jdx/mise/pull/12122)
+- update rust crate blake3 to v1.8.6 by @renovate[bot] in [#12129](https://github.com/jdx/mise/pull/12129)
+- update rust crate clap to v4.6.6 by @renovate[bot] in [#12130](https://github.com/jdx/mise/pull/12130)
+- update dependency esbuild to v0.28.2 by @renovate[bot] in [#12126](https://github.com/jdx/mise/pull/12126)
+- update dependency python to v3.14.7 by @renovate[bot] in [#12127](https://github.com/jdx/mise/pull/12127)
+- lock file maintenance by @renovate[bot] in [#12084](https://github.com/jdx/mise/pull/12084)
+- update rust crate ctor to v1.0.13 by @renovate[bot] in [#12134](https://github.com/jdx/mise/pull/12134)
+- update rust crate expr-lang to v2 by @renovate[bot] in [#12154](https://github.com/jdx/mise/pull/12154)
+- update aws-sdk-rust monorepo to v1.10.1 by @renovate[bot] in [#12139](https://github.com/jdx/mise/pull/12139)
+
+### 📦 Registry
+
+- point vlang at the maintained v backend by @jdx in [#12153](https://github.com/jdx/mise/pull/12153)
+- fix llama.cpp version test by @jdx in [#12157](https://github.com/jdx/mise/pull/12157)
+
+### Chore
+
+- **(ci)** refresh cursor cloud agent environment by @jdx in [#12112](https://github.com/jdx/mise/pull/12112)
+- **(ci)** prevent stale snapcraft releases by @jdx in [#12142](https://github.com/jdx/mise/pull/12142)
+- **(ci)** ignore dependency rust-version in automated builds by @jdx in [#12159](https://github.com/jdx/mise/pull/12159)
+- **(ci)** retry transient R2 upload failures by @jdx in [#12158](https://github.com/jdx/mise/pull/12158)
+- **(ci)** skip redundant release cargo check by @jdx in [#12166](https://github.com/jdx/mise/pull/12166)
+- **(ci)** propagate rust-version override to release build by @jdx in [#12175](https://github.com/jdx/mise/pull/12175)
+
+### Security
+
+- **(backend)** restrict forge tokens to api origin by @jdx in [#12167](https://github.com/jdx/mise/pull/12167)
+- block tool install code in safe mode by @jdx in [#12140](https://github.com/jdx/mise/pull/12140)
+
+### New Contributors
+
+- @sgammon made their first contribution in [#12156](https://github.com/jdx/mise/pull/12156)
+- @ascarter made their first contribution in [#12074](https://github.com/jdx/mise/pull/12074)
+- @TrevorBurnham made their first contribution in [#12106](https://github.com/jdx/mise/pull/12106)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (3)
+
+- [`Arata1202/ascdir`](https://github.com/Arata1202/ascdir)
+- [`Genymobile/scrcpy`](https://github.com/Genymobile/scrcpy)
+- [`cloudsmith-io/cloudsmith-cli`](https://github.com/cloudsmith-io/cloudsmith-cli)
+
 ## [2026.8.8](https://github.com/jdx/mise/compare/v2026.8.7..v2026.8.8) - 2026-08-17
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6356,7 +6356,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.8.8"
+version = "2026.8.9"
 dependencies = [
  "age 0.12.1",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.8.8"
+version = "2026.8.9"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.8.8 macos-arm64 (2026-08-17)
+2026.8.9 macos-arm64 (2026-08-19)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -26,7 +26,7 @@ _mise() {
 
   local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
   [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
-  local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_8.spec"
+  local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_9.spec"
   if [[ ! -f "$spec_file" ]]; then
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
     mise usage >| "$spec_file"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -11,7 +11,7 @@ _mise() {
     _comp_initialize -n : -- "$@" || return
     local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
     [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
-    local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_8.spec"
+    local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_9.spec"
     if [[ ! -f "$spec_file" ]]; then
         find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
         mise usage >| "$spec_file"

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -9,7 +9,7 @@ if ! type -P usage &> /dev/null
 end
 set -l spec_dir (if set -q XDG_CACHE_HOME; echo $XDG_CACHE_HOME; else; echo $HOME/.cache; end)/usage
 test -d "$spec_dir"; or mkdir -p -m 700 "$spec_dir"
-set -l spec_file "$spec_dir/usage__usage_spec_mise_2026_8_8.spec"
+set -l spec_file "$spec_dir/usage__usage_spec_mise_2026_8_9.spec"
 if not test -f "$spec_file"
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
     mise usage | string collect > "$spec_file"

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_8_8.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_8_9.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/crates/vfox/embedded-plugins/vfox-gcloud/hooks/post_install.lua
+++ b/crates/vfox/embedded-plugins/vfox-gcloud/hooks/post_install.lua
@@ -102,14 +102,11 @@ function PLUGIN:PostInstall(ctx)
 
     -- The SDK extracts directly to the root path
     local sdk_path = root_path
-    local install_script = file.join_path(sdk_path, "install.sh")
-
-    -- Check if install script exists
-    if not file.exists(install_script) then
-        -- On Windows, use install.bat
-        if RUNTIME.osType == "windows" or RUNTIME.osType == "Windows" then
-            install_script = file.join_path(sdk_path, "install.bat")
-        end
+    local install_script
+    if RUNTIME.osType == "windows" or RUNTIME.osType == "Windows" then
+        install_script = file.join_path(sdk_path, "install.bat")
+    else
+        install_script = file.join_path(sdk_path, "install.sh")
     end
 
     if not file.exists(install_script) then
@@ -126,9 +123,11 @@ function PLUGIN:PostInstall(ctx)
         "--quiet",
     }
 
-    -- For versions >= 352.0.0, disable Python installation
-    -- (gcloud bundles its own Python in newer versions)
-    if version ~= "" and version_gte(version, "352.0.0") then
+    -- Only the Linux x86_64 archive bundles Python. Other platforms must use
+    -- CLOUDSDK_PYTHON or let the installer provision a supported interpreter.
+    local is_linux = RUNTIME.osType == "linux" or RUNTIME.osType == "Linux"
+    local is_x86_64 = RUNTIME.archType == "amd64" or RUNTIME.archType == "x86_64"
+    if version ~= "" and version_gte(version, "352.0.0") and is_linux and is_x86_64 then
         table.insert(args, "--install-python")
         table.insert(args, "false")
     end

--- a/crates/vfox/embedded-plugins/vfox-gcloud/hooks/pre_install.lua
+++ b/crates/vfox/embedded-plugins/vfox-gcloud/hooks/pre_install.lua
@@ -3,10 +3,27 @@
 --- @return table Version information with download URL
 
 local http = require("http")
+local os = require("os")
 
 -- GCS bucket configuration
 local GCS_BUCKET = "cloud-sdk-release"
 local BASE_URL = "https://storage.googleapis.com/" .. GCS_BUCKET
+
+local function use_bundled_python()
+    local value = os.getenv("MISE_TOOL_OPTS__BUNDLED_PYTHON")
+    if not value or value == "" then
+        return true
+    end
+
+    value = string.lower(value)
+    if value == "true" or value == "1" or value == "yes" or value == "on" then
+        return true
+    elseif value == "false" or value == "0" or value == "no" or value == "off" then
+        return false
+    end
+
+    error("bundled_python must be true or false, got: " .. value)
+end
 
 --- Get OS name for download URL
 local function get_os_name()
@@ -59,9 +76,15 @@ local function build_filename(version)
     local arch_name = get_arch_name()
     local ext = get_extension()
 
+    -- Prefer Google's Windows archive with its own Python runtime. The
+    -- unbundled archive requires a compatible Python to already be on PATH.
+    local variant = ""
+    if os_name == "windows" and arch_name == "x86_64" and use_bundled_python() then
+        variant = "-bundled-python"
+    end
+
     -- Format: google-cloud-sdk-{version}-{os}-{arch}.tar.gz
-    -- For bundled Python (recommended): google-cloud-sdk-{version}-{os}-{arch}-bundled-python.tar.gz
-    return "google-cloud-sdk-" .. version .. "-" .. os_name .. "-" .. arch_name .. ext
+    return "google-cloud-sdk-" .. version .. "-" .. os_name .. "-" .. arch_name .. variant .. ext
 end
 
 --- Fetch SHA256 checksum for the file

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.8.8";
+  version = "2026.8.9";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "32.6k",
+      stars: "32.7k",
     };
   },
 };

--- a/mise.lock
+++ b/mise.lock
@@ -220,9 +220,9 @@ version = "1.21.1"
 backend = "aqua:cargo-bins/cargo-binstall"
 
 [tools.cargo-binstall."platforms.linux-arm64"]
-checksum = "sha256:1dc2979f3c83aade9a1b4344589d14fafa63459b759222528d11419f5cca9cc2"
-url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.21.1/cargo-binstall-aarch64-unknown-linux-musl.tgz"
-url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/489425352"
+checksum = "sha256:1ff106d1e20182f7da77265f60e24e419f81b85fe6264cf4df9bdcdf5bb021bd"
+url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.21.1/cargo-binstall-aarch64-unknown-linux-gnu.tgz"
+url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/489425373"
 provenance = "github-attestations"
 
 [tools.cargo-binstall."platforms.linux-arm64-musl"]
@@ -232,15 +232,15 @@ url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/asset
 provenance = "github-attestations"
 
 [tools.cargo-binstall."platforms.linux-x64"]
-checksum = "sha256:630c8f8803a686aa6779497f0f0fb51d49822fb5fc3c514d8ced33b34e338e6e"
-url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.21.1/cargo-binstall-x86_64-unknown-linux-musl.tgz"
-url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/489425174"
+checksum = "sha256:d8ff7fd6567cf80d438c6c143484a81e84bd237e2507aa0f85b5707beced0bbc"
+url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.21.1/cargo-binstall-x86_64-unknown-linux-gnu.tgz"
+url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/489425192"
 provenance = "github-attestations"
 
 [tools.cargo-binstall."platforms.linux-x64-baseline"]
-checksum = "sha256:630c8f8803a686aa6779497f0f0fb51d49822fb5fc3c514d8ced33b34e338e6e"
-url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.21.1/cargo-binstall-x86_64-unknown-linux-musl.tgz"
-url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/489425174"
+checksum = "sha256:d8ff7fd6567cf80d438c6c143484a81e84bd237e2507aa0f85b5707beced0bbc"
+url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.21.1/cargo-binstall-x86_64-unknown-linux-gnu.tgz"
+url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/489425192"
 provenance = "github-attestations"
 
 [tools.cargo-binstall."platforms.linux-x64-musl"]
@@ -278,14 +278,14 @@ version = "1.48.0"
 backend = "aqua:mitsuhiko/insta"
 
 [tools.cargo-insta."platforms.linux-x64"]
-checksum = "sha256:703aa7d151ae59cac0bf8e7c2c27da4aca8070f3cb178f624ae10621ef77f5f5"
-url = "https://github.com/mitsuhiko/insta/releases/download/1.48.0/cargo-insta-x86_64-unknown-linux-musl.tar.xz"
-url_api = "https://api.github.com/repos/mitsuhiko/insta/releases/assets/444757872"
+checksum = "sha256:1c05a480a5a7f755f0ea15b2d8e2f71ad51b9c3a270d38ac72005c57ac0a1487"
+url = "https://github.com/mitsuhiko/insta/releases/download/1.48.0/cargo-insta-x86_64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/mitsuhiko/insta/releases/assets/444757866"
 
 [tools.cargo-insta."platforms.linux-x64-baseline"]
-checksum = "sha256:703aa7d151ae59cac0bf8e7c2c27da4aca8070f3cb178f624ae10621ef77f5f5"
-url = "https://github.com/mitsuhiko/insta/releases/download/1.48.0/cargo-insta-x86_64-unknown-linux-musl.tar.xz"
-url_api = "https://api.github.com/repos/mitsuhiko/insta/releases/assets/444757872"
+checksum = "sha256:1c05a480a5a7f755f0ea15b2d8e2f71ad51b9c3a270d38ac72005c57ac0a1487"
+url = "https://github.com/mitsuhiko/insta/releases/download/1.48.0/cargo-insta-x86_64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/mitsuhiko/insta/releases/assets/444757866"
 
 [tools.cargo-insta."platforms.linux-x64-musl"]
 checksum = "sha256:703aa7d151ae59cac0bf8e7c2c27da4aca8070f3cb178f624ae10621ef77f5f5"
@@ -438,9 +438,9 @@ version = "2.13.1"
 backend = "aqua:orhun/git-cliff"
 
 [tools.git-cliff."platforms.linux-arm64"]
-checksum = "sha256:4054c124b926c117f3fa048939bc8be0a954f29f3b6f367627e8cb22c1971882"
-url = "https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.13.1-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/orhun/git-cliff/releases/assets/405850720"
+checksum = "sha256:9619b7f0c584229f8a2331c1905afe88bd938bdc9102926c2073836a42f02455"
+url = "https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.13.1-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/orhun/git-cliff/releases/assets/405850077"
 
 [tools.git-cliff."platforms.linux-arm64-musl"]
 checksum = "sha256:4054c124b926c117f3fa048939bc8be0a954f29f3b6f367627e8cb22c1971882"
@@ -448,14 +448,14 @@ url = "https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.
 url_api = "https://api.github.com/repos/orhun/git-cliff/releases/assets/405850720"
 
 [tools.git-cliff."platforms.linux-x64"]
-checksum = "sha256:200d2535da6d9703f3bcc8a4d159c3b55eacdb01cf2148c55b3eee9dd04d5249"
-url = "https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.13.1-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/orhun/git-cliff/releases/assets/405850671"
+checksum = "sha256:9a1263f24e59a2f508c7b3d3283c9dea94a8bf697f96dbc18cc783cac6284546"
+url = "https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.13.1-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/orhun/git-cliff/releases/assets/405850439"
 
 [tools.git-cliff."platforms.linux-x64-baseline"]
-checksum = "sha256:200d2535da6d9703f3bcc8a4d159c3b55eacdb01cf2148c55b3eee9dd04d5249"
-url = "https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.13.1-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/orhun/git-cliff/releases/assets/405850671"
+checksum = "sha256:9a1263f24e59a2f508c7b3d3283c9dea94a8bf697f96dbc18cc783cac6284546"
+url = "https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.13.1-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/orhun/git-cliff/releases/assets/405850439"
 
 [tools.git-cliff."platforms.linux-x64-musl"]
 checksum = "sha256:200d2535da6d9703f3bcc8a4d159c3b55eacdb01cf2148c55b3eee9dd04d5249"
@@ -1068,9 +1068,9 @@ version = "5.1.0"
 backend = "aqua:jdx/usage"
 
 [tools.usage."platforms.linux-arm64"]
-checksum = "sha256:e2056b06c8d13f109389d53e758b4e79208f01360dec996751bc48ce658eb200"
-url = "https://github.com/jdx/usage/releases/download/v5.1.0/usage-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/507608014"
+checksum = "sha256:6eb5a37fab31b928cfa10f239307812ab1b26f11e465f524302d7fd2c8ac4503"
+url = "https://github.com/jdx/usage/releases/download/v5.1.0/usage-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/507607925"
 
 [tools.usage."platforms.linux-arm64-musl"]
 checksum = "sha256:e2056b06c8d13f109389d53e758b4e79208f01360dec996751bc48ce658eb200"
@@ -1078,14 +1078,14 @@ url = "https://github.com/jdx/usage/releases/download/v5.1.0/usage-aarch64-unkno
 url_api = "https://api.github.com/repos/jdx/usage/releases/assets/507608014"
 
 [tools.usage."platforms.linux-x64"]
-checksum = "sha256:a702c639f8e25d1e10f42ab37e09b8f73634c09b23c7abe2ebd6ab6f9665e99c"
-url = "https://github.com/jdx/usage/releases/download/v5.1.0/usage-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/507608023"
+checksum = "sha256:788c103416d4ed8e335484a40886c9abf5879dd5394959727d5c0cc9f327902b"
+url = "https://github.com/jdx/usage/releases/download/v5.1.0/usage-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/507607768"
 
 [tools.usage."platforms.linux-x64-baseline"]
-checksum = "sha256:a702c639f8e25d1e10f42ab37e09b8f73634c09b23c7abe2ebd6ab6f9665e99c"
-url = "https://github.com/jdx/usage/releases/download/v5.1.0/usage-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/507608023"
+checksum = "sha256:788c103416d4ed8e335484a40886c9abf5879dd5394959727d5c0cc9f327902b"
+url = "https://github.com/jdx/usage/releases/download/v5.1.0/usage-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/507607768"
 
 [tools.usage."platforms.linux-x64-musl"]
 checksum = "sha256:a702c639f8e25d1e10f42ab37e09b8f73634c09b23c7abe2ebd6ab6f9665e99c"

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.8.8
+Version: 2026.8.9
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.8.8"
+version: "2026.8.9"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "650d3177e2d95b32ad4f7d474c318adc8a53b212"
+  "tag": "9b7652faaca0903a3110bfc111d8227d703f89b8"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -427,6 +427,22 @@ packages:
           linux: unknown-linux-gnu
           amd64: x86_64
   - type: github_release
+    repo_owner: Arata1202
+    repo_name: ascdir
+    description: Manage App Store Connect text metadata as local files
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: ascdir_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: Arriven
     repo_name: db1000n
     version_constraint: "false"
@@ -3762,6 +3778,94 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+  - type: github_release
+    repo_owner: Genymobile
+    repo_name: scrcpy
+    description: Display and control your Android device
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.5-fixversion"
+        asset: scrcpy-{{.OS}}-v1.5.{{.Format}}
+        format: zip
+        files:
+          - name: scrcpy
+            src: scrcpy-{{.OS}}/scrcpy
+        replacements:
+          windows: win64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS.txt
+          algorithm: sha256
+        supported_envs:
+          - windows/amd64
+      - version_constraint: Version == "v3.0"
+        asset: scrcpy-{{.OS}}-{{.Version}}.zip
+        format: zip
+        files:
+          - name: scrcpy
+            src: "{{.AssetWithoutExt}}/scrcpy"
+        replacements:
+          windows: win64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS.txt
+          algorithm: sha256
+        supported_envs:
+          - windows/amd64
+      - version_constraint: semver("<= 1.1.0")
+        asset: scrcpy-{{.OS}}-with-deps-{{.Version}}.{{.Format}}
+        format: zip
+        files:
+          - name: scrcpy
+            src: scrcpy-windows-{{.Version}}/scrcpy
+        checksum:
+          type: github_release
+          asset: SHA256SUMS.txt
+          algorithm: sha256
+        supported_envs:
+          - windows/amd64
+      - version_constraint: semver("<= 2.7.0")
+        asset: scrcpy-{{.OS}}-{{.Version}}.{{.Format}}
+        format: zip
+        files:
+          - name: scrcpy
+            src: "{{.AssetWithoutExt}}/scrcpy"
+        replacements:
+          windows: win64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS.txt
+          algorithm: sha256
+        supported_envs:
+          - windows/amd64
+      - version_constraint: "true"
+        asset: scrcpy-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: scrcpy
+            src: "{{.AssetWithoutExt}}/scrcpy"
+        replacements:
+          amd64: x86_64
+          darwin: macos
+          windows: win64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            asset: scrcpy-{{.OS}}-{{.Version}}.{{.Format}}
+            files:
+              - name: scrcpy
+                src: "{{.AssetWithoutExt}}/scrcpy"
+        supported_envs:
+          - darwin
+          - linux/amd64
+          - windows/amd64
   - type: github_release
     repo_owner: Getdeck
     repo_name: getdeck
@@ -26957,6 +27061,35 @@ packages:
           linux: Linux
           amd64: x86_64
           windows: Windows
+  - type: github_release
+    repo_owner: cloudsmith-io
+    repo_name: cloudsmith-cli
+    description: Cloudsmith Command Line Interface (CLI)
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.19.0")
+        no_asset: true
+      - version_constraint: "true"
+        asset: cloudsmith-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: cloudsmith
+            src: cloudsmith/cloudsmith
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            asset: cloudsmith-{{trimV .Version}}-{{.OS}}-{{.Arch}}-gnu.{{.Format}}
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
   - type: go_install
     repo_owner: cloudspannerecosystem
     repo_name: spanner-cli


### PR DESCRIPTION
### 🚀 Features

- **(bootstrap)** expose resource provenance by @jdx in [#12100](https://github.com/jdx/mise/pull/12100)
- **(bootstrap)** support self-updating and adopted brew casks by @ascarter in [#12074](https://github.com/jdx/mise/pull/12074)
- **(bootstrap)** compose config roots by @jdx in [#12105](https://github.com/jdx/mise/pull/12105)
- **(bootstrap)** compose services and compose projects by @jdx in [#12132](https://github.com/jdx/mise/pull/12132)
- **(bootstrap)** add symlink copy controls by @jdx in [#12121](https://github.com/jdx/mise/pull/12121)
- **(config)** implicitly trust config for execution commands by @jdx in [#12107](https://github.com/jdx/mise/pull/12107)
- **(config)** support environment-specific conf.d files by @jdx in [#12151](https://github.com/jdx/mise/pull/12151)
- **(config)** support relative ignored config globs by @jdx in [#12169](https://github.com/jdx/mise/pull/12169)
- **(system)** let plugins declare candidate package names by @jdx in [#12149](https://github.com/jdx/mise/pull/12149)
- **(vfox)** pass tool options in hook contexts by @jdx in [#12174](https://github.com/jdx/mise/pull/12174)

### 🐛 Bug Fixes

- **(aqua)** prefer glibc assets with musl fallback by @jdx in [#12093](https://github.com/jdx/mise/pull/12093)
- **(backend)** keep flavour queries from crossing a '+' by @Marukome0743 in [#12118](https://github.com/jdx/mise/pull/12118)
- **(backend)** key the remote version cache by listing tool options by @JamBalaya56562 in [#12164](https://github.com/jdx/mise/pull/12164)
- **(bootstrap)** create missing directory parents by @jdx in [#12096](https://github.com/jdx/mise/pull/12096)
- **(docs)** route tool search results to mise-versions by @jdx in [#12097](https://github.com/jdx/mise/pull/12097)
- **(github)** match arm assets on arm64 by @jdx in [#12098](https://github.com/jdx/mise/pull/12098)
- **(hook-env)** preserve runtime environment overrides by @jdx in [#12094](https://github.com/jdx/mise/pull/12094)
- **(http)** order remote versions consistently by @jdx in [#12170](https://github.com/jdx/mise/pull/12170)
- **(python)** resolve configured uv for automatic venv by @jdx in [#12177](https://github.com/jdx/mise/pull/12177)
- **(shell)** branch on the exit code in the pwsh command-not-found hook by @JamBalaya56562 in [#12089](https://github.com/jdx/mise/pull/12089)
- **(shell)** skip mise's own commands in the pwsh command-not-found hook by @JamBalaya56562 in [#12131](https://github.com/jdx/mise/pull/12131)
- **(shell)** refresh the environment on auto-install when --no-hook-env omits the hook by @JamBalaya56562 in [#12117](https://github.com/jdx/mise/pull/12117)
- **(system)** resolve dependency executables on Windows by @jdx in [#12178](https://github.com/jdx/mise/pull/12178)
- **(task)** support azure devops cloud ssh urls (remote git sources) by @cheesemans in [#12102](https://github.com/jdx/mise/pull/12102)
- **(task)** normalize Windows task environment paths by @jdx in [#12173](https://github.com/jdx/mise/pull/12173)
- **(use)** scope global install hooks by @jdx in [#12101](https://github.com/jdx/mise/pull/12101)
- **(vfox)** follow symlinks when fingerprinting plugin sources by @jdx in [#12155](https://github.com/jdx/mise/pull/12155)
- **(vfox)** honor systemDependencies in embedded plugins by @jdx in [#12152](https://github.com/jdx/mise/pull/12152)
- **(vfox)** apply netrc credentials to HTTP requests by @jdx in [#12168](https://github.com/jdx/mise/pull/12168)
- **(which)** report uninstalled --tool version instead of "not active" by @TrevorBurnham in [#12106](https://github.com/jdx/mise/pull/12106)
- asset selection for non-gz tar variants by @sgammon in [#12156](https://github.com/jdx/mise/pull/12156)

### 🚜 Refactor

- **(backend)** remove legacy RTX environment variables by @jdx in [#12172](https://github.com/jdx/mise/pull/12172)

### 📚 Documentation

- fix installing mise links by @jdx in [#12104](https://github.com/jdx/mise/pull/12104)

### ⚡ Performance

- **(activate)** stop pwsh running hook-env twice per directory change by @jdx in [#12147](https://github.com/jdx/mise/pull/12147)
- **(cache)** batch remote blob prefetch by @jdx in [#12103](https://github.com/jdx/mise/pull/12103)
- **(config)** gate idiomatic file detection on idiomatic_version_file_enable_tools by @jdx in [#12143](https://github.com/jdx/mise/pull/12143)
- **(release)** build windows with the serious profile and one TLS stack by @jdx in [#12146](https://github.com/jdx/mise/pull/12146)
- **(vfox)** cache plugin metadata on disk by @jdx in [#12145](https://github.com/jdx/mise/pull/12145)

### 🧪 Testing

- **(java)** cover version matching with unit tests instead of live metadata by @Marukome0743 in [#12116](https://github.com/jdx/mise/pull/12116)

### 📦️ Dependency Updates

- update h2 to 0.4.16 for RUSTSEC-2026-0258 by @Marukome0743 in [#12119](https://github.com/jdx/mise/pull/12119)
- update ghcr.io/jdx/mise:rpm docker digest to 50e4032 by @renovate[bot] in [#12124](https://github.com/jdx/mise/pull/12124)
- update swatinem/rust-cache digest to 6323deb by @renovate[bot] in [#12125](https://github.com/jdx/mise/pull/12125)
- update ghcr.io/jdx/mise:deb docker digest to bf1cd85 by @renovate[bot] in [#12123](https://github.com/jdx/mise/pull/12123)
- update rust crate async-trait to v0.1.92 by @renovate[bot] in [#12128](https://github.com/jdx/mise/pull/12128)
- update ghcr.io/jdx/mise:alpine docker digest to d21f898 by @renovate[bot] in [#12122](https://github.com/jdx/mise/pull/12122)
- update rust crate blake3 to v1.8.6 by @renovate[bot] in [#12129](https://github.com/jdx/mise/pull/12129)
- update rust crate clap to v4.6.6 by @renovate[bot] in [#12130](https://github.com/jdx/mise/pull/12130)
- update dependency esbuild to v0.28.2 by @renovate[bot] in [#12126](https://github.com/jdx/mise/pull/12126)
- update dependency python to v3.14.7 by @renovate[bot] in [#12127](https://github.com/jdx/mise/pull/12127)
- lock file maintenance by @renovate[bot] in [#12084](https://github.com/jdx/mise/pull/12084)
- update rust crate ctor to v1.0.13 by @renovate[bot] in [#12134](https://github.com/jdx/mise/pull/12134)
- update rust crate expr-lang to v2 by @renovate[bot] in [#12154](https://github.com/jdx/mise/pull/12154)
- update aws-sdk-rust monorepo to v1.10.1 by @renovate[bot] in [#12139](https://github.com/jdx/mise/pull/12139)

### 📦 Registry

- point vlang at the maintained v backend by @jdx in [#12153](https://github.com/jdx/mise/pull/12153)
- fix llama.cpp version test by @jdx in [#12157](https://github.com/jdx/mise/pull/12157)

### Chore

- **(ci)** refresh cursor cloud agent environment by @jdx in [#12112](https://github.com/jdx/mise/pull/12112)
- **(ci)** prevent stale snapcraft releases by @jdx in [#12142](https://github.com/jdx/mise/pull/12142)
- **(ci)** ignore dependency rust-version in automated builds by @jdx in [#12159](https://github.com/jdx/mise/pull/12159)
- **(ci)** retry transient R2 upload failures by @jdx in [#12158](https://github.com/jdx/mise/pull/12158)
- **(ci)** skip redundant release cargo check by @jdx in [#12166](https://github.com/jdx/mise/pull/12166)
- **(ci)** propagate rust-version override to release build by @jdx in [#12175](https://github.com/jdx/mise/pull/12175)

### Security

- **(backend)** restrict forge tokens to api origin by @jdx in [#12167](https://github.com/jdx/mise/pull/12167)
- block tool install code in safe mode by @jdx in [#12140](https://github.com/jdx/mise/pull/12140)

### New Contributors

- @sgammon made their first contribution in [#12156](https://github.com/jdx/mise/pull/12156)
- @ascarter made their first contribution in [#12074](https://github.com/jdx/mise/pull/12074)
- @TrevorBurnham made their first contribution in [#12106](https://github.com/jdx/mise/pull/12106)

## 📦 Aqua Registry Updates

### New Packages (3)

- [`Arata1202/ascdir`](https://github.com/Arata1202/ascdir)
- [`Genymobile/scrcpy`](https://github.com/Genymobile/scrcpy)
- [`cloudsmith-io/cloudsmith-cli`](https://github.com/cloudsmith-io/cloudsmith-cli)