### PR TITLE
fix(which): report uninstalled --tool version instead of "not active"

### DIFF
--- a/e2e/cli/test_which_tool_not_installed
+++ b/e2e/cli/test_which_tool_not_installed
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# `--tool` replaces the config's request, so an uninstalled version leaves
+# nothing for `mise which` to search. The error must blame the version rather
+# than claiming the bin is not active in this directory.
+
+assert "mise use dummy@1.0.0"
+
+assert_fail_contains "mise which dummy --tool=dummy@2.0.0" "dummy@2.0.0 is not installed"
+assert_fail_contains "mise which dummy --tool=dummy@2.0.0" "mise install dummy@2.0.0"
+
+# A fuzzy request names the version it resolved to, so the reason the lookup
+# missed is visible.
+assert_fail_contains "mise which dummy --tool=dummy@2" "resolved to 2.0.0"

--- a/e2e/cli/test_which_tool_not_installed
+++ b/e2e/cli/test_which_tool_not_installed
@@ -6,9 +6,8 @@
 
 assert "mise use dummy@1.0.0"
 
-assert_fail_contains "mise which dummy --tool=dummy@2.0.0" "dummy@2.0.0 is not installed"
-assert_fail_contains "mise which dummy --tool=dummy@2.0.0" "mise install dummy@2.0.0"
+assert_fail_matches "mise which dummy --tool=dummy@2.0.0" 'dummy@2\.0\.0 is not installed[[:space:]]+.*mise install dummy@2\.0\.0.*mise ls dummy'
 
-# A fuzzy request names the version it resolved to, so the reason the lookup
-# missed is visible.
-assert_fail_contains "mise which dummy --tool=dummy@2" "resolved to 2.0.0"
+# A fuzzy request keeps the version the user asked for and names what it
+# resolved to, so the reason the lookup missed is visible.
+assert_fail_matches "mise which dummy --tool=dummy@2" 'dummy@2 is not installed \(resolved to 2\.0\.0\)'

--- a/src/cli/which.rs
+++ b/src/cli/which.rs
@@ -57,6 +57,9 @@ impl Which {
                 Ok(())
             }
             None => {
+                if let Some(msg) = self.uninstalled_tool_message(&config, &ts) {
+                    bail!(msg);
+                }
                 if let Some(msg) =
                     crate::shims::unavailable_configured_tool_message(&config, &ts, &bin_name)
                 {
@@ -95,6 +98,30 @@ impl Which {
         }
         let ts = tsb.build(config).await?;
         Ok(ts)
+    }
+    /// `--tool` replaces whatever the config requested, so a version that isn't
+    /// installed leaves nothing for [`Toolset::which`] to search. Saying the bin
+    /// "is not currently active" would blame the config instead of the flag.
+    fn uninstalled_tool_message(&self, config: &Arc<Config>, ts: &Toolset) -> Option<String> {
+        let tool = self.tool.as_ref()?;
+        let tv = ts
+            .list_current_versions()
+            .into_iter()
+            .find(|(b, tv)| {
+                tv.ba() == tool.ba.as_ref() && !b.is_version_installed(config, tv, true)
+            })
+            .map(|(_, tv)| tv)?;
+        let requested = tool.version.clone().unwrap_or_else(|| tv.version.clone());
+        let resolved = if requested == tv.version {
+            String::new()
+        } else {
+            format!(" (resolved to {})", tv.version)
+        };
+        Some(format!(
+            "{}@{requested} is not installed{resolved}\n\
+             hint: run `mise install {}@{requested}`, or `mise ls {}` to see installed versions",
+            tool.short, tool.short, tool.short
+        ))
     }
     fn has_shim(&self, shim: &str) -> bool {
         SHIMS.join(shim).exists()


### PR DESCRIPTION
`mise which <bin> --tool=<tool>@<version>` reports the wrong reason when the requested version isn't installed:

```
$ mise which java --tool=java@25
mise ERROR java is a mise bin however it is not currently active. Use `mise use` to activate it in this directory.
```

The error message is misleading, because running `mise use` doesn't have any effect.  `Toolset::which` only searches installed versions, so an uninstalled `--tool` version returns `None` and `mise which` fell through to guessing the reason from the shim's presence.

This PR makes the error message more accurate and informative:

```
$ mise which java --tool=java@25
mise ERROR java@25 is not installed (resolved to 25.0.2)
mise ERROR hint: run `mise install java@25`, or `mise ls java` to see installed versions
```

The existing messages are unchanged when `--tool` isn't passed or when the requested version is installed but doesn't provide the bin.

Test: `e2e/cli/test_which_tool_not_installed`.

*AI-assisted — Tool: Claude Code; model: anthropic/global.anthropic.claude-opus-5[1m]; version: 2.1.233.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `which` output when an explicitly requested tool version is not installed.
  * Error messages now identify the resolved version and provide guidance for installing it or viewing available versions.
  * Clarified results for fuzzy version requests, making it easier to understand which installed version was selected.
* **Tests**
  * Added end-to-end coverage for unavailable explicit versions and fuzzy version resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->