### PR TITLE
chore(release): make publishing retries idempotent

### DIFF
--- a/xtasks/release-plz
+++ b/xtasks/release-plz
@@ -50,6 +50,24 @@ exists_on_crates() {
 	return 1
 }
 
+# Returns 2 when Cargo's index reports that the version already exists even
+# though the registry API checks above have not caught up yet.
+publish_crate() {
+	local crate_name="$1"
+	local publish_log
+	publish_log="$(mktemp)"
+	if cargo publish --allow-dirty --no-verify -p "$crate_name" 2>&1 | tee "$publish_log"; then
+		rm -f "$publish_log"
+		return 0
+	fi
+	if grep -Fq "already exists on crates.io index" "$publish_log"; then
+		rm -f "$publish_log"
+		return 2
+	fi
+	rm -f "$publish_log"
+	return 1
+}
+
 # Git pathspecs used to decide whether a subcrate has meaningfully changed.
 # Some crates embed vendored/generated content that the release process refreshes
 # on every run (e.g. vfox's embedded-plugins are deleted and re-cloned each
@@ -306,19 +324,30 @@ bump_and_publish_subcrate() {
 		advance_package_version "$crate_name" "$crate_dir/Cargo.toml" "$year.$month.0"
 	fi
 
-	local new_version
+	local new_version publish_result
 	new_version="$(cargo pkgid -p "$crate_name" | cut -d# -f2)"
 
-	# Keep bumping if the version already exists on crates.io
-	# This handles cases where a version was published but local code has changed since
-	while exists_on_crates "$crate_name" "$new_version"; do
-		echo "$crate_name@$new_version already on crates.io, bumping again"
+	# Keep bumping if the version already exists on crates.io. Cargo's index can
+	# observe a new version before the API used by exists_on_crates does, so also
+	# recover from an authoritative publish-time conflict instead of failing a
+	# retry after an earlier release attempt uploaded only some workspace crates.
+	while true; do
+		if exists_on_crates "$crate_name" "$new_version"; then
+			echo "$crate_name@$new_version already on crates.io, bumping again"
+		else
+			echo "Publishing $crate_name@$new_version"
+			publish_result=0
+			publish_crate "$crate_name" || publish_result=$?
+			if [[ $publish_result -eq 0 ]]; then
+				break
+			elif [[ $publish_result -ne 2 ]]; then
+				return "$publish_result"
+			fi
+			echo "$crate_name@$new_version reached the crates.io index during publication, bumping again"
+		fi
 		bump_package_version "$crate_name" "$crate_dir/Cargo.toml" patch
 		new_version="$(cargo pkgid -p "$crate_name" | cut -d# -f2)"
 	done
-
-	echo "Publishing $crate_name@$new_version"
-	cargo publish --allow-dirty -p "$crate_name"
 
 	# Create tag for this subcrate release
 	local tag_name="${crate_name}-v${new_version}"
@@ -362,7 +391,7 @@ if [[ $cur_version != "$latest_version" ]]; then
 	bump_and_publish_subcrate "aqua-registry" "crates/aqua-registry" "AQUA_REGISTRY_VERSION"
 	use_published_aqua_registry "$AQUA_REGISTRY_VERSION"
 
-	# Copy schema into crate directory so cargo publish verification can find it
+	# Copy the schema into the crate directory so the published package includes it.
 	cp schema/mise.json crates/mise-interactive-config/mise.json
 	bump_and_publish_subcrate "mise-interactive-config" "crates/mise-interactive-config" "INTERACTIVE_CONFIG_VERSION"
 	rm -f crates/mise-interactive-config/mise.json
@@ -371,7 +400,13 @@ if [[ $cur_version != "$latest_version" ]]; then
 	if exists_on_crates mise "$cur_version"; then
 		echo "mise@$cur_version already on crates.io, skipping publish"
 	else
-		cargo publish --allow-dirty -p mise
+		publish_result=0
+		publish_crate mise || publish_result=$?
+		if [[ $publish_result -eq 2 ]]; then
+			echo "mise@$cur_version reached the crates.io index during publication, continuing"
+		elif [[ $publish_result -ne 0 ]]; then
+			exit "$publish_result"
+		fi
 	fi
 
 	mise_tag="v$cur_version"


### PR DESCRIPTION
## Summary

- skip Cargo’s redundant verification build when publishing mise and its subcrates
- detect publish-time crates.io index conflicts that race the registry API
- bump conflicted subcrate versions and continue fixed-version mise publishes safely

## Why

Two consecutive `2026.8.9` publishing attempts exposed complementary retry failures:

1. `cargo publish` repeated a verification build and rejected AWS dependencies declaring Rust 1.94.1 while the release runner has 1.94.0, even though the workflow’s preceding full-feature build intentionally uses `--ignore-rust-version`.
2. The first attempt published several workspace crates before failing. On retry, crates.io’s index knew `vfox@2026.8.12` existed while the API checks had not caught up, so the script tried to publish the occupied version and stopped.

The workflow already performs the full-feature build, so `--no-verify` removes only redundant compilation. Publish output is now checked for the authoritative index conflict: subcrates advance to the next version, while mise’s fixed release version is treated as already published. Other publishing failures remain fatal.

## Validation

- `bash -n xtasks/release-plz`
- `hk run check --no-stage xtasks/release-plz`
- `git diff --check`
- confirmed both failure modes against release-plz runs 32281253308 and 32281543088

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the only path that uploads crates to crates.io; behavior changes around duplicate versions and skipped verify builds could affect release outcomes if packaging is wrong.
> 
> **Overview**
> **Release publishing** now goes through a shared `publish_crate` helper that runs `cargo publish` with **`--allow-dirty --no-verify`**, skipping Cargo’s redundant verification build after the workflow’s full-feature `--ignore-rust-version` compile (fixes releases blocked when verify re-resolves deps with stricter `rust-version` than the runner).
> 
> Subcrate and **`mise`** publish paths use this helper and treat **“already exists on crates.io index”** as a recoverable case: bump the version and retry when the index is ahead of `exists_on_crates` API checks, instead of failing mid-workspace on a partial prior attempt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a600c0c40606f1f53318588f1194a38f3737f1ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release publishing efficiency by skipping redundant verification builds.
  * Added automatic patch-version retries when a package version already exists.
  * Improved handling of publishing conflicts and failures, allowing unaffected releases to continue when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->