### PR TITLE
chore(ci): ignore dependency rust-version in automated builds

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -108,7 +108,7 @@ fi
 rustup toolchain install "$msrv" --profile minimal --no-self-update -c rustfmt,clippy
 rustup default "$msrv"
 
-cargo build --all-features
+cargo build --all-features --ignore-rust-version
 # Always invoke this binary. `mise activate --shims` prepends shims that may
 # point at an older mise which still ran tool-level postinstall under MISE_SAFE.
 mise_bin=/usr/local/bin/mise

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -78,7 +78,7 @@ jobs:
             echo "SCCACHE_CACHE_SIZE=$SCCACHE_CACHE_SIZE"
           } >> "$GITHUB_ENV"
           sccache --zero-stats
-      - run: cargo build --all-features
+      - run: cargo build --all-features --ignore-rust-version
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mise

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -39,7 +39,7 @@ jobs:
           git_commit_gpgsign: true
           git_tag_gpgsign: true
       - run: mkdir -p "$HOME/bin" && echo "$HOME/bin" >> "$GITHUB_PATH"
-      - run: cargo build --all-features && cp target/debug/mise "$HOME"/bin
+      - run: cargo build --all-features --ignore-rust-version && cp target/debug/mise "$HOME"/bin
       - uses: ./.github/actions/mise-tools
       - run: mise x -- bun i
       - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5

--- a/.github/workflows/test-vfox.yml
+++ b/.github/workflows/test-vfox.yml
@@ -45,7 +45,7 @@ jobs:
           } >> "$GITHUB_ENV"
           sccache --zero-stats
       - run: |
-          cargo build --all-features
+          cargo build --all-features --ignore-rust-version
           echo "$PWD/target/debug" >> "$GITHUB_PATH"
       - run: mise -v
       - run: mise --cd crates/vfox run build

--- a/packaging/mise/Dockerfile
+++ b/packaging/mise/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /usr/src/mise
 COPY . /usr/src/mise/
 RUN apt-get update && apt-get install -y --no-install-recommends cmake \
     && rm -rf /var/lib/apt/lists/*
-RUN cargo build --release
+RUN cargo build --release --ignore-rust-version
 
 FROM rust@sha256:1bcff4befb740599103a2c7cb51058e14479b2e35e3a34a3f0dc4ede09927488 AS runtime
 

--- a/scripts/build-tarball.ps1
+++ b/scripts/build-tarball.ps1
@@ -17,7 +17,7 @@ $BaseName = "mise-v$Version-$Env:OS-$Env:ARCH"
 # OpenSSL was compiled into every release and never called.
 $Features = "rustls-native-roots,self_update,vfox/vendored-lua"
 
-cargo build --profile=serious --no-default-features --features "$Features" --target "$Target"
+cargo build --profile=serious --ignore-rust-version --no-default-features --features "$Features" --target "$Target"
 cargo build --profile=serious -p mise-shim --target "$Target"
 mkdir -p dist/mise/bin
 cp "target/$Target/serious/mise.exe" dist/mise/bin/mise.exe

--- a/scripts/build-tarball.sh
+++ b/scripts/build-tarball.sh
@@ -103,11 +103,11 @@ if [[ -n "${MISE_PGO:-}" ]]; then
 		build_tool=cross
 	fi
 	MISE_PGO_BUILD_TOOL="$build_tool" MISE_PGO_TARGET="$RUST_TRIPLE" \
-		bash scripts/pgo.bash --no-default-features --features "$features"
+		bash scripts/pgo.bash --ignore-rust-version --no-default-features --features "$features"
 elif [[ $os == "linux" ]]; then
-	cross build --profile=serious --target "$RUST_TRIPLE" --no-default-features --features "$features"
+	cross build --profile=serious --target "$RUST_TRIPLE" --ignore-rust-version --no-default-features --features "$features"
 else
-	cargo build --profile=serious --target "$RUST_TRIPLE" --no-default-features --features "$features"
+	cargo build --profile=serious --target "$RUST_TRIPLE" --ignore-rust-version --no-default-features --features "$features"
 fi
 
 # Use CARGO_TARGET_DIR if set, otherwise default to target


### PR DESCRIPTION
## Summary
- ignore dependency `rust-version` metadata in the release-plz, registry, and vfox bootstrap builds
- apply the same behavior to Linux, macOS, and Windows release tarball builds
- cover the published mise Docker image and Cursor MSRV bootstrap
- leave ordinary developer builds unchanged

COPR and PPA packaging already use `--ignore-rust-version` from #11926, so they required no additional changes.

## Root cause
The AWS SDK dependency update declares Rust 1.94.1, while some automated builders currently provide Rust 1.94.0 or intentionally build with mise’s Rust 1.93 MSRV. Cargo exits on the dependency metadata before compilation unless these controlled builds pass `--ignore-rust-version`. CI separately compiles the locked dependency set with the project MSRV, so actual incompatible syntax and API use still fail.

## Impact
Release automation, registry and vfox checks, release tarballs, Docker publishing, and Cursor environment setup can compile the verified lockfile on their intended Rust toolchains instead of failing on dependency metadata alone.

## Validation
- `mise run lint-fix` (includes Actionlint, ShellCheck, formatting, and full all-features Cargo checking)
- `shellcheck scripts/build-tarball.sh .cursor/install.sh`
- `bash -n scripts/build-tarball.sh .cursor/install.sh`
- verified Cargo supports `--ignore-rust-version`
- `git diff --check`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-flag-only change with no runtime or application logic; aligns remaining builds with existing test CI behavior.
> 
> **Overview**
> Adds **`--ignore-rust-version`** to every **`cargo build`** path that was still enforcing dependency **`rust-version`** metadata, so builds succeed when the host toolchain is one patch behind (e.g. runner on 1.94.0 vs AWS SDK requiring 1.94.1).
> 
> **CI and bootstrap:** registry, vfox, and release-plz all-feature debug builds now pass the flag, matching the pattern already used elsewhere in test workflows.
> 
> **Release and dev environments:** the same flag is applied to Cloud Agent **`.cursor/install.sh`**, **`packaging/mise/Dockerfile`** release build, and **`scripts/build-tarball.sh`** / **`.ps1`** (including PGO and cross paths).
> 
> Behavior of features, profiles, and targets is unchanged; only Cargo’s MSRV gate from transitive crates is skipped for these invocations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d78f28a08343c000cb10b9db8705651dab6d85c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build, packaging, release, and testing workflows now support compilation with Rust toolchains that do not meet the declared minimum version.
  * Tarball and container builds apply the same compatibility setting across supported targets.
  * No changes were made to application functionality or end-user features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->