### PR TITLE
docs: fix mobile tables and banner overlays

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -193,24 +193,26 @@ export default withMermaid(
     var c = JSON.parse(localStorage.getItem("jdx-banner-cache") || "null");
     var expires = c && c.expires ? Date.parse(c.expires) : NaN;
     var now = Date.now();
-    var valid =
+    var metadataValid =
       c &&
       typeof c.id === "string" &&
       typeof c.height === "string" &&
-      /^[1-9]\d*(?:\.\d+)?px$/.test(c.height) &&
+      /^[1-9]\\d*(?:\\.\\d+)?px$/.test(c.height) &&
       Number.isFinite(c.width) &&
-      c.width === innerWidth &&
       typeof c.fontSize === "string" &&
-      c.fontSize === getComputedStyle(d).fontSize &&
       Number.isFinite(c.pixelRatio) &&
-      c.pixelRatio === devicePixelRatio &&
       Number.isFinite(c.cachedAt) &&
       c.cachedAt <= now &&
       now - c.cachedAt < 300000 &&
       (!c.expires || (typeof c.expires === "string" && Number.isFinite(expires) && now < expires));
-    if (valid && localStorage.getItem("jdx-banner-dismissed") !== c.id)
+    var contextMatches =
+      metadataValid &&
+      c.width === innerWidth &&
+      c.fontSize === getComputedStyle(d).fontSize &&
+      c.pixelRatio === devicePixelRatio;
+    if (contextMatches && localStorage.getItem("jdx-banner-dismissed") !== c.id)
       d.style.setProperty("--vp-layout-top-height", c.height);
-    else if (c)
+    else if (c && !metadataValid)
       localStorage.removeItem("jdx-banner-cache");
   } catch (e) {}
 })();`,

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -192,12 +192,17 @@ export default withMermaid(
     }
     var c = JSON.parse(localStorage.getItem("jdx-banner-cache") || "null");
     var expires = c && c.expires ? Date.parse(c.expires) : NaN;
+    var now = Date.now();
     if (
       c &&
       c.id &&
       c.height &&
       c.width === innerWidth &&
-      (!c.expires || isNaN(expires) || Date.now() < expires) &&
+      c.fontSize === getComputedStyle(d).fontSize &&
+      c.pixelRatio === devicePixelRatio &&
+      Number.isFinite(c.cachedAt) &&
+      now - c.cachedAt < 300000 &&
+      (!c.expires || (Number.isFinite(expires) && now < expires)) &&
       localStorage.getItem("jdx-banner-dismissed") !== c.id
     )
       d.style.setProperty("--vp-layout-top-height", c.height);

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -193,19 +193,25 @@ export default withMermaid(
     var c = JSON.parse(localStorage.getItem("jdx-banner-cache") || "null");
     var expires = c && c.expires ? Date.parse(c.expires) : NaN;
     var now = Date.now();
-    if (
+    var valid =
       c &&
-      c.id &&
-      c.height &&
+      typeof c.id === "string" &&
+      typeof c.height === "string" &&
+      /^[1-9]\d*(?:\.\d+)?px$/.test(c.height) &&
+      Number.isFinite(c.width) &&
       c.width === innerWidth &&
+      typeof c.fontSize === "string" &&
       c.fontSize === getComputedStyle(d).fontSize &&
+      Number.isFinite(c.pixelRatio) &&
       c.pixelRatio === devicePixelRatio &&
       Number.isFinite(c.cachedAt) &&
+      c.cachedAt <= now &&
       now - c.cachedAt < 300000 &&
-      (!c.expires || (Number.isFinite(expires) && now < expires)) &&
-      localStorage.getItem("jdx-banner-dismissed") !== c.id
-    )
+      (!c.expires || (typeof c.expires === "string" && Number.isFinite(expires) && now < expires));
+    if (valid && localStorage.getItem("jdx-banner-dismissed") !== c.id)
       d.style.setProperty("--vp-layout-top-height", c.height);
+    else if (c)
+      localStorage.removeItem("jdx-banner-cache");
   } catch (e) {}
 })();`,
       ],

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -190,10 +190,17 @@ export default withMermaid(
     } else {
       d.classList.add("preboot-sidebar");
     }
