### PR TITLE
fix(bootstrap): compose symlink-each targets by leaf

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -39,6 +39,9 @@ Equivalent declarations are deduplicated. Different declarations for the same
 dotfile target, edit `(path, id)`, managed file, managed directory, service, or
 Compose project are errors that identify both declaring configs. Independent
 roots never acquire precedence from their order in `config_roots`.
+Same-target `symlink-each` declarations are the exception: their source trees
+compose when their leaf paths are disjoint, while overlapping leaves or
+file/directory collisions are reported with both declaring configs.
 
 Other configuration such as tools, tasks, packages, hooks, and repos is not
 collected from these roots. Use their existing explicit workflows when those

--- a/e2e/cli/test_bootstrap_config_roots
+++ b/e2e/cli/test_bootstrap_config_roots
@@ -193,6 +193,14 @@ rm "$shared_tree/conf.d/b.toml"
 assert_succeed "mise bootstrap dotfiles apply --yes"
 assert "find '$MISE_STATE_DIR/dotfiles' -type f | wc -l | tr -d ' '" "2"
 
+# Unapply uses recorded ownership and does not need to traverse composed
+# source trees that have become unreadable.
+chmod 000 "$root_a/tree/conf.d"
+assert_succeed "mise bootstrap dotfiles unapply --yes"
+chmod 755 "$root_a/tree/conf.d"
+assert_fail "test -e $shared_tree"
+assert_succeed "mise bootstrap dotfiles apply --yes"
+
 # The leaf identity, rather than only the shared directory target, conflicts.
 echo conflict >"$root_b/tree/conf.d/a.toml"
 assert_fail "mise bootstrap dotfiles status" "conflicting symlink-each declarations for $shared_tree/conf.d/a.toml"

--- a/e2e/cli/test_bootstrap_config_roots
+++ b/e2e/cli/test_bootstrap_config_roots
@@ -202,7 +202,17 @@ assert_fail "test -e $shared_tree"
 assert_succeed "mise bootstrap dotfiles apply --yes"
 
 # The leaf identity, rather than only the shared directory target, conflicts.
+# Use an equivalent target spelling in one contributor to cover filtered
+# applies: lexical aliases must still be selected and validated together.
+aliased_shared_tree="$PWD/roots/../shared-tree"
+cat <<EOF >"$root_b/mise.toml"
+[dotfiles]
+"$aliased_shared_tree" = { source = "tree", mode = "symlink-each" }
+EOF
 echo conflict >"$root_b/tree/conf.d/a.toml"
 assert_fail "mise bootstrap dotfiles status" "conflicting symlink-each declarations for $shared_tree/conf.d/a.toml"
 assert_fail "mise bootstrap dotfiles status" "$root_a/mise.toml"
 assert_fail "mise bootstrap dotfiles status" "$root_b/mise.toml"
+assert_fail "mise bootstrap dotfiles apply --yes '$shared_tree'" "conflicting symlink-each declarations for $shared_tree/conf.d/a.toml"
+assert "readlink $shared_tree/conf.d/a.toml" "$root_a/tree/conf.d/a.toml"
+assert "readlink $shared_tree/conf.d/b.toml" "$root_b/tree/conf.d/b.toml"

--- a/e2e/cli/test_bootstrap_config_roots
+++ b/e2e/cli/test_bootstrap_config_roots
@@ -167,3 +167,34 @@ cat <<EOF >"$root_b/mise.toml"
 line = "from b"
 EOF
 assert_fail "mise bootstrap dotfiles status" "conflicting dotfile edit declarations"
