### PR TITLE
feat(vfox): pass tool options in hook contexts

### DIFF
--- a/crates/vfox/src/context.rs
+++ b/crates/vfox/src/context.rs
@@ -1,9 +1,11 @@
-use mlua::{UserData, UserDataFields};
+use indexmap::IndexMap;
+use mlua::{LuaSerdeExt, UserData, UserDataFields};
 
 #[derive(Debug)]
 pub(crate) struct Context {
     pub args: Vec<String>,
     pub(crate) version: Option<String>,
+    pub(crate) options: IndexMap<String, toml::Value>,
     // pub(crate) runtime_version: String,
 }
 
@@ -11,6 +13,49 @@ impl UserData for Context {
     fn add_fields<F: UserDataFields<Self>>(fields: &mut F) {
         fields.add_field_method_get("args", |_, t| Ok(t.args.clone()));
         fields.add_field_method_get("version", |_, t| Ok(t.version.clone()));
+        fields.add_field_method_get("options", |lua, t| lua.to_value(&t.options));
         // fields.add_field_method_get("runtimeVersion", |_, t| Ok(t.runtime_version.clone()));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serializes_options_to_lua() {
+        let lua = mlua::Lua::new();
+        let options = IndexMap::from([
+            ("enabled".to_string(), toml::Value::Boolean(true)),
+            ("retries".to_string(), toml::Value::Integer(3)),
+            (
+                "channels".to_string(),
+                toml::Value::Array(vec![
+                    toml::Value::String("stable".to_string()),
+                    toml::Value::String("beta".to_string()),
+                ]),
+            ),
+        ]);
+        lua.globals()
+            .set(
+                "ctx",
+                Context {
+                    args: vec![],
+                    version: Some("1.0.0".to_string()),
+                    options,
+                },
+            )
+            .unwrap();
+
+        lua.load(
+            r#"
+            assert(ctx.options.enabled == true)
+            assert(ctx.options.retries == 3)
+            assert(ctx.options.channels[1] == "stable")
+            assert(ctx.options.channels[2] == "beta")
+            "#,
+        )
+        .exec()
+        .unwrap();
     }
 }

