### PR TITLE
perf(cache): batch remote blob prefetch

### DIFF
--- a/crates/mise-cache-core/src/agent.rs
+++ b/crates/mise-cache-core/src/agent.rs
@@ -266,6 +266,22 @@ fn queue_prefetch_digest(
     pending.insert(digest, ());
 }
 
+fn queue_prefetch_directory(
+    seen: &BTreeMap<CacheDigest, ()>,
+    pending: &mut BTreeMap<CacheDigest, ()>,
+    digest: CacheDigest,
+    limit: usize,
+) -> bool {
+    if seen.contains_key(&digest) || pending.contains_key(&digest) {
+        return true;
+    }
+    if seen.len().saturating_add(pending.len()) >= limit {
+        return false;
+    }
+    pending.insert(digest, ());
+    true
+}
+
 /// Shared state for an agent hosted by the top-level `mise run` process.
 ///
 /// Transport listeners deliberately live in mise so the task-run lifecycle owns
@@ -895,6 +911,7 @@ impl CacheAgent {
             let mut following = BTreeMap::new();
             let mut directory_limit_exceeded = false;
             for digest in pending_directories.into_keys() {
+                following.remove(&digest);
                 if seen_directories.insert(digest.clone(), ()).is_some() {
                     continue;
                 }
@@ -917,11 +934,12 @@ impl CacheAgent {
                             }
                         }
                         for child in &directory.directories {
-                            if !seen_directories.contains_key(&child.digest)
-                                && !following.contains_key(&child.digest)
-                                && seen_directories.len().saturating_add(following.len())
-                                    >= MAX_PREFETCH_DIRECTORY_OBJECTS
-                            {
+                            if !queue_prefetch_directory(
+                                &seen_directories,
+                                &mut following,
+                                child.digest.clone(),
+                                MAX_PREFETCH_DIRECTORY_OBJECTS,
+                            ) {
                                 warn!("remote action output tree is too large to prefetch");
                                 directory_limit_exceeded = true;
                                 break;
@@ -931,7 +949,6 @@ impl CacheAgent {
                                 self.flush_prefetch_digest_batch(remote, &mut verified, &mut next)
                                     .await;
                             }
-                            following.insert(child.digest.clone(), ());
                         }
                         parsed_directories.insert(digest, directory);
                     }
@@ -1811,6 +1828,29 @@ mod tests {
     use super::*;
     use crate::ACTION_RESULT_MEDIA_TYPE;
     use std::time::Duration;
+
+    #[test]
+    fn directory_queue_counts_only_unique_unseen_nodes() {
+        let shared = CacheDigest::blake3(b"shared");
+        let first = CacheDigest::blake3(b"first");
+        let second = CacheDigest::blake3(b"second");
+        let overflow = CacheDigest::blake3(b"overflow");
+        let seen = BTreeMap::from([(shared.clone(), ())]);
+        let mut pending = BTreeMap::new();
+
+        assert!(queue_prefetch_directory(&seen, &mut pending, shared, 3));
+        assert!(pending.is_empty());
+        assert!(queue_prefetch_directory(
+            &seen,
+            &mut pending,
+            first.clone(),
+            3
+        ));
+        assert!(queue_prefetch_directory(&seen, &mut pending, first, 3));
+        assert!(queue_prefetch_directory(&seen, &mut pending, second, 3));
+        assert!(!queue_prefetch_directory(&seen, &mut pending, overflow, 3));
+        assert_eq!(pending.len(), 2);
+    }
 
     async fn handshake(stream: &mut (impl AsyncRead + AsyncWrite + Unpin), version: &str) {
         let request = AgentRequest::Hello {

--- a/crates/mise-cache-core/src/agent.rs
+++ b/crates/mise-cache-core/src/agent.rs
@@ -259,15 +259,11 @@ fn queue_prefetch_digest(
     verified: &BTreeMap<CacheDigest, PathBuf>,
     pending: &mut BTreeMap<CacheDigest, ()>,
     digest: CacheDigest,
-) -> bool {
+) {
     if verified.contains_key(&digest) || pending.contains_key(&digest) {
-        return true;
-    }
-    if verified.len().saturating_add(pending.len()) >= MAX_PREFETCH_OBJECTS_PER_WAVE {
-        return false;
+        return;
     }
     pending.insert(digest, ());
-    true
 }
 
 /// Shared state for an agent hosted by the top-level `mise run` process.
@@ -879,11 +875,8 @@ impl CacheAgent {
                     .and_then(|path| Self::parse_rustc_metadata(path))
                 {
                     Ok(metadata) => {
-                        if !queue_prefetch_digest(&verified, &mut next, metadata.stdout.clone())
-                            || !queue_prefetch_digest(&verified, &mut next, metadata.stderr.clone())
-                        {
-                            warn!("remote action prefetch wave contains too many objects");
-                        }
+                        queue_prefetch_digest(&verified, &mut next, metadata.stdout.clone());
+                        queue_prefetch_digest(&verified, &mut next, metadata.stderr.clone());
                         rustc_metadata.insert(metadata_digest.clone(), metadata);
                     }
                     Err(error) => warn!(
@@ -900,6 +893,7 @@ impl CacheAgent {
         let mut seen_directories = BTreeMap::new();
         loop {
             let mut following = BTreeMap::new();
+            let mut directory_limit_exceeded = false;
             for digest in pending_directories.into_keys() {
                 if seen_directories.insert(digest.clone(), ()).is_some() {
                     continue;
@@ -916,15 +910,26 @@ impl CacheAgent {
                 {
                     Ok(directory) => {
                         for file in &directory.files {
-                            if !queue_prefetch_digest(&verified, &mut next, file.digest.clone()) {
-                                warn!("remote action prefetch wave contains too many objects");
-                                break;
+                            queue_prefetch_digest(&verified, &mut next, file.digest.clone());
+                            if next.len() >= MAX_PREFETCH_OBJECTS_PER_WAVE {
+                                self.flush_prefetch_digest_batch(remote, &mut verified, &mut next)
+                                    .await;
                             }
                         }
                         for child in &directory.directories {
-                            if !queue_prefetch_digest(&verified, &mut next, child.digest.clone()) {
-                                warn!("remote action prefetch wave contains too many objects");
+                            if !seen_directories.contains_key(&child.digest)
+                                && !following.contains_key(&child.digest)
+                                && seen_directories.len().saturating_add(following.len())
+                                    >= MAX_PREFETCH_DIRECTORY_OBJECTS
+                            {
+                                warn!("remote action output tree is too large to prefetch");
+                                directory_limit_exceeded = true;
                                 break;
+                            }
+                            queue_prefetch_digest(&verified, &mut next, child.digest.clone());
+                            if next.len() >= MAX_PREFETCH_OBJECTS_PER_WAVE {
+                                self.flush_prefetch_digest_batch(remote, &mut verified, &mut next)
+                                    .await;
                             }
                             following.insert(child.digest.clone(), ());
                         }
@@ -935,15 +940,13 @@ impl CacheAgent {
                         digest.hash
                     ),
                 }
+                if directory_limit_exceeded {
+                    following.clear();
+                    break;
+                }
             }
-            if next.is_empty() {
-                break;
-            }
-            verified.extend(
-                self.prefetch_remote_blobs(remote, next.into_keys().collect())
-                    .await,
-            );
-            next = BTreeMap::new();
+            self.flush_prefetch_digest_batch(remote, &mut verified, &mut next)
+                .await;
             if following.is_empty() {
                 break;
             }
@@ -979,6 +982,19 @@ impl CacheAgent {
                 ),
             }
         }
+    }
+
+    async fn flush_prefetch_digest_batch(
+        &self,
+        remote: &RemoteCacheClient,
+        verified: &mut BTreeMap<CacheDigest, PathBuf>,
+        pending: &mut BTreeMap<CacheDigest, ()>,
+    ) {
+        if pending.is_empty() {
+            return;
+        }
+        let digests = std::mem::take(pending).into_keys().collect();
+        verified.extend(self.prefetch_remote_blobs(remote, digests).await);
     }
 
     async fn prefetch_remote_blobs(

--- a/crates/mise-cache-core/src/agent.rs
+++ b/crates/mise-cache-core/src/agent.rs
@@ -4,7 +4,7 @@ use crate::{
     canonical_json,
 };
 use eyre::{Result, bail};
-use futures_util::{StreamExt, stream};
+use futures_util::{FutureExt, StreamExt, future::BoxFuture, stream};
 use log::warn;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -852,7 +852,11 @@ impl CacheAgent {
         Ok(Some(PrefetchedAction { adapter, result }))
     }
 
-    async fn prefetch_resolved_actions(&self, actions: Vec<PrefetchedAction>) {
+    fn prefetch_resolved_actions(&self, actions: Vec<PrefetchedAction>) -> BoxFuture<'_, ()> {
+        self.prefetch_resolved_actions_inner(actions).boxed()
+    }
+
+    async fn prefetch_resolved_actions_inner(&self, actions: Vec<PrefetchedAction>) {
         let Some(remote) = self.remote.as_deref() else {
             return;
         };

--- a/crates/mise-cache-core/src/agent.rs
+++ b/crates/mise-cache-core/src/agent.rs
@@ -12,7 +12,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, Weak};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
 
 const MAX_EXECUTABLE_IDENTITIES: usize = 64;
@@ -23,7 +23,10 @@ const MAX_TASK_ACTION_PREDICTIONS: usize = 16 * 1024;
 const MAX_ACTION_PREDICTION_PAYLOAD: usize = 256 * 1024;
 const MAX_REMOTE_TRANSFERS: usize = 64;
 const MAX_PREFETCH_TRANSFERS: usize = 48;
+const MAX_PREFETCH_ACTION_BATCH: usize = 256;
+const PREFETCH_ACTION_BATCH_DELAY: Duration = Duration::from_millis(5);
 const MAX_PREFETCH_DIRECTORY_OBJECTS: usize = 100_000;
+const MAX_PREFETCH_OBJECTS_PER_WAVE: usize = 100_000;
 
 /// Remote action-cache access owned by one task session.
 pub struct AgentRemoteCache {
@@ -250,6 +253,21 @@ fn atomic_saturating_add(target: &AtomicU64, value: u64) {
     let _ = target.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
         Some(current.saturating_add(value))
     });
+}
+
+fn queue_prefetch_digest(
+    verified: &BTreeMap<CacheDigest, PathBuf>,
+    pending: &mut BTreeMap<CacheDigest, ()>,
+    digest: CacheDigest,
+) -> bool {
+    if verified.contains_key(&digest) || pending.contains_key(&digest) {
+        return true;
+    }
+    if verified.len().saturating_add(pending.len()) >= MAX_PREFETCH_OBJECTS_PER_WAVE {
+        return false;
+    }
+    pending.insert(digest, ());
+    true
 }
 
 /// Shared state for an agent hosted by the top-level `mise run` process.
@@ -736,7 +754,22 @@ impl CacheAgent {
             tasks.spawn(async move { agent.resolve_prefetch_action(action, adapter).await });
         }
         let mut resolved = Vec::new();
-        while let Some(result) = tasks.join_next().await {
+        while !tasks.is_empty() {
+            let result = if resolved.is_empty() {
+                tasks.join_next().await
+            } else {
+                match tokio::time::timeout(PREFETCH_ACTION_BATCH_DELAY, tasks.join_next()).await {
+                    Ok(result) => result,
+                    Err(_) => {
+                        self.prefetch_resolved_actions(std::mem::take(&mut resolved))
+                            .await;
+                        continue;
+                    }
+                }
+            };
+            let Some(result) = result else {
+                break;
+            };
             match result {
                 Ok(Ok(Some(action))) => resolved.push(action),
                 Ok(Ok(None)) => {}
@@ -747,8 +780,14 @@ impl CacheAgent {
                 let agent = self.clone();
                 tasks.spawn(async move { agent.resolve_prefetch_action(action, adapter).await });
             }
+            if resolved.len() == MAX_PREFETCH_ACTION_BATCH {
+                self.prefetch_resolved_actions(std::mem::take(&mut resolved))
+                    .await;
+            }
         }
-        self.prefetch_resolved_actions(resolved).await;
+        if !resolved.is_empty() {
+            self.prefetch_resolved_actions(resolved).await;
+        }
     }
 
     #[cfg(test)]
@@ -822,19 +861,30 @@ impl CacheAgent {
                 top_level.insert(digest.clone(), ());
             }
         }
-        self.prefetch_remote_blobs(remote, top_level.into_keys().collect())
+        let mut verified = self
+            .prefetch_remote_blobs(remote, top_level.into_keys().collect())
             .await;
 
         let mut next = BTreeMap::new();
-        let mut directories = BTreeMap::new();
+        let mut pending_directories = BTreeMap::new();
+        let mut parsed_directories = BTreeMap::new();
+        let mut rustc_metadata = BTreeMap::new();
         for action in &actions {
             if action.adapter == "rustc"
-                && let Some(metadata) = &action.result.metadata
+                && let Some(metadata_digest) = &action.result.metadata
             {
-                match self.load_rustc_metadata(metadata) {
+                match verified
+                    .get(metadata_digest)
+                    .ok_or_else(|| eyre::eyre!("remote rustc action metadata is missing"))
+                    .and_then(|path| Self::parse_rustc_metadata(path))
+                {
                     Ok(metadata) => {
-                        next.insert(metadata.stdout, ());
-                        next.insert(metadata.stderr, ());
+                        if !queue_prefetch_digest(&verified, &mut next, metadata.stdout.clone())
+                            || !queue_prefetch_digest(&verified, &mut next, metadata.stderr.clone())
+                        {
+                            warn!("remote action prefetch wave contains too many objects");
+                        }
+                        rustc_metadata.insert(metadata_digest.clone(), metadata);
                     }
                     Err(error) => warn!(
                         "remote rustc action metadata prefetch failed for {}: {error}",
@@ -843,14 +893,14 @@ impl CacheAgent {
                 }
             }
             if let Some(output_root) = &action.result.output_root {
-                directories.insert(output_root.clone(), ());
+                pending_directories.insert(output_root.clone(), ());
             }
         }
 
         let mut seen_directories = BTreeMap::new();
         loop {
             let mut following = BTreeMap::new();
-            for digest in directories.into_keys() {
+            for digest in pending_directories.into_keys() {
                 if seen_directories.insert(digest.clone(), ()).is_some() {
                     continue;
                 }
@@ -859,15 +909,26 @@ impl CacheAgent {
                     following.clear();
                     break;
                 }
-                match self.load_cache_directory(&digest) {
+                match verified
+                    .get(&digest)
+                    .ok_or_else(|| eyre::eyre!("remote action output directory is missing"))
+                    .and_then(|path| Self::parse_cache_directory(path))
+                {
                     Ok(directory) => {
-                        for file in directory.files {
-                            next.insert(file.digest, ());
+                        for file in &directory.files {
+                            if !queue_prefetch_digest(&verified, &mut next, file.digest.clone()) {
+                                warn!("remote action prefetch wave contains too many objects");
+                                break;
+                            }
                         }
-                        for directory in directory.directories {
-                            next.insert(directory.digest.clone(), ());
-                            following.insert(directory.digest, ());
+                        for child in &directory.directories {
+                            if !queue_prefetch_digest(&verified, &mut next, child.digest.clone()) {
+                                warn!("remote action prefetch wave contains too many objects");
+                                break;
+                            }
+                            following.insert(child.digest.clone(), ());
                         }
+                        parsed_directories.insert(digest, directory);
                     }
                     Err(error) => warn!(
                         "remote action output directory prefetch failed for {}: {error}",
@@ -878,17 +939,24 @@ impl CacheAgent {
             if next.is_empty() {
                 break;
             }
-            self.prefetch_remote_blobs(remote, next.into_keys().collect())
-                .await;
+            verified.extend(
+                self.prefetch_remote_blobs(remote, next.into_keys().collect())
+                    .await,
+            );
             next = BTreeMap::new();
             if following.is_empty() {
                 break;
             }
-            directories = following;
+            pending_directories = following;
         }
 
         for action in actions {
-            match self.validate_prefetched_action(&action) {
+            match Self::validate_prefetched_action(
+                &action,
+                &verified,
+                &rustc_metadata,
+                &parsed_directories,
+            ) {
                 Ok(()) => {
                     if let Err(error) = self.actions.store(&action.result) {
                         warn!(
@@ -913,11 +981,18 @@ impl CacheAgent {
         }
     }
 
-    async fn prefetch_remote_blobs(&self, remote: &RemoteCacheClient, digests: Vec<CacheDigest>) {
+    async fn prefetch_remote_blobs(
+        &self,
+        remote: &RemoteCacheClient,
+        digests: Vec<CacheDigest>,
+    ) -> BTreeMap<CacheDigest, PathBuf> {
+        let mut verified = BTreeMap::new();
         let mut missing = BTreeMap::new();
         for digest in digests {
             match self.find_verified_blob(&digest) {
-                Ok(Some(_)) => {}
+                Ok(Some(path)) => {
+                    verified.insert(digest, path);
+                }
                 Ok(None) => {
                     missing.insert(digest, ());
                 }
@@ -928,86 +1003,119 @@ impl CacheAgent {
             }
         }
         if missing.is_empty() {
-            return;
+            return verified;
         }
 
-        let requested = missing.keys().cloned().collect::<Vec<_>>();
-        let transfer_started = Instant::now();
-        match remote
-            .get_blob_pack(&requested, self.remote_staging_dir.as_path())
-            .await
-        {
-            Ok(Some(pack)) => {
-                atomic_saturating_add(
-                    &self.stats.remote_blob_transfer_duration_ns,
-                    duration_ns(transfer_started),
-                );
-                atomic_saturating_add(&self.stats.remote_blob_pack_requests, pack.requests);
-                atomic_saturating_add(
-                    &self.stats.remote_blob_pack_blobs,
-                    pack.blobs.len().try_into().unwrap_or(u64::MAX),
-                );
-                for (digest, source) in pack.blobs {
-                    atomic_saturating_add(&self.stats.downloaded_bytes, digest.size);
-                    let lock = self.write_lock(&digest);
-                    let _guard = lock.lock().await;
-                    match self.find_verified_blob(&digest) {
-                        Ok(Some(_)) => {
-                            missing.remove(&digest);
-                        }
-                        Ok(None) => {
-                            let cas_started = Instant::now();
-                            let stored = self.cas.store_verified_file(&digest, &source);
-                            atomic_saturating_add(
-                                &self.stats.local_cas_write_duration_ns,
-                                duration_ns(cas_started),
-                            );
-                            match stored {
-                                Ok(path) => {
-                                    self.remember_verified_blob(&digest, &path);
-                                    self.stats.stores.fetch_add(1, Ordering::Relaxed);
-                                    atomic_saturating_add(&self.stats.stored_bytes, digest.size);
-                                    missing.remove(&digest);
-                                }
-                                Err(error) => warn!(
-                                    "remote cache packed blob ingest failed for {}: {error}",
-                                    digest.hash
-                                ),
-                            }
-                        }
-                        Err(error) => warn!(
-                            "local cache blob lookup failed for {}: {error}",
-                            digest.hash
-                        ),
+        let mut pack_candidates = missing.clone();
+        while !pack_candidates.is_empty() {
+            let requested = pack_candidates.keys().cloned().collect::<Vec<_>>();
+            let transfer_started = Instant::now();
+            let pack = match remote
+                .get_blob_pack(&requested, self.remote_staging_dir.as_path())
+                .await
+            {
+                Ok(Some(pack)) => pack,
+                Ok(None) => break,
+                Err(error) => {
+                    atomic_saturating_add(
+                        &self.stats.remote_blob_transfer_duration_ns,
+                        duration_ns(transfer_started),
+                    );
+                    warn!(
+                        "remote cache blob pack failed; falling back to individual blobs: {error}"
+                    );
+                    break;
+                }
+            };
+            atomic_saturating_add(
+                &self.stats.remote_blob_transfer_duration_ns,
+                duration_ns(transfer_started),
+            );
+            atomic_saturating_add(&self.stats.remote_blob_pack_requests, pack.requests);
+            atomic_saturating_add(
+                &self.stats.remote_blob_pack_blobs,
+                pack.blobs.len().try_into().unwrap_or(u64::MAX),
+            );
+            if pack.requested.is_empty() {
+                break;
+            }
+            for digest in &pack.requested {
+                pack_candidates.remove(digest);
+            }
+            let mut ingests = stream::iter(pack.blobs.into_iter().map(|(digest, source)| {
+                let digest_for_result = digest.clone();
+                async move {
+                    (
+                        digest_for_result,
+                        self.ingest_packed_blob(digest, source).await,
+                    )
+                }
+            }))
+            .buffer_unordered(MAX_PREFETCH_TRANSFERS);
+            while let Some((digest, result)) = ingests.next().await {
+                match result {
+                    Ok(path) => {
+                        missing.remove(&digest);
+                        verified.insert(digest, path);
                     }
+                    Err(error) => warn!(
+                        "remote cache packed blob ingest failed for {}: {error}",
+                        digest.hash
+                    ),
                 }
             }
-            Ok(None) => {}
-            Err(error) => {
-                atomic_saturating_add(
-                    &self.stats.remote_blob_transfer_duration_ns,
-                    duration_ns(transfer_started),
-                );
-                warn!("remote cache blob pack failed; falling back to individual blobs: {error}");
-            }
         }
 
-        let mut transfers = stream::iter(missing.into_keys().map(|digest| async move {
-            if let Err(error) = self.fetch_remote_blob_prefetch(remote, &digest).await {
-                warn!(
-                    "remote cache blob prefetch failed for {}: {error}",
-                    digest.hash
-                );
+        let mut transfers = stream::iter(missing.into_keys().map(|digest| {
+            let digest_for_result = digest.clone();
+            async move {
+                (
+                    digest_for_result,
+                    self.fetch_remote_blob_prefetch(remote, &digest).await,
+                )
             }
         }))
         .buffer_unordered(MAX_PREFETCH_TRANSFERS);
-        while transfers.next().await.is_some() {}
+        while let Some((digest, result)) = transfers.next().await {
+            match result {
+                Ok(path) => {
+                    verified.insert(digest, path);
+                }
+                Err(error) => warn!(
+                    "remote cache blob prefetch failed for {}: {error}",
+                    digest.hash
+                ),
+            }
+        }
+        verified
     }
 
-    fn load_rustc_metadata(&self, digest: &CacheDigest) -> Result<RustcMetadata> {
-        let path = self
-            .find_verified_blob(digest)?
-            .ok_or_else(|| eyre::eyre!("remote rustc action metadata is missing"))?;
+    async fn ingest_packed_blob(&self, digest: CacheDigest, source: PathBuf) -> Result<PathBuf> {
+        atomic_saturating_add(&self.stats.downloaded_bytes, digest.size);
+        let digest_size = digest.size;
+        let lock = self.write_lock(&digest);
+        let _guard = lock.lock().await;
+        let agent = self.clone();
+        let (path, stored, cas_duration_ns) = tokio::task::spawn_blocking(move || {
+            if let Some(path) = agent.find_verified_blob(&digest)? {
+                return Ok::<_, eyre::Report>((path, false, 0));
+            }
+            let cas_started = Instant::now();
+            let path = agent.cas.store_verified_file(&digest, &source)?;
+            let cas_duration_ns = duration_ns(cas_started);
+            agent.remember_verified_blob(&digest, &path);
+            Ok((path, true, cas_duration_ns))
+        })
+        .await??;
+        atomic_saturating_add(&self.stats.local_cas_write_duration_ns, cas_duration_ns);
+        if stored {
+            self.stats.stores.fetch_add(1, Ordering::Relaxed);
+            atomic_saturating_add(&self.stats.stored_bytes, digest_size);
+        }
+        Ok(path)
+    }
+
+    fn parse_rustc_metadata(path: &Path) -> Result<RustcMetadata> {
         let bytes = fs::read(path)?;
         let metadata: RustcMetadata = serde_json::from_slice(&bytes)?;
         if metadata.version != 1 || metadata.kind != "rustc" || canonical_json(&metadata)? != bytes
@@ -1017,10 +1125,7 @@ impl CacheAgent {
         Ok(metadata)
     }
 
-    fn load_cache_directory(&self, digest: &CacheDigest) -> Result<CacheDirectory> {
-        let path = self
-            .find_verified_blob(digest)?
-            .ok_or_else(|| eyre::eyre!("remote action output directory is missing"))?;
+    fn parse_cache_directory(path: &Path) -> Result<CacheDirectory> {
         let bytes = fs::read(path)?;
         let directory: CacheDirectory = serde_json::from_slice(&bytes)?;
         if directory.version != 1 || canonical_json(&directory)? != bytes {
@@ -1029,19 +1134,34 @@ impl CacheAgent {
         Ok(directory)
     }
 
-    fn validate_prefetched_action(&self, action: &PrefetchedAction) -> Result<()> {
-        if self.find_verified_blob(&action.result.action)?.is_none() {
+    #[cfg(test)]
+    fn load_cache_directory(&self, digest: &CacheDigest) -> Result<CacheDirectory> {
+        let path = self
+            .find_verified_blob(digest)?
+            .ok_or_else(|| eyre::eyre!("remote action output directory is missing"))?;
+        Self::parse_cache_directory(&path)
+    }
+
+    fn validate_prefetched_action(
+        action: &PrefetchedAction,
+        verified: &BTreeMap<CacheDigest, PathBuf>,
+        rustc_metadata: &BTreeMap<CacheDigest, RustcMetadata>,
+        directories: &BTreeMap<CacheDigest, CacheDirectory>,
+    ) -> Result<()> {
+        if !verified.contains_key(&action.result.action) {
             bail!("remote action descriptor is missing");
         }
         if let Some(metadata) = &action.result.metadata {
             if action.adapter == "rustc" {
-                let metadata = self.load_rustc_metadata(metadata)?;
+                let metadata = rustc_metadata
+                    .get(metadata)
+                    .ok_or_else(|| eyre::eyre!("remote rustc action metadata is missing"))?;
                 for digest in [&metadata.stdout, &metadata.stderr] {
-                    if self.find_verified_blob(digest)?.is_none() {
+                    if !verified.contains_key(digest) {
                         bail!("remote rustc action diagnostic blob is missing");
                     }
                 }
-            } else if self.find_verified_blob(metadata)?.is_none() {
+            } else if !verified.contains_key(metadata) {
                 bail!("remote action metadata is missing");
             }
         }
@@ -1059,17 +1179,19 @@ impl CacheAgent {
             if seen.len() > MAX_PREFETCH_DIRECTORY_OBJECTS {
                 bail!("remote action output tree is too large");
             }
-            let directory = self.load_cache_directory(&digest)?;
-            for file in directory.files {
-                if self.find_verified_blob(&file.digest)?.is_none() {
+            let directory = directories
+                .get(&digest)
+                .ok_or_else(|| eyre::eyre!("remote action output directory is missing"))?;
+            for file in &directory.files {
+                if !verified.contains_key(&file.digest) {
                     bail!("remote action output file is missing");
                 }
             }
             pending.extend(
                 directory
                     .directories
-                    .into_iter()
-                    .map(|directory| directory.digest),
+                    .iter()
+                    .map(|directory| directory.digest.clone()),
             );
         }
         Ok(())
@@ -1090,12 +1212,8 @@ impl CacheAgent {
             if seen.len() > MAX_PREFETCH_DIRECTORY_OBJECTS {
                 bail!("remote action output tree is too large");
             }
-            let path = self.fetch_remote_blob_prefetch(remote, &digest).await?;
-            let bytes = fs::read(path)?;
-            let directory: CacheDirectory = serde_json::from_slice(&bytes)?;
-            if directory.version != 1 || canonical_json(&directory)? != bytes {
-                bail!("remote action output directory is invalid");
-            }
+            self.fetch_remote_blob_prefetch(remote, &digest).await?;
+            let directory = self.load_cache_directory(&digest)?;
             let mut transfers = stream::iter(directory.files.into_iter().map(|file| async move {
                 self.fetch_remote_blob_prefetch(remote, &file.digest)
                     .await
@@ -2521,6 +2639,83 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn preserves_successful_pack_metrics_when_a_later_chunk_falls_back() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let mut entries = [
+            (CacheDigest::blake3(b"first"), b"first".as_slice()),
+            (CacheDigest::blake3(b"second"), b"second".as_slice()),
+        ];
+        entries.sort_by(|left, right| left.0.cmp(&right.0));
+        let (first_digest, first_bytes) = entries[0].clone();
+        let (second_digest, second_bytes) = entries[1].clone();
+        let capabilities = server
+            .mock("GET", "/v1/capabilities")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "protocol":{"major":1},
+                    "features":{"blob_packs":true},
+                    "limits":{"max_batch_items":1,"max_pack_bytes":1048576}
+                })
+                .to_string(),
+            )
+            .expect(1)
+            .create_async()
+            .await;
+        let first_pack = server
+            .mock("POST", "/v1/blobs:pack")
+            .match_body(mockito::Matcher::Json(serde_json::json!({
+                "digests": [&first_digest]
+            })))
+            .with_status(200)
+            .with_header("content-type", crate::BLOB_PACK_MEDIA_TYPE)
+            .with_body(blob_pack_body(&[(first_digest.clone(), first_bytes)]))
+            .expect(1)
+            .create_async()
+            .await;
+        let failed_pack = server
+            .mock("POST", "/v1/blobs:pack")
+            .match_body(mockito::Matcher::Json(serde_json::json!({
+                "digests": [&second_digest]
+            })))
+            .with_status(500)
+            .expect(1)
+            .create_async()
+            .await;
+        let fallback = server
+            .mock("GET", blob_path(&second_digest).as_str())
+            .with_status(200)
+            .with_body(second_bytes)
+            .expect(1)
+            .create_async()
+            .await;
+        let agent = remote_agent(
+            &server,
+            directory.path().join("reader"),
+            RemoteCacheMode::ReadOnly,
+        );
+        let remote = agent.remote.as_deref().unwrap();
+
+        let verified = agent
+            .prefetch_remote_blobs(remote, vec![first_digest.clone(), second_digest.clone()])
+            .await;
+
+        assert_eq!(verified.len(), 2);
+        assert_eq!(fs::read(&verified[&first_digest]).unwrap(), first_bytes);
+        assert_eq!(fs::read(&verified[&second_digest]).unwrap(), second_bytes);
+        let stats = agent.stats();
+        assert_eq!(stats.remote_blob_pack_requests, 1);
+        assert_eq!(stats.remote_blob_pack_blobs, 1);
+        assert_eq!(stats.remote_blob_requests, 1);
+        capabilities.assert_async().await;
+        first_pack.assert_async().await;
+        failed_pack.assert_async().await;
+        fallback.assert_async().await;
+    }
+
+    #[tokio::test]
     async fn foreground_action_lookup_does_not_wait_for_prefetch_output() {
         let directory = tempfile::tempdir().unwrap();
         let mut server = mockito::Server::new_async().await;
@@ -2740,7 +2935,7 @@ mod tests {
     }
 
     fn blob_pack_body(entries: &[(CacheDigest, &[u8])]) -> Vec<u8> {
-        let mut pack = b"MISEPK01".to_vec();
+        let mut pack = crate::BLOB_PACK_MAGIC.to_vec();
         for (digest, bytes) in entries {
             pack.push(match digest.algorithm.as_str() {
                 "blake3" => 1,

--- a/crates/mise-cache-core/src/agent.rs
+++ b/crates/mise-cache-core/src/agent.rs
@@ -164,6 +164,10 @@ pub struct AgentStats {
     pub remote_action_lookup_duration_ns: u64,
     /// Number of blob requests made to the remote cache.
     pub remote_blob_requests: u64,
+    /// Number of packed blob requests made to the remote cache.
+    pub remote_blob_pack_requests: u64,
+    /// Number of verified blobs received through packed responses.
+    pub remote_blob_pack_blobs: u64,
     /// Cumulative time spent downloading and verifying remote blobs.
     pub remote_blob_transfer_duration_ns: u64,
     /// Cumulative time spent ingesting downloaded blobs into the local CAS.
@@ -207,6 +211,8 @@ struct AtomicAgentStats {
     remote_action_lookups: AtomicU64,
     remote_action_lookup_duration_ns: AtomicU64,
     remote_blob_requests: AtomicU64,
+    remote_blob_pack_requests: AtomicU64,
+    remote_blob_pack_blobs: AtomicU64,
     remote_blob_transfer_duration_ns: AtomicU64,
     local_cas_write_duration_ns: AtomicU64,
     prefetch_runs: AtomicU64,
@@ -294,6 +300,11 @@ struct TaskActionState {
     baseline_loaded: bool,
     predictions: BTreeMap<CacheDigest, ActionPrediction>,
     remote_etag: Option<String>,
+}
+
+struct PrefetchedAction {
+    adapter: String,
+    result: RemoteActionResult,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -646,6 +657,8 @@ impl CacheAgent {
                 .remote_action_lookup_duration_ns
                 .load(Ordering::Relaxed),
             remote_blob_requests: self.stats.remote_blob_requests.load(Ordering::Relaxed),
+            remote_blob_pack_requests: self.stats.remote_blob_pack_requests.load(Ordering::Relaxed),
+            remote_blob_pack_blobs: self.stats.remote_blob_pack_blobs.load(Ordering::Relaxed),
             remote_blob_transfer_duration_ns: self
                 .stats
                 .remote_blob_transfer_duration_ns
@@ -720,22 +733,37 @@ impl CacheAgent {
                 break;
             };
             let agent = self.clone();
-            tasks.spawn(async move { agent.prefetch_action(action, adapter).await });
+            tasks.spawn(async move { agent.resolve_prefetch_action(action, adapter).await });
         }
+        let mut resolved = Vec::new();
         while let Some(result) = tasks.join_next().await {
             match result {
-                Ok(Ok(())) => {}
+                Ok(Ok(Some(action))) => resolved.push(action),
+                Ok(Ok(None)) => {}
                 Ok(Err(error)) => warn!("remote action prefetch failed: {error}"),
                 Err(error) => warn!("remote action prefetch task failed: {error}"),
             }
             if let Some((action, adapter)) = actions.next() {
                 let agent = self.clone();
-                tasks.spawn(async move { agent.prefetch_action(action, adapter).await });
+                tasks.spawn(async move { agent.resolve_prefetch_action(action, adapter).await });
             }
         }
+        self.prefetch_resolved_actions(resolved).await;
     }
 
+    #[cfg(test)]
     async fn prefetch_action(&self, action: CacheDigest, adapter: String) -> Result<()> {
+        if let Some(action) = self.resolve_prefetch_action(action, adapter).await? {
+            self.prefetch_resolved_actions(vec![action]).await;
+        }
+        Ok(())
+    }
+
+    async fn resolve_prefetch_action(
+        &self,
+        action: CacheDigest,
+        adapter: String,
+    ) -> Result<Option<PrefetchedAction>> {
         let remote = self
             .remote
             .as_ref()
@@ -744,7 +772,7 @@ impl CacheAgent {
             let lock = self.action_lock(&action);
             let _guard = lock.lock().await;
             if self.actions.find(&action)?.is_some() {
-                return Ok(());
+                return Ok(None);
             }
             if let Some(result) = self
                 .pending_remote_actions
@@ -760,7 +788,9 @@ impl CacheAgent {
                     let _permit = self.remote_transfers.acquire().await?;
                     self.get_remote_action_result(remote, &action).await?
                 };
-                let Some(result) = result else { return Ok(()) };
+                let Some(result) = result else {
+                    return Ok(None);
+                };
                 self.pending_remote_actions
                     .lock()
                     .unwrap()
@@ -768,36 +798,284 @@ impl CacheAgent {
                 result
             }
         };
-        self.fetch_remote_blob_prefetch(remote, &result.action)
-            .await?;
-        if let Some(metadata) = &result.metadata {
-            let path = self.fetch_remote_blob_prefetch(remote, metadata).await?;
-            if adapter == "rustc" {
-                let bytes = fs::read(path)?;
-                let metadata: RustcMetadata = serde_json::from_slice(&bytes)?;
-                if metadata.version != 1
-                    || metadata.kind != "rustc"
-                    || canonical_json(&metadata)? != bytes
-                {
-                    bail!("remote rustc action metadata is invalid");
-                }
-                self.fetch_remote_blob_prefetch(remote, &metadata.stdout)
-                    .await?;
-                self.fetch_remote_blob_prefetch(remote, &metadata.stderr)
-                    .await?;
+        Ok(Some(PrefetchedAction { adapter, result }))
+    }
+
+    async fn prefetch_resolved_actions(&self, actions: Vec<PrefetchedAction>) {
+        let Some(remote) = self.remote.as_deref() else {
+            return;
+        };
+        if actions.is_empty() {
+            return;
+        }
+
+        let mut top_level = BTreeMap::new();
+        for action in &actions {
+            for digest in [
+                Some(&action.result.action),
+                action.result.metadata.as_ref(),
+                action.result.output_root.as_ref(),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                top_level.insert(digest.clone(), ());
             }
         }
-        if let Some(output_root) = &result.output_root {
-            self.prefetch_output_tree(remote, output_root).await?;
+        self.prefetch_remote_blobs(remote, top_level.into_keys().collect())
+            .await;
+
+        let mut next = BTreeMap::new();
+        let mut directories = BTreeMap::new();
+        for action in &actions {
+            if action.adapter == "rustc"
+                && let Some(metadata) = &action.result.metadata
+            {
+                match self.load_rustc_metadata(metadata) {
+                    Ok(metadata) => {
+                        next.insert(metadata.stdout, ());
+                        next.insert(metadata.stderr, ());
+                    }
+                    Err(error) => warn!(
+                        "remote rustc action metadata prefetch failed for {}: {error}",
+                        action.result.action.hash
+                    ),
+                }
+            }
+            if let Some(output_root) = &action.result.output_root {
+                directories.insert(output_root.clone(), ());
+            }
         }
-        self.actions.store(&result)?;
-        self.pending_remote_actions.lock().unwrap().remove(&action);
-        self.stats
-            .prefetched_actions
-            .fetch_add(1, Ordering::Relaxed);
+
+        let mut seen_directories = BTreeMap::new();
+        loop {
+            let mut following = BTreeMap::new();
+            for digest in directories.into_keys() {
+                if seen_directories.insert(digest.clone(), ()).is_some() {
+                    continue;
+                }
+                if seen_directories.len() > MAX_PREFETCH_DIRECTORY_OBJECTS {
+                    warn!("remote action output tree is too large to prefetch");
+                    following.clear();
+                    break;
+                }
+                match self.load_cache_directory(&digest) {
+                    Ok(directory) => {
+                        for file in directory.files {
+                            next.insert(file.digest, ());
+                        }
+                        for directory in directory.directories {
+                            next.insert(directory.digest.clone(), ());
+                            following.insert(directory.digest, ());
+                        }
+                    }
+                    Err(error) => warn!(
+                        "remote action output directory prefetch failed for {}: {error}",
+                        digest.hash
+                    ),
+                }
+            }
+            if next.is_empty() {
+                break;
+            }
+            self.prefetch_remote_blobs(remote, next.into_keys().collect())
+                .await;
+            next = BTreeMap::new();
+            if following.is_empty() {
+                break;
+            }
+            directories = following;
+        }
+
+        for action in actions {
+            match self.validate_prefetched_action(&action) {
+                Ok(()) => {
+                    if let Err(error) = self.actions.store(&action.result) {
+                        warn!(
+                            "remote action prefetch could not publish {}: {error}",
+                            action.result.action.hash
+                        );
+                        continue;
+                    }
+                    self.pending_remote_actions
+                        .lock()
+                        .unwrap()
+                        .remove(&action.result.action);
+                    self.stats
+                        .prefetched_actions
+                        .fetch_add(1, Ordering::Relaxed);
+                }
+                Err(error) => warn!(
+                    "remote action prefetch was incomplete for {}: {error}",
+                    action.result.action.hash
+                ),
+            }
+        }
+    }
+
+    async fn prefetch_remote_blobs(&self, remote: &RemoteCacheClient, digests: Vec<CacheDigest>) {
+        let mut missing = BTreeMap::new();
+        for digest in digests {
+            match self.find_verified_blob(&digest) {
+                Ok(Some(_)) => {}
+                Ok(None) => {
+                    missing.insert(digest, ());
+                }
+                Err(error) => warn!(
+                    "local cache blob lookup failed for {}: {error}",
+                    digest.hash
+                ),
+            }
+        }
+        if missing.is_empty() {
+            return;
+        }
+
+        let requested = missing.keys().cloned().collect::<Vec<_>>();
+        let transfer_started = Instant::now();
+        match remote
+            .get_blob_pack(&requested, self.remote_staging_dir.as_path())
+            .await
+        {
+            Ok(Some(pack)) => {
+                atomic_saturating_add(
+                    &self.stats.remote_blob_transfer_duration_ns,
+                    duration_ns(transfer_started),
+                );
+                atomic_saturating_add(&self.stats.remote_blob_pack_requests, pack.requests);
+                atomic_saturating_add(
+                    &self.stats.remote_blob_pack_blobs,
+                    pack.blobs.len().try_into().unwrap_or(u64::MAX),
+                );
+                for (digest, source) in pack.blobs {
+                    atomic_saturating_add(&self.stats.downloaded_bytes, digest.size);
+                    let lock = self.write_lock(&digest);
+                    let _guard = lock.lock().await;
+                    match self.find_verified_blob(&digest) {
+                        Ok(Some(_)) => {
+                            missing.remove(&digest);
+                        }
+                        Ok(None) => {
+                            let cas_started = Instant::now();
+                            let stored = self.cas.store_verified_file(&digest, &source);
+                            atomic_saturating_add(
+                                &self.stats.local_cas_write_duration_ns,
+                                duration_ns(cas_started),
+                            );
+                            match stored {
+                                Ok(path) => {
+                                    self.remember_verified_blob(&digest, &path);
+                                    self.stats.stores.fetch_add(1, Ordering::Relaxed);
+                                    atomic_saturating_add(&self.stats.stored_bytes, digest.size);
+                                    missing.remove(&digest);
+                                }
+                                Err(error) => warn!(
+                                    "remote cache packed blob ingest failed for {}: {error}",
+                                    digest.hash
+                                ),
+                            }
+                        }
+                        Err(error) => warn!(
+                            "local cache blob lookup failed for {}: {error}",
+                            digest.hash
+                        ),
+                    }
+                }
+            }
+            Ok(None) => {}
+            Err(error) => {
+                atomic_saturating_add(
+                    &self.stats.remote_blob_transfer_duration_ns,
+                    duration_ns(transfer_started),
+                );
+                warn!("remote cache blob pack failed; falling back to individual blobs: {error}");
+            }
+        }
+
+        let mut transfers = stream::iter(missing.into_keys().map(|digest| async move {
+            if let Err(error) = self.fetch_remote_blob_prefetch(remote, &digest).await {
+                warn!(
+                    "remote cache blob prefetch failed for {}: {error}",
+                    digest.hash
+                );
+            }
+        }))
+        .buffer_unordered(MAX_PREFETCH_TRANSFERS);
+        while transfers.next().await.is_some() {}
+    }
+
+    fn load_rustc_metadata(&self, digest: &CacheDigest) -> Result<RustcMetadata> {
+        let path = self
+            .find_verified_blob(digest)?
+            .ok_or_else(|| eyre::eyre!("remote rustc action metadata is missing"))?;
+        let bytes = fs::read(path)?;
+        let metadata: RustcMetadata = serde_json::from_slice(&bytes)?;
+        if metadata.version != 1 || metadata.kind != "rustc" || canonical_json(&metadata)? != bytes
+        {
+            bail!("remote rustc action metadata is invalid");
+        }
+        Ok(metadata)
+    }
+
+    fn load_cache_directory(&self, digest: &CacheDigest) -> Result<CacheDirectory> {
+        let path = self
+            .find_verified_blob(digest)?
+            .ok_or_else(|| eyre::eyre!("remote action output directory is missing"))?;
+        let bytes = fs::read(path)?;
+        let directory: CacheDirectory = serde_json::from_slice(&bytes)?;
+        if directory.version != 1 || canonical_json(&directory)? != bytes {
+            bail!("remote action output directory is invalid");
+        }
+        Ok(directory)
+    }
+
+    fn validate_prefetched_action(&self, action: &PrefetchedAction) -> Result<()> {
+        if self.find_verified_blob(&action.result.action)?.is_none() {
+            bail!("remote action descriptor is missing");
+        }
+        if let Some(metadata) = &action.result.metadata {
+            if action.adapter == "rustc" {
+                let metadata = self.load_rustc_metadata(metadata)?;
+                for digest in [&metadata.stdout, &metadata.stderr] {
+                    if self.find_verified_blob(digest)?.is_none() {
+                        bail!("remote rustc action diagnostic blob is missing");
+                    }
+                }
+            } else if self.find_verified_blob(metadata)?.is_none() {
+                bail!("remote action metadata is missing");
+            }
+        }
+        let mut pending = action
+            .result
+            .output_root
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut seen = BTreeMap::new();
+        while let Some(digest) = pending.pop() {
+            if seen.insert(digest.clone(), ()).is_some() {
+                continue;
+            }
+            if seen.len() > MAX_PREFETCH_DIRECTORY_OBJECTS {
+                bail!("remote action output tree is too large");
+            }
+            let directory = self.load_cache_directory(&digest)?;
+            for file in directory.files {
+                if self.find_verified_blob(&file.digest)?.is_none() {
+                    bail!("remote action output file is missing");
+                }
+            }
+            pending.extend(
+                directory
+                    .directories
+                    .into_iter()
+                    .map(|directory| directory.digest),
+            );
+        }
         Ok(())
     }
 
+    #[cfg(test)]
     async fn prefetch_output_tree(
         &self,
         remote: &RemoteCacheClient,
@@ -2124,6 +2402,125 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn prefetches_complete_actions_in_directory_wave_blob_packs() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let action_bytes = b"packed action descriptor";
+        let stdout_bytes = b"packed stdout";
+        let stderr_bytes = b"packed stderr";
+        let artifact_bytes = b"packed artifact";
+        let action = CacheDigest::blake3(action_bytes);
+        let stdout = CacheDigest::blake3(stdout_bytes);
+        let stderr = CacheDigest::blake3(stderr_bytes);
+        let artifact = CacheDigest::blake3(artifact_bytes);
+        let metadata_bytes = canonical_json(&RustcMetadata {
+            version: 1,
+            kind: "rustc".into(),
+            stdout: stdout.clone(),
+            stderr: stderr.clone(),
+        })
+        .unwrap();
+        let metadata = CacheDigest::blake3(&metadata_bytes);
+        let directory_bytes = canonical_json(&serde_json::json!({
+            "directories": [],
+            "files": [{
+                "digest": artifact,
+                "executable": false,
+                "mode": 420,
+                "name": "artifact",
+            }],
+            "symlinks": [],
+            "version": 1,
+        }))
+        .unwrap();
+        let output_root = CacheDigest::blake3(&directory_bytes);
+        let result = RemoteActionResult {
+            action: action.clone(),
+            metadata: Some(metadata.clone()),
+            output_root: Some(output_root.clone()),
+            version: 1,
+        };
+        let action_result = server
+            .mock("GET", action_path(&action).as_str())
+            .with_status(200)
+            .with_header("content-type", ACTION_RESULT_MEDIA_TYPE)
+            .with_body(serde_json::to_vec(&result).unwrap())
+            .expect(1)
+            .create_async()
+            .await;
+        let capabilities = server
+            .mock("GET", "/v1/capabilities")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "protocol":{"major":1},
+                    "features":{"blob_packs":true},
+                    "limits":{"max_batch_items":100,"max_pack_bytes":1048576}
+                })
+                .to_string(),
+            )
+            .expect(1)
+            .create_async()
+            .await;
+        let mut top = vec![
+            (action.clone(), action_bytes.as_slice()),
+            (metadata.clone(), metadata_bytes.as_slice()),
+            (output_root.clone(), directory_bytes.as_slice()),
+        ];
+        top.sort_by(|left, right| left.0.cmp(&right.0));
+        let first_pack = server
+            .mock("POST", "/v1/blobs:pack")
+            .match_body(mockito::Matcher::Json(serde_json::json!({
+                "digests": top.iter().map(|(digest, _)| digest).collect::<Vec<_>>()
+            })))
+            .with_status(200)
+            .with_header("content-type", crate::BLOB_PACK_MEDIA_TYPE)
+            .with_body(blob_pack_body(&top))
+            .expect(1)
+            .create_async()
+            .await;
+        let mut leaves = vec![
+            (stdout.clone(), stdout_bytes.as_slice()),
+            (stderr.clone(), stderr_bytes.as_slice()),
+            (artifact.clone(), artifact_bytes.as_slice()),
+        ];
+        leaves.sort_by(|left, right| left.0.cmp(&right.0));
+        let second_pack = server
+            .mock("POST", "/v1/blobs:pack")
+            .match_body(mockito::Matcher::Json(serde_json::json!({
+                "digests": leaves.iter().map(|(digest, _)| digest).collect::<Vec<_>>()
+            })))
+            .with_status(200)
+            .with_header("content-type", crate::BLOB_PACK_MEDIA_TYPE)
+            .with_body(blob_pack_body(&leaves))
+            .expect(1)
+            .create_async()
+            .await;
+        let agent = remote_agent(
+            &server,
+            directory.path().join("reader"),
+            RemoteCacheMode::ReadOnly,
+        );
+
+        agent
+            .prefetch_action(action.clone(), "rustc".into())
+            .await
+            .unwrap();
+
+        assert_eq!(agent.actions.find(&action).unwrap(), Some(result));
+        let stats = agent.stats();
+        assert_eq!(stats.prefetched_actions, 1);
+        assert_eq!(stats.remote_blob_requests, 0);
+        assert_eq!(stats.remote_blob_pack_requests, 2);
+        assert_eq!(stats.remote_blob_pack_blobs, 6);
+        action_result.assert_async().await;
+        capabilities.assert_async().await;
+        first_pack.assert_async().await;
+        second_pack.assert_async().await;
+    }
+
+    #[tokio::test]
     async fn foreground_action_lookup_does_not_wait_for_prefetch_output() {
         let directory = tempfile::tempdir().unwrap();
         let mut server = mockito::Server::new_async().await;
@@ -2340,6 +2737,21 @@ mod tests {
         let output_root = CacheDigest::blake3(&directory);
         responses.insert(blob_path(&output_root), directory);
         (responses, output_root)
+    }
+
+    fn blob_pack_body(entries: &[(CacheDigest, &[u8])]) -> Vec<u8> {
+        let mut pack = b"MISEPK01".to_vec();
+        for (digest, bytes) in entries {
+            pack.push(match digest.algorithm.as_str() {
+                "blake3" => 1,
+                "sha256" => 2,
+                algorithm => panic!("unexpected test digest algorithm {algorithm}"),
+            });
+            pack.extend(hex::decode(&digest.hash).unwrap());
+            pack.extend(digest.size.to_be_bytes());
+            pack.extend_from_slice(bytes);
+        }
+        pack
     }
 
     async fn delayed_blob_server(

--- a/crates/mise-cache-core/src/lib.rs
+++ b/crates/mise-cache-core/src/lib.rs
@@ -41,6 +41,8 @@ const DIGEST_LIST_MEDIA_TYPE: &str = "application/vnd.mise.cache-digests.v1+json
 const BLOB_PACK_MAGIC: &[u8; 8] = b"MISEPK01";
 const MAX_STAGED_BLOB_PACK_BYTES: u64 = 256 * 1024 * 1024;
 const MAX_STAGED_BLOB_PACK_ITEMS: usize = 2 * 1024;
+const BLOB_PACK_TIMEOUT_BYTES_PER_UNIT: u64 = MAX_STAGED_BLOB_PACK_BYTES / 4;
+const BLOB_PACK_TIMEOUT_ITEMS_PER_UNIT: usize = MAX_STAGED_BLOB_PACK_ITEMS / 4;
 
 /// Serialize a protocol object using the JSON Canonicalization Scheme.
 ///
@@ -522,7 +524,8 @@ impl RemoteCacheClient {
     ) -> Result<Option<DownloadedBlobPack>> {
         let url = self.blob_pack_endpoint()?;
         let body = serde_json::to_vec(&DigestList { digests })?;
-        retry_async("POST", &url, self.retries, || async {
+        let download_timeout = blob_pack_download_timeout(self.download_timeout, digests);
+        let download = retry_async("POST", &url, self.retries, || async {
             let response = self
                 .request(reqwest::Method::POST, url.clone(), BLOB_PACK_MEDIA_TYPE)
                 .await?
@@ -551,8 +554,10 @@ impl RemoteCacheClient {
             Ok(Some(
                 decode_blob_pack(response, digests, staging_dir).await?,
             ))
-        })
-        .await
+        });
+        tokio::time::timeout(download_timeout, download)
+            .await
+            .map_err(|_| eyre!("remote cache blob pack download timed out for {url}"))?
     }
 
     pub async fn get_action_result(
@@ -778,6 +783,17 @@ fn blob_pack_chunk(digests: &[CacheDigest], limits: BlobPackLimits) -> Result<Ve
         chunk.push(digest.clone());
     }
     Ok(chunk)
+}
+
+fn blob_pack_download_timeout(base: Duration, digests: &[CacheDigest]) -> Duration {
+    let bytes = digests
+        .iter()
+        .fold(0_u64, |total, digest| total.saturating_add(digest.size));
+    let byte_units = bytes.div_ceil(BLOB_PACK_TIMEOUT_BYTES_PER_UNIT);
+    let item_units = digests.len().div_ceil(BLOB_PACK_TIMEOUT_ITEMS_PER_UNIT);
+    let item_units = u64::try_from(item_units).unwrap_or(u64::MAX);
+    let multiplier = byte_units.max(item_units).max(1);
+    base.saturating_mul(u32::try_from(multiplier).unwrap_or(u32::MAX))
 }
 
 async fn decode_blob_pack(
@@ -1550,6 +1566,31 @@ mod tests {
         )
         .unwrap();
         assert_eq!(chunk.len(), 1);
+    }
+
+    #[test]
+    fn blob_pack_timeout_scales_with_declared_work() {
+        let base = Duration::from_secs(10);
+        let small = CacheDigest::blake3(b"small");
+        assert_eq!(blob_pack_download_timeout(base, &[small]), base);
+
+        let large = CacheDigest {
+            algorithm: "blake3".into(),
+            hash: "0".repeat(64),
+            size: MAX_STAGED_BLOB_PACK_BYTES,
+        };
+        assert_eq!(
+            blob_pack_download_timeout(base, &[large]),
+            base.saturating_mul(4)
+        );
+
+        let many = (0..=BLOB_PACK_TIMEOUT_ITEMS_PER_UNIT)
+            .map(|index| CacheDigest::blake3(index.to_string().as_bytes()))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            blob_pack_download_timeout(base, &many),
+            base.saturating_mul(2)
+        );
     }
 
     #[test]

--- a/crates/mise-cache-core/src/lib.rs
+++ b/crates/mise-cache-core/src/lib.rs
@@ -1,5 +1,6 @@
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use eyre::{Result, bail, eyre};
+use futures_util::TryStreamExt as _;
 use log::warn;
 use reqwest::StatusCode;
 use reqwest::header::{
@@ -7,12 +8,14 @@ use reqwest::header::{
 };
 use serde::{Deserialize, Serialize};
 use sha2::Digest as _;
+use std::collections::BTreeSet;
 use std::fs::{self, File};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use url::{Host, Url};
 
 mod agent;
@@ -33,6 +36,9 @@ pub const CLIENT_METADATA_MEDIA_TYPE: &str = "application/vnd.mise.cache-client-
 pub const TASK_ACTION_MANIFEST_MEDIA_TYPE: &str =
     "application/vnd.mise.cache-task-action-manifest.v1+json";
 pub const BLOB_MEDIA_TYPE: &str = "application/octet-stream";
+pub const BLOB_PACK_MEDIA_TYPE: &str = "application/vnd.mise.cache-blob-pack.v1";
+const DIGEST_LIST_MEDIA_TYPE: &str = "application/vnd.mise.cache-digests.v1+json";
+const BLOB_PACK_MAGIC: &[u8; 8] = b"MISEPK01";
 
 /// Serialize a protocol object using the JSON Canonicalization Scheme.
 ///
@@ -258,6 +264,57 @@ pub struct RemoteActionManifest {
     pub etag: String,
 }
 
+/// A verified set of remote CAS objects downloaded through blob-pack streams.
+pub struct RemoteBlobPack {
+    _directories: Vec<tempfile::TempDir>,
+    pub blobs: Vec<(CacheDigest, PathBuf)>,
+    pub requests: u64,
+}
+
+struct DownloadedBlobPack {
+    directory: tempfile::TempDir,
+    blobs: Vec<(CacheDigest, PathBuf)>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RemoteCacheCapabilities {
+    protocol: CapabilityProtocol,
+    #[serde(default)]
+    features: CapabilityFeatures,
+    #[serde(default)]
+    limits: CapabilityLimits,
+}
+
+#[derive(Debug, Deserialize)]
+struct CapabilityProtocol {
+    major: u8,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct CapabilityFeatures {
+    #[serde(default)]
+    blob_packs: bool,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct CapabilityLimits {
+    #[serde(default)]
+    max_batch_items: u64,
+    #[serde(default)]
+    max_pack_bytes: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct BlobPackLimits {
+    max_items: usize,
+    max_bytes: u64,
+}
+
+#[derive(Serialize)]
+struct DigestList<'a> {
+    digests: &'a [CacheDigest],
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ManifestPutOutcome {
     Stored,
@@ -271,6 +328,8 @@ pub struct RemoteCacheClient {
     credential: RemoteCacheCredential,
     download_timeout: Duration,
     retries: i64,
+    capabilities: tokio::sync::OnceCell<Option<BlobPackLimits>>,
+    blob_packs_disabled: AtomicBool,
 }
 
 impl RemoteCacheClient {
@@ -298,6 +357,8 @@ impl RemoteCacheClient {
             credential,
             download_timeout: config.download_timeout,
             retries: config.retries,
+            capabilities: tokio::sync::OnceCell::new(),
+            blob_packs_disabled: AtomicBool::new(false),
         })
     }
 
@@ -331,6 +392,18 @@ impl RemoteCacheClient {
         ))?)
     }
 
+    fn capabilities_endpoint(&self) -> Result<Url> {
+        Ok(self
+            .base_url
+            .join(&format!("v{PROTOCOL_VERSION}/capabilities"))?)
+    }
+
+    fn blob_pack_endpoint(&self) -> Result<Url> {
+        Ok(self
+            .base_url
+            .join(&format!("v{PROTOCOL_VERSION}/blobs:pack"))?)
+    }
+
     async fn request(
         &self,
         method: reqwest::Method,
@@ -348,6 +421,138 @@ impl RemoteCacheClient {
         } else {
             Ok(request)
         }
+    }
+
+    async fn blob_pack_limits(&self) -> Result<Option<BlobPackLimits>> {
+        self.capabilities
+            .get_or_try_init(|| async {
+                let url = self.capabilities_endpoint()?;
+                let response = self
+                    .client
+                    .get(url)
+                    .header(PROTOCOL_HEADER, u16::from(PROTOCOL_VERSION))
+                    .header(ACCEPT, "application/json")
+                    .send()
+                    .await?;
+                if matches!(
+                    response.status(),
+                    StatusCode::NOT_FOUND
+                        | StatusCode::METHOD_NOT_ALLOWED
+                        | StatusCode::NOT_IMPLEMENTED
+                ) {
+                    return Ok(None);
+                }
+                let capabilities: RemoteCacheCapabilities =
+                    response.error_for_status()?.json().await?;
+                if capabilities.protocol.major != PROTOCOL_VERSION {
+                    bail!(
+                        "remote cache capability protocol {} is incompatible with client protocol {PROTOCOL_VERSION}",
+                        capabilities.protocol.major
+                    );
+                }
+                if !capabilities.features.blob_packs {
+                    return Ok(None);
+                }
+                let max_items = usize::try_from(capabilities.limits.max_batch_items)
+                    .ok()
+                    .filter(|limit| *limit > 0)
+                    .ok_or_else(|| {
+                        eyre!("remote cache blob packs require a positive max_batch_items limit")
+                    })?;
+                if capabilities.limits.max_pack_bytes == 0 {
+                    bail!("remote cache blob packs require a positive max_pack_bytes limit");
+                }
+                Ok(Some(BlobPackLimits {
+                    max_items,
+                    max_bytes: capabilities.limits.max_pack_bytes,
+                }))
+            })
+            .await
+            .copied()
+    }
+
+    /// Download verified CAS objects using the server's negotiated blob-pack extension.
+    ///
+    /// `None` means the server does not support blob packs. Objects omitted by a
+    /// supported server are absent from `blobs`, so callers can retry them through
+    /// the ordinary single-blob endpoint.
+    pub async fn get_blob_pack(
+        &self,
+        digests: &[CacheDigest],
+        staging_dir: &Path,
+    ) -> Result<Option<RemoteBlobPack>> {
+        if digests.is_empty() || self.blob_packs_disabled.load(Ordering::Relaxed) {
+            return Ok(None);
+        }
+        let Some(limits) = self.blob_pack_limits().await? else {
+            return Ok(None);
+        };
+        let chunks = blob_pack_chunks(digests, limits)?;
+
+        fs::create_dir_all(staging_dir)?;
+        let mut directories = Vec::with_capacity(chunks.len());
+        let mut blobs = Vec::new();
+        let mut requests = 0_u64;
+        for chunk in chunks {
+            match self.download_blob_pack_chunk(&chunk, staging_dir).await? {
+                Some(mut pack) => {
+                    requests += 1;
+                    blobs.append(&mut pack.blobs);
+                    directories.push(pack.directory);
+                }
+                None => {
+                    self.blob_packs_disabled.store(true, Ordering::Relaxed);
+                    return Ok(None);
+                }
+            }
+        }
+        Ok(Some(RemoteBlobPack {
+            _directories: directories,
+            blobs,
+            requests,
+        }))
+    }
+
+    async fn download_blob_pack_chunk(
+        &self,
+        digests: &[CacheDigest],
+        staging_dir: &Path,
+    ) -> Result<Option<DownloadedBlobPack>> {
+        let url = self.blob_pack_endpoint()?;
+        let body = serde_json::to_vec(&DigestList { digests })?;
+        let download = retry_async("POST", &url, self.retries, || async {
+            let response = self
+                .request(reqwest::Method::POST, url.clone(), BLOB_PACK_MEDIA_TYPE)
+                .await?
+                .header(CONTENT_TYPE, DIGEST_LIST_MEDIA_TYPE)
+                .body(body.clone())
+                .send()
+                .await?;
+            if matches!(
+                response.status(),
+                StatusCode::NOT_FOUND
+                    | StatusCode::METHOD_NOT_ALLOWED
+                    | StatusCode::NOT_IMPLEMENTED
+            ) {
+                return Ok(None);
+            }
+            let response = response.error_for_status()?;
+            let media_type = response
+                .headers()
+                .get(CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.split(';').next())
+                .map(str::trim);
+            if media_type != Some(BLOB_PACK_MEDIA_TYPE) {
+                bail!("remote cache blob pack has an invalid content type");
+            }
+            Ok(Some(
+                decode_blob_pack(response, digests, staging_dir).await?,
+            ))
+        });
+        tokio::time::timeout(self.download_timeout, download)
+            .await
+            .map_err(|_| eyre!("remote cache blob pack download timed out for {url}"))?
     }
 
     pub async fn get_action_result(
@@ -552,6 +757,132 @@ impl RemoteCacheClient {
             Ok(())
         })
         .await
+    }
+}
+
+fn blob_pack_chunks(
+    digests: &[CacheDigest],
+    limits: BlobPackLimits,
+) -> Result<Vec<Vec<CacheDigest>>> {
+    let mut unique = BTreeSet::new();
+    for digest in digests {
+        digest.validate()?;
+        unique.insert(digest.clone());
+    }
+    let mut chunks = Vec::new();
+    let mut chunk = Vec::new();
+    let mut chunk_bytes = 0_u64;
+    for digest in unique {
+        if digest.size > limits.max_bytes {
+            continue;
+        }
+        if chunk.len() == limits.max_items
+            || chunk_bytes.saturating_add(digest.size) > limits.max_bytes
+        {
+            chunks.push(std::mem::take(&mut chunk));
+            chunk_bytes = 0;
+        }
+        chunk_bytes = chunk_bytes.saturating_add(digest.size);
+        chunk.push(digest);
+    }
+    if !chunk.is_empty() {
+        chunks.push(chunk);
+    }
+    Ok(chunks)
+}
+
+async fn decode_blob_pack(
+    response: reqwest::Response,
+    requested: &[CacheDigest],
+    staging_dir: &Path,
+) -> Result<DownloadedBlobPack> {
+    let requested = requested.iter().cloned().collect::<BTreeSet<_>>();
+    let stream = response.bytes_stream().map_err(std::io::Error::other);
+    let mut reader = tokio_util::io::StreamReader::new(stream);
+    let mut magic = [0_u8; BLOB_PACK_MAGIC.len()];
+    reader.read_exact(&mut magic).await?;
+    if &magic != BLOB_PACK_MAGIC {
+        bail!("remote cache blob pack has invalid magic");
+    }
+
+    let directory = tempfile::tempdir_in(staging_dir)?;
+    let mut seen = BTreeSet::new();
+    let mut blobs = Vec::new();
+    loop {
+        let mut algorithm = [0_u8; 1];
+        if reader.read(&mut algorithm).await? == 0 {
+            break;
+        }
+        let (algorithm, mut hasher) = match algorithm[0] {
+            1 => (
+                "blake3",
+                BlobPackHasher::Blake3(Box::new(blake3::Hasher::new())),
+            ),
+            2 => ("sha256", BlobPackHasher::Sha256(sha2::Sha256::new())),
+            _ => bail!("remote cache blob pack has an invalid digest algorithm"),
+        };
+        let mut hash = [0_u8; 32];
+        reader.read_exact(&mut hash).await?;
+        let mut size = [0_u8; 8];
+        reader.read_exact(&mut size).await?;
+        let digest = CacheDigest {
+            algorithm: algorithm.into(),
+            hash: hex::encode(hash),
+            size: u64::from_be_bytes(size),
+        };
+        if !requested.contains(&digest) {
+            bail!("remote cache blob pack returned an unrequested digest");
+        }
+        if !seen.insert(digest.clone()) {
+            bail!("remote cache blob pack returned a duplicate digest");
+        }
+
+        let path = directory.path().join(blobs.len().to_string());
+        let mut output = tokio::fs::File::create(&path).await?;
+        let mut remaining = digest.size;
+        let mut buffer = [0_u8; 64 * 1024];
+        while remaining > 0 {
+            let limit = usize::try_from(remaining.min(buffer.len() as u64)).unwrap();
+            let count = reader.read(&mut buffer[..limit]).await?;
+            if count == 0 {
+                bail!("remote cache blob pack ended before a blob was complete");
+            }
+            output.write_all(&buffer[..count]).await?;
+            hasher.update(&buffer[..count]);
+            remaining -= count as u64;
+        }
+        output.flush().await?;
+        drop(output);
+        if !hasher.matches(&digest.hash) {
+            bail!("remote cache blob pack failed digest verification");
+        }
+        blobs.push((digest, path));
+    }
+    Ok(DownloadedBlobPack { directory, blobs })
+}
+
+enum BlobPackHasher {
+    Blake3(Box<blake3::Hasher>),
+    Sha256(sha2::Sha256),
+}
+
+impl BlobPackHasher {
+    fn update(&mut self, bytes: &[u8]) {
+        match self {
+            Self::Blake3(hasher) => {
+                hasher.update(bytes);
+            }
+            Self::Sha256(hasher) => {
+                hasher.update(bytes);
+            }
+        }
+    }
+
+    fn matches(self, expected: &str) -> bool {
+        match self {
+            Self::Blake3(hasher) => hasher.finalize().to_hex().as_str() == expected,
+            Self::Sha256(hasher) => hex::encode(hasher.finalize()) == expected,
+        }
     }
 }
 
@@ -983,12 +1314,193 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn downloads_negotiated_blob_packs_and_omits_missing_objects() {
+        let mut server = mockito::Server::new_async().await;
+        let first_bytes = b"first packed blob";
+        let second_bytes = b"second packed blob";
+        let first = CacheDigest::blake3(first_bytes);
+        let second = CacheDigest::blake3(second_bytes);
+        let missing = CacheDigest::blake3(b"missing packed blob");
+        let capabilities = server
+            .mock("GET", "/v1/capabilities")
+            .match_header(PROTOCOL_HEADER, "1")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "protocol":{"major":1},
+                    "features":{"blob_packs":true},
+                    "limits":{"max_batch_items":100,"max_pack_bytes":1024}
+                })
+                .to_string(),
+            )
+            .expect(1)
+            .create_async()
+            .await;
+        let packed = encode_blob_pack(&[
+            (&first, first_bytes.as_slice()),
+            (&second, second_bytes.as_slice()),
+        ]);
+        let request = server
+            .mock("POST", "/v1/blobs:pack")
+            .match_header(PROTOCOL_HEADER, "1")
+            .match_header(NAMESPACE_HEADER, "test")
+            .match_header("content-type", DIGEST_LIST_MEDIA_TYPE)
+            .with_status(200)
+            .with_header("content-type", BLOB_PACK_MEDIA_TYPE)
+            .with_body(packed)
+            .expect(1)
+            .create_async()
+            .await;
+        let client = test_client(&server);
+        let staging = tempfile::tempdir().unwrap();
+
+        let pack = client
+            .get_blob_pack(
+                &[first.clone(), missing, second.clone(), first.clone()],
+                staging.path(),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(pack.requests, 1);
+        assert_eq!(pack.blobs.len(), 2);
+        assert_eq!(fs::read(&pack.blobs[0].1).unwrap(), first_bytes);
+        assert_eq!(fs::read(&pack.blobs[1].1).unwrap(), second_bytes);
+        capabilities.assert_async().await;
+        request.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn rejects_unrequested_blob_pack_frames() {
+        let mut server = mockito::Server::new_async().await;
+        let requested = CacheDigest::blake3(b"requested");
+        let injected_bytes = b"not requested";
+        let injected = CacheDigest::blake3(injected_bytes);
+        server
+            .mock("GET", "/v1/capabilities")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "protocol":{"major":1},
+                    "features":{"blob_packs":true},
+                    "limits":{"max_batch_items":100,"max_pack_bytes":1024}
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+        server
+            .mock("POST", "/v1/blobs:pack")
+            .with_status(200)
+            .with_header("content-type", BLOB_PACK_MEDIA_TYPE)
+            .with_body(encode_blob_pack(&[(&injected, injected_bytes.as_slice())]))
+            .create_async()
+            .await;
+        let client = test_client(&server);
+        let staging = tempfile::tempdir().unwrap();
+
+        let error = client
+            .get_blob_pack(&[requested], staging.path())
+            .await
+            .err()
+            .unwrap();
+
+        assert!(error.to_string().contains("unrequested digest"));
+    }
+
+    #[tokio::test]
+    async fn falls_back_when_blob_packs_are_not_advertised() {
+        let mut server = mockito::Server::new_async().await;
+        let capabilities = server
+            .mock("GET", "/v1/capabilities")
+            .with_status(404)
+            .expect(1)
+            .create_async()
+            .await;
+        let client = test_client(&server);
+        let staging = tempfile::tempdir().unwrap();
+
+        assert!(
+            client
+                .get_blob_pack(&[CacheDigest::blake3(b"blob")], staging.path())
+                .await
+                .unwrap()
+                .is_none()
+        );
+        capabilities.assert_async().await;
+    }
+
+    #[test]
+    fn blob_pack_chunks_honor_item_and_byte_limits() {
+        let first = CacheDigest::blake3(b"1234");
+        let second = CacheDigest::blake3(b"5678");
+        let oversized = CacheDigest::blake3(b"123456789");
+        let chunks = blob_pack_chunks(
+            &[first.clone(), second.clone(), first.clone(), oversized],
+            BlobPackLimits {
+                max_items: 10,
+                max_bytes: 7,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(chunks.len(), 2);
+        let mut expected = vec![first, second];
+        expected.sort();
+        assert_eq!(chunks.concat(), expected);
+
+        let chunks = blob_pack_chunks(
+            &[CacheDigest::blake3(b"a"), CacheDigest::blake3(b"b")],
+            BlobPackLimits {
+                max_items: 1,
+                max_bytes: 100,
+            },
+        )
+        .unwrap();
+        assert_eq!(chunks.len(), 2);
+    }
+
     #[test]
     fn bearer_authorization_headers_are_sensitive() {
         let header = authorization_header(Some(" test-token ")).unwrap().unwrap();
         assert_eq!(header, "Bearer test-token");
         assert!(header.is_sensitive());
         assert!(authorization_header(Some(" ")).unwrap().is_none());
+    }
+
+    fn test_client(server: &mockito::ServerGuard) -> RemoteCacheClient {
+        RemoteCacheClient::new(RemoteCacheConfig {
+            base_url: server.url().parse().unwrap(),
+            namespace: "test".into(),
+            token: None,
+            token_file: None,
+            oidc_audience: None,
+            connect_timeout: Duration::from_secs(1),
+            read_timeout: Duration::from_secs(1),
+            download_timeout: Duration::from_secs(1),
+            retries: 0,
+        })
+        .unwrap()
+    }
+
+    fn encode_blob_pack(entries: &[(&CacheDigest, &[u8])]) -> Vec<u8> {
+        let mut pack = BLOB_PACK_MAGIC.to_vec();
+        for (digest, contents) in entries {
+            assert_eq!(digest.size, contents.len() as u64);
+            pack.push(match digest.algorithm.as_str() {
+                "blake3" => 1,
+                "sha256" => 2,
+                algorithm => panic!("unexpected test digest algorithm {algorithm}"),
+            });
+            pack.extend(hex::decode(&digest.hash).unwrap());
+            pack.extend(digest.size.to_be_bytes());
+            pack.extend_from_slice(contents);
+        }
+        pack
     }
 
     #[tokio::test]

--- a/crates/mise-cache-core/src/lib.rs
+++ b/crates/mise-cache-core/src/lib.rs
@@ -39,6 +39,8 @@ pub const BLOB_MEDIA_TYPE: &str = "application/octet-stream";
 pub const BLOB_PACK_MEDIA_TYPE: &str = "application/vnd.mise.cache-blob-pack.v1";
 const DIGEST_LIST_MEDIA_TYPE: &str = "application/vnd.mise.cache-digests.v1+json";
 const BLOB_PACK_MAGIC: &[u8; 8] = b"MISEPK01";
+const MAX_STAGED_BLOB_PACK_BYTES: u64 = 256 * 1024 * 1024;
+const MAX_STAGED_BLOB_PACK_ITEMS: usize = 2 * 1024;
 
 /// Serialize a protocol object using the JSON Canonicalization Scheme.
 ///
@@ -266,9 +268,10 @@ pub struct RemoteActionManifest {
 
 /// A verified set of remote CAS objects downloaded through blob-pack streams.
 pub struct RemoteBlobPack {
-    _directories: Vec<tempfile::TempDir>,
+    _directory: tempfile::TempDir,
     pub blobs: Vec<(CacheDigest, PathBuf)>,
     pub requests: u64,
+    pub requested: Vec<CacheDigest>,
 }
 
 struct DownloadedBlobPack {
@@ -428,10 +431,8 @@ impl RemoteCacheClient {
             .get_or_try_init(|| async {
                 let url = self.capabilities_endpoint()?;
                 let response = self
-                    .client
-                    .get(url)
-                    .header(PROTOCOL_HEADER, u16::from(PROTOCOL_VERSION))
-                    .header(ACCEPT, "application/json")
+                    .request(reqwest::Method::GET, url, "application/json")
+                    .await?
                     .send()
                     .await?;
                 if matches!(
@@ -463,8 +464,11 @@ impl RemoteCacheClient {
                     bail!("remote cache blob packs require a positive max_pack_bytes limit");
                 }
                 Ok(Some(BlobPackLimits {
-                    max_items,
-                    max_bytes: capabilities.limits.max_pack_bytes,
+                    max_items: max_items.min(MAX_STAGED_BLOB_PACK_ITEMS),
+                    max_bytes: capabilities
+                        .limits
+                        .max_pack_bytes
+                        .min(MAX_STAGED_BLOB_PACK_BYTES),
                 }))
             })
             .await
@@ -487,30 +491,28 @@ impl RemoteCacheClient {
         let Some(limits) = self.blob_pack_limits().await? else {
             return Ok(None);
         };
-        let chunks = blob_pack_chunks(digests, limits)?;
-
         fs::create_dir_all(staging_dir)?;
-        let mut directories = Vec::with_capacity(chunks.len());
-        let mut blobs = Vec::new();
-        let mut requests = 0_u64;
-        for chunk in chunks {
-            match self.download_blob_pack_chunk(&chunk, staging_dir).await? {
-                Some(mut pack) => {
-                    requests += 1;
-                    blobs.append(&mut pack.blobs);
-                    directories.push(pack.directory);
-                }
-                None => {
-                    self.blob_packs_disabled.store(true, Ordering::Relaxed);
-                    return Ok(None);
-                }
+        let chunk = blob_pack_chunk(digests, limits)?;
+        if chunk.is_empty() {
+            return Ok(Some(RemoteBlobPack {
+                _directory: tempfile::tempdir_in(staging_dir)?,
+                blobs: Vec::new(),
+                requests: 0,
+                requested: Vec::new(),
+            }));
+        }
+        match self.download_blob_pack_chunk(&chunk, staging_dir).await? {
+            Some(pack) => Ok(Some(RemoteBlobPack {
+                _directory: pack.directory,
+                blobs: pack.blobs,
+                requests: 1,
+                requested: chunk,
+            })),
+            None => {
+                self.blob_packs_disabled.store(true, Ordering::Relaxed);
+                Ok(None)
             }
         }
-        Ok(Some(RemoteBlobPack {
-            _directories: directories,
-            blobs,
-            requests,
-        }))
     }
 
     async fn download_blob_pack_chunk(
@@ -520,7 +522,7 @@ impl RemoteCacheClient {
     ) -> Result<Option<DownloadedBlobPack>> {
         let url = self.blob_pack_endpoint()?;
         let body = serde_json::to_vec(&DigestList { digests })?;
-        let download = retry_async("POST", &url, self.retries, || async {
+        retry_async("POST", &url, self.retries, || async {
             let response = self
                 .request(reqwest::Method::POST, url.clone(), BLOB_PACK_MEDIA_TYPE)
                 .await?
@@ -549,10 +551,8 @@ impl RemoteCacheClient {
             Ok(Some(
                 decode_blob_pack(response, digests, staging_dir).await?,
             ))
-        });
-        tokio::time::timeout(self.download_timeout, download)
-            .await
-            .map_err(|_| eyre!("remote cache blob pack download timed out for {url}"))?
+        })
+        .await
     }
 
     pub async fn get_action_result(
@@ -760,35 +760,24 @@ impl RemoteCacheClient {
     }
 }
 
-fn blob_pack_chunks(
-    digests: &[CacheDigest],
-    limits: BlobPackLimits,
-) -> Result<Vec<Vec<CacheDigest>>> {
-    let mut unique = BTreeSet::new();
-    for digest in digests {
-        digest.validate()?;
-        unique.insert(digest.clone());
-    }
-    let mut chunks = Vec::new();
+fn blob_pack_chunk(digests: &[CacheDigest], limits: BlobPackLimits) -> Result<Vec<CacheDigest>> {
+    let mut seen = BTreeSet::new();
     let mut chunk = Vec::new();
     let mut chunk_bytes = 0_u64;
-    for digest in unique {
-        if digest.size > limits.max_bytes {
+    for digest in digests {
+        digest.validate()?;
+        if !seen.insert(digest.clone()) || digest.size > limits.max_bytes {
             continue;
         }
         if chunk.len() == limits.max_items
             || chunk_bytes.saturating_add(digest.size) > limits.max_bytes
         {
-            chunks.push(std::mem::take(&mut chunk));
-            chunk_bytes = 0;
+            break;
         }
         chunk_bytes = chunk_bytes.saturating_add(digest.size);
-        chunk.push(digest);
+        chunk.push(digest.clone());
     }
-    if !chunk.is_empty() {
-        chunks.push(chunk);
-    }
-    Ok(chunks)
+    Ok(chunk)
 }
 
 async fn decode_blob_pack(
@@ -1325,6 +1314,7 @@ mod tests {
         let capabilities = server
             .mock("GET", "/v1/capabilities")
             .match_header(PROTOCOL_HEADER, "1")
+            .match_header(AUTHORIZATION.as_str(), "Bearer test-token")
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(
@@ -1434,12 +1424,113 @@ mod tests {
         capabilities.assert_async().await;
     }
 
+    #[tokio::test]
+    async fn disables_blob_packs_when_the_advertised_endpoint_is_unavailable() {
+        let mut server = mockito::Server::new_async().await;
+        let capabilities = server
+            .mock("GET", "/v1/capabilities")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "protocol":{"major":1},
+                    "features":{"blob_packs":true},
+                    "limits":{"max_batch_items":100,"max_pack_bytes":1024}
+                })
+                .to_string(),
+            )
+            .expect(1)
+            .create_async()
+            .await;
+        let request = server
+            .mock("POST", "/v1/blobs:pack")
+            .with_status(404)
+            .expect(1)
+            .create_async()
+            .await;
+        let client = test_client(&server);
+        let staging = tempfile::tempdir().unwrap();
+        let digest = CacheDigest::blake3(b"blob");
+
+        assert!(
+            client
+                .get_blob_pack(std::slice::from_ref(&digest), staging.path())
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            client
+                .get_blob_pack(&[digest], staging.path())
+                .await
+                .unwrap()
+                .is_none()
+        );
+        capabilities.assert_async().await;
+        request.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn rejects_truncated_blob_pack_frames() {
+        let mut server = mockito::Server::new_async().await;
+        let contents = b"complete blob";
+        let digest = CacheDigest::blake3(contents);
+        let mut pack = encode_blob_pack(&[(&digest, contents.as_slice())]);
+        pack.truncate(pack.len() - 3);
+        mock_blob_pack_capabilities(&mut server).await;
+        server
+            .mock("POST", "/v1/blobs:pack")
+            .with_status(200)
+            .with_header("content-type", BLOB_PACK_MEDIA_TYPE)
+            .with_body(pack)
+            .create_async()
+            .await;
+        let client = test_client(&server);
+        let staging = tempfile::tempdir().unwrap();
+
+        let error = match client.get_blob_pack(&[digest], staging.path()).await {
+            Err(error) => error,
+            Ok(_) => panic!("truncated pack should be rejected"),
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("ended before a blob was complete")
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_blob_pack_frames_with_corrupt_content() {
+        let mut server = mockito::Server::new_async().await;
+        let digest = CacheDigest::blake3(b"expected");
+        let corrupt = b"corrupt!";
+        let pack = encode_blob_pack(&[(&digest, corrupt.as_slice())]);
+        mock_blob_pack_capabilities(&mut server).await;
+        server
+            .mock("POST", "/v1/blobs:pack")
+            .with_status(200)
+            .with_header("content-type", BLOB_PACK_MEDIA_TYPE)
+            .with_body(pack)
+            .create_async()
+            .await;
+        let client = test_client(&server);
+        let staging = tempfile::tempdir().unwrap();
+
+        let error = match client.get_blob_pack(&[digest], staging.path()).await {
+            Err(error) => error,
+            Ok(_) => panic!("corrupt pack should be rejected"),
+        };
+
+        assert!(error.to_string().contains("failed digest verification"));
+    }
+
     #[test]
-    fn blob_pack_chunks_honor_item_and_byte_limits() {
+    fn blob_pack_chunk_honors_item_and_byte_limits() {
         let first = CacheDigest::blake3(b"1234");
         let second = CacheDigest::blake3(b"5678");
         let oversized = CacheDigest::blake3(b"123456789");
-        let chunks = blob_pack_chunks(
+        let chunk = blob_pack_chunk(
             &[first.clone(), second.clone(), first.clone(), oversized],
             BlobPackLimits {
                 max_items: 10,
@@ -1448,12 +1539,9 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(chunks.len(), 2);
-        let mut expected = vec![first, second];
-        expected.sort();
-        assert_eq!(chunks.concat(), expected);
+        assert_eq!(chunk, vec![first]);
 
-        let chunks = blob_pack_chunks(
+        let chunk = blob_pack_chunk(
             &[CacheDigest::blake3(b"a"), CacheDigest::blake3(b"b")],
             BlobPackLimits {
                 max_items: 1,
@@ -1461,7 +1549,7 @@ mod tests {
             },
         )
         .unwrap();
-        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunk.len(), 1);
     }
 
     #[test]
@@ -1476,7 +1564,7 @@ mod tests {
         RemoteCacheClient::new(RemoteCacheConfig {
             base_url: server.url().parse().unwrap(),
             namespace: "test".into(),
-            token: None,
+            token: Some("test-token".into()),
             token_file: None,
             oidc_audience: None,
             connect_timeout: Duration::from_secs(1),
@@ -1485,6 +1573,23 @@ mod tests {
             retries: 0,
         })
         .unwrap()
+    }
+
+    async fn mock_blob_pack_capabilities(server: &mut mockito::ServerGuard) {
+        server
+            .mock("GET", "/v1/capabilities")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "protocol":{"major":1},
+                    "features":{"blob_packs":true},
+                    "limits":{"max_batch_items":100,"max_pack_bytes":1024}
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
     }
 
     fn encode_blob_pack(entries: &[(&CacheDigest, &[u8])]) -> Vec<u8> {

--- a/docs/tasks/remote-cache-protocol.md
+++ b/docs/tasks/remote-cache-protocol.md
@@ -109,13 +109,15 @@ the JSON representation, and `size` is an unsigned decimal integer.
   },
   "features": {
     "batch": true,
+    "blob_packs": true,
     "resumable_uploads": true,
     "delegated_transfers": true
   },
   "limits": {
     "max_batch_items": 1000,
     "max_inline_blob_bytes": 1048576,
-    "max_blob_bytes": 107374182400
+    "max_blob_bytes": 107374182400,
+    "max_pack_bytes": 107374182400
   }
 }
 ```
@@ -293,6 +295,30 @@ the cache service's `Authorization` header to the delegated host.
 Clients verify the complete uncompressed digest before using downloaded content. A mismatch is a
 cache miss, emits a visible integrity warning, and must be reported to server telemetry when the
 reporting capability is enabled.
+
+### Read a blob pack
+
+Servers advertising `features.blob_packs` accept `POST /v1/blobs:pack` with the same
+`application/vnd.mise.cache-digests.v1+json` body as `blobs:missing`. The aggregate declared size
+must not exceed `limits.max_pack_bytes`, and the number of digests must not exceed
+`limits.max_batch_items`.
+
+A successful response uses `application/vnd.mise.cache-blob-pack.v1` and begins with the eight-byte
+ASCII magic `MISEPK01`. The remainder is a stream of frames in request order:
+
+| Field     | Encoding                                    |
+| --------- | ------------------------------------------- |
+| Algorithm | one byte: `1` for BLAKE3 or `2` for SHA-256 |
+| Hash      | raw 32-byte digest                          |
+| Size      | unsigned big-endian 64-bit byte length      |
+| Content   | exactly `size` bytes                        |
+
+The server omits missing and unauthorized blobs and emits duplicate requests once. Clients reject
+unrequested or duplicate frames, stream each frame to bounded temporary storage, verify its full
+digest, and only then admit it to local CAS. Clients fall back to ordinary single-blob reads when
+the capability is absent, a digest exceeds the advertised pack limit, or an expected blob is
+omitted. A pack is a transfer optimization only; its framing does not change CAS identity or action
+semantics.
 
 ### Upload blobs
 

--- a/docs/tasks/remote-cache-protocol.md
+++ b/docs/tasks/remote-cache-protocol.md
@@ -301,7 +301,8 @@ reporting capability is enabled.
 Servers advertising `features.blob_packs` accept `POST /v1/blobs:pack` with the same
 `application/vnd.mise.cache-digests.v1+json` body as `blobs:missing`. The aggregate declared size
 must not exceed `limits.max_pack_bytes`, and the number of digests must not exceed
-`limits.max_batch_items`.
+`limits.max_batch_items`. Servers return `400 Bad Request` when the item limit is exceeded and
+`413 Content Too Large` when the aggregate declared size exceeds the byte limit.
 
 A successful response uses `application/vnd.mise.cache-blob-pack.v1` and begins with the eight-byte
 ASCII magic `MISEPK01`. The remainder is a stream of frames in request order:

--- a/src/cache/session.rs
+++ b/src/cache/session.rs
@@ -254,6 +254,8 @@ struct ActionCacheStatsReport {
     remote_manifest_lookups: u64,
     remote_action_lookups: u64,
     remote_blob_requests: u64,
+    remote_blob_pack_requests: u64,
+    remote_blob_pack_blobs: u64,
     remote_manifest_lookup_duration_ns: u64,
     remote_action_lookup_duration_ns: u64,
     remote_blob_transfer_duration_ns: u64,
@@ -283,6 +285,8 @@ impl From<&AgentStats> for ActionCacheStatsReport {
             remote_manifest_lookups: stats.remote_manifest_lookups,
             remote_action_lookups: stats.remote_action_lookups,
             remote_blob_requests: stats.remote_blob_requests,
+            remote_blob_pack_requests: stats.remote_blob_pack_requests,
+            remote_blob_pack_blobs: stats.remote_blob_pack_blobs,
             remote_manifest_lookup_duration_ns: stats.remote_manifest_lookup_duration_ns,
             remote_action_lookup_duration_ns: stats.remote_action_lookup_duration_ns,
             remote_blob_transfer_duration_ns: stats.remote_blob_transfer_duration_ns,
@@ -891,6 +895,8 @@ mod tests {
             restored_output_files: 7,
             restored_output_bytes: 2048,
             remote_blob_requests: 4,
+            remote_blob_pack_requests: 2,
+            remote_blob_pack_blobs: 100,
             materialization_duration_ns: 9,
             ..AgentStats::default()
         };
@@ -909,6 +915,8 @@ mod tests {
         assert_eq!(report["restored_output_files"], 7);
         assert_eq!(report["restored_output_bytes"], 2048);
         assert_eq!(report["remote_blob_requests"], 4);
+        assert_eq!(report["remote_blob_pack_requests"], 2);
+        assert_eq!(report["remote_blob_pack_blobs"], 100);
         assert_eq!(report["materialization_duration_ns"], 9);
     }
 }


### PR DESCRIPTION
## Summary

- negotiate the server's `blob_packs` capability and advertised item/byte limits
- stream verified pack frames into bounded temporary storage before admitting them to local CAS
- resolve a task's predicted action results concurrently, then prefetch top-level objects and directory waves in packed requests
- fall back to concurrent single-blob reads for older servers, oversized objects, omitted objects, or failed packs
- report individual blob requests separately from pack request and packed-blob counts
- document the compatible protocol v1 blob-pack extension

## Why

The aube qualification on mise 2026.8.8 restored every predicted action, but made 3,076 individual blob requests. Prefetch consumed 506.20 seconds of the 527.48-second cache session, while cumulative local CAS writes and materialization accounted for only 6.39 seconds.

The production cache server already supports streamed blob packs. Grouping the known action objects and each discovered directory wave removes the per-object HTTP round trips without changing CAS identity or action-result semantics. A typical shallow Rust output graph now needs roughly two or three pack requests instead of thousands of blob GETs.

## Safety and compatibility

- capability negotiation remains within protocol v1
- clients honor `max_batch_items` and `max_pack_bytes`
- unrequested, duplicate, truncated, malformed, and digest-mismatched frames are rejected
- pack files remain temporary until their complete digest is verified
- missing or unsupported packs transparently use the existing single-blob path
- foreground compiler requests do not acquire locks behind a whole pack download

## Validation

- `cargo test -p mise-cache-core --all-features`
- `cargo test --bin mise cache::session`
- `mise run test:e2e e2e/tasks/test_task_rust_cache_restore`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `hk run check --no-stage crates/mise-cache-core/src/agent.rs crates/mise-cache-core/src/lib.rs docs/tasks/remote-cache-protocol.md src/cache/session.rs`
- verified the production server advertises `blob_packs` with a 10,000-item / 5 GiB limit

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches remote cache transfer and prefetch correctness (pack parsing, completeness checks before storing actions); failures degrade to per-blob GETs rather than changing CAS semantics.
> 
> **Overview**
> **Remote action prefetch** now resolves predicted actions concurrently, batches up to 256 resolved actions (with a short coalesce delay), then downloads CAS objects in **waves**—first top-level digests, then directory trees—using **`POST /v1/blobs:pack`** when the server advertises `blob_packs`, with per-wave caps and validation before publishing to the local action cache.
> 
> **`RemoteCacheClient`** gains capability negotiation (`/v1/capabilities`), streaming **`MISEPK01`** pack decode with digest verification, chunking against server limits, scaled timeouts, and disabling packs after a failed endpoint; missing or omitted blobs still use concurrent single-blob GETs.
> 
> **Observability**: `AgentStats` / session reports add `remote_blob_pack_requests` and `remote_blob_pack_blobs` alongside existing blob request counts. **Docs** describe the v1 blob-pack extension (`max_pack_bytes`, frame format, fallback rules).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45d41578af6589969c7c3ea8461c0c452826549d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved remote cache performance by downloading multiple cached items in efficient batches, including recursively discovered data.
  * Added automatic fallback to individual downloads when batched transfers are unavailable or incomplete.
  * Added validation to ensure downloaded cache data is complete and unmodified before use.
  * Added cache transfer metrics to session statistics.

* **Documentation**
  * Documented batched remote cache transfers, limits, validation, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->