### PR TITLE
security: block tool install code in safe mode

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -39,6 +39,7 @@ When enabled, mise **refuses with an error** (never a silent fallback) to:
 
 - run `exec()` or `read_file()` in config templates
 - run hooks (suppressed like `--no-hooks`, since hooks fire ambiently from `mise env`/`hook-env`)
+- run tool-level `postinstall` hooks or apply tool-level `install_env` during installation
 - run tasks
 - execute asdf plugin scripts
 - install plugins

--- a/e2e/config/test_safe_mode
+++ b/e2e/config/test_safe_mode
@@ -98,6 +98,20 @@ assert "mise latest dummy" "2.0.0"
 echo "=== plugin installation is refused ==="
 assert_fail "MISE_SAFE=1 mise plugins install tiny https://github.com/jdx/vfox-tiny" "installing plugins is disabled in safe mode (MISE_SAFE=1)"
 
+echo "=== tool-level install options are refused before installation ==="
+cat <<'EOF' >mise.toml
+[tools]
+dummy = { version = "1", postinstall = "touch postinstall-ran" }
+EOF
+assert_fail "MISE_SAFE=1 mise install --force" "running tool-level postinstall hooks for dummy is disabled in safe mode (MISE_SAFE=1)"
+assert_fail "test -e postinstall-ran"
+
+cat <<'EOF' >mise.toml
+[tools]
+dummy = { version = "1", install_env = { BASH_ENV = "./untrusted.sh" } }
+EOF
+assert_fail "MISE_SAFE=1 mise install --force" "using tool-level install_env for dummy is disabled in safe mode (MISE_SAFE=1)"
+
 # Note: safe mode also skips the trust requirement (trust_check returns Ok when
 # `safe` is set). That isn't exercised here because the e2e harness auto-trusts
 # the workdir (MISE_TRUSTED_CONFIG_PATHS) and applies CI-implicit trust, so a

--- a/e2e/config/test_safe_mode
+++ b/e2e/config/test_safe_mode
@@ -101,16 +101,20 @@ assert_fail "MISE_SAFE=1 mise plugins install tiny https://github.com/jdx/vfox-t
 echo "=== tool-level install options are refused before installation ==="
 cat <<'EOF' >mise.toml
 [tools]
-dummy = { version = "1", postinstall = "touch postinstall-ran" }
+"http:safe-install" = { version = "1.0.0", url = "https://example.invalid/archive.tar.gz", postinstall = "touch postinstall-ran" }
 EOF
-assert_fail "MISE_SAFE=1 mise install --force" "running tool-level postinstall hooks for dummy is disabled in safe mode (MISE_SAFE=1)"
+assert_fail "MISE_SAFE=1 mise install --force" "running tool-level postinstall hooks for http:safe-install is disabled in safe mode (MISE_SAFE=1)"
 assert_fail "test -e postinstall-ran"
+assert_fail "MISE_SAFE=1 mise install-into http:safe-install@1.0.0 safe-install-into" "running tool-level postinstall hooks for http:safe-install is disabled in safe mode (MISE_SAFE=1)"
+assert_fail "test -e safe-install-into"
 
 cat <<'EOF' >mise.toml
 [tools]
-dummy = { version = "1", install_env = { BASH_ENV = "./untrusted.sh" } }
+"http:safe-install" = { version = "1.0.0", url = "https://example.invalid/archive.tar.gz", install_env = { BASH_ENV = "./untrusted.sh" } }
 EOF
