### PR TITLE
fix(shell): refresh the environment on auto-install when --no-hook-env omits the hook

### DIFF
--- a/e2e-win/pwsh_command_not_found.Tests.ps1
+++ b/e2e-win/pwsh_command_not_found.Tests.ps1
@@ -40,38 +40,39 @@ Describe 'the pwsh command-not-found hook branches on the exit code' {
     }
 
     It 'refreshes the environment itself when --no-hook-env leaves _mise_hook undefined' {
-        # Now that the branch can actually be taken, what it calls has to exist. `--no-hook-env`
-        # suppresses the `_mise_hook` definition while still emitting this block.
+        # `--no-hook-env` suppresses the `_mise_hook` definition while still emitting this block,
+        # so the refresh has to be spelled out here rather than reached through that function.
         $script = mise activate pwsh --no-hook-env | Out-String
 
         $script | Should -Not -Match 'function Global:_mise_hook'
         $script | Should -Match 'hook-not-found -s pwsh'
 
-        # A `-Not -Match` alone passes on any build that never had the branch, and a positive match
-        # that merely wants `Test-Path` somewhere would accept a guard around nothing. Pin the whole
-        # shape instead.
-        $guardedCall = 'LASTEXITCODE -eq 0\)\{[^}]*if \(Test-Path -Path Function:\\_mise_hook\)\{\s*_mise_hook\s*\}'
-        $script | Should -Match $guardedCall
-
-        # Then require it to be the only call in the branch: a second one, added later and left
-        # unguarded, would still satisfy the shape above.
         $branch = [regex]::Match($script, '(?s)hook-not-found -s pwsh.*?StopSearch = \$true').Value
         $branch | Should -Not -BeNullOrEmpty
-        $calls = [regex]::Matches($branch, '(?m)^\s*_mise_hook\s*$').Count
-        $calls | Should -Be 1 -Because 'the guarded one is the only call the branch may make'
 
-        # Not throwing is only half of it: skipping the refresh leaves the tool that was just
-        # installed off PATH, so the handoff finds nothing. The branch has to refresh on its own.
-        $fallback = 'Function:\\_mise_hook\)\{\s*_mise_hook\s*\} else \{'
-        $script | Should -Match $fallback
-        # With the definition suppressed, the only `hook-env` left in the script is that fallback.
-        $script | Should -Match 'hook-env.*-s pwsh'
+        # Nothing in the branch may call `_mise_hook`: an unresolved name inside a
+        # CommandNotFoundAction throws out of the handler, taking the $EventArgs handoff with it.
+        $calls = [regex]::Matches($branch, '(?m)^\s*_mise_hook\s*$').Count
+        $calls | Should -Be 0 -Because 'the refresh is inline, which is what makes it work under the flag'
+
+        # The refresh itself, gated the way `_mise_hook` gates its own body: `deactivate` unsets
+        # MISE_SHELL but leaves this handler registered, and a CommandNotFoundAction runs
+        # in-process, so an ungated refresh would re-apply mise's PATH there for good.
+        $refresh = '(?s)if \(\$env:MISE_SHELL -eq "pwsh"\)\{.*?hook-env[^\r\n]*--force -s pwsh'
+        $branch | Should -Match $refresh
+
+        # And it has to be the only one. The comment here used to promise uniqueness while the
+        # assertion under it checked mere existence, which a stray unguarded call would satisfy.
+        $hookEnvCalls = [regex]::Matches($script, 'hook-env[^\r\n]*-s pwsh').Count
+        $hookEnvCalls | Should -Be 1 -Because 'with the definition suppressed, this is the only hook-env in the script'
     }
 
     It 'because an unresolved name inside the handler throws instead of continuing' {
-        # A plain script block carries on past a command it cannot resolve, so the guard only looks
-        # unnecessary until it is run where mise actually runs it: inside a CommandNotFoundAction,
-        # where the same call aborts the handler and takes the $EventArgs handoff with it.
+        # Why the branch inlines `hook-env` instead of calling `_mise_hook`. A plain script block
+        # carries on past a command it cannot resolve, so the difference only shows up where mise
+        # actually runs this: inside a CommandNotFoundAction, where the call to a function
+        # `--no-hook-env` never defined aborts the handler and takes the $EventArgs handoff with
+        # it. `Guarded` here stands for any shape that does not make that call.
         function Invoke-MiseHandoffProbe {
             param([bool] $Guarded)
 

--- a/e2e-win/pwsh_command_not_found.Tests.ps1
+++ b/e2e-win/pwsh_command_not_found.Tests.ps1
@@ -39,7 +39,7 @@ Describe 'the pwsh command-not-found hook branches on the exit code' {
         $viaCode | Should -Be 'false' -Because 'the new form is right in both directions'
     }
 
-    It 'guards _mise_hook, which --no-hook-env leaves undefined' {
+    It 'refreshes the environment itself when --no-hook-env leaves _mise_hook undefined' {
         # Now that the branch can actually be taken, what it calls has to exist. `--no-hook-env`
         # suppresses the `_mise_hook` definition while still emitting this block.
         $script = mise activate pwsh --no-hook-env | Out-String
@@ -59,6 +59,13 @@ Describe 'the pwsh command-not-found hook branches on the exit code' {
         $branch | Should -Not -BeNullOrEmpty
         $calls = [regex]::Matches($branch, '(?m)^\s*_mise_hook\s*$').Count
         $calls | Should -Be 1 -Because 'the guarded one is the only call the branch may make'
+
+        # Not throwing is only half of it: skipping the refresh leaves the tool that was just
+        # installed off PATH, so the handoff finds nothing. The branch has to refresh on its own.
+        $fallback = 'Function:\\_mise_hook\)\{\s*_mise_hook\s*\} else \{'
+        $script | Should -Match $fallback
+        # With the definition suppressed, the only `hook-env` left in the script is that fallback.
+        $script | Should -Match 'hook-env.*-s pwsh'
     }
 
     It 'because an unresolved name inside the handler throws instead of continuing' {

--- a/e2e-win/pwsh_command_not_found.Tests.ps1
+++ b/e2e-win/pwsh_command_not_found.Tests.ps1
@@ -117,7 +117,7 @@ Describe 'the pwsh command-not-found hook branches on the exit code' {
         # Reached false too, and the probe would look like it had demonstrated the abort.
         $unguarded.Entered | Should -BeTrue -Because 'the handler has to run for the rest to mean anything'
         $unguarded.Reached | Should -BeFalse -Because 'the handoff never runs when the hook is undefined'
-        # The surfaced error names the command the user typed, not the hook that went missing —
+        # The surfaced error names the command the user typed, not the hook that went missing,
         # so there is nothing in the message to match on, only the type.
         $unguarded.Error.Exception | Should -BeOfType ([System.Management.Automation.CommandNotFoundException])
 

--- a/e2e/cli/test_zsh_hook_not_found_no_hook_env
+++ b/e2e/cli/test_zsh_hook_not_found_no_hook_env
@@ -17,12 +17,14 @@ set -eu
 
 eval "$(mise activate zsh --no-hook-env)"
 
-# The premise: the definition is gone, the handler is not.
-if (($+functions[_mise_hook])); then
+# The premise: the definition is gone, the handler is not. `typeset -f` rather than
+# `$+functions`: that special comes from `zsh/parameter`, which zsh dlopens on first
+# reference, and the point of the line under test is that this path no longer loads it.
+if typeset -f _mise_hook >/dev/null 2>&1; then
   echo "expected --no-hook-env to omit _mise_hook"
   exit 1
 fi
-if ! (($+functions[command_not_found_handler])); then
+if ! typeset -f command_not_found_handler >/dev/null 2>&1; then
   echo "expected the command-not-found handler to be installed"
   exit 1
 fi
@@ -56,7 +58,7 @@ if [ -n "${MISE_SHELL:-}" ]; then
   echo "expected deactivate to unset MISE_SHELL"
   exit 1
 fi
-if ! (($+functions[command_not_found_handler])); then
+if ! typeset -f command_not_found_handler >/dev/null 2>&1; then
   echo "expected deactivate to leave the command-not-found handler installed"
   exit 1
 fi

--- a/e2e/cli/test_zsh_hook_not_found_no_hook_env
+++ b/e2e/cli/test_zsh_hook_not_found_no_hook_env
@@ -8,11 +8,12 @@ set -eu
 # hook-not-found had just installed was still not on PATH when the handler ran "$@".
 # bash and fish already refresh here; this is the zsh half.
 #
+# The second half of the test is the other side of that refresh: `mise deactivate`
+# leaves this handler registered, so the refresh has to be gated on MISE_SHELL.
+#
 # Checks are written out rather than using the assert.sh helpers: those declare
 # `local status`, and `status` is read-only in zsh, so they misreport. Every other zsh
 # test in this suite checks directly for the same reason.
-
-mise use -g tiny@3.1.0
 
 eval "$(mise activate zsh --no-hook-env)"
 
@@ -26,21 +27,16 @@ if ! (($+functions[command_not_found_handler])); then
   exit 1
 fi
 
-cat >mise.toml <<EOF
+# `bins = ["rtx-tiny"]` in registry/tiny.toml is what maps the missing bin back to the
+# tool, so declaring tiny in the local config is all the setup this needs.
+cat >mise.toml <<TOML
 [tools]
 tiny = "3.0.0"
-EOF
+TOML
 
-mise uninstall tiny@3.0.0 || true
-if mise ls tiny --installed | grep -q 3.0.0; then
-  echo "precondition: tiny@3.0.0 should not be installed yet"
-  exit 1
-fi
-
-# The tiny plugin provides rtx-tiny. Call the handler directly rather than relying on zsh
-# dispatching an unknown command from a non-interactive script: this runs exactly the line
-# under test, and its exit status is the assertion. Without the refresh the handler
-# installs the tool and then fails to run it.
+# Call the handler directly rather than relying on zsh dispatching an unknown command from
+# a non-interactive script: this runs exactly the line under test, and its exit status is
+# the assertion. Without the refresh the handler installs the tool and then fails to run it.
 if ! command_not_found_handler rtx-tiny >/dev/null; then
   echo "the handler installed the tool but could not run it: the environment was never refreshed"
   exit 1
@@ -48,5 +44,37 @@ fi
 
 if ! mise ls tiny --installed | grep -q 3.0.0; then
   echo "expected the handler to have installed tiny@3.0.0"
+  exit 1
+fi
+
+# `mise deactivate` unsets MISE_SHELL but leaves this handler registered. The handler may
+# still install what the user asked for; what it must not do is put mise's environment back
+# into a shell that was explicitly deactivated.
+mise deactivate
+
+if [ -n "${MISE_SHELL:-}" ]; then
+  echo "expected deactivate to unset MISE_SHELL"
+  exit 1
+fi
+if ! (($+functions[command_not_found_handler])); then
+  echo "expected deactivate to leave the command-not-found handler installed"
+  exit 1
+fi
+
+cat >mise.toml <<TOML
+[tools]
+tiny = "3.1.0"
+TOML
+
+# Fails on the handoff, exactly as it did before this handler refreshed anything: without
+# MISE_SHELL there is no refresh, so "$@" does not find the tool. That is the point.
+command_not_found_handler rtx-tiny >/dev/null 2>&1 || true
+
+if ! mise ls tiny --installed | grep -q 3.1.0; then
+  echo "expected the handler to still install what was asked for"
+  exit 1
+fi
+if [ -n "${__MISE_SESSION:-}" ]; then
+  echo "the handler re-applied mise's environment in a shell the user had deactivated"
   exit 1
 fi

--- a/e2e/cli/test_zsh_hook_not_found_no_hook_env
+++ b/e2e/cli/test_zsh_hook_not_found_no_hook_env
@@ -1,0 +1,52 @@
+#!/usr/bin/env zsh
+# shellcheck disable=SC1071
+set -eu
+
+# `mise activate zsh --no-hook-env` omits the `_mise_hook` definition, but the
+# command-not-found handler is emitted independently (not_found_auto_install is on by
+# default) and called it. Nothing refreshed the environment, so a tool that
+# hook-not-found had just installed was still not on PATH when the handler ran "$@".
+# bash and fish already refresh here; this is the zsh half.
+#
+# Checks are written out rather than using the assert.sh helpers: those declare
+# `local status`, and `status` is read-only in zsh, so they misreport. Every other zsh
+# test in this suite checks directly for the same reason.
+
+mise use -g tiny@3.1.0
+
+eval "$(mise activate zsh --no-hook-env)"
+
+# The premise: the definition is gone, the handler is not.
+if (($+functions[_mise_hook])); then
+  echo "expected --no-hook-env to omit _mise_hook"
+  exit 1
+fi
+if ! (($+functions[command_not_found_handler])); then
+  echo "expected the command-not-found handler to be installed"
+  exit 1
+fi
+
+cat >mise.toml <<EOF
+[tools]
+tiny = "3.0.0"
+EOF
+
+mise uninstall tiny@3.0.0 || true
+if mise ls tiny --installed | grep -q 3.0.0; then
+  echo "precondition: tiny@3.0.0 should not be installed yet"
+  exit 1
+fi
+
+# The tiny plugin provides rtx-tiny. Call the handler directly rather than relying on zsh
+# dispatching an unknown command from a non-interactive script: this runs exactly the line
+# under test, and its exit status is the assertion. Without the refresh the handler
+# installs the tool and then fails to run it.
+if ! command_not_found_handler rtx-tiny >/dev/null; then
+  echo "the handler installed the tool but could not run it: the environment was never refreshed"
+  exit 1
+fi
+
+if ! mise ls tiny --installed | grep -q 3.0.0; then
+  echo "expected the handler to have installed tiny@3.0.0"
+  exit 1
+fi

--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -223,13 +223,20 @@ impl Shell for Pwsh {
                                 & '{exe}' hook-not-found -s pwsh -- $Name | Out-Null
                                 if ($LASTEXITCODE -eq 0){{
                                     # `--no-hook-env` omits the `_mise_hook` definition but still
-                                    # emits this block, and an unresolved name inside a
-                                    # CommandNotFoundAction throws out of the handler instead of
-                                    # continuing: the handoff below would never run, so the tool
-                                    # just installed would still not start. The `mise` wrapper and
-                                    # the prompt function guard the call for the same reason.
+                                    # emits this block, so the refresh cannot depend on it: an
+                                    # unresolved name inside a CommandNotFoundAction throws out of
+                                    # the handler, and skipping the refresh leaves the tool that was
+                                    # just installed off PATH for the handoff below. fish inlines
+                                    # `hook-env` here for the same reason.
                                     if (Test-Path -Path Function:\_mise_hook){{
                                         _mise_hook
+                                    }} else {{
+                                        $status = $global:LASTEXITCODE
+                                        $output = & '{exe}' hook-env{flags} -s pwsh | Out-String
+                                        if ($output -and $output.Trim()) {{
+                                            $output | Invoke-Expression
+                                        }}
+                                        $global:LASTEXITCODE = $status
                                     }}
                                     if (Get-Command $Name -ErrorAction SilentlyContinue){{
                                         $EventArgs.Command = Get-Command $Name
@@ -374,6 +381,25 @@ mod tests {
             guard < call,
             "the guard has to run before the call it avoids"
         );
+    }
+
+    /// `--no-hook-env` drops the `_mise_hook` definition but still emits the
+    /// command-not-found block, so that block has to refresh the environment on its own —
+    /// otherwise the tool it just installed is not on PATH when the handoff looks for it.
+    #[test]
+    fn test_activate_no_hook_env_refreshes_after_auto_install() {
+        let opts = ActivateOptions {
+            exe: Path::new("/some/dir/mise").to_path_buf(),
+            flags: " --status".into(),
+            no_hook_env: true,
+            prelude: vec![],
+        };
+        let script = Pwsh::default().activate(opts);
+
+        assert!(!script.contains("function Global:_mise_hook"));
+        assert!(script.contains("hook-not-found -s pwsh"));
+        // With the definition gone, the only `hook-env` left in the script is the fallback.
+        assert!(script.contains("hook-env --status -s pwsh"));
     }
 
     #[test]

--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -222,21 +222,29 @@ impl Shell for Pwsh {
                                 # and get its status; this is the same thing spelled for pwsh.
                                 & '{exe}' hook-not-found -s pwsh -- $Name | Out-Null
                                 if ($LASTEXITCODE -eq 0){{
-                                    # `--no-hook-env` omits the `_mise_hook` definition but still
-                                    # emits this block, so the refresh cannot depend on it: an
-                                    # unresolved name inside a CommandNotFoundAction throws out of
-                                    # the handler, and skipping the refresh leaves the tool that was
-                                    # just installed off PATH for the handoff below. fish inlines
-                                    # `hook-env` here for the same reason.
-                                    if (Test-Path -Path Function:\_mise_hook){{
-                                        _mise_hook
-                                    }} else {{
-                                        $status = $global:LASTEXITCODE
-                                        $output = & '{exe}' hook-env{flags} -s pwsh | Out-String
+                                    # Refresh inline rather than through `_mise_hook`:
+                                    # `--no-hook-env` omits that definition while still emitting
+                                    # this block, an unresolved name inside a
+                                    # CommandNotFoundAction throws out of the handler, and
+                                    # skipping the refresh leaves the tool just installed off
+                                    # PATH for the handoff below. fish inlines `hook-env` here
+                                    # for the same reason.
+                                    #
+                                    # The MISE_SHELL check is the one `_mise_hook` carries.
+                                    # `deactivate` unsets the variable but leaves this handler
+                                    # registered, and a CommandNotFoundAction runs in-process:
+                                    # without the gate, a deactivated session would get mise's
+                                    # PATH and `__MISE_SESSION` re-applied for good.
+                                    #
+                                    # `--force` because an install just happened: with
+                                    # `hook_env.cache_ttl` set and an inherited `__MISE_SESSION`,
+                                    # the TTL fast path returns before the check that would
+                                    # notice it, and the handoff below would find nothing.
+                                    if ($env:MISE_SHELL -eq "pwsh"){{
+                                        $output = & '{exe}' hook-env{flags} --force -s pwsh | Out-String
                                         if ($output -and $output.Trim()) {{
                                             $output | Invoke-Expression
                                         }}
-                                        $global:LASTEXITCODE = $status
                                     }}
                                     if (Get-Command $Name -ErrorAction SilentlyContinue){{
                                         $EventArgs.Command = Get-Command $Name
@@ -383,6 +391,18 @@ mod tests {
         );
     }
 
+    /// The text of the command-not-found handler, from the `hook-not-found` call to the
+    /// `$EventArgs` handoff that ends the block.
+    fn command_not_found_branch(script: &str) -> &str {
+        let start = script
+            .find("hook-not-found -s pwsh")
+            .expect("activate should emit a command-not-found handler");
+        let end = script[start..]
+            .find("$EventArgs.StopSearch")
+            .expect("the handler should hand the resolved command back");
+        &script[start..start + end]
+    }
+
     /// `--no-hook-env` drops the `_mise_hook` definition but still emits the
     /// command-not-found block, so that block has to refresh the environment on its own —
     /// otherwise the tool it just installed is not on PATH when the handoff looks for it.
@@ -398,8 +418,41 @@ mod tests {
 
         assert!(!script.contains("function Global:_mise_hook"));
         assert!(script.contains("hook-not-found -s pwsh"));
-        // With the definition gone, the only `hook-env` left in the script is the fallback.
-        assert!(script.contains("hook-env --status -s pwsh"));
+        // With the definition gone, the only `hook-env` left in the script is this refresh.
+        // `--force` so an inherited `__MISE_SESSION` plus `hook_env.cache_ttl` cannot make it
+        // exit early on the one call that follows a fresh install.
+        assert!(script.contains("hook-env --status --force -s pwsh"));
+    }
+
+    /// `deactivate` unsets `MISE_SHELL` but leaves the handler registered, and a
+    /// `CommandNotFoundAction` runs in-process: an ungated refresh would re-apply mise's
+    /// PATH permanently in a session the user had deactivated. `_mise_hook` carries the
+    /// same check, and the refresh must not be reached through it — that indirection is
+    /// what `--no-hook-env` removes.
+    #[test]
+    fn test_activate_command_not_found_refresh_is_gated_on_mise_shell() {
+        for no_hook_env in [false, true] {
+            let opts = ActivateOptions {
+                exe: Path::new("/some/dir/mise").to_path_buf(),
+                flags: " --status".into(),
+                no_hook_env,
+                prelude: vec![],
+            };
+            let script = Pwsh::default().activate(opts);
+            let branch = command_not_found_branch(&script);
+
+            let gate = branch
+                .find(r#"if ($env:MISE_SHELL -eq "pwsh"){"#)
+                .expect("the refresh should be gated on MISE_SHELL");
+            let refresh = branch
+                .find("hook-env --status --force -s pwsh")
+                .expect("the handler should refresh the environment after an install");
+            assert!(gate < refresh, "the gate has to precede what it guards");
+            assert!(
+                !branch.lines().any(|l| l.trim() == "_mise_hook"),
+                "the refresh is inline: routing it through _mise_hook is what --no-hook-env breaks"
+            );
+        }
     }
 
     #[test]

--- a/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
@@ -189,13 +189,20 @@ if (-not (Test-Path variable:global:__mise_pwsh_command_not_found)){
                     & '/some/dir/mise' hook-not-found -s pwsh -- $Name | Out-Null
                     if ($LASTEXITCODE -eq 0){
                         # `--no-hook-env` omits the `_mise_hook` definition but still
-                        # emits this block, and an unresolved name inside a
-                        # CommandNotFoundAction throws out of the handler instead of
-                        # continuing: the handoff below would never run, so the tool
-                        # just installed would still not start. The `mise` wrapper and
-                        # the prompt function guard the call for the same reason.
+                        # emits this block, so the refresh cannot depend on it: an
+                        # unresolved name inside a CommandNotFoundAction throws out of
+                        # the handler, and skipping the refresh leaves the tool that was
+                        # just installed off PATH for the handoff below. fish inlines
+                        # `hook-env` here for the same reason.
                         if (Test-Path -Path Function:\_mise_hook){
                             _mise_hook
+                        } else {
+                            $status = $global:LASTEXITCODE
+                            $output = & '/some/dir/mise' hook-env --status -s pwsh | Out-String
+                            if ($output -and $output.Trim()) {
+                                $output | Invoke-Expression
+                            }
+                            $global:LASTEXITCODE = $status
                         }
                         if (Get-Command $Name -ErrorAction SilentlyContinue){
                             $EventArgs.Command = Get-Command $Name

--- a/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
@@ -188,21 +188,29 @@ if (-not (Test-Path variable:global:__mise_pwsh_command_not_found)){
                     # and get its status; this is the same thing spelled for pwsh.
                     & '/some/dir/mise' hook-not-found -s pwsh -- $Name | Out-Null
                     if ($LASTEXITCODE -eq 0){
-                        # `--no-hook-env` omits the `_mise_hook` definition but still
-                        # emits this block, so the refresh cannot depend on it: an
-                        # unresolved name inside a CommandNotFoundAction throws out of
-                        # the handler, and skipping the refresh leaves the tool that was
-                        # just installed off PATH for the handoff below. fish inlines
-                        # `hook-env` here for the same reason.
-                        if (Test-Path -Path Function:\_mise_hook){
-                            _mise_hook
-                        } else {
-                            $status = $global:LASTEXITCODE
-                            $output = & '/some/dir/mise' hook-env --status -s pwsh | Out-String
+                        # Refresh inline rather than through `_mise_hook`:
+                        # `--no-hook-env` omits that definition while still emitting
+                        # this block, an unresolved name inside a
+                        # CommandNotFoundAction throws out of the handler, and
+                        # skipping the refresh leaves the tool just installed off
+                        # PATH for the handoff below. fish inlines `hook-env` here
+                        # for the same reason.
+                        #
+                        # The MISE_SHELL check is the one `_mise_hook` carries.
+                        # `deactivate` unsets the variable but leaves this handler
+                        # registered, and a CommandNotFoundAction runs in-process:
+                        # without the gate, a deactivated session would get mise's
+                        # PATH and `__MISE_SESSION` re-applied for good.
+                        #
+                        # `--force` because an install just happened: with
+                        # `hook_env.cache_ttl` set and an inherited `__MISE_SESSION`,
+                        # the TTL fast path returns before the check that would
+                        # notice it, and the handoff below would find nothing.
+                        if ($env:MISE_SHELL -eq "pwsh"){
+                            $output = & '/some/dir/mise' hook-env --status --force -s pwsh | Out-String
                             if ($output -and $output.Trim()) {
                                 $output | Invoke-Expression
                             }
-                            $global:LASTEXITCODE = $status
                         }
                         if (Get-Command $Name -ErrorAction SilentlyContinue){
                             $EventArgs.Command = Get-Command $Name

--- a/src/shell/snapshots/mise__shell__zsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__zsh__tests__activate.snap
@@ -79,7 +79,14 @@ if [ -z "${_mise_cmd_not_found:-}" ]; then
 
     function command_not_found_handler() {
         if [[ "$1" != "mise" && "$1" != "mise-"* ]] && /some/dir/mise hook-not-found -s zsh -- "$1"; then
-          _mise_hook
+          # `--no-hook-env` omits the `_mise_hook` definition while this handler is
+          # still emitted, so refresh inline when it is absent: otherwise "$@" runs
+          # before the tool that was just installed is on PATH. fish does the same.
+          if (( $+functions[_mise_hook] )); then
+            _mise_hook
+          else
+            eval "$(/some/dir/mise hook-env --status -s zsh)"
+          fi
           "$@"
         elif [ -n "$(declare -f _command_not_found_handler)" ]; then
             _command_not_found_handler "$@"

--- a/src/shell/snapshots/mise__shell__zsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__zsh__tests__activate.snap
@@ -79,13 +79,21 @@ if [ -z "${_mise_cmd_not_found:-}" ]; then
 
     function command_not_found_handler() {
         if [[ "$1" != "mise" && "$1" != "mise-"* ]] && /some/dir/mise hook-not-found -s zsh -- "$1"; then
-          # `--no-hook-env` omits the `_mise_hook` definition while this handler is
-          # still emitted, so refresh inline when it is absent: otherwise "$@" runs
-          # before the tool that was just installed is on PATH. fish does the same.
-          if (( $+functions[_mise_hook] )); then
-            _mise_hook
-          else
-            eval "$(/some/dir/mise hook-env --status -s zsh)"
+          # Refresh inline rather than through `_mise_hook`: `--no-hook-env` omits
+          # that definition while still emitting this handler, and without a refresh
+          # "$@" runs before the tool just installed is on PATH. Called with no
+          # arguments `_mise_hook` is this same eval, so one inline call -- fish's
+          # shape -- covers both modes and leaves nothing to keep in sync.
+          #
+          # MISE_SHELL is the gate `deactivate` turns off: it unsets the variable but
+          # leaves this handler registered, and a shell the user deactivated must not
+          # have mise's environment applied back to it.
+          #
+          # `--force` because an install just happened: with `hook_env.cache_ttl` set
+          # and an inherited `__MISE_SESSION`, the TTL fast path returns before the
+          # check that would notice it, and "$@" would fail exactly as before.
+          if [ -n "${MISE_SHELL:-}" ]; then
+            eval "$(/some/dir/mise hook-env --status --force -s zsh)"
           fi
           "$@"
         elif [ -n "$(declare -f _command_not_found_handler)" ]; then

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -113,13 +113,21 @@ impl Shell for Zsh {
 
                 function command_not_found_handler() {{
                     if [[ "$1" != "mise" && "$1" != "mise-"* ]] && {exe} hook-not-found -s zsh -- "$1"; then
-                      # `--no-hook-env` omits the `_mise_hook` definition while this handler is
-                      # still emitted, so refresh inline when it is absent: otherwise "$@" runs
-                      # before the tool that was just installed is on PATH. fish does the same.
-                      if (( $+functions[_mise_hook] )); then
-                        _mise_hook
-                      else
-                        eval "$({exe} hook-env{flags} -s zsh)"
+                      # Refresh inline rather than through `_mise_hook`: `--no-hook-env` omits
+                      # that definition while still emitting this handler, and without a refresh
+                      # "$@" runs before the tool just installed is on PATH. Called with no
+                      # arguments `_mise_hook` is this same eval, so one inline call -- fish's
+                      # shape -- covers both modes and leaves nothing to keep in sync.
+                      #
+                      # MISE_SHELL is the gate `deactivate` turns off: it unsets the variable but
+                      # leaves this handler registered, and a shell the user deactivated must not
+                      # have mise's environment applied back to it.
+                      #
+                      # `--force` because an install just happened: with `hook_env.cache_ttl` set
+                      # and an inherited `__MISE_SESSION`, the TTL fast path returns before the
+                      # check that would notice it, and "$@" would fail exactly as before.
+                      if [ -n "${{MISE_SHELL:-}}" ]; then
+                        eval "$({exe} hook-env{flags} --force -s zsh)"
                       fi
                       "$@"
                     elif [ -n "$(declare -f _command_not_found_handler)" ]; then
@@ -212,6 +220,14 @@ mod tests {
         assert_snapshot!(zsh.activate(opts));
     }
 
+    /// The text of `command_not_found_handler`, which `activate` emits last.
+    fn command_not_found_handler(script: &str) -> &str {
+        let start = script
+            .find("function command_not_found_handler()")
+            .expect("activate should emit a command-not-found handler");
+        &script[start..]
+    }
+
     /// `--no-hook-env` drops the `_mise_hook` definition but still emits
     /// `command_not_found_handler`, so the handler has to refresh the environment on its
     /// own — otherwise `"$@"` runs before the tool it just installed is on PATH.
@@ -227,8 +243,52 @@ mod tests {
 
         assert!(!script.contains("_mise_hook() {"));
         assert!(script.contains("hook-not-found -s zsh"));
-        // With the definition gone, the only `hook-env` left in the script is the fallback.
-        assert!(script.contains("hook-env --status -s zsh"));
+        // With the definition gone, the only `hook-env` left in the script is this refresh.
+        // `--force` so an inherited `__MISE_SESSION` plus `hook_env.cache_ttl` cannot make it
+        // exit early on the one call that follows a fresh install.
+        assert!(script.contains("hook-env --status --force -s zsh"));
+    }
+
+    /// `deactivate` unsets `MISE_SHELL` but leaves this handler registered, so an
+    /// ungated refresh would re-apply mise's environment in a shell the user had
+    /// deactivated. It is the same gate `_mise_hook` carries in the other shells.
+    #[test]
+    fn test_activate_command_not_found_refresh_is_gated_on_mise_shell() {
+        for no_hook_env in [false, true] {
+            let opts = ActivateOptions {
+                exe: Path::new("/some/dir/mise").to_path_buf(),
+                flags: " --status".into(),
+                no_hook_env,
+                prelude: vec![],
+            };
+            let script = Zsh::default().activate(opts);
+            let handler = command_not_found_handler(&script);
+
+            let gate = handler
+                .find(r#"if [ -n "${MISE_SHELL:-}" ]; then"#)
+                .expect("the refresh should be gated on MISE_SHELL");
+            let refresh = handler
+                .find("hook-env --status --force -s zsh")
+                .expect("the handler should refresh the environment after an install");
+            assert!(gate < refresh, "the gate has to precede what it guards");
+        }
+    }
+
+    /// Referencing a `zsh/parameter` special autoloads the module via dlopen, which can
+    /// deadlock under Rosetta in login shells (jdx/mise#11187). `_mise_hook_env_state` was
+    /// rewritten to avoid exactly that; the handler must not reintroduce it, and under
+    /// `--no-hook-env` nothing else in the script would have loaded the module first.
+    #[test]
+    fn test_activate_command_not_found_avoids_zsh_parameter_module() {
+        let opts = ActivateOptions {
+            exe: Path::new("/some/dir/mise").to_path_buf(),
+            flags: " --status".into(),
+            no_hook_env: true,
+            prelude: vec![],
+        };
+        let script = Zsh::default().activate(opts);
+
+        assert!(!command_not_found_handler(&script).contains("$+functions"));
     }
 
     #[test]

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -113,7 +113,14 @@ impl Shell for Zsh {
 
                 function command_not_found_handler() {{
                     if [[ "$1" != "mise" && "$1" != "mise-"* ]] && {exe} hook-not-found -s zsh -- "$1"; then
-                      _mise_hook
+                      # `--no-hook-env` omits the `_mise_hook` definition while this handler is
+                      # still emitted, so refresh inline when it is absent: otherwise "$@" runs
+                      # before the tool that was just installed is on PATH. fish does the same.
+                      if (( $+functions[_mise_hook] )); then
+                        _mise_hook
+                      else
+                        eval "$({exe} hook-env{flags} -s zsh)"
+                      fi
                       "$@"
                     elif [ -n "$(declare -f _command_not_found_handler)" ]; then
                         _command_not_found_handler "$@"
@@ -203,6 +210,25 @@ mod tests {
             prelude: vec![],
         };
         assert_snapshot!(zsh.activate(opts));
+    }
+
+    /// `--no-hook-env` drops the `_mise_hook` definition but still emits
+    /// `command_not_found_handler`, so the handler has to refresh the environment on its
+    /// own — otherwise `"$@"` runs before the tool it just installed is on PATH.
+    #[test]
+    fn test_activate_no_hook_env_refreshes_after_auto_install() {
+        let opts = ActivateOptions {
+            exe: Path::new("/some/dir/mise").to_path_buf(),
+            flags: " --status".into(),
+            no_hook_env: true,
+            prelude: vec![],
+        };
+        let script = Zsh::default().activate(opts);
+
+        assert!(!script.contains("_mise_hook() {"));
+        assert!(script.contains("hook-not-found -s zsh"));
+        // With the definition gone, the only `hook-env` left in the script is the fallback.
+        assert!(script.contains("hook-env --status -s zsh"));
     }
 
     #[test]


### PR DESCRIPTION
`mise activate <shell> --no-hook-env` omits the `_mise_hook` definition, but the command-not-found block is emitted independently — under `not_found_auto_install`, which is on by default — and calls it. So `hook-not-found` installs the tool and then nothing refreshes the environment: the command the user just typed is still not on `PATH`.

Reproduced end-to-end on the released build (2026.8.3, linux-x64), with a control. In every case the tool **is** installed; only one case cannot run it:

| activation | installed | runnable afterwards |
| --- | --- | --- |
| `mise activate zsh` | ✅ | **RAN** |
| `mise activate zsh --no-hook-env` | ✅ | **NOTRUN** |
| `mise activate bash` | ✅ | **RAN** |
| `mise activate bash --no-hook-env` | ✅ | **RAN** |

## Two of the four shells already get this right, by two different means

| shell | `--no-hook-env` defines `_mise_hook` | how the handler refreshes | works under the flag |
| --- | --- | --- | --- |
| bash | yes — [`bash.rs:44-52`](https://github.com/jdx/mise/blob/main/src/shell/bash.rs#L44-L52) always renders `activate.sh` and passes the flag through as `__MISE_HOOK_ENABLED_VALUE__`, so it decides whether the hook is *installed*, not whether the function *exists* | `_mise_hook` | ✅ |
| fish | no | inlines `hook-env … \| source` ([`fish.rs:121-122`](https://github.com/jdx/mise/blob/main/src/shell/fish.rs#L121-L122)) | ✅ |
| zsh | no | `_mise_hook` | ❌ |
| pwsh | no | `_mise_hook` | ❌ |

So "the auto-install path refreshes the environment even under `--no-hook-env`" is settled by existing behaviour in two shells. This brings the other two in line rather than deciding anything new.

## Why fish's shape and not bash's

Emitting the `_mise_hook` definition unconditionally would also switch on pwsh's existing wrapper call — `if ($(Test-Path -Path Function:\_mise_hook)){ _mise_hook }` inside the generated `mise` function — so `mise use` would start modifying the environment under a flag whose documented purpose is the opposite: *"you can call `mise hook-env` manually which will output the env vars to stdout without actually modifying the environment"*.

Refreshing inside the command-not-found block instead changes nothing outside `not_found_auto_install`.

## The change

One inline `hook-env` per shell, gated on `MISE_SHELL` — fish's shape, in the same place fish puts it.

**zsh**:

```zsh
if [ -n "${MISE_SHELL:-}" ]; then
  eval "$(mise hook-env --force -s zsh)"
fi
"$@"
```

**pwsh**:

```powershell
if ($env:MISE_SHELL -eq "pwsh"){
    $output = & 'mise' hook-env --force -s pwsh | Out-String
    if ($output -and $output.Trim()) { $output | Invoke-Expression }
}
```

Three things fall out of that shape, each of which the earlier guarded-fallback version got wrong:

- **`MISE_SHELL` rather than "is `_mise_hook` defined"**. `deactivate` unsets the function (zsh) and `MISE_SHELL` (pwsh) but leaves `command_not_found_handler` / the `CommandNotFoundAction` delegate registered, so "the definition is absent" is *also* the post-`deactivate` condition. Keying on it applied mise's environment to a shell the user had explicitly deactivated — permanently in pwsh, where the handler runs in-process rather than in a subshell. `MISE_SHELL` is the gate `_mise_hook` itself carries, and the one `deactivate` turns off; `activate` exports it even under `--no-hook-env`.
- **No branch to keep in sync**. Called with no arguments `_mise_hook` *is* this call, so the zsh version was selecting between two copies of one invocation, and the pwsh version duplicated `Global:_mise_hook`'s body minus exactly its `MISE_SHELL` line — drift on day one.
- **No `$+functions`**. Referencing a `zsh/parameter` special autoloads the module via dlopen, which can deadlock under Rosetta in login shells (#11187) — the hazard `_mise_hook_env_state` was rewritten 50 lines up to avoid, and under `--no-hook-env` nothing else in the script would have loaded the module first.

`--force` because an install just *did* happen: with `hook_env.cache_ttl` set and an inherited `__MISE_SESSION`, the TTL fast path returns before the data-dir mtime check that would notice it, and the handoff fails exactly as it did before the fix. `_mise_hook` and fish's inline call share that hole; this is the one call site that knows an install preceded it.

The `$LASTEXITCODE` save/restore is gone: the branch is only entered when `$LASTEXITCODE -eq 0`, so the saved value could only ever be `0`, and nothing between the refresh and the handoff reads it. Running the refresh from the handler's scope is safe because pwsh `hook-env` output is only `${Env:X}='…'` and `Remove-Item … Env:/X`, which are process-level and not scoped.

Accepted, not fixed: after the first auto-install in a `--no-hook-env` session, `__MISE_SESSION` / `__MISE_DIFF` are set for that session, so a later manual `mise hook-env` early-exits and prints nothing. That is inherent to refreshing at all, and fish has behaved this way for as long as it has had this line — worth revisiting for all three shells together rather than here.

## How this surfaced

#12089 fixed the pwsh condition — `if (& native)` tested stdout rather than the exit code — and so made this branch reachable for the first time. The `Test-Path` guard added there stops the handler from throwing; it does not make the installed command usable. Greptile raised the second half during that review.

The two shells fail differently, measured rather than assumed:

- **pwsh**: an unresolved name inside a `CommandNotFoundAction` throws out of the handler, so the `$EventArgs` handoff never runs.
- **zsh**: the undefined call **re-enters** `command_not_found_handler` (with `_mise_hook` as the missing command), which then falls through and continues — so zsh does not abort, it just runs `"$@"` before `PATH` has been updated, after a wasted `hook-not-found` invocation.

## Tests

- **Unit, per shell** — with `no_hook_env: true` the refresh is the only `hook-env` in the generated script, so that assertion is exact; plus one per shell pinning the `MISE_SHELL` gate ahead of the call it guards under *both* flag settings, one asserting the pwsh branch contains no `_mise_hook` call, and one asserting the zsh handler contains no `$+functions`.
- **Both activate snapshots** — the command-not-found block is emitted regardless of the flag, so both change.
- **`e2e/cli/test_zsh_hook_not_found_no_hook_env`** (new) — activates with `--no-hook-env`, asserts `_mise_hook` really is undefined, then calls `command_not_found_handler rtx-tiny` directly rather than relying on zsh dispatching an unknown command from a non-interactive script. Its exit status is the assertion. It then runs `mise deactivate` and calls the handler again: the tool still gets installed, and `__MISE_SESSION` has to stay unset.

  The setup is just a local `mise.toml` — `bins = ["rtx-tiny"]` in `registry/tiny.toml` is what maps the missing bin back to the tool, and the harness gives each test a fresh `MISE_DATA_DIR`, so the global `mise use` and the uninstall-and-check that were here guarded a state that cannot occur.

  Its checks are written out rather than using the `assert.sh` helpers. Those declare `local status`, and `status` is read-only in zsh, so under `zsh` they print `read-only variable: status` and capture nothing — the first revision of this test failed in CI for that reason and not for anything it was testing. Every other zsh test in the suite checks directly, which is presumably the same discovery made earlier; `run_test` does still source `assert.sh` for zsh tests, so the helpers look available when they are not. Worth fixing separately.
- **`e2e-win/pwsh_command_not_found.Tests.ps1`** — pins the gated inline refresh, and counts `hook-env` occurrences instead of matching one, which is what its comment had claimed while the assertion under it accepted any number.

## Verification

The zsh half was measured in WSL (zsh 5.9, released mise): the table at the top, plus the mechanism — after the failing case, running `eval "$(mise hook-env -s zsh)"` by hand turns `NOTRUN` into `RAN`. That is the line this PR adds, so the fix is demonstrated even though the binary measured predates it.

**No local build was run** — this machine cannot build mise. Type checking, the snapshots and both e2e suites are left to CI. The two snapshots were instead re-derived from the `formatdoc!` templates by hand and diffed against the checked-in files.

~~Not in scope, still open: pwsh lacks the `mise` / `mise-*` guard its siblings have in the same handler.~~ #12131 has since landed that guard, and this branch is rebased on top of it (now on `main` through #12152, which includes #12147's rework of the pwsh chpwd/prompt pair — the command-not-found block is untouched by it).

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.235.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved command-not-found handling in PowerShell and zsh when environment hooks are disabled.
- Automatically refreshes the environment after installing a missing tool, allowing it to run immediately.
- Prevents unnecessary environment refreshes when the directory and relevant settings are unchanged.
- Ensures command-not-found handling remains available after deactivation without reactivating the environment.
- Preserves existing hook behavior while avoiding undefined hook calls and preventing attempts to install mise’s own commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


