### PR TITLE
fix(task): preserve system task precedence

### DIFF
--- a/e2e/tasks/test_task_global_config_dedup
+++ b/e2e/tasks/test_task_global_config_dedup
@@ -84,3 +84,18 @@ EOF
 assert \
   "MISE_GLOBAL_CONFIG_FILE='$HOME/global-config/include-order.toml' MISE_SYSTEM_CONFIG_FILE='$HOME/global-config/missing.toml' mise run include-winner" \
   "$HOME/second-global-tasks/include-winner"
+
+local_include_marker="$MISE_TMP_DIR/local-include-render-count"
+: >"$local_include_marker"
+mkdir -p "$HOME/.config/mise/tasks"
+cat >"$HOME/mise.toml" <<EOF
+[task_config]
+includes = ["{{ exec(command='echo .config/mise/tasks; echo rendered >> $local_include_marker') }}"]
+EOF
+
+# Detecting explicit local task context must inspect the raw include option.
+# Rendering it again would repeat effectful template functions during one load.
+MISE_GLOBAL_CONFIG_FILE="$HOME/global-config/user.toml" \
+  MISE_SYSTEM_CONFIG_FILE="$HOME/global-config/missing.toml" \
+  mise -C "$HOME" tasks >/dev/null
+assert "wc -l < '$local_include_marker' | tr -d ' '" "1"

--- a/e2e/tasks/test_task_global_config_precedence
+++ b/e2e/tasks/test_task_global_config_precedence
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+export MISE_EXPERIMENTAL=1
+
+mkdir -p "$HOME/.config/mise/conf.d" "$HOME/.config/mise/tasks"
+
+cat <<'EOF' >"$MISE_SYSTEM_DIR/config.toml"
+[tasks.e]
+description = "system/config/e"
+env = { SYSTEM_PRECEDENCE = "applied" }
+
+[tasks.system-vs-conf-d]
+run = "echo system"
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/conf.d/01-base.toml"
+[tasks.e]
+description = "global/conf.d/01/e"
+env = { LOWER_PRECEDENCE = "applied" }
+
+[tasks.system-vs-conf-d]
+run = "echo conf-d"
+
+[tasks.conf-d-order]
+run = "echo conf-d-01"
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/conf.d/02-override.toml"
+[tasks.conf-d-order]
+run = "echo conf-d-02"
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/config.toml"
+[tasks.e]
+description = "global/config/e"
+env = { HIGHER_PRECEDENCE = "applied" }
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/tasks/e"
+#!/usr/bin/env bash
+echo "HIGHER_PRECEDENCE=${HIGHER_PRECEDENCE:-<unset>}"
+echo "LOWER_PRECEDENCE=${LOWER_PRECEDENCE:-<unset>}"
+echo "SYSTEM_PRECEDENCE=${SYSTEM_PRECEDENCE:-<unset>}"
+EOF
+chmod +x "$HOME/.config/mise/tasks/e"
+
+mkdir -p "$TMPDIR/outside-home"
+assert_contains "mise tasks --global" "e"
+assert_contains "mise run e" "HIGHER_PRECEDENCE=applied"
+assert_contains "mise run e" "LOWER_PRECEDENCE=<unset>"
+assert_contains "mise run e" "SYSTEM_PRECEDENCE=<unset>"
+assert_contains "mise -C '$TMPDIR/outside-home' run e" "HIGHER_PRECEDENCE=applied"
+assert_contains "mise -C '$TMPDIR/outside-home' run e" "LOWER_PRECEDENCE=<unset>"
+assert_contains "mise -C '$TMPDIR/outside-home' run e" "SYSTEM_PRECEDENCE=<unset>"
+assert "mise run system-vs-conf-d" "conf-d"
+assert "mise run conf-d-order" "conf-d-02"

