### PR TITLE
fix(http): order remote versions consistently

### DIFF
--- a/docs/dev-tools/backends/http.md
+++ b/docs/dev-tools/backends/http.md
@@ -342,6 +342,25 @@ The version list URL can return data in multiple formats:
 
 Version prefixes like `v` are automatically stripped.
 
+mise preserves the order returned by the version source. By default, version
+resolution treats the last matching entry as the latest one. If the source
+returns semantic versions in another order, set `version_order = "semver"` to
+select versions by semantic precedence while keeping `mise ls-remote` in the
+source's canonical order. See [Version ordering](/dev-tools/#version-ordering)
+for the complete ordering contract.
+
+GitHub's releases API, for example, returns releases newest first. Opt into
+semantic ordering when using it as an HTTP version source:
+
+```toml
+[tools."http:my-tool"]
+version = "latest"
+version_order = "semver"
+url = "https://example.com/my-tool-{{ version }}.tar.gz"
+version_list_url = "https://api.github.com/repos/owner/my-tool/releases"
+version_json_path = ".[].tag_name"
+```
+
 ### `version_regex`
 
 Extract versions from the version list URL response using a regular expression:
@@ -409,7 +428,10 @@ version_list_url = "https://example.com/versions.txt"
 version_expr = 'split(body, "\n")'
 ```
 
-The expression receives the HTTP response body as the `body` variable and should return an array of version strings.
+The expression receives the HTTP response body as the `body` variable and
+should return an array of version strings. It also receives `versions`, which
+contains values already extracted by `version_regex` or `version_json_path` and
+is empty when no earlier extractor produced values.
 
 Example expressions:
 
@@ -423,18 +445,32 @@ version_expr = 'filter(split(body, "\n"), # != "")'
 # Parse JSON and extract object keys (useful for HashiCorp-style JSON)
 # e.g., {"versions": {"1.0.0": {}, "2.0.0": {}}}
 version_expr = 'keys(fromJSON(body).versions)'
+
+# Sort versions with mise's version-aware comparator
+version_expr = 'fromJSON(body) | map({ trimPrefix(#.tag_name, "v") }) | sortVersions()'
 ```
 
