### PR TITLE
fix: asset selection for non-gz tar variants

### DIFF
--- a/src/backend/asset_matcher.rs
+++ b/src/backend/asset_matcher.rs
@@ -600,7 +600,15 @@ impl AssetPicker {
         }
 
         if format.is_archive() {
-            return 10;
+            return match format {
+                // Since we are downloading, prefer small archives: zstd and xz
+                // tend to be smaller archives.
+                ExtractionFormat::TarZst => 15,
+                // xz comes in after zst because it can cost more CPU to decompress.
+                ExtractionFormat::TarXz => 13,
+                // All other archive formats roughly created equal.
+                _ => 10,
+            };
         }
 
         // Platform-agnostic runtime archives (composer.phar, foo.jar, bar.pyz)
@@ -1688,6 +1696,36 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-1.0.0-dar
 
         let picked = picker.pick_best_asset(&assets).unwrap();
         assert_eq!(picked, "tool-1.0.0-linux-x86_64.tar.gz");
+    }
+
+    #[test]
+    fn test_archive_format_preference_order() {
+        let picker = AssetPicker::with_libc("linux".to_string(), "x86_64".to_string(), None);
+        let tar_zst = "tool-1.0.0-linux-x86_64.tar.zst";
+        let tar_xz = "tool-1.0.0-linux-x86_64.tar.xz";
+        let tar_gz = "tool-1.0.0-linux-x86_64.tar.gz";
+
+        let picked = picker
+            .pick_best_asset(&[tar_gz.to_string(), tar_xz.to_string(), tar_zst.to_string()])
+            .unwrap();
+        assert_eq!(picked, tar_zst);
+
+        let picked = picker
+            .pick_best_asset(&[tar_gz.to_string(), tar_xz.to_string()])
+            .unwrap();
+        assert_eq!(picked, tar_xz);
+    }
+
+    #[test]
+    fn test_asset_name_stem_strips_shorthand_archive_suffixes() {
+        assert_eq!(
+            asset_name_stem("tool-1.0.0-linux-x86_64.tzst"),
+            "tool-1.0.0-linux-x86_64"
+        );
+        assert_eq!(
+            asset_name_stem("tool-1.0.0-linux-x86_64.txz"),
+            "tool-1.0.0-linux-x86_64"
+        );
     }
 
     #[test]

--- a/src/backend/asset_matcher.rs
+++ b/src/backend/asset_matcher.rs
@@ -744,8 +744,8 @@ fn asset_matches_preferred_name(asset: &str, preferred_name: &str) -> bool {
 fn asset_name_stem(asset: &str) -> String {
     let mut name = asset.rsplit('/').next().unwrap_or(asset).to_lowercase();
     let suffixes = [
-        ".tar.gz", ".tar.xz", ".tar.bz2", ".tar.zst", ".tgz", ".tar", ".zip", ".gz", ".xz", ".bz2",
-        ".zst", ".phar", ".jar", ".pyz", ".exe", ".msi",
+        ".tar.gz", ".tar.xz", ".tar.bz2", ".tar.zst", ".tgz", ".txz", ".tzst", ".tar", ".zip",
+        ".gz", ".xz", ".bz2", ".zst", ".phar", ".jar", ".pyz", ".exe", ".msi",
     ];
 
     if let Some(suffix) = suffixes.iter().find(|suffix| name.ends_with(*suffix)) {


### PR DESCRIPTION
This PR applies two changes:

(1) The extensions `txz` and `tzst` were not considered as part of `asset_name_stem` in `src/backend/asset_matcher.rs`, resulting in e.g. `asset-1.tgz` and `asset-2.txz` being considered _different_ assets (rather than merely differing by format), when e.g. `asset-1.tar.gz` and `asset-2.tar.xz` would match.

(2) It seems smart for `mise` to explicitly prefer `tar.xz` and `tar.zst` formats (regardless of extension expression as three-letter or longer) over e.g. `tar.gz` or others, since `xz` and `zst` typically produce smaller archives, and `mise` users care more about decompressing/downloading than CPU overhead for compression.

If (2) is too opinionated, (1) can be taken alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved archive asset matching by prioritizing `.tar.zst` archives, followed by `.tar.xz`, before other supported formats.
- Improved recognition of compressed archive filenames using `.txz` and `.tzst` suffixes.
- Added validation to ensure archive selection consistently follows the preferred format order.
- Archive downloads should now select the most appropriate available format more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->