### PR TITLE
fix(system): resolve dependency executables on Windows

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -635,25 +635,8 @@ fn parse_matching_registry_idiomatic_file(
     }
 }
 
-fn executable_names(bin: &str) -> Vec<String> {
-    let mut names = vec![bin.to_string()];
-    if cfg!(target_os = "windows") && Path::new(bin).extension().is_none() {
-        for ext in &Settings::get().windows_executable_extensions {
-            let name = if ext.is_empty() {
-                bin.to_string()
-            } else {
-                format!("{bin}.{ext}")
-            };
-            if !names.contains(&name) {
-                names.push(name);
-            }
-        }
-    }
-    names
-}
-
 fn which_non_pristine_executable(bin: &str) -> Option<PathBuf> {
-    executable_names(bin)
+    file::executable_names(bin)
         .into_iter()
         .find_map(file::which_non_pristine)
 }
@@ -689,7 +672,7 @@ fn is_spawnable(path: &Path) -> bool {
 ///   searching **past** a candidate it rejects, so `None` means "nothing spawnable
 ///   exists" rather than "the first thing I looked at was not spawnable".
 ///
-/// Directory-major only matters on Windows, where [`executable_names`] yields several
+/// Directory-major only matters on Windows, where [`file::executable_names`] yields several
 /// candidates per directory. It is the order `CreateProcess`+`PATHEXT`, `cmd.exe` and the
 /// `which` crate all use, and the order [`Backend::which`] has always used. It diverges
 /// from [`which_non_pristine_executable`], which is *name-major* — the bare name is tried
@@ -697,13 +680,13 @@ fn is_spawnable(path: &Path) -> bool {
 /// directory-major resolves the case this exists for: mise's own node install ships a
 /// shebang `npm` and an `npm.cmd` side by side in one directory, with no `npm.exe`.
 ///
-/// On unix `executable_names` returns exactly one name, so both orders are the same
+/// On unix `file::executable_names` returns exactly one name, so both orders are the same
 /// traversal and this degenerates to `file::_which` with a different predicate.
 fn which_in_dirs<I>(dirs: I, bin: &str, spawnable: bool) -> Option<PathBuf>
 where
     I: IntoIterator<Item = PathBuf>,
 {
-    let names = executable_names(bin);
+    let names = file::executable_names(bin);
     dirs.into_iter().find_map(|dir| {
         names.iter().map(|name| dir.join(name)).find(|candidate| {
             if spawnable {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -641,24 +641,6 @@ fn which_non_pristine_executable(bin: &str) -> Option<PathBuf> {
         .find_map(file::which_non_pristine)
 }
 
-/// True when the OS will accept `path` as the program argument of a spawn.
-///
-/// [`file::can_execute_directly`] is *pure extension inspection* on Windows — it never
-/// touches the filesystem, so it answers true for a `foo.exe` that is not there. The
-/// `is_file()` guard supplies the existence check that [`file::is_executable`] performs
-/// inline; without it a lookup built on this would hand back paths to missing files.
-///
-/// The guard is `cfg!(windows)`-gated deliberately. On unix `can_execute_directly`
-/// delegates to `is_executable`, which stats already — and which answers true for a
-/// mode-0755 *directory*. Adding `is_file()` unconditionally would silently narrow every
-/// unix lookup below it, so unix keeps today's answer exactly.
-fn is_spawnable(path: &Path) -> bool {
-    if cfg!(windows) && !path.is_file() {
-        return false;
-    }
-    file::can_execute_directly(path)
-}
-
 /// Resolve `bin` inside `dirs`, in the order the OS itself resolves: directory-major,
 /// extension-minor.
 ///
@@ -690,7 +672,7 @@ where
     dirs.into_iter().find_map(|dir| {
         names.iter().map(|name| dir.join(name)).find(|candidate| {
             if spawnable {
-                is_spawnable(candidate)
+                file::is_spawnable(candidate)
             } else {
                 candidate.exists() && file::is_executable(candidate)
             }
@@ -910,7 +892,7 @@ mod tests {
         for name in ["a.ps1", "b.PS1", "c.vbs", "d.VBS"] {
             let path = dir.path().join(name);
             fs::write(&path, "exit 0\n").unwrap();
-            assert!(!is_spawnable(&path), "{name} must not be spawnable");
+            assert!(!file::is_spawnable(&path), "{name} must not be spawnable");
             assert!(
                 file::is_executable(&path),
                 "{name} should still satisfy the permissive predicate"
@@ -956,10 +938,10 @@ mod tests {
         let subdir = dir.path().join("subdir");
         fs::create_dir(&subdir).unwrap();
 
-        assert!(is_spawnable(&tool));
-        assert!(!is_spawnable(&plain));
+        assert!(file::is_spawnable(&tool));
+        assert!(!file::is_spawnable(&plain));
         assert_eq!(
-            is_spawnable(&subdir),
+            file::is_spawnable(&subdir),
             file::is_executable(&subdir),
             "a mode-0755 directory must be answered the same either way"
         );

--- a/src/file.rs
+++ b/src/file.rs
@@ -1592,6 +1592,18 @@ pub fn which<P: AsRef<Path>>(name: P) -> Option<PathBuf> {
     path
 }
 
+/// Returns the first executable in PATH, expanding configured executable
+/// extensions on Windows when `name` has no extension.
+pub(crate) fn which_with_extensions(name: &str) -> Option<PathBuf> {
+    let names = executable_names(name);
+    env::PATH.iter().find_map(|dir| {
+        names
+            .iter()
+            .map(|name| dir.join(name))
+            .find(|candidate| is_executable(candidate))
+    })
+}
+
 /// returns the first executable in PATH
 /// will include mise bin paths or other paths added by mise
 pub fn which_non_pristine<P: AsRef<Path>>(name: P) -> Option<PathBuf> {
@@ -1708,6 +1720,29 @@ fn _which<P: AsRef<Path>>(name: P, paths: &[PathBuf]) -> Option<PathBuf> {
         let bin = path.join(name);
         if is_executable(&bin) { Some(bin) } else { None }
     })
+}
+
+#[cfg(not(windows))]
+pub(crate) fn executable_names(bin: &str) -> Vec<String> {
+    vec![bin.to_string()]
+}
+
+#[cfg(windows)]
+pub(crate) fn executable_names(bin: &str) -> Vec<String> {
+    let mut names = vec![bin.to_string()];
+    if Path::new(bin).extension().is_none() {
+        for ext in &Settings::get().windows_executable_extensions {
+            let name = if ext.is_empty() {
+                bin.to_string()
+            } else {
+                format!("{bin}.{ext}")
+            };
+            if !names.contains(&name) {
+                names.push(name);
+            }
+        }
+    }
+    names
 }
 
 pub fn un_gz(input: &Path, dest: &Path) -> Result<()> {

--- a/src/file.rs
+++ b/src/file.rs
@@ -1426,7 +1426,7 @@ pub(crate) fn os_can_launch_extension(ext: &str) -> bool {
 /// Note that on Windows this never touches the filesystem — it is pure extension
 /// inspection, so it answers true for a `foo.exe` that does not exist. `is_executable`
 /// checks `is_file()` inline; this one does not. A lookup that walks candidate paths must
-/// compose the two, which is what `backend::is_spawnable` does.
+/// compose the two, which is what [`is_spawnable`] does.
 pub fn can_execute_directly(path: &Path) -> bool {
     #[cfg(windows)]
     {
@@ -1440,6 +1440,14 @@ pub fn can_execute_directly(path: &Path) -> bool {
     {
         is_executable(path)
     }
+}
+
+/// True when the OS will accept `path` as the program argument of a spawn.
+pub(crate) fn is_spawnable(path: &Path) -> bool {
+    if cfg!(windows) && !path.is_file() {
+        return false;
+    }
+    can_execute_directly(path)
 }
 
 #[cfg(unix)]
@@ -1592,15 +1600,15 @@ pub fn which<P: AsRef<Path>>(name: P) -> Option<PathBuf> {
     path
 }
 
-/// Returns the first executable in PATH, expanding configured executable
-/// extensions on Windows when `name` has no extension.
-pub(crate) fn which_with_extensions(name: &str) -> Option<PathBuf> {
+/// Returns the first directly spawnable executable in PATH, expanding configured
+/// executable extensions on Windows when `name` has no extension.
+pub(crate) fn which_spawnable(name: &str) -> Option<PathBuf> {
     let names = executable_names(name);
     env::PATH.iter().find_map(|dir| {
         names
             .iter()
             .map(|name| dir.join(name))
-            .find(|candidate| is_executable(candidate))
+            .find(|candidate| is_spawnable(candidate))
     })
 }
 

--- a/src/system/deps.rs
+++ b/src/system/deps.rs
@@ -307,7 +307,7 @@ async fn check_bin(
     name: &str,
     constraint: Option<&VersionConstraint>,
 ) -> (bool, Option<String>, Option<String>) {
-    let Some(path) = crate::file::which(name) else {
+    let Some(path) = crate::file::which_with_extensions(name) else {
         return (false, None, Some(format!("`{name}` not found on PATH")));
     };
     let Some(constraint) = constraint else {
@@ -349,7 +349,7 @@ async fn check_pkgconfig(
     name: &str,
     constraint: Option<&VersionConstraint>,
 ) -> (bool, Option<String>, Option<String>) {
-    if crate::file::which("pkg-config").is_none() {
+    if crate::file::which_with_extensions("pkg-config").is_none() {
         return (
             false,
             None,
@@ -884,9 +884,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_check_bin_present_and_missing() {
-        // `file::which` does no PATHEXT resolution, so on Windows the name must
-        // carry the `.exe` extension (cmd.exe lives in System32, on PATH on CI).
-        let present = if cfg!(windows) { "cmd.exe" } else { "sh" };
+        // The bare name resolves through configured executable extensions on Windows.
+        let present = if cfg!(windows) { "cmd" } else { "sh" };
         let (ok, _, _) = check_bin(present, None).await;
         assert!(ok);
 

--- a/src/system/deps.rs
+++ b/src/system/deps.rs
@@ -307,13 +307,13 @@ async fn check_bin(
     name: &str,
     constraint: Option<&VersionConstraint>,
 ) -> (bool, Option<String>, Option<String>) {
-    let Some(path) = crate::file::which_with_extensions(name) else {
+    let Some(path) = crate::file::which_spawnable(name) else {
         return (false, None, Some(format!("`{name}` not found on PATH")));
     };
     let Some(constraint) = constraint else {
         return (true, None, None);
     };
-    match run_capture(&path.to_string_lossy(), &["--version"]).await {
+    match run_capture(&path, &["--version"]).await {
         Some((_, output)) => match extract_version(&output) {
             Some(v) => {
                 let versioning = Versioning::new(&v);
@@ -349,14 +349,14 @@ async fn check_pkgconfig(
     name: &str,
     constraint: Option<&VersionConstraint>,
 ) -> (bool, Option<String>, Option<String>) {
-    if crate::file::which_with_extensions("pkg-config").is_none() {
+    let Some(path) = crate::file::which_spawnable("pkg-config") else {
         return (
             false,
             None,
             Some("pkg-config is not installed (needed to detect this library)".to_string()),
         );
-    }
-    match run_capture("pkg-config", &["--exists", name]).await {
+    };
+    match run_capture(&path, &["--exists", name]).await {
         Some((true, _)) => {}
         Some((false, _)) => {
             return (
@@ -377,7 +377,7 @@ async fn check_pkgconfig(
     let Some(constraint) = constraint else {
         return (true, None, None);
     };
-    match run_capture("pkg-config", &["--modversion", name]).await {
+    match run_capture(&path, &["--modversion", name]).await {
         Some((true, output)) => {
             let v = output.trim().to_string();
             match Versioning::new(&v) {
@@ -456,7 +456,11 @@ async fn check_command(cmd: &str) -> (bool, Option<String>, Option<String>) {
 /// Silent and side-effect free — never elevates. A 5s wall-clock timeout keeps
 /// a hanging binary (e.g. one that blocks on `--version`) from stalling the
 /// whole install.
-async fn run_capture(program: &str, args: &[&str]) -> Option<(bool, String)> {
+async fn run_capture(
+    program: impl AsRef<std::ffi::OsStr>,
+    args: &[&str],
+) -> Option<(bool, String)> {
+    let program = program.as_ref();
     let fut = tokio::process::Command::new(program)
         .args(args)
         .stdin(std::process::Stdio::null())
@@ -465,7 +469,10 @@ async fn run_capture(program: &str, args: &[&str]) -> Option<(bool, String)> {
         Ok(Ok(output)) => output,
         Ok(Err(_)) => return None,
         Err(_) => {
-            debug!("system dep: `{program}` timed out, treating check as inconclusive");
+            debug!(
+                "system dep: `{}` timed out, treating check as inconclusive",
+                program.to_string_lossy()
+            );
             return None;
         }
     };


### PR DESCRIPTION
## Summary
- expand `windows_executable_extensions` when system dependency checks resolve bare binary names
- share executable-name expansion between system dependency and backend lookups
- cover bare `cmd` resolution in the Windows system dependency test

## Root cause

System dependency checks used the literal-only `file::which`, so declarations such as `{ bin = "curl" }` did not find `curl.exe` on Windows. The same issue affected the `pkg-config` availability check.

## Impact

Plugin authors can use one extensionless dependency declaration across platforms without false missing-dependency warnings on Windows.

Closes https://github.com/jdx/mise/discussions/12171

## Validation
- `mise run lint-fix`
- `cargo test --locked --bin mise system::deps::tests` (12 passed)
- Windows-target cross-check attempted; native dependency build scripts require unavailable MSVC/Visual Studio tools on this Linux host

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to system dependency PATH lookup and shared file helpers; backend which/spawn semantics are refactored to call the same expansion logic without altering the documented name-major vs directory-major behavior.
> 
> **Overview**
> **System dependency checks** no longer use literal-only `file::which`, which failed on Windows when plugins declare extensionless bins like `curl` or `pkg-config` while only `curl.exe` exists on PATH.
> 
> The PR **centralizes Windows executable-name expansion** in `file::executable_names` (moved out of `backend/mod.rs`) and adds **`file::which_with_extensions`**, which walks PATH in name-major order and tries configured `windows_executable_extensions`. `check_bin` and the `pkg-config` probe now call that helper instead of `which`.
> 
> **Backend PATH resolution is unchanged in intent**: `which_non_pristine_executable` and directory-major `which_in_dirs` still use the shared `executable_names` helper; the system-deps test now expects bare `cmd` to resolve on Windows without requiring `cmd.exe` in the test name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 746c5097d5b04565810a799240475ed1d25a78d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved executable detection on Windows when names are provided without file extensions.
  * Updated executable and `pkg-config` discovery to recognize configured Windows executable extensions.
  * Ensured discovered commands are directly launchable before they are used.
  * Preserved existing PATH traversal and lookup behavior across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->