### PR TITLE
fix(task): normalize Windows task environment paths

### DIFF
--- a/e2e-win/task.Tests.ps1
+++ b/e2e-win/task.Tests.ps1
@@ -75,6 +75,45 @@ Write-Output "windows"
         mise run filetask.bat | Select -Last 1 | Should -Be 'mytask'
     }
 
+    It 'uses native separators in task path environment variables' {
+        @'
+[tasks.path_env]
+shell = "pwsh -NoProfile -Command"
+quiet = true
+run = '''
+[ordered]@{
+    original_cwd = $env:MISE_ORIGINAL_CWD
+    config_root = $env:MISE_CONFIG_ROOT
+    project_root = $env:MISE_PROJECT_ROOT
+    task_dir = $env:MISE_TASK_DIR
+    task_file = $env:MISE_TASK_FILE
+} | ConvertTo-Json -Compress
+'''
+'@ | Out-File -FilePath "$TestDrive\mise.task-path-env.toml" -Encoding utf8NoBOM
+
+        $oldConfig = $env:MISE_CONFIG_FILE
+        # Preserve the slash spelling that config discovery can produce when a global config is
+        # found through `.config/mise/config.toml` relative to the invocation directory (#12160).
+        $env:MISE_CONFIG_FILE = "$TestDrive/mise.task-path-env.toml"
+        try {
+            $paths = mise run path_env | ConvertFrom-Json
+            $LASTEXITCODE | Should -Be 0
+            foreach ($property in $paths.PSObject.Properties) {
+                $property.Value.Contains('/') | Should -BeFalse -Because (
+                    "$($property.Name) used mixed separators: $($property.Value)"
+                )
+            }
+        }
+        finally {
+            if ($null -eq $oldConfig) {
+                Remove-Item -Path Env:\MISE_CONFIG_FILE -ErrorAction SilentlyContinue
+            } else {
+                $env:MISE_CONFIG_FILE = $oldConfig
+            }
+            Remove-Item -Path "$TestDrive\mise.task-path-env.toml" -ErrorAction SilentlyContinue
+        }
+    }
+
     # `windows_executable_extensions` is what decides whether a file with no extension and no
     # shebang is a task at all -- there is no permission bit here for `is_executable` to consult.
     # Nothing else in this suite covers that boundary, and it is the reason the extensionless

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -92,6 +92,27 @@ struct PreparedTaskContext {
     extra_vars: Option<IndexMap<String, String>>,
 }
 
+/// Format a task path for a child process without leaking the mixture of `/` and `\` that
+/// `PathBuf` preserves when a Windows root is joined to a multi-component config pattern.
+///
+/// Extended-length paths are exempt: `/` is an ordinary character after the `\\?\` prefix, so
+/// rewriting it there could change which file the value names. Unix paths are returned unchanged.
+fn task_env_path(path: &Path) -> String {
+    let path = path.display().to_string();
+    #[cfg(windows)]
+    {
+        if path.starts_with(r"\\?\") {
+            path
+        } else {
+            path.replace('/', "\\")
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        path
+    }
+}
+
 #[derive(Clone, Copy)]
 struct TaskInjectionContext<'a> {
     config: &'a Arc<Config>,
@@ -2046,7 +2067,7 @@ impl TaskExecutor {
                 &mut env,
                 &mut nested_mise_diff_exclude_keys,
                 "MISE_ORIGINAL_CWD",
-                cwd.display().to_string(),
+                task_env_path(cwd),
             );
         }
 
