### PR TITLE
security(backend): restrict forge tokens to api origin

### DIFF
--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -1170,9 +1170,9 @@ impl UnifiedGitBackend {
             asset.url_api.clone()
         };
         let headers = if self.is_gitlab() {
-            gitlab::get_headers(&download_url)
+            gitlab::get_headers(&download_url, &api_url)
         } else if self.is_forgejo() {
-            forgejo::get_headers(&download_url)
+            forgejo::get_headers(&download_url, &api_url)
         } else {
             github::get_headers(&download_url)?
         };
@@ -1413,9 +1413,9 @@ impl UnifiedGitBackend {
         };
 
         let headers = if self.is_gitlab() {
-            gitlab::get_headers(&url)
+            gitlab::get_headers(&url, &opts.api_url())
         } else if self.is_forgejo() {
-            forgejo::get_headers(&url)
+            forgejo::get_headers(&url, &opts.api_url())
         } else {
             github::get_headers(&url)?
         };
@@ -1520,9 +1520,9 @@ impl UnifiedGitBackend {
             asset.url_api.clone()
         };
         let headers = if self.is_gitlab() {
-            gitlab::get_headers(&url)
+            gitlab::get_headers(&url, &opts.api_url())
         } else if self.is_forgejo() {
-            forgejo::get_headers(&url)
+            forgejo::get_headers(&url, &opts.api_url())
         } else {
             github::get_headers(&url)?
         };

