### PR TITLE
fix(use): scope global install hooks

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -161,8 +161,13 @@ Hooks are executed with the following environment variables set:
 
 - `MISE_ORIGINAL_CWD`: The directory that the user is in.
 - `MISE_PROJECT_ROOT`: The root directory of the project.
+- `MISE_CONFIG_ROOT`: The root directory of the config that defines the hook.
 - `MISE_PREVIOUS_DIR`: The directory that the user was in before the directory change (only if a directory change occurred).
 - `MISE_INSTALLED_TOOLS`: A JSON array of tools that were installed (only for `postinstall` hooks).
+
+Global hooks use the active project's root for `MISE_PROJECT_ROOT` and the global config root for
+`MISE_CONFIG_ROOT`. For global-only operations such as `mise use --global`, both variables use the
+global config root and project hooks do not run.
 
 Inline `run` hooks can be written as `{ run = "..." }` for any hook type. The string shorthand
 (`enter = "echo hi"`) is equivalent to `{ run = "echo hi" }`.

--- a/e2e/config/test_hooks_global
+++ b/e2e/config/test_hooks_global
@@ -12,18 +12,37 @@ enter = 'echo GLOBAL-ENTER'
 leave = 'echo GLOBAL-LEAVE'
 cd = 'echo GLOBAL-CD'
 preinstall = 'echo GLOBAL-PREINSTALL'
-postinstall = 'echo GLOBAL-POSTINSTALL'
+postinstall = 'echo GLOBAL-POSTINSTALL PROJECT_ROOT=\$MISE_PROJECT_ROOT CONFIG_ROOT=\$MISE_CONFIG_ROOT'
 EOF
 
 # Set up a project config with tools
 cat <<EOF >mise.toml
 [tools]
 dummy = 'latest'
+[hooks]
+preinstall = 'echo PROJECT-PREINSTALL'
+postinstall = 'echo PROJECT-POSTINSTALL'
 EOF
 
 # Global preinstall/postinstall hooks should fire during install
 assert_contains "mise i 2>&1" "GLOBAL-PREINSTALL"
 assert_contains "mise i dummy@1 2>&1" "GLOBAL-POSTINSTALL"
+
+# A global use from inside a project only runs global install hooks (#7183, #8795).
+# The global hook's config root remains global while its project root reflects
+# the scope of the install.
+mkdir -p subdir
+project_root="$PWD"
+output="$(cd subdir && mise use --global dummy@2 2>&1)"
+assert_contains_text "$output" "GLOBAL-POSTINSTALL PROJECT_ROOT=$HOME CONFIG_ROOT=$HOME"
+assert_not_contains_text "$output" "PROJECT-PREINSTALL"
+assert_not_contains_text "$output" "PROJECT-POSTINSTALL"
+
+# For a project install, global hooks receive the active project root while
+# retaining the global config root.
+output="$(cd subdir && mise install dummy@3 2>&1)"
+assert_contains_text "$output" "GLOBAL-POSTINSTALL PROJECT_ROOT=$project_root CONFIG_ROOT=$HOME"
+assert_contains_text "$output" "PROJECT-POSTINSTALL"
 
 # Initialize hook-env session
 eval "$(mise hook-env)"
@@ -39,7 +58,6 @@ assert_contains "mise hook-env 2>&1" "GLOBAL-CD"
 eval "$(mise hook-env)"
 
 # cd within workdir should still trigger global cd hook
