### PR TITLE
test(aqua): remove canonical package gate

### DIFF
--- a/src/aqua/standard_registry.rs
+++ b/src/aqua/standard_registry.rs
@@ -108,39 +108,6 @@ mod tests {
     }
 
     #[test]
-    fn aqua_backends_name_canonical_packages() {
-        let stale = crate::registry::baked_registry()
-            .iter()
-            .flat_map(|(short, tool)| {
-                tool.backends
-                    .iter()
-                    .map(move |backend| (short, backend.full))
-            })
-            .filter_map(|(short, full)| {
-                let id = full.strip_prefix("aqua:")?;
-                let id = id.split('[').next().unwrap_or(id);
-                if AQUA_STANDARD_REGISTRY_FILES.contains_key(id) {
-                    return None;
-                }
-                let Some(canonical) = AQUA_STANDARD_REGISTRY_ALIASES.get(id) else {
-                    return Some(format!(
-                        "  registry/{short}.toml: aqua:{id} names no package"
-                    ));
-                };
-                // The gate lowercases both sides, so a case-only alias still matches.
-                (!canonical.eq_ignore_ascii_case(id))
-                    .then(|| format!("  registry/{short}.toml: aqua:{id} -> aqua:{canonical}"))
-            })
-            .collect::<Vec<_>>();
-
-        assert!(
-            stale.is_empty(),
-            "aqua backends not naming a package the aqua registry keys:\n{}",
-            stale.join("\n")
-        );
-    }
-
-    #[test]
     fn test_baked_registry_numeric_replacement_keys() {
         let package = package("sharkdp/hyperfine").unwrap().unwrap();
 


### PR DESCRIPTION
## Why
release-plz refreshes the vendored Aqua registry on the `release` branch. At that point, `main` still contains registry entries written against the older Aqua snapshot. If upstream changes a package’s canonical name, the canonical-package test fails the release-plz PR immediately.

There is no good workflow to update those mise registry entries first: changing them on `main` would fail against the older vendored snapshot, while changing them in the generated release PR couples a manual registry edit to every affected release. Valid Aqua aliases continue to resolve correctly, so requiring every entry to use the canonical name from one particular snapshot is unnecessarily brittle.

## Summary
- remove the test requiring mise registry Aqua package IDs to match Aqua’s current canonical names
- allow valid Aqua aliases to survive canonical-name changes during release-plz registry refreshes

## Testing
- `cargo test aqua::standard_registry::tests`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*