### PR TITLE
fix(vfox): apply netrc credentials to HTTP requests

### DIFF
--- a/crates/vfox/src/http.rs
+++ b/crates/vfox/src/http.rs
@@ -1,4 +1,6 @@
-use reqwest::{Client, ClientBuilder, StatusCode};
+use reqwest::header::HeaderMap;
+use reqwest::{Client, ClientBuilder, StatusCode, Url};
+use std::sync::Arc;
 use std::sync::LazyLock;
 use std::time::Duration;
 use tokio::sync::watch;
@@ -11,6 +13,8 @@ pub static CLIENT: LazyLock<Client> = LazyLock::new(|| {
 });
 
 pub(crate) const URL_REWRITER_REGISTRY_KEY: &str = "url_rewriter_fn";
+pub(crate) const HTTP_HEADERS_RESOLVER_REGISTRY_KEY: &str = "http_headers_resolver_fn";
+pub(crate) type HttpHeadersResolver = Arc<dyn Fn(&Url) -> HeaderMap + Send + Sync>;
 
 static HTTP_CANCELLATION: LazyLock<HttpCancellation> = LazyLock::new(Default::default);
 

--- a/crates/vfox/src/lua_mod/http.rs
+++ b/crates/vfox/src/lua_mod/http.rs
@@ -204,15 +204,37 @@ fn add_default_headers_for_request(
 
     // Do not forward credentials selected for the original origin, but retain
     // non-sensitive plugin headers that may be required by the replacement.
-    if !same_origin {
-        return headers
+    let headers = if !same_origin {
+        headers
             .iter()
             .filter(|(name, _)| !is_sensitive_header(name))
             .map(|(name, value)| (name.clone(), value.clone()))
-            .collect();
-    }
+            .collect()
+    } else {
+        add_default_headers(lua, original_url, headers)
+    };
 
-    add_default_headers(lua, original_url, headers)
+    add_resolved_headers(lua, request_url, headers)
+}
+
+fn add_resolved_headers(lua: &Lua, url: &str, mut headers: HeaderMap) -> HeaderMap {
+    let Ok(resolver) =
+        lua.named_registry_value::<mlua::Function>(crate::http::HTTP_HEADERS_RESOLVER_REGISTRY_KEY)
+    else {
+        return headers;
+    };
+    let Ok(table) = resolver.call::<Table>(url) else {
+        return headers;
+    };
+    let Ok(resolved) = into_headers(&table) else {
+        return headers;
+    };
+    for (name, value) in resolved {
+        if let Some(name) = name {
+            headers.entry(name).or_insert(value);
+        }
+    }
+    headers
 }
 
 fn is_sensitive_header(name: &HeaderName) -> bool {
@@ -627,6 +649,16 @@ mod tests {
             .unwrap();
         lua.set_named_registry_value(crate::http::URL_REWRITER_REGISTRY_KEY, rewriter)
             .unwrap();
+        let headers_resolver = lua
+            .create_function(|lua, _: String| {
+                lua.create_table_from([("Authorization", "Basic bWlycm9yOnNlY3JldA==")])
+            })
+            .unwrap();
+        lua.set_named_registry_value(
+            crate::http::HTTP_HEADERS_RESOLVER_REGISTRY_KEY,
+            headers_resolver,
+        )
+        .unwrap();
 
         let temp_dir = tempfile::TempDir::new().unwrap();
         let download_path = temp_dir.path().join("download.txt");
@@ -701,7 +733,13 @@ mod tests {
                     .and_then(|value| value.to_str().ok()),
                 Some("application/vnd.vfox+json")
             );
-            assert!(!request.headers.contains_key(AUTHORIZATION));
+            assert_eq!(
+                request
+                    .headers
+                    .get(AUTHORIZATION)
+                    .and_then(|value| value.to_str().ok()),
+                Some("Basic bWlycm9yOnNlY3JldA==")
+            );
             assert!(!request.headers.contains_key("cookie"));
             assert!(!request.headers.contains_key("cookie2"));
             assert!(!request.headers.contains_key("proxy-authorization"));

--- a/crates/vfox/src/plugin.rs
+++ b/crates/vfox/src/plugin.rs
@@ -12,6 +12,7 @@ use crate::config::Config;
 use crate::context::Context;
 use crate::embedded_plugins::{self, EmbeddedPlugin};
 use crate::error::Result;
+use crate::http::HttpHeadersResolver;
 use crate::metadata::Metadata;
 use crate::runtime::Runtime;
 use crate::sdk_info::SdkInfo;
@@ -148,6 +149,26 @@ impl Plugin {
             .create_function(move |_, value: String| Ok(rewrite_url(value, &rewriter)))?;
         self.lua
             .set_named_registry_value(crate::http::URL_REWRITER_REGISTRY_KEY, func)?;
+        Ok(())
+    }
+
+    /// Register the default HTTP headers resolver used by artifact downloads
+    /// and the Lua HTTP module.
+    pub(crate) fn set_http_headers_resolver(&self, resolver: HttpHeadersResolver) -> Result<()> {
+        let func = self.lua.create_function(move |lua, value: String| {
+            let table = lua.create_table()?;
+            let Ok(url) = Url::parse(&value) else {
+                return Ok(table);
+            };
+            for (name, value) in resolver(&url).iter() {
+                if let Ok(value) = value.to_str() {
+                    table.set(name.as_str(), value)?;
+                }
+            }
+            Ok(table)
+        })?;
+        self.lua
+            .set_named_registry_value(crate::http::HTTP_HEADERS_RESOLVER_REGISTRY_KEY, func)?;
         Ok(())
     }
 

--- a/crates/vfox/src/vfox.rs
+++ b/crates/vfox/src/vfox.rs
@@ -1,6 +1,7 @@
 use indexmap::IndexMap;
 use itertools::Itertools;
 use reqwest::Url;
+use reqwest::header::HeaderMap;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -23,7 +24,7 @@ use crate::hooks::parse_legacy_file::ParseLegacyFileResponse;
 use crate::hooks::post_install::PostInstallContext;
 use crate::hooks::pre_install::{PreInstall, PreInstallAttestation, VerifiedAttestation};
 use crate::hooks::pre_uninstall::PreUninstallContext;
-use crate::http::{CLIENT, retry_async};
+use crate::http::{CLIENT, HttpHeadersResolver, retry_async};
 use crate::metadata::Metadata;
 use crate::plugin::Plugin;
 use crate::registry;
@@ -69,6 +70,7 @@ pub struct Vfox {
     /// Optional runtime env type (`gnu` or `musl`) exposed to plugin hooks.
     pub runtime_env_type: Option<String>,
     url_rewriter: Option<UrlRewriter>,
+    http_headers_resolver: Option<HttpHeadersResolver>,
     log_tx: Option<mpsc::Sender<String>>,
 }
 
@@ -94,6 +96,10 @@ impl std::fmt::Debug for Vfox {
                 "url_rewriter",
                 &self.url_rewriter.as_ref().map(|_| "<closure>"),
             )
+            .field(
+                "http_headers_resolver",
+                &self.http_headers_resolver.as_ref().map(|_| "<closure>"),
+            )
             .finish_non_exhaustive()
     }
 }
