### PR TITLE
feat(bootstrap): compose config roots

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -16,6 +16,31 @@ ready, but that do not belong in `[tools]`: native libraries, Homebrew
 formulae, dotfile repositories, shell rc files, editor config, macOS
 preferences, user services, and one-time machine setup.
 
+## Composing configuration roots
+
+`[bootstrap].config_roots` composes declarative resources from independent
+configuration roots into the current bootstrap operation:
+
+```toml
+[bootstrap]
+config_roots = ["bundles/*"]
+```
+
+Entries are relative to the declaring config root and may use single-level `*`
+globs. Each matched directory is loaded with the normal active configuration
+environments. Relative resource sources and template `config_root` values remain
+relative to the config that declared them.
+
+Composition includes `[dotfiles]`, `[bootstrap.files]`, and
+`[bootstrap.directories]`. Equivalent declarations are deduplicated. Different
+declarations for the same dotfile target, edit `(path, id)`, managed file, or
+managed directory are errors that identify both declaring configs. Independent
+roots never acquire precedence from their order in `config_roots`.
+
+Other configuration such as tools, tasks, packages, services, hooks, and repos
+is not collected from these roots. Use their existing explicit workflows when
+those resources need aggregate behavior.
+
 ## How it runs
 
 `mise bootstrap` runs these steps in order:

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -29,7 +29,9 @@ config_roots = ["bundles/*"]
 Entries are relative to the declaring config root and may use single-level `*`
 globs. Each matched directory is loaded with the normal active configuration
 environments. Relative resource sources and template `config_root` values remain
-relative to the config that declared them.
+relative to the config that declared them. Variables declared by a selected root
+are available to that root's dotfile templates without leaking into sibling
+roots.
 
 Composition includes `[dotfiles]`, `[bootstrap.files]`, and
 `[bootstrap.directories]`. Equivalent declarations are deduplicated. Different

--- a/e2e/cli/test_bootstrap_config_roots
+++ b/e2e/cli/test_bootstrap_config_roots
@@ -12,21 +12,22 @@ managed_dir="$PWD/managed-dir"
 leaked_repo="$PWD/not-collected-repo"
 outside_root="$PWD/../outside-root"
 
-mkdir -p "$root_a" "$root_b" "$outside_root"
+mkdir -p "$root_a" "$root_b" "$outside_root" "$PWD/aliases"
 echo a >"$root_a/a.txt"
 echo b >"$root_b/b.txt"
 echo env >"$root_a/env.txt"
-echo '{{ vars.root_value }}' >"$root_a/vars.tmpl"
+echo '{{ vars.root_value }}|{{ config_root }}' >"$root_a/vars.tmpl"
 
 cat <<EOF >"$outside_root/mise.toml"
 [dotfiles]
 "$PWD/escaped.conf" = { content = "escaped" }
 EOF
 ln -s "$outside_root" "$PWD/roots/escaped"
+ln -s "$root_a" "$PWD/aliases/a"
 
 cat <<EOF >mise.toml
 [bootstrap]
-config_roots = ["roots/*"]
+config_roots = ["roots/*", "aliases/a"]
 EOF
 
 cat <<EOF >"$root_a/mise.toml"
@@ -75,7 +76,7 @@ assert_succeed "MISE_ENV=dev mise bootstrap dotfiles apply --yes"
 assert "cat $target_a" "a"
 assert "cat $target_b" "b"
 assert "cat $target_env" "env"
-assert "cat $target_vars" "from-root-a"
+assert "cat $target_vars" "from-root-a|$root_a"
 assert "cat $shared_target" "shared"
 assert_fail "test -e $PWD/escaped.conf"
 

--- a/e2e/cli/test_bootstrap_config_roots
+++ b/e2e/cli/test_bootstrap_config_roots
@@ -5,15 +5,24 @@ root_b="$PWD/roots/b"
 target_a="$PWD/a.conf"
 target_b="$PWD/b.conf"
 target_env="$PWD/env.conf"
+target_vars="$PWD/vars.conf"
 shared_target="$PWD/shared.conf"
 managed_file="$PWD/managed.conf"
 managed_dir="$PWD/managed-dir"
 leaked_repo="$PWD/not-collected-repo"
+outside_root="$PWD/../outside-root"
 
-mkdir -p "$root_a" "$root_b"
+mkdir -p "$root_a" "$root_b" "$outside_root"
 echo a >"$root_a/a.txt"
 echo b >"$root_b/b.txt"
 echo env >"$root_a/env.txt"
+echo '{{ vars.root_value }}' >"$root_a/vars.tmpl"
+
+cat <<EOF >"$outside_root/mise.toml"
+[dotfiles]
+"$PWD/escaped.conf" = { content = "escaped" }
+EOF
+ln -s "$outside_root" "$PWD/roots/escaped"
 
 cat <<EOF >mise.toml
 [bootstrap]
@@ -21,8 +30,12 @@ config_roots = ["roots/*"]
 EOF
 
 cat <<EOF >"$root_a/mise.toml"
+[vars]
+root_value = "from-root-a"
+
 [dotfiles]
 "$target_a" = { source = "a.txt", mode = "copy" }
+"$target_vars" = { source = "vars.tmpl", mode = "template" }
 "$shared_target" = { content = "shared" }
 
 [bootstrap.files."$managed_file"]
@@ -55,14 +68,16 @@ content = "managed"
 mode = "0755"
 EOF
 
-assert_succeed "MISE_ENV=dev mise bootstrap dotfiles status --json | jq -e '.files | length == 4'"
+assert_succeed "MISE_ENV=dev mise bootstrap dotfiles status --json | jq -e '.files | length == 5'"
 assert_succeed "MISE_ENV=dev mise bootstrap dotfiles status --json | jq -e '.files[] | select(.target == \"$target_a\") | .origin.config == \"$root_a/mise.toml\" and .origin.config_root == \"$root_a\"'"
 assert_succeed "MISE_ENV=dev mise bootstrap dotfiles status --json | jq -e '.files[] | select(.target == \"$target_env\") | .origin.config == \"$root_a/mise.dev.toml\" and .origin.environment == [\"dev\"]'"
 assert_succeed "MISE_ENV=dev mise bootstrap dotfiles apply --yes"
 assert "cat $target_a" "a"
 assert "cat $target_b" "b"
 assert "cat $target_env" "env"
+assert "cat $target_vars" "from-root-a"
 assert "cat $shared_target" "shared"
+assert_fail "test -e $PWD/escaped.conf"
 
 assert_succeed "mise bootstrap files status --json | jq -e 'length == 2'"
 assert_succeed "mise bootstrap files status --json | jq -e '.[] | select(.id.name == \"$managed_file\") | .origin.config == \"$root_a/mise.toml\"'"

