### PR TITLE
docs: fix installing mise links

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ Get up and running with mise in minutes.
 
 ## 1. Install `mise` CLI {#installing-mise-cli}
 
-See [installing mise](/installing-mise) for other ways to install mise (`macport`, `apt`, `yum`, `nix`, etc.).
+See [installing mise](/installing-mise.html) for other ways to install mise (`macport`, `apt`, `yum`, `nix`, etc.).
 
 :::tabs key:installing-mise
 == Linux/macOS

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -5,7 +5,7 @@ This glossary defines key terms and concepts used throughout the mise documentat
 ## Core Concepts
 
 **Activation**
-: The process of loading mise's context (tools, environment variables, PATH modifications) into your shell session. Typically done via `eval "$(mise activate bash)"` in your shell rc file. See [Installing mise](/installing-mise) for setup instructions.
+: The process of loading mise's context (tools, environment variables, PATH modifications) into your shell session. Typically done via `eval "$(mise activate bash)"` in your shell rc file. See [Installing mise](/installing-mise.html) for setup instructions.
 
 **Backend**
 : A package manager or ecosystem that mise uses to install and manage tools. Each backend knows how to fetch, install, and manage tools from its respective source. See [Backends](#backends) below and [Backend Architecture](/dev-tools/backend_architecture) for details.


### PR DESCRIPTION
## Summary

- add the `.html` suffix to two Installing mise links
- stop the docs crawler from requesting the extensionless 404 URL

## Root cause

The production site serves `/installing-mise.html`, while two Markdown links pointed to `/installing-mise`. Unlike canonicalized routes elsewhere in the docs, that extensionless route returns 404.

## Impact

Readers and the Algolia crawler now reach the installation guide successfully from Getting Started and the glossary.

## Validation

- `git diff --check`
- `mise run docs:build`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link fixes with no runtime or security impact.
> 
> **Overview**
> Fixes two Markdown links that pointed at `/installing-mise`, which **404s on the production site** because the page is served as `/installing-mise.html`.
> 
> Updates the **Getting Started** install section and the glossary **Activation** entry so readers and the Algolia crawler reach the installation guide successfully.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e80ec3b3c5039e85c14d595536e339df287a97f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated links to the “Installing mise” documentation to include the `.html` extension.
  * Corrected the installation reference in the Activation glossary definition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->