### PR TITLE
fix(set): refuse a --file mise cannot read back

### DIFF
--- a/e2e/cli/test_set_use_consistency
+++ b/e2e/cli/test_set_use_consistency
@@ -94,6 +94,74 @@ else
   test_failures=$((test_failures + 1))
 fi
 
+echo "=== Testing paths mise cannot read back ==="
+
+# Test 5b: a path that does not exist. Neither command can tell "directory the user meant to
+# create" from "file with an unrecognised name", and a file mise refuses to read is worse than an
+# error: `mise set` used to write one and exit 0. A target per command, so that one creating a
+# file cannot be misread as the other doing it, and so nothing has to be deleted to tell them
+# apart — the trap at the top of this file owns cleanup.
+echo "Test 5b: --path/--file pointing at something that does not exist"
+missing_use="$test_project/missing_for_use"
+missing_set="$test_project/missing_for_set"
+
+if mise use --path "$missing_use" dummy@1.0.0 >/dev/null 2>&1; then
+  echo "✗ mise use --path accepted a path that does not exist"
+  test_failures=$((test_failures + 1))
+else
+  echo "✓ mise use --path rejected it"
+fi
+if [ -e "$missing_use" ]; then
+  echo "✗ mise use --path created $missing_use"
+  test_failures=$((test_failures + 1))
+fi
+
+if mise set --file "$missing_set" MISSING_VAR=1 >/dev/null 2>&1; then
+  echo "✗ mise set --file accepted a path that does not exist"
+  test_failures=$((test_failures + 1))
+else
+  echo "✓ mise set --file rejected it"
+fi
+if [ -e "$missing_set" ]; then
+  echo "✗ mise set --file created $missing_set, which mise cannot read back"
+  test_failures=$((test_failures + 1))
+fi
+
+# Test 5c: a name mise does recognise, but not as TOML. Both halves of it: creating one, and being
+# pointed at one that already exists. The second is why the check runs before mise looks at whether
+# the file is there — otherwise it fails later as invalid TOML, which does not say what is wrong.
+echo "Test 5c: mise set --file pointing at a .tool-versions"
+mkdir -p "$test_project/tvnew" "$test_project/tvold"
+tv_new="$test_project/tvnew/.tool-versions"
+tv_existing="$test_project/tvold/.tool-versions"
+printf 'node 20\n' >"$tv_existing"
+
+if mise set --file "$tv_new" TV_VAR=1 >/dev/null 2>&1; then
+  echo "✗ mise set --file wrote TOML to a new .tool-versions path"
+  test_failures=$((test_failures + 1))
+else
+  echo "✓ mise set --file rejected a new .tool-versions path"
+fi
+if [ -e "$tv_new" ]; then
+  echo "✗ mise set --file created $tv_new"
+  test_failures=$((test_failures + 1))
+fi
+
+# Whitespace is squeezed before matching so that wrapping the message cannot break the assertion.
+if tv_output=$(mise set --file "$tv_existing" TV_VAR=1 2>&1); then
+  echo "✗ mise set --file wrote TOML to an existing .tool-versions"
+  test_failures=$((test_failures + 1))
+elif ! printf '%s' "$tv_output" | tr -s '[:space:]' ' ' | grep -Fq 'cannot write TOML'; then
+  echo "✗ mise set --file rejected an existing .tool-versions without saying why: $tv_output"
+  test_failures=$((test_failures + 1))
+else
+  echo "✓ mise set --file rejected an existing .tool-versions with a reason"
+fi
+if [ "$(cat "$tv_existing")" != "node 20" ]; then
+  echo "✗ mise set --file modified $tv_existing"
+  test_failures=$((test_failures + 1))
+fi
+
 echo "=== Testing environment-specific configs ==="
 
 # Test 6: Both should handle --env consistently

--- a/src/cli/set.rs
+++ b/src/cli/set.rs
@@ -130,7 +130,7 @@ impl Set {
         }
 
         let filename = self.filename()?;