--- a/e2e/tasks/test_task_global_include_precedence
+++ b/e2e/tasks/test_task_global_include_precedence
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+export MISE_EXPERIMENTAL=1
+
+mkdir -p "$HOME/.config/mise/conf.d" "$HOME/.config/mise/tasks" \
+  "$HOME/global-custom-tasks" "$HOME/high-global-tasks"
+
+cat <<'EOF' >"$MISE_SYSTEM_DIR/config.toml"
+[tasks.g]
+run = "echo system-inline/g"
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/conf.d/01-base.toml"
+[task_config]
+includes = ["global-custom-tasks"]
+EOF
+
+cat <<EOF >"$HOME/.config/mise/conf.d/02-override.toml"
+[task_config]
+includes = [".config/mise/tasks"]
+
+[tasks.i]
+run = "echo lower-inline/i"
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/config.toml"
+[task_config]
+includes = [".config/mise/tasks", "high-global-tasks"]
+
+[tasks.f]
+run = "echo high-inline/f"
+EOF
+
+cat <<'EOF' >"$HOME/global-custom-tasks/f"
+#!/usr/bin/env bash
+echo lower-script/f
+EOF
+chmod +x "$HOME/global-custom-tasks/f"
+
+cat <<'EOF' >"$HOME/global-custom-tasks/h"
+#!/usr/bin/env bash
+echo lower-script/h
+EOF
+chmod +x "$HOME/global-custom-tasks/h"
+
+cat <<'EOF' >"$HOME/global-custom-tasks/file-collision"
+#!/usr/bin/env bash
+echo lower-script/file-collision
+EOF
+chmod +x "$HOME/global-custom-tasks/file-collision"
+
+cat <<'EOF' >"$HOME/high-global-tasks/i"
+#!/usr/bin/env bash
+echo high-script/i
+EOF
+chmod +x "$HOME/high-global-tasks/i"
+
+cat <<'EOF' >"$HOME/high-global-tasks/file-collision"
+#!/usr/bin/env bash
+echo high-script/file-collision
+EOF
+chmod +x "$HOME/high-global-tasks/file-collision"
+
+mkdir -p "$TMPDIR/outside-home"
+assert_contains "mise -C '$TMPDIR/outside-home' run f" "high-inline/f"
+assert_not_contains "mise -C '$TMPDIR/outside-home' run f" "lower-script/f"
+assert_contains "mise -C '$TMPDIR/outside-home' run g" "system-inline/g"
+assert_contains "mise -C '$TMPDIR/outside-home' run h" "lower-script/h"
+assert_contains "mise -C '$TMPDIR/outside-home' run i" "high-script/i"
+assert_not_contains "mise -C '$TMPDIR/outside-home' run i" "lower-inline/i"
+assert "mise -C '$TMPDIR/outside-home' run file-collision" "high-script/file-collision"

--- a/e2e/tasks/test_task_global_source_context_precedence
+++ b/e2e/tasks/test_task_global_source_context_precedence
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+export MISE_EXPERIMENTAL=1
+
+mkdir -p "$HOME/.config/mise/conf.d" "$HOME/.config/mise/tasks" \
+  "$HOME/high-global-dir" "$HOME/low-global-dir"
+ln -s ".config/mise/tasks" "$HOME/linked-global-tasks"
+
+cat <<EOF >"$HOME/.config/mise/conf.d/02-override.toml"
+[task_config]
+dir = "$HOME/low-global-dir"
+includes = ["linked-global-tasks"]
+shell = "$HOME/low-shell -c"
+
+[task_config.input_groups]
+rust = ["Cargo.toml"]
+
+[tasks.j]
+env = { INLINE_METADATA = "applied" }
+
+[tasks.group-overlay]
+sources = ["@group:rust"]
+
+[tasks.explicit-shell-overlay]
+shell = "$HOME/explicit-shell -c"
+EOF
+
+cat <<EOF >"$HOME/.config/mise/config.toml"
+[task_config]
+includes = [".config/mise/tasks"]
+dir = "$HOME/high-global-dir"
+shell = "$HOME/high-shell -c"
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/tasks/j"
+#!/usr/bin/env bash
+echo same-script/j
+echo "INLINE_METADATA=${INLINE_METADATA:-<unset>}"
+echo "TASK_DIR=$PWD"
+EOF
+chmod +x "$HOME/.config/mise/tasks/j"
+cat <<'EOF' >"$HOME/.config/mise/tasks/group-overlay"
+#!/usr/bin/env bash
+echo group-overlay
+EOF
+chmod +x "$HOME/.config/mise/tasks/group-overlay"
+cat <<'EOF' >"$HOME/.config/mise/tasks/explicit-shell-overlay"
+#!/usr/bin/env bash
+echo explicit-shell-overlay
+EOF
+chmod +x "$HOME/.config/mise/tasks/explicit-shell-overlay"
+
+mkdir -p "$TMPDIR/outside-home"
+assert_contains "mise -C '$TMPDIR/outside-home' run j" "same-script/j"
+assert_contains "mise -C '$TMPDIR/outside-home' run j" "INLINE_METADATA=applied"
+assert_contains "mise -C '$TMPDIR/outside-home' run j" "TASK_DIR=$HOME/high-global-dir"
+assert_not_contains "mise -C '$TMPDIR/outside-home' run j" "TASK_DIR=$HOME/low-global-dir"
+assert \
+  "mise -C '$TMPDIR/outside-home' tasks ls --json | jq -r '.[] | select(.name == \"group-overlay\") | .sources[0]'" \
+  "$HOME/Cargo.toml"
+assert \
+  "mise -C '$TMPDIR/outside-home' tasks ls --json | jq -r '.[] | select(.name == \"j\") | .shell'" \
+  "$HOME/high-shell -c"
+assert \
+  "mise -C '$TMPDIR/outside-home' tasks ls --json | jq -r '.[] | select(.name == \"explicit-shell-overlay\") | .shell'" \
+  "$HOME/explicit-shell -c"
+
+# An explicit project include of the same global scripts must retain local
+# precedence. Same-source deduplication may discard only the incidental copy
+# discovered while walking the global config root, not project task context.
+mkdir -p "$HOME/project" "$HOME/local-project-dir"
+
+cat <<'EOF' >>"$HOME/.config/mise/config.toml"
+
+[tasks.local-overlay-wins]
+env = { GLOBAL_CONTEXT = "applied" }
+EOF
+
+cat <<EOF >"$HOME/project/mise.toml"
+[task_config]
+includes = ["$HOME/.config/mise/tasks"]
+dir = "$HOME/local-project-dir"
+
+[tasks.local-overlay-wins]
+env = { LOCAL_CONTEXT = "applied" }
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/tasks/local-overlay-wins"
+#!/usr/bin/env bash
+echo "LOCAL_CONTEXT=${LOCAL_CONTEXT:-<unset>}"
+echo "GLOBAL_CONTEXT=${GLOBAL_CONTEXT:-<unset>}"
+EOF
+chmod +x "$HOME/.config/mise/tasks/local-overlay-wins"
+
+cat <<'EOF' >"$HOME/.config/mise/tasks/local-dir-wins"
+#!/usr/bin/env bash
+echo "TASK_DIR=$PWD"
+EOF
+chmod +x "$HOME/.config/mise/tasks/local-dir-wins"
+
+assert_contains "mise -C '$HOME/project' run local-overlay-wins" "LOCAL_CONTEXT=applied"
+assert_contains "mise -C '$HOME/project' run local-overlay-wins" "GLOBAL_CONTEXT=<unset>"
+assert_contains "mise -C '$HOME/project' run local-dir-wins" "TASK_DIR=$HOME/local-project-dir"
+assert_not_contains "mise -C '$HOME/project' run local-dir-wins" "TASK_DIR=$HOME/high-global-dir"

