### PR TITLE
test(config): cover path_is_idiomatic skip for non-enabled tools

### DIFF
--- a/e2e/config/test_idiomatic_version_file_plugin_gate
+++ b/e2e/config/test_idiomatic_version_file_plugin_gate
@@ -32,6 +32,19 @@ EOF
 mise env >/dev/null
 assert_fail "test -f '$marker'"
 
+# Enabling a different tool still classifies config.toml through path_is_idiomatic()
+# (the empty-set early return no longer applies) but must not boot this plugin.
+# load_idiomatic_filenames() only queries enabled tools, so this is the unique
+# coverage for the per-backend skip in the fallback path.
+cat <<EOF >"$MISE_CONFIG_DIR/config.toml"
+[settings]
+experimental = true
+idiomatic_version_file_enable_tools = ["other"]
+EOF
+
+mise env >/dev/null
+assert_fail "test -f '$marker'"
+
 # enabling the tool for idiomatic version files opts into loading its metadata
 cat <<EOF >"$MISE_CONFIG_DIR/config.toml"
 [settings]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses Greptile feedback on #12143: the enabled-tool assertion loaded plugin metadata through `load_idiomatic_filenames()` before `path_is_idiomatic()` ran, so it would still pass if the fallback per-backend gate were removed.

This adds a case that sets `idiomatic_version_file_enable_tools = ["other"]`. That still classifies global `config.toml` through `path_is_idiomatic()` (the empty-set early return no longer applies) but must not boot the `sideeffect` plugin. `load_idiomatic_filenames()` only queries enabled tools, so a missing skip in `path_is_idiomatic()` is the only way the metadata marker can appear.

The existing empty-set and enable-`sideeffect` assertions are unchanged (the latter remains a positive control that the plugin actually loads).

*AI-assisted — Tool: Cursor; model: SpaceXAI/cursor-grok-4.5-high; version: unavailable.*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-565cde1c-0304-4b35-a03a-ebd0aa3adc85?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-565cde1c-0304-4b35-a03a-ebd0aa3adc85&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

