### PR TITLE
perf(release): build windows with the serious profile and one TLS stack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,12 @@ jobs:
     if: github.event_name != 'pull_request' || github.head_ref == 'release'
     name: build-tarball-windows-${{matrix.arch}}
     runs-on: windows-latest
-    timeout-minutes: 60
+    # Matches the Linux tarball job. 60 was sized for a non-LTO build; the fat-LTO
+    # link this job now does is the long pole and its cost varies a lot with
+    # available memory — locally the same relink took ~20 minutes with RAM to spare
+    # and ~180 minutes when it did not. If this proves too tight on a runner,
+    # thin LTO for Windows is the fallback.
+    timeout-minutes: 150
     strategy:
       fail-fast: false
       matrix:

--- a/scripts/build-tarball.ps1
+++ b/scripts/build-tarball.ps1
@@ -5,12 +5,23 @@ $Target = $args[0]
 $Version = ./scripts/get-version.ps1
 $BaseName = "mise-v$Version-$Env:OS-$Env:ARCH"
 
-# TODO: use "serious" feature
-cargo build --release --features rustls-native-roots,openssl/vendored --target "$Target"
-cargo build --release -p mise-shim --target "$Target"
+# Keep this list in sync with scripts/build-tarball.sh. `--no-default-features`
+# matters: the default set turns on `native-tls`, and without disabling it the
+# binary carries a second TLS stack (native-tls + schannel) next to the rustls
+# one we actually use.
+#
+# No `openssl/vendored` here. It was needed when mise linked git2/libgit2
+# (removed in 3463ef185, which moved to the pure-Rust gix), and it survived a
+# revert/re-apply of the MITM-firewall fix (93b0d136e, f336df457) that left it
+# stacked alongside rustls. On Windows native-tls is schannel, so vendored
+# OpenSSL was compiled into every release and never called.
+$Features = "rustls-native-roots,self_update,vfox/vendored-lua"
+
+cargo build --profile=serious --no-default-features --features "$Features" --target "$Target"
+cargo build --profile=serious -p mise-shim --target "$Target"
 mkdir -p dist/mise/bin
-cp "target/$Target/release/mise.exe" dist/mise/bin/mise.exe
-cp "target/$Target/release/mise-shim.exe" dist/mise/bin/mise-shim.exe
+cp "target/$Target/serious/mise.exe" dist/mise/bin/mise.exe
+cp "target/$Target/serious/mise-shim.exe" dist/mise/bin/mise-shim.exe
 cp README.md dist/mise/README.md
 cp LICENSE dist/mise/LICENSE
 Set-Location dist


### PR DESCRIPTION
## Windows release binaries are built differently from every other platform

Not deliberately — the differences accumulated through a revert and a copy-paste.

`scripts/build-tarball.sh` (Linux/macOS):

```sh
features="rustls-native-roots,self_update,vfox/vendored-lua,openssl/vendored"
cargo build --profile=serious --no-default-features --features "$features" ...
# plus PGO (scripts/pgo.bash) and, on x86_64-linux, BOLT (scripts/bolt.bash)
```

`scripts/build-tarball.ps1` (Windows), before this PR:

```powershell
# TODO: use "serious" feature
cargo build --release --features rustls-native-roots,openssl/vendored --target "$Target"
```

Three separate problems:

**1. `--release`, not `--profile=serious`.** `[profile.release]` in `Cargo.toml` sets nothing;
`serious` adds `lto = true` and `panic = "abort"`. Windows has shipped un-LTO'd builds since the
`serious` profile was introduced — the `TODO` on that line is the only record of it.
`panic = "abort"` is already an understood configuration here (`#[cfg(panic = "abort")]` in
`src/main.rs`), because Linux and macOS have shipped it for a long time.

**2. Missing `--no-default-features`, so the binary carries two TLS stacks.** `default` includes
`native-tls`. Adding `rustls-native-roots` on top does not replace it — it stacks. The old build
compiles `native-tls` + `schannel` + `tokio-native-tls` alongside `rustls` + `ring` +
`rustls-native-certs`, and links them: comparing the two binaries, `native-tls` strings go 4 → 0
and `schannel` 10 → 4.

**3. `openssl/vendored` built OpenSSL from source on every release for nothing.** The old build
compiles `openssl-src v300.6.1+3.6.3`, `openssl-sys`, `openssl` and `openssl-macros`; the new one
compiles none of them.

To be precise about what that cost: **build time, not image size.** Searching either shipped binary
for OpenSSL runtime markers finds none — the only `openssl` strings belong to an embedded Lua helper
that locates OpenSSL when building *other* tools, and it is identical in both binaries. So the
vendored OpenSSL was compiled and then discarded at link time.

The flag dates to `e73760a04`, when mise linked git2/libgit2. `3463ef185` replaced git2 with the
pure-Rust `gix`, ending the need. `87204c15c` then removed it in favour of `rustls-native-roots`,
`93b0d136e` reverted that, and `f336df457` re-applied the fix while keeping `openssl/vendored`
alongside rustls. `Cargo.toml` already lists `openssl` under `ignored` because nothing in mise
references it directly.

