### PR TITLE
fix(python): resolve configured uv for automatic venv

### DIFF
--- a/e2e/core/test_python_uv_venv_x_tiny
+++ b/e2e/core/test_python_uv_venv_x_tiny
@@ -24,5 +24,11 @@ touch uv.lock
 
 mise i
 
-# Validate that uv venv takes precedence when executing via another tool
-assert "mise x tiny@3 -- which python" "$PWD/.venv/bin/python"
+# Installation evaluates the environment before uv is available, so it must
+# leave venv creation for the subsequent exec.
+assert_directory_not_exists "$PWD/.venv"
+
+# Validate that a fresh environment computation creates and selects the uv
+# venv while executing through another tool override.
+assert "mise x --fresh-env tiny@3 -- which python" "$PWD/.venv/bin/python"
+assert_directory_exists "$PWD/.venv"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -746,6 +746,14 @@ fn which_non_pristine_spawnable(bin: &str) -> Option<PathBuf> {
     which_in_dirs(dirs, bin, true)
 }
 
+pub(crate) fn which_no_shims_spawnable(bin: &str) -> Option<PathBuf> {
+    let dirs = env::PATH_NON_PRISTINE
+        .iter()
+        .filter(|p| !file::is_mise_shims_dir(p))
+        .cloned();
+    which_in_dirs(dirs, bin, true)
+}
+
 pub(crate) async fn configured_toolset_or_path_which(
     config: &Arc<Config>,
     tools: impl IntoIterator<Item = String>,

--- a/src/config/env_directive/venv.rs
+++ b/src/config/env_directive/venv.rs
@@ -5,7 +5,7 @@ use crate::config::config_file::trust_check;
 use crate::config::env_directive::{EnvDirectiveContext, EnvResults};
 use crate::config::{Config, Settings};
 use crate::env_diff::EnvMap;
-use crate::file::{display_path, which_no_shims};
+use crate::file::display_path;
 use crate::lock_file::LockFile;
 use crate::registry::tool_enabled;
 use crate::toolset::Toolset;
@@ -183,7 +183,9 @@ pub(crate) async fn create_python_venv(
         return Ok(false);
     }
 
-    let uv_bin = if let Some(uv_bin) = ts.which_bin(config, "uv").await {
+    let uv_bin = if !require_uv && Settings::get().python.venv_stdlib {
+        None
+    } else if let Some(uv_bin) = ts.which_bin_spawnable(config, "uv").await {
         Some(uv_bin)
     } else {
         // Commands such as `mise x tiny@3` can provide a caller toolset that does not
@@ -194,9 +196,9 @@ pub(crate) async fn create_python_venv(
         let mut uv_ts: Toolset = filtered_trs.into();
         let _ = uv_ts.resolve(config).await;
         uv_ts
-            .which_bin(config, "uv")
+            .which_bin_spawnable(config, "uv")
             .await
-            .or_else(|| which_no_shims("uv"))
+            .or_else(|| backend::which_no_shims_spawnable("uv"))
     };
 
     if require_uv && uv_bin.is_none() {

--- a/src/config/env_directive/venv.rs
+++ b/src/config/env_directive/venv.rs
@@ -183,10 +183,21 @@ pub(crate) async fn create_python_venv(
         return Ok(false);
     }
 
-    let uv_bin = ts
-        .which_bin(config, "uv")
-        .await
-        .or_else(|| which_no_shims("uv"));
+    let uv_bin = if let Some(uv_bin) = ts.which_bin(config, "uv").await {
+        Some(uv_bin)
+    } else {
+        // Commands such as `mise x tiny@3` can provide a caller toolset that does not
+        // include the configured uv version. Resolve a uv-only toolset as a fallback so
+        // an installed configured uv remains available for automatic venv creation.
+        let trs = config.get_tool_request_set().await?;
+        let filtered_trs = trs.filter_by_tool(HashSet::from(["uv".to_string()]));
+        let mut uv_ts: Toolset = filtered_trs.into();
+        let _ = uv_ts.resolve(config).await;
+        uv_ts
+            .which_bin(config, "uv")
+            .await
+            .or_else(|| which_no_shims("uv"))
+    };
 
     if require_uv && uv_bin.is_none() {
         warn_once!(


### PR DESCRIPTION
## Summary

- fall back to the configured `uv` tool when automatic Python venv creation cannot find `uv` in the caller's toolset
- keep fallback resolution limited to `uv` to avoid re-entering unrelated tool dependency resolution
- skip `uv` resolution in stdlib venv mode and require every selected `uv` path to be directly spawnable

## Root cause

Commands such as `mise x tiny@3` can construct a caller toolset that omits the configured `uv` version. Automatic venv creation only searched that caller toolset and the system PATH, so it could report that `uv` was unavailable immediately after mise installed it.

## Impact

`python.uv_venv_auto = "create|source"` can now create and activate the project venv when invoked through another tool override, even if the caller's toolset does not expose the configured `uv` binary.

The fallback also avoids mise shims and selects a directly launchable executable on Windows.

## Validation

- `mise run test:e2e e2e/core/test_python_uv_venv_x_tiny`
- focused E2E test passed five additional times from fresh isolated homes on the parent branch
- `mise run lint-fix`
- `cargo test --bin mise spawnable`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UV discovery when it isn’t available in the caller’s configured toolset.
  * Added reliable fallback resolution through configured tools and executable PATH entries.
  * Avoided unnecessary UV lookup when standard-library virtual environment creation is configured and UV isn’t required.
  * Improved fresh-environment handling for UV virtual environments, including scenarios using tool overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core env/venv and binary resolution paths used on every `mise x`/`exec`; fallback is scoped to `uv` only but still changes when auto-venv runs and which executable is chosen.
> 
> **Overview**
> Fixes automatic Python venv creation when **`mise x` runs with a narrow tool override** (e.g. `tiny@3`) so the env step can still find the **configured `uv`** even though that binary is not on the caller’s toolset.
> 
> **`venv` env directive:** `uv` lookup now uses **spawnable** paths (`which_bin_spawnable`), then falls back to a **uv-only** resolved toolset from the global config, then **`which_no_shims_spawnable`** on PATH—avoiding shims and matching Windows launch requirements. **`uv` is not resolved at all** when stdlib venv mode applies and `uv` is not required.
> 
> **Backend:** adds **`which_no_shims_spawnable`** for PATH search without mise shims.
> 
> **E2E:** documents that **`mise i` does not create `.venv`** before `uv` is usable; **`mise x --fresh-env tiny@3`** must create it and select `.venv/bin/python`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c9af4c840a8db31ecf351460a0360a450794475. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->