-mkdir -p subdir
 cd ~/workdir/subdir || exit 1
 assert_contains "mise hook-env 2>&1" "GLOBAL-CD"
 eval "$(mise hook-env)"

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -583,6 +583,7 @@ impl Install {
                     None,
                     Some(&[]),
                     self.is_dry_run(),
+                    false,
                 )
                 .await;
                 (vec![], Ok(()))

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -192,6 +192,7 @@ impl Use {
                     jobs: self.jobs,
                     raw: self.raw,
                     dry_run: self.is_dry_run(),
+                    global_hooks_only: self.global,
                     resolve_options,
                     ..Default::default()
                 },

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -84,7 +84,7 @@ pub struct Config {
     aliases: AliasMap,
     env: OnceCell<EnvResults>,
     env_with_sources: OnceCell<EnvWithSources>,
-    hooks: OnceCell<Vec<(PathBuf, Hook)>>,
+    hooks: OnceCell<Vec<(PathBuf, Option<PathBuf>, Hook)>>,
     tasks_cache: Arc<DashMap<crate::task::TaskLoadContext, Arc<BTreeMap<String, Task>>>>,
     /// Lenient graph shared across task-loading and strict inspection contexts.
     /// Provider errors remain on the graph so strict consumers can reject it.
@@ -1256,26 +1256,27 @@ impl Config {
         Ok(env_results)
     }
 
-    pub async fn hooks(&self) -> Result<&Vec<(PathBuf, Hook)>> {
+    pub async fn hooks(&self) -> Result<&Vec<(PathBuf, Option<PathBuf>, Hook)>> {
         self.hooks
             .get_or_try_init(|| async {
                 self.config_files
                     .values()
                     .map(|cf| {
-                        let is_global = cf.project_root().is_none();
-                        let root = cf.project_root().unwrap_or_else(|| cf.config_root());
+                        let project_root = cf.project_root();
+                        let is_global = project_root.is_none();
+                        let config_root = cf.config_root();
                         let mut hooks = cf.hooks()?;
                         if is_global {
                             for h in &mut hooks {
                                 h.global = true;
                             }
                         }
-                        Ok((root, hooks))
+                        Ok((config_root, project_root, hooks))
                     })
-                    .map_ok(|(root, hooks)| {
+                    .map_ok(|(config_root, project_root, hooks)| {
                         hooks
                             .into_iter()
-                            .map(|h| (root.clone(), h))
+                            .map(|h| (config_root.clone(), project_root.clone(), h))
                             .collect::<Vec<_>>()
                     })
                     .flatten_ok()

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -309,8 +309,8 @@ pub async fn run_all_hooks(config: &Arc<Config>, ts: &Toolset, shell: &dyn Shell
     }
 }
 
-async fn all_hooks(config: &Arc<Config>) -> &'static Vec<(PathBuf, Hook)> {
-    static ALL_HOOKS: OnceCell<Vec<(PathBuf, Hook)>> = OnceCell::const_new();
+async fn all_hooks(config: &Arc<Config>) -> &'static Vec<(PathBuf, Option<PathBuf>, Hook)> {
+    static ALL_HOOKS: OnceCell<Vec<(PathBuf, Option<PathBuf>, Hook)>> = OnceCell::const_new();
     ALL_HOOKS
         .get_or_init(async || {
             let mut hooks = config.hooks().await.cloned().unwrap_or_default();
@@ -321,14 +321,18 @@ async fn all_hooks(config: &Arc<Config>) -> &'static Vec<(PathBuf, Hook)> {
                 if let Ok(cf) = config_file::parse(p).await
                     && let Ok(mut h) = cf.hooks()
                 {
-                    let is_global = cf.project_root().is_none();
+                    let project_root = cf.project_root();
+                    let is_global = project_root.is_none();
                     if is_global {
                         for hook in &mut h {
                             hook.global = true;
                         }
                     }
-                    let root = cf.project_root().unwrap_or_else(|| cf.config_root());
-                    hooks.extend(h.into_iter().map(|h| (root.clone(), h)));
+                    let config_root = cf.config_root();
+                    hooks.extend(
+                        h.into_iter()
+                            .map(|h| (config_root.clone(), project_root.clone(), h)),
+                    );
                 }
             }
             hooks
@@ -344,7 +348,7 @@ pub async fn run_one_hook(
     shell: Option<&dyn Shell>,
     dry_run: bool,
 ) {
-    run_one_hook_with_context(config, ts, hook, shell, None, dry_run).await
+    run_one_hook_with_context(config, ts, hook, shell, None, dry_run, false).await
 }
 
 /// Run a hook with optional installed tools context (for postinstall hooks)
@@ -356,6 +360,7 @@ pub async fn run_one_hook_with_context(
     shell: Option<&dyn Shell>,
     installed_tools: Option<&[InstalledToolInfo]>,
     dry_run: bool,
+    global_only: bool,
 ) {
     if Settings::no_hooks() || Settings::get().no_hooks.unwrap_or(false) {
         return;
@@ -370,10 +375,14 @@ pub async fn run_one_hook_with_context(
         return;
     }
     let shell_name = shell.map(|s| s.to_string()).unwrap_or_default();
-    for (root, h) in all_hooks(config).await {
+    for (config_root, hook_project_root, h) in all_hooks(config).await {
         if hook != h.hook || !matches_shell(h, &shell_name) {
             continue;
         }
+        if global_only && !h.global {
+            continue;
+        }
+        let root = hook_project_root.as_ref().unwrap_or(config_root);
         trace!("processing hook {hook} in {root:?}");
         // Global hooks skip directory matching — they fire for all projects
         if !h.global {
@@ -408,7 +417,24 @@ pub async fn run_one_hook_with_context(
                 _ => {}
             }
         }
-        run_matched_hook(config, ts, root, h, shell, installed_tools, dry_run).await;
+        let project_root = if h.global && !global_only {
+            config.project_root.as_deref().unwrap_or(config_root)
+        } else {
+            root
+        };
+        run_matched_hook(
+            config,
+            ts,
+            HookRoots {
+                config: config_root,
+                project: project_root,
+            },
+            h,
+            shell,
+            installed_tools,
+            dry_run,
+        )
+        .await;
     }
 }
 
@@ -437,35 +463,54 @@ pub async fn run_enter_hooks_for_newly_loaded_configs(
         return;
     }
     let shell_name = shell.to_string();
-    for (root, h) in config.hooks().await.cloned().unwrap_or_default() {
-        if h.hook != Hooks::Enter || h.global || !cwd.starts_with(&root) {
+    for (config_root, project_root, h) in config.hooks().await.cloned().unwrap_or_default() {
+        let root = project_root.as_ref().unwrap_or(&config_root);
+        if h.hook != Hooks::Enter || h.global || !cwd.starts_with(root) {
             continue;
         }
         if !matches_shell(&h, &shell_name) {
             continue;
         }
-        if !newly_loaded_roots.contains(&root) {
+        if !newly_loaded_roots.contains(root.as_path()) {
             continue;
         }
-        run_matched_hook(config, ts, &root, &h, Some(shell), None, false).await;
+        run_matched_hook(
+            config,
+            ts,
+            HookRoots {
+                config: &config_root,
+                project: root,
+            },
+            &h,
+            Some(shell),
+            None,
+            false,
+        )
+        .await;
     }
+}
+
+#[derive(Clone, Copy)]
+struct HookRoots<'a> {
+    config: &'a Path,
+    project: &'a Path,
 }
 
 async fn run_matched_hook(
     config: &Arc<Config>,
     ts: &Toolset,
-    root: &Path,
+    roots: HookRoots<'_>,
     hook: &Hook,
     shell: Option<&dyn Shell>,
     installed_tools: Option<&[InstalledToolInfo]>,
     dry_run: bool,
 ) {
     if dry_run {
-        if let Err(e) = preview_matched_hook(root, hook) {
+        if let Err(e) = preview_matched_hook(roots.project, hook) {
             warn!(
                 "failed to preview {} hook in {}: {e}",
                 hook.hook,
-                root.display()
+                roots.project.display()
             );
         }
         return;
@@ -473,8 +518,21 @@ async fn run_matched_hook(
     let hook_type = hook.hook;
     match &hook.action {
         HookAction::Task { task_name } => {
-            if let Err(e) = execute_task(config, ts, root, hook, task_name, installed_tools).await {
-                warn!("{hook_type} hook in {} failed: {e}", root.display());
+            if let Err(e) = execute_task(
+                config,
+                ts,
+                roots.config,
+                roots.project,
+                hook,
+                task_name,
+                installed_tools,
+            )
+            .await
+            {
+                warn!(
+                    "{hook_type} hook in {} failed: {e}",
+                    roots.project.display()
+                );
             }
         }
         HookAction::CurrentShell { script, .. } => {
@@ -482,11 +540,11 @@ async fn run_matched_hook(
                 // Set hook environment variables so shell hooks can access them
                 println!(
                     "{}",
-                    shell.set_env("MISE_PROJECT_ROOT", &root.to_string_lossy())
+                    shell.set_env("MISE_PROJECT_ROOT", &roots.project.to_string_lossy())
                 );
                 println!(
                     "{}",
-                    shell.set_env("MISE_CONFIG_ROOT", &root.to_string_lossy())
+                    shell.set_env("MISE_CONFIG_ROOT", &roots.config.to_string_lossy())
                 );
                 if let Some(cwd) = dirs::CWD.as_ref() {
                     println!(
@@ -509,9 +567,21 @@ async fn run_matched_hook(
             println!("{script}");
         }
         HookAction::Run { .. } => {
-            if let Err(e) = execute(config, ts, root, hook, installed_tools).await {
+            if let Err(e) = execute(
+                config,
+                ts,
+                roots.config,
+                roots.project,
+                hook,
+                installed_tools,
+            )
+            .await
+            {
                 // Warn but continue running remaining hooks of this type
-                warn!("{hook_type} hook in {} failed: {e}", root.display());
+                warn!(
+                    "{hook_type} hook in {} failed: {e}",
+                    roots.project.display()
+                );
             }
         }
     }
@@ -561,7 +631,8 @@ fn matches_shell(hook: &Hook, shell_name: &str) -> bool {
 async fn execute(
     config: &Arc<Config>,
     ts: &Toolset,
-    root: &Path,
+    config_root: &Path,
+    project_root: &Path,
     hook: &Hook,
     installed_tools: Option<&[InstalledToolInfo]>,
 ) -> Result<()> {
@@ -621,7 +692,7 @@ async fn execute(
         (ctx, env)
     };
     let rendered_script = if let Some(tera_ctx) = tera_ctx {
-        let mut tera = get_tera(Some(root));
+        let mut tera = get_tera(Some(project_root));
         render_str(&mut tera, run, &tera_ctx)?
     } else {
         run.to_string()
@@ -641,7 +712,7 @@ async fn execute(
     }
     env.insert(
         "MISE_PROJECT_ROOT".to_string(),
-        root.to_string_lossy().to_string(),
+        project_root.to_string_lossy().to_string(),
     );
     if let Some((Some(old), _new)) = hook_env::dir_change() {
         env.insert(
@@ -657,7 +728,7 @@ async fn execute(
     }
     env.insert(
         "MISE_CONFIG_ROOT".to_string(),
-        root.to_string_lossy().to_string(),
+        config_root.to_string_lossy().to_string(),
     );
     // Prevent recursive hook execution (e.g. hook runs `mise run` which spawns
     // a shell that activates mise and re-triggers hooks)
@@ -689,7 +760,7 @@ async fn execute(
             c.env_clear();
             c.envs(env.iter());
             if matches!(hook.hook, Hooks::Preinstall | Hooks::Postinstall) {
-                c.current_dir(root);
+                c.current_dir(project_root);
             }
             // Send the hook's stdout to mise's stderr (matching the duct
             // `stdout_to_stderr()` the non-cmd path uses) by handing the child a
@@ -708,7 +779,7 @@ async fn execute(
 
     let command = cmd(&shell[0], args).stdout_to_stderr().full_env(env);
     let command = if matches!(hook.hook, Hooks::Preinstall | Hooks::Postinstall) {
-        command.dir(root)
+        command.dir(project_root)
     } else {
         command
     };
@@ -719,7 +790,8 @@ async fn execute(
 async fn execute_task(
     config: &Arc<Config>,
     ts: &Toolset,
-    root: &Path,
+    config_root: &Path,
+    project_root: &Path,
     hook: &Hook,
     task_name: &str,
     installed_tools: Option<&[InstalledToolInfo]>,
@@ -739,11 +811,11 @@ async fn execute_task(
     }
     env.insert(
         "MISE_PROJECT_ROOT".to_string(),
-        root.to_string_lossy().to_string(),
+        project_root.to_string_lossy().to_string(),
     );
     env.insert(
         "MISE_CONFIG_ROOT".to_string(),
-        root.to_string_lossy().to_string(),
+        config_root.to_string_lossy().to_string(),
     );
     if let Some((Some(old), _new)) = hook_env::dir_change() {
         env.insert(
@@ -758,7 +830,7 @@ async fn execute_task(
     }
     env.insert("MISE_NO_HOOKS".to_string(), "1".to_string());
 
-    cmd(mise_bin, task_hook_args(root, hook.hook, task_name))
+    cmd(mise_bin, task_hook_args(project_root, hook.hook, task_name))
         .stdout_to_stderr()
         .full_env(env)
         .run()?;

--- a/src/toolset/install_options.rs
+++ b/src/toolset/install_options.rs
@@ -16,6 +16,8 @@ pub struct InstallOptions {
     pub auto_install_disable_tools: Option<Vec<String>>,
     pub resolve_options: ResolveOptions,
     pub dry_run: bool,
+    /// Only run hooks defined in global config files.
+    pub global_hooks_only: bool,
     /// require lockfile URLs to be present; fail if not
     pub locked: bool,
     /// Override the install directory (e.g. for --system or --shared)
@@ -37,6 +39,7 @@ impl Default for InstallOptions {
             auto_install_disable_tools: Settings::get().auto_install_disable_tools.clone(),
             resolve_options: Default::default(),
             dry_run: false,
+            global_hooks_only: false,
             locked: Settings::get().locked,
             install_dir: None,
             yes: Settings::get().yes,

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -181,7 +181,16 @@ impl Toolset {
         };
         mpr.init_footer(opts.dry_run, &footer_reason, versions.len());
 
-        hooks::run_one_hook(config, self, Hooks::Preinstall, None, opts.dry_run).await;
+        hooks::run_one_hook_with_context(
+            config,
+            self,
+            Hooks::Preinstall,
+            None,
+            None,
+            opts.dry_run,
+            opts.global_hooks_only,
+        )
+        .await;
 
         show_python_install_hint(&versions);
 
@@ -286,6 +295,7 @@ impl Toolset {
                 None,
                 None,
                 opts.dry_run,
+                opts.global_hooks_only,
             )
             .await;
         } else {
@@ -302,6 +312,7 @@ impl Toolset {
                 None,
                 Some(&installed_tools),
                 opts.dry_run,
+                opts.global_hooks_only,
             )
             .await;
         }


### PR DESCRIPTION
## Summary
- run only global install hooks for `mise use --global`
- keep `MISE_PROJECT_ROOT` distinct from the hook-owning `MISE_CONFIG_ROOT`
- document the root semantics and add regression coverage

## Root cause
`mise use --global` scoped tool resolution to global config, but install hook selection still walked every loaded config and filtered project hooks only by the current working directory. Hook metadata also collapsed the active project root and config root into one path.

This fixes the behavior reported in https://github.com/jdx/mise/discussions/8795#discussioncomment-18053609 and completes the intent of #8058 / discussion #7183.

## Validation
- `mise run test:e2e e2e/config/test_hooks_global`
- adjacent hook E2E suite covering shell, task-backed, environment, and error-handling hooks
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise run lint-fix`
- changed-file `hk run check --safe --format json`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install-hook selection and env vars hooks may rely on; behavior is intentional but could surprise users depending on old collapsed-root semantics.
> 
> **Overview**
> **`mise use --global`** now runs only **global** `preinstall`/`postinstall` hooks, so project hooks no longer fire when updating the global config from inside a project.
> 
> Hook metadata tracks **config root** and **project root** separately. **`MISE_CONFIG_ROOT`** is the directory of the config that defines the hook; **`MISE_PROJECT_ROOT`** reflects the active project (or the global config root for global-only installs). Global hooks on normal project installs still run, but get the active project as `MISE_PROJECT_ROOT` while `MISE_CONFIG_ROOT` stays on the global config.
> 
> Docs and **`e2e/config/test_hooks_global`** cover these semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63890eeb83f96c94cc9640112fd442d43585a686. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->