### PR TITLE
fix(vfox): honor systemDependencies in embedded plugins

### DIFF
--- a/e2e/plugins/test_plugin_system_deps_embedded
+++ b/e2e/plugins/test_plugin_system_deps_embedded
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Embedded vfox plugins ship compiled into the binary and have no plugin
+# directory, so reading declarations from the directory alone dropped every one
+# of them. lua declares cc/make/curl (and readline as optional); those must be
+# reported like any filesystem plugin's, rather than surfacing as a failed
+# compile partway through `mise install`.
+
+cat >mise.toml <<'TOML'
+[tools]
+lua = "5.4.8"
+TOML
+
+out="$(MISE_EXPERIMENTAL=1 mise bootstrap status 2>&1 || true)"
+
+assert_contains_text "$out" "lua: cc"
+assert_contains_text "$out" "lua: make"
+assert_contains_text "$out" "lua: curl"
+# declared `optional`, so it is reported but never blocks or prompts
+assert_contains_text "$out" "lua: pkg-config readline"
+
+# a user-installed plugin directory still wins over the embedded copy
+PLUGIN_DIR="$MISE_DATA_DIR/plugins/lua"
+mkdir -p "$PLUGIN_DIR"
+cat >"$PLUGIN_DIR/metadata.lua" <<'LUA'
+PLUGIN = {}
+PLUGIN.name = "lua"
+PLUGIN.version = "0.1.0"
+PLUGIN.systemDependencies = {
+	{ bin = "overridden-binary-xyz" },
+}
+LUA
+
+out="$(MISE_EXPERIMENTAL=1 mise bootstrap status 2>&1 || true)"
+assert_contains_text "$out" "overridden-binary-xyz"
+assert_not_contains_text "$out" "lua: curl"

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -634,29 +634,41 @@ impl VfoxBackend {
         }
     }
 
