### PR TITLE
feat(bootstrap): expose resource provenance

### DIFF
--- a/docs/bootstrap/files.md
+++ b/docs/bootstrap/files.md
@@ -102,3 +102,5 @@ The JSON output from `mise bootstrap plan`, `mise bootstrap status`, and
 and directories. It identifies the declaring config, that config's
 `config_root`, any configuration environment encoded by its filename, and a
 resolved source path when the file uses `source`.
+Paths are ordinary strings when they are valid UTF-8. On Unix, a path containing
+non-UTF-8 bytes uses `mise:path-bytes:<base64url>` so provenance remains lossless.

--- a/docs/bootstrap/files.md
+++ b/docs/bootstrap/files.md
@@ -96,3 +96,9 @@ change.
 `mise bootstrap plan` includes these resources and automatically orders a
 managed file after its managed parent directory. Removal reverses that
 dependency so children are removed before their parent.
+
+The JSON output from `mise bootstrap plan`, `mise bootstrap status`, and
+`mise bootstrap files status` includes an `origin` object for managed files
+and directories. It identifies the declaring config, that config's
+`config_root`, any configuration environment encoded by its filename, and a
+resolved source path when the file uses `source`.

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -59,6 +59,12 @@ that declares the entry, so a global `~/.config/mise/config.toml` can manage
 dotfiles kept next to it, and a project config can ship machine setup from
 the repo.
 
+`mise bootstrap dotfiles status --json` includes an `origin` object for every
+entry. It reports the declaring config, its `config_root`, any configuration
+environment encoded by that config filename, and the resolved source path.
+This makes layered dotfile declarations inspectable without reconstructing
+their precedence by hand.
+
 Use `content` to declare a literal whole file inline instead of keeping a
 separate source file. Inline content is written as a private regular file
 (`0600` on Unix) and cannot be combined with `source`, `mode`, or `exclude`:

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -62,6 +62,8 @@ the repo.
 `mise bootstrap dotfiles status --json` includes an `origin` object for every
 entry. It reports the declaring config, its `config_root`, any configuration
 environment encoded by that config filename, and the resolved source path.
+Paths are ordinary strings when they are valid UTF-8. On Unix, a path containing
+non-UTF-8 bytes uses `mise:path-bytes:<base64url>` so provenance remains lossless.
 This makes layered dotfile declarations inspectable without reconstructing
 their precedence by hand.
 

--- a/e2e/cli/test_bootstrap_secrets
+++ b/e2e/cli/test_bootstrap_secrets
@@ -8,18 +8,20 @@ fi
 secret_value="mise-bootstrap-secret-7f9d3a"
 secret_env="MISE_BOOTSTRAP_TEST_SECRET"
 managed_file="$PWD/secret.conf"
+template_source="$PWD/secret.conf.tmpl"
 static_file="$PWD/static.conf"
 static_dir="$PWD/static-dir"
 managed_owner="$(id -un)"
 managed_group="$(id -gn)"
 
 unset "$secret_env"
+echo 'token={{ secret(name="cache_token") }}' >"$template_source"
 cat <<EOF >mise.toml
 [bootstrap.secrets]
 cache_token = { env = "$secret_env", description = "Cache token" }
 
 [bootstrap.files."$managed_file"]
-content = 'token={{ secret(name="cache_token") }}'
+source = "secret.conf.tmpl"
 template = true
 owner = "$managed_owner"
 group = "$managed_group"
@@ -56,6 +58,8 @@ assert_contains "mise bootstrap plan" "$managed_file"
 assert_contains "mise bootstrap plan" "$static_file"
 assert_contains "mise bootstrap plan" "$static_dir"
 assert_contains "mise bootstrap plan" "unknown"
+assert_succeed "mise bootstrap plan --json | jq -e '.resources[] | select(.id.name == \"$managed_file\") | .origin.source == \"$template_source\"'"
+assert_succeed "mise bootstrap files status --json | jq -e '.[] | select(.id.name == \"$managed_file\") | .origin.source == \"$template_source\"'"
 assert_fail "mise bootstrap plan --detailed-exitcode"
 assert_succeed "mise bootstrap --only repos --dry-run"
 

--- a/e2e/cli/test_bootstrap_system_files
+++ b/e2e/cli/test_bootstrap_system_files
@@ -51,6 +51,8 @@ assert "cat $managed_file" "first"
 assert "stat -c %a $managed_nested" "750"
 assert_succeed "mise bootstrap files status --missing"
 assert_succeed "mise bootstrap files status --json | jq -e . >/dev/null"
+assert_succeed "mise bootstrap files status --json | jq -e '.[] | select(.id.kind == \"file\") | .origin.config == \"$PWD/mise.toml\" and .origin.config_root == \"$PWD\"'"
+assert_succeed "mise bootstrap plan --json | jq -e '.resources[] | select(.id.kind == \"file\") | .origin.config == \"$PWD/mise.toml\" and .origin.config_root == \"$PWD\"'"
 assert_contains "mise bootstrap status --json" '"files"'
 
 # Applying the same declarations again is a no-op.

