### PR TITLE
registry: add workerd (github:cloudflare/workerd)

### DIFF
--- a/registry/workerd.toml
+++ b/registry/workerd.toml
@@ -1,0 +1,5 @@
+backends = ["github:cloudflare/workerd"]
+bins = ["workerd"]
+description = "The JavaScript/Wasm runtime that powers Cloudflare Workers"
+test = { cmd = "workerd --version | tr -d '-'", expected = "workerd {{ (version | split(pat='.'))[1] }}" }
+version_order = "source"


### PR DESCRIPTION
Workerd is Cloudflare JavaScript/WASM runtime and is used to serve applications outside of Cloudflare Workers environment.

== Popularity

- **GitHub:** 8,613 stars and 706 forks
- **npm:** 77,742,243 downloads of `workerd` in the last month
- **Releases:** 561 published GitHub releases; latest `v1.20260819.1` on 2026-08-19
- **Maintenance:** repository last pushed on 2026-08-19
- **Usage:** workerd is the open-source runtime that powers Cloudflare Workers

== Details

Tier-1 `github:` is used.

`cloudflare/workerd` is not available in the Aqua registry, while its GitHub releases provide prebuilt binaries for:

- Linux x64 and ARM64
- macOS x64 and ARM64
- Windows x64

The GitHub backend successfully discovers and installs these published release assets.

`version_order = "source"` is intentional because workerd uses date-based versions such as `1.20260819.1`, rather than strict `MAJOR.MINOR.PATCH` semantic versions. Source ordering also preserves upstream GitHub release order when multiple revisions are published for the same date.

== Verification

Version listing works and includes patch releases:

```console
$ mise ls-remote workerd | grep '^1\.20260807'
1.20260807.1
1.20260807.2
```

Installation and the registry test pass on Linux x64:

```console
$ target/debug/mise test-tool workerd@1.20260807.2
mise workerd@1.20260807.2 ✓ installed
mise $ workerd --version | tr -d '-'
workerd 20260807
mise workerd: OK
```

Disclaimer: I am affiliated with Cloudflare, but want this in my personal capacity: I use workerd to run webapps in my homelab. Anecdotally I also know quite a few people and companies using workerd to run applications as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metadata for the `workerd` backend, including source information, binary details, description, and version detection settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->