### PR TITLE
fix(backend): normalize shorthand archive stems

### DIFF
--- a/src/backend/asset_matcher.rs
+++ b/src/backend/asset_matcher.rs
@@ -593,6 +593,8 @@ impl AssetPicker {
 
         if format == ExtractionFormat::Zip {
             if self.target_os == "windows" {
+                // Native Windows ZIP extraction is faster than tar. Keep this
+                // strictly above every tar format score below.
                 return 15;
             } else {
                 return 5;
@@ -601,12 +603,11 @@ impl AssetPicker {
 
         if format.is_archive() {
             return match format {
-                // Since we are downloading, prefer small archives: zstd and xz
-                // tend to be smaller archives.
-                ExtractionFormat::TarZst => 15,
-                // xz comes in after zst because it can cost more CPU to decompress.
-                ExtractionFormat::TarXz => 13,
-                // All other archive formats roughly created equal.
+                // Prefer zstd over xz over other tarballs: zstd decompresses
+                // faster, which usually beats xz's slightly smaller download.
+                // Stay below the Windows ZIP score so zip still wins there.
+                ExtractionFormat::TarZst => 12,
+                ExtractionFormat::TarXz => 11,
                 _ => 10,
             };
         }
@@ -751,16 +752,41 @@ fn asset_matches_preferred_name(asset: &str, preferred_name: &str) -> bool {
 
 fn asset_name_stem(asset: &str) -> String {
     let mut name = asset.rsplit('/').next().unwrap_or(asset).to_lowercase();
-    let suffixes = [
-        ".tar.gz", ".tar.xz", ".tar.bz2", ".tar.zst", ".tgz", ".txz", ".tzst", ".tar", ".zip",
-        ".gz", ".xz", ".bz2", ".zst", ".phar", ".jar", ".pyz", ".exe", ".msi",
-    ];
-
-    if let Some(suffix) = suffixes.iter().find(|suffix| name.ends_with(*suffix)) {
+    if let Some(suffix_len) = extraction_suffix_len(&name) {
+        name.truncate(name.len() - suffix_len);
+        return name;
+    }
+    // Runtime/installer suffixes are not ExtractionFormats but still need to
+    // be stripped so preferred_name matching sees the same stem as archives.
+    const EXTRA_SUFFIXES: [&str; 5] = [".phar", ".jar", ".pyz", ".exe", ".msi"];
+    if let Some(suffix) = EXTRA_SUFFIXES.iter().find(|suffix| name.ends_with(*suffix)) {
         name.truncate(name.len() - suffix.len());
     }
-
     name
+}
+
+/// Length of the archive/compression suffix recognized by [`ExtractionFormat`].
+///
+/// Shorthand names like `.txz` / `.tzst` / `.tbz2` must be stripped as a whole
+/// unit. A naive `.xz` / `.zst` / `.bz2` match leaves a trailing `t` in the
+/// stem, which then fails [`asset_matches_preferred_name`].
+fn extraction_suffix_len(name: &str) -> Option<usize> {
+    let format = ExtractionFormat::from_file_name(name);
+    if format == ExtractionFormat::Raw {
+        return None;
+    }
+    if let Some(idx) = name.rfind(".tar.") {
+        let ext = &name[idx + 1..];
+        if ExtractionFormat::from_ext(ext) == Some(format) {
+            return Some(name.len() - idx);
+        }
+    }
+    if let Some((_, ext)) = name.rsplit_once('.') {
+        if ExtractionFormat::from_ext(ext) == Some(format) {
+            return Some(ext.len() + 1);
+        }
+    }
+    None
 }
 
 /// Detects platform information from a URL
@@ -953,8 +979,13 @@ impl AssetMatcher {
             .trim_end_matches(".tar.gz")
             .trim_end_matches(".tar.xz")
             .trim_end_matches(".tar.bz2")
+            .trim_end_matches(".tar.zst")
             .trim_end_matches(".zip")
-            .trim_end_matches(".tgz");
+            .trim_end_matches(".tgz")
+            .trim_end_matches(".txz")
+            .trim_end_matches(".tzst")
+            .trim_end_matches(".tbz2")
+            .trim_end_matches(".tbz");
 
         // Try exact match with checksum extension
         for ext in CHECKSUM_EXTENSIONS.iter() {
@@ -1714,6 +1745,35 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-1.0.0-dar
             .pick_best_asset(&[tar_gz.to_string(), tar_xz.to_string()])
             .unwrap();
         assert_eq!(picked, tar_xz);
+
+        let tzst = "tool-1.0.0-linux-x86_64.tzst";
+        let txz = "tool-1.0.0-linux-x86_64.txz";
+        let tgz = "tool-1.0.0-linux-x86_64.tgz";
+        let picked = picker
+            .pick_best_asset(&[tgz.to_string(), txz.to_string(), tzst.to_string()])
+            .unwrap();
+        assert_eq!(picked, tzst);
+        let picked = picker
+            .pick_best_asset(&[tgz.to_string(), txz.to_string()])
+            .unwrap();
+        assert_eq!(picked, txz);
+    }
+
+    #[test]
+    fn test_shorthand_txz_preferred_over_tgz_with_preferred_name() {
+        // Elide-style names: equal platform scores, `.tgz` vs `.txz`.
+        // Stem-stripping `.txz` as `.xz` left a trailing `t`, so preferred_name
+        // matching failed and the +20 bonus made `.tgz` win even after xz was
+        // scored above gzip. Both the stem and format-score fixes are required.
+        let assets = vec![
+            "elide.linux-amd64.tgz".to_string(),
+            "elide.linux-amd64.txz".to_string(),
+            "elide.linux-amd64.zip".to_string(),
+        ];
+        let picker = AssetPicker::with_libc("linux".to_string(), "x86_64".to_string(), None)
+            .with_preferred_name("elide");
+        let picked = picker.pick_best_asset(&assets).unwrap();
+        assert_eq!(picked, "elide.linux-amd64.txz");
     }
 
     #[test]
@@ -1725,6 +1785,22 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-1.0.0-dar
         assert_eq!(
             asset_name_stem("tool-1.0.0-linux-x86_64.txz"),
             "tool-1.0.0-linux-x86_64"
+        );
+        assert_eq!(
+            asset_name_stem("tool-1.0.0-linux-x86_64.tbz2"),
+            "tool-1.0.0-linux-x86_64"
+        );
+        assert_eq!(
+            asset_name_stem("tool-1.0.0-linux-x86_64.tbz"),
+            "tool-1.0.0-linux-x86_64"
+        );
+        assert_eq!(
+            asset_name_stem("tool-1.0.0-linux-x86_64.tgz"),
+            "tool-1.0.0-linux-x86_64"
+        );
+        assert_eq!(
+            asset_name_stem("elide.linux-amd64.txz"),
+            "elide.linux-amd64"
         );
     }
 
@@ -2704,6 +2780,28 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-darwin.ta
             score_linux_zip,
             score_linux_tar
         );
+
+        // Windows ZIP must strictly outrank tar.zst / tar.xz, not merely tie
+        // and win on the shortest-name fallback.
+        let zip = "tool-1.0.0-windows-x86_64.zip";
+        let tar_zst = "tool-1.0.0-windows-x86_64.tar.zst";
+        let tar_xz = "tool-1.0.0-windows-x86_64.tar.xz";
+        assert!(
+            picker_win.score_asset(zip) > picker_win.score_asset(tar_zst),
+            "Windows zip score ({}) should beat tar.zst ({})",
+            picker_win.score_asset(zip),
+            picker_win.score_asset(tar_zst)
+        );
+        assert!(
+            picker_win.score_asset(zip) > picker_win.score_asset(tar_xz),
+            "Windows zip score ({}) should beat tar.xz ({})",
+            picker_win.score_asset(zip),
+            picker_win.score_asset(tar_xz)
+        );
+        let picked = picker_win
+            .pick_best_asset(&[tar_zst.to_string(), tar_xz.to_string(), zip.to_string()])
+            .unwrap();
+        assert_eq!(picked, zip);
     }
 
     #[test]

--- a/src/backend/asset_matcher.rs
+++ b/src/backend/asset_matcher.rs
@@ -775,16 +775,15 @@ fn extraction_suffix_len(name: &str) -> Option<usize> {
     if format == ExtractionFormat::Raw {
         return None;
     }
-    if let Some(idx) = name.rfind(".tar.") {
-        let ext = &name[idx + 1..];
-        if ExtractionFormat::from_ext(ext) == Some(format) {
-            return Some(name.len() - idx);
-        }
+    if let Some(idx) = name.rfind(".tar.")
+        && ExtractionFormat::from_ext(&name[idx + 1..]) == Some(format)
+    {
+        return Some(name.len() - idx);
     }
-    if let Some((_, ext)) = name.rsplit_once('.') {
-        if ExtractionFormat::from_ext(ext) == Some(format) {
-            return Some(ext.len() + 1);
-        }
+    if let Some((_, ext)) = name.rsplit_once('.')
+        && ExtractionFormat::from_ext(ext) == Some(format)
+    {
+        return Some(ext.len() + 1);
     }
     None
 }

--- a/src/backend/asset_matcher.rs
+++ b/src/backend/asset_matcher.rs
@@ -593,8 +593,6 @@ impl AssetPicker {
 
         if format == ExtractionFormat::Zip {
             if self.target_os == "windows" {
-                // Native Windows ZIP extraction is faster than tar. Keep this
-                // strictly above every tar format score below.
                 return 15;
             } else {
                 return 5;
@@ -603,11 +601,12 @@ impl AssetPicker {
 
         if format.is_archive() {
             return match format {
-                // Prefer zstd over xz over other tarballs: zstd decompresses
-                // faster, which usually beats xz's slightly smaller download.
-                // Stay below the Windows ZIP score so zip still wins there.
-                ExtractionFormat::TarZst => 12,
-                ExtractionFormat::TarXz => 11,
+                // Since we are downloading, prefer small archives: zstd and xz
+                // tend to be smaller archives.
+                ExtractionFormat::TarZst => 15,
+                // xz comes in after zst because it can cost more CPU to decompress.
+                ExtractionFormat::TarXz => 13,
+                // All other archive formats roughly created equal.
                 _ => 10,
             };
         }
@@ -765,27 +764,50 @@ fn asset_name_stem(asset: &str) -> String {
     name
 }
 
-/// Length of the archive/compression suffix recognized by [`ExtractionFormat`].
+/// Length of an archive/compression suffix that can be removed when matching an
+/// asset's preferred name.
 ///
 /// Shorthand names like `.txz` / `.tzst` / `.tbz2` must be stripped as a whole
-/// unit. A naive `.xz` / `.zst` / `.bz2` match leaves a trailing `t` in the
-/// stem, which then fails [`asset_matches_preferred_name`].
+/// unit. Keeping a separate suffix table in sync with [`ExtractionFormat`]
+/// omitted bzip shorthands, and a shorter `.bz2` match left a trailing `t` that
+/// then failed [`asset_matches_preferred_name`].
 fn extraction_suffix_len(name: &str) -> Option<usize> {
-    let format = ExtractionFormat::from_file_name(name);
-    if format == ExtractionFormat::Raw {
-        return None;
-    }
-    if let Some(idx) = name.rfind(".tar.")
-        && ExtractionFormat::from_ext(&name[idx + 1..]) == Some(format)
+    let lowercase = name.to_lowercase();
+    let format = ExtractionFormat::from_file_name(&lowercase);
+    if let Some(idx) = lowercase.rfind(".tar.")
+        && ExtractionFormat::from_ext(&lowercase[idx + 1..]) == Some(format)
+        && is_asset_stem_format(format, &lowercase[idx + 1..])
     {
-        return Some(name.len() - idx);
+        return Some(lowercase.len() - idx);
     }
-    if let Some((_, ext)) = name.rsplit_once('.')
+    if let Some((_, ext)) = lowercase.rsplit_once('.')
         && ExtractionFormat::from_ext(ext) == Some(format)
+        && is_asset_stem_format(format, ext)
     {
         return Some(ext.len() + 1);
     }
     None
+}
+
+/// Keep preferred-name normalization scoped to the suffix families mise
+/// already treated as executable assets, plus the missing bzip shorthands.
+/// Other `ExtractionFormat` variants include unsupported archives (`rar`,
+/// `tar.br`, ...) and semantically distinct packages (`vsix`); granting those
+/// the preferred-name bonus can make them beat an installable asset.
+fn is_asset_stem_format(format: ExtractionFormat, ext: &str) -> bool {
+    match format {
+        ExtractionFormat::TarGz
+        | ExtractionFormat::Gz
+        | ExtractionFormat::TarXz
+        | ExtractionFormat::Xz
+        | ExtractionFormat::TarBz2
+        | ExtractionFormat::Bz2
+        | ExtractionFormat::TarZst
+        | ExtractionFormat::Zst
+        | ExtractionFormat::Tar => true,
+        ExtractionFormat::Zip => ext == "zip",
+        _ => false,
+    }
 }
 
 /// Detects platform information from a URL
@@ -974,17 +996,9 @@ impl AssetMatcher {
 
     /// Find checksum file for a given asset
     pub fn find_checksum_for(&self, asset_name: &str, assets: &[String]) -> Option<String> {
-        let base_name = asset_name
-            .trim_end_matches(".tar.gz")
-            .trim_end_matches(".tar.xz")
-            .trim_end_matches(".tar.bz2")
-            .trim_end_matches(".tar.zst")
-            .trim_end_matches(".zip")
-            .trim_end_matches(".tgz")
-            .trim_end_matches(".txz")
-            .trim_end_matches(".tzst")
-            .trim_end_matches(".tbz2")
-            .trim_end_matches(".tbz");
+        let base_name = extraction_suffix_len(asset_name)
+            .map(|suffix_len| &asset_name[..asset_name.len() - suffix_len])
+            .unwrap_or(asset_name);
 
         // Try exact match with checksum extension
         for ext in CHECKSUM_EXTENSIONS.iter() {
@@ -1334,6 +1348,20 @@ mod tests {
         let assets = vec!["tool-1.0.0.tar.gz".to_string(), "checksums.txt".to_string()];
         let checksum = matcher.find_checksum_for("tool-1.0.0.tar.gz", &assets);
         assert_eq!(checksum, Some("checksums.txt".to_string()));
+    }
+
+    #[test]
+    fn test_find_stem_checksum_for_shorthand_archives() {
+        let matcher = AssetMatcher::new();
+        for suffix in ["tar.zst", "txz", "tzst", "tbz2", "tbz", "TXZ"] {
+            let asset = format!("tool.{suffix}");
+            let assets = vec![asset.clone(), "tool.sha256".to_string()];
+            assert_eq!(
+                matcher.find_checksum_for(&asset, &assets),
+                Some("tool.sha256".to_string()),
+                "failed to match checksum for {asset}"
+            );
+        }
     }
 
     // ========== Checksum Helper Tests ==========
@@ -1760,10 +1788,9 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-1.0.0-dar
 
     #[test]
     fn test_shorthand_txz_preferred_over_tgz_with_preferred_name() {
-        // Elide-style names: equal platform scores, `.tgz` vs `.txz`.
-        // Stem-stripping `.txz` as `.xz` left a trailing `t`, so preferred_name
-        // matching failed and the +20 bonus made `.tgz` win even after xz was
-        // scored above gzip. Both the stem and format-score fixes are required.
+        // #12156 changed both txz stem handling and xz format scoring. Preserve
+        // coverage for their combined effect with the Elide-style names that
+        // originally exposed the issue.
         let assets = vec![
             "elide.linux-amd64.tgz".to_string(),
             "elide.linux-amd64.txz".to_string(),
@@ -1776,31 +1803,39 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-1.0.0-dar
     }
 
     #[test]
+    fn test_tbz2_receives_preferred_name_bonus() {
+        let assets = vec![
+            "other.linux-amd64.tar.zst".to_string(),
+            "elide.linux-amd64.tbz2".to_string(),
+        ];
+        let picker = AssetPicker::with_libc("linux".to_string(), "x86_64".to_string(), None)
+            .with_preferred_name("elide");
+        let picked = picker.pick_best_asset(&assets).unwrap();
+        assert_eq!(picked, "elide.linux-amd64.tbz2");
+    }
+
+    #[test]
     fn test_asset_name_stem_strips_shorthand_archive_suffixes() {
-        assert_eq!(
-            asset_name_stem("tool-1.0.0-linux-x86_64.tzst"),
-            "tool-1.0.0-linux-x86_64"
-        );
-        assert_eq!(
-            asset_name_stem("tool-1.0.0-linux-x86_64.txz"),
-            "tool-1.0.0-linux-x86_64"
-        );
-        assert_eq!(
-            asset_name_stem("tool-1.0.0-linux-x86_64.tbz2"),
-            "tool-1.0.0-linux-x86_64"
-        );
-        assert_eq!(
-            asset_name_stem("tool-1.0.0-linux-x86_64.tbz"),
-            "tool-1.0.0-linux-x86_64"
-        );
-        assert_eq!(
-            asset_name_stem("tool-1.0.0-linux-x86_64.tgz"),
-            "tool-1.0.0-linux-x86_64"
-        );
+        let stem = "tool-1.0.0-linux-x86_64";
+        for suffix in [
+            "tar.gz", "tgz", "gz", "tar.xz", "txz", "xz", "tar.bz2", "tbz2", "tbz", "bz2",
+            "tar.zst", "tzst", "zst", "tar", "zip",
+        ] {
+            assert_eq!(
+                asset_name_stem(&format!("{stem}.{suffix}")),
+                stem,
+                "failed to strip .{suffix}"
+            );
+        }
         assert_eq!(
             asset_name_stem("elide.linux-amd64.txz"),
             "elide.linux-amd64"
         );
+
+        for suffix in ["rar", "tbr", "tlz4", "tsz", "vsix"] {
+            let asset = format!("{stem}.{suffix}");
+            assert_eq!(asset_name_stem(&asset), asset);
+        }
     }
 
     #[test]
@@ -2779,28 +2814,6 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-darwin.ta
             score_linux_zip,
             score_linux_tar
         );
-
-        // Windows ZIP must strictly outrank tar.zst / tar.xz, not merely tie
-        // and win on the shortest-name fallback.
-        let zip = "tool-1.0.0-windows-x86_64.zip";
-        let tar_zst = "tool-1.0.0-windows-x86_64.tar.zst";
-        let tar_xz = "tool-1.0.0-windows-x86_64.tar.xz";
-        assert!(
-            picker_win.score_asset(zip) > picker_win.score_asset(tar_zst),
-            "Windows zip score ({}) should beat tar.zst ({})",
-            picker_win.score_asset(zip),
-            picker_win.score_asset(tar_zst)
-        );
-        assert!(
-            picker_win.score_asset(zip) > picker_win.score_asset(tar_xz),
-            "Windows zip score ({}) should beat tar.xz ({})",
-            picker_win.score_asset(zip),
-            picker_win.score_asset(tar_xz)
-        );
-        let picked = picker_win
-            .pick_best_asset(&[tar_zst.to_string(), tar_xz.to_string(), zip.to_string()])
-            .unwrap();
-        assert_eq!(picked, zip);
     }
 
     #[test]

--- a/src/backend/asset_matcher.rs
+++ b/src/backend/asset_matcher.rs
@@ -805,7 +805,9 @@ fn is_asset_stem_format(format: ExtractionFormat, ext: &str) -> bool {
         | ExtractionFormat::TarZst
         | ExtractionFormat::Zst
         | ExtractionFormat::Tar => true,
-        ExtractionFormat::Zip => ext == "zip",
+        // VSIX uses ZIP extraction too, but it is an extension package rather
+        // than a preferred executable asset.
+        ExtractionFormat::Zip if ext == "zip" => true,
         _ => false,
     }
 }


### PR DESCRIPTION
## Summary

- fix the `.tbz` / `.tbz2` preferred-name bug still present on `main`
- replace the manually ordered archive-stem suffix list with `ExtractionFormat`-validated parsing
- reuse the same suffix logic for stem-only checksum companions, including shorthand and mixed-case suffixes
- preserve the `.txz` / `.tzst` behavior already fixed by #12156 without boosting unsupported archive types

## Current `main`: fixed vs still broken

### Already fixed by #12156

Preferred-name handling for `.txz` and `.tzst` is working on current `main`. Those complete suffixes appear before the shorter `.xz` and `.zst` entries, so they no longer leave a trailing `t`.

The Elide-style selection between `elide.linux-amd64.tgz` and `elide.linux-amd64.txz` also works on `main`: both names receive the preferred-name bonus, and the xz format score makes `.txz` win.

Therefore, the claim that current `main` still strips `.txz` as `.xz` is incorrect. That describes the historical failure before #12156, not the current code.

### Still broken on `main`

The equivalent bzip shorthand cases were missed:

- `.tbz2` is not in the stem suffix list, so the later `.bz2` entry matches and leaves a trailing `t`.
- `.tbz` is not in the list at all, so the suffix remains attached.

For example:

```text
elide.linux-amd64.tbz2
                     └─ main removes only .bz2

result: elide.linux-amd64.t
```

That result no longer matches the preferred repository name, so the asset loses the +20 preferred-name bonus and can lose to a different archive.

Checksum companion discovery has a separate incomplete suffix list. On `main`, assets such as `tool.txz`, `tool.tzst`, `tool.tbz2`, `tool.tbz`, and `tool.tar.zst` cannot find a stem-only checksum named `tool.sha256`. Mixed-case suffixes such as `tool.TXZ` have the same problem.

## What was incomplete in #12156

The Elide failure that motivated #12156 was a `preferred_name` problem, not a case of `.tgz` and `.txz` being treated as the same asset. `asset_name_stem` is only used when applying the preferred-name bonus, and the GitHub backend sets that preferred name to the repository name.

Historically, stripping `.txz` as the shorter `.xz` suffix left a trailing `t`. `.tgz` then received the +20 bonus while `.txz` did not. Before the format scores were separated, the shortest-name and alphabetical tiebreak also favored `.tgz`.

#12156 fixed that specific case by landing both the complete `.txz` / `.tzst` stem entries and the xz/zstd score ordering. Its weakness was the diagnosis and coverage: it added manual special cases without testing the actual Elide preferred-name path, did not generalize the fix to `.tbz` / `.tbz2`, and left checksum suffix handling out of sync.

This PR fixes those residual stem and checksum gaps. It deliberately excludes unsupported or semantically distinct `ExtractionFormat` variants such as `.rar`, `.tbr`, and `.vsix` from the preferred-name bonus.

The separate draft #12200 fixes the direct scoring regression introduced by #12156: `TarZst` tying the Windows ZIP score instead of remaining strictly below it.

## Tests

- `cargo test --bin mise backend::asset_matcher`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved archive matching by prioritizing TarZst and TarXz formats while retaining reliable ZIP matching.
  - Improved preferred-name matching across case variations and supported executable and archive suffixes.
  - Added support for shorthand archive extensions, including `.tbz2`, when matching names and checksums.
  - Prevented ZIP-based extension packages such as `.vsix` from being incorrectly treated as standard ZIP archives.
  - Improved checksum matching and excluded unsupported formats from name processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