--- a/e2e/cli/test_dotfiles_files
+++ b/e2e/cli/test_dotfiles_files
@@ -27,6 +27,13 @@ EOF
 assert_contains "mise bootstrap dotfiles status" "missing"
 assert_contains "MISE_EXPERIMENTAL=0 mise dotfiles status" "missing"
 assert_fail "mise dotfiles status --missing"
+assert_succeed "mise dotfiles status --json | jq -e '.files[] | select(.target == \"~/.gitconfig\") | .origin.config == \"$PWD/mise.toml\" and .origin.config_root == \"$PWD\" and .origin.source == \"$PWD/dotfiles/gitconfig\"'"
+
+cat <<EOF >mise.dev.toml
+[dotfiles]
+"~/.dev-origin" = { content = "dev" }
+EOF
+assert_succeed "MISE_ENV=dev mise dotfiles status --json | jq -e '.files[] | select(.target == \"~/.dev-origin\") | .origin.environment == [\"dev\"]'"
 
 # system commands do not manage dotfiles
 assert_succeed "mise bootstrap packages apply --yes"

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -1939,13 +1939,21 @@ impl BootstrapPlan {
         } else if output.resources.is_empty() {
             info!("nothing configured for bootstrap planning");
         } else {
-            let mut table = MiseTable::new(false, &["Action", "Resource", "Current", "Desired"]);
+            let mut table = MiseTable::new(
+                false,
+                &["Action", "Resource", "Current", "Desired", "Config"],
+            );
             for resource in &output.resources {
                 table.add_row(vec![
                     resource.action.to_string(),
                     resource.id.to_string(),
                     resource.current.clone(),
                     resource.desired.clone(),
+                    resource
+                        .origin
+                        .as_ref()
+                        .map(|origin| origin.config.display_user())
+                        .unwrap_or_default(),
                 ]);
             }
             table.print()?;
@@ -2138,13 +2146,20 @@ impl BootstrapFilesStatus {
         } else if resources.is_empty() {
             info!("no system files or directories configured");
         } else {
-            let mut table = MiseTable::new(false, &["Action", "Resource", "Current", "Desired"]);
+            let mut table = MiseTable::new(
+                false,
+                &["Action", "Resource", "Current", "Desired", "Config"],
+            );
             for resource in resources {
                 table.add_row(vec![
                     resource.action.to_string(),
                     resource.id.to_string(),
                     resource.current,
                     resource.desired,
+                    resource
+                        .origin
+                        .map(|origin| origin.config.display_user())
+                        .unwrap_or_default(),
                 ]);
             }
             table.print()?;

--- a/src/cli/dotfiles/add.rs
+++ b/src/cli/dotfiles/add.rs
@@ -392,6 +392,12 @@ impl PlannedAdd {
                 .parent()
                 .unwrap_or(std::path::Path::new("."))
                 .to_path_buf(),
+            origin: crate::system::resources::ResourceOrigin {
+                config: config_path.to_path_buf(),
+                config_root: crate::config::config_file::config_root::config_root(config_path),
+                environment: crate::config::environments_for_config_path(config_path),
+                source: Some(self.source.clone()),
+            },
         }
     }
 }

--- a/src/cli/dotfiles/status.rs
+++ b/src/cli/dotfiles/status.rs
@@ -58,6 +58,7 @@ impl DotfilesStatus {
                     "source": (req.mode != system::files::FileMode::Content)
                         .then(|| req.source.display_user()),
                     "mode": req.mode.name(),
+                    "origin": &req.origin,
                     "state": match &state {
                         FileState::Applied => "applied",
                         FileState::Missing => "missing",
@@ -74,6 +75,7 @@ impl DotfilesStatus {
                     } else {
                         req.source.display_user()
                     },
+                    req.origin.config.display_user(),
                     state_str,
                 ]);
             }
@@ -113,6 +115,7 @@ impl DotfilesStatus {
                 json_edits.push(json!({
                     "path": req.path_raw,
                     "edit": req.describe_op(),
+                    "origin": &req.origin,
                     "state": match &state {
                         FileState::Applied => "applied",
                         FileState::Missing => "missing",
@@ -121,7 +124,12 @@ impl DotfilesStatus {
                     },
                 }));
             } else {
-                edit_rows.push(vec![req.path_raw.clone(), req.describe_op(), state_str]);
+                edit_rows.push(vec![
+                    req.path_raw.clone(),
+                    req.describe_op(),
+                    req.origin.config.display_user(),
+                    state_str,
+                ]);
             }
         }
 
