### PR TITLE
feat(node): support corepack-compatible package manager checksums

### DIFF
--- a/docs/mise-cookbook/nodejs.md
+++ b/docs/mise-cookbook/nodejs.md
@@ -112,14 +112,9 @@ This example uses `pnpm` as the package manager. This will skip installing depen
 [tools]
 node = '24'
 
-[hooks]
-# Enabling corepack will install the `pnpm` package manager specified in your package.json
-# alternatively, you can also install `pnpm` with mise
-postinstall = 'npx corepack enable'
-
 [settings]
-# This must be enabled to make the hooks work
-experimental = true
+# Read the pnpm version from package.json's packageManager field
+idiomatic_version_file_enable_tools = ['pnpm']
 
 [env]
 _.path = ['{{config_root}}/node_modules/.bin']
@@ -139,5 +134,57 @@ depends = ['pnpm-install']
 With this setup, getting started in a NodeJS project is as simple as running `mise dev`:
 
 - `mise` will install the correct version of NodeJS
-- `mise` will enable `corepack`
+- `mise` will install the `pnpm` version declared in `package.json`
 - `pnpm install` will be run before `node --run dev`
+
+## Replacing Corepack
+
+mise can install and select npm, pnpm, and Yarn without Corepack. The simplest
+setup is to declare both Node.js and the package manager in `mise.toml`:
+
+```toml [mise.toml]
+[tools]
+node = '24'
+pnpm = '10.15.0'
+```
+
+To keep `package.json` as the package-manager version source, enable its
+[idiomatic version file](/configuration.html#idiomatic-version-files) support:
+
+```json [package.json]
+{
+  "packageManager": "pnpm@10.15.0+sha224.88208eb7c2e7de6ed534fa298248dee656723116995eda4b508fd0c9"
+}
+```
+
+```toml [mise.toml]
+[tools]
+node = '24'
+
+[settings]
+idiomatic_version_file_enable_tools = ['pnpm']
+```
+
+Run `mise install` to install the declared versions. With shell activation,
+mise's shims can also install a missing configured package manager when it is
+first invoked. This uses
+[`not_found_auto_install`](/configuration/settings.html#not_found_auto_install),
+which is enabled by default.
+
+Corepack-style `+sha1`, `+sha224`, `+sha256`, `+sha384`, and `+sha512` suffixes
+are verified against the exact package-manager artifact before installation.
+For npm, pnpm, and Yarn Classic this is the registry tarball; for modern Yarn it
+is Yarn's published CLI file. Without a checksum, mise uses the package
+manager's preferred registry backend (usually Aqua) and that backend's normal
+verification.
+
+Enable each package manager that a repository may declare:
+
+```toml [mise.toml]
+[settings]
+idiomatic_version_file_enable_tools = ['npm', 'pnpm', 'yarn']
+```
+
+Unlike Corepack, mise does not supply a built-in "known good" package-manager
+version when a project declares none. Configure the version in `mise.toml`,
+`package.json`, or your global mise config instead.

--- a/docs/mise-cookbook/nodejs.md
+++ b/docs/mise-cookbook/nodejs.md
@@ -4,7 +4,7 @@ Here are some tips on managing [Node.js](/lang/node.html) projects with mise.
 
 ## Getting started with Node.js
 
-To install Node.JS, in a directory, you can use the following command:
+To install Node.js, in a directory, you can use the following command:
 
 ```shell
 mise use node
@@ -16,7 +16,7 @@ This will install the latest version of Node.js and create a `mise.toml` file wi
 node = "latest"
 ```
 
-If you want to install Node.JS globally instead (for example, node v26), you can use the following command:
+If you want to install Node.js globally instead (for example, node v26), you can use the following command:
 
 ```shell
 mise use -g node@26
@@ -106,14 +106,29 @@ echo "NODE_ENV: $NODE_ENV"
 
 ## Example with `pnpm`
 
-This example uses `pnpm` as the package manager. This will skip installing dependencies if the lock file hasn't changed.
+This example uses `pnpm` as the package manager. It expects
+`devEngines.packageManager` in `package.json` to pin the pnpm version:
+
+```json [package.json]
+{
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "10.15.0"
+    }
+  }
+}
+```
+
+The install task is skipped when `package.json`, `pnpm-lock.yaml`, and
+`mise.toml` have not changed.
 
 ```toml [mise.toml]
 [tools]
 node = '24'
 
 [settings]
-# Read the pnpm version from package.json's packageManager field
+# Read the pnpm version from package.json
 idiomatic_version_file_enable_tools = ['pnpm']
 
 [env]
@@ -131,9 +146,9 @@ run = 'node --run dev'
 depends = ['pnpm-install']
 ```
 
-With this setup, getting started in a NodeJS project is as simple as running `mise dev`:
+With this setup, getting started in a Node.js project is as simple as running `mise dev`:
 
-- `mise` will install the correct version of NodeJS
+- `mise` will install the correct version of Node.js
 - `mise` will install the `pnpm` version declared in `package.json`
 - `pnpm install` will be run before `node --run dev`
 

--- a/docs/mise-cookbook/nodejs.md
+++ b/docs/mise-cookbook/nodejs.md
@@ -121,7 +121,8 @@ This example uses `pnpm` as the package manager. It expects
 ```
 
 The install task is skipped when `package.json`, `pnpm-lock.yaml`, and
