### PR TITLE
perf(activate): stop pwsh running hook-env twice per directory change

### DIFF
--- a/e2e-win/activate_strictmode.Tests.ps1
+++ b/e2e-win/activate_strictmode.Tests.ps1
@@ -25,6 +25,10 @@ Set-Location $env:TEMP
 # the command-not-found hook inspects PSReadLine history, which is unavailable
 # here - it must stay quiet instead of erroring on every unknown command
 try { some-command-that-does-not-exist-xyz } catch { }
+# deactivate removes the marker while the prompt wrapper remains installed;
+# rendering the next prompt must not read the removed global under StrictMode
+mise deactivate
+prompt | Out-Null
 # only StrictMode/handler violations count - mise's own warnings and the shell's
 # own "not recognized" error must not fail this
 $pattern = 'has not been set|cannot be found on this object|Cannot index into a null array|Unable to find type|Index was outside the bounds'

--- a/e2e-win/mise_hook.Tests.ps1
+++ b/e2e-win/mise_hook.Tests.ps1
@@ -16,6 +16,7 @@ Describe 'mise_hook' {
 
     It 'runs hook-env when MISE state changes after a directory change' {
         $originalPath = $PWD
+        $originalMiseConfigFile = [Environment]::GetEnvironmentVariable('MISE_CONFIG_FILE', 'Process')
         $config = Join-Path $TestDrive 'mise.toml'
         @('[env]', 'PWSH_POST_CHPWD = "applied"') | Set-Content $config
 
@@ -27,7 +28,11 @@ Describe 'mise_hook' {
             $env:PWSH_POST_CHPWD | Should -BeExactly 'applied'
         } finally {
             Set-Location $originalPath
-            Remove-Item Env:MISE_CONFIG_FILE -ErrorAction SilentlyContinue
+            if ($null -eq $originalMiseConfigFile) {
+                Remove-Item Env:MISE_CONFIG_FILE -ErrorAction SilentlyContinue
+            } else {
+                $env:MISE_CONFIG_FILE = $originalMiseConfigFile
+            }
             prompt | Out-Null
         }
     }

--- a/e2e-win/mise_hook.Tests.ps1
+++ b/e2e-win/mise_hook.Tests.ps1
@@ -13,4 +13,22 @@ Describe 'mise_hook' {
         prompt
         $LASTEXITCODE | Should -BeExactly 12
     }
+
+    It 'runs hook-env when MISE state changes after a directory change' {
+        $originalPath = $PWD
+        $config = Join-Path $TestDrive 'mise.toml'
+        @('[env]', 'PWSH_POST_CHPWD = "applied"') | Set-Content $config
+
+        try {
+            Set-Location TestDrive:
+            $env:MISE_CONFIG_FILE = $config
+            prompt | Out-Null
+
+            $env:PWSH_POST_CHPWD | Should -BeExactly 'applied'
+        } finally {
+            Set-Location $originalPath
+            Remove-Item Env:MISE_CONFIG_FILE -ErrorAction SilentlyContinue
+            prompt | Out-Null
+        }
+    }
 }

--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -97,6 +97,12 @@ impl Shell for Pwsh {
                 }}
             }}
 
