### PR TITLE
feat(bootstrap): forward config environments to remote hosts

### DIFF
--- a/docs/bootstrap/remote.md
+++ b/docs/bootstrap/remote.md
@@ -13,6 +13,7 @@ machine needs local `ssh` and `tar` commands.
 source = "."
 exclude = [".env.local", "artifacts"]
 copy_link = ["modules/common", "playbooks/shared"]
+mise_env = ["linux", "server"]
 
 [bootstrap.remote.hosts.cache]
 host = "cache.example.com"
@@ -21,11 +22,15 @@ port = 22
 identity_file = "~/.ssh/mise-cache"
 tags = ["cache", "production"]
 ssh_options = ["ServerAliveInterval=30"]
+mise_env = ["linux", "cache"]
 ```
 
 `source` is the local project directory sent to the host. Relative `source`,
 `identity_file`, and `mise_bin` paths are resolved from the config file that
 declares them. A host-level `source` overrides `[bootstrap.remote].source`.
+A host-level `mise_env` overrides `[bootstrap.remote].mise_env`; the ordered
+values are passed as `MISE_ENV` to the staged `mise bootstrap` process. Use
+`--remote-env <ENV>` to override the configured list for every selected host.
 Higher-precedence config files win when the same inventory name is declared in
 more than one layer. Top-level `exclude` patterns are unioned across every
 loaded config layer and applied to every host, so a nearer project can add
@@ -197,9 +202,11 @@ mise bootstrap remote cache --yes --update
 mise bootstrap remote cache --only packages,files,services,compose
 mise bootstrap remote cache --skip tools,task
 mise bootstrap remote cache --prompt-secrets
+mise bootstrap remote cache --remote-env linux,server
 ```
 
-Local environment variables are deliberately not copied to SSH hosts. Use
-`--prompt-secrets` for an attended run. Provider-backed secret environment
-transport can be layered on separately without putting values in config,
-archives, process arguments, plans, or logs.
+Local environment variables are deliberately not copied to SSH hosts. An
+explicitly configured `mise_env` is remote orchestration metadata rather than
+an inherited local environment. Use `--prompt-secrets` for an attended run.
+Provider-backed secret environment transport can be layered on separately
+without putting values in config, archives, process arguments, plans, or logs.

--- a/docs/cli/bootstrap/remote.md
+++ b/docs/cli/bootstrap/remote.md
@@ -107,7 +107,7 @@ Prompt securely for missing secret inputs on the remote host
 
 ### `--remote-env… <ENV>`
 
-Config environments to load on the remote host
+Config environments to load on the remote host; repeat or delimit with commas (for example, ci,dotfiles)
 
 ### `--remote-mise <COMMAND>`
 

--- a/docs/cli/bootstrap/remote.md
+++ b/docs/cli/bootstrap/remote.md
@@ -69,10 +69,6 @@ Keep the remote staging directory for debugging
 
 Local mise binary to upload (escape hatch for custom architectures)
 
-### `--remote-env… <ENV>`
-
-Config environments to load on the remote host
-
 ### `--only… <ONLY>`
 
 Run only one or more remote bootstrap parts
@@ -108,6 +104,10 @@ SSH port override
 ### `--prompt-secrets`
 
 Prompt securely for missing secret inputs on the remote host
+
+### `--remote-env… <ENV>`
+
+Config environments to load on the remote host
 
 ### `--remote-mise <COMMAND>`
 

--- a/docs/cli/bootstrap/remote.md
+++ b/docs/cli/bootstrap/remote.md
@@ -69,6 +69,10 @@ Keep the remote staging directory for debugging
 
 Local mise binary to upload (escape hatch for custom architectures)
 
+### `--remote-env… <ENV>`
+
+Config environments to load on the remote host
+
 ### `--only… <ONLY>`
 
 Run only one or more remote bootstrap parts

--- a/e2e/cli/test_bootstrap_remote
+++ b/e2e/cli/test_bootstrap_remote
@@ -22,6 +22,10 @@ cp bin/mise "bin with space/mise"
 
 cat >"$HOME/.local/bin/mise" <<'EOF'
 #!/bin/sh
+if test "${1:-}" = "--cd" && test "${MISE_ENV:-}" = "unexpected"; then
+  echo "inherited remote MISE_ENV was not cleared" >&2
+  exit 43
+fi
 if test "${1:-}" = "--cd" && test -e "$2/layered-secret"; then
   echo "layered remote exclude was not applied" >&2
   exit 42
