### PR TITLE
feat(bootstrap): compose services and compose projects

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -33,15 +33,16 @@ relative to the config that declared them. Variables declared by a selected root
 are available to that root's dotfile templates without leaking into sibling
 roots.
 
-Composition includes `[dotfiles]`, `[bootstrap.files]`, and
-`[bootstrap.directories]`. Equivalent declarations are deduplicated. Different
-declarations for the same dotfile target, edit `(path, id)`, managed file, or
-managed directory are errors that identify both declaring configs. Independent
+Composition includes `[dotfiles]`, `[bootstrap.files]`,
+`[bootstrap.directories]`, `[bootstrap.services]`, and `[bootstrap.compose]`.
+Equivalent declarations are deduplicated. Different declarations for the same
+dotfile target, edit `(path, id)`, managed file, managed directory, service, or
+Compose project are errors that identify both declaring configs. Independent
 roots never acquire precedence from their order in `config_roots`.
 
-Other configuration such as tools, tasks, packages, services, hooks, and repos
-is not collected from these roots. Use their existing explicit workflows when
-those resources need aggregate behavior.
+Other configuration such as tools, tasks, packages, hooks, and repos is not
+collected from these roots. Use their existing explicit workflows when those
+resources need aggregate behavior.
 
 ## How it runs
 

--- a/e2e-win/bootstrap.Tests.ps1
+++ b/e2e-win/bootstrap.Tests.ps1
@@ -48,4 +48,23 @@ content = "managed"
         $LASTEXITCODE | Should -Not -Be 0
         $out | Should -BeLike '*managed system files are only supported on Unix*'
     }
+
+    It 'rejects services selected through bootstrap config roots' {
+        $serviceRoot = Join-Path $TestDrive 'service-root'
+        New-Item -ItemType Directory -Path $serviceRoot | Out-Null
+        @"
+[bootstrap.services.example]
+state = "stopped"
+enabled = false
+"@ | Out-File -FilePath (Join-Path $serviceRoot 'mise.toml') -Encoding utf8NoBOM
+
+        @"
+[bootstrap]
+config_roots = ["service-root"]
+"@ | Out-File -FilePath mise.toml -Encoding utf8NoBOM
+
+        $out = mise bootstrap services apply --yes 2>&1 | Out-String
+        $LASTEXITCODE | Should -Not -Be 0
+        $out | Should -BeLike '*bootstrap system services are only supported on Linux*'
+    }
 }

--- a/e2e/cli/test_bootstrap_config_roots
+++ b/e2e/cli/test_bootstrap_config_roots
@@ -45,6 +45,14 @@ content = "managed"
 [bootstrap.directories."$managed_dir"]
 mode = "0755"
 
+[bootstrap.services.shared]
+state = "stopped"
+enabled = false
+
+[bootstrap.compose.shared]
+project_dir = "$root_a"
+state = "stopped"
+
 [bootstrap.repos."$leaked_repo"]
 url = "https://example.com/not-collected.git"
 
@@ -67,6 +75,14 @@ content = "managed"
 
 [bootstrap.directories."$managed_dir"]
 mode = "0755"
+
+[bootstrap.services.shared]
+state = "stopped"
+enabled = false
+
+[bootstrap.compose.shared]
+project_dir = "$root_a"
+state = "stopped"
 EOF
 
 assert_succeed "MISE_ENV=dev mise bootstrap dotfiles status --json | jq -e '.files | length == 5'"
@@ -83,6 +99,8 @@ assert_fail "test -e $PWD/escaped.conf"
 assert_succeed "mise bootstrap files status --json | jq -e 'length == 2'"
 assert_succeed "mise bootstrap files status --json | jq -e '.[] | select(.id.name == \"$managed_file\") | .origin.config == \"$root_a/mise.toml\"'"
 assert_succeed "mise bootstrap plan --json | jq -e '.resources[] | select(.id.name == \"$managed_dir\") | .origin.config == \"$root_a/mise.toml\"'"
+assert_succeed "mise bootstrap plan --json | jq -e '[.resources[] | select(.id.kind == \"service\" and .id.name == \"shared\")] | length == 1 and .[0].origin.config == \"$root_a/mise.toml\"'"
+assert_succeed "mise bootstrap plan --json | jq -e '[.resources[] | select(.id.kind == \"compose\" and .id.name == \"shared\")] | length == 1 and .[0].origin.config == \"$root_a/mise.toml\"'"
 assert_not_contains "mise bootstrap plan --json" "$leaked_repo"
 assert_not_contains "mise tasks ls" "leaked-root-task"
 
