### PR TITLE
fix(task): preserve user-global task ownership

### DIFF
--- a/e2e/tasks/test_task_global_config_dedup
+++ b/e2e/tasks/test_task_global_config_dedup
@@ -107,3 +107,18 @@ EOF
 assert \
   "MISE_GLOBAL_CONFIG_FILE='$HOME/global-config/include-order.toml' MISE_SYSTEM_CONFIG_FILE='$HOME/global-config/missing.toml' mise run include-winner" \
   "$HOME/second-global-tasks/include-winner"
+
+local_include_marker="$MISE_TMP_DIR/local-include-render-count"
+: >"$local_include_marker"
+mkdir -p "$HOME/.config/mise/tasks"
+cat >"$HOME/mise.toml" <<EOF
+[task_config]
+includes = ["{{ exec(command='echo .config/mise/tasks; echo rendered >> $local_include_marker') }}"]
+EOF
+
+# Detecting explicit local task context must inspect the raw include option.
+# Rendering it again would repeat effectful template functions during one load.
+MISE_GLOBAL_CONFIG_FILE="$HOME/global-config/user.toml" \
+  MISE_SYSTEM_CONFIG_FILE="$HOME/global-config/missing.toml" \
+  mise -C "$HOME" tasks >/dev/null
+assert "wc -l < '$local_include_marker' | tr -d ' '" "1"

--- a/e2e/tasks/test_task_global_config_dedup
+++ b/e2e/tasks/test_task_global_config_dedup
@@ -122,3 +122,25 @@ MISE_GLOBAL_CONFIG_FILE="$HOME/global-config/user.toml" \
   MISE_SYSTEM_CONFIG_FILE="$HOME/global-config/missing.toml" \
   mise -C "$HOME" tasks >/dev/null
 assert "wc -l < '$local_include_marker' | tr -d ' '" "1"
+
+mkdir -p "$PWD/.mise/tasks" "$PWD/local-project-dir" "$HOME/global-project-dir"
+cat >"$PWD/.mise/tasks/shared-project-task" <<'EOF'
+#!/usr/bin/env bash
+echo "$PWD"
+EOF
+chmod +x "$PWD/.mise/tasks/shared-project-task"
+cat >"$PWD/mise.toml" <<EOF
+[task_config]
+dir = "$PWD/local-project-dir"
+EOF
+cat >"$HOME/global-config/project-tasks.toml" <<EOF
+[task_config]
+includes = ["$PWD/.mise/tasks"]
+dir = "$HOME/global-project-dir"
+EOF
+
+# The presence of a user-global config must not disable the existing
+# global-wins same-source rule for ordinary project directories.
+assert \
+  "MISE_GLOBAL_CONFIG_FILE='$HOME/global-config/project-tasks.toml' MISE_SYSTEM_CONFIG_FILE='$HOME/global-config/missing.toml' mise run shared-project-task" \
+  "$HOME/global-project-dir"

--- a/e2e/tasks/test_task_ls_global
+++ b/e2e/tasks/test_task_ls_global
@@ -85,3 +85,168 @@ assert "mise run systemglobalfile" "PROJECT_ROOT=$PWD"
 assert "mise run relative-meta" "RELATIVE_OVERLAY=applied"
 assert "mise run templated-meta" "TEMPLATED_OVERLAY=applied"
 assert_fail "mise run lower-global-only" "no task lower-global-only found"