## Change

Make the Windows build match every other platform: `--profile=serious`, `--no-default-features`,
the same feature list minus the dead `openssl/vendored`.

## Measurements

Snapdragon X Elite (X1E80100), Windows 11, `aarch64-pc-windows-msvc`, Defender real-time protection
on. Both binaries built from this commit, so the only variables are profile and features. A/B
samples interleaved with the leading binary alternating, so background load hits both equally.
Medians of 25. `MISE_DISABLE_VERSION_CHECK=1` throughout — without it the update warning adds a
cache read, and sometimes a network call, to an arbitrary subset of samples.

Binary: **114.5 MB → 75.0 MB** (−34%).

| scenario | before | after | delta |
|---|---|---|---|
| `hook-env` (steady state, per prompt) | 22.9ms | 22.2ms | −0.7ms (−3.1%) |
| `hook-env` (full run, on `cd`) | 55.9ms | 53.2ms | −2.7ms (−4.8%) |
| `--version` (startup floor) | 26.4ms | 25.0ms | −1.4ms (−5.3%) |
| `env -s pwsh` | 55.9ms | 52.8ms | −3.1ms (−5.5%) |
| `current` | 44.3ms | 42.9ms | −1.4ms (−3.2%) |
| `bin-paths` | 46.9ms | 44.9ms | −2.0ms (−4.3%) |
| `ls --installed` | 52.8ms | 50.8ms | −2.0ms (−3.8%) |
| `task ls` | 59.5ms | 58.8ms | −0.7ms (−1.2%) |

A consistent 3-5%. Every scenario improves, which is the signal worth having from a change that
costs nothing at runtime — but it is not a dramatic win and should not be sold as one.

## What this does *not* fix, and two things I got wrong on the way to that

**This is not a fix for prompt latency.** On Windows roughly 22ms of every invocation is the OS
creating a process. A bare `cmd.exe /c ver` measures 24.7ms on this machine, and an early-exiting
`hook-env` measures 22.9ms — so a steady-state prompt is very nearly *all* process creation. No
compiler flag touches that. (#12147 goes after the spawn count instead.)

**Binary size does not drive startup.** It is tempting to assume 114MB → 75MB is itself the win. It
is not. Windows demand-pages the image, so pages never touched are never read:

| binary | size | `--version` |
|---|---|---|
| shipped 2025.9.9 | 44.1 MB | 32.0ms |
| built from `main` | 114.5 MB | 31.9ms |

Identical. A cross-binary size/startup correlation looks convincing but is confounded by different
programs doing different amounts of startup work.

**`should_exit_early_fast()` was already doing its job.** An earlier reading of mine had `hook-env`
costing only ~5ms more than `--version`, which suggested per-prompt work was already negligible.
That gap was an artifact of the version check inflating `--version`. With it disabled, a *full*
`hook-env` run does ~16ms of work on 2025.9.9 and ~38ms on current `main`. Most prompts do not take
that path — with a session present and the directory unchanged the fast path short-circuits before
the logger is even initialised — but the `cd` path is real work and has grown.

## Release job timeout

`timeout-minutes` for the Windows tarball job goes 60 → 150, matching the Linux tarball job (macOS
already allows 300). 60 was sized for a build with no LTO.

The fat-LTO link is now the long pole, and its cost turned out to be very memory-sensitive: locally
the same relink took ~20 minutes with RAM to spare and ~180 minutes when only ~2.6GB was free (no
sleep events, CPU at full clock on AC power). Worth watching on the first real run. If it is too
tight on a runner, thin LTO for Windows is the fallback — most of the cross-crate benefit at a
fraction of the link cost.

## Verification

TLS end to end with the new binary, since dropping `native-tls` is part of this change:

- `ls-remote node` (node's release host), `ls-remote jq` (aqua registry) and `ls-remote ripgrep`
  (GitHub) all resolve
- `install jq@1.8.1` downloads, verifies, extracts, and the installed binary runs

## Not included here

PGO and BOLT remain Linux/macOS-only. PGO is reachable on Windows (`-Cprofile-generate` works on
MSVC) but `scripts/pgo.bash` is a bash workload runner, so that is a separate change.

Also worth noting: `.github/workflows/perf.yml` records startup cost for every commit on `main`, on
one pinned **Linux** runner. Nothing measures Windows, which is why a divergence this old went
unnoticed. Its precision comes from cachegrind, which has no Windows equivalent, so closing that gap
needs a different instrument.

## Stack

#12147 builds on this branch: it removes a redundant `hook-env` spawn per directory change on pwsh
(~32ms, ~32% off every `cd`). It is stacked only so its measurements are not confounded by this
build change; the two are independent in effect.

---
*This PR was generated by Claude Code.*