-    /// Loads (or reads from the disk cache) the metadata snapshot of a
-    /// filesystem plugin. Returns `None` for tools without a plugin dir
-    /// (embedded plugins) — their metadata is compiled in and cheap to load.
+    /// This plugin's metadata: idiomatic filenames, tool dependencies and
+    /// system dependencies.
+    ///
+    /// An installed plugin directory wins so a user override still applies, and
+    /// it is read through the disk cache — loading it boots a Lua VM and runs
+    /// the plugin's top-level code. An embedded plugin is used otherwise;
+    /// reading only the directory would silently drop the declarations of every
+    /// embedded plugin, since those ship compiled into the binary and have no
+    /// directory. `None` when there is no plugin at all.
     fn plugin_metadata_snapshot(&self) -> eyre::Result<Option<VfoxMetadataSnapshot>> {
         let plugin_path = dirs::PLUGINS.join(&self.pathname);
-        if !plugin_path.exists() {
+        let installed = plugin_path.exists();
+        if !installed && vfox::embedded_plugins::get_embedded_plugin(&self.pathname).is_none() {
             return Ok(None);
         }
-        let cache = self.metadata_snapshot_cache.get_or_init(|| {
-            CacheManagerBuilder::new(self.ba.cache_path.join("metadata.msgpack.z"))
-                .with_cache_key(lua_sources_fingerprint(&plugin_path))
-                .build()
-        });
-        let snapshot = cache.get_or_try_init(|| {
-            let plugin = vfox::Plugin::from_dir(&plugin_path)?;
+        let load = || {
+            let plugin = vfox::Plugin::from_name_or_dir(&self.pathname, &plugin_path)?;
             let metadata = plugin.get_metadata()?;
             Ok(VfoxMetadataSnapshot {
                 legacy_filenames: metadata.legacy_filenames,
                 depends: metadata.depends,
                 system_dependencies: metadata.system_dependencies,
             })
-        })?;
-        Ok(Some(snapshot.clone()))
+        };
+        if !installed {
+            // Embedded: the Lua is compiled in, so loading costs no I/O and
+            // there are no source files to key a cache on.
+            return Ok(Some(load()?));
+        }
+        let cache = self.metadata_snapshot_cache.get_or_init(|| {
+            CacheManagerBuilder::new(self.ba.cache_path.join("metadata.msgpack.z"))
+                .with_cache_key(lua_sources_fingerprint(&plugin_path))
+                .build()
+        });
+        Ok(Some(cache.get_or_try_init(load)?.clone()))
     }
 
     fn load_metadata_deps(&self) -> eyre::Result<Vec<String>> {


### PR DESCRIPTION
## Problem

`VfoxBackend::load_metadata_deps` and `load_system_deps` both read metadata from the plugin *directory* and returned empty when it was absent:

```rust
let plugin_path = dirs::PLUGINS.join(&self.pathname);
if !plugin_path.exists() {
    return Ok(vec![]);
}
```

That is the case for **every embedded plugin** — they ship compiled into the binary and have no directory. So the `systemDependencies` declared by `vfox-lua` (cc, make, curl, optional readline), `vfox-redis`, `vfox-chicken`, and `vfox-chezscheme` (cc, make) have never been honored. `mise install lua` compiles from source and fails partway through when `cc` is missing, instead of reporting it up front — precisely what the feature exists to prevent.

Verified rather than inferred, with `lua = "5.4.8"` configured:

```
# before — the tool is listed, its declared prerequisites are not
$ mise bootstrap status
tools  lua@5.4.8  5.4.8  missing

# after
plugin-deps  lua: cc                    satisfied
plugin-deps  lua: make                  satisfied
plugin-deps  lua: curl                  satisfied
plugin-deps  lua: pkg-config readline   optional missing
```

`_idiomatic_filenames` in the same file already handles embedded plugins (it goes through `vfox.metadata()`), so the inconsistency was only in these two loaders.

## Fix

Resolve the plugin the way everything else does — an installed directory wins so a user override still applies, embedded otherwise — reusing the existing sync `Plugin::from_name_or_dir`, which is the same precedence as `Vfox::install_plugin`. Still returns empty when there is genuinely no plugin, so tools without one are unaffected.

## This is user-visible

`system_deps` defaults to `prompt`, so a user installing one of those four tools **without a C toolchain will now be prompted to install one** instead of hitting a failed build. That is the intended behavior of the feature and strictly better than the current failure mode, but it is a behavior change worth a release note. Users who already have `cc`/`make` see nothing new (the checks simply report `satisfied`), and `readline` is declared `optional`, so it never blocks or prompts.

## Tests

New e2e `e2e/plugins/test_plugin_system_deps_embedded` asserts lua's four declarations are reported, and that a user-installed `plugins/lua` directory still overrides the embedded copy. Mutation-checked: restoring the directory-only lookup fails it with `expected 'lua: cc' to be in output`.

## Note

This touches the same two functions as #12145. They are independent changes (that one adds caching, this one fixes which plugins are read at all) and both are small, so whichever lands second is a trivial rebase — happy to do it.

Found while auditing the embedded plugins after #12149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-visible: installs for lua/redis/chicken/chezscheme may now prompt for missing build tools (intended); logic change in metadata resolution for all embedded plugins.
> 
> **Overview**
> **Embedded vfox plugins** (e.g. lua) now contribute `systemDependencies` and tool `depends` to bootstrap/install checks instead of being skipped when no `plugins/<name>` directory exists.
> 
> `plugin_metadata_snapshot` in `VfoxBackend` resolves plugins with **`Plugin::from_name_or_dir`** (installed directory wins, embedded fallback), loads embedded metadata directly without the disk cache, and still caches filesystem plugins keyed on Lua sources. `load_metadata_deps` / `load_system_deps` pick this up automatically.
> 
> Adds e2e **`test_plugin_system_deps_embedded`** to assert lua reports cc/make/curl/readline and that a user `metadata.lua` override replaces embedded declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2fd13bdf5f39b198a47927e36fc919ee77d561d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for loading metadata from both installed and embedded plugins.
  * Installed plugin metadata now takes precedence over embedded metadata.
  * Dependency status can report requirements such as `cc`, `make`, `curl`, and optional `readline`.

* **Tests**
  * Added end-to-end coverage for embedded Lua plugin dependencies and metadata overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->