+
+# The user-global pass owns HOME's task include scope. An unrelated local HOME
+# config must not resurrect omitted defaults or let them override an explicitly
+# included global task with the same name.
+cat <<'EOF' >~/.config/mise/tasks/collision
+#!/usr/bin/env bash
+echo default-task
+EOF
+chmod +x ~/.config/mise/tasks/collision
+cat <<'EOF' >~/.config/mise/tasks/omitted-only
+#!/usr/bin/env bash
+echo omitted-task
+EOF
+chmod +x ~/.config/mise/tasks/omitted-only
+cat <<'EOF' >~/dotfiles/tasks/collision
+#!/usr/bin/env bash
+echo custom-task
+EOF
+chmod +x ~/dotfiles/tasks/collision
+cat >~/.config/mise/config.toml <<'TOML'
+tasks.myglobal = { run = 'echo myglobal' }
+
+[task_config]
+includes = ["dotfiles/tasks"]
+TOML
+cat >"$HOME/mise.toml" <<'TOML'
+[env]
+UNRELATED_HOME_CONFIG = "present"
+
+[tasks.home-inline]
+run = "echo home-inline"
+TOML
+
+assert "mise run collision" "custom-task"
+assert_fail "mise run omitted-only"
+assert_not_contains "mise tasks --global" "omitted-only"
+assert "mise run home-inline" "home-inline"
+
+# Cascade control alone does not supply file-task context at the HOME root, so
+# it must not resurrect defaults omitted by the user-global config.
+cat >"$HOME/mise.toml" <<'TOML'
+[task_config]
+cascade = true
+TOML
+assert_fail "mise run omitted-only"
+
+# A local ancestor config can explicitly include the global task directory even
+# when the global config replaces that default include. Source deduplication
+# must not discard a task that the independent global pass did not load.
+cat >"$HOME/mise.toml" <<'TOML'
+[task_config]
+includes = [".config/mise/tasks"]
+TOML
+cat >"$HOME/.config/mise/config.toml" <<'TOML'
+tasks.myglobal = { run = 'echo myglobal' }
+
+[task_config]
+includes = ["dotfiles/tasks"]
+TOML
+
+assert "mise run myglobalfile" "myglobalfile"
+assert_contains "mise tasks --global" "myglobalfile"
+
+# Explicit task configuration at the HOME root owns its default file tasks even
+# when the user-global config replaces those defaults.
+mkdir -p "$HOME/.mise/conf.d" "$HOME/local-task-dir"
+cat >"$HOME/.config/mise/tasks/local-dir-context" <<'EOF'
+#!/usr/bin/env bash
+echo "$PWD"
+EOF
+chmod +x "$HOME/.config/mise/tasks/local-dir-context"
+cat >"$HOME/mise.toml" <<'EOF'
+[env]
+UNRELATED_HOME_CONFIG = "present"
+EOF
+cat >"$HOME/.mise/conf.d/20-task-context.toml" <<EOF
+[task_config]
+dir = "$HOME/local-task-dir"
+EOF
+assert "mise run local-dir-context" "$HOME/local-task-dir"
+
+# Input defaults from a local conf.d fragment also establish explicit ownership
+# of HOME's default file-task scope.
+touch "$HOME/local-global-input"
+cat >"$HOME/.config/mise/tasks/local-input-context" <<'EOF'
+#!/usr/bin/env bash
+echo local-input-context
+EOF
+chmod +x "$HOME/.config/mise/tasks/local-input-context"
+cat >"$HOME/.mise/conf.d/20-task-context.toml" <<'EOF'
+[task_config]
+global_inputs = ["local-global-input"]
+EOF
+assert \
+  "MISE_EXPERIMENTAL=1 mise tasks ls --json | jq -r '.[] | select(.name == \"local-input-context\") | .sources[0]'" \
+  "$HOME/local-global-input"
+
+# Rust-cache defaults are also file-task context even when explicitly disabled.
+cat >"$HOME/.config/mise/tasks/local-rust-cache-context" <<'EOF'
+#!/usr/bin/env bash
+echo local-rust-cache-context
+EOF
+chmod +x "$HOME/.config/mise/tasks/local-rust-cache-context"
+cat >"$HOME/.mise/conf.d/20-task-context.toml" <<'EOF'
+[task_config]
+rust_cache = false
+EOF
+assert "mise run local-rust-cache-context" "local-rust-cache-context"
+: >"$HOME/.mise/conf.d/20-task-context.toml"
+
+cat >"$HOME/local-shell-wrapper" <<'EOF'
+#!/usr/bin/env bash
+echo LOCAL_SHELL
+exec bash "$@"
+EOF
+chmod +x "$HOME/local-shell-wrapper"
+cat >"$HOME/.config/mise/tasks/local-shell-context" <<'EOF'
+#!/usr/bin/env bash
+echo LOCAL_TASK
+EOF
+chmod +x "$HOME/.config/mise/tasks/local-shell-context"
+cat >"$HOME/mise.toml" <<EOF
+[task_config]
+shell = "$HOME/local-shell-wrapper -c"
+EOF
+assert \
+  "mise tasks ls --json | jq -r '.[] | select(.name == \"local-shell-context\") | .shell'" \
+  "$HOME/local-shell-wrapper -c"
+
+# Effective task context may cascade from an ancestor into a custom global
+# root. The HOME/global-root filter must use that effective context, not only
+# config files located directly at the root.
+custom_global_root="$HOME/nested/global-root"
+mkdir -p "$custom_global_root/.config/mise/tasks" "$HOME/nested/cascaded-dir"
+cat >"$HOME/nested/mise.toml" <<EOF
+[task_config]
+cascade = true
+dir = "$HOME/nested/cascaded-dir"
+EOF
+cat >"$custom_global_root/.config/mise/tasks/cascaded-context" <<'EOF'
+#!/usr/bin/env bash
+echo "$PWD"
+EOF
+chmod +x "$custom_global_root/.config/mise/tasks/cascaded-context"
+cat >"$HOME/custom-global.toml" <<'EOF'
+[task_config]
+includes = ["empty-global-tasks"]
+EOF
+assert \
+  "MISE_GLOBAL_CONFIG_ROOT='$custom_global_root' MISE_GLOBAL_CONFIG_FILE='$HOME/custom-global.toml' MISE_SYSTEM_CONFIG_FILE='$HOME/missing-system.toml' mise -C '$custom_global_root' run cascaded-context" \
+  "$HOME/nested/cascaded-dir"
+
+# A root-local cascade opt-out also disables ancestor file-task context for
+# ownership checks, so omitted global defaults stay omitted.
+cat >"$custom_global_root/mise.toml" <<'EOF'
+[task_config]
+cascade = false
+EOF
+cat >"$custom_global_root/.config/mise/tasks/omitted-after-cascade-opt-out" <<'EOF'
+#!/usr/bin/env bash
+echo should-not-run
+EOF
+chmod +x "$custom_global_root/.config/mise/tasks/omitted-after-cascade-opt-out"
+assert_fail \
+  "MISE_GLOBAL_CONFIG_ROOT='$custom_global_root' MISE_GLOBAL_CONFIG_FILE='$HOME/custom-global.toml' MISE_SYSTEM_CONFIG_FILE='$HOME/missing-system.toml' mise -C '$custom_global_root' run omitted-after-cascade-opt-out"

