### PR TITLE
test(e2e): make the assert helpers usable from zsh

### DIFF
--- a/e2e/assert.sh
+++ b/e2e/assert.sh
@@ -39,16 +39,16 @@ run_with_timeout() {
     elapsed=$((elapsed + 1))
   done
 
-  local status=0
+  local exit_status=0
   if ((timed_out == 1)); then
-    status=124
+    exit_status=124
   else
-    wait "$cmd_pid" || status=$?
+    wait "$cmd_pid" || exit_status=$?
   fi
 
   cat "$output_file"
   rm -f "$output_file"
-  return "$status"
+  return "$exit_status"
 }
 
 parse_timeout_seconds() {
@@ -117,18 +117,18 @@ wait_for_file() {
 [[ -n ${TEST_NAME:-} ]] || fail "tests should be called using run_test"
 
 quiet_assert_succeed() {
-  local status=0
+  local exit_status=0
   debug "$ $1"
-  bash -c "$1" || status=$?
-  if [[ $status -ne 0 ]]; then
-    fail "[$1] command failed with status $status"
+  bash -c "$1" || exit_status=$?
+  if [[ $exit_status -ne 0 ]]; then
+    fail "[$1] command failed with status $exit_status"
   fi
 }
 quiet_assert_fail() {
-  local status=0
+  local exit_status=0
   debug "$ $1"
-  MISE_FRIENDLY_ERROR=1 RUST_BACKTRACE=0 bash -c "$1 2>&1" || status=$?
-  if [[ $status -eq 0 ]]; then
+  MISE_FRIENDLY_ERROR=1 RUST_BACKTRACE=0 bash -c "$1 2>&1" || exit_status=$?
+  if [[ $exit_status -eq 0 ]]; then
     fail "[$1] command succeeded but was expected to fail"
   fi
 }

--- a/e2e/cli/test_zsh_hook_not_found_no_hook_env
+++ b/e2e/cli/test_zsh_hook_not_found_no_hook_env
@@ -10,10 +10,6 @@ set -eu
 #
 # The second half of the test is the other side of that refresh: `mise deactivate`
 # leaves this handler registered, so the refresh has to be gated on MISE_SHELL.
-#
-# Checks are written out rather than using the assert.sh helpers: those declare
-# `local status`, and `status` is read-only in zsh, so they misreport. Every other zsh
-# test in this suite checks directly for the same reason.
 
 eval "$(mise activate zsh --no-hook-env)"
 

--- a/e2e/shell/test_zsh_assert_helpers
+++ b/e2e/shell/test_zsh_assert_helpers
@@ -1,0 +1,66 @@
+#!/usr/bin/env zsh
+# shellcheck disable=SC1071
+set -eu
+
+# `run_test` sources assert.sh into zsh tests as well as bash ones, so the helpers have to
+# work in both. They used to declare `local status`, and `status` is read-only in zsh: the
+# assignment failed, nothing was captured, and `assert`/`assert_contains` reported the
+# output as empty — failing tests whose subject had actually passed.
+#
+# This test is the harness checking itself. It touches one call per site the fix changed,
+# and it deliberately calls no mise command, so a failure here means the helpers and
+# nothing else.
+
+# quiet_assert_succeed — reached through assert, assert_contains and assert_succeed
+assert "echo hi" "hi"
+assert_contains "echo hello" "ell"
+assert_succeed "true"
+
+# quiet_assert_fail — reached through assert_fail
+assert_fail "false"
+
+# The other direction, and the one that produced false greens rather than false reds: a
+# command that *succeeded* has to be rejected. Rejection happens by calling `fail`, which
+# exits, so this cannot be written as `if assert_fail ...` or `assert_fail ... || ...` —
+# `set -e` is suspended in those positions, the exit is swallowed, and the check would pass
+# against a broken helper. bash behaves the same way, so the child shell is not a zsh
+# workaround: it is the only place the call is a plain top-level statement.
+#
+# The markers keep this from passing for the wrong reason. A non-zero child exit on its own
+# proves nothing — an unset TEST_ROOT or a failed `source` produces one too — so READY has
+# to be there and RETURNED must not be.
+child_out=$(zsh -f -euo pipefail -c '
+  source "$TEST_ROOT/assert.sh"
+  echo READY
+  assert_fail "true"
+  echo RETURNED
+' 2>/dev/null) || true
+
+if [[ $child_out != *READY* ]]; then
+  echo "the child shell never got as far as assert_fail (setup failed): '$child_out'"
+  exit 1
+fi
+if [[ $child_out == *RETURNED* ]]; then
+  echo "assert_fail accepted a command that succeeded"
+  exit 1
+fi
+
+# run_with_timeout, in assert.sh. Both paths, because the rename touched the status it
+# returns and only the timeout path produces a value that is not 0.
+run_with_timeout 2 true
+timed_out=0
+run_with_timeout 1 sleep 5 || timed_out=$?
+if [ "$timed_out" -ne 124 ]; then
+  echo "run_with_timeout returned $timed_out on a timeout, expected 124"
+  exit 1
+fi
+
+# as_group, in style.sh, which assert.sh sources. Same reason: it has to hand a failing
+# child's status back out, and only the failing case shows that.
+as_group "assert helpers" true
+group_status=0
+as_group "deliberately failing" false || group_status=$?
+if [ "$group_status" -eq 0 ]; then
+  echo "as_group reported success for a command that failed"
+  exit 1
+fi

--- a/e2e/style.sh
+++ b/e2e/style.sh
@@ -47,10 +47,10 @@ else
 fi
 
 as_group() {
-  local status=0
+  local exit_status=0
   start_group "$1"
   shift
-  "$*" || status=$?
+  "$*" || exit_status=$?
   end_group
-  return "$status"
+  return "$exit_status"
 }


### PR DESCRIPTION
`run_test` sources `assert.sh` into zsh tests as well as bash ones:

```bash
# e2e/run_test:147
within_isolated_env zsh -f -euo pipefail -c "source \"$SCRIPT_DIR/assert.sh\" && source \"$TEST_SCRIPT\""
```

But the helpers declare `local status`, and **`status` is read-only in zsh** — it is the named form of `$?`. The assignment fails, nothing is captured, and the assertion reports on an empty string.

## What it actually does

Measured under zsh 5.9, sourcing `assert.sh` unchanged from `main`:

| call | subject | verdict on `main` |
| --- | --- | --- |
| `assert "echo hi" "hi"` | passes | **fails** — `expected 'hi' but got ''` |
| `assert_contains "echo hello" "ell"` | passes | **fails** |
| `assert_fail "true"` | should fail the test | **passes silently** |
| `assert_succeed`, `run_with_timeout`, `as_group` | — | verdict right, but each prints `read-only variable: status` |

The third row is the one worth stopping on. A false red gets investigated; **a false green does not.** Under zsh, an `assert_fail` whose command succeeded let the test through:

| shell | version | `assert_fail "true"` |
| --- | --- | --- |
| bash | main | stopped the test ✅ |
| bash | this PR | stopped the test ✅ |
| zsh | main | **continued** ❌ |
| zsh | this PR | stopped the test ✅ |

This is not theoretical. It cost #12117 a CI round, where the log read:

```
quiet_assert_fail:1: read-only variable: status
quiet_assert_succeed:1: read-only variable: status
##[error][mise ls tiny --installed] expected '3.0.0' to be in ''
```

The tool *was* installed. The assertion was reporting the helper's own breakage.

Corroborating: all four zsh tests already in the suite use **zero** assert helpers and hand-roll their checks instead — which reads like the same discovery, made quietly, more than once.

## The change

`status` → `exit_status` at the four sites that reach zsh:

| file | function |
| --- | --- |
| `e2e/assert.sh` | `run_with_timeout` |
| `e2e/assert.sh` | `quiet_assert_succeed` — behind `assert`, `assert_contains`, `assert_succeed` |
| `e2e/assert.sh` | `quiet_assert_fail` — behind `assert_fail` |
| `e2e/style.sh` | `as_group` — `assert.sh` sources `style.sh`, so it comes along |

The name is deliberately not `st` or `rc`: this bug came from a variable that reads like a shell special, so the replacement is one that cannot.

**Left alone on purpose**, so it does not look like an oversight: `e2e/run_test:140`, `e2e/cli/test_error_display:15` and `e2e/cli/test_nonexistent_cwd:25` also say `local status`, but all three are `#!/usr/bin/env bash` and are never sourced into zsh.

Nothing else in `assert.sh` or `style.sh` is zsh-hostile — the other locals (`actual`, `file`, `command`, `filter`, `os`, `arch`, …) are not zsh specials, and there is no `${var,,}`, `mapfile` or `declare -A`.

## Tests

`e2e/shell/test_zsh_assert_helpers` — the harness checking itself, one call per site the fix touches. It runs no mise command, so a failure there means the helpers and nothing else. The zsh shebang is what matters: `e2e/shell/test_zsh` drives zsh through `exec zsh "$TEST_DIR/zsh_script"`, which never sources `assert.sh`, so only a `#!/usr/bin/env zsh` test exercises this path.

`e2e/cli/test_zsh_hook_not_found_no_hook_env` loses three comment lines that explained the workaround; its checks are untouched.

## Verification

zsh 5.9 in WSL, with the control in both directions (the tables above), plus `shfmt -d` and `shellcheck -x` clean on the changed files. The bash suite is the other control: `assert.sh` is sourced for bash tests too, so a rename that broke anything would take it down.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added zsh coverage for shell assertion helpers, including successful, failed, timed-out, grouped, and invalid command scenarios.
  * Expanded validation without invoking application commands, improving confidence in shell-level behavior.

* **Refactor**
  * Improved exit-status handling for better shell compatibility and clarity.
  * Preserved existing command execution, grouping, cleanup, and result behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->