### PR TITLE
fix(task): harden remote task cache lifecycle

### DIFF
--- a/e2e/helpers/scripts/git_http_backend_server.py
+++ b/e2e/helpers/scripts/git_http_backend_server.py
@@ -14,8 +14,9 @@ import socketserver
 from pathlib import Path
 
 class GitHTTPHandler(http.server.BaseHTTPRequestHandler):
-    def __init__(self, *args, repo_dir=None, upload_pack_count_file=None, **kwargs):
+    def __init__(self, *args, repo_dir=None, request_log=None, upload_pack_count_file=None, **kwargs):
         self.repo_dir = repo_dir
+        self.request_log = request_log
         self.upload_pack_count_file = upload_pack_count_file
         super().__init__(*args, **kwargs)
 
@@ -26,6 +27,10 @@ class GitHTTPHandler(http.server.BaseHTTPRequestHandler):
         self.handle_git_request()
 
     def handle_git_request(self):
+        if self.request_log:
+            with open(self.request_log, 'a') as log:
+                log.write(f'{self.command} {self.path}\n')
+
         # Set up environment for git-http-backend
         env = os.environ.copy()
         env['GIT_PROJECT_ROOT'] = str(self.repo_dir)
@@ -111,7 +116,7 @@ class GitHTTPHandler(http.server.BaseHTTPRequestHandler):
         except Exception as e:
             self.send_error(500, f"Server error: {str(e)}")
 
-def create_test_repo(repo_path):
+def create_test_repo(repo_path, server_port):
     """Create a minimal test repository"""
     # Create a regular (non-bare) repository
     subprocess.run(['git', 'init', repo_path], check=True)
@@ -127,6 +132,27 @@ def create_test_repo(repo_path):
     remote_task_file = xtasks_dir / 'remote-task'
     remote_task_file.write_text('#!/usr/bin/env bash\necho "remote task executed"\n')
     remote_task_file.chmod(0o755)
+
+    remote_task_dir = Path(repo_path) / 'xtasks' / 'remote'
+    remote_task_dir.mkdir(parents=True)
+    remote_metadata_file = remote_task_dir / 'remote_metadata.toml'
+    remote_metadata_file.write_text(
+        '#!/usr/bin/env bash\n'
+        '#MISE description="remote git metadata"\n'
+        '#MISE tools={dummy="1.0.0"}\n'
+        '#MISE env._.file="remote.env"\n'
+        'echo "remote path: $0"\n'
+        'echo "$REMOTE_RELATIVE_ENV"\n'
+        'dummy\n'
+    )
+    remote_metadata_file.chmod(0o755)
+    (remote_task_dir / 'remote.env').write_text('REMOTE_RELATIVE_ENV="relative env loaded"\n')
+    nested_remote_file = remote_task_dir / 'nested'
+    nested_remote_file.write_text(
+        '#!/usr/bin/env bash\n'
+        'echo "nested remote task executed"\n'
+    )
+    nested_remote_file.chmod(0o755)
 
     snapshot_root = Path(repo_path) / 'xtasks' / 'snapshot'
     snapshot_parent = snapshot_root / 'parent' / 'snapshot_parent'
@@ -165,6 +191,9 @@ def create_test_repo(repo_path):
         '[toml_table_task]\n'
         'run = "echo toml_table_task executed"\n'
         'description = "TOML task with table form"\n'
+        '\n'
+        '[nested_remote]\n'
+        f'file = "git::http://localhost:{server_port}/repo.git//xtasks/remote/nested"\n'
     )
 
     # A standalone toml file in a sibling directory to test the
@@ -203,18 +232,17 @@ def start_server(port=0):
     repo_path = temp_dir / 'repo'
     upload_pack_count_path = os.environ.get('MISE_GIT_HTTP_UPLOAD_PACK_COUNT_FILE')
     upload_pack_count_file = Path(upload_pack_count_path) if upload_pack_count_path else None
+    request_log = os.environ.get('MISE_GIT_HTTP_REQUEST_LOG')
     if upload_pack_count_file is not None:
         upload_pack_count_file.parent.mkdir(parents=True, exist_ok=True)
         upload_pack_count_file.write_text('')
-
-    print(f"Creating test repository at {repo_path}")
-    create_test_repo(str(repo_path))
 
     # Create handler with repo directory
     def handler(*args, **kwargs):
         return GitHTTPHandler(
             *args,
             repo_dir=temp_dir,
+            request_log=request_log,
             upload_pack_count_file=upload_pack_count_file,
             **kwargs,
         )
@@ -223,6 +251,8 @@ def start_server(port=0):
     # This avoids race conditions between finding and binding
     with socketserver.TCPServer(("", port), handler) as httpd:
         actual_port = httpd.server_address[1]
+        print(f"Creating test repository at {repo_path}")
+        create_test_repo(str(repo_path), actual_port)
         print(f"Git HTTP server running on port {actual_port}")
         print(f"Repository URL: http://localhost:{actual_port}/repo.git")
 

--- a/e2e/helpers/scripts/git_http_backend_server.py
+++ b/e2e/helpers/scripts/git_http_backend_server.py
@@ -14,8 +14,9 @@ import socketserver
 from pathlib import Path
 
 class GitHTTPHandler(http.server.BaseHTTPRequestHandler):
-    def __init__(self, *args, repo_dir=None, **kwargs):
+    def __init__(self, *args, repo_dir=None, upload_pack_count_file=None, **kwargs):
         self.repo_dir = repo_dir
+        self.upload_pack_count_file = upload_pack_count_file
         super().__init__(*args, **kwargs)
 
     def do_GET(self):
@@ -46,6 +47,14 @@ class GitHTTPHandler(http.server.BaseHTTPRequestHandler):
         # Read request body for POST
         content_length = int(self.headers.get('Content-Length', 0))
         request_body = self.rfile.read(content_length) if content_length > 0 else b''
+
+        if (
+            self.command == 'POST'
+            and path_info.endswith('/git-upload-pack')
+            and self.upload_pack_count_file is not None
+        ):
+            with self.upload_pack_count_file.open('a') as count_file:
+                count_file.write('1\n')
 
         # Set content type if provided
         if 'Content-Type' in self.headers:
@@ -119,6 +128,33 @@ def create_test_repo(repo_path):
     remote_task_file.write_text('#!/usr/bin/env bash\necho "remote task executed"\n')
     remote_task_file.chmod(0o755)
 
+    snapshot_root = Path(repo_path) / 'xtasks' / 'snapshot'
+    snapshot_parent = snapshot_root / 'parent' / 'snapshot_parent'
+    snapshot_parent.parent.mkdir(parents=True)
+    snapshot_parent.write_text(
+        '#!/usr/bin/env bash\n'
+        '#MISE depends=["snapshot_child"]\n'
+        'echo "snapshot parent checkout: ${0%%/xtasks/*}"\n'
+    )
+    snapshot_parent.chmod(0o755)
+
+    snapshot_child = snapshot_root / 'child' / 'snapshot_child'
+    snapshot_child.parent.mkdir(parents=True)
+    snapshot_child.write_text(
+        '#!/usr/bin/env bash\n'
+        'echo "snapshot child checkout: ${0%%/xtasks/*}"\n'
+    )
+    snapshot_child.chmod(0o755)
+
+    snapshot_failure = snapshot_root / 'failure' / 'snapshot_failure'
+    snapshot_failure.parent.mkdir(parents=True)
+    snapshot_failure.write_text(
+        '#!/usr/bin/env bash\n'
+        'echo "snapshot failure"\n'
+        'exit 1\n'
+    )
+    snapshot_failure.chmod(0o755)
+
     # A toml task file colocated with the executable scripts. Keys are task
     # names; values are the run command (or a table). Used by tests covering
     # remote toml task includes.
@@ -165,13 +201,23 @@ def start_server(port=0):
     # Create temp directory
     temp_dir = Path(tempfile.mkdtemp(prefix='mise_git_http_'))
     repo_path = temp_dir / 'repo'
+    upload_pack_count_path = os.environ.get('MISE_GIT_HTTP_UPLOAD_PACK_COUNT_FILE')
+    upload_pack_count_file = Path(upload_pack_count_path) if upload_pack_count_path else None
+    if upload_pack_count_file is not None:
+        upload_pack_count_file.parent.mkdir(parents=True, exist_ok=True)
+        upload_pack_count_file.write_text('')
 
     print(f"Creating test repository at {repo_path}")
     create_test_repo(str(repo_path))
 
     # Create handler with repo directory
     def handler(*args, **kwargs):
-        return GitHTTPHandler(*args, repo_dir=temp_dir, **kwargs)
+        return GitHTTPHandler(
+            *args,
+            repo_dir=temp_dir,
+            upload_pack_count_file=upload_pack_count_file,
+            **kwargs,
+        )
 
     # Let the OS assign an available port if port=0
     # This avoids race conditions between finding and binding
@@ -206,6 +252,8 @@ def start_server(port=0):
             port_file.unlink(missing_ok=True)
             info_file.unlink(missing_ok=True)
             ready_file.unlink(missing_ok=True)
+            if upload_pack_count_file is not None:
+                upload_pack_count_file.unlink(missing_ok=True)
 
 if __name__ == '__main__':
     port = int(sys.argv[1]) if len(sys.argv) > 1 else 0

--- a/e2e/helpers/scripts/http_test_server.py
+++ b/e2e/helpers/scripts/http_test_server.py
@@ -22,6 +22,8 @@ HEADERS_LOG_DIR = None
 
 class TestFileHandler(http.server.SimpleHTTPRequestHandler):
     changing_remote_revision = 0
+    changing_alias_revision = 0
+    raw_help_revision = 0
 
     def do_GET(self):
         """Handle GET requests for test files"""
@@ -33,6 +35,102 @@ class TestFileHandler(http.server.SimpleHTTPRequestHandler):
             self.send_header('Content-Type', 'text/plain')
             self.end_headers()
             content = '#!/usr/bin/env bash\necho "running mytask"\n'
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-template':
+            if marker := os.environ.get('MISE_HTTP_REQUEST_MARKER'):
+                Path(marker).touch()
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE description="{{ exec(command=\'touch $MISE_REMOTE_TEMPLATE_MARKER\') }}"\n'
+                '#MISE depends=["remote_dep"]\n'
+                '#USAGE flag "--remote-flag" help="Remote usage flag"\n'
+                'echo "remote template task ran"\n'
+            )
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-raw-help':
+            TestFileHandler.raw_help_revision += 1
+            revision = TestFileHandler.raw_help_revision
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE raw_args=true\n'
+                f'echo "remote raw help revision {revision}"\n'
+            )
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-deferred-template':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE confirm="\\u007b\\u007b exec(command=\'touch $MISE_REMOTE_DEFERRED_MARKER\') \\u007d\\u007d"\n'
+                '#MISE env={REMOTE_DEFERRED="\\u007b\\u007b exec(command=\'touch $MISE_REMOTE_DEFERRED_MARKER\') \\u007d\\u007d"}\n'
+                'echo "remote deferred task ran"\n'
+            )
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-source':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            source_path = json.dumps(os.environ['MISE_REMOTE_SOURCE_SCRIPT'])
+            venv_path = json.dumps(os.environ['MISE_REMOTE_VENV'])
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE confirm="run remote source task?"\n'
+                '#MISE env={_={source=%s,python={venv={path=%s}}}}\n'
+                'echo "remote source task ran: VIRTUAL_ENV=$VIRTUAL_ENV"\n'
+            ) % (source_path, venv_path)
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-sops-file':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            sops_file = json.dumps(os.environ['MISE_REMOTE_SOPS_FILE'])
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE env={_={file=%s}}\n'
+                'echo "remote sops task ran: $REMOTE_SOPS_VALUE"\n'
+            ) % sops_file
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-tools':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE alias="remote-tools-alias"\n'
+                '#MISE tools={dummy="1.0.0"}\n'
+                'if command -v dummy >/dev/null 2>&1; then dummy; else echo "dummy not installed"; fi\n'
+            )
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-changing-alias':
+            TestFileHandler.changing_alias_revision += 1
+            revision = TestFileHandler.changing_alias_revision
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            alias = '#MISE alias="remote-changing-alias"\n' if revision == 1 else ''
+            content = (
+                '#!/usr/bin/env bash\n'
+                f'{alias}'
+                f'echo "remote changing alias revision {revision}"\n'
+            )
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-hidden':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE hide=true\n'
+                '#MISE description="hidden remote metadata"\n'
+                'echo "hidden remote task ran"\n'
+            )
             self.wfile.write(content.encode('utf-8'))
         elif self.path == '/test/remote-changing':
             TestFileHandler.changing_remote_revision += 1

--- a/e2e/tasks/test_task_remote_git_https
+++ b/e2e/tasks/test_task_remote_git_https
@@ -45,7 +45,7 @@ LOCAL_GIT_URL="http://localhost:${SERVER_PORT}/repo.git"
 # Update cache directory paths for local server
 REMOTE_TASKS_DIR="${MISE_CACHE_DIR}/remote-git-tasks-cache"
 # Hash for localhost URL will be different than GitHub URL
-LOCAL_CACHE_HASH=$(echo -n "${LOCAL_GIT_URL}v2025.1.17" | shasum -a 256 | cut -d' ' -f1)
+LOCAL_CACHE_HASH=$(printf '%s\0%s' "${LOCAL_GIT_URL}" "v2025.1.17" | shasum -a 256 | cut -d' ' -f1)
 MISE_LOCAL_CACHE_DIR="${REMOTE_TASKS_DIR}/${LOCAL_CACHE_HASH}"
 
 git init

--- a/e2e/tasks/test_task_remote_git_includes
+++ b/e2e/tasks/test_task_remote_git_includes
@@ -8,15 +8,17 @@ PORT_FILE="$TMPDIR/mise_git_http_port"
 READY_FILE="$TMPDIR/mise_git_http_ready"
 INFO_FILE="$TMPDIR/mise_git_http_info"
 UPLOAD_PACK_COUNT_FILE="$TMPDIR/mise_git_http_upload_pack_count"
+REQUEST_LOG="$TMPDIR/mise_git_http_requests"
 
 # Clean up any previous server files
-rm -f "$PORT_FILE" "$READY_FILE" "$INFO_FILE" "$UPLOAD_PACK_COUNT_FILE"
+rm -f "$PORT_FILE" "$READY_FILE" "$INFO_FILE" "$UPLOAD_PACK_COUNT_FILE" "$REQUEST_LOG"
 
 # Start local git HTTP server with OS-assigned port to avoid race conditions
 MISE_GIT_HTTP_PORT_FILE="$PORT_FILE" \
   MISE_GIT_HTTP_READY_FILE="$READY_FILE" \
   MISE_GIT_HTTP_INFO_FILE="$INFO_FILE" \
   MISE_GIT_HTTP_UPLOAD_PACK_COUNT_FILE="$UPLOAD_PACK_COUNT_FILE" \
+  MISE_GIT_HTTP_REQUEST_LOG="$REQUEST_LOG" \
   python3 "${TEST_ROOT}/helpers/scripts/git_http_backend_server.py" 0 &
 SERVER_PID=$!
 
@@ -52,7 +54,7 @@ git init
 # Ensure cleanup on exit
 cleanup() {
   kill "$SERVER_PID" 2>/dev/null || true
-  rm -f "$PORT_FILE" "$READY_FILE" "$INFO_FILE" "$UPLOAD_PACK_COUNT_FILE"
+  rm -f "$PORT_FILE" "$READY_FILE" "$INFO_FILE" "$UPLOAD_PACK_COUNT_FILE" "$REQUEST_LOG"
 }
 trap cleanup EXIT
 
@@ -66,6 +68,11 @@ includes = [
     "git::${LOCAL_GIT_URL}//xtasks/lint"
 ]
 EOF
+
+# Safe-mode parsing must reject an untrusted remote include before cloning it.
+: >"$REQUEST_LOG"
+assert_fail "MISE_SAFE=1 MISE_TRUSTED_CONFIG_PATHS=$TMPDIR/not-trusted MISE_YES=0 mise tasks"
+assert_fail "test -s '$REQUEST_LOG'"
 
 # The xtasks/lint directory contains multiple task files
 # We should be able to see and run them
@@ -164,6 +171,18 @@ assert_contains "mise tasks" "toml_table_task"
 assert_contains "mise run toml_task" "toml_task executed"
 assert_contains "mise run toml_table_task" "toml_table_task executed"
 
+# A remote TOML include may declare another remote file task. Preserve the
+# local config as trust provenance through both remote layers.
+NESTED_ARTIFACT_TMPDIR="$TMPDIR/nested-remote-git-artifacts"
+mkdir -p "$NESTED_ARTIFACT_TMPDIR"
+assert_contains "TMPDIR=$NESTED_ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run nested_remote" "nested remote task executed"
+assert_directory_empty "$NESTED_ARTIFACT_TMPDIR"
+
+PROVENANCE_STATE_DIR="$TMPDIR/remote-git-provenance-state"
+mkdir -p "$PROVENANCE_STATE_DIR"
+assert_contains "MISE_STATE_DIR=$PROVENANCE_STATE_DIR MISE_TRUSTED_CONFIG_PATHS='' MISE_YES=1 mise run nested_remote" "nested remote task executed"
+assert "find '$PROVENANCE_STATE_DIR/trusted-configs' -mindepth 1 \\( -type f -o -type l \\) 2>/dev/null | wc -l | tr -d ' '" "1"
+
 mise cache clear # Clear cache to force redownload
 
 #################################################################################
@@ -179,6 +198,23 @@ EOF
 
 assert_contains "mise tasks" "standalone_task"
 assert_contains "mise run standalone_task" "standalone_task executed"
+
+#################################################################################
+# Test config-declared remote Git task metadata and tool installation
+#################################################################################
+
+cat <<EOF >mise.toml
+[tasks.remote_metadata_a]
+file = "git::${LOCAL_GIT_URL}//xtasks/remote/remote_metadata.toml"
+
+[tasks.remote_metadata_b]
+file = "git::${LOCAL_GIT_URL}//xtasks/remote/remote_metadata.toml"
+EOF
+
+mise trust
+assert_contains "mise tasks info remote_metadata_a" "remote git metadata"
+assert_contains "mise run remote_metadata_a" "This is Dummy 1.0.0!"
+assert_contains "mise run remote_metadata_a" "relative env loaded"
 
 #################################################################################
 # Test no-cache Git task snapshots

--- a/e2e/tasks/test_task_remote_git_includes
+++ b/e2e/tasks/test_task_remote_git_includes
@@ -194,7 +194,7 @@ EOF
 
 ARTIFACT_TMPDIR="$TMPDIR/remote-git-artifacts"
 mkdir -p "$ARTIFACT_TMPDIR"
-output=$(quiet_assert_succeed "TMPDIR=$ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run remote_git_a ::: remote_git_b")
+output=$(quiet_assert_succeed "TMPDIR=$ARTIFACT_TMPDIR MISE_GIX=0 MISE_TASK_REMOTE_NO_CACHE=true mise run remote_git_a ::: remote_git_b")
 path_count=$(grep -o 'snapshot child checkout: .*' <<<"$output" | sort -u | wc -l)
 [[ $path_count -eq 2 ]] || fail "no-cache Git tasks did not retain two distinct snapshots"
 assert_directory_empty "$ARTIFACT_TMPDIR"
@@ -220,7 +220,7 @@ upload_packs_after=$(wc -l <"$UPLOAD_PACK_COUNT_FILE")
 assert_contains_text "$output" "snapshot parent checkout:"
 assert_contains_text "$output" "snapshot child checkout:"
 snapshot_checkout_count=$(
-  grep -o 'snapshot \(parent\|child\) checkout: .*' <<<"$output" |
+  grep -Eo 'snapshot (parent|child) checkout: .*' <<<"$output" |
     sed 's/snapshot [^ ]* checkout: //' |
     sort -u |
     wc -l

--- a/e2e/tasks/test_task_remote_git_includes
+++ b/e2e/tasks/test_task_remote_git_includes
@@ -114,7 +114,7 @@ EOF
 
 INCLUDE_ARTIFACT_TMPDIR="$TMPDIR/remote-git-include-artifacts"
 mkdir -p "$INCLUDE_ARTIFACT_TMPDIR"
-assert_succeed "TMPDIR=$INCLUDE_ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run remote-task" # Remote task should be redownloaded
+assert_succeed "TMPDIR=$INCLUDE_ARTIFACT_TMPDIR mise run --no-cache remote-task" # CLI no-cache must also redownload includes
 assert_directory_empty "$INCLUDE_ARTIFACT_TMPDIR"
 assert_directory_not_exists "${REMOTE_TASKS_DIR}"
 

--- a/e2e/tasks/test_task_remote_git_includes
+++ b/e2e/tasks/test_task_remote_git_includes
@@ -7,14 +7,16 @@
 PORT_FILE="$TMPDIR/mise_git_http_port"
 READY_FILE="$TMPDIR/mise_git_http_ready"
 INFO_FILE="$TMPDIR/mise_git_http_info"
+UPLOAD_PACK_COUNT_FILE="$TMPDIR/mise_git_http_upload_pack_count"
 
 # Clean up any previous server files
-rm -f "$PORT_FILE" "$READY_FILE" "$INFO_FILE"
+rm -f "$PORT_FILE" "$READY_FILE" "$INFO_FILE" "$UPLOAD_PACK_COUNT_FILE"
 
 # Start local git HTTP server with OS-assigned port to avoid race conditions
 MISE_GIT_HTTP_PORT_FILE="$PORT_FILE" \
   MISE_GIT_HTTP_READY_FILE="$READY_FILE" \
   MISE_GIT_HTTP_INFO_FILE="$INFO_FILE" \
+  MISE_GIT_HTTP_UPLOAD_PACK_COUNT_FILE="$UPLOAD_PACK_COUNT_FILE" \
   python3 "${TEST_ROOT}/helpers/scripts/git_http_backend_server.py" 0 &
 SERVER_PID=$!
 
@@ -50,7 +52,7 @@ git init
 # Ensure cleanup on exit
 cleanup() {
   kill "$SERVER_PID" 2>/dev/null || true
-  rm -f "$PORT_FILE" "$READY_FILE" "$INFO_FILE"
+  rm -f "$PORT_FILE" "$READY_FILE" "$INFO_FILE" "$UPLOAD_PACK_COUNT_FILE"
 }
 trap cleanup EXIT
 
@@ -103,7 +105,10 @@ includes = [
 ]
 EOF
 
-assert_succeed "MISE_TASK_REMOTE_NO_CACHE=true mise run remote-task" # Remote task should be redownloaded
+INCLUDE_ARTIFACT_TMPDIR="$TMPDIR/remote-git-include-artifacts"
+mkdir -p "$INCLUDE_ARTIFACT_TMPDIR"
+assert_succeed "TMPDIR=$INCLUDE_ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run remote-task" # Remote task should be redownloaded
+assert_directory_empty "$INCLUDE_ARTIFACT_TMPDIR"
 assert_directory_not_exists "${REMOTE_TASKS_DIR}"
 
 assert_succeed "mise run remote-task" # Cache should be used
@@ -174,5 +179,88 @@ EOF
 
 assert_contains "mise tasks" "standalone_task"
 assert_contains "mise run standalone_task" "standalone_task executed"
+
+#################################################################################
+# Test no-cache Git task snapshots
+#################################################################################
+
+cat <<EOF >mise.toml
+[tasks.remote_git_a]
+file = "git::${LOCAL_GIT_URL}//xtasks/snapshot/child/snapshot_child"
+
+[tasks.remote_git_b]
+file = "git::${LOCAL_GIT_URL}//xtasks/snapshot/child/snapshot_child"
+EOF
+
+ARTIFACT_TMPDIR="$TMPDIR/remote-git-artifacts"
+mkdir -p "$ARTIFACT_TMPDIR"
+output=$(quiet_assert_succeed "TMPDIR=$ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run remote_git_a ::: remote_git_b")
+path_count=$(grep -o 'snapshot child checkout: .*' <<<"$output" | sort -u | wc -l)
+[[ $path_count -eq 2 ]] || fail "no-cache Git tasks did not retain two distinct snapshots"
+assert_directory_empty "$ARTIFACT_TMPDIR"
+
+#################################################################################
+# Test one coherent no-cache Git include snapshot per command
+#################################################################################
+
+cat <<EOF >mise.toml
+[task_config]
+includes = [
+    "git::${LOCAL_GIT_URL}//xtasks/snapshot/parent?ref=v2025.1.17",
+    "git::${LOCAL_GIT_URL}//xtasks/snapshot/child?ref=v2025.1.17",
+    "git::${LOCAL_GIT_URL}//xtasks/snapshot/failure?ref=v2025.1.17"
+]
+EOF
+
+upload_packs_before=$(wc -l <"$UPLOAD_PACK_COUNT_FILE")
+output=$(quiet_assert_succeed "TMPDIR=$ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run snapshot_parent")
+upload_packs_after=$(wc -l <"$UPLOAD_PACK_COUNT_FILE")
+[[ $((upload_packs_after - upload_packs_before)) -eq 1 ]] ||
+  fail "one command cloned the same Git repository/ref more than once"
+assert_contains_text "$output" "snapshot parent checkout:"
+assert_contains_text "$output" "snapshot child checkout:"
+snapshot_checkout_count=$(
+  grep -o 'snapshot \(parent\|child\) checkout: .*' <<<"$output" |
+    sed 's/snapshot [^ ]* checkout: //' |
+    sort -u |
+    wc -l
+)
+[[ $snapshot_checkout_count -eq 1 ]] || fail "one command mixed multiple Git include snapshots"
+assert_directory_empty "$ARTIFACT_TMPDIR"
+
+#################################################################################
+# Test cleanup after an ordinary task-loading error
+#################################################################################
+
+cat <<EOF >mise.toml
+[task_config]
+includes = [
+    "git::${LOCAL_GIT_URL}//xtasks/lint?ref=v2025.1.17",
+    "git::${LOCAL_GIT_URL}//xtasks/missing?ref=v2025.1.17"
+]
+EOF
+
+assert_fail "TMPDIR=$ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise tasks"
+assert_directory_empty "$ARTIFACT_TMPDIR"
+
+#################################################################################
+# Test cleanup after a requested nonzero exit
+#################################################################################
+
+cat <<EOF >mise.toml
+[task_config]
+includes = [
+    "git::${LOCAL_GIT_URL}//xtasks/snapshot/failure?ref=v2025.1.17"
+]
+EOF
+
+assert_fail "TMPDIR=$ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run snapshot_failure"
+# A failed run may leave its unrelated tempfile::tempdir (`.tmp*`) for the e2e
+# harness; the command-scoped remote checkout itself must be gone.
+for artifact in "$ARTIFACT_TMPDIR"/* "$ARTIFACT_TMPDIR"/.[!.]* "$ARTIFACT_TMPDIR"/..?*; do
+  [[ -e $artifact || -L $artifact ]] || continue
+  artifact_name=${artifact##*/}
+  [[ $artifact_name == .tmp* ]] || fail "unexpected remote task artifact remains: $artifact"
+done
 
 echo "All tests passed!"