--- a/e2e/tasks/test_task_ls_global
+++ b/e2e/tasks/test_task_ls_global
@@ -99,6 +99,14 @@ cat <<'EOF' >~/.config/mise/tasks/omitted-only
 echo omitted-task
 EOF
 chmod +x ~/.config/mise/tasks/omitted-only
+omitted_render_marker="$MISE_TMP_DIR/omitted-task-render-count"
+: >"$omitted_render_marker"
+cat >~/.config/mise/tasks/omitted-effect <<EOF
+#!/usr/bin/env bash
+#MISE description="{{ exec(command='echo rendered >> $omitted_render_marker') }}"
+echo omitted-effect
+EOF
+chmod +x ~/.config/mise/tasks/omitted-effect
 cat <<'EOF' >~/dotfiles/tasks/collision
 #!/usr/bin/env bash
 echo custom-task
@@ -118,10 +126,26 @@ UNRELATED_HOME_CONFIG = "present"
 run = "echo home-inline"
 TOML
 
+mise tasks >/dev/null
+assert "wc -l < '$omitted_render_marker' | tr -d ' '" "0"
 assert "mise run collision" "custom-task"
 assert_fail "mise run omitted-only"
 assert_not_contains "mise tasks --global" "omitted-only"
 assert "mise run home-inline" "home-inline"