@@ -114,6 +120,13 @@ impl Vfox {
         F: Fn(&mut Url) + Send + Sync + 'static,
     {
         self.url_rewriter = Some(Arc::new(rewriter));
+    }
+
+    pub fn set_http_headers_resolver<F>(&mut self, resolver: F)
+    where
+        F: Fn(&Url) -> HeaderMap + Send + Sync + 'static,
+    {
+        self.http_headers_resolver = Some(Arc::new(resolver));
     }
 
     fn rewrite_url(&self, url: &mut Url) {
@@ -181,6 +194,9 @@ impl Vfox {
         self.set_cmd_shell(&plugin)?;
         if let Some(rewriter) = &self.url_rewriter {
             plugin.set_url_rewriter(rewriter.clone())?;
+        }
+        if let Some(resolver) = &self.http_headers_resolver {
+            plugin.set_http_headers_resolver(resolver.clone())?;
         }
         Ok(plugin)
     }
@@ -566,7 +582,11 @@ impl Vfox {
         self.log_emit(format!("Downloading {request_url}"));
         let url_str = request_url.to_string();
         let bytes = retry_async(&url_str, || async {
-            let resp = CLIENT.get(request_url.clone()).send().await?;
+            let mut request = CLIENT.get(request_url.clone());
+            if let Some(resolver) = &self.http_headers_resolver {
+                request = request.headers(resolver(&request_url));
+            }
+            let resp = request.send().await?;
             let resp = resp.error_for_status()?;
             resp.bytes().await
         })
@@ -769,6 +789,7 @@ impl Default for Vfox {
             github_token_resolver: None,
             runtime_env_type: None,
             url_rewriter: None,
+            http_headers_resolver: None,
             log_tx: None,
         }
     }
@@ -818,6 +839,7 @@ mod tests {
                 github_token_resolver: None,
                 runtime_env_type: None,
                 url_rewriter: None,
+                http_headers_resolver: None,
                 log_tx: None,
             }
         }
@@ -956,6 +978,49 @@ mod tests {
             path,
             PathBuf::from("custom/downloads/vfox-dummy/1.0.0/dummy-1.0.0/tool.tar.gz")
         );
+    }
+
+    #[tokio::test]
+    async fn test_download_resolves_headers_after_url_rewrite() {
+        use reqwest::header::{AUTHORIZATION, HeaderValue};
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/mirror/tool.tar.gz"))
+            .and(header("Authorization", "Basic bWlycm9yOnNlY3JldA=="))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"artifact"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let temp = TempDir::new().unwrap();
+        let plugin_dir = temp.path().join("dummy");
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+        let plugin = Plugin::from_dir(&plugin_dir).unwrap();
+        let mut vfox = Vfox::test();
+        let mirror_url = Url::parse(&format!("{}/mirror/tool.tar.gz", server.uri())).unwrap();
+        vfox.set_url_rewriter({
+            let mirror_url = mirror_url.clone();
+            move |url| *url = mirror_url.clone()
+        });
+        vfox.set_http_headers_resolver(move |url| {
+            assert_eq!(url, &mirror_url);
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                AUTHORIZATION,
+                HeaderValue::from_static("Basic bWlycm9yOnNlY3JldA=="),
+            );
+            headers
+        });
+
+        let original_url = Url::parse("https://upstream.invalid/tool.tar.gz").unwrap();
+        let downloaded = vfox
+            .download(&original_url, &plugin, "1.0.0", temp.path())
+            .await
+            .unwrap();
+        assert_eq!(std::fs::read(downloaded).unwrap(), b"artifact");
     }
 
     #[tokio::test]

