### PR TITLE
chore: ignore test/.cache from the unit test harness

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -4,3 +4,6 @@ cache/
 state/
 cwd/
 test-build-output.txt
+# unit tests point HOME here without pointing XDG_CACHE_HOME anywhere, so
+# tools that default to ~/.cache (aube) write into the repo
+.cache/


### PR DESCRIPTION
Running `cargo test` writes cache artifacts into the working tree, where they sit untracked *and* unignored — one broad `git add` away from being committed. That is exactly how `test/.cache/aube/` ended up in #12149 (caught in review, since removed).

## Cause

The unit-test harness points `HOME` at `<repo>/test` ([src/test.rs](https://github.com/jdx/mise/blob/main/src/test.rs)) and explicitly redirects `MISE_CACHE_DIR`, `MISE_CONFIG_DIR`, `MISE_DATA_DIR`, and `MISE_STATE_DIR` — but not `XDG_CACHE_HOME`. So anything defaulting to `~/.cache` (aube, and its generated `node-gyp` lazy-bin shims) lands in `test/.cache/`.

`test/.gitignore` already covers `cache/`, `data/`, `state/`, and `cwd/` — `.cache/` looks like a simple oversight, since every sibling scratch directory is listed.

## Change

One line. I checked what actually leaks rather than guessing: after a full unit-test run, `test/.cache/` is the only untracked path under `test/`; everything else is either a tracked fixture (`config/`, `fixtures/`, `plugins/`, `has-linked-version-external`) or already ignored. Verified after the change that `git status --untracked-files=all test/` is clean following `cargo test`, and that no tracked fixture is newly ignored.

## Alternative

The root cause could instead be fixed in the harness by pointing `XDG_CACHE_HOME` at `test/data/cache` (already ignored), which would keep the repo clean for any future tool that respects XDG. I went with the `.gitignore` line because it is inert — it cannot change test behavior — but happy to switch if you would rather fix it at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Gitignore-only change; no runtime or test harness behavior changes.
> 
> **Overview**
> Adds **`test/.cache/`** to **`test/.gitignore`** so cache written under `~/.cache` during **`cargo test`** stays untracked.
> 
> The harness sets **`HOME`** to **`test/`** and redirects mise dirs (**`MISE_CACHE_DIR`**, etc.) but not **`XDG_CACHE_HOME`**, so tools such as **aube** (and related **node-gyp** shims) land in **`test/.cache/`** instead of the already-ignored **`cache/`** tree. The comment documents that gap so it is not mistaken for an oversight next to the other ignored scratch dirs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3607b9eca087675ed5d39a61930fa136a52f6060. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comments clarifying test HOME and cache behavior.
* **Chores**
  * Updated test repository ignore rules to exclude cache files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->