+
+# Inline HOME tasks are retained as definitions, not merged onto an omitted
+# default file task with the same name.
+cat >"$HOME/mise.toml" <<'TOML'
+[env]
+UNRELATED_HOME_CONFIG = "present"
+
+[tasks.home-inline]
+run = "echo home-inline"
+
+[tasks.collision]
+run = "echo home-inline-collision"
+TOML
+assert "mise run collision" "home-inline-collision"
 
 # Cascade control alone does not supply file-task context at the HOME root, so
 # it must not resurrect defaults omitted by the user-global config.
@@ -165,6 +189,20 @@ cat >"$HOME/.mise/conf.d/20-task-context.toml" <<EOF
 dir = "$HOME/local-task-dir"
 EOF
 assert "mise run local-dir-context" "$HOME/local-task-dir"
+
+# Explicit root-local context wins when the user-global scope loads the same
+# physical task source.
+cat >"$HOME/.config/mise/config.toml" <<'EOF'
+[task_config]
+includes = [".config/mise/tasks"]
+EOF
+assert "mise run local-dir-context" "$HOME/local-task-dir"
+cat >"$HOME/.config/mise/config.toml" <<'TOML'
+tasks.myglobal = { run = 'echo myglobal' }
+
+[task_config]
+includes = ["dotfiles/tasks"]
+TOML
 
 # Input defaults from a local conf.d fragment also establish explicit ownership
 # of HOME's default file-task scope.

--- a/e2e/tasks/test_task_monorepo_config_dedup
+++ b/e2e/tasks/test_task_monorepo_config_dedup
@@ -3,6 +3,7 @@
 export MISE_EXPERIMENTAL=1
 
 marker="$MISE_TMP_DIR/monorepo-config-render-count"
+: >"$marker"
 mkdir -p apps/example
 
 cat <<'EOF' >mise.toml

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3650,10 +3650,12 @@ async fn load_local_tasks_with_context(
             &d,
             local_configs.clone(),
             templates,
-            false,
-            effective_cascaded_task_config,
-            None,
-            load_file_tasks,
+            LoadTaskSourcesOptions {
+                monorepo_context: false,
+                cascaded_task_config: effective_cascaded_task_config,
+                rendered_file_tasks: None,
+                load_file_tasks,
+            },
         )
         .await?
         .into_tasks();
@@ -4187,10 +4189,12 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
             &env::MISE_GLOBAL_CONFIG_ROOT,
             configs,
             templates,
-            false,
-            None,
-            Some(&mut rendered_file_tasks),
-            true,
+            LoadTaskSourcesOptions {
+                monorepo_context: false,
+                cascaded_task_config: None,
+                rendered_file_tasks: Some(&mut rendered_file_tasks),
+                load_file_tasks: true,
+            },
         )
         .await?;
         rendered_file_tasks.finish_config();
@@ -4957,13 +4961,22 @@ async fn load_tasks_from_configs(
         dir,
         configs,
         templates,
-        monorepo_context,
-        cascaded_task_config,
-        None,
-        true,
+        LoadTaskSourcesOptions {
+            monorepo_context,
+            cascaded_task_config,
+            rendered_file_tasks: None,
+            load_file_tasks: true,
+        },
     )
     .await?
     .into_tasks())
+}
+
+struct LoadTaskSourcesOptions<'a> {
+    monorepo_context: bool,
+    cascaded_task_config: Option<&'a CascadedTaskConfig>,
+    rendered_file_tasks: Option<&'a mut RenderedTaskCache>,
+    load_file_tasks: bool,
 }
 
 /// Load file and inline task sources without merging them.
