### PR TITLE
fix(self-update): sweep stale copies before the TEMP length check

### DIFF
--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -164,6 +164,8 @@ impl Doctor {
         self.analyze_plugins();
         self.analyze_backend_mismatches();
         self.analyze_system_deps(ts).await;
+        #[cfg(windows)]
+        self.analyze_self_update_leftovers();
         self.check_path_ordering(ts, &config).await;
         self.check_shim_shadowing(&desired_shims).await;
         data.insert(
@@ -318,6 +320,8 @@ impl Doctor {
                 *version::V
             ));
         }
+        #[cfg(windows)]
+        self.analyze_self_update_leftovers();
 
         miseprintln!();
 
@@ -394,6 +398,27 @@ impl Doctor {
                 self.warnings.push(msg);
             }
         }
+    }
+
+    /// Windows `self-update` moves the running mise.exe aside and spawns a copy of it to do the
+    /// deleting; when that copy fails to remove itself both stay in `TEMP`, a full mise.exe each.
+    /// Only another `self-update` collects them, so without this nothing says they are there: they
+    /// sit outside the cache, and their generated names mean nothing to anyone reading a directory
+    /// listing. Reported rather than deleted — `doctor` is not a command that should remove files.
+    #[cfg(windows)]
+    fn analyze_self_update_leftovers(&mut self) {
+        let orphans = crate::cli::self_update::helper_orphans();
+        if orphans.is_empty() {
+            return;
+        }
+        let total: u64 = orphans.iter().map(|(_, size)| size).sum();
+        let plural = if orphans.len() == 1 { "y" } else { "ies" };
+        self.warnings.push(format!(
+            "{} stale cop{plural} of mise ({}) left by self-update in {}\n`mise self-update` removes them",
+            orphans.len(),
+            bytesize::ByteSize::b(total).display().iec(),
+            display_path(std::env::temp_dir()),
+        ));
     }
 
     fn analyze_settings(&mut self) -> eyre::Result<()> {

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -148,32 +148,60 @@ fn helper_name_len(exe_stem: Option<&str>) -> usize {
 /// Delete the copies of mise that earlier updates left in `TEMP`.
 ///
 /// `self-replace` moves the running binary aside and spawns a copy of it to delete the leftovers.
-/// When that copy does not recognise itself — measured with `TEMP` at 199 and 201 characters, just
-/// under the length #12062 refuses outright — the deletion never happens and a **full copy of
-/// mise.exe** stays in `TEMP` for good. Nothing else collects them: they are not under the cache, so
+/// When that copy does not delete itself the deletion never happens and a **full copy of mise.exe**
+/// stays in `TEMP` for good. Nothing else collects them: they are not under the cache, so
 /// `mise cache clear` does not reach them, and their names mean nothing to anyone else.
+///
+/// A long `TEMP` is not the only trigger, though it was the one this was first written for
+/// (measured at 199 and 201 characters, just under the length #12062 refuses outright). Measured
+/// again on a `TEMP` of 31: a successful update leaves **both** copies — the `__relocated__`
+/// original and the `__selfdelete__` helper — and neither is locked afterwards, so any later mise
+/// can remove them. That is what this exists to do.
 ///
 /// Best effort by design. A copy another mise is still using cannot be deleted on Windows, which is
 /// the outcome we want, so failures are ignored rather than warned about.
 #[cfg(windows)]
 fn sweep_helper_orphans() {
-    let Some(stem) = current_exe_stem() else {
-        return;
-    };
-    let Ok(entries) = std::fs::read_dir(std::env::temp_dir()) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let name = entry.file_name();
-        let Some(name) = name.to_str() else { continue };
-        if !env::is_self_replace_helper(name, &stem) {
-            continue;
-        }
-        match std::fs::remove_file(entry.path()) {
-            Ok(()) => debug!("removed stale self-update copy: {name}"),
-            Err(e) => trace!("could not remove {name}: {e}"),
+    for (path, _) in helper_orphans() {
+        match std::fs::remove_file(&path) {
+            Ok(()) => debug!("removed stale self-update copy: {}", path.display()),
+            Err(e) => trace!("could not remove {}: {e}", path.display()),
         }
     }
+}
+
+/// The copies an earlier update left in `TEMP`, with their sizes.
+///
+/// Shared with `mise doctor` so that "what counts as a leftover" has one definition rather than two
+/// that can drift: the predicate stays [`env::is_self_replace_helper`], and this is only the walk.
+/// A file whose size cannot be read is still reported, at 0 — it exists, which is the part that
+/// matters, and the size is decoration.
+#[cfg(windows)]
+pub(crate) fn helper_orphans() -> Vec<(std::path::PathBuf, u64)> {
+    let Some(stem) = current_exe_stem() else {
+        return Vec::new();
+    };
+    helper_orphans_in(&std::env::temp_dir(), &stem)
+}
+
+#[cfg(windows)]
+fn helper_orphans_in(dir: &std::path::Path, stem: &str) -> Vec<(std::path::PathBuf, u64)> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| env::is_self_replace_helper(name, stem))
+        })
+        .map(|entry| {
+            let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
+            (entry.path(), size)
+        })
+        .collect()
 }
 
 #[cfg(windows)]
