### PR TITLE
test(java): cover version matching with unit tests instead of live metadata

### DIFF
--- a/e2e/core/test_java_vendor_prefix
+++ b/e2e/core/test_java_vendor_prefix
@@ -6,10 +6,9 @@
 # The bug: fuzzy_match_filter uses pattern ^{query}([-.].+)?$ which doesn't match
 # versions like "temurin-25.0.1" because after "temurin-" there's a digit, not "-" or "."
 
-# Regression: numeric queries should not match unintended versions.
-# For example "11.0.1" must not match "11.0.10".
-assert_contains "mise latest java 11.0.1" "11.0.1"
-assert_not_contains "mise latest java 11.0.1" "11.0.10"
+# Numeric queries must not match longer versions ("11.0.1" vs "11.0.10"). That is
+# pure matching logic, so it is covered by unit tests in src/plugins/core/java.rs
+# instead — the versions available here differ per platform.
 
 # Test 1: ls-remote with full prefix+version works
 assert_contains "mise ls-remote java temurin-25" "temurin-25"

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -863,4 +863,51 @@ mod tests {
                 .is_empty()
         );
     }
+
+    fn match_versions(versions: &[&str], query: &str) -> Vec<String> {
+        JavaPlugin::new().fuzzy_match_filter(
+            versions.iter().map(|v| v.to_string()).collect(),
+            query,
+            true,
+        )
+    }
+
+    /// A numeric query must not bleed into a longer version: "11.0.1" selects
+    /// "11.0.1" and its build numbers, never "11.0.10".
+    #[test]
+    fn numeric_query_does_not_match_a_longer_version() {
+        let versions = ["11.0.1", "11.0.1+13", "11.0.10", "11.0.10+9"];
+        assert_eq!(
+            match_versions(&versions, "11.0.1"),
+            ["11.0.1".to_string(), "11.0.1+13".to_string()]
+        );
+    }
+
+    /// `mise upgrade --bump` queries with just the vendor prefix, which has to
+    /// match versions whose next character is a digit. See discussion #7328.
+    #[test]
+    fn vendor_prefix_query_matches_versions_starting_with_a_digit() {
+        let versions = ["temurin-25.0.1", "corretto-25.0.1.9.1", "zulu-25.0.1"];
+        assert_eq!(
+            match_versions(&versions, "temurin-"),
+            ["temurin-25.0.1".to_string()]
+        );
+        assert_eq!(
+            match_versions(&versions, "corretto-"),
+            ["corretto-25.0.1.9.1".to_string()]
+        );
+    }
+
+    /// A vendor-qualified major version stays within that major version.
+    #[test]
+    fn vendor_query_with_major_version_keeps_the_major_version() {
+        let versions = ["temurin-21.0.9+11", "temurin-21.0.10+7", "temurin-25.0.1+9"];
+        assert_eq!(
+            match_versions(&versions, "temurin-21"),
+            [
+                "temurin-21.0.9+11".to_string(),
+                "temurin-21.0.10+7".to_string()
+            ]
+        );
+    }
 }


### PR DESCRIPTION
## Problem

`e2e/core/test_java_vendor_prefix` opens with an assertion that depends on which Java builds the upstream metadata happens to publish:

```bash
assert_contains "mise latest java 11.0.1" "11.0.1"
assert_not_contains "mise latest java 11.0.1" "11.0.10"
```

`11.0.1` exists in `mise-java.jdx.dev/jvm/ga/linux/x86_64.json`, but **not** in `macosx/aarch64.json` — that platform starts at `11.0.10`. So on Apple Silicon `mise latest java 11.0.1` returns nothing, the first assertion fails, and the file aborts before reaching any of the vendor-prefix checks it was written for (discussion #7328).

CI is unaffected because the e2e job runs on Linux, so this only shows up for contributors developing on macOS arm64 — where the test provides no coverage at all today.

## Change

The property being tested — a numeric query must not bleed into a longer version — is pure matching logic and does not need live metadata. It moves to unit tests over a fixed version list in `src/plugins/core/java.rs`, next to the code under test.

Java carries its own `fuzzy_match_filter` override rather than using `Backend::fuzzy_match_filter`, so these tests exercise that override directly:

- `numeric_query_does_not_match_a_longer_version` — `11.0.1` selects `11.0.1` and `11.0.1+13`, never `11.0.10`
- `vendor_prefix_query_matches_versions_starting_with_a_digit` — `temurin-` matches `temurin-25.0.1` (the #7328 regression itself)
- `vendor_query_with_major_version_keeps_the_major_version` — `temurin-21` stays within 21.x

The e2e file keeps its platform-independent assertions unchanged.

Net effect: the same property is now verified on every platform instead of only where the metadata happens to cooperate, and the e2e file runs to completion on macOS arm64.

## Verification

- `cargo test --bin mise java` — 5 passed
- `mise run test:e2e e2e/core/test_java_vendor_prefix` — passes end to end on macOS arm64, including the assertions that were previously unreachable there
- `cargo fmt --all -- --check` and `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean

*AI-assisted — Tool: Claude Code; model: Anthropic/claude-opus-5; version: 2.1.222.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for Java version filtering, including exact numeric matches, vendor-prefixed versions, and vendor-plus-major queries.
  * Updated end-to-end coverage to avoid duplicating version-matching assertions already covered by unit tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->