### PR TITLE
docs(node): replace corepack with mise-managed pnpm

### DIFF
--- a/docs/mise-cookbook/nodejs.md
+++ b/docs/mise-cookbook/nodejs.md
@@ -4,7 +4,7 @@ Here are some tips on managing [Node.js](/lang/node.html) projects with mise.
 
 ## Getting started with Node.js
 
-To install Node.JS, in a directory, you can use the following command:
+To install Node.js, in a directory, you can use the following command:
 
 ```shell
 mise use node
@@ -16,7 +16,7 @@ This will install the latest version of Node.js and create a `mise.toml` file wi
 node = "latest"
 ```
 
-If you want to install Node.JS globally instead (for example, node v26), you can use the following command:
+If you want to install Node.js globally instead (for example, node v26), you can use the following command:
 
 ```shell
 mise use -g node@26
@@ -112,14 +112,10 @@ This example uses `pnpm` as the package manager. This will skip installing depen
 [tools]
 node = '24'
 
-[hooks]
-# Enabling corepack will install the `pnpm` package manager specified in your package.json
-# alternatively, you can also install `pnpm` with mise
-postinstall = 'npx corepack enable'
-
 [settings]
-# This must be enabled to make the hooks work
-experimental = true
+# Use the pnpm version specified in package.json
+# https://mise.jdx.dev/configuration.html#idiomatic-version-files
+idiomatic_version_file_enable_tools = ['pnpm']
 
 [env]
 _.path = ['{{config_root}}/node_modules/.bin']
@@ -136,8 +132,8 @@ run = 'node --run dev'
 depends = ['pnpm-install']
 ```
 
-With this setup, getting started in a NodeJS project is as simple as running `mise dev`:
+With this setup, getting started in a Node.js project is as simple as running `mise dev`:
 
-- `mise` will install the correct version of NodeJS
-- `mise` will enable `corepack`
+- `mise` will install the correct version of Node.js
+- `mise` will install the pnpm version specified in `package.json`
 - `pnpm install` will be run before `node --run dev`

--- a/docs/mise-cookbook/nodejs.md
+++ b/docs/mise-cookbook/nodejs.md
@@ -121,7 +121,7 @@ This example uses `pnpm` as the package manager. It expects the `devEngines.pack
 }
 ```
 
-The install task will be skipped when the lockfile has not changed.
+The install task will be skipped when `package.json`, `pnpm-lock.yaml`, and `mise.toml` have not changed.
 
 ```toml [mise.toml]
 [tools]

--- a/docs/mise-cookbook/nodejs.md
+++ b/docs/mise-cookbook/nodejs.md
@@ -106,7 +106,16 @@ echo "NODE_ENV: $NODE_ENV"
 
 ## Example with `pnpm`
 
-This example uses `pnpm` as the package manager. This will skip installing dependencies if the lock file hasn't changed.
+This example uses `pnpm` as the package manager. It expects the `packageManager` field in
+`package.json` to pin the pnpm version:
+
+```json [package.json]
+{
+  "packageManager": "pnpm@10.15.0"
+}
+```
+
+The install task will be skipped when the lockfile has not changed.
 
 ```toml [mise.toml]
 [tools]
@@ -114,7 +123,6 @@ node = '24'
 
 [settings]
 # Use the pnpm version specified in package.json
-# https://mise.jdx.dev/configuration.html#idiomatic-version-files
 idiomatic_version_file_enable_tools = ['pnpm']
 
 [env]

--- a/docs/mise-cookbook/nodejs.md
+++ b/docs/mise-cookbook/nodejs.md
@@ -106,12 +106,18 @@ echo "NODE_ENV: $NODE_ENV"
 
 ## Example with `pnpm`
 
-This example uses `pnpm` as the package manager. It expects the `packageManager` field in
+This example uses `pnpm` as the package manager. It expects the `devEngines.packageManager` field in
 `package.json` to pin the pnpm version:
 
 ```json [package.json]
 {
-  "packageManager": "pnpm@10.15.0"
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "^11.22.0",
+      "onFail": "download"
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
Corepack is now recommended against for pnpm:

- https://github.com/pnpm/pnpm/issues/11732#issuecomment-5267508169
- https://x.com/karlhorky/status/2090378284546555940

Switch[ Node.js cookbook pnpm recipe](https://mise.jdx.dev/mise-cookbook/nodejs.html#example-with-pnpm) from Corepack to [Idiomatic Version Files](https://mise.jdx.dev/configuration.html#idiomatic-version-files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized Node.js terminology throughout the guide.
  * Updated pnpm setup guidance to use mise’s version-file support instead of Corepack.
  * Added an example for pinning pnpm with `devEngines.packageManager`.
  * Clarified that mise installs the pnpm version specified in `package.json`.
  * Documented when installation tasks are skipped because relevant project files are unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->