### PR TITLE
feat(config): support relative ignored config globs

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -521,13 +521,14 @@ parsed — so only information available at OS level can be used.
 <div v-pre>
 
 ```toml
-# ~/.config/mise/miserc.toml
+# /workspaces/vcs/.config/miserc.toml
 
 # Use $HOME to set a ceiling path (stops config search at home directory)
 ceiling_paths = ["{{ env.HOME }}"]
 
-# Ignore a config path relative to home
-ignored_config_paths = ["{{ env.HOME }}/shared"]
+# Paths are relative to the directory containing this miserc file.
+# Recursive glob patterns are supported.
+ignored_config_paths = ["../vendor/**/mise.toml"]
 ```
 
 </div>

--- a/e2e/config/test_config_ignored_paths
+++ b/e2e/config/test_config_ignored_paths
@@ -35,3 +35,32 @@ assert_contains "MISE_IGNORED_CONFIG_PATHS=$CHILD_DIR mise env" "PARENT"
 # Multiple colon-separated paths: both configs ignored
 assert_not_contains "MISE_IGNORED_CONFIG_PATHS=$CHILD_DIR:$WORKDIR mise env" "CHILD"
 assert_not_contains "MISE_IGNORED_CONFIG_PATHS=$CHILD_DIR:$WORKDIR mise env" "PARENT"
+
+# Relative paths in a local .config/miserc.toml are based on the declaring
+# file, and recursive glob patterns selectively ignore matching config names.
+cd "$WORKDIR"
+mkdir -p .config vendor/jj/.config
+cat <<EOF >vendor/jj/.config/mise.toml
+[env]
+IGNORED_VENDOR_CONFIG = "true"
+EOF
+cat <<EOF >vendor/jj/.mise.toml
+[env]
+VISIBLE_VENDOR_CONFIG = "true"
+EOF
+cat <<EOF >.config/miserc.toml
+ignored_config_paths = ["../vendor/./**/mise.toml"]
+EOF
+
+assert_not_contains "mise -C vendor/jj env" "IGNORED_VENDOR_CONFIG"
+assert_contains "mise -C vendor/jj env" "VISIBLE_VENDOR_CONFIG"
+
+# Environment values use the invocation directory as their relative base,
+# even when -C changes the directory used for config discovery.
+rm .config/miserc.toml
+assert_not_contains \
+  "MISE_IGNORED_CONFIG_PATHS='vendor/**/mise.toml' mise -C vendor/jj env" \
+  "IGNORED_VENDOR_CONFIG"
+assert_contains \
+  "MISE_IGNORED_CONFIG_PATHS='vendor/**/mise.toml' mise -C vendor/jj env" \
+  "VISIBLE_VENDOR_CONFIG"

--- a/settings.toml
+++ b/settings.toml
@@ -1327,6 +1327,11 @@ config file discovery has already occurred by the time `mise.toml` is read.
 
 Paths are separated by the OS path separator when using the environment variable,
 `mise settings set`, or `mise settings add` (`:` on Unix, `;` on Windows).
