### PR TITLE
fix(backend): preserve Windows ZIP preference

### DIFF
--- a/src/backend/asset_matcher.rs
+++ b/src/backend/asset_matcher.rs
@@ -593,6 +593,8 @@ impl AssetPicker {
 
         if format == ExtractionFormat::Zip {
             if self.target_os == "windows" {
+                // Native Windows ZIP extraction is faster than tar. Keep this
+                // strictly above every tar format score below.
                 return 15;
             } else {
                 return 5;
@@ -601,12 +603,11 @@ impl AssetPicker {
 
         if format.is_archive() {
             return match format {
-                // Since we are downloading, prefer small archives: zstd and xz
-                // tend to be smaller archives.
-                ExtractionFormat::TarZst => 15,
-                // xz comes in after zst because it can cost more CPU to decompress.
-                ExtractionFormat::TarXz => 13,
-                // All other archive formats roughly created equal.
+                // Prefer zstd over xz over other tarballs: zstd decompresses
+                // faster, which usually beats xz's slightly smaller download.
+                // Stay below the Windows ZIP score so zip still wins there.
+                ExtractionFormat::TarZst => 12,
+                ExtractionFormat::TarXz => 11,
                 _ => 10,
             };
         }
@@ -2704,6 +2705,28 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-darwin.ta
             score_linux_zip,
             score_linux_tar
         );
+
+        // Windows ZIP must strictly outrank tar.zst / tar.xz, not merely tie
+        // and win on the shortest-name fallback.
+        let zip = "tool-1.0.0-windows-x86_64.zip";
+        let tar_zst = "tool-1.0.0-windows-x86_64.tar.zst";
+        let tar_xz = "tool-1.0.0-windows-x86_64.tar.xz";
+        assert!(
+            picker_win.score_asset(zip) > picker_win.score_asset(tar_zst),
+            "Windows zip score ({}) should beat tar.zst ({})",
+            picker_win.score_asset(zip),
+            picker_win.score_asset(tar_zst)
+        );
+        assert!(
+            picker_win.score_asset(zip) > picker_win.score_asset(tar_xz),
+            "Windows zip score ({}) should beat tar.xz ({})",
+            picker_win.score_asset(zip),
+            picker_win.score_asset(tar_xz)
+        );
+        let picked = picker_win
+            .pick_best_asset(&[tar_zst.to_string(), tar_xz.to_string(), zip.to_string()])
+            .unwrap();
+        assert_eq!(picked, zip);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- keep Windows ZIP's score strictly above every tar archive format
- retain `tar.zst` > `tar.xz` > other tarball ordering below ZIP
- test both the raw score relationship and final asset selection

## What was wrong in #12156

#12156 raised `TarZst` to score 15, equal to the existing Windows ZIP score. ZIP then won only incidentally through the shortest-name tiebreak, so the change did not actually retain the documented Windows ZIP preference.

This restores a strict ordering: Windows ZIP at 15, then `tar.zst` / `tar.xz` / other tarballs at 12 / 11 / 10. The regression test checks the scores directly and verifies ZIP is selected over both `tar.zst` and `tar.xz`.

The companion draft #12199 handles the residual bzip shorthand and checksum-stem gaps in #12156 and adds the missing Elide-style preferred-name integration coverage.

## Tests

- `cargo test --bin mise backend::asset_matcher`
- `cargo clippy --bin mise --all-features --tests -- -D warnings`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*