@@ -94,6 +112,44 @@ assert_fail "mise bootstrap dotfiles status" "conflicting dotfile declarations f
 assert_fail "mise bootstrap dotfiles status" "$root_a/mise.toml"
 assert_fail "mise bootstrap dotfiles status" "$root_b/mise.toml"
 
+cat <<EOF >"$root_a/mise.toml"
+[bootstrap.services.shared]
+state = "stopped"
+enabled = false
+
+[bootstrap.compose.shared]
+project_dir = "$root_a"
+state = "stopped"
+EOF
+cat <<EOF >"$root_b/mise.toml"
+[bootstrap.services.shared]
+state = "running"
+
+[bootstrap.compose.shared]
+project_dir = "$root_b"
+state = "stopped"
+EOF
+assert_fail "mise bootstrap plan" "conflicting bootstrap service declarations for shared"
+assert_fail "mise bootstrap plan" "$root_a/mise.toml"
+assert_fail "mise bootstrap plan" "$root_b/mise.toml"
+
+cat <<EOF >"$root_b/mise.toml"
+[bootstrap.services.shared]
+state = "stopped"
+enabled = false
+
+[bootstrap.compose.shared]
+project_dir = "$root_b"
+state = "stopped"
+EOF
+assert_fail "mise bootstrap plan" "conflicting bootstrap compose declarations for shared"
+assert_fail "mise bootstrap plan" "$root_a/mise.toml"
+assert_fail "mise bootstrap plan" "$root_b/mise.toml"
+
+cat <<EOF >"$root_a/mise.toml"
+[bootstrap.files."$managed_file"]
+content = "managed"
+EOF
 cat <<EOF >"$root_b/mise.toml"
 [bootstrap.files."$managed_file"]
 content = "different"

--- a/src/system/compose.rs
+++ b/src/system/compose.rs
@@ -6,8 +6,8 @@ use eyre::{Result, bail, eyre};
 use indexmap::{IndexMap, IndexSet};
 use serde::{Deserialize, Serialize};
 
