### PR TITLE
fix(backend): keep flavour queries from crossing a '+'

### DIFF
--- a/e2e/cli/test_latest
+++ b/e2e/cli/test_latest
@@ -21,8 +21,10 @@ assert "mise latest python@anaconda-2 | grep -E '\\-2(\\.[0-9]+)*$'"
 # Ruby
 # assert shorthand is a N.N.N version
 assert "mise latest ruby | grep -E '^[0-9]+(\\.[0-9]+)*$'"
-# assert vendor version ends with -N.N.N
-assert "mise latest ruby@truffleruby | grep -E '\\-[0-9]+(\\.[0-9]+)*$'"
+# assert base flavour preference (e.g. truffleruby instead of truffleruby+graalvm)
+assert "mise latest ruby@truffleruby | grep -E '^truffleruby\\-[0-9]+(\\.[0-9]+)*$'"
+# assert an explicit flavour still resolves to that flavour
+assert "mise latest ruby@truffleruby+graalvm | grep -E '^truffleruby\\+graalvm\\-[0-9]+(\\.[0-9]+)*$'"
 # assert vendor 22 version ends with -22.N.N
 assert "mise latest ruby@truffleruby-22 | grep -E '\\-22(\\.[0-9]+)*$'"
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1476,6 +1476,36 @@ mod tests {
     }
 
     #[test]