@@ -143,14 +151,15 @@ impl DotfilesStatus {
                 info!("nothing configured in [dotfiles]");
             }
             if !file_rows.is_empty() {
-                let mut table = MiseTable::new(false, &["Target", "Mode", "Source", "State"]);
+                let mut table =
+                    MiseTable::new(false, &["Target", "Mode", "Source", "Config", "State"]);
                 for row in file_rows {
                     table.add_row(row);
                 }
                 table.print()?;
             }
             if !edit_rows.is_empty() {
-                let mut table = MiseTable::new(false, &["File", "Edit", "State"]);
+                let mut table = MiseTable::new(false, &["File", "Edit", "Config", "State"]);
                 for row in edit_rows {
                     table.add_row(row);
                 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1720,6 +1720,25 @@ pub(crate) fn config_paths_in_dir(dir: &Path) -> Vec<PathBuf> {
     config_paths_in_dir_with_filenames(dir, &DEFAULT_CONFIG_FILENAMES)
 }
 
+/// Return the active configuration environment encoded in a loaded config
+/// filename. A vector matches the ordered MISE_ENV model and leaves room for
+/// future config forms that represent more than one environment.
+pub(crate) fn environments_for_config_path(path: &Path) -> Vec<String> {
+    let Some(filename) = path.file_name().and_then(|name| name.to_str()) else {
+        return vec![];
+    };
+    env::MISE_ENV_WITH_AUTO
+        .iter()
+        .filter(|environment| {
+            ["config", "mise", ".mise"].into_iter().any(|prefix| {
+                filename == format!("{prefix}.{environment}.toml")
+                    || filename == format!("{prefix}.{environment}.local.toml")
+            })
+        })
+        .cloned()
+        .collect()
+}
+
 fn config_paths_in_dir_with_filenames(dir: &Path, filenames: &[String]) -> Vec<PathBuf> {
     let config_paths: Vec<PathBuf> = filenames
         .iter()

--- a/src/system/edits.rs
+++ b/src/system/edits.rs
@@ -34,6 +34,7 @@ use crate::config::{Config, ConfigMap};
 use crate::file;
 use crate::path::PathExt;
 use crate::system::files::FileState;
+use crate::system::resources::ResourceOrigin;
 use crate::ui::prompt;
 
 /// one `[dotfiles]` edit entry as written in mise.toml. Operations stay loosely typed so configs using operations
@@ -107,6 +108,7 @@ pub struct EditRequest {
     pub base: PathBuf,
     /// config file that declared this edit
     pub config_path: PathBuf,
+    pub origin: ResourceOrigin,
 }
 
 impl EditRequest {
@@ -228,6 +230,12 @@ fn resolve_entry(
             "\"{path_raw}\".{id:?}: ids may only contain letters, digits, '_', '-', and '.', ignoring entry"
         );
     }
+    let mut origin = ResourceOrigin {
+        config: config_path.to_path_buf(),
+        config_root: crate::config::config_file::config_root::config_root(config_path),
+        environment: crate::config::environments_for_config_path(config_path),
+        source: None,
+    };
     let entry = match entry {
         EditTomlEntry::Block(inline) => EditTomlTable {
             block: Some(inline),
@@ -260,11 +268,13 @@ fn resolve_entry(
                 (Some(inline), None) => BlockSource::Inline(inline),
                 (None, Some(src)) => {
                     let src = file::replace_path(&src);
-                    BlockSource::File(if src.is_relative() {
+                    let src = if src.is_relative() {
                         base.join(src)
                     } else {
                         src
-                    })
+                    };
+                    origin.source = Some(src.clone());
+                    BlockSource::File(src)
                 }
                 (None, None) => unreachable!("is_block"),
             };
@@ -305,6 +315,7 @@ fn resolve_entry(
         op,
         base: base.to_path_buf(),
         config_path: config_path.to_path_buf(),
+        origin,
     })
 }
 

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -32,6 +32,7 @@ use crate::dirs;
 use crate::file;
 use crate::hash::hash_to_str;
 use crate::path::PathExt;
+use crate::system::resources::ResourceOrigin;
 use crate::ui::prompt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -114,6 +115,7 @@ pub struct FileRequest {
     /// directory of the declaring config file — base dir for template
     /// functions like `exec` and `read_file`
     pub base: PathBuf,
+    pub origin: ResourceOrigin,
 }
 
 const SYMLINK_EACH_STATE_VERSION: u8 = 1;
@@ -164,6 +166,12 @@ pub fn files_from_config_files(config_files: &ConfigMap) -> Vec<FileRequest> {
     // config_files is ordered local -> global; reverse for global -> local
     for (path, cf) in config_files.iter().rev() {
         let base = path.parent().unwrap_or(Path::new(".")).to_path_buf();
+        let origin = ResourceOrigin {
+            config: path.clone(),
+            config_root: cf.config_root(),
+            environment: crate::config::environments_for_config_path(path),
+            source: None,
+        };
         let Some(dotfiles) = cf.dotfiles_config() else {
             continue;
         };
@@ -171,7 +179,7 @@ pub fn files_from_config_files(config_files: &ConfigMap) -> Vec<FileRequest> {
             let Some(entry) = file_entry_from_toml(&target_raw, value) else {
                 continue;
             };
-            merge_file_entry(target_raw, entry, &base, &mut merged);
+            merge_file_entry(target_raw, entry, &base, &origin, &mut merged);
         }
     }
     merged.into_values().collect()
@@ -208,6 +216,7 @@ fn merge_file_entry(
     target_raw: String,
     entry: FileTomlEntry,
     base: &Path,
+    origin: &ResourceOrigin,
     merged: &mut IndexMap<PathBuf, FileRequest>,
 ) {
     let (source, content, mode, exclude) = match entry {
@@ -272,6 +281,7 @@ fn merge_file_entry(
                 mode: FileMode::Content,
                 exclude: vec![],
                 base: base.to_path_buf(),
+                origin: origin.clone(),
             },
         );
         return;
@@ -293,6 +303,8 @@ fn merge_file_entry(
             }
         },
     };
+    let mut origin = origin.clone();
+    origin.source = Some(source.clone());
     for req in expand_request(
         target_raw,
         target,
@@ -300,6 +312,7 @@ fn merge_file_entry(
         mode,
         exclude,
         base.to_path_buf(),
+        origin,
     ) {
         merged.insert(req.target.clone(), req);
     }
@@ -399,6 +412,7 @@ fn expand_request(
     mode: FileMode,
     exclude: Vec<glob::Pattern>,
     base: PathBuf,
+    origin: ResourceOrigin,
 ) -> Vec<FileRequest> {
     if !is_glob_pattern(&source) {
         return vec![FileRequest {
@@ -409,6 +423,7 @@ fn expand_request(
             mode,
             exclude,
             base,
+            origin,
         }];
     }
 
@@ -452,6 +467,10 @@ fn expand_request(
             mode,
             exclude,
             base,
+            origin: ResourceOrigin {
+                source: Some(matches[0].clone()),
+                ..origin
+            },
         }];
     }
 
@@ -475,11 +494,15 @@ fn expand_request(
             Some(FileRequest {
                 target_raw: target_path.display_user().to_string(),
                 target: target_path,
-                source: matched_source,
+                source: matched_source.clone(),
                 content: None,
                 mode,
                 exclude: exclude.clone(),
                 base: base.clone(),
+                origin: ResourceOrigin {
+                    source: Some(matched_source.clone()),
+                    ..origin.clone()
+                },
             })
         })
         .collect()
@@ -2137,6 +2160,12 @@ mod tests {
             mode,
             exclude: vec![],
             base: source.parent().expect("source parent").to_path_buf(),
+            origin: ResourceOrigin {
+                config: PathBuf::from("/mise.toml"),
+                config_root: PathBuf::from("/"),
+                environment: vec![],
+                source: Some(source.to_path_buf()),
+            },
         }
     }
 

--- a/src/system/managed_files.rs
+++ b/src/system/managed_files.rs
@@ -370,9 +370,14 @@ fn merged_files_from_config(
                         target.display()
                     );
                 }
+                let mut file_origin = origin.clone();
+                file_origin.source = file
+                    .source
+                    .as_deref()
+                    .map(|source| resolve_source_path(&base, source));
                 merged
                     .entry(target)
-                    .or_insert_with(|| (file, base.clone(), origin.clone()));
+                    .or_insert_with(|| (file, base.clone(), file_origin));
             }
         }
     }