--- a/docs/dev-tools/backends/vfox.md
+++ b/docs/dev-tools/backends/vfox.md
@@ -108,6 +108,10 @@ The vfox backend honors mise's [`url_replacements`](/url-replacements.html) sett
 tool artifact downloads and requests made through the plugin's built-in Lua HTTP module. This
 includes `http.get`, `http.head`, `http.download_file`, and their `try_*` variants.
 
+After applying URL replacements, vfox also uses mise's [`netrc`](/configuration/settings.html#netrc)
+setting to add HTTP Basic authentication for the destination host. An explicit `Authorization`
+header supplied by a plugin takes precedence when the request stays on the same origin.
+
 ## Tool Options
 
 The following [tool-options](/dev-tools/#tool-options) are available for the `vfox` backend—these

--- a/e2e/backend/test_vfox_url_replacements
+++ b/e2e/backend/test_vfox_url_replacements
@@ -5,6 +5,7 @@ set -euo pipefail
 PLUGIN_DIR="$PWD/vfox-url-replacements"
 SERVER_ROOT="$PWD/server"
 PORT_FILE="$PWD/server-port"
+NETRC_FILE="$PWD/netrc"
 mkdir -p "$PLUGIN_DIR/hooks" "$SERVER_ROOT/archive/bin"
 
 cat >"$PLUGIN_DIR/metadata.lua" <<'LUA'
@@ -76,8 +77,26 @@ import sys
 
 root, port_file = sys.argv[1:]
 os.chdir(root)
+
+class AuthenticatedHandler(http.server.SimpleHTTPRequestHandler):
+    def authenticate(self):
+        if self.headers.get("Authorization") == "Basic bWlycm9yOnNlY3JldA==":
+            return True
+        self.send_response(401)
+        self.send_header("WWW-Authenticate", 'Basic realm="vfox-test"')
+        self.end_headers()
+        return False
+
+    def do_GET(self):
+        if self.authenticate():
+            super().do_GET()
+
+    def do_HEAD(self):
+        if self.authenticate():
+            super().do_HEAD()
+
 socketserver.TCPServer.allow_reuse_address = True
-with socketserver.TCPServer(("127.0.0.1", 0), http.server.SimpleHTTPRequestHandler) as httpd:
+with socketserver.TCPServer(("127.0.0.1", 0), AuthenticatedHandler) as httpd:
     with open(port_file, "w") as file:
         file.write(str(httpd.server_address[1]))
     httpd.serve_forever()
@@ -89,7 +108,17 @@ trap cleanup EXIT
 wait_for_file "$PORT_FILE" "vfox URL replacement server port" 30 "$SERVER_PID"
 SERVER_PORT=$(cat "$PORT_FILE")
 
+cat >"$NETRC_FILE" <<'EOF'
+machine 127.0.0.1
+  login mirror
+  password secret
+EOF
+chmod 600 "$NETRC_FILE"
+
 cat >mise.toml <<EOF
+[settings]
+netrc_file = "$NETRC_FILE"
+
 [settings.url_replacements]
 "https://upstream.invalid/tool.tar.gz" = "http://127.0.0.1:$SERVER_PORT/mirrored-artifact"
 "https://upstream.invalid/" = "http://127.0.0.1:$SERVER_PORT/"

--- a/src/http.rs
+++ b/src/http.rs
@@ -1687,7 +1687,7 @@ fn apply_netrc_credentials(
 }
 
 /// Get HTTP Basic authentication headers from netrc file for the given URL
-fn netrc_headers(url: &Url) -> HeaderMap {
+pub(crate) fn netrc_headers(url: &Url) -> HeaderMap {
     let mut headers = HeaderMap::new();
     if let Some(host) = url.host_str()
         && let Some((login, password)) = netrc::get_credentials(host)

--- a/src/plugins/vfox_plugin.rs
+++ b/src/plugins/vfox_plugin.rs
@@ -150,6 +150,7 @@ impl VfoxPlugin {
             crate::github::resolve_token("github.com").map(|(token, _)| token)
         }));
         vfox.set_url_rewriter(crate::http::apply_url_replacements);
+        vfox.set_http_headers_resolver(crate::http::netrc_headers);
         let rx = vfox.log_subscribe();
         Ok((vfox, rx))
     }


