### PR TITLE
chore(ci): propagate rust-version override to release build

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -47,6 +47,9 @@ jobs:
       - run: mise run release-plz
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
+          # render tasks rebuild mise after bumping its version. Allow that nested
+          # build to use dependencies whose rust-version metadata exceeds our MSRV.
+          MISE_CARGO_BUILD_EXTRA_ARGS: --ignore-rust-version
           # The full-feature build above already covers compilation. Avoid HK's
           # redundant cargo-check, which enforces dependency rust-version metadata.
           HK_SKIP_STEPS: cargo-check

--- a/tasks.toml
+++ b/tasks.toml
@@ -14,8 +14,8 @@ depends = ['lint:*']
 
 [build]
 alias = "b"
-run = "cargo build --all-features"
-run_windows = "cargo build"
+run = "cargo build --all-features {{ get_env(name='MISE_CARGO_BUILD_EXTRA_ARGS', default='') }}"
+run_windows = "cargo build {{ get_env(name='MISE_CARGO_BUILD_EXTRA_ARGS', default='') }}"
 description = "Build the project"
 #sources = ["Cargo.*", "src/**/*.rs"]
 #outputs = ["target/debug/mise"]


### PR DESCRIPTION
## Summary
- allow the shared build task to accept CI-only Cargo arguments
- pass `--ignore-rust-version` to the nested build triggered by release rendering

## Root cause
The AWS SDK lockfile update raised dependency `rust-version` metadata to Rust 1.94.1. The release workflow's bootstrap build already ignored that metadata, but `xtasks/release-plz` later runs `mise run render`, whose dependencies invoke the shared `build` task without the flag. This caused [release-plz job 96043790137](https://github.com/jdx/mise/actions/runs/32245063044/job/96043790137) to fail on Rust 1.94.0.

## Impact
Release rendering can rebuild the version-bumped binary while preserving mise's Rust 1.93 MSRV policy. Normal local builds remain unchanged unless the explicit project-specific environment variable is set.

## Validation
- `hk run check --safe --format json .github/workflows/release-plz.yml tasks.toml`
- `actionlint .github/workflows/release-plz.yml`
- `MISE_CARGO_BUILD_EXTRA_ARGS=--ignore-rust-version mise run --dry-run render`
- `cargo +1.93 check --locked --all-features --ignore-rust-version`

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c4665fd9a950cbed3bb0742477907130ca0ace07. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->