### PR TITLE
fix(docs): route tool search results to mise-versions

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -11,9 +11,27 @@ import { data as starsData } from "../stars.data";
 export default {
   extends: DefaultTheme,
   Layout,
-  enhanceApp({ app }) {
+  enhanceApp({ app, router }) {
     enhanceAppWithTabs(app);
     initBanner();
+
+    const onBeforeRouteChange = router.onBeforeRouteChange;
+    router.onBeforeRouteChange = async (to) => {
+      if (typeof window !== "undefined") {
+        const url = new URL(to, window.location.origin);
+        if (
+          url.origin === window.location.origin &&
+          url.pathname.startsWith("/tools/")
+        ) {
+          const toolPath = url.pathname.replace(/\.html$/, "");
+          window.location.assign(
+            `https://mise-versions.jdx.dev${toolPath}${url.search}${url.hash}`,
+          );
+          return false;
+        }
+      }
+      return onBeforeRouteChange?.(to);
+    };
   },
   setup() {
     onMounted(() => {


### PR DESCRIPTION
## What changed

- intercept VitePress navigation to `/tools/*` search results
- send those results to the canonical `mise-versions.jdx.dev` tool page
- preserve query strings and fragments while removing VitePress's generated `.html` suffix

## Why

VitePress 1.6.4 normalizes every Algolia result URL to a local path. Tool records indexed from `mise-versions.jdx.dev` therefore appeared correctly in search but opened broken URLs such as `mise.jdx.dev/tools/terragrunt`.

This keeps documentation results on the docs router while routing tool results to the site that owns them.

## Validation

- `prettier --check docs/.vitepress/theme/index.ts`
- `bun run docs:build`
- searched for `terragrunt` in a local docs preview and verified the selected result opened `https://mise-versions.jdx.dev/tools/terragrunt`
