### PR TITLE
fix(oci): relocate pipx virtual environments

### DIFF
--- a/src/oci/builder.rs
+++ b/src/oci/builder.rs
@@ -30,6 +30,9 @@ pub const ANNOTATION_TOOL_SHORT: &str = "dev.mise.tool.short";
 pub const ANNOTATION_TOOL_VERSION: &str = "dev.mise.tool.version";
 pub const ANNOTATION_LAYER_PREFIX: &str = "dev.mise.layer.prefix";
 pub const ANNOTATION_LAYER_OWNER: &str = "dev.mise.layer.owner";
+pub const ANNOTATION_LAYER_RELOCATION: &str = "dev.mise.layer.relocation";
+
+const TOOL_LAYER_RELOCATION_VERSION: &str = "1";
 
 /// Options passed to the builder from the CLI.
 #[derive(Debug, Clone)]
@@ -65,6 +68,7 @@ struct ReuseKey {
     version: String,
     prefix: String,
     owner: String,
+    relocation: String,
 }
 
 /// A tool layer taken verbatim from the remote cache image.
@@ -83,11 +87,12 @@ fn build_reuse_index(remote: &registry::RemoteImage) -> IndexMap<ReuseKey, Reuse
     let mut index = IndexMap::new();
     for (layer, diff_id) in remote.manifest.layers.iter().zip(&remote.diff_ids) {
         let a = &layer.annotations;
-        let (Some(short), Some(version), Some(prefix), Some(owner)) = (
+        let (Some(short), Some(version), Some(prefix), Some(owner), Some(relocation)) = (
             a.get(ANNOTATION_TOOL_SHORT),
             a.get(ANNOTATION_TOOL_VERSION),
             a.get(ANNOTATION_LAYER_PREFIX),
             a.get(ANNOTATION_LAYER_OWNER),
+            a.get(ANNOTATION_LAYER_RELOCATION),
         ) else {
             continue;
         };
@@ -97,6 +102,7 @@ fn build_reuse_index(remote: &registry::RemoteImage) -> IndexMap<ReuseKey, Reuse
                 version: version.clone(),
                 prefix: prefix.clone(),
                 owner: owner.clone(),
+                relocation: relocation.clone(),
             },
             ReusedLayer {
                 media_type: layer.media_type.clone(),
@@ -268,6 +274,19 @@ impl Builder {
         // the layer is never built locally and the tool doesn't need to be
         // installed at all.
         let owner_str = format!("{}:{}", owner.uid, owner.gid);
+        let python = versions
+            .iter()
+            .find(|(_, tv)| tv.ba().short == "python")
+            .map(|(_, tv)| tv);
+        let relocation_paths: Vec<(PathBuf, PathBuf)> = versions
+            .iter()
+            .map(|(_, tv)| {
+                (
+                    tv.install_path(),
+                    PathBuf::from(tool_in_image_path(&mount_point, tv)),
+                )
+            })
+            .collect();
         let reuse_index = self
             .opts
             .reuse_from
@@ -283,6 +302,7 @@ impl Builder {
                         version: tv.version.clone(),
                         prefix: tool_tar_prefix(&mount_point, tv),
                         owner: owner_str.clone(),
+                        relocation: tool_layer_relocation_key(tv, python),
                     })
                     .cloned()
             })
