### PR TITLE
chore: release 2026.8.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## [2026.8.10](https://github.com/jdx/mise/compare/v2026.8.9..v2026.8.10) - 2026-08-20
+
+### 🚀 Features
+
+- **(bootstrap)** forward config environments to remote hosts by @jdx in [#12182](https://github.com/jdx/mise/pull/12182)
+- **(cache)** consume blob pack response metadata by @jdx in [#12193](https://github.com/jdx/mise/pull/12193)
+
+### 🐛 Bug Fixes
+
+- **(backend)** preserve Windows ZIP preference by @risu729 in [#12200](https://github.com/jdx/mise/pull/12200)
+- **(backend)** normalize shorthand archive stems by @risu729 in [#12199](https://github.com/jdx/mise/pull/12199)
+- **(bootstrap)** compose symlink-each targets by leaf by @jdx in [#12190](https://github.com/jdx/mise/pull/12190)
+- **(brew)** accept null cask auto_updates metadata by @jdx in [#12192](https://github.com/jdx/mise/pull/12192)
+- **(registry)** point aqua backends at renamed packages by @kkom in [#12186](https://github.com/jdx/mise/pull/12186)
+- **(self-update)** sweep stale copies before the TEMP length check by @JamBalaya56562 in [#12205](https://github.com/jdx/mise/pull/12205)
+- **(sync)** reconcile external provider links by @risu729 in [#11682](https://github.com/jdx/mise/pull/11682)
+- **(system)** recognize pacman package providers by @jdx in [#12183](https://github.com/jdx/mise/pull/12183)
+
+### 📚 Documentation
+
+- **(trust)** use neutral config file help by @risu729 in [#12210](https://github.com/jdx/mise/pull/12210)
+- fix mobile tables and banner overlays by @jdx in [#12184](https://github.com/jdx/mise/pull/12184)
+- clarify registry addition popularity bar by @jdx in [#12208](https://github.com/jdx/mise/pull/12208)
+
+### ⚡ Performance
+
+- **(cache)** batch foreground blob lookups by @jdx in [#12191](https://github.com/jdx/mise/pull/12191)
+
+### 🧪 Testing
+
+- **(aqua)** remove canonical package gate by @jdx in [#12209](https://github.com/jdx/mise/pull/12209)
+- **(e2e)** make the assert helpers usable from zsh by @JamBalaya56562 in [#12176](https://github.com/jdx/mise/pull/12176)
+
+### 📦 Registry
+
+- install azure-cli from the official Windows zip by @JamBalaya56562 in [#12161](https://github.com/jdx/mise/pull/12161)
+
+### New Contributors
+
+- @kkom made their first contribution in [#12186](https://github.com/jdx/mise/pull/12186)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (4)
+
+- [`bazel-contrib/buildtools/buildifier`](https://github.com/bazel-contrib/buildtools)
+- [`bazel-contrib/buildtools/buildozer`](https://github.com/bazel-contrib/buildtools)
+- [`gohugoio/hugo/hugo-extended-withdeploy`](https://github.com/gohugoio/hugo)
+- [`leoafarias/fvm`](https://github.com/leoafarias/fvm)
+
+#### Updated Packages (1)
+
+- [`Arata1202/ascdir`](https://github.com/Arata1202/ascdir)
+
 ## [2026.8.9](https://github.com/jdx/mise/compare/v2026.8.8..v2026.8.9) - 2026-08-19
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6356,7 +6356,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.8.9"
+version = "2026.8.10"
 dependencies = [
  "age 0.12.1",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.8.9"
+version = "2026.8.10"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.8.9 macos-arm64 (2026-08-19)
+2026.8.10 macos-arm64 (2026-08-20)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -26,7 +26,7 @@ _mise() {
 
   local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
   [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
-  local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_9.spec"
+  local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_10.spec"
   if [[ ! -f "$spec_file" ]]; then
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
     mise usage >| "$spec_file"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -11,7 +11,7 @@ _mise() {
     _comp_initialize -n : -- "$@" || return
     local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
     [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
-    local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_9.spec"
+    local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_10.spec"
     if [[ ! -f "$spec_file" ]]; then
         find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
         mise usage >| "$spec_file"

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -9,7 +9,7 @@ if ! type -P usage &> /dev/null
 end
 set -l spec_dir (if set -q XDG_CACHE_HOME; echo $XDG_CACHE_HOME; else; echo $HOME/.cache; end)/usage
 test -d "$spec_dir"; or mkdir -p -m 700 "$spec_dir"
-set -l spec_file "$spec_dir/usage__usage_spec_mise_2026_8_9.spec"
+set -l spec_file "$spec_dir/usage__usage_spec_mise_2026_8_10.spec"
 if not test -f "$spec_file"
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
     mise usage | string collect > "$spec_file"

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_8_9.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_8_10.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.8.9";
+  version = "2026.8.10";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.8.9
+Version: 2026.8.10
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.8.9"
+version: "2026.8.10"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "9b7652faaca0903a3110bfc111d8227d703f89b8"
+  "tag": "82038621bcc3fb6cd45864dc0b8bbfe0618240a0"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -429,7 +429,7 @@ packages:
   - type: github_release
     repo_owner: Arata1202
     repo_name: ascdir
-    description: Manage App Store Connect text metadata as local files
+    description: Manage App Store Connect metadata and product-page assets as reviewable files
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
@@ -19131,6 +19131,126 @@ packages:
     files:
       - name: bats
         src: bats-core-{{trimV .Version}}/bin/bats
+  - name: bazel-contrib/buildtools/buildifier
+    aliases:
+      - name: bazelbuild/buildtools/buildifier
+    type: github_release
+    repo_owner: bazel-contrib
+    repo_name: buildtools
+    description: Format BUILD, BUILD.bazel and BUCK files in a standard way
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "0.4.3"
+        asset: buildifier.{{.OS}}
+        format: raw
+        replacements:
+          darwin: OSX
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "0.25.0"
+        asset: buildifier.{{.OS}}
+        format: raw
+        replacements:
+          darwin: mac
+        supported_envs:
+          - darwin
+      - version_constraint: Version == "4.0.0"
+        asset: buildifier-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "4.0.1"
+        asset: buildifier-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+      - version_constraint: semver("<= 0.22.0")
+        asset: buildifier.{{.OS}}
+        format: raw
+        replacements:
+          darwin: osx
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= 3.5.0")
+        asset: buildifier.{{.OS}}
+        format: raw
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: windows
+            asset: buildifier
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: "true"
+        asset: buildifier-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+  - name: bazel-contrib/buildtools/buildozer
+    aliases:
+      - name: bazelbuild/buildtools/buildozer
+    type: github_release
+    repo_owner: bazel-contrib
+    repo_name: buildtools
+    description: Buildozer is a command line tool to rewrite multiple Bazel BUILD files using standard commands
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "0.4.3"
+        asset: buildozer.{{.OS}}
+        format: raw
+        replacements:
+          darwin: OSX
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "0.25.0"
+        asset: buildozer.{{.OS}}
+        format: raw
+        replacements:
+          darwin: mac
+        supported_envs:
+          - darwin
+      - version_constraint: Version == "4.0.0"
+        asset: buildozer-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "4.0.1"
+        asset: buildozer-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+      - version_constraint: semver("<= 0.22.0")
+        asset: buildozer.{{.OS}}
+        format: raw
+        replacements:
+          darwin: osx
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= 3.5.0")
+        asset: buildozer.{{.OS}}
+        format: raw
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: windows
+            asset: buildozer
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: "true"
+        asset: buildozer-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
   - type: github_release
     repo_owner: bazelbuild
     repo_name: bazel
@@ -19353,122 +19473,6 @@ packages:
           - darwin
           - linux
           - amd64
-  - name: bazelbuild/buildtools/buildifier
-    type: github_release
-    repo_owner: bazelbuild
-    repo_name: buildtools
-    description: Format BUILD, BUILD.bazel and BUCK files in a standard way
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: Version == "0.4.3"
-        asset: buildifier.{{.OS}}
-        format: raw
-        replacements:
-          darwin: OSX
-        supported_envs:
-          - linux/amd64
-          - darwin
-      - version_constraint: Version == "0.25.0"
-        asset: buildifier.{{.OS}}
-        format: raw
-        replacements:
-          darwin: mac
-        supported_envs:
-          - darwin
-      - version_constraint: Version == "4.0.0"
-        asset: buildifier-{{.OS}}-{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "4.0.1"
-        asset: buildifier-{{.OS}}-{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-      - version_constraint: semver("<= 0.22.0")
-        asset: buildifier.{{.OS}}
-        format: raw
-        replacements:
-          darwin: osx
-        supported_envs:
-          - darwin
-      - version_constraint: semver("<= 3.5.0")
-        asset: buildifier.{{.OS}}
-        format: raw
-        replacements:
-          darwin: mac
-        overrides:
-          - goos: windows
-            asset: buildifier
-        supported_envs:
-          - darwin
-          - windows/amd64
-      - version_constraint: "true"
-        asset: buildifier-{{.OS}}-{{.Arch}}
-        format: raw
-        windows_arm_emulation: true
-  - name: bazelbuild/buildtools/buildozer
-    type: github_release
-    repo_owner: bazelbuild
-    repo_name: buildtools
-    description: Buildozer is a command line tool to rewrite multiple Bazel BUILD files using standard commands
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: Version == "0.4.3"
-        asset: buildozer.{{.OS}}
-        format: raw
-        replacements:
-          darwin: OSX
-        supported_envs:
-          - linux/amd64
-          - darwin
-      - version_constraint: Version == "0.25.0"
-        asset: buildozer.{{.OS}}
-        format: raw
-        replacements:
-          darwin: mac
-        supported_envs:
-          - darwin
-      - version_constraint: Version == "4.0.0"
-        asset: buildozer-{{.OS}}-{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "4.0.1"
-        asset: buildozer-{{.OS}}-{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-      - version_constraint: semver("<= 0.22.0")
-        asset: buildozer.{{.OS}}
-        format: raw
-        replacements:
-          darwin: osx
-        supported_envs:
-          - darwin
-      - version_constraint: semver("<= 3.5.0")
-        asset: buildozer.{{.OS}}
-        format: raw
-        replacements:
-          darwin: mac
-        overrides:
-          - goos: windows
-            asset: buildozer
-        supported_envs:
-          - darwin
-          - windows/amd64
-      - version_constraint: "true"
-        asset: buildozer-{{.OS}}-{{.Arch}}
-        format: raw
-        windows_arm_emulation: true
   - type: github_release
     repo_owner: bcicen
     repo_name: ctop
@@ -28569,210 +28573,6 @@ packages:
         supported_envs:
           - linux/amd64
           - windows/amd64
-  - type: github_release
-    repo_owner: conceptadev
-    repo_name: fvm
-    aliases:
-      - name: leoafarias/fvm
-    description: "Flutter Version Management: A simple CLI to manage Flutter SDK versions"
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: semver("<= 0.1.13")
-        asset: fvm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        supported_envs:
-          - linux/amd64
-          - darwin
-      - version_constraint: semver("<= 0.2.8")
-        asset: fvm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: semver("<= 0.3.0")
-        asset: fvm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: semver("<= 0.8.3")
-        no_asset: true
-      - version_constraint: Version == "App-1.0.0-alpha"
-        asset: fvm-app-{{.OS}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        supported_envs:
-          - windows/amd64
-      - version_constraint: Version == "App-1.0.0-alpha.1"
-        asset: fvm_{{.OS}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        supported_envs:
-          - windows/amd64
-      - version_constraint: semver("<= 1.2.3")
-        no_asset: true
-      - version_constraint: semver("<= 1.3.4")
-        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        files:
-          - name: fvm
-            src: fvm/fvm
-        replacements:
-          amd64: x64
-          darwin: macos
-        overrides:
-          - goos: windows
-            format: zip
-            files:
-              - name: fvm
-                src: fvm/fvm.bat
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 1.3.8")
-        no_asset: true
-      - version_constraint: semver("<= 2.2.4")
-        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        files:
-          - name: fvm
-            src: fvm/fvm
-        replacements:
-          amd64: x64
-          darwin: macos
-        overrides:
-          - goos: windows
-            format: zip
-            files:
-              - name: fvm
-                src: fvm/fvm.bat
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "2.2.5-dev"
-        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        files:
-          - name: fvm
-            src: fvm/fvm
-        replacements:
-          amd64: x64
-          darwin: macos
-        supported_envs:
-          - linux/amd64
-          - darwin
-      - version_constraint: Version == "2.2.5-dev.1"
-        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        files:
-          - name: fvm
-            src: fvm/fvm
-        replacements:
-          amd64: x64
-        supported_envs:
-          - linux/amd64
-      - version_constraint: semver("<= 2.3.1")
-        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        files:
-          - name: fvm
-            src: fvm/fvm
-        replacements:
-          amd64: x64
-          darwin: macos
-        overrides:
-          - goos: windows
-            format: zip
-            files:
-              - name: fvm
-                src: fvm/fvm.bat
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 2.4.1")
-        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        files:
-          - name: fvm
-            src: fvm/fvm
-        replacements:
-          amd64: x64
-          darwin: macos
-        overrides:
-          - goos: windows
-            format: zip
-            files:
-              - name: fvm
-                src: fvm/fvm.bat
-      - version_constraint: semver("<= 3.0.0-alpha.2")
-        no_asset: true
-      - version_constraint: semver("<= 4.0.0")
-        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        files:
-          - name: fvm
-            src: fvm/fvm
-        replacements:
-          amd64: x64
-          darwin: macos
-        overrides:
-          - goos: windows
-            format: zip
-            files:
-              - name: fvm
-                src: fvm/fvm.bat
-      - version_constraint: "true"
-        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        files:
-          - name: fvm
-            src: fvm/fvm
-        replacements:
-          amd64: x64
-          darwin: macos
-        overrides:
-          - goos: windows
-            format: zip
-            files:
-              - name: fvm
-                src: fvm/fvm
   - name: concourse/concourse/concourse
     type: github_release
     repo_owner: concourse
@@ -44757,6 +44557,79 @@ packages:
           - goos: darwin
             format: pkg
             asset: hugo_extended_{{trimV .Version}}_{{.OS}}-universal.{{.Format}}
+            files:
+              - name: hugo
+                src: Payload/hugo
+          - goos: windows
+            format: zip
+  - name: gohugoio/hugo/hugo-extended-withdeploy
+    type: github_release
+    repo_owner: gohugoio
+    repo_name: hugo
+    description: The world’s fastest framework for building websites
+    files:
+      - name: hugo
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.139.5"
+        no_asset: true
+      - version_constraint: semver("< 0.137.0")
+        no_asset: true
+      - version_constraint: Version == "v0.137.0"
+        asset: hugo_extended_withdeploy_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: hugo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: hugo_extended_withdeploy_{{trimV .Version}}_{{.OS}}-universal.{{.Format}}
+        supported_envs:
+          - darwin
+          - linux/amd64
+      - version_constraint: semver("<= 0.138.0")
+        asset: hugo_extended_withdeploy_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: hugo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: hugo_extended_withdeploy_{{trimV .Version}}_{{.OS}}-universal.{{.Format}}
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - linux/amd64
+          - windows
+      - version_constraint: semver("<= 0.152.2")
+        asset: hugo_extended_withdeploy_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: hugo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: hugo_extended_withdeploy_{{trimV .Version}}_{{.OS}}-universal.{{.Format}}
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: hugo_extended_withdeploy_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: hugo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            format: pkg
+            asset: hugo_extended_withdeploy_{{trimV .Version}}_{{.OS}}-universal.{{.Format}}
             files:
               - name: hugo
                 src: Payload/hugo
@@ -62136,6 +62009,211 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+  - type: github_release
+    repo_owner: leoafarias
+    repo_name: fvm
+    aliases:
+      - name: leoafarias/fvm
+      - name: conceptadev/fvm
+    description: "Flutter Version Management: A simple CLI to manage Flutter SDK versions"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.13")
+        asset: fvm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.2.8")
+        asset: fvm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.3.0")
+        asset: fvm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.8.3")
+        no_asset: true
+      - version_constraint: Version == "App-1.0.0-alpha"
+        asset: fvm-app-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        supported_envs:
+          - windows/amd64
+      - version_constraint: Version == "App-1.0.0-alpha.1"
+        asset: fvm_{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        supported_envs:
+          - windows/amd64
+      - version_constraint: semver("<= 1.2.3")
+        no_asset: true
+      - version_constraint: semver("<= 1.3.4")
+        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: fvm
+            src: fvm/fvm
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: fvm
+                src: fvm/fvm.bat
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.3.8")
+        no_asset: true
+      - version_constraint: semver("<= 2.2.4")
+        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: fvm
+            src: fvm/fvm
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: fvm
+                src: fvm/fvm.bat
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "2.2.5-dev"
+        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        files:
+          - name: fvm
+            src: fvm/fvm
+        replacements:
+          amd64: x64
+          darwin: macos
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "2.2.5-dev.1"
+        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        files:
+          - name: fvm
+            src: fvm/fvm
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 2.3.1")
+        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: fvm
+            src: fvm/fvm
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: fvm
+                src: fvm/fvm.bat
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 2.4.1")
+        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: fvm
+            src: fvm/fvm
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: fvm
+                src: fvm/fvm.bat
+      - version_constraint: semver("<= 3.0.0-alpha.2")
+        no_asset: true
+      - version_constraint: semver("<= 4.0.0")
+        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: fvm
+            src: fvm/fvm
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: fvm
+                src: fvm/fvm.bat
+      - version_constraint: "true"
+        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: fvm
+            src: fvm/fvm
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: fvm
+                src: fvm/fvm
   - type: github_release
     repo_owner: levibostian
     repo_name: decaf


### PR DESCRIPTION
### 🚀 Features

- **(bootstrap)** forward config environments to remote hosts by @jdx in [#12182](https://github.com/jdx/mise/pull/12182)
- **(cache)** consume blob pack response metadata by @jdx in [#12193](https://github.com/jdx/mise/pull/12193)

### 🐛 Bug Fixes

- **(backend)** preserve Windows ZIP preference by @risu729 in [#12200](https://github.com/jdx/mise/pull/12200)
- **(backend)** normalize shorthand archive stems by @risu729 in [#12199](https://github.com/jdx/mise/pull/12199)
- **(bootstrap)** compose symlink-each targets by leaf by @jdx in [#12190](https://github.com/jdx/mise/pull/12190)
- **(brew)** accept null cask auto_updates metadata by @jdx in [#12192](https://github.com/jdx/mise/pull/12192)
- **(registry)** point aqua backends at renamed packages by @kkom in [#12186](https://github.com/jdx/mise/pull/12186)
- **(self-update)** sweep stale copies before the TEMP length check by @JamBalaya56562 in [#12205](https://github.com/jdx/mise/pull/12205)
- **(sync)** reconcile external provider links by @risu729 in [#11682](https://github.com/jdx/mise/pull/11682)
- **(system)** recognize pacman package providers by @jdx in [#12183](https://github.com/jdx/mise/pull/12183)

### 📚 Documentation

- **(trust)** use neutral config file help by @risu729 in [#12210](https://github.com/jdx/mise/pull/12210)
- fix mobile tables and banner overlays by @jdx in [#12184](https://github.com/jdx/mise/pull/12184)
- clarify registry addition popularity bar by @jdx in [#12208](https://github.com/jdx/mise/pull/12208)

### ⚡ Performance

- **(cache)** batch foreground blob lookups by @jdx in [#12191](https://github.com/jdx/mise/pull/12191)

### 🧪 Testing

- **(aqua)** remove canonical package gate by @jdx in [#12209](https://github.com/jdx/mise/pull/12209)
- **(e2e)** make the assert helpers usable from zsh by @JamBalaya56562 in [#12176](https://github.com/jdx/mise/pull/12176)

### 📦 Registry

- install azure-cli from the official Windows zip by @JamBalaya56562 in [#12161](https://github.com/jdx/mise/pull/12161)

### New Contributors

- @kkom made their first contribution in [#12186](https://github.com/jdx/mise/pull/12186)

## 📦 Aqua Registry Updates

### New Packages (4)

- [`bazel-contrib/buildtools/buildifier`](https://github.com/bazel-contrib/buildtools)
- [`bazel-contrib/buildtools/buildozer`](https://github.com/bazel-contrib/buildtools)
- [`gohugoio/hugo/hugo-extended-withdeploy`](https://github.com/gohugoio/hugo)
- [`leoafarias/fvm`](https://github.com/leoafarias/fvm)

### Updated Packages (1)

- [`Arata1202/ascdir`](https://github.com/Arata1202/ascdir)