### PR TITLE
fix(brew): accept null cask auto_updates metadata

### DIFF
--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -59,7 +59,7 @@ struct Cask {
     #[serde(default)]
     old_tokens: Vec<String>,
     version: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_default")]
     auto_updates: bool,
     url: String,
     #[serde(default)]
@@ -8505,6 +8505,18 @@ mod tests {
         assert!(cask.depends_on.formula.is_empty());
         assert!(cask.conflicts_with.cask.is_empty());
         assert!(cask.auto_updates);
+        Ok(())
+    }
+
+    #[test]
+    fn cask_metadata_treats_null_auto_updates_as_false() -> Result<()> {
+        let cask: Cask = serde_json::from_value(serde_json::json!({
+            "token": "example",
+            "version": "1.0.0",
+            "url": "https://example.com/example.zip",
+            "auto_updates": null
+        }))?;
+        assert!(!cask.auto_updates);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- treat explicit null auto_updates cask metadata as the default false value
- add regression coverage for the Homebrew API metadata shape
- restore deserialization for the majority of current Homebrew casks

The Homebrew cask API currently emits null for auto_updates on 5,795 of 7,702 casks. Serde default handling only covered a missing field, causing those casks to fail during metadata fetch.

Reported in https://github.com/jdx/mise/discussions/10582#discussioncomment-18086055

## Testing
- cargo test --locked --bin mise cask_metadata
- mise run lint-fix

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow deserialization fix with regression test; no auth, security, or broader behavioral changes beyond accepting null metadata.
> 
> **Overview**
> **Homebrew cask metadata** now deserializes when the API sends `"auto_updates": null` instead of failing the whole cask fetch.
> 
> `auto_updates` uses the same `deserialize_null_default` pattern already applied to `depends_on` and `conflicts_with`, so explicit JSON `null` maps to the default `false`. A unit test locks in that behavior for the common API shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70dfbd82af061348c7ffcc40d8ffcdc55b84a1c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where package metadata with a null automatic-update value could not be loaded.
  * Null values are now safely treated as automatic updates being disabled.
  * Added regression coverage to help prevent the issue from recurring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->