@@ -462,7 +467,7 @@ impl ManagedFileRequest {
         path: PathBuf,
         config: ManagedFileTomlConfig,
         base: &Path,
-        mut origin: ResourceOrigin,
+        origin: ResourceOrigin,
         secrets: &super::secrets::SecretValues,
     ) -> Result<Self> {
         let owner = nonempty("owner", config.owner)?;
@@ -476,13 +481,7 @@ impl ManagedFileRequest {
                 )
             }
             (Some(source), None, ManagedState::Present) => {
-                let source = Path::new(&source);
-                let source = if source.is_absolute() {
-                    source.to_path_buf()
-                } else {
-                    base.join(source)
-                };
-                origin.source = Some(source.clone());
+                let source = resolve_source_path(base, &source);
                 Some(fs::read_to_string(&source).wrap_err_with(|| {
                     format!(
                         "[bootstrap.files].\"{}\": failed to read source {}",
@@ -559,6 +558,15 @@ impl ManagedFileRequest {
                 path: self.path.clone(),
             },
         }))
+    }
+}
+
+fn resolve_source_path(base: &Path, source: &str) -> PathBuf {
+    let source = Path::new(source);
+    if source.is_absolute() {
+        source.to_path_buf()
+    } else {
+        base.join(source)
     }
 }
 

--- a/src/system/managed_files.rs
+++ b/src/system/managed_files.rs
@@ -11,7 +11,7 @@ use path_absolutize::Absolutize;
 use serde::{Deserialize, Serialize};
 
 use crate::config::Config;