-assert_fail "MISE_SAFE=1 mise install --force" "using tool-level install_env for dummy is disabled in safe mode (MISE_SAFE=1)"
+assert_fail "MISE_SAFE=1 mise install --force" "using tool-level install_env for http:safe-install is disabled in safe mode (MISE_SAFE=1)"
+assert_fail "MISE_SAFE=1 mise install-into http:safe-install@1.0.0 safe-install-into" "using tool-level install_env for http:safe-install is disabled in safe mode (MISE_SAFE=1)"
+assert_fail "test -e safe-install-into"
 
 # Note: safe mode also skips the trust requirement (trust_check returns Ok when
 # `safe` is set). That isn't exercised here because the e2e harness auto-trusts

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3120,6 +3120,7 @@ pub trait Backend: Debug + Send + Sync {
         }
         install_state::clear_incomplete_marker_best_effort(&tv.ba().short, &tv.tv_pathname());
         if let Some(script) = tv.request.options().get("postinstall") {
+            Settings::ensure_not_safe("running tool-level postinstall hooks")?;
             ctx.pr
                 .finish_with_message("running custom postinstall hook".to_string());
             self.run_postinstall_hook(&ctx, &tv, script).await?;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2979,6 +2979,10 @@ pub trait Backend: Debug + Send + Sync {
         ctx: InstallContext,
         mut tv: ToolVersion,
     ) -> eyre::Result<ToolVersion> {
+        // Toolset installs preflight these options before doing any work, but
+        // direct callers such as `install-into` must be protected here too.
+        tv.request.ensure_safe_install_options()?;
+
         // Check for --locked mode: if enabled and no lockfile URL exists, fail early
         // Exempt tool stubs from lockfile requirements since they are ephemeral
         // Also exempt backends that don't support URL locking (e.g., Rust uses rustup)
@@ -3120,7 +3124,6 @@ pub trait Backend: Debug + Send + Sync {
         }
         install_state::clear_incomplete_marker_best_effort(&tv.ba().short, &tv.tv_pathname());
         if let Some(script) = tv.request.options().get("postinstall") {
-            Settings::ensure_not_safe("running tool-level postinstall hooks")?;
             ctx.pr
                 .finish_with_message("running custom postinstall hook".to_string());
             self.run_postinstall_hook(&ctx, &tv, script).await?;

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -20,7 +20,10 @@ use crate::runtime_symlinks::is_runtime_symlink;
 use crate::toolset::tool_version::ResolveOptions;
 use crate::toolset::{ToolSource, ToolVersion, ToolVersionOptions};
 use crate::{backend, lockfile};
-use crate::{backend::ABackend, config::Config};
+use crate::{
+    backend::ABackend,
+    config::{Config, Settings},
+};
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum ToolRequest {
@@ -243,6 +246,27 @@ impl ToolRequest {
             | Self::Path { options: o, .. }
             | Self::System { options: o, .. } => o.clone(),
         }
+    }
+
+    /// Rejects install options that can execute configuration-provided code in safe mode.
+    pub fn ensure_safe_install_options(&self) -> Result<()> {
+        if !Settings::safe_mode() {
+            return Ok(());
+        }
+        let options = self.options();
+        if options.get("postinstall").is_some() {
+            Settings::ensure_not_safe(&format!(
+                "running tool-level postinstall hooks for {}",
+                self.ba().short
+            ))?;
+        }
+        if !options.core.install_env.is_empty() {
+            Settings::ensure_not_safe(&format!(
+                "using tool-level install_env for {}",
+                self.ba().short
+            ))?;
+        }
+        Ok(())
     }
 
     pub async fn is_install_satisfied(&self, config: &Arc<Config>) -> bool {

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -733,23 +733,8 @@ impl Toolset {
 }
 
 fn ensure_safe_install_options(versions: &[ToolRequest]) -> Result<()> {
-    if !Settings::safe_mode() {
-        return Ok(());
-    }
     for request in versions {
-        let options = request.options();
-        if options.get("postinstall").is_some() {
-            Settings::ensure_not_safe(&format!(
-                "running tool-level postinstall hooks for {}",
-                request.ba().short
-            ))?;
-        }
-        if !options.core.install_env.is_empty() {
-            Settings::ensure_not_safe(&format!(
-                "using tool-level install_env for {}",
-                request.ba().short
-            ))?;
-        }
+        request.ensure_safe_install_options()?;
     }
     Ok(())
 }

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -167,6 +167,7 @@ impl Toolset {
 
         self.init_request_options(&mut versions);
         ensure_compatible_install_requests(&versions)?;
+        ensure_safe_install_options(&versions)?;
 
         // Validate shared install destinations before plugin installation or
         // hooks introduce side effects.
@@ -729,6 +730,28 @@ impl Toolset {
     fn parse_plugin_key(key: &str) -> (PluginType, &str) {
         PluginType::from_plugin_config(key)
     }
+}
+
+fn ensure_safe_install_options(versions: &[ToolRequest]) -> Result<()> {
+    if !Settings::safe_mode() {
+        return Ok(());
+    }
+    for request in versions {
+        let options = request.options();
+        if options.get("postinstall").is_some() {
+            Settings::ensure_not_safe(&format!(
+                "running tool-level postinstall hooks for {}",
+                request.ba().short
+            ))?;
+        }
+        if !options.core.install_env.is_empty() {
+            Settings::ensure_not_safe(&format!(
+                "using tool-level install_env for {}",
+                request.ba().short
+            ))?;
+        }
+    }
+    Ok(())
 }
 
 /// Whether install-time resolution should refresh the remote-versions cache


### PR DESCRIPTION
## Summary

- reject tool-level `postinstall` hooks before installation when `MISE_SAFE=1`
- reject tool-level `install_env` before it can reach installer subprocesses
- keep a backend-level postinstall guard as defense in depth
- document and test the safe-mode boundary

## Root cause

Safe mode suppressed project hooks, environment directives, tasks, and plugin execution, but tool-level install options used a separate backend path with no safe-mode gate. A project `postinstall` could therefore execute during `MISE_SAFE=1 mise install`, and `install_env` could inject variables into installer subprocesses.

## Validation

- `mise run format` (includes repository lint-fix, all-features check, and build)
- `mise run test:e2e e2e/config/test_safe_mode`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow security hardening gated on safe mode only; normal installs are unchanged, with defense-in-depth at toolset and backend layers.
> 
> **Overview**
> **Safe mode (`MISE_SAFE=1`) now rejects tool-level install hooks that could run untrusted config during installation.**
> 
> Previously, safe mode blocked project hooks, tasks, and plugin scripts, but per-tool `postinstall` and `install_env` still ran on the install path. This change adds `ToolRequest::ensure_safe_install_options()` to fail before any install work when those options are set, wired into bulk `mise install` and again at `Backend::install_version` so `install-into` is covered too.
> 
> Documentation in `docs/security.md` lists these restrictions, and e2e tests assert installs abort with clear errors and leave no side effects (e.g. no `postinstall` files created).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea000aca32333686536fea35dd80316b1988922f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Safe mode now blocks tool-level `postinstall` hooks during installation.
  * Safe mode rejects tool-level environment settings during installation.
  * Blocked operations provide clear security errors and prevent installation side effects.

* **Documentation**
  * Updated safe mode documentation to describe these restrictions.

* **Tests**
  * Added end-to-end coverage for both protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->