### PR TITLE
fix(shell): skip mise's own commands in the pwsh command-not-found hook

### DIFF
--- a/e2e-win/pwsh_command_not_found.Tests.ps1
+++ b/e2e-win/pwsh_command_not_found.Tests.ps1
@@ -119,3 +119,38 @@ Describe 'the pwsh command-not-found hook branches on the exit code' {
         $guarded.Error | Should -BeNullOrEmpty -Because 'the handoff ran, so nothing propagated out'
     }
 }
+
+Describe 'the pwsh command-not-found hook leaves mise its own names' {
+    It 'skips them before spending a hook-not-found call' {
+        $script = mise activate pwsh | Out-String
+
+        $guard = $script.IndexOf("if (`$Name -eq 'mise' -or `$Name -like 'mise-*') { return }")
+        ($guard -ge 0) | Should -BeTrue -Because 'bash, zsh and fish all skip mise''s own names'
+
+        # Position matters, not just presence: past the guard the handler pays a full mise
+        # startup only to be told that `mise-foo` is not a tool.
+        $call = $script.IndexOf('hook-not-found -s pwsh')
+        ($guard -lt $call) | Should -BeTrue -Because 'the guard exists to avoid that call'
+    }
+
+    It 'skips exactly mise and mise-*, and nothing that merely contains it' {
+        # Evaluate the condition the script actually ships rather than a copy of it, so a
+        # rewrite to `-like ''mise*''` or `-match ''mise''` fails here instead of silently
+        # swallowing somebody else''s tool.
+        $script = mise activate pwsh | Out-String
+        $pattern = '(?m)^\s*if \((\$Name -eq .+?)\) \{ return \}'
+        $condition = [regex]::Match($script, $pattern).Groups[1].Value
+        $condition | Should -Not -BeNullOrEmpty
+
+        $skips = [scriptblock]::Create("param(`$Name) $condition")
+
+        # mise's own names, in the casing Windows lets you type them in
+        foreach ($name in 'mise', 'MISE', 'mise-foo', 'MISE-FOO') {
+            (& $skips $name) | Should -BeTrue -Because "$name is mise, not a tool"
+        }
+        # and names that only look like it
+        foreach ($name in 'premise', 'mise2', 'misexyz', 'my-mise-tool') {
+            (& $skips $name) | Should -BeFalse -Because "$name is somebody else's tool"
+        }
+    }
+}

