### PR TITLE
fix(vfox): follow symlinks when fingerprinting plugin sources

### DIFF
--- a/e2e/backend/test_vfox_metadata_cache
+++ b/e2e/backend/test_vfox_metadata_cache
@@ -61,3 +61,23 @@ assert_fail "test -f '$marker'" # re-cached under the new sources
 write_metadata "0.2.0"
 mise env >/dev/null
 assert "test -f '$marker'"
+
+# Lua resolves symlinks, so the fingerprint has to as well. A module symlinked
+# in from outside the plugin contributes nothing to a traversal that skips
+# links, so its edits would never invalidate the cache.
+mkdir -p "$PWD/external"
+printf 'return { description = "linked-first" }\n' >"$PWD/external/meta.lua"
+rm -f "$PLUGIN_DIR/lib/meta.lua"
+ln -s "$PWD/external/meta.lua" "$PLUGIN_DIR/lib/meta.lua"
+
+rm -f "$marker"
+mise env >/dev/null
+assert "test -f '$marker'" # sources changed (now a link), so it reloads
+
+rm -f "$marker"
+mise env >/dev/null
+assert_fail "test -f '$marker'" # cached again
+
+printf 'return { description = "linked-second" }\n' >"$PWD/external/meta.lua"
+mise env >/dev/null
+assert "test -f '$marker'" # editing through the symlink invalidates

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -62,7 +62,11 @@ struct VfoxMetadataSnapshot {
 /// lazily: plugins whose metadata is never requested read nothing.
 fn lua_sources_fingerprint(plugin_path: &Path) -> String {
     let mut sources: Vec<(String, Vec<u8>)> = WalkDir::new(plugin_path)
-        .follow_links(false)
+        // Lua resolves symlinks, so the fingerprint has to as well: a plugin
+        // linked into place (`mise plugins link`) or carrying a symlinked
+        // module would otherwise contribute nothing and never invalidate.
+        // Symlink cycles surface as errors here and are skipped below.
+        .follow_links(true)
         .into_iter()
         .filter_map(|e| e.ok())
         .filter(|e| e.file_type().is_file())


### PR DESCRIPTION
Follow-up to #12145, which landed before this was caught.

## Problem

`lua_sources_fingerprint` walks the plugin with `follow_links(false)`, so a symlinked entry fails the `is_file()` filter and contributes nothing to the cache key — while Lua resolves the symlink and reads it anyway. Editing the link target therefore leaves the key unchanged and serves stale idiomatic filenames, tool dependencies, and system dependencies.

This is not hypothetical: `mise plugins link` puts the whole plugin directory in place as a symlink, which is the documented way to develop a plugin (and what jdx/vfox-mysql's own CI does). For those the fingerprint is **empty**, so every edit is invisible to the cache.

Reproduced against the merged code — a plugin whose `lib/meta.lua` is a symlink:

```
run1                              → metadata loaded
run2 (cached)                     → not loaded   ✓ expected
run3 after changing link target   → not loaded   ✗ STALE
```

With the fix, run3 reloads.

## Fix

`follow_links(true)`. Symlink cycles surface as errors from walkdir and are already dropped by the existing `.filter_map(|e| e.ok())`, so a loop cannot hang the walk.

## Tests

Extends `e2e/backend/test_vfox_metadata_cache` with a module symlinked in from outside the plugin: linking it invalidates, the next run is cached, and editing through the symlink invalidates again. Mutation-checked — restoring `follow_links(false)` fails the new phase.

Also verified the `mise plugins link` shape (entire plugin directory symlinked) end to end: edits through the link now invalidate correctly, where before the fingerprint saw nothing at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to cache-key computation for vfox plugin metadata; improves correctness for symlinked plugin development with no auth or install-path changes.
> 
> **Overview**
> **vfox metadata cache** keys off a hash of plugin `.lua` files via `lua_sources_fingerprint`. The walk now uses **`follow_links(true)`** so symlinked modules and **`mise plugins link`** layouts are included in the fingerprint, matching how Lua loads them. Without this, edits through symlinks could leave the cache key unchanged and serve stale idiomatic filenames, depends, and system dependencies.
> 
> **e2e** extends `test_vfox_metadata_cache` with `lib/meta.lua` symlinked to an external file: linking invalidates, the next run is cached, and editing the target invalidates again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26ef8ac4548e6d08b84e30827e9431a69d9f5954. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Metadata cache now refreshes correctly when linked Lua modules are replaced or their targets change.
  * Changes to symlinked plugin sources are detected, ensuring updated metadata is loaded when needed.

* **Tests**
  * Added end-to-end coverage for cache reuse, symlink creation, and changes to external symlink targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->