### PR TITLE
docs(trust): use neutral config file help

### DIFF
--- a/docs/cli/trust.md
+++ b/docs/cli/trust.md
@@ -30,7 +30,7 @@ worktrees can check out branches with different config contents.
 
 ### `[CONFIG_FILE]`
 
-The config file to trust
+The config file whose trust status to change
 
 ## Flags
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -4631,7 +4631,7 @@ Remove explicit trust for this config
 .PP
 .TP
 \fB<CONFIG_FILE>\fR
-The config file to trust
+The config file whose trust status to change
 .SH "MISE UNINSTALL"
 Removes installed tool versions
 

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -4478,7 +4478,7 @@ Show the trusted status of config files from the current directory and its paren
 Does not trust or untrust any files.
 """#
     flag --untrust help="Remove explicit trust for this config"
-    arg "[CONFIG_FILE]" help="The config file to trust" required=#false
+    arg "[CONFIG_FILE]" help="The config file whose trust status to change" required=#false
 }
 cmd uninstall help="Removes installed tool versions" effect=destructive {
     long_help #"""

--- a/src/cli/trust.rs
+++ b/src/cli/trust.rs
@@ -35,7 +35,7 @@ use itertools::Itertools;
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct Trust {
-    /// The config file to trust
+    /// The config file whose trust status to change
     #[clap(value_hint = ValueHint::FilePath, verbatim_doc_comment)]
     config_file: Option<PathBuf>,
 


### PR DESCRIPTION
## Summary
- describe `CONFIG_FILE` with wording that applies to both trust and untrust operations
- regenerate the usage documentation and man page

## Testing
- `mise run render:mangen`
- `mise run lint-fix`
- `target/debug/mise trust --help`
- `target/debug/mise trust --untrust --help`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the `trust` command’s config file argument to indicate it can change a file’s trust status, including untrusting or ignoring configurations.
  * Updated the CLI documentation and generated command reference for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->