--- a/crates/vfox/src/hooks/available.rs
+++ b/crates/vfox/src/hooks/available.rs
@@ -12,7 +12,7 @@ impl Plugin {
 
     pub async fn available_async(&self) -> Result<Vec<AvailableVersion>> {
         debug!("[vfox:{}] available_async", self.name);
-        let ctx = self.context(None)?;
+        let ctx = self.context(None, Default::default())?;
         let available = self
             .eval_async(chunk! {
                 require "hooks/available"

--- a/crates/vfox/src/hooks/post_install.rs
+++ b/crates/vfox/src/hooks/post_install.rs
@@ -1,7 +1,8 @@
 use crate::Plugin;
 use crate::error::Result;
 use crate::sdk_info::SdkInfo;
-use mlua::{IntoLua, Lua, Value};
+use indexmap::IndexMap;
+use mlua::{IntoLua, Lua, LuaSerdeExt, Value};
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
@@ -20,6 +21,7 @@ pub struct PostInstallContext {
     pub root_path: PathBuf,
     pub runtime_version: String,
     pub sdk_info: BTreeMap<String, SdkInfo>,
+    pub options: IndexMap<String, toml::Value>,
 }
 
 impl IntoLua for PostInstallContext {
@@ -28,6 +30,7 @@ impl IntoLua for PostInstallContext {
         table.set("rootPath", self.root_path.to_string_lossy().to_string())?;
         table.set("runtimeVersion", self.runtime_version)?;
         table.set("sdkInfo", self.sdk_info)?;
+        table.set("options", lua.to_value(&self.options)?)?;
         Ok(Value::Table(table))
     }
 }
@@ -53,6 +56,7 @@ mod tests {
             root_path: root.clone(),
             runtime_version: "runtime_version".to_string(),
             sdk_info: BTreeMap::new(),
+            options: Default::default(),
         };
         p.post_install(ctx).await.unwrap();
         assert_eq!(
@@ -85,6 +89,7 @@ mod tests {
             root_path: root.clone(),
             runtime_version: "153.0.8009.0".to_string(),
             sdk_info: BTreeMap::from([("chromedriver".to_string(), sdk_info)]),
+            options: Default::default(),
         };
 
         plugin.post_install(ctx).await.unwrap();

--- a/crates/vfox/src/hooks/pre_install.rs
+++ b/crates/vfox/src/hooks/pre_install.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use indexmap::IndexMap;
 use mlua::prelude::LuaError;
 use mlua::{FromLua, Lua, Table, Value};
 
@@ -9,8 +10,17 @@ use crate::runtime::Runtime;
 
 impl Plugin {
     pub async fn pre_install(&self, version: &str) -> Result<PreInstall> {
+        self.pre_install_with_options(version, Default::default())
+            .await
+    }
+
+    pub async fn pre_install_with_options(
+        &self,
+        version: &str,
+        options: IndexMap<String, toml::Value>,
+    ) -> Result<PreInstall> {
         debug!("[vfox:{}] pre_install", self.name);
-        let ctx = self.context(Some(version.to_string()))?;
+        let ctx = self.context(Some(version.to_string()), options)?;
         let pre_install = self
             .eval_async(chunk! {
                 require "hooks/pre_install"
@@ -27,11 +37,22 @@ impl Plugin {
         os: &str,
         arch: &str,
     ) -> Result<PreInstall> {
+        self.pre_install_for_platform_with_options(version, os, arch, Default::default())
+            .await
+    }
+
+    pub async fn pre_install_for_platform_with_options(
+        &self,
+        version: &str,
+        os: &str,
+        arch: &str,
+        options: IndexMap<String, toml::Value>,
+    ) -> Result<PreInstall> {
         debug!(
             "[vfox:{}] pre_install_for_platform os={} arch={}",
             self.name, os, arch
         );
-        let ctx = self.context(Some(version.to_string()))?;
+        let ctx = self.context(Some(version.to_string()), options)?;
         let target_os = os.to_string();
         let target_arch = arch.to_string();
         let target_runtime = Runtime::with_platform(self.dir.clone(), os, arch);

--- a/crates/vfox/src/plugin.rs
+++ b/crates/vfox/src/plugin.rs
@@ -207,10 +207,15 @@ impl Plugin {
         Self::from_dir(&dir).unwrap()
     }
 
-    pub(crate) fn context(&self, version: Option<String>) -> Result<Context> {
+    pub(crate) fn context(
+        &self,
+        version: Option<String>,
+        options: indexmap::IndexMap<String, toml::Value>,
+    ) -> Result<Context> {
         let ctx = Context {
             args: vec![],
             version,
+            options,
             // version: "1.0.0".to_string(),
             // runtime_version: "xxx".to_string(),
         };

--- a/crates/vfox/src/vfox.rs
+++ b/crates/vfox/src/vfox.rs
@@ -297,9 +297,29 @@ impl Vfox {
         install_dir: ID,
         download_dir: DD,
     ) -> Result<InstallResult> {
+        self.install_with_download_dir_and_options(
+            sdk,
+            version,
+            install_dir,
+            download_dir,
+            Default::default(),
+        )
+        .await
+    }
+
+    pub async fn install_with_download_dir_and_options<ID: AsRef<Path>, DD: AsRef<Path>>(
+        &self,
+        sdk: &str,
+        version: &str,
+        install_dir: ID,
+        download_dir: DD,
+        options: IndexMap<String, toml::Value>,
+    ) -> Result<InstallResult> {
         self.install_plugin(sdk)?;
         let sdk = self.get_sdk_with_env(sdk)?;
-        let pre_install = sdk.pre_install(version).await?;
+        let pre_install = sdk
+            .pre_install_with_options(version, options.clone())
+            .await?;
         let install_dir = install_dir.as_ref();
         let download_dir = download_dir.as_ref();
         trace!("{pre_install:?}");
@@ -321,6 +341,7 @@ impl Vfox {
                 root_path: install_dir.to_path_buf(),
                 runtime_version: version.to_string(),
                 sdk_info: BTreeMap::from([(sdk_info.name.clone(), sdk_info)]),
+                options,
             })
             .await?;
         }
@@ -362,8 +383,21 @@ impl Vfox {
         os: &str,
         arch: &str,
     ) -> Result<PreInstall> {
+        self.pre_install_for_platform_with_options(sdk, version, os, arch, Default::default())
+            .await
+    }
+
+    pub async fn pre_install_for_platform_with_options(
+        &self,
+        sdk: &str,
+        version: &str,
+        os: &str,
+        arch: &str,
+        options: IndexMap<String, toml::Value>,
+    ) -> Result<PreInstall> {
         let sdk = self.get_sdk_with_env(sdk)?;
-        sdk.pre_install_for_platform(version, os, arch).await
+        sdk.pre_install_for_platform_with_options(version, os, arch, options)
+            .await
     }
 
     /// Returns the download URL and the highest-priority verified attestation type
@@ -376,8 +410,26 @@ impl Vfox {
         os: &str,
         arch: &str,
     ) -> Result<(Option<String>, Option<VerifiedAttestation>)> {
+        self.pre_install_provenance_for_platform_with_options(
+            sdk,
+            version,
+            os,
+            arch,
+            Default::default(),
+        )
+        .await
+    }
+
+    pub async fn pre_install_provenance_for_platform_with_options(
+        &self,
+        sdk: &str,
+        version: &str,
+        os: &str,
+        arch: &str,
+        options: IndexMap<String, toml::Value>,
+    ) -> Result<(Option<String>, Option<VerifiedAttestation>)> {
         let pre = self
-            .pre_install_for_platform(sdk, version, os, arch)
+            .pre_install_for_platform_with_options(sdk, version, os, arch, options)
             .await?;
         let att = pre.attestation.and_then(attestation_to_verified);
         // Note: pre.sha256 / pre.sha512 are intentionally not returned here;

--- a/docs/dev-tools/backends/vfox.md
+++ b/docs/dev-tools/backends/vfox.md
@@ -117,20 +117,26 @@ header supplied by a plugin takes precedence when the request stays on the same 
 The following [tool-options](/dev-tools/#tool-options) are available for the `vfox` backend—these
 go in `[tools]` in `mise.toml`.
 
-Traditional vfox lifecycle hooks for a selected tool version can read custom options from their
-hook environment. Option names are uppercased and exposed with the `MISE_TOOL_OPTS__` prefix:
+Traditional vfox `PreInstall` and `PostInstall` hooks receive custom options in the structured
+`ctx.options` table. Scalar values use mise's existing string representation, while arrays and
+tables remain structured:
 
 ```toml
 [tools]
-"vfox:example/plugin" = { version = "1.0.0", extensions = "opentelemetry,swoole" }
+"vfox:example/plugin" = { version = "1.0.0", bundled = false, channels = ["stable", "beta"] }
 ```
 
 ```lua
-local extensions = os.getenv("MISE_TOOL_OPTS__EXTENSIONS")
+function PLUGIN:PreInstall(ctx)
+    local bundled = ctx.options.bundled == "false"
+    local channels = ctx.options.channels
+    -- ...
+end
 ```
 
-These variables are available only while mise runs the plugin hook and are not exported to the
-user's shell. Backend plugins should use the structured `ctx.options` value instead.
+Existing plugins can continue reading custom options from their hook environment with the
+`MISE_TOOL_OPTS__` prefix. Those variables are available only while mise runs the plugin hook and
+are not exported to the user's shell. New plugins should use `ctx.options`.
 
 ### `install_env`
 

--- a/e2e/backend/test_vfox_install_structured_options
+++ b/e2e/backend/test_vfox_install_structured_options
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# Traditional vfox PreInstall and PostInstall hooks receive custom tool options
+# in ctx.options.
+
+PLUGIN_DIR="$PWD/vfox-structured-options"
+MARKER="$PWD/structured-options-marker"
+
+mkdir -p "$PLUGIN_DIR/hooks"
+
+cat >"$PLUGIN_DIR/metadata.lua" <<'LUA'
+PLUGIN = {}
+PLUGIN.name = "structured-options"
+PLUGIN.version = "0.1.0"
+PLUGIN.homepage = "https://example.com/structured-options"
+PLUGIN.license = "MIT"
+PLUGIN.description = "Structured tool options test plugin"
+LUA
+
+cat >"$PLUGIN_DIR/hooks/available.lua" <<'LUA'
+function PLUGIN:Available(ctx)
+	return {
+		{ version = "1.0.0" },
+	}
+end
+LUA
+
+cat >"$PLUGIN_DIR/hooks/pre_install.lua" <<'LUA'
+local function assert_options(options)
+	assert(options.enabled == "true", "expected normalized boolean option")
+	assert(options.retries == "3", "expected normalized integer option")
+	assert(options.label == "structured", "expected string option")
+	assert(options.channels[1] == "stable", "expected first array option")
+	assert(options.channels[2] == "beta", "expected second array option")
+	assert(options.settings.mode == "strict", "expected nested table option")
+end
+
+function PLUGIN:PreInstall(ctx)
+	assert_options(ctx.options)
+	return {
+		version = ctx.version,
+	}
+end
+LUA
+
+cat >"$PLUGIN_DIR/hooks/post_install.lua" <<'LUA'
+function PLUGIN:PostInstall(ctx)
+	local options = ctx.options
+	assert(options.enabled == "true", "expected normalized boolean option")
+	assert(options.retries == "3", "expected normalized integer option")
+	assert(options.label == "structured", "expected string option")
+	assert(options.channels[1] == "stable", "expected first array option")
+	assert(options.channels[2] == "beta", "expected second array option")
+	assert(options.settings.mode == "strict", "expected nested table option")
+
+	local marker = assert(io.open(options.marker, "w"))
+	assert(marker:write("structured"))
+	assert(marker:close())
+end
+LUA
+
+cat >"$PLUGIN_DIR/hooks/env_keys.lua" <<'LUA'
+function PLUGIN:EnvKeys(ctx)
+	return {}
+end
+LUA
+
+git -C "$PLUGIN_DIR" init
+git -C "$PLUGIN_DIR" add .
+git -C "$PLUGIN_DIR" -c user.name="mise" -c user.email="mise@example.com" commit -m "initial plugin"
+
+cat >mise.toml <<EOF
+[tools]
+"vfox:file://$PLUGIN_DIR" = { version = "1.0.0", enabled = true, retries = 3, label = "structured", channels = ["stable", "beta"], settings = { mode = "strict" }, marker = "$MARKER" }
+EOF
+
+mise install
+assert "cat '$MARKER'" "structured"

--- a/e2e/backend/test_vfox_install_structured_options
+++ b/e2e/backend/test_vfox_install_structured_options
@@ -67,7 +67,7 @@ LUA
 
 git -C "$PLUGIN_DIR" init
 git -C "$PLUGIN_DIR" add .
-git -C "$PLUGIN_DIR" -c user.name="mise" -c user.email="mise@example.com" commit -m "initial plugin"
+git -C "$PLUGIN_DIR" -c user.name="mise" -c user.email="mise@example.com" commit -m "test(vfox): create structured options plugin"
 
 cat >mise.toml <<EOF
 [tools]

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -364,11 +364,12 @@ impl Backend for VfoxBackend {
 
         // Use default vfox behavior for traditional plugins
         let result = vfox
-            .install_with_download_dir(
+            .install_with_download_dir_and_options(
                 &self.pathname,
                 &tv.version,
                 tv.install_path(),
                 tv.download_path(),
+                tool_options.into_backend_options().into_map(),
             )
             .await?;
 
@@ -506,8 +507,13 @@ impl Backend for VfoxBackend {
 
         let (mut vfox, _log_rx) = self.plugin.vfox()?;
         vfox.cmd_env = Some(self.cmd_env_for_tv(&config, tv).await);
+        let options = self
+            .tool_options_for_tv(&config, tv)
+            .await
+            .into_backend_options()
+            .into_map();
         let pre_install = vfox
-            .pre_install_for_platform(&self.pathname, &tv.version, os, arch)
+            .pre_install_for_platform_with_options(&self.pathname, &tv.version, os, arch, options)
             .await?;
 
         Ok(pre_install.url)
@@ -531,8 +537,19 @@ impl Backend for VfoxBackend {
 
         let (mut vfox, _log_rx) = self.plugin.vfox()?;
         vfox.cmd_env = Some(self.cmd_env_for_tv(&config, tv).await);
+        let options = self
+            .tool_options_for_tv(&config, tv)
+            .await
+            .into_backend_options()
+            .into_map();
         let (url, att) = vfox
-            .pre_install_provenance_for_platform(&self.pathname, &tv.version, os, arch)
+            .pre_install_provenance_for_platform_with_options(
+                &self.pathname,
+                &tv.version,
+                os,
+                arch,
+                options,
+            )
             .await?;
 
         let provenance = att.map(verified_attestation_to_provenance);


### PR DESCRIPTION
## Summary

- pass configured tool options to traditional vfox `PreInstall` and `PostInstall` hooks as `ctx.options`
- use the same structured options when resolving cross-platform download URLs and provenance
- preserve existing vfox crate callers with option-aware API variants
- document the hook contract and cover it with an end-to-end plugin install test

mise keeps its existing tool-option representation: scalar values are strings, while arrays and tables remain structured Lua values. Existing hook environment variables continue to work for compatibility.

Related to https://github.com/mise-plugins/vfox-gcloud/issues/6.

## Tests

- `mise run test:e2e e2e/backend/test_vfox_install_structured_options`
- `mise --cd crates/vfox run test`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the install and lock resolution path for vfox plugins, but behavior is backward compatible (empty options by default) and covered by unit and e2e tests.
> 
> **Overview**
> **Traditional vfox plugins** can read `[tools]` custom options from **`ctx.options`** in `PreInstall` and `PostInstall` instead of relying only on hook env vars. Scalars stay strings (mise’s usual normalization); arrays and nested tables stay structured in Lua.
> 
> The **mise vfox backend** passes the same option map into install, cross-platform `PreInstall` (download URLs), and lock/provenance resolution so option-driven download logic stays consistent. The **vfox crate** gains option-aware install/pre-install APIs; existing callers keep working via wrappers that default to empty options.
> 
> Docs describe the `ctx.options` contract; an **e2e install test** asserts scalars, arrays, and nested tables in both hooks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b64096f6d308723d5b00b239bed9e7da6c26a543. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - vfox installations now pass configured tool options to pre-install and post-install hooks.
  - Plugins can access structured options, including strings, booleans, numbers, arrays, and nested tables.
  - Platform-specific pre-installation and provenance lookups support the same options.
  - Added support for resolving HTTP headers during downloads, including authentication after URL rewriting.

- **Documentation**
  - Updated vfox guidance with TOML and Lua examples for structured options.
  - Clarified compatibility with environment-variable-based plugins and HTTP authentication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->