@@ -338,6 +358,7 @@ impl Builder {
             short: String,
             version: String,
             prefix: String,
+            relocation: String,
             layer: ToolLayer,
         }
         enum ToolLayer {
@@ -347,6 +368,7 @@ impl Builder {
         let mut tool_layers: Vec<ToolLayerEntry> = Vec::new();
         for (i, (_, tv)) in versions.iter().enumerate() {
             let tv_prefix = tool_tar_prefix(&mount_point, tv);
+            let relocation_key = tool_layer_relocation_key(tv, python);
             let layer = if let Some(reused) = &tool_reuse[i] {
                 info!(
                     "oci: reusing {} layer from the cache image (unchanged)",
@@ -354,14 +376,42 @@ impl Builder {
                 );
                 ToolLayer::Reused(reused.clone())
             } else {
-                let blob = layer::build_layer_from_dir(&tv.install_path(), &tv_prefix, owner)
-                    .wrap_err_with(|| format!("building layer for {}", tv.style()))?;
+                let is_pipx = tv.ba().backend_type() == BackendType::Pipx;
+                let external_python = if is_pipx {
+                    python.map(|python| {
+                        PathBuf::from(tool_in_image_path(&mount_point, python)).join("bin/python")
+                    })
+                } else {
+                    None
+                };
+                // Only pipx layers are expected to link into another tool's
+                // install. Other backends get their own mapping for shebang
+                // relocation without making their reuse key depend on the
+                // complete toolset.
+                let paths = if is_pipx {
+                    relocation_paths.clone()
+                } else {
+                    vec![(
+                        tv.install_path(),
+                        PathBuf::from(tool_in_image_path(&mount_point, tv)),
+                    )]
+                };
+                let relocation =
+                    layer::ToolRelocation::new(paths).with_external_python(external_python);
+                let blob = layer::build_relocated_tool_layer_from_dir(
+                    &tv.install_path(),
+                    &tv_prefix,
+                    owner,
+                    &relocation,
+                )
+                .wrap_err_with(|| format!("building layer for {}", tv.style()))?;
                 ToolLayer::Built(blob)
             };
             tool_layers.push(ToolLayerEntry {
                 short: tv.ba().short.clone(),
                 version: tv.version.clone(),
                 prefix: tv_prefix,
+                relocation: relocation_key,
                 layer,
             });
         }
@@ -473,6 +523,10 @@ impl Builder {
             annotations.insert(ANNOTATION_TOOL_VERSION.to_string(), entry.version.clone());
             annotations.insert(ANNOTATION_LAYER_PREFIX.to_string(), entry.prefix.clone());
             annotations.insert(ANNOTATION_LAYER_OWNER.to_string(), owner_str.clone());
+            annotations.insert(
+                ANNOTATION_LAYER_RELOCATION.to_string(),
+                entry.relocation.clone(),
+            );
             let (media_type, digest, size, diff_id, reused) = match &entry.layer {
                 ToolLayer::Built(blob) => {
                     layout.write_blob_with_digest(&blob.digest, &blob.bytes)?;
@@ -1117,6 +1171,17 @@ fn tool_tar_prefix(mount_point: &str, tv: &ToolVersion) -> String {
         .to_string()
 }
 
+fn tool_layer_relocation_key(tv: &ToolVersion, python: Option<&ToolVersion>) -> String {
+    if tv.ba().backend_type() == BackendType::Pipx {
+        format!(
+            "{TOOL_LAYER_RELOCATION_VERSION}:python={}",
+            python.map_or("none", |python| python.version.as_str())
+        )
+    } else {
+        TOOL_LAYER_RELOCATION_VERSION.to_string()
+    }
+}
+
 fn synthesize_embedded_config_toml(
     versions: &[(Arc<dyn crate::backend::Backend>, ToolVersion)],
     _mount_point: &str,
@@ -1217,14 +1282,15 @@ mod tests {
     }
 
     #[test]
-    fn reuse_index_keys_on_all_four_annotations() {
+    fn reuse_index_keys_on_all_relocation_annotations() {
         let full = [
             (ANNOTATION_TOOL_SHORT, "jq"),
             (ANNOTATION_TOOL_VERSION, "1.8.1"),
             (ANNOTATION_LAYER_PREFIX, "mise/installs/jq/1.8.1"),
             (ANNOTATION_LAYER_OWNER, "0:0"),
+            (ANNOTATION_LAYER_RELOCATION, TOOL_LAYER_RELOCATION_VERSION),
         ];
-        // Second layer lacks prefix/owner (pushed by an older mise) —
+        // Second layer lacks prefix/owner/relocation (pushed by an older mise) —
         // not reusable.
         let partial = [
             (ANNOTATION_TOOL_SHORT, "node"),
@@ -1249,6 +1315,7 @@ mod tests {
                 version: "1.8.1".into(),
                 prefix: "mise/installs/jq/1.8.1".into(),
                 owner: "0:0".into(),
+                relocation: TOOL_LAYER_RELOCATION_VERSION.into(),
             })
             .unwrap();
         assert_eq!(hit.digest, "sha256:aaa");
@@ -1261,6 +1328,7 @@ mod tests {
                     version: "1.8.1".into(),
                     prefix: "mise/installs/jq/1.8.1".into(),
                     owner: "1000:1000".into(),
+                    relocation: TOOL_LAYER_RELOCATION_VERSION.into(),
                 })
                 .is_none()
         );

--- a/src/oci/builder.rs
+++ b/src/oci/builder.rs
@@ -9,11 +9,12 @@ use std::sync::Arc;
 
 use eyre::{Context, Result, bail};
 use indexmap::{IndexMap, IndexSet};
+use sha2::{Digest, Sha256};
 
 use crate::backend::backend_type::BackendType;
 use crate::config::{Config, Settings};
 use crate::file;
-use crate::oci::layer::{self, LayerBlob, LayerOwner};
+use crate::oci::layer::{self, LayerBlob, LayerOwner, PythonRelocation};
 use crate::oci::layout::ImageLayout;
 use crate::oci::manifest::{self, Descriptor, ImageConfig, ImageManifest, Platform, RootFs};
 use crate::oci::packages;
@@ -32,7 +33,7 @@ pub const ANNOTATION_LAYER_PREFIX: &str = "dev.mise.layer.prefix";
 pub const ANNOTATION_LAYER_OWNER: &str = "dev.mise.layer.owner";
 pub const ANNOTATION_LAYER_RELOCATION: &str = "dev.mise.layer.relocation";
 
-const TOOL_LAYER_RELOCATION_VERSION: &str = "1";
+const TOOL_LAYER_RELOCATION_VERSION: &str = "2";
 
 /// Options passed to the builder from the CLI.
 #[derive(Debug, Clone)]
@@ -274,17 +275,13 @@ impl Builder {
         // the layer is never built locally and the tool doesn't need to be
         // installed at all.
         let owner_str = format!("{}:{}", owner.uid, owner.gid);
-        let python = versions
+        let python_relocations: Vec<PythonRelocation> = versions
             .iter()
-            .find(|(_, tv)| tv.ba().short == "python")
-            .map(|(_, tv)| tv);
-        let relocation_paths: Vec<(PathBuf, PathBuf)> = versions
-            .iter()
-            .map(|(_, tv)| {
-                (
-                    tv.install_path(),
-                    PathBuf::from(tool_in_image_path(&mount_point, tv)),
-                )
+            .filter(|(_, tv)| tv.ba().short == "python")
+            .map(|(_, tv)| PythonRelocation {
+                version: tv.version.clone(),
+                host: tv.install_path(),
+                image: PathBuf::from(tool_in_image_path(&mount_point, tv)),
             })
             .collect();
         let reuse_index = self
@@ -302,7 +299,7 @@ impl Builder {
                         version: tv.version.clone(),
                         prefix: tool_tar_prefix(&mount_point, tv),
                         owner: owner_str.clone(),
-                        relocation: tool_layer_relocation_key(tv, python),
+                        relocation: tool_layer_relocation_key(tv, &python_relocations),
                     })
                     .cloned()
             })
@@ -368,7 +365,7 @@ impl Builder {
         let mut tool_layers: Vec<ToolLayerEntry> = Vec::new();
         for (i, (_, tv)) in versions.iter().enumerate() {
             let tv_prefix = tool_tar_prefix(&mount_point, tv);
-            let relocation_key = tool_layer_relocation_key(tv, python);
+            let relocation_key = tool_layer_relocation_key(tv, &python_relocations);
             let layer = if let Some(reused) = &tool_reuse[i] {
                 info!(
                     "oci: reusing {} layer from the cache image (unchanged)",
@@ -377,27 +374,27 @@ impl Builder {
                 ToolLayer::Reused(reused.clone())
             } else {
                 let is_pipx = tv.ba().backend_type() == BackendType::Pipx;
-                let external_python = if is_pipx {
-                    python.map(|python| {
-                        PathBuf::from(tool_in_image_path(&mount_point, python)).join("bin/python")
-                    })
-                } else {
-                    None
-                };
                 // Only pipx layers are expected to link into another tool's
                 // install. Other backends get their own mapping for shebang
                 // relocation without making their reuse key depend on the
                 // complete toolset.
-                let paths = if is_pipx {
-                    relocation_paths.clone()
+                let mut paths = vec![(
+                    tv.install_path(),
+                    PathBuf::from(tool_in_image_path(&mount_point, tv)),
+                )];
+                if is_pipx {
+                    paths.extend(
+                        python_relocations
+                            .iter()
+                            .map(|python| (python.host.clone(), python.image.clone())),
+                    );
+                }
+                let pythons = if is_pipx {
+                    python_relocations.clone()
                 } else {
-                    vec![(
-                        tv.install_path(),
-                        PathBuf::from(tool_in_image_path(&mount_point, tv)),
-                    )]
+                    Vec::new()
                 };
-                let relocation =
-                    layer::ToolRelocation::new(paths).with_external_python(external_python);
+                let relocation = layer::ToolRelocation::new(paths).with_pythons(pythons);
                 let blob = layer::build_relocated_tool_layer_from_dir(
                     &tv.install_path(),
                     &tv_prefix,
@@ -1171,15 +1168,32 @@ fn tool_tar_prefix(mount_point: &str, tv: &ToolVersion) -> String {
         .to_string()
 }
 
-fn tool_layer_relocation_key(tv: &ToolVersion, python: Option<&ToolVersion>) -> String {
+fn tool_layer_relocation_key(tv: &ToolVersion, pythons: &[PythonRelocation]) -> String {
     if tv.ba().backend_type() == BackendType::Pipx {
         format!(
             "{TOOL_LAYER_RELOCATION_VERSION}:python={}",
-            python.map_or("none", |python| python.version.as_str())
+            python_relocation_fingerprint(pythons)
         )
     } else {
         TOOL_LAYER_RELOCATION_VERSION.to_string()
     }
+}
+
+fn python_relocation_fingerprint(pythons: &[PythonRelocation]) -> String {
+    let mut pythons = pythons.to_vec();
+    pythons.sort_by(|a, b| (&a.version, &a.host, &a.image).cmp(&(&b.version, &b.host, &b.image)));
+    let mut hash = Sha256::new();
+    for python in pythons {
+        for input in [
+            python.version,
+            python.host.to_string_lossy().into_owned(),
+            python.image.to_string_lossy().into_owned(),
+        ] {
+            hash.update(input.len().to_le_bytes());
+            hash.update(input.as_bytes());
+        }
+    }
+    layer::hex_encode(&hash.finalize())
 }
 
 fn synthesize_embedded_config_toml(
@@ -1279,6 +1293,35 @@ mod tests {
                 .collect(),
             platform: None,
         }
+    }
+
+    #[test]
+    fn python_relocation_fingerprint_covers_exact_inputs_and_not_order() {
+        let python_313 = PythonRelocation {
+            version: "3.13.9".into(),
+            host: "/host/python/3.13.9".into(),
+            image: "/mise/installs/python/3.13.9".into(),
+        };
+        let python_314 = PythonRelocation {
+            version: "3.14.3".into(),
+            host: "/host/python/3.14.3".into(),
+            image: "/mise/installs/python/3.14.3".into(),
+        };
+        let fingerprint = python_relocation_fingerprint(&[python_313.clone(), python_314.clone()]);
+        assert_eq!(
+            fingerprint,
+            python_relocation_fingerprint(&[python_314.clone(), python_313.clone()])
+        );
+        assert_ne!(fingerprint, python_relocation_fingerprint(&[python_314]));
+
+        let python_313_fingerprint =
+            python_relocation_fingerprint(std::slice::from_ref(&python_313));
+        let mut changed_target = python_313;
+        changed_target.image = "/opt/python/3.13.9".into();
+        assert_ne!(
+            python_313_fingerprint,
+            python_relocation_fingerprint(&[changed_target])
+        );
     }
 
     #[test]

--- a/src/oci/builder.rs
+++ b/src/oci/builder.rs
@@ -1189,7 +1189,7 @@ fn python_relocation_fingerprint(pythons: &[PythonRelocation]) -> String {
             python.host.to_string_lossy().into_owned(),
             python.image.to_string_lossy().into_owned(),
         ] {
-            hash.update(input.len().to_le_bytes());
+            hash.update((input.len() as u64).to_le_bytes());
             hash.update(input.as_bytes());
         }
     }

--- a/src/oci/builder.rs
+++ b/src/oci/builder.rs
@@ -277,7 +277,7 @@ impl Builder {
         let owner_str = format!("{}:{}", owner.uid, owner.gid);
         let python_relocations: Vec<PythonRelocation> = versions
             .iter()
-            .filter(|(_, tv)| tv.ba().short == "python")
+            .filter(|(backend, _)| is_python_backend(backend.as_ref()))
             .map(|(_, tv)| PythonRelocation {
                 version: tv.version.clone(),
                 host: tv.install_path(),
@@ -1179,6 +1179,10 @@ fn tool_layer_relocation_key(tv: &ToolVersion, pythons: &[PythonRelocation]) -> 
     }
 }
 
+fn is_python_backend(backend: &dyn crate::backend::Backend) -> bool {
+    backend.get_type() == BackendType::Core && backend.tool_name() == "python"
+}
+
 fn python_relocation_fingerprint(pythons: &[PythonRelocation]) -> String {
     let mut pythons = pythons.to_vec();
     pythons.sort_by(|a, b| (&a.version, &a.host, &a.image).cmp(&(&b.version, &b.host, &b.image)));
@@ -1293,6 +1297,14 @@ mod tests {
                 .collect(),
             platform: None,
         }
+    }
+
+    #[test]
+    fn recognizes_an_alias_resolved_to_core_python() {
+        let alias =
+            crate::cli::args::BackendArg::new("py".to_string(), Some("core:python".to_string()));
+        let backend = crate::backend::arg_to_backend(alias).unwrap();
+        assert!(is_python_backend(backend.as_ref()));
     }
 
     #[test]

--- a/src/oci/layer.rs
+++ b/src/oci/layer.rs
@@ -11,7 +11,7 @@
 //! input tree, which is required for the "swap one tool → swap one layer"
 //! caching story.
 
-use std::io::{BufRead, Read, Write};
+use std::io::{BufRead, Cursor, Read, Write};
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
@@ -35,19 +35,26 @@ use walkdir::WalkDir;
 #[derive(Debug, Clone, Default)]
 pub struct ToolRelocation {
     paths: Vec<(PathBuf, PathBuf)>,
-    external_python: Option<PathBuf>,
+    pythons: Vec<PythonRelocation>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PythonRelocation {
+    pub version: String,
+    pub host: PathBuf,
+    pub image: PathBuf,
 }
 
 impl ToolRelocation {
     pub fn new(paths: Vec<(PathBuf, PathBuf)>) -> Self {
         Self {
             paths,
-            external_python: None,
+            pythons: Vec::new(),
         }
     }
 
-    pub fn with_external_python(mut self, target: Option<PathBuf>) -> Self {
-        self.external_python = target;
+    pub fn with_pythons(mut self, pythons: Vec<PythonRelocation>) -> Self {
+        self.pythons = pythons;
         self
     }
 }
@@ -414,10 +421,10 @@ fn build_layer_from_entries(
                     header.set_mode(e.mode);
                     apply_owner(&mut header, e.owner);
                     header.set_mtime(0);
-                    if let Some(contents) = relocated_script_contents(e, relocation)? {
-                        header.set_size(contents.len() as u64);
+                    if let Some(mut contents) = relocated_file_contents(e, relocation)? {
+                        header.set_size(contents.size);
                         builder
-                            .append_data(&mut header, &path_in_tar, contents.as_slice())
+                            .append_data(&mut header, &path_in_tar, &mut contents.reader)
                             .wrap_err_with(|| format!("writing {path_in_tar}"))?;
                     } else {
                         header.set_size(e.size);
@@ -611,8 +618,9 @@ fn file_is_executable(path: &Path, _md: &std::fs::Metadata) -> bool {
 /// the layer extracts to a different prefix inside the container.
 ///
 /// Known cross-tool targets are rebased to their in-image install path. Pipx
-/// venv interpreter links may also use the configured in-image Python. Other
-/// absolute targets outside the tool tree are left alone with a warning.
+/// venv interpreter links may also use a compatible configured Python, as
+/// identified by the venv's pyvenv.cfg. Other absolute targets outside the
+/// tool tree are left alone with a warning.
 fn rebase_symlink_target(
     raw: &Path,
     link_abs_path: &Path,
@@ -637,9 +645,9 @@ fn rebase_symlink_target(
     } else if let Some(target) = relocate_absolute_path(&target_canon, relocation) {
         return target;
     } else if is_python_interpreter_link(link_abs_path)
-        && let Some(target) = relocation.and_then(|r| r.external_python.clone())
+        && let Some(target) = compatible_python(link_abs_path, relocation)
     {
-        return target;
+        return target.image.join("bin/python");
     } else {
         warn!(
             "oci layer: symlink {} → {} has an absolute target outside the tool's install dir; \
@@ -688,10 +696,29 @@ fn is_python_interpreter_link(path: &Path) -> bool {
         })
 }
 
+struct RelocatedFileContents {
+    size: u64,
+    reader: Box<dyn Read>,
+}
+
+fn relocated_file_contents(
+    entry: &Entry,
+    relocation: Option<&ToolRelocation>,
+) -> Result<Option<RelocatedFileContents>> {
+    if entry
+        .abs
+        .file_name()
+        .is_some_and(|name| name == "pyvenv.cfg")
+    {
+        return relocated_pyvenv_contents(entry, relocation);
+    }
+    relocated_script_contents(entry, relocation)
+}
+
 fn relocated_script_contents(
     entry: &Entry,
     relocation: Option<&ToolRelocation>,
-) -> Result<Option<Vec<u8>>> {
+) -> Result<Option<RelocatedFileContents>> {
     if entry.mode & 0o111 == 0 {
         return Ok(None);
     }
@@ -729,10 +756,106 @@ fn relocated_script_contents(
         return Ok(None);
     }
 
-    let mut relocated = Vec::with_capacity(entry.size as usize + shebang.len() - original.len());
-    relocated.extend_from_slice(shebang.as_bytes());
-    reader.read_to_end(&mut relocated)?;
-    Ok(Some(relocated))
+    let size = entry.size - line.len() as u64 + shebang.len() as u64;
+    let contents = Cursor::new(shebang.into_bytes()).chain(reader);
+    Ok(Some(RelocatedFileContents {
+        size,
+        reader: Box::new(contents),
+    }))
+}
+
+fn relocated_pyvenv_contents(
+    entry: &Entry,
+    relocation: Option<&ToolRelocation>,
+) -> Result<Option<RelocatedFileContents>> {
+    let Some(python) = compatible_python(&entry.abs, relocation) else {
+        return Ok(None);
+    };
+    let original = std::fs::read_to_string(&entry.abs)
+        .wrap_err_with(|| format!("reading {}", entry.abs.display()))?;
+    let venv_image = entry
+        .abs
+        .parent()
+        .and_then(|path| relocate_absolute_path(path, relocation));
+    let mut changed = false;
+    let mut output = String::with_capacity(original.len());
+    for line in original.split_inclusive('\n') {
+        let newline = if line.ends_with('\n') { "\n" } else { "" };
+        let line = line.trim_end_matches('\n').trim_end_matches('\r');
+        let key = line.split_once('=').map(|(key, _)| key.trim());
+        let replacement = match key {
+            Some("home") => Some(format!("home = {}", python.image.join("bin").display())),
+            Some("executable") => Some(format!(
+                "executable = {}",
+                python.image.join("bin/python").display()
+            )),
+            Some("command") => venv_image.as_ref().map(|venv| {
+                format!(
+                    "command = {} -m venv {}",
+                    python.image.join("bin/python").display(),
+                    venv.display()
+                )
+            }),
+            _ => None,
+        };
+        if let Some(replacement) = replacement {
+            changed |= replacement != line;
+            output.push_str(&replacement);
+        } else {
+            output.push_str(line);
+        }
+        output.push_str(newline);
+    }
+    if !changed {
+        return Ok(None);
+    }
+    let bytes = output.into_bytes();
+    Ok(Some(RelocatedFileContents {
+        size: bytes.len() as u64,
+        reader: Box::new(Cursor::new(bytes)),
+    }))
+}
+
+fn compatible_python<'a>(
+    path: &Path,
+    relocation: Option<&'a ToolRelocation>,
+) -> Option<&'a PythonRelocation> {
+    let relocation = relocation?;
+    let version = pyvenv_version(path)?;
+    if let Some(exact) = relocation
+        .pythons
+        .iter()
+        .find(|python| python.version == version)
+    {
+        return Some(exact);
+    }
+    let requested = python_major_minor(&version)?;
+    let mut compatible = relocation
+        .pythons
+        .iter()
+        .filter(|python| python_major_minor(&python.version) == Some(requested));
+    let candidate = compatible.next()?;
+    compatible.next().is_none().then_some(candidate)
+}
+
+fn pyvenv_version(path: &Path) -> Option<String> {
+    let cfg = path.ancestors().find_map(|dir| {
+        let cfg = dir.join("pyvenv.cfg");
+        cfg.is_file().then_some(cfg)
+    })?;
+    let contents = std::fs::read_to_string(cfg).ok()?;
+    contents.lines().find_map(|line| {
+        let (key, value) = line.split_once('=')?;
+        matches!(key.trim(), "version" | "version_info").then(|| value.trim().to_string())
+    })
+}
+
+fn python_major_minor(version: &str) -> Option<(&str, &str)> {
+    let mut parts = version.split('.');
+    let major = parts.next()?;
+    let minor = parts.next()?;
+    (major.chars().all(|c| c.is_ascii_digit()) && minor.chars().all(|c| c.is_ascii_digit()))
+        .then_some((major, minor))
 }
 
 pub(crate) fn hex_encode(bytes: &[u8]) -> String {
@@ -1090,6 +1213,11 @@ mod tests {
         )
         .unwrap();
         symlink("/usr/sbin/python", pipx.join("gitlabcis/bin/python")).unwrap();
+        fs::write(
+            pipx.join("gitlabcis/pyvenv.cfg"),
+            "home = /usr/sbin\nimplementation = CPython\nversion_info = 3.14.3\nexecutable = /usr/sbin/python\ncommand = /usr/sbin/python -m venv /tmp/host-venv\n",
+        )
+        .unwrap();
 
         let launcher = pipx.join("bin/gitlabcis");
         fs::write(
@@ -1106,9 +1234,13 @@ mod tests {
         let image_python = PathBuf::from("/mise/installs/python/3.14.3");
         let relocation = ToolRelocation::new(vec![
             (pipx.clone(), image_pipx.clone()),
-            (python, image_python.clone()),
+            (python.clone(), image_python.clone()),
         ])
-        .with_external_python(Some(image_python.join("bin/python")));
+        .with_pythons(vec![PythonRelocation {
+            version: "3.14.3".to_string(),
+            host: python,
+            image: image_python.clone(),
+        }]);
         let blob = build_relocated_tool_layer_from_dir(
             &pipx,
             "mise/installs/pipx-gitlabcis/1.20.0",
@@ -1120,12 +1252,16 @@ mod tests {
         let decoder = flate2::read::GzDecoder::new(blob.bytes.as_slice());
         let mut archive = Archive::new(decoder);
         let mut launcher_contents = String::new();
+        let mut pyvenv_contents = String::new();
         let mut links = std::collections::BTreeMap::new();
         for entry in archive.entries().unwrap() {
             let mut entry = entry.unwrap();
             let path = entry.path().unwrap().to_string_lossy().into_owned();
             if path.ends_with("bin/gitlabcis") {
                 entry.read_to_string(&mut launcher_contents).unwrap();
+            }
+            if path.ends_with("gitlabcis/pyvenv.cfg") {
+                entry.read_to_string(&mut pyvenv_contents).unwrap();
             }
             if let Some(target) = entry.header().link_name() {
                 links.insert(path, target.into_owned());
@@ -1144,6 +1280,47 @@ mod tests {
             links["mise/installs/pipx-gitlabcis/1.20.0/gitlabcis/bin/python3"],
             image_python.join("bin/python")
         );
+        assert!(pyvenv_contents.contains("home = /mise/installs/python/3.14.3/bin\n"));
+        assert!(pyvenv_contents.contains("executable = /mise/installs/python/3.14.3/bin/python\n"));
+        assert!(pyvenv_contents.contains(
+            "command = /mise/installs/python/3.14.3/bin/python -m venv /mise/installs/pipx-gitlabcis/1.20.0/gitlabcis\n"
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn does_not_relocate_pipx_to_an_incompatible_python() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().unwrap();
+        let pipx = dir.path().join("pipx-tool/1.0.0");
+        fs::create_dir_all(pipx.join("venv/bin")).unwrap();
+        fs::write(
+            pipx.join("venv/pyvenv.cfg"),
+            "home = /usr/bin\nversion_info = 3.13.9\nexecutable = /usr/bin/python3.13\n",
+        )
+        .unwrap();
+        symlink("/usr/bin/python3.13", pipx.join("venv/bin/python")).unwrap();
+
+        let relocation = ToolRelocation::new(vec![(
+            pipx.clone(),
+            PathBuf::from("/mise/installs/pipx-tool/1.0.0"),
+        )])
+        .with_pythons(vec![PythonRelocation {
+            version: "3.14.3".to_string(),
+            host: PathBuf::from("/host/python/3.14.3"),
+            image: PathBuf::from("/mise/installs/python/3.14.3"),
+        }]);
+        let entries =
+            collect_sorted_entries(&pipx, false, LayerOwner::default(), Some(&relocation)).unwrap();
+        let python = entries
+            .iter()
+            .find(|entry| entry.rel == Path::new("venv/bin/python"))
+            .unwrap();
+        match &python.kind {
+            EntryKind::Symlink(target) => assert_eq!(target, Path::new("/usr/bin/python3.13")),
+            kind => panic!("expected symlink, got {kind:?}"),
+        }
     }
 
     #[cfg(unix)]

--- a/src/oci/layer.rs
+++ b/src/oci/layer.rs
@@ -11,7 +11,7 @@
 //! input tree, which is required for the "swap one tool → swap one layer"
 //! caching story.
 
-use std::io::Write;
+use std::io::{BufRead, Read, Write};
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
@@ -25,6 +25,32 @@ use jdx_tar::Archive;
 use jdx_tar::{Builder, EntryType, Header};
 use sha2::{Digest, Sha256};
 use walkdir::WalkDir;
+
+/// Host-to-image path mappings used while packaging an installed tool.
+///
+/// Most tools are relocatable as-is, but virtual environments commonly embed
+/// their host install path in launcher shebangs and interpreter symlinks.
+/// Keeping the mappings here lets the layer writer fix those references while
+/// retaining the one-layer-per-tool layout.
+#[derive(Debug, Clone, Default)]
+pub struct ToolRelocation {
+    paths: Vec<(PathBuf, PathBuf)>,
+    external_python: Option<PathBuf>,
+}
+
+impl ToolRelocation {
+    pub fn new(paths: Vec<(PathBuf, PathBuf)>) -> Self {
+        Self {
+            paths,
+            external_python: None,
+        }
+    }
+
+    pub fn with_external_python(mut self, target: Option<PathBuf>) -> Self {
+        self.external_python = target;
+        self
+    }
+}
 
 /// The result of building a layer blob.
 #[derive(Debug, Clone)]
@@ -100,8 +126,23 @@ pub fn build_layer_from_dir(
         eyre::bail!("not a directory: {}", src_dir.display());
     }
 
-    let entries = collect_sorted_entries(src_dir, false, owner)?;
-    build_layer_from_entries(&entries, target_prefix, owner)
+    let entries = collect_sorted_entries(src_dir, false, owner, None)?;
+    build_layer_from_entries(&entries, target_prefix, owner, None)
+}
+
+/// Build a tool layer while rebasing host paths embedded by its installer.
+pub fn build_relocated_tool_layer_from_dir(
+    src_dir: &Path,
+    target_prefix: &str,
+    owner: LayerOwner,
+    relocation: &ToolRelocation,
+) -> Result<LayerBlob> {
+    if !src_dir.is_dir() {
+        eyre::bail!("not a directory: {}", src_dir.display());
+    }
+
+    let entries = collect_sorted_entries(src_dir, false, owner, Some(relocation))?;
+    build_layer_from_entries(&entries, target_prefix, owner, Some(relocation))
 }
 
 /// Build a reproducible layer from one host file, symlink, or directory.
@@ -168,7 +209,7 @@ pub fn build_layer_from_path(
         owner,
         size,
     };
-    build_layer_from_entries(&[entry], &prefix, owner)
+    build_layer_from_entries(&[entry], &prefix, owner, None)
 }
 
 /// Build a layer from a source directory, preserving uid/gid/mode from disk.
@@ -180,8 +221,8 @@ pub fn build_layer_from_dir_preserve_metadata(
         eyre::bail!("not a directory: {}", src_dir.display());
     }
 
-    let entries = collect_sorted_entries(src_dir, true, LayerOwner::default())?;
-    build_layer_from_entries(&entries, target_prefix, LayerOwner::default())
+    let entries = collect_sorted_entries(src_dir, true, LayerOwner::default(), None)?;
+    build_layer_from_entries(&entries, target_prefix, LayerOwner::default(), None)
 }
 
 /// Build a layer from an in-memory list of (path_in_tar, content) pairs.
@@ -265,6 +306,7 @@ fn collect_sorted_entries(
     src_dir: &Path,
     preserve_metadata: bool,
     owner: LayerOwner,
+    relocation: Option<&ToolRelocation>,
 ) -> Result<Vec<Entry>> {
     // Canonicalize once so we can match symlink targets that traverse via
     // different path spellings (e.g. with `..` components or through
@@ -290,7 +332,8 @@ fn collect_sorted_entries(
             (EntryKind::Dir, mode, 0u64)
         } else if file_type.is_symlink() {
             let raw_target = std::fs::read_link(entry.path())?;
-            let target = rebase_symlink_target(&raw_target, &abs, &canonical_src, src_dir);
+            let target =
+                rebase_symlink_target(&raw_target, &abs, &canonical_src, src_dir, relocation);
             let mode = if preserve_metadata {
                 mode_from_metadata(&md)
             } else {
@@ -332,6 +375,7 @@ fn build_layer_from_entries(
     entries: &[Entry],
     target_prefix: &str,
     owner: LayerOwner,
+    relocation: Option<&ToolRelocation>,
 ) -> Result<LayerBlob> {
     let prefix = target_prefix.trim_matches('/');
 
@@ -369,13 +413,20 @@ fn build_layer_from_entries(
                     let mut header = Header::new_gnu(EntryType::File);
                     header.set_mode(e.mode);
                     apply_owner(&mut header, e.owner);
-                    header.set_size(e.size);
                     header.set_mtime(0);
-                    let f = std::fs::File::open(&e.abs)
-                        .wrap_err_with(|| format!("opening {}", e.abs.display()))?;
-                    builder
-                        .append_data(&mut header, &path_in_tar, f)
-                        .wrap_err_with(|| format!("writing {path_in_tar}"))?;
+                    if let Some(contents) = relocated_script_contents(e, relocation)? {
+                        header.set_size(contents.len() as u64);
+                        builder
+                            .append_data(&mut header, &path_in_tar, contents.as_slice())
+                            .wrap_err_with(|| format!("writing {path_in_tar}"))?;
+                    } else {
+                        header.set_size(e.size);
+                        let f = std::fs::File::open(&e.abs)
+                            .wrap_err_with(|| format!("opening {}", e.abs.display()))?;
+                        builder
+                            .append_data(&mut header, &path_in_tar, f)
+                            .wrap_err_with(|| format!("writing {path_in_tar}"))?;
+                    }
                 }
                 EntryKind::Symlink(target) => {
                     let mut header = Header::new_gnu(EntryType::Symlink);
@@ -559,14 +610,15 @@ fn file_is_executable(path: &Path, _md: &std::fs::Metadata) -> bool {
 /// install tree, rewrite it to a *relative* symlink so it stays valid after
 /// the layer extracts to a different prefix inside the container.
 ///
-/// Absolute targets that fall outside the tool tree are left alone with a
-/// warning — they'd be dangling inside the container either way, and
-/// rewriting them requires knowledge we don't have at layer-build time.
+/// Known cross-tool targets are rebased to their in-image install path. Pipx
+/// venv interpreter links may also use the configured in-image Python. Other
+/// absolute targets outside the tool tree are left alone with a warning.
 fn rebase_symlink_target(
     raw: &Path,
     link_abs_path: &Path,
     canonical_src: &Path,
     src_dir: &Path,
+    relocation: Option<&ToolRelocation>,
 ) -> PathBuf {
     if !raw.is_absolute() {
         return raw.to_path_buf();
@@ -582,6 +634,12 @@ fn rebase_symlink_target(
         r.to_path_buf()
     } else if let Ok(r) = raw.strip_prefix(src_dir) {
         r.to_path_buf()
+    } else if let Some(target) = relocate_absolute_path(&target_canon, relocation) {
+        return target;
+    } else if is_python_interpreter_link(link_abs_path)
+        && let Some(target) = relocation.and_then(|r| r.external_python.clone())
+    {
+        return target;
     } else {
         warn!(
             "oci layer: symlink {} → {} has an absolute target outside the tool's install dir; \
@@ -606,6 +664,75 @@ fn rebase_symlink_target(
     }
     out.push(rel_target);
     out
+}
+
+fn relocate_absolute_path(raw: &Path, relocation: Option<&ToolRelocation>) -> Option<PathBuf> {
+    let relocation = relocation?;
+    relocation.paths.iter().find_map(|(host, image)| {
+        let canonical_host = std::fs::canonicalize(host).unwrap_or_else(|_| host.clone());
+        raw.strip_prefix(&canonical_host)
+            .ok()
+            .map(|rel| image.join(rel))
+    })
+}
+
+fn is_python_interpreter_link(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| {
+            name == "python"
+                || name == "python3"
+                || name
+                    .strip_prefix("python3.")
+                    .is_some_and(|minor| minor.chars().all(|c| c.is_ascii_digit()))
+        })
+}
+
+fn relocated_script_contents(
+    entry: &Entry,
+    relocation: Option<&ToolRelocation>,
+) -> Result<Option<Vec<u8>>> {
+    if entry.mode & 0o111 == 0 {
+        return Ok(None);
+    }
+    let Some(relocation) = relocation else {
+        return Ok(None);
+    };
+
+    let mut file = std::fs::File::open(&entry.abs)
+        .wrap_err_with(|| format!("opening executable {}", entry.abs.display()))?;
+    if entry.size < 2 {
+        return Ok(None);
+    }
+    let mut magic = [0; 2];
+    file.read_exact(&mut magic)?;
+    if magic != *b"#!" {
+        return Ok(None);
+    }
+
+    let mut reader = std::io::BufReader::new(file);
+    let mut line = b"#!".to_vec();
+    reader.read_until(b'\n', &mut line)?;
+    if !line.ends_with(b"\n") {
+        return Ok(None);
+    }
+
+    let mut shebang = String::from_utf8_lossy(&line).into_owned();
+    let original = shebang.clone();
+    for (host, image) in &relocation.paths {
+        shebang = shebang.replace(
+            &host.to_string_lossy().to_string(),
+            &image.to_string_lossy(),
+        );
+    }
+    if shebang == original {
+        return Ok(None);
+    }
+
+    let mut relocated = Vec::with_capacity(entry.size as usize + shebang.len() - original.len());
+    relocated.extend_from_slice(shebang.as_bytes());
+    reader.read_to_end(&mut relocated)?;
+    Ok(Some(relocated))
 }
 
 pub(crate) fn hex_encode(bytes: &[u8]) -> String {
@@ -787,7 +914,7 @@ mod tests {
             },
         ];
 
-        let blob = build_layer_from_entries(&entries, "", LayerOwner::default()).unwrap();
+        let blob = build_layer_from_entries(&entries, "", LayerOwner::default(), None).unwrap();
 
         assert_layer_mode(&blob, "bin", 0o1777);
         assert_layer_mode(&blob, "bin/helper", 0o4755);
@@ -914,7 +1041,7 @@ mod tests {
         // as-is with a warning; we only assert it doesn't panic).
         symlink("/usr/bin/false", src.join("bin/external")).unwrap();
 
-        let entries = collect_sorted_entries(src, false, LayerOwner::default()).unwrap();
+        let entries = collect_sorted_entries(src, false, LayerOwner::default(), None).unwrap();
         let npm = entries
             .iter()
             .find(|e| e.rel == Path::new("bin/npm"))
@@ -941,6 +1068,86 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn relocates_pipx_shebangs_and_python_links() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+
+        let dir = tempdir().unwrap();
+        let installs = dir.path().join("installs");
+        let python = installs.join("python/3.14.3");
+        let pipx = installs.join("pipx-gitlabcis/1.20.0");
+        fs::create_dir_all(python.join("bin")).unwrap();
+        fs::create_dir_all(installs.join("python")).unwrap();
+        fs::create_dir_all(pipx.join("gitlabcis/bin")).unwrap();
+        fs::create_dir_all(pipx.join("bin")).unwrap();
+        fs::write(python.join("bin/python"), b"python").unwrap();
+        symlink("./3.14.3", installs.join("python/latest")).unwrap();
+
+        // uv-created venvs can point either through a mise runtime alias or
+        // at the host interpreter uv selected during installation.
+        symlink(
+            installs.join("python/latest/bin/python"),
+            pipx.join("gitlabcis/bin/python3"),
+        )
+        .unwrap();
+        symlink("/usr/sbin/python", pipx.join("gitlabcis/bin/python")).unwrap();
+
+        let launcher = pipx.join("bin/gitlabcis");
+        fs::write(
+            &launcher,
+            format!(
+                "#!{}\nfrom gitlabcis.cli.main import main\n",
+                pipx.join("gitlabcis/bin/python").display()
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&launcher, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let image_pipx = PathBuf::from("/mise/installs/pipx-gitlabcis/1.20.0");
+        let image_python = PathBuf::from("/mise/installs/python/3.14.3");
+        let relocation = ToolRelocation::new(vec![
+            (pipx.clone(), image_pipx.clone()),
+            (python, image_python.clone()),
+        ])
+        .with_external_python(Some(image_python.join("bin/python")));
+        let blob = build_relocated_tool_layer_from_dir(
+            &pipx,
+            "mise/installs/pipx-gitlabcis/1.20.0",
+            LayerOwner::default(),
+            &relocation,
+        )
+        .unwrap();
+
+        let decoder = flate2::read::GzDecoder::new(blob.bytes.as_slice());
+        let mut archive = Archive::new(decoder);
+        let mut launcher_contents = String::new();
+        let mut links = std::collections::BTreeMap::new();
+        for entry in archive.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            let path = entry.path().unwrap().to_string_lossy().into_owned();
+            if path.ends_with("bin/gitlabcis") {
+                entry.read_to_string(&mut launcher_contents).unwrap();
+            }
+            if let Some(target) = entry.header().link_name() {
+                links.insert(path, target.into_owned());
+            }
+        }
+
+        assert!(
+            launcher_contents
+                .starts_with("#!/mise/installs/pipx-gitlabcis/1.20.0/gitlabcis/bin/python\n")
+        );
+        assert_eq!(
+            links["mise/installs/pipx-gitlabcis/1.20.0/gitlabcis/bin/python"],
+            image_python.join("bin/python")
+        );
+        assert_eq!(
+            links["mise/installs/pipx-gitlabcis/1.20.0/gitlabcis/bin/python3"],
+            image_python.join("bin/python")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn long_symlink_target_written_via_gnu_longlink() {
         use std::os::unix::fs::symlink;
 
@@ -958,8 +1165,8 @@ mod tests {
         );
         symlink(&long_target, src.join("bin/cli")).unwrap();
 
-        let entries = collect_sorted_entries(src, false, LayerOwner::default()).unwrap();
-        let blob = build_layer_from_entries(&entries, "mise", LayerOwner::default()).unwrap();
+        let entries = collect_sorted_entries(src, false, LayerOwner::default(), None).unwrap();
+        let blob = build_layer_from_entries(&entries, "mise", LayerOwner::default(), None).unwrap();
 
         // The GNU @LongLink extension must round-trip back to the full target.
         let decoder = flate2::read::GzDecoder::new(blob.bytes.as_slice());

--- a/src/oci/layer.rs
+++ b/src/oci/layer.rs
@@ -756,7 +756,16 @@ fn relocated_script_contents(
         return Ok(None);
     }
 
-    let size = entry.size - line.len() as u64 + shebang.len() as u64;
+    let Some(size) = entry
+        .size
+        .checked_sub(line.len() as u64)
+        .and_then(|rest| rest.checked_add(shebang.len() as u64))
+    else {
+        // The file changed after collect_sorted_entries recorded its size.
+        // Let the ordinary file path detect a short read instead of creating
+        // a relocated tar header with a wrapped size.
+        return Ok(None);
+    };
     let contents = Cursor::new(shebang.into_bytes()).chain(reader);
     Ok(Some(RelocatedFileContents {
         size,
@@ -829,6 +838,17 @@ fn compatible_python<'a>(
     {
         return Some(exact);
     }
+    if let Some(requested) = python_release(&version) {
+        let mut compatible = relocation
+            .pythons
+            .iter()
+            .filter(|python| python_release(&python.version) == Some(requested));
+        if let Some(candidate) = compatible.next()
+            && compatible.next().is_none()
+        {
+            return Some(candidate);
+        }
+    }
     let requested = python_major_minor(&version)?;
     let mut compatible = relocation
         .pythons
@@ -836,6 +856,17 @@ fn compatible_python<'a>(
         .filter(|python| python_major_minor(&python.version) == Some(requested));
     let candidate = compatible.next()?;
     compatible.next().is_none().then_some(candidate)
+}
+
+fn python_release(version: &str) -> Option<(&str, &str, &str)> {
+    let mut parts = version.split('.');
+    let major = parts.next()?;
+    let minor = parts.next()?;
+    let patch = parts.next()?;
+    [major, minor, patch]
+        .iter()
+        .all(|part| part.chars().all(|c| c.is_ascii_digit()))
+        .then_some((major, minor, patch))
 }
 
 fn pyvenv_version(path: &Path) -> Option<String> {
@@ -1215,7 +1246,7 @@ mod tests {
         symlink("/usr/sbin/python", pipx.join("gitlabcis/bin/python")).unwrap();
         fs::write(
             pipx.join("gitlabcis/pyvenv.cfg"),
-            "home = /usr/sbin\nimplementation = CPython\nversion_info = 3.14.3\nexecutable = /usr/sbin/python\ncommand = /usr/sbin/python -m venv /tmp/host-venv\n",
+            "home = /usr/sbin\nimplementation = CPython\nversion_info = 3.14.3.final.0\nexecutable = /usr/sbin/python\ncommand = /usr/sbin/python -m venv /tmp/host-venv\n",
         )
         .unwrap();
 
@@ -1236,11 +1267,18 @@ mod tests {
             (pipx.clone(), image_pipx.clone()),
             (python.clone(), image_python.clone()),
         ])
-        .with_pythons(vec![PythonRelocation {
-            version: "3.14.3".to_string(),
-            host: python,
-            image: image_python.clone(),
-        }]);
+        .with_pythons(vec![
+            PythonRelocation {
+                version: "3.14.2".to_string(),
+                host: installs.join("python/3.14.2"),
+                image: PathBuf::from("/mise/installs/python/3.14.2"),
+            },
+            PythonRelocation {
+                version: "3.14.3".to_string(),
+                host: python,
+                image: image_python.clone(),
+            },
+        ]);
         let blob = build_relocated_tool_layer_from_dir(
             &pipx,
             "mise/installs/pipx-gitlabcis/1.20.0",

--- a/src/oci/layer.rs
+++ b/src/oci/layer.rs
@@ -676,9 +676,11 @@ fn rebase_symlink_target(
 
 fn relocate_absolute_path(raw: &Path, relocation: Option<&ToolRelocation>) -> Option<PathBuf> {
     let relocation = relocation?;
+    let canonical_raw = std::fs::canonicalize(raw).unwrap_or_else(|_| raw.to_path_buf());
     relocation.paths.iter().find_map(|(host, image)| {
         let canonical_host = std::fs::canonicalize(host).unwrap_or_else(|_| host.clone());
-        raw.strip_prefix(&canonical_host)
+        canonical_raw
+            .strip_prefix(&canonical_host)
             .ok()
             .map(|rel| image.join(rel))
     })
@@ -1359,6 +1361,27 @@ mod tests {
             EntryKind::Symlink(target) => assert_eq!(target, Path::new("/usr/bin/python3.13")),
             kind => panic!("expected symlink, got {kind:?}"),
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn relocation_matches_canonicalized_source_paths() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().unwrap();
+        let real = dir.path().join("real");
+        let alias = dir.path().join("alias");
+        fs::create_dir_all(real.join("venv")).unwrap();
+        symlink(&real, &alias).unwrap();
+
+        let relocation = ToolRelocation::new(vec![(
+            alias.clone(),
+            PathBuf::from("/mise/installs/pipx-tool/1.0.0"),
+        )]);
+        assert_eq!(
+            relocate_absolute_path(&alias.join("venv"), Some(&relocation)),
+            Some(PathBuf::from("/mise/installs/pipx-tool/1.0.0/venv"))
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- rewrite host-absolute executable shebangs to the OCI mount point
- rebase pipx virtual-environment interpreter links to the Python tool included in the image, including links through runtime aliases such as `python/latest`
- version tool-layer relocation metadata so previously cached unrelocated layers are not reused

This addresses the failure reported in https://github.com/jdx/mise/discussions/12195.

## Testing

- `cargo test --locked --bin mise oci::` (72 passed)
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how OCI tool layers are packed and cached, including shebang/symlink rewriting and a new reuse annotation. Incorrect relocation or cache-key logic could produce broken images or skip rebuilding layers that need it.
> 
> **Overview**
> Makes pipx (and other tool) layers relocatable inside OCI images so host-absolute Python paths no longer dangle at runtime.
> 
> When packing a tool layer, executable shebangs are rewritten to the in-image prefix, `pyvenv.cfg` `home`/`executable`/`command` are remapped, and venv interpreter symlinks (including aliases like `python/latest`) are rebased onto a compatible Python from the toolset. Only pipx layers take a full Python mapping so other tools’ reuse keys stay independent of the rest of the toolset.
> 
> Layer reuse now requires a `dev.mise.layer.relocation` annotation (version `2`, plus a Python fingerprint for pipx). Older cached layers without it are rebuilt instead of reused.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ff4bbafe0d13732ae1b325f367124949b832ac0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - OCI tool layers now support relocating embedded paths, Python interpreter links, virtual-environment settings, and executable shebangs when packaged into images.
  - Python relocation supports exact version and compatible major/minor version matching, including recognized Python aliases.
  - pipx-based tools account for all installed Python relocation mappings, improving portability across image environments.
- **Bug Fixes**
  - Layer reuse now accounts for relocation settings and fingerprints.
  - Layers without relocation metadata are no longer incorrectly reused.
- **Tests**
  - Added coverage for relocation behavior, version matching, canonical paths, fingerprint stability, and cache validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->