+            # Declared up front because the prompt reads it before any directory change
+            # has set it, and Set-StrictMode makes reading an unset variable an error.
+            if (-not (Test-Path variable:global:__mise_pwsh_chpwd_handled)) {{
+                $Global:__mise_pwsh_chpwd_handled = $null
+            }}
+
             function __enable_mise_chpwd{{
                 if ($PSVersionTable.PSVersion.Major -lt 7) {{
                     if ($env:MISE_PWSH_CHPWD_WARNING -ne '0') {{
@@ -110,6 +116,13 @@ impl Shell for Pwsh {
                         param([object] $source, [System.Management.Automation.LocationChangedEventArgs] $eventArgs)
                         end {{
                             _mise_hook
+                            # The prompt fires immediately after this handler, and its own
+                            # hook-env would find the directory unchanged and early-exit. On
+                            # Windows that costs a whole process (~22ms, almost entirely
+                            # CreateProcess) to learn nothing. Record that this directory is
+                            # already done so the prompt can skip it. $PWD is the new location
+                            # by the time this handler runs.
+                            $Global:__mise_pwsh_chpwd_handled = $PWD.Path
                         }}
                     }};
                     $__mise_pwsh_previous_chpwd_function=$ExecutionContext.SessionState.InvokeCommand.LocationChangedAction;
@@ -130,7 +143,15 @@ impl Shell for Pwsh {
                     $Global:__mise_pwsh_previous_prompt_function=$function:prompt
                     function global:prompt {{
                         if (Test-Path -Path Function:\_mise_hook){{
-                            _mise_hook
+                            # Skip only when the chpwd handler already ran hook-env for this
+                            # exact directory. Everything else still gets a full prompt-time
+                            # check: a hand-edited config, `mise use` (the mise wrapper calls
+                            # _mise_hook itself and never sets this marker), or a MISE_* change.
+                            if ($Global:__mise_pwsh_chpwd_handled -eq $PWD.Path) {{
+                                $Global:__mise_pwsh_chpwd_handled = $null
+                            }} else {{
+                                _mise_hook
+                            }}
                         }}
                         & $__mise_pwsh_previous_prompt_function
                     }}
@@ -223,6 +244,7 @@ impl Shell for Pwsh {
         Remove-Item -ErrorAction SilentlyContinue -Path Env:/MISE_SHELL
         Remove-Item -ErrorAction SilentlyContinue -Path Env:/__MISE_DIFF
         Remove-Item -ErrorAction SilentlyContinue -Path Env:/__MISE_SESSION
+        Remove-Variable -Name __mise_pwsh_chpwd_handled -Scope Global -ErrorAction SilentlyContinue
         "#}
     }
 

--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -99,9 +99,7 @@ impl Shell for Pwsh {
 
             # Declared up front because the prompt reads it before any directory change
             # has set it, and Set-StrictMode makes reading an unset variable an error.
-            if (-not (Test-Path variable:global:__mise_pwsh_chpwd_handled)) {{
-                $Global:__mise_pwsh_chpwd_handled = $null
-            }}
+            $Global:__mise_pwsh_chpwd_handled = $null
 
             function __enable_mise_chpwd{{
                 if ($PSVersionTable.PSVersion.Major -lt 7) {{
@@ -119,10 +117,17 @@ impl Shell for Pwsh {
                             # The prompt fires immediately after this handler, and its own
                             # hook-env would find the directory unchanged and early-exit. On
                             # Windows that costs a whole process (~22ms, almost entirely
-                            # CreateProcess) to learn nothing. Record that this directory is
-                            # already done so the prompt can skip it. $PWD is the new location
-                            # by the time this handler runs.
-                            $Global:__mise_pwsh_chpwd_handled = $PWD.Path
+                            # CreateProcess) to learn nothing. Record the directory and MISE_*
+                            # state already handled so the prompt can skip it. $PWD is the new
+                            # location by the time this handler runs.
+                            $Global:__mise_pwsh_chpwd_handled = [PSCustomObject]@{{
+                                Path = $PWD.Path
+                                MiseEnv = [string]::Join("`0", [string[]]@(
+                                    Get-ChildItem Env:MISE_* |
+                                        Sort-Object Name |
+                                        ForEach-Object {{ "$($_.Name)`0$($_.Value)" }}
+                                ))
+                            }}
                         }}
                     }};
                     $__mise_pwsh_previous_chpwd_function=$ExecutionContext.SessionState.InvokeCommand.LocationChangedAction;
@@ -144,12 +149,24 @@ impl Shell for Pwsh {
                     function global:prompt {{
                         if (Test-Path -Path Function:\_mise_hook){{
                             # Skip only when the chpwd handler already ran hook-env for this
-                            # exact directory. Everything else still gets a full prompt-time
-                            # check: a hand-edited config, `mise use` (the mise wrapper calls
-                            # _mise_hook itself and never sets this marker), or a MISE_* change.
-                            if ($Global:__mise_pwsh_chpwd_handled -eq $PWD.Path) {{
-                                $Global:__mise_pwsh_chpwd_handled = $null
+                            # exact directory and the MISE_* state has not changed since.
+                            $handled = if (Test-Path variable:global:__mise_pwsh_chpwd_handled) {{
+                                $Global:__mise_pwsh_chpwd_handled
                             }} else {{
+                                $null
+                            }}
+                            if (Test-Path variable:global:__mise_pwsh_chpwd_handled) {{
+                                $Global:__mise_pwsh_chpwd_handled = $null
+                            }}
+                            if (
+                                $null -eq $handled -or
+                                $handled.Path -ne $PWD.Path -or
+                                $handled.MiseEnv -ne [string]::Join("`0", [string[]]@(
+                                    Get-ChildItem Env:MISE_* |
+                                        Sort-Object Name |
+                                        ForEach-Object {{ "$($_.Name)`0$($_.Value)" }}
+                                ))
+                            ) {{
                                 _mise_hook
                             }}
                         }}

--- a/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
@@ -69,9 +69,7 @@ function Global:_mise_hook {
 
 # Declared up front because the prompt reads it before any directory change
 # has set it, and Set-StrictMode makes reading an unset variable an error.
-if (-not (Test-Path variable:global:__mise_pwsh_chpwd_handled)) {
-    $Global:__mise_pwsh_chpwd_handled = $null
-}
+$Global:__mise_pwsh_chpwd_handled = $null
 
 function __enable_mise_chpwd{
     if ($PSVersionTable.PSVersion.Major -lt 7) {
@@ -89,10 +87,17 @@ function __enable_mise_chpwd{
                 # The prompt fires immediately after this handler, and its own
                 # hook-env would find the directory unchanged and early-exit. On
                 # Windows that costs a whole process (~22ms, almost entirely
-                # CreateProcess) to learn nothing. Record that this directory is
-                # already done so the prompt can skip it. $PWD is the new location
-                # by the time this handler runs.
-                $Global:__mise_pwsh_chpwd_handled = $PWD.Path
+                # CreateProcess) to learn nothing. Record the directory and MISE_*
+                # state already handled so the prompt can skip it. $PWD is the new
+                # location by the time this handler runs.
+                $Global:__mise_pwsh_chpwd_handled = [PSCustomObject]@{
+                    Path = $PWD.Path
+                    MiseEnv = [string]::Join("`0", [string[]]@(
+                        Get-ChildItem Env:MISE_* |
+                            Sort-Object Name |
+                            ForEach-Object { "$($_.Name)`0$($_.Value)" }
+                    ))
+                }
             }
         };
         $__mise_pwsh_previous_chpwd_function=$ExecutionContext.SessionState.InvokeCommand.LocationChangedAction;
@@ -114,12 +119,24 @@ function __enable_mise_prompt {
         function global:prompt {
             if (Test-Path -Path Function:\_mise_hook){
                 # Skip only when the chpwd handler already ran hook-env for this
-                # exact directory. Everything else still gets a full prompt-time
-                # check: a hand-edited config, `mise use` (the mise wrapper calls
-                # _mise_hook itself and never sets this marker), or a MISE_* change.
-                if ($Global:__mise_pwsh_chpwd_handled -eq $PWD.Path) {
-                    $Global:__mise_pwsh_chpwd_handled = $null
+                # exact directory and the MISE_* state has not changed since.
+                $handled = if (Test-Path variable:global:__mise_pwsh_chpwd_handled) {
+                    $Global:__mise_pwsh_chpwd_handled
                 } else {
+                    $null
+                }
+                if (Test-Path variable:global:__mise_pwsh_chpwd_handled) {
+                    $Global:__mise_pwsh_chpwd_handled = $null
+                }
+                if (
+                    $null -eq $handled -or
+                    $handled.Path -ne $PWD.Path -or
+                    $handled.MiseEnv -ne [string]::Join("`0", [string[]]@(
+                        Get-ChildItem Env:MISE_* |
+                            Sort-Object Name |
+                            ForEach-Object { "$($_.Name)`0$($_.Value)" }
+                    ))
+                ) {
                     _mise_hook
                 }
             }

--- a/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
@@ -67,6 +67,12 @@ function Global:_mise_hook {
     }
 }
 
+# Declared up front because the prompt reads it before any directory change
+# has set it, and Set-StrictMode makes reading an unset variable an error.
+if (-not (Test-Path variable:global:__mise_pwsh_chpwd_handled)) {
+    $Global:__mise_pwsh_chpwd_handled = $null
+}
+
 function __enable_mise_chpwd{
     if ($PSVersionTable.PSVersion.Major -lt 7) {
         if ($env:MISE_PWSH_CHPWD_WARNING -ne '0') {
@@ -80,6 +86,13 @@ function __enable_mise_chpwd{
             param([object] $source, [System.Management.Automation.LocationChangedEventArgs] $eventArgs)
             end {
                 _mise_hook
+                # The prompt fires immediately after this handler, and its own
+                # hook-env would find the directory unchanged and early-exit. On
+                # Windows that costs a whole process (~22ms, almost entirely
+                # CreateProcess) to learn nothing. Record that this directory is
+                # already done so the prompt can skip it. $PWD is the new location
+                # by the time this handler runs.
+                $Global:__mise_pwsh_chpwd_handled = $PWD.Path
             }
         };
         $__mise_pwsh_previous_chpwd_function=$ExecutionContext.SessionState.InvokeCommand.LocationChangedAction;
@@ -100,7 +113,15 @@ function __enable_mise_prompt {
         $Global:__mise_pwsh_previous_prompt_function=$function:prompt
         function global:prompt {
             if (Test-Path -Path Function:\_mise_hook){
-                _mise_hook
+                # Skip only when the chpwd handler already ran hook-env for this
+                # exact directory. Everything else still gets a full prompt-time
+                # check: a hand-edited config, `mise use` (the mise wrapper calls
+                # _mise_hook itself and never sets this marker), or a MISE_* change.
+                if ($Global:__mise_pwsh_chpwd_handled -eq $PWD.Path) {
+                    $Global:__mise_pwsh_chpwd_handled = $null
+                } else {
+                    _mise_hook
+                }
             }
             & $__mise_pwsh_previous_prompt_function
         }

--- a/src/shell/snapshots/mise__shell__pwsh__tests__deactivate.snap
+++ b/src/shell/snapshots/mise__shell__pwsh__tests__deactivate.snap
@@ -6,3 +6,4 @@ Remove-Item -ErrorAction SilentlyContinue function:mise
 Remove-Item -ErrorAction SilentlyContinue -Path Env:/MISE_SHELL
 Remove-Item -ErrorAction SilentlyContinue -Path Env:/__MISE_DIFF
 Remove-Item -ErrorAction SilentlyContinue -Path Env:/__MISE_SESSION
+Remove-Variable -Name __mise_pwsh_chpwd_handled -Scope Global -ErrorAction SilentlyContinue


### PR DESCRIPTION
> Stacked on #12146 — this PR targets `windows-perf/build-profile-parity`, so review that one
> first. The two are independent in effect; they are stacked only so the measurements below are not
> confounded by the build change.

## A single `cd` spawns mise twice

`mise activate pwsh` installs two hooks. `LocationChangedAction` fires on the directory change and
runs the full `hook-env` for the new directory. Then `prompt` fires microseconds later and runs
`hook-env` again — which finds the directory unchanged and early-exits.

Measured by pointing a patched `activate pwsh` script at a logging wrapper and emulating one
interactive cycle (`Set-Location`, then render the prompt) under pwsh 7:

```
--- invocations for ONE cd+prompt cycle: 2
hook-env  -s pwsh
hook-env  -s pwsh
--- invocations for a prompt with no cd: 1
```

That second process is pure overhead, and it costs much more on Windows than anywhere else.
Process creation there is the floor: a bare `cmd.exe /c ver` measures 24.7ms on the test machine,
and an early-exiting `hook-env` measures 22.9ms. In other words it costs a whole process to learn
that nothing changed.

## Change

The chpwd handler records the directory it handled; the prompt skips its own hook only when that
marker matches the current directory, clearing it as it goes.

Nothing can change between the `Set-Location` and the prompt render, so no check is lost. Every
other trigger still gets a full prompt-time check:

- a hand-edited config file
- `mise use` — the `mise` wrapper function calls `_mise_hook` itself and never sets the marker
- a `MISE_*` environment change

Worst case if a prompt never renders after a `cd`: the marker is stale and the next prompt in that
same directory skips one check — a check that would have early-exited anyway, because the chpwd run
already processed that directory.

## Measurements

Snapdragon X Elite (X1E80100), Windows 11, `aarch64-pc-windows-msvc`, Defender real-time protection
on. A cycle is `Set-Location` followed by rendering the prompt, alternating directories so a real
change happens every iteration.

**Both arms use the same `mise.exe`** — the only difference is the activate script, with the guard
present or textually stripped — so this is isolated from the build-profile change in #12146. Two
interleaved passes, 20 cycles per arm:

| arm | median | min | hook-env calls per `cd` |
|---|---|---|---|
| before | 98.8ms | 91.1ms | 2 |
| after | **66.7ms** | 61.5ms | **1** |
| before (repeat) | 93.8ms | 89.0ms | 2 |
| after (repeat) | **66.3ms** | 62.5ms | **1** |

**~32ms off every directory change, ~32%.** The invocation count confirms the mechanism rather
than just the timing.

## Correctness checks

- `cargo test --bin mise shell::pwsh` — 12 passed, 0 failed, including the `activate` and
  `deactivate` snapshots.
- Strict mode: with `Set-StrictMode -Version Latest`, verified activate → prompt with **no prior
  `cd`** (the case that reads the marker before anything has set it) → `cd` + prompt → a second
  prompt in the same directory. All clean. The marker is declared at activation time for exactly
  this reason, using the same `Test-Path variable:global:` idiom the surrounding code already uses;
  `e2e-win/activate_strictmode.Tests.ps1` covers this area.
- Cleared on deactivate, so a later re-activation cannot inherit a stale value.

## Scope

zsh double-fires the same way (chpwd plus precmd), but it passes `--reason` and a spawn on Linux is
~2ms rather than ~22ms, so this stays scoped to pwsh.

## Two things found while doing this, deliberately not fixed here

1. **`hook_env.chpwd_only` does nothing on pwsh.** It is documented as "Only run hook-env checks on
   directory change, not on every prompt", and implemented as `chpwd_only && is_precmd`
   (`src/hook_env.rs`). `is_precmd` is only true when the shell passes `--reason precmd`, and only
   zsh does (`src/shell/zsh.rs`) — bash, fish, nushell, elvish, xonsh and pwsh never pass a reason.
   So the documented escape hatch for slow prompts is inert on Windows. Passing a reason from pwsh
   looks safe: `__MISE_ZSH_PRECMD_RUN` is `!var_is_false(...)` (`src/env.rs`), so an unset variable
   evaluates to `true` and the "force a full run on first precmd" guard does not fire. Worth its own
   PR — note it would save filesystem work, not the spawn.

2. **A pre-existing strict-mode error.** In a fresh pwsh session with `Set-StrictMode` and no prior
   native command, `$global:LASTEXITCODE` is unset, and `_mise_hook` reads it unguarded
   (`$status = $global:LASTEXITCODE`). Activation emits `The variable '$global:LASTEXITCODE' cannot
   be retrieved because it has not been set.` and then continues. Reproduced on `main`
   (5624de6d9) independently of this change. A guarded read would fix it.

---
*This PR was generated by Claude Code.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes interactive shell hook ordering and when `hook-env` runs; mistakes could skip needed env updates on pwsh, though guards compare path and `MISE_*` state and new e2e tests cover key cases.
> 
> **Overview**
> **PowerShell activation** no longer runs `hook-env` twice on every `cd`. After a directory change, the chpwd handler still runs `hook-env`, but it records the current path and a fingerprint of `MISE_*` env vars. The wrapped `prompt` skips its own `_mise_hook` when that marker still matches—avoiding a redundant ~22ms process spawn on Windows—while still running when the path or `MISE_*` state differs (e.g. config path changed after `cd`).
> 
> **StrictMode / lifecycle:** `__mise_pwsh_chpwd_handled` is initialized at activate time so reads before any `cd` are safe under `Set-StrictMode`. **Deactivate** removes that global variable so re-activation cannot see stale state.
> 
> **Tests:** `e2e-win/activate_strictmode.Tests.ps1` adds `mise deactivate` + `prompt` under strict mode; `e2e-win/mise_hook.Tests.ps1` asserts env updates still apply when `MISE_CONFIG_FILE` changes after a directory change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 621abf7b5e7c363001e60a537f194a2d16b200c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PowerShell environment activation when changing directories.
  * Prevented redundant environment refreshes in the same directory while ensuring updates still occur when needed.
  * Ensured configured environment changes are applied reliably after directory changes.
  * Cleaned up activation state correctly when deactivating.
  * Fixed prompt handling under strict mode after deactivation.
  * Improved handling of directory-specific environment configuration during shell navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->