@@ -173,6 +177,11 @@ assert_fail "test -d $remote_stage"
 : >"$ssh_log"
 assert_succeed "mise bootstrap remote layered --dry-run --yes"
 assert_contains "cat $ssh_log" "$HOME/.local/bin/mise version"
+
+: >"$ssh_log"
+assert_succeed "MISE_ENV=unexpected mise bootstrap remote layered --dry-run --yes"
+assert_contains "cat $ssh_log" "'MISE_ENV=' $HOME/.local/bin/mise --cd"
+assert_not_contains "cat $ssh_log" "MISE_ENV=unexpected"
 
 : >"$ssh_log"
 assert_succeed "mise bootstrap remote --host root@ad-hoc.test --source . --remote-mise $HOME/.local/bin/mise --dry-run --yes"

--- a/e2e/cli/test_bootstrap_remote
+++ b/e2e/cli/test_bootstrap_remote
@@ -98,12 +98,14 @@ cat >source/mise.toml <<EOF
 [bootstrap.remote]
 source = "."
 exclude = ["generated", "layered-secret"]
+mise_env = ["default", "linux"]
 
 [bootstrap.remote.hosts.cache]
 host = "example.test"
 user = "ubuntu"
 tags = ["cache", "production"]
 remote_mise = "mise"
+mise_env = ["server", "linux"]
 
 [bootstrap.remote.hosts.relative]
 host = "relative.test"
@@ -132,6 +134,7 @@ assert_fail "test -d '$bad_remote_stage'"
 
 assert_succeed "mise bootstrap remote cache --dry-run --yes --skip tools"
 assert_contains "cat $ssh_log" "ubuntu@example.test"
+assert_contains "cat $ssh_log" "MISE_ENV=server,linux"
 assert_contains "cat $ssh_log" "bootstrap --dry-run --yes --skip tools"
 assert_fail "test -d $remote_stage"
 
@@ -152,7 +155,13 @@ assert_fail "test -L $copy_links_stage/project/shared/nested/value-link"
 : >"$ssh_log"
 assert_succeed "mise bootstrap remote relative --dry-run --yes"
 assert_contains "cat $ssh_log" "$remote_stage/project/bin/mise version"
+assert_contains "cat $ssh_log" "MISE_ENV=default,linux"
 assert_fail "test -d $remote_stage"
+
+: >"$ssh_log"
+assert_succeed "mise bootstrap remote cache --remote-env ci,dotfiles --dry-run --yes"
+assert_contains "cat $ssh_log" "MISE_ENV=ci,dotfiles"
+assert_not_contains "cat $ssh_log" "MISE_ENV=server,linux"
 
 : >"$ssh_log"
 assert_succeed "mise bootstrap remote relative --all --dry-run --yes"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1628,7 +1628,7 @@ SSH port override
 Prompt securely for missing secret inputs on the remote host
 .TP
 \fB\-\-remote\-env\fR \fI<ENV>\fR
-Config environments to load on the remote host
+Config environments to load on the remote host; repeat or delimit with commas (for example, ci,dotfiles)
 .TP
 \fB\-\-remote\-mise\fR \fI<COMMAND>\fR
 Existing mise executable name or path; relative paths use the staged project

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1627,6 +1627,9 @@ SSH port override
 \fB\-\-prompt\-secrets\fR
 Prompt securely for missing secret inputs on the remote host
 .TP
+\fB\-\-remote\-env\fR \fI<ENV>\fR
+Config environments to load on the remote host
+.TP
 \fB\-\-remote\-mise\fR \fI<COMMAND>\fR
 Existing mise executable name or path; relative paths use the staged project
 .TP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -867,7 +867,7 @@ Examples:
             arg <PORT>
         }
         flag --prompt-secrets help="Prompt securely for missing secret inputs on the remote host"
