### PR TITLE
refactor(backend): remove legacy RTX environment variables

### DIFF
--- a/docs/dev-tools/backends/vfox.md
+++ b/docs/dev-tools/backends/vfox.md
@@ -114,8 +114,7 @@ The following [tool-options](/dev-tools/#tool-options) are available for the `vf
 go in `[tools]` in `mise.toml`.
 
 Traditional vfox lifecycle hooks for a selected tool version can read custom options from their
-hook environment. Option names are uppercased and exposed with both the current and legacy-compatible
-prefixes:
+hook environment. Option names are uppercased and exposed with the `MISE_TOOL_OPTS__` prefix:
 
 ```toml
 [tools]
@@ -124,7 +123,6 @@ prefixes:
 
 ```lua
 local extensions = os.getenv("MISE_TOOL_OPTS__EXTENSIONS")
--- RTX_TOOL_OPTS__EXTENSIONS contains the same value for legacy compatibility.
 ```
 
 These variables are available only while mise runs the plugin hook and are not exported to the

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -132,8 +132,7 @@ Use [`_.python.venv`](/lang/python.html#automatic-virtualenv-activation) in the 
 :::
 
 For asdf plugins and version-specific vfox lifecycle hooks, this is passed as
-`MISE_TOOL_OPTS__VIRTUALENV=.venv` and the legacy-compatible
-`RTX_TOOL_OPTS__VIRTUALENV=.venv`. These variables are scoped to the plugin hook environment; mise
+`MISE_TOOL_OPTS__VIRTUALENV=.venv`. These variables are scoped to the plugin hook environment; mise
 does not export them to the user's shell. Custom backend options are passed to the plugin in that
 format; mise-managed fields such as `depends`, `install_env`, and `os` are not exported.
 

--- a/e2e/backend/test_vfox_tool_options
+++ b/e2e/backend/test_vfox_tool_options
@@ -94,29 +94,28 @@ git -C "$PLUGIN_DIR" -c user.name=mise -c user.email=mise@example.com commit -qm
 cat >mise.toml <<EOF
 [env]
 MISE_TOOL_OPTS__CONFIG_OVERRIDE = "from-config"
-RTX_TOOL_OPTS__CONFIG_OVERRIDE = "from-config"
 MISE_TEST_OPTION_OS_MARKER = "$OS_MARKER"
 
 [tools]
-"vfox:file://$PLUGIN_DIR" = { version = "1.0.0", extensions = "opentelemetry,swoole", config_override = "from-option", install_override = "from-option", retries = 2, install_env = { MISE_TOOL_OPTS__INSTALL_OVERRIDE = "from-install-env", RTX_TOOL_OPTS__INSTALL_OVERRIDE = "from-install-env" } }
+"vfox:file://$PLUGIN_DIR" = { version = "1.0.0", extensions = "opentelemetry,swoole", config_override = "from-option", install_override = "from-option", retries = 2, install_env = { MISE_TOOL_OPTS__INSTALL_OVERRIDE = "from-install-env" } }
 EOF
 
 export MISE_LOCKFILE=1
 detect_platform
 
-MISE_TOOL_OPTS__EXTENSIONS=ambient RTX_TOOL_OPTS__EXTENSIONS=ambient mise lock --platform "$MISE_PLATFORM"
+MISE_TOOL_OPTS__EXTENSIONS=ambient mise lock --platform "$MISE_PLATFORM"
 assert \
   "cat '$PRE_MARKER'" \
-  "opentelemetry,swoole|opentelemetry,swoole|from-config|from-config|from-option|from-option|2"
+  "opentelemetry,swoole|missing|from-config|missing|from-option|missing|2"
 
-MISE_TOOL_OPTS__EXTENSIONS=ambient RTX_TOOL_OPTS__EXTENSIONS=ambient mise install
+MISE_TOOL_OPTS__EXTENSIONS=ambient mise install
 assert \
   "cat '$PRE_MARKER'" \
-  "opentelemetry,swoole|opentelemetry,swoole|from-config|from-config|from-option|from-option|2"
+  "opentelemetry,swoole|missing|from-config|missing|from-option|missing|2"
 assert \
   "cat '$POST_MARKER'" \
-  "opentelemetry,swoole|opentelemetry,swoole|from-config|from-config|from-install-env|from-install-env"
-assert "cat '$OS_MARKER'" "opentelemetry,swoole"
+  "opentelemetry,swoole|missing|from-config|missing|from-install-env|missing"
+assert "cat '$OS_MARKER'" ""
 assert "mise exec -- tool-options" "tool-options"
 assert_contains "mise env" "VFOX_TOOL_OPTION=opentelemetry,swoole"
 assert_not_contains "mise env" "MISE_TOOL_OPTS__EXTENSIONS"
@@ -124,4 +123,4 @@ assert_not_contains "mise env" "MISE_TOOL_OPTS__EXTENSIONS"
 mise uninstall "vfox:file://$PLUGIN_DIR@1.0.0"
 assert \
   "cat '$UNINSTALL_MARKER'" \
-  "opentelemetry,swoole|opentelemetry,swoole"
+  "opentelemetry,swoole|missing"

--- a/src/backend/asdf.rs
+++ b/src/backend/asdf.rs
@@ -228,8 +228,6 @@ impl AsdfBackend {
     ) -> Result<ScriptManager> {
         let mut sm = self.plugin.script_man.clone();
         for (key, value) in tv.request.options().opts_as_strings() {
-            let k = format!("RTX_TOOL_OPTS__{}", key.to_uppercase());
-            sm = sm.with_env(k, value.clone());
             let k = format!("MISE_TOOL_OPTS__{}", key.to_uppercase());
             sm = sm.with_env(k, value);
         }
@@ -241,7 +239,6 @@ impl AsdfBackend {
         }
         if let Some(project_root) = &config.project_root {
             let project_root = project_root.to_string_lossy().to_string();
-            sm = sm.with_env("RTX_PROJECT_ROOT", project_root.clone());
             sm = sm.with_env("MISE_PROJECT_ROOT", project_root);
         }
         let install_type = match &tv.request {
@@ -268,10 +265,6 @@ impl AsdfBackend {
             .with_env("ASDF_INSTALL_PATH", &install)
             .with_env("ASDF_INSTALL_TYPE", install_type)
             .with_env("ASDF_INSTALL_VERSION", install_version)
-            .with_env("RTX_DOWNLOAD_PATH", &download)
-            .with_env("RTX_INSTALL_PATH", &install)
-            .with_env("RTX_INSTALL_TYPE", install_type)
-            .with_env("RTX_INSTALL_VERSION", install_version)
             .with_env("MISE_DOWNLOAD_PATH", download)
             .with_env("MISE_INSTALL_PATH", install)
             .with_env("MISE_INSTALL_TYPE", install_type)

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -113,14 +113,12 @@ fn set_env_var(
 fn add_tool_option_env(env: &mut indexmap::IndexMap<String, String>, options: &ToolOptions) {
     for (key, value) in options.opts_as_strings() {
         let key = key.to_uppercase();
-        set_env_var(env, format!("RTX_TOOL_OPTS__{key}"), value.clone());
         set_env_var(env, format!("MISE_TOOL_OPTS__{key}"), value);
     }
 }
 
 fn is_tool_option_env_key(key: &str) -> bool {
-    let matches =
-        |key: &str| key.starts_with("MISE_TOOL_OPTS__") || key.starts_with("RTX_TOOL_OPTS__");
+    let matches = |key: &str| key.starts_with("MISE_TOOL_OPTS__");
     if cfg!(windows) {
         matches(&key.to_uppercase())
     } else {
@@ -823,7 +821,6 @@ mod test {
 
         let mut env = indexmap::indexmap! {
             "MISE_TOOL_OPTS__EXTENSIONS".to_string() => "ambient".to_string(),
-            "RTX_TOOL_OPTS__EXTENSIONS".to_string() => "ambient".to_string(),
         };
         add_tool_option_env(&mut env, &options);
 
@@ -831,12 +828,7 @@ mod test {
             env.get("MISE_TOOL_OPTS__EXTENSIONS").unwrap(),
             "opentelemetry\nswoole"
         );
-        assert_eq!(
-            env.get("RTX_TOOL_OPTS__EXTENSIONS").unwrap(),
-            "opentelemetry\nswoole"
-        );
         assert_eq!(env.get("MISE_TOOL_OPTS__RETRIES").unwrap(), "2");
-        assert_eq!(env.get("RTX_TOOL_OPTS__RETRIES").unwrap(), "2");
         assert!(!env.contains_key("MISE_TOOL_OPTS__DEPENDS"));
         assert!(!env.contains_key("MISE_TOOL_OPTS__INSTALL_ENV"));
     }
@@ -845,18 +837,15 @@ mod test {
     fn test_restore_config_tool_option_env() {
         let mut env = indexmap::indexmap! {
             "MISE_TOOL_OPTS__EXTENSIONS".to_string() => "generated".to_string(),
-            "RTX_TOOL_OPTS__EXTENSIONS".to_string() => "generated".to_string(),
         };
         let config_env = indexmap::indexmap! {
             "MISE_TOOL_OPTS__EXTENSIONS".to_string() => "configured".to_string(),
-            "RTX_TOOL_OPTS__EXTENSIONS".to_string() => "configured".to_string(),
             "UNRELATED".to_string() => "ignored".to_string(),
         };
 
         restore_config_tool_option_env(&mut env, &config_env);
 
         assert_eq!(env["MISE_TOOL_OPTS__EXTENSIONS"], "configured");
-        assert_eq!(env["RTX_TOOL_OPTS__EXTENSIONS"], "configured");
         assert!(!env.contains_key("UNRELATED"));
     }
 
@@ -876,9 +865,8 @@ mod test {
 
         add_tool_option_env(&mut env, &options);
 
-        assert_eq!(env.len(), 2);
+        assert_eq!(env.len(), 1);
         assert_eq!(env["MISE_TOOL_OPTS__EXTENSIONS"], "configured");
-        assert_eq!(env["RTX_TOOL_OPTS__EXTENSIONS"], "configured");
     }
 
     #[tokio::test]

--- a/src/plugins/asdf_plugin.rs
+++ b/src/plugins/asdf_plugin.rs
@@ -477,10 +477,7 @@ fn build_script_man(name: &str, plugin_path: &Path) -> ScriptManager {
     let plugin_path_s = plugin_path.to_string_lossy().to_string();
     let token = env::GITHUB_TOKEN.as_deref().unwrap_or("");
     ScriptManager::new(plugin_path.to_path_buf())
-        .with_env("ASDF_PLUGIN_PATH", plugin_path_s.clone())
-        .with_env("RTX_PLUGIN_PATH", plugin_path_s.clone())
-        .with_env("RTX_PLUGIN_NAME", name.to_string())
-        .with_env("RTX_SHIMS_DIR", *dirs::SHIMS)
+        .with_env("ASDF_PLUGIN_PATH", plugin_path_s)
         .with_env("MISE_PLUGIN_NAME", name.to_string())
         .with_env("MISE_PLUGIN_PATH", plugin_path)
         .with_env("MISE_SHIMS_DIR", *dirs::SHIMS)

--- a/src/toolset/toolset_env.rs
+++ b/src/toolset/toolset_env.rs
@@ -350,15 +350,13 @@ impl Toolset {
         // Collect and process MISE_ADD_PATH values into paths
         let paths_to_add: Vec<PathBuf> = entries
             .iter()
-            .filter(|(k, _)| k == "MISE_ADD_PATH" || k == "RTX_ADD_PATH")
+            .filter(|(k, _)| k == "MISE_ADD_PATH")
             .flat_map(|(_, v)| env::split_paths(v))
             .collect();
 
         let mut env: EnvMap = entries
             .into_iter()
-            .filter(|(k, _)| k != "RTX_ADD_PATH")
             .filter(|(k, _)| k != "MISE_ADD_PATH")
-            .filter(|(k, _)| !k.starts_with("RTX_TOOL_OPTS__"))
             .filter(|(k, _)| !k.starts_with("MISE_TOOL_OPTS__"))
             .rev()
             .collect();

--- a/src/toolset/toolset_paths.rs
+++ b/src/toolset/toolset_paths.rs
@@ -80,7 +80,7 @@ impl Toolset {
             paths.push(venv.venv_path.clone());
         }
 
-        // 4. tool_add_paths (MISE_ADD_PATH/RTX_ADD_PATH from tools)
+        // 4. tool_add_paths (MISE_ADD_PATH from tools)
         paths.extend(env_results.tool_add_paths);
 
         // 5. Tool paths
@@ -115,7 +115,7 @@ impl Toolset {
             tool_paths.push(venv.venv_path.clone());
         }
 
-        // tool_add_paths (MISE_ADD_PATH/RTX_ADD_PATH from tools)
+        // tool_add_paths (MISE_ADD_PATH from tools)
         tool_paths.extend(env_results.tool_add_paths);
 
         // Tool installation paths


### PR DESCRIPTION
## Summary
- stop exporting `RTX_TOOL_OPTS__*` to asdf and vfox plugin hooks
- remove the remaining `RTX_*` plugin/install metadata aliases and `RTX_ADD_PATH` handling
- document only the current `MISE_*` environment variables and verify legacy tool-option variables are absent throughout vfox lifecycle hooks

## Impact
Plugin authors should use the existing `MISE_*` variables. Standard `ASDF_*` variables remain available to asdf plugins.

## Validation
- `cargo test --bin mise backend::vfox::test`
- `mise run test:e2e e2e/backend/test_vfox_tool_options`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b65318379c5dd10ebf70622eefe423726e3e590e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tool and plugin documentation to reference only the current `MISE_*` environment variables.
  * Removed legacy `RTX_*` variable examples and references.

* **Bug Fixes**
  * Standardized environment variables used by tool and plugin scripts.
  * Removed handling of deprecated `RTX_*` variables while preserving `MISE_*` behavior.
  * Updated path and tool-option handling across supported integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->