--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -150,6 +150,13 @@ impl Shell for Pwsh {
                     $_mise_pwsh_cmd_not_found_hook = [EventHandler[System.Management.Automation.CommandLookupEventArgs]] {{
                         param([object] $Name, [System.Management.Automation.CommandLookupEventArgs] $eventArgs)
                         end {{
+                            # mise's own commands are not tools: `mise-foo` must not be
+                            # looked up as something to install, and `deactivate` removes
+                            # the wrapper function while leaving this handler registered,
+                            # so `mise` itself reaches here too. bash, zsh and fish all
+                            # skip these names before calling hook-not-found. `-like`
+                            # rather than a prefix match: `mise2` is somebody else's tool.
+                            if ($Name -eq 'mise' -or $Name -like 'mise-*') {{ return }}
                             # Only auto-install when the missing command is what the
                             # user actually typed. PSReadLine is absent in
                             # non-interactive sessions, and even when its module is
@@ -303,6 +310,31 @@ mod tests {
             prelude: vec![],
         };
         assert_snapshot!(pwsh.activate(opts));
+    }
+
+    /// bash, zsh and fish all skip mise's own names before calling `hook-not-found`.
+    /// The guard has to come first: past it the handler pays a full mise startup just to
+    /// be told that `mise-foo` is not a tool.
+    #[test]
+    fn test_activate_command_not_found_skips_mise_itself() {
+        let opts = ActivateOptions {
+            exe: Path::new("/some/dir/mise").to_path_buf(),
+            flags: " --status".into(),
+            no_hook_env: false,
+            prelude: vec![],
+        };
+        let script = Pwsh::default().activate(opts);
+
+        let guard = script
+            .find("if ($Name -eq 'mise' -or $Name -like 'mise-*') { return }")
+            .expect("the command-not-found handler should skip mise's own commands");
+        let call = script
+            .find("hook-not-found -s pwsh")
+            .expect("the command-not-found handler should still call hook-not-found");
+        assert!(
+            guard < call,
+            "the guard has to run before the call it avoids"
+        );
     }
 
     #[test]

--- a/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
@@ -116,6 +116,13 @@ if (-not (Test-Path variable:global:__mise_pwsh_command_not_found)){
         $_mise_pwsh_cmd_not_found_hook = [EventHandler[System.Management.Automation.CommandLookupEventArgs]] {
             param([object] $Name, [System.Management.Automation.CommandLookupEventArgs] $eventArgs)
             end {
+                # mise's own commands are not tools: `mise-foo` must not be
+                # looked up as something to install, and `deactivate` removes
+                # the wrapper function while leaving this handler registered,
+                # so `mise` itself reaches here too. bash, zsh and fish all
+                # skip these names before calling hook-not-found. `-like`
+                # rather than a prefix match: `mise2` is somebody else's tool.
+                if ($Name -eq 'mise' -or $Name -like 'mise-*') { return }
                 # Only auto-install when the missing command is what the
                 # user actually typed. PSReadLine is absent in
                 # non-interactive sessions, and even when its module is


### PR DESCRIPTION
Of the four shells that emit a command-not-found handler, **pwsh is the only one that does not skip mise's own names**:

| shell | guard |
| --- | --- |
| bash | [`command_not_found.sh:10`](https://github.com/jdx/mise/blob/main/src/assets/bash/command_not_found.sh#L10) — `[[ $1 != "mise" && $1 != "mise-"* ]]` |
| zsh | [`zsh.rs:115`](https://github.com/jdx/mise/blob/main/src/shell/zsh.rs#L115) — same condition |
| fish | [`fish.rs:120`](https://github.com/jdx/mise/blob/main/src/shell/fish.rs#L120) — `string match -qrv -- '^(?:mise$\|mise-)'` |
| **pwsh** | **none** |

Until #12089 the pwsh branch could never be taken — the condition read stdout instead of the exit code — so the missing guard had no observable effect. It does now.

## What it costs

`hook-not-found` for a name no tool provides still builds the whole toolset before answering. Measured on Windows, three runs:

```
mise hook-not-found -s pwsh -- mise-nonexistent-probe
  exit=127  500-557 ms  no output
```

So an interactive pwsh user who types `mise-foo` waits half a second before the shell says "not found". The other three shells never make the call.

## And `mise` itself reaches the handler

pwsh's [`deactivate`](https://github.com/jdx/mise/blob/main/src/shell/pwsh.rs#L198) removes the wrapper function but leaves the `CommandNotFoundAction` registered. Measured in a child pwsh:

| | `function mise` | handler registered |
| --- | --- | --- |
| after `mise activate pwsh` | ✅ | ✅ |
| after `mise deactivate` | **gone** | **still there** |

So after deactivating, typing `mise` lands in the handler and `install_missing_bin("mise")` runs. Nothing installs today — no registry entry is named `mise` or `mise-*` — but that function matches on *bin names a configured tool provides* ([`toolset_install.rs:592`](https://github.com/jdx/mise/blob/main/src/toolset/toolset_install.rs#L592)), so it is a live edge rather than an impossible one. Naming `mise` explicitly is exactly what the other three shells do.

**That `deactivate` leaves the handler registered is a separate bug** and is not touched here.

## The change

One early return at the top of the handler, before the PSReadLine work, since a skipped name should not pay for that either:

```powershell
if ($Name -eq 'mise' -or $Name -like 'mise-*') { return }
```

`$Name` is the command name — `CommandNotFoundAction` passes it as the delegate's sender.

**The spelling was chosen by measurement.** Both tidier-looking forms are too broad:

| name | `-eq 'mise' -or -like 'mise-*'` | `-like 'mise*'` | `-match 'mise'` |
| --- | --- | --- | --- |
| `mise`, `MISE` | skip | skip | skip |
| `mise-foo`, `MISE-FOO` | skip | skip | skip |
| `premise` | run | run | **skipped — wrong** |
| `mise2`, `misexyz` | run | **skipped — wrong** | **skipped — wrong** |
| `my-mise-tool` | run | run | **skipped — wrong** |

`-eq` and `-like` are case-insensitive in PowerShell, so `MISE-FOO` is skipped too. That differs from bash and zsh, which compare case-sensitively — and it is the right difference here, because Windows command lookup is case-insensitive in the first place.

## Tests

- **Unit** — asserts the guard is present *and* that it precedes the `hook-not-found` call, since position is the whole point.
- **Snapshot** — the activate snapshot picks up the new lines.
- **`e2e-win/pwsh_command_not_found.Tests.ps1`** — a shape check, plus one that pulls the condition **out of the emitted script** and evaluates it against the table above, so shortening it to `-like 'mise*'` fails there instead of quietly swallowing someone else's tool.

## Verification

The measurements above are from this Windows machine. **No local build was run** — this box cannot build mise, so the snapshot was hand-edited with every new line's indentation checked against the source (`formatdoc!` strips exactly 12 spaces here), and type checking, the snapshot and the e2e suite are left to CI. Local Pester currently fails the text-dependent cases because the installed binary predates both this change and #12089; the condition-extraction test was verified against the updated snapshot text instead.

Independent of #12117, which touches a different part of the same `formatdoc!`; whichever lands second wants a rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PowerShell command-not-found handling now skips `mise` and `mise-*` commands before attempting automatic installation.
  * Matching is case-insensitive, while similarly named commands continue to use the normal handling flow.

* **Tests**
  * Added coverage for exact command matches, prefixed command names, and near-matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->