+
+Relative paths in `.miserc.toml` are resolved from the directory containing that
+file. Relative paths from the environment or CLI are resolved from the directory
+where mise was invoked. Glob patterns are supported, including recursive `**`
+patterns. Paths without glob metacharacters retain directory-prefix matching.
 """
 env = "MISE_IGNORED_CONFIG_PATHS"
 parse_env = "list_by_os_path_separator"

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -30,6 +30,7 @@ use crate::{
     registry::REGISTRY,
 };
 use eyre::{Result, eyre};
+use globset::{GlobBuilder, GlobMatcher};
 use idiomatic_version::IdiomaticVersionFile;
 use indexmap::IndexMap;
 use serde::Deserialize;
@@ -611,13 +612,50 @@ fn path_is_under_any(path: &Path, ignored: &[PathBuf]) -> bool {
         .any(|p| canonical.starts_with(p))
 }
 
+#[derive(Default)]
+struct IgnoredConfigPathMatcher {
+    literals: Vec<PathBuf>,
+    globs: Vec<GlobMatcher>,
+}
+
+impl IgnoredConfigPathMatcher {
+    fn new(paths: &[PathBuf]) -> Self {
+        let mut matcher = Self::default();
+        for path in paths {
+            let pattern = path.to_string_lossy();
+            if !pattern.contains(['*', '?', '[', '{']) {
+                matcher.literals.push(path.clone());
+                continue;
+            }
+            match GlobBuilder::new(&pattern).literal_separator(true).build() {
+                Ok(glob) => matcher.globs.push(glob.compile_matcher()),
+                Err(err) => {
+                    warn!("invalid ignored_config_paths glob {pattern}: {err}");
+                    matcher.literals.push(path.clone());
+                }
+            }
+        }
+        matcher
+    }
+
+    fn is_match(&self, path: &Path) -> bool {
+        path_is_under_any(path, &self.literals)
+            || self.globs.iter().any(|glob| glob.is_match(path))
+            || file::canonicalize_cached(path)
+                .is_some_and(|path| self.globs.iter().any(|glob| glob.is_match(&path)))
+    }
+}
+
+static IGNORED_CONFIG_PATH_MATCHER: Lazy<IgnoredConfigPathMatcher> =
+    Lazy::new(|| IgnoredConfigPathMatcher::new(&env::MISE_IGNORED_CONFIG_PATHS));
+
 /// Whether `path` is under an explicitly-configured `ignored_config_paths`
 /// (`MISE_IGNORED_CONFIG_PATHS`) entry.
 ///
 /// This is an explicit "never load this config" instruction and is a hard
 /// block: it takes precedence over `trusted_config_paths`.
 pub fn is_ignored_via_setting(path: &Path) -> bool {
-    path_is_under_any(path, &env::MISE_IGNORED_CONFIG_PATHS)
+    IGNORED_CONFIG_PATH_MATCHER.is_match(path)
 }
 
 /// Whether `path` is in the persisted ignore list.
@@ -1023,6 +1061,26 @@ mod ignored_config_path_tests {
             &tmp.path().join("other").join("config.toml"),
             &ignored
         ));
+    }
+
+    #[test]
+    fn recursive_glob_matches_config_path_but_not_sibling_name() {
+        let root = tempfile::tempdir().unwrap();
+        let pattern = root.path().join("vendor").join("**").join("mise.toml");
+        let matcher = IgnoredConfigPathMatcher::new(&[pattern]);
+
+        assert!(matcher.is_match(&root.path().join("vendor/jj/.config/mise.toml")));
+        assert!(!matcher.is_match(&root.path().join("vendor/jj/.config/.mise.toml")));
+    }
+
+    #[test]
+    fn literal_entries_keep_directory_prefix_behavior() {
+        let root = tempfile::tempdir().unwrap();
+        let ignored = root.path().join("vendor");
+        let matcher = IgnoredConfigPathMatcher::new(&[ignored]);
+
+        assert!(matcher.is_match(&root.path().join("vendor/jj/mise.toml")));
+        assert!(!matcher.is_match(&root.path().join("vendor-other/mise.toml")));
     }
 }
 

--- a/src/config/miserc.rs
+++ b/src/config/miserc.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use eyre::Result;
+use path_absolutize::Absolutize;
 use tera::Context;
 
 use crate::config::config_file::diagnostic::toml_parse_error;
@@ -22,11 +23,13 @@ use crate::tera::{
 };
 
 static MISERC: OnceLock<MisercSettings> = OnceLock::new();
+static INVOCATION_CWD: OnceLock<Option<PathBuf>> = OnceLock::new();
 
 /// Initialize miserc settings by loading .miserc.toml files.
 /// This must be called early in the initialization process, before
 /// MISE_ENV or other early settings are accessed.
 pub fn init() -> Result<()> {
+    let _ = invocation_cwd();
     let settings = load_miserc_settings()?;
     let _ = MISERC.set(settings);
     // Discard any files tracked via hash_file/file_size/last_modified during miserc
@@ -35,6 +38,14 @@ pub fn init() -> Result<()> {
     // contribute to that list.
     let _ = take_tera_accessed_files();
     Ok(())
+}
+
+/// The working directory mise was invoked from, before settings such as `cd`
+/// change the process working directory.
+pub fn invocation_cwd() -> Option<&'static Path> {
+    INVOCATION_CWD
+        .get_or_init(|| std::env::current_dir().ok())
+        .as_deref()
 }
 
 /// Get the loaded miserc settings, or default if not initialized.
@@ -139,13 +150,32 @@ fn load_miserc_settings() -> Result<MisercSettings> {
         if let Ok(content) = file::read_to_string(&path) {
             let config_root = path.parent().unwrap_or(Path::new("."));
             let content = render_miserc_template(&mut tera, &content, config_root);
-            let settings = toml::from_str::<MisercSettings>(&content)
+            let mut settings = toml::from_str::<MisercSettings>(&content)
                 .map_err(|e| toml_parse_error(&e, &content, &path))?;
+            resolve_ignored_config_paths(&mut settings, config_root);
             merge_settings(&mut merged, settings);
         }
     }
 
     Ok(merged)
+}
+
+fn resolve_ignored_config_paths(settings: &mut MisercSettings, config_root: &Path) {
+    let Some(paths) = settings.ignored_config_paths.take() else {
+        return;
+    };
+    settings.ignored_config_paths = Some(
+        paths
+            .into_iter()
+            .map(|path| resolve_ignored_config_path(path, config_root))
+            .collect(),
+    );
+}
+
+pub(crate) fn resolve_ignored_config_path(path: PathBuf, relative_to: &Path) -> PathBuf {
+    file::replace_path(path)
+        .absolutize_from(relative_to)
+        .into_owned()
 }
 
 /// Merge source settings into target, where source values override target.
@@ -261,6 +291,23 @@ ceiling_paths = ["/home/user"]
             Some(vec!["development".to_string(), "local".to_string()])
         );
         assert!(settings.ceiling_paths.is_some());
+    }
+
+    #[test]
+    fn test_resolve_ignored_config_paths_from_declaring_file() {
+        let mut settings = MisercSettings {
+            ignored_config_paths: Some(BTreeSet::from([PathBuf::from("../vendor/./**/mise.toml")])),
+            ..Default::default()
+        };
+
+        resolve_ignored_config_paths(&mut settings, Path::new("/workspaces/vcs/.config"));
+
+        assert_eq!(
+            settings.ignored_config_paths,
+            Some(BTreeSet::from([PathBuf::from(
+                "/workspaces/vcs/vendor/**/mise.toml"
+            )]))
+        );
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2244,10 +2244,7 @@ fn detect_auto_env_candidate_files() -> Vec<PathBuf> {
     // same file (e.g. ~/.config/mise/config.{env}.toml when cwd is under $HOME)
     let mut found = IndexSet::new();
     for dir in all_dirs().unwrap_or_default() {
-        if env::MISE_IGNORED_CONFIG_PATHS
-            .iter()
-            .any(|p| dir.starts_with(p))
-        {
+        if config_file::is_ignored_via_setting(&dir) {
             continue;
         }
         for env_name in &candidate_envs {
@@ -2431,10 +2428,7 @@ fn is_default_config_dir_override_filtered(path: &Path) -> bool {
 }
 
 fn config_dir_is_ignored(dir: &Path, include_ignored: bool) -> bool {
-    !include_ignored
-        && env::MISE_IGNORED_CONFIG_PATHS
-            .iter()
-            .any(|p| dir.starts_with(p))
+    !include_ignored && config_file::is_ignored_via_setting(dir)
 }
 
 fn config_path_is_ignored(path: &Path, include_ignored: bool) -> bool {

--- a/src/env.rs
+++ b/src/env.rs
@@ -373,17 +373,18 @@ pub static MISE_GLOBAL_CONFIG_ROOT: Lazy<PathBuf> =
 pub static MISE_SYSTEM_CONFIG_FILE: Lazy<Option<PathBuf>> =
     Lazy::new(|| var_path("MISE_SYSTEM_CONFIG_FILE"));
 pub static MISE_IGNORED_CONFIG_PATHS: Lazy<Vec<PathBuf>> = Lazy::new(|| {
+    let invocation_cwd = miserc::invocation_cwd()
+        .map(Path::to_path_buf)
+        .or_else(|| current_dir().ok())
+        .unwrap_or_default();
     var_os("MISE_IGNORED_CONFIG_PATHS")
         .map(|v| {
             split_paths(&v)
                 .filter(|p| !p.as_os_str().is_empty())
-                .map(replace_path)
+                .map(|p| miserc::resolve_ignored_config_path(p, &invocation_cwd))
                 .collect()
         })
-        .or_else(|| {
-            miserc::get_ignored_config_paths()
-                .map(|paths| paths.iter().cloned().map(replace_path).collect())
-        })
+        .or_else(|| miserc::get_ignored_config_paths().map(|paths| paths.iter().cloned().collect()))
         .unwrap_or_default()
 });
 pub static MISE_CEILING_PATHS: Lazy<HashSet<PathBuf>> = Lazy::new(|| {


### PR DESCRIPTION
## Summary
- resolve relative `ignored_config_paths` entries in `.miserc.toml` against the declaring file
- resolve environment-provided relative entries against mise's invocation directory
- support glob patterns, including recursive `**`, while preserving literal directory-prefix matching
- centralize ignored-path checks and document the new behavior

## Why
This addresses https://github.com/jdx/mise/discussions/12162. Vendored repositories can now be excluded portably without hard-coded workspace paths or one literal entry per config file.

## Root cause
Ignored paths were stored as plain `PathBuf` values and matched only with component-prefix comparisons. Miserc merging discarded the declaring file's location before relative entries could be resolved, and no glob matcher was used.

## Validation
- `mise run lint-fix`
- `cargo test --bin mise ignored_config_path -- --nocapture`
- `mise run test:e2e e2e/config/test_config_ignored_paths`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes early-init config discovery and ignore semantics; incorrect resolution or glob matching could skip or load the wrong configs, though behavior is covered by unit and e2e tests.
> 
> **Overview**
> **`ignored_config_paths`** now resolves relative paths differently by source: entries in **`.miserc.toml`** are absolutized from the declaring file’s directory, while **`MISE_IGNORED_CONFIG_PATHS`** (and CLI) use the directory mise was invoked from—captured early as **`invocation_cwd`**—even when **`-C`** changes config discovery.
> 
> Matching adds **glob patterns** (including recursive **`**`**) via a shared **`IgnoredConfigPathMatcher`**, while paths without glob metacharacters keep **directory-prefix** behavior. Config discovery and auto-env scanning route ignored checks through **`is_ignored_via_setting`** instead of ad hoc prefix compares.
> 
> Docs and e2e cover miserc globs, env-relative patterns with **`-C`**, and the updated settings/templates examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99b31d4f6053a9d92bf8edcee460d7384239ad2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added recursive glob support for ignored configuration paths.
  - Relative ignore paths now resolve from the file, environment, or command location where they are declared.
  - Added directory-prefix matching for non-glob paths.

- **Bug Fixes**
  - Improved consistency when ignoring configuration files and directories.
  - Invalid patterns are handled safely as literal paths with a warning.

- **Documentation**
  - Updated configuration examples and settings documentation to explain path resolution and recursive patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->