### PR TITLE
chore(ci): retry transient R2 upload failures

### DIFF
--- a/xtasks/docs/release
+++ b/xtasks/docs/release
@@ -7,6 +7,8 @@ set -xeuo pipefail
 aws --version
 export AWS_REGION=auto
 export AWS_ENDPOINT_URL=https://6e243906ff257b965bcae8025c2fc344.r2.cloudflarestorage.com
+export AWS_RETRY_MODE=standard
+export AWS_MAX_ATTEMPTS=10
 
 if [ "${DRY_RUN:-true}" = "true" ]; then
 	aws() {


### PR DESCRIPTION
## Summary
- configure the docs R2 upload to use AWS CLI standard retries
- raise the retry budget from the default 3 total attempts to 10

## Root cause
The docs deployment in https://github.com/jdx/mise/actions/runs/32211817549/job/95945857508 failed when Cloudflare R2 returned a transient `503 ServiceUnavailable` while writing `lang/go.html`. Cloudflare recommends retrying these errors with exponential backoff, but the AWS CLI standard retry mode only makes 3 total attempts by default.

This keeps the existing upload behavior while giving transient R2 contention enough time to clear.

## Validation
- `hk run check --safe --format json --files0-from <(printf 'xtasks/docs/release\0')`
- `bash -n xtasks/docs/release`
- mocked-AWS dry run of `xtasks/docs/release`
- `mise run docs:release` completed the docs build; no live upload was attempted locally because the AWS CLI is unavailable

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability Improvements**
  * Release operations now automatically retry failed AWS requests up to 10 times, helping transient failures complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->