--- a/e2e/tasks/test_task_remote_metadata_trust
+++ b/e2e/tasks/test_task_remote_metadata_trust
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+
+# Remote task metadata can render Tera templates during discovery and install
+# tools before execution. Both actions must respect the defining config's trust.
+
+HTTP_PORT_FILE="$TMPDIR/mise_http_test_port"
+MARKER="$TMPDIR/remote-template-executed"
+DEFERRED_MARKER="$TMPDIR/remote-deferred-template-executed"
+SOURCE_MARKER="$TMPDIR/remote-source-executed"
+SOURCE_SCRIPT="$TMPDIR/remote-source.sh"
+REMOTE_VENV="$TMPDIR/remote-venv"
+SOPS_MARKER="$TMPDIR/remote-sops-executed"
+SOPS_FILE="$TMPDIR/remote-sops.yaml"
+FAKE_SOPS_BIN="$TMPDIR/remote-fake-sops-bin"
+REQUEST_MARKER="$TMPDIR/remote-template-requested"
+mkdir -p "$REMOTE_VENV/bin"
+cat <<'EOF' >"$SOURCE_SCRIPT"
+touch "$MISE_REMOTE_SOURCE_MARKER"
+EOF
+mkdir -p "$FAKE_SOPS_BIN"
+cat <<'EOF' >"$FAKE_SOPS_BIN/sops"
+#!/usr/bin/env bash
+touch "$MISE_REMOTE_SOPS_MARKER"
+cat
+EOF
+chmod +x "$FAKE_SOPS_BIN/sops"
+cat <<'EOF' >"$SOPS_FILE"
+sops:
+  version: "3.8.1"
+REMOTE_SOPS_VALUE: decrypted
+EOF
+MISE_HTTP_TEST_PORT_FILE="$HTTP_PORT_FILE" \
+  MISE_HTTP_REQUEST_MARKER="$REQUEST_MARKER" \
+  MISE_REMOTE_SOURCE_SCRIPT="$SOURCE_SCRIPT" \
+  MISE_REMOTE_VENV="$REMOTE_VENV" \
+  MISE_REMOTE_SOPS_FILE="$SOPS_FILE" \
+  python3 "${TEST_ROOT}/helpers/scripts/http_test_server.py" 0 &
+HTTP_SERVER_PID=$!
+
+cleanup() {
+  kill "$HTTP_SERVER_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+wait_for_file "$HTTP_PORT_FILE" "HTTP test server port file" 30 "$HTTP_SERVER_PID"
+HTTP_PORT=$(cat "$HTTP_PORT_FILE")
+
+UNTRUSTED_ENV="env -u CI -u GITHUB_ACTION -u GITHUB_ACTIONS MISE_TRUSTED_CONFIG_PATHS=$TMPDIR/not-trusted MISE_YES=0 MISE_REMOTE_TEMPLATE_MARKER=$MARKER MISE_REMOTE_DEFERRED_MARKER=$DEFERRED_MARKER MISE_REMOTE_SOURCE_MARKER=$SOURCE_MARKER MISE_REMOTE_SOURCE_SCRIPT=$SOURCE_SCRIPT MISE_REMOTE_VENV=$REMOTE_VENV MISE_REMOTE_SOPS_MARKER=$SOPS_MARKER"
+
+cat <<EOF >mise.toml
+[tasks.remote_template]
+file = "http://localhost:${HTTP_PORT}/test/remote-template"
+
+[tasks.remote_dep]
+run = "echo remote dependency"
+EOF
+
+# Safe mode makes config parsing inert, but it must not turn remote discovery
+# into an SSRF-capable trust bypass.
+assert_fail "$UNTRUSTED_ENV MISE_SAFE=1 mise tasks ls" "not trusted"
+[[ ! -e $REQUEST_MARKER ]] || fail "safe-mode discovery fetched an untrusted remote task"
+
+assert_fail "$UNTRUSTED_ENV mise tasks ls" "not trusted"
+assert_fail "$UNTRUSTED_ENV mise tasks deps remote_template" "not trusted"
+assert_fail "$UNTRUSTED_ENV mise run remote_template --help" "not trusted"
+[[ ! -e $REQUEST_MARKER ]] || fail "remote task was fetched during untrusted passive discovery"
+[[ ! -e $MARKER ]] || fail "remote metadata template executed before trust"
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_succeed "$UNTRUSTED_ENV mise tasks ls"
+assert_contains "$UNTRUSTED_ENV mise tasks deps remote_template" "remote_dep"
+assert_contains "$UNTRUSTED_ENV mise run remote_template --help" "--remote-flag"
+[[ -e $REQUEST_MARKER ]] || fail "trusted passive discovery did not fetch the remote task"
+[[ -e $MARKER ]] || fail "trusted remote metadata template did not render"
+assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
+
+# A trusted config vouches for an explicitly included task file even when that
+# file is outside the config's trust root. Preserve that provenance when the
+# include declares a remote task, including for temporary no-cache snapshots.
+INCLUDED_TASK_DIR="$TMPDIR/included-remote-tasks"
+mkdir -p "$INCLUDED_TASK_DIR"
+cat <<EOF >"$INCLUDED_TASK_DIR/tasks.toml"
+[included_remote_template]
+file = "http://localhost:${HTTP_PORT}/test/remote-template"
+EOF
+cat <<EOF >mise.toml
+[task_config]
+includes = ["$INCLUDED_TASK_DIR/tasks.toml"]
+EOF
+
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_contains "$UNTRUSTED_ENV mise tasks info included_remote_template" "remote_dep"
+assert_contains "$UNTRUSTED_ENV MISE_TASK_REMOTE_NO_CACHE=true mise tasks info included_remote_template" "remote_dep"
+assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
+
+# Deferred metadata (confirmation and task env) can render after initial task
+# discovery, so decoded header templates must still require the defining
+# config's trust before either path gets a chance to execute.
+cat <<EOF >mise.toml
+[tasks.remote_deferred]
+file = "http://localhost:${HTTP_PORT}/test/remote-deferred-template"
+EOF
+
+assert_fail "$UNTRUSTED_ENV mise run remote_deferred" "not trusted"
+[[ ! -e $DEFERRED_MARKER ]] || fail "deferred remote metadata template executed before trust"
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_contains "$UNTRUSTED_ENV MISE_YES=1 mise run remote_deferred" "remote deferred task ran"
+[[ -e $DEFERRED_MARKER ]] || fail "trusted remote task env template did not render"
+assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
+
+# Template-free env metadata can still execute code or install tooling. It must
+# require the defining config's trust before resolution and before confirmation.
+cat <<EOF >mise.toml
+[tasks.remote_source]
+file = "http://localhost:${HTTP_PORT}/test/remote-source"
+EOF
+
+assert_fail "$UNTRUSTED_ENV mise run --dry-run remote_source" "not trusted"
+[[ ! -e $SOURCE_MARKER ]] || fail "remote source directive executed before trust"
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_contains "$UNTRUSTED_ENV MISE_YES=1 mise run remote_source" "remote source task ran: VIRTUAL_ENV=$REMOTE_VENV"
+[[ -e $SOURCE_MARKER ]] || fail "trusted remote source directive did not execute"
+assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
+
+# Static file directives read outside the task sandbox, and structured SOPS
+# files can execute the configured sops binary. Neither may happen before the
+# defining config is trusted, including during dry-run.
+cat <<EOF >mise.toml
+[tasks.remote_sops_file]
+file = "http://localhost:${HTTP_PORT}/test/remote-sops-file"
+EOF
+
+assert_fail "$UNTRUSTED_ENV PATH=$FAKE_SOPS_BIN:$PATH MISE_SOPS_ROPS=0 mise run --dry-run remote_sops_file" "not trusted"
+[[ ! -e $SOPS_MARKER ]] || fail "remote sops file executed a tool before trust"
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_contains "$UNTRUSTED_ENV PATH=$FAKE_SOPS_BIN:$PATH MISE_SOPS_ROPS=0 mise run remote_sops_file" "remote sops task ran: decrypted"
+[[ -e $SOPS_MARKER ]] || fail "trusted remote sops file did not execute the configured tool"
+assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
+
+# Remote visibility is metadata too: ordinary listings must apply hide after
+# fetching, while --hidden still exposes the task and its remote description.
+cat <<EOF >mise.toml
+[tasks.remote_hidden]
+file = "http://localhost:${HTTP_PORT}/test/remote-hidden"
+EOF
+
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_not_contains "$UNTRUSTED_ENV mise tasks ls" "remote_hidden"
+assert_contains "$UNTRUSTED_ENV mise tasks ls --hidden" "hidden remote metadata"
+assert_not_contains "$UNTRUSTED_ENV mise tasks deps" "remote_hidden"
+assert_contains "$UNTRUSTED_ENV mise tasks deps --hidden" "remote_hidden"
+assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
+
+# Locally known hidden metadata is monotonic, so passive listings must not
+# fetch that task merely to discard it afterward.
+rm -f "$REQUEST_MARKER"
+cat <<EOF >mise.toml
+[tasks.locally_hidden_remote]
+file = "http://localhost:${HTTP_PORT}/test/remote-template"
+hide = true
+EOF
+
+assert_not_contains "$UNTRUSTED_ENV mise tasks deps" "locally_hidden_remote"
+[[ ! -e $REQUEST_MARKER ]] || fail "tasks deps fetched a locally hidden remote task"
+
+# Tool metadata is consumed for runtime activation even when installation is
+# disabled, so every consumption path must require trust. Disabled modes still
+# remain authoritative after trust and must not install the missing fixture.
+cat <<EOF >mise.toml
+[tasks.remote_tools]
+file = "http://localhost:${HTTP_PORT}/test/remote-tools"
+
+[tasks.remote_alias_parent]
+depends = ["remote-tools-alias"]
+run = "echo remote alias parent ran"
+
+[tasks.remote_alias_delegate]
+run = [{ task = "remote-tools-alias" }]
+EOF
+
+assert_fail "$UNTRUSTED_ENV mise run remote_tools" "not trusted"
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
+assert_fail "$UNTRUSTED_ENV mise run --skip-tools remote_tools" "not trusted"
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
+assert_fail "$UNTRUSTED_ENV MISE_TASK_RUN_AUTO_INSTALL=0 mise run remote_tools" "not trusted"
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
+assert_fail "$UNTRUSTED_ENV MISE_AUTO_INSTALL=0 mise run remote_tools" "not trusted"
+assert_fail "$UNTRUSTED_ENV mise run --dry-run --skip-tools remote_tools" "not trusted"
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
+
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_contains "$UNTRUSTED_ENV mise tasks info remote-tools-alias" "remote-tools-alias"
+assert_contains "$UNTRUSTED_ENV mise tasks deps remote-tools-alias" "remote_tools"
+assert_contains "$UNTRUSTED_ENV mise run --skip-tools remote-tools-alias" "dummy not installed"
+assert_contains "$UNTRUSTED_ENV MISE_TASK_RUN_AUTO_INSTALL=0 mise remote-tools-alias" "dummy not installed"
+assert_contains "$UNTRUSTED_ENV mise run --skip-tools remote_alias_parent" "remote alias parent ran"
+assert_contains "$UNTRUSTED_ENV mise run --skip-tools remote_alias_delegate" "dummy not installed"
+assert_contains "$UNTRUSTED_ENV MISE_TASK_RUN_AUTO_INSTALL=0 mise run remote_tools" "dummy not installed"
+assert_contains "$UNTRUSTED_ENV MISE_AUTO_INSTALL=0 mise run remote_tools" "dummy not installed"
+assert_contains "$UNTRUSTED_ENV mise run remote_tools" "This is Dummy 1.0.0!"
+
+# A prefixed alias already known from local metadata must not trigger remote
+# alias discovery for unrelated tasks.
+cat <<EOF >mise.toml
+monorepo_root = true
+
+[monorepo]
+config_roots = ["projects/*"]
+
+[tasks.local_prefixed_alias]
+alias = "local-alias"
+run = "echo local prefixed alias ran"
+
+[tasks.unrelated_remote]
+file = "http://localhost:${HTTP_PORT}/test/remote-template"
+EOF
+
+rm -f "$REQUEST_MARKER"
+assert_contains "mise //:local-alias" "local prefixed alias ran"
+[[ ! -e $REQUEST_MARKER ]] || fail "known local prefixed alias fetched unrelated remote metadata"
+
+# Prefixed monorepo aliases must use the same synthesized alias map in bare
+# dispatch and dynamic task delegation as normal `mise run` resolution.
+cat <<EOF >mise.toml
+monorepo_root = true
+
+[monorepo]
+config_roots = ["projects/*"]
+
+[tasks.remote_tools]
+file = "http://localhost:${HTTP_PORT}/test/remote-tools"
+
+[tasks.remote_prefixed_alias_delegate]
+run = [{ task = "//:remote-tools-alias" }]
+EOF
+
+assert_contains "MISE_TASK_RUN_AUTO_INSTALL=0 mise //:remote-tools-alias" "This is Dummy 1.0.0!"
+assert_contains "mise run --skip-tools remote_prefixed_alias_delegate" "This is Dummy 1.0.0!"
+
+# Bare remote-alias dispatch must retain the snapshot whose header established
+# the alias, rather than selecting revision 1 and executing a second download.
+cat <<EOF >mise.toml
+[tasks.remote_changing_alias]
+file = "http://localhost:${HTTP_PORT}/test/remote-changing-alias"
+EOF
+
+assert_contains "MISE_TASK_REMOTE_NO_CACHE=true mise remote-changing-alias" "remote changing alias revision 1"
+
+# A remote raw-args task must execute the same snapshot used to decide that
+# --help should pass through, rather than fetching a mutable source twice.
+cat <<EOF >mise.toml
+[tasks.remote_raw_help]
+file = "http://localhost:${HTTP_PORT}/test/remote-raw-help"
+EOF
+
+assert_contains "MISE_TASK_REMOTE_NO_CACHE=true mise run remote_raw_help --help" "remote raw help revision 1"
+
+# Two no-cache tasks using the same mutable URL must retain the exact body that
+# was parsed for each Task instead of both executing the final download path.
+cat <<EOF >mise.toml
+[tasks.remote_revision_a]
+file = "http://localhost:${HTTP_PORT}/test/remote-changing"
+
+[tasks.remote_revision_b]
+file = "http://localhost:${HTTP_PORT}/test/remote-changing"
+EOF
+
+ARTIFACT_TMPDIR="$TMPDIR/remote-artifacts"
+mkdir -p "$ARTIFACT_TMPDIR"
+output=$(quiet_assert_succeed "TMPDIR=$ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run remote_revision_a ::: remote_revision_b")
+assert_contains_text "$output" "remote revision 1"
+assert_contains_text "$output" "remote revision 2"
+assert_fail "find '$ARTIFACT_TMPDIR' -mindepth 1 -print -quit | grep -q ."

--- a/e2e/tasks/test_task_remote_metadata_trust
+++ b/e2e/tasks/test_task_remote_metadata_trust
@@ -45,7 +45,7 @@ trap cleanup EXIT
 wait_for_file "$HTTP_PORT_FILE" "HTTP test server port file" 30 "$HTTP_SERVER_PID"
 HTTP_PORT=$(cat "$HTTP_PORT_FILE")
 
-UNTRUSTED_ENV="env -u CI -u GITHUB_ACTION -u GITHUB_ACTIONS MISE_TRUSTED_CONFIG_PATHS=$TMPDIR/not-trusted MISE_YES=0 MISE_REMOTE_TEMPLATE_MARKER=$MARKER MISE_REMOTE_DEFERRED_MARKER=$DEFERRED_MARKER MISE_REMOTE_SOURCE_MARKER=$SOURCE_MARKER MISE_REMOTE_SOURCE_SCRIPT=$SOURCE_SCRIPT MISE_REMOTE_VENV=$REMOTE_VENV MISE_REMOTE_SOPS_MARKER=$SOPS_MARKER"
+UNTRUSTED_ENV="env -u CI -u GITHUB_ACTION -u GITHUB_ACTIONS MISE_PARANOID=1 MISE_TRUSTED_CONFIG_PATHS=$TMPDIR/not-trusted MISE_YES=0 MISE_REMOTE_TEMPLATE_MARKER=$MARKER MISE_REMOTE_DEFERRED_MARKER=$DEFERRED_MARKER MISE_REMOTE_SOURCE_MARKER=$SOURCE_MARKER MISE_REMOTE_SOURCE_SCRIPT=$SOURCE_SCRIPT MISE_REMOTE_VENV=$REMOTE_VENV MISE_REMOTE_SOPS_MARKER=$SOPS_MARKER"
 
 cat <<EOF >mise.toml
 [tasks.remote_template]
@@ -159,8 +159,10 @@ file = "http://localhost:${HTTP_PORT}/test/remote-template"
 hide = true
 EOF
 
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
 assert_not_contains "$UNTRUSTED_ENV mise tasks deps" "locally_hidden_remote"
 [[ ! -e $REQUEST_MARKER ]] || fail "tasks deps fetched a locally hidden remote task"
+assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
 
 # Tool metadata is consumed for runtime activation even when installation is
 # disabled, so every consumption path must require trust. Disabled modes still

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -1,6 +1,6 @@
 use crate::Result;
 use crate::cmd::{RunningPidGuard, prepare_noninteractive_child};
-use crate::config::Config;
+use crate::config::{Config, Settings};
 use clap::Parser;
 use rmcp::{
     RoleServer, ServiceExt,
@@ -374,11 +374,22 @@ impl ServerHandler for MiseServer {
                     data: None,
                 })?;
 
-                let tasks = config.tasks().await.map_err(|e| ErrorData {
-                    code: ErrorCode::INTERNAL_ERROR,
-                    message: Cow::Owned(format!("Failed to load tasks: {e}")),
-                    data: None,
-                })?;
+                let remote_no_cache = Settings::get().task.remote_no_cache.unwrap_or(false);
+                let _artifacts =
+                    remote_no_cache.then(crate::task::task_fetcher::RemoteTaskArtifactsGuard::new);
+                let task_config = if remote_no_cache {
+                    config.with_config_files(config.config_files.clone())
+                } else {
+                    config
+                };
+                let tasks = task_config
+                    .tasks_with_context_no_cache(None, remote_no_cache)
+                    .await
+                    .map_err(|e| ErrorData {
+                        code: ErrorCode::INTERNAL_ERROR,
+                        message: Cow::Owned(format!("Failed to load tasks: {e}")),
+                        data: None,
+                    })?;
 
                 let task_list: Vec<_> = tasks.iter().map(|(name, task)| {
                     json!({

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -809,8 +809,13 @@ impl Cli {
             version::show_latest().await;
             return Err(request_exit(0));
         }
-        let _remote_task_artifacts = crate::task::task_fetcher::RemoteTaskArtifactsGuard::new();
         let cmd = cli.get_command().await?;
+        if matches!(&cmd, Commands::Mcp(_)) {
+            // MCP scopes no-cache artifacts per request because the server is
+            // long-lived and must not pin its first remote snapshot forever.
+            return measure!("run {cmd}", { cmd.run().await });
+        }
+        let _remote_task_artifacts = crate::task::task_fetcher::RemoteTaskArtifactsGuard::new();
         measure!("run {cmd}", { cmd.run().await })
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,5 @@
 use crate::config::{Config, Settings, config_file};
-use crate::task::TaskOutput;
+use crate::task::{GetMatchingExt, TaskOutput};
 use crate::ui::{self, ctrlc};
 use crate::{Result, backend, request_exit};
 use crate::{cli::args::ToolArg, path::PathExt};
@@ -838,7 +838,25 @@ impl Cli {
                 } else {
                     config.tasks().await?
                 };
-                if tasks.iter().any(|(_, t)| t.is_match(&task)) {
+                let task_refs = crate::task::build_task_ref_map(tasks.iter());
+                let task_exists = if tasks.iter().any(|(_, candidate)| candidate.is_match(&task))
+                    || !task_refs.get_matching(&task)?.is_empty()
+                {
+                    true
+                } else {
+                    // Bare remote aliases exist only after parsing their headers.
+                    // Reuse is guaranteed by the command-scoped artifact map.
+                    let resolved_tasks = crate::task::task_fetcher::TaskFetcher::new(false)
+                        .require_trust_before_fetch()
+                        .fetch_task_map(&config, &tasks)
+                        .await?;
+                    let resolved_refs = crate::task::build_task_ref_map(resolved_tasks.iter());
+                    resolved_tasks
+                        .values()
+                        .any(|candidate| candidate.is_match(&task))
+                        || !resolved_refs.get_matching(&task)?.is_empty()
+                };
+                if task_exists {
                     return Ok(Commands::Run(Box::new(run::Run {
                         task: Some(task),
                         args: self.task_args.unwrap_or_default(),

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -601,7 +601,13 @@ impl Run {
                 )
                 .collect_vec();
 
-            let task_list = get_task_lists(&config, &args, false, false, false).await?;
+            let mut task_list = get_task_lists(&config, &args, false, false, false).await?;
+            // Help is passive discovery, but remote usage and metadata must be
+            // fetched before display. Require trust before that network/Git work.
+            crate::task::task_fetcher::TaskFetcher::new(self.no_cache)
+                .require_trust_before_fetch()
+                .fetch_tasks(&config, &mut task_list)
+                .await?;
 
             if let Some(task) = task_list.first() {
                 // raw_args tasks act as proxies for tools that handle their

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -15,7 +15,7 @@ use crate::file::display_path;
 use crate::task::has_any_usage_spec;
 use crate::task::task_executor::TaskRunContext;
 use crate::task::task_helpers::task_needs_permit;
-use crate::task::task_list::{get_task_lists, resolve_depends};
+use crate::task::task_list::{get_task_lists_with_no_cache, resolve_depends_with_no_cache};
 use crate::task::task_output::TaskOutput;
 use crate::task::task_output_handler::OutputHandler;
 use crate::task::{Deps, Task, TaskCacheMode, usage_command_for_args};
@@ -332,6 +332,7 @@ async fn get_affected_task_list(
     head: Option<&str>,
     explain: bool,
     json: bool,
+    no_cache: bool,
 ) -> Result<Vec<Task>> {
     Settings::get().ensure_experimental("affected tasks")?;
     let workspace_root = config
@@ -396,7 +397,8 @@ async fn get_affected_task_list(
         .collect::<BTreeSet<_>>();
 
     let args = affected_task_args(args);
-    let mut tasks = get_task_lists(config, &args, true, only, false).await?;
+    let mut tasks =
+        get_task_lists_with_no_cache(config, &args, true, only, false, no_cache).await?;
     // Restrict only the task-pattern matches. `Run::run` calls `resolve_depends`
     // after this returns, so prerequisites from unaffected projects remain intact.
     tasks.retain(|task| {
@@ -601,7 +603,9 @@ impl Run {
                 )
                 .collect_vec();
 
-            let mut task_list = get_task_lists(&config, &args, false, false, false).await?;
+            let mut task_list =
+                get_task_lists_with_no_cache(&config, &args, false, false, false, self.no_cache)
+                    .await?;
             // Help is passive discovery, but remote usage and metadata must be
             // fetched before display. Require trust before that network/Git work.
             crate::task::task_fetcher::TaskFetcher::new(self.no_cache)
@@ -657,10 +661,19 @@ impl Run {
                 self.affected_head.as_deref(),
                 self.affected_explain,
                 self.affected_json,
+                self.no_cache,
             )
             .await?
         } else {
-            get_task_lists(&config, &args, true, self.skip_deps, self.all).await?
+            get_task_lists_with_no_cache(
+                &config,
+                &args,
+                true,
+                self.skip_deps,
+                self.all,
+                self.no_cache,
+            )
+            .await?
         };
         if self.affected_json {
             return Ok(());
@@ -706,7 +719,8 @@ impl Run {
         // 2. Include monorepo subdirectory tools in the toolset before installing
         // 3. Validate and install tools for the complete dependency set before execution
         let execution_tasks = task_list.clone();
-        let resolved_tasks = resolve_depends(&config, task_list).await?;
+        let resolved_tasks =
+            resolve_depends_with_no_cache(&config, task_list, self.no_cache).await?;
 
         // Collect subdirectory config files from all resolved tasks. In
         // monorepos these come from sub mise.toml files referenced via the
@@ -1164,7 +1178,7 @@ impl Run {
     async fn prepare_tasks(&mut self, config: &Arc<Config>, mut tasks: Vec<Task>) -> Result<Deps> {
         let fetcher = crate::task::task_fetcher::TaskFetcher::new(self.no_cache);
         fetcher.fetch_tasks(config, &mut tasks).await?;
-        let mut tasks = Deps::new(config, tasks).await?;
+        let mut tasks = Deps::new_with_no_cache(config, tasks, self.no_cache).await?;
         tasks.mark_ambiguous_prefixes();
         self.is_linear = tasks.is_linear();
         Ok(tasks)
@@ -1234,6 +1248,7 @@ impl Run {
             continue_on_error: self.continue_on_error,
             dry_run: self.dry_run,
             skip_deps: self.skip_deps,
+            no_cache: self.no_cache,
             task_cache: self.task_cache,
             task_cache_explain: self.task_cache_explain,
             task_cache_explain_json: self.task_cache_explain_json,

--- a/src/cli/tasks/deps.rs
+++ b/src/cli/tasks/deps.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashSet, sync::Arc};
 
 use crate::config::Config;
+use crate::task::task_fetcher::TaskFetcher;
 use crate::task::{Deps, GetMatchingExt, Task, build_task_ref_map};
 use crate::ui::style::{self};
 use crate::ui::tree::{print_tree, print_tree_compact};
@@ -53,9 +54,19 @@ impl TasksDeps {
     async fn get_all_tasks(&self, config: &Arc<Config>) -> Result<Vec<Task>> {
         // Use TaskLoadContext::all() to load tasks from entire monorepo
         let ctx = crate::task::TaskLoadContext::all();
-        Ok(config
-            .tasks_with_context(Some(&ctx))
-            .await?
+        let tasks = config.tasks_with_context(Some(&ctx)).await?;
+        let visible_tasks = tasks
+            .iter()
+            // A local/overlay hide=true survives remote metadata merging, so
+            // do not fetch tasks that cannot appear in ordinary output.
+            .filter(|(_, task)| self.hidden || !task.hide)
+            .map(|(name, task)| (name.clone(), task.clone()))
+            .collect();
+        let resolved = TaskFetcher::new(false)
+            .require_trust_before_fetch()
+            .fetch_task_map(config, &visible_tasks)
+            .await?;
+        Ok(resolved
             .values()
             .filter(|t| self.hidden || !t.hide)
             .cloned()
@@ -78,26 +89,76 @@ impl TasksDeps {
             .filter(|t| t.starts_with("//"))
             .map(|s| s.as_str())
             .collect();
-        let monorepo_tasks = if !monorepo_patterns.is_empty() {
+        let mut monorepo_tasks = if !monorepo_patterns.is_empty() {
             let ctx = crate::task::TaskLoadContext::from_patterns(monorepo_patterns.into_iter());
-            Some(config.tasks_with_context(Some(&ctx)).await?)
+            Some(
+                config
+                    .tasks_with_context(Some(&ctx))
+                    .await?
+                    .as_ref()
+                    .clone(),
+            )
         } else {
             None
         };
 
         // Load non-monorepo tasks once (only if needed)
         let has_regular = task_names.iter().any(|t| !t.starts_with("//"));
-        let regular_tasks = if has_regular {
-            Some(config.tasks().await?)
+        let mut regular_tasks = if has_regular {
+            Some(config.tasks().await?.as_ref().clone())
         } else {
             None
         };
 
-        // Build task ref maps once (not per-task)
+        let monorepo_needs_remote = if let Some(tasks) = &monorepo_tasks {
+            let refs = build_task_ref_map(tasks.iter());
+            task_names
+                .iter()
+                .filter(|name| name.starts_with("//"))
+                .map(|name| refs.get_matching(name))
+                .collect::<Result<Vec<_>>>()?
+                .iter()
+                .any(Vec::is_empty)
+        } else {
+            false
+        };
+        if monorepo_needs_remote && let Some(tasks) = &monorepo_tasks {
+            monorepo_tasks = Some(
+                TaskFetcher::new(false)
+                    .require_trust_before_fetch()
+                    .fetch_task_map(config, tasks)
+                    .await?,
+            );
+        }
+
+        let regular_needs_remote = if let Some(tasks) = &regular_tasks {
+            let refs = build_task_ref_map(tasks.iter());
+            task_names
+                .iter()
+                .filter(|name| !name.starts_with("//"))
+                .map(|name| refs.get_matching(name))
+                .collect::<Result<Vec<_>>>()?
+                .iter()
+                .any(Vec::is_empty)
+        } else {
+            false
+        };
+        if regular_needs_remote && let Some(tasks) = &regular_tasks {
+            regular_tasks = Some(
+                TaskFetcher::new(false)
+                    .require_trust_before_fetch()
+                    .fetch_task_map(config, tasks)
+                    .await?,
+            );
+        }
+
+        // Build task ref maps once (not per-task), after any remote-alias retry.
         let monorepo_ref_map = monorepo_tasks
             .as_ref()
-            .map(|t| build_task_ref_map(t.iter()));
-        let regular_ref_map = regular_tasks.as_ref().map(|t| build_task_ref_map(t.iter()));
+            .map(|tasks| build_task_ref_map(tasks.iter()));
+        let regular_ref_map = regular_tasks
+            .as_ref()
+            .map(|tasks| build_task_ref_map(tasks.iter()));
 
         // Look up each task from the appropriate cache
         let mut tasks = vec![];
@@ -142,7 +203,7 @@ impl TasksDeps {
     /// ```
     ///
     async fn print_deps_tree(&self, config: &Arc<Config>, tasks: Vec<Task>) -> Result<()> {
-        let deps = Deps::new(config, tasks.clone()).await?;
+        let deps = Deps::new_for_display(config, tasks.clone()).await?;
         // filter out nodes that are not selected
         let start_indexes = deps.graph.node_indices().filter(|&idx| {
             let task = &deps.graph[idx];
@@ -181,7 +242,7 @@ impl TasksDeps {
     /// ```
     //
     async fn print_deps_dot(&self, config: &Arc<Config>, tasks: Vec<Task>) -> Result<()> {
-        let deps = Deps::new(config, tasks).await?;
+        let deps = Deps::new_for_display(config, tasks).await?;
         miseprintln!(
             "{:?}",
             Dot::with_attr_getters(

--- a/src/cli/tasks/info.rs
+++ b/src/cli/tasks/info.rs
@@ -43,7 +43,23 @@ impl TasksInfo {
 
         use crate::task::GetMatchingExt;
         let matching = tasks_with_aliases.get_matching(&task_name).ok();
-        let task = matching.and_then(|m| m.first().cloned().cloned());
+        let mut task =
+            matching.and_then(|matching| matching.into_iter().next().map(|task| (**task).clone()));
+
+        // A remote task's aliases only become available after its #MISE header
+        // is fetched. Avoid fetching every remote task for ordinary name hits,
+        // but retry a miss against trusted, resolved remote metadata.
+        if task.is_none() {
+            let resolved_tasks = TaskFetcher::new(false)
+                .require_trust_before_fetch()
+                .fetch_task_map(&config, &tasks)
+                .await?;
+            let resolved_with_aliases = crate::task::build_task_ref_map(resolved_tasks.iter());
+            task = resolved_with_aliases
+                .get_matching(&task_name)
+                .ok()
+                .and_then(|matching| matching.into_iter().next().map(|task| (**task).clone()));
+        }
 
         if let Some(task) = task {
             // Resolve remote task files before displaying task info
@@ -51,6 +67,7 @@ impl TasksInfo {
             // always pass no_cache=false as the command doesn't take no-cache argument
             // MISE_TASK_REMOTE_NO_CACHE env var is still respected if set
             TaskFetcher::new(false)
+                .require_trust_before_fetch()
                 .fetch_tasks(&config, &mut tasks)
                 .await?;
             let task = &tasks[0];

--- a/src/cli/tasks/ls.rs
+++ b/src/cli/tasks/ls.rs
@@ -144,22 +144,27 @@ impl TasksLs {
 
         let all_tasks = config.tasks_with_context(ctx.as_ref()).await?;
 
-        let tasks = all_tasks
+        let mut tasks = all_tasks
             .values()
+            // A local/overlay hide=true is monotonic when remote metadata is
+            // merged, so avoid fetching tasks that can never become visible.
             .filter(|t| self.hidden || !t.hide)
             .filter(|t| !self.local || !t.global)
             .filter(|t| !self.global || t.global)
             .cloned()
-            .sorted_by(|a, b| self.sort(a, b))
             .collect::<Vec<Task>>();
 
         // Resolve remote task files before any operation that may need them
-        let mut tasks = tasks;
         // always pass no_cache=false as the command doesn't take no-cache argument
         // MISE_TASK_REMOTE_NO_CACHE env var is still respected if set
         TaskFetcher::new(false)
+            .require_trust_before_fetch()
             .fetch_tasks(&config, &mut tasks)
             .await?;
+        // Remote #MISE headers can contribute hide/alias/description metadata,
+        // so visibility and metadata-based sorting must happen after fetching.
+        tasks.retain(|task| self.hidden || !task.hide);
+        tasks.sort_by(|a, b| self.sort(a, b));
 
         // Warn about non-executable files only when there are truly no tasks at all
         // (not just filtered out by --hidden/--local/--global)

--- a/src/cli/tasks/validate.rs
+++ b/src/cli/tasks/validate.rs
@@ -70,6 +70,7 @@ impl TasksValidate {
         // always no_cache=false as the command doesn't take no-cache argument
         // MISE_TASK_REMOTE_NO_CACHE env var is still respected if set
         TaskFetcher::new(false)
+            .require_trust_before_fetch()
             .fetch_tasks(&config, &mut resolved_tasks)
             .await?;
         let all_tasks: BTreeMap<String, Task> = resolved_tasks

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -454,6 +454,23 @@ pub fn trust_check(path: &Path) -> eyre::Result<()> {
     Err(UntrustedConfig(path.into()))?
 }
 
+/// Require trust before configuration can cause remote network or Git work.
+///
+/// Safe mode makes ordinary config parsing trust-exempt because its executable
+/// features are disabled. A remote fetch is still an external side effect,
+/// though, so safe mode only permits it when the owner was already trusted.
+/// Outside safe mode this preserves the normal interactive trust prompt.
+pub fn trust_check_remote_fetch(path: &Path) -> eyre::Result<()> {
+    if !remote_fetch_trust_allows(Settings::safe_mode(), is_path_trusted(path)) {
+        Err(UntrustedConfig(path.into()))?
+    }
+    trust_check(path)
+}
+
+fn remote_fetch_trust_allows(safe_mode: bool, is_trusted: bool) -> bool {
+    !safe_mode || is_trusted
+}
+
 pub fn is_trusted(path: &Path) -> bool {
     let canonicalized_path = match path.canonicalize() {
         Ok(p) => p,
@@ -1273,5 +1290,13 @@ mod tests {
             result2,
             Path::new("/tmp/trusted/infra-mise.toml-a1b2c3d4e5f67890.monorepo")
         );
+    }
+
+    #[test]
+    fn test_remote_fetch_trust_policy() {
+        assert!(!remote_fetch_trust_allows(true, false));
+        assert!(remote_fetch_trust_allows(true, true));
+        assert!(remote_fetch_trust_allows(false, false));
+        assert!(remote_fetch_trust_allows(false, true));
     }
 }

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -240,6 +240,17 @@ impl EnvDirective {
             | EnvDirective::Module(_, _, opts) => opts,
         }
     }
+
+    /// Whether resolving this directive can execute code or install tooling.
+    fn requires_remote_trust(&self) -> bool {
+        matches!(
+            self,
+            EnvDirective::File(..)
+                | EnvDirective::Source(..)
+                | EnvDirective::PythonVenv { .. }
+                | EnvDirective::Module(..)
+        )
+    }
 }
 
 impl From<(String, String)> for EnvDirective {
@@ -332,6 +343,7 @@ pub struct EnvResults {
     pub watch_files: Vec<PathBuf>,
     /// True if any directive declared cacheable=false or is a dynamic module
     pub has_uncacheable: bool,
+    pub(crate) trust_source: Option<PathBuf>,
 }
 
 pub(super) struct EnvDirectiveContext<'a> {
@@ -359,6 +371,10 @@ impl EnvDirectiveContext<'_> {
 
     fn normalize_path(&self, path: PathBuf) -> PathBuf {
         (self.normalize_path)(self.config_root, path)
+    }
+
+    fn trust_check_source(&self) -> eyre::Result<()> {
+        self.results.trust_check_source(self.source)
     }
 }
 
@@ -418,25 +434,80 @@ impl EnvResults {
         input: Vec<(EnvDirective, PathBuf)>,
         resolve_opts: EnvResolveOptions,
     ) -> eyre::Result<Self> {
-        Self::resolve_with_toolset(config, ctx, initial, input, resolve_opts, None).await
+        Self::resolve_with_toolset_and_trust_source(
+            config,
+            ctx,
+            initial,
+            input,
+            resolve_opts,
+            None,
+            None,
+        )
+        .await
+    }
+
+    /// Resolve directives relative to their source paths while checking trust
+    /// against separate provenance for remote task metadata.
+    pub async fn resolve_with_trust_source(
+        config: &Arc<Config>,
+        ctx: tera::Context,
+        initial: &EnvMap,
+        input: Vec<(EnvDirective, PathBuf)>,
+        resolve_opts: EnvResolveOptions,
+        trust_source: Option<&Path>,
+    ) -> eyre::Result<Self> {
+        Self::resolve_with_toolset_and_trust_source(
+            config,
+            ctx,
+            initial,
+            input,
+            resolve_opts,
+            None,
+            trust_source,
+        )
+        .await
     }
 
     /// [`Self::resolve`] for callers that already have a resolved toolset. See
     /// [`EnvDirectiveContext::toolset`] for why a directive would want it.
     pub async fn resolve_with_toolset(
         config: &Arc<Config>,
+        ctx: tera::Context,
+        initial: &EnvMap,
+        input: Vec<(EnvDirective, PathBuf)>,
+        resolve_opts: EnvResolveOptions,
+        toolset: Option<&Toolset>,
+    ) -> eyre::Result<Self> {
+        Self::resolve_with_toolset_and_trust_source(
+            config,
+            ctx,
+            initial,
+            input,
+            resolve_opts,
+            toolset,
+            None,
+        )
+        .await
+    }
+
+    async fn resolve_with_toolset_and_trust_source(
+        config: &Arc<Config>,
         mut ctx: tera::Context,
         initial: &EnvMap,
         input: Vec<(EnvDirective, PathBuf)>,
         resolve_opts: EnvResolveOptions,
         toolset: Option<&Toolset>,
+        trust_source: Option<&Path>,
     ) -> eyre::Result<Self> {
         // trace!("resolve: input: {:#?}", &input);
         let mut env = initial
             .iter()
             .map(|(k, v)| (k.clone(), (v.clone(), None)))
             .collect::<IndexMap<_, _>>();
-        let mut r = Self::default();
+        let mut r = Self {
+            trust_source: trust_source.map(Path::to_path_buf),
+            ..Default::default()
+        };
         let normalize_path = |config_root: &Path, p: PathBuf| {
             let p = p.strip_prefix("./").unwrap_or(&p);
             match p.strip_prefix("~/") {
@@ -508,6 +579,13 @@ impl EnvResults {
 
         for (directive, source) in filtered_input {
             let mut tera = None;
+            if directive.requires_remote_trust() && r.trust_source.is_some() {
+                r.trust_check_source(&source).wrap_err_with(|| {
+                    format!(
+                        "remote task environment directive {directive} requires its defining config to be trusted"
+                    )
+                })?;
+            }
             // trace!(
             //     "resolve: directive: {:?}, source: {:?}",
             //     &directive,
@@ -992,7 +1070,7 @@ impl EnvResults {
 
         // Step 1: Tera template expansion
         if contains_template_syntax(input) {
-            trust_check(path)?;
+            self.trust_check_source(path)?;
             let tera = tera.get_or_insert_with(|| {
                 let mut tera = get_tera(path.parent());
                 // Re-bind exec() to the accumulated env vars — but never in safe
@@ -1035,6 +1113,10 @@ impl EnvResults {
         }
 
         Ok(output)
+    }
+
+    fn trust_check_source(&self, fallback: &Path) -> eyre::Result<()> {
+        trust_check(self.trust_source.as_deref().unwrap_or(fallback))
     }
 
     pub fn is_empty(&self) -> bool {

--- a/src/config/env_directive/venv.rs
+++ b/src/config/env_directive/venv.rs
@@ -1,7 +1,6 @@
 use crate::Result;
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
-use crate::config::config_file::trust_check;
 use crate::config::env_directive::{EnvDirectiveContext, EnvResults};
 use crate::config::{Config, Settings};
 use crate::env_diff::EnvMap;
@@ -257,7 +256,7 @@ impl EnvResults {
             debug!("python venv skipped: the python tool is disabled");
             return Ok(());
         }
-        trust_check(ctx.source)?;
+        ctx.trust_check_source()?;
         let venv = ctx.parse_template(&path)?;
         let venv = ctx.normalize_path(venv.into());
         let venv_lock = LockFile::new(&venv).lock()?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4505,9 +4505,7 @@ async fn resolve_git_url_to_path(git_url: &str) -> Result<TaskFileArtifact> {
 
     let artifact = checkout.with_path(checkout.path.join(source.path));
     let metadata = artifact.path.symlink_metadata()?;
-    if metadata.file_type().is_file() {
-        file::make_executable(&artifact.path)?;
-    } else if !metadata.file_type().is_dir() {
+    if !metadata.file_type().is_file() && !metadata.file_type().is_dir() {
         bail!(
             "remote task path is not a regular file or directory: {}",
             display_path(&artifact.path)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -28,8 +28,9 @@ use crate::config::env_directive::{EnvResolveOptions, EnvResults, ToolsFilter};
 use crate::config::tracking::Tracker;
 use crate::env::{MISE_DEFAULT_CONFIG_FILENAME, MISE_DEFAULT_TOOL_VERSIONS_FILENAME};
 use crate::file::display_path;
+use crate::remote_source::RemoteSource;
 use crate::shorthands::{Shorthands, get_shorthands};
-use crate::task::task_file_providers::TaskFileProvidersBuilder;
+use crate::task::task_file_providers::{TaskFileArtifact, TaskFileProvidersBuilder};
 use crate::task::task_sources::TaskOutputs;
 use crate::task::{
     RunEntry, Task, TaskCacheConfig, TaskRustCacheConfig, TaskTemplate, monorepo_scope,
@@ -62,6 +63,26 @@ use crate::wildcard::Wildcard;
 type AliasMap = IndexMap<String, Alias>;
 pub(crate) type ConfigMap = IndexMap<PathBuf, Arc<dyn ConfigFile>>;
 pub type EnvWithSources = IndexMap<String, (String, PathBuf)>;
+type RemoteTaskIncludeKey = (String, Option<String>);
+type RemoteTaskIncludeArtifacts = DashMap<RemoteTaskIncludeKey, Arc<OnceCell<TaskFileArtifact>>>;
+static REMOTE_TASK_INCLUDE_ARTIFACTS: Lazy<RemoteTaskIncludeArtifacts> = Lazy::new(DashMap::new);
+
+pub(crate) fn clear_remote_task_include_artifacts() {
+    REMOTE_TASK_INCLUDE_ARTIFACTS.clear();
+}
+
+#[cfg(test)]
+pub(crate) fn insert_remote_task_include_artifact_for_test() {
+    REMOTE_TASK_INCLUDE_ARTIFACTS.insert(
+        ("https://example.test/repo.git".into(), None),
+        Arc::new(OnceCell::new()),
+    );
+}
+
+#[cfg(test)]
+pub(crate) fn remote_task_include_artifact_count_for_test() -> usize {
+    REMOTE_TASK_INCLUDE_ARTIFACTS.len()
+}
 
 pub(crate) struct MonorepoUnion {
     pub config_files: ConfigMap,
@@ -4434,16 +4455,49 @@ fn is_mise_config_file_in_task_include(root: &Path, path: &Path) -> bool {
     })
 }
 
-async fn resolve_git_url_to_path(git_url: &str) -> Result<PathBuf> {
+async fn resolve_git_url_to_path(git_url: &str) -> Result<TaskFileArtifact> {
     let no_cache = Settings::get().task.remote_no_cache.unwrap_or(false);
-    let task_file_providers = TaskFileProvidersBuilder::new()
-        .with_cache(!no_cache)
-        .build();
-
-    match task_file_providers.get_provider(git_url) {
-        Some(provider) => provider.get_local_path(git_url).await,
-        None => bail!("No provider found for git URL: {}", git_url),
+    if !no_cache {
+        let task_file_providers = TaskFileProvidersBuilder::new().with_cache(true).build();
+        return match task_file_providers.get_provider(git_url) {
+            Some(provider) => provider.get_local_artifact(git_url).await,
+            None => bail!("No provider found for git URL: {}", git_url),
+        };
     }
+
+    let source = RemoteSource::parse_git(git_url)
+        .ok_or_else(|| eyre!("No provider found for git URL: {}", git_url))?;
+    let cache_key = (source.url.clone(), source.git_ref.clone());
+    let checkout = REMOTE_TASK_INCLUDE_ARTIFACTS
+        .entry(cache_key)
+        .or_insert_with(|| Arc::new(OnceCell::new()))
+        .clone();
+    let checkout = checkout
+        .get_or_try_init(|| async {
+            let task_file_providers = TaskFileProvidersBuilder::new().with_cache(false).build();
+            let provider = task_file_providers
+                .get_provider(git_url)
+                .ok_or_else(|| eyre!("No provider found for git URL: {}", git_url))?;
+            let artifact = provider.get_local_artifact(git_url).await?;
+            let checkout_path = artifact
+                .cleanup_path()
+                .ok_or_else(|| eyre!("no cleanup path for no-cache Git task include"))?
+                .to_path_buf();
+            Ok::<TaskFileArtifact, eyre::Report>(artifact.with_path(checkout_path))
+        })
+        .await?;
+
+    let artifact = checkout.with_path(checkout.path.join(source.path));
+    let metadata = artifact.path.symlink_metadata()?;
+    if metadata.file_type().is_file() {
+        file::make_executable(&artifact.path)?;
+    } else if !metadata.file_type().is_dir() {
+        bail!(
+            "remote task path is not a regular file or directory: {}",
+            display_path(&artifact.path)
+        );
+    }
+    Ok(artifact)
 }
 
 /// Check if a pattern contains glob metacharacters
@@ -4869,12 +4923,16 @@ async fn load_task_sources_from_configs(
         None
     };
     for include in &includes {
-        let paths = if include.starts_with("git::") {
+        let artifacts = if include.starts_with("git::") {
             vec![resolve_git_url_to_path(include).await?]
         } else {
             expand_task_include(&resolve_dir, include)
+                .into_iter()
+                .map(TaskFileArtifact::persistent)
+                .collect()
         };
-        for p in paths {
+        for artifact in artifacts {
+            let p = artifact.path;
             let mut loaded = load_tasks_includes(
                 config,
                 &p,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -67,6 +67,12 @@ pub(crate) type ConfigMap = IndexMap<PathBuf, Arc<dyn ConfigFile>>;
 pub type EnvWithSources = IndexMap<String, (String, PathBuf)>;
 type RemoteTaskIncludeKey = (String, Option<String>);
 type RemoteTaskIncludeArtifacts = DashMap<RemoteTaskIncludeKey, Arc<OnceCell<TaskFileArtifact>>>;
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct TasksCacheKey {
+    context: crate::task::TaskLoadContext,
+    remote_no_cache: bool,
+}
+type TasksCache = DashMap<TasksCacheKey, Arc<OnceCell<Arc<BTreeMap<String, Task>>>>>;
 static REMOTE_TASK_INCLUDE_ARTIFACTS: Lazy<RemoteTaskIncludeArtifacts> = Lazy::new(DashMap::new);
 
 pub(crate) fn take_remote_task_include_artifacts() -> Vec<Arc<OnceCell<TaskFileArtifact>>> {
@@ -132,7 +138,7 @@ pub struct Config {
     env: OnceCell<EnvResults>,
     env_with_sources: OnceCell<EnvWithSources>,
     hooks: OnceCell<Vec<(PathBuf, Option<PathBuf>, Hook)>>,
-    tasks_cache: Arc<DashMap<crate::task::TaskLoadContext, Arc<BTreeMap<String, Task>>>>,
+    tasks_cache: Arc<TasksCache>,
     /// Lenient graph shared across task-loading and strict inspection contexts.
     /// Provider errors remain on the graph so strict consumers can reject it.
     workspace_project_graph_cache:
@@ -851,33 +857,42 @@ impl Config {
         &self,
         ctx: Option<&crate::task::TaskLoadContext>,
     ) -> Result<Arc<BTreeMap<String, Task>>> {
-        // Use the entire context as cache key
-        // Default context (None) becomes TaskLoadContext::default()
-        let cache_key = ctx.cloned().unwrap_or_default();
+        self.tasks_with_context_no_cache(ctx, false).await
+    }
 
-        // Check if already cached
-        if let Some(cached) = self.tasks_cache.get(&cache_key) {
-            return Ok(cached.value().clone());
-        }
-
-        // Not cached, load tasks
-        let tasks = measure!("config::load_all_tasks_with_context", {
-            self.load_all_tasks_with_context(ctx).await?
-        });
-        let tasks_arc = Arc::new(tasks);
-
-        // Insert into cache
-        self.tasks_cache.insert(cache_key, tasks_arc.clone());
-
-        Ok(tasks_arc)
+    pub async fn tasks_with_context_no_cache(
+        &self,
+        ctx: Option<&crate::task::TaskLoadContext>,
+        no_cache: bool,
+    ) -> Result<Arc<BTreeMap<String, Task>>> {
+        let remote_no_cache = no_cache || Settings::get().task.remote_no_cache.unwrap_or(false);
+        let cache_key = TasksCacheKey {
+            context: ctx.cloned().unwrap_or_default(),
+            remote_no_cache,
+        };
+        let cell = self
+            .tasks_cache
+            .entry(cache_key)
+            .or_insert_with(|| Arc::new(OnceCell::new()))
+            .clone();
+        let tasks = cell
+            .get_or_try_init(|| async {
+                let tasks = measure!("config::load_all_tasks_with_context", {
+                    self.load_all_tasks_with_context(ctx, remote_no_cache)
+                        .await?
+                });
+                Ok::<_, eyre::Report>(Arc::new(tasks))
+            })
+            .await?;
+        Ok(tasks.clone())
     }
 
     pub async fn reload_tasks_with_context(
         &self,
         ctx: Option<&crate::task::TaskLoadContext>,
     ) -> Result<Arc<BTreeMap<String, Task>>> {
-        let cache_key = ctx.cloned().unwrap_or_default();
-        self.tasks_cache.remove(&cache_key);
+        let context = ctx.cloned().unwrap_or_default();
+        self.tasks_cache.retain(|key, _| key.context != context);
         self.tasks_with_context(ctx).await
     }
 
@@ -945,6 +960,7 @@ impl Config {
     async fn load_all_tasks_with_context(
         &self,
         ctx: Option<&crate::task::TaskLoadContext>,
+        remote_no_cache: bool,
     ) -> Result<BTreeMap<String, Task>> {
         let config = Config::get().await?;
         time!("load_all_tasks");
@@ -960,8 +976,8 @@ impl Config {
         );
 
         let mut local_tasks =
-            load_local_tasks_with_context(&config, ctx, &task_definitions).await?;
-        let global_tasks = load_global_tasks(&config, &task_definitions).await?;
+            load_local_tasks_with_context(&config, ctx, &task_definitions, remote_no_cache).await?;
+        let global_tasks = load_global_tasks(&config, &task_definitions, remote_no_cache).await?;
         local_tasks.retain(|local| {
             !global_tasks
                 .iter()
@@ -2889,8 +2905,15 @@ impl Debug for Config {
         s.field("Config Files", &config_files);
         // Note: tasks are now lazily loaded and cached, so we can't access them synchronously here
         // Try to get the default (current hierarchy) cache entry
-        let default_ctx = crate::task::TaskLoadContext::default();
-        if let Some(tasks) = self.tasks_cache.get(&default_ctx) {
+        let default_key = TasksCacheKey {
+            context: crate::task::TaskLoadContext::default(),
+            remote_no_cache: Settings::get().task.remote_no_cache.unwrap_or(false),
+        };
+        if let Some(tasks) = self
+            .tasks_cache
+            .get(&default_key)
+            .and_then(|cell| cell.get().cloned())
+        {
             s.field(
                 "Tasks",
                 &tasks.values().map(|t| t.to_string()).collect_vec(),
@@ -3496,6 +3519,7 @@ async fn load_local_tasks_with_context(
     config: &Arc<Config>,
     ctx: Option<&crate::task::TaskLoadContext>,
     templates: &TaskDefinitions,
+    remote_no_cache: bool,
 ) -> Result<Vec<Task>> {
     let mut tasks = vec![];
     let monorepo_config = find_monorepo_config(&config.config_files);
@@ -3527,8 +3551,14 @@ async fn load_local_tasks_with_context(
             );
             continue;
         }
-        let mut dir_tasks =
-            load_tasks_in_dir_with_definitions(config, &d, &local_config_files, templates).await?;
+        let mut dir_tasks = load_tasks_in_dir_with_definitions(
+            config,
+            &d,
+            &local_config_files,
+            templates,
+            remote_no_cache,
+        )
+        .await?;
 
         if let Some(ref monorepo_root) = monorepo_root {
             prefix_monorepo_task_names(&mut dir_tasks, &d, monorepo_root);
@@ -3629,6 +3659,7 @@ async fn load_local_tasks_with_context(
                             &templates,
                             true,
                             cascaded_task_config.as_ref(),
+                            remote_no_cache,
                         )
                         .await?;
                         prefix_monorepo_task_names(&mut tasks, &subdir, &monorepo_root);
@@ -3644,6 +3675,7 @@ async fn load_local_tasks_with_context(
                         &templates,
                         true,
                         cascaded_task_config.as_ref(),
+                        remote_no_cache,
                     )
                     .await?;
                     prefix_monorepo_task_names(&mut tasks, &subdir, &monorepo_root);
@@ -4008,7 +4040,11 @@ fn discover_monorepo_subdirs(
     Ok(subdirs)
 }
 
-async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) -> Result<Vec<Task>> {
+async fn load_global_tasks(
+    config: &Arc<Config>,
+    templates: &TaskDefinitions,
+    remote_no_cache: bool,
+) -> Result<Vec<Task>> {
     // User-global config overrides system config. Within each group the path
     // lists are lowest-first, so reverse them before applying first-wins task
     // precedence.
@@ -4049,6 +4085,7 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
             false,
             None,
             Some(&mut rendered_file_tasks),
+            remote_no_cache,
         )
         .await?;
         rendered_file_tasks.finish_config();
@@ -4474,9 +4511,8 @@ fn is_mise_config_file_in_task_include(root: &Path, path: &Path) -> bool {
     })
 }
 
-async fn resolve_git_url_to_path(git_url: &str) -> Result<TaskFileArtifact> {
-    let no_cache = Settings::get().task.remote_no_cache.unwrap_or(false);
-    if !no_cache {
+async fn resolve_git_url_to_path(git_url: &str, remote_no_cache: bool) -> Result<TaskFileArtifact> {
+    if !remote_no_cache {
         let task_file_providers = TaskFileProvidersBuilder::new().with_cache(true).build();
         return match task_file_providers.get_provider(git_url) {
             Some(provider) => provider.get_local_artifact(git_url).await,
@@ -4687,7 +4723,9 @@ pub async fn load_tasks_in_dir(
             .and_then(|graph| graph.as_ref().ok())
             .map(Arc::as_ref),
     );
-    load_tasks_in_dir_with_definitions(config, dir, config_files, &definitions).await
+    let remote_no_cache = Settings::get().task.remote_no_cache.unwrap_or(false);
+    load_tasks_in_dir_with_definitions(config, dir, config_files, &definitions, remote_no_cache)
+        .await
 }
 
 async fn load_tasks_in_dir_with_definitions(
@@ -4695,6 +4733,7 @@ async fn load_tasks_in_dir_with_definitions(
     dir: &Path,
     config_files: &ConfigMap,
     templates: &TaskDefinitions,
+    remote_no_cache: bool,
 ) -> Result<Vec<Task>> {
     let configs = configs_at_root(dir, config_files);
     let cascaded_task_config = cascaded_task_config_for_dir(dir, config_files)?;
@@ -4705,6 +4744,7 @@ async fn load_tasks_in_dir_with_definitions(
         templates,
         false,
         cascaded_task_config.as_ref(),
+        remote_no_cache,
     )
     .await
 }
@@ -4865,6 +4905,7 @@ async fn load_tasks_from_configs(
     templates: &TaskDefinitions,
     monorepo_context: bool,
     cascaded_task_config: Option<&CascadedTaskConfig>,
+    remote_no_cache: bool,
 ) -> Result<Vec<Task>> {
     Ok(load_task_sources_from_configs(
         config,
@@ -4874,6 +4915,7 @@ async fn load_tasks_from_configs(
         monorepo_context,
         cascaded_task_config,
         None,
+        remote_no_cache,
     )
     .await?
     .into_tasks())
@@ -4892,6 +4934,7 @@ async fn load_task_sources_from_configs(
     monorepo_context: bool,
     cascaded_task_config: Option<&CascadedTaskConfig>,
     mut rendered_file_tasks: Option<&mut RenderedTaskCache>,
+    remote_no_cache: bool,
 ) -> Result<TaskSources> {
     let cascaded_task_config =
         if configs.iter().find_map(|cf| cf.task_config().cascade) == Some(false) {
@@ -5011,7 +5054,7 @@ async fn load_task_sources_from_configs(
     };
     for include in &includes {
         let artifacts = if include.starts_with("git::") {
-            vec![resolve_git_url_to_path(include).await?]
+            vec![resolve_git_url_to_path(include, remote_no_cache).await?]
         } else {
             expand_task_include(&resolve_dir, include)
                 .into_iter()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -30,9 +30,7 @@ use crate::env::{MISE_DEFAULT_CONFIG_FILENAME, MISE_DEFAULT_TOOL_VERSIONS_FILENA
 use crate::file::display_path;
 use crate::remote_source::RemoteSource;
 use crate::shorthands::{Shorthands, get_shorthands};
-use crate::task::task_file_providers::{
-    TaskFileArtifact, TaskFileProvidersBuilder, prepare_remote_git_path,
-};
+use crate::task::task_file_providers::{TaskFileArtifact, TaskFileProvidersBuilder};
 use crate::task::task_sources::TaskOutputs;
 use crate::task::{
     RunEntry, Task, TaskCacheConfig, TaskRustCacheConfig, TaskTemplate, monorepo_scope,
@@ -4505,7 +4503,15 @@ async fn resolve_git_url_to_path(git_url: &str) -> Result<TaskFileArtifact> {
         .await?;
 
     let artifact = checkout.with_path(checkout.path.join(source.path));
-    prepare_remote_git_path(&checkout.path, &artifact.path)?;
+    let metadata = artifact.path.symlink_metadata()?;
+    if metadata.file_type().is_file() {
+        file::make_executable(&artifact.path)?;
+    } else if !metadata.file_type().is_dir() {
+        bail!(
+            "remote task path is not a regular file or directory: {}",
+            display_path(&artifact.path)
+        );
+    }
     Ok(artifact)
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -30,7 +30,9 @@ use crate::env::{MISE_DEFAULT_CONFIG_FILENAME, MISE_DEFAULT_TOOL_VERSIONS_FILENA
 use crate::file::display_path;
 use crate::remote_source::RemoteSource;
 use crate::shorthands::{Shorthands, get_shorthands};
-use crate::task::task_file_providers::{TaskFileArtifact, TaskFileProvidersBuilder};
+use crate::task::task_file_providers::{
+    TaskFileArtifact, TaskFileProvidersBuilder, prepare_remote_git_path,
+};
 use crate::task::task_sources::TaskOutputs;
 use crate::task::{
     RunEntry, Task, TaskCacheConfig, TaskRustCacheConfig, TaskTemplate, monorepo_scope,
@@ -67,8 +69,23 @@ type RemoteTaskIncludeKey = (String, Option<String>);
 type RemoteTaskIncludeArtifacts = DashMap<RemoteTaskIncludeKey, Arc<OnceCell<TaskFileArtifact>>>;
 static REMOTE_TASK_INCLUDE_ARTIFACTS: Lazy<RemoteTaskIncludeArtifacts> = Lazy::new(DashMap::new);
 
+#[cfg(test)]
 pub(crate) fn clear_remote_task_include_artifacts() {
-    REMOTE_TASK_INCLUDE_ARTIFACTS.clear();
+    drop(take_remote_task_include_artifacts());
+}
+
+pub(crate) fn take_remote_task_include_artifacts() -> Vec<Arc<OnceCell<TaskFileArtifact>>> {
+    let keys = REMOTE_TASK_INCLUDE_ARTIFACTS
+        .iter()
+        .map(|entry| entry.key().clone())
+        .collect_vec();
+    keys.into_iter()
+        .filter_map(|key| {
+            REMOTE_TASK_INCLUDE_ARTIFACTS
+                .remove(&key)
+                .map(|(_, artifact)| artifact)
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -4488,15 +4505,7 @@ async fn resolve_git_url_to_path(git_url: &str) -> Result<TaskFileArtifact> {
         .await?;
 
     let artifact = checkout.with_path(checkout.path.join(source.path));
-    let metadata = artifact.path.symlink_metadata()?;
-    if metadata.file_type().is_file() {
-        file::make_executable(&artifact.path)?;
-    } else if !metadata.file_type().is_dir() {
-        bail!(
-            "remote task path is not a regular file or directory: {}",
-            display_path(&artifact.path)
-        );
-    }
+    prepare_remote_git_path(&checkout.path, &artifact.path)?;
     Ok(artifact)
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -30,7 +30,9 @@ use crate::env::{MISE_DEFAULT_CONFIG_FILENAME, MISE_DEFAULT_TOOL_VERSIONS_FILENA
 use crate::file::display_path;
 use crate::remote_source::RemoteSource;
 use crate::shorthands::{Shorthands, get_shorthands};
-use crate::task::task_file_providers::{TaskFileArtifact, TaskFileProvidersBuilder};
+use crate::task::task_file_providers::{
+    TaskFileArtifact, TaskFileProvidersBuilder, validate_remote_git_path,
+};
 use crate::task::task_sources::TaskOutputs;
 use crate::task::{
     RunEntry, Task, TaskCacheConfig, TaskRustCacheConfig, TaskTemplate, monorepo_scope,
@@ -1211,6 +1213,7 @@ impl Config {
                 tool_add_paths: Vec::new(),
                 watch_files: cached.watch_files.clone(),
                 has_uncacheable: false,
+                trust_source: None,
             };
             let redact_keys = self
                 .redaction_keys()
@@ -4504,14 +4507,41 @@ async fn resolve_git_url_to_path(git_url: &str) -> Result<TaskFileArtifact> {
         .await?;
 
     let artifact = checkout.with_path(checkout.path.join(source.path));
-    let metadata = artifact.path.symlink_metadata()?;
-    if !metadata.file_type().is_file() && !metadata.file_type().is_dir() {
-        bail!(
-            "remote task path is not a regular file or directory: {}",
-            display_path(&artifact.path)
-        );
-    }
+    validate_remote_git_path(&checkout.path, &artifact.path)?;
     Ok(artifact)
+}
+
+fn trust_check_remote_task_include(owner: &Path, include: &str) -> Result<()> {
+    config_file::trust_check_remote_fetch(owner).wrap_err_with(|| {
+        format!(
+            "fetching remote task include {include} requires its defining config {} to be trusted",
+            display_path(owner)
+        )
+    })
+}
+
+fn trust_check_remote_task_includes(owner: &Path, includes: &[String]) -> Result<bool> {
+    let mut found_remote = false;
+    for include in includes
+        .iter()
+        .filter(|include| include.starts_with("git::"))
+    {
+        trust_check_remote_task_include(owner, include)?;
+        found_remote = true;
+    }
+    Ok(found_remote)
+}
+
+fn preserve_remote_task_trust_source(tasks: &mut [Task], source: &Path) {
+    for task in tasks {
+        if task.file.as_ref().is_some_and(|file| {
+            let file = file.to_string_lossy();
+            file.starts_with("git::") || file.starts_with("http://") || file.starts_with("https://")
+        }) {
+            task.remote_config_source
+                .get_or_insert_with(|| source.to_path_buf());
+        }
+    }
 }
 
 /// Check if a pattern contains glob metacharacters
@@ -4688,6 +4718,7 @@ struct TaskSources {
 struct CascadedTaskConfig {
     task_config: TaskConfig,
     includes_root: PathBuf,
+    includes_source: Option<PathBuf>,
 }
 
 fn merge_cascaded_task_config(
@@ -4721,10 +4752,14 @@ fn merge_cascaded_task_config(
     }) {
         cascaded.task_config.global_pass_through_env = global_pass_through_env;
     }
-    if let Some((includes, root)) = configs
+    if let Some((includes, root, source)) = configs
         .iter()
         .find_map(|cf| match cf.task_config_includes() {
-            Ok(Some(includes)) => Some(Ok((includes, cf.config_root()))),
+            Ok(Some(includes)) => Some(Ok((
+                includes,
+                cf.config_root(),
+                cf.get_path().to_path_buf(),
+            ))),
             Ok(None) => None,
             Err(err) => Some(Err(err)),
         })
@@ -4732,6 +4767,7 @@ fn merge_cascaded_task_config(
     {
         cascaded.task_config.includes = Some(includes);
         cascaded.includes_root = root;
+        cascaded.includes_source = Some(source);
     }
     Ok(())
 }
@@ -4761,6 +4797,7 @@ fn cascaded_task_config_for_dir(
                 cascaded = Some(CascadedTaskConfig {
                     task_config: TaskConfig::default(),
                     includes_root: root,
+                    includes_source: None,
                 });
             }
             _ => {}
@@ -4863,27 +4900,63 @@ async fn load_task_sources_from_configs(
             cascaded_task_config
         };
     let is_global = configs.iter().any(|cf| is_global_config(cf.get_path()));
-    // a config can only vouch for task include files when it was actually
-    // trusted — safe configs load without trust and cannot vouch for anything
-    let require_task_include_trust = !configs.iter().any(|cf| is_path_trusted(cf.get_path()));
-    let (includes, resolve_dir, include_config_precedence) = configs
+    let (includes, resolve_dir, include_config_precedence, include_owner) = configs
         .iter()
         .enumerate()
         .find_map(|(precedence, cf)| match cf.task_config_includes() {
-            Ok(Some(includes)) => Some(Ok((includes, cf.config_root(), precedence))),
+            Ok(Some(includes)) => Some(Ok((
+                includes,
+                cf.config_root(),
+                precedence,
+                Some(cf.get_path().to_path_buf()),
+            ))),
             Ok(None) => None,
             Err(err) => Some(Err(err)),
         })
         .transpose()?
         .or_else(|| {
             cascaded_task_config.and_then(|tc| {
-                tc.task_config
-                    .includes
-                    .clone()
-                    .map(|includes| (includes, tc.includes_root.clone(), configs.len()))
+                tc.task_config.includes.clone().map(|includes| {
+                    (
+                        includes,
+                        tc.includes_root.clone(),
+                        configs.len(),
+                        tc.includes_source.clone(),
+                    )
+                })
             })
         })
-        .unwrap_or_else(|| (default_task_includes(), dir.to_path_buf(), configs.len()));
+        .unwrap_or_else(|| {
+            (
+                default_task_includes(),
+                dir.to_path_buf(),
+                configs.len(),
+                None,
+            )
+        });
+
+    let remote_includes_authorized = match include_owner.as_deref() {
+        Some(owner) => trust_check_remote_task_includes(owner, &includes)?,
+        None if includes.iter().any(|include| include.starts_with("git::")) => {
+            bail!("remote task include has no defining config provenance")
+        }
+        None => false,
+    };
+
+    let vouching_config_source = include_owner
+        .as_ref()
+        .filter(|owner| remote_includes_authorized || is_path_trusted(owner))
+        .cloned()
+        .or_else(|| {
+            if include_owner.is_some() {
+                return None;
+            }
+            configs
+                .iter()
+                .find(|cf| is_path_trusted(cf.get_path()))
+                .map(|cf| cf.get_path().to_path_buf())
+        });
+    let require_task_include_trust = vouching_config_source.is_none();
 
     // Resolve task defaults once for the config root so inline tasks from
     // lower-precedence overlay files use the same defaults as file tasks.
@@ -4968,6 +5041,9 @@ async fn load_task_sources_from_configs(
                 apply_task_config_cache_default(task, &task_config.cache);
                 apply_task_config_rust_cache_default(task, &task_config.rust_cache);
                 task_config.environment.apply(task)?;
+            }
+            if let Some(source) = &vouching_config_source {
+                preserve_remote_task_trust_source(&mut loaded, source);
             }
             if is_global || is_global_task_include_path(&p) {
                 mark_tasks_as_global(&mut loaded);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -67,11 +67,6 @@ type RemoteTaskIncludeKey = (String, Option<String>);
 type RemoteTaskIncludeArtifacts = DashMap<RemoteTaskIncludeKey, Arc<OnceCell<TaskFileArtifact>>>;
 static REMOTE_TASK_INCLUDE_ARTIFACTS: Lazy<RemoteTaskIncludeArtifacts> = Lazy::new(DashMap::new);
 
-#[cfg(test)]
-pub(crate) fn clear_remote_task_include_artifacts() {
-    drop(take_remote_task_include_artifacts());
-}
-
 pub(crate) fn take_remote_task_include_artifacts() -> Vec<Arc<OnceCell<TaskFileArtifact>>> {
     let keys = REMOTE_TASK_INCLUDE_ARTIFACTS
         .iter()
@@ -87,16 +82,22 @@ pub(crate) fn take_remote_task_include_artifacts() -> Vec<Arc<OnceCell<TaskFileA
 }
 
 #[cfg(test)]
-pub(crate) fn insert_remote_task_include_artifact_for_test() {
-    REMOTE_TASK_INCLUDE_ARTIFACTS.insert(
-        ("https://example.test/repo.git".into(), None),
-        Arc::new(OnceCell::new()),
-    );
-}
+mod remote_task_include_tests {
+    use super::*;
 
-#[cfg(test)]
-pub(crate) fn remote_task_include_artifact_count_for_test() -> usize {
-    REMOTE_TASK_INCLUDE_ARTIFACTS.len()
+    #[test]
+    fn take_remote_task_include_artifacts_drains_cache() {
+        drop(take_remote_task_include_artifacts());
+        REMOTE_TASK_INCLUDE_ARTIFACTS.insert(
+            ("https://example.test/repo.git".into(), None),
+            Arc::new(OnceCell::new()),
+        );
+
+        let artifacts = take_remote_task_include_artifacts();
+
+        assert!(REMOTE_TASK_INCLUDE_ARTIFACTS.is_empty());
+        assert_eq!(artifacts.len(), 1);
+    }
 }
 
 pub(crate) struct MonorepoUnion {

--- a/src/remote_source.rs
+++ b/src/remote_source.rs
@@ -60,13 +60,9 @@ impl RemoteSource {
 fn parse_git_with(regex: &Regex, file: &str) -> Option<RemoteGitSource> {
     let captures = regex.captures(file)?;
     let path = captures.name("path").unwrap().as_str();
-    let mut components = path.split('/');
-    let first = components.next()?;
-    if path.contains('\\')
-        || is_windows_drive_component(first)
-        || std::iter::once(first)
-            .chain(components)
-            .any(|component| component.is_empty() || component == "." || component == "..")
+    if path
+        .split('/')
+        .any(|component| component.is_empty() || component == "." || component == "..")
     {
         return None;
     }
@@ -75,11 +71,6 @@ fn parse_git_with(regex: &Regex, file: &str) -> Option<RemoteGitSource> {
         path: path.to_string(),
         git_ref: captures.name("ref").map(|m| m.as_str().to_string()),
     })
-}
-
-fn is_windows_drive_component(component: &str) -> bool {
-    let bytes = component.as_bytes();
-    bytes.len() == 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
 }
 
 #[cfg(test)]
@@ -151,15 +142,6 @@ mod tests {
         assert!(
             RemoteSource::parse_git("git::https://myserver.com/example.git//plugin/./other")
                 .is_none()
-        );
-        assert!(
-            RemoteSource::parse_git("git::https://myserver.com/example.git//..\\outside").is_none()
-        );
-        assert!(
-            RemoteSource::parse_git("git::https://myserver.com/example.git//C:/outside").is_none()
-        );
-        assert!(
-            RemoteSource::parse_git("git::https://myserver.com/example.git//C:\\outside").is_none()
         );
     }
 

--- a/src/remote_source.rs
+++ b/src/remote_source.rs
@@ -60,9 +60,13 @@ impl RemoteSource {
 fn parse_git_with(regex: &Regex, file: &str) -> Option<RemoteGitSource> {
     let captures = regex.captures(file)?;
     let path = captures.name("path").unwrap().as_str();
-    if path
-        .split('/')
-        .any(|component| component.is_empty() || component == "." || component == "..")
+    let mut components = path.split('/');
+    let first = components.next()?;
+    if path.contains('\\')
+        || is_windows_drive_component(first)
+        || std::iter::once(first)
+            .chain(components)
+            .any(|component| component.is_empty() || component == "." || component == "..")
     {
         return None;
     }
@@ -71,6 +75,11 @@ fn parse_git_with(regex: &Regex, file: &str) -> Option<RemoteGitSource> {
         path: path.to_string(),
         git_ref: captures.name("ref").map(|m| m.as_str().to_string()),
     })
+}
+
+fn is_windows_drive_component(component: &str) -> bool {
+    let bytes = component.as_bytes();
+    bytes.len() == 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
 }
 
 #[cfg(test)]
@@ -142,6 +151,15 @@ mod tests {
         assert!(
             RemoteSource::parse_git("git::https://myserver.com/example.git//plugin/./other")
                 .is_none()
+        );
+        assert!(
+            RemoteSource::parse_git("git::https://myserver.com/example.git//..\\outside").is_none()
+        );
+        assert!(
+            RemoteSource::parse_git("git::https://myserver.com/example.git//C:/outside").is_none()
+        );
+        assert!(
+            RemoteSource::parse_git("git::https://myserver.com/example.git//C:\\outside").is_none()
         );
     }
 

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -127,20 +127,27 @@ fn same_task_without_phase(task: &Task, other: &Task) -> bool {
 /// manages a dependency graph of tasks so `mise run` knows what to run next
 impl Deps {
     pub async fn new(config: &Arc<Config>, tasks: Vec<Task>) -> eyre::Result<Self> {
-        Self::new_with_cycle_limit(config, tasks, Some(1)).await
+        Self::new_with_options(config, tasks, Some(1), false).await
     }
 
     pub(crate) async fn new_for_validation(
         config: &Arc<Config>,
         tasks: Vec<Task>,
     ) -> eyre::Result<Self> {
-        Self::new_with_cycle_limit(config, tasks, None).await
+        Self::new_with_options(config, tasks, None, true).await
     }
 
-    async fn new_with_cycle_limit(
+    /// Build a dependency graph for passive display without allowing remote
+    /// providers to perform network or Git work from an untrusted config.
+    pub async fn new_for_display(config: &Arc<Config>, tasks: Vec<Task>) -> eyre::Result<Self> {
+        Self::new_with_options(config, tasks, Some(1), true).await
+    }
+
+    async fn new_with_options(
         config: &Arc<Config>,
         tasks: Vec<Task>,
         cycle_limit: Option<usize>,
+        trust_before_fetch: bool,
     ) -> eyre::Result<Self> {
         let mut graph = DiGraph::new();
         let mut indexes = HashMap::new();
@@ -165,7 +172,11 @@ impl Deps {
         }
         let all_tasks_to_run = resolve_depends(config, tasks).await?;
         let no_cache = Settings::get().task.remote_no_cache.unwrap_or(false);
-        let fetcher = TaskFetcher::new(no_cache);
+        let fetcher = if trust_before_fetch {
+            TaskFetcher::new(no_cache).require_trust_before_fetch()
+        } else {
+            TaskFetcher::new(no_cache)
+        };
         while let Some(mut a) = stack.pop() {
             if seen.contains(&a) {
                 // prevent infinite loop

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -2,7 +2,7 @@ use crate::config::Settings;
 use crate::config::env_directive::EnvDirective;
 use crate::task::task_fetcher::TaskFetcher;
 use crate::task::{Task, TaskRunPhase, dep_has_usage_ref, parse_usage_values_from_task};
-use crate::{config::Config, task::task_list::resolve_depends};
+use crate::{config::Config, task::task_list::resolve_depends_with_no_cache};
 use itertools::Itertools;
 use petgraph::Direction;
 use petgraph::algo::kosaraju_scc;
@@ -127,20 +127,28 @@ fn same_task_without_phase(task: &Task, other: &Task) -> bool {
 /// manages a dependency graph of tasks so `mise run` knows what to run next
 impl Deps {
     pub async fn new(config: &Arc<Config>, tasks: Vec<Task>) -> eyre::Result<Self> {
-        Self::new_with_options(config, tasks, Some(1), false).await
+        Self::new_with_options(config, tasks, Some(1), false, false).await
+    }
+
+    pub async fn new_with_no_cache(
+        config: &Arc<Config>,
+        tasks: Vec<Task>,
+        no_cache: bool,
+    ) -> eyre::Result<Self> {
+        Self::new_with_options(config, tasks, Some(1), false, no_cache).await
     }
 
     pub(crate) async fn new_for_validation(
         config: &Arc<Config>,
         tasks: Vec<Task>,
     ) -> eyre::Result<Self> {
-        Self::new_with_options(config, tasks, None, true).await
+        Self::new_with_options(config, tasks, None, true, false).await
     }
 
     /// Build a dependency graph for passive display without allowing remote
     /// providers to perform network or Git work from an untrusted config.
     pub async fn new_for_display(config: &Arc<Config>, tasks: Vec<Task>) -> eyre::Result<Self> {
-        Self::new_with_options(config, tasks, Some(1), true).await
+        Self::new_with_options(config, tasks, Some(1), true, false).await
     }
 
     async fn new_with_options(
@@ -148,6 +156,7 @@ impl Deps {
         tasks: Vec<Task>,
         cycle_limit: Option<usize>,
         trust_before_fetch: bool,
+        no_cache: bool,
     ) -> eyre::Result<Self> {
         let mut graph = DiGraph::new();
         let mut indexes = HashMap::new();
@@ -170,8 +179,8 @@ impl Deps {
             stack.push(t.clone());
             add_idx(&t, &mut graph);
         }
-        let all_tasks_to_run = resolve_depends(config, tasks).await?;
-        let no_cache = Settings::get().task.remote_no_cache.unwrap_or(false);
+        let all_tasks_to_run = resolve_depends_with_no_cache(config, tasks, no_cache).await?;
+        let no_cache = no_cache || Settings::get().task.remote_no_cache.unwrap_or(false);
         let fetcher = if trust_before_fetch {
             TaskFetcher::new(no_cache).require_trust_before_fetch()
         } else {
@@ -211,7 +220,9 @@ impl Deps {
             // Update the graph node with the fetched version of the task
             // (add_idx may have returned an existing index with an unfetched task)
             graph[a_idx] = a.clone();
-            let resolved = a.resolve_depends(config, &all_tasks_to_run).await?;
+            let resolved = a
+                .resolve_depends(config, &all_tasks_to_run, no_cache)
+                .await?;
             for b in resolved.depends {
                 let b = b.with_run_phase(a.run_phase);
                 let b_idx = add_idx(&b, &mut graph);
@@ -333,12 +344,13 @@ impl Deps {
     /// Create a sub-graph that prunes tasks already completed by the caller.
     /// `completed` is a snapshot of task keys that have finished in the parent
     /// graph — these are removed from the sub-graph so they don't run again.
-    pub async fn new_pruned(
+    pub async fn new_pruned_with_no_cache(
         config: &Arc<Config>,
         tasks: Vec<Task>,
         completed: &TaskCompletionState,
+        no_cache: bool,
     ) -> eyre::Result<Self> {
-        let mut deps = Self::new(config, tasks).await?;
+        let mut deps = Self::new_with_no_cache(config, tasks, no_cache).await?;
         deps.did_work.extend(completed.did_work.iter().cloned());
         deps.cache_keys.extend(completed.cache_keys.clone());
         let mut to_remove = vec![];
@@ -766,9 +778,10 @@ mod tests {
         };
         let config = Config::get().await.unwrap();
 
-        let deps = Deps::new_pruned(&config, vec![completed_task], &completion_state)
-            .await
-            .unwrap();
+        let deps =
+            Deps::new_pruned_with_no_cache(&config, vec![completed_task], &completion_state, false)
+                .await
+                .unwrap();
         let propagated = deps.completion_state();
 
         assert!(deps.is_empty());

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -9,7 +9,7 @@ use crate::tera::{TeraEngine, contains_template_syntax, get_tera, render_str};
 use crate::ui::tree::TreeItem;
 use crate::{dirs, env, file};
 use console::{measure_text_width, truncate_str};
-use eyre::{Result, bail, eyre};
+use eyre::{Result, WrapErr, bail, eyre};
 use globset::{GlobBuilder, GlobMatcher};
 use indexmap::IndexMap;
 use itertools::Itertools;
@@ -37,6 +37,17 @@ pub(crate) fn reset() {
     TASK_VARS_CACHE.lock().unwrap().clear();
     TASK_ENV_CACHE.lock().unwrap().clear();
 }
+
+#[derive(Debug)]
+pub(crate) struct TaskNotFoundError(String);
+
+impl Display for TaskNotFoundError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for TaskNotFoundError {}
 
 /// Type alias for tracking failed tasks with their exit codes
 pub type FailedTasks = Arc<std::sync::Mutex<Vec<(Task, Option<i32>)>>>;
@@ -107,7 +118,7 @@ impl Task {
     }
 }
 
-use crate::config::config_file::ConfigFile;
+use crate::config::config_file::{ConfigFile, trust_check};
 use crate::env_diff::EnvMap;
 use crate::file::display_path;
 use crate::fuzzy::{FuzzyMatcher, FuzzyPattern};
@@ -781,6 +792,15 @@ pub struct Task {
     #[serde(skip)]
     pub remote_file_source: Option<String>,
 
+    /// Config file that declared a remote task. The fetched task's local path
+    /// is not the trust authority for its metadata.
+    #[serde(skip)]
+    pub remote_config_source: Option<PathBuf>,
+
+    /// Whether the fetched remote header contributed tool requirements.
+    #[serde(skip)]
+    pub remote_metadata_has_tools: bool,
+
     /// Block reads, writes, network, and env vars
     #[serde(default)]
     pub deny_all: bool,
@@ -1052,6 +1072,16 @@ pub(crate) fn file_has_decoded_template(path: &Path, body: &str) -> bool {
     }
 }
 
+/// Check decoded remote script header values regardless of the fetched path's
+/// extension. A remote script may legitimately end in `.toml`.
+pub(crate) fn script_header_has_decoded_template(body: &str) -> bool {
+    use crate::config::config_file::mise_toml::toml_value_has_template;
+    scan_mise_header_entries(file::strip_utf8_bom(body))
+        .into_iter()
+        .filter_map(|entry| entry.parse_toml().ok())
+        .any(|value| toml_value_has_template(&value))
+}
+
 fn parse_task_script_usage(file: &Path) -> usage::Result<usage::Spec> {
     let script = std::fs::read_to_string(file)?;
     // Same reason as the `#MISE` header scan: `#USAGE` on line 1 is invisible behind a mark.
@@ -1290,6 +1320,21 @@ impl Task {
     }
 
     pub(crate) fn tool_args(&self) -> Result<Vec<ToolArg>> {
+        if self.remote_metadata_has_tools {
+            let remote_source = self.remote_file_source.as_deref().unwrap_or(&self.name);
+            let config_source = self.remote_config_source.as_deref().ok_or_else(|| {
+                eyre!(
+                    "remote task {remote_source} has tool metadata without defining config provenance"
+                )
+            })?;
+            trust_check(config_source).wrap_err_with(|| {
+                format!(
+                    "tool metadata from remote task {} requires its defining config {} to be trusted",
+                    remote_source,
+                    display_path(config_source)
+                )
+            })?;
+        }
         self.tools
             .iter()
             .map(|(tool, value)| value.to_tool_arg(tool))
@@ -1645,7 +1690,7 @@ impl Task {
         config: &Arc<Config>,
         tasks_to_run: &[Task],
     ) -> Result<ResolvedTaskDependencies> {
-        use crate::task::TaskLoadContext;
+        use crate::task::{TaskLoadContext, task_fetcher::TaskFetcher};
 
         if let Some(err) = &self.workspace_dependency_error {
             bail!("{err}");
@@ -1678,62 +1723,76 @@ impl Task {
         };
 
         let all_tasks = config.tasks_with_context(ctx.as_ref()).await?;
-        let tasks = build_task_ref_map(all_tasks.iter());
-        // Skip deps with unresolved {{usage.*}} references — they'll be resolved
-        // later when render_depends_with_usage() is called with actual arg values.
-        let depends = self
-            .depends
-            .iter()
-            .filter(|td| !dep_has_usage_ref(td))
-            .map(|td| match_tasks_with_context(&tasks, td, Some(self)))
-            .flatten_ok()
-            .collect_vec();
-        let wait_for = self
-            .wait_for
-            .iter()
-            .filter(|td| !dep_has_usage_ref(td))
-            .map(|td| {
-                match_tasks_with_context(&tasks, td, Some(self))
-                    .map(|tasks| tasks.into_iter().map(|t| (t, td)).collect_vec())
+        let resolve = |all_tasks: &BTreeMap<String, Task>| -> Result<_> {
+            let tasks = build_task_ref_map(all_tasks.iter());
+            // Skip deps with unresolved {{usage.*}} references — they'll be resolved
+            // later when render_depends_with_usage() is called with actual arg values.
+            let depends = self
+                .depends
+                .iter()
+                .filter(|td| !dep_has_usage_ref(td))
+                .map(|td| match_tasks_with_context(&tasks, td, Some(self)))
+                .flatten_ok()
+                .collect_vec();
+            let wait_for = self
+                .wait_for
+                .iter()
+                .filter(|td| !dep_has_usage_ref(td))
+                .map(|td| {
+                    match_tasks_with_context(&tasks, td, Some(self))
+                        .map(|tasks| tasks.into_iter().map(|t| (t, td)).collect_vec())
+                })
+                .flatten_ok()
+                .filter_map_ok(|(t, td)| {
+                    if td.env.is_empty() && td.args.is_empty() {
+                        // Name-based matching: wait for any running instance of this task
+                        // regardless of env/args variant (e.g., "VERBOSE=1 setup" matches "setup").
+                        // Return the actual task from tasks_to_run so the dependency graph
+                        // gets the correct env/args-variant node.
+                        tasks_to_run
+                            .iter()
+                            .find(|tr| tr.name == t.name)
+                            .map(|tr| (*tr).clone())
+                    } else {
+                        // Full identity matching: user explicitly wants a specific env/args variant
+                        tasks_to_run.contains(&t).then_some(t)
+                    }
+                })
+                .collect_vec();
+            let depends_post = self
+                .depends_post
+                .iter()
+                .filter(|td| !dep_has_usage_ref(td))
+                .map(|td| match_tasks_with_context(&tasks, td, Some(self)))
+                .flatten_ok()
+                .filter_ok(|t| t.name != self.name)
+                .collect::<Result<Vec<_>>>()?;
+            let depends = depends
+                .into_iter()
+                .filter_ok(|t| t.name != self.name)
+                .collect::<Result<_>>()?;
+            let wait_for = wait_for
+                .into_iter()
+                .filter_ok(|t| t.name != self.name)
+                .collect::<Result<_>>()?;
+            Ok(ResolvedTaskDependencies {
+                depends,
+                wait_for,
+                depends_post,
             })
-            .flatten_ok()
-            .filter_map_ok(|(t, td)| {
-                if td.env.is_empty() && td.args.is_empty() {
-                    // Name-based matching: wait for any running instance of this task
-                    // regardless of env/args variant (e.g., "VERBOSE=1 setup" matches "setup").
-                    // Return the actual task from tasks_to_run so the dependency graph
-                    // gets the correct env/args-variant node.
-                    tasks_to_run
-                        .iter()
-                        .find(|tr| tr.name == t.name)
-                        .map(|tr| (*tr).clone())
-                } else {
-                    // Full identity matching: user explicitly wants a specific env/args variant
-                    tasks_to_run.contains(&t).then_some(t)
-                }
-            })
-            .collect_vec();
-        let depends_post = self
-            .depends_post
-            .iter()
-            .filter(|td| !dep_has_usage_ref(td))
-            .map(|td| match_tasks_with_context(&tasks, td, Some(self)))
-            .flatten_ok()
-            .filter_ok(|t| t.name != self.name)
-            .collect::<Result<Vec<_>>>()?;
-        let depends = depends
-            .into_iter()
-            .filter_ok(|t| t.name != self.name)
-            .collect::<Result<_>>()?;
-        let wait_for = wait_for
-            .into_iter()
-            .filter_ok(|t| t.name != self.name)
-            .collect::<Result<_>>()?;
-        Ok(ResolvedTaskDependencies {
-            depends,
-            wait_for,
-            depends_post,
-        })
+        };
+
+        match resolve(&all_tasks) {
+            Ok(dependencies) => Ok(dependencies),
+            Err(err) if err.downcast_ref::<TaskNotFoundError>().is_some() => {
+                let all_tasks = TaskFetcher::new(false)
+                    .require_trust_before_fetch()
+                    .fetch_task_map(config, &all_tasks)
+                    .await?;
+                resolve(&all_tasks)
+            }
+            Err(err) => Err(err),
+        }
     }
 
     /// Expands `^task` dependencies to the matching task in every upstream workspace project.
@@ -2816,7 +2875,7 @@ impl Task {
         env_directives.extend(self.overlay_env.iter().cloned());
 
         // Resolve environment directives using the same system as global env
-        let env_results = EnvResults::resolve(
+        let env_results = EnvResults::resolve_with_trust_source(
             config,
             tera_ctx.clone(),
             &env,
@@ -2826,6 +2885,7 @@ impl Task {
                 tools: ToolsFilter::Both,
                 warn_on_missing_required: false,
             },
+            self.remote_config_source.as_deref(),
         )
         .await?;
         // Register task-specific redactions with the global redactor
@@ -3092,7 +3152,7 @@ fn match_tasks_with_context(
             }
         }
 
-        return Err(eyre!(err_msg));
+        return Err(TaskNotFoundError(err_msg).into());
     };
 
     Ok(matches)
@@ -3147,6 +3207,8 @@ impl Default for Task {
             usage: "".to_string(),
             timeout: None,
             remote_file_source: None,
+            remote_config_source: None,
+            remote_metadata_has_tools: false,
             deny_all: false,
             deny_read: false,
             deny_write: false,

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1689,6 +1689,7 @@ impl Task {
         &self,
         config: &Arc<Config>,
         tasks_to_run: &[Task],
+        no_cache: bool,
     ) -> Result<ResolvedTaskDependencies> {
         use crate::task::{TaskLoadContext, task_fetcher::TaskFetcher};
 
@@ -1722,7 +1723,9 @@ impl Task {
             None
         };
 
-        let all_tasks = config.tasks_with_context(ctx.as_ref()).await?;
+        let all_tasks = config
+            .tasks_with_context_no_cache(ctx.as_ref(), no_cache)
+            .await?;
         let resolve = |all_tasks: &BTreeMap<String, Task>| -> Result<_> {
             let tasks = build_task_ref_map(all_tasks.iter());
             // Skip deps with unresolved {{usage.*}} references — they'll be resolved
@@ -1785,7 +1788,7 @@ impl Task {
         match resolve(&all_tasks) {
             Ok(dependencies) => Ok(dependencies),
             Err(err) if err.downcast_ref::<TaskNotFoundError>().is_some() => {
-                let all_tasks = TaskFetcher::new(false)
+                let all_tasks = TaskFetcher::new(no_cache)
                     .require_trust_before_fetch()
                     .fetch_task_map(config, &all_tasks)
                     .await?;

--- a/src/task/task_context_builder.rs
+++ b/src/task/task_context_builder.rs
@@ -9,7 +9,7 @@ use crate::toolset::{Toolset, ToolsetBuilder};
 use eyre::Result;
 use indexmap::IndexMap;
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
 type EnvResolutionResult = (
@@ -252,7 +252,7 @@ impl TaskContextBuilder {
 
         // Resolve config-level env from ALL config files, not just task_cf
         let config_env_results = self
-            .resolve_env_directives(config, &tera_ctx, &env, all_config_env_entries)
+            .resolve_env_directives(config, &tera_ctx, &env, all_config_env_entries, None)
             .await?;
         Self::apply_env_results(&mut env, &config_env_results);
 
@@ -267,7 +267,13 @@ impl TaskContextBuilder {
 
         let task_env_directives = self.build_task_env_directives(task);
         let task_env_results = self
-            .resolve_env_directives(config, &tera_ctx, &env, task_env_directives)
+            .resolve_env_directives(
+                config,
+                &tera_ctx,
+                &env,
+                task_env_directives,
+                task.remote_config_source.as_deref(),
+            )
             .await?;
 
         let task_env = self.extract_task_env(&task_env_results);
@@ -418,8 +424,9 @@ impl TaskContextBuilder {
         tera_ctx: &tera::Context,
         env: &BTreeMap<String, String>,
         directives: Vec<(EnvDirective, PathBuf)>,
+        trust_source: Option<&Path>,
     ) -> Result<EnvResults> {
-        EnvResults::resolve(
+        EnvResults::resolve_with_trust_source(
             config,
             tera_ctx.clone(),
             env,
@@ -429,6 +436,7 @@ impl TaskContextBuilder {
                 tools: ToolsFilter::Both,
                 warn_on_missing_required: false,
             },
+            trust_source,
         )
         .await
     }

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -1004,16 +1004,21 @@ impl TaskExecutor {
             name
         }));
         let tasks = config.tasks_with_context(Some(&ctx)).await?;
-        let tasks_map: BTreeMap<String, Task> = tasks
-            .values()
-            .flat_map(|t| {
-                t.aliases
-                    .iter()
-                    .map(|a| (a.to_string(), t.clone()))
-                    .chain(once((t.name.clone(), t.clone())))
-                    .collect::<Vec<_>>()
-            })
-            .collect();
+        let mut resolved_tasks = tasks.as_ref().clone();
+        let needs_remote_aliases = {
+            let tasks_map = crate::task::build_task_ref_map(resolved_tasks.iter());
+            specs.iter().try_fold(false, |missing, spec| {
+                let (name, _) = split_task_spec(spec);
+                Ok::<_, eyre::Report>(missing || tasks_map.get_matching(name)?.is_empty())
+            })?
+        };
+        if needs_remote_aliases {
+            resolved_tasks = crate::task::task_fetcher::TaskFetcher::new(false)
+                .require_trust_before_fetch()
+                .fetch_task_map(config, &resolved_tasks)
+                .await?;
+        }
+        let tasks_map = crate::task::build_task_ref_map(resolved_tasks.iter());
         let mut to_run: Vec<Task> = vec![];
         for spec in specs {
             let (name, args) = split_task_spec(spec);

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -278,6 +278,7 @@ pub struct TaskExecutorConfig {
     pub continue_on_error: bool,
     pub dry_run: bool,
     pub skip_deps: bool,
+    pub no_cache: bool,
     pub task_cache: TaskCacheMode,
     pub task_cache_explain: bool,
     pub task_cache_explain_json: bool,
@@ -303,6 +304,7 @@ pub struct TaskExecutor {
     pub continue_on_error: bool,
     pub dry_run: bool,
     pub skip_deps: bool,
+    pub no_cache: bool,
     pub task_cache: TaskCacheMode,
     pub task_cache_explain: bool,
     pub task_cache_explain_json: bool,
@@ -356,6 +358,7 @@ impl TaskExecutor {
             continue_on_error: config.continue_on_error,
             dry_run: config.dry_run,
             skip_deps: config.skip_deps,
+            no_cache: config.no_cache,
             task_cache: config.task_cache,
             task_cache_explain: config.task_cache_explain,
             task_cache_explain_json: config.task_cache_explain_json,
@@ -1003,7 +1006,9 @@ impl TaskExecutor {
             let (name, _) = split_task_spec(s);
             name
         }));
-        let tasks = config.tasks_with_context(Some(&ctx)).await?;
+        let tasks = config
+            .tasks_with_context_no_cache(Some(&ctx), self.no_cache)
+            .await?;
         let mut resolved_tasks = tasks.as_ref().clone();
         let needs_remote_aliases = {
             let tasks_map = crate::task::build_task_ref_map(resolved_tasks.iter());
@@ -1060,7 +1065,8 @@ impl TaskExecutor {
                 to_run.push(t);
             }
         }
-        let sub_deps = Deps::new_pruned(config, to_run, completion_state).await?;
+        let sub_deps =
+            Deps::new_pruned_with_no_cache(config, to_run, completion_state, self.no_cache).await?;
         let sub_deps = Arc::new(Mutex::new(sub_deps));
 
         // Pump subgraph into scheduler and signal completion via oneshot when done

--- a/src/task/task_fetcher.rs
+++ b/src/task/task_fetcher.rs
@@ -1,9 +1,11 @@
+use crate::config::config_file::{trust_check, trust_check_remote_fetch};
 use crate::config::{Config, Settings};
-use crate::task::Task;
 use crate::task::task_file_providers::{TaskFileArtifact, TaskFileProvidersBuilder};
+use crate::task::{Task, script_header_has_decoded_template};
 use dashmap::DashMap;
-use eyre::Result;
+use eyre::{Result, WrapErr};
 use std::{
+    collections::BTreeMap,
     path::PathBuf,
     sync::{Arc, LazyLock, Mutex},
 };
@@ -65,11 +67,21 @@ fn take_remote_task_artifacts() -> Vec<Arc<OnceCell<TaskFileArtifact>>> {
 /// Handles fetching remote task files and converting them to local paths
 pub struct TaskFetcher {
     no_cache: bool,
+    trust_before_fetch: bool,
 }
 
 impl TaskFetcher {
     pub fn new(no_cache: bool) -> Self {
-        Self { no_cache }
+        Self {
+            no_cache,
+            trust_before_fetch: false,
+        }
+    }
+
+    /// Require trust before a remote provider performs network or Git work.
+    pub fn require_trust_before_fetch(mut self) -> Self {
+        self.trust_before_fetch = true;
+        self
     }
 
     /// Fetch remote task files, converting remote paths to local cached paths
@@ -89,6 +101,24 @@ impl TaskFetcher {
                 }
 
                 let original = t.clone();
+                let defining_cf = original
+                    .cf
+                    .clone()
+                    .or_else(|| config.config_files.get(&original.config_source).cloned());
+                let defining_config_source = original
+                    .remote_config_source
+                    .clone()
+                    .or_else(|| defining_cf.as_ref().map(|cf| cf.get_path().to_path_buf()))
+                    .unwrap_or_else(|| original.config_source.clone());
+
+                if self.trust_before_fetch {
+                    trust_check_remote_fetch(&defining_config_source).wrap_err_with(|| {
+                        format!(
+                            "fetching remote task {source} requires its defining config to be trusted"
+                        )
+                    })?;
+                }
+
                 let provider = task_file_providers
                     .get_provider(&source)
                     .ok_or_else(|| eyre::eyre!("No provider found for file: {}", source))?;
@@ -123,12 +153,25 @@ impl TaskFetcher {
                 // Parse the downloaded script as a regular file task so all #MISE
                 // metadata is honored. The inline TOML task remains the higher-
                 // precedence overlay, matching local file-task behavior.
+                let body = crate::file::read_to_string(&local_path).wrap_err_with(|| {
+                    format!("failed to read remote task metadata from {source}")
+                })?;
+                let header_has_templates = script_header_has_decoded_template(&body);
                 let mut remote = Task::from_path_unrendered_with_cf(
                     &local_path,
                     prefix,
                     &config_root,
                     original.cf.clone(),
-                )?;
+                )
+                .wrap_err_with(|| format!("failed to parse remote task metadata from {source}"))?;
+                if header_has_templates {
+                    trust_check(&defining_config_source).wrap_err_with(|| {
+                        format!(
+                            "remote task metadata from {source} requires its defining config to be trusted"
+                        )
+                    })?;
+                }
+                let remote_metadata_has_tools = !remote.tools.is_empty();
                 remote.name.clone_from(&original.name);
                 remote.display_name.clone_from(&original.display_name);
 
@@ -141,18 +184,40 @@ impl TaskFetcher {
                 remote.inherited_env.clone_from(&original.inherited_env);
                 remote.overlay_env.clone_from(&original.overlay_env);
                 remote.overlay_vars.clone_from(&original.overlay_vars);
-                remote.render(config, &config_root).await?;
+                remote
+                    .render(config, &config_root)
+                    .await
+                    .wrap_err_with(|| {
+                        format!("failed to render remote task metadata from {source}")
+                    })?;
                 remote.merge_toml_overlay(original.clone());
 
                 // Preserve runtime state that is not task metadata and therefore is
                 // intentionally not handled by merge_toml_overlay().
                 remote.global = original.global;
                 remote.remote_file_source = Some(source);
+                remote.remote_config_source = Some(defining_config_source);
+                remote.remote_metadata_has_tools = remote_metadata_has_tools;
                 *t = remote;
             }
         }
 
         Ok(())
+    }
+
+    /// Clone and resolve a task map so consumers can retry alias/dependency
+    /// matching against metadata that only exists in remote headers.
+    pub async fn fetch_task_map(
+        &self,
+        config: &Arc<Config>,
+        tasks: &BTreeMap<String, Task>,
+    ) -> Result<BTreeMap<String, Task>> {
+        let mut resolved = tasks.values().cloned().collect::<Vec<_>>();
+        self.fetch_tasks(config, &mut resolved).await?;
+        Ok(resolved
+            .into_iter()
+            .map(|task| (task.name.clone(), task))
+            .collect())
     }
 
     /// Check if a source path is a remote task file (git or http/https)

--- a/src/task/task_fetcher.rs
+++ b/src/task/task_fetcher.rs
@@ -178,7 +178,6 @@ mod tests {
         let _test_lock = REMOTE_TASK_ARTIFACT_TEST_LOCK.lock().await;
         assert_eq!(*REMOTE_TASK_ARTIFACT_SCOPES.lock().unwrap(), 0);
         REMOTE_TASK_ARTIFACTS.clear();
-        crate::config::clear_remote_task_include_artifacts();
 
         let outer = RemoteTaskArtifactsGuard::new();
         let inner = RemoteTaskArtifactsGuard::new();
@@ -190,21 +189,12 @@ mod tests {
             },
             Arc::new(OnceCell::new()),
         );
-        crate::config::insert_remote_task_include_artifact_for_test();
 
         drop(inner);
         assert_eq!(REMOTE_TASK_ARTIFACTS.len(), 1);
-        assert_eq!(
-            crate::config::remote_task_include_artifact_count_for_test(),
-            1
-        );
 
         drop(outer);
         assert!(REMOTE_TASK_ARTIFACTS.is_empty());
-        assert_eq!(
-            crate::config::remote_task_include_artifact_count_for_test(),
-            0
-        );
     }
 
     #[tokio::test]

--- a/src/task/task_fetcher.rs
+++ b/src/task/task_fetcher.rs
@@ -21,24 +21,45 @@ static REMOTE_TASK_ARTIFACTS: LazyLock<RemoteTaskArtifacts> = LazyLock::new(Dash
 static REMOTE_TASK_ARTIFACT_SCOPES: Mutex<usize> = Mutex::new(0);
 
 /// Keeps no-cache remote task snapshots alive for one command or direct caller.
-pub(crate) struct RemoteTaskArtifactsGuard;
+pub(crate) struct RemoteTaskArtifactsGuard(());
 
 impl RemoteTaskArtifactsGuard {
     pub(crate) fn new() -> Self {
         *REMOTE_TASK_ARTIFACT_SCOPES.lock().unwrap() += 1;
-        Self
+        Self(())
     }
 }
 
 impl Drop for RemoteTaskArtifactsGuard {
     fn drop(&mut self) {
-        let mut scopes = REMOTE_TASK_ARTIFACT_SCOPES.lock().unwrap();
-        *scopes -= 1;
-        if *scopes == 0 {
-            crate::config::clear_remote_task_include_artifacts();
-            REMOTE_TASK_ARTIFACTS.clear();
-        }
+        let (include_artifacts, task_artifacts) = {
+            let mut scopes = REMOTE_TASK_ARTIFACT_SCOPES.lock().unwrap();
+            *scopes -= 1;
+            if *scopes != 0 {
+                return;
+            }
+            (
+                crate::config::take_remote_task_include_artifacts(),
+                take_remote_task_artifacts(),
+            )
+        };
+        drop(include_artifacts);
+        drop(task_artifacts);
     }
+}
+
+fn take_remote_task_artifacts() -> Vec<Arc<OnceCell<TaskFileArtifact>>> {
+    let keys = REMOTE_TASK_ARTIFACTS
+        .iter()
+        .map(|entry| entry.key().clone())
+        .collect::<Vec<_>>();
+    keys.into_iter()
+        .filter_map(|key| {
+            REMOTE_TASK_ARTIFACTS
+                .remove(&key)
+                .map(|(_, artifact)| artifact)
+        })
+        .collect()
 }
 
 /// Handles fetching remote task files and converting them to local paths

--- a/src/task/task_fetcher.rs
+++ b/src/task/task_fetcher.rs
@@ -35,6 +35,7 @@ impl Drop for RemoteTaskArtifactsGuard {
         let mut scopes = REMOTE_TASK_ARTIFACT_SCOPES.lock().unwrap();
         *scopes -= 1;
         if *scopes == 0 {
+            crate::config::clear_remote_task_include_artifacts();
             REMOTE_TASK_ARTIFACTS.clear();
         }
     }
@@ -156,6 +157,7 @@ mod tests {
         let _test_lock = REMOTE_TASK_ARTIFACT_TEST_LOCK.lock().await;
         assert_eq!(*REMOTE_TASK_ARTIFACT_SCOPES.lock().unwrap(), 0);
         REMOTE_TASK_ARTIFACTS.clear();
+        crate::config::clear_remote_task_include_artifacts();
 
         let outer = RemoteTaskArtifactsGuard::new();
         let inner = RemoteTaskArtifactsGuard::new();
@@ -167,11 +169,21 @@ mod tests {
             },
             Arc::new(OnceCell::new()),
         );
+        crate::config::insert_remote_task_include_artifact_for_test();
+
         drop(inner);
         assert_eq!(REMOTE_TASK_ARTIFACTS.len(), 1);
+        assert_eq!(
+            crate::config::remote_task_include_artifact_count_for_test(),
+            1
+        );
 
         drop(outer);
         assert!(REMOTE_TASK_ARTIFACTS.is_empty());
+        assert_eq!(
+            crate::config::remote_task_include_artifact_count_for_test(),
+            0
+        );
     }
 
     #[tokio::test]

--- a/src/task/task_file_providers/mod.rs
+++ b/src/task/task_file_providers/mod.rs
@@ -12,8 +12,12 @@ mod remote_task_http;
 use crate::Result;
 use async_trait::async_trait;
 use local_task::LocalTask;
-use remote_task_git::RemoteTaskGitBuilder;
+use remote_task_git::{RemoteTaskGit, RemoteTaskGitBuilder};
 use remote_task_http::RemoteTaskHttpBuilder;
+
+pub(crate) fn prepare_remote_git_path(checkout_root: &Path, path: &Path) -> Result<()> {
+    RemoteTaskGit::prepare_remote_path(checkout_root, path)
+}
 
 #[async_trait]
 pub trait TaskFileProvider: Debug + Send + Sync {

--- a/src/task/task_file_providers/mod.rs
+++ b/src/task/task_file_providers/mod.rs
@@ -12,12 +12,8 @@ mod remote_task_http;
 use crate::Result;
 use async_trait::async_trait;
 use local_task::LocalTask;
-use remote_task_git::{RemoteTaskGit, RemoteTaskGitBuilder};
+use remote_task_git::RemoteTaskGitBuilder;
 use remote_task_http::RemoteTaskHttpBuilder;
-
-pub(crate) fn prepare_remote_git_path(checkout_root: &Path, path: &Path) -> Result<()> {
-    RemoteTaskGit::prepare_remote_path(checkout_root, path)
-}
 
 #[async_trait]
 pub trait TaskFileProvider: Debug + Send + Sync {

--- a/src/task/task_file_providers/mod.rs
+++ b/src/task/task_file_providers/mod.rs
@@ -77,21 +77,32 @@ fn retry_remove_temporary_artifact(mut remove: impl FnMut() -> io::Result<()>) -
 #[derive(Debug, Clone)]
 pub struct TaskFileArtifact {
     pub path: PathBuf,
-    _cleanup: Option<Arc<TaskFileArtifactCleanup>>,
+    cleanup: Option<Arc<TaskFileArtifactCleanup>>,
 }
 
 impl TaskFileArtifact {
     pub(crate) fn persistent(path: PathBuf) -> Self {
         Self {
             path,
-            _cleanup: None,
+            cleanup: None,
         }
     }
 
     pub(crate) fn temporary(path: PathBuf, cleanup_path: PathBuf) -> Self {
         Self {
             path,
-            _cleanup: Some(Arc::new(TaskFileArtifactCleanup { path: cleanup_path })),
+            cleanup: Some(Arc::new(TaskFileArtifactCleanup { path: cleanup_path })),
+        }
+    }
+
+    pub(crate) fn cleanup_path(&self) -> Option<&Path> {
+        self.cleanup.as_ref().map(|cleanup| cleanup.path.as_path())
+    }
+
+    pub(crate) fn with_path(&self, path: PathBuf) -> Self {
+        Self {
+            path,
+            cleanup: self.cleanup.clone(),
         }
     }
 }

--- a/src/task/task_file_providers/mod.rs
+++ b/src/task/task_file_providers/mod.rs
@@ -12,8 +12,13 @@ mod remote_task_http;
 use crate::Result;
 use async_trait::async_trait;
 use local_task::LocalTask;
-use remote_task_git::RemoteTaskGitBuilder;
+use remote_task_git::{RemoteTaskGit, RemoteTaskGitBuilder};
 use remote_task_http::RemoteTaskHttpBuilder;
+
+pub(crate) fn validate_remote_git_path(checkout_root: &Path, path: &Path) -> Result<()> {
+    RemoteTaskGit::validate_remote_path(checkout_root, path)?;
+    Ok(())
+}
 
 #[async_trait]
 pub trait TaskFileProvider: Debug + Send + Sync {

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -101,7 +101,7 @@ impl RemoteTaskGit {
 
     fn get_cache_key(&self, repo_structure: &GitRepoStructure) -> String {
         let key = format!(
-            "{}{}",
+            "{}\0{}",
             repo_structure.url_without_path,
             repo_structure.branch.to_owned().unwrap_or("".to_string())
         );
@@ -132,12 +132,19 @@ impl RemoteTaskGit {
         git_repo.clone(repo_structure.url_without_path.as_str(), clone_options)
     }
 
+    fn path_cache_destination(&self, cache_key: &str, repo_path: &str) -> PathBuf {
+        // Hash the complete identity into one component so gix temporary pack
+        // paths remain below the legacy Windows path limit.
+        let path_key = hash::hash_sha256_to_str(&format!("{cache_key}\0{repo_path}"));
+        self.storage_path.join(format!("path-{path_key}"))
+    }
+
     fn fetch_to_destination(
         &self,
         repo_structure: &GitRepoStructure,
         destination: &PathBuf,
         reuse_existing: bool,
-    ) -> Result<PathBuf> {
+    ) -> Result<Option<PathBuf>> {
         let repo_file_path = repo_structure.path.clone();
         let full_path = destination.join(&repo_file_path);
 
@@ -152,10 +159,17 @@ impl RemoteTaskGit {
             })
             .lock()?;
 
-        if reuse_existing && full_path.exists() {
+        let destination_metadata = destination.symlink_metadata().ok();
+        let published_directory = destination_metadata
+            .as_ref()
+            .is_some_and(|metadata| metadata.file_type().is_dir());
+        if reuse_existing && published_directory && full_path.exists() {
             debug!("Using cached file: {:?}", full_path);
             Self::prepare_remote_path(destination, &full_path)?;
-            return Ok(full_path);
+            return Ok(Some(full_path));
+        }
+        if reuse_existing && destination_metadata.is_some() {
+            return Ok(None);
         }
 
         let mut tmp_destination = destination.as_os_str().to_os_string();
@@ -165,30 +179,59 @@ impl RemoteTaskGit {
             crate::file::remove_all(&tmp_destination)?;
         }
 
-        match Self::clone_to(repo_structure, &tmp_destination) {
-            Ok(()) => {
-                if destination.exists()
-                    && let Err(e) = crate::file::remove_all(destination)
-                {
-                    let _ = crate::file::remove_all(&tmp_destination);
-                    return Err(e);
-                }
-                if let Err(e) = std::fs::rename(&tmp_destination, destination) {
-                    let _ = crate::file::remove_all(&tmp_destination);
-                    return Err(eyre::eyre!(
-                        "failed to move cloned repo into cache at {}: {e}",
-                        display_path(destination)
-                    ));
-                }
-            }
-            Err(e) => {
-                let _ = crate::file::remove_all(&tmp_destination);
-                return Err(e);
-            }
+        if let Err(err) = Self::clone_to(repo_structure, &tmp_destination) {
+            let _ = crate::file::remove_all(&tmp_destination);
+            return Err(err);
         }
 
-        Self::prepare_remote_path(destination, &full_path)?;
-        Ok(full_path)
+        let tmp_full_path = tmp_destination.join(&repo_file_path);
+        if let Err(err) = Self::prepare_remote_path(&tmp_destination, &tmp_full_path) {
+            let _ = crate::file::remove_all(&tmp_destination);
+            return Err(err);
+        }
+
+        let destination_metadata = destination.symlink_metadata().ok();
+        let published_directory = destination_metadata
+            .as_ref()
+            .is_some_and(|metadata| metadata.file_type().is_dir());
+        if destination_metadata.is_some() {
+            let _ = crate::file::remove_all(&tmp_destination);
+            if reuse_existing && published_directory && full_path.exists() {
+                Self::prepare_remote_path(destination, &full_path)?;
+                return Ok(Some(full_path));
+            }
+            return Ok(None);
+        }
+
+        if let Err(err) = file::rename(&tmp_destination, destination) {
+            let _ = crate::file::remove_all(&tmp_destination);
+            return Err(eyre::eyre!(
+                "failed to move cloned repo into cache at {}: {err}",
+                display_path(destination)
+            ));
+        }
+
+        Ok(Some(full_path))
+    }
+
+    fn get_cached_path(&self, repo_structure: &GitRepoStructure) -> Result<PathBuf> {
+        let cache_key = self.get_cache_key(repo_structure);
+        let destination = self.storage_path.join(&cache_key);
+        if let Some(path) = self.fetch_to_destination(repo_structure, &destination, true)? {
+            return Ok(path);
+        }
+
+        // Never replace a published repo tree that another process may still
+        // be reading. A path-specific snapshot handles paths added later.
+        let destination = self.path_cache_destination(&cache_key, &repo_structure.path);
+        self.fetch_to_destination(repo_structure, &destination, true)?
+            .ok_or_else(|| {
+                eyre::eyre!(
+                    "remote git task cache at {} does not contain {}",
+                    display_path(&destination),
+                    repo_structure.path
+                )
+            })
     }
 }
 
@@ -206,9 +249,13 @@ impl TaskFileProvider for RemoteTaskGit {
 
     async fn get_local_path(&self, file: &str) -> Result<PathBuf> {
         let repo_structure = self.get_repo_structure(file);
+        if self.is_cached {
+            return self.get_cached_path(&repo_structure);
+        }
         let cache_key = self.get_cache_key(&repo_structure);
-        let destination = self.storage_path.join(&cache_key);
-        self.fetch_to_destination(&repo_structure, &destination, self.is_cached)
+        let destination = self.unique_artifact_root(&cache_key)?;
+        self.fetch_to_destination(&repo_structure, &destination, false)?
+            .ok_or_else(|| eyre::eyre!("failed to publish remote git task snapshot"))
     }
 
     async fn get_local_artifact(&self, file: &str) -> Result<TaskFileArtifact> {
@@ -232,6 +279,114 @@ impl TaskFileProvider for RemoteTaskGit {
 mod tests {
 
     use super::*;
+    use std::process::Command;
+
+    fn run_git(repo: &std::path::Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn test_repo() -> tempfile::TempDir {
+        let repo = tempfile::tempdir().unwrap();
+        run_git(repo.path(), &["init"]);
+        run_git(repo.path(), &["config", "user.name", "Mise Test"]);
+        run_git(
+            repo.path(),
+            &["config", "user.email", "mise-test@example.com"],
+        );
+        repo
+    }
+
+    fn commit_file(repo: &std::path::Path, path: &str, body: &str) {
+        let path = repo.join(path);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, body).unwrap();
+        run_git(repo, &["add", "."]);
+        run_git(repo, &["commit", "-m", "update task fixture"]);
+    }
+
+    #[test]
+    fn test_cached_missing_path_preserves_published_repo_tree() {
+        let source = test_repo();
+        commit_file(source.path(), "tasks/first", "first revision\n");
+        let source_url = url::Url::from_directory_path(source.path())
+            .unwrap()
+            .to_string();
+        let storage = tempfile::tempdir().unwrap();
+        let provider = RemoteTaskGit {
+            storage_path: storage.path().to_path_buf(),
+            is_cached: true,
+        };
+
+        let first_repo = GitRepoStructure::new(&source_url, "tasks/first", None);
+        let first_path = provider.get_cached_path(&first_repo).unwrap();
+        let cache_key = provider.get_cache_key(&first_repo);
+        let published_repo = storage.path().join(&cache_key);
+        let reader_marker = published_repo.join("reader-marker");
+        std::fs::write(&reader_marker, "live reader state\n").unwrap();
+
+        commit_file(source.path(), "tasks/second", "second revision\n");
+        let second_repo = GitRepoStructure::new(&source_url, "tasks/second", None);
+        let second_path = provider.get_cached_path(&second_repo).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&first_path)
+                .unwrap()
+                .replace("\r\n", "\n"),
+            "first revision\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&reader_marker).unwrap(),
+            "live reader state\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&second_path)
+                .unwrap()
+                .replace("\r\n", "\n"),
+            "second revision\n"
+        );
+        assert!(first_path.starts_with(&published_repo));
+        assert!(!second_path.starts_with(&published_repo));
+
+        commit_file(source.path(), "tasks/second", "third revision\n");
+        let cached_second_path = provider.get_cached_path(&second_repo).unwrap();
+        assert_eq!(cached_second_path, second_path);
+        assert_eq!(
+            std::fs::read_to_string(cached_second_path)
+                .unwrap()
+                .replace("\r\n", "\n"),
+            "second revision\n"
+        );
+    }
+
+    #[test]
+    fn test_missing_path_does_not_publish_invalid_cache_tree() {
+        let source = test_repo();
+        commit_file(source.path(), "tasks/first", "first revision\n");
+        let source_url = url::Url::from_directory_path(source.path())
+            .unwrap()
+            .to_string();
+        let storage = tempfile::tempdir().unwrap();
+        let provider = RemoteTaskGit {
+            storage_path: storage.path().to_path_buf(),
+            is_cached: true,
+        };
+        let missing_repo = GitRepoStructure::new(&source_url, "tasks/missing", None);
+        let destination = storage.path().join(provider.get_cache_key(&missing_repo));
+
+        assert!(provider.get_cached_path(&missing_repo).is_err());
+        assert!(!destination.exists());
+    }
 
     fn parse_ssh(file: &str) -> Option<GitRepoStructure> {
         RemoteSource::parse_git_ssh(file).map(Into::into)
@@ -624,6 +779,13 @@ mod tests {
                 "git::https://dev.azure/org/project/_git/example//myfile?ref=v1.0.0",
                 "git::https://dev.azure/org/project/_git/example//subfolder/myfile?ref=v1.0.0",
                 true,
+            ),
+            // URL and ref need an explicit identity boundary. These otherwise
+            // concatenate to the same text.
+            (
+                "git::https://github.com/example.git//myfile?ref=next.gitmain",
+                "git::https://github.com/example.gitnext.git//myfile?ref=main",
+                false,
             ),
         ];
 

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -1,5 +1,5 @@
 use crate::Result;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 
@@ -69,8 +69,16 @@ impl GitRepoStructure {
 
 impl RemoteTaskGit {
     /// Make fetched task files executable while leaving task include directories intact.
-    fn prepare_remote_path(path: &PathBuf) -> Result<()> {
+    pub(super) fn prepare_remote_path(checkout_root: &Path, path: &Path) -> Result<()> {
         let metadata = path.symlink_metadata()?;
+        let checkout_root = checkout_root.canonicalize()?;
+        let canonical_path = path.canonicalize()?;
+        if !canonical_path.starts_with(&checkout_root) {
+            eyre::bail!(
+                "remote task path escapes its Git checkout: {}",
+                display_path(path)
+            );
+        }
         if metadata.file_type().is_file() {
             return file::make_executable(path);
         }
@@ -138,7 +146,7 @@ impl RemoteTaskGit {
 
         if reuse_existing && full_path.exists() {
             debug!("Using cached file: {:?}", full_path);
-            Self::prepare_remote_path(&full_path)?;
+            Self::prepare_remote_path(destination, &full_path)?;
             return Ok(full_path);
         }
 
@@ -171,7 +179,7 @@ impl RemoteTaskGit {
             }
         }
 
-        Self::prepare_remote_path(&full_path)?;
+        Self::prepare_remote_path(destination, &full_path)?;
         Ok(full_path)
     }
 
@@ -217,7 +225,7 @@ impl TaskFileProvider for RemoteTaskGit {
         let artifact = TaskFileArtifact::temporary(artifact_root.clone(), artifact_root.clone());
         Self::clone_to(&repo_structure, &artifact_root)?;
         let path = artifact_root.join(repo_structure.path);
-        Self::prepare_remote_path(&path)?;
+        Self::prepare_remote_path(&artifact_root, &path)?;
         Ok(artifact.with_path(path))
     }
 }
@@ -252,7 +260,7 @@ mod tests {
         fs::write(&task_file, "#!/usr/bin/env bash\necho ok\n").unwrap();
         fs::set_permissions(&task_file, fs::Permissions::from_mode(0o644)).unwrap();
 
-        RemoteTaskGit::prepare_remote_path(&task_file).unwrap();
+        RemoteTaskGit::prepare_remote_path(temp_dir.path(), &task_file).unwrap();
 
         assert!(file::is_executable(&task_file));
     }
@@ -270,7 +278,7 @@ mod tests {
         fs::set_permissions(&target, fs::Permissions::from_mode(0o644)).unwrap();
         symlink(&target, &task_file).unwrap();
 
-        let error = RemoteTaskGit::prepare_remote_path(&task_file).unwrap_err();
+        let error = RemoteTaskGit::prepare_remote_path(temp_dir.path(), &task_file).unwrap_err();
 
         assert!(error.to_string().contains("not a regular file"));
         assert_eq!(
@@ -283,7 +291,53 @@ mod tests {
     fn test_prepare_remote_path_allows_task_include_directory() {
         let temp_dir = tempfile::tempdir().unwrap();
 
-        RemoteTaskGit::prepare_remote_path(&temp_dir.path().to_path_buf()).unwrap();
+        RemoteTaskGit::prepare_remote_path(temp_dir.path(), temp_dir.path()).unwrap();
+    }
+
+    #[test]
+    fn test_prepare_remote_path_rejects_path_outside_checkout() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let checkout = temp_dir.path().join("checkout");
+        let outside = temp_dir.path().join("outside-task");
+        std::fs::create_dir(&checkout).unwrap();
+        std::fs::write(&outside, "#!/usr/bin/env bash\necho outside\n").unwrap();
+
+        let escaped_path = checkout.join("..").join("outside-task");
+        let error = RemoteTaskGit::prepare_remote_path(&checkout, &escaped_path).unwrap_err();
+
+        assert!(error.to_string().contains("escapes its Git checkout"));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_prepare_remote_path_rejects_windows_backslash_escape() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let checkout = temp_dir.path().join("checkout");
+        let outside = temp_dir.path().join("outside-task");
+        std::fs::create_dir(&checkout).unwrap();
+        std::fs::write(&outside, "echo outside\n").unwrap();
+
+        let escaped_path = checkout.join(r"..\outside-task");
+        let error = RemoteTaskGit::prepare_remote_path(&checkout, &escaped_path).unwrap_err();
+
+        assert!(error.to_string().contains("escapes its Git checkout"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_prepare_remote_path_rejects_intermediate_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let checkout = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let outside_task = outside.path().join("task");
+        std::fs::write(&outside_task, "#!/usr/bin/env bash\necho outside\n").unwrap();
+        symlink(outside.path(), checkout.path().join("linked-dir")).unwrap();
+
+        let escaped_path = checkout.path().join("linked-dir/task");
+        let error = RemoteTaskGit::prepare_remote_path(checkout.path(), &escaped_path).unwrap_err();
+
+        assert!(error.to_string().contains("escapes its Git checkout"));
     }
 
     #[test]

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -174,16 +174,6 @@ impl RemoteTaskGit {
         Self::prepare_remote_path(&full_path)?;
         Ok(full_path)
     }
-
-    #[cfg(test)]
-    fn parse_ssh(file: &str) -> Option<GitRepoStructure> {
-        RemoteSource::parse_git_ssh(file).map(|source| source.into())
-    }
-
-    #[cfg(test)]
-    fn parse_https(file: &str) -> Option<GitRepoStructure> {
-        RemoteSource::parse_git_https(file).map(|source| source.into())
-    }
 }
 
 impl From<RemoteGitSource> for GitRepoStructure {
@@ -226,6 +216,14 @@ impl TaskFileProvider for RemoteTaskGit {
 mod tests {
 
     use super::*;
+
+    fn parse_ssh(file: &str) -> Option<GitRepoStructure> {
+        RemoteSource::parse_git_ssh(file).map(Into::into)
+    }
+
+    fn parse_https(file: &str) -> Option<GitRepoStructure> {
+        RemoteSource::parse_git_https(file).map(Into::into)
+    }
 
     #[test]
     fn test_unique_artifact_root_remains_reserved_for_clone() {
@@ -307,11 +305,7 @@ mod tests {
         ];
 
         for url in test_cases {
-            assert!(
-                RemoteTaskGit::parse_ssh(url).is_some(),
-                "Failed for: {}",
-                url
-            );
+            assert!(parse_ssh(url).is_some(), "Failed for: {}", url);
         }
     }
 
@@ -329,11 +323,7 @@ mod tests {
         ];
 
         for url in test_cases {
-            assert!(
-                RemoteTaskGit::parse_ssh(url).is_none(),
-                "Should fail for: {}",
-                url
-            );
+            assert!(parse_ssh(url).is_none(), "Should fail for: {}", url);
         }
     }
 
@@ -355,11 +345,7 @@ mod tests {
         ];
 
         for url in test_cases {
-            assert!(
-                RemoteTaskGit::parse_https(url).is_some(),
-                "Failed for: {}",
-                url
-            );
+            assert!(parse_https(url).is_some(), "Failed for: {}", url);
         }
     }
 
@@ -376,11 +362,7 @@ mod tests {
         ];
 
         for url in test_cases {
-            assert!(
-                RemoteTaskGit::parse_https(url).is_none(),
-                "Should fail for: {}",
-                url
-            );
+            assert!(parse_https(url).is_none(), "Should fail for: {}", url);
         }
     }
 
@@ -444,7 +426,7 @@ mod tests {
         ];
 
         for (url, expected_repo, expected_path, expected_branch) in test_cases {
-            let repo = RemoteTaskGit::parse_ssh(url).unwrap();
+            let repo = parse_ssh(url).unwrap();
             assert_eq!(expected_repo, repo.url_without_path);
             assert_eq!(expected_path, repo.path);
             assert_eq!(expected_branch, repo.branch);
@@ -493,7 +475,7 @@ mod tests {
         ];
 
         for (url, expected_repo, expected_path, expected_branch) in test_cases {
-            let repo = RemoteTaskGit::parse_https(url).unwrap();
+            let repo = parse_https(url).unwrap();
             assert_eq!(expected_repo, repo.url_without_path);
             assert_eq!(expected_path, repo.path);
             assert_eq!(expected_branch, repo.branch);
@@ -538,8 +520,8 @@ mod tests {
         ];
 
         for (first_url, second_url, expected) in test_cases {
-            let first_repo = RemoteTaskGit::parse_ssh(first_url).unwrap();
-            let second_repo = RemoteTaskGit::parse_ssh(second_url).unwrap();
+            let first_repo = parse_ssh(first_url).unwrap();
+            let second_repo = parse_ssh(second_url).unwrap();
             let first_cache_key = remote_task_git.get_cache_key(&first_repo);
             let second_cache_key = remote_task_git.get_cache_key(&second_repo);
             assert_eq!(expected, first_cache_key == second_cache_key);
@@ -584,8 +566,8 @@ mod tests {
         ];
 
         for (first_url, second_url, expected) in test_cases {
-            let first_repo = RemoteTaskGit::parse_https(first_url).unwrap();
-            let second_repo = RemoteTaskGit::parse_https(second_url).unwrap();
+            let first_repo = parse_https(first_url).unwrap();
+            let second_repo = parse_https(second_url).unwrap();
             let first_cache_key = remote_task_git.get_cache_key(&first_repo);
             let second_cache_key = remote_task_git.get_cache_key(&second_repo);
             assert_eq!(expected, first_cache_key == second_cache_key);

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -1,5 +1,5 @@
 use crate::Result;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 
@@ -68,19 +68,35 @@ impl GitRepoStructure {
 }
 
 impl RemoteTaskGit {
-    /// Make fetched task files executable while leaving task include directories intact.
-    fn prepare_remote_path(path: &PathBuf) -> Result<()> {
+    pub(super) fn validate_remote_path(
+        checkout_root: &Path,
+        path: &Path,
+    ) -> Result<std::fs::Metadata> {
         let metadata = path.symlink_metadata()?;
-        if metadata.file_type().is_file() {
-            return file::make_executable(path);
+        let checkout_root = checkout_root.canonicalize()?;
+        let canonical_path = path.canonicalize()?;
+        if !canonical_path.starts_with(&checkout_root) {
+            eyre::bail!(
+                "remote task path escapes its Git checkout: {}",
+                display_path(path)
+            );
         }
-        if metadata.file_type().is_dir() {
-            return Ok(());
+        if metadata.file_type().is_file() || metadata.file_type().is_dir() {
+            return Ok(metadata);
         }
         eyre::bail!(
             "remote task path is not a regular file or directory: {}",
             display_path(path)
         )
+    }
+
+    /// Make fetched task files executable while leaving task include directories intact.
+    fn prepare_remote_path(checkout_root: &Path, path: &Path) -> Result<()> {
+        let metadata = Self::validate_remote_path(checkout_root, path)?;
+        if metadata.file_type().is_file() {
+            file::make_executable(path)?;
+        }
+        Ok(())
     }
 
     fn get_cache_key(&self, repo_structure: &GitRepoStructure) -> String {
@@ -138,7 +154,7 @@ impl RemoteTaskGit {
 
         if reuse_existing && full_path.exists() {
             debug!("Using cached file: {:?}", full_path);
-            Self::prepare_remote_path(&full_path)?;
+            Self::prepare_remote_path(destination, &full_path)?;
             return Ok(full_path);
         }
 
@@ -171,7 +187,7 @@ impl RemoteTaskGit {
             }
         }
 
-        Self::prepare_remote_path(&full_path)?;
+        Self::prepare_remote_path(destination, &full_path)?;
         Ok(full_path)
     }
 }
@@ -207,7 +223,7 @@ impl TaskFileProvider for RemoteTaskGit {
         let artifact = TaskFileArtifact::temporary(artifact_root.clone(), artifact_root.clone());
         Self::clone_to(&repo_structure, &artifact_root)?;
         let path = artifact_root.join(repo_structure.path);
-        Self::prepare_remote_path(&path)?;
+        Self::prepare_remote_path(&artifact_root, &path)?;
         Ok(artifact.with_path(path))
     }
 }
@@ -250,7 +266,7 @@ mod tests {
         fs::write(&task_file, "#!/usr/bin/env bash\necho ok\n").unwrap();
         fs::set_permissions(&task_file, fs::Permissions::from_mode(0o644)).unwrap();
 
-        RemoteTaskGit::prepare_remote_path(&task_file).unwrap();
+        RemoteTaskGit::prepare_remote_path(temp_dir.path(), &task_file).unwrap();
 
         assert!(file::is_executable(&task_file));
     }
@@ -268,7 +284,7 @@ mod tests {
         fs::set_permissions(&target, fs::Permissions::from_mode(0o644)).unwrap();
         symlink(&target, &task_file).unwrap();
 
-        let error = RemoteTaskGit::prepare_remote_path(&task_file).unwrap_err();
+        let error = RemoteTaskGit::prepare_remote_path(temp_dir.path(), &task_file).unwrap_err();
 
         assert!(error.to_string().contains("not a regular file"));
         assert_eq!(
@@ -281,7 +297,53 @@ mod tests {
     fn test_prepare_remote_path_allows_task_include_directory() {
         let temp_dir = tempfile::tempdir().unwrap();
 
-        RemoteTaskGit::prepare_remote_path(&temp_dir.path().to_path_buf()).unwrap();
+        RemoteTaskGit::prepare_remote_path(temp_dir.path(), temp_dir.path()).unwrap();
+    }
+
+    #[test]
+    fn test_prepare_remote_path_rejects_path_outside_checkout() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let checkout = temp_dir.path().join("checkout");
+        let outside = temp_dir.path().join("outside-task");
+        std::fs::create_dir(&checkout).unwrap();
+        std::fs::write(&outside, "#!/usr/bin/env bash\necho outside\n").unwrap();
+
+        let escaped_path = checkout.join("..").join("outside-task");
+        let error = RemoteTaskGit::prepare_remote_path(&checkout, &escaped_path).unwrap_err();
+
+        assert!(error.to_string().contains("escapes its Git checkout"));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_prepare_remote_path_rejects_windows_backslash_escape() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let checkout = temp_dir.path().join("checkout");
+        let outside = temp_dir.path().join("outside-task");
+        std::fs::create_dir(&checkout).unwrap();
+        std::fs::write(&outside, "echo outside\n").unwrap();
+
+        let escaped_path = checkout.join(r"..\outside-task");
+        let error = RemoteTaskGit::prepare_remote_path(&checkout, &escaped_path).unwrap_err();
+
+        assert!(error.to_string().contains("escapes its Git checkout"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_prepare_remote_path_rejects_intermediate_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let checkout = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let outside_task = outside.path().join("task");
+        std::fs::write(&outside_task, "#!/usr/bin/env bash\necho outside\n").unwrap();
+        symlink(outside.path(), checkout.path().join("linked-dir")).unwrap();
+
+        let escaped_path = checkout.path().join("linked-dir/task");
+        let error = RemoteTaskGit::prepare_remote_path(checkout.path(), &escaped_path).unwrap_err();
+
+        assert!(error.to_string().contains("escapes its Git checkout"));
     }
 
     #[test]

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -1,5 +1,5 @@
 use crate::Result;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use async_trait::async_trait;
 
@@ -69,16 +69,8 @@ impl GitRepoStructure {
 
 impl RemoteTaskGit {
     /// Make fetched task files executable while leaving task include directories intact.
-    pub(super) fn prepare_remote_path(checkout_root: &Path, path: &Path) -> Result<()> {
+    fn prepare_remote_path(path: &PathBuf) -> Result<()> {
         let metadata = path.symlink_metadata()?;
-        let checkout_root = checkout_root.canonicalize()?;
-        let canonical_path = path.canonicalize()?;
-        if !canonical_path.starts_with(&checkout_root) {
-            eyre::bail!(
-                "remote task path escapes its Git checkout: {}",
-                display_path(path)
-            );
-        }
         if metadata.file_type().is_file() {
             return file::make_executable(path);
         }
@@ -146,7 +138,7 @@ impl RemoteTaskGit {
 
         if reuse_existing && full_path.exists() {
             debug!("Using cached file: {:?}", full_path);
-            Self::prepare_remote_path(destination, &full_path)?;
+            Self::prepare_remote_path(&full_path)?;
             return Ok(full_path);
         }
 
@@ -179,7 +171,7 @@ impl RemoteTaskGit {
             }
         }
 
-        Self::prepare_remote_path(destination, &full_path)?;
+        Self::prepare_remote_path(&full_path)?;
         Ok(full_path)
     }
 
@@ -225,7 +217,7 @@ impl TaskFileProvider for RemoteTaskGit {
         let artifact = TaskFileArtifact::temporary(artifact_root.clone(), artifact_root.clone());
         Self::clone_to(&repo_structure, &artifact_root)?;
         let path = artifact_root.join(repo_structure.path);
-        Self::prepare_remote_path(&artifact_root, &path)?;
+        Self::prepare_remote_path(&path)?;
         Ok(artifact.with_path(path))
     }
 }
@@ -260,7 +252,7 @@ mod tests {
         fs::write(&task_file, "#!/usr/bin/env bash\necho ok\n").unwrap();
         fs::set_permissions(&task_file, fs::Permissions::from_mode(0o644)).unwrap();
 
-        RemoteTaskGit::prepare_remote_path(temp_dir.path(), &task_file).unwrap();
+        RemoteTaskGit::prepare_remote_path(&task_file).unwrap();
 
         assert!(file::is_executable(&task_file));
     }
@@ -278,7 +270,7 @@ mod tests {
         fs::set_permissions(&target, fs::Permissions::from_mode(0o644)).unwrap();
         symlink(&target, &task_file).unwrap();
 
-        let error = RemoteTaskGit::prepare_remote_path(temp_dir.path(), &task_file).unwrap_err();
+        let error = RemoteTaskGit::prepare_remote_path(&task_file).unwrap_err();
 
         assert!(error.to_string().contains("not a regular file"));
         assert_eq!(
@@ -291,53 +283,7 @@ mod tests {
     fn test_prepare_remote_path_allows_task_include_directory() {
         let temp_dir = tempfile::tempdir().unwrap();
 
-        RemoteTaskGit::prepare_remote_path(temp_dir.path(), temp_dir.path()).unwrap();
-    }
-
-    #[test]
-    fn test_prepare_remote_path_rejects_path_outside_checkout() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let checkout = temp_dir.path().join("checkout");
-        let outside = temp_dir.path().join("outside-task");
-        std::fs::create_dir(&checkout).unwrap();
-        std::fs::write(&outside, "#!/usr/bin/env bash\necho outside\n").unwrap();
-
-        let escaped_path = checkout.join("..").join("outside-task");
-        let error = RemoteTaskGit::prepare_remote_path(&checkout, &escaped_path).unwrap_err();
-
-        assert!(error.to_string().contains("escapes its Git checkout"));
-    }
-
-    #[test]
-    #[cfg(windows)]
-    fn test_prepare_remote_path_rejects_windows_backslash_escape() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let checkout = temp_dir.path().join("checkout");
-        let outside = temp_dir.path().join("outside-task");
-        std::fs::create_dir(&checkout).unwrap();
-        std::fs::write(&outside, "echo outside\n").unwrap();
-
-        let escaped_path = checkout.join(r"..\outside-task");
-        let error = RemoteTaskGit::prepare_remote_path(&checkout, &escaped_path).unwrap_err();
-
-        assert!(error.to_string().contains("escapes its Git checkout"));
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn test_prepare_remote_path_rejects_intermediate_symlink_escape() {
-        use std::os::unix::fs::symlink;
-
-        let checkout = tempfile::tempdir().unwrap();
-        let outside = tempfile::tempdir().unwrap();
-        let outside_task = outside.path().join("task");
-        std::fs::write(&outside_task, "#!/usr/bin/env bash\necho outside\n").unwrap();
-        symlink(outside.path(), checkout.path().join("linked-dir")).unwrap();
-
-        let escaped_path = checkout.path().join("linked-dir/task");
-        let error = RemoteTaskGit::prepare_remote_path(checkout.path(), &escaped_path).unwrap_err();
-
-        assert!(error.to_string().contains("escapes its Git checkout"));
+        RemoteTaskGit::prepare_remote_path(&temp_dir.path().to_path_buf()).unwrap();
     }
 
     #[test]

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -12,7 +12,7 @@ use crate::{
     remote_source::{RemoteGitSource, RemoteSource},
 };
 
-use super::TaskFileProvider;
+use super::{TaskFileArtifact, TaskFileProvider};
 
 #[derive(Debug)]
 pub struct RemoteTaskGitBuilder {
@@ -98,6 +98,83 @@ impl RemoteTaskGit {
             .unwrap()
     }
 
+    fn unique_artifact_root(&self, cache_key: &str) -> Result<PathBuf> {
+        file::create_dir_all(&self.storage_path)?;
+        let temp_dir = tempfile::Builder::new()
+            .prefix(&format!("{cache_key}-"))
+            .tempdir_in(&self.storage_path)?;
+        Ok(temp_dir.keep())
+    }
+
+    fn clone_to(repo_structure: &GitRepoStructure, destination: &PathBuf) -> Result<()> {
+        let git_repo = git::Git::new(destination);
+        let mut clone_options = CloneOptions::default();
+        if let Some(branch) = &repo_structure.branch {
+            trace!("Use specific branch {}", branch);
+            clone_options = clone_options.branch(branch);
+        }
+        git_repo.clone(repo_structure.url_without_path.as_str(), clone_options)
+    }
+
+    fn fetch_to_destination(
+        &self,
+        repo_structure: &GitRepoStructure,
+        destination: &PathBuf,
+        reuse_existing: bool,
+    ) -> Result<PathBuf> {
+        let repo_file_path = repo_structure.path.clone();
+        let full_path = destination.join(&repo_file_path);
+
+        debug!("Repo structure: {:?}", repo_structure);
+
+        let _lock = LockFile::new(destination)
+            .with_callback(|l| {
+                debug!(
+                    "waiting for lock on remote git task cache: {}",
+                    display_path(l)
+                );
+            })
+            .lock()?;
+
+        if reuse_existing && full_path.exists() {
+            debug!("Using cached file: {:?}", full_path);
+            Self::prepare_remote_path(&full_path)?;
+            return Ok(full_path);
+        }
+
+        let mut tmp_destination = destination.as_os_str().to_os_string();
+        tmp_destination.push(".clone-tmp");
+        let tmp_destination = PathBuf::from(tmp_destination);
+        if tmp_destination.exists() {
+            crate::file::remove_all(&tmp_destination)?;
+        }
+
+        match Self::clone_to(repo_structure, &tmp_destination) {
+            Ok(()) => {
+                if destination.exists()
+                    && let Err(e) = crate::file::remove_all(destination)
+                {
+                    let _ = crate::file::remove_all(&tmp_destination);
+                    return Err(e);
+                }
+                if let Err(e) = std::fs::rename(&tmp_destination, destination) {
+                    let _ = crate::file::remove_all(&tmp_destination);
+                    return Err(eyre::eyre!(
+                        "failed to move cloned repo into cache at {}: {e}",
+                        display_path(destination)
+                    ));
+                }
+            }
+            Err(e) => {
+                let _ = crate::file::remove_all(&tmp_destination);
+                return Err(e);
+            }
+        }
+
+        Self::prepare_remote_path(&full_path)?;
+        Ok(full_path)
+    }
+
     #[cfg(test)]
     fn parse_ssh(file: &str) -> Option<GitRepoStructure> {
         RemoteSource::parse_git_ssh(file).map(|source| source.into())
@@ -125,69 +202,23 @@ impl TaskFileProvider for RemoteTaskGit {
         let repo_structure = self.get_repo_structure(file);
         let cache_key = self.get_cache_key(&repo_structure);
         let destination = self.storage_path.join(&cache_key);
-        let repo_file_path = repo_structure.path.clone();
-        let full_path = destination.join(&repo_file_path);
+        self.fetch_to_destination(&repo_structure, &destination, self.is_cached)
+    }
 
-        debug!("Repo structure: {:?}", repo_structure);
-
-        let _lock = LockFile::new(&destination)
-            .with_callback(|l| {
-                debug!(
-                    "waiting for lock on remote git task cache: {}",
-                    display_path(l)
-                );
-            })
-            .lock()?;
-
+    async fn get_local_artifact(&self, file: &str) -> Result<TaskFileArtifact> {
         if self.is_cached {
-            trace!("Cache mode enabled");
-            if full_path.exists() {
-                debug!("Using cached file: {:?}", full_path);
-                Self::prepare_remote_path(&full_path)?;
-                return Ok(full_path);
-            }
-        } else {
-            trace!("Cache mode disabled");
+            return Ok(TaskFileArtifact::persistent(
+                self.get_local_path(file).await?,
+            ));
         }
-
-        let tmp_destination = self.storage_path.join(format!("{}.clone-tmp", cache_key));
-        if tmp_destination.exists() {
-            crate::file::remove_all(&tmp_destination)?;
-        }
-
-        let git_repo = git::Git::new(&tmp_destination);
-
-        let mut clone_options = CloneOptions::default();
-
-        if let Some(branch) = &repo_structure.branch {
-            trace!("Use specific branch {}", branch);
-            clone_options = clone_options.branch(branch);
-        }
-
-        match git_repo.clone(repo_structure.url_without_path.as_str(), clone_options) {
-            Ok(()) => {
-                if destination.exists()
-                    && let Err(e) = crate::file::remove_all(&destination)
-                {
-                    let _ = crate::file::remove_all(&tmp_destination);
-                    return Err(e);
-                }
-                if let Err(e) = std::fs::rename(&tmp_destination, &destination) {
-                    let _ = crate::file::remove_all(&tmp_destination);
-                    return Err(eyre::eyre!(
-                        "failed to move cloned repo into cache at {}: {e}",
-                        display_path(&destination)
-                    ));
-                }
-            }
-            Err(e) => {
-                let _ = crate::file::remove_all(&tmp_destination);
-                return Err(e);
-            }
-        }
-
-        Self::prepare_remote_path(&full_path)?;
-        Ok(full_path)
+        let repo_structure = self.get_repo_structure(file);
+        let cache_key = self.get_cache_key(&repo_structure);
+        let artifact_root = self.unique_artifact_root(&cache_key)?;
+        let artifact = TaskFileArtifact::temporary(artifact_root.clone(), artifact_root.clone());
+        Self::clone_to(&repo_structure, &artifact_root)?;
+        let path = artifact_root.join(repo_structure.path);
+        Self::prepare_remote_path(&path)?;
+        Ok(artifact.with_path(path))
     }
 }
 
@@ -195,6 +226,20 @@ impl TaskFileProvider for RemoteTaskGit {
 mod tests {
 
     use super::*;
+
+    #[test]
+    fn test_unique_artifact_root_remains_reserved_for_clone() {
+        let storage = tempfile::tempdir().unwrap();
+        let provider = RemoteTaskGit {
+            storage_path: storage.path().to_path_buf(),
+            is_cached: false,
+        };
+
+        let artifact_root = provider.unique_artifact_root("cache-key").unwrap();
+
+        assert!(artifact_root.is_dir());
+        assert_eq!(std::fs::read_dir(&artifact_root).unwrap().count(), 0);
+    }
 
     #[test]
     #[cfg(unix)]

--- a/src/task/task_file_providers/remote_task_http.rs
+++ b/src/task/task_file_providers/remote_task_http.rs
@@ -2,7 +2,9 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 
-use crate::{Result, dirs, env, file, hash, http::HTTP, remote_source::RemoteSource};
+use crate::{
+    Result, dirs, env, file, hash, http::HTTP, lock_file::LockFile, remote_source::RemoteSource,
+};
 
 use super::{TaskFileArtifact, TaskFileProvider};
 
@@ -54,6 +56,28 @@ impl RemoteTaskHttp {
         Ok(())
     }
 
+    fn temp_download_path(destination: &PathBuf) -> PathBuf {
+        let mut path = destination.as_os_str().to_os_string();
+        path.push(".download-tmp");
+        path.into()
+    }
+
+    async fn download_file_atomically(&self, file: &str, destination: &PathBuf) -> Result<()> {
+        let temp = Self::temp_download_path(destination);
+        if temp.exists() {
+            file::remove_file(&temp)?;
+        }
+        if let Err(error) = self.download_file(file, &temp).await {
+            let _ = file::remove_file(&temp);
+            return Err(error);
+        }
+        if let Err(error) = file::rename(&temp, destination) {
+            let _ = file::remove_file(&temp);
+            return Err(error);
+        }
+        Ok(())
+    }
+
     async fn get_unique_artifact(&self, file: &str) -> Result<TaskFileArtifact> {
         let cache_key = self.get_cache_key(file);
         file::create_dir_all(&self.storage_path)?;
@@ -77,25 +101,22 @@ impl TaskFileProvider for RemoteTaskHttp {
     async fn get_local_path(&self, file: &str) -> Result<PathBuf> {
         let cache_key = self.get_cache_key(file);
         let destination = self.storage_path.join(&cache_key);
-
-        match self.is_cached {
-            true => {
-                trace!("Cache mode enabled");
-
-                if destination.exists() {
-                    debug!("Using cached file: {:?}", destination);
-                    return Ok(destination);
-                }
+        if self.is_cached {
+            trace!("Cache mode enabled");
+            file::create_dir_all(&self.storage_path)?;
+            let _lock = LockFile::new(&destination).lock()?;
+            if destination.exists() {
+                debug!("Using cached file: {:?}", destination);
+                return Ok(destination);
             }
-            false => {
-                trace!("Cache mode disabled");
-
-                if destination.exists() {
-                    file::remove_file(&destination)?;
-                }
-            }
+            self.download_file_atomically(file, &destination).await?;
+            return Ok(destination);
         }
 
+        trace!("Cache mode disabled");
+        if destination.exists() {
+            file::remove_file(&destination)?;
+        }
         self.download_file(file, &destination).await?;
         Ok(destination)
     }
@@ -271,6 +292,29 @@ mod tests {
         assert!(fetch.await.unwrap_err().is_cancelled());
         release.store(true, Ordering::SeqCst);
         assert_eq!(std::fs::read_dir(storage.path()).unwrap().count(), 0);
+        remote.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_cached_download_failure_leaves_no_partial_file() {
+        let mut server = mockito::Server::new_async().await;
+        let remote = server
+            .mock("GET", "/task")
+            .with_status(500)
+            .expect(4)
+            .create_async()
+            .await;
+        let storage = tempfile::tempdir().unwrap();
+        let provider = RemoteTaskHttp {
+            storage_path: storage.path().to_path_buf(),
+            is_cached: true,
+        };
+        let request_url = format!("{}/task", server.url());
+        let destination = storage.path().join(provider.get_cache_key(&request_url));
+
+        assert!(provider.get_local_path(&request_url).await.is_err());
+        assert!(!destination.exists());
+        assert!(!RemoteTaskHttp::temp_download_path(&destination).exists());
         remote.assert_async().await;
     }
 }

--- a/src/task/task_file_providers/remote_task_http.rs
+++ b/src/task/task_file_providers/remote_task_http.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 
@@ -49,20 +49,20 @@ impl RemoteTaskHttp {
         hash::hash_sha256_to_str(file)
     }
 
-    async fn download_file(&self, file: &str, destination: &PathBuf) -> Result<()> {
+    async fn download_file(&self, file: &str, destination: &Path) -> Result<()> {
         trace!("Downloading file: {}", file);
         HTTP.download_file(file, destination, None).await?;
         file::make_executable(destination)?;
         Ok(())
     }
 
-    fn temp_download_path(destination: &PathBuf) -> PathBuf {
+    fn temp_download_path(destination: &Path) -> PathBuf {
         let mut path = destination.as_os_str().to_os_string();
         path.push(".download-tmp");
         path.into()
     }
 
-    async fn download_file_atomically(&self, file: &str, destination: &PathBuf) -> Result<()> {
+    async fn download_file_atomically(&self, file: &str, destination: &Path) -> Result<()> {
         let temp = Self::temp_download_path(destination);
         if temp.exists() {
             file::remove_file(&temp)?;
@@ -114,10 +114,9 @@ impl TaskFileProvider for RemoteTaskHttp {
         }
 
         trace!("Cache mode disabled");
-        if destination.exists() {
-            file::remove_file(&destination)?;
-        }
-        self.download_file(file, &destination).await?;
+        file::create_dir_all(&self.storage_path)?;
+        let _lock = LockFile::new(&destination).lock()?;
+        self.download_file_atomically(file, &destination).await?;
         Ok(destination)
     }
 
@@ -154,7 +153,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_http_remote_task_get_local_path_without_cache() {
+    async fn test_http_remote_task_get_local_artifact_without_cache() {
         let paths = vec![
             "/myfile.py",
             "/subpath/myfile.sh",

--- a/src/task/task_file_providers/remote_task_http.rs
+++ b/src/task/task_file_providers/remote_task_http.rs
@@ -311,10 +311,12 @@ mod tests {
         };
         let request_url = format!("{}/task", server.url());
         let destination = storage.path().join(provider.get_cache_key(&request_url));
+        let temp_destination = RemoteTaskHttp::temp_download_path(&destination);
+        std::fs::write(&temp_destination, b"partial download").unwrap();
 
         assert!(provider.get_local_path(&request_url).await.is_err());
         assert!(!destination.exists());
-        assert!(!RemoteTaskHttp::temp_download_path(&destination).exists());
+        assert!(!temp_destination.exists());
         remote.assert_async().await;
     }
 }

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -413,6 +413,17 @@ pub async fn get_task_lists(
     only: bool,
     prompt_all: bool,
 ) -> Result<Vec<Task>> {
+    get_task_lists_with_no_cache(config, args, prompt, only, prompt_all, false).await
+}
+
+pub async fn get_task_lists_with_no_cache(
+    config: &Arc<Config>,
+    args: &[String],
+    prompt: bool,
+    only: bool,
+    prompt_all: bool,
+    no_cache: bool,
+) -> Result<Vec<Task>> {
     if prompt_all {
         let mut task = prompt_for_task(config, true).await?;
         if only {
@@ -520,9 +531,11 @@ pub async fn get_task_lists(
         };
 
         let all_tasks = if let Some(ref ctx) = effective_context {
-            config.tasks_with_context(Some(ctx)).await?
+            config
+                .tasks_with_context_no_cache(Some(ctx), no_cache)
+                .await?
         } else {
-            config.tasks().await?
+            config.tasks_with_context_no_cache(None, no_cache).await?
         };
 
         let find_matching_tasks =
@@ -591,7 +604,11 @@ pub async fn get_task_lists(
 
 /// Resolve all dependencies for a list of tasks
 /// Iteratively discovers path hints by loading tasks and their dependencies
-pub async fn resolve_depends(config: &Arc<Config>, tasks: Vec<Task>) -> Result<Vec<Task>> {
+pub async fn resolve_depends_with_no_cache(
+    config: &Arc<Config>,
+    tasks: Vec<Task>,
+    no_cache: bool,
+) -> Result<Vec<Task>> {
     // Iteratively discover all path hints by loading tasks and their dependencies
     // This handles chains like: //A:B -> :C -> :D -> //E:F where we need to discover E
     let mut all_path_hints = HashSet::new();
@@ -631,7 +648,9 @@ pub async fn resolve_depends(config: &Arc<Config>, tasks: Vec<Task>) -> Result<V
             load_all: false,
         });
 
-        let loaded_tasks = config.tasks_with_context(ctx.as_ref()).await?;
+        let loaded_tasks = config
+            .tasks_with_context_no_cache(ctx.as_ref(), no_cache)
+            .await?;
 
         // Find new tasks that haven't been processed yet
         tasks_to_process = loaded_tasks
@@ -651,7 +670,9 @@ pub async fn resolve_depends(config: &Arc<Config>, tasks: Vec<Task>) -> Result<V
         None
     };
 
-    let all_tasks = config.tasks_with_context(ctx.as_ref()).await?;
+    let all_tasks = config
+        .tasks_with_context_no_cache(ctx.as_ref(), no_cache)
+        .await?;
 
     let resolve = |all_tasks: &BTreeMap<String, Task>| {
         tasks

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -1,5 +1,6 @@
 use crate::config::{self, Config};
 use crate::file::display_path;
+use crate::task::task_fetcher::TaskFetcher;
 use crate::task::{
     GetMatchingExt, Task, TaskLoadContext, extract_monorepo_path, is_workspace_project_task,
     resolve_task_pattern,
@@ -524,25 +525,38 @@ pub async fn get_task_lists(
             config.tasks().await?
         };
 
-        let tasks_with_aliases = crate::task::build_task_ref_map(all_tasks.iter());
+        let find_matching_tasks =
+            |tasks_with_aliases: &BTreeMap<String, &Task>| -> Result<Vec<Task>> {
+                let mut matches = tasks_with_aliases
+                    .get_matching(&t)?
+                    .into_iter()
+                    .map(|task| (**task).clone())
+                    .collect_vec();
+                if matches.is_empty()
+                    && t != original_name
+                    && !original_name.starts_with("//")
+                    && !original_name.starts_with(':')
+                {
+                    matches = tasks_with_aliases
+                        .get_matching(&original_name)?
+                        .into_iter()
+                        .map(|task| (**task).clone())
+                        .collect_vec();
+                }
+                Ok(matches)
+            };
 
-        let mut cur_tasks = tasks_with_aliases
-            .get_matching(&t)?
-            .into_iter()
-            .cloned()
-            .collect_vec();
-        // If the task name was auto-expanded to monorepo syntax (e.g., "hello" -> "//:hello")
-        // but no monorepo task matched, fall back to the original bare name to find global tasks
-        if cur_tasks.is_empty()
-            && t != original_name
-            && !original_name.starts_with("//")
-            && !original_name.starts_with(':')
-        {
-            cur_tasks = tasks_with_aliases
-                .get_matching(&original_name)?
-                .into_iter()
-                .cloned()
-                .collect_vec();
+        let tasks_with_aliases = crate::task::build_task_ref_map(all_tasks.iter());
+        let mut cur_tasks = find_matching_tasks(&tasks_with_aliases)?;
+        if cur_tasks.is_empty() {
+            // Remote aliases exist only after parsing their headers. A miss is
+            // passive discovery, so require trust before fetching them.
+            let resolved_tasks = TaskFetcher::new(false)
+                .require_trust_before_fetch()
+                .fetch_task_map(config, &all_tasks)
+                .await?;
+            let resolved_with_aliases = crate::task::build_task_ref_map(resolved_tasks.iter());
+            cur_tasks = find_matching_tasks(&resolved_with_aliases)?;
         }
         if cur_tasks.is_empty() {
             // Check if this is a "default" task (either plain "default" or monorepo syntax like "//:default")
@@ -639,12 +653,31 @@ pub async fn resolve_depends(config: &Arc<Config>, tasks: Vec<Task>) -> Result<V
 
     let all_tasks = config.tasks_with_context(ctx.as_ref()).await?;
 
-    tasks
-        .into_iter()
-        .map(|t| {
-            let depends = t.all_depends(&all_tasks)?;
-            Ok(once(t).chain(depends).collect::<Vec<_>>())
-        })
-        .flatten_ok()
-        .collect()
+    let resolve = |all_tasks: &BTreeMap<String, Task>| {
+        tasks
+            .iter()
+            .cloned()
+            .map(|task| {
+                let depends = task.all_depends(all_tasks)?;
+                Ok(once(task).chain(depends).collect::<Vec<_>>())
+            })
+            .flatten_ok()
+            .collect::<Result<Vec<_>>>()
+    };
+
+    match resolve(&all_tasks) {
+        Ok(tasks) => Ok(tasks),
+        Err(error)
+            if error
+                .downcast_ref::<crate::task::TaskNotFoundError>()
+                .is_some() =>
+        {
+            let resolved_tasks = TaskFetcher::new(false)
+                .require_trust_before_fetch()
+                .fetch_task_map(config, &all_tasks)
+                .await?;
+            resolve(&resolved_tasks)
+        }
+        Err(error) => Err(error),
+    }
 }

--- a/src/task/task_tool_installer.rs
+++ b/src/task/task_tool_installer.rs
@@ -225,6 +225,7 @@ impl<'a> TaskToolInstaller<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::task::Task;
 
     #[test]
     fn test_task_tool_installer_new() {
@@ -232,5 +233,23 @@ mod tests {
         let cli_tools: Vec<ToolArg> = vec![];
         let installer = TaskToolInstaller::new(&context_builder, &cli_tools);
         assert_eq!(installer.cli_tools.len(), 0);
+    }
+
+    #[test]
+    fn test_remote_tool_metadata_without_provenance_fails_closed() {
+        let task = Task {
+            name: "remote".into(),
+            remote_file_source: Some("https://example.com/task".into()),
+            remote_metadata_has_tools: true,
+            ..Default::default()
+        };
+
+        let error = task.tool_args().unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("tool metadata without defining config provenance")
+        );
     }
 }


### PR DESCRIPTION
Replaces the auto-closed #11203.

## Work order

1. #12254 — contain remote Git task paths (independent)
2. #12202 — require trust before remote metadata discovery
3. #12256 — guard remote metadata side effects
4. #12257 — resolve trusted metadata in task commands
5. This PR — harden cache lifecycle after the trust stack is merged and rebased

This branch has intentionally not been rebased as part of the split. Rebase it after the preceding trust stack lands.

## Summary

- publish remote HTTP task downloads atomically under a lock so readers never observe partial cache files
- coalesce concurrent task loads while keeping no-cache distinct from cached task maps
- propagate CLI no-cache through remote Git includes and dynamically discovered dependencies
- keep published Git cache trees immutable and use a path-specific fallback when a later task path is missing
- separate URL, ref, and path cache-key components with collision-resistant hashes
- give long-lived MCP sessions a fresh per-request no-cache task snapshot

## Split boundaries

- remote Git snapshot scope and cleanup mechanics are in merged #12000
- remote Git path containment is in #12254
- trust and remote metadata behavior are split across #12202, #12256, and #12257

## Validation

- cargo check --locked
- mise run lint-fix
- focused unit tests for remote HTTP, remote Git, dependency loading, and task fetching
- mise run test:e2e e2e/tasks/test_task_remote_git_includes e2e/tasks/test_task_remote_git_https

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*