### PR TITLE
fix(lock): resolve explicit selectors to concrete versions

### DIFF
--- a/e2e/lockfile/test_lockfile_alias
+++ b/e2e/lockfile/test_lockfile_alias
@@ -11,6 +11,7 @@ tiny = "myalias"
 
 [tool_alias.tiny.versions]
 myalias = "2"
+missing = "prefix:999"
 
 [settings]
 lockfile = true
@@ -25,3 +26,31 @@ rm -rf "$MISE_DATA_DIR/installs/tiny"
 mise install
 assert "mise ls tiny --json --current | jq -r '.[0].requested_version'" "myalias"
 assert "mise ls tiny --json --current | jq -r '.[0].version'" "2.0.0"
+
+# Explicit selectors must resolve independently of the configured version and
+# write a concrete result.
+cat <<EOF >mise.toml
+[tools]
+tiny = "1.0.0"
+
+[tool_alias.tiny.versions]
+myalias = "2"
+missing = "prefix:999"
+
+[settings]
+lockfile = true
+EOF
+rm mise.lock
+mise lock tiny@myalias
+assert_contains "cat mise.lock" 'version = "2.0.0"'
+rm mise.lock
+mise lock tiny@2
+assert_contains "cat mise.lock" 'version = "2.0.0"'
+assert_fail_contains "mise lock tiny@999 2>&1" "to a concrete version"
+assert_contains "cat mise.lock" 'version = "2.0.0"'
+assert_fail_contains "MISE_OFFLINE=1 mise lock tiny@prefix:999 2>&1" "failed to resolve specified"
+assert_contains "cat mise.lock" 'version = "2.0.0"'
+assert_fail_contains "MISE_OFFLINE=1 mise lock tiny@missing 2>&1" "failed to resolve specified"
+assert_contains "cat mise.lock" 'version = "2.0.0"'
+assert_fail_contains "MISE_OFFLINE=1 mise lock tiny@sub-1:4 2>&1" "to a concrete version"
+assert_contains "cat mise.lock" 'version = "2.0.0"'

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -4094,6 +4094,8 @@ pub(crate) mod test_helpers {
         ba: Arc<BackendArg>,
         remote_versions: Vec<VersionInfo>,
         stable_result: Option<String>,
+        rolling_channel: Option<String>,
+        channel_result: Option<String>,
         list_calls: AtomicUsize,
     }
 
@@ -4107,8 +4109,16 @@ pub(crate) mod test_helpers {
                 ba,
                 remote_versions,
                 stable_result: stable_result.map(str::to_string),
+                rolling_channel: None,
+                channel_result: None,
                 list_calls: AtomicUsize::new(0),
             }