-`mise.toml` have not changed.
+`mise.toml` have not changed and `node_modules/.pnpm/lock.yaml` exists and is up
+to date.
 
 ```toml [mise.toml]
 [tools]

--- a/e2e/core/test_package_manager_checksum_slow
+++ b/e2e/core/test_package_manager_checksum_slow
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+mise settings set idiomatic_version_file_enable_tools "pnpm,yarn"
+
+cat >mise.toml <<'EOF'
+[tools]
+node = "24"
+EOF
+
+cat >package.json <<'EOF'
+{
+  "packageManager": "pnpm@10.15.0+sha224.00000000000000000000000000000000000000000000000000000000"
+}
+EOF
+
+assert_fail mise install
+
+cat >package.json <<'EOF'
+{
+  "packageManager": "pnpm@10.15.0+sha224.88208eb7c2e7de6ed534fa298248dee656723116995eda4b508fd0c9"
+}
+EOF
+
+assert "mise x -- pnpm --version" "10.15.0"
+
+cat >package.json <<'EOF'
+{
+  "packageManager": "yarn@4.14.1+sha224.88b7a7244bbd9040380c417f7eb556d85c67640b651f113cb4c72113"
+}
+EOF
+
+assert "mise x -- yarn --version" "4.14.1"

--- a/e2e/core/test_package_manager_checksum_slow
+++ b/e2e/core/test_package_manager_checksum_slow
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-mise settings set idiomatic_version_file_enable_tools "pnpm,yarn"
+mise settings set idiomatic_version_file_enable_tools "bun,pnpm,yarn"
 
 cat >mise.toml <<'EOF'
 [tools]
@@ -49,3 +49,31 @@ cat >package.json <<'EOF'
 EOF
 
 assert "mise x -- yarn --version" "4.14.1"
+
+cat >package.json <<'EOF'
+{
+  "devEngines": {
+    "runtime": {
+      "name": "bun",
+      "version": "1.3.14"
+    }
+  },
+  "packageManager": "bun@1.3.14+sha224.00000000000000000000000000000000000000000000000000000000"
+}
+EOF
+
+assert_fail mise install
+
+cat >package.json <<'EOF'
+{
+  "devEngines": {
+    "runtime": {
+      "name": "bun",
+      "version": "1.3.14"
+    }
+  },
+  "packageManager": "bun@1.3.14+sha224.f9bc5e43d5833c794213050a0e428787c253a62a8be1ba47d0a03bf0"
+}
+EOF
+
+assert "mise x -- bun --version" "1.3.14"

--- a/e2e/core/test_package_manager_checksum_slow
+++ b/e2e/core/test_package_manager_checksum_slow
@@ -5,6 +5,9 @@ mise settings set idiomatic_version_file_enable_tools "pnpm,yarn"
 cat >mise.toml <<'EOF'
 [tools]
 node = "24"
+
+[tool_alias]
+yarn = "aqua:yarnpkg/berry"
 EOF
 
 cat >package.json <<'EOF'
@@ -22,6 +25,22 @@ cat >package.json <<'EOF'
 EOF
 
 assert "mise x -- pnpm --version" "10.15.0"
+
+cat >mise.lock <<EOF
+$LOCKFILE_HEADER
+
+[[tools.yarn]]
+version = "4.14.1"
+backend = "aqua:yarnpkg/berry"
+EOF
+
+cat >package.json <<'EOF'
+{
+  "packageManager": "yarn@4.14.1+sha224.00000000000000000000000000000000000000000000000000000000"
+}
+EOF
+
+assert_fail mise install
 
 cat >package.json <<'EOF'
 {

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -192,6 +192,10 @@ impl<'a> HttpOptions<'a> {
         self.values.platform_string("bin_path")
     }
 
+    fn windows_script_interpreter(&self) -> Option<String> {
+        self.values.platform_string("windows_script_interpreter")
+    }
+
     fn checksum_expr(&self) -> Option<&'a str> {
         self.values.str("checksum_expr")
     }
@@ -335,6 +339,13 @@ impl HttpBackend {
             if let Some(bin_path) = opts.bin_path() {
                 parts.push(format!("binpath_{bin_path}"));
             }
+        }
+
+        if let Some(interpreter) = opts.windows_script_interpreter() {
+            parts.push(format!(
+                "windows_script_interpreter_{}",
+                hash::hash_blake3_to_str(&interpreter)
+            ));
         }
 
         let key = parts.join("_");
@@ -620,6 +631,10 @@ impl HttpBackend {
         file::copy(file_path, &dest_file)?;
 
         file::make_executable(&dest_file)?;
+        #[cfg(windows)]
+        if let Some(interpreter) = opts.windows_script_interpreter() {
+            write_windows_script_launcher(&dest_file, &interpreter)?;
+        }
         Ok(ExtractionType::RawFile { filename })
     }
 
@@ -969,6 +984,27 @@ impl HttpBackend {
     }
 }
 
+#[cfg(any(windows, test))]
+fn windows_script_launcher(interpreter: &str) -> Result<String> {
+    ensure_plain_bin_name("windows_script_interpreter", interpreter)?;
+    if interpreter.is_empty()
+        || !interpreter
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-'))
+    {
+        eyre::bail!("windows_script_interpreter: {interpreter:?} must be a plain executable name");
+    }
+    Ok(format!("@echo off\r\n{interpreter} \"%~dpn0\" %*\r\n"))
+}
+
+#[cfg(windows)]
+fn write_windows_script_launcher(script: &Path, interpreter: &str) -> Result<()> {
+    file::write(
+        script.with_extension("cmd"),
+        windows_script_launcher(interpreter)?,
+    )
+}
+
 /// Returns install-time-only option keys for HTTP backend.
 pub fn install_time_option_keys() -> Vec<String> {
     vec![
@@ -980,6 +1016,7 @@ pub fn install_time_option_keys() -> Vec<String> {
         "version_expr".into(),
         "format".into(),
         "rename_exe".into(),
+        "windows_script_interpreter".into(),
         "checksum_url".into(),
         "checksum_expr".into(),
     ]
@@ -1289,6 +1326,15 @@ mod tests {
     use super::*;
     use crate::cli::args::BackendResolution;
     use crate::toolset::{ToolRequest, ToolSource};
+
+    #[test]
+    fn windows_script_launcher_invokes_extensionless_script() {
+        assert_eq!(
+            windows_script_launcher("node").unwrap(),
+            "@echo off\r\nnode \"%~dpn0\" %*\r\n"
+        );
+        assert!(windows_script_launcher("node & echo injected").is_err());
+    }
 
     fn http_test_tv(version: &str) -> ToolVersion {
         http_test_tv_with_installs(version, None)

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -985,7 +985,7 @@ impl HttpBackend {
 }
 
 #[cfg(any(windows, test))]
-fn windows_script_launcher(interpreter: &str) -> Result<String> {
+fn windows_script_launcher(script: &Path, interpreter: &str) -> Result<(PathBuf, String)> {
     ensure_plain_bin_name("windows_script_interpreter", interpreter)?;
     if interpreter.is_empty()
         || !interpreter
@@ -994,15 +994,27 @@ fn windows_script_launcher(interpreter: &str) -> Result<String> {
     {
         eyre::bail!("windows_script_interpreter: {interpreter:?} must be a plain executable name");
     }
-    Ok(format!("@echo off\r\n{interpreter} \"%~dpn0\" %*\r\n"))
+    let filename = script
+        .file_name()
+        .and_then(|filename| filename.to_str())
+        .ok_or_else(|| eyre::eyre!("Windows script launcher requires a UTF-8 file name"))?;
+    ensure_plain_bin_name("windows script", filename)?;
+    if filename.is_empty()
+        || !filename
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-'))
+    {
+        eyre::bail!("Windows script file name {filename:?} contains unsupported characters");
+    }
+    let launcher = script.with_file_name(format!("{filename}.cmd"));
+    let body = format!("@echo off\r\n{interpreter} \"%~dp0{filename}\" %*\r\n");
+    Ok((launcher, body))
 }
 
 #[cfg(windows)]
 fn write_windows_script_launcher(script: &Path, interpreter: &str) -> Result<()> {
-    file::write(
-        script.with_extension("cmd"),
-        windows_script_launcher(interpreter)?,
-    )
+    let (launcher, body) = windows_script_launcher(script, interpreter)?;
+    file::write(launcher, body)
 }
 
 /// Returns install-time-only option keys for HTTP backend.
@@ -1328,12 +1340,18 @@ mod tests {
     use crate::toolset::{ToolRequest, ToolSource};
 
     #[test]
-    fn windows_script_launcher_invokes_extensionless_script() {
-        assert_eq!(
-            windows_script_launcher("node").unwrap(),
-            "@echo off\r\nnode \"%~dpn0\" %*\r\n"
-        );
-        assert!(windows_script_launcher("node & echo injected").is_err());
+    fn windows_script_launcher_preserves_script_filename() {
+        for filename in ["tool", "tool.js", "tool.cmd"] {
+            let script = Path::new("C:/tools").join(filename);
+            let (launcher, body) = windows_script_launcher(&script, "node").unwrap();
+            assert_eq!(launcher, script.with_file_name(format!("{filename}.cmd")));
+            assert_eq!(
+                body,
+                format!("@echo off\r\nnode \"%~dp0{filename}\" %*\r\n")
+            );
+            assert_ne!(launcher, script);
+        }
+        assert!(windows_script_launcher(Path::new("tool.js"), "node & echo injected").is_err());
     }
 
     fn http_test_tv(version: &str) -> ToolVersion {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3008,10 +3008,10 @@ pub trait Backend: Debug + Send + Sync {
                 .collect()
         } else if crate::config::config_file::idiomatic_version::package_json::is_package_json(path)
         {
-            crate::config::config_file::idiomatic_version::package_json::parse(path, self.id())?
-                .into_iter()
-                .map(|version| (version, None))
-                .collect()
+            crate::config::config_file::idiomatic_version::package_json::parse_with_options(
+                path,
+                self.id(),
+            )?
         } else {
             self._parse_idiomatic_file_with_options(path).await?
         };

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -84,6 +84,10 @@ impl<'a> NpmOptions<'a> {
         self.values.str("aube_args")
     }
 
+    fn checksum(&self) -> Option<&'a str> {
+        self.values.str("checksum")
+    }
+
     fn trust_policy_excludes(&self) -> eyre::Result<Vec<String>> {
         Self::string_list_option(
             self.values.raw().opts.get("trust_policy_excludes"),
@@ -403,6 +407,7 @@ impl Backend for NPMBackend {
             .await;
         let request_options = tv.request.options();
         let options = NpmOptions::new(&request_options);
+        let package = self.package_install_spec(ctx, &tv, &options).await?;
         let install_before_args = match ctx.before_date {
             Some(before_date) => {
                 self.warn_if_package_manager_may_not_support_release_age(ctx, package_manager)
@@ -415,16 +420,18 @@ impl Backend for NPMBackend {
         match package_manager {
             NpmPackageManager::Auto => unreachable!("auto package manager should be resolved"),
             NpmPackageManager::Aube => {
-                self.install_via_aube_embed(ctx, &tv, &options).await?;
+                self.install_via_aube_embed(ctx, &tv, &options, &package)
+                    .await?;
             }
             NpmPackageManager::AubeCli => {
-                self.install_via_aube_cli(ctx, &tv, &options).await?;
+                self.install_via_aube_cli(ctx, &tv, &options, &package)
+                    .await?;
             }
             NpmPackageManager::Bun => {
                 let mut cmd =
                     CmdLineRunner::new(self.spawn_program(&ctx.config, Some(&ctx.ts), "bun").await)
                         .arg("install")
-                        .arg(format!("{}@{}", self.tool_name(), tv.version))
+                        .arg(&package)
                         .arg("--global")
                         // Isolated linker does not symlink binaries into BUN_INSTALL_BIN properly.
                         // https://github.com/jdx/mise/discussions/7541
@@ -457,7 +464,7 @@ impl Backend for NPMBackend {
                 )
                 .arg("add")
                 .arg("--global")
-                .arg(format!("{}@{}", self.tool_name(), tv.version))
+                .arg(&package)
                 .arg("--global-dir")
                 .arg(tv.install_path())
                 .arg("--global-bin-dir")
@@ -505,7 +512,7 @@ impl Backend for NPMBackend {
                     CmdLineRunner::new(self.spawn_program(&ctx.config, Some(&ctx.ts), "npm").await)
                         .arg("install")
                         .arg("-g")
-                        .arg(format!("{}@{}", self.tool_name(), tv.version))
+                        .arg(&package)
                         .arg("--prefix")
                         .arg(tv.install_path())
                         .args(install_before_args)
@@ -559,6 +566,30 @@ impl Backend for NPMBackend {
 }
 
 impl NPMBackend {
+    async fn package_install_spec(
+        &self,
+        ctx: &InstallContext,
+        tv: &ToolVersion,
+        options: &NpmOptions<'_>,
+    ) -> Result<String> {
+        let Some(checksum) = options.checksum() else {
+            return Ok(format!("{}@{}", self.tool_name(), tv.version));
+        };
+        let (algorithm, digest) = checksum
+            .split_once(':')
+            .ok_or_else(|| eyre::eyre!("invalid packageManager checksum {checksum:?}"))?;
+        let download_dir = tv.download_path();
+        crate::file::create_dir_all(&download_dir)?;
+        let archive = download_dir.join("package.tgz");
+        ctx.pr
+            .set_message(format!("download {}@{}", self.tool_name(), tv.version));
+        npm_registry::download_tarball(&self.tool_name(), &tv.version, &archive).await?;
+        ctx.pr
+            .set_message(format!("verify {}@{}", self.tool_name(), tv.version));
+        crate::hash::ensure_checksum(&archive, digest, Some(ctx.pr.as_ref()), algorithm)?;
+        Ok(archive.to_string_lossy().into_owned())
+    }
+
     pub fn from_arg(ba: BackendArg) -> Self {
         Self {
             latest_version_cache: TokioMutex::new(
@@ -928,6 +959,7 @@ impl NPMBackend {
         ctx: &InstallContext,
         tv: &ToolVersion,
         options: &NpmOptions<'_>,
+        package: &str,
     ) -> Result<()> {
         crate::backend::aube_host::init();
         let install_path = tv.install_path();
@@ -972,7 +1004,7 @@ impl NPMBackend {
         };
         opts.ignore_scripts = matches!(allow_builds, AllowBuilds::None);
 
-        let package = format!("{}@{}", self.tool_name(), tv.version);
+        let package = package.to_string();
         let install = aube::embed::add_with_overrides(
             &install_path,
             std::slice::from_ref(&package),
@@ -1007,6 +1039,7 @@ impl NPMBackend {
         ctx: &InstallContext,
         tv: &ToolVersion,
         options: &NpmOptions<'_>,
+        package: &str,
     ) -> Result<()> {
         let bin_dir = tv.install_path().join("bin");
         let aube_program = self
@@ -1022,7 +1055,7 @@ impl NPMBackend {
         let mut cmd = CmdLineRunner::new(aube_program)
             .arg("add")
             .arg("--global")
-            .arg(format!("{}@{}", self.tool_name(), tv.version))
+            .arg(package)
             .with_pr(ctx.pr.as_ref())
             .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
             .env_values(tv.install_env())

--- a/src/backend/npm_registry.rs
+++ b/src/backend/npm_registry.rs
@@ -12,6 +12,7 @@
 //! authenticate mise-owned metadata queries. User-level `~/.npmrc` (or
 //! `NPM_CONFIG_USERCONFIG`) and `NPM_CONFIG_*` env vars still apply.
 
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::LazyLock as Lazy;
 
@@ -108,6 +109,18 @@ fn sort_versions<'a>(versions: impl Iterator<Item = &'a String>) -> Vec<&'a Stri
 pub async fn latest_dist_tag(name: &str) -> Result<Option<String>> {
     let packument = fetch_packument(name).await?;
     Ok(packument.dist_tags.get("latest").cloned())
+}
+
+/// Download the exact npm registry tarball for a package version, honoring
+/// user npm registry and authentication configuration.
+pub async fn download_tarball(name: &str, version: &str, path: &Path) -> Result<()> {
+    let metadata = CLIENT.fetch_single_version_metadata(name, version).await?;
+    let dist = metadata
+        .dist
+        .ok_or_else(|| eyre::eyre!("npm package {name}@{version} has no dist metadata"))?;
+    let bytes = CLIENT.fetch_tarball_bytes(&dist.tarball).await?;
+    crate::file::write(path, bytes)?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -435,6 +435,15 @@ impl BackendArg {
             return env_value;
         }
 
+        // An explicitly resolved full backend must not be replaced by a short-name
+        // alias or lockfile entry. This is also used by package.json checksum
+        // declarations, which require the backend that publishes the verified artifact.
+        if self.resolution.explicit
+            && let Some(full) = &self.full
+        {
+            return full.clone();
+        }
+
         if config::is_loaded() {
             if let Some(full) = Config::get_()
                 .all_aliases

--- a/src/config/config_file/idiomatic_version/mod.rs
+++ b/src/config/config_file/idiomatic_version/mod.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use eyre::{Result, eyre};
 
 use crate::backend::BackendList;
-use crate::cli::args::BackendArg;
+use crate::cli::args::{BackendArg, BackendResolution};
 use crate::config::config_file::ConfigFile;
 use crate::file;
 use crate::toolset::{ToolRequest, ToolRequestSet, ToolSource};
@@ -33,9 +33,14 @@ impl IdiomaticVersionFile {
         for plugin in plugins {
             match plugin.parse_idiomatic_file_with_options(&path).await {
                 Ok(versions) => {
-                    for (version, options) in versions {
-                        let mut tr =
-                            ToolRequest::new(plugin.ba().clone(), &version, source.clone())?;
+                    for (version, mut options) in versions {
+                        let backend = package_manager_checksum_backend(
+                            plugin.ba(),
+                            &version,
+                            &mut options,
+                            &path,
+                        )?;
+                        let mut tr = ToolRequest::new(backend, &version, source.clone())?;
                         tr.set_options(options);
                         tools.add_version(tr, &source);
                     }
@@ -56,6 +61,57 @@ impl IdiomaticVersionFile {
             file::display_path(&self.path)
         )
     }
+}
+
+fn package_manager_checksum_backend(
+    backend: &std::sync::Arc<BackendArg>,
+    version: &str,
+    options: &mut crate::toolset::ToolVersionOptions,
+    path: &Path,
+) -> Result<std::sync::Arc<BackendArg>> {
+    if !package_json::is_package_json(path) {
+        return Ok(backend.clone());
+    }
+    let Some(checksum) = options.opts.shift_remove("package_manager_checksum") else {
+        return Ok(backend.clone());
+    };
+    options.opts.insert("checksum".to_string(), checksum);
+
+    let full = match backend.short.as_str() {
+        "npm" => "npm:npm",
+        "pnpm" => "npm:pnpm",
+        "yarn" => {
+            let version = semver::Version::parse(version).map_err(|error| {
+                eyre!("packageManager checksum requires an exact Yarn version: {error}")
+            })?;
+            if version.major < 2 {
+                "npm:yarn"
+            } else {
+                options.opts.insert(
+                    "url".to_string(),
+                    toml::Value::String(format!(
+                        "https://repo.yarnpkg.com/{version}/packages/yarnpkg-cli/bin/yarn.js"
+                    )),
+                );
+                options
+                    .opts
+                    .insert("bin".to_string(), toml::Value::String("yarn".to_string()));
+                "http:yarn"
+            }
+        }
+        _ => return Ok(backend.clone()),
+    };
+    let tool_name = full
+        .split_once(':')
+        .map(|(_, tool_name)| tool_name)
+        .unwrap_or(full);
+    Ok(std::sync::Arc::new(BackendArg::new_raw(
+        backend.short.clone(),
+        Some(full.to_string()),
+        tool_name.to_string(),
+        None,
+        BackendResolution::new(true),
+    )))
 }
 
 impl ConfigFile for IdiomaticVersionFile {
@@ -200,5 +256,36 @@ mod tests {
             err.to_string()
                 .contains("cannot remove tools from idiomatic version file")
         );
+    }
+
+    #[test]
+    fn test_package_manager_checksums_use_matching_corepack_artifacts() {
+        let path = Path::new("package.json");
+        for (tool, version, expected) in [
+            ("npm", "11.0.0", "npm:npm"),
+            ("pnpm", "10.0.0", "npm:pnpm"),
+            ("yarn", "1.22.22", "npm:yarn"),
+            ("yarn", "4.0.0", "http:yarn"),
+        ] {
+            let mut options = crate::toolset::ToolVersionOptions::default();
+            options.opts.insert(
+                "package_manager_checksum".to_string(),
+                toml::Value::String("sha224:abc".to_string()),
+            );
+            let backend = MockBackend::new(tool, false, None).ba;
+            let backend =
+                package_manager_checksum_backend(&backend, version, &mut options, path).unwrap();
+            assert_eq!(backend.full(), expected);
+            if expected == "http:yarn" {
+                assert_eq!(
+                    options.opts.get("url").and_then(toml::Value::as_str),
+                    Some("https://repo.yarnpkg.com/4.0.0/packages/yarnpkg-cli/bin/yarn.js")
+                );
+                assert_eq!(
+                    options.opts.get("bin").and_then(toml::Value::as_str),
+                    Some("yarn")
+                );
+            }
+        }
     }
 }

--- a/src/config/config_file/idiomatic_version/mod.rs
+++ b/src/config/config_file/idiomatic_version/mod.rs
@@ -78,6 +78,12 @@ fn package_manager_checksum_backend(
     options.opts.insert("checksum".to_string(), checksum);
 
     let full = match backend.short.as_str() {
+        "bun" => {
+            options
+                .opts
+                .insert("allow_builds".to_string(), toml::Value::Boolean(true));
+            "npm:bun"
+        }
         "npm" => "npm:npm",
         "pnpm" => "npm:pnpm",
         "yarn" => {
@@ -266,6 +272,7 @@ mod tests {
     fn test_package_manager_checksums_use_matching_corepack_artifacts() {
         let path = Path::new("package.json");
         for (tool, version, expected) in [
+            ("bun", "1.3.14", "npm:bun"),
             ("npm", "11.0.0", "npm:npm"),
             ("pnpm", "10.0.0", "npm:pnpm"),
             ("yarn", "1.22.22", "npm:yarn"),
@@ -280,6 +287,12 @@ mod tests {
             let backend =
                 package_manager_checksum_backend(&backend, version, &mut options, path).unwrap();
             assert_eq!(backend.full(), expected);
+            if tool == "bun" {
+                assert_eq!(
+                    options.opts.get("allow_builds"),
+                    Some(&toml::Value::Boolean(true))
+                );
+            }
             if expected == "http:yarn" {
                 assert_eq!(
                     options.opts.get("url").and_then(toml::Value::as_str),

--- a/src/config/config_file/idiomatic_version/mod.rs
+++ b/src/config/config_file/idiomatic_version/mod.rs
@@ -96,6 +96,10 @@ fn package_manager_checksum_backend(
                 options
                     .opts
                     .insert("bin".to_string(), toml::Value::String("yarn".to_string()));
+                options.opts.insert(
+                    "windows_script_interpreter".to_string(),
+                    toml::Value::String("node".to_string()),
+                );
                 "http:yarn"
             }
         }
@@ -284,6 +288,13 @@ mod tests {
                 assert_eq!(
                     options.opts.get("bin").and_then(toml::Value::as_str),
                     Some("yarn")
+                );
+                assert_eq!(
+                    options
+                        .opts
+                        .get("windows_script_interpreter")
+                        .and_then(toml::Value::as_str),
+                    Some("node")
                 );
             }
         }

--- a/src/config/config_file/idiomatic_version/package_json.rs
+++ b/src/config/config_file/idiomatic_version/package_json.rs
@@ -1,4 +1,5 @@
 use crate::file;
+use crate::toolset::ToolVersionOptions;
 use eyre::Result;
 use serde::Deserialize;
 use serde::de::Deserializer;
@@ -81,7 +82,7 @@ impl PackageJsonData {
             .filter(|pm| pm.name.as_deref() == Some(tool_name))
             .and_then(|pm| pm.version.as_deref())
             .filter(|v| !v.is_empty())
-            .map(str::to_string)
+            .map(version_without_checksum)
             .or_else(|| {
                 // Fall back to packageManager field (e.g. "pnpm@9.1.0+sha256.abc")
                 let pm_field = self.package_manager.as_deref()?;
@@ -89,20 +90,49 @@ impl PackageJsonData {
                 if name != tool_name {
                     return None;
                 }
-                // Strip +sha... suffix
-                let version = rest.split('+').next().unwrap_or(rest).trim();
+                let version = version_without_checksum(rest);
                 if version.is_empty() {
                     return None;
                 }
-                Some(version.to_string())
+                Some(version)
+            })
+    }
+
+    fn package_manager_checksum(&self, tool_name: &str) -> Option<String> {
+        self.dev_engines
+            .as_ref()
+            .and_then(|de| de.package_manager.as_ref())
+            .filter(|pm| pm.name.as_deref() == Some(tool_name))
+            .and_then(|pm| pm.version.as_deref())
+            .and_then(checksum_from_version)
+            .or_else(|| {
+                let raw = self.package_manager.as_deref()?;
+                let (name, version) = raw.split_once('@')?;
+                (name == tool_name)
+                    .then(|| checksum_from_version(version))
+                    .flatten()
             })
     }
 }
 
-pub fn parse(path: &Path, tool_name: &str) -> Result<Vec<String>> {
+fn version_without_checksum(raw: &str) -> String {
+    raw.split('+').next().unwrap_or(raw).trim().to_string()
+}
+
+fn checksum_from_version(raw: &str) -> Option<String> {
+    let (_, checksum) = raw.split_once('+')?;
+    if let Some((algorithm, digest)) = checksum.split_once('.') {
+        return Some(format!("{algorithm}:{digest}"));
+    }
+    Some(checksum.to_string())
+}
+
+pub fn parse_with_options(
+    path: &Path,
+    tool_name: &str,
+) -> Result<Vec<(String, Option<ToolVersionOptions>)>> {
     let pkg = PackageJsonData::parse(path)?;
-    // We ignore unknown tools in package.json
-    let v = match tool_name {
+    let version = match tool_name {
         "node" | "deno" => pkg.runtime_version(tool_name),
         "bun" => pkg
             .runtime_version(tool_name)
@@ -110,11 +140,26 @@ pub fn parse(path: &Path, tool_name: &str) -> Result<Vec<String>> {
         "npm" | "yarn" | "pnpm" => pkg.package_manager_version(tool_name),
         _ => None,
     };
-    if let Some(v) = v {
-        Ok(vec![v])
-    } else {
-        Ok(vec![])
-    }
+    let Some(version) = version else {
+        return Ok(vec![]);
+    };
+
+    let options = pkg.package_manager_checksum(tool_name).map(|checksum| {
+        let mut options = ToolVersionOptions::default();
+        options.opts.insert(
+            "package_manager_checksum".to_string(),
+            toml::Value::String(checksum),
+        );
+        options
+    });
+    Ok(vec![(version, options)])
+}
+
+pub fn parse(path: &Path, tool_name: &str) -> Result<Vec<String>> {
+    Ok(parse_with_options(path, tool_name)?
+        .into_iter()
+        .map(|(version, _)| version)
+        .collect())
 }
 
 #[cfg(test)]
@@ -162,6 +207,53 @@ mod tests {
 
         assert_eq!(parse(&path, "bun").unwrap(), vec!["1.0.0".to_string()]);
         assert_eq!(parse(&path, "node").unwrap(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_package_manager_checksum_becomes_install_option() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("package.json");
+        fs::write(&path, r#"{"packageManager":"pnpm@9.1.0+sha224.abcdef"}"#).unwrap();
+
+        let parsed = parse_with_options(&path, "pnpm").unwrap();
+        assert_eq!(parsed[0].0, "9.1.0");
+        assert_eq!(
+            parsed[0]
+                .1
+                .as_ref()
+                .and_then(|options| options.opts.get("package_manager_checksum"))
+                .and_then(toml::Value::as_str),
+            Some("sha224:abcdef")
+        );
+    }
+
+    #[test]
+    fn test_dev_engines_package_manager_checksum_becomes_install_option() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("package.json");
+        fs::write(
+            &path,
+            r#"{
+                "devEngines": {
+                    "packageManager": {
+                        "name": "yarn",
+                        "version": "4.1.0+sha512.abcdef"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let parsed = parse_with_options(&path, "yarn").unwrap();
+        assert_eq!(parsed[0].0, "4.1.0");
+        assert_eq!(
+            parsed[0]
+                .1
+                .as_ref()
+                .and_then(|options| options.opts.get("package_manager_checksum"))
+                .and_then(toml::Value::as_str),
+            Some("sha512:abcdef")
+        );
     }
 
     #[test]

--- a/src/config/config_file/idiomatic_version/package_json.rs
+++ b/src/config/config_file/idiomatic_version/package_json.rs
@@ -72,51 +72,39 @@ impl PackageJsonData {
             .map(str::to_string)
     }
 
-    /// Extract a package manager version for the given tool name.
+    /// Extract a package manager version and checksum from the same declaration.
     /// Checks devEngines.packageManager first, then falls back to the packageManager field.
-    fn package_manager_version(&self, tool_name: &str) -> Option<String> {
-        // Try devEngines.packageManager first
+    fn package_manager_spec(&self, tool_name: &str) -> Option<(String, Option<String>)> {
         self.dev_engines
             .as_ref()
             .and_then(|de| de.package_manager.as_ref())
             .filter(|pm| pm.name.as_deref() == Some(tool_name))
             .and_then(|pm| pm.version.as_deref())
             .filter(|v| !v.is_empty())
-            .map(version_without_checksum)
+            .and_then(parse_package_manager_version)
             .or_else(|| {
-                // Fall back to packageManager field (e.g. "pnpm@9.1.0+sha256.abc")
                 let pm_field = self.package_manager.as_deref()?;
                 let (name, rest) = pm_field.split_once('@')?;
                 if name != tool_name {
                     return None;
                 }
-                let version = version_without_checksum(rest);
-                if version.is_empty() {
-                    return None;
-                }
-                Some(version)
+                parse_package_manager_version(rest)
             })
     }
 
-    fn package_manager_checksum(&self, tool_name: &str) -> Option<String> {
-        self.dev_engines
-            .as_ref()
-            .and_then(|de| de.package_manager.as_ref())
-            .filter(|pm| pm.name.as_deref() == Some(tool_name))
-            .and_then(|pm| pm.version.as_deref())
-            .and_then(checksum_from_version)
-            .or_else(|| {
-                let raw = self.package_manager.as_deref()?;
-                let (name, version) = raw.split_once('@')?;
-                (name == tool_name)
-                    .then(|| checksum_from_version(version))
-                    .flatten()
-            })
+    #[cfg(test)]
+    fn package_manager_version(&self, tool_name: &str) -> Option<String> {
+        self.package_manager_spec(tool_name)
+            .map(|(version, _)| version)
     }
 }
 
-fn version_without_checksum(raw: &str) -> String {
-    raw.split('+').next().unwrap_or(raw).trim().to_string()
+fn parse_package_manager_version(raw: &str) -> Option<(String, Option<String>)> {
+    let version = raw.split('+').next().unwrap_or(raw).trim();
+    if version.is_empty() {
+        return None;
+    }
+    Some((version.to_string(), checksum_from_version(raw)))
 }
 
 fn checksum_from_version(raw: &str) -> Option<String> {
@@ -132,19 +120,23 @@ pub fn parse_with_options(
     tool_name: &str,
 ) -> Result<Vec<(String, Option<ToolVersionOptions>)>> {
     let pkg = PackageJsonData::parse(path)?;
-    let version = match tool_name {
-        "node" | "deno" => pkg.runtime_version(tool_name),
+    let (version, checksum) = match tool_name {
+        "node" | "deno" => pkg
+            .runtime_version(tool_name)
+            .map(|version| (version, None)),
         "bun" => pkg
             .runtime_version(tool_name)
-            .or_else(|| pkg.package_manager_version(tool_name)),
-        "npm" | "yarn" | "pnpm" => pkg.package_manager_version(tool_name),
+            .map(|version| (version, None))
+            .or_else(|| pkg.package_manager_spec(tool_name)),
+        "npm" | "yarn" | "pnpm" => pkg.package_manager_spec(tool_name),
         _ => None,
-    };
-    let Some(version) = version else {
+    }
+    .unwrap_or_default();
+    if version.is_empty() {
         return Ok(vec![]);
-    };
+    }
 
-    let options = pkg.package_manager_checksum(tool_name).map(|checksum| {
+    let options = checksum.map(|checksum| {
         let mut options = ToolVersionOptions::default();
         options.opts.insert(
             "package_manager_checksum".to_string(),
@@ -254,6 +246,28 @@ mod tests {
                 .and_then(toml::Value::as_str),
             Some("sha512:abcdef")
         );
+    }
+
+    #[test]
+    fn test_package_manager_checksum_uses_selected_declaration() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("package.json");
+        fs::write(
+            &path,
+            r#"{
+                "devEngines": {
+                    "packageManager": {
+                        "name": "pnpm",
+                        "version": "10.0.0"
+                    }
+                },
+                "packageManager": "pnpm@9.0.0+sha224.unrelated"
+            }"#,
+        )
+        .unwrap();
+
+        let parsed = parse_with_options(&path, "pnpm").unwrap();
+        assert_eq!(parsed, vec![("10.0.0".to_string(), None)]);
     }
 
     #[test]

--- a/src/config/config_file/idiomatic_version/package_json.rs
+++ b/src/config/config_file/idiomatic_version/package_json.rs
@@ -75,6 +75,11 @@ impl PackageJsonData {
     /// Extract a package manager version and checksum from the same declaration.
     /// Checks devEngines.packageManager first, then falls back to the packageManager field.
     fn package_manager_spec(&self, tool_name: &str) -> Option<(String, Option<String>)> {
+        self.dev_engine_package_manager_spec(tool_name)
+            .or_else(|| self.top_level_package_manager_spec(tool_name))
+    }
+
+    fn dev_engine_package_manager_spec(&self, tool_name: &str) -> Option<(String, Option<String>)> {
         self.dev_engines
             .as_ref()
             .and_then(|de| de.package_manager.as_ref())
@@ -82,14 +87,29 @@ impl PackageJsonData {
             .and_then(|pm| pm.version.as_deref())
             .filter(|v| !v.is_empty())
             .and_then(parse_package_manager_version)
-            .or_else(|| {
-                let pm_field = self.package_manager.as_deref()?;
-                let (name, rest) = pm_field.split_once('@')?;
-                if name != tool_name {
-                    return None;
-                }
-                parse_package_manager_version(rest)
-            })
+    }
+
+    fn top_level_package_manager_spec(&self, tool_name: &str) -> Option<(String, Option<String>)> {
+        let pm_field = self.package_manager.as_deref()?;
+        let (name, rest) = pm_field.split_once('@')?;
+        if name != tool_name {
+            return None;
+        }
+        parse_package_manager_version(rest)
+    }
+
+    fn package_manager_checksum_for_version(
+        &self,
+        tool_name: &str,
+        version: &str,
+    ) -> Option<String> {
+        [
+            self.dev_engine_package_manager_spec(tool_name),
+            self.top_level_package_manager_spec(tool_name),
+        ]
+        .into_iter()
+        .flatten()
+        .find_map(|(candidate, checksum)| (candidate == version).then_some(checksum).flatten())
     }
 
     #[cfg(test)]
@@ -127,13 +147,7 @@ pub fn parse_with_options(
         "bun" => pkg
             .runtime_version(tool_name)
             .map(|version| {
-                let checksum = pkg.package_manager_spec(tool_name).and_then(
-                    |(package_manager_version, checksum)| {
-                        (package_manager_version == version)
-                            .then_some(checksum)
-                            .flatten()
-                    },
-                );
+                let checksum = pkg.package_manager_checksum_for_version(tool_name, &version);
                 (version, checksum)
             })
             .or_else(|| pkg.package_manager_spec(tool_name)),
@@ -330,6 +344,40 @@ mod tests {
         assert_eq!(
             parse_with_options(&path, "bun").unwrap(),
             vec![("1.3.14".to_string(), None)]
+        );
+    }
+
+    #[test]
+    fn test_bun_runtime_uses_unshadowed_matching_checksum() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("package.json");
+        fs::write(
+            &path,
+            r#"{
+                "devEngines": {
+                    "runtime": {
+                        "name": "bun",
+                        "version": "1.3.14"
+                    },
+                    "packageManager": {
+                        "name": "bun",
+                        "version": "1.3.13+sha224.unrelated"
+                    }
+                },
+                "packageManager": "bun@1.3.14+sha224.abcdef"
+            }"#,
+        )
+        .unwrap();
+
+        let parsed = parse_with_options(&path, "bun").unwrap();
+        assert_eq!(parsed[0].0, "1.3.14");
+        assert_eq!(
+            parsed[0]
+                .1
+                .as_ref()
+                .and_then(|options| options.opts.get("package_manager_checksum"))
+                .and_then(toml::Value::as_str),
+            Some("sha224:abcdef")
         );
     }
 

--- a/src/config/config_file/idiomatic_version/package_json.rs
+++ b/src/config/config_file/idiomatic_version/package_json.rs
@@ -126,7 +126,16 @@ pub fn parse_with_options(
             .map(|version| (version, None)),
         "bun" => pkg
             .runtime_version(tool_name)
-            .map(|version| (version, None))
+            .map(|version| {
+                let checksum = pkg.package_manager_spec(tool_name).and_then(
+                    |(package_manager_version, checksum)| {
+                        (package_manager_version == version)
+                            .then_some(checksum)
+                            .flatten()
+                    },
+                );
+                (version, checksum)
+            })
             .or_else(|| pkg.package_manager_spec(tool_name)),
         "npm" | "yarn" | "pnpm" => pkg.package_manager_spec(tool_name),
         _ => None,
@@ -268,6 +277,60 @@ mod tests {
 
         let parsed = parse_with_options(&path, "pnpm").unwrap();
         assert_eq!(parsed, vec![("10.0.0".to_string(), None)]);
+    }
+
+    #[test]
+    fn test_bun_runtime_uses_matching_package_manager_checksum() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("package.json");
+        fs::write(
+            &path,
+            r#"{
+                "devEngines": {
+                    "runtime": {
+                        "name": "bun",
+                        "version": "1.3.14"
+                    }
+                },
+                "packageManager": "bun@1.3.14+sha224.abcdef"
+            }"#,
+        )
+        .unwrap();
+
+        let parsed = parse_with_options(&path, "bun").unwrap();
+        assert_eq!(parsed[0].0, "1.3.14");
+        assert_eq!(
+            parsed[0]
+                .1
+                .as_ref()
+                .and_then(|options| options.opts.get("package_manager_checksum"))
+                .and_then(toml::Value::as_str),
+            Some("sha224:abcdef")
+        );
+    }
+
+    #[test]
+    fn test_bun_runtime_ignores_different_package_manager_checksum() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("package.json");
+        fs::write(
+            &path,
+            r#"{
+                "devEngines": {
+                    "runtime": {
+                        "name": "bun",
+                        "version": "1.3.14"
+                    }
+                },
+                "packageManager": "bun@1.3.13+sha224.unrelated"
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            parse_with_options(&path, "bun").unwrap(),
+            vec![("1.3.14".to_string(), None)]
+        );
     }
 
     #[test]

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -11,7 +11,7 @@ use digest::Digest;
 use eyre::{Result, bail};
 use md5::Md5;
 use sha1::Sha1;
-use sha2::{Sha256, Sha512};
+use sha2::{Sha224, Sha256, Sha384, Sha512};
 use siphasher::sip::SipHasher;
 
 pub fn hash_to_str<T: Hash>(t: &T) -> String {
@@ -109,6 +109,8 @@ pub fn ensure_checksum(
             }
         }
         "sha256" => file_hash_prog::<Sha256>(path, pr)?,
+        "sha224" => file_hash_prog::<Sha224>(path, pr)?,
+        "sha384" => file_hash_prog::<Sha384>(path, pr)?,
         "sha1" => {
             if use_external_hasher && file::which("sha1sum").is_some() {
                 let out = cmd!("sha1sum", path).read()?;
@@ -171,5 +173,27 @@ mod tests {
         let path = Path::new(".test-tool-versions");
         let hash = file_hash_prog::<Sha256>(path, None).unwrap();
         assert_snapshot!(hash);
+    }
+
+    #[test]
+    fn test_corepack_checksum_algorithms() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("package.tgz");
+        file::write(&path, b"corepack").unwrap();
+
+        ensure_checksum(
+            &path,
+            "8aba612a6193520492b81c698962a0d81c3609da7ab498d028ac452e",
+            None,
+            "sha224",
+        )
+        .unwrap();
+        ensure_checksum(
+            &path,
+            "cbedf1fe9f759bba045da15cecdfb24340308ffdae357bbb0a10bed2535aa957c7cad13d8081847203cd409a7a7e3cda",
+            None,
+            "sha384",
+        )
+        .unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- honor Corepack checksum suffixes from `packageManager` and `devEngines.packageManager`
- install and verify the exact npm, pnpm, Yarn Classic, or modern Yarn artifact named by the declaration
- document using mise as a Corepack replacement, including package.json discovery and lazy shim installation

## Testing
- `mise run lint`
- `cargo check --locked`
- `cargo test --locked --bin mise config::config_file::idiomatic_version`
- `cargo test --locked --bin mise hash::tests`
- `mise run build`
- `TEST_ALL=1 mise run test:e2e e2e/core/test_package_manager_checksum_slow`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes package-manager install paths, checksum verification, and backend selection from package.json. Incorrect verification or backend pinning could install the wrong artifact.
> 
> **Overview**
> mise now treats Corepack `+sha*` suffixes in `packageManager` / `devEngines.packageManager` as install checksums and verifies the matching artifact before install.
> 
> When a checksum is present, npm/pnpm/Yarn Classic/bun install from the npm registry tarball; Yarn 2+ uses Yarn’s published CLI via the HTTP backend. Explicit backend resolution is preserved so aliases cannot swap the verified source. SHA-224 and SHA-384 hashing is added for those suffixes.
> 
> The HTTP backend can emit a Windows `.cmd` launcher (`windows_script_interpreter`) so Yarn’s JS CLI runs on Windows. Docs drop the Corepack hook example and describe using mise as a Corepack replacement, including idiomatic `package.json` discovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d45ea54e2b22fa755e5d5c8d2910422d276cd57e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added checksum verification for npm, pnpm, Yarn, and Bun installations.
  * Added support for SHA-224 and SHA-384 checksums.
  * Added support for modern Yarn versions and Windows script launchers.
  * Package managers can now use project-declared versions with verified downloads.
  * Added guidance for replacing Corepack with mise-managed package-manager versions.

* **Bug Fixes**
  * Improved handling of package-manager declarations, version-file options, and checksum metadata.
  * Invalid checksums and verification failures now produce installation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->