--- a/e2e/cli/test_bootstrap_config_roots
+++ b/e2e/cli/test_bootstrap_config_roots
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+root_a="$PWD/roots/a"
+root_b="$PWD/roots/b"
+target_a="$PWD/a.conf"
+target_b="$PWD/b.conf"
+target_env="$PWD/env.conf"
+shared_target="$PWD/shared.conf"
+managed_file="$PWD/managed.conf"
+managed_dir="$PWD/managed-dir"
+leaked_repo="$PWD/not-collected-repo"
+
+mkdir -p "$root_a" "$root_b"
+echo a >"$root_a/a.txt"
+echo b >"$root_b/b.txt"
+echo env >"$root_a/env.txt"
+
+cat <<EOF >mise.toml
+[bootstrap]
+config_roots = ["roots/*"]
+EOF
+
+cat <<EOF >"$root_a/mise.toml"
+[dotfiles]
+"$target_a" = { source = "a.txt", mode = "copy" }
+"$shared_target" = { content = "shared" }
+
+[bootstrap.files."$managed_file"]
+content = "managed"
+
+[bootstrap.directories."$managed_dir"]
+mode = "0755"
+
+[bootstrap.repos."$leaked_repo"]
+url = "https://example.com/not-collected.git"
+
+[tasks.leaked-root-task]
+run = "exit 1"
+EOF
+
+cat <<EOF >"$root_a/mise.dev.toml"
+[dotfiles]
+"$target_env" = { source = "env.txt", mode = "copy" }
+EOF
+
+cat <<EOF >"$root_b/mise.toml"
+[dotfiles]
+"$target_b" = { source = "b.txt", mode = "copy" }
+"$shared_target" = { content = "shared" }
+
+[bootstrap.files."$managed_file"]
+content = "managed"
+
+[bootstrap.directories."$managed_dir"]
+mode = "0755"
+EOF
+
+assert_succeed "MISE_ENV=dev mise bootstrap dotfiles status --json | jq -e '.files | length == 4'"
+assert_succeed "MISE_ENV=dev mise bootstrap dotfiles status --json | jq -e '.files[] | select(.target == \"$target_a\") | .origin.config == \"$root_a/mise.toml\" and .origin.config_root == \"$root_a\"'"
+assert_succeed "MISE_ENV=dev mise bootstrap dotfiles status --json | jq -e '.files[] | select(.target == \"$target_env\") | .origin.config == \"$root_a/mise.dev.toml\" and .origin.environment == [\"dev\"]'"
+assert_succeed "MISE_ENV=dev mise bootstrap dotfiles apply --yes"
+assert "cat $target_a" "a"
+assert "cat $target_b" "b"
+assert "cat $target_env" "env"
+assert "cat $shared_target" "shared"
+
+assert_succeed "mise bootstrap files status --json | jq -e 'length == 2'"
+assert_succeed "mise bootstrap files status --json | jq -e '.[] | select(.id.name == \"$managed_file\") | .origin.config == \"$root_a/mise.toml\"'"
+assert_succeed "mise bootstrap plan --json | jq -e '.resources[] | select(.id.name == \"$managed_dir\") | .origin.config == \"$root_a/mise.toml\"'"
+assert_not_contains "mise bootstrap plan --json" "$leaked_repo"
+assert_not_contains "mise tasks ls" "leaked-root-task"
+
+cat <<EOF >"$root_b/mise.toml"
+[dotfiles]
+"$target_a" = { source = "b.txt", mode = "copy" }
+EOF
+assert_fail "mise bootstrap dotfiles status" "conflicting dotfile declarations for $target_a"
+assert_fail "mise bootstrap dotfiles status" "$root_a/mise.toml"
+assert_fail "mise bootstrap dotfiles status" "$root_b/mise.toml"
+
+cat <<EOF >"$root_b/mise.toml"
+[bootstrap.files."$managed_file"]
+content = "different"
+EOF
+assert_fail "mise bootstrap files status" "conflicting managed file declarations for $managed_file"
+assert_fail "mise bootstrap files status" "$root_a/mise.toml"
+assert_fail "mise bootstrap files status" "$root_b/mise.toml"
+
+cat <<EOF >"$root_a/mise.toml"
+[dotfiles."$PWD/edit.conf/shared"]
+line = "from a"
+EOF
+cat <<EOF >"$root_b/mise.toml"
+[dotfiles."$PWD/edit.conf/shared"]
+line = "from b"
+EOF
+assert_fail "mise bootstrap dotfiles status" "conflicting dotfile edit declarations"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -3874,6 +3874,13 @@
       "type": "object",
       "description": "machine-global bootstrapping (system packages, repos, macOS defaults, launchd agents, login shell)",
       "properties": {
+        "config_roots": {
+          "type": "array",
+          "description": "independent config roots whose dotfiles and managed files/directories are composed into bootstrap",
+          "items": {
+            "type": "string"
+          }
+        },
         "plugins": {
           "type": "object",
           "description": "package manager plugins to install with `mise bootstrap plugins apply`, keyed by manager name",

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -1373,7 +1373,7 @@ impl Bootstrap {
         } else {
             self.run_hooks(&hooks, BootstrapHookPhase::PreDotfiles)
                 .await?;
-            let files = system::files::files_from_config(&config);
+            let files = system::files::files_from_config(&config)?;
             if files.is_empty() {
                 debug!("bootstrap: no whole-file [dotfiles] entries configured, skipping");
             } else {
@@ -1390,7 +1390,7 @@ impl Bootstrap {
                 }
             }
 
-            let edits = system::edits::edits_from_config(&config);
+            let edits = system::edits::edits_from_config(&config)?;
             if edits.is_empty() {
                 debug!("bootstrap: no edit [dotfiles] entries configured, skipping");
             } else {
@@ -2883,7 +2883,7 @@ impl BootstrapStatus {
         report: &mut BootstrapStatusReport,
     ) -> Result<()> {
         let mut json_files = vec![];
-        for req in system::files::files_from_config(config) {
+        for req in system::files::files_from_config(config)? {
             let state = match system::files::check(config, &req) {
                 Ok(state) => state,
                 Err(err) => system::files::FileState::Differs(format!("{err}")),
@@ -2919,7 +2919,7 @@ impl BootstrapStatus {
         }
 
         let mut json_edits = vec![];
-        for req in system::edits::edits_from_config(config) {
+        for req in system::edits::edits_from_config(config)? {
             let state = match system::edits::check(config, &req) {
                 Ok(state) => state,
                 Err(err) => system::files::FileState::Differs(format!("{err}")),

--- a/src/cli/dotfiles/add.rs
+++ b/src/cli/dotfiles/add.rs
@@ -77,7 +77,7 @@ impl DotfilesAdd {
             None => system::files::default_mode(),
         };
         let config = Config::get().await?;
-        let managed = system::files::files_from_config(&config);
+        let managed = system::files::files_from_config(&config)?;
         let config_path = resolve_target_config_path(ConfigPathOptions {
             global: self.global || !self.local,
             path: self.path.clone(),
@@ -88,7 +88,7 @@ impl DotfilesAdd {
         })?;
 
         let mut planned = vec![];
-        let managed_edits = system::edits::edits_from_config(&config);
+        let managed_edits = system::edits::edits_from_config(&config)?;
         for target_raw in &self.targets {
             let target = system::files::resolve_target_arg(target_raw)
                 .components()

--- a/src/cli/dotfiles/apply.rs
+++ b/src/cli/dotfiles/apply.rs
@@ -41,7 +41,7 @@ impl DotfilesApply {
         Vec<system::files::FileRequest>,
         Vec<system::edits::EditRequest>,
     )> {
-        let all_files = system::files::files_from_config(config);
+        let all_files = system::files::files_from_config(config)?;
         let files = all_files
             .iter()
             .filter(|req| {
@@ -49,7 +49,7 @@ impl DotfilesApply {
             })
             .cloned()
             .collect::<Vec<_>>();
-        let all_edits = system::edits::edits_from_config(config);
+        let all_edits = system::edits::edits_from_config(config)?;
         let edits = all_edits
             .iter()
             .filter(|req| system::edits::matches_target(req, &self.targets))

--- a/src/cli/dotfiles/edit.rs
+++ b/src/cli/dotfiles/edit.rs
@@ -91,12 +91,12 @@ fn source_for_target(
     target: &std::path::Path,
     raw: &str,
 ) -> Result<Option<PathBuf>> {
-    for req in system::files::files_from_config(config) {
+    for req in system::files::files_from_config(config)? {
         if system::files::matches_target(&req.target, &req.target_raw, &[raw.to_string()]) {
             return Ok(Some(req.source));
         }
     }
-    let matching_edits = system::edits::edits_from_config(config)
+    let matching_edits = system::edits::edits_from_config(config)?
         .into_iter()
         .filter(|req| system::edits::matches_target(req, &[raw.to_string()]))
         .collect::<Vec<_>>();
@@ -143,11 +143,11 @@ fn open_or_create(path: &std::path::Path) -> Result<()> {
 async fn apply_target(target: &str) -> Result<()> {
     let config = Config::reset().await?;
     let targets = vec![target.to_string()];
-    let files = system::files::files_from_config(&config)
+    let files = system::files::files_from_config(&config)?
         .into_iter()
         .filter(|req| system::files::matches_target(&req.target, &req.target_raw, &targets))
         .collect::<Vec<_>>();
-    let edits = system::edits::edits_from_config(&config)
+    let edits = system::edits::edits_from_config(&config)?
         .into_iter()
         .filter(|req| system::edits::matches_target(req, &targets))
         .collect::<Vec<_>>();

--- a/src/cli/dotfiles/status.rs
+++ b/src/cli/dotfiles/status.rs
@@ -30,7 +30,7 @@ impl DotfilesStatus {
         let config = Config::get().await?;
         let mut any_missing = false;
 
-        let all_files = system::files::files_from_config(&config);
+        let all_files = system::files::files_from_config(&config)?;
         let files = all_files
             .iter()
             .filter(|req| {
@@ -81,7 +81,7 @@ impl DotfilesStatus {
             }
         }
 
-        let all_edits = system::edits::edits_from_config(&config);
+        let all_edits = system::edits::edits_from_config(&config)?;
         let edits = all_edits
             .iter()
             .filter(|req| system::edits::matches_target(req, &self.targets))

--- a/src/cli/dotfiles/unapply.rs
+++ b/src/cli/dotfiles/unapply.rs
@@ -32,7 +32,7 @@ pub struct DotfilesUnapply {
 impl DotfilesUnapply {
     pub async fn run(self) -> Result<()> {
         let config = Config::get().await?;
-        let all_files = system::files::files_from_config(&config);
+        let all_files = system::files::files_from_config(&config)?;
         let files = all_files
             .iter()
             .filter(|req| {
@@ -40,7 +40,7 @@ impl DotfilesUnapply {
             })
             .cloned()
             .collect::<Vec<_>>();
-        let all_edits = system::edits::edits_from_config(&config);
+        let all_edits = system::edits::edits_from_config(&config)?;
         let edits = all_edits
             .iter()
             .filter(|req| system::edits::matches_target(req, &self.targets))

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,7 +1,7 @@
 use dashmap::DashMap;
 use eyre::{Context, Result, bail, eyre};
 use indexmap::{IndexMap, IndexSet};
-use itertools::Itertools;
+use itertools::{Either, Itertools};
 use path_absolutize::Absolutize;
 pub use settings::{CompilePurpose, Settings};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -71,6 +71,7 @@ pub(crate) struct MonorepoUnion {
 
 pub struct Config {
     pub config_files: ConfigMap,
+    bootstrap_config_maps: Vec<ConfigMap>,
     pub project_root: Option<PathBuf>,
     pub all_aliases: AliasMap,
     pub repo_urls: HashMap<String, String>,
@@ -169,6 +170,7 @@ impl Config {
         Arc::new(Self {
             tera_ctx: self.tera_ctx.clone(),
             config_files,
+            bootstrap_config_maps: self.bootstrap_config_maps.clone(),
             env: OnceCell::new(),
             env_with_sources: OnceCell::new(),
             shorthands: self.shorthands.clone(),
@@ -245,6 +247,7 @@ impl Config {
         let mut config = Self {
             tera_ctx: BASE_CONTEXT.clone(),
             config_files,
+            bootstrap_config_maps: vec![],
             env: OnceCell::new(),
             env_with_sources: OnceCell::new(),
             shorthands: get_shorthands(&Settings::get()),
@@ -265,6 +268,7 @@ impl Config {
         let vars_config = Arc::new(Self {
             tera_ctx: config.tera_ctx.clone(),
             config_files: config.config_files.clone(),
+            bootstrap_config_maps: vec![],
             env: OnceCell::new(),
             env_with_sources: OnceCell::new(),
             shorthands: config.shorthands.clone(),
@@ -305,6 +309,7 @@ impl Config {
         measure!("config::load validate", {
             config.validate()?;
         });
+        config.bootstrap_config_maps = load_bootstrap_config_maps(&config.config_files).await?;
 
         config.all_aliases = measure!("config::load all_aliases", { config.load_all_aliases() });
 
@@ -364,6 +369,14 @@ impl Config {
                 .map(|(k, (v, _))| (k.clone(), v.clone()))
                 .collect()
         })
+    }
+
+    pub(crate) fn bootstrap_config_maps(&self) -> impl Iterator<Item = &ConfigMap> {
+        if self.bootstrap_config_maps.is_empty() {
+            Either::Left(std::iter::once(&self.config_files))
+        } else {
+            Either::Right(self.bootstrap_config_maps.iter())
+        }
     }
     pub async fn env(self: &Arc<Self>) -> eyre::Result<IndexMap<String, String>> {
         Ok(self
@@ -1438,6 +1451,41 @@ fn find_monorepo_config(config_files: &ConfigMap) -> Option<&Arc<dyn ConfigFile>
     config_files
         .values()
         .find(|cf| cf.monorepo_root() == Some(true))
+}
+
+async fn load_bootstrap_config_maps(config_files: &ConfigMap) -> Result<Vec<ConfigMap>> {
+    let Some((declaring_config, patterns)) = config_files.iter().find_map(|(path, cf)| {
+        cf.bootstrap_config()
+            .and_then(|bootstrap| bootstrap.config_roots.map(|patterns| (path, patterns)))
+    }) else {
+        return Ok(vec![]);
+    };
+    if patterns.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let declaring_root = config_files
+        .get(declaring_config)
+        .expect("declaring bootstrap config is loaded")
+        .config_root();
+    let mut roots = expand_bootstrap_config_roots(&declaring_root, &patterns)?;
+    roots.sort();
+    roots.dedup();
+    if roots.is_empty() {
+        bail!("[bootstrap].config_roots did not match any config roots");
+    }
+
+    let mut base = config_files.clone();
+    base.retain(|path, _| {
+        is_global_config(path) || !roots.iter().any(|root| path.starts_with(root))
+    });
+    let mut maps = vec![base];
+    let idiomatic_filenames = BTreeMap::new();
+    for root in roots {
+        let paths = config_paths_in_dir_with_filenames(&root, &DEFAULT_CONFIG_FILENAMES);
+        maps.push(load_config_files_from_paths(&paths, &idiomatic_filenames).await?);
+    }
+    Ok(maps)
 }
 
 async fn load_idiomatic_filenames() -> BTreeMap<String, Vec<String>> {
@@ -3502,13 +3550,33 @@ fn expand_config_roots_inner(
     ctx: Option<&crate::task::TaskLoadContext>,
     filenames: Option<&[String]>,
 ) -> Result<Vec<PathBuf>> {
+    expand_config_roots_inner_for("monorepo", root, patterns, ctx, filenames)
+}
+
+fn expand_bootstrap_config_roots(root: &Path, patterns: &[String]) -> Result<Vec<PathBuf>> {
+    expand_config_roots_inner_for(
+        "bootstrap",
+        root,
+        patterns,
+        None,
+        Some(&DEFAULT_CONFIG_FILENAMES),
+    )
+}
+
+fn expand_config_roots_inner_for(
+    section: &str,
+    root: &Path,
+    patterns: &[String],
+    ctx: Option<&crate::task::TaskLoadContext>,
+    filenames: Option<&[String]>,
+) -> Result<Vec<PathBuf>> {
     let mut subdirs = Vec::new();
 
     for pattern in patterns {
         // Reject absolute paths and parent directory escapes
         if pattern.starts_with('/') || pattern.starts_with("..") || pattern.contains("/../") {
             warn!(
-                "[monorepo] config_roots: '{}' must be a relative path within the monorepo",
+                "[{section}].config_roots: '{}' must be a relative path within the config root",
                 pattern
             );
             continue;
@@ -3517,7 +3585,7 @@ fn expand_config_roots_inner(
         // Reject recursive glob patterns (**)
         if pattern.contains("**") {
             warn!(
-                "[monorepo] config_roots: recursive glob '**' not supported in '{}', use single-level '*' instead",
+                "[{section}].config_roots: recursive glob '**' not supported in '{}', use single-level '*' instead",
                 pattern
             );
             continue;
@@ -3534,7 +3602,7 @@ fn expand_config_roots_inner(
                                 // Verify path is within monorepo root
                                 if path.strip_prefix(root).is_err() {
                                     warn!(
-                                        "[monorepo] config_roots: glob matched path outside monorepo root: {}",
+                                        "[{section}].config_roots: glob matched path outside config root: {}",
                                         path.display()
                                     );
                                     continue;
@@ -3548,13 +3616,13 @@ fn expand_config_roots_inner(
                                 }
                             }
                             Err(e) => {
-                                warn!("[monorepo] config_roots glob error: {e}");
+                                warn!("[{section}].config_roots glob error: {e}");
                             }
                         }
                     }
                 }
                 Err(e) => {
-                    warn!("[monorepo] config_roots invalid glob pattern '{pattern}': {e}");
+                    warn!("[{section}].config_roots invalid glob pattern '{pattern}': {e}");
                 }
             }
         } else {
@@ -3566,7 +3634,7 @@ fn expand_config_roots_inner(
                 && !canonical.starts_with(&canonical_root)
             {
                 warn!(
-                    "[monorepo] config_roots: '{}' resolves outside monorepo root",
+                    "[{section}].config_roots: '{}' resolves outside config root",
                     pattern
                 );
                 continue;
@@ -3578,12 +3646,12 @@ fn expand_config_roots_inner(
                     subdirs.push(path);
                 } else {
                     warn!(
-                        "[monorepo] config_roots: '{}' has no mise config file",
+                        "[{section}].config_roots: '{}' has no mise config file",
                         pattern
                     );
                 }
             } else {
-                warn!("[monorepo] config_roots: '{}' does not exist", pattern);
+                warn!("[{section}].config_roots: '{}' does not exist", pattern);
             }
         }
     }
@@ -5628,6 +5696,7 @@ mod tests {
         let config = Config {
             tera_ctx: BASE_CONTEXT.clone(),
             config_files: Default::default(),
+            bootstrap_config_maps: vec![],
             env: OnceCell::new(),
             env_with_sources: OnceCell::new(),
             shorthands: get_shorthands(&Settings::get()),
@@ -5706,6 +5775,7 @@ mod tests {
         let config = Config {
             tera_ctx: BASE_CONTEXT.clone(),
             config_files: Default::default(),
+            bootstrap_config_maps: vec![],
             env: OnceCell::new(),
             env_with_sources: OnceCell::new(),
             shorthands: get_shorthands(&Settings::get()),
@@ -5788,6 +5858,7 @@ mod tests {
         let config = Config {
             tera_ctx: BASE_CONTEXT.clone(),
             config_files: Default::default(),
+            bootstrap_config_maps: vec![],
             env: OnceCell::new(),
             env_with_sources: OnceCell::new(),
             shorthands: get_shorthands(&Settings::get()),
@@ -5872,6 +5943,7 @@ mod tests {
         let config = Config {
             tera_ctx: BASE_CONTEXT.clone(),
             config_files: Default::default(),
+            bootstrap_config_maps: vec![],
             env: OnceCell::new(),
             env_with_sources: OnceCell::new(),
             shorthands: get_shorthands(&Settings::get()),
@@ -5931,6 +6003,7 @@ mod tests {
             let config = Config {
                 tera_ctx: BASE_CONTEXT.clone(),
                 config_files: Default::default(),
+                bootstrap_config_maps: vec![],
                 env: OnceCell::new(),
                 env_with_sources: OnceCell::new(),
                 shorthands: get_shorthands(&Settings::get()),
@@ -6015,6 +6088,7 @@ config_roots = ["apps/api", "apps/web"]
         let config = Config {
             tera_ctx: BASE_CONTEXT.clone(),
             config_files,
+            bootstrap_config_maps: vec![],
             env: OnceCell::new(),
             env_with_sources: OnceCell::new(),
             shorthands: get_shorthands(&Settings::get()),
@@ -6187,6 +6261,7 @@ config_roots = ["apps/api", "apps/web"]
         let config = Config {
             tera_ctx: BASE_CONTEXT.clone(),
             config_files: Default::default(),
+            bootstrap_config_maps: vec![],
             env: OnceCell::new(),
             env_with_sources: OnceCell::new(),
             shorthands: get_shorthands(&Settings::get()),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -8,7 +8,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::env::join_paths;
 use std::fmt::{Debug, Formatter};
 use std::iter::once;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::LazyLock as Lazy;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, SystemTime};
@@ -69,9 +69,16 @@ pub(crate) struct MonorepoUnion {
     pub repo_urls: HashMap<String, String>,
 }
 
+/// One independently composed bootstrap hierarchy and its scoped template context.
+#[derive(Clone)]
+struct BootstrapConfigMap {
+    config_files: ConfigMap,
+    tera_ctx: tera::Context,
+}
+
 pub struct Config {
     pub config_files: ConfigMap,
-    bootstrap_config_maps: Vec<ConfigMap>,
+    bootstrap_config_maps: Vec<BootstrapConfigMap>,
     pub project_root: Option<PathBuf>,
     pub all_aliases: AliasMap,
     pub repo_urls: HashMap<String, String>,
@@ -309,7 +316,7 @@ impl Config {
         measure!("config::load validate", {
             config.validate()?;
         });
-        config.bootstrap_config_maps = load_bootstrap_config_maps(&config.config_files).await?;
+        config.bootstrap_config_maps = load_bootstrap_config_maps(&config).await?;
 
         config.all_aliases = measure!("config::load all_aliases", { config.load_all_aliases() });
 
@@ -371,12 +378,26 @@ impl Config {
         })
     }
 
+    /// Returns the independent config hierarchies that contribute bootstrap resources.
     pub(crate) fn bootstrap_config_maps(&self) -> impl Iterator<Item = &ConfigMap> {
         if self.bootstrap_config_maps.is_empty() {
             Either::Left(std::iter::once(&self.config_files))
         } else {
-            Either::Right(self.bootstrap_config_maps.iter())
+            Either::Right(
+                self.bootstrap_config_maps
+                    .iter()
+                    .map(|config| &config.config_files),
+            )
         }
+    }
+
+    /// Returns the root-scoped template context for a bootstrap resource declaration.
+    pub(crate) fn bootstrap_tera_ctx(&self, config_path: &Path) -> &tera::Context {
+        self.bootstrap_config_maps
+            .iter()
+            .find(|config| config.config_files.contains_key(config_path))
+            .map(|config| &config.tera_ctx)
+            .unwrap_or(&self.tera_ctx)
     }
     pub async fn env(self: &Arc<Self>) -> eyre::Result<IndexMap<String, String>> {
         Ok(self
@@ -1453,8 +1474,9 @@ fn find_monorepo_config(config_files: &ConfigMap) -> Option<&Arc<dyn ConfigFile>
         .find(|cf| cf.monorepo_root() == Some(true))
 }
 
-async fn load_bootstrap_config_maps(config_files: &ConfigMap) -> Result<Vec<ConfigMap>> {
-    let Some((declaring_config, patterns)) = config_files.iter().find_map(|(path, cf)| {
+/// Loads each selected bootstrap root as an independent hierarchy with scoped variables.
+async fn load_bootstrap_config_maps(config: &Config) -> Result<Vec<BootstrapConfigMap>> {
+    let Some((declaring_config, patterns)) = config.config_files.iter().find_map(|(path, cf)| {
         cf.bootstrap_config()
             .and_then(|bootstrap| bootstrap.config_roots.map(|patterns| (path, patterns)))
     }) else {
@@ -1464,7 +1486,8 @@ async fn load_bootstrap_config_maps(config_files: &ConfigMap) -> Result<Vec<Conf
         return Ok(vec![]);
     }
 
-    let declaring_root = config_files
+    let declaring_root = config
+        .config_files
         .get(declaring_config)
         .expect("declaring bootstrap config is loaded")
         .config_root();
@@ -1475,15 +1498,33 @@ async fn load_bootstrap_config_maps(config_files: &ConfigMap) -> Result<Vec<Conf
         bail!("[bootstrap].config_roots did not match any config roots");
     }
 
-    let mut base = config_files.clone();
+    let mut base = config.config_files.clone();
     base.retain(|path, _| {
         is_global_config(path) || !roots.iter().any(|root| path.starts_with(root))
     });
-    let mut maps = vec![base];
+    let mut maps = vec![BootstrapConfigMap {
+        config_files: base,
+        tera_ctx: config.tera_ctx.clone(),
+    }];
     let idiomatic_filenames = BTreeMap::new();
     for root in roots {
         let paths = config_paths_in_dir_with_filenames(&root, &DEFAULT_CONFIG_FILENAMES);
-        maps.push(load_config_files_from_paths(&paths, &idiomatic_filenames).await?);
+        let config_files = load_config_files_from_paths(&paths, &idiomatic_filenames).await?;
+        let vars_config = config.with_config_files(config_files.clone());
+        let vars_results = load_vars(&vars_config).await?;
+        let mut vars = config.vars.clone();
+        vars.extend(
+            vars_results
+                .vars
+                .iter()
+                .map(|(key, (value, _))| (key.clone(), value.clone())),
+        );
+        let mut tera_ctx = config.tera_ctx.clone();
+        tera_ctx.insert("vars", &vars);
+        maps.push(BootstrapConfigMap {
+            config_files,
+            tera_ctx,
+        });
     }
     Ok(maps)
 }
@@ -3553,6 +3594,7 @@ fn expand_config_roots_inner(
     expand_config_roots_inner_for("monorepo", root, patterns, ctx, filenames)
 }
 
+/// Expands bootstrap root patterns using the normal mise config filenames.
 fn expand_bootstrap_config_roots(root: &Path, patterns: &[String]) -> Result<Vec<PathBuf>> {
     expand_config_roots_inner_for(
         "bootstrap",
@@ -3563,6 +3605,7 @@ fn expand_bootstrap_config_roots(root: &Path, patterns: &[String]) -> Result<Vec
     )
 }
 
+/// Expands safe, single-level config-root patterns for a named config section.
 fn expand_config_roots_inner_for(
     section: &str,
     root: &Path,
@@ -3573,8 +3616,13 @@ fn expand_config_roots_inner_for(
     let mut subdirs = Vec::new();
 
     for pattern in patterns {
-        // Reject absolute paths and parent directory escapes
-        if pattern.starts_with('/') || pattern.starts_with("..") || pattern.contains("/../") {
+        // Reject absolute paths and parent directory escapes.
+        if Path::new(pattern).components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        }) {
             warn!(
                 "[{section}].config_roots: '{}' must be a relative path within the config root",
                 pattern
@@ -3594,25 +3642,44 @@ fn expand_config_roots_inner_for(
         if pattern.contains('*') {
             // Single-level glob expansion
             let full_pattern = root.join(pattern);
+            let canonical_root = match root.canonicalize() {
+                Ok(root) => root,
+                Err(err) => {
+                    warn!(
+                        "[{section}].config_roots: failed to resolve config root {}: {err}",
+                        root.display()
+                    );
+                    continue;
+                }
+            };
             match glob::glob(&full_pattern.to_string_lossy()) {
                 Ok(entries) => {
                     for entry in entries {
                         match entry {
                             Ok(path) => {
-                                // Verify path is within monorepo root
-                                if path.strip_prefix(root).is_err() {
+                                let canonical = match path.canonicalize() {
+                                    Ok(path) => path,
+                                    Err(err) => {
+                                        warn!(
+                                            "[{section}].config_roots: failed to resolve glob match {}: {err}",
+                                            path.display()
+                                        );
+                                        continue;
+                                    }
+                                };
+                                if !canonical.starts_with(&canonical_root) {
                                     warn!(
                                         "[{section}].config_roots: glob matched path outside config root: {}",
                                         path.display()
                                     );
                                     continue;
                                 }
-                                if path.is_dir()
+                                if canonical.is_dir()
                                     && filenames.is_none_or(|filenames| {
-                                        has_mise_config_with_filenames(&path, filenames)
+                                        has_mise_config_with_filenames(&canonical, filenames)
                                     })
                                 {
-                                    subdirs.push(path);
+                                    subdirs.push(canonical);
                                 }
                             }
                             Err(e) => {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3595,7 +3595,7 @@ fn expand_config_roots_inner(
     ctx: Option<&crate::task::TaskLoadContext>,
     filenames: Option<&[String]>,
 ) -> Result<Vec<PathBuf>> {
-    expand_config_roots_inner_for("monorepo", root, patterns, ctx, filenames)
+    expand_config_roots_inner_for("monorepo", root, patterns, ctx, filenames, false)
 }
 
 /// Expands bootstrap root patterns using the normal mise config filenames.
@@ -3606,6 +3606,7 @@ fn expand_bootstrap_config_roots(root: &Path, patterns: &[String]) -> Result<Vec
         patterns,
         None,
         Some(&DEFAULT_CONFIG_FILENAMES),
+        true,
     )
 }
 
@@ -3616,6 +3617,7 @@ fn expand_config_roots_inner_for(
     patterns: &[String],
     ctx: Option<&crate::task::TaskLoadContext>,
     filenames: Option<&[String]>,
+    canonicalize_results: bool,
 ) -> Result<Vec<PathBuf>> {
     let mut subdirs = Vec::new();
     let canonical_root = match root.canonicalize() {
@@ -3655,7 +3657,7 @@ fn expand_config_roots_inner_for(
 
         if pattern.contains('*') {
             // Single-level glob expansion
-            let full_pattern = canonical_root.join(pattern);
+            let full_pattern = root.join(pattern);
             match glob::glob(&full_pattern.to_string_lossy()) {
                 Ok(entries) => {
                     for entry in entries {
@@ -3683,7 +3685,11 @@ fn expand_config_roots_inner_for(
                                         has_mise_config_with_filenames(&canonical, filenames)
                                     })
                                 {
-                                    subdirs.push(canonical);
+                                    subdirs.push(if canonicalize_results {
+                                        canonical
+                                    } else {
+                                        path
+                                    });
                                 }
                             }
                             Err(e) => {
@@ -3698,7 +3704,7 @@ fn expand_config_roots_inner_for(
             }
         } else {
             // Explicit path
-            let path = canonical_root.join(pattern);
+            let path = root.join(pattern);
             let canonical = match path.canonicalize() {
                 Ok(path) => path,
                 Err(_) => {
@@ -3717,7 +3723,11 @@ fn expand_config_roots_inner_for(
                 if filenames
                     .is_none_or(|filenames| has_mise_config_with_filenames(&canonical, filenames))
                 {
-                    subdirs.push(canonical);
+                    subdirs.push(if canonicalize_results {
+                        canonical
+                    } else {
+                        path
+                    });
                 } else {
                     warn!(
                         "[{section}].config_roots: '{}' has no mise config file",
@@ -3734,11 +3744,11 @@ fn expand_config_roots_inner_for(
     if let Some(ctx) = ctx {
         subdirs.retain(|dir| {
             let rel_path = dir
-                .strip_prefix(&canonical_root)
+                .strip_prefix(root)
                 .ok()
                 .and_then(|p| p.to_str())
                 .unwrap_or("");
-            ctx.should_load_subdir(rel_path, canonical_root.to_str().unwrap_or(""))
+            ctx.should_load_subdir(rel_path, root.to_str().unwrap_or(""))
         });
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1500,7 +1500,10 @@ async fn load_bootstrap_config_maps(config: &Config) -> Result<Vec<BootstrapConf
 
     let mut base = config.config_files.clone();
     base.retain(|path, _| {
-        is_global_config(path) || !roots.iter().any(|root| path.starts_with(root))
+        is_global_config(path)
+            || !path
+                .canonicalize()
+                .is_ok_and(|path| roots.iter().any(|root| path.starts_with(root)))
     });
     let mut maps = vec![BootstrapConfigMap {
         config_files: base,
@@ -1521,6 +1524,7 @@ async fn load_bootstrap_config_maps(config: &Config) -> Result<Vec<BootstrapConf
         );
         let mut tera_ctx = config.tera_ctx.clone();
         tera_ctx.insert("vars", &vars);
+        tera_ctx.insert("config_root", &root);
         maps.push(BootstrapConfigMap {
             config_files,
             tera_ctx,
@@ -3614,6 +3618,16 @@ fn expand_config_roots_inner_for(
     filenames: Option<&[String]>,
 ) -> Result<Vec<PathBuf>> {
     let mut subdirs = Vec::new();
+    let canonical_root = match root.canonicalize() {
+        Ok(root) => root,
+        Err(err) => {
+            warn!(
+                "[{section}].config_roots: failed to resolve config root {}: {err}",
+                root.display()
+            );
+            return Ok(subdirs);
+        }
+    };
 
     for pattern in patterns {
         // Reject absolute paths and parent directory escapes.
@@ -3641,17 +3655,7 @@ fn expand_config_roots_inner_for(
 
         if pattern.contains('*') {
             // Single-level glob expansion
-            let full_pattern = root.join(pattern);
-            let canonical_root = match root.canonicalize() {
-                Ok(root) => root,
-                Err(err) => {
-                    warn!(
-                        "[{section}].config_roots: failed to resolve config root {}: {err}",
-                        root.display()
-                    );
-                    continue;
-                }
-            };
+            let full_pattern = canonical_root.join(pattern);
             match glob::glob(&full_pattern.to_string_lossy()) {
                 Ok(entries) => {
                     for entry in entries {
@@ -3694,23 +3698,26 @@ fn expand_config_roots_inner_for(
             }
         } else {
             // Explicit path
-            let path = root.join(pattern);
-            // Verify path is within monorepo root after resolution
-            if let Ok(canonical) = path.canonicalize()
-                && let Ok(canonical_root) = root.canonicalize()
-                && !canonical.starts_with(&canonical_root)
-            {
+            let path = canonical_root.join(pattern);
+            let canonical = match path.canonicalize() {
+                Ok(path) => path,
+                Err(_) => {
+                    warn!("[{section}].config_roots: '{}' does not exist", pattern);
+                    continue;
+                }
+            };
+            if !canonical.starts_with(&canonical_root) {
                 warn!(
                     "[{section}].config_roots: '{}' resolves outside config root",
                     pattern
                 );
                 continue;
             }
-            if path.is_dir() {
+            if canonical.is_dir() {
                 if filenames
-                    .is_none_or(|filenames| has_mise_config_with_filenames(&path, filenames))
+                    .is_none_or(|filenames| has_mise_config_with_filenames(&canonical, filenames))
                 {
-                    subdirs.push(path);
+                    subdirs.push(canonical);
                 } else {
                     warn!(
                         "[{section}].config_roots: '{}' has no mise config file",
@@ -3718,7 +3725,7 @@ fn expand_config_roots_inner_for(
                     );
                 }
             } else {
-                warn!("[{section}].config_roots: '{}' does not exist", pattern);
+                warn!("[{section}].config_roots: '{}' is not a directory", pattern);
             }
         }
     }
@@ -3727,11 +3734,11 @@ fn expand_config_roots_inner_for(
     if let Some(ctx) = ctx {
         subdirs.retain(|dir| {
             let rel_path = dir
-                .strip_prefix(root)
+                .strip_prefix(&canonical_root)
                 .ok()
                 .and_then(|p| p.to_str())
                 .unwrap_or("");
-            ctx.should_load_subdir(rel_path, root.to_str().unwrap_or(""))
+            ctx.should_load_subdir(rel_path, canonical_root.to_str().unwrap_or(""))
         });
     }
 

--- a/src/system/edits.rs
+++ b/src/system/edits.rs
@@ -73,14 +73,14 @@ pub struct EditTomlTable {
 }
 
 /// where a block's content comes from
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum BlockSource {
     Inline(String),
     /// absolute path, resolved against the declaring config file
     File(PathBuf),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum EditOp {
     Block {
         source: BlockSource,
@@ -147,8 +147,34 @@ pub fn matches_target(req: &EditRequest, filters: &[String]) -> bool {
 /// Aggregate edit `[dotfiles]` entries across all loaded config files. Entries
 /// union global -> local, keyed by `(path, id)`; a more local config overrides
 /// an edit with the same id. Malformed entries warn and are skipped.
-pub fn edits_from_config(config: &Config) -> Vec<EditRequest> {
-    edits_from_config_files(&config.config_files)
+pub fn edits_from_config(config: &Config) -> Result<Vec<EditRequest>> {
+    let mut composed: IndexMap<String, EditRequest> = IndexMap::new();
+    for config_files in config.bootstrap_config_maps() {
+        for request in edits_from_config_files(config_files) {
+            let key = format!("{}\u{0}{}", request.path.display(), request.id);
+            if let Some(existing) = composed.get(&key) {
+                if edit_requests_match(existing, &request) {
+                    continue;
+                }
+                bail!(
+                    "conflicting dotfile edit declarations for {}/{}\n\n  first:\n    {}\n\n  second:\n    {}",
+                    request.path.display(),
+                    request.id,
+                    existing.origin.conflict_description(),
+                    request.origin.conflict_description(),
+                );
+            }
+            composed.insert(key, request);
+        }
+    }
+    Ok(composed.into_values().collect())
+}
+
+fn edit_requests_match(first: &EditRequest, second: &EditRequest) -> bool {
+    first.path == second.path
+        && first.id == second.id
+        && first.op == second.op
+        && (!matches!(first.op, EditOp::Block { template: true, .. }) || first.base == second.base)
 }
 
 pub fn edits_from_config_files(config_files: &ConfigMap) -> Vec<EditRequest> {

--- a/src/system/edits.rs
+++ b/src/system/edits.rs
@@ -153,7 +153,7 @@ pub fn edits_from_config(config: &Config) -> Result<Vec<EditRequest>> {
         for request in edits_from_config_files(config_files) {
             let key = format!("{}\u{0}{}", request.path.display(), request.id);
             if let Some(existing) = composed.get(&key) {
-                if edit_requests_match(existing, &request) {
+                if edit_requests_match(config, existing, &request) {
                     continue;
                 }
                 bail!(
@@ -170,11 +170,15 @@ pub fn edits_from_config(config: &Config) -> Result<Vec<EditRequest>> {
     Ok(composed.into_values().collect())
 }
 
-fn edit_requests_match(first: &EditRequest, second: &EditRequest) -> bool {
+/// Returns whether sibling declarations produce the same file edit.
+fn edit_requests_match(config: &Config, first: &EditRequest, second: &EditRequest) -> bool {
     first.path == second.path
         && first.id == second.id
         && first.op == second.op
-        && (!matches!(first.op, EditOp::Block { template: true, .. }) || first.base == second.base)
+        && (!matches!(first.op, EditOp::Block { template: true, .. })
+            || first.base == second.base
+                && config.bootstrap_tera_ctx(&first.origin.config)
+                    == config.bootstrap_tera_ctx(&second.origin.config))
 }
 
 pub fn edits_from_config_files(config_files: &ConfigMap) -> Vec<EditRequest> {
@@ -433,7 +437,12 @@ fn desired_content(config: &Config, req: &EditRequest) -> Result<Option<String>>
     };
     let content = if *template {
         let mut tera = crate::tera::get_tera(Some(&req.base));
-        crate::tera::render_str(&mut tera, &raw, &config.tera_ctx).map_err(|err| {
+        crate::tera::render_str(
+            &mut tera,
+            &raw,
+            config.bootstrap_tera_ctx(&req.origin.config),
+        )
+        .map_err(|err| {
             eyre::eyre!(
                 "[dotfiles].\"{}/{}\": failed to render template: {err}",
                 req.path_raw,

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -152,8 +152,38 @@ pub enum FileState {
 /// Aggregate whole-file `[dotfiles]` entries across all loaded config files.
 /// Keys union global -> local; a more local config overrides an entry for the
 /// same target. Malformed entries and unknown modes warn and are skipped.
-pub fn files_from_config(config: &Config) -> Vec<FileRequest> {
-    files_from_config_files(&config.config_files)
+pub fn files_from_config(config: &Config) -> Result<Vec<FileRequest>> {
+    let mut composed: IndexMap<PathBuf, FileRequest> = IndexMap::new();
+    for config_files in config.bootstrap_config_maps() {
+        for request in files_from_config_files(config_files) {
+            if let Some(existing) = composed.get(&request.target) {
+                if file_requests_match(existing, &request) {
+                    continue;
+                }
+                bail!(
+                    "conflicting dotfile declarations for {}\n\n  first:\n    {}\n\n  second:\n    {}",
+                    request.target.display(),
+                    existing.origin.conflict_description(),
+                    request.origin.conflict_description(),
+                );
+            }
+            composed.insert(request.target.clone(), request);
+        }
+    }
+    Ok(composed.into_values().collect())
+}
+
+fn file_requests_match(first: &FileRequest, second: &FileRequest) -> bool {
+    first.target == second.target
+        && first.source == second.source
+        && first.content == second.content
+        && first.mode == second.mode
+        && first
+            .exclude
+            .iter()
+            .map(glob::Pattern::as_str)
+            .eq(second.exclude.iter().map(glob::Pattern::as_str))
+        && (first.mode != FileMode::Template || first.base == second.base)
 }
 
 /// Aggregate `[dotfiles]` across a specific set of config files. This is

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -157,7 +157,7 @@ pub fn files_from_config(config: &Config) -> Result<Vec<FileRequest>> {
     for config_files in config.bootstrap_config_maps() {
         for request in files_from_config_files(config_files) {
             if let Some(existing) = composed.get(&request.target) {
-                if file_requests_match(existing, &request) {
+                if file_requests_match(config, existing, &request) {
                     continue;
                 }
                 bail!(
@@ -173,7 +173,8 @@ pub fn files_from_config(config: &Config) -> Result<Vec<FileRequest>> {
     Ok(composed.into_values().collect())
 }
 
-fn file_requests_match(first: &FileRequest, second: &FileRequest) -> bool {
+/// Returns whether sibling declarations produce the same whole-file resource.
+fn file_requests_match(config: &Config, first: &FileRequest, second: &FileRequest) -> bool {
     first.target == second.target
         && first.source == second.source
         && first.content == second.content
@@ -183,7 +184,10 @@ fn file_requests_match(first: &FileRequest, second: &FileRequest) -> bool {
             .iter()
             .map(glob::Pattern::as_str)
             .eq(second.exclude.iter().map(glob::Pattern::as_str))
-        && (first.mode != FileMode::Template || first.base == second.base)
+        && (first.mode != FileMode::Template
+            || first.base == second.base
+                && config.bootstrap_tera_ctx(&first.origin.config)
+                    == config.bootstrap_tera_ctx(&second.origin.config))
 }
 
 /// Aggregate `[dotfiles]` across a specific set of config files. This is
@@ -848,7 +852,12 @@ fn check_content(target: &Path, expected: &[u8]) -> Result<FileState> {
 pub fn render_template(config: &Config, req: &FileRequest) -> Result<String> {
     let raw = file::read_to_string(&req.source)?;
     let mut tera = crate::tera::get_tera(Some(&req.base));
-    let rendered = crate::tera::render_str(&mut tera, &raw, &config.tera_ctx).map_err(|err| {
+    let rendered = crate::tera::render_str(
+        &mut tera,
+        &raw,
+        config.bootstrap_tera_ctx(&req.origin.config),
+    )
+    .map_err(|err| {
         eyre::eyre!(
             "[dotfiles].\"{}\": failed to render template {}: {err}",
             req.target_raw,

--- a/src/system/managed_files.rs
+++ b/src/system/managed_files.rs
@@ -10,10 +10,10 @@ use indexmap::IndexMap;
 use path_absolutize::Absolutize;
 use serde::{Deserialize, Serialize};
 
-use crate::config::Config;
+use crate::config::{Config, ConfigMap};
 use crate::system::resources::{ResourceAction, ResourceId, ResourceOrigin, ResourcePlan};
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 pub struct ManagedFileTomlConfig {
     pub source: Option<String>,
     pub content: Option<String>,
@@ -30,7 +30,7 @@ pub struct ManagedFileTomlConfig {
     pub notify: Vec<String>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 pub struct ManagedDirectoryTomlConfig {
     pub owner: Option<String>,
     pub group: Option<String>,
@@ -343,12 +343,44 @@ fn files_from_config(
 fn merged_files_from_config(
     config: &Config,
 ) -> Result<IndexMap<PathBuf, (ManagedFileTomlConfig, PathBuf, ResourceOrigin)>> {
-    let mut merged: IndexMap<PathBuf, (ManagedFileTomlConfig, PathBuf, ResourceOrigin)> =
+    let mut composed: IndexMap<PathBuf, (ManagedFileTomlConfig, PathBuf, ResourceOrigin)> =
         IndexMap::new();
+    for config_files in config.bootstrap_config_maps() {
+        for (path, declaration) in merged_files_from_config_files(config_files)? {
+            if let Some(existing) = composed.get(&path) {
+                if managed_file_declarations_match(existing, &declaration) {
+                    continue;
+                }
+                bail!(
+                    "conflicting managed file declarations for {}\n\n  first:\n    {}\n\n  second:\n    {}",
+                    path.display(),
+                    existing.2.conflict_description(),
+                    declaration.2.conflict_description(),
+                );
+            }
+            composed.insert(path, declaration);
+        }
+    }
+    Ok(composed)
+}
+
+fn managed_file_declarations_match(
+    first: &(ManagedFileTomlConfig, PathBuf, ResourceOrigin),
+    second: &(ManagedFileTomlConfig, PathBuf, ResourceOrigin),
+) -> bool {
+    first.0 == second.0
+        && first.2.source == second.2.source
+        && (!first.0.template || first.1 == second.1)
+}
+
+fn merged_files_from_config_files(
+    config_files: &ConfigMap,
+) -> Result<IndexMap<PathBuf, (ManagedFileTomlConfig, PathBuf, ResourceOrigin)>> {
+    let mut merged = IndexMap::new();
     // Config files are ordered from highest to lowest precedence. Preserve the
     // first declaration of a target so a parent or global layer cannot replace
     // the nearer project declaration.
-    for cf in config.config_files.values() {
+    for cf in config_files.values() {
         if let Some(bootstrap) = cf.bootstrap_config() {
             let mut layer_paths = IndexMap::new();
             let base = cf
@@ -385,9 +417,35 @@ fn merged_files_from_config(
 }
 
 fn directories_from_config(config: &Config) -> Result<Vec<ManagedDirectoryRequest>> {
-    let mut merged: IndexMap<PathBuf, (ManagedDirectoryTomlConfig, ResourceOrigin)> =
+    let mut composed: IndexMap<PathBuf, (ManagedDirectoryTomlConfig, ResourceOrigin)> =
         IndexMap::new();
-    for cf in config.config_files.values() {
+    for config_files in config.bootstrap_config_maps() {
+        for (path, declaration) in directories_from_config_files(config_files)? {
+            if let Some(existing) = composed.get(&path) {
+                if existing.0 == declaration.0 {
+                    continue;
+                }
+                bail!(
+                    "conflicting managed directory declarations for {}\n\n  first:\n    {}\n\n  second:\n    {}",
+                    path.display(),
+                    existing.1.conflict_description(),
+                    declaration.1.conflict_description(),
+                );
+            }
+            composed.insert(path, declaration);
+        }
+    }
+    composed
+        .into_iter()
+        .map(|(path, (config, origin))| ManagedDirectoryRequest::from_toml(path, config, origin))
+        .collect()
+}
+
+fn directories_from_config_files(
+    config_files: &ConfigMap,
+) -> Result<IndexMap<PathBuf, (ManagedDirectoryTomlConfig, ResourceOrigin)>> {
+    let mut merged = IndexMap::new();
+    for cf in config_files.values() {
         if let Some(bootstrap) = cf.bootstrap_config() {
             let origin = ResourceOrigin {
                 config: cf.get_path().to_path_buf(),
@@ -410,10 +468,7 @@ fn directories_from_config(config: &Config) -> Result<Vec<ManagedDirectoryReques
             }
         }
     }
-    merged
-        .into_iter()
-        .map(|(path, (config, origin))| ManagedDirectoryRequest::from_toml(path, config, origin))
-        .collect()
+    Ok(merged)
 }
 
 fn validate_requests(

--- a/src/system/managed_files.rs
+++ b/src/system/managed_files.rs
@@ -364,6 +364,7 @@ fn merged_files_from_config(
     Ok(composed)
 }
 
+/// Returns whether sibling declarations produce the same managed file.
 fn managed_file_declarations_match(
     first: &(ManagedFileTomlConfig, PathBuf, ResourceOrigin),
     second: &(ManagedFileTomlConfig, PathBuf, ResourceOrigin),
@@ -373,6 +374,7 @@ fn managed_file_declarations_match(
         && (!first.0.template || first.1 == second.1)
 }
 
+/// Merges managed files within one config hierarchy using normal precedence.
 fn merged_files_from_config_files(
     config_files: &ConfigMap,
 ) -> Result<IndexMap<PathBuf, (ManagedFileTomlConfig, PathBuf, ResourceOrigin)>> {
@@ -441,6 +443,7 @@ fn directories_from_config(config: &Config) -> Result<Vec<ManagedDirectoryReques
         .collect()
 }
 
+/// Merges managed directories within one config hierarchy using normal precedence.
 fn directories_from_config_files(
     config_files: &ConfigMap,
 ) -> Result<IndexMap<PathBuf, (ManagedDirectoryTomlConfig, ResourceOrigin)>> {

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -73,6 +73,9 @@ pub mod systemd;
 /// `[bootstrap]` as parsed from a single mise.toml
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct BootstrapTomlConfig {
+    /// Independent configuration roots whose declarative files and dotfiles
+    /// participate in bootstrap composition.
+    pub config_roots: Option<Vec<String>>,
     /// Logical secret name -> environment input declaration.
     #[serde(default)]
     pub secrets: IndexMap<String, secrets::SecretTomlConfig>,

--- a/src/system/resources.rs
+++ b/src/system/resources.rs
@@ -32,6 +32,7 @@ pub struct ResourceOrigin {
 }
 
 impl ResourceOrigin {
+    /// Formats the declaration and source paths for a sibling-resource conflict.
     pub fn conflict_description(&self) -> String {
         let mut description = format!("config: {}", self.config.display());
         if let Some(source) = &self.source {

--- a/src/system/resources.rs
+++ b/src/system/resources.rs
@@ -31,6 +31,16 @@ pub struct ResourceOrigin {
     pub source: Option<PathBuf>,
 }
 
+impl ResourceOrigin {
+    pub fn conflict_description(&self) -> String {
+        let mut description = format!("config: {}", self.config.display());
+        if let Some(source) = &self.source {
+            description.push_str(&format!("\n    source: {}", source.display()));
+        }
+        description
+    }
+}
+
 const ENCODED_PATH_PREFIX: &str = "mise:path-";
 
 fn serialize_path<S>(path: &Path, serializer: S) -> Result<S::Ok, S::Error>


### PR DESCRIPTION
## Summary

- add `[bootstrap].config_roots` for composing declarative bootstrap resources from independent config roots
- load each root's normal active environment-specific config files while preserving source-relative paths and provenance
- compose only `[dotfiles]`, `[bootstrap.files]`, and `[bootstrap.directories]`
- deduplicate equivalent declarations and report conflicting sibling declarations with both origins
- document the behavior and add schema plus end-to-end coverage

This is a focused follow-up to #12100 and the design discussion in #12099.

## Semantics

```toml
[bootstrap]
config_roots = ["bundles/*"]
```

Selected roots contribute bootstrap file resources independently. They do not gain precedence from array or glob order. Tools, tasks, packages, services, hooks, and repos from selected roots are not collected.

## Validation

- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise run test:e2e e2e/cli/test_bootstrap_config_roots`
- `mise run test:e2e e2e/cli/test_dotfiles_files e2e/cli/test_dotfiles_edits e2e/cli/test_bootstrap_system_files e2e/cli/test_bootstrap_secrets`
- `mise run render:schema`
- changed-file hk checks (schema, Prettier, rustfmt, cargo check, Markdown lint)
- `shellcheck e2e/cli/test_bootstrap_config_roots`
- `shfmt -d e2e/cli/test_bootstrap_config_roots`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how bootstrap/dotfile resources are loaded and merged across config hierarchies, with new failure modes on conflicts; scope is limited to declarative file resources and is covered by e2e tests.
> 
> **Overview**
> Adds **`[bootstrap].config_roots`** so bootstrap can merge **`[dotfiles]`**, **`[bootstrap.files]`**, and **`[bootstrap.directories]`** from multiple independent directories (single-level `*` globs or explicit paths), each loaded with the active **`MISE_ENV`** layers.
> 
> Each matched root gets its own config hierarchy and **scoped `vars` / `config_root` for templates**; sibling roots do not override each other by list order. **Identical declarations dedupe**; **conflicts** on the same target (dotfile, edit id, managed file/dir) **fail with both declaring configs**. Tools, tasks, repos, and other sections are **not** pulled from those roots.
> 
> **`files_from_config`**, **`edits_from_config`**, and managed-file/directory aggregation now **`Result`** and iterate **`bootstrap_config_maps`** instead of only the main **`config_files`**. Root expansion reuses hardened **`config_roots`** logic (canonical paths, escape rejection). Schema, **`docs/bootstrap.md`**, and an e2e test cover composition, env overlays, exclusions, and conflicts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28445c85af2a977d0ed8084a20b6d01d15e4a057. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for composing bootstrap configuration from multiple independent roots.
  * Bootstrap processing now includes dotfiles, managed files, and directories across active environments.
  * Equivalent duplicate declarations are combined automatically, with root-specific templating preserved.

* **Bug Fixes**
  * Conflicting declarations now produce clear errors identifying their sources.
  * Configuration and bootstrap commands consistently report loading and composition errors.

* **Documentation**
  * Documented configuration-root matching, ordering, supported resources, exclusions, and conflict behavior.

* **Tests**
  * Added end-to-end coverage for merging, environment-specific configuration, exclusions, and conflict handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->