-use crate::system::resources::{ResourceAction, ResourceId, ResourcePlan};
+use crate::system::resources::{ResourceAction, ResourceId, ResourceOrigin, ResourcePlan};
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct ManagedFileTomlConfig {
@@ -63,6 +63,7 @@ pub struct ManagedFileRequest {
     pub state: ManagedState,
     pub replace: bool,
     pub notify: Vec<String>,
+    pub origin: ResourceOrigin,
     inspection: Option<PathInspection>,
 }
 
@@ -76,6 +77,7 @@ pub struct ManagedDirectoryRequest {
     pub recursive: bool,
     pub replace: bool,
     pub notify: Vec<String>,
+    pub origin: ResourceOrigin,
     inspection: Option<PathInspection>,
 }
 
@@ -200,9 +202,16 @@ pub fn status_requests_from_config(
         .iter()
         .map(|directory| (directory.path.as_path(), directory.state))
         .collect::<std::collections::HashMap<_, _>>();
-    for (path, (file, base)) in merged_files_from_config(config)? {
+    for (path, (file, base, origin)) in merged_files_from_config(config)? {
         let state = file.state;
-        match ManagedFileRequest::from_toml(config, path.clone(), file, &base, secrets) {
+        match ManagedFileRequest::from_toml(
+            config,
+            path.clone(),
+            file,
+            &base,
+            origin.clone(),
+            secrets,
+        ) {
             Ok(file) => files.push(file),
             Err(error) if super::secrets::is_unavailable(&error) => {
                 if directory_states.contains_key(path.as_path()) {
@@ -212,12 +221,15 @@ pub fn status_requests_from_config(
                     );
                 }
                 validate_present_ancestors(&path, state, &directory_states)?;
-                unavailable.push(ResourcePlan::new(
-                    ResourceId::new("file", path.to_string_lossy().into_owned()),
-                    "not inspected: required secret unavailable",
-                    "template rendered",
-                    ResourceAction::Unknown,
-                ));
+                unavailable.push(
+                    ResourcePlan::new(
+                        ResourceId::new("file", path.to_string_lossy().into_owned()),
+                        "not inspected: required secret unavailable",
+                        "template rendered",
+                        ResourceAction::Unknown,
+                    )
+                    .with_origin(origin),
+                );
             }
             Err(error) => return Err(error),
         }
@@ -322,16 +334,17 @@ fn files_from_config(
 ) -> Result<Vec<ManagedFileRequest>> {
     merged_files_from_config(config)?
         .into_iter()
-        .map(|(path, (file, base))| {
-            ManagedFileRequest::from_toml(config, path, file, &base, secrets)
+        .map(|(path, (file, base, origin))| {
+            ManagedFileRequest::from_toml(config, path, file, &base, origin, secrets)
         })
         .collect()
 }
 
 fn merged_files_from_config(
     config: &Config,
-) -> Result<IndexMap<PathBuf, (ManagedFileTomlConfig, PathBuf)>> {
-    let mut merged: IndexMap<PathBuf, (ManagedFileTomlConfig, PathBuf)> = IndexMap::new();
+) -> Result<IndexMap<PathBuf, (ManagedFileTomlConfig, PathBuf, ResourceOrigin)>> {
+    let mut merged: IndexMap<PathBuf, (ManagedFileTomlConfig, PathBuf, ResourceOrigin)> =
+        IndexMap::new();
     // Config files are ordered from highest to lowest precedence. Preserve the
     // first declaration of a target so a parent or global layer cannot replace
     // the nearer project declaration.
@@ -343,6 +356,12 @@ fn merged_files_from_config(
                 .parent()
                 .unwrap_or_else(|| Path::new("."))
                 .to_path_buf();
+            let origin = ResourceOrigin {
+                config: cf.get_path().to_path_buf(),
+                config_root: cf.config_root(),
+                environment: crate::config::environments_for_config_path(cf.get_path()),
+                source: None,
+            };
             for (path, file) in bootstrap.files {
                 let target = absolute_target(&path)?;
                 if let Some(previous) = layer_paths.insert(target.clone(), path.clone()) {
@@ -351,7 +370,9 @@ fn merged_files_from_config(
                         target.display()
                     );
                 }
-                merged.entry(target).or_insert_with(|| (file, base.clone()));
+                merged
+                    .entry(target)
+                    .or_insert_with(|| (file, base.clone(), origin.clone()));
             }
         }
     }
@@ -359,9 +380,16 @@ fn merged_files_from_config(
 }
 
 fn directories_from_config(config: &Config) -> Result<Vec<ManagedDirectoryRequest>> {
-    let mut merged: IndexMap<PathBuf, ManagedDirectoryTomlConfig> = IndexMap::new();
+    let mut merged: IndexMap<PathBuf, (ManagedDirectoryTomlConfig, ResourceOrigin)> =
+        IndexMap::new();
     for cf in config.config_files.values() {
         if let Some(bootstrap) = cf.bootstrap_config() {
+            let origin = ResourceOrigin {
+                config: cf.get_path().to_path_buf(),
+                config_root: cf.config_root(),
+                environment: crate::config::environments_for_config_path(cf.get_path()),
+                source: None,
+            };
             let mut layer_paths = IndexMap::new();
             for (path, directory) in bootstrap.directories {
                 let target = absolute_target(&path)?;
@@ -371,13 +399,15 @@ fn directories_from_config(config: &Config) -> Result<Vec<ManagedDirectoryReques
                         target.display()
                     );
                 }
-                merged.entry(target).or_insert(directory);
+                merged
+                    .entry(target)
+                    .or_insert_with(|| (directory, origin.clone()));
             }
         }
     }
     merged
         .into_iter()
-        .map(|(path, config)| ManagedDirectoryRequest::from_toml(path, config))
+        .map(|(path, (config, origin))| ManagedDirectoryRequest::from_toml(path, config, origin))
         .collect()
 }
 
@@ -432,6 +462,7 @@ impl ManagedFileRequest {
         path: PathBuf,
         config: ManagedFileTomlConfig,
         base: &Path,
+        mut origin: ResourceOrigin,
         secrets: &super::secrets::SecretValues,
     ) -> Result<Self> {
         let owner = nonempty("owner", config.owner)?;
@@ -451,6 +482,7 @@ impl ManagedFileRequest {
                 } else {
                     base.join(source)
                 };
+                origin.source = Some(source.clone());
                 Some(fs::read_to_string(&source).wrap_err_with(|| {
                     format!(
                         "[bootstrap.files].\"{}\": failed to read source {}",
@@ -492,12 +524,13 @@ impl ManagedFileRequest {
             state: config.state,
             replace: config.replace,
             notify: config.notify,
+            origin,
             inspection: None,
         })
     }
 
     pub fn plan(&self) -> Result<ResourcePlan> {
-        plan_file(self)
+        plan_file(self).map(|plan| plan.with_origin(self.origin.clone()))
     }
 
     fn operation(&self) -> Result<Option<PrivilegedAction>> {
@@ -530,7 +563,11 @@ impl ManagedFileRequest {
 }
 
 impl ManagedDirectoryRequest {
-    fn from_toml(path: PathBuf, config: ManagedDirectoryTomlConfig) -> Result<Self> {
+    fn from_toml(
+        path: PathBuf,
+        config: ManagedDirectoryTomlConfig,
+        origin: ResourceOrigin,
+    ) -> Result<Self> {
         if config.state == ManagedState::Present && config.recursive {
             bail!(
                 "[bootstrap.directories].\"{}\": recursive is only valid with state = \"absent\"",
@@ -546,12 +583,13 @@ impl ManagedDirectoryRequest {
             recursive: config.recursive,
             replace: config.replace,
             notify: config.notify,
+            origin,
             inspection: None,
         })
     }
 
     pub fn plan(&self) -> Result<ResourcePlan> {
-        plan_directory(self)
+        plan_directory(self).map(|plan| plan.with_origin(self.origin.clone()))
     }
 
     fn operation(&self) -> Result<Option<PrivilegedAction>> {
@@ -1452,6 +1490,12 @@ mod tests {
             state,
             replace: false,
             notify: vec![],
+            origin: ResourceOrigin {
+                config: PathBuf::from("/mise.toml"),
+                config_root: PathBuf::from("/"),
+                environment: vec![],
+                source: None,
+            },
             inspection: None,
         }
     }
@@ -1466,6 +1510,12 @@ mod tests {
             recursive: false,
             replace: false,
             notify: vec![],
+            origin: ResourceOrigin {
+                config: PathBuf::from("/mise.toml"),
+                config_root: PathBuf::from("/"),
+                environment: vec![],
+                source: None,
+            },
             inspection: None,
         }
     }

--- a/src/system/resources.rs
+++ b/src/system/resources.rs
@@ -33,7 +33,7 @@ pub struct ResourceOrigin {
 
 const ENCODED_PATH_PREFIX: &str = "mise:path-";
 
-fn serialize_path<S>(path: &PathBuf, serializer: S) -> Result<S::Ok, S::Error>
+fn serialize_path<S>(path: &Path, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {

--- a/src/system/resources.rs
+++ b/src/system/resources.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use eyre::{Result, bail};
 use indexmap::{IndexMap, IndexSet};
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 
 use crate::config::Config;
 use crate::system::packages::{PackageRequest, PackageState};
@@ -19,10 +19,32 @@ pub struct ResourceId {
 /// Where a declarative resource came from.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct ResourceOrigin {
+    #[serde(serialize_with = "serialize_path_lossy")]
     pub config: PathBuf,
+    #[serde(serialize_with = "serialize_path_lossy")]
     pub config_root: PathBuf,
     pub environment: Vec<String>,
+    #[serde(serialize_with = "serialize_optional_path_lossy")]
     pub source: Option<PathBuf>,
+}
+
+fn serialize_path_lossy<S>(path: &PathBuf, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&path.to_string_lossy())
+}
+
+fn serialize_optional_path_lossy<S>(
+    path: &Option<PathBuf>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    path.as_deref()
+        .map(|path| path.to_string_lossy())
+        .serialize(serializer)
 }
 
 impl ResourceId {
@@ -623,6 +645,27 @@ fn package_resource_state(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn resource_origin_serializes_non_utf8_paths_lossily() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let invalid_path = PathBuf::from(OsString::from_vec(b"/tmp/invalid-\xff".to_vec()));
+        let origin = ResourceOrigin {
+            config: invalid_path.clone(),
+            config_root: invalid_path.clone(),
+            environment: vec![],
+            source: Some(invalid_path.clone()),
+        };
+
+        let value = serde_json::to_value(origin).unwrap();
+        let expected = invalid_path.to_string_lossy();
+        assert_eq!(value["config"], expected.as_ref());
+        assert_eq!(value["config_root"], expected.as_ref());
+        assert_eq!(value["source"], expected.as_ref());
+    }
 
     fn resource(name: &str) -> ResourcePlan {
         ResourcePlan::new(

--- a/src/system/resources.rs
+++ b/src/system/resources.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, VecDeque};
 use std::fmt;
+use std::path::PathBuf;
 
 use eyre::{Result, bail};
 use indexmap::{IndexMap, IndexSet};
@@ -13,6 +14,15 @@ use crate::system::packages::{PackageRequest, PackageState};
 pub struct ResourceId {
     pub kind: String,
     pub name: String,
+}
+
+/// Where a declarative resource came from.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ResourceOrigin {
+    pub config: PathBuf,
+    pub config_root: PathBuf,
+    pub environment: Vec<String>,
+    pub source: Option<PathBuf>,
 }
 
 impl ResourceId {
@@ -60,6 +70,8 @@ pub struct ResourcePlan {
     pub current: String,
     pub desired: String,
     pub action: ResourceAction,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub origin: Option<ResourceOrigin>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub depends_on: Vec<ResourceId>,
 }
@@ -76,8 +88,14 @@ impl ResourcePlan {
             current: current.into(),
             desired: desired.into(),
             action,
+            origin: None,
             depends_on: vec![],
         }
+    }
+
+    pub fn with_origin(mut self, origin: ResourceOrigin) -> Self {
+        self.origin = Some(origin);
+        self
     }
 }
 

--- a/src/system/resources.rs
+++ b/src/system/resources.rs
@@ -1,7 +1,10 @@
+use std::borrow::Cow;
 use std::collections::{HashMap, VecDeque};
 use std::fmt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
+use base64::Engine;
+use base64::prelude::BASE64_URL_SAFE_NO_PAD;
 use eyre::{Result, bail};
 use indexmap::{IndexMap, IndexSet};
 use serde::{Serialize, Serializer};
@@ -19,32 +22,58 @@ pub struct ResourceId {
 /// Where a declarative resource came from.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct ResourceOrigin {
-    #[serde(serialize_with = "serialize_path_lossy")]
+    #[serde(serialize_with = "serialize_path")]
     pub config: PathBuf,
-    #[serde(serialize_with = "serialize_path_lossy")]
+    #[serde(serialize_with = "serialize_path")]
     pub config_root: PathBuf,
     pub environment: Vec<String>,
-    #[serde(serialize_with = "serialize_optional_path_lossy")]
+    #[serde(serialize_with = "serialize_optional_path")]
     pub source: Option<PathBuf>,
 }
 
-fn serialize_path_lossy<S>(path: &PathBuf, serializer: S) -> Result<S::Ok, S::Error>
+const ENCODED_PATH_PREFIX: &str = "mise:path-";
+
+fn serialize_path<S>(path: &PathBuf, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
-    serializer.serialize_str(&path.to_string_lossy())
+    serializer.serialize_str(&path_json_string(path))
 }
 
-fn serialize_optional_path_lossy<S>(
-    path: &Option<PathBuf>,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
+fn serialize_optional_path<S>(path: &Option<PathBuf>, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
-    path.as_deref()
-        .map(|path| path.to_string_lossy())
-        .serialize(serializer)
+    path.as_deref().map(path_json_string).serialize(serializer)
+}
+
+fn path_json_string(path: &Path) -> Cow<'_, str> {
+    if let Some(path) = path.to_str()
+        && !path.starts_with(ENCODED_PATH_PREFIX)
+    {
+        return Cow::Borrowed(path);
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+
+        let encoded = BASE64_URL_SAFE_NO_PAD.encode(path.as_os_str().as_bytes());
+        Cow::Owned(format!("{ENCODED_PATH_PREFIX}bytes:{encoded}"))
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStrExt;
+
+        let bytes = path
+            .as_os_str()
+            .encode_wide()
+            .flat_map(u16::to_le_bytes)
+            .collect::<Vec<_>>();
+        let encoded = BASE64_URL_SAFE_NO_PAD.encode(bytes);
+        Cow::Owned(format!("{ENCODED_PATH_PREFIX}utf16:{encoded}"))
+    }
 }
 
 impl ResourceId {
@@ -648,11 +677,12 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn resource_origin_serializes_non_utf8_paths_lossily() {
+    fn resource_origin_serializes_non_utf8_paths_losslessly() {
         use std::ffi::OsString;
         use std::os::unix::ffi::OsStringExt;
 
         let invalid_path = PathBuf::from(OsString::from_vec(b"/tmp/invalid-\xff".to_vec()));
+        let other_invalid_path = PathBuf::from(OsString::from_vec(b"/tmp/invalid-\xfe".to_vec()));
         let origin = ResourceOrigin {
             config: invalid_path.clone(),
             config_root: invalid_path.clone(),
@@ -661,10 +691,11 @@ mod tests {
         };
 
         let value = serde_json::to_value(origin).unwrap();
-        let expected = invalid_path.to_string_lossy();
-        assert_eq!(value["config"], expected.as_ref());
-        assert_eq!(value["config_root"], expected.as_ref());
-        assert_eq!(value["source"], expected.as_ref());
+        let encoded = value["config"].as_str().unwrap();
+        assert!(encoded.starts_with("mise:path-bytes:"));
+        assert_eq!(value["config_root"], encoded);
+        assert_eq!(value["source"], encoded);
+        assert_ne!(encoded, path_json_string(&other_invalid_path));
     }
 
     fn resource(name: &str) -> ResourcePlan {

--- a/src/system/shell_activation.rs
+++ b/src/system/shell_activation.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use crate::file;
 use crate::system::edits::{BlockSource, EditOp, EditRequest};
+use crate::system::resources::ResourceOrigin;
 
 #[derive(Debug, Clone)]
 pub struct ShellActivationRequest {
@@ -33,6 +34,12 @@ impl ShellActivationRequest {
                 },
                 base: PathBuf::from("."),
                 config_path: PathBuf::from("[bootstrap.mise_shell_activate]"),
+                origin: ResourceOrigin {
+                    config: PathBuf::from("[bootstrap.mise_shell_activate]"),
+                    config_root: PathBuf::from("."),
+                    environment: vec![],
+                    source: None,
+                },
             },
         }
     }


### PR DESCRIPTION
## Summary

- retain the declaring config, config root, active config environment, and resolved source for dotfile and managed file/directory declarations
- expose provenance in dotfile status and bootstrap plan/status JSON
- show the declaring config in human-readable dotfile status and bootstrap file/plan tables
- document the JSON contract and cover base and environment-specific declarations in e2e tests

## Why

Discussion #12099 proposes composing declarative bootstrap resources from multiple selected config roots. Composition needs declaration provenance before mise can produce deterministic cross-root conflict diagnostics or explain why a resource is active. This implements the discussion's smaller foundational step without changing the existing config hierarchy or introducing accidental precedence between sibling roots.

This PR intentionally does not collect sibling config roots. A follow-up can build a conflict-aware composition layer on top of the retained origins.

## Validation

- `cargo check --tests`
- `mise run format`
- `hk run check --safe --format json --files0-from <(git diff --name-only -z HEAD)`
- `mise run test:e2e e2e/cli/test_dotfiles_files e2e/cli/test_bootstrap_system_files`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only metadata and display changes; no change to apply precedence or convergence behavior.
> 
> **Overview**
> Adds **declaration provenance** for dotfiles, managed bootstrap files/directories, and dotfile edits so layered configs can be inspected without hand-reconstructing precedence.
> 
> A new `ResourceOrigin` (declaring config, `config_root`, environment from the config filename, optional resolved `source`) is threaded through parsing and attached to `ResourcePlan` / status payloads. **JSON** from `mise bootstrap plan`, bootstrap files status, and `mise dotfiles status` includes an `origin` object; paths that are not valid UTF-8 serialize as `mise:path-bytes:<base64url>` on Unix for lossless round-tripping. **Human tables** gain a **Config** column on bootstrap plan/files status and dotfiles status.
> 
> `environments_for_config_path` derives active `MISE_ENV` segments from config filenames (e.g. `mise.dev.toml`). Docs describe the JSON contract; e2e tests assert origins for templates, system files, and env-specific dotfiles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 560aca70b3ce50189d69a935226ef056dc1709f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bootstrap plan and status tables now show the originating configuration for each managed file or directory.
  * Dotfile status tables now display configuration origins for files and edits.
  * JSON output includes origin details such as configuration path, configuration root, environment, and resolved source file.
  * Source-backed templates now report their resolved source path.

* **Documentation**
  * Added documentation describing origin metadata in bootstrap and dotfile JSON status output.

* **Tests**
  * Added coverage for origin details across bootstrap and dotfile commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->