### PR TITLE
mise: ARM fixes

### DIFF
--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -116,8 +116,6 @@ Supported os/arch:
 - `linux-x64-musl`
 - `linux-arm64`
 - `linux-arm64-musl`
-- `linux-armv6`
-- `linux-armv6-musl`
 - `linux-armv7`
 - `linux-armv7-musl`
 

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -1110,6 +1110,7 @@ impl AquaBackend {
         };
         let target_arch = match target.arch_name() {
             "x64" => "amd64",
+            "arm" => "armv7l",
             other => other,
         };
         (target_os, target_arch)
@@ -5146,7 +5147,7 @@ pub(crate) fn arch() -> &'static str {
     if cfg!(target_arch = "x86_64") {
         "amd64"
     } else if cfg!(target_arch = "arm") {
-        "armv6l"
+        "armv7l"
     } else if cfg!(target_arch = "aarch64") {
         "arm64"
     } else {

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -3644,6 +3644,41 @@ packages:
     }
 
     #[test]
+    fn arm32_arch_is_rejected_by_validate() {
+        // The upstream aqua registry only ships amd64/arm64 assets and rejects ARM32 entries, so
+        // mise must refuse these hosts instead of hunting for a nonexistent armv7l asset.
+        let registry = ParsedRegistry::parse_yaml(
+            r#"
+packages:
+  - type: github_release
+    repo_owner: example
+    repo_name: tool
+    asset: tool.tar.gz
+"#,
+        )
+        .unwrap();
+        let pkg = registry.package("example/tool").unwrap();
+
+        for unsupported in ["arm", "armv7l"] {
+            let error = validate_platform(&pkg, "v1.0.0", "linux", unsupported)
+                .unwrap_err()
+                .to_string();
+            assert!(
+                error.contains(&format!(
+                    "does not support 32-bit ARM (linux/{unsupported})"
+                )),
+                "{unsupported} should be rejected by validate: {error}"
+            );
+        }
+        for supported in ["amd64", "arm64"] {
+            assert!(
+                validate_platform(&pkg, "v1.0.0", "linux", supported).is_ok(),
+                "{supported} should be accepted by validate"
+            );
+        }
+    }
+
+    #[test]
     fn cargo_warning_uses_crate_name() {
         let registry = ParsedRegistry::parse_yaml(
             r#"
@@ -4912,18 +4947,33 @@ async fn get_tags_with_release_dates(
         .collect())
 }
 
+/// The upstream aqua registry does not support 32-bit ARM and has rejected ARM32 entries, so
+/// there is never an `armv7l` asset to pick: bail out early instead of searching for one.
+fn is_arm32_arch(arch: &str) -> bool {
+    matches!(arch, "arm" | "armv7l")
+}
+
 fn validate(pkg: &AquaPackage, version: &str) -> Result<()> {
+    validate_platform(pkg, version, os(), arch())
+}
+
+/// Test seam over `validate` with the host platform baked in. Accepting `os`/`arch` lets tests
+/// exercise the ARM32 rejection regardless of the architecture the test suite is built for.
+fn validate_platform(pkg: &AquaPackage, version: &str, os: &str, arch: &str) -> Result<()> {
+    if is_arm32_arch(arch) {
+        bail!(
+            "the aqua registry does not support 32-bit ARM ({os}/{arch}): only amd64 and arm64 are supported"
+        );
+    }
     if pkg.no_asset.unwrap_or(false) {
         bail!("no asset released");
     }
     if let Some(message) = &pkg.error_message {
         bail!("{}", message);
     }
-    if !is_platform_supported(&pkg.supported_envs, os(), arch()) {
+    if !is_platform_supported(&pkg.supported_envs, os, arch) {
         bail!(
-            "unsupported env: {}/{} (supported: {:?})",
-            os(),
-            arch(),
+            "unsupported env: {os}/{arch} (supported: {:?})",
             pkg.supported_envs
         );
     }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -84,9 +84,9 @@ impl Platform {
 
         // Validate architecture
         match self.arch.as_str() {
-            "x64" | "arm64" | "x86" | "loongarch64" | "riscv64" => {}
+            "x64" | "arm64" | "arm" | "x86" | "loongarch64" | "riscv64" => {}
             _ => bail!(
-                "Unsupported architecture '{}'. Supported: x64, arm64, x86, loongarch64, riscv64",
+                "Unsupported architecture '{}'. Supported: x64, arm64, arm, x86, loongarch64, riscv64",
                 self.arch
             ),
         }

--- a/src/system/remote.rs
+++ b/src/system/remote.rs
@@ -1921,7 +1921,6 @@ fn normalize_arch(value: &str) -> String {
         "x86_64" | "amd64" => "x86_64".to_string(),
         "aarch64" | "arm64" => "aarch64".to_string(),
         "armv7l" | "armv7" => "armv7".to_string(),
-        "armv6l" | "armv6" => "armv6".to_string(),
         other => other.to_string(),
     }
 }


### PR DESCRIPTION
An example of what went wrong:

```
mise i fd
fd@10.4.2       install                                                                                                                                                         ◟
mise ERROR Failed to install aqua:sharkdp/fd@latest: no asset found: fd-v10.4.2-armv6l-unknown-linux-musl.tar.gz
Available assets:
fd-musl_10.4.2_amd64.deb
fd-musl_10.4.2_arm64.deb
fd-musl_10.4.2_armhf.deb
fd-musl_10.4.2_i686.deb
fd-v10.4.2-aarch64-apple-darwin.tar.gz
fd-v10.4.2-aarch64-pc-windows-msvc.zip
fd-v10.4.2-aarch64-unknown-linux-gnu.tar.gz
fd-v10.4.2-aarch64-unknown-linux-musl.tar.gz
fd-v10.4.2-arm-unknown-linux-gnueabihf.tar.gz
fd-v10.4.2-arm-unknown-linux-musleabihf.tar.gz
fd-v10.4.2-i686-pc-windows-msvc.zip
fd-v10.4.2-i686-unknown-linux-gnu.tar.gz
fd-v10.4.2-i686-unknown-linux-musl.tar.gz
fd-v10.4.2-x86_64-pc-windows-gnu.zip
fd-v10.4.2-x86_64-pc-windows-msvc.zip
fd-v10.4.2-x86_64-unknown-linux-gnu.tar.gz
fd-v10.4.2-x86_64-unknown-linux-musl.tar.gz
fd_10.4.2_amd64.deb
fd_10.4.2_arm64.deb
fd_10.4.2_armhf.deb
fd_10.4.2_i686.deb
```

armv6l is bogus. It's v7 according to mise doctor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ARM architecture detection and platform mapping for Aqua packages.
  - Added clearer validation for unsupported 32-bit ARM systems, including `arm` and `armv7l`.
  - Updated remote architecture handling to avoid incorrectly classifying ARMv6 systems.
  - Added regression coverage for 32-bit ARM validation.

- **Documentation**
  - Removed Linux ARMv6 variants from the documented supported platform list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->