--- a/e2e/tasks/test_task_ls_global
+++ b/e2e/tasks/test_task_ls_global
@@ -79,3 +79,164 @@ assert "mise run customglobalfile" "PROJECT_ROOT=$PWD"
 assert "mise run systemglobalfile" "PROJECT_ROOT=$PWD"
 assert "mise run relative-meta" "RELATIVE_OVERLAY=applied"
 assert "mise run templated-meta" "TEMPLATED_OVERLAY=applied"
+
+# The user-global pass owns HOME's task include scope. An unrelated local HOME
+# config must not resurrect omitted defaults or let them override an explicitly
+# included global task with the same name.
+cat <<'EOF' >~/.config/mise/tasks/collision
+#!/usr/bin/env bash
+echo default-task
+EOF
+chmod +x ~/.config/mise/tasks/collision
+cat <<'EOF' >~/.config/mise/tasks/omitted-only
+#!/usr/bin/env bash
+echo omitted-task
+EOF
+chmod +x ~/.config/mise/tasks/omitted-only
+cat <<'EOF' >~/dotfiles/tasks/collision
+#!/usr/bin/env bash
+echo custom-task
+EOF
+chmod +x ~/dotfiles/tasks/collision
+cat >~/.config/mise/config.toml <<'TOML'
+tasks.myglobal = { run = 'echo myglobal' }
+
+[task_config]
+includes = ["dotfiles/tasks"]
+TOML
+cat >"$HOME/mise.toml" <<'TOML'
+[env]
+UNRELATED_HOME_CONFIG = "present"
+TOML
+
+assert "mise run collision" "custom-task"
+assert_fail "mise run omitted-only"
+assert_not_contains "mise tasks --global" "omitted-only"
+
+# Cascade control alone does not supply file-task context at the HOME root, so
+# it must not resurrect defaults omitted by the user-global config.
+cat >"$HOME/mise.toml" <<'TOML'
+[task_config]
+cascade = true
+TOML
+assert_fail "mise run omitted-only"
+
+# A local ancestor config can explicitly include the global task directory even
+# when the global config replaces that default include. Source deduplication
+# must not discard a task that the independent global pass did not load.
+cat >"$HOME/mise.toml" <<'TOML'
+[task_config]
+includes = [".config/mise/tasks"]
+TOML
+cat >"$HOME/.config/mise/config.toml" <<'TOML'
+tasks.myglobal = { run = 'echo myglobal' }
+
+[task_config]
+includes = ["dotfiles/tasks"]
+TOML
+
+assert "mise run myglobalfile" "myglobalfile"
+assert_contains "mise tasks --global" "myglobalfile"
+
+# Explicit task configuration at the HOME root owns its default file tasks even
+# when the user-global config replaces those defaults.
+mkdir -p "$HOME/.mise/conf.d" "$HOME/local-task-dir"
+cat >"$HOME/.config/mise/tasks/local-dir-context" <<'EOF'
+#!/usr/bin/env bash
+echo "$PWD"
+EOF
+chmod +x "$HOME/.config/mise/tasks/local-dir-context"
+cat >"$HOME/mise.toml" <<'EOF'
+[env]
+UNRELATED_HOME_CONFIG = "present"
+EOF
+cat >"$HOME/.mise/conf.d/20-task-context.toml" <<EOF
+[task_config]
+dir = "$HOME/local-task-dir"
+EOF
+assert "mise run local-dir-context" "$HOME/local-task-dir"
+
+# Input defaults from a local conf.d fragment also establish explicit ownership
+# of HOME's default file-task scope.
+touch "$HOME/local-global-input"
+cat >"$HOME/.config/mise/tasks/local-input-context" <<'EOF'
+#!/usr/bin/env bash
+echo local-input-context
+EOF
+chmod +x "$HOME/.config/mise/tasks/local-input-context"
+cat >"$HOME/.mise/conf.d/20-task-context.toml" <<'EOF'
+[task_config]
+global_inputs = ["local-global-input"]
+EOF
+assert \
+  "MISE_EXPERIMENTAL=1 mise tasks ls --json | jq -r '.[] | select(.name == \"local-input-context\") | .sources[0]'" \
+  "$HOME/local-global-input"
+
+# Rust-cache defaults are also file-task context even when explicitly disabled.
+cat >"$HOME/.config/mise/tasks/local-rust-cache-context" <<'EOF'
+#!/usr/bin/env bash
+echo local-rust-cache-context
+EOF
+chmod +x "$HOME/.config/mise/tasks/local-rust-cache-context"
+cat >"$HOME/.mise/conf.d/20-task-context.toml" <<'EOF'
+[task_config]
+rust_cache = false
+EOF
+assert "mise run local-rust-cache-context" "local-rust-cache-context"
+: >"$HOME/.mise/conf.d/20-task-context.toml"
+
+cat >"$HOME/local-shell-wrapper" <<'EOF'
+#!/usr/bin/env bash
+echo LOCAL_SHELL
+exec bash "$@"
+EOF
+chmod +x "$HOME/local-shell-wrapper"
+cat >"$HOME/.config/mise/tasks/local-shell-context" <<'EOF'
+#!/usr/bin/env bash
+echo LOCAL_TASK
+EOF
+chmod +x "$HOME/.config/mise/tasks/local-shell-context"
+cat >"$HOME/mise.toml" <<EOF
+[task_config]
+shell = "$HOME/local-shell-wrapper -c"
+EOF
+assert \
+  "mise tasks ls --json | jq -r '.[] | select(.name == \"local-shell-context\") | .shell'" \
+  "$HOME/local-shell-wrapper -c"
+
+# Effective task context may cascade from an ancestor into a custom global
+# root. The HOME/global-root filter must use that effective context, not only
+# config files located directly at the root.
+custom_global_root="$HOME/nested/global-root"
+mkdir -p "$custom_global_root/.config/mise/tasks" "$HOME/nested/cascaded-dir"
+cat >"$HOME/nested/mise.toml" <<EOF
+[task_config]
+cascade = true
+dir = "$HOME/nested/cascaded-dir"
+EOF
+cat >"$custom_global_root/.config/mise/tasks/cascaded-context" <<'EOF'
+#!/usr/bin/env bash
+echo "$PWD"
+EOF
+chmod +x "$custom_global_root/.config/mise/tasks/cascaded-context"
+cat >"$HOME/custom-global.toml" <<'EOF'
+[task_config]
+includes = ["empty-global-tasks"]
+EOF
+assert \
+  "MISE_GLOBAL_CONFIG_ROOT='$custom_global_root' MISE_GLOBAL_CONFIG_FILE='$HOME/custom-global.toml' MISE_SYSTEM_CONFIG_FILE='$HOME/missing-system.toml' mise -C '$custom_global_root' run cascaded-context" \
+  "$HOME/nested/cascaded-dir"
+
+# A root-local cascade opt-out also disables ancestor file-task context for
+# ownership checks, so omitted global defaults stay omitted.
+cat >"$custom_global_root/mise.toml" <<'EOF'
+[task_config]
+cascade = false
+EOF
+cat >"$custom_global_root/.config/mise/tasks/omitted-after-cascade-opt-out" <<'EOF'
+#!/usr/bin/env bash
+echo should-not-run
+EOF
+chmod +x "$custom_global_root/.config/mise/tasks/omitted-after-cascade-opt-out"
+assert_fail \
+  "MISE_GLOBAL_CONFIG_ROOT='$custom_global_root' MISE_GLOBAL_CONFIG_FILE='$HOME/custom-global.toml' MISE_SYSTEM_CONFIG_FILE='$HOME/missing-system.toml' mise -C '$custom_global_root' run omitted-after-cascade-opt-out"

