### PR TITLE
docs: clarify registry addition popularity bar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,18 +4,18 @@ This file is the canonical agent guide. `CLAUDE.md` is a symlink to `AGENTS.md` 
 
 ## Registry Submissions: READ THIS FIRST
 
-**Most registry PRs from agents get rejected.** Before adding anything to `registry/`, understand the rules:
+**Most new registry additions from agents get rejected.** Before adding a new tool to `registry/`, understand the rules:
 
 - **mise does not host self-written, personal, niche, or low-popularity tools.** The registry is curated for tools that are *already* widely used. "It works" or "it has tests" is not the bar.
-- **Tools that aren't VERY popular will be rejected without explanation.** Per [contributing.md](docs/contributing.md): "@jdx won't explain why a given tool wasn't accepted." There is no appeal, no checklist, no second chance — the PR is closed and that's it.
+- **There is a high bar for new registry additions: tools generally need thousands of GitHub stars, not hundreds.** jdx will reject projects that do not meet this popularity bar and will not give a reason. Per [contributing.md](docs/contributing.md): "@jdx won't explain why a given tool wasn't accepted." There is no appeal, no checklist, no second chance — the PR is closed and that's it.
 - **Wasted PRs are the default outcome** for tools the agent or user has not vetted against this bar. Do not submit one speculatively.
 
-### Required pre-submission check
+### Required check for new registry additions
 
-Before touching `registry/`, ALWAYS do the following:
+Before adding a new tool or shorthand to `registry/`, ALWAYS do the following. This check does not apply when editing an existing registry entry; do not ask the user about popularity for maintenance or fixes to tools already in the registry.
 
-1. **Ask the user:** "Is this tool already widely used outside your own projects?" — if it's the user's own tool, a fork, an internal/company tool, or something with a small audience, **stop and tell them the PR will be rejected.** Do not submit.
-2. **Actively check popularity for every registry PR — no exceptions.** Look up real numbers; do not guess. Useful sources:
+1. **Warn the user clearly and ask:** "New registry additions have a high popularity bar: jdx generally rejects projects without thousands of GitHub stars and will not give a reason. Is this tool already widely used outside your own projects and does it meet that bar?" If it's the user's own tool, a fork, an internal/company tool, or something with a small audience, **stop and tell them the PR will be rejected.** Do not submit.
+2. **Actively check popularity for every new registry addition — no exceptions.** Look up real numbers; do not guess. Useful sources:
    - GitHub stars and fork count (`gh repo view owner/repo --json stargazerCount,forkCount`)
    - Recent release activity / last commit date (`gh repo view owner/repo --json pushedAt,latestRelease`)
    - Download counts on relevant package registries (npm `npmjs.com/package/x`, crates.io, PyPI, Homebrew analytics, etc.)
@@ -25,7 +25,7 @@ Before touching `registry/`, ALWAYS do the following:
    - Active maintenance (recent releases, not abandoned)
    - Real third-party usage (referenced in docs, blog posts, other tools, package registries)
    - Recognizable in its ecosystem
-4. **Include the popularity data in the PR description.** Every registry PR body MUST contain a short section like:
+4. **Include the popularity data in the PR description.** Every PR adding a new registry tool or shorthand MUST contain a short section like:
 
    ```
    ## Popularity
@@ -34,7 +34,7 @@ Before touching `registry/`, ALWAYS do the following:
    - Used by: <project A>, <project B>
    ```
 
-   This is non-negotiable — it lets the maintainer evaluate the submission without re-doing the research. PRs without it look speculative and are more likely to be rejected.
+   This is non-negotiable for new additions — it lets the maintainer evaluate the submission without re-doing the research. New-tool PRs without it look speculative and are more likely to be rejected.
 5. **If the tool is borderline or numbers are low, warn the user clearly** that the PR is likely to be rejected without reason, and ask if they still want to proceed. Do not soften this — users have repeatedly been surprised when their PR was closed, and the agent should have warned them up front.
 6. **Suggest the alternative:** users can install any tool themselves via explicit backend syntax (`mise use aqua:owner/repo`, `mise use github:owner/repo`, `mise use cargo:name`, `mise use npm:name`, etc.) or by writing a [tool plugin](https://mise.jdx.dev/tool-plugin-development.html). The registry is *only* for shorthand convenience for popular tools — not for enabling installation.
 


### PR DESCRIPTION
## Summary
- state that new registry additions generally require thousands of GitHub stars
- warn that rejected additions will not receive an explanation
- exempt maintenance of existing registry entries from the popularity prompt and checks

## Testing
- `git diff --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent guidance in `AGENTS.md`; no runtime or registry behavior changes.
> 
> **Overview**
> **Tightens agent guidance in `AGENTS.md` for new `registry/` tools**, not for edits to entries already in the registry.
> 
> The intro and bullets now say new additions generally need **thousands of GitHub stars** (not hundreds), that rejections come **without explanation**, and that speculative new-tool PRs are the usual failure mode. The pre-submission section is renamed and scoped to **new** tools/shorthands only, with an explicit carve-out so popularity prompts and checks do **not** apply to maintenance on existing registry entries.
> 
> Step 1 adds a **mandatory warning** to the user about that bar before proceeding. Wording throughout shifts from generic “registry PRs” to **new registry additions**, including when popularity data is required in the PR body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 225931da3b9a32ccae3d0f7f26dd3808f4ab63ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the requirements for submitting new registry tools or shorthands.
  * Increased clarity around the popularity threshold and required GitHub star evidence.
  * Specified that popularity checks apply only to new additions, not updates to existing entries.
  * Added required wording and documentation expectations for new registry submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->