+
+# Same-target symlink-each declarations compose by leaf path. Their ownership
+# state remains independent even when only one contributor needs an apply.
+shared_tree="$PWD/shared-tree"
+mkdir -p "$root_a/tree/conf.d" "$root_b/tree/conf.d"
+echo a >"$root_a/tree/conf.d/a.toml"
+echo b >"$root_b/tree/conf.d/b.toml"
+cat <<EOF >"$root_a/mise.toml"
+[dotfiles]
+"$shared_tree" = { source = "tree", mode = "symlink-each" }
+EOF
+cat <<EOF >"$root_b/mise.toml"
+[dotfiles]
+"$shared_tree" = { source = "tree", mode = "symlink-each" }
+EOF
+assert_succeed "mise bootstrap dotfiles status --json | jq -e '[.files[] | select(.target == \"$shared_tree\")] | length == 2'"
+assert_succeed "mise bootstrap dotfiles apply --yes"
+assert "readlink $shared_tree/conf.d/a.toml" "$root_a/tree/conf.d/a.toml"
+assert "readlink $shared_tree/conf.d/b.toml" "$root_b/tree/conf.d/b.toml"
+assert_succeed "mise bootstrap dotfiles status --missing"
+
+rm -rf "$MISE_STATE_DIR/dotfiles"
+rm "$shared_tree/conf.d/b.toml"
+assert_succeed "mise bootstrap dotfiles apply --yes"
+assert "find '$MISE_STATE_DIR/dotfiles' -type f | wc -l | tr -d ' '" "2"
+
+# The leaf identity, rather than only the shared directory target, conflicts.
+echo conflict >"$root_b/tree/conf.d/a.toml"
+assert_fail "mise bootstrap dotfiles status" "conflicting symlink-each declarations for $shared_tree/conf.d/a.toml"
+assert_fail "mise bootstrap dotfiles status" "$root_a/mise.toml"
+assert_fail "mise bootstrap dotfiles status" "$root_b/mise.toml"

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -2912,7 +2912,9 @@ impl BootstrapStatus {
         report: &mut BootstrapStatusReport,
     ) -> Result<()> {
         let mut json_files = vec![];
-        for req in system::files::files_from_config(config)? {
+        let files = system::files::files_from_config(config)?;
+        system::files::validate_composed_symlink_each(&files)?;
+        for req in files {
             let state = match system::files::check(config, &req) {
                 Ok(state) => state,
                 Err(err) => system::files::FileState::Differs(format!("{err}")),

--- a/src/cli/dotfiles/status.rs
+++ b/src/cli/dotfiles/status.rs
@@ -31,6 +31,7 @@ impl DotfilesStatus {
         let mut any_missing = false;
 
         let all_files = system::files::files_from_config(&config)?;
+        system::files::validate_composed_symlink_each(&all_files)?;
         let files = all_files
             .iter()
             .filter(|req| {

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -101,7 +101,7 @@ pub enum FileTomlEntry {
 pub struct FileRequest {
     /// target path as written in config (display/merge key)
     pub target_raw: String,
-    /// absolute target path (`~` expanded)
+    /// absolute, lexically normalized target path (`~` expanded)
     pub target: PathBuf,
     /// absolute source path (relative sources resolve against the config
     /// file's directory; omitted sources resolve under dotfiles.root)
@@ -361,7 +361,7 @@ fn merge_file_entry(
             }
         },
     };
-    let target = file::replace_path(&target_raw);
+    let target = resolve_target_arg(&target_raw);
     if target.is_relative() {
         warn!(
             "[dotfiles].\"{target_raw}\": target must be absolute or start with ~/, ignoring entry"

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -177,14 +177,13 @@ pub fn files_from_config(config: &Config) -> Result<Vec<FileRequest>> {
         }
     }
     let composed = composed.into_values().flatten().collect::<Vec<_>>();
-    validate_composed_symlink_each(&composed)?;
     Ok(composed)
 }
 
 /// Same-target `symlink-each` declarations compose by their expanded target
 /// paths. Shared directories are fine, but two sources cannot own the same
 /// leaf or require a directory where another source places a leaf.
-fn validate_composed_symlink_each(requests: &[FileRequest]) -> Result<()> {
+pub(crate) fn validate_composed_symlink_each(requests: &[FileRequest]) -> Result<()> {
     let mut groups: IndexMap<&Path, Vec<&FileRequest>> = IndexMap::new();
     for request in requests
         .iter()
@@ -1258,6 +1257,7 @@ pub fn plan_apply<'a>(
     requests: &'a [FileRequest],
     opts: &ApplyOpts,
 ) -> Result<ApplyPlan<'a>> {
+    validate_composed_symlink_each(requests)?;
     // pre-rendered template output rides along so it's written as compared,
     // and exec() in templates runs once per apply
     let mut todo: Vec<(&FileRequest, Option<String>)> = vec![];

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -153,13 +153,19 @@ pub enum FileState {
 /// Keys union global -> local; a more local config overrides an entry for the
 /// same target. Malformed entries and unknown modes warn and are skipped.
 pub fn files_from_config(config: &Config) -> Result<Vec<FileRequest>> {
-    let mut composed: IndexMap<PathBuf, FileRequest> = IndexMap::new();
+    let mut composed: IndexMap<PathBuf, Vec<FileRequest>> = IndexMap::new();
     for config_files in config.bootstrap_config_maps() {
         for request in files_from_config_files(config_files) {
-            if let Some(existing) = composed.get(&request.target) {
-                if file_requests_match(config, existing, &request) {
-                    continue;
-                }
+            let siblings = composed.entry(request.target.clone()).or_default();
+            if siblings
+                .iter()
+                .any(|existing| file_requests_match(config, existing, &request))
+            {
+                continue;
+            }
+            if let Some(existing) = siblings.iter().find(|existing| {
+                existing.mode != FileMode::SymlinkEach || request.mode != FileMode::SymlinkEach
+            }) {
                 bail!(
                     "conflicting dotfile declarations for {}\n\n  first:\n    {}\n\n  second:\n    {}",
                     request.target.display(),
@@ -167,10 +173,69 @@ pub fn files_from_config(config: &Config) -> Result<Vec<FileRequest>> {
                     request.origin.conflict_description(),
                 );
             }
-            composed.insert(request.target.clone(), request);
+            siblings.push(request);
         }
     }
-    Ok(composed.into_values().collect())
+    let composed = composed.into_values().flatten().collect::<Vec<_>>();
+    validate_composed_symlink_each(&composed)?;
+    Ok(composed)
+}
+
+/// Same-target `symlink-each` declarations compose by their expanded target
+/// paths. Shared directories are fine, but two sources cannot own the same
+/// leaf or require a directory where another source places a leaf.
+fn validate_composed_symlink_each(requests: &[FileRequest]) -> Result<()> {
+    let mut groups: IndexMap<&Path, Vec<&FileRequest>> = IndexMap::new();
+    for request in requests
+        .iter()
+        .filter(|request| request.mode == FileMode::SymlinkEach)
+    {
+        groups.entry(&request.target).or_default().push(request);
+    }
+
+    for siblings in groups.into_values().filter(|siblings| siblings.len() > 1) {
+        let mut leaves: IndexMap<PathBuf, &FileRequest> = IndexMap::new();
+        let mut directories: IndexMap<PathBuf, &FileRequest> = IndexMap::new();
+        for request in siblings {
+            // Preserve the normal source-missing/type diagnostic. Once every
+            // source directory exists its complete composed footprint can be
+            // checked before status or apply performs any mutation.
+            if !request.source.is_dir() {
+                continue;
+            }
+            for (_, target) in walk_source_files(request)? {
+                if let Some(existing) = leaves.get(&target).or_else(|| directories.get(&target)) {
+                    return Err(composed_symlink_each_conflict(&target, existing, request));
+                }
+                leaves.insert(target, request);
+            }
+            for directory in needed_dirs(request)?
+                .into_iter()
+                .filter(|directory| *directory != request.target)
+            {
+                if let Some(existing) = leaves.get(&directory) {
+                    return Err(composed_symlink_each_conflict(
+                        &directory, existing, request,
+                    ));
+                }
+                directories.entry(directory).or_insert(request);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn composed_symlink_each_conflict(
+    path: &Path,
+    first: &FileRequest,
+    second: &FileRequest,
+) -> eyre::Report {
+    eyre::eyre!(
+        "conflicting symlink-each declarations for {}\n\n  first:\n    {}\n\n  second:\n    {}",
+        path.display(),
+        first.origin.conflict_description(),
+        second.origin.conflict_description(),
+    )
 }
 
 /// Returns whether sibling declarations produce the same whole-file resource.
@@ -1171,7 +1236,7 @@ pub fn execute_apply(plan: ApplyPlan<'_>, opts: &ApplyOpts) -> Result<bool> {
         info!("files: {}", describe_applied(req)?);
     }
     for req in plan.record_symlink_each {
-        if !plan.todo.iter().any(|(todo, _)| todo.target == req.target) {
+        if !plan.todo.iter().any(|(todo, _)| std::ptr::eq(*todo, req)) {
             save_symlink_each_state(req);
         }
     }
@@ -2210,6 +2275,70 @@ mod tests {
 
     fn symlink_req(source: &Path, target: &Path) -> FileRequest {
         link_req(source, target, FileMode::Symlink)
+    }
+
+    #[test]
+    fn composed_symlink_each_allows_disjoint_leaves() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let source_a = dir.path().join("a");
+        let source_b = dir.path().join("b");
+        let target = dir.path().join("target");
+        file::create_dir_all(source_a.join("conf.d"))?;
+        file::create_dir_all(source_b.join("conf.d"))?;
+        file::write(source_a.join("conf.d/a.toml"), "a")?;
+        file::write(source_b.join("conf.d/b.toml"), "b")?;
+
+        validate_composed_symlink_each(&[
+            link_req(&source_a, &target, FileMode::SymlinkEach),
+            link_req(&source_b, &target, FileMode::SymlinkEach),
+        ])?;
+        Ok(())
+    }
+
+    #[test]
+    fn composed_symlink_each_rejects_duplicate_leaves() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let source_a = dir.path().join("a");
+        let source_b = dir.path().join("b");
+        let target = dir.path().join("target");
+        file::create_dir_all(&source_a)?;
+        file::create_dir_all(&source_b)?;
+        file::write(source_a.join("shared"), "a")?;
+        file::write(source_b.join("shared"), "b")?;
+
+        let err = validate_composed_symlink_each(&[
+            link_req(&source_a, &target, FileMode::SymlinkEach),
+            link_req(&source_b, &target, FileMode::SymlinkEach),
+        ])
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains(&target.join("shared").to_string_lossy().to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn composed_symlink_each_rejects_file_directory_collisions() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let source_a = dir.path().join("a");
+        let source_b = dir.path().join("b");
+        let target = dir.path().join("target");
+        file::create_dir_all(&source_a)?;
+        file::create_dir_all(source_b.join("shared"))?;
+        file::write(source_a.join("shared"), "a")?;
+        file::write(source_b.join("shared/nested"), "b")?;
+
+        let err = validate_composed_symlink_each(&[
+            link_req(&source_a, &target, FileMode::SymlinkEach),
+            link_req(&source_b, &target, FileMode::SymlinkEach),
+        ])
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains(&target.join("shared").to_string_lossy().to_string())
+        );
+        Ok(())
     }
 
     /// The fix: a file the user wrote is not mise's to replace. This used to pass on Windows,


### PR DESCRIPTION
## Summary

- allow independent config roots to contribute same-target `symlink-each` trees when their leaf paths are disjoint
- reject duplicate leaves and file/directory footprint collisions before any mutation, with both declaring config origins
- preserve per-source ownership state when one shared-target contributor is already applied and another still needs work
- document the composition semantics and add focused unit/e2e coverage

This follows up on #12105 and the verified behavior reported in [discussion #12099](https://github.com/jdx/mise/discussions/12099#discussioncomment-18085233).

## Validation

- `mise run format`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --bin mise system::files::tests::composed_symlink_each`
- `mise run test:e2e e2e/cli/test_bootstrap_config_roots`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dotfile merge/apply semantics for multi-root `symlink-each` and filesystem symlink layout; mistakes could mis-link or partially unapply shared trees, though validation and e2e tests narrow the blast radius.
> 
> **Overview**
> **Multi-root bootstrap** can now merge multiple `symlink-each` dotfile entries that share one target directory when each config root only maps **disjoint leaf paths** under that tree, instead of treating same-target declarations as always conflicting.
> 
> **Validation** runs before status/apply via `validate_composed_symlink_each`: overlapping leaves, file-vs-directory footprint clashes, and lexically equivalent target spellings still fail with both declaring config origins. Dotfile targets are **lexically normalized** so aliases like `roots/../shared-tree` group with the canonical path.
> 
> **Apply** records `symlink-each` ownership per `FileRequest` (pointer identity), so partial applies and unapply keep independent state files and can tear down links without re-walking unreadable composed source trees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8efdd4926ff143eced8e46ab8626ce3258dba7b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multiple `symlink-each` declarations can share a target when managing separate leaf paths.
  * Identical requests are safely deduplicated.
  * Removing one shared link preserves independently managed links.

* **Bug Fixes**
  * Clear errors identify overlapping leaves and file/directory conflicts.
  * Equivalent target paths are detected consistently.
  * Status and bootstrap operations validate composed symlink configurations consistently.

* **Documentation**
  * Added guidance for composing same-target `symlink-each` declarations and handling conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->