-The [expr-lang](https://expr-lang.org/) library provides built-in functions including:
+The [expr-lang](https://expr-lang.org/) library provides built-in functions
+including:
 
 - **`fromJSON(string)`**: Parse a JSON string into a value
 - **`toJSON(value)`**: Convert a value to a JSON string
 - **`keys(map)`**: Get the keys of an object/map as an array
 - **`values(map)`**: Get the values of an object/map as an array
 - **`len(value)`**: Get the length of a string, array, or map
+- **`filter(array, predicate)`** and **`map(array, predicate)`**: Filter or transform array values
+- **`sort(array)`** and **`reverse(array)`**: Reorder values lexically
+- **`int(value)`**, **`float(value)`**, and **`string(value)`**: Convert compatible values
+
+mise adds **`sortVersions(array)`** for version-aware ordering. Prefer
+`version_order = "semver"` when only version resolution needs semantic ordering;
+use `sortVersions()` when the expression itself or the list returned by
+`mise ls-remote` must be sorted.
 
 ::: tip
-`version_expr` takes precedence over `version_regex` and `version_json_path` if multiple are specified. Use it when the other options aren't flexible enough for your use case.
+`version_expr` is the final extraction step, so its result becomes the version
+list. Use the `versions` variable to post-process values produced by
+`version_regex` or `version_json_path`.
 :::
 
 ### `bin_path`

--- a/docs/dev-tools/backends/http.md
+++ b/docs/dev-tools/backends/http.md
@@ -345,9 +345,9 @@ Version prefixes like `v` are automatically stripped.
 mise preserves the order returned by the version source. By default, version
 resolution treats the last matching entry as the latest one. If the source
 returns semantic versions in another order, set `version_order = "semver"` to
-select versions by semantic precedence while keeping `mise ls-remote` in the
-source's canonical order. See [Version ordering](/dev-tools/#version-ordering)
-for the complete ordering contract.
+order `mise ls-remote` and select versions by semantic precedence. See
+[Version ordering](/dev-tools/#version-ordering) for the complete ordering
+contract.
 
 GitHub's releases API, for example, returns releases newest first. Opt into
 semantic ordering when using it as an HTTP version source:
@@ -463,9 +463,9 @@ including:
 - **`int(value)`**, **`float(value)`**, and **`string(value)`**: Convert compatible values
 
 mise adds **`sortVersions(array)`** for version-aware ordering. Prefer
-`version_order = "semver"` when only version resolution needs semantic ordering;
-use `sortVersions()` when the expression itself or the list returned by
-`mise ls-remote` must be sorted.
+`version_order = "semver"` when the discovered versions follow semantic
+versioning; use `sortVersions()` when the expression itself needs a sorted
+intermediate value.
 
 ::: tip
 `version_expr` is the final extraction step, so its result becomes the version

--- a/docs/dev-tools/index.md
+++ b/docs/dev-tools/index.md
@@ -171,14 +171,12 @@ important for repositories containing multiple products: their repository-wide
 Latest release may not contain an asset for every package.
 
 With `version_order = "semver"`, mise orders valid semantic versions by
-precedence when resolving that fallback list or a version prefix. Opaque versions
-retain their source order before semantic versions, so exact requests such as
-`nightly` continue to work. Build metadata does not affect precedence. Registry
-entries may set this option for tools known to follow semantic versioning; users
-can set `version_order = "source"` to restore the backend's default ordering.
-
-The option affects version resolution only. `mise ls-remote` continues to show
-the canonical order returned by the backend.
+precedence in `mise ls-remote` output and when resolving that list or a version
+prefix. Opaque versions retain their source order before semantic versions, so
+exact requests such as `nightly` continue to work. Build metadata does not affect
+precedence. Registry entries may set this option for tools known to follow
+semantic versioning; users can set `version_order = "source"` to restore the
+backend's default ordering.
 
 ### Tool postinstall commands
 

--- a/e2e/backend/test_version_order
+++ b/e2e/backend/test_version_order
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# version_order changes candidate selection without changing the canonical
-# source order displayed by ls-remote.
+# version_order changes both candidate selection and the order displayed by
+# ls-remote.
 
 VERSION_LIST_DIR="$TMPDIR/version-order-list"
 mkdir -p "$VERSION_LIST_DIR"
@@ -39,6 +39,10 @@ version_regex = '(v[0-9.]+|nightly)'
 EOF
 
 assert "mise latest http:version-order" "v10.34.5"
+assert "mise ls-remote http:version-order" "v11.11.0
+nightly
+v10.99.0
+v10.34.5"
 
 cat <<EOF >mise.toml
 [tools."http:version-order"]
@@ -52,10 +56,10 @@ EOF
 assert "mise latest http:version-order" "v11.11.0"
 assert "mise latest http:version-order@10" "v10.99.0"
 assert "mise latest http:version-order nightly" "nightly"
-assert "mise ls-remote http:version-order" "v11.11.0
-nightly
+assert "mise ls-remote http:version-order" "nightly
+v10.34.5
 v10.99.0
-v10.34.5"
+v11.11.0"
 
 assert_fail 'mise install --dry-run "cargo:ripgrep[version_order=semver]@14.1.1"' \
   "cargo backend does not support version_order"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2053,6 +2053,8 @@ pub trait Backend: Debug + Send + Sync {
     ///
     /// In offline mode, this reads the existing remote-versions cache without
     /// fetching or writing. If no cache exists, it returns an empty list.
+    /// The returned list applies the backend's configured `version_order`; the
+    /// cached value remains in source order.
     async fn list_remote_versions_with_info(
         &self,
         config: &Arc<Config>,
@@ -2072,14 +2074,19 @@ pub trait Backend: Debug + Send + Sync {
             &resolved_opts,
             self.remote_version_listing_tool_option_keys(),
         );
-        self.list_remote_versions_with_info_and_options(
-            config,
-            resolved_opts.options(),
-            resolved_opts.options(),
-            refresh,
-            has_local_version_listing_override,
-        )
-        .await
+        let opts = resolved_opts.options();
+        let versions = self
+            .list_remote_versions_with_info_and_options(
+                config,
+                opts,
+                opts,
+                refresh,
+                has_local_version_listing_override,
+            )
+            .await?;
+        Ok(self
+            .version_order(opts)?
+            .order_by(versions, |version| version.version.as_str()))
     }
 
     /// List remote versions while selecting candidates with the active request's options.
@@ -2097,14 +2104,18 @@ pub trait Backend: Debug + Send + Sync {
             &resolved_opts,
             self.remote_version_listing_tool_option_keys(),
         );
-        self.list_remote_versions_with_info_and_options(
-            config,
-            resolved_opts.options(),
-            opts,
-            refresh,
-            has_local_version_listing_override,
-        )
-        .await
+        let versions = self
+            .list_remote_versions_with_info_and_options(
+                config,
+                resolved_opts.options(),
+                opts,
+                refresh,
+                has_local_version_listing_override,
+            )
+            .await?;
+        Ok(self
+            .version_order(opts)?
+            .order_by(versions, |version| version.version.as_str()))
     }
 
     /// Common remote-version listing hook for both config- and request-aware callers.
@@ -3874,8 +3885,9 @@ pub trait Backend: Debug + Send + Sync {
 
     /// Select the ordering policy supported by this backend.
     ///
-    /// Backends must opt in explicitly before `version_order` can affect
-    /// resolution. This keeps opaque version schemes source-ordered by default.
+    /// Backends must opt in explicitly before `version_order` can affect remote
+    /// version listing or resolution. This keeps opaque version schemes
+    /// source-ordered by default.
     fn version_order(&self, opts: &ToolVersionOptions) -> eyre::Result<VersionOrder> {
         if opts.opts.contains_key("version_order") {
             bail!("{} backend does not support version_order", self.get_type())

--- a/src/backend/options.rs
+++ b/src/backend/options.rs
@@ -6,7 +6,7 @@ use crate::backend::static_helpers::{
 use crate::toolset::ToolVersionOptions;
 use eyre::{Result, bail};
 
-/// The ordering policy a backend applies to eligible version candidates.
+/// The ordering policy a backend applies to remote versions.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum VersionOrder {
     #[default]
@@ -33,27 +33,35 @@ impl VersionOrder {
     }
 
     pub(crate) fn order(self, versions: Vec<String>) -> Vec<String> {
+        self.order_by(versions, String::as_str)
+    }
+
+    pub(crate) fn order_by<T, F>(self, versions: Vec<T>, version: F) -> Vec<T>
+    where
+        F: for<'a> Fn(&'a T) -> &'a str,
+    {
         if self == Self::Source {
             return versions;
         }
 
         let mut opaque = Vec::new();
         let mut semantic = Vec::new();
-        for (source_index, version) in versions.into_iter().enumerate() {
+        for (source_index, value) in versions.into_iter().enumerate() {
+            let version = version(&value);
             let normalized = version
                 .strip_prefix('v')
                 .or_else(|| version.strip_prefix('V'))
-                .unwrap_or(&version);
+                .unwrap_or(version);
             match semver::Version::parse(normalized) {
-                Ok(parsed) => semantic.push((source_index, version, parsed)),
-                Err(_) => opaque.push(version),
+                Ok(parsed) => semantic.push((source_index, value, parsed)),
+                Err(_) => opaque.push(value),
             }
         }
         semantic.sort_by(|(left_index, _, left), (right_index, _, right)| {
             left.cmp_precedence(right)
                 .then_with(|| left_index.cmp(right_index))
         });
-        opaque.extend(semantic.into_iter().map(|(_, version, _)| version));
+        opaque.extend(semantic.into_iter().map(|(_, value, _)| value));
         opaque
     }
 }
@@ -393,6 +401,39 @@ mod tests {
         assert_eq!(
             VersionOrder::Semver.order(versions),
             ["nightly", "v10.34.5", "v10.99.0", "v11.11.0"]
+        );
+    }
+
+    #[test]
+    fn test_semver_order_by_preserves_associated_metadata() {
+        #[derive(Debug, PartialEq, Eq)]
+        struct Item {
+            version: String,
+            metadata: usize,
+        }
+
+        let items = vec![
+            Item {
+                version: "2.0.0".into(),
+                metadata: 2,
+            },
+            Item {
+                version: "1.0.0".into(),
+                metadata: 1,
+            },
+        ];
+        assert_eq!(
+            VersionOrder::Semver.order_by(items, |item| item.version.as_str()),
+            vec![
+                Item {
+                    version: "1.0.0".into(),
+                    metadata: 1,
+                },
+                Item {
+                    version: "2.0.0".into(),
+                    metadata: 2,
+                },
+            ]
         );
     }
 }


### PR DESCRIPTION
## Summary

- apply `version_order` to remote version listings so `mise ls-remote` and version resolution use the same order
- preserve source order in the remote-version cache and apply ordering when returning results
- retain `VersionInfo` metadata while ordering
- cover every backend that supports `version_order`: HTTP, Aqua, GitHub, GitLab, and Forgejo
- document HTTP ordering, `sortVersions()`, the `versions` expression input, and relevant expr-lang helpers

## Root cause

Semantic ordering was applied only while selecting resolution candidates. `mise ls-remote` read the same remote list without applying `version_order`, so its displayed order could disagree with the version selected as `latest`.

The shared remote-list wrappers now apply the backend ordering policy after reading the source-ordered cache. This keeps cache behavior stable while making plain and JSON listings consistent with resolution.

Addresses https://github.com/jdx/mise/discussions/12165.

## Validation

- `cargo test --locked --bin mise backend::options::tests`
- `mise run test:e2e e2e/backend/test_version_order`
- `mise run lint-fix`
- `mise run docs:build`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Semantic version ordering now applies to both remote version listings and version selection.
  * `mise ls-remote` displays versions according to the configured ordering, while opaque versions retain source order.

* **Documentation**
  * Clarified HTTP backend version handling and source-order behavior.
  * Documented `version_order = "semver"` and expanded `version_expr` guidance, including version-aware sorting.
  * Added a GitHub releases configuration example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->