--- a/e2e/tasks/test_task_monorepo_config_dedup
+++ b/e2e/tasks/test_task_monorepo_config_dedup
@@ -3,6 +3,7 @@
 export MISE_EXPERIMENTAL=1
 
 marker="$MISE_TMP_DIR/monorepo-config-render-count"
+: >"$marker"
 mkdir -p apps/example
 
 cat <<'EOF' >mise.toml

--- a/e2e/tasks/test_task_system_config_home_dedup
+++ b/e2e/tasks/test_task_system_config_home_dedup
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+mkdir -p "$HOME/.config/mise/tasks"
+
+cat <<'EOF' >"$HOME/.config/mise/tasks/system-meta"
+#!/usr/bin/env bash
+echo "SYSTEM_METADATA=${SYSTEM_METADATA:-<unset>}"
+EOF
+chmod +x "$HOME/.config/mise/tasks/system-meta"
+
+cat <<'EOF' >"$MISE_SYSTEM_DIR/config.toml"
+[tasks.system-meta]
+env = { SYSTEM_METADATA = "applied" }
+EOF
+
+# With no user-global config, the local hierarchy still walks HOME and sees the
+# same default script. The system/global pass must own the decorated copy.
+assert "mise run system-meta" "SYSTEM_METADATA=applied"
+assert_contains "mise tasks --global" "system-meta"
+
+# The same rule applies when the global config root is moved away from HOME.
+custom_root="$HOME/custom-global-root"
+mkdir -p "$custom_root/.config/mise/tasks"
+cat <<'EOF' >"$custom_root/.config/mise/tasks/custom-root-meta"
+#!/usr/bin/env bash
+echo "CUSTOM_ROOT_METADATA=${CUSTOM_ROOT_METADATA:-<unset>}"
+EOF
+chmod +x "$custom_root/.config/mise/tasks/custom-root-meta"
+
+cat <<'EOF' >>"$MISE_SYSTEM_DIR/config.toml"
+
+[tasks.custom-root-meta]
+env = { CUSTOM_ROOT_METADATA = "applied" }
+EOF
+
+assert "MISE_GLOBAL_CONFIG_ROOT='$custom_root' mise -C '$custom_root' run custom-root-meta" \
+  "CUSTOM_ROOT_METADATA=applied"
+assert_contains "MISE_GLOBAL_CONFIG_ROOT='$custom_root' mise -C '$custom_root' tasks --global" \
+  "custom-root-meta"
+
+# An explicit local conf.d include/dir at HOME remains local context even when
+# the system pass sees the same script through its default global task directory.
+mkdir -p "$HOME/.mise/conf.d" "$HOME/local-dir"
+cat <<EOF >"$HOME/.mise/conf.d/local.toml"
+[task_config]
+includes = [".config/mise/tasks"]
+dir = "$HOME/local-dir"
+
+[tasks.system-meta]
+env = { LOCAL_METADATA = "applied" }
+EOF
+cat <<'EOF' >"$HOME/.config/mise/tasks/system-meta"
+#!/usr/bin/env bash
+echo "LOCAL_METADATA=${LOCAL_METADATA:-<unset>}"
+echo "SYSTEM_METADATA=${SYSTEM_METADATA:-<unset>}"
+echo "TASK_DIR=$PWD"
+EOF
+assert_contains "mise run system-meta" "LOCAL_METADATA=applied"
+assert_contains "mise run system-meta" "SYSTEM_METADATA=<unset>"
+assert_contains "mise run system-meta" "TASK_DIR=$HOME/local-dir"
+
+# System configs can omit the default directory. Local-only default tasks must
+# not be removed merely because the system pass exists.
+rm "$HOME/.mise/conf.d/local.toml"
+cat <<'EOF' >>"$MISE_SYSTEM_DIR/config.toml"
+
+[task_config]
+includes = ["system-only-tasks"]
+EOF
+cat <<'EOF' >"$HOME/.config/mise/tasks/local-only"
+#!/usr/bin/env bash
+echo local-only
+EOF
+chmod +x "$HOME/.config/mise/tasks/local-only"
+assert "mise run local-only" "local-only"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,7 +4,7 @@ use indexmap::{IndexMap, IndexSet};
 use itertools::{Either, Itertools};
 use path_absolutize::Absolutize;
 pub use settings::{CompilePurpose, Settings};
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::env::join_paths;
 use std::fmt::{Debug, Formatter};
 use std::iter::once;
