### PR TITLE
registry: fix llama.cpp version test

### DIFF
--- a/registry/llama.cpp.toml
+++ b/registry/llama.cpp.toml
@@ -1,5 +1,5 @@
 description = "LLM inference in C/C++"
-test = { cmd = "llama-cli --version", expected = "version: {{version}}" }
+test = { cmd = "llama-cli --version", expected = "build {{version}}" }
 version_order = "source"
 
 bins = [


### PR DESCRIPTION
## Summary
- update the llama.cpp registry test to match its nightly build number
- keep mise's existing `b*` nightly release versioning unchanged

## Root cause
llama.cpp introduced semantic version output, so `llama-cli --version` now reports `version: 0.1.1-dev (build 10472, ...)`. The registry test incorrectly expected the nightly build number immediately after `version:` even though the correct build was installed.

## Validation
- `target/debug/mise test-tool llama.cpp`
- `target/debug/mise ls-remote llama.cpp`
- `mise run lint-fix`

## Popularity
- GitHub: 124,573 stars and 21,883 forks
- Active maintenance: latest release published 2026-08-18; repository pushed 2026-08-18

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line registry test expectation change with no runtime or install logic changes.
> 
> **Overview**
> Updates the **llama.cpp** registry install check so it matches how `llama-cli --version` prints versions today. The expected substring changes from `version: {{version}}` to **`build {{version}}`**, so mise still validates the nightly build id (`b*` releases) without assuming it appears right after `version:`.
> 
> No changes to backends, bins, or how versions are resolved—only the post-install test assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e258b1bd7daf399310c96a0ced1905ae82e7edb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the displayed version information check to match the current `llama-cli` output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->