-        let mut mise_toml = get_mise_toml(&filename)?;
+        let mut mise_toml = get_mise_toml(&filename).await?;
 
         if let Some(env_names) = &self.remove {
             for name in env_names {
@@ -450,8 +450,11 @@ impl Set {
     }
 }
 
-fn get_mise_toml(filename: &Path) -> Result<MiseToml> {
+async fn get_mise_toml(filename: &Path) -> Result<MiseToml> {
     let path = env::current_dir()?.join(filename);
+    // Before the exists/does-not-exist split, so a `.tool-versions` says why it is refused instead
+    // of failing later as invalid TOML, and so a name mise cannot read back is never created.
+    crate::config::config_file::ensure_writable_as_toml(&path).await?;
     let mise_toml = if path.exists() {
         MiseToml::from_file(&path)?
     } else {

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -294,6 +294,28 @@ pub(crate) async fn parse_or_init(path: &Path) -> eyre::Result<Arc<dyn ConfigFil
     Ok(cf)
 }
 
+/// Refuse a path mise would not read back as a TOML config.
+///
+/// [`parse_or_init`] gives this check to every caller that goes through a [`ConfigFile`]. Callers
+/// that write TOML directly — `mise set` builds a `MiseToml` itself — bypassed it and would happily
+/// create a file that `detect_config_file_type` then refuses to recognise, or write TOML into a
+/// name mise reads as `.tool-versions`. One definition of "a path mise can write TOML to", rather
+/// than two that drift apart.
+pub(crate) async fn ensure_writable_as_toml(path: &Path) -> eyre::Result<()> {
+    match detect_config_file_type(path).await {
+        Some(ConfigFileType::MiseToml) => Ok(()),
+        Some(ConfigFileType::ToolVersions) => Err(eyre!(
+            "cannot write TOML to {}: mise reads that name as a .tool-versions file",
+            display_path(path)
+        )),
+        // `unsupported_config_file_error` already says the useful thing for these: they are
+        // idiomatic version files, and it names the alternatives.
+        Some(ConfigFileType::IdiomaticVersion(_)) | None => {
+            Err(unsupported_config_file_error(path))
+        }
+    }
+}
+
 /// Lock a config file for a read-modify-write operation, then read its latest contents.
 ///
 /// Callers must keep the returned lock alive until after [`ConfigFile::save`]. Acquiring the


### PR DESCRIPTION
`mise set --file` writes to any path it is given. When that path is one mise's own type detection rejects, the write still succeeds — leaving a file the writer cannot read back.

Measured on 2026.8.9:

```
$ mise set --file /tmp/x/does-not-exist FOO=1     # exit 0
$ cat /tmp/x/does-not-exist
[env]
FOO = "1"
```

`mise use --path` given the same argument refuses:

| `--path` / `--file` points at | `mise use --path X` | `mise set --file X` |
| --- | --- | --- |
| an existing directory | writes `X/mise.toml` ✅ | writes `X/mise.toml` ✅ |
| **a path that does not exist** | `unknown config file type`, exit 1 | **exit 0**, creates the file |

## The worse case

A name mise *does* recognise, but not as TOML:

```
$ mise set --file some/dir/.tool-versions BAR=2     # exit 0
$ cat some/dir/.tool-versions
[env]
BAR = "2"
```

Now the name and the contents disagree: mise reads `.tool-versions` in its own format, so `[env]` is not env at all. (An existing `.tool-versions` is spared, but only by accident — `MiseToml::from_file` fails on it with `Invalid TOML in config file`, which does not say what is actually wrong.)

## Why the two commands differ

Both resolve the target the same way, through `resolve_target_config_path`. What happens next is where they part:

- `use` goes through `config_file::parse_or_init`, which calls `init` → `detect_config_file_type` → `unsupported_config_file_error` when the name means nothing.
- `set` calls `get_mise_toml`, which asks no questions:

```rust
fn get_mise_toml(filename: &Path) -> Result<MiseToml> {
    let path = env::current_dir()?.join(filename);
    let mise_toml = if path.exists() {
        MiseToml::from_file(&path)?
    } else {
        MiseToml::init(&path)      // any name at all
    };
    Ok(mise_toml)
}
```

`detect_config_file_type` accepts `.tool-versions` names, `MISE_OVERRIDE_CONFIG_FILENAMES`, the default `mise.toml`, opted-in idiomatic version files, and **anything ending in `.toml`**. Everything else is `None` — which is exactly what `set` was creating.

## The change

`config_file::ensure_writable_as_toml` — the check `parse_or_init` already performs, exposed for callers that build a `MiseToml` themselves — and `set` now goes through it, before the exists/does-not-exist split so an existing `.tool-versions` says why it is refused rather than failing later as invalid TOML.

One definition of "a path mise can write TOML to" instead of two that drift.

**Compatibility.** The only inputs that newly fail are explicit `--file` arguments naming something mise cannot read as TOML. Paths that do not name a file (`--global`, `--env`, plain cwd) all resolve to `.toml` names and are unaffected; `set --file dir/` on an existing directory still resolves to `dir/mise.toml`. Anyone relying on the old behaviour was writing a file mise would never load.

## Tests

`e2e/cli/test_set_use_consistency` already exists for exactly this question, and already covers `--path`/`--file` against an **existing** directory. Added the two cases it was missing: a path that does not exist, and a `.tool-versions` path — asserting for both that the command fails **and that no file is created**. The exit code alone would not catch this bug; creating the file is the damage.

No unit test: the check is `async` and reaches Settings and the registry through `detect_config_file_type`, so a unit test would need more scaffolding than the e2e case that already covers it end to end.

## Notes

This was recorded in my own triage notes as "`mise use --path` panics on a non-existent directory". Re-measuring before writing anything showed the panic is long fixed and only the asymmetry remains — two neighbouring entries in the same list turned out to be fixed as well. The measurements above are all from today's build.

**No local build was run** — this machine cannot build mise, so type checking and the tests are CI's. The before/after numbers quoted here are the *before* only; I have not claimed a measurement of the fixed binary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `mise set --file` now rejects unsupported or unwritable configuration paths before creating files.
  * TOML output is prevented when targeting `.tool-versions` files.
  * `mise use --path` and `mise set --file` consistently report errors for nonexistent or incompatible paths.
  * Existing configuration files remain unchanged when an invalid update is attempted.

* **Tests**
  * Added end-to-end coverage for invalid paths and attempts to write TOML to `.tool-versions`.
  * Added coverage confirming failed operations do not create new filesystem entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->