--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -553,7 +553,7 @@ impl SPMBackend {
         file::create_dir_all(&bundle_dir)?;
         let download_path = tv.download_path().join(&asset.name);
         let headers = match provider.kind {
-            GitProviderKind::GitLab => gitlab::get_headers(&asset.url),
+            GitProviderKind::GitLab => gitlab::get_headers(&asset.url, &provider.api_url),
             GitProviderKind::GitHub => github::get_headers(&asset.url)?,
         };
         ctx.pr.set_message(format!("download {}", asset.name));

--- a/src/forgejo.rs
+++ b/src/forgejo.rs
@@ -90,7 +90,7 @@ const MAX_RELEASE_FALLBACK_PAGES: usize = 3;
 
 async fn list_releases_(api_url: &str, repo: &str) -> Result<Vec<ForgejoRelease>> {
     let url = format!("{api_url}/repos/{repo}/releases?limit=100");
-    let headers = get_headers(&url);
+    let headers = get_headers(&url, api_url);
     let (mut releases, mut headers) = crate::http::HTTP_FETCH
         .json_headers_with_headers::<Vec<ForgejoRelease>, _>(url, &headers)
         .await?;
@@ -107,7 +107,7 @@ async fn list_releases_(api_url: &str, repo: &str) -> Result<Vec<ForgejoRelease>
         {
             break;
         }
-        headers = get_headers(&next);
+        headers = get_headers(&next, api_url);
         let (more, h) = crate::http::HTTP_FETCH
             .json_headers_with_headers::<Vec<ForgejoRelease>, _>(next, &headers)
             .await?;
@@ -140,7 +140,7 @@ async fn get_release_(api_url: &str, repo: &str, tag: &str) -> Result<ForgejoRel
     } else {
         format!("{api_url}/repos/{repo}/releases/tags/{tag}")
     };
-    let headers = get_headers(&url);
+    let headers = get_headers(&url, api_url);
     crate::http::HTTP_FETCH
         .json_with_headers(url, &headers)
         .await
@@ -160,13 +160,19 @@ fn cache_dir() -> PathBuf {
     dirs::CACHE.join("forgejo")
 }
 
-pub fn get_headers<U: IntoUrl>(url: U) -> HeaderMap {
+pub fn get_headers<U: IntoUrl>(url: U, api_url: &str) -> HeaderMap {
     let mut headers = HeaderMap::new();
     // An invalid URL just means no auth headers; the real error surfaces when the
     // request is made. Avoid panicking here. See #3547.
     let Ok(url) = url.into_url() else {
         return headers;
     };
+    let Ok(api_url) = reqwest::Url::parse(api_url) else {
+        return headers;
+    };
+    if url.origin() != api_url.origin() {
+        return headers;
+    }
 
     if let Some((token, _source)) = resolve_token(url.host_str().unwrap_or("codeberg.org")) {
         headers.insert(
@@ -612,6 +618,27 @@ something_else = "value"
         fn drop(&mut self) {
             *test_support::TOKENS_FILE_OVERRIDE.write().unwrap() = None;
         }
+    }
+
+    #[test]
+    fn test_get_headers_only_authenticates_api_origin() {
+        let api_url = "https://forgejo.example.com/api/v1";
+        let _token = TokensFileOverrideGuard::set("forgejo.example.com");
+
+        let headers = get_headers(
+            "https://forgejo.example.com/releases/download/tool.tar.gz",
+            api_url,
+        );
+        assert_eq!(
+            headers.get(reqwest::header::AUTHORIZATION).unwrap(),
+            format!("Bearer {TEST_TOKEN}").as_str()
+        );
+
+        let headers = get_headers("https://downloads.example.com/tool.tar.gz", api_url);
+        assert!(!headers.contains_key(reqwest::header::AUTHORIZATION));
+
+        let headers = get_headers("http://forgejo.example.com/api/v1/page2", api_url);
+        assert!(!headers.contains_key(reqwest::header::AUTHORIZATION));
     }
 
     // Regression: every paginated request must carry the Authorization header. This loop is

--- a/src/forgejo.rs
+++ b/src/forgejo.rs
@@ -295,12 +295,6 @@ pub fn resolve_token(host: &str) -> Option<(String, TokenSource)> {
     None
 }
 
-/// Returns true if the given hostname has a token available from a non-env-var source.
-pub fn is_forgejo_host(host: &str) -> bool {
-    MISE_FORGEJO_TOKENS.contains_key(host)
-        || (Settings::get().forgejo.fj_cli_tokens && FJ_HOSTS.contains_key(host))
-}
-
 // ── forgejo_tokens.toml ────────────────────────────────────────────
 
 static MISE_FORGEJO_TOKENS: Lazy<HashMap<String, String>> = Lazy::new(|| {

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -137,7 +137,7 @@ async fn list_releases_(api_url: &str, repo: &str, list_all: bool) -> Result<Vec
         urlencoding::encode(repo)
     );
 
-    let headers = get_headers(&url);
+    let headers = get_headers(&url, api_url);
     let (mut releases, mut headers) = crate::http::HTTP_FETCH
         .json_headers_with_headers::<Vec<GitlabRelease>, _>(&url, &headers)
         .await?;
@@ -149,7 +149,7 @@ async fn list_releases_(api_url: &str, repo: &str, list_all: bool) -> Result<Vec
             // previous page at this point (that is how `next_page` reads `Link`), and
             // `json_headers_with_headers` bypasses the automatic host auth, so reusing it
             // would send page 2 onward unauthenticated. Same defect github had (#6318).
-            headers = get_headers(&url);
+            headers = get_headers(&url, api_url);
             let (more, h) = crate::http::HTTP_FETCH
                 .json_headers_with_headers::<Vec<GitlabRelease>, _>(&url, &headers)
                 .await?;
@@ -193,7 +193,7 @@ async fn list_tags_(api_url: &str, repo: &str, list_all: bool) -> Result<Vec<Str
         api_url,
         urlencoding::encode(repo)
     );
-    let headers = get_headers(&url);
+    let headers = get_headers(&url, api_url);
     let (mut tags, mut headers) = crate::http::HTTP_FETCH
         .json_headers_with_headers::<Vec<GitlabTag>, _>(&url, &headers)
         .await?;
@@ -202,7 +202,7 @@ async fn list_tags_(api_url: &str, repo: &str, list_all: bool) -> Result<Vec<Str
         while let Some(next) = next_page(&headers) {
             url = crate::http::resolve_pagination_url(&url, &next)?;
             // Re-derive auth for every page — see the comment in `list_releases_`.
-            headers = get_headers(&url);
+            headers = get_headers(&url, api_url);
             let (more, h) = crate::http::HTTP_FETCH
                 .json_headers_with_headers::<Vec<GitlabTag>, _>(&url, &headers)
                 .await?;
@@ -242,7 +242,7 @@ async fn get_release_(api_url: &str, repo: &str, tag: &str) -> Result<GitlabRele
         urlencoding::encode(repo),
         tag
     );
-    let headers = get_headers(&url);
+    let headers = get_headers(&url, api_url);
     crate::http::HTTP_FETCH
         .json_with_headers(url, &headers)
         .await
@@ -262,13 +262,19 @@ fn cache_dir() -> PathBuf {
     dirs::CACHE.join("gitlab")
 }
 
-pub fn get_headers<U: IntoUrl>(url: U) -> HeaderMap {
+pub fn get_headers<U: IntoUrl>(url: U, api_url: &str) -> HeaderMap {
     let mut headers = HeaderMap::new();
     // An invalid URL just means no auth headers; the real error surfaces when the
     // request is made. Avoid panicking here. See #3547.
     let Ok(url) = url.into_url() else {
         return headers;
     };
+    let Ok(api_url) = reqwest::Url::parse(api_url) else {
+        return headers;
+    };
+    if url.origin() != api_url.origin() {
+        return headers;
+    }
     let lookup_host = url.host_str().unwrap_or("gitlab.com");
 
     if let Some((token, _source)) = resolve_token(lookup_host) {
@@ -699,6 +705,27 @@ hosts:
             "released_at": null,
             "assets": { "sources": [], "links": [] },
         })
+    }
+
+    #[test]
+    fn test_get_headers_only_authenticates_api_origin() {
+        let api_url = "https://gitlab.example.com/api/v4";
+        let _token = TokensFileOverrideGuard::set("gitlab.example.com");
+
+        let headers = get_headers(
+            "https://gitlab.example.com/releases/download/tool.tar.gz",
+            api_url,
+        );
+        assert_eq!(
+            headers.get(reqwest::header::AUTHORIZATION).unwrap(),
+            format!("Bearer {TEST_TOKEN}").as_str()
+        );
+
+        let headers = get_headers("https://downloads.example.com/tool.tar.gz", api_url);
+        assert!(!headers.contains_key(reqwest::header::AUTHORIZATION));
+
+        let headers = get_headers("http://gitlab.example.com/api/v4/page2", api_url);
+        assert!(!headers.contains_key(reqwest::header::AUTHORIZATION));
     }
 
     // Regression: every paginated request must carry the Authorization header. Before the

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -398,12 +398,6 @@ pub fn resolve_token(host: &str) -> Option<(String, TokenSource)> {
     None
 }
 
-/// Returns true if the given hostname has a token available from a non-env-var source.
-pub fn is_gitlab_host(host: &str) -> bool {
-    MISE_GITLAB_TOKENS.contains_key(host)
-        || (Settings::get().gitlab.glab_cli_tokens && GLAB_HOSTS.contains_key(host))
-}
-
 // ── gitlab_tokens.toml ─────────────────────────────────────────────
 
 static MISE_GITLAB_TOKENS: Lazy<HashMap<String, String>> = Lazy::new(|| {

--- a/src/http.rs
+++ b/src/http.rs
@@ -1630,18 +1630,29 @@ fn host_auth_headers(url: &Url) -> Result<HeaderMap> {
     let Some(host) = url.host_str() else {
         return Ok(HeaderMap::new());
     };
+    // Generic HTTP callers have no configured forge API URL to use as a trust
+    // boundary. Only infer that boundary for HTTPS requests. Backend-specific
+    // callers pass their configured API URL directly and can therefore support
+    // explicitly configured HTTP instances without trusting arbitrary HTTP URLs.
+    let Some(api_url) = inferred_forge_api_url(url) else {
+        return Ok(HeaderMap::new());
+    };
 
     let is_gitlab = host == "gitlab.com" || crate::gitlab::is_gitlab_host(host);
     if is_gitlab {
-        return Ok(crate::gitlab::get_headers(url.as_str(), url.as_str()));
+        return Ok(crate::gitlab::get_headers(url.as_str(), api_url));
     }
 
     let is_forgejo = host == "codeberg.org" || crate::forgejo::is_forgejo_host(host);
     if is_forgejo {
-        return Ok(crate::forgejo::get_headers(url.as_str(), url.as_str()));
+        return Ok(crate::forgejo::get_headers(url.as_str(), api_url));
     }
 
     Ok(HeaderMap::new())
+}
+
+fn inferred_forge_api_url(url: &Url) -> Option<&str> {
+    (url.scheme() == "https").then(|| url.as_str())
 }
 
 /// Decide whether netrc credentials should be applied to a request.
@@ -2830,6 +2841,15 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         // original host, so netrc (scoped to the new host) wins.
         assert!(netrc_should_apply(true, true));
         assert!(netrc_should_apply(true, false));
+    }
+
+    #[test]
+    fn test_inferred_forge_api_url_requires_https() {
+        let https = Url::parse("https://gitlab.com/api/v4/projects").unwrap();
+        assert_eq!(inferred_forge_api_url(&https), Some(https.as_str()));
+
+        let http = Url::parse("http://gitlab.com/api/v4/projects").unwrap();
+        assert_eq!(inferred_forge_api_url(&http), None);
     }
 
     fn basic_netrc_headers() -> HeaderMap {

--- a/src/http.rs
+++ b/src/http.rs
@@ -1627,32 +1627,11 @@ fn host_auth_headers(url: &Url) -> Result<HeaderMap> {
         return crate::github::get_headers(url.as_str());
     }
 
-    let Some(host) = url.host_str() else {
-        return Ok(HeaderMap::new());
-    };
-    // Generic HTTP callers have no configured forge API URL to use as a trust
-    // boundary. Only infer that boundary for HTTPS requests. Backend-specific
-    // callers pass their configured API URL directly and can therefore support
-    // explicitly configured HTTP instances without trusting arbitrary HTTP URLs.
-    let Some(api_url) = inferred_forge_api_url(url) else {
-        return Ok(HeaderMap::new());
-    };
-
-    let is_gitlab = host == "gitlab.com" || crate::gitlab::is_gitlab_host(host);
-    if is_gitlab {
-        return Ok(crate::gitlab::get_headers(url.as_str(), api_url));
-    }
-
-    let is_forgejo = host == "codeberg.org" || crate::forgejo::is_forgejo_host(host);
-    if is_forgejo {
-        return Ok(crate::forgejo::get_headers(url.as_str(), api_url));
-    }
-
+    // A generic URL does not carry the configured GitLab or Forgejo API origin,
+    // so it cannot establish a safe trust boundary for those tokens. Their
+    // backend-specific callers must pass the request and API URLs directly to
+    // the corresponding `get_headers` function.
     Ok(HeaderMap::new())
-}
-
-fn inferred_forge_api_url(url: &Url) -> Option<&str> {
-    (url.scheme() == "https").then(|| url.as_str())
 }
 
 /// Decide whether netrc credentials should be applied to a request.
@@ -2841,15 +2820,6 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         // original host, so netrc (scoped to the new host) wins.
         assert!(netrc_should_apply(true, true));
         assert!(netrc_should_apply(true, false));
-    }
-
-    #[test]
-    fn test_inferred_forge_api_url_requires_https() {
-        let https = Url::parse("https://gitlab.com/api/v4/projects").unwrap();
-        assert_eq!(inferred_forge_api_url(&https), Some(https.as_str()));
-
-        let http = Url::parse("http://gitlab.com/api/v4/projects").unwrap();
-        assert_eq!(inferred_forge_api_url(&http), None);
     }
 
     fn basic_netrc_headers() -> HeaderMap {

--- a/src/http.rs
+++ b/src/http.rs
@@ -1633,12 +1633,12 @@ fn host_auth_headers(url: &Url) -> Result<HeaderMap> {
 
     let is_gitlab = host == "gitlab.com" || crate::gitlab::is_gitlab_host(host);
     if is_gitlab {
-        return Ok(crate::gitlab::get_headers(url.as_str()));
+        return Ok(crate::gitlab::get_headers(url.as_str(), url.as_str()));
     }
 
     let is_forgejo = host == "codeberg.org" || crate::forgejo::is_forgejo_host(host);
     if is_forgejo {
-        return Ok(crate::forgejo::get_headers(url.as_str()));
+        return Ok(crate::forgejo::get_headers(url.as_str(), url.as_str()));
     }
 
     Ok(HeaderMap::new())


### PR DESCRIPTION
## Summary

- bind GitLab and Forgejo authentication headers to the configured API origin
- prevent tokens from being sent to third-party release asset hosts or cross-origin pagination URLs
- preserve authentication for same-origin release permalinks and self-hosted instances
- apply the same protection to Git-backed tool downloads and Swift artifact bundles

## Root cause

`gitlab::get_headers` and `forgejo::get_headers` resolved environment tokens for any URL host they received. Release metadata and pagination responses can supply URLs on unrelated hosts, so those call sites could attach a forge token to a destination outside the configured forge instance.

## Impact

Users with GitLab or Forgejo tokens configured could disclose those tokens when installing a tool whose release asset points to another host. A malicious or compromised forge instance could also redirect pagination to an unrelated host and receive the token.

## Fix

Pass the configured API URL into both header builders and add authentication only when the request URL has the same scheme, host, and port. This also blocks HTTPS-to-HTTP downgrade links while retaining environment-token support for self-hosted instances.

## Validation

- `cargo test --bin mise test_get_headers_only_authenticates_api_origin`
- `cargo test --bin mise sends_auth_on_every_page`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security fix for credential disclosure on tool installs; behavior change may affect downloads that previously sent tokens to external asset hosts (intentionally).
> 
> **Overview**
> Fixes a **token leak** where GitLab and Forgejo `Authorization` headers could be attached to any URL whose host matched token lookup—including third-party release CDNs and cross-origin pagination links from a malicious or compromised forge.
> 
> `gitlab::get_headers` and `forgejo::get_headers` now take the configured **API URL** and add Bearer auth only when the request URL shares the same **origin** (scheme, host, port). Same-origin release permalinks on self-hosted instances still work; unrelated hosts and HTTPS→HTTP downgrade links do not get tokens.
> 
> Call sites in the GitHub backend (downloads, assets), SPM artifact bundles, and all GitLab/Forgejo API/pagination paths pass `api_url`. Generic HTTP auto-auth in `host_auth_headers` no longer applies GitLab/Forgejo tokens (only GitHub API URLs); those backends must supply headers explicitly. **`is_gitlab_host` / `is_forgejo_host`** were removed as unused.
> 
> Unit tests **`test_get_headers_only_authenticates_api_origin`** lock in same-origin vs third-party vs scheme-mismatch behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c146adbe73b8c5ab9d5b7562a20193140fe10e43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication handling for GitLab and Forgejo release, tag, and artifact requests.
  - Authentication is now limited to secure requests sharing the configured service origin, reducing unintended credential exposure.
  - Fixed authentication consistency for paginated release and tag results.
  - Downloads and provenance verification now use the configured service endpoint when preparing requests.
  - Invalid service URLs are handled safely without causing failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->