+    fn test_fuzzy_match_versions_flavour_query_does_not_cross_a_plus() {
+        // "truffleruby" and "truffleruby+graalvm" are distinct flavours, so a
+        // bare flavour name must not select the other one.
+        let versions = ["truffleruby-34.0.1", "truffleruby+graalvm-34.0.1"]
+            .map(String::from)
+            .to_vec();
+        assert_eq!(
+            fuzzy_match_versions(versions.clone(), "truffleruby", true),
+            ["truffleruby-34.0.1".to_string()]
+        );
+        assert_eq!(
+            fuzzy_match_versions(versions, "truffleruby+graalvm", true),
+            ["truffleruby+graalvm-34.0.1".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_fuzzy_match_versions_numeric_query_still_matches_build_metadata() {
+        // `+` remains a separator for numeric queries, where it introduces
+        // semver build metadata rather than a different flavour.
+        let versions = ["1.9.1", "v1.9.1+hotfix.2", "1.9.10"]
+            .map(String::from)
+            .to_vec();
+        assert_eq!(
+            fuzzy_match_versions(versions, "1.9.1", true),
+            ["1.9.1".to_string(), "v1.9.1+hotfix.2".to_string()]
+        );
+    }
+
+    #[test]
     fn test_fuzzy_match_versions_pep440_drops_alphas_but_honors_exact_match() {
         let versions = vec![
             "3.13.0".to_string(),
@@ -4853,10 +4883,23 @@ pub(crate) fn fuzzy_match_versions(
     // but NOT "1.20". The old pattern achieved this by requiring a separator after the query.
     // However, vendor-prefixed queries like "temurin-" need to match digits immediately after
     // the prefix (e.g. "temurin-25.0.1").
+    // `+` separates semver build metadata ("1.9.1" -> "1.9.1+hotfix.2"), but it
+    // also separates flavour names ("truffleruby" -> "truffleruby+graalvm"). Only
+    // treat it as a separator for numeric queries, so a bare flavour name cannot
+    // select a different flavour.
+    let numeric_query = query
+        .strip_prefix(['v', 'V'])
+        .unwrap_or(query)
+        .starts_with(|c: char| c.is_ascii_digit());
+    let sep = if query == "latest" || numeric_query {
+        "[+\\-.]"
+    } else {
+        "[\\-.]"
+    };
     let query_regex = if query != "latest" && query.ends_with('-') {
         Regex::new(&format!("^{query_pattern}.*$")).unwrap()
     } else {
-        Regex::new(&format!("^{query_pattern}([+\\-.].+)?$")).unwrap()
+        Regex::new(&format!("^{query_pattern}({sep}.+)?$")).unwrap()
     };
 
     // Also create a regex without the 'v' prefix if query starts with 'v'
@@ -4866,7 +4909,7 @@ pub(crate) fn fuzzy_match_versions(
         let re = if query.ends_with('-') {
             Regex::new(&format!("^{without_v}.*$")).unwrap()
         } else {
-            Regex::new(&format!("^{without_v}([+\\-.].+)?$")).unwrap()
+            Regex::new(&format!("^{without_v}({sep}.+)?$")).unwrap()
         };
         Some(re)
     } else {


### PR DESCRIPTION
Reported in https://github.com/jdx/mise/discussions/2498#discussioncomment-18061569.

## Problem

`ruby@truffleruby` selects the GraalVM flavour instead of the native TruffleRuby build:

```console
$ mise latest ruby@truffleruby
truffleruby+graalvm-34.0.1
```

`fuzzy_match_versions` accepts `+` as a separator directly after the query:

```rust
Regex::new(&format!("^{query_pattern}([+\\-.].+)?$")).unwrap()
```

So `truffleruby` matches `truffleruby-34.0.1` *and* `truffleruby+graalvm-34.0.1`, and `find_match_in_list` returns the last entry. ruby-build lists the graalvm builds after the native ones, so graalvm wins every time.

This is a regression. Up to v2025.12.9 the pattern was `^{query}([-.].+)?$` and `ruby@truffleruby` resolved to `truffleruby-*`. `+` entered the class in #7332 (v2025.12.10), whose subject was vendor prefixes like `temurin-`; its description quoted the previous pattern as `^{query}([+-.].+)?$` when the code read `^{query}([-.].+)?$`, so the `+` looks like it was carried over by mistake rather than intended.

It also contradicts a rule mise already applies elsewhere: `e2e/cli/test_latest` asserts "base vendor preference (e.g. liberica instead of liberica-nik)", implemented for Java by the `vendor_dashes` sort in `src/plugins/core/java.rs`. `truffleruby` vs `truffleruby+graalvm` is the same relationship. `docs/lang/ruby.md` likewise documents `ruby@truffleruby` as "latest version of truffleruby".

## Change

`+` means two different things depending on the query:

- after a numeric query it introduces semver build metadata — `1.9.1` → `1.9.1+hotfix.2`
- after a name query it separates flavours — `truffleruby` → `truffleruby+graalvm`

So it stays a separator for numeric queries (a leading `v`/`V` is stripped before the check, keeping `v1.9.1` numeric) and is dropped for name queries.

## Blast radius

Only tools whose versions contain `+` are affected at all, and only when queried by a bare name. Counted from `mise ls-remote`:

| tool | versions containing `+` | effect |
| --- | --- | --- |
| ruby | 31, all `truffleruby+graalvm-*` | fixed by this PR |
| flutter | 11, e.g. `v1.9.1+hotfix.2` | none — reached by numeric queries |
| java | 1080 | none — Java overrides `fuzzy_match_filter` with its own copy |
| node, go, deno, bun, crystal, dotnet, swift, kotlin, scala, erlang, elixir, `npm:`, `cargo:`, `go:` | 0 | none |

The `aqua:` and `ubi:` backends already use `^{query}([-.].+)?$` without `+`, so the two largest backends have been running with this behaviour all along.

## Verification

Behaviour before → after:

| query | before | after |
| --- | --- | --- |
| `ruby@truffleruby` | `truffleruby+graalvm-34.0.1` | **`truffleruby-34.0.1`** |
| `ruby@truffleruby+graalvm` | `truffleruby+graalvm-34.0.1` | unchanged |
| `ruby@truffleruby-22` / `ruby@jruby` / `ruby` | — | unchanged |
| `flutter@1.9.1` / `flutter@1.12.13` | `v1.9.1+hotfix.2` / `v1.12.13+hotfix.5` | unchanged |
| `java@temurin` / `java@temurin-21` / `java@liberica` | — | unchanged |
| `python@anaconda` / `node@22` | — | unchanged |

Tests:

- new unit tests in `src/backend/mod.rs` for both directions — a flavour query does not cross `+`, and a numeric query still matches build metadata
- `e2e/cli/test_latest` asserted `mise latest ruby@truffleruby` ends with `-N.N.N`, which `truffleruby+graalvm-34.0.1` also satisfies — that is why the regression went unnoticed. It now anchors the flavour, mirroring the Java `liberica` assertion, plus a case for the explicit `truffleruby+graalvm` query.
- `cargo test --bin mise backend::` — 584 passed
- `mise run test:e2e e2e/cli/test_latest e2e/core/test_ruby_ls_remote e2e/cli/test_ls_remote e2e/cli/test_lock_version` — pass
- `cargo fmt --all -- --check` and `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean

*AI-assisted — Tool: Claude Code; model: Anthropic/claude-opus-5; version: 2.1.222.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved version matching for precise flavour-specific queries.
  - Preserved correct matching for semantic-version build metadata.
  - Ensured the default Ruby CLI selection prefers the base `truffleruby` flavour.
  - Explicit requests for `truffleruby+graalvm` continue to select that flavour.

- **Tests**
  - Added coverage for flavour-specific selection and version matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->