### PR TITLE
perf(config): gate idiomatic file detection on idiomatic_version_file_enable_tools

### DIFF
--- a/e2e/config/test_idiomatic_version_file_plugin_gate
+++ b/e2e/config/test_idiomatic_version_file_plugin_gate
@@ -32,6 +32,19 @@ EOF
 mise env >/dev/null
 assert_fail "test -f '$marker'"
 
+# Enabling a different tool still classifies config.toml through path_is_idiomatic()
+# (the empty-set early return no longer applies) but must not boot this plugin.
+# load_idiomatic_filenames() only queries enabled tools, so this is the unique
+# coverage for the per-backend skip in the fallback path.
+cat <<EOF >"$MISE_CONFIG_DIR/config.toml"
+[settings]
+experimental = true
+idiomatic_version_file_enable_tools = ["other"]
+EOF
+
+mise env >/dev/null
+assert_fail "test -f '$marker'"
+
 # enabling the tool for idiomatic version files opts into loading its metadata
 cat <<EOF >"$MISE_CONFIG_DIR/config.toml"
 [settings]

--- a/e2e/config/test_idiomatic_version_file_plugin_gate
+++ b/e2e/config/test_idiomatic_version_file_plugin_gate
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Config files not named mise.toml (e.g. the global config.toml) are classified via
+# path_is_idiomatic(), which used to query idiomatic_filenames() on every backend —
+# booting a Lua VM for every installed vfox plugin (and running any top-level code
+# in its metadata.lua) on every mise invocation, even though idiomatic version
+# files are opt-in. Plugin metadata must not load unless the tool is listed in
+# idiomatic_version_file_enable_tools.
+
+marker="$PWD/metadata-loaded"
+
+mkdir -p "$MISE_DATA_DIR/plugins/sideeffect"
+cat <<EOF >"$MISE_DATA_DIR/plugins/sideeffect/metadata.lua"
+PLUGIN = {
+    name = "sideeffect",
+    version = "0.1.0",
+    description = "records when its metadata is loaded",
+}
+local f = io.open("$marker", "w")
+if f then
+    f:write("loaded")
+    f:close()
+end
+EOF
+
+# a global config file not named mise.toml exercises the idiomatic-file fallback
+# in detect_config_file_type()
+cat <<EOF >"$MISE_CONFIG_DIR/config.toml"
+[settings]
+experimental = true
+EOF
+
+mise env >/dev/null
+assert_fail "test -f '$marker'"
+
+# enabling the tool for idiomatic version files opts into loading its metadata
+cat <<EOF >"$MISE_CONFIG_DIR/config.toml"
+[settings]
+experimental = true
+idiomatic_version_file_enable_tools = ["sideeffect"]
+EOF
+
+mise env >/dev/null
+assert "test -f '$marker'"

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -785,18 +785,33 @@ pub(crate) fn matching_idiomatic_filenames<'a>(
 }
 
 async fn path_is_idiomatic(path: &Path) -> Option<Vec<Arc<dyn Backend>>> {
-    let disable_files = Settings::try_get()
-        .map(|settings| settings.idiomatic_version_file_disable_files.clone())
+    let (enable_tools, disable_files) = Settings::try_get()
+        .map(|settings| {
+            (
+                settings.idiomatic_version_file_enable_tools.clone(),
+                settings.idiomatic_version_file_disable_files.clone(),
+            )
+        })
         .unwrap_or_default();
-    path_is_idiomatic_with_disabled_files(path, &disable_files).await
+    path_is_idiomatic_for_enabled_tools(path, &enable_tools, &disable_files).await
 }
 