@@ -201,12 +229,15 @@ impl SelfUpdate {
             }
             bail!("mise is installed via a package manager, cannot update");
         }
-        #[cfg(windows)]
-        Self::ensure_temp_dir_can_replace_binary()?;
         // Before the update, not after: this run is about to create a copy of its own, and that one
-        // is in use rather than stale.
+        // is in use rather than stale. Before the length check too, and that ordering is the whole
+        // point: a `TEMP` long enough to refuse the update is the case the leftovers come from, so
+        // running the sweep afterwards means the only machines that accumulate them are the only
+        // machines that never reach the code that collects them.
         #[cfg(windows)]
         sweep_helper_orphans();
+        #[cfg(windows)]
+        Self::ensure_temp_dir_can_replace_binary()?;
         let status = self.do_update()?;
 
         if status.updated() {
@@ -544,6 +575,49 @@ mod tests {
         let tmp = temp_dir_of_len(202);
         assert!(!temp_dir_breaks_self_replace(&tmp, Some("mise")));
         assert!(temp_dir_breaks_self_replace(&tmp, Some("mise-dev")));
+    }
+
+    /// The walk, not the predicate — `env::is_self_replace_helper` has its own tests. What matters
+    /// here is that `doctor` and the sweep see the same set, and that a directory full of unrelated
+    /// files does not turn into a warning about mise.
+    #[test]
+    fn only_the_generated_copies_are_collected() {
+        let dir = tempfile::tempdir().unwrap();
+        let rand = "a".repeat(env::SELF_REPLACE_RANDOM_LEN);
+        let collected = [
+            format!(".mise.{rand}.__selfdelete__.exe"),
+            format!(".mise.{rand}.__relocated__.exe"),
+        ];
+        let ignored = [
+            "mise.exe".to_string(),
+            // a different binary's leftovers are not ours to delete
+            format!(".other.{rand}.__selfdelete__.exe"),
+            // near-misses on the random segment: too short, and not lowercase
+            format!(".mise.{}.__selfdelete__.exe", "a".repeat(31)),
+            format!(".mise.{}A.__selfdelete__.exe", "a".repeat(31)),
+            "setup-x64.exe".to_string(),
+        ];
+        for name in collected.iter().chain(ignored.iter()) {
+            std::fs::write(dir.path().join(name), b"xyz").unwrap();
+        }
+
+        let found = helper_orphans_in(dir.path(), "mise");
+        let mut names = found
+            .iter()
+            .map(|(p, _)| p.file_name().unwrap().to_str().unwrap().to_string())
+            .collect::<Vec<_>>();
+        names.sort();
+        let mut want = collected.to_vec();
+        want.sort();
+        assert_eq!(names, want);
+        // the size is what `doctor` adds up, so it has to come from the files rather than a count
+        assert_eq!(found.iter().map(|(_, size)| size).sum::<u64>(), 6);
+    }
+
+    #[test]
+    fn a_missing_directory_is_not_an_error() {
+        // `TEMP` pointing at something unreadable must not take `self-update` or `doctor` down.
+        assert!(helper_orphans_in(Path::new("C:\\nope\\nope\\nope"), "mise").is_empty());
     }
 
     #[test]


### PR DESCRIPTION
`mise self-update` on Windows leaves two full copies of mise.exe in `TEMP` — the original moved aside as `__relocated__`, and the `__selfdelete__` helper spawned to remove it. `sweep_helper_orphans()` exists to collect them, but it is unreachable from the machines that need it most, and nothing tells anyone the files are there.

**The update itself works.** This is not a report of a broken update — measured here, 2026.8.6 → 2026.8.9, exit 0, binary and `mise-shim.exe` both replaced.

## What is actually left behind

Measured on Windows 11, `TEMP` = `C:\Users\…\AppData\Local\Temp` (31 characters):

```
%TEMP%\.mise.<32 chars>.__selfdelete__.exe   91,446,784
%TEMP%\.mise.<32 chars>.__relocated__.exe    91,446,784
```

- still there after 60 s
- **not locked** — both open with `FileShare.None`, so any later mise process can delete them
- reproduced with 2026.8.9 updating itself (`--force`), so this is current behaviour, not something the pre-#12080 binary did

Only the next `self-update` collects them, and only if it gets that far.

Splitting the responsibility by `argv[0]`, same binary each time:

| `argv[0]` | exit | output | deleted itself |
| --- | --- | --- | --- |
| `mise.exe` | 2 | help, 83 lines | — |
| `.mise.<32>.__relocated__.exe` | **0** | none | n/a — #12080's early return, working |
| `.mise.<32>.__selfdelete__.exe` | **1** | none | **no** |

The `__relocated__` row shows mise's own argv0 handling is fine. The `__selfdelete__` row is intercepted before `main` (mise's fast path would exit 0, and no help is printed), i.e. inside `self-replace`. **That failure is upstream and this PR does not try to fix it** — it only makes mise's own recovery reachable and visible.

