### PR TITLE
fix(task): preserve explicit global task overlays

### DIFF
--- a/docs/tasks/file-tasks.md
+++ b/docs/tasks/file-tasks.md
@@ -11,6 +11,10 @@ In addition to defining tasks through the configuration, they can also be define
 These are the default file-task directories. If [`task_config.includes`](/tasks/task-configuration.html#task_config.includes)
 is set for the current config scope, mise searches only the paths listed there instead.
 
+Global file tasks live in `$MISE_CONFIG_DIR/tasks` (default `~/.config/mise/tasks`) and system-wide
+file tasks in `$MISE_SYSTEM_DIR/tasks` (default `/etc/mise/tasks`). These directories are picked up
+even when the scope has no config file at all.
+
 Here is an example of a file task that builds a Rust CLI:
 
 ```bash [mise-tasks/build]

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -1484,6 +1484,12 @@ The default file-task directories are:
 - `.config/mise/tasks`
 - `mise/tasks`
 
+For the user-global scope, the `.config/mise/tasks` entry points at the actual config dir: when
+`MISE_CONFIG_DIR` is set to a non-default location, `$MISE_CONFIG_DIR/tasks` is used instead (and
+the default location is no longer treated as global). The system scope similarly uses
+`$MISE_SYSTEM_DIR/tasks` (default `/etc/mise/tasks`). Both directories are loaded even when no
+config file exists in that scope, so a scripts-only setup works without a `config.toml`.
+
 If you want to keep the defaults and add another directory, include the defaults explicitly:
 
 ```toml

--- a/e2e/tasks/test_task_global_config_precedence
+++ b/e2e/tasks/test_task_global_config_precedence
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+export MISE_EXPERIMENTAL=1
+
+mkdir -p "$HOME/.config/mise/conf.d" "$HOME/.config/mise/tasks"
+
+cat <<'EOF' >"$MISE_SYSTEM_DIR/config.toml"
+[tasks.e]
+description = "system/config/e"
+env = { SYSTEM_PRECEDENCE = "applied" }
+
+[tasks.system-vs-conf-d]
+run = "echo system"
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/conf.d/01-base.toml"
+[tasks.e]
+description = "global/conf.d/01/e"
+env = { LOWER_PRECEDENCE = "applied" }
+
+[tasks.system-vs-conf-d]
+run = "echo conf-d"
+
+[tasks.conf-d-order]
+run = "echo conf-d-01"
+
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/conf.d/02-override.toml"
+[tasks.conf-d-order]
+run = "echo conf-d-02"
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/config.toml"
+[task_config]
+includes = [".config/mise/tasks"]
+
+[tasks.e]
+description = "global/config/e"
+env = { HIGHER_PRECEDENCE = "applied" }
+
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/tasks/e"
+#!/usr/bin/env bash
+echo "HIGHER_PRECEDENCE=${HIGHER_PRECEDENCE:-<unset>}"
+echo "LOWER_PRECEDENCE=${LOWER_PRECEDENCE:-<unset>}"
+echo "SYSTEM_PRECEDENCE=${SYSTEM_PRECEDENCE:-<unset>}"
+EOF
+chmod +x "$HOME/.config/mise/tasks/e"
+
+mkdir -p "$TMPDIR/outside-home"
+assert_contains "mise tasks --global" "global/config/e"
+assert_contains "mise run e" "HIGHER_PRECEDENCE=applied"
+assert_contains "mise run e" "LOWER_PRECEDENCE=<unset>"
+assert_contains "mise run e" "SYSTEM_PRECEDENCE=<unset>"
+assert_contains "mise -C '$TMPDIR/outside-home' run e" "HIGHER_PRECEDENCE=applied"
+assert_contains "mise -C '$TMPDIR/outside-home' run e" "LOWER_PRECEDENCE=<unset>"
+assert_contains "mise -C '$TMPDIR/outside-home' run e" "SYSTEM_PRECEDENCE=<unset>"
+assert "mise run system-vs-conf-d" "conf-d"
+assert "mise run conf-d-order" "conf-d-02"

--- a/e2e/tasks/test_task_global_default_includes
+++ b/e2e/tasks/test_task_global_default_includes
@@ -64,3 +64,56 @@ chmod +x ~/custom-tasks/custom-included
 assert "mise run custom-included" "custom-included"
 assert "mise tasks --global" "custom-included
 system-scripts-only"
+
+# glob metacharacters in the config dir path must not break discovery
+mkdir -p "$HOME/cfg [x]/tasks"
+cat <<'EOF' >"$HOME/cfg [x]/tasks/metachar-task"
+#!/usr/bin/env bash
+echo metachar-task
+EOF
+chmod +x "$HOME/cfg [x]/tasks/metachar-task"
+assert "MISE_CONFIG_DIR='$HOME/cfg [x]' mise run metachar-task" "metachar-task"
+
+unset MISE_CONFIG_DIR
+
+# with the default config dir, the config-dir entry still resolves relative to
+# a custom global root
+cat >~/.config/mise/config.toml <<'TOML'
+tasks.myglobal = { run = 'echo myglobal' }
+TOML
+mkdir -p ~/groot/.config/mise/tasks
+cat <<'EOF' >~/groot/.config/mise/tasks/groot-task
+#!/usr/bin/env bash
+echo groot-task
+EOF
+chmod +x ~/groot/.config/mise/tasks/groot-task
+assert "MISE_GLOBAL_CONFIG_ROOT=$HOME/groot mise tasks --global" "groot-task
+myglobal
+scripts-only
+system-scripts-only"
+
+# run from outside HOME so the ancestor walk cannot reach the global dirs and
+# only the global scopes themselves are observed
+mkdir -p "$TMPDIR/outside"
+
+# a nonexistent MISE_GLOBAL_CONFIG_FILE disables the user scope entirely
+assert "MISE_GLOBAL_CONFIG_FILE=$HOME/nope.toml mise -C '$TMPDIR/outside' tasks --global" "system-scripts-only"
+
+# a scope whose config file was consumed by the other scope stays disabled
+cat >"$HOME/shared-global.toml" <<'TOML'
+[task_config]
+includes = []
+TOML
+assert_empty "MISE_GLOBAL_CONFIG_FILE=$HOME/shared-global.toml MISE_SYSTEM_CONFIG_FILE=$HOME/shared-global.toml mise -C '$TMPDIR/outside' tasks --global"
+
+# --no-config disables global file-task discovery too
+assert_empty "MISE_NO_CONFIG=1 mise -C '$TMPDIR/outside' tasks --global"
+
+# a config dir inside a project keeps that project's task context
+mkdir -p "$HOME/proj/.config/mise/tasks"
+cat <<'EOF' >"$HOME/proj/.config/mise/tasks/proj-pwd"
+#!/usr/bin/env bash
+echo "PWD=$PWD"
+EOF
+chmod +x "$HOME/proj/.config/mise/tasks/proj-pwd"
+assert "MISE_CONFIG_DIR=$HOME/proj/.config/mise mise -C $HOME/proj run proj-pwd" "PWD=$HOME/proj"

--- a/e2e/tasks/test_task_global_default_includes
+++ b/e2e/tasks/test_task_global_default_includes
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+echo "tasks.mylocal = { run = 'echo mylocal' }" >mise.toml
+
+# the user-global scope owns its config dir's tasks/ even without a config file
+mkdir -p "$MISE_CONFIG_DIR/tasks"
+cat <<'EOF' >"$MISE_CONFIG_DIR/tasks/scripts-only"
+#!/usr/bin/env bash
+echo scripts-only
+EOF
+chmod +x "$MISE_CONFIG_DIR/tasks/scripts-only"
+
+assert "mise run scripts-only" "scripts-only"
+assert "mise tasks --global" "scripts-only"
+
+# the system scope owns its tasks dir even without a system config file
+mkdir -p "$MISE_SYSTEM_DIR/tasks"
+cat <<'EOF' >"$MISE_SYSTEM_DIR/tasks/system-scripts-only"
+#!/usr/bin/env bash
+echo system-scripts-only
+EOF
+chmod +x "$MISE_SYSTEM_DIR/tasks/system-scripts-only"
+
+assert "mise run system-scripts-only" "system-scripts-only"
+assert "mise tasks --global" "scripts-only
+system-scripts-only"
+
+# a relocated config dir owns its own tasks/; the default location is no
+# longer part of the global scope but stays discoverable as a HOME-local task
+mkdir -p ~/relocated-config/tasks
+cat <<'EOF' >~/relocated-config/tasks/relocated
+#!/usr/bin/env bash
+echo relocated
+EOF
+chmod +x ~/relocated-config/tasks/relocated
+
+export MISE_CONFIG_DIR="$HOME/relocated-config"
+assert "mise run relocated" "relocated"
+assert "mise tasks --global" "relocated
+system-scripts-only"
+assert "mise run scripts-only" "scripts-only"
+
+# a config file in the relocated dir keeps the same default include
+cat >"$MISE_CONFIG_DIR/config.toml" <<'TOML'
+tasks.myglobal = { run = 'echo myglobal' }
+TOML
+assert "mise run relocated" "relocated"
+assert "mise tasks --global" "myglobal
+relocated
+system-scripts-only"
+
+# explicit task_config.includes still replaces the default include
+cat >"$MISE_CONFIG_DIR/config.toml" <<'TOML'
+[task_config]
+includes = ["custom-tasks"]
+TOML
+mkdir -p ~/custom-tasks
+cat <<'EOF' >~/custom-tasks/custom-included
+#!/usr/bin/env bash
+echo custom-included
+EOF
+chmod +x ~/custom-tasks/custom-included
+
+assert "mise run custom-included" "custom-included"
+assert "mise tasks --global" "custom-included
+system-scripts-only"

--- a/e2e/tasks/test_task_global_include_precedence
+++ b/e2e/tasks/test_task_global_include_precedence
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+export MISE_EXPERIMENTAL=1
+
+mkdir -p "$HOME/.config/mise/conf.d" "$HOME/.config/mise/tasks" \
+  "$HOME/global-custom-tasks" "$HOME/high-global-tasks"
+
+cat <<'EOF' >"$MISE_SYSTEM_DIR/config.toml"
+[tasks.g]
+run = "echo system-inline/g"
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/conf.d/01-base.toml"
+[task_config]
+includes = ["global-custom-tasks"]
+EOF
+
+cat <<EOF >"$HOME/.config/mise/conf.d/02-override.toml"
+[task_config]
+includes = [".config/mise/tasks"]
+
+[tasks.i]
+run = "echo lower-inline/i"
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/config.toml"
+[task_config]
+includes = [".config/mise/tasks", "high-global-tasks"]
+
+[tasks.f]
+run = "echo high-inline/f"
+EOF
+
+cat <<'EOF' >"$HOME/global-custom-tasks/f"
+#!/usr/bin/env bash
+echo lower-script/f
+EOF
+chmod +x "$HOME/global-custom-tasks/f"
+
+cat <<'EOF' >"$HOME/global-custom-tasks/h"
+#!/usr/bin/env bash
+echo lower-script/h
+EOF
+chmod +x "$HOME/global-custom-tasks/h"
+
+cat <<'EOF' >"$HOME/global-custom-tasks/file-collision"
+#!/usr/bin/env bash
+echo lower-script/file-collision
+EOF
+chmod +x "$HOME/global-custom-tasks/file-collision"
+
+cat <<'EOF' >"$HOME/high-global-tasks/i"
+#!/usr/bin/env bash
+echo high-script/i
+EOF
+chmod +x "$HOME/high-global-tasks/i"
+
+cat <<'EOF' >"$HOME/high-global-tasks/file-collision"
+#!/usr/bin/env bash
+echo high-script/file-collision
+EOF
+chmod +x "$HOME/high-global-tasks/file-collision"
+
+mkdir -p "$TMPDIR/outside-home"
+assert_contains "mise -C '$TMPDIR/outside-home' run f" "high-inline/f"
+assert_not_contains "mise -C '$TMPDIR/outside-home' run f" "lower-script/f"
+assert_contains "mise -C '$TMPDIR/outside-home' run g" "system-inline/g"
+# the highest config with explicit includes owns the scope's include set, so
+# 01-base's include dir is not loaded at all
+assert_fail "mise -C '$TMPDIR/outside-home' run h" "no task h found"
+assert_contains "mise -C '$TMPDIR/outside-home' run i" "high-script/i"
+assert_not_contains "mise -C '$TMPDIR/outside-home' run i" "lower-inline/i"
+assert "mise -C '$TMPDIR/outside-home' run file-collision" "high-script/file-collision"

--- a/e2e/tasks/test_task_global_source_context_precedence
+++ b/e2e/tasks/test_task_global_source_context_precedence
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+export MISE_EXPERIMENTAL=1
+
+mkdir -p "$HOME/.config/mise/conf.d" "$HOME/.config/mise/tasks" \
+  "$HOME/high-global-dir" "$HOME/low-global-dir"
+ln -s ".config/mise/tasks" "$HOME/linked-global-tasks"
+cat <<'EOF' >"$HOME/high-shell"
+#!/usr/bin/env bash
+exec sh "$@"
+EOF
+chmod +x "$HOME/high-shell"
+
+cat <<EOF >"$HOME/.config/mise/conf.d/02-override.toml"
+[task_config]
+dir = "$HOME/low-global-dir"
+includes = ["linked-global-tasks", "shared-tasks.toml"]
+shell = "$HOME/low-shell -c"
+
+[task_config.input_groups]
+rust = ["Cargo.toml"]
+
+[tasks.j]
+env = { INLINE_METADATA = "applied" }
+
+[tasks.group-overlay]
+sources = ["@group:rust"]
+
+[tasks.explicit-shell-overlay]
+shell = "$HOME/explicit-shell -c"
+
+[tasks.toml-overlay]
+env = { TOML_INLINE_METADATA = "applied" }
+
+[tasks.output-contract]
+sources = ["lower-input"]
+
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/conf.d/01-base.toml"
+[tasks.j]
+env = { LOWER_INLINE_METADATA = "applied" }
+EOF
+
+cat <<EOF >"$HOME/.config/mise/config.toml"
+[task_config]
+includes = [".config/mise/tasks", "shared-tasks.toml"]
+dir = "$HOME/high-global-dir"
+shell = "$HOME/high-shell -c"
+EOF
+
+cat <<'EOF' >"$HOME/shared-tasks.toml"
+[toml-overlay]
+run = '''
+echo "TOML_INLINE_METADATA=${TOML_INLINE_METADATA:-<unset>}"
+echo "TASK_DIR=$PWD"
+'''
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/tasks/j"
+#!/usr/bin/env bash
+echo same-script/j
+echo "INLINE_METADATA=${INLINE_METADATA:-<unset>}"
+echo "LOWER_INLINE_METADATA=${LOWER_INLINE_METADATA:-<unset>}"
+echo "TASK_DIR=$PWD"
+EOF
+chmod +x "$HOME/.config/mise/tasks/j"
+cat <<'EOF' >"$HOME/.config/mise/tasks/group-overlay"
+#!/usr/bin/env bash
+echo group-overlay
+EOF
+chmod +x "$HOME/.config/mise/tasks/group-overlay"
+cat <<'EOF' >"$HOME/.config/mise/tasks/explicit-shell-overlay"
+#!/usr/bin/env bash
+echo explicit-shell-overlay
+EOF
+chmod +x "$HOME/.config/mise/tasks/explicit-shell-overlay"
+cat <<'EOF' >"$HOME/.config/mise/tasks/output-contract"
+#!/usr/bin/env bash
+#MISE outputs=["high-artifact"]
+echo output-contract
+EOF
+chmod +x "$HOME/.config/mise/tasks/output-contract"
+mkdir -p "$TMPDIR/outside-home"
+assert_contains "mise -C '$TMPDIR/outside-home' run j" "same-script/j"
+assert_contains "mise -C '$TMPDIR/outside-home' run j" "INLINE_METADATA=applied"
+assert_contains "mise -C '$TMPDIR/outside-home' run j" "LOWER_INLINE_METADATA=<unset>"
+assert_contains "mise -C '$TMPDIR/outside-home' run j" "TASK_DIR=$HOME/high-global-dir"
+assert_not_contains "mise -C '$TMPDIR/outside-home' run j" "TASK_DIR=$HOME/low-global-dir"
+assert \
+  "mise -C '$TMPDIR/outside-home' tasks ls --json | jq -r '.[] | select(.name == \"group-overlay\") | .sources[0]'" \
+  "$HOME/Cargo.toml"
+assert \
+  "mise -C '$TMPDIR/outside-home' tasks ls --json | jq -c '.[] | select(.name == \"group-overlay\") | .outputs'" \
+  '{"auto":true}'
+assert \
+  "mise -C '$TMPDIR/outside-home' tasks ls --json | jq -r '.[] | select(.name == \"j\") | .shell'" \
+  "$HOME/high-shell -c"
+assert \
+  "mise -C '$TMPDIR/outside-home' tasks ls --json | jq -r '.[] | select(.name == \"explicit-shell-overlay\") | .shell'" \
+  "$HOME/explicit-shell -c"
+assert_contains "mise -C '$TMPDIR/outside-home' run toml-overlay" \
+  "TOML_INLINE_METADATA=applied"
+assert_contains "mise -C '$TMPDIR/outside-home' run toml-overlay" \
+  "TASK_DIR=$HOME/high-global-dir"
+assert \
+  "mise -C '$TMPDIR/outside-home' tasks ls --json | jq -c '.[] | select(.name == \"output-contract\") | .outputs'" \
+  '["high-artifact"]'

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3376,14 +3376,33 @@ async fn apply_task_config_inputs(
     Ok(())
 }
 
+const CONFIG_DIR_DEFAULT_TASK_INCLUDE: &str = ".config/mise/tasks";
+
 fn default_task_includes() -> Vec<String> {
     vec![
         "mise-tasks".to_string(),
         ".mise-tasks".to_string(),
         ".mise/tasks".to_string(),
-        ".config/mise/tasks".to_string(),
+        CONFIG_DIR_DEFAULT_TASK_INCLUDE.to_string(),
         "mise/tasks".to_string(),
     ]
+}
+
+/// Default task includes for a global/system scope. The root-relative
+/// `.config/mise/tasks` entry is pinned to the scope's own config dir so a
+/// relocated `MISE_CONFIG_DIR` (or the system config dir) keeps owning its
+/// `tasks/` directory.
+fn scope_default_task_includes(scope_tasks_dir: &Path) -> Vec<String> {
+    default_task_includes()
+        .into_iter()
+        .map(|include| {
+            if include == CONFIG_DIR_DEFAULT_TASK_INCLUDE {
+                scope_tasks_dir.to_string_lossy().to_string()
+            } else {
+                include
+            }
+        })
+        .collect()
 }
 
 fn is_global_task_include_path(path: &Path) -> bool {
@@ -4077,10 +4096,16 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
     // Compose user-global and system configs as separate scopes so task_config
     // fields follow the same override semantics as local config files. Load the
     // user scope first so a user task replaces a same-named system task without
-    // inheriting metadata from it.
+    // inheriting metadata from it. Each scope owns its config dir's `tasks/`
+    // directory even when no config file exists in that scope, so scripts-only
+    // setups don't depend on the ancestor walk reaching the global root.
     let mut seen_configs = BTreeSet::new();
-    let mut config_groups = vec![];
-    for config_paths in [global_config_files(), system_config_files()] {
+    let mut tasks: IndexMap<String, Task> = IndexMap::new();
+    let mut rendered_file_tasks = RenderedTaskCache::default();
+    for (config_paths, scope_tasks_dir) in [
+        (global_config_files(), dirs::CONFIG.join("tasks")),
+        (system_config_files(), dirs::SYSTEM_CONFIG.join("tasks")),
+    ] {
         let configs = config_paths
             .iter()
             .rev()
@@ -4096,25 +4121,20 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
             })
             .filter(|cf| seen_configs.insert(file::desymlink_path(cf.get_path())))
             .collect::<Vec<_>>();
-        if !configs.is_empty() {
-            config_groups.push(configs);
-        }
-    }
-
-    // Aggregate the user and system scopes high-to-low. Each scope has already
-    // composed its file and inline tasks, so precedence between scopes is a
-    // simple first-wins replacement by task name.
-    let mut tasks: IndexMap<String, Task> = IndexMap::new();
-    let mut rendered_file_tasks = RenderedTaskCache::default();
-    for configs in config_groups {
+        // Aggregate the user and system scopes high-to-low. Each scope has
+        // already composed its file and inline tasks, so precedence between
+        // scopes is a simple first-wins replacement by task name.
         let sources = load_task_sources_from_configs(
             config,
             &env::MISE_GLOBAL_CONFIG_ROOT,
             configs,
             templates,
-            false,
-            None,
-            Some(&mut rendered_file_tasks),
+            TaskSourceLoadOptions {
+                monorepo_context: false,
+                cascaded_task_config: None,
+                rendered_file_tasks: Some(&mut rendered_file_tasks),
+                scope_default_tasks_dir: Some(scope_tasks_dir),
+            },
         )
         .await?;
         rendered_file_tasks.finish_config();
@@ -4881,12 +4901,25 @@ async fn load_tasks_from_configs(
         dir,
         configs,
         templates,
-        monorepo_context,
-        cascaded_task_config,
-        None,
+        TaskSourceLoadOptions {
+            monorepo_context,
+            cascaded_task_config,
+            rendered_file_tasks: None,
+            scope_default_tasks_dir: None,
+        },
     )
     .await?
     .into_tasks())
+}
+
+struct TaskSourceLoadOptions<'a> {
+    monorepo_context: bool,
+    cascaded_task_config: Option<&'a CascadedTaskConfig>,
+    rendered_file_tasks: Option<&'a mut RenderedTaskCache>,
+    /// For global/system scopes: the scope's own `tasks/` directory. It pins
+    /// the config-dir entry of the default includes to that scope's config dir
+    /// and is the sole default include when the scope has no config files.
+    scope_default_tasks_dir: Option<PathBuf>,
 }
 
 /// Load file and inline task sources without merging them.