-async fn path_is_idiomatic_with_disabled_files(
+async fn path_is_idiomatic_for_enabled_tools(
     path: &Path,
+    enable_tools: &BTreeSet<String>,
     disable_files: &BTreeSet<String>,
 ) -> Option<Vec<Arc<dyn Backend>>> {
+    // Idiomatic version files are opt-in per tool. Skipping non-enabled backends is
+    // also what keeps `idiomatic_filenames()` from booting a Lua VM for every
+    // installed vfox plugin on every invocation just to classify a config path.
+    if enable_tools.is_empty() {
+        return None;
+    }
     let mut backends_by_filename = BTreeMap::<String, Vec<Arc<dyn Backend>>>::new();
     for b in backend::list() {
+        if !enable_tools.contains(b.id()) {
+            continue;
+        }
         match b.idiomatic_filenames().await {
             Ok(filenames) => {
                 for filename in filenames {
@@ -1000,14 +1015,16 @@ mod tests {
     async fn test_detect_config_file_type() {
         env::set_var("MISE_EXPERIMENTAL", "true");
         backend::load_tools().await.unwrap();
-        assert!(matches!(
+        // Idiomatic version files are opt-in; with the default (empty)
+        // `idiomatic_version_file_enable_tools` they are not detected.
+        assert_eq!(
             detect_config_file_type(Path::new("/foo/bar/.nvmrc")).await,
-            Some(ConfigFileType::IdiomaticVersion(_))
-        ));
-        assert!(matches!(
-            detect_config_file_type(Path::new("/foo/bar/.ruby-version")).await,
-            Some(ConfigFileType::IdiomaticVersion(_))
-        ));
+            None
+        );
+        assert_eq!(
+            detect_config_file_type(Path::new("/foo/bar/rust-toolchain.toml")).await,
+            Some(ConfigFileType::MiseToml)
+        );
         assert_eq!(
             detect_config_file_type(Path::new("/foo/bar/.test-tool-versions")).await,
             Some(ConfigFileType::ToolVersions)
@@ -1016,14 +1033,36 @@ mod tests {
             detect_config_file_type(Path::new("/foo/bar/mise.toml")).await,
             Some(ConfigFileType::MiseToml)
         );
-        assert!(matches!(
-            detect_config_file_type(Path::new("/foo/bar/rust-toolchain.toml")).await,
-            Some(ConfigFileType::IdiomaticVersion(_))
-        ));
-        assert!(matches!(
-            detect_config_file_type(Path::new("/foo/bar/.config/goreleaser.yaml")).await,
-            Some(ConfigFileType::IdiomaticVersion(_))
-        ));
+    }
+
+    #[tokio::test]
+    async fn test_path_is_idiomatic_for_enabled_tools() -> Result<()> {
+        backend::load_tools().await?;
+        let disable_files = BTreeSet::new();
+        for (enabled, path) in [
+            ("node", "/foo/bar/.nvmrc"),
+            ("ruby", "/foo/bar/.ruby-version"),
+            ("rust", "/foo/bar/rust-toolchain.toml"),
+            ("goreleaser", "/foo/bar/.config/goreleaser.yaml"),
+        ] {
+            let enable_tools = BTreeSet::from([enabled.to_string()]);
+            let backends =
+                path_is_idiomatic_for_enabled_tools(Path::new(path), &enable_tools, &disable_files)
+                    .await
+                    .unwrap_or_else(|| panic!("{path} should be idiomatic for {enabled}"));
+            assert!(backends.iter().any(|b| b.id() == enabled));
+            // A file for a non-enabled tool must not match.
+            assert!(
+                path_is_idiomatic_for_enabled_tools(
+                    Path::new(path),
+                    &BTreeSet::from(["zig".to_string()]),
+                    &disable_files,
+                )
+                .await
+                .is_none()
+            );
+        }
+        Ok(())
     }
 
     #[tokio::test]
@@ -1036,7 +1075,14 @@ mod tests {
         let path = config_dir.join("goreleaser.yaml");
         file::write(&path, "version: 2\n")?;
 
-        let tools = parse(&path)
+        let backends = path_is_idiomatic_for_enabled_tools(
+            &path,
+            &BTreeSet::from(["goreleaser".to_string()]),
+            &BTreeSet::new(),
+        )
+        .await
+        .expect("goreleaser should be matched from its nested idiomatic path");
+        let tools = IdiomaticVersionFile::parse(path.clone(), backends)
             .await?
             .to_tool_request_set()?
             .into_iter()
@@ -1103,11 +1149,13 @@ mod tests {
     #[tokio::test]
     async fn test_path_is_idiomatic_respects_disabled_files() -> Result<()> {
         backend::load_tools().await?;
+        let enabled = BTreeSet::from(["node".to_string(), "pnpm".to_string()]);
         let disabled = BTreeSet::from(["node:package.json".to_string()]);
 
-        let backends = path_is_idiomatic_with_disabled_files(Path::new("package.json"), &disabled)
-            .await
-            .expect("package.json should remain idiomatic for package managers");
+        let backends =
+            path_is_idiomatic_for_enabled_tools(Path::new("package.json"), &enabled, &disabled)
+                .await
+                .expect("package.json should remain idiomatic for package managers");
 
         assert!(!backends.iter().any(|backend| backend.id() == "node"));
         assert!(backends.iter().any(|backend| backend.id() == "pnpm"));

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -27,6 +27,7 @@ use crate::watch_files::WatchFile;
 use crate::{
     backend::{self, Backend},
     config, dirs, env, file, hash,
+    registry::REGISTRY,
 };
 use eyre::{Result, eyre};
 use idiomatic_version::IdiomaticVersionFile;
@@ -268,16 +269,14 @@ impl dyn ConfigFile {
     }
 }
 
-async fn init(path: &Path) -> Arc<dyn ConfigFile> {
+async fn init(path: &Path) -> Result<Arc<dyn ConfigFile>> {
     match detect_config_file_type(path).await {
-        Some(ConfigFileType::MiseToml) => Arc::new(MiseToml::init(path)),
-        Some(ConfigFileType::ToolVersions) => Arc::new(ToolVersions::init(path)),
-        Some(ConfigFileType::IdiomaticVersion(backends)) => Arc::new(
-            IdiomaticVersionFile::parse(path.to_path_buf(), backends)
-                .await
-                .expect("failed to parse idiomatic version file"),
-        ),
-        _ => panic!("Unknown config file type: {}", path.display()),
+        Some(ConfigFileType::MiseToml) => Ok(Arc::new(MiseToml::init(path))),
+        Some(ConfigFileType::ToolVersions) => Ok(Arc::new(ToolVersions::init(path))),
+        Some(ConfigFileType::IdiomaticVersion(backends)) => Ok(Arc::new(
+            IdiomaticVersionFile::parse(path.to_path_buf(), backends).await?,
+        )),
+        None => Err(unsupported_config_file_error(path)),
     }
 }
 
@@ -289,7 +288,7 @@ pub async fn parse_or_init(path: &Path) -> eyre::Result<Arc<dyn ConfigFile>> {
     };
     let cf = match path.exists() {
         true => parse(&path).await?,
-        false => init(&path).await,
+        false => init(&path).await?,
     };
     Ok(cf)
 }
@@ -337,7 +336,7 @@ pub async fn parse(path: &Path) -> Result<Arc<dyn ConfigFile>> {
         Some(ConfigFileType::IdiomaticVersion(backends)) => Ok(Arc::new(
             IdiomaticVersionFile::parse(path.to_path_buf(), backends).await?,
         )),
-        _ => Ok(Arc::new(MiseToml::default())),
+        None => Err(unsupported_config_file_error(path)),
     }
 }
 
@@ -784,6 +783,24 @@ pub(crate) fn matching_idiomatic_filenames<'a>(
         .collect()
 }
 
+fn path_matches_registry_idiomatic(path: &Path) -> bool {
+    let filenames = REGISTRY
+        .values()
+        .flat_map(|rt| rt.idiomatic_files.iter().map(|f| f.path));
+    !matching_idiomatic_filenames(path, filenames).is_empty()
+}
+
+fn unsupported_config_file_error(path: &Path) -> eyre::Report {
+    if path_matches_registry_idiomatic(path) {
+        eyre!(
+            "cannot update idiomatic version file {}; use mise.toml, .tool-versions, or --path to choose a writable config file",
+            display_path(path)
+        )
+    } else {
+        eyre!("unknown config file type: {}", display_path(path))
+    }
+}
+
 async fn path_is_idiomatic(path: &Path) -> Option<Vec<Arc<dyn Backend>>> {
     let (enable_tools, disable_files) = Settings::try_get()
         .map(|settings| {
@@ -862,6 +879,11 @@ async fn detect_config_file_type(path: &Path) -> Option<ConfigFileType> {
         f => {
             if let Some(backends) = path_is_idiomatic(path).await {
                 Some(ConfigFileType::IdiomaticVersion(backends))
+            } else if path_matches_registry_idiomatic(path) {
+                // Known idiomatic filenames stay unrecognized until the tool is
+                // opted in. Do not fall through to MiseToml for names like
+                // rust-toolchain.toml.
+                None
             } else if f.ends_with(".toml") {
                 Some(ConfigFileType::MiseToml)
             } else {
@@ -1022,8 +1044,12 @@ mod tests {
             None
         );
         assert_eq!(
+            detect_config_file_type(Path::new("/foo/bar/package.json")).await,
+            None
+        );
+        assert_eq!(
             detect_config_file_type(Path::new("/foo/bar/rust-toolchain.toml")).await,
-            Some(ConfigFileType::MiseToml)
+            None
         );
         assert_eq!(
             detect_config_file_type(Path::new("/foo/bar/.test-tool-versions")).await,
@@ -1032,6 +1058,19 @@ mod tests {
         assert_eq!(
             detect_config_file_type(Path::new("/foo/bar/mise.toml")).await,
             Some(ConfigFileType::MiseToml)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_parse_or_init_rejects_disabled_idiomatic_file() {
+        backend::load_tools().await.unwrap();
+        let err = parse_or_init(Path::new("package.json"))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("cannot update idiomatic version file"),
+            "unexpected error: {err}"
         );
     }
 


### PR DESCRIPTION
## Problem

`path_is_idiomatic()` queries `idiomatic_filenames()` on **every backend** to classify any config path not named exactly `mise.toml`/`.tool-versions` — which includes the global `~/.config/mise/config.toml` nearly every user has. For each installed vfox plugin/tool this boots a Lua VM and executes any top-level code in its `metadata.lua`, on **every mise invocation** — even though idiomatic version files are opt-in (`idiomatic_version_file_enable_tools` defaults to empty), and even though the discovery path (`load_idiomatic_filenames_for_tools`) already honors the opt-in.

This is especially costly for nested `mise run`/`mise x` chains in scripts, which pay the full cost at every nesting level. It gets pathological when a plugin's metadata does real work: `vfox-mysql`'s `metadata.lua` shells out to `apt-cache show libaio1t64` at load time (fix for that coming separately).

## Fix

Honor `idiomatic_version_file_enable_tools` in the fallback classification path too: return early when it's empty, and skip backends not in the set. This matches the documented opt-in semantics and the behavior of the gated discovery path. Direct parses of idiomatic files (tracked configs, explicit paths) now also respect the opt-in, which is consistent with idiomatic files being disabled by default.

## Measurements

Real-world HOME with a global `config.toml` and 4 installed vfox-backed tools (one with the apt-cache probe), release build, linux-x64:

| Scenario | before | after |
|---|---|---|
| `mise x -- true` | ~392–530ms | ~14ms |
| 3-level nested `mise run` chain | ~2.7s | <100ms |

Debug-log verification: the released binary logs 4× `[vfox] Getting metadata for …` per invocation; with this change, 0.

## Tests

- New e2e test `e2e/config/test_idiomatic_version_file_plugin_gate`: a vfox plugin whose `metadata.lua` writes a marker file must not load with default settings, and must load once the tool is listed in `idiomatic_version_file_enable_tools`.
- Updated unit tests to the gated semantics; idiomatic matching (incl. nested registry paths like `.config/goreleaser.yaml`) is now covered via an explicit-args variant to avoid mutating process-global settings in parallel tests.
- All idiomatic-related e2e tests already opt in via `idiomatic_version_file_enable_tools`, so they're unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core config file type detection and when plugin metadata loads, which affects every invocation and writable config paths for idiomatic filenames; behavior is intentional but could surprise users who relied on implicit idiomatic parsing without enabling tools.
> 
> **Overview**
> **Idiomatic version file classification** now honors `idiomatic_version_file_enable_tools` on the fallback path used for non-`mise.toml` configs (including global `config.toml`). With an empty enable list, classification skips all backends instead of calling `idiomatic_filenames()` on every tool—avoiding vfox Lua/metadata work on each invocation. Only tools in the enable set are queried when the list is non-empty.
> 
> **Detection semantics:** Known registry idiomatic paths (e.g. `rust-toolchain.toml`) no longer fall through to generic `MiseToml` when the tool is not opted in; they stay unrecognized until enabled. `parse`/`init`/`lock_and_parse_or_init` return explicit errors (including a dedicated message for disabled idiomatic files) instead of panicking or defaulting to empty `MiseToml`.
> 
> **Tests:** New e2e `test_idiomatic_version_file_plugin_gate` asserts plugin `metadata.lua` does not run unless the tool is enabled; unit tests updated for gated detection and per-tool matching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b6f85c02a931eb04c3d63c426343f3681d92ca2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Changes**
  * Idiomatic version files are recognized only for explicitly enabled tools.
  * Disabled filenames and unenabled tool files remain unrecognized.
  * Standard configuration filenames continue to be detected as before.
  * Configuration processing now reports unsupported-file errors instead of falling back unexpectedly.
* **Bug Fixes**
  * Prevented unintended plugin activation and side effects during environment evaluation.
  * Improved error messages with guidance for supported alternatives.
* **Tests**
  * Added coverage for enabled, disabled, nested, and unsupported configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->