-    var id = localStorage.getItem("jdx-banner-id");
-    var h = localStorage.getItem("jdx-banner-height");
-    if (id && h && localStorage.getItem("jdx-banner-dismissed") !== id)
-      d.style.setProperty("--vp-layout-top-height", h);
+    var c = JSON.parse(localStorage.getItem("jdx-banner-cache") || "null");
+    var expires = c && c.expires ? Date.parse(c.expires) : NaN;
+    if (
+      c &&
+      c.id &&
+      c.height &&
+      c.width === innerWidth &&
+      (!c.expires || isNaN(expires) || Date.now() < expires) &&
+      localStorage.getItem("jdx-banner-dismissed") !== c.id
+    )
+      d.style.setProperty("--vp-layout-top-height", c.height);
   } catch (e) {}
 })();`,
       ],

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -66,7 +66,7 @@
     flex-direction: column;
     gap: 0.125rem;
     font-size: 0.8rem;
-    padding: 0.5rem 2.75rem;
+    padding: 0.5rem max(2.75rem, 44px);
     line-height: 1.3;
     text-wrap: balance;
   }

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -53,6 +53,8 @@
   place-items: center;
   width: 2.75rem;
   height: 2.75rem;
+  min-width: 44px;
+  min-height: 44px;
   padding: 0;
   opacity: 0.85;
 }
@@ -64,7 +66,7 @@
     flex-direction: column;
     gap: 0.125rem;
     font-size: 0.8rem;
-    padding: 0.5rem 2.25rem;
+    padding: 0.5rem 2.75rem;
     line-height: 1.3;
     text-wrap: balance;
   }

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -8,7 +8,7 @@
   gap: 0.75rem;
   align-items: center;
   justify-content: center;
-  padding: 0.5rem 2.75rem;
+  padding: 0.5rem 3.25rem 0.5rem 2.75rem;
   background: var(--vp-c-brand-1, #3451b2);
   color: #fff;
   font-size: 0.9rem;

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -14,6 +14,7 @@
   font-size: 0.9rem;
   line-height: 1.4;
   text-align: center;
+  min-height: 2.75rem;
   /* arrives async (remote fetch) — fade in instead of popping */
   animation: jdx-banner-in 0.25s ease;
 }
@@ -48,7 +49,11 @@
   font-size: 1.25rem;
   cursor: pointer;
   line-height: 1;
-  padding: 0 0.5rem;
+  display: grid;
+  place-items: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
   opacity: 0.85;
 }
 .jdx-banner button:hover {
@@ -64,8 +69,12 @@
     text-wrap: balance;
   }
   .jdx-banner button {
-    top: 0.25rem;
-    right: 0.25rem;
-    transform: none;
+    top: 50%;
+    right: 0;
+    transform: translateY(-50%);
   }
+}
+
+body:has(.DocSearch-Container) > .jdx-banner {
+  visibility: hidden;
 }

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -13,33 +13,46 @@ const ENDPOINT = "https://jdx.dev/banner.json";
 const STORAGE_KEY = "jdx-banner-dismissed";
 // Cached by the inline head script (config.ts) to reserve the banner's
 // space before first paint so the header doesn't jump when it arrives.
-const ID_KEY = "jdx-banner-id";
-const HEIGHT_KEY = "jdx-banner-height";
+const CACHE_KEY = "jdx-banner-cache";
+
+function getDismissedId(): string | null {
+  try {
+    return localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
 
 export function initBanner(): void {
   if (typeof window === "undefined") return;
-  fetch(ENDPOINT)
+  const controller = new AbortController();
+  const timeout = window.setTimeout(() => controller.abort(), 5000);
+  fetch(ENDPOINT, { signal: controller.signal })
     .then((r) => (r.ok ? (r.json() as Promise<BannerData>) : null))
     .then((b) => {
       if (
         !b ||
         !b.enabled ||
         isExpired(b.expires) ||
-        localStorage.getItem(STORAGE_KEY) === b.id
+        getDismissedId() === b.id
       ) {
         clearReserved();
         return;
       }
       render(b);
     })
-    .catch(clearReserved);
+    .catch(clearCurrentReservation)
+    .finally(() => window.clearTimeout(timeout));
+}
+
+function clearCurrentReservation(): void {
+  document.documentElement.style.removeProperty("--vp-layout-top-height");
 }
 
 function clearReserved(): void {
-  document.documentElement.style.removeProperty("--vp-layout-top-height");
+  clearCurrentReservation();
   try {
-    localStorage.removeItem(ID_KEY);
-    localStorage.removeItem(HEIGHT_KEY);
+    localStorage.removeItem(CACHE_KEY);
   } catch {
     // localStorage unavailable — nothing cached to clear.
   }
@@ -86,8 +99,15 @@ function render(b: BannerData): void {
       `${el.offsetHeight}px`,
     );
     try {
-      localStorage.setItem(ID_KEY, b.id);
-      localStorage.setItem(HEIGHT_KEY, `${el.offsetHeight}px`);
+      localStorage.setItem(
+        CACHE_KEY,
+        JSON.stringify({
+          id: b.id,
+          height: `${el.offsetHeight}px`,
+          width: window.innerWidth,
+          expires: b.expires ?? null,
+        }),
+      );
     } catch {
       // localStorage unavailable — skip caching; next load just pops in.
     }
@@ -103,7 +123,11 @@ function render(b: BannerData): void {
   btn.setAttribute("aria-label", "Dismiss");
   btn.textContent = "\u00d7";
   btn.addEventListener("click", () => {
-    localStorage.setItem(STORAGE_KEY, b.id);
+    try {
+      localStorage.setItem(STORAGE_KEY, b.id);
+    } catch {
+      // Dismiss for this page even when localStorage is unavailable.
+    }
     observer?.disconnect();
     el.remove();
     clearReserved();

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -15,7 +15,12 @@ const STORAGE_KEY = "jdx-banner-dismissed";
 // space before first paint so the header doesn't jump when it arrives.
 const CACHE_KEY = "jdx-banner-cache";
 let activeBanner:
-  { element: HTMLElement; observer: ResizeObserver | null } | undefined;
+  | {
+      id: string;
+      element: HTMLElement;
+      observer: ResizeObserver | null;
+    }
+  | undefined;
 
 function getDismissedId(): string | null {
   try {
@@ -46,6 +51,10 @@ export function initBanner(): void {
       ) {
         removeActiveBanner();
         clearReserved();
+        return;
+      }
+      if (activeBanner?.id === b.id) {
+        cacheBanner(b, activeBanner.element.offsetHeight);
         return;
       }
       render(b);
@@ -113,6 +122,26 @@ function isHttpUrl(value: string): boolean {
   }
 }
 
+function cacheBanner(b: BannerData, height: number): void {
+  try {
+    localStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({
+        id: b.id,
+        height: `${height}px`,
+        width: window.innerWidth,
+        fontSize: getComputedStyle(document.documentElement).fontSize,
+        pixelRatio: window.devicePixelRatio,
+        cachedAt: Date.now(),
+        expires: b.expires ?? null,
+        banner: b,
+      }),
+    );
+  } catch {
+    // localStorage unavailable — skip caching; next load just pops in.
+  }
+}
+
 function removeActiveBanner(): void {
   activeBanner?.observer?.disconnect();
   activeBanner?.element.remove();
@@ -144,24 +173,7 @@ function render(b: BannerData, persist = true): void {
       "--vp-layout-top-height",
       `${el.offsetHeight}px`,
     );
-    try {
-      if (!persist) return;
-      localStorage.setItem(
-        CACHE_KEY,
-        JSON.stringify({
-          id: b.id,
-          height: `${el.offsetHeight}px`,
-          width: window.innerWidth,
-          fontSize: getComputedStyle(document.documentElement).fontSize,
-          pixelRatio: window.devicePixelRatio,
-          cachedAt: Date.now(),
-          expires: b.expires ?? null,
-          banner: b,
-        }),
-      );
-    } catch {
-      // localStorage unavailable — skip caching; next load just pops in.
-    }
+    if (persist) cacheBanner(b, el.offsetHeight);
   };
 
   const observer =
@@ -185,7 +197,7 @@ function render(b: BannerData, persist = true): void {
   el.appendChild(btn);
 
   document.body.prepend(el);
-  activeBanner = { element: el, observer };
+  activeBanner = { id: b.id, element: el, observer };
 
   requestAnimationFrame(syncHeight);
   observer?.observe(el);

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -20,6 +20,7 @@ let activeBanner:
       element: HTMLElement;
       observer: ResizeObserver | null;
       update: (banner: BannerData) => void;
+      cancelExpiration: () => void;
     }
   | undefined;
 
@@ -144,6 +145,7 @@ function cacheBanner(b: BannerData, height: number): void {
 }
 
 function removeActiveBanner(): void {
+  activeBanner?.cancelExpiration();
   activeBanner?.observer?.disconnect();
   activeBanner?.element.remove();
   activeBanner = undefined;
@@ -193,9 +195,35 @@ function render(b: BannerData, persist = true): void {
     typeof ResizeObserver !== "undefined"
       ? new ResizeObserver(syncHeight)
       : null;
+  let expirationTimer: number | undefined;
+  const cancelExpiration = () => {
+    if (expirationTimer !== undefined) window.clearTimeout(expirationTimer);
+    expirationTimer = undefined;
+  };
+  const scheduleExpiration = () => {
+    cancelExpiration();
+    if (!currentBanner.expires) return;
+    const expiresAt = Date.parse(currentBanner.expires);
+    if (Number.isNaN(expiresAt)) return;
+    const expire = () => {
+      if (activeBanner?.element !== el) return;
+      const remaining = expiresAt - Date.now();
+      if (remaining <= 0) {
+        removeActiveBanner();
+        clearReserved();
+        return;
+      }
+      expirationTimer = window.setTimeout(
+        expire,
+        Math.min(remaining, 2_147_483_647),
+      );
+    };
+    expire();
+  };
   const update = (next: BannerData) => {
     shouldPersist = true;
     updateContent(next);
+    scheduleExpiration();
     requestAnimationFrame(syncHeight);
   };
 
@@ -215,7 +243,14 @@ function render(b: BannerData, persist = true): void {
   el.appendChild(btn);
 
   document.body.prepend(el);
-  activeBanner = { id: b.id, element: el, observer, update };
+  activeBanner = {
+    id: b.id,
+    element: el,
+    observer,
+    update,
+    cancelExpiration,
+  };
+  scheduleExpiration();
 
   requestAnimationFrame(syncHeight);
   observer?.observe(el);

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -19,6 +19,7 @@ let activeBanner:
       id: string;
       element: HTMLElement;
       observer: ResizeObserver | null;
+      update: (banner: BannerData) => void;
     }
   | undefined;
 
@@ -54,7 +55,7 @@ export function initBanner(): void {
         return;
       }
       if (activeBanner?.id === b.id) {
-        cacheBanner(b, activeBanner.element.offsetHeight);
+        activeBanner.update(b);
         return;
       }
       render(b);
@@ -150,36 +151,53 @@ function removeActiveBanner(): void {
 
 function render(b: BannerData, persist = true): void {
   removeActiveBanner();
+  let currentBanner = b;
+  let shouldPersist = persist;
   const el = document.createElement("div");
   el.className = "jdx-banner";
   el.setAttribute("role", "region");
   el.setAttribute("aria-label", "Site announcement");
 
   const msg = document.createElement("span");
-  msg.textContent = b.message;
   el.appendChild(msg);
 
-  if (b.link && isHttpUrl(b.link)) {
-    const a = document.createElement("a");
-    a.href = b.link;
-    a.target = "_blank";
-    a.rel = "noopener";
-    a.textContent = b.linkText || "Learn more";
-    el.appendChild(a);
-  }
+  const link = document.createElement("a");
+  link.target = "_blank";
+  link.rel = "noopener";
+  el.appendChild(link);
+
+  const updateContent = (next: BannerData) => {
+    currentBanner = next;
+    msg.textContent = next.message;
+    if (next.link && isHttpUrl(next.link)) {
+      link.href = next.link;
+      link.textContent = next.linkText || "Learn more";
+      link.hidden = false;
+    } else {
+      link.removeAttribute("href");
+      link.textContent = "";
+      link.hidden = true;
+    }
+  };
+  updateContent(b);
 
   const syncHeight = () => {
     document.documentElement.style.setProperty(
       "--vp-layout-top-height",
       `${el.offsetHeight}px`,
     );
-    if (persist) cacheBanner(b, el.offsetHeight);
+    if (shouldPersist) cacheBanner(currentBanner, el.offsetHeight);
   };
 
   const observer =
     typeof ResizeObserver !== "undefined"
       ? new ResizeObserver(syncHeight)
       : null;
+  const update = (next: BannerData) => {
+    shouldPersist = true;
+    updateContent(next);
+    requestAnimationFrame(syncHeight);
+  };
 
   const btn = document.createElement("button");
   btn.type = "button";
@@ -187,7 +205,7 @@ function render(b: BannerData, persist = true): void {
   btn.textContent = "\u00d7";
   btn.addEventListener("click", () => {
     try {
-      localStorage.setItem(STORAGE_KEY, b.id);
+      localStorage.setItem(STORAGE_KEY, currentBanner.id);
     } catch {
       // Dismiss for this page even when localStorage is unavailable.
     }
@@ -197,7 +215,7 @@ function render(b: BannerData, persist = true): void {
   el.appendChild(btn);
 
   document.body.prepend(el);
-  activeBanner = { id: b.id, element: el, observer };
+  activeBanner = { id: b.id, element: el, observer, update };
 
   requestAnimationFrame(syncHeight);
   observer?.observe(el);

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -14,6 +14,8 @@ const STORAGE_KEY = "jdx-banner-dismissed";
 // Cached by the inline head script (config.ts) to reserve the banner's
 // space before first paint so the header doesn't jump when it arrives.
 const CACHE_KEY = "jdx-banner-cache";
+let activeBanner:
+  { element: HTMLElement; observer: ResizeObserver | null } | undefined;
 
 function getDismissedId(): string | null {
   try {
@@ -25,6 +27,9 @@ function getDismissedId(): string | null {
 
 export function initBanner(): void {
   if (typeof window === "undefined") return;
+  const cachedBanner = readCachedBanner();
+  if (cachedBanner) render(cachedBanner, false);
+
   const controller = new AbortController();
   const timeout = window.setTimeout(() => controller.abort(), 5000);
   fetch(ENDPOINT, { signal: controller.signal })
@@ -39,13 +44,40 @@ export function initBanner(): void {
         isExpired(b.expires) ||
         getDismissedId() === b.id
       ) {
+        removeActiveBanner();
         clearReserved();
         return;
       }
       render(b);
     })
-    .catch(clearCachedReservation)
+    .catch(() => {
+      clearCachedReservation();
+      if (!activeBanner) clearCurrentReservation();
+    })
     .finally(() => window.clearTimeout(timeout));
+}
+
+function readCachedBanner(): BannerData | null {
+  if (
+    !document.documentElement.style.getPropertyValue("--vp-layout-top-height")
+  ) {
+    return null;
+  }
+  try {
+    const cached = JSON.parse(localStorage.getItem(CACHE_KEY) ?? "null");
+    const b = cached?.banner;
+    return b &&
+      typeof b.id === "string" &&
+      typeof b.enabled === "boolean" &&
+      typeof b.message === "string" &&
+      (!b.link || typeof b.link === "string") &&
+      (!b.linkText || typeof b.linkText === "string") &&
+      (!b.expires || typeof b.expires === "string")
+      ? b
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 function clearCachedReservation(): void {
@@ -81,7 +113,14 @@ function isHttpUrl(value: string): boolean {
   }
 }
 
-function render(b: BannerData): void {
+function removeActiveBanner(): void {
+  activeBanner?.observer?.disconnect();
+  activeBanner?.element.remove();
+  activeBanner = undefined;
+}
+
+function render(b: BannerData, persist = true): void {
+  removeActiveBanner();
   const el = document.createElement("div");
   el.className = "jdx-banner";
   el.setAttribute("role", "region");
@@ -106,6 +145,7 @@ function render(b: BannerData): void {
       `${el.offsetHeight}px`,
     );
     try {
+      if (!persist) return;
       localStorage.setItem(
         CACHE_KEY,
         JSON.stringify({
@@ -116,6 +156,7 @@ function render(b: BannerData): void {
           pixelRatio: window.devicePixelRatio,
           cachedAt: Date.now(),
           expires: b.expires ?? null,
+          banner: b,
         }),
       );
     } catch {
@@ -138,13 +179,13 @@ function render(b: BannerData): void {
     } catch {
       // Dismiss for this page even when localStorage is unavailable.
     }
-    observer?.disconnect();
-    el.remove();
+    removeActiveBanner();
     clearReserved();
   });
   el.appendChild(btn);
 
   document.body.prepend(el);
+  activeBanner = { element: el, observer };
 
   requestAnimationFrame(syncHeight);
   observer?.observe(el);

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -28,7 +28,10 @@ export function initBanner(): void {
   const controller = new AbortController();
   const timeout = window.setTimeout(() => controller.abort(), 5000);
   fetch(ENDPOINT, { signal: controller.signal })
-    .then((r) => (r.ok ? (r.json() as Promise<BannerData>) : null))
+    .then((r) => {
+      if (!r.ok) throw new Error(`banner request failed: ${r.status}`);
+      return r.json() as Promise<BannerData>;
+    })
     .then((b) => {
       if (
         !b ||
@@ -41,8 +44,16 @@ export function initBanner(): void {
       }
       render(b);
     })
-    .catch(clearCurrentReservation)
+    .catch(clearCachedReservation)
     .finally(() => window.clearTimeout(timeout));
+}
+
+function clearCachedReservation(): void {
+  try {
+    localStorage.removeItem(CACHE_KEY);
+  } catch {
+    // localStorage unavailable — nothing cached to clear.
+  }
 }
 
 function clearCurrentReservation(): void {
@@ -51,11 +62,7 @@ function clearCurrentReservation(): void {
 
 function clearReserved(): void {
   clearCurrentReservation();
-  try {
-    localStorage.removeItem(CACHE_KEY);
-  } catch {
-    // localStorage unavailable — nothing cached to clear.
-  }
+  clearCachedReservation();
 }
 
 function isExpired(expires: string | undefined): boolean {
@@ -105,6 +112,9 @@ function render(b: BannerData): void {
           id: b.id,
           height: `${el.offsetHeight}px`,
           width: window.innerWidth,
+          fontSize: getComputedStyle(document.documentElement).fontSize,
+          pixelRatio: window.devicePixelRatio,
+          cachedAt: Date.now(),
           expires: b.expires ?? null,
         }),
       );

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -909,7 +909,8 @@ div[class*="language-"] .copy:hover {
   font-size: 0.95rem;
   width: 100%;
   margin: 0;
-  display: table;
+  display: block;
+  overflow-x: auto;
 }
 
 .vp-doc th {


### PR DESCRIPTION
## Summary

- keep the announcement dismiss control at a 44px mobile touch target
- hide the announcement while the Algolia search modal is open
- restore horizontal scrolling for wide documentation tables

## Why

The fixed announcement obscured most of the mobile search input, and wide tables expanded the layout viewport enough to push banner content and its dismiss control offscreen.

## Validation

- `mise run docs:build`
- `mise run lint-fix`
- Chromium mobile audit at 320px and 390px widths
- verified the Getting Started compatibility table stays within the 320px layout viewport

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site styling and client-side banner behavior only; no auth, data, or backend changes.
> 
> **Overview**
> Fixes mobile docs layout issues where the fixed announcement bar covered search and wide tables blew out the viewport.
> 
> **Banner layout and caching** — Replaces separate `localStorage` id/height keys with a validated **`jdx-banner-cache`** blob (height, viewport width/font size/pixel ratio, 5‑minute TTL, optional expiry, full banner payload). The inline head script only restores `--vp-layout-top-height` when cache metadata matches the current environment and the banner isn’t dismissed; stale cache is removed. Runtime logic shows a cached banner immediately, fetches with a **5s abort**, updates in place when the same `id` returns, schedules expiry removal, and on fetch failure clears reservation only if nothing is on screen.
> 
> **Banner UI** — Dismiss control gets a **44px** touch target and centered positioning on small screens; padding/`min-height` adjusted so controls stay on screen. Banner is **hidden** while Algolia **`.DocSearch-Container`** is open.
> 
> **Tables** — Doc tables use **`display: block`** and **`overflow-x: auto`** so wide content scrolls horizontally instead of expanding the layout viewport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f3f51c6a902ee61394dd27680614a208b7ddd8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved banner sizing and close-button positioning, including better behavior on mobile.
  * Enabled horizontal scrolling for wide documentation tables.
* **Bug Fixes**
  * The banner now hides while the search overlay is open.
  * Improved banner loading and recovery when content cannot be fetched.
  * Banner layout is restored more reliably across page loads and viewport sizes.
  * Improved validation of cached banner settings and expiration data.
  * Banner dismissal continues to work when browser storage is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->