@@ -2062,7 +2083,7 @@ impl TaskExecutor {
                 &mut env,
                 &mut nested_mise_diff_exclude_keys,
                 "MISE_PROJECT_ROOT",
-                root.display().to_string(),
+                task_env_path(&root),
             );
         }
         if let Some(monorepo_root) = config.monorepo_root() {
@@ -2070,7 +2091,7 @@ impl TaskExecutor {
                 &mut env,
                 &mut nested_mise_diff_exclude_keys,
                 "MISE_MONOREPO_ROOT",
-                monorepo_root.display().to_string(),
+                task_env_path(&monorepo_root),
             );
         }
         Self::insert_env_excluded_from_nested_mise_diff(
@@ -2094,14 +2115,14 @@ impl TaskExecutor {
             &mut env,
             &mut nested_mise_diff_exclude_keys,
             "MISE_TASK_FILE",
-            task_file.display().to_string(),
+            task_env_path(&task_file),
         );
         if let Some(dir) = task_file.parent() {
             Self::insert_env_excluded_from_nested_mise_diff(
                 &mut env,
                 &mut nested_mise_diff_exclude_keys,
                 "MISE_TASK_DIR",
-                dir.display().to_string(),
+                task_env_path(dir),
             );
         }
         if let Some(config_root) = &task.config_root {
@@ -2109,7 +2130,7 @@ impl TaskExecutor {
                 &mut env,
                 &mut nested_mise_diff_exclude_keys,
                 "MISE_CONFIG_ROOT",
-                config_root.display().to_string(),
+                task_env_path(config_root),
             );
         }
         if Settings::get().env_cache {
@@ -2382,6 +2403,31 @@ fn shell_from_shebang(path: &Path) -> Option<Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn task_env_path_preserves_host_path_spelling() {
+        #[cfg(windows)]
+        {
+            assert_eq!(
+                task_env_path(Path::new(r"C:\Users\me\.config/mise/config.toml")),
+                r"C:\Users\me\.config\mise\config.toml"
+            );
+            assert_eq!(
+                task_env_path(Path::new(r"\\server\share/tasks/build.ps1")),
+                r"\\server\share\tasks\build.ps1"
+            );
+            // Within an extended-length path `/` is data, not a separator.
+            assert_eq!(
+                task_env_path(Path::new(r"\\?\C:\tasks/a/b")),
+                r"\\?\C:\tasks/a/b"
+            );
+        }
+        #[cfg(not(windows))]
+        assert_eq!(
+            task_env_path(Path::new(r"/tmp/tasks\build")),
+            r"/tmp/tasks\build"
+        );
+    }
 
     #[test]
     fn task_cache_stats_saturate_and_accumulate() {


### PR DESCRIPTION
## Summary

- emit task path environment variables with native Windows separators
- preserve extended-length paths, where `/` can be literal filename data
- add unit coverage and a Windows Pester regression for slash-spelled config paths

## Root cause

Windows config discovery can join a native path root to a slash-containing config pattern. The resulting `PathBuf` is valid, but it preserves that mixed spelling. Task environment setup serialized the path directly, so `MISE_TASK_DIR` and `MISE_TASK_FILE` changed spelling depending on where the task was invoked.

This fixes the behavior reported in https://github.com/jdx/mise/discussions/12160 and applies the same native spelling to every path-valued task environment variable.

## Validation

- `mise run lint`
- `cargo test --locked --bin mise task::task_executor::tests::task_env_path_preserves_host_path_spelling`
- Windows Pester regression added to `e2e-win/task.Tests.ps1`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to string formatting of task env paths on Windows; Unix behavior is unchanged and extended-path handling is explicitly preserved.
> 
> **Overview**
> On **Windows**, path-valued task environment variables (`MISE_ORIGINAL_CWD`, `MISE_PROJECT_ROOT`, `MISE_TASK_FILE`, `MISE_TASK_DIR`, `MISE_CONFIG_ROOT`, `MISE_MONOREPO_ROOT`, etc.) are now emitted through **`task_env_path`**, which converts forward slashes to backslashes so children never see mixed separators when config discovery joins a native root to slash-style patterns (e.g. `.config/mise/config.toml`).
> 
> **Extended-length paths** (`\\?\...`) are left unchanged because `/` can be literal after that prefix.
> 
> Coverage adds a **unit test** for normalization edge cases and a **Windows Pester** test that runs a task with `MISE_CONFIG_FILE` spelled with `/` and asserts none of the path env vars contain `/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8582137f4b8ab29346abece1102085a0128408d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed task-related environment variables on Windows to consistently use native path separators.
  * Preserved extended-length and UNC path formats while leaving Unix paths unchanged.
  * Added coverage to verify path handling across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->