+        }
+
+        pub fn with_rolling_channel(mut self, channel: &str, result: Option<&str>) -> Self {
+            self.rolling_channel = Some(channel.to_string());
+            self.channel_result = result.map(str::to_string);
+            self
         }
 
         pub fn stable_and_prerelease(ba: Arc<BackendArg>) -> Self {
@@ -4165,6 +4175,21 @@ pub(crate) mod test_helpers {
                 .unwrap_or_default()
                 .into_iter()
                 .collect()
+        }
+
+        fn is_rolling_channel(&self, version: &str) -> bool {
+            self.rolling_channel.as_deref() == Some(version)
+        }
+
+        async fn resolve_channel_version(
+            &self,
+            _config: &Arc<Config>,
+            version: &str,
+        ) -> eyre::Result<Option<String>> {
+            Ok(self
+                .is_rolling_channel(version)
+                .then(|| self.channel_result.clone())
+                .flatten())
         }
 
         async fn _list_remote_versions(

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -4695,18 +4695,30 @@ mod latest_version_tests {
         let _ = fs::remove_dir_all(&alpha.ba().cache_path);
 
         assert_eq!(
-            alpha.list_remote_versions(&config).await.unwrap(),
+            alpha
+                .list_remote_versions_with_selection_options(&config, &alpha.ba().opts(), false)
+                .await
+                .unwrap(),
             vec!["1.0.0".to_string()]
         );
         // The defect: this read back the list `alpha` had cached under the shared key.
         assert_eq!(
-            beta.list_remote_versions(&config).await.unwrap(),
+            beta.list_remote_versions_with_selection_options(&config, &beta.ba().opts(), false)
+                .await
+                .unwrap(),
             vec!["2.0.0".to_string()]
         );
         // Same option value, same entry — which is what shows the key follows the value rather
         // than the instance, and that the fix did not trade staleness for a refetch every time.
         assert_eq!(
-            alpha_again.list_remote_versions(&config).await.unwrap(),
+            alpha_again
+                .list_remote_versions_with_selection_options(
+                    &config,
+                    &alpha_again.ba().opts(),
+                    false,
+                )
+                .await
+                .unwrap(),
             vec!["1.0.0".to_string()]
         );
         assert_eq!(alpha_again.list_calls(), 0);
@@ -4733,7 +4745,10 @@ mod latest_version_tests {
             .unwrap();
 
         assert_eq!(
-            backend.list_remote_versions(&config).await.unwrap(),
+            backend
+                .list_remote_versions_with_selection_options(&config, &backend.ba().opts(), false)
+                .await
+                .unwrap(),
             vec!["1.0.0".to_string()]
         );
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2559,7 +2559,11 @@ pub trait Backend: Debug + Send + Sync {
         query: &str,
         selection_opts: &ToolVersionOptions,
     ) -> Vec<String> {
-        let versions = self.list_installed_versions();
+        let versions = self
+            .list_installed_versions()
+            .into_iter()
+            .filter(|v| !install_state::incomplete_file_path(&self.ba().short, v).exists())
+            .collect();
         let filter = !self.include_prereleases(selection_opts);
         self.fuzzy_match_filter(versions, query, filter)
     }
@@ -2809,7 +2813,7 @@ pub trait Backend: Debug + Send + Sync {
             .into_iter()
             .filter(|v| !v.starts_with('.'))
             .filter(|v| !is_runtime_symlink(&self.ba().installs_path.join(v)))
-            .filter(|v| !self.ba().installs_path.join(v).join("incomplete").exists())
+            .filter(|v| !install_state::incomplete_file_path(&self.ba().short, v).exists())
             .filter(|v| v != "latest")
             .filter(|v| !filter_prereleases || !self.is_prerelease_version(v))
             .collect_vec();
@@ -5032,6 +5036,7 @@ mod latest_version_tests {
             stable_result: Some("9.9.9".to_string()),
             stable_info: None,
             remote_versions: vec![],
+            listing_keys: &[],
             stable_calls: AtomicUsize::new(0),
             stable_info_calls: AtomicUsize::new(0),
             list_calls: AtomicUsize::new(0),
@@ -5041,6 +5046,58 @@ mod latest_version_tests {
             backend.latest_installed_version(None).unwrap(),
             Some("nightly".into())
         );
+    }
+
+    #[tokio::test]
+    async fn test_latest_installed_version_ignores_incomplete_installs() {
+        let _config = Config::get().await.unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let name = format!(
+            "latest-incomplete-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let mut ba = BackendArg::new_raw(
+            name.clone(),
+            None,
+            name,
+            None,
+            BackendResolution::new(false),
+        );
+        ba.installs_path = temp_dir.path().join("installs");
+        fs::create_dir_all(ba.installs_path.join("1.0.0")).unwrap();
+        fs::create_dir_all(ba.installs_path.join("2.0.0")).unwrap();
+        let marker = install_state::incomplete_file_path(&ba.short, "2.0.0");
+        fs::create_dir_all(marker.parent().unwrap()).unwrap();
+        fs::write(&marker, []).unwrap();
+
+        let backend = LatestBackend {
+            ba: Arc::new(ba),
+            stable_result: None,
+            stable_info: None,
+            remote_versions: vec![],
+            listing_keys: &[],
+            stable_calls: AtomicUsize::new(0),
+            stable_info_calls: AtomicUsize::new(0),
+            list_calls: AtomicUsize::new(0),
+        };
+
+        assert_eq!(
+            backend.latest_installed_version(None).unwrap(),
+            Some("1.0.0".into())
+        );
+        assert_eq!(
+            backend
+                .latest_installed_version_with_selection_options(
+                    Some("2".into()),
+                    &ToolVersionOptions::default(),
+                )
+                .unwrap(),
+            None
+        );
+        fs::remove_file(marker).unwrap();
     }
 
     #[tokio::test]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1924,6 +1924,13 @@ pub trait Backend: Debug + Send + Sync {
         false
     }
 
+    /// Whether an installed version string should be treated as a prerelease.
+    /// This is separate from fuzzy query matching so opaque stable versions such
+    /// as `nightly` are not discarded while resolving the latest installed tool.
+    fn is_prerelease_version(&self, version: &str) -> bool {
+        VERSION_REGEX.is_match(version)
+    }
+
     /// Tool option keys whose non-registry overrides change the backend's
     /// remote version list. When any of these keys come from a backend alias,
     /// config, or inline backend arg, the versions host must be skipped because
@@ -2796,19 +2803,16 @@ pub trait Backend: Debug + Send + Sync {
             return Ok(find_match_in_list(&matches, &query));
         }
 
-        let filter = !self.include_prereleases(selection_opts);
-        let matches = self.fuzzy_match_filter(
-            file::dir_subdirs(&self.ba().installs_path)
-                .unwrap_or_default()
-                .into_iter()
-                .filter(|v| !v.starts_with('.'))
-                .filter(|v| !is_runtime_symlink(&self.ba().installs_path.join(v)))
-                .filter(|v| !self.ba().installs_path.join(v).join("incomplete").exists())
-                .filter(|v| v != "latest")
-                .collect(),
-            "latest",
-            filter,
-        );
+        let filter_prereleases = !self.include_prereleases(selection_opts);
+        let matches = file::dir_subdirs(&self.ba().installs_path)
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|v| !v.starts_with('.'))
+            .filter(|v| !is_runtime_symlink(&self.ba().installs_path.join(v)))
+            .filter(|v| !self.ba().installs_path.join(v).join("incomplete").exists())
+            .filter(|v| v != "latest")
+            .filter(|v| !filter_prereleases || !self.is_prerelease_version(v))
+            .collect_vec();
         let installed_symlink = self.ba().installs_path.join("latest");
         if installed_symlink.exists()
             && let Some(target) = file::resolve_symlink(&installed_symlink)?
@@ -4152,6 +4156,13 @@ pub(crate) mod test_helpers {
             &self.ba
         }
 
+        fn list_installed_versions(&self) -> Vec<String> {
+            file::dir_subdirs(&self.ba.installs_path)
+                .unwrap_or_default()
+                .into_iter()
+                .collect()
+        }
+
         async fn _list_remote_versions(
             &self,
             _config: &Arc<Config>,
@@ -4961,8 +4972,9 @@ mod latest_version_tests {
         assert_eq!(backend.list_calls(), 0);
     }
 
-    #[test]
-    fn test_latest_installed_version_ignores_real_latest_dir() {
+    #[tokio::test]
+    async fn test_latest_installed_version_ignores_real_latest_dir() {
+        let _config = Config::get().await.unwrap();
         let temp_dir = tempfile::tempdir().unwrap();
         let mut ba = BackendArg::new_raw(
             "latest-real-dir".into(),
@@ -4989,6 +5001,45 @@ mod latest_version_tests {
         assert_eq!(
             backend.latest_installed_version(None).unwrap(),
             Some("2.0.0".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_latest_installed_version_keeps_opaque_stable_versions() {
+        let _config = Config::get().await.unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut ba = BackendArg::new_raw(
+            "latest-opaque-version".into(),
+            None,
+            "latest-opaque-version".into(),
+            None,
+            BackendResolution::new(false),
+        );
+        ba.installs_path = temp_dir
+            .path()
+            .join("installs")
+            .join("latest-opaque-version");
+        fs::create_dir_all(ba.installs_path.join("nightly")).unwrap();
+        fs::create_dir_all(ba.installs_path.join("2.0.0-rc1")).unwrap();
+        file::make_symlink_or_file(
+            &ba.installs_path.join("nightly"),
+            &ba.installs_path.join("latest"),
+        )
+        .unwrap();
+
+        let backend = LatestBackend {
+            ba: Arc::new(ba),
+            stable_result: Some("9.9.9".to_string()),
+            stable_info: None,
+            remote_versions: vec![],
+            stable_calls: AtomicUsize::new(0),
+            stable_info_calls: AtomicUsize::new(0),
+            list_calls: AtomicUsize::new(0),
+        };
+
+        assert_eq!(
+            backend.latest_installed_version(None).unwrap(),
+            Some("nightly".into())
         );
     }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2547,11 +2547,13 @@ pub trait Backend: Debug + Send + Sync {
         }
         Ok(Some(link))
     }
-    fn list_installed_versions_matching(&self, query: &str) -> Vec<String> {
+    fn list_installed_versions_matching_with_selection_options(
+        &self,
+        query: &str,
+        selection_opts: &ToolVersionOptions,
+    ) -> Vec<String> {
         let versions = self.list_installed_versions();
-        // No async config lookup available here; fall back to inline/registry
-        // opts, which is the best we have for a sync path.
-        let filter = !self.include_prereleases(&self.ba().opts());
+        let filter = !self.include_prereleases(selection_opts);
         self.fuzzy_match_filter(versions, query, filter)
     }
     /// List versions matching a query using the active request's selection options.
@@ -2781,34 +2783,49 @@ pub trait Backend: Debug + Send + Sync {
         .await
     }
     fn latest_installed_version(&self, query: Option<String>) -> eyre::Result<Option<String>> {
-        match query {
-            Some(query) => {
-                let matches = self.list_installed_versions_matching(&query);
-                Ok(find_match_in_list(&matches, &query))
-            }
-            None => {
-                let installed_symlink = self.ba().installs_path.join("latest");
-                if installed_symlink.exists()
-                    && let Some(target) = file::resolve_symlink(&installed_symlink)?
-                {
-                    let version = target
-                        .file_name()
-                        .ok_or_else(|| eyre!("Invalid symlink target"))?
-                        .to_string_lossy()
-                        .to_string();
-                    return Ok(Some(version));
-                }
-                Ok(file::dir_subdirs(&self.ba().installs_path)
-                    .unwrap_or_default()
-                    .into_iter()
-                    .filter(|v| !v.starts_with('.'))
-                    .filter(|v| !is_runtime_symlink(&self.ba().installs_path.join(v)))
-                    .filter(|v| !self.ba().installs_path.join(v).join("incomplete").exists())
-                    .filter(|v| v != "latest")
-                    .sorted_by_cached_key(|v| (Versioning::new(v), v.to_string()))
-                    .last())
+        self.latest_installed_version_with_selection_options(query, &self.ba().opts())
+    }
+    fn latest_installed_version_with_selection_options(
+        &self,
+        query: Option<String>,
+        selection_opts: &ToolVersionOptions,
+    ) -> eyre::Result<Option<String>> {
+        if let Some(query) = query {
+            let matches = self
+                .list_installed_versions_matching_with_selection_options(&query, selection_opts);
+            return Ok(find_match_in_list(&matches, &query));
+        }
+
+        let filter = !self.include_prereleases(selection_opts);
+        let matches = self.fuzzy_match_filter(
+            file::dir_subdirs(&self.ba().installs_path)
+                .unwrap_or_default()
+                .into_iter()
+                .filter(|v| !v.starts_with('.'))
+                .filter(|v| !is_runtime_symlink(&self.ba().installs_path.join(v)))
+                .filter(|v| !self.ba().installs_path.join(v).join("incomplete").exists())
+                .filter(|v| v != "latest")
+                .collect(),
+            "latest",
+            filter,
+        );
+        let installed_symlink = self.ba().installs_path.join("latest");
+        if installed_symlink.exists()
+            && let Some(target) = file::resolve_symlink(&installed_symlink)?
+        {
+            let version = target
+                .file_name()
+                .ok_or_else(|| eyre!("Invalid symlink target"))?
+                .to_string_lossy()
+                .to_string();
+            if matches.contains(&version) {
+                return Ok(Some(version));
             }
         }
+        Ok(matches
+            .into_iter()
+            .sorted_by_cached_key(|v| (Versioning::new(v), v.to_string()))
+            .last())
     }
 
     /// Get version info for a specific version (including checksum for rolling releases)
@@ -4055,6 +4072,108 @@ pub trait Backend: Debug + Send + Sync {
             conda_deps: None,
             ..Default::default()
         })
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_helpers {
+    use super::*;
+    use crate::install_context::InstallContext;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Debug)]
+    pub struct RemoteVersionsBackend {
+        ba: Arc<BackendArg>,
+        remote_versions: Vec<VersionInfo>,
+        stable_result: Option<String>,
+        list_calls: AtomicUsize,
+    }
+
+    impl RemoteVersionsBackend {
+        pub fn new(
+            ba: Arc<BackendArg>,
+            remote_versions: Vec<VersionInfo>,
+            stable_result: Option<&str>,
+        ) -> Self {
+            Self {
+                ba,
+                remote_versions,
+                stable_result: stable_result.map(str::to_string),
+                list_calls: AtomicUsize::new(0),
+            }
+        }
+
+        pub fn stable_and_prerelease(ba: Arc<BackendArg>) -> Self {
+            Self::new(
+                ba,
+                vec![
+                    VersionInfo {
+                        version: "1.0.0".to_string(),
+                        ..Default::default()
+                    },
+                    VersionInfo {
+                        version: "1.1.0-rc.1".to_string(),
+                        prerelease: true,
+                        ..Default::default()
+                    },
+                ],
+                Some("1.0.0"),
+            )
+        }
+
+        pub fn list_calls(&self) -> usize {
+            self.list_calls.load(Ordering::SeqCst)
+        }
+    }
+
+    pub fn prerelease_options() -> ToolVersionOptions {
+        let mut options = ToolVersionOptions::default();
+        options
+            .opts
+            .insert("prerelease".to_string(), toml::Value::Boolean(true));
+        options
+    }
+
+    pub fn request_tool_version(ba: Arc<BackendArg>, options: ToolVersionOptions) -> ToolVersion {
+        ToolVersion::new(
+            ToolRequest::Version {
+                backend: ba,
+                version: "1".to_string(),
+                options,
+                source: crate::toolset::ToolSource::Argument,
+            },
+            "1.0.0".to_string(),
+        )
+    }
+
+    #[async_trait]
+    impl Backend for RemoteVersionsBackend {
+        fn ba(&self) -> &Arc<BackendArg> {
+            &self.ba
+        }
+
+        async fn _list_remote_versions(
+            &self,
+            _config: &Arc<Config>,
+        ) -> eyre::Result<Vec<VersionInfo>> {
+            self.list_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self.remote_versions.clone())
+        }
+
+        async fn latest_stable_version(
+            &self,
+            _config: &Arc<Config>,
+        ) -> eyre::Result<Option<String>> {
+            Ok(self.stable_result.clone())
+        }
+
+        async fn install_version_(
+            &self,
+            _ctx: &InstallContext,
+            tv: ToolVersion,
+        ) -> Result<ToolVersion> {
+            Ok(tv)
+        }
     }
 }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1967,32 +1967,6 @@ pub trait Backend: Debug + Send + Sync {
         Ok(deps)
     }
 
-    async fn list_remote_versions(&self, config: &Arc<Config>) -> eyre::Result<Vec<String>> {
-        Ok(self
-            .list_remote_versions_with_info(config)
-            .await?
-            .into_iter()
-            .map(|v| v.version)
-            .collect())
-    }
-
-    /// Like `list_remote_versions` but with explicit refresh control. Pass
-    /// `refresh = true` to bypass the cached remote-versions list and re-fetch
-    /// upstream. Used by install-time resolution for selectors whose answer
-    /// depends on the freshest upstream entry (e.g. `latest`).
-    async fn list_remote_versions_with_refresh(
-        &self,
-        config: &Arc<Config>,
-        refresh: bool,
-    ) -> eyre::Result<Vec<String>> {
-        Ok(self
-            .list_remote_versions_with_info_with_refresh(config, refresh)
-            .await?
-            .into_iter()
-            .map(|v| v.version)
-            .collect())
-    }
-
     /// List remote versions using the fully layered candidate-selection options
     /// from the request currently being resolved. By default, backend listing/source
     /// options still use the config-based path below because those affect fetching
@@ -2580,35 +2554,6 @@ pub trait Backend: Debug + Send + Sync {
         let filter = !self.include_prereleases(&self.ba().opts());
         self.fuzzy_match_filter(versions, query, filter)
     }
-    async fn list_versions_matching(
-        &self,
-        config: &Arc<Config>,
-        query: &str,
-    ) -> eyre::Result<Vec<String>> {
-        let opts = config.get_tool_opts_with_overrides(self.ba()).await?;
-        self.list_versions_matching_with_selection_options(config, query, &opts, None, false)
-            .await
-    }
-
-    /// List versions matching a query, optionally filtered by release date.
-    /// Use this when you have a `before_date` from ResolveOptions.
-    async fn list_versions_matching_with_opts(
-        &self,
-        config: &Arc<Config>,
-        query: &str,
-        before_date: Option<Timestamp>,
-        refresh: bool,
-    ) -> eyre::Result<Vec<String>> {
-        let opts = config.get_tool_opts_with_overrides(self.ba()).await?;
-        self.list_versions_matching_with_selection_options(
-            config,
-            query,
-            &opts,
-            before_date,
-            refresh,
-        )
-        .await
-    }
     /// List versions matching a query using the active request's selection options.
     async fn list_versions_matching_with_selection_options(
         &self,
@@ -2711,22 +2656,6 @@ pub trait Backend: Debug + Send + Sync {
         before_date: Option<Timestamp>,
     ) -> eyre::Result<Option<String>> {
         self.latest_version_with_refresh(config, query, before_date, false)
-            .await
-    }
-
-    /// Get the latest version without applying release-date cutoffs.
-    ///
-    /// This is intended for diagnostics that compare a date-filtered result
-    /// with the absolute latest result. Normal resolution should use
-    /// `latest_version` so global, per-tool, and default release-age cutoffs are
-    /// honored.
-    async fn latest_version_unfiltered(
-        &self,
-        config: &Arc<Config>,
-        query: Option<String>,
-    ) -> eyre::Result<Option<String>> {
-        let opts = config.get_tool_opts_with_overrides(self.ba()).await?;
-        self.latest_version_unfiltered_with_selection_options(config, query, &opts)
             .await
     }
 
@@ -4604,7 +4533,11 @@ mod latest_version_tests {
 
         assert_eq!(
             backend
-                .latest_version_unfiltered(&config, Some("latest".to_string()))
+                .latest_version_unfiltered_with_selection_options(
+                    &config,
+                    Some("latest".to_string()),
+                    &ToolVersionOptions::default(),
+                )
                 .await
                 .unwrap()
                 .as_deref(),
@@ -4691,7 +4624,14 @@ mod latest_version_tests {
         let mut partial = SettingsPartial::empty();
         partial.offline = Some(true);
         Settings::reset(Some(partial));
-        let versions = backend.list_remote_versions(&config).await.unwrap();
+        let versions = backend
+            .list_remote_versions_with_selection_options(
+                &config,
+                &ToolVersionOptions::default(),
+                false,
+            )
+            .await
+            .unwrap();
         Settings::reset(None);
 
         assert_eq!(versions, vec!["1.0.0".to_string(), "2.0.0".to_string()]);

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -274,6 +274,10 @@ impl Backend for NPMBackend {
         true
     }
 
+    fn is_prerelease_version(&self, version: &str) -> bool {
+        is_semver_prerelease(version)
+    }
+
     fn get_dependencies(&self) -> eyre::Result<Vec<&str>> {
         // Version queries hit the npm registry over HTTP and installs use the
         // embedded aube package manager, so by default neither needs a
@@ -2616,6 +2620,9 @@ mod tests {
         assert!(is_semver_prerelease("3.0.0-foo"));
         // Maintainer-invented tag mise's regex doesn't know about — still flagged.
         assert!(is_semver_prerelease("4.0.0-internal-build-7"));
+
+        let backend = NPMBackend::from_arg("npm:prerelease-test".into());
+        assert!(backend.is_prerelease_version("4.0.0-internal-build-7"));
     }
 
     #[test]
@@ -2625,6 +2632,36 @@ mod tests {
         assert!(!is_semver_prerelease("v22.6.0"));
         // Build metadata alone is not a pre-release.
         assert!(!is_semver_prerelease("1.0.0+sha.abc1234"));
+    }
+
+    #[test]
+    fn test_latest_installed_filters_arbitrary_semver_prerelease() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut ba = BackendArg::from("npm:installed-prerelease-test");
+        ba.installs_path = temp_dir.path().join("installs");
+        std::fs::create_dir_all(ba.installs_path.join("1.0.0")).unwrap();
+        std::fs::create_dir_all(ba.installs_path.join("2.0.0-internal-build-7")).unwrap();
+        let backend = NPMBackend::from_arg(ba);
+        let mut prerelease_options = ToolVersionOptions::default();
+        prerelease_options
+            .opts
+            .insert("prerelease".into(), toml::Value::Boolean(true));
+
+        assert_eq!(
+            backend
+                .latest_installed_version_with_selection_options(
+                    None,
+                    &ToolVersionOptions::default(),
+                )
+                .unwrap(),
+            Some("1.0.0".into())
+        );
+        assert_eq!(
+            backend
+                .latest_installed_version_with_selection_options(None, &prerelease_options)
+                .unwrap(),
+            Some("2.0.0-internal-build-7".into())
+        );
     }
 
     #[test]

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -1071,7 +1071,10 @@ mod tests {
         );
 
         assert_eq!(
-            backend.list_remote_versions(&config).await.unwrap(),
+            backend
+                .list_remote_versions_with_selection_options(&config, &backend.ba().opts(), false,)
+                .await
+                .unwrap(),
             vec!["1.0.0", "2.0.0"]
         );
         assert_eq!(
@@ -1203,11 +1206,25 @@ mod tests {
         );
 
         assert_eq!(
-            first_backend.list_remote_versions(&config).await.unwrap(),
+            first_backend
+                .list_remote_versions_with_selection_options(
+                    &config,
+                    &first_backend.ba().opts(),
+                    false,
+                )
+                .await
+                .unwrap(),
             vec!["1.0.0"]
         );
         assert_eq!(
-            second_backend.list_remote_versions(&config).await.unwrap(),
+            second_backend
+                .list_remote_versions_with_selection_options(
+                    &config,
+                    &second_backend.ba().opts(),
+                    false,
+                )
+                .await
+                .unwrap(),
             vec!["2.0.0"]
         );
         first_registry.assert_async().await;

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -15,7 +15,7 @@ use crate::github::{self, GithubRelease};
 use crate::hash::hash_to_str;
 use crate::http::HTTP_FETCH;
 use crate::install_context::InstallContext;
-use crate::plugins::PEP440_PRERELEASE_REGEX;
+use crate::plugins::{PEP440_PRERELEASE_REGEX, VERSION_REGEX};
 use crate::semver::semver_is_older_than;
 use crate::timeout;
 use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions, Toolset, ToolsetBuilder};
@@ -122,6 +122,10 @@ impl Backend for PIPXBackend {
 
     fn mark_prereleases_from_version_pattern(&self) -> bool {
         true
+    }
+
+    fn is_prerelease_version(&self, version: &str) -> bool {
+        VERSION_REGEX.is_match(version) || PEP440_PRERELEASE_REGEX.is_match(version)
     }
 
     /// PyPI versions follow PEP 440, so the shared filter alone (which only

--- a/src/cli/latest.rs
+++ b/src/cli/latest.rs
@@ -65,11 +65,21 @@ impl Latest {
             plugin.ensure_installed(&config, &mpr, false, false).await?;
             backend = tool.ba.backend()?;
         }
+        let selection_opts = config.get_tool_opts_with_overrides(backend.ba()).await?;
         let prefix = match &tool.tvr {
             Some(ToolRequest::Sub {
                 sub, orig_version, ..
             }) => Some(
-                resolve_sub_base(&config, &backend, sub, orig_version, before_date, false).await?,
+                resolve_sub_base(
+                    &config,
+                    &backend,
+                    &selection_opts,
+                    sub,
+                    orig_version,
+                    before_date,
+                    false,
+                )
+                .await?,
             ),
             _ => match prefix {
                 Some(v) => Some(config.resolve_alias(&backend, &v).await?),

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -8,7 +8,9 @@ use crate::install_before::resolve_cli_minimum_release_age;
 use crate::lockfile::{self, LockResolutionResult, Lockfile};
 use crate::platform::Platform;
 use crate::task::Task;
-use crate::toolset::{ResolveOptions, ToolRequest, ToolSource, Toolset, ToolsetBuilder};
+use crate::toolset::{
+    ResolveOptions, ToolRequest, ToolSource, ToolVersionOptions, Toolset, ToolsetBuilder,
+};
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::{cli::args::ToolArg, config::Settings};
 use console::style;
@@ -46,6 +48,27 @@ fn push_unique_lock_tool(tools: &mut Vec<LockTool>, tool: LockTool) {
     {
         tools.push(tool);
     }
+}
+
+fn options_for_lock_request(
+    tv: &crate::toolset::ToolVersion,
+    specified_request: &ToolRequest,
+) -> ToolVersionOptions {
+    specified_request
+        .ba()
+        .opts_with_config(Some(tv.request.options()))
+}
+
+fn is_known_concrete_lock_version(backend: &dyn crate::backend::Backend, version: &str) -> bool {
+    if backend.is_rolling_channel(version) || crate::semver::is_npm_semver_range_query(version) {
+        return false;
+    }
+    version.matches('.').count() >= 2
+        || backend.is_exact_version(version)
+        || backend
+            .list_installed_versions()
+            .iter()
+            .any(|installed| installed == version)
 }
 
 /// Update lockfile checksums and URLs for all specified platforms
@@ -1061,6 +1084,7 @@ impl Lock {
             {
                 if let Some(Some(request)) = specified_versions.get(&ba.short) {
                     let version = request.version();
+                    let request_options = options_for_lock_request(&tv, request);
                     let backend = crate::backend::get(&ba);
                     let effective_version = match &backend {
                         Some(backend) => config.resolve_alias(backend, &version).await?,
@@ -1069,41 +1093,46 @@ impl Lock {
                     let request = ToolRequest::new_opts(
                         Arc::new(ba.clone()),
                         &effective_version,
-                        tv.request.options(),
+                        request_options.clone(),
                         ToolSource::Argument,
-                    );
-                    let resolve_options = request
-                        .as_ref()
-                        .ok()
-                        .and_then(|request| request.resolve_options(context.resolve_options).ok());
-                    let is_rolling = backend
-                        .is_some_and(|backend| backend.is_rolling_channel(&effective_version));
-                    if let (Ok(request), Some(mut resolve_options)) = (request, resolve_options)
-                        && (self.bump || resolve_options.before_date.is_some() || is_rolling)
-                    {
-                        resolve_options.use_locked_version = false;
+                    )?;
+                    let mut resolve_options = request.resolve_options(context.resolve_options)?;
+                    resolve_options.use_locked_version = false;
+                    if self.bump || resolve_options.before_date.is_some() {
                         resolve_options.latest_versions = true;
-                        match request.resolve(config, &resolve_options).await {
-                            Ok(resolved_tv) => tv = resolved_tv,
-                            Err(err) if is_rolling => {
-                                return Err(err.wrap_err(format!(
-                                    "failed to resolve specified rolling channel {request}"
-                                )));
-                            }
-                            Err(err) => debug!("failed to resolve specified {request}: {err}"),
-                        }
-                    } else if version == "latest" {
-                        if let Some(latest_version) = crate::backend::get(&ba)
-                            .and_then(|b| {
-                                b.latest_installed_version(Some("latest".to_string())).ok()
-                            })
-                            .flatten()
-                        {
-                            tv.version = latest_version;
-                        }
-                    } else {
-                        tv.version = version;
                     }
+                    let resolved_tv =
+                        request
+                            .resolve(config, &resolve_options)
+                            .await
+                            .map_err(|err| {
+                                err.wrap_err(format!("failed to resolve specified {request}"))
+                            })?;
+                    let mut concrete = backend.as_ref().is_none_or(|backend| {
+                        is_known_concrete_lock_version(backend.as_ref(), &resolved_tv.version)
+                    });
+                    let offline = Settings::get().offline() || resolve_options.offline;
+                    if !concrete
+                        && !offline
+                        && let Some(backend) = &backend
+                        && !backend.is_rolling_channel(&resolved_tv.version)
+                        && !crate::semver::is_npm_semver_range_query(&resolved_tv.version)
+                    {
+                        concrete = backend
+                            .list_versions_matching_with_selection_options(
+                                config,
+                                &resolved_tv.version,
+                                &request.options(),
+                                None,
+                                resolve_options.refresh_remote_versions,
+                            )
+                            .await?
+                            .contains(&resolved_tv.version);
+                    }
+                    if !concrete {
+                        eyre::bail!("failed to resolve specified {request} to a concrete version");
+                    }
+                    tv = resolved_tv;
                 }
                 tools.push((ba, tv));
             }
@@ -1392,8 +1421,10 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 #[cfg(test)]
 mod tests {
     use super::{
-        Lock, LockTaskResult, LockTaskStatus, classify_lock_result, push_unique_lock_tool,
+        Lock, LockTaskResult, LockTaskStatus, classify_lock_result, is_known_concrete_lock_version,
+        options_for_lock_request, push_unique_lock_tool,
     };
+    use crate::backend::test_helpers::RemoteVersionsBackend;
     use crate::cli::args::{BackendArg, ToolArg};
     use crate::lockfile::{Lockfile, PlatformInfo, apply_lock_result};
     use crate::platform::Platform;
@@ -1565,6 +1596,47 @@ mod tests {
         assert_eq!(tools[1].0.full(), "http:one");
         assert_eq!(tools[2].0.full(), "http:two");
         assert_ne!(tools[0].1.request.options(), tools[1].1.request.options());
+    }
+
+    #[tokio::test]
+    async fn lock_request_options_preserve_config_and_inline_precedence() {
+        let _config = crate::config::Config::get().await.unwrap();
+        let plain_tool = ToolArg::from_str("vfox:tiny@latest").unwrap();
+        let inline_tool = ToolArg::from_str("vfox:tiny[prerelease=true]@latest").unwrap();
+        let mut config_options = ToolVersionOptions::default();
+        config_options
+            .opts
+            .insert("prerelease".to_string(), toml::Value::Boolean(false));
+        let configured_request =
+            ToolRequest::new_opts(plain_tool.ba, "1.0.0", config_options, ToolSource::Argument)
+                .unwrap();
+        let configured_tv = ToolVersion::new(configured_request, "1.0.0".to_string());
+
+        let plain_options = options_for_lock_request(&configured_tv, &plain_tool.tvr.unwrap());
+        let inline_options = options_for_lock_request(&configured_tv, &inline_tool.tvr.unwrap());
+
+        assert_eq!(
+            plain_options.get_string("prerelease").as_deref(),
+            Some("false")
+        );
+        assert_eq!(
+            inline_options.get_string("prerelease").as_deref(),
+            Some("true")
+        );
+    }
+
+    #[test]
+    fn symbolic_lock_versions_are_not_concrete_even_when_installed() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut ba = BackendArg::from("lock-symbolic-version-test");
+        ba.installs_path = temp_dir.path().join("installs");
+        std::fs::create_dir_all(ba.installs_path.join("edge")).unwrap();
+        let backend = RemoteVersionsBackend::new(Arc::new(ba), vec![], None)
+            .with_rolling_channel("edge", None);
+
+        assert!(!is_known_concrete_lock_version(&backend, "edge"));
+        assert!(!is_known_concrete_lock_version(&backend, "^1.2.3"));
+        assert!(!is_known_concrete_lock_version(&backend, "1.2.x"));
     }
 
     #[test]

--- a/src/cli/ls_remote.rs
+++ b/src/cli/ls_remote.rs
@@ -106,14 +106,23 @@ impl LsRemote {
     ) -> Result<()> {
         let before_date =
             resolve_before_date_for_backend(config, plugin.as_ref(), before_date).await?;
+        let selection_opts = config.get_tool_opts_with_overrides(plugin.ba()).await?;
         let prefix = match &self.plugin {
             Some(tool_arg) => match &tool_arg.tvr {
                 Some(ToolRequest::Version { version: v, .. }) => Some(v.clone()),
                 Some(ToolRequest::Sub {
                     sub, orig_version, ..
                 }) => Some(
-                    resolve_sub_base(config, &plugin, sub, orig_version, before_date, false)
-                        .await?,
+                    resolve_sub_base(
+                        config,
+                        &plugin,
+                        &selection_opts,
+                        sub,
+                        orig_version,
+                        before_date,
+                        false,
+                    )
+                    .await?,
                 ),
                 _ => self.prefix.clone(),
             },

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -15,8 +15,9 @@ use crate::toolset::is_outdated_version;
 use crate::toolset::outdated_info::OutdatedInfo;
 use crate::toolset::outdated_info::prefixed_latest_query;
 use crate::toolset::{
-    ConfigScope, InstallOptions, ResolveOptions, ToolSource, ToolVersion, ToolsetBuilder,
-    get_versions_needed_by_tracked_configs_excluding_locks, get_versions_needed_by_tracked_stubs,
+    ConfigScope, InstallOptions, ResolveOptions, ToolRequest, ToolSource, ToolVersion,
+    ToolsetBuilder, get_versions_needed_by_tracked_configs_excluding_locks,
+    get_versions_needed_by_tracked_stubs, resolve_sub_base_unfiltered,
 };
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::progress_report::SingleReport;
@@ -790,7 +791,24 @@ impl Upgrade {
         backend: &ABackend,
     ) -> Result<Option<String>> {
         if self.bump || (opts.inactive && tv.request.source() == &ToolSource::Unknown) {
-            let (prefix, prefix_version) = split_version_prefix(&tv.request.version());
+            let version = config.resolve_alias(backend, &tv.request.version()).await?;
+            let rolling = backend.is_rolling_channel(&version);
+            if rolling {
+                if let Some(concrete) = backend.resolve_channel_version(config, &version).await? {
+                    return Ok(Some(concrete));
+                }
+                return Ok(backend
+                    .latest_version_with_selection_options(
+                        config,
+                        Some(version.clone()),
+                        &tv.request.options(),
+                        opts.before_date,
+                        false,
+                    )
+                    .await?
+                    .or(Some(version)));
+            }
+            let (prefix, prefix_version) = split_version_prefix(&version);
             backend
                 .latest_version_with_selection_options(
                     config,
@@ -824,10 +842,39 @@ impl Upgrade {
         backend: &ABackend,
     ) -> Result<Option<String>> {
         let query = if self.bump || (opts.inactive && tv.request.source() == &ToolSource::Unknown) {
-            let (prefix, prefix_version) = split_version_prefix(&tv.request.version());
+            let version = config.resolve_alias(backend, &tv.request.version()).await?;
+            let rolling = backend.is_rolling_channel(&version);
+            if rolling {
+                return Ok(backend
+                    .resolve_channel_version(config, &version)
+                    .await?
+                    .or(Some(version)));
+            }
+            let (prefix, prefix_version) = split_version_prefix(&version);
             prefixed_latest_query(&prefix, &prefix_version)
         } else {
-            Some(tv.request.version())
+            let version = config.resolve_alias(backend, &tv.request.version()).await?;
+            match ToolRequest::new_opts(
+                tv.request.ba().clone(),
+                &version,
+                tv.request.options(),
+                tv.request.source().clone(),
+            )? {
+                ToolRequest::Sub {
+                    sub, orig_version, ..
+                } => Some(
+                    resolve_sub_base_unfiltered(
+                        config,
+                        backend,
+                        &tv.request.options(),
+                        &sub,
+                        &orig_version,
+                    )
+                    .await?,
+                ),
+                ToolRequest::Prefix { prefix, .. } => Some(prefix),
+                request => Some(request.version()),
+            }
         };
         backend
             .latest_version_unfiltered_with_selection_options(config, query, &tv.request.options())
@@ -1008,12 +1055,14 @@ mod tests {
         release_is_eligible_at,
     };
     use crate::backend::{
-        ABackend,
+        ABackend, VersionInfo,
         test_helpers::{RemoteVersionsBackend, prerelease_options, request_tool_version},
     };
     use crate::cli::args::BackendArg;
     use crate::config::Config;
-    use crate::toolset::{ResolveOptions, ToolVersionOptions};
+    use crate::toolset::{
+        ResolveOptions, ToolRequest, ToolSource, ToolVersion, ToolVersionOptions,
+    };
     use jiff::tz::TimeZone;
     use std::sync::Arc;
 
@@ -1065,6 +1114,161 @@ mod tests {
                 .unwrap()
                 .as_deref(),
             Some("1.1.0-rc.1")
+        );
+    }
+
+    #[tokio::test]
+    async fn upgrade_preserves_range_and_unresolved_rolling_selectors() {
+        let config = Config::get().await.unwrap();
+        let ba = Arc::new(BackendArg::from("upgrade-selector-test"));
+        let backend_impl = RemoteVersionsBackend::new(
+            ba.clone(),
+            vec![
+                VersionInfo {
+                    version: "1.0.0".into(),
+                    ..Default::default()
+                },
+                VersionInfo {
+                    version: "edge".into(),
+                    ..Default::default()
+                },
+            ],
+            Some("1.0.0"),
+        )
+        .with_rolling_channel("edge", None);
+        let backend: ABackend = Arc::new(backend_impl);
+        let prefix = ToolVersion::new(
+            ToolRequest::Prefix {
+                backend: ba.clone(),
+                prefix: "1".into(),
+                options: ToolVersionOptions::default(),
+                source: ToolSource::Argument,
+            },
+            "1.0.0".into(),
+        );
+        let sub = ToolVersion::new(
+            ToolRequest::Sub {
+                backend: ba.clone(),
+                sub: "1".into(),
+                orig_version: "2".into(),
+                options: ToolVersionOptions::default(),
+                source: ToolSource::Argument,
+            },
+            "1.0.0".into(),
+        );
+        let rolling = ToolVersion::new(
+            ToolRequest::Version {
+                backend: ba,
+                version: "edge".into(),
+                options: ToolVersionOptions::default(),
+                source: ToolSource::Argument,
+            },
+            "edge".into(),
+        );
+        let rolling_upgrade = Upgrade {
+            bump: true,
+            dry_run: true,
+            ..Default::default()
+        };
+        let prefix_upgrade = Upgrade {
+            dry_run: true,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            prefix_upgrade
+                .baseline_latest_for_upgrade_with_backend(
+                    &config,
+                    &prefix,
+                    &ResolveOptions::default(),
+                    &backend,
+                )
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("1.0.0")
+        );
+        assert_eq!(
+            prefix_upgrade
+                .baseline_latest_for_upgrade_with_backend(
+                    &config,
+                    &sub,
+                    &ResolveOptions::default(),
+                    &backend,
+                )
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("1.0.0")
+        );
+        assert_eq!(
+            rolling_upgrade
+                .latest_for_upgrade_with_backend(
+                    &config,
+                    &rolling,
+                    &ResolveOptions::default(),
+                    &backend,
+                )
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("edge")
+        );
+    }
+
+    #[tokio::test]
+    async fn upgrade_sub_latest_baseline_ignores_minimum_release_age() {
+        let config = Config::get().await.unwrap();
+        let ba = Arc::new(BackendArg::from("upgrade-sub-latest-baseline-test"));
+        let backend: ABackend = Arc::new(RemoteVersionsBackend::new(
+            ba.clone(),
+            vec![
+                VersionInfo {
+                    version: "1.0.0".into(),
+                    created_at: Some("2020-01-01T00:00:00Z".into()),
+                    ..Default::default()
+                },
+                VersionInfo {
+                    version: "2.0.0".into(),
+                    created_at: Some("2020-01-01T00:00:00Z".into()),
+                    ..Default::default()
+                },
+                VersionInfo {
+                    version: "3.0.0".into(),
+                    created_at: Some("2099-01-01T00:00:00Z".into()),
+                    ..Default::default()
+                },
+            ],
+            Some("3.0.0"),
+        ));
+        let mut options = ToolVersionOptions::default();
+        options.opts.insert(
+            "minimum_release_age".into(),
+            toml::Value::String("1d".into()),
+        );
+        let sub = ToolVersion::new(
+            ToolRequest::Sub {
+                backend: ba,
+                sub: "1".into(),
+                orig_version: "latest".into(),
+                options,
+                source: ToolSource::Argument,
+            },
+            "1.0.0".into(),
+        );
+
+        assert_eq!(
+            Upgrade::default()
+                .baseline_latest_for_upgrade_with_backend(
+                    &config,
+                    &sub,
+                    &ResolveOptions::default(),
+                    &backend,
+                )
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("2.0.0")
         );
     }
 

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::backend::pipx::PIPXBackend;
+use crate::backend::{ABackend, pipx::PIPXBackend};
 use crate::cli::args::{BackendArg, ToolArg};
 use crate::config::{Config, Settings, config_file};
 use crate::errors::split_install_result;
@@ -35,6 +35,7 @@ use jiff::{Span, Timestamp, civil::date};
 ///
 /// This will update mise.lock if it is enabled, see https://mise.jdx.dev/configuration/settings.html#lockfile
 #[derive(Debug, clap::Args)]
+#[cfg_attr(test, derive(Default))]
 #[clap(visible_alias = "up", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct Upgrade {
     /// Tool(s) to upgrade
@@ -777,6 +778,17 @@ impl Upgrade {
         opts: &ResolveOptions,
     ) -> Result<Option<String>> {
         let backend = tv.backend()?;
+        self.latest_for_upgrade_with_backend(config, tv, opts, &backend)
+            .await
+    }
+
+    async fn latest_for_upgrade_with_backend(
+        &self,
+        config: &Arc<Config>,
+        tv: &ToolVersion,
+        opts: &ResolveOptions,
+        backend: &ABackend,
+    ) -> Result<Option<String>> {
         if self.bump || (opts.inactive && tv.request.source() == &ToolSource::Unknown) {
             let (prefix, prefix_version) = split_version_prefix(&tv.request.version());
             backend
@@ -800,6 +812,17 @@ impl Upgrade {
         opts: &ResolveOptions,
     ) -> Result<Option<String>> {
         let backend = tv.backend()?;
+        self.baseline_latest_for_upgrade_with_backend(config, tv, opts, &backend)
+            .await
+    }
+
+    async fn baseline_latest_for_upgrade_with_backend(
+        &self,
+        config: &Arc<Config>,
+        tv: &ToolVersion,
+        opts: &ResolveOptions,
+        backend: &ABackend,
+    ) -> Result<Option<String>> {
         let query = if self.bump || (opts.inactive && tv.request.source() == &ToolSource::Unknown) {
             let (prefix, prefix_version) = split_version_prefix(&tv.request.version());
             prefixed_latest_query(&prefix, &prefix_version)
@@ -981,10 +1004,69 @@ After removal, `-l` will become shorthand for `--local`. Use `-b` or `--bump` in
 #[cfg(test)]
 mod tests {
     use super::{
-        current_version_satisfies_hidden_release, format_hidden_release_details,
+        Upgrade, current_version_satisfies_hidden_release, format_hidden_release_details,
         release_is_eligible_at,
     };
+    use crate::backend::{
+        ABackend,
+        test_helpers::{RemoteVersionsBackend, prerelease_options, request_tool_version},
+    };
+    use crate::cli::args::BackendArg;
+    use crate::config::Config;
+    use crate::toolset::{ResolveOptions, ToolVersionOptions};
     use jiff::tz::TimeZone;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn upgrade_latest_uses_request_prerelease_option() {
+        let config = Config::get().await.unwrap();
+        let ba = Arc::new(BackendArg::from("upgrade-request-options-test"));
+        let backend: ABackend = Arc::new(RemoteVersionsBackend::stable_and_prerelease(ba.clone()));
+        backend
+            .get_remote_version_cache()
+            .lock()
+            .await
+            .clear()
+            .unwrap();
+        let upgrade = Upgrade {
+            bump: true,
+            dry_run: true,
+            ..Default::default()
+        };
+        let resolve_options = ResolveOptions::default();
+        let stable = request_tool_version(ba.clone(), ToolVersionOptions::default());
+        let prerelease = request_tool_version(ba, prerelease_options());
+
+        assert_eq!(
+            upgrade
+                .latest_for_upgrade_with_backend(&config, &stable, &resolve_options, &backend,)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("1.0.0")
+        );
+        assert_eq!(
+            upgrade
+                .latest_for_upgrade_with_backend(&config, &prerelease, &resolve_options, &backend,)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("1.1.0-rc.1")
+        );
+        assert_eq!(
+            upgrade
+                .baseline_latest_for_upgrade_with_backend(
+                    &config,
+                    &prerelease,
+                    &resolve_options,
+                    &backend,
+                )
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("1.1.0-rc.1")
+        );
+    }
 
     #[test]
     fn test_current_version_satisfies_hidden_release() {

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -780,10 +780,12 @@ impl Upgrade {
         if self.bump || (opts.inactive && tv.request.source() == &ToolSource::Unknown) {
             let (prefix, prefix_version) = split_version_prefix(&tv.request.version());
             backend
-                .latest_version(
+                .latest_version_with_selection_options(
                     config,
                     prefixed_latest_query(&prefix, &prefix_version),
+                    &tv.request.options(),
                     opts.before_date,
+                    false,
                 )
                 .await
         } else {
@@ -804,7 +806,9 @@ impl Upgrade {
         } else {
             Some(tv.request.version())
         };
-        backend.latest_version_unfiltered(config, query).await
+        backend
+            .latest_version_unfiltered_with_selection_options(config, query, &tv.request.options())
+            .await
     }
 }
 

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -461,6 +461,10 @@ impl Backend for JavaPlugin {
         false
     }
 
+    fn is_prerelease_version(&self, version: &str) -> bool {
+        VERSION_REGEX.is_match(version)
+    }
+
     fn remote_version_listing_tool_option_keys(&self) -> &'static [&'static str] {
         &["release_type"]
     }
@@ -823,6 +827,52 @@ mod tests {
                 ("release_type".to_string(), "ea".to_string()),
                 ("shorthand_vendor".to_string(), default_vendor.clone())
             ])
+        );
+    }
+
+    #[tokio::test]
+    async fn request_options_select_java_release_metadata() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let ga_cache = CacheManagerBuilder::new(temp_dir.path().join("ga.msgpack.z")).build();
+        let ea_cache = CacheManagerBuilder::new(temp_dir.path().join("ea.msgpack.z")).build();
+        let metadata = |version: &str| JavaMetadata {
+            image_type: Some("jdk".to_string()),
+            java_version: version.to_string(),
+            jvm_impl: "hotspot".to_string(),
+            vendor: "temurin".to_string(),
+            version: version.to_string(),
+            ..Default::default()
+        };
+        ga_cache
+            .write(&HashMap::from([(
+                "ga-only".to_string(),
+                metadata("17.0.1"),
+            )]))
+            .unwrap();
+        ea_cache
+            .write(&HashMap::from([("ea-only".to_string(), metadata("26-ea"))]))
+            .unwrap();
+        let plugin = JavaPlugin {
+            ba: Arc::new(plugins::core::new_backend_arg("java")),
+            java_metadata_ea_cache: ea_cache,
+            java_metadata_ga_cache: ga_cache,
+            java_metadata_target_cache: tokio::sync::Mutex::new(HashMap::new()),
+        };
+        let config = Config::get().await.unwrap();
+        let ga_opts = opts_with_release_type("ga");
+        let ea_opts = opts_with_release_type("ea");
+
+        let versions = plugin
+            .list_remote_versions_with_info_and_options(&config, &ga_opts, &ea_opts, false, false)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            versions
+                .into_iter()
+                .map(|version| version.version)
+                .collect_vec(),
+            vec!["ea-only"]
         );
     }
 

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -491,15 +491,6 @@ impl Backend for JavaPlugin {
         self.fuzzy_match_filter(versions, query, true)
     }
 
-    async fn list_versions_matching(
-        &self,
-        config: &Arc<Config>,
-        query: &str,
-    ) -> eyre::Result<Vec<String>> {
-        let versions = self.list_remote_versions(config).await?;
-        Ok(self.fuzzy_match_filter(versions, query, true))
-    }
-
     fn get_aliases(&self) -> Result<BTreeMap<String, String>> {
         let aliases = BTreeMap::from([("lts".into(), "25".into())]);
         Ok(aliases)

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -485,12 +485,6 @@ impl Backend for JavaPlugin {
         self.list_remote_versions_for_options(selection_opts).await
     }
 
-    fn list_installed_versions_matching(&self, query: &str) -> Vec<String> {
-        let versions = self.list_installed_versions();
-        // Java doesn't support the `prerelease` opt-in; always filter.
-        self.fuzzy_match_filter(versions, query, true)
-    }
-
     fn get_aliases(&self) -> Result<BTreeMap<String, String>> {
         let aliases = BTreeMap::from([("lts".into(), "25".into())]);
         Ok(aliases)

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -1053,6 +1053,11 @@ impl Backend for PythonPlugin {
         crate::backend::fuzzy_match_versions_pep440(versions, query, filter_prereleases)
     }
 
+    fn is_prerelease_version(&self, version: &str) -> bool {
+        plugins::VERSION_REGEX.is_match(version)
+            || plugins::PEP440_PRERELEASE_REGEX.is_match(version)
+    }
+
     async fn security_info(&self) -> Vec<crate::backend::SecurityFeature> {
         use crate::backend::SecurityFeature;
 

--- a/src/plugins/core/ruby_windows.rs
+++ b/src/plugins/core/ruby_windows.rs
@@ -298,6 +298,7 @@ fn locked_archive(locked_url: Option<&str>) -> Option<(String, String)> {
 #[cfg(test)]
 mod tests {
     use crate::config::Config;
+    use crate::toolset::ToolVersionOptions;
     use indoc::indoc;
     use pretty_assertions::assert_eq;
 
@@ -326,7 +327,13 @@ mod tests {
         let plugin = RubyPlugin::new();
         assert!(
             !plugin
-                .list_versions_matching(&config, "3")
+                .list_versions_matching_with_selection_options(
+                    &config,
+                    "3",
+                    &ToolVersionOptions::default(),
+                    None,
+                    false,
+                )
                 .await
                 .unwrap()
                 .is_empty(),
@@ -334,7 +341,13 @@ mod tests {
         );
         assert!(
             !plugin
-                .list_versions_matching(&config, "truffleruby-24")
+                .list_versions_matching_with_selection_options(
+                    &config,
+                    "truffleruby-24",
+                    &ToolVersionOptions::default(),
+                    None,
+                    false,
+                )
                 .await
                 .unwrap()
                 .is_empty(),
@@ -342,7 +355,13 @@ mod tests {
         );
         assert!(
             !plugin
-                .list_versions_matching(&config, "truffleruby+graalvm-24")
+                .list_versions_matching_with_selection_options(
+                    &config,
+                    "truffleruby+graalvm-24",
+                    &ToolVersionOptions::default(),
+                    None,
+                    false,
+                )
                 .await
                 .unwrap()
                 .is_empty(),

--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -312,7 +312,7 @@ impl Backend for ZigPlugin {
         //
         // list_installed_versions() is already ordered ascending by install_state
         // (the canonical version sort), so take the last "-dev." entry instead of
-        // re-sorting here. list_installed_versions_matching() is unusable: it drops
+        // re-sorting here. Generic installed-version matching is unusable: it drops
         // prereleases (the "-dev." nightlies) unless the tool opts into them.
         // rfind() walks from the newest end (the list is double-ended), giving the
         // latest nightly without re-sorting.

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -39,8 +39,8 @@ pub use tool_request_set::{
     ToolRequestSet, ToolRequestSetBuilder, tool_env_var_name, tool_env_vars, tool_from_env_var_name,
 };
 pub use tool_source::ToolSource;
-pub(crate) use tool_version::resolve_sub_base;
 pub use tool_version::{ResolveOptions, ToolVersion};
+pub(crate) use tool_version::{resolve_sub_base, resolve_sub_base_unfiltered};
 pub use tool_version_list::ToolVersionList;
 pub use tool_version_options::{
     CoreToolOptions, EPHEMERAL_OPT_KEYS, RawBackendOptions, ResolvedToolOptions, ToolOptionSource,

--- a/src/toolset/outdated_info.rs
+++ b/src/toolset/outdated_info.rs
@@ -107,7 +107,14 @@ impl OutdatedInfo {
         let latest_result = if use_backend_latest {
             let prefix = prefixed_latest_query(&prefix, &prefix_version);
             // For bumps and installed-but-inactive tools (`--no-source`), use backend latest.
-            t.latest_version(config, prefix, opts.before_date).await
+            t.latest_version_with_selection_options(
+                config,
+                prefix,
+                &tv.request.options(),
+                opts.before_date,
+                false,
+            )
+            .await
         } else {
             tv.latest_version_with_opts(config, opts)
                 .await

--- a/src/toolset/outdated_info.rs
+++ b/src/toolset/outdated_info.rs
@@ -219,7 +219,24 @@ async fn latest_for_outdated(
     use_backend_latest: bool,
 ) -> eyre::Result<Option<String>> {
     if use_backend_latest {
-        let (prefix, prefix_version) = split_version_prefix(&tv.request.version());
+        let version = config.resolve_alias(backend, &tv.request.version()).await?;
+        let rolling = backend.is_rolling_channel(&version);
+        if rolling {
+            if let Some(concrete) = backend.resolve_channel_version(config, &version).await? {
+                return Ok(Some(concrete));
+            }
+            return Ok(backend
+                .latest_version_with_selection_options(
+                    config,
+                    Some(version.clone()),
+                    &tv.request.options(),
+                    opts.before_date,
+                    false,
+                )
+                .await?
+                .or(Some(version)));
+        }
+        let (prefix, prefix_version) = split_version_prefix(&version);
         let query = prefixed_latest_query(&prefix, &prefix_version);
         backend
             .latest_version_with_selection_options(
@@ -458,7 +475,7 @@ mod tests {
         prefixed_latest_query,
     };
     use crate::backend::{
-        ABackend,
+        ABackend, VersionInfo,
         test_helpers::{RemoteVersionsBackend, prerelease_options, request_tool_version},
     };
     use crate::cli::args::{BackendArg, BackendResolution};
@@ -493,6 +510,46 @@ mod tests {
                 .unwrap()
                 .as_deref(),
             Some("1.1.0-rc.1")
+        );
+    }
+
+    #[tokio::test]
+    async fn outdated_preserves_unresolved_rolling_selector() {
+        let config = Config::get().await.unwrap();
+        let ba = Arc::new(BackendArg::from("outdated-rolling-test"));
+        let backend: ABackend = Arc::new(
+            RemoteVersionsBackend::new(
+                ba.clone(),
+                vec![VersionInfo {
+                    version: "edge".into(),
+                    ..Default::default()
+                }],
+                None,
+            )
+            .with_rolling_channel("edge", None),
+        );
+        let rolling = ToolVersion::new(
+            ToolRequest::Version {
+                backend: ba,
+                version: "edge".into(),
+                options: ToolVersionOptions::default(),
+                source: ToolSource::Argument,
+            },
+            "edge".into(),
+        );
+
+        assert_eq!(
+            latest_for_outdated(
+                &config,
+                &backend,
+                &rolling,
+                &crate::toolset::ResolveOptions::default(),
+                true,
+            )
+            .await
+            .unwrap()
+            .as_deref(),
+            Some("edge")
         );
     }
 

--- a/src/toolset/outdated_info.rs
+++ b/src/toolset/outdated_info.rs
@@ -66,7 +66,9 @@ impl OutdatedInfo {
             // When minimum_release_age causes "latest" to resolve to a version not yet
             // installed on disk, fall back to finding the highest installed version.
             // Otherwise to_remove in `mise up` won't know which old version to uninstall.
-            let Some(current) = backend.latest_installed_version(None)? else {
+            let Some(current) = backend
+                .latest_installed_version_with_selection_options(None, &tv.request.options())?
+            else {
                 return Ok(None);
             };
             let current_tv = ToolVersion::new(tv.request.clone(), current);
@@ -81,7 +83,9 @@ impl OutdatedInfo {
             ToolRequest::Prefix { prefix, .. } => Some(prefix.clone()),
             _ => return Ok(None),
         };
-        let Some(current) = backend.latest_installed_version(query)? else {
+        let Some(current) = backend
+            .latest_installed_version_with_selection_options(query, &tv.request.options())?
+        else {
             return Ok(None);
         };
         let current_tv = ToolVersion::new(tv.request.clone(), current);
@@ -100,26 +104,11 @@ impl OutdatedInfo {
     ) -> eyre::Result<Option<Self>> {
         let t = tv.backend()?;
         // prefix is something like "temurin-" or "corretto-"
-        let (prefix, prefix_version) = split_version_prefix(&tv.request.version());
+        let (prefix, _) = split_version_prefix(&tv.request.version());
         let use_backend_latest =
             bump || (opts.inactive && tv.request.source() == &ToolSource::Unknown);
 
-        let latest_result = if use_backend_latest {
-            let prefix = prefixed_latest_query(&prefix, &prefix_version);
-            // For bumps and installed-but-inactive tools (`--no-source`), use backend latest.
-            t.latest_version_with_selection_options(
-                config,
-                prefix,
-                &tv.request.options(),
-                opts.before_date,
-                false,
-            )
-            .await
-        } else {
-            tv.latest_version_with_opts(config, opts)
-                .await
-                .map(Option::from)
-        };
+        let latest_result = latest_for_outdated(config, &t, &tv, opts, use_backend_latest).await;
         let latest = match latest_result {
             Ok(Some(latest)) => latest,
             Ok(None) => {
@@ -219,6 +208,32 @@ impl OutdatedInfo {
         } else {
             "[NONE]".to_string()
         }
+    }
+}
+
+async fn latest_for_outdated(
+    config: &Arc<Config>,
+    backend: &ABackend,
+    tv: &ToolVersion,
+    opts: &ResolveOptions,
+    use_backend_latest: bool,
+) -> eyre::Result<Option<String>> {
+    if use_backend_latest {
+        let (prefix, prefix_version) = split_version_prefix(&tv.request.version());
+        let query = prefixed_latest_query(&prefix, &prefix_version);
+        backend
+            .latest_version_with_selection_options(
+                config,
+                query,
+                &tv.request.options(),
+                opts.before_date,
+                false,
+            )
+            .await
+    } else {
+        tv.latest_version_with_opts(config, opts)
+            .await
+            .map(Option::from)
     }
 }
 
@@ -438,10 +453,48 @@ mod tests {
     use std::sync::Arc;
     use test_log::test;
 
-    use super::{OutdatedInfo, check_semver_bump, is_outdated_version, prefixed_latest_query};
+    use super::{
+        OutdatedInfo, check_semver_bump, is_outdated_version, latest_for_outdated,
+        prefixed_latest_query,
+    };
+    use crate::backend::{
+        ABackend,
+        test_helpers::{RemoteVersionsBackend, prerelease_options, request_tool_version},
+    };
     use crate::cli::args::{BackendArg, BackendResolution};
     use crate::config::Config;
     use crate::toolset::{ToolRequest, ToolSource, ToolVersion, ToolVersionOptions, install_state};
+
+    #[tokio::test]
+    async fn outdated_latest_uses_request_prerelease_option() {
+        let config = Config::get().await.unwrap();
+        let ba = Arc::new(BackendArg::from("outdated-request-options-test"));
+        let backend: ABackend = Arc::new(RemoteVersionsBackend::stable_and_prerelease(ba.clone()));
+        backend
+            .get_remote_version_cache()
+            .lock()
+            .await
+            .clear()
+            .unwrap();
+        let stable = request_tool_version(ba.clone(), ToolVersionOptions::default());
+        let prerelease = request_tool_version(ba, prerelease_options());
+        let resolve_options = crate::toolset::ResolveOptions::default();
+
+        assert_eq!(
+            latest_for_outdated(&config, &backend, &stable, &resolve_options, true)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("1.0.0")
+        );
+        assert_eq!(
+            latest_for_outdated(&config, &backend, &prerelease, &resolve_options, true)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("1.1.0-rc.1")
+        );
+    }
 
     #[test]
     fn test_is_outdated_version() {

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -159,12 +159,7 @@ impl ToolRequest {
         source: ToolSource,
     ) -> eyre::Result<Self> {
         let mut tvr = Self::new(backend, s, source)?;
-        match &mut tvr {
-            Self::Version { options: o, .. }
-            | Self::Prefix { options: o, .. }
-            | Self::Ref { options: o, .. } => *o = options,
-            _ => Default::default(),
-        }
+        tvr.set_options(options);
         Ok(tvr)
     }
     pub fn set_source(&mut self, source: ToolSource) -> Self {
@@ -777,6 +772,24 @@ mod tests {
         let (query, boundary) = version.lockfile_version_query();
         assert_str_eq!(query, "0.8");
         assert!(!boundary);
+    }
+
+    #[test]
+    fn test_new_opts_applies_options_to_sub_requests() {
+        let mut options = ToolVersionOptions::default();
+        options
+            .opts
+            .insert("prerelease".into(), toml::Value::Boolean(true));
+
+        let request = ToolRequest::new_opts(
+            test_ba(),
+            "sub-1:latest",
+            options.clone(),
+            ToolSource::Argument,
+        )
+        .unwrap();
+
+        assert_eq!(request.options(), options);
     }
 
     #[test]

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -433,7 +433,8 @@ impl ToolRequest {
             return Ok(Some(lt.version));
         }
         if let Some(backend) = backend::get(self.ba()) {
-            let matches = backend.list_installed_versions_matching(v);
+            let matches =
+                backend.list_installed_versions_matching_with_selection_options(v, &self.options());
             if matches.iter().any(|m| m == v) {
                 return Ok(Some(v.to_string()));
             }

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -837,6 +837,34 @@ pub(crate) async fn resolve_sub_base(
     tool_request::version_sub(&v, sub)
 }
 
+/// Resolve the base of a `sub-N:<base>` request without applying release-age cutoffs.
+///
+/// Upgrade uses this to compare an age-filtered candidate with the true upstream
+/// baseline. In particular, `sub-N:latest` must derive its range from the unfiltered
+/// latest release or hidden releases will disappear from the comparison.
+pub(crate) async fn resolve_sub_base_unfiltered(
+    config: &Arc<Config>,
+    backend: &ABackend,
+    selection_opts: &ToolVersionOptions,
+    sub: &str,
+    base: &str,
+) -> Result<String> {
+    let base = if base == "latest" {
+        base.to_string()
+    } else {
+        config.resolve_alias(backend, base).await?
+    };
+    let v = if base == "latest" {
+        backend
+            .latest_version_unfiltered_with_selection_options(config, None, selection_opts)
+            .await?
+            .ok_or_else(|| ToolVersion::no_versions_found(backend, None))?
+    } else {
+        base
+    };
+    tool_request::version_sub(&v, sub)
+}
+
 impl Display for ToolVersion {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}@{}", self.ba().full(), self.version)

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -491,7 +491,8 @@ impl ToolVersion {
         if v == "latest" {
             if !opts.latest_versions
                 && !should_filter_installed_versions
-                && let Some(v) = backend.latest_installed_version(None)?
+                && let Some(v) = backend
+                    .latest_installed_version_with_selection_options(None, &selection_opts)?
             {
                 return build(v);
             }
@@ -531,15 +532,15 @@ impl ToolVersion {
             }
             return Err(Self::no_versions_found(backend, opts.before_date));
         }
-        let installed_matches =
-            (!opts.latest_versions).then(|| backend.list_installed_versions_matching(&v));
+        let installed_matches = (!opts.latest_versions).then(|| {
+            backend.list_installed_versions_matching_with_selection_options(&v, &selection_opts)
+        });
         if installed_matches
             .as_ref()
             .is_some_and(|matches| matches.contains(&v))
         {
             return build(v);
         }
-
         let mut pin_remote_matches = None;
         if opts.prefer_exact_version && !is_offline && !crate::semver::is_npm_semver_range_query(&v)
         {
@@ -742,7 +743,9 @@ impl ToolVersion {
             && !prefer_offline;
         if !opts.latest_versions
             && !should_filter_installed_versions
-            && let Some(v) = backend.list_installed_versions_matching(prefix).last()
+            && let Some(v) = backend
+                .list_installed_versions_matching_with_selection_options(prefix, &selection_opts)
+                .last()
         {
             return Ok(Self::new(request, v.to_string()));
         }
@@ -1033,49 +1036,13 @@ impl Display for ResolveOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::backend::{Backend, VersionInfo};
+    use crate::backend::{
+        Backend, VersionInfo,
+        test_helpers::{RemoteVersionsBackend, prerelease_options},
+    };
     use crate::cli::args::BackendResolution;
-    use crate::install_context::InstallContext;
     use crate::toolset::CoreToolOptions;
-    use async_trait::async_trait;
-    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
     use std::time::{SystemTime, UNIX_EPOCH};
-
-    #[derive(Debug)]
-    struct RequestOptionsBackend {
-        ba: Arc<BackendArg>,
-        list_calls: AtomicUsize,
-    }
-
-    #[async_trait]
-    impl Backend for RequestOptionsBackend {
-        fn ba(&self) -> &Arc<BackendArg> {
-            &self.ba
-        }
-
-        async fn _list_remote_versions(&self, _config: &Arc<Config>) -> Result<Vec<VersionInfo>> {
-            self.list_calls.fetch_add(1, AtomicOrdering::SeqCst);
-            Ok(vec![
-                VersionInfo {
-                    version: "1.0.0".to_string(),
-                    ..Default::default()
-                },
-                VersionInfo {
-                    version: "1.1.0-rc.1".to_string(),
-                    prerelease: true,
-                    ..Default::default()
-                },
-            ])
-        }
-
-        async fn install_version_(
-            &self,
-            _ctx: &InstallContext,
-            tv: ToolVersion,
-        ) -> Result<ToolVersion> {
-            Ok(tv)
-        }
-    }
 
     fn unique_name(prefix: &str) -> String {
         format!(
@@ -1105,10 +1072,7 @@ mod tests {
     async fn resolve_version_uses_each_requests_prerelease_option() {
         let config = Config::get().await.unwrap();
         let ba = Arc::new(BackendArg::from(unique_name("request-options")));
-        let backend_impl = Arc::new(RequestOptionsBackend {
-            ba: ba.clone(),
-            list_calls: AtomicUsize::new(0),
-        });
+        let backend_impl = Arc::new(RemoteVersionsBackend::stable_and_prerelease(ba.clone()));
         backend_impl
             .get_remote_version_cache()
             .lock()
@@ -1117,10 +1081,6 @@ mod tests {
             .unwrap();
 
         let stable_options = ToolVersionOptions::default();
-        let mut prerelease_options = ToolVersionOptions::default();
-        prerelease_options
-            .opts
-            .insert("prerelease".to_string(), toml::Value::Boolean(true));
         let stable_request = ToolRequest::Version {
             backend: ba.clone(),
             version: "1".to_string(),
@@ -1130,7 +1090,7 @@ mod tests {
         let prerelease_request = ToolRequest::Version {
             backend: ba,
             version: "1".to_string(),
-            options: prerelease_options,
+            options: prerelease_options(),
             source: ToolSource::Argument,
         };
         let resolve_options = ResolveOptions {
@@ -1156,7 +1116,140 @@ mod tests {
 
         assert_eq!(stable.version, "1.0.0");
         assert_eq!(prerelease.version, "1.1.0-rc.1");
-        assert_eq!(backend_impl.list_calls.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(backend_impl.list_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn resolve_version_uses_request_options_for_installed_versions() {
+        let config = Config::get().await.unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let short = unique_name("request-options-installed");
+        let mut ba = BackendArg::from(short);
+        ba.installs_path = temp_dir.path().join("installs");
+        std::fs::create_dir_all(ba.installs_path.join("1.0.0")).unwrap();
+        std::fs::create_dir_all(ba.installs_path.join("1.1.0-rc.1")).unwrap();
+        let ba = Arc::new(ba);
+        let backend_impl = Arc::new(RemoteVersionsBackend::new(ba.clone(), vec![], None));
+
+        let stable_request = ToolRequest::Version {
+            backend: ba.clone(),
+            version: "latest".to_string(),
+            options: ToolVersionOptions::default(),
+            source: ToolSource::Argument,
+        };
+        let prerelease_request = ToolRequest::Version {
+            backend: ba,
+            version: "latest".to_string(),
+            options: prerelease_options(),
+            source: ToolSource::Argument,
+        };
+        let resolve_options = ResolveOptions {
+            use_locked_version: false,
+            ..Default::default()
+        };
+
+        let backend: ABackend = backend_impl.clone();
+        let stable = ToolVersion::resolve_version(
+            &config,
+            stable_request,
+            &backend,
+            "latest",
+            &resolve_options,
+        )
+        .await
+        .unwrap();
+        let prerelease = ToolVersion::resolve_version(
+            &config,
+            prerelease_request,
+            &backend,
+            "latest",
+            &resolve_options,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(stable.version, "1.0.0");
+        assert_eq!(prerelease.version, "1.1.0-rc.1");
+        assert_eq!(backend_impl.list_calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn resolve_version_uses_each_requests_minimum_release_age() {
+        let config = Config::get().await.unwrap();
+        let ba = Arc::new(BackendArg::from(unique_name("request-age")));
+        let backend_impl = Arc::new(RemoteVersionsBackend::new(
+            ba.clone(),
+            vec![
+                VersionInfo {
+                    version: "1.0.0".to_string(),
+                    created_at: Some("2000-01-01T00:00:00Z".to_string()),
+                    ..Default::default()
+                },
+                VersionInfo {
+                    version: "1.1.0".to_string(),
+                    created_at: Some("2999-01-01T00:00:00Z".to_string()),
+                    ..Default::default()
+                },
+            ],
+            None,
+        ));
+        backend_impl
+            .get_remote_version_cache()
+            .lock()
+            .await
+            .clear()
+            .unwrap();
+
+        let unrestricted_request = ToolRequest::Version {
+            backend: ba.clone(),
+            version: "1".to_string(),
+            options: ToolVersionOptions::default(),
+            source: ToolSource::Argument,
+        };
+        let mut aged_options = ToolVersionOptions::default();
+        aged_options.opts.insert(
+            "minimum_release_age".to_string(),
+            toml::Value::String("1d".to_string()),
+        );
+        let aged_request = ToolRequest::Version {
+            backend: ba,
+            version: "1".to_string(),
+            options: aged_options,
+            source: ToolSource::Argument,
+        };
+        let resolve_options = ResolveOptions {
+            latest_versions: true,
+            use_locked_version: false,
+            ..Default::default()
+        };
+        let unrestricted_resolve_options = unrestricted_request
+            .resolve_options(&resolve_options)
+            .unwrap();
+        let aged_resolve_options = aged_request.resolve_options(&resolve_options).unwrap();
+
+        let backend: ABackend = backend_impl.clone();
+        let unrestricted = ToolVersion::resolve_version(
+            &config,
+            unrestricted_request,
+            &backend,
+            "1",
+            &unrestricted_resolve_options,
+        )
+        .await
+        .unwrap();
+        let aged = ToolVersion::resolve_version(
+            &config,
+            aged_request,
+            &backend,
+            "1",
+            &aged_resolve_options,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(unrestricted.version, "1.1.0");
+        assert_eq!(aged.version, "1.0.0");
+        assert_eq!(backend_impl.list_calls(), 1);
     }
 
     #[test]

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -118,14 +118,14 @@ impl ToolVersion {
         }
         let tv = match request.clone() {
             ToolRequest::Version { version: v, .. } => {
-                Self::resolve_version(config, request, &v, &opts).await?
+                Self::resolve_version(config, request, &backend, &v, &opts).await?
             }
             ToolRequest::Prefix { prefix, .. } => {
-                Self::resolve_prefix(config, request, &prefix, &opts).await?
+                Self::resolve_prefix(config, request, &backend, &prefix, &opts).await?
             }
             ToolRequest::Sub {
                 sub, orig_version, ..
-            } => Self::resolve_sub(config, request, &sub, &orig_version, &opts).await?,
+            } => Self::resolve_sub(config, request, &backend, &sub, &orig_version, &opts).await?,
             _ => {
                 let version = request.version();
                 Self::new(request, version)
@@ -350,21 +350,11 @@ impl ToolVersion {
     async fn resolve_version(
         config: &Arc<Config>,
         request: ToolRequest,
+        backend: &ABackend,
         v: &str,
         opts: &ResolveOptions,
     ) -> Result<ToolVersion> {
-        let backend = request.backend()?;
-        Self::resolve_version_with_backend(config, request, backend, v, opts).await
-    }
-
-    async fn resolve_version_with_backend(
-        config: &Arc<Config>,
-        request: ToolRequest,
-        backend: ABackend,
-        v: &str,
-        opts: &ResolveOptions,
-    ) -> Result<ToolVersion> {
-        let v = config.resolve_alias(&backend, v).await?;
+        let v = config.resolve_alias(backend, v).await?;
 
         // Re-check the lockfile after alias resolution (e.g., "lts" → "24")
         // The initial lockfile check in resolve() uses the unresolved alias which
@@ -418,11 +408,11 @@ impl ToolVersion {
                 return Self::resolve_path(PathBuf::from(p), &request);
             }
             Some(("prefix", p)) => {
-                return Self::resolve_prefix(config, request, p, opts).await;
+                return Self::resolve_prefix(config, request, backend, p, opts).await;
             }
             Some((part, v)) if part.starts_with("sub-") => {
                 let sub = part.split_once('-').unwrap().1;
-                return Self::resolve_sub(config, request, sub, v, opts).await;
+                return Self::resolve_sub(config, request, backend, sub, v, opts).await;
             }
             _ => (),
         }
@@ -539,7 +529,7 @@ impl ToolVersion {
             if opts.offline {
                 return build(v);
             }
-            return Err(Self::no_versions_found(&backend, opts.before_date));
+            return Err(Self::no_versions_found(backend, opts.before_date));
         }
         let installed_matches =
             (!opts.latest_versions).then(|| backend.list_installed_versions_matching(&v));
@@ -693,11 +683,11 @@ impl ToolVersion {
     async fn resolve_sub(
         config: &Arc<Config>,
         request: ToolRequest,
+        backend: &ABackend,
         sub: &str,
         v: &str,
         opts: &ResolveOptions,
     ) -> Result<Self> {
-        let backend = request.backend()?;
         let selection_opts = request.options();
         if v == "latest" && opts.offline {
             let pathname = request.version().replace([':', '/'], "-");
@@ -707,7 +697,10 @@ impl ToolVersion {
                 && target.starts_with("./")
                 && let Some(version) = target.file_name().map(|v| v.to_string_lossy().to_string())
             {
-                return Box::pin(Self::resolve_version(config, request, &version, opts)).await;
+                return Box::pin(Self::resolve_version(
+                    config, request, backend, &version, opts,
+                ))
+                .await;
             }
             // Can't resolve sub-N:latest offline (no remote latest, and
             // applying version_sub to latest_installed_version would shift
@@ -719,7 +712,7 @@ impl ToolVersion {
         }
         let v = resolve_sub_base(
             config,
-            &backend,
+            backend,
             &selection_opts,
             sub,
             v,
@@ -727,16 +720,16 @@ impl ToolVersion {
             opts.refresh_remote_versions,
         )
         .await?;
-        Box::pin(Self::resolve_version(config, request, &v, opts)).await
+        Box::pin(Self::resolve_version(config, request, backend, &v, opts)).await
     }
 
     async fn resolve_prefix(
         config: &Arc<Config>,
         request: ToolRequest,
+        backend: &ABackend,
         prefix: &str,
         opts: &ResolveOptions,
     ) -> Result<Self> {
-        let backend = request.backend()?;
         let selection_opts = request.options();
         let settings = Settings::get();
         let is_offline = settings.offline() || opts.offline;
@@ -767,7 +760,7 @@ impl ToolVersion {
             .await?;
         let v = matches
             .last()
-            .ok_or_else(|| Self::no_versions_found(&backend, opts.before_date))?;
+            .ok_or_else(|| Self::no_versions_found(backend, opts.before_date))?;
         Ok(Self::new(request, v.to_string()))
     }
 
@@ -1112,11 +1105,11 @@ mod tests {
     async fn resolve_version_uses_each_requests_prerelease_option() {
         let config = Config::get().await.unwrap();
         let ba = Arc::new(BackendArg::from(unique_name("request-options")));
-        let backend = Arc::new(RequestOptionsBackend {
+        let backend_impl = Arc::new(RequestOptionsBackend {
             ba: ba.clone(),
             list_calls: AtomicUsize::new(0),
         });
-        backend
+        backend_impl
             .get_remote_version_cache()
             .lock()
             .await
@@ -1146,19 +1139,15 @@ mod tests {
             ..Default::default()
         };
 
-        let stable = ToolVersion::resolve_version_with_backend(
-            &config,
-            stable_request,
-            backend.clone(),
-            "1",
-            &resolve_options,
-        )
-        .await
-        .unwrap();
-        let prerelease = ToolVersion::resolve_version_with_backend(
+        let backend: ABackend = backend_impl.clone();
+        let stable =
+            ToolVersion::resolve_version(&config, stable_request, &backend, "1", &resolve_options)
+                .await
+                .unwrap();
+        let prerelease = ToolVersion::resolve_version(
             &config,
             prerelease_request,
-            backend.clone(),
+            &backend,
             "1",
             &resolve_options,
         )
@@ -1167,7 +1156,7 @@ mod tests {
 
         assert_eq!(stable.version, "1.0.0");
         assert_eq!(prerelease.version, "1.1.0-rc.1");
-        assert_eq!(backend.list_calls.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(backend_impl.list_calls.load(AtomicOrdering::SeqCst), 1);
     }
 
     #[test]

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -717,20 +717,16 @@ impl ToolVersion {
             let version = request.version();
             return Ok(Self::new(request, version));
         }
-        let v = match v {
-            "latest" => backend
-                .latest_version_with_selection_options(
-                    config,
-                    None,
-                    &selection_opts,
-                    opts.before_date,
-                    opts.refresh_remote_versions,
-                )
-                .await?
-                .ok_or_else(|| Self::no_versions_found(&backend, opts.before_date))?,
-            _ => config.resolve_alias(&backend, v).await?,
-        };
-        let v = tool_request::version_sub(&v, sub);
+        let v = resolve_sub_base(
+            config,
+            &backend,
+            &selection_opts,
+            sub,
+            v,
+            opts.before_date,
+            opts.refresh_remote_versions,
+        )
+        .await?;
         Box::pin(Self::resolve_version(config, request, &v, opts)).await
     }
 
@@ -814,6 +810,7 @@ impl ToolVersion {
 pub(crate) async fn resolve_sub_base(
     config: &Arc<Config>,
     backend: &ABackend,
+    selection_opts: &ToolVersionOptions,
     sub: &str,
     base: &str,
     before_date: Option<Timestamp>,
@@ -829,7 +826,13 @@ pub(crate) async fn resolve_sub_base(
     };
     let v = if base == "latest" {
         backend
-            .latest_version_with_refresh(config, None, before_date, refresh_remote_versions)
+            .latest_version_with_selection_options(
+                config,
+                None,
+                selection_opts,
+                before_date,
+                refresh_remote_versions,
+            )
             .await?
             .ok_or_else(|| ToolVersion::no_versions_found(backend, before_date))?
     } else {

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -354,6 +354,16 @@ impl ToolVersion {
         opts: &ResolveOptions,
     ) -> Result<ToolVersion> {
         let backend = request.backend()?;
+        Self::resolve_version_with_backend(config, request, backend, v, opts).await
+    }
+
+    async fn resolve_version_with_backend(
+        config: &Arc<Config>,
+        request: ToolRequest,
+        backend: ABackend,
+        v: &str,
+        opts: &ResolveOptions,
+    ) -> Result<ToolVersion> {
         let v = config.resolve_alias(&backend, v).await?;
 
         // Re-check the lockfile after alias resolution (e.g., "lts" → "24")
@@ -417,6 +427,7 @@ impl ToolVersion {
             _ => (),
         }
 
+        let selection_opts = request.options();
         let build = |v| Ok(Self::new(request.clone(), v));
 
         if v.matches('.').count() >= 2 {
@@ -496,9 +507,10 @@ impl ToolVersion {
             }
             if !is_offline
                 && let Some(v) = backend
-                    .latest_version_with_refresh(
+                    .latest_version_with_selection_options(
                         config,
                         None,
+                        &selection_opts,
                         opts.before_date,
                         opts.refresh_remote_versions,
                     )
@@ -508,7 +520,11 @@ impl ToolVersion {
             }
             if !is_offline {
                 let versions = backend
-                    .list_remote_versions_with_refresh(config, opts.refresh_remote_versions)
+                    .list_remote_versions_with_selection_options(
+                        config,
+                        &selection_opts,
+                        opts.refresh_remote_versions,
+                    )
                     .await?;
                 if versions.is_empty()
                     && let Some(v) = backend.unresolved_latest_version()
@@ -541,7 +557,13 @@ impl ToolVersion {
             // bypasses an installed fuzzy match. Some backend exact resolvers
             // only validate syntax and defer existence checks to installation.
             let matches = backend
-                .list_versions_matching_with_opts(config, &v, None, opts.refresh_remote_versions)
+                .list_versions_matching_with_selection_options(
+                    config,
+                    &v,
+                    &selection_opts,
+                    None,
+                    opts.refresh_remote_versions,
+                )
                 .await?;
             if matches.contains(&v) {
                 return build(v);
@@ -576,8 +598,9 @@ impl ToolVersion {
                 let versions = match opts.before_date {
                     Some(before) => {
                         let versions_with_info = backend
-                            .list_remote_versions_with_info_with_refresh(
+                            .list_remote_versions_with_info_with_selection_options(
                                 config,
+                                &selection_opts,
                                 opts.refresh_remote_versions,
                             )
                             .await?;
@@ -588,7 +611,11 @@ impl ToolVersion {
                     }
                     None => {
                         backend
-                            .list_remote_versions_with_refresh(config, opts.refresh_remote_versions)
+                            .list_remote_versions_with_selection_options(
+                                config,
+                                &selection_opts,
+                                opts.refresh_remote_versions,
+                            )
                             .await?
                     }
                 };
@@ -626,9 +653,10 @@ impl ToolVersion {
             Some(matches) => matches,
             None => {
                 backend
-                    .list_versions_matching_with_opts(
+                    .list_versions_matching_with_selection_options(
                         config,
                         &v,
+                        &selection_opts,
                         opts.before_date,
                         opts.refresh_remote_versions,
                     )
@@ -644,7 +672,15 @@ impl ToolVersion {
         // If date filter is active and exact version not found, check without filter.
         // Explicit pinned versions like "22.5.0" should not be filtered by date.
         if opts.before_date.is_some() {
-            let all_versions = backend.list_versions_matching(config, &v).await?;
+            let all_versions = backend
+                .list_versions_matching_with_selection_options(
+                    config,
+                    &v,
+                    &selection_opts,
+                    None,
+                    false,
+                )
+                .await?;
             if all_versions.contains(&v) {
                 // Exact match exists but was filtered by date - use it anyway
                 return build(v);
@@ -662,6 +698,7 @@ impl ToolVersion {
         opts: &ResolveOptions,
     ) -> Result<Self> {
         let backend = request.backend()?;
+        let selection_opts = request.options();
         if v == "latest" && opts.offline {
             let pathname = request.version().replace([':', '/'], "-");
             let path = backend.ba().installs_path.join(&pathname);
@@ -680,15 +717,20 @@ impl ToolVersion {
             let version = request.version();
             return Ok(Self::new(request, version));
         }
-        let v = resolve_sub_base(
-            config,
-            &backend,
-            sub,
-            v,
-            opts.before_date,
-            opts.refresh_remote_versions,
-        )
-        .await?;
+        let v = match v {
+            "latest" => backend
+                .latest_version_with_selection_options(
+                    config,
+                    None,
+                    &selection_opts,
+                    opts.before_date,
+                    opts.refresh_remote_versions,
+                )
+                .await?
+                .ok_or_else(|| Self::no_versions_found(&backend, opts.before_date))?,
+            _ => config.resolve_alias(&backend, v).await?,
+        };
+        let v = tool_request::version_sub(&v, sub);
         Box::pin(Self::resolve_version(config, request, &v, opts)).await
     }
 
@@ -699,6 +741,7 @@ impl ToolVersion {
         opts: &ResolveOptions,
     ) -> Result<Self> {
         let backend = request.backend()?;
+        let selection_opts = request.options();
         let settings = Settings::get();
         let is_offline = settings.offline() || opts.offline;
         let prefer_offline =
@@ -718,9 +761,10 @@ impl ToolVersion {
             return Ok(Self::new(request, prefix.to_string()));
         }
         let matches = backend
-            .list_versions_matching_with_opts(
+            .list_versions_matching_with_selection_options(
                 config,
                 prefix,
+                &selection_opts,
                 opts.before_date,
                 opts.refresh_remote_versions,
             )
@@ -993,9 +1037,49 @@ impl Display for ResolveOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::backend::{Backend, VersionInfo};
     use crate::cli::args::BackendResolution;
+    use crate::install_context::InstallContext;
     use crate::toolset::CoreToolOptions;
+    use async_trait::async_trait;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[derive(Debug)]
+    struct RequestOptionsBackend {
+        ba: Arc<BackendArg>,
+        list_calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl Backend for RequestOptionsBackend {
+        fn ba(&self) -> &Arc<BackendArg> {
+            &self.ba
+        }
+
+        async fn _list_remote_versions(&self, _config: &Arc<Config>) -> Result<Vec<VersionInfo>> {
+            self.list_calls.fetch_add(1, AtomicOrdering::SeqCst);
+            Ok(vec![
+                VersionInfo {
+                    version: "1.0.0".to_string(),
+                    ..Default::default()
+                },
+                VersionInfo {
+                    version: "1.1.0-rc.1".to_string(),
+                    prerelease: true,
+                    ..Default::default()
+                },
+            ])
+        }
+
+        async fn install_version_(
+            &self,
+            _ctx: &InstallContext,
+            tv: ToolVersion,
+        ) -> Result<ToolVersion> {
+            Ok(tv)
+        }
+    }
 
     fn unique_name(prefix: &str) -> String {
         format!(
@@ -1019,6 +1103,68 @@ mod tests {
         );
         backend.installs_path = installs_path;
         backend
+    }
+
+    #[tokio::test]
+    async fn resolve_version_uses_each_requests_prerelease_option() {
+        let config = Config::get().await.unwrap();
+        let ba = Arc::new(BackendArg::from(unique_name("request-options")));
+        let backend = Arc::new(RequestOptionsBackend {
+            ba: ba.clone(),
+            list_calls: AtomicUsize::new(0),
+        });
+        backend
+            .get_remote_version_cache()
+            .lock()
+            .await
+            .clear()
+            .unwrap();
+
+        let stable_options = ToolVersionOptions::default();
+        let mut prerelease_options = ToolVersionOptions::default();
+        prerelease_options
+            .opts
+            .insert("prerelease".to_string(), toml::Value::Boolean(true));
+        let stable_request = ToolRequest::Version {
+            backend: ba.clone(),
+            version: "1".to_string(),
+            options: stable_options,
+            source: ToolSource::Argument,
+        };
+        let prerelease_request = ToolRequest::Version {
+            backend: ba,
+            version: "1".to_string(),
+            options: prerelease_options,
+            source: ToolSource::Argument,
+        };
+        let resolve_options = ResolveOptions {
+            latest_versions: true,
+            use_locked_version: false,
+            ..Default::default()
+        };
+
+        let stable = ToolVersion::resolve_version_with_backend(
+            &config,
+            stable_request,
+            backend.clone(),
+            "1",
+            &resolve_options,
+        )
+        .await
+        .unwrap();
+        let prerelease = ToolVersion::resolve_version_with_backend(
+            &config,
+            prerelease_request,
+            backend.clone(),
+            "1",
+            &resolve_options,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(stable.version, "1.0.0");
+        assert_eq!(prerelease.version, "1.1.0-rc.1");
+        assert_eq!(backend.list_calls.load(AtomicOrdering::SeqCst), 1);
     }
 
     #[test]

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -765,9 +765,9 @@ fn should_refresh_remote_versions(
     }
     match tr {
         ToolRequest::Version { version, .. } => version == "latest",
-        ToolRequest::Prefix { prefix, .. } => {
-            backend.list_installed_versions_matching(prefix).is_empty()
-        }
+        ToolRequest::Prefix { prefix, .. } => backend
+            .list_installed_versions_matching_with_selection_options(prefix, &tr.options())
+            .is_empty(),
         ToolRequest::Sub { orig_version, .. } => orig_version == "latest",
         ToolRequest::Ref { .. } | ToolRequest::Path { .. } | ToolRequest::System { .. } => false,
     }


### PR DESCRIPTION
## What

Resolve explicit lock requests through the normal request-aware resolver and reject selectors that do not produce concrete versions.

This covers aliases, prefixes, sub-version requests, npm ranges, rolling channels, and offline resolution while preserving the existing lockfile when resolution fails. Configured options remain the base layer and explicit inline options win.

## Stack

Stack order: #12060 → #11720 → #12196 → #12197 → **this PR**.

This PR directly depends on #12197. Review and merge the stack in the order shown above.

Because the source branches live in a contributor fork, GitHub requires this PR to target `main` and therefore displays prerequisite commits cumulatively. Review the focused layer here:

https://github.com/risu729/mise/compare/agent/fix-upgrade-selector-resolution...agent/fix-lock-concrete-selectors

## Test

- `mise run format`
- `mise run test:unit -- lock_request_options_preserve_config_and_inline_precedence`
- `mise run test:unit -- symbolic_lock_versions_are_not_concrete_even_when_installed`
- `mise run test:e2e e2e/lockfile/test_lockfile_alias`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Version selection now respects request-specific options, including prerelease preferences, rolling channels, release-age limits, and aliases.
  * Upgrade, latest-version, outdated-tool, and sub-version resolution provide more accurate results.
  * Lockfile commands validate concrete versions and report clearer errors for unresolved or offline selectors.

* **Bug Fixes**
  * Improved handling of incomplete installations, runtime links, prerelease versions, and cached release metadata.
  * Lockfiles are preserved when selectors cannot be resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->