@@ -4898,10 +4931,14 @@ async fn load_task_sources_from_configs(
     dir: &Path,
     configs: Vec<&Arc<dyn ConfigFile>>,
     templates: &TaskDefinitions,
-    monorepo_context: bool,
-    cascaded_task_config: Option<&CascadedTaskConfig>,
-    mut rendered_file_tasks: Option<&mut RenderedTaskCache>,
+    options: TaskSourceLoadOptions<'_>,
 ) -> Result<TaskSources> {
+    let TaskSourceLoadOptions {
+        monorepo_context,
+        cascaded_task_config,
+        mut rendered_file_tasks,
+        scope_default_tasks_dir,
+    } = options;
     let cascaded_task_config =
         if configs.iter().find_map(|cf| cf.task_config().cascade) == Some(false) {
             None
@@ -4929,7 +4966,19 @@ async fn load_task_sources_from_configs(
                     .map(|includes| (includes, tc.includes_root.clone(), configs.len()))
             })
         })
-        .unwrap_or_else(|| (default_task_includes(), dir.to_path_buf(), configs.len()));
+        .unwrap_or_else(|| {
+            let includes = match &scope_default_tasks_dir {
+                // A global/system scope without any config file still owns its
+                // config dir's tasks/ directory, but does not claim the
+                // root-relative defaults a config at the root would.
+                Some(tasks_dir) if configs.is_empty() => {
+                    vec![tasks_dir.to_string_lossy().to_string()]
+                }
+                Some(tasks_dir) => scope_default_task_includes(tasks_dir),
+                None => default_task_includes(),
+            };
+            (includes, dir.to_path_buf(), configs.len())
+        });
 
     // Resolve task defaults once for the config root so inline tasks from
     // lower-precedence overlay files use the same defaults as file tasks.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3376,33 +3376,25 @@ async fn apply_task_config_inputs(
     Ok(())
 }
 