-use crate::config::Config;
-use crate::system::resources::{ResourceAction, ResourceId, ResourcePlan};
+use crate::config::{Config, ConfigMap};
+use crate::system::resources::{ResourceAction, ResourceId, ResourceOrigin, ResourcePlan};
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -52,7 +52,7 @@ pub enum ComposeRemoveImages {
     All,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 pub struct ComposeTomlConfig {
     pub project_dir: PathBuf,
     #[serde(default)]
@@ -125,6 +125,7 @@ pub struct ComposeRequest {
     engine_command: Vec<String>,
     explicit_dependencies: Vec<ResourceId>,
     path_dependencies: Vec<ResourceId>,
+    origin: Option<ResourceOrigin>,
     inspection: Option<ComposeInspection>,
 }
 
@@ -155,18 +156,50 @@ struct ComposeContainer {
 }
 
 pub fn prepare_requests_from_config(config: &Config) -> Result<Vec<ComposeRequest>> {
+    let mut composed: IndexMap<String, (ComposeTomlConfig, ResourceOrigin)> = IndexMap::new();
+    for config_files in config.bootstrap_config_maps() {
+        for (name, declaration) in compose_from_config_files(config_files) {
+            if let Some(existing) = composed.get(&name) {
+                if existing.0 == declaration.0 {
+                    continue;
+                }
+                bail!(
+                    "conflicting bootstrap compose declarations for {name}\n\n  first:\n    {}\n\n  second:\n    {}",
+                    existing.1.conflict_description(),
+                    declaration.1.conflict_description(),
+                );
+            }
+            composed.insert(name, declaration);
+        }
+    }
+    composed
+        .into_iter()
+        .map(|(name, (config, origin))| {
+            ComposeRequest::from_toml_with_origin(name, config, Some(origin))
+        })
+        .collect()
+}
+
+fn compose_from_config_files(
+    config_files: &ConfigMap,
+) -> IndexMap<String, (ComposeTomlConfig, ResourceOrigin)> {
     let mut merged = IndexMap::new();
-    for cf in config.config_files.values() {
+    for (path, cf) in config_files {
         if let Some(bootstrap) = cf.bootstrap_config() {
+            let origin = ResourceOrigin {
+                config: path.clone(),
+                config_root: cf.config_root(),
+                environment: crate::config::environments_for_config_path(path),
+                source: None,
+            };
             for (name, project) in bootstrap.compose {
-                merged.entry(name).or_insert(project);
+                merged
+                    .entry(name)
+                    .or_insert_with(|| (project, origin.clone()));
             }
         }
     }
     merged
-        .into_iter()
-        .map(|(name, config)| ComposeRequest::from_toml(name, config))
-        .collect()
 }
 
 pub fn requests_from_config(config: &Config) -> Result<Vec<ComposeRequest>> {
@@ -267,7 +300,16 @@ fn apply_action(
 }
 
 impl ComposeRequest {
+    #[cfg(test)]
     fn from_toml(name: String, config: ComposeTomlConfig) -> Result<Self> {
+        Self::from_toml_with_origin(name, config, None)
+    }
+
+    fn from_toml_with_origin(
+        name: String,
+        config: ComposeTomlConfig,
+        origin: Option<ResourceOrigin>,
+    ) -> Result<Self> {
         if name.is_empty() {
             bail!("bootstrap compose project names cannot be empty");
         }
@@ -358,6 +400,7 @@ impl ComposeRequest {
             engine_command: config.engine_command,
             explicit_dependencies,
             path_dependencies,
+            origin,
             inspection: None,
         })
     }
@@ -374,9 +417,14 @@ impl ComposeRequest {
         let id = ResourceId::new("compose", &self.name);
         let desired = self.desired();
         let Some(inspection) = &self.inspection else {
-            return ResourcePlan::new(id, "not inspected", desired, ResourceAction::Unknown);
+            return self.with_origin(ResourcePlan::new(
+                id,
+                "not inspected",
+                desired,
+                ResourceAction::Unknown,
+            ));
         };
-        match inspection {
+        let plan = match inspection {
             ComposeInspection::Unavailable(reason) => ResourcePlan::new(
                 id,
                 format!("unavailable: {reason}"),
@@ -433,6 +481,14 @@ impl ComposeRequest {
                     action,
                 )
             }
+        };
+        self.with_origin(plan)
+    }
+
+    fn with_origin(&self, plan: ResourcePlan) -> ResourcePlan {
+        match &self.origin {
+            Some(origin) => plan.with_origin(origin.clone()),
+            None => plan,
         }
     }
 

--- a/src/system/services.rs
+++ b/src/system/services.rs
@@ -5,8 +5,8 @@ use eyre::{Result, bail, eyre};
 use indexmap::{IndexMap, IndexSet};
 use serde::{Deserialize, Serialize};
 
-use crate::config::Config;
-use crate::system::resources::{ResourceAction, ResourceId, ResourcePlan};
+use crate::config::{Config, ConfigMap};
+use crate::system::resources::{ResourceAction, ResourceId, ResourceOrigin, ResourcePlan};
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -26,7 +26,7 @@ pub enum ServiceChangeAction {
     None,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 pub struct ServiceTomlConfig {
     #[serde(default)]
     pub state: ServiceState,
@@ -57,6 +57,7 @@ pub struct ServiceRequest {
     pub enabled: bool,
     pub masked: bool,
     pub on_change: ServiceChangeAction,
+    pub origin: Option<ResourceOrigin>,
     inspection: Option<ServiceInspection>,
 }
 
@@ -139,18 +140,50 @@ struct ServicePlan {
 }
 
 pub fn prepare_requests_from_config(config: &Config) -> Result<Vec<ServiceRequest>> {
+    let mut composed: IndexMap<String, (ServiceTomlConfig, ResourceOrigin)> = IndexMap::new();
+    for config_files in config.bootstrap_config_maps() {
+        for (name, declaration) in services_from_config_files(config_files) {
+            if let Some(existing) = composed.get(&name) {
+                if existing.0 == declaration.0 {
+                    continue;
+                }
+                bail!(
+                    "conflicting bootstrap service declarations for {name}\n\n  first:\n    {}\n\n  second:\n    {}",
+                    existing.1.conflict_description(),
+                    declaration.1.conflict_description(),
+                );
+            }
+            composed.insert(name, declaration);
+        }
+    }
+    composed
+        .into_iter()
+        .map(|(name, (config, origin))| {
+            ServiceRequest::from_toml_with_origin(name, config, Some(origin))
+        })
+        .collect()
+}
+
+fn services_from_config_files(
+    config_files: &ConfigMap,
+) -> IndexMap<String, (ServiceTomlConfig, ResourceOrigin)> {
     let mut merged = IndexMap::new();
-    for cf in config.config_files.values() {
+    for (path, cf) in config_files {
         if let Some(bootstrap) = cf.bootstrap_config() {
+            let origin = ResourceOrigin {
+                config: path.clone(),
+                config_root: cf.config_root(),
+                environment: crate::config::environments_for_config_path(path),
+                source: None,
+            };
             for (name, service) in bootstrap.services {
-                merged.entry(name).or_insert(service);
+                merged
+                    .entry(name)
+                    .or_insert_with(|| (service, origin.clone()));
             }
         }
     }
     merged
-        .into_iter()
-        .map(|(name, config)| ServiceRequest::from_toml(name, config))
-        .collect()
 }
 
 pub fn requests_from_config(config: &Config) -> Result<Vec<ServiceRequest>> {
@@ -181,7 +214,16 @@ pub fn inspect_requests(requests: &mut [ServiceRequest]) {
 }
 
 impl ServiceRequest {
+    #[cfg(test)]
     fn from_toml(name: String, config: ServiceTomlConfig) -> Result<Self> {
+        Self::from_toml_with_origin(name, config, None)
+    }
+
+    fn from_toml_with_origin(
+        name: String,
+        config: ServiceTomlConfig,
+        origin: Option<ResourceOrigin>,
+    ) -> Result<Self> {
         let unit = normalize_unit_name(&name)?;
         if config.masked && config.state == ServiceState::Running {
             bail!("bootstrap service '{name}' cannot be both masked and running");
@@ -196,6 +238,7 @@ impl ServiceRequest {
             enabled: config.enabled,
             masked: config.masked,
             on_change: config.on_change,
+            origin,
             inspection: None,
         })
     }
@@ -204,9 +247,14 @@ impl ServiceRequest {
         let id = ResourceId::new("service", &self.name);
         let desired = self.desired();
         let Some(inspection) = &self.inspection else {
-            return ResourcePlan::new(id, "not inspected", desired, ResourceAction::Unknown);
+            return self.with_origin(ResourcePlan::new(
+                id,
+                "not inspected",
+                desired,
+                ResourceAction::Unknown,
+            ));
         };
-        match inspection {
+        let plan = match inspection {
             ServiceInspection::Missing => {
                 ResourcePlan::new(id, "unit not found", desired, ResourceAction::Unknown)
             }
@@ -247,6 +295,14 @@ impl ServiceRequest {
                     },
                 )
             }
+        };
+        self.with_origin(plan)
+    }
+
+    fn with_origin(&self, plan: ResourcePlan) -> ResourcePlan {
+        match &self.origin {
+            Some(origin) => plan.with_origin(origin.clone()),
+            None => plan,
         }
     }
 
@@ -335,6 +391,7 @@ impl ServiceRequest {
             enabled: action.enabled,
             masked: action.masked,
             on_change: action.on_change,
+            origin: None,
             inspection: None,
         }
     }

--- a/src/system/services_non_linux.rs
+++ b/src/system/services_non_linux.rs
@@ -188,9 +188,11 @@ pub fn apply_privileged_plan_from_stdin() -> Result<()> {
 }
 
 fn reject_configured(config: &Config) -> Result<Vec<ServiceRequest>> {
-    let configured = config.config_files.values().any(|cf| {
-        cf.bootstrap_config()
-            .is_some_and(|bootstrap| !bootstrap.services.is_empty())
+    let configured = config.bootstrap_config_maps().any(|config_files| {
+        config_files.values().any(|cf| {
+            cf.bootstrap_config()
+                .is_some_and(|bootstrap| !bootstrap.services.is_empty())
+        })
     });
     if configured {
         bail!("bootstrap system services are only supported on Linux");

--- a/src/system/services_non_linux.rs
+++ b/src/system/services_non_linux.rs
@@ -4,8 +4,8 @@ use eyre::{Result, bail};
 use indexmap::{IndexMap, IndexSet};
 use serde::{Deserialize, Serialize};
 
-use crate::config::Config;
-use crate::system::resources::{ResourceId, ResourcePlan};
+use crate::config::{Config, ConfigMap};
+use crate::system::resources::{ResourceId, ResourceOrigin, ResourcePlan};
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -25,7 +25,7 @@ pub enum ServiceChangeAction {
     None,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 pub struct ServiceTomlConfig {
     #[serde(default)]
     pub state: ServiceState,
@@ -75,24 +75,48 @@ impl ServiceNotifications {
 }
 
 pub fn prepare_requests_from_config(config: &Config) -> Result<Vec<ServiceRequest>> {
-    let mut names = IndexSet::new();
-    for cf in config.config_files.values() {
-        if let Some(bootstrap) = cf.bootstrap_config() {
-            for (name, service) in bootstrap.services {
-                let _ = (
-                    service.state,
-                    service.enabled,
-                    service.masked,
-                    service.on_change,
+    let mut composed: IndexMap<String, (ServiceTomlConfig, ResourceOrigin)> = IndexMap::new();
+    for config_files in config.bootstrap_config_maps() {
+        for (name, declaration) in services_from_config_files(config_files) {
+            if let Some(existing) = composed.get(&name) {
+                if existing.0 == declaration.0 {
+                    continue;
+                }
+                bail!(
+                    "conflicting bootstrap service declarations for {name}\n\n  first:\n    {}\n\n  second:\n    {}",
+                    existing.1.conflict_description(),
+                    declaration.1.conflict_description(),
                 );
-                names.insert(name);
+            }
+            composed.insert(name, declaration);
+        }
+    }
+    Ok(composed
+        .into_iter()
+        .map(|(name, _)| ServiceRequest { name })
+        .collect())
+}
+
+fn services_from_config_files(
+    config_files: &ConfigMap,
+) -> IndexMap<String, (ServiceTomlConfig, ResourceOrigin)> {
+    let mut merged = IndexMap::new();
+    for (path, cf) in config_files {
+        if let Some(bootstrap) = cf.bootstrap_config() {
+            let origin = ResourceOrigin {
+                config: path.clone(),
+                config_root: cf.config_root(),
+                environment: crate::config::environments_for_config_path(path),
+                source: None,
+            };
+            for (name, service) in bootstrap.services {
+                merged
+                    .entry(name)
+                    .or_insert_with(|| (service, origin.clone()));
             }
         }
     }
-    Ok(names
-        .into_iter()
-        .map(|name| ServiceRequest { name })
-        .collect())
+    merged
 }
 
 pub fn requests_from_config(config: &Config) -> Result<Vec<ServiceRequest>> {


### PR DESCRIPTION
## Summary

- collect `[bootstrap.services]` and `[bootstrap.compose]` from every `[bootstrap].config_roots` hierarchy
- deduplicate identical declarations and reject conflicting names with diagnostics for both declaring configs
- preserve declaration origins in bootstrap plans and document the expanded composition behavior

## Stack

Depends on #12105, which introduces config-root composition for dotfiles, managed files, and managed directories.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise run test:e2e e2e/cli/test_bootstrap_config_roots e2e/cli/test_bootstrap_services e2e/cli/test_bootstrap_compose`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how bootstrap service and Compose config is loaded and merged platform-wide; incorrect composition or conflict handling could affect Linux provisioning plans and non-Linux error paths.
> 
> **Overview**
> Extends **`[bootstrap].config_roots`** composition to **`[bootstrap.services]`** and **`[bootstrap.compose]`**, matching dotfiles/files/directories: declarations are merged across root hierarchies, identical entries are deduplicated, and differing definitions for the same name fail with errors that name both declaring configs.
> 
> **`prepare_requests_from_config`** in `services.rs`, `compose.rs`, and the non-Linux services stub now walks **`bootstrap_config_maps()`** instead of flat **`config_files`**, attaches **`ResourceOrigin`** to plans, and adds **`Eq`/`PartialEq`** on the TOML config structs for equality-based dedup. On non-Linux, services reached only via config roots still trigger the existing Linux-only rejection (covered by a new Windows e2e test).
> 
> Docs update the composition list and conflict rules; e2e **`test_bootstrap_config_roots`** asserts plan origins and service/compose conflict behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0916c1a5fbf794fdac1bace677f1292404fe0a64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->