### PR TITLE
chore(deps): update h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4825,9 +4825,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Problem

The `lint` job fails on every pull request against `main`, at `rm -rf ~/.cargo/advisory-dbs && cargo deny check`:

```
error[vulnerability]: h2 unbounded empty DATA frames
    ├ ID: RUSTSEC-2026-0258
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0258
    ├ Solution: Upgrade to >=0.4.16 (try `cargo update -p h2`)

advisories FAILED, bans ok, licenses ok, sources ok
```

`h2` is reached only transitively (through `reqwest`, `hyper-util`, `aws-smithy-http-client`, `mockito`, `wiremock`, and others) and is not declared in any `Cargo.toml`, so this is a lockfile-only bump: 0.4.15 → 0.4.16.

`main` itself has not run `lint` since the advisory was published, which is why the breakage only shows on PRs.

## Note on how the bump was applied

`cargo update -p h2 --precise 0.4.16` produced 20 changed lines: alongside h2 it reverted unrelated entries — `windows-sys 0.61.2` down to 0.52.0/0.59.0/0.60.2 across a dozen crates, `errno 0.2.8` → 0.3.14, and `getrandom 0.4.3` → 0.3.4. That churn is unrelated to the advisory, so the h2 entry was updated on its own instead. The result is a two-line diff.

h2 0.4.16 does not change its dependency set, so the rest of the lock entry is untouched.

## Verification

- `cargo check --locked` succeeds and leaves `Cargo.lock` unmodified, confirming the lockfile is self-consistent
- `cargo deny check` → `advisories ok, bans ok, licenses ok, sources ok`

#12084 (lock file maintenance) also carries this bump, but it is currently failing `build-ubuntu`, `build-windows`, `unit-macos`, `windows-unit` and `nightly`. This PR isolates the advisory fix so `lint` can go green independently of that.

*AI-assisted — Tool: Claude Code; model: Anthropic/claude-opus-5; version: 2.1.222.*
