### PR TITLE
chore(ci): prevent stale snapcraft releases

### DIFF
--- a/.github/workflows/snapcraft-publish.yml
+++ b/.github/workflows/snapcraft-publish.yml
@@ -8,8 +8,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: snapcraft-publish-${{ github.event_name == 'release' && 'release' || github.ref }}
+  # Release events can arrive out of version order, so let the shared gate decide.
+  cancel-in-progress: false
+
 jobs:
-  publish-snapcraft:
+  build-snapcraft:
     strategy:
       fail-fast: false
       matrix:
@@ -25,6 +30,18 @@ jobs:
           snapcraft-channel: stable
         id: snapbuild
 
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: snap-${{ matrix.runs-on }}
+          path: ${{ steps.snapbuild.outputs.snap }}
+          retention-days: 1
+
+  check-release:
+    needs: build-snapcraft
+    runs-on: ubuntu-24.04
+    outputs:
+      publish: ${{ steps.release.outputs.publish }}
+    steps:
       - name: Check release is current
         id: release
         env:
@@ -33,7 +50,17 @@ jobs:
         run: |
           publish=true
           if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
-            latest_tag="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name)"
+            latest_tag=""
+            for attempt in 1 2 3; do
+              if latest_tag="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name)"; then
+                break
+              fi
+              if [[ "$attempt" == 3 ]]; then
+                echo "::error::Failed to fetch the latest release after $attempt attempts"
+                exit 1
+              fi
+              sleep "$((attempt * 5))"
+            done
             if [[ "$RELEASE_TAG" != "$latest_tag" ]]; then
               echo "Skipping stale release $RELEASE_TAG; latest is $latest_tag"
               publish=false
@@ -41,10 +68,34 @@ jobs:
           fi
           echo "publish=$publish" >> "$GITHUB_OUTPUT"
 
+  publish-snapcraft:
+    needs: check-release
+    if: needs.check-release.outputs.publish == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        artifact: [snap-ubuntu-24.04, snap-ubuntu-24.04-arm]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ${{ matrix.artifact }}
+          path: dist
+
+      - name: Find snap package
+        id: snap
+        run: |
+          mapfile -t snaps < <(find dist -maxdepth 1 -type f -name '*.snap')
+          if [[ "${#snaps[@]}" != 1 ]]; then
+            echo "::error::Expected one snap package, found ${#snaps[@]}"
+            exit 1
+          fi
+          echo "path=${snaps[0]}" >> "$GITHUB_OUTPUT"
+
       - uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1.2.0
-        if: steps.release.outputs.publish == 'true'
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:
-          snap: ${{ steps.snapbuild.outputs.snap }}
+          snap: ${{ steps.snap.outputs.path }}
           release: stable

--- a/.github/workflows/snapcraft-publish.yml
+++ b/.github/workflows/snapcraft-publish.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         runs-on: [ubuntu-24.04, ubuntu-24.04-arm]
     runs-on: ${{ matrix.runs-on }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/snapcraft-publish.yml
+++ b/.github/workflows/snapcraft-publish.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         runs-on: [ubuntu-24.04, ubuntu-24.04-arm]
     runs-on: ${{ matrix.runs-on }}
-    timeout-minutes: 20
+    timeout-minutes: 40
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -25,7 +25,24 @@ jobs:
           snapcraft-channel: stable
         id: snapbuild
 
+      - name: Check release is current
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          publish=true
+          if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
+            latest_tag="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name)"
+            if [[ "$RELEASE_TAG" != "$latest_tag" ]]; then
+              echo "Skipping stale release $RELEASE_TAG; latest is $latest_tag"
+              publish=false
+            fi
+          fi
+          echo "publish=$publish" >> "$GITHUB_OUTPUT"
+
       - uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1.2.0
+        if: steps.release.outputs.publish == 'true'
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:


### PR DESCRIPTION
## Summary
- increase the Snapcraft build timeout from 20 to 60 minutes
- serialize release-triggered workflows and make one release-currentness decision after both architecture builds
- retry the GitHub release lookup and publish both architecture artifacts only when the shared gate succeeds
- preserve manual workflow dispatches with a separate concurrency key

## Root cause
The amd64 builds for 2026.8.6 through 2026.8.8 were canceled at the 20-minute job timeout while Rust was still compiling. The 2026.8.8 and 2026.8.7 workflows also overlapped, allowing the older arm64 release to overwrite the newer stable channel after its build completed later.

## Impact
Snapcraft builds have enough time to finish, and overlapping release workflows cannot downgrade the stable channel or make inconsistent per-architecture publish decisions.

## Validation
- `git diff --check`
- `actionlint .github/workflows/snapcraft-publish.yml`
- `hk run check --safe --format json --files0-from -` scoped to the workflow (Prettier and Actionlint passed)

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes for Snapcraft release timing and artifact handoff; no application runtime or auth logic is modified.
> 
> **Overview**
> **Snapcraft publishing is split into build → gate → publish**, so long builds can finish without racing older releases onto the stable channel.
> 
> The workflow adds a **shared concurrency group** for release runs (without canceling in-flight jobs) and raises the **build job timeout to 60 minutes**. Builds upload per-arch **`.snap` artifacts** instead of publishing immediately.
> 
> A new **`check-release` job** runs after both matrix builds and, for `release` events only, compares the triggering tag to GitHub’s **latest** release (with retries). If the tag is stale, **`publish-snapcraft` is skipped**; **`workflow_dispatch` still publishes**.
> 
> Publishing downloads each artifact, validates exactly one snap file, then calls **`snapcore/action-publish`** with that path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19468775b20ed116e1d08826315383486274e59b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability Improvements**
  * Release builds can now run concurrently, reducing delays.
  * Stale releases are detected and skipped automatically.
  * Release verification retries when needed.
  * Build time limits have been increased for more reliable completion.

* **Publishing**
  * Snap artifacts are temporarily stored and validated before publication.
  * Exactly one artifact is published for each release entry.
  * Manual publishing remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->