@@ -4975,11 +4988,14 @@ async fn load_task_sources_from_configs(
     dir: &Path,
     configs: Vec<&Arc<dyn ConfigFile>>,
     templates: &TaskDefinitions,
-    monorepo_context: bool,
-    cascaded_task_config: Option<&CascadedTaskConfig>,
-    mut rendered_file_tasks: Option<&mut RenderedTaskCache>,
-    load_file_tasks: bool,
+    options: LoadTaskSourcesOptions<'_>,
 ) -> Result<TaskSources> {
+    let LoadTaskSourcesOptions {
+        monorepo_context,
+        cascaded_task_config,
+        mut rendered_file_tasks,
+        load_file_tasks,
+    } = options;
     let cascaded_task_config =
         if configs.iter().find_map(|cf| cf.task_config().cascade) == Some(false) {
             None

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,7 +4,7 @@ use indexmap::{IndexMap, IndexSet};
 use itertools::{Either, Itertools};
 use path_absolutize::Absolutize;
 pub(crate) use settings::{CompilePurpose, Settings};
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::env::join_paths;
 use std::fmt::{Debug, Formatter};
 use std::iter::once;
@@ -982,12 +982,14 @@ impl Config {
             load_local_tasks_with_context(&config, ctx, &task_definitions).await?;
         let global_tasks = load_global_tasks(&config, &task_definitions).await?;
         local_tasks.retain(|local| {
-            !global_tasks
-                .iter()
-                .any(|global| tasks_have_same_source(local, global))
+            !local.suppress_if_global_duplicate
+                || !global_tasks
+                    .iter()
+                    .any(|global| tasks_have_same_source(&local.task, global))
         });
         let mut tasks: BTreeMap<String, Task> = local_tasks
             .into_iter()
+            .map(|local| local.task)
             .chain(global_tasks)
             .rev()
             .inspect(|t| {
@@ -3557,11 +3559,28 @@ fn dir_is_in_enclosing_monorepo(
         && !file::path_starts_with_resolved(dir, selected_root)
 }
 
+struct LoadedLocalTask {
+    task: Task,
+    suppress_if_global_duplicate: bool,
+}
+
+fn task_config_has_file_context(task_config: &TaskConfig) -> bool {
+    task_config.includes.is_some()
+        || task_config.dir.is_some()
+        || task_config.shell.is_some()
+        || task_config.cache.is_some()
+        || task_config.rust_cache.is_some()
+        || !task_config.global_env.is_empty()
+        || !task_config.global_pass_through_env.is_empty()
+        || !task_config.global_inputs.is_empty()
+        || !task_config.input_groups.is_empty()
+}
+
 async fn load_local_tasks_with_context(
     config: &Arc<Config>,
     ctx: Option<&crate::task::TaskLoadContext>,
     templates: &TaskDefinitions,
-) -> Result<Vec<Task>> {
+) -> Result<Vec<LoadedLocalTask>> {
     let mut tasks = vec![];
     let monorepo_config = find_monorepo_config(&config.config_files);
     let monorepo_root = monorepo_config.and_then(|cf| cf.project_root().map(|p| p.to_path_buf()));
@@ -3578,6 +3597,11 @@ async fn load_local_tasks_with_context(
         .as_deref()
         .map(|root| enclosing_monorepo_roots(&config.config_files, root))
         .unwrap_or_default();
+    let user_global_config_paths = global_config_files();
+    let has_user_global_config = config
+        .config_files
+        .values()
+        .any(|cf| config_set_contains(&user_global_config_paths, cf.get_path()));
     for d in all_dirs()? {
         if cfg!(test) && !d.starts_with(*dirs::HOME) {
             continue;
@@ -3592,14 +3616,55 @@ async fn load_local_tasks_with_context(
             );
             continue;
         }
-        let mut dir_tasks =
-            load_tasks_in_dir_with_definitions(config, &d, &local_config_files, templates).await?;
+        let local_configs = configs_at_root(&d, &local_config_files);
+        let cascaded_task_config = cascaded_task_config_for_dir(&d, &local_config_files)?;
+        let effective_cascaded_task_config =
+            if local_configs.iter().find_map(|cf| cf.task_config().cascade) == Some(false) {
+                None
+            } else {
+                cascaded_task_config.as_ref()
+            };
+        let mut dir_tasks = load_tasks_from_configs(
+            config,
+            &d,
+            local_configs.clone(),
+            templates,
+            false,
+            effective_cascaded_task_config,
+        )
+        .await?;
+
+        let mut suppress_if_global_duplicate = !has_user_global_config;
+        let mut local_inline_task_names = HashSet::new();
+        if has_user_global_config && file::same_file(&d, &env::MISE_GLOBAL_CONFIG_ROOT) {
+            let local_file_context = local_configs
+                .iter()
+                .any(|cf| task_config_has_file_context(cf.task_config()))
+                || effective_cascaded_task_config
+                    .is_some_and(|tc| task_config_has_file_context(&tc.task_config));
+            suppress_if_global_duplicate = false;
+            if !local_file_context {
+                local_inline_task_names = local_configs
+                    .iter()
+                    .flat_map(|cf| cf.tasks())
+                    .map(|task| task.name.clone())
+                    .collect();
+                // A user-global config owns the HOME include decision, so
+                // omitted defaults must not be resurrected by the local
+                // hierarchy walk.
+                dir_tasks.retain(|task| local_inline_task_names.contains(&task.name));
+            }
+        }
 
         if let Some(ref monorepo_root) = monorepo_root {
             prefix_monorepo_task_names(&mut dir_tasks, &d, monorepo_root);
         }
 
-        tasks.extend(dir_tasks);
+        tasks.extend(dir_tasks.into_iter().map(|task| LoadedLocalTask {
+            suppress_if_global_duplicate: suppress_if_global_duplicate
+                && !local_inline_task_names.contains(&task.name),
+            task,
+        }));
     }
 
     // Determine if we should load monorepo tasks from subdirectories
@@ -3725,7 +3790,10 @@ async fn load_local_tasks_with_context(
         }
 
         while let Some(result) = join_set.join_next().await {
-            tasks.extend(result??);
+            tasks.extend(result??.into_iter().map(|task| LoadedLocalTask {
+                task,
+                suppress_if_global_duplicate: !has_user_global_config,
+            }));
         }
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3624,37 +3624,44 @@ async fn load_local_tasks_with_context(
             } else {
                 cascaded_task_config.as_ref()
             };
-        let mut dir_tasks = load_tasks_from_configs(
+        let at_user_global_root =
+            has_user_global_config && file::same_file(&d, &env::MISE_GLOBAL_CONFIG_ROOT);
+        let local_file_context = at_user_global_root
+            && (local_configs
+                .iter()
+                .any(|cf| task_config_has_file_context(cf.task_config()))
+                || effective_cascaded_task_config
+                    .is_some_and(|tc| task_config_has_file_context(&tc.task_config)));
+        let local_inline_task_names = if at_user_global_root {
+            local_configs
+                .iter()
+                .flat_map(|cf| cf.tasks())
+                .map(|task| task.name.clone())
+                .collect::<HashSet<_>>()
+        } else {
+            HashSet::new()
+        };
+        // A user-global config owns the root include decision. When no local
+        // file-task context overrides it, do not even render incidental default
+        // files from the local hierarchy walk.
+        let load_file_tasks = !at_user_global_root || local_file_context;
+        let mut dir_tasks = load_task_sources_from_configs(
             config,
             &d,
             local_configs.clone(),
             templates,
             false,
             effective_cascaded_task_config,
+            None,
+            load_file_tasks,
         )
-        .await?;
+        .await?
+        .into_tasks();
 
-        let mut suppress_if_global_duplicate = !has_user_global_config;
-        let mut local_inline_task_names = HashSet::new();
-        if has_user_global_config && file::same_file(&d, &env::MISE_GLOBAL_CONFIG_ROOT) {
-            let local_file_context = local_configs
-                .iter()
-                .any(|cf| task_config_has_file_context(cf.task_config()))
-                || effective_cascaded_task_config
-                    .is_some_and(|tc| task_config_has_file_context(&tc.task_config));
-            suppress_if_global_duplicate = false;
-            if !local_file_context {
-                local_inline_task_names = local_configs
-                    .iter()
-                    .flat_map(|cf| cf.tasks())
-                    .map(|task| task.name.clone())
-                    .collect();
-                // A user-global config owns the HOME include decision, so
-                // omitted defaults must not be resurrected by the local
-                // hierarchy walk.
-                dir_tasks.retain(|task| local_inline_task_names.contains(&task.name));
-            }
-        }
+        // Preserve legacy global-wins source deduplication for ordinary local
+        // directories. Only explicit root-local ownership and inline task names
+        // should keep the local rendering of a source also loaded globally.
+        let suppress_if_global_duplicate = !local_file_context;
 
         if let Some(ref monorepo_root) = monorepo_root {
             prefix_monorepo_task_names(&mut dir_tasks, &d, monorepo_root);
@@ -3792,7 +3799,7 @@ async fn load_local_tasks_with_context(
         while let Some(result) = join_set.join_next().await {
             tasks.extend(result??.into_iter().map(|task| LoadedLocalTask {
                 task,
-                suppress_if_global_duplicate: !has_user_global_config,
+                suppress_if_global_duplicate: true,
             }));
         }
     }
@@ -4183,6 +4190,7 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
             false,
             None,
             Some(&mut rendered_file_tasks),
+            true,
         )
         .await?;
         rendered_file_tasks.finish_config();
@@ -4952,6 +4960,7 @@ async fn load_tasks_from_configs(
         monorepo_context,
         cascaded_task_config,
         None,
+        true,
     )
     .await?
     .into_tasks())
@@ -4969,6 +4978,7 @@ async fn load_task_sources_from_configs(
     monorepo_context: bool,
     cascaded_task_config: Option<&CascadedTaskConfig>,
     mut rendered_file_tasks: Option<&mut RenderedTaskCache>,
+    load_file_tasks: bool,
 ) -> Result<TaskSources> {
     let cascaded_task_config =
         if configs.iter().find_map(|cf| cf.task_config().cascade) == Some(false) {
@@ -5050,43 +5060,45 @@ async fn load_task_sources_from_configs(
     } else {
         None
     };
-    for include in &includes {
-        let artifacts = if include.starts_with("git::") {
-            vec![resolve_git_url_to_path(include).await?]
-        } else {
-            expand_task_include(&resolve_dir, include)
-                .into_iter()
-                .map(TaskFileArtifact::persistent)
-                .collect()
-        };
-        for artifact in artifacts {
-            let p = artifact.path;
-            let mut loaded = load_tasks_includes(
-                config,
-                &p,
-                dir,
-                &task_config,
-                templates,
-                LoadTaskIncludesOptions {
-                    monorepo_cf,
-                    require_trust: require_task_include_trust,
-                    rendered_file_tasks: rendered_file_tasks.as_deref_mut(),
-                },
-            )
-            .await?;
-            for task in &mut loaded {
-                if task.is_toml_include {
-                    task.config_precedence = include_config_precedence;
+    if load_file_tasks {
+        for include in &includes {
+            let artifacts = if include.starts_with("git::") {
+                vec![resolve_git_url_to_path(include).await?]
+            } else {
+                expand_task_include(&resolve_dir, include)
+                    .into_iter()
+                    .map(TaskFileArtifact::persistent)
+                    .collect()
+            };
+            for artifact in artifacts {
+                let p = artifact.path;
+                let mut loaded = load_tasks_includes(
+                    config,
+                    &p,
+                    dir,
+                    &task_config,
+                    templates,
+                    LoadTaskIncludesOptions {
+                        monorepo_cf,
+                        require_trust: require_task_include_trust,
+                        rendered_file_tasks: rendered_file_tasks.as_deref_mut(),
+                    },
+                )
+                .await?;
+                for task in &mut loaded {
+                    if task.is_toml_include {
+                        task.config_precedence = include_config_precedence;
+                    }
+                    apply_task_config_inputs(task, config, &task_config.inputs).await?;
+                    apply_task_config_cache_default(task, &task_config.cache);
+                    apply_task_config_rust_cache_default(task, &task_config.rust_cache);
+                    task_config.environment.apply(task)?;
                 }
-                apply_task_config_inputs(task, config, &task_config.inputs).await?;
-                apply_task_config_cache_default(task, &task_config.cache);
-                apply_task_config_rust_cache_default(task, &task_config.rust_cache);
-                task_config.environment.apply(task)?;
+                if is_global || is_global_task_include_path(&p) {
+                    mark_tasks_as_global(&mut loaded);
+                }
+                file_tasks.extend(loaded);
             }
-            if is_global || is_global_task_include_path(&p) {
-                mark_tasks_as_global(&mut loaded);
-            }
-            file_tasks.extend(loaded);
         }
     }
 


### PR DESCRIPTION
## Stack

Built on #12229, which makes task includes override within each user/system global scope and prevents system task metadata from decorating user-global tasks. That PR has merged, and this branch is now rebased onto `main`, so the diff contains only this PR's own changes.

The corresponding system-only root behavior remains in #12204 and will be rebased after this PR merges.

## Summary

- keep the effective user-global include decision authoritative when the local config walk reaches HOME or a custom global root
- skip incidental default file sources before include expansion, parsing, template rendering, and inline-task merging
- retain genuine HOME-local inline definitions and file tasks with explicit local task context
- use effective cascade state when deciding whether HOME-local context intentionally owns file tasks
- preserve the existing global-wins same-source behavior for ordinary project and monorepo directories

## Bug examples

- A user-global config can replace the default task directories with `includes = ["~/dotfiles/tasks"]`. The later HOME-local walk previously rediscovered `~/.config/mise/tasks`, leaving an omitted default task runnable and allowing its script to replace a same-name HOME-local inline task.
- Even when an omitted default task was removed from the final task list, its `#MISE` template metadata was previously rendered first. An effectful template could therefore run—and a malformed one could fail task loading—for a task the user-global include decision had excluded.
- A HOME-local `.mise/conf.d` fragment that explicitly changes the task directory, global inputs, or Rust cache intentionally owns its local file tasks. Those tasks remain local, including when the user-global scope loaded the same physical source.
- With a custom global root, an ancestor can supply cascading task context such as `dir` while a root-local config sets `cascade = false`. The ownership check previously still used that ancestor context and resurrected default tasks omitted by the user-global includes. It now uses the effective context, so those omitted tasks remain unavailable.

## Testing

- `mise run lint-fix`
- `mise run test:e2e e2e/tasks/test_task_ls_global e2e/tasks/test_task_global_config_dedup e2e/tasks/test_task_monorepo_config_dedup`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task discovery across local, global, and system configurations.
  * Prevented duplicate tasks when configurations overlap.
  * Respected disabled cascading and global task precedence.
  * Preserved discovery for relative includes and inline task definitions.
  * Improved handling of task directories, working directories, shell settings, and global inputs.
* **Tests**
  * Expanded coverage for configuration inheritance, collisions, monorepos, and global task execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