-const CONFIG_DIR_DEFAULT_TASK_INCLUDE: &str = ".config/mise/tasks";
-
 fn default_task_includes() -> Vec<String> {
+    default_task_includes_with_config_dir(".config/mise/tasks".to_string())
+}
+
+/// Default task includes for a global/system scope. The config-dir entry is
+/// pinned to the scope's own config dir so a relocated `MISE_CONFIG_DIR` (or
+/// the system config dir) keeps owning its `tasks/` directory.
+fn scope_default_task_includes(scope_tasks_dir: &Path) -> Vec<String> {
+    default_task_includes_with_config_dir(scope_tasks_dir.to_string_lossy().to_string())
+}
+
+fn default_task_includes_with_config_dir(config_dir_tasks: String) -> Vec<String> {
     vec![
         "mise-tasks".to_string(),
         ".mise-tasks".to_string(),
         ".mise/tasks".to_string(),
-        CONFIG_DIR_DEFAULT_TASK_INCLUDE.to_string(),
+        config_dir_tasks,
         "mise/tasks".to_string(),
     ]
-}
-
-/// Default task includes for a global/system scope. The root-relative
-/// `.config/mise/tasks` entry is pinned to the scope's own config dir so a
-/// relocated `MISE_CONFIG_DIR` (or the system config dir) keeps owning its
-/// `tasks/` directory.
-fn scope_default_task_includes(scope_tasks_dir: &Path) -> Vec<String> {
-    default_task_includes()
-        .into_iter()
-        .map(|include| {
-            if include == CONFIG_DIR_DEFAULT_TASK_INCLUDE {
-                scope_tasks_dir.to_string_lossy().to_string()
-            } else {
-                include
-            }
-        })
-        .collect()
 }
 
 fn is_global_task_include_path(path: &Path) -> bool {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3318,17 +3318,17 @@ fn render_task_input_entries(
         .collect()
 }
 
-async fn apply_task_config_inputs(
-    task: &mut Task,
+async fn resolve_task_config_inputs(
+    task: &Task,
     config: &Arc<Config>,
     task_inputs: &ResolvedTaskInputs,
-) -> Result<()> {
+) -> Result<Option<ResolvedTaskInputs>> {
     let has_group_references = task
         .sources
         .iter()
         .any(|source| source.starts_with(TASK_INPUT_GROUP_PREFIX));
     if task_inputs.is_empty() && !has_group_references {
-        return Ok(());
+        return Ok(None);
     }
     Settings::get().ensure_experimental("task input groups")?;
 
@@ -3355,23 +3355,29 @@ async fn apply_task_config_inputs(
         )),
         None => None,
     };
-    let task_inputs = ResolvedTaskInputs {
+    Ok(Some(ResolvedTaskInputs {
         global_inputs,
         input_groups,
-    };
-    let had_sources = !task.sources.is_empty();
-    let mut sources = expand_task_inputs(
+    }))
+}
+
+fn apply_task_input_groups(task: &mut Task, task_inputs: &ResolvedTaskInputs) -> Result<()> {
+    task.sources = expand_task_inputs(
         &task.sources,
-        &task_inputs,
+        task_inputs,
         Path::new(""),
         &task.name,
         &mut vec![],
         false,
     )?;
+    Ok(())
+}
+
+fn apply_task_global_inputs(task: &mut Task, task_inputs: &ResolvedTaskInputs) -> Result<()> {
     if let Some((global_inputs, root)) = &task_inputs.global_inputs {
-        sources.extend(expand_task_inputs(
+        task.sources.extend(expand_task_inputs(
             global_inputs,
-            &task_inputs,
+            task_inputs,
             root,
             &task.name,
             &mut vec![],
@@ -3379,9 +3385,18 @@ async fn apply_task_config_inputs(
         )?);
     }
 
-    task.sources = sources;
-    if !had_sources && !task.sources.is_empty() && task.outputs.is_empty() {
-        task.outputs = TaskOutputs::Auto;
+    task.infer_auto_outputs();
+    Ok(())
+}
+
+async fn apply_task_config_inputs(
+    task: &mut Task,
+    config: &Arc<Config>,
+    task_inputs: &ResolvedTaskInputs,
+) -> Result<()> {
+    if let Some(task_inputs) = resolve_task_config_inputs(task, config, task_inputs).await? {
+        apply_task_input_groups(task, &task_inputs)?;
+        apply_task_global_inputs(task, &task_inputs)?;
     }
     Ok(())
 }
@@ -4196,14 +4211,21 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
 /// one wins. Callers load `file_tasks` in declared `task_config.includes`
 /// order, so the later include in the list takes precedence — see
 /// `load_tasks_in_dir`.
-fn merge_file_and_config_tasks(file_tasks: Vec<Task>, config_tasks: Vec<Task>) -> Vec<Task> {
+fn merge_file_and_config_tasks(
+    file_tasks: Vec<Task>,
+    config_tasks: Vec<LoadedConfigTask>,
+) -> Vec<Task> {
     let mut by_name: IndexMap<String, Task> = IndexMap::new();
     for t in prefer_windows_file_task_siblings(file_tasks) {
         by_name.insert(t.name.clone(), t);
     }
     let mut seen_config_task_names = BTreeSet::new();
     let mut pending_inline_overlays: IndexMap<String, Vec<Task>> = IndexMap::new();
-    for t in config_tasks {
+    for LoadedConfigTask {
+        effective: t,
+        explicit_overlay,
+    } in config_tasks
+    {
         if !seen_config_task_names.insert(t.name.clone()) {
             let has_command = !t.run.is_empty() || !t.run_windows.is_empty() || t.file.is_some();
             if pending_inline_overlays.contains_key(&t.name) && has_command {
@@ -4230,10 +4252,28 @@ fn merge_file_and_config_tasks(file_tasks: Vec<Task>, config_tasks: Vec<Task>) -
                 } else {
                     *existing = t;
                 }
+            } else if t.run.is_empty()
+                && t.run_windows.is_empty()
+                && t.file.is_none()
+                && let Some(overlay) = explicit_overlay
+            {
+                // A lower-precedence inline metadata block still decorates the
+                // selected TOML-include task, but only with its explicit
+                // fields so the higher task's config context is preserved.
+                existing.merge_toml_overlay(overlay);
+                existing.infer_auto_outputs();
             }
         } else if let Some(existing) = by_name.get_mut(&t.name) {
             if existing.file.is_some() {
-                existing.merge_toml_overlay(t);
+                if let Some(overlay) = explicit_overlay {
+                    // Global scopes overlay only the block's explicit fields so
+                    // inherited context and inferred outputs cannot replace the
+                    // selected script's own contract.
+                    existing.merge_toml_overlay(overlay);
+                    existing.infer_auto_outputs();
+                } else {
+                    existing.merge_toml_overlay(t);
+                }
             }
         } else {
             if t.run.is_empty() && t.run_windows.is_empty() && t.file.is_none() {
@@ -4352,10 +4392,10 @@ async fn load_config_tasks(
     templates: &TaskDefinitions,
     monorepo_cf: Option<&Arc<dyn ConfigFile>>,
     task_config: &ResolvedTaskConfig,
-) -> Result<Vec<Task>> {
+) -> Result<Vec<LoadedConfigTask>> {
     let is_global = is_global_config(cf.get_path());
     let config_root = Arc::new(config_root.to_path_buf());
-    let mut tasks = vec![];
+    let mut loaded_tasks = vec![];
     for t in cf.tasks().into_iter() {
         let config_root = config_root.clone();
         let config = config.clone();
@@ -4371,6 +4411,9 @@ async fn load_config_tasks(
         }
         // Resolve template if the task extends one
         resolve_task_template(&mut t, templates)?;
+        let has_explicit_dir = t.dir.is_some();
+        let has_explicit_shell = t.shell.is_some();
+        let has_explicit_outputs = !t.outputs.is_empty();
         if t.dir.is_none() {
             t.dir = task_config.dir.clone();
         }
@@ -4379,11 +4422,36 @@ async fn load_config_tasks(
         }
         match t.render(&config, &config_root).await {
             Ok(()) => {
-                apply_task_config_inputs(&mut t, &config, &task_config.inputs).await?;
+                let resolved_task_inputs =
+                    resolve_task_config_inputs(&t, &config, &task_config.inputs).await?;
+                if let Some(task_inputs) = &resolved_task_inputs {
+                    apply_task_input_groups(&mut t, task_inputs)?;
+                }
+                let explicit_overlay = if is_global {
+                    let mut overlay = t.clone();
+                    if !has_explicit_dir {
+                        overlay.dir = None;
+                    }
+                    if !has_explicit_shell {
+                        overlay.shell = None;
+                    }
+                    if !has_explicit_outputs {
+                        overlay.outputs = TaskOutputs::default();
+                    }
+                    Some(overlay)
+                } else {
+                    None
+                };
+                if let Some(task_inputs) = &resolved_task_inputs {
+                    apply_task_global_inputs(&mut t, task_inputs)?;
+                }
                 apply_task_config_cache_default(&mut t, &task_config.cache);
                 apply_task_config_rust_cache_default(&mut t, &task_config.rust_cache);
                 task_config.environment.apply(&mut t)?;
-                tasks.push(t);
+                loaded_tasks.push(LoadedConfigTask {
+                    effective: t,
+                    explicit_overlay,
+                });
             }
             Err(e) => {
                 if monorepo_cf.is_some() {
@@ -4398,7 +4466,7 @@ async fn load_config_tasks(
             }
         }
     }
-    Ok(tasks)
+    Ok(loaded_tasks)
 }
 
 struct LoadTaskIncludesOptions<'a> {
@@ -4783,7 +4851,12 @@ async fn load_tasks_in_dir_with_definitions(
 
 struct TaskSources {
     file_tasks: Vec<Task>,
-    config_tasks: Vec<Task>,
+    config_tasks: Vec<LoadedConfigTask>,
+}
+
+struct LoadedConfigTask {
+    effective: Task,
+    explicit_overlay: Option<Task>,
 }
 
 #[derive(Clone)]
@@ -5051,7 +5124,7 @@ async fn load_task_sources_from_configs(
     for (precedence, cf) in configs.iter().enumerate() {
         let dir = dir.to_path_buf();
         let monorepo_cf = monorepo_context.then_some(*cf);
-        let mut loaded = load_config_tasks(
+        let loaded = load_config_tasks(
             config,
             (*cf).clone(),
             &dir,
@@ -5060,10 +5133,20 @@ async fn load_task_sources_from_configs(
             &task_config,
         )
         .await?;
-        for task in &mut loaded {
-            task.config_precedence = precedence;
+        for LoadedConfigTask {
+            mut effective,
+            mut explicit_overlay,
+        } in loaded
+        {
+            effective.config_precedence = precedence;
+            if let Some(overlay) = &mut explicit_overlay {
+                overlay.config_precedence = precedence;
+            }
+            config_tasks.push(LoadedConfigTask {
+                effective,
+                explicit_overlay,
+            });
         }
-        config_tasks.extend(loaded);
     }
 
     let mut file_tasks = vec![];
@@ -5734,10 +5817,13 @@ mod tests {
                 ..Default::default()
             },
         ];
-        let config_tasks = vec![Task {
-            name: "hello".to_string(),
-            description: "windows task metadata".to_string(),
-            ..Default::default()
+        let config_tasks = vec![LoadedConfigTask {
+            effective: Task {
+                name: "hello".to_string(),
+                description: "windows task metadata".to_string(),
+                ..Default::default()
+            },
+            explicit_overlay: None,
         }];
 
         let tasks = merge_file_and_config_tasks(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -982,9 +982,19 @@ impl Config {
             load_local_tasks_with_context(&config, ctx, &task_definitions).await?;
         let global_tasks = load_global_tasks(&config, &task_definitions).await?;
         local_tasks.retain(|local| {
-            !global_tasks
-                .iter()
-                .any(|global| tasks_have_same_source(local, global))
+            !global_tasks.iter().any(|global| {
+                // Drop a local rediscovery of a global source only when both
+                // readings share a config root. A differing root (e.g.
+                // MISE_CONFIG_DIR pointing inside a project) is a genuinely
+                // different context, and the local reading keeps shadowing the
+                // global one by name.
+                tasks_have_same_source(local, global)
+                    && local
+                        .config_root
+                        .as_ref()
+                        .zip(global.config_root.as_ref())
+                        .is_none_or(|(l, g)| file::desymlink_path(l) == file::desymlink_path(g))
+            })
         });
         let mut tasks: BTreeMap<String, Task> = local_tasks
             .into_iter()
@@ -3377,33 +3387,34 @@ async fn apply_task_config_inputs(
 }
 
 fn default_task_includes() -> Vec<String> {
-    default_task_includes_with_config_dir(".config/mise/tasks".to_string())
+    let mut includes = default_task_includes_without_config_dir();
+    includes.insert(3, ".config/mise/tasks".to_string());
+    includes
 }
 
-/// Default task includes for a global/system scope. The config-dir entry is
-/// pinned to the scope's own config dir so a relocated `MISE_CONFIG_DIR` (or
-/// the system config dir) keeps owning its `tasks/` directory.
-fn scope_default_task_includes(scope_tasks_dir: &Path) -> Vec<String> {
-    default_task_includes_with_config_dir(scope_tasks_dir.to_string_lossy().to_string())
-}
-
-fn default_task_includes_with_config_dir(config_dir_tasks: String) -> Vec<String> {
+fn default_task_includes_without_config_dir() -> Vec<String> {
     vec![
         "mise-tasks".to_string(),
         ".mise-tasks".to_string(),
         ".mise/tasks".to_string(),
-        config_dir_tasks,
         "mise/tasks".to_string(),
     ]
 }
 
-fn is_global_task_include_path(path: &Path) -> bool {
+/// The user-global and system scopes' own `tasks/` directories, in scope
+/// order. Both the global task loader and the global include marking/trust
+/// exemption derive from this list so they cannot drift apart.
+fn global_scope_tasks_dirs() -> [PathBuf; 2] {
     [
         dirs::CONFIG.join("tasks"),
         dirs::SYSTEM_CONFIG.join("tasks"),
     ]
-    .iter()
-    .any(|prefix| file::path_starts_with_resolved(path, prefix))
+}
+
+fn is_global_task_include_path(path: &Path) -> bool {
+    global_scope_tasks_dirs()
+        .iter()
+        .any(|prefix| file::path_starts_with_resolved(path, prefix))
 }
 
 #[async_backtrace::framed]
@@ -4094,10 +4105,16 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
     let mut seen_configs = BTreeSet::new();
     let mut tasks: IndexMap<String, Task> = IndexMap::new();
     let mut rendered_file_tasks = RenderedTaskCache::default();
-    for (config_paths, scope_tasks_dir) in [
-        (global_config_files(), dirs::CONFIG.join("tasks")),
-        (system_config_files(), dirs::SYSTEM_CONFIG.join("tasks")),
+    let [user_tasks_dir, system_tasks_dir] = global_scope_tasks_dirs();
+    for (config_paths, scope_tasks_dir, pin_config_dir_include) in [
+        (
+            global_config_files(),
+            user_tasks_dir,
+            *env::MISE_CONFIG_DIR_OVERRIDDEN,
+        ),
+        (system_config_files(), system_tasks_dir, true),
     ] {
+        let scope_has_candidates = !config_paths.is_empty();
         let configs = config_paths
             .iter()
             .rev()
@@ -4113,6 +4130,32 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
             })
             .filter(|cf| seen_configs.insert(file::desymlink_path(cf.get_path())))
             .collect::<Vec<_>>();
+        let scope_task_defaults = if configs.is_empty() {
+            // Only a scope with no config files at all claims its own tasks
+            // dir. A scope whose candidates did not load (a nonexistent
+            // MISE_GLOBAL_CONFIG_FILE, --no-config) or were consumed by the
+            // other scope keeps that explicit configuration authoritative.
+            if scope_has_candidates || Settings::no_config() {
+                continue;
+            }
+            ScopeTaskDefaults {
+                includes: vec![],
+                pinned_dir: Some(scope_tasks_dir),
+            }
+        } else if pin_config_dir_include {
+            // The scope's config dir is not where the root-relative default
+            // include points, so pin the config-dir entry to the scope's own
+            // tasks dir instead.
+            ScopeTaskDefaults {
+                includes: default_task_includes_without_config_dir(),
+                pinned_dir: Some(scope_tasks_dir),
+            }
+        } else {
+            ScopeTaskDefaults {
+                includes: default_task_includes(),
+                pinned_dir: None,
+            }
+        };
         // Aggregate the user and system scopes high-to-low. Each scope has
         // already composed its file and inline tasks, so precedence between
         // scopes is a simple first-wins replacement by task name.
@@ -4125,7 +4168,7 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
                 monorepo_context: false,
                 cascaded_task_config: None,
                 rendered_file_tasks: Some(&mut rendered_file_tasks),
-                scope_default_tasks_dir: Some(scope_tasks_dir),
+                scope_task_defaults: Some(scope_task_defaults),
             },
         )
         .await?;
@@ -4897,21 +4940,29 @@ async fn load_tasks_from_configs(
             monorepo_context,
             cascaded_task_config,
             rendered_file_tasks: None,
-            scope_default_tasks_dir: None,
+            scope_task_defaults: None,
         },
     )
     .await?
     .into_tasks())
 }
 
+/// A global/system scope's default task includes, applied only when no config
+/// supplies explicit `task_config.includes`.
+struct ScopeTaskDefaults {
+    /// Relative default patterns, resolved against the global root.
+    includes: Vec<String>,
+    /// The scope's own `tasks/` directory, loaded as a literal path so glob
+    /// metacharacters or non-UTF-8 bytes in the directory path cannot break
+    /// discovery.
+    pinned_dir: Option<PathBuf>,
+}
+
 struct TaskSourceLoadOptions<'a> {
     monorepo_context: bool,
     cascaded_task_config: Option<&'a CascadedTaskConfig>,
     rendered_file_tasks: Option<&'a mut RenderedTaskCache>,
-    /// For global/system scopes: the scope's own `tasks/` directory. It pins
-    /// the config-dir entry of the default includes to that scope's config dir
-    /// and is the sole default include when the scope has no config files.
-    scope_default_tasks_dir: Option<PathBuf>,
+    scope_task_defaults: Option<ScopeTaskDefaults>,
 }
 
 /// Load file and inline task sources without merging them.
@@ -4929,7 +4980,7 @@ async fn load_task_sources_from_configs(
         monorepo_context,
         cascaded_task_config,
         mut rendered_file_tasks,
-        scope_default_tasks_dir,
+        scope_task_defaults,
     } = options;
     let cascaded_task_config =
         if configs.iter().find_map(|cf| cf.task_config().cascade) == Some(false) {
@@ -4941,6 +4992,7 @@ async fn load_task_sources_from_configs(
     // a config can only vouch for task include files when it was actually
     // trusted — safe configs load without trust and cannot vouch for anything
     let require_task_include_trust = !configs.iter().any(|cf| is_path_trusted(cf.get_path()));
+    let mut pinned_scope_dir = None;
     let (includes, resolve_dir, include_config_precedence) = configs
         .iter()
         .enumerate()
@@ -4959,14 +5011,11 @@ async fn load_task_sources_from_configs(
             })
         })
         .unwrap_or_else(|| {
-            let includes = match &scope_default_tasks_dir {
-                // A global/system scope without any config file still owns its
-                // config dir's tasks/ directory, but does not claim the
-                // root-relative defaults a config at the root would.
-                Some(tasks_dir) if configs.is_empty() => {
-                    vec![tasks_dir.to_string_lossy().to_string()]
+            let includes = match scope_task_defaults {
+                Some(defaults) => {
+                    pinned_scope_dir = defaults.pinned_dir;
+                    defaults.includes
                 }
-                Some(tasks_dir) => scope_default_task_includes(tasks_dir),
                 None => default_task_includes(),
             };
             (includes, dir.to_path_buf(), configs.len())
@@ -5023,14 +5072,35 @@ async fn load_task_sources_from_configs(
     } else {
         None
     };
-    for include in &includes {
-        let artifacts = if include.starts_with("git::") {
-            vec![resolve_git_url_to_path(include).await?]
-        } else {
-            expand_task_include(&resolve_dir, include)
+    enum TaskIncludeEntry<'a> {
+        Pattern(&'a str),
+        /// A literal directory bypassing glob expansion, so metacharacters or
+        /// non-UTF-8 bytes in the path cannot break discovery.
+        Dir(&'a Path),
+    }
+    let mut include_entries = includes
+        .iter()
+        .map(|include| TaskIncludeEntry::Pattern(include))
+        .collect::<Vec<_>>();
+    if let Some(dir_path) = &pinned_scope_dir {
+        // Keep the config-dir entry's position from default_task_includes()
+        // so later-include-wins precedence among the defaults is unchanged.
+        let pos = include_entries.len().min(3);
+        include_entries.insert(pos, TaskIncludeEntry::Dir(dir_path));
+    }
+    for entry in include_entries {
+        let artifacts = match entry {
+            TaskIncludeEntry::Pattern(include) if include.starts_with("git::") => {
+                vec![resolve_git_url_to_path(include).await?]
+            }
+            TaskIncludeEntry::Pattern(include) => expand_task_include(&resolve_dir, include)
                 .into_iter()
                 .map(TaskFileArtifact::persistent)
-                .collect()
+                .collect(),
+            TaskIncludeEntry::Dir(path) if path.exists() => {
+                vec![TaskFileArtifact::persistent(path.to_path_buf())]
+            }
+            TaskIncludeEntry::Dir(_) => vec![],
         };
         for artifact in artifacts {
             let p = artifact.path;

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -2646,15 +2646,19 @@ impl Task {
     }
 
     fn store_raw_render_inputs(&mut self) {
-        if !self.sources.is_empty() && self.outputs.is_empty() {
-            self.outputs = TaskOutputs::Auto;
-        }
+        self.infer_auto_outputs();
         self.raw_outputs = self.outputs.raw_templates_without_env();
         // Save unrendered dependency templates so they can be re-rendered later
         // with parent task args available (for passing args to dependencies).
         self.depends_raw = Some(self.depends.clone());
         self.depends_post_raw = Some(self.depends_post.clone());
         self.wait_for_raw = Some(self.wait_for.clone());
+    }
+
+    pub(crate) fn infer_auto_outputs(&mut self) {
+        if !self.sources.is_empty() && self.outputs.is_empty() {
+            self.outputs = TaskOutputs::Auto;
+        }
     }
 
     fn parse_plain_depends(&mut self) -> Result<()> {


### PR DESCRIPTION
## Stack

Stacked on #12294, which gives the user-global and system task scopes default includes without a config file. Review commit `a331fb1d1` for this layer only.

This branch was previously stacked on #12203. It has been re-cut onto main + #12294: the old #12203 ownership machinery is gone from the diff, and the layer was adapted to the scope-composed global loading that #12229 merged.

## Summary

- keep each rendered global task paired with the explicit inline metadata that produced it
- within a global scope, apply lower-precedence explicit inline metadata to the selected task source without importing inherited directory, shell, outputs, or inferred automatic outputs
- recognize both executable task files and included TOML tasks as overlay targets
- preserve explicit output contracts while recalculating inferred automatic outputs after merging

## Bug examples

- A user-global `config.toml` selects a shared TOML task file via `task_config.includes`, and a lower `conf.d` fragment adds `[tasks.build] env = { MODE = "release" }`. The lower explicit metadata previously never applied because lower-precedence inline blocks were dropped for TOML-include tasks; it now overlays only its explicit fields.
- A lower inline block with `sources` infers `outputs = { auto = true }`. That inferred value previously erased a higher script's explicit `#MISE outputs=["artifact"]` contract when the block was merged; the explicit contract is now preserved.

## Changes from the previous revision

- The cross-scope (user vs system) overlay from the old stack is intentionally dropped: #12229's merged contract (`test_task_global_config_dedup`) is that a user task replaces a same-source system task without inheriting the system scope's inline metadata.
- `test_task_global_include_precedence` now expects the highest config's explicit `task_config.includes` to own the scope's include set (the semantics #12229 merged and `test_task_ls_global` already asserts) instead of aggregating per-config include sets.
- The explicit-project-include scenario (a project including the global tasks dir keeps local context) is deferred to a follow-up on same-source collision precedence; it depended on the old #12203 ownership machinery.

## Testing

- `mise run lint`
- `cargo test --bin mise -- task` / `cargo test --bin mise -- config::tests`
- `mise run test:e2e e2e/tasks/test_task_global_config_precedence e2e/tasks/test_task_global_include_precedence e2e/tasks/test_task_global_source_context_precedence e2e/tasks/test_task_global_config_dedup e2e/tasks/test_task_ls_global e2e/tasks/test_task_global_default_includes e2e/tasks/test_task_global_config_root e2e/tasks/test_task_monorepo_config_dedup e2e/tasks/test_task_monorepo_global_tasks e2e/tasks/test_task_toml_include_inline_precedence e2e/tasks/test_task_includes_env_precedence e2e/tasks/test_task_include_trust e2e/tasks/test_task_config_includes_templates e2e/tasks/test_task_local_overrides_git_include`

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved global and system task discovery, including task directories without configuration files.
  * Added support for custom configuration roots and reliable task-directory resolution.
  * Improved task precedence when combining global, project, inline, and script-based tasks.
  * Automatic output detection is now applied consistently to tasks with sources.

* **Documentation**
  * Documented global and system-wide task directories and resolution behavior.

* **Tests**
  * Added end-to-end coverage for task precedence, includes, source context, and default discovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->