## 1. The sweep ran after the check that refuses to run

```rust
Self::ensure_temp_dir_can_replace_binary()?;   // bail!s when TEMP is too long
sweep_helper_orphans();                        // never reached
```

`ensure_temp_dir_can_replace_binary` bails when `TEMP` is long enough that replacing the binary would leave nothing installed (#12062). So on exactly the machines the sweep's own doc comment blames for the orphaning, `mise self-update` refuses and **never sweeps** — the user is told to shorten `TEMP`, while the copies already sitting in the long one are collected by nothing, ever.

Swapped. The sweep needs only `current_exe_stem()` and `temp_dir()`; it has no dependency on the length check.

No test: reaching that ordering from a test means taking `run()` apart, and refactoring for testability alone would widen the change more than the fix is worth. It is one statement, verified by reading.

## 2. `mise doctor` reports them

Nothing else could tell you. They sit outside the cache — `mise cache clear` does not reach them, as the doc comment already noted — and the generated names mean nothing in a directory listing. 183 MB was sitting on this machine and only a deliberate measurement found it.

The walk is extracted as `helper_orphans()` so the sweep and the report share one definition of what counts as a leftover; the predicate is still `env::is_self_replace_helper`. Warnings do not affect doctor's exit code — only `errors` do.

**A trade-off worth objecting to if you disagree:** running `doctor` right after `self-update` will warn about the copies that update just made. I kept the wording factual (what is there, and that `self-update` removes it) rather than claiming they are old, instead of adding an age threshold — a knob for a condition that clears itself on the next update.

## Also corrected

The sweep's doc comment attributed the orphaning to a long `TEMP`. That was where it was first measured, but it is not the only trigger: `TEMP` is 31 characters here and both copies are still left. Comment updated to say so — a wrong sentence in a doc comment justifies the gap it describes.

## Tests

`helper_orphans_in` covers the walk against a directory holding both suffixes, another binary's leftovers, two near-misses on the random segment (too short, not lowercase), and unrelated files — plus an unreadable directory, since `TEMP` pointing somewhere odd must not take `self-update` or `doctor` down. The predicate itself already has thorough tests in `env.rs`.

## Verification

The measurements above are from this machine. **No local build was run** — this box cannot build mise, so type checking and the tests are CI's. I have deliberately not deleted the two orphans, so the doctor wording can be checked against a real fixture once a build exists rather than asserted from reading.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows self-update cleanup so stale helper files can be removed during later update attempts.
  * Added handling for missing temporary directories without interrupting self-update operations.

* **New Features**
  * `mise doctor` now detects leftover Windows self-update files and reports their count and total size.
  * Doctor diagnostics explain that running `mise self-update` removes these files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->