@@ -924,12 +924,14 @@ impl Config {
             load_local_tasks_with_context(&config, ctx, &task_definitions).await?;
         let global_tasks = load_global_tasks(&config, &task_definitions).await?;
         local_tasks.retain(|local| {
-            !global_tasks
-                .iter()
-                .any(|global| tasks_have_same_source(local, global))
+            !local.suppress_if_global_duplicate
+                || !global_tasks
+                    .iter()
+                    .any(|global| tasks_have_same_source(&local.task, global))
         });
         let mut tasks: BTreeMap<String, Task> = local_tasks
             .into_iter()
+            .map(|local| local.task)
             .chain(global_tasks)
             .rev()
             .inspect(|t| {
@@ -3203,17 +3205,17 @@ fn render_task_input_entries(
         .collect()
 }
 
-async fn apply_task_config_inputs(
-    task: &mut Task,
+async fn resolve_task_config_inputs(
+    task: &Task,
     config: &Arc<Config>,
     task_inputs: &ResolvedTaskInputs,
-) -> Result<()> {
+) -> Result<Option<ResolvedTaskInputs>> {
     let has_group_references = task
         .sources
         .iter()
         .any(|source| source.starts_with(TASK_INPUT_GROUP_PREFIX));
     if task_inputs.is_empty() && !has_group_references {
-        return Ok(());
+        return Ok(None);
     }
     Settings::get().ensure_experimental("task input groups")?;
 
@@ -3240,23 +3242,33 @@ async fn apply_task_config_inputs(
         )),
         None => None,
     };
-    let task_inputs = ResolvedTaskInputs {
+    Ok(Some(ResolvedTaskInputs {
         global_inputs,
         input_groups,
-    };
-    let had_sources = !task.sources.is_empty();
-    let mut sources = expand_task_inputs(
+    }))
+}
+
+fn apply_task_input_groups(task: &mut Task, task_inputs: &ResolvedTaskInputs) -> Result<()> {
+    task.sources = expand_task_inputs(
         &task.sources,
-        &task_inputs,
+        task_inputs,
         Path::new(""),
         &task.name,
         &mut vec![],
         false,
     )?;
+    Ok(())
+}
+
+fn apply_task_global_inputs(
+    task: &mut Task,
+    task_inputs: &ResolvedTaskInputs,
+    had_sources: bool,
+) -> Result<()> {
     if let Some((global_inputs, root)) = &task_inputs.global_inputs {
-        sources.extend(expand_task_inputs(
+        task.sources.extend(expand_task_inputs(
             global_inputs,
-            &task_inputs,
+            task_inputs,
             root,
             &task.name,
             &mut vec![],
@@ -3264,9 +3276,21 @@ async fn apply_task_config_inputs(
         )?);
     }
 
-    task.sources = sources;
     if !had_sources && !task.sources.is_empty() && task.outputs.is_empty() {
         task.outputs = TaskOutputs::Auto;
+    }
+    Ok(())
+}
+
+async fn apply_task_config_inputs(
+    task: &mut Task,
+    config: &Arc<Config>,
+    task_inputs: &ResolvedTaskInputs,
+) -> Result<()> {
+    let had_sources = !task.sources.is_empty();
+    if let Some(task_inputs) = resolve_task_config_inputs(task, config, task_inputs).await? {
+        apply_task_input_groups(task, &task_inputs)?;
+        apply_task_global_inputs(task, &task_inputs, had_sources)?;
     }
     Ok(())
 }
@@ -3452,11 +3476,28 @@ fn dir_is_in_enclosing_monorepo(
         && !file::path_starts_with_resolved(dir, selected_root)
 }
 
+struct LoadedLocalTask {
+    task: Task,
+    suppress_if_global_duplicate: bool,
+}
+
+fn task_config_has_file_context(task_config: &TaskConfig) -> bool {
+    task_config.includes.is_some()
+        || task_config.dir.is_some()
+        || task_config.shell.is_some()
+        || task_config.cache.is_some()
+        || task_config.rust_cache.is_some()
+        || !task_config.global_env.is_empty()
+        || !task_config.global_pass_through_env.is_empty()
+        || !task_config.global_inputs.is_empty()
+        || !task_config.input_groups.is_empty()
+}
+
 async fn load_local_tasks_with_context(
     config: &Arc<Config>,
     ctx: Option<&crate::task::TaskLoadContext>,
     templates: &TaskDefinitions,
-) -> Result<Vec<Task>> {
+) -> Result<Vec<LoadedLocalTask>> {
     let mut tasks = vec![];
     let monorepo_config = find_monorepo_config(&config.config_files);
     let monorepo_root = monorepo_config.and_then(|cf| cf.project_root().map(|p| p.to_path_buf()));
@@ -3473,6 +3514,11 @@ async fn load_local_tasks_with_context(
         .as_deref()
         .map(|root| enclosing_monorepo_roots(&config.config_files, root))
         .unwrap_or_default();
+    let user_global_config_paths = global_config_files();
+    let has_user_global_config = config
+        .config_files
+        .values()
+        .any(|cf| config_set_contains(&user_global_config_paths, cf.get_path()));
     for d in all_dirs()? {
         if cfg!(test) && !d.starts_with(*dirs::HOME) {
             continue;
@@ -3487,14 +3533,55 @@ async fn load_local_tasks_with_context(
             );
             continue;
         }
-        let mut dir_tasks =
-            load_tasks_in_dir_with_definitions(config, &d, &local_config_files, templates).await?;
+        let local_configs = configs_at_root(&d, &local_config_files);
+        let cascaded_task_config = cascaded_task_config_for_dir(&d, &local_config_files)?;
+        let effective_cascaded_task_config =
+            if local_configs.iter().find_map(|cf| cf.task_config().cascade) == Some(false) {
+                None
+            } else {
+                cascaded_task_config.as_ref()
+            };
+        let mut dir_tasks = load_tasks_from_configs(
+            config,
+            &d,
+            local_configs.clone(),
+            templates,
+            false,
+            effective_cascaded_task_config,
+        )
+        .await?;
+
+        let mut suppress_if_global_duplicate = !has_user_global_config;
+        let mut local_inline_task_names = HashSet::new();
+        if has_user_global_config && file::same_file(&d, &env::MISE_GLOBAL_CONFIG_ROOT) {
+            let local_file_context = local_configs
+                .iter()
+                .any(|cf| task_config_has_file_context(cf.task_config()))
+                || effective_cascaded_task_config
+                    .is_some_and(|tc| task_config_has_file_context(&tc.task_config));
+            suppress_if_global_duplicate = false;
+            if !local_file_context {
+                local_inline_task_names = local_configs
+                    .iter()
+                    .flat_map(|cf| cf.tasks())
+                    .map(|task| task.name.clone())
+                    .collect();
+                // A user-global config owns the HOME include decision, so
+                // omitted defaults must not be resurrected by the local
+                // hierarchy walk.
+                dir_tasks.retain(|task| local_inline_task_names.contains(&task.name));
+            }
+        }
 
         if let Some(ref monorepo_root) = monorepo_root {
             prefix_monorepo_task_names(&mut dir_tasks, &d, monorepo_root);
         }
 
-        tasks.extend(dir_tasks);
+        tasks.extend(dir_tasks.into_iter().map(|task| LoadedLocalTask {
+            suppress_if_global_duplicate: suppress_if_global_duplicate
+                && !local_inline_task_names.contains(&task.name),
+            task,
+        }));
     }
 
     // Determine if we should load monorepo tasks from subdirectories
@@ -3620,7 +3707,10 @@ async fn load_local_tasks_with_context(
         }
 
         while let Some(result) = join_set.join_next().await {
-            tasks.extend(result??);
+            tasks.extend(result??.into_iter().map(|task| LoadedLocalTask {
+                task,
+                suppress_if_global_duplicate: !has_user_global_config,
+            }));
         }
     }
 
@@ -4013,7 +4103,7 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
         .await?;
         rendered_file_tasks.finish_config();
         let mut inline_tasks = IndexMap::new();
-        for task in &sources.config_tasks {
+        for task in &sources.config_task_overlays {
             inline_tasks
                 .entry(task.name.clone())
                 .or_insert_with(|| task.clone());
@@ -4213,10 +4303,11 @@ async fn load_config_tasks(
     templates: &TaskDefinitions,
     monorepo_cf: Option<&Arc<dyn ConfigFile>>,
     task_config: &ResolvedTaskConfig,
-) -> Result<Vec<Task>> {
+) -> Result<LoadedConfigTasks> {
     let is_global = is_global_config(cf.get_path());
     let config_root = Arc::new(config_root.to_path_buf());
     let mut tasks = vec![];
+    let mut overlays = vec![];
     for t in cf.tasks().into_iter() {
         let config_root = config_root.clone();
         let config = config.clone();
@@ -4232,6 +4323,8 @@ async fn load_config_tasks(
         }
         // Resolve template if the task extends one
         resolve_task_template(&mut t, templates)?;
+        let has_explicit_dir = t.dir.is_some();
+        let has_explicit_shell = t.shell.is_some();
         if t.dir.is_none() {
             t.dir = task_config.dir.clone();
         }
@@ -4240,7 +4333,25 @@ async fn load_config_tasks(
         }
         match t.render(&config, &config_root).await {
             Ok(()) => {
-                apply_task_config_inputs(&mut t, &config, &task_config.inputs).await?;
+                let had_sources = !t.sources.is_empty();
+                let resolved_task_inputs =
+                    resolve_task_config_inputs(&t, &config, &task_config.inputs).await?;
+                if let Some(task_inputs) = &resolved_task_inputs {
+                    apply_task_input_groups(&mut t, task_inputs)?;
+                }
+                if is_global {
+                    let mut overlay = t.clone();
+                    if !has_explicit_dir {
+                        overlay.dir = None;
+                    }
+                    if !has_explicit_shell {
+                        overlay.shell = None;
+                    }
+                    overlays.push(overlay);
+                }
+                if let Some(task_inputs) = &resolved_task_inputs {
+                    apply_task_global_inputs(&mut t, task_inputs, had_sources)?;
+                }
                 apply_task_config_cache_default(&mut t, &task_config.cache);
                 apply_task_config_rust_cache_default(&mut t, &task_config.rust_cache);
                 task_config.environment.apply(&mut t)?;
@@ -4259,7 +4370,7 @@ async fn load_config_tasks(
             }
         }
     }
-    Ok(tasks)
+    Ok(LoadedConfigTasks { tasks, overlays })
 }
 
 struct LoadTaskIncludesOptions<'a> {
@@ -4614,6 +4725,12 @@ async fn load_tasks_in_dir_with_definitions(
 struct TaskSources {
     file_tasks: Vec<Task>,
     config_tasks: Vec<Task>,
+    config_task_overlays: Vec<Task>,
+}
+
+struct LoadedConfigTasks {
+    tasks: Vec<Task>,
+    overlays: Vec<Task>,
 }
 
 #[derive(Clone)]
@@ -4844,6 +4961,7 @@ async fn load_task_sources_from_configs(
     };
 
     let mut config_tasks = vec![];
+    let mut config_task_overlays = vec![];
     for (precedence, cf) in configs.iter().enumerate() {
         let dir = dir.to_path_buf();
         let monorepo_cf = monorepo_context.then_some(*cf);
@@ -4856,10 +4974,14 @@ async fn load_task_sources_from_configs(
             &task_config,
         )
         .await?;
-        for task in &mut loaded {
+        for task in &mut loaded.tasks {
             task.config_precedence = precedence;
         }
-        config_tasks.extend(loaded);
+        for task in &mut loaded.overlays {
+            task.config_precedence = precedence;
+        }
+        config_tasks.extend(loaded.tasks);
+        config_task_overlays.extend(loaded.overlays);
     }
 
     let mut file_tasks = vec![];
@@ -4907,6 +5029,7 @@ async fn load_task_sources_from_configs(
     Ok(TaskSources {
         file_tasks,
         config_tasks,
+        config_task_overlays,
     })
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3519,6 +3519,11 @@ async fn load_local_tasks_with_context(
         .config_files
         .values()
         .any(|cf| config_set_contains(&user_global_config_paths, cf.get_path()));
+    let system_config_paths = system_config_files();
+    let has_system_config = config
+        .config_files
+        .values()
+        .any(|cf| config_set_contains(&system_config_paths, cf.get_path()));
     for d in all_dirs()? {
         if cfg!(test) && !d.starts_with(*dirs::HOME) {
             continue;
@@ -3551,25 +3556,33 @@ async fn load_local_tasks_with_context(
         )
         .await?;
 
-        let mut suppress_if_global_duplicate = !has_user_global_config;
+        let mut suppress_if_global_duplicate = false;
         let mut local_inline_task_names = HashSet::new();
-        if has_user_global_config && file::same_file(&d, &env::MISE_GLOBAL_CONFIG_ROOT) {
+        if (has_user_global_config || has_system_config)
+            && file::same_file(&d, &env::MISE_GLOBAL_CONFIG_ROOT)
+        {
             let local_file_context = local_configs
                 .iter()
                 .any(|cf| task_config_has_file_context(cf.task_config()))
                 || effective_cascaded_task_config
                     .is_some_and(|tc| task_config_has_file_context(&tc.task_config));
-            suppress_if_global_duplicate = false;
             if !local_file_context {
                 local_inline_task_names = local_configs
                     .iter()
                     .flat_map(|cf| cf.tasks())
                     .map(|task| task.name.clone())
                     .collect();
-                // A user-global config owns the HOME include decision, so
-                // omitted defaults must not be resurrected by the local
-                // hierarchy walk.
-                dir_tasks.retain(|task| local_inline_task_names.contains(&task.name));
+                if has_user_global_config {
+                    // A user-global config owns the HOME include decision, so
+                    // omitted defaults must not be resurrected by the local
+                    // hierarchy walk.
+                    dir_tasks.retain(|task| local_inline_task_names.contains(&task.name));
+                } else {
+                    // A system config is lower precedence than local HOME
+                    // tasks. Suppress only incidental copies of sources that
+                    // the system pass actually loaded.
+                    suppress_if_global_duplicate = true;
+                }
             }
         }
 
@@ -3709,7 +3722,7 @@ async fn load_local_tasks_with_context(
         while let Some(result) = join_set.join_next().await {
             tasks.extend(result??.into_iter().map(|task| LoadedLocalTask {
                 task,
-                suppress_if_global_duplicate: !has_user_global_config,
+                suppress_if_global_duplicate: false,
             }));
         }
     }


### PR DESCRIPTION
Recreates #11206 on the current configuration architecture.

Stacked on #12203. The final commit is the system-precedence delta; #12203 should be reviewed and merged first.

## Summary

- let explicit local HOME task context override system task metadata
- suppress only incidental local copies of task sources already loaded by the system pass
- cover custom global roots and local `.mise/conf.d` ownership without replaying the obsolete global-first loader

## Bug examples

- A system config can add `SYSTEM_METADATA=applied` to `~/.config/mise/tasks/system-meta`. The local HOME walk previously rediscovered the same script and its undecorated copy could win, so the task printed `SYSTEM_METADATA=<unset>`. This fix suppresses that incidental duplicate and retains the system metadata.
- Conversely, if `$HOME/.mise/conf.d/local.toml` explicitly includes that script and supplies a local directory or task metadata, broad same-source deduplication could discard the intentional local definition. The selective suppression now preserves explicit local context, so the local directory and metadata override the lower-precedence system values.

## Testing

- `mise run lint-fix`
- `mise run test:e2e e2e/tasks/test_task_system_config_home_dedup e2e/tasks/test_task_ls_global e2e/tasks/test_task_global_source_context_precedence`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved task configuration precedence across system, global, included, and local sources.
  - Prevented duplicate evaluation of task templates and duplicate task loading.
  - Preserved task metadata, directories, shells, inputs, and working-directory settings when configurations overlap.
  - Ensured local task definitions and explicit project includes retain the expected precedence.
  - Improved global task behavior when using custom roots or running outside the home directory.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->