-        flag --remote-env help="Config environments to load on the remote host" var=#true {
+        flag --remote-env help="Config environments to load on the remote host; repeat or delimit with commas (for example, ci,dotfiles)" var=#true {
             arg <ENV>
         }
         flag --remote-mise help="Existing mise executable name or path; relative paths use the staged project" {

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -858,6 +858,9 @@ Examples:
         flag --mise-bin help="Local mise binary to upload (escape hatch for custom architectures)" {
             arg <MISE_BIN>
         }
+        flag --remote-env help="Config environments to load on the remote host" var=#true {
+            arg <ENV>
+        }
         flag --only help="Run only one or more remote bootstrap parts" var=#true {
             arg <ONLY> {
                 choices plugins packages accounts files services firewall compose repos dotfiles mise-shell-activate shell macos-defaults defaults macos-launchd-agents launchd linux-systemd-units systemd user tools task final-hook

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -858,9 +858,6 @@ Examples:
         flag --mise-bin help="Local mise binary to upload (escape hatch for custom architectures)" {
             arg <MISE_BIN>
         }
-        flag --remote-env help="Config environments to load on the remote host" var=#true {
-            arg <ENV>
-        }
         flag --only help="Run only one or more remote bootstrap parts" var=#true {
             arg <ONLY> {
                 choices plugins packages accounts files services firewall compose repos dotfiles mise-shell-activate shell macos-defaults defaults macos-launchd-agents launchd linux-systemd-units systemd user tools task final-hook
@@ -870,6 +867,9 @@ Examples:
             arg <PORT>
         }
         flag --prompt-secrets help="Prompt securely for missing secret inputs on the remote host"
+        flag --remote-env help="Config environments to load on the remote host" var=#true {
+            arg <ENV>
+        }
         flag --remote-mise help="Existing mise executable name or path; relative paths use the staged project" {
             arg <COMMAND>
         }

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -3881,6 +3881,126 @@
             "type": "string"
           }
         },