### PR DESCRIPTION
## Summary

- pass mise's destination-specific HTTP headers into the vfox runtime without duplicating settings or netrc parsing
- apply netrc credentials to traditional vfox artifact downloads and every Lua HTTP helper, including custom backend hooks
- resolve credentials after URL replacement while preserving explicit same-origin plugin authorization
- document the behavior and require Basic authentication in the vfox URL-replacement e2e test

## Root cause

Vfox owns separate reqwest clients for artifact downloads and Lua HTTP helpers. Mise supplied URL rewriting and GitHub token resolution to that runtime, but did not supply its netrc-derived headers, so `MISE_NETRC` and `MISE_NETRC_FILE` only affected the main HTTP client.

## User impact

Private artifact servers and authenticated mirrors can now be used by vfox plugins without embedding Authorization headers in plugin code or shelling out to curl.

## Validation

- `mise run format`
- `mise --cd crates/vfox run test` (114 passed, 2 ignored)
- `mise --cd crates/vfox run lint`
- `mise run test:e2e e2e/backend/test_vfox_url_replacements`

Addresses https://github.com/jdx/mise/discussions/12163

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 17e05c2d0f3c03e6c100d363457d4689748018d5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP authentication support for requests after URL replacements.
  * Destination hosts can now use configured `netrc` credentials.
  * Plugin-provided `Authorization` headers take precedence when applicable.

* **Bug Fixes**
  * Preserved required headers during rewritten downloads, including cross-origin requests.

* **Documentation**
  * Documented authentication behavior and header precedence for URL replacements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->