+        "remote": {
+          "type": "object",
+          "description": "OpenSSH targets used by `mise bootstrap remote`",
+          "properties": {
+            "source": {
+              "type": "string",
+              "description": "local project directory sent to inventory hosts"
+            },
+            "mise_env": {
+              "type": "array",
+              "description": "default ordered config environments loaded by remote bootstrap",
+              "items": {
+                "type": "string"
+              }
+            },
+            "copy_links": {
+              "type": "boolean",
+              "description": "dereference every symbolic link in the source archive"
+            },
+            "copy_link": {
+              "type": "array",
+              "description": "source-relative symbolic links to dereference",
+              "items": {
+                "type": "string"
+              }
+            },
+            "exclude": {
+              "type": "array",
+              "description": "additional source archive exclusion patterns",
+              "items": {
+                "type": "string"
+              }
+            },
+            "hosts": {
+              "type": "object",
+              "description": "remote bootstrap inventory keyed by target name",
+              "additionalProperties": {
+                "type": "object",
+                "required": ["host"],
+                "properties": {
+                  "host": {
+                    "type": "string",
+                    "description": "SSH host name or address"
+                  },
+                  "user": {
+                    "type": "string",
+                    "description": "SSH user"
+                  },
+                  "port": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 65535,
+                    "description": "SSH port"
+                  },
+                  "identity_file": {
+                    "type": "string",
+                    "description": "SSH identity file"
+                  },
+                  "source": {
+                    "type": "string",
+                    "description": "host-specific local project directory to send"
+                  },
+                  "mise_env": {
+                    "type": "array",
+                    "description": "ordered config environments loaded by remote bootstrap",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "copy_links": {
+                    "type": "boolean",
+                    "description": "dereference every symbolic link in this host's source archive"
+                  },
+                  "copy_link": {
+                    "type": "array",
+                    "description": "source-relative symbolic links to dereference for this host",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "exclude": {
+                    "type": "array",
+                    "description": "additional source archive exclusion patterns for this host",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "ssh_options": {
+                    "type": "array",
+                    "description": "OpenSSH options passed with `-o`",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "tags": {
+                    "type": "array",
+                    "description": "inventory selection tags",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "mise_bin": {
+                    "type": "string",
+                    "description": "local mise executable to upload"
+                  },
+                  "remote_mise": {
+                    "type": "string",
+                    "description": "existing mise executable name or path on the host"
+                  },
+                  "bootstrap_command": {
+                    "type": "string",
+                    "description": "remote shell command that installs mise"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        },
         "plugins": {
           "type": "object",
           "description": "package manager plugins to install with `mise bootstrap plugins apply`, keyed by manager name",

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -667,7 +667,7 @@ struct BootstrapRemote {
     #[clap(long)]
     prompt_secrets: bool,
 
-    /// Config environments to load on the remote host
+    /// Config environments to load on the remote host; repeat or delimit with commas (for example, ci,dotfiles)
     #[clap(long, value_name = "ENV", value_delimiter = ',')]
     remote_env: Option<Vec<String>>,
 

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -655,10 +655,6 @@ struct BootstrapRemote {
     )]
     mise_bin: Option<std::path::PathBuf>,
 
-    /// Config environments to load on the remote host
-    #[clap(long, value_name = "ENV", value_delimiter = ',')]
-    remote_env: Option<Vec<String>>,
-
     /// Run only one or more remote bootstrap parts
     #[clap(long, value_enum, value_delimiter = ',', conflicts_with = "skip")]
     only: Vec<BootstrapPart>,
@@ -670,6 +666,10 @@ struct BootstrapRemote {
     /// Prompt securely for missing secret inputs on the remote host
     #[clap(long)]
     prompt_secrets: bool,
+
+    /// Config environments to load on the remote host
+    #[clap(long, value_name = "ENV", value_delimiter = ',')]
+    remote_env: Option<Vec<String>>,
 
     /// Existing mise executable name or path; relative paths use the staged project
     #[clap(

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -655,6 +655,10 @@ struct BootstrapRemote {
     )]
     mise_bin: Option<std::path::PathBuf>,
 
+    /// Config environments to load on the remote host
+    #[clap(long, value_name = "ENV", value_delimiter = ',')]
+    remote_env: Option<Vec<String>>,
+
     /// Run only one or more remote bootstrap parts
     #[clap(long, value_enum, value_delimiter = ',', conflicts_with = "skip")]
     only: Vec<BootstrapPart>,
@@ -2369,6 +2373,7 @@ impl BootstrapRemote {
 
         let overrides = system::remote::RemoteOverrides {
             source: self.source,
+            mise_env: self.remote_env,
             copy_links: self.copy_links,
             copy_link: self.copy_link,
             port: self.port,

--- a/src/system/remote.rs
+++ b/src/system/remote.rs
@@ -415,9 +415,7 @@ async fn run_staged(
         "env".to_string(),
         format!("MISE_TRUSTED_CONFIG_PATHS={project}"),
     ];
-    if !session.host.mise_env.is_empty() {
-        argv.push(format!("MISE_ENV={}", session.host.mise_env.join(",")));
-    }
+    argv.push(format!("MISE_ENV={}", session.host.mise_env.join(",")));
     argv.extend([mise, "--cd".to_string(), project, "bootstrap".to_string()]);
     if options.dry_run {
         argv.push("--dry-run".to_string());

--- a/src/system/remote.rs
+++ b/src/system/remote.rs
@@ -16,6 +16,7 @@ const RELEASE_BASE_URL: &str = "https://github.com/jdx/mise/releases/download";
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct RemoteTomlConfig {
     pub source: Option<PathBuf>,
+    pub mise_env: Option<Vec<String>>,
     #[serde(default)]
     pub copy_links: bool,
     #[serde(default)]
@@ -33,6 +34,7 @@ pub struct RemoteHostTomlConfig {
     pub port: Option<u16>,
     pub identity_file: Option<PathBuf>,
     pub source: Option<PathBuf>,
+    pub mise_env: Option<Vec<String>>,
     pub copy_links: Option<bool>,
     #[serde(default)]
     pub copy_link: Vec<PathBuf>,
@@ -55,6 +57,7 @@ pub struct RemoteHost {
     pub port: Option<u16>,
     pub identity_file: Option<PathBuf>,
     pub source: PathBuf,
+    pub mise_env: Vec<String>,
     pub copy_links: bool,
     pub copy_link: Vec<PathBuf>,
     pub exclude: Vec<String>,
@@ -68,6 +71,7 @@ pub struct RemoteHost {
 #[derive(Clone, Debug, Default)]
 pub struct RemoteOverrides {
     pub source: Option<PathBuf>,
+    pub mise_env: Option<Vec<String>>,
     pub copy_links: bool,
     pub copy_link: Vec<PathBuf>,
     pub port: Option<u16>,
@@ -124,6 +128,7 @@ pub fn hosts_from_config(
         let remote = bootstrap.remote;
         let base = cf.get_path().parent().unwrap_or_else(|| Path::new("."));
         let default_source = resolve_local_path(base, remote.source.as_deref())?;
+        let default_mise_env = remote.mise_env;
         let default_copy_links = remote.copy_links;
         let default_copy_link = remote.copy_link;
         for (name, host) in remote.hosts {
@@ -149,6 +154,9 @@ pub fn hosts_from_config(
                 port: host.port,
                 identity_file,
                 source,
+                mise_env: host
+                    .mise_env
+                    .unwrap_or_else(|| default_mise_env.clone().unwrap_or_default()),
                 copy_links: host.copy_links.unwrap_or(default_copy_links),
                 copy_link: dedupe_paths(copy_link),
                 exclude: dedupe(exclude),
@@ -189,6 +197,7 @@ pub fn ad_hoc_host(
         port: None,
         identity_file: None,
         source,
+        mise_env: vec![],
         copy_links: false,
         copy_link: vec![],
         exclude: dedupe(
@@ -211,6 +220,9 @@ impl RemoteHost {
     pub fn apply_overrides(&mut self, overrides: &RemoteOverrides) -> Result<()> {
         if let Some(source) = &overrides.source {
             self.source = absolutize(source)?;
+        }
+        if let Some(mise_env) = &overrides.mise_env {
+            self.mise_env.clone_from(mise_env);
         }
         if overrides.copy_links {
             self.copy_links = true;
@@ -310,6 +322,12 @@ impl RemoteHost {
         for exclude in &self.exclude {
             validate_value("archive exclude", exclude)?;
         }
+        for env in &self.mise_env {
+            validate_value("mise environment", env)?;
+            if env.contains(',') {
+                bail!("remote mise environment cannot contain a comma: {env}");
+            }
+        }
         if let Some(remote_mise) = &self.remote_mise {
             validate_remote_executable(remote_mise)?;
         }
@@ -396,11 +414,11 @@ async fn run_staged(
     let mut argv = vec![
         "env".to_string(),
         format!("MISE_TRUSTED_CONFIG_PATHS={project}"),
-        mise,
-        "--cd".to_string(),
-        project,
-        "bootstrap".to_string(),
     ];
+    if !session.host.mise_env.is_empty() {
+        argv.push(format!("MISE_ENV={}", session.host.mise_env.join(",")));
+    }
+    argv.extend([mise, "--cd".to_string(), project, "bootstrap".to_string()]);
     if options.dry_run {
         argv.push("--dry-run".to_string());
     }


### PR DESCRIPTION
## Summary
- add `[bootstrap.remote].mise_env` defaults and per-host `mise_env` overrides
- add `--remote-env` as a command-line override for selected hosts
- pass the resolved ordered environments to staged bootstrap processes through `MISE_ENV`
- document the behavior and regenerate CLI usage docs

## Motivation

Remote bootstrap deliberately does not inherit the orchestrator environment, but it previously had no explicit way to select `mise.<env>.toml` files on the target. This adds per-target orchestration metadata without copying arbitrary local environment variables.

Context: https://github.com/jdx/mise/discussions/12179

## Validation
- `mise run test:e2e e2e/cli/test_bootstrap_remote`
- `mise run lint-fix`
- `mise run render:usage`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote bootstrap command construction and which config layers run on targets; wrong env lists could apply unintended packages/dotfiles, but scope is limited to explicit metadata rather than full env forwarding.
> 
> **Overview**
> Remote bootstrap can now pick which `mise.<env>.toml` layers load on each SSH target without copying the orchestrator’s full environment.
> 
> **Config:** `[bootstrap.remote].mise_env` sets a default ordered list; each inventory host can override with its own `mise_env`. **CLI:** `--remote-env` (repeatable or comma-separated) overrides that list for the selected hosts. The resolved values are sent to the staged remote `mise bootstrap` as `MISE_ENV=…`; orchestrator `MISE_ENV` is not inherited (empty when nothing is configured). Values are validated (no commas).
> 
> Docs, JSON schema for `[bootstrap.remote]`, usage/man output, and e2e coverage for config, CLI override, and env isolation are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1123a61c5f277e8aed0a020359d19330b41bd4dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting configuration environments during remote bootstrapping with repeatable `--remote-env` options.
  * Remote hosts can use globally configured or host-specific environments, with host settings taking precedence.
  * Command-line options can override configured environments for selected hosts.
  * Added configuration schema support for remote bootstrap settings and host inventories.
* **Bug Fixes**
  * Ensured remote bootstrap consistently clears inherited environments when none are configured.
* **Documentation**
  * Clarified environment configuration, precedence, and separation from local variables and provider-backed secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->