### PR TITLE
fix(task): compose global task overlay precedence

### DIFF
--- a/e2e/tasks/test_task_global_config_dedup
+++ b/e2e/tasks/test_task_global_config_dedup
@@ -84,3 +84,18 @@ EOF
 assert \
   "MISE_GLOBAL_CONFIG_FILE='$HOME/global-config/include-order.toml' MISE_SYSTEM_CONFIG_FILE='$HOME/global-config/missing.toml' mise run include-winner" \
   "$HOME/second-global-tasks/include-winner"
+
+local_include_marker="$MISE_TMP_DIR/local-include-render-count"
+: >"$local_include_marker"
+mkdir -p "$HOME/.config/mise/tasks"
+cat >"$HOME/mise.toml" <<EOF
+[task_config]
+includes = ["{{ exec(command='echo .config/mise/tasks; echo rendered >> $local_include_marker') }}"]
+EOF
+
+# Detecting explicit local task context must inspect the raw include option.
+# Rendering it again would repeat effectful template functions during one load.
+MISE_GLOBAL_CONFIG_FILE="$HOME/global-config/user.toml" \
+  MISE_SYSTEM_CONFIG_FILE="$HOME/global-config/missing.toml" \
+  mise -C "$HOME" tasks >/dev/null
+assert "wc -l < '$local_include_marker' | tr -d ' '" "1"

--- a/e2e/tasks/test_task_global_config_precedence
+++ b/e2e/tasks/test_task_global_config_precedence
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+export MISE_EXPERIMENTAL=1
+
+mkdir -p "$HOME/.config/mise/conf.d" "$HOME/.config/mise/tasks"
+
+cat <<'EOF' >"$MISE_SYSTEM_DIR/config.toml"
+[tasks.e]
+description = "system/config/e"
+env = { SYSTEM_PRECEDENCE = "applied" }
+
+[tasks.system-vs-conf-d]
+run = "echo system"
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/conf.d/01-base.toml"
+[tasks.e]
+description = "global/conf.d/01/e"
+env = { LOWER_PRECEDENCE = "applied" }
+
+[tasks.system-vs-conf-d]
+run = "echo conf-d"
+
+[tasks.conf-d-order]
+run = "echo conf-d-01"
+
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/conf.d/02-override.toml"
+[tasks.conf-d-order]
+run = "echo conf-d-02"
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/config.toml"
+[task_config]
+includes = [".config/mise/tasks"]
+
+[tasks.e]
+description = "global/config/e"
+env = { HIGHER_PRECEDENCE = "applied" }
+
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/tasks/e"
+#!/usr/bin/env bash
+echo "HIGHER_PRECEDENCE=${HIGHER_PRECEDENCE:-<unset>}"
+echo "LOWER_PRECEDENCE=${LOWER_PRECEDENCE:-<unset>}"
+echo "SYSTEM_PRECEDENCE=${SYSTEM_PRECEDENCE:-<unset>}"
+EOF
+chmod +x "$HOME/.config/mise/tasks/e"
+
+mkdir -p "$TMPDIR/outside-home"
+assert_contains "mise tasks --global" "global/config/e"
+assert_contains "mise run e" "HIGHER_PRECEDENCE=applied"
+assert_contains "mise run e" "LOWER_PRECEDENCE=<unset>"
+assert_contains "mise run e" "SYSTEM_PRECEDENCE=<unset>"
+assert_contains "mise -C '$TMPDIR/outside-home' run e" "HIGHER_PRECEDENCE=applied"
+assert_contains "mise -C '$TMPDIR/outside-home' run e" "LOWER_PRECEDENCE=<unset>"
+assert_contains "mise -C '$TMPDIR/outside-home' run e" "SYSTEM_PRECEDENCE=<unset>"
+assert "mise run system-vs-conf-d" "conf-d"
+assert "mise run conf-d-order" "conf-d-02"

--- a/e2e/tasks/test_task_global_config_precedence
+++ b/e2e/tasks/test_task_global_config_precedence
@@ -14,6 +14,9 @@ run = "echo system"
 EOF
 
 cat <<'EOF' >"$HOME/.config/mise/conf.d/01-base.toml"
+[task_config]
+includes = ["dependency-tasks.toml"]
+
 [tasks.e]
 description = "global/conf.d/01/e"
 env = { LOWER_PRECEDENCE = "applied" }
@@ -24,21 +27,58 @@ run = "echo conf-d"
 [tasks.conf-d-order]
 run = "echo conf-d-01"
 
+[tasks.metadata-over-command]
+run = '''
+echo "HIGH_METADATA=${HIGH_METADATA:-<unset>}"
+echo "MIDDLE_METADATA=${MIDDLE_METADATA:-<unset>}"
+echo "OVERLAY_ORDER=${OVERLAY_ORDER:-<unset>}"
+'''
+
+[tasks.inline-dependency-wrapper]
+depends = ["dependency-child"]
+EOF
+
+cat <<'EOF' >"$HOME/dependency-tasks.toml"
+[dependency-wrapper]
+depends = ["dependency-child"]
+
+[dependency-child]
+run = "echo dependency-child"
+EOF
+
+cat <<'EOF' >"$HOME/included-command-tasks.toml"
+[inline-dependency-replaces-include]
+run = "echo included-command-should-not-run"
 EOF
 
 cat <<'EOF' >"$HOME/.config/mise/conf.d/02-override.toml"
+[tasks.metadata-over-command]
+env = { MIDDLE_METADATA = "applied", OVERLAY_ORDER = "middle" }
+
 [tasks.conf-d-order]
 run = "echo conf-d-02"
 EOF
 
 cat <<'EOF' >"$HOME/.config/mise/config.toml"
 [task_config]
-includes = [".config/mise/tasks"]
+includes = [".config/mise/tasks", "included-command-tasks.toml"]
 
 [tasks.e]
 description = "global/config/e"
 env = { HIGHER_PRECEDENCE = "applied" }
 
+[tasks.metadata-over-command]
+sources = ["pending-input"]
+env = { HIGH_METADATA = "applied", OVERLAY_ORDER = "high" }
+
+[tasks.dependency-wrapper]
+description = "high metadata on a dependency-only task"
+
+[tasks.inline-dependency-wrapper]
+description = "high metadata on an inline dependency-only task"
+
+[tasks.inline-dependency-replaces-include]
+depends = ["dependency-child"]
 EOF
 
 cat <<'EOF' >"$HOME/.config/mise/tasks/e"
@@ -59,3 +99,10 @@ assert_contains "mise -C '$TMPDIR/outside-home' run e" "LOWER_PRECEDENCE=<unset>
 assert_contains "mise -C '$TMPDIR/outside-home' run e" "SYSTEM_PRECEDENCE=<unset>"
 assert "mise run system-vs-conf-d" "conf-d"
 assert "mise run conf-d-order" "conf-d-02"
+assert "mise run metadata-over-command" \
+  $'HIGH_METADATA=applied\nMIDDLE_METADATA=applied\nOVERLAY_ORDER=high'
+assert "mise tasks ls --json | jq -c '.[] | select(.name == \"metadata-over-command\") | .outputs'" \
+  '{"auto":true}'
+assert "mise run dependency-wrapper" "dependency-child"
+assert "mise run inline-dependency-wrapper" "dependency-child"
+assert "mise run inline-dependency-replaces-include" "dependency-child"

--- a/e2e/tasks/test_task_global_include_precedence
+++ b/e2e/tasks/test_task_global_include_precedence
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+export MISE_EXPERIMENTAL=1
+
+mkdir -p "$HOME/.config/mise/conf.d" "$HOME/.config/mise/tasks" \
+  "$HOME/global-custom-tasks" "$HOME/high-global-tasks"
+
+cat <<'EOF' >"$MISE_SYSTEM_DIR/config.toml"
+[tasks.g]
+run = "echo system-inline/g"
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/conf.d/01-base.toml"
+[task_config]
+includes = ["global-custom-tasks"]
+EOF
+
+cat <<EOF >"$HOME/.config/mise/conf.d/02-override.toml"
+[task_config]
+includes = [".config/mise/tasks"]
+
+[tasks.i]
+run = "echo lower-inline/i"
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/config.toml"
+[task_config]
+includes = [".config/mise/tasks", "high-global-tasks"]
+
+[tasks.f]
+run = "echo high-inline/f"
+EOF
+
+cat <<'EOF' >"$HOME/global-custom-tasks/f"
+#!/usr/bin/env bash
+echo lower-script/f
+EOF
+chmod +x "$HOME/global-custom-tasks/f"
+
+cat <<'EOF' >"$HOME/global-custom-tasks/h"
+#!/usr/bin/env bash
+echo lower-script/h
+EOF
+chmod +x "$HOME/global-custom-tasks/h"
+
+cat <<'EOF' >"$HOME/global-custom-tasks/file-collision"
+#!/usr/bin/env bash
+echo lower-script/file-collision
+EOF
+chmod +x "$HOME/global-custom-tasks/file-collision"
+
+cat <<'EOF' >"$HOME/high-global-tasks/i"
+#!/usr/bin/env bash
+echo high-script/i
+EOF
+chmod +x "$HOME/high-global-tasks/i"
+
+cat <<'EOF' >"$HOME/high-global-tasks/file-collision"
+#!/usr/bin/env bash
+echo high-script/file-collision
+EOF
+chmod +x "$HOME/high-global-tasks/file-collision"
+
+mkdir -p "$TMPDIR/outside-home"
+assert_contains "mise -C '$TMPDIR/outside-home' run f" "high-inline/f"
+assert_not_contains "mise -C '$TMPDIR/outside-home' run f" "lower-script/f"
+assert_contains "mise -C '$TMPDIR/outside-home' run g" "system-inline/g"
+assert_contains "mise -C '$TMPDIR/outside-home' run h" "lower-script/h"
+assert_contains "mise -C '$TMPDIR/outside-home' run i" "high-script/i"
+assert_not_contains "mise -C '$TMPDIR/outside-home' run i" "lower-inline/i"
+assert "mise -C '$TMPDIR/outside-home' run file-collision" "high-script/file-collision"

--- a/e2e/tasks/test_task_global_source_context_precedence
+++ b/e2e/tasks/test_task_global_source_context_precedence
@@ -110,7 +110,7 @@ assert \
 # An explicit project include of the same global scripts must retain local
 # precedence. Same-source deduplication may discard only the incidental copy
 # discovered while walking the global config root, not project task context.
-mkdir -p "$HOME/project" "$HOME/local-project-dir"
+mkdir -p "$HOME/project/.config/mise/conf.d" "$HOME/local-project-dir"
 
 cat <<'EOF' >>"$HOME/.config/mise/config.toml"
 
@@ -126,6 +126,16 @@ dir = "$HOME/local-project-dir"
 [tasks.local-overlay-wins]
 env = { LOCAL_CONTEXT = "applied" }
 
+[tasks.local-dependency-wrapper]
+description = "higher local metadata"
+
+[tasks.local-dependency-child]
+run = "echo local-dependency-child"
+EOF
+
+cat <<'EOF' >"$HOME/project/.config/mise/conf.d/01-dependency-base.toml"
+[tasks.local-dependency-wrapper]
+depends = ["local-dependency-child"]
 EOF
 
 cat <<'EOF' >"$HOME/.config/mise/tasks/local-overlay-wins"
@@ -145,3 +155,4 @@ assert_contains "mise -C '$HOME/project' run local-overlay-wins" "LOCAL_CONTEXT=
 assert_contains "mise -C '$HOME/project' run local-overlay-wins" "GLOBAL_CONTEXT=<unset>"
 assert_contains "mise -C '$HOME/project' run local-dir-wins" "TASK_DIR=$HOME/local-project-dir"
 assert_not_contains "mise -C '$HOME/project' run local-dir-wins" "TASK_DIR=$HOME/high-global-dir"
+assert "mise -C '$HOME/project' run local-dependency-wrapper" "local-dependency-child"

--- a/e2e/tasks/test_task_global_source_context_precedence
+++ b/e2e/tasks/test_task_global_source_context_precedence
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+
+export MISE_EXPERIMENTAL=1
+
+mkdir -p "$HOME/.config/mise/conf.d" "$HOME/.config/mise/tasks" \
+  "$HOME/high-global-dir" "$HOME/low-global-dir"
+ln -s ".config/mise/tasks" "$HOME/linked-global-tasks"
+cat <<'EOF' >"$HOME/high-shell"
+#!/usr/bin/env bash
+exec sh "$@"
+EOF
+chmod +x "$HOME/high-shell"
+
+cat <<EOF >"$HOME/.config/mise/conf.d/02-override.toml"
+[task_config]
+dir = "$HOME/low-global-dir"
+includes = ["linked-global-tasks", "shared-tasks.toml"]
+shell = "$HOME/low-shell -c"
+
+[task_config.input_groups]
+rust = ["Cargo.toml"]
+
+[tasks.j]
+env = { INLINE_METADATA = "applied" }
+
+[tasks.group-overlay]
+sources = ["@group:rust"]
+
+[tasks.explicit-shell-overlay]
+shell = "$HOME/explicit-shell -c"
+
+[tasks.toml-overlay]
+env = { TOML_INLINE_METADATA = "applied" }
+
+[tasks.output-contract]
+sources = ["lower-input"]
+
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/conf.d/01-base.toml"
+[tasks.j]
+env = { LOWER_INLINE_METADATA = "applied" }
+EOF
+
+cat <<EOF >"$HOME/.config/mise/config.toml"
+[task_config]
+includes = [".config/mise/tasks", "shared-tasks.toml"]
+dir = "$HOME/high-global-dir"
+shell = "$HOME/high-shell -c"
+EOF
+
+cat <<'EOF' >"$HOME/shared-tasks.toml"
+[toml-overlay]
+run = '''
+echo "TOML_INLINE_METADATA=${TOML_INLINE_METADATA:-<unset>}"
+echo "TASK_DIR=$PWD"
+'''
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/tasks/j"
+#!/usr/bin/env bash
+echo same-script/j
+echo "INLINE_METADATA=${INLINE_METADATA:-<unset>}"
+echo "LOWER_INLINE_METADATA=${LOWER_INLINE_METADATA:-<unset>}"
+echo "TASK_DIR=$PWD"
+EOF
+chmod +x "$HOME/.config/mise/tasks/j"
+cat <<'EOF' >"$HOME/.config/mise/tasks/group-overlay"
+#!/usr/bin/env bash
+echo group-overlay
+EOF
+chmod +x "$HOME/.config/mise/tasks/group-overlay"
+cat <<'EOF' >"$HOME/.config/mise/tasks/explicit-shell-overlay"
+#!/usr/bin/env bash
+echo explicit-shell-overlay
+EOF
+chmod +x "$HOME/.config/mise/tasks/explicit-shell-overlay"
+cat <<'EOF' >"$HOME/.config/mise/tasks/output-contract"
+#!/usr/bin/env bash
+#MISE outputs=["high-artifact"]
+echo output-contract
+EOF
+chmod +x "$HOME/.config/mise/tasks/output-contract"
+mkdir -p "$TMPDIR/outside-home"
+assert_contains "mise -C '$TMPDIR/outside-home' run j" "same-script/j"
+assert_contains "mise -C '$TMPDIR/outside-home' run j" "INLINE_METADATA=applied"
+assert_contains "mise -C '$TMPDIR/outside-home' run j" "LOWER_INLINE_METADATA=<unset>"
+assert_contains "mise -C '$TMPDIR/outside-home' run j" "TASK_DIR=$HOME/high-global-dir"
+assert_not_contains "mise -C '$TMPDIR/outside-home' run j" "TASK_DIR=$HOME/low-global-dir"
+assert \
+  "mise -C '$TMPDIR/outside-home' tasks ls --json | jq -r '.[] | select(.name == \"group-overlay\") | .sources[0]'" \
+  "$HOME/Cargo.toml"
+assert \
+  "mise -C '$TMPDIR/outside-home' tasks ls --json | jq -c '.[] | select(.name == \"group-overlay\") | .outputs'" \
+  '{"auto":true}'
+assert \
+  "mise -C '$TMPDIR/outside-home' tasks ls --json | jq -r '.[] | select(.name == \"j\") | .shell'" \
+  "$HOME/high-shell -c"
+assert \
+  "mise -C '$TMPDIR/outside-home' tasks ls --json | jq -r '.[] | select(.name == \"explicit-shell-overlay\") | .shell'" \
+  "$HOME/explicit-shell -c"
+assert_contains "mise -C '$TMPDIR/outside-home' run toml-overlay" \
+  "TOML_INLINE_METADATA=applied"
+assert_contains "mise -C '$TMPDIR/outside-home' run toml-overlay" \
+  "TASK_DIR=$HOME/high-global-dir"
+assert \
+  "mise -C '$TMPDIR/outside-home' tasks ls --json | jq -c '.[] | select(.name == \"output-contract\") | .outputs'" \
+  '["high-artifact"]'
+
+# An explicit project include of the same global scripts must retain local
+# precedence. Same-source deduplication may discard only the incidental copy
+# discovered while walking the global config root, not project task context.
+mkdir -p "$HOME/project" "$HOME/local-project-dir"
+
+cat <<'EOF' >>"$HOME/.config/mise/config.toml"
+
+[tasks.local-overlay-wins]
+env = { GLOBAL_CONTEXT = "applied" }
+EOF
+
+cat <<EOF >"$HOME/project/mise.toml"
+[task_config]
+includes = ["$HOME/.config/mise/tasks"]
+dir = "$HOME/local-project-dir"
+
+[tasks.local-overlay-wins]
+env = { LOCAL_CONTEXT = "applied" }
+
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/tasks/local-overlay-wins"
+#!/usr/bin/env bash
+echo "LOCAL_CONTEXT=${LOCAL_CONTEXT:-<unset>}"
+echo "GLOBAL_CONTEXT=${GLOBAL_CONTEXT:-<unset>}"
+EOF
+chmod +x "$HOME/.config/mise/tasks/local-overlay-wins"
+
+cat <<'EOF' >"$HOME/.config/mise/tasks/local-dir-wins"
+#!/usr/bin/env bash
+echo "TASK_DIR=$PWD"
+EOF
+chmod +x "$HOME/.config/mise/tasks/local-dir-wins"
+
+assert_contains "mise -C '$HOME/project' run local-overlay-wins" "LOCAL_CONTEXT=applied"
+assert_contains "mise -C '$HOME/project' run local-overlay-wins" "GLOBAL_CONTEXT=<unset>"
+assert_contains "mise -C '$HOME/project' run local-dir-wins" "TASK_DIR=$HOME/local-project-dir"
+assert_not_contains "mise -C '$HOME/project' run local-dir-wins" "TASK_DIR=$HOME/high-global-dir"

--- a/e2e/tasks/test_task_ls_global
+++ b/e2e/tasks/test_task_ls_global
@@ -79,3 +79,168 @@ assert "mise run customglobalfile" "PROJECT_ROOT=$PWD"
 assert "mise run systemglobalfile" "PROJECT_ROOT=$PWD"
 assert "mise run relative-meta" "RELATIVE_OVERLAY=applied"
 assert "mise run templated-meta" "TEMPLATED_OVERLAY=applied"
+
+# The user-global pass owns HOME's task include scope. An unrelated local HOME
+# config must not resurrect omitted defaults or let them override an explicitly
+# included global task with the same name.
+cat <<'EOF' >~/.config/mise/tasks/collision
+#!/usr/bin/env bash
+echo default-task
+EOF
+chmod +x ~/.config/mise/tasks/collision
+cat <<'EOF' >~/.config/mise/tasks/omitted-only
+#!/usr/bin/env bash
+echo omitted-task
+EOF
+chmod +x ~/.config/mise/tasks/omitted-only
+cat <<'EOF' >~/dotfiles/tasks/collision
+#!/usr/bin/env bash
+echo custom-task
+EOF
+chmod +x ~/dotfiles/tasks/collision
+cat >~/.config/mise/config.toml <<'TOML'
+tasks.myglobal = { run = 'echo myglobal' }
+
+[task_config]
+includes = ["dotfiles/tasks"]
+TOML
+cat >"$HOME/mise.toml" <<'TOML'
+[env]
+UNRELATED_HOME_CONFIG = "present"
+
+[tasks.home-inline]
+run = "echo home-inline"
+TOML
+
+assert "mise run collision" "custom-task"
+assert_fail "mise run omitted-only"
+assert_not_contains "mise tasks --global" "omitted-only"
+assert "mise run home-inline" "home-inline"
+
+# Cascade control alone does not supply file-task context at the HOME root, so
+# it must not resurrect defaults omitted by the user-global config.
+cat >"$HOME/mise.toml" <<'TOML'
+[task_config]
+cascade = true
+TOML
+assert_fail "mise run omitted-only"
+
+# A local ancestor config can explicitly include the global task directory even
+# when the global config replaces that default include. Source deduplication
+# must not discard a task that the independent global pass did not load.
+cat >"$HOME/mise.toml" <<'TOML'
+[task_config]
+includes = [".config/mise/tasks"]
+TOML
+cat >"$HOME/.config/mise/config.toml" <<'TOML'
+tasks.myglobal = { run = 'echo myglobal' }
+
+[task_config]
+includes = ["dotfiles/tasks"]
+TOML
+
+assert "mise run myglobalfile" "myglobalfile"
+assert_contains "mise tasks --global" "myglobalfile"
+
+# Explicit task configuration at the HOME root owns its default file tasks even
+# when the user-global config replaces those defaults.
+mkdir -p "$HOME/.mise/conf.d" "$HOME/local-task-dir"
+cat >"$HOME/.config/mise/tasks/local-dir-context" <<'EOF'
+#!/usr/bin/env bash
+echo "$PWD"
+EOF
+chmod +x "$HOME/.config/mise/tasks/local-dir-context"
+cat >"$HOME/mise.toml" <<'EOF'
+[env]
+UNRELATED_HOME_CONFIG = "present"
+EOF
+cat >"$HOME/.mise/conf.d/20-task-context.toml" <<EOF
+[task_config]
+dir = "$HOME/local-task-dir"
+EOF
+assert "mise run local-dir-context" "$HOME/local-task-dir"
+
+# Input defaults from a local conf.d fragment also establish explicit ownership
+# of HOME's default file-task scope.
+touch "$HOME/local-global-input"
+cat >"$HOME/.config/mise/tasks/local-input-context" <<'EOF'
+#!/usr/bin/env bash
+echo local-input-context
+EOF
+chmod +x "$HOME/.config/mise/tasks/local-input-context"
+cat >"$HOME/.mise/conf.d/20-task-context.toml" <<'EOF'
+[task_config]
+global_inputs = ["local-global-input"]
+EOF
+assert \
+  "MISE_EXPERIMENTAL=1 mise tasks ls --json | jq -r '.[] | select(.name == \"local-input-context\") | .sources[0]'" \
+  "$HOME/local-global-input"
+
+# Rust-cache defaults are also file-task context even when explicitly disabled.
+cat >"$HOME/.config/mise/tasks/local-rust-cache-context" <<'EOF'
+#!/usr/bin/env bash
+echo local-rust-cache-context
+EOF
+chmod +x "$HOME/.config/mise/tasks/local-rust-cache-context"
+cat >"$HOME/.mise/conf.d/20-task-context.toml" <<'EOF'
+[task_config]
+rust_cache = false
+EOF
+assert "mise run local-rust-cache-context" "local-rust-cache-context"
+: >"$HOME/.mise/conf.d/20-task-context.toml"
+
+cat >"$HOME/local-shell-wrapper" <<'EOF'
+#!/usr/bin/env bash
+echo LOCAL_SHELL
+exec bash "$@"
+EOF
+chmod +x "$HOME/local-shell-wrapper"
+cat >"$HOME/.config/mise/tasks/local-shell-context" <<'EOF'
+#!/usr/bin/env bash
+echo LOCAL_TASK
+EOF
+chmod +x "$HOME/.config/mise/tasks/local-shell-context"
+cat >"$HOME/mise.toml" <<EOF
+[task_config]
+shell = "$HOME/local-shell-wrapper -c"
+EOF
+assert \
+  "mise tasks ls --json | jq -r '.[] | select(.name == \"local-shell-context\") | .shell'" \
+  "$HOME/local-shell-wrapper -c"
+
+# Effective task context may cascade from an ancestor into a custom global
+# root. The HOME/global-root filter must use that effective context, not only
+# config files located directly at the root.
+custom_global_root="$HOME/nested/global-root"
+mkdir -p "$custom_global_root/.config/mise/tasks" "$HOME/nested/cascaded-dir"
+cat >"$HOME/nested/mise.toml" <<EOF
+[task_config]
+cascade = true
+dir = "$HOME/nested/cascaded-dir"
+EOF
+cat >"$custom_global_root/.config/mise/tasks/cascaded-context" <<'EOF'
+#!/usr/bin/env bash
+echo "$PWD"
+EOF
+chmod +x "$custom_global_root/.config/mise/tasks/cascaded-context"
+cat >"$HOME/custom-global.toml" <<'EOF'
+[task_config]
+includes = ["empty-global-tasks"]
+EOF
+assert \
+  "MISE_GLOBAL_CONFIG_ROOT='$custom_global_root' MISE_GLOBAL_CONFIG_FILE='$HOME/custom-global.toml' MISE_SYSTEM_CONFIG_FILE='$HOME/missing-system.toml' mise -C '$custom_global_root' run cascaded-context" \
+  "$HOME/nested/cascaded-dir"
+
+# A root-local cascade opt-out also disables ancestor file-task context for
+# ownership checks, so omitted global defaults stay omitted.
+cat >"$custom_global_root/mise.toml" <<'EOF'
+[task_config]
+cascade = false
+EOF
+cat >"$custom_global_root/.config/mise/tasks/omitted-after-cascade-opt-out" <<'EOF'
+#!/usr/bin/env bash
+echo should-not-run
+EOF
+chmod +x "$custom_global_root/.config/mise/tasks/omitted-after-cascade-opt-out"
+assert_fail \
+  "MISE_GLOBAL_CONFIG_ROOT='$custom_global_root' MISE_GLOBAL_CONFIG_FILE='$HOME/custom-global.toml' MISE_SYSTEM_CONFIG_FILE='$HOME/missing-system.toml' mise -C '$custom_global_root' run omitted-after-cascade-opt-out"

--- a/e2e/tasks/test_task_monorepo_config_dedup
+++ b/e2e/tasks/test_task_monorepo_config_dedup
@@ -3,6 +3,7 @@
 export MISE_EXPERIMENTAL=1
 
 marker="$MISE_TMP_DIR/monorepo-config-render-count"
+: >"$marker"
 mkdir -p apps/example
 
 cat <<'EOF' >mise.toml

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4051,6 +4051,26 @@ fn discover_monorepo_subdirs(
     Ok(subdirs)
 }
 
+enum GlobalTaskState {
+    Resolved {
+        task: Task,
+        has_inline_definition: bool,
+    },
+    Pending {
+        fallback: Task,
+        overlays: Vec<Task>,
+    },
+}
+
+impl GlobalTaskState {
+    fn into_task(self) -> Task {
+        match self {
+            Self::Resolved { task, .. } => task,
+            Self::Pending { fallback, .. } => fallback,
+        }
+    }
+}
+
 async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) -> Result<Vec<Task>> {
     // User-global config overrides system config. Within each group the path
     // lists are lowest-first, so reverse them before applying first-wins task
@@ -4077,11 +4097,11 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
 
     // Global config files keep independent task include sets. Aggregate their
     // results high-to-low. When a lower config supplies the first inline
-    // definition for a task source already rediscovered by a higher config,
-    // apply only that inline metadata to the higher task so its config context
-    // is preserved.
-    let mut tasks: IndexMap<String, Task> = IndexMap::new();
-    let mut seen_config_task_names = BTreeSet::new();
+    // definition for a script already rediscovered by a higher config, apply
+    // only that inline metadata to the higher script so its config context is
+    // preserved. A metadata-only task remains pending until the nearest lower
+    // execution- or include-backed definition supplies its runnable base.
+    let mut tasks: IndexMap<String, GlobalTaskState> = IndexMap::new();
     let mut rendered_file_tasks = RenderedTaskCache::default();
     for cf in configs {
         let sources = load_task_sources_from_configs(
@@ -4106,24 +4126,69 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
                 .or_insert_with(|| task.clone());
         }
         let loaded = sources.into_tasks();
-        for task in loaded {
-            if let Some(inline_task) = inline_tasks.get(&task.name) {
-                if seen_config_task_names.insert(task.name.clone()) {
-                    if let Some(existing) = tasks.get_mut(&task.name) {
-                        if tasks_have_same_source(existing, &task) {
-                            existing.merge_toml_overlay(inline_task.clone());
-                            existing.infer_auto_outputs();
+        for mut task in loaded {
+            let name = task.name.clone();
+            let inline_task = inline_tasks.get(&name);
+            let can_back_inline_overlay = task_defines_execution(&task) || task.is_toml_include;
+            if let Some(state) = tasks.get_mut(&name) {
+                match state {
+                    GlobalTaskState::Pending { overlays, .. } => {
+                        if can_back_inline_overlay {
+                            for overlay in std::mem::take(overlays).into_iter().rev() {
+                                task.merge_toml_overlay(overlay);
+                            }
+                            task.infer_auto_outputs();
+                            *state = GlobalTaskState::Resolved {
+                                task,
+                                has_inline_definition: true,
+                            };
+                        } else if let Some(inline_task) = inline_task {
+                            overlays.push(inline_task.clone());
                         }
-                    } else {
-                        tasks.insert(task.name.clone(), task);
+                    }
+                    GlobalTaskState::Resolved {
+                        task: selected,
+                        has_inline_definition,
+                    } => {
+                        if let Some(inline_task) = inline_task {
+                            if !*has_inline_definition {
+                                *has_inline_definition = true;
+                                if tasks_have_same_source(selected, &task) {
+                                    selected.merge_toml_overlay(inline_task.clone());
+                                    selected.infer_auto_outputs();
+                                }
+                            }
+                        }
+                    }
+                }
+                continue;
+            }
+
+            let state = if let Some(inline_task) = inline_task {
+                if can_back_inline_overlay {
+                    GlobalTaskState::Resolved {
+                        task,
+                        has_inline_definition: true,
+                    }
+                } else {
+                    GlobalTaskState::Pending {
+                        fallback: task,
+                        overlays: vec![inline_task.clone()],
                     }
                 }
             } else {
-                tasks.entry(task.name.clone()).or_insert(task);
-            }
+                GlobalTaskState::Resolved {
+                    task,
+                    has_inline_definition: false,
+                }
+            };
+            tasks.insert(name, state);
         }
     }
-    Ok(tasks.into_values().collect())
+    Ok(tasks
+        .into_values()
+        .map(GlobalTaskState::into_task)
+        .collect())
 }
 
 /// Combine file tasks (auto-discovered executable scripts and included TOML
@@ -4135,13 +4200,22 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
 /// [`Task::merge_toml_overlay`]. An inline block replaces a same-named task from
 /// an included TOML file. When the same name appears in multiple inline blocks
 /// (e.g. `mise.toml` and `mise.local.toml`), the highest-precedence block wins.
-/// If that block has no command, it overlays the nearest lower-precedence
-/// command-bearing block; definitions below that selected base are skipped.
+/// If that block has no execution, it overlays the nearest lower-precedence
+/// execution-bearing block; definitions below that selected base are skipped.
 /// When the same name appears in more than one file task (e.g. a local
 /// `.mise/tasks` script and a same-named task from a `git::` include), the last
 /// one wins. Callers load `file_tasks` in declared `task_config.includes`
 /// order, so the later include in the list takes precedence — see
 /// `load_tasks_in_dir`.
+fn task_defines_execution(task: &Task) -> bool {
+    !task.run.is_empty()
+        || !task.run_windows.is_empty()
+        || task.file.is_some()
+        || !task.depends.is_empty()
+        || !task.depends_post.is_empty()
+        || !task.wait_for.is_empty()
+}
+
 fn merge_file_and_config_tasks(file_tasks: Vec<Task>, config_tasks: Vec<Task>) -> Vec<Task> {
     let mut by_name: IndexMap<String, Task> = IndexMap::new();
     for t in prefer_windows_file_task_siblings(file_tasks) {
@@ -4151,8 +4225,8 @@ fn merge_file_and_config_tasks(file_tasks: Vec<Task>, config_tasks: Vec<Task>) -
     let mut pending_inline_overlays: IndexMap<String, Vec<Task>> = IndexMap::new();
     for t in config_tasks {
         if !seen_config_task_names.insert(t.name.clone()) {
-            let has_command = !t.run.is_empty() || !t.run_windows.is_empty() || t.file.is_some();
-            if pending_inline_overlays.contains_key(&t.name) && has_command {
+            let defines_execution = task_defines_execution(&t);
+            if pending_inline_overlays.contains_key(&t.name) && defines_execution {
                 let overlays = pending_inline_overlays
                     .shift_remove(&t.name)
                     .expect("pending inline overlays should be present");
@@ -4171,7 +4245,7 @@ fn merge_file_and_config_tasks(file_tasks: Vec<Task>, config_tasks: Vec<Task>) -
             .filter(|existing| existing.is_toml_include)
         {
             if t.config_precedence <= existing.config_precedence {
-                if t.run.is_empty() && t.run_windows.is_empty() && t.file.is_none() {
+                if !task_defines_execution(&t) {
                     existing.merge_toml_overlay(t);
                 } else {
                     *existing = t;
@@ -4182,7 +4256,7 @@ fn merge_file_and_config_tasks(file_tasks: Vec<Task>, config_tasks: Vec<Task>) -
                 existing.merge_toml_overlay(t);
             }
         } else {
-            if t.run.is_empty() && t.run_windows.is_empty() && t.file.is_none() {
+            if !task_defines_execution(&t) {
                 pending_inline_overlays
                     .entry(t.name.clone())
                     .or_default()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3205,17 +3205,17 @@ fn render_task_input_entries(
         .collect()
 }
 
-async fn apply_task_config_inputs(
-    task: &mut Task,
+async fn resolve_task_config_inputs(
+    task: &Task,
     config: &Arc<Config>,
     task_inputs: &ResolvedTaskInputs,
-) -> Result<()> {
+) -> Result<Option<ResolvedTaskInputs>> {
     let has_group_references = task
         .sources
         .iter()
         .any(|source| source.starts_with(TASK_INPUT_GROUP_PREFIX));
     if task_inputs.is_empty() && !has_group_references {
-        return Ok(());
+        return Ok(None);
     }
     Settings::get().ensure_experimental("task input groups")?;
 
@@ -3242,23 +3242,29 @@ async fn apply_task_config_inputs(
         )),
         None => None,
     };
-    let task_inputs = ResolvedTaskInputs {
+    Ok(Some(ResolvedTaskInputs {
         global_inputs,
         input_groups,
-    };
-    let had_sources = !task.sources.is_empty();
-    let mut sources = expand_task_inputs(
+    }))
+}
+
+fn apply_task_input_groups(task: &mut Task, task_inputs: &ResolvedTaskInputs) -> Result<()> {
+    task.sources = expand_task_inputs(
         &task.sources,
-        &task_inputs,
+        task_inputs,
         Path::new(""),
         &task.name,
         &mut vec![],
         false,
     )?;
+    Ok(())
+}
+
+fn apply_task_global_inputs(task: &mut Task, task_inputs: &ResolvedTaskInputs) -> Result<()> {
     if let Some((global_inputs, root)) = &task_inputs.global_inputs {
-        sources.extend(expand_task_inputs(
+        task.sources.extend(expand_task_inputs(
             global_inputs,
-            &task_inputs,
+            task_inputs,
             root,
             &task.name,
             &mut vec![],
@@ -3266,9 +3272,18 @@ async fn apply_task_config_inputs(
         )?);
     }
 
-    task.sources = sources;
-    if !had_sources && !task.sources.is_empty() && task.outputs.is_empty() {
-        task.outputs = TaskOutputs::Auto;
+    task.infer_auto_outputs();
+    Ok(())
+}
+
+async fn apply_task_config_inputs(
+    task: &mut Task,
+    config: &Arc<Config>,
+    task_inputs: &ResolvedTaskInputs,
+) -> Result<()> {
+    if let Some(task_inputs) = resolve_task_config_inputs(task, config, task_inputs).await? {
+        apply_task_input_groups(task, &task_inputs)?;
+        apply_task_global_inputs(task, &task_inputs)?;
     }
     Ok(())
 }
@@ -4062,9 +4077,9 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
 
     // Global config files keep independent task include sets. Aggregate their
     // results high-to-low. When a lower config supplies the first inline
-    // definition for a script already rediscovered by a higher config, apply
-    // only that inline metadata to the higher script so its config context is
-    // preserved.
+    // definition for a task source already rediscovered by a higher config,
+    // apply only that inline metadata to the higher task so its config context
+    // is preserved.
     let mut tasks: IndexMap<String, Task> = IndexMap::new();
     let mut seen_config_task_names = BTreeSet::new();
     let mut rendered_file_tasks = RenderedTaskCache::default();
@@ -4081,7 +4096,11 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
         .await?;
         rendered_file_tasks.finish_config();
         let mut inline_tasks = IndexMap::new();
-        for task in &sources.config_tasks {
+        for task in sources
+            .config_tasks
+            .iter()
+            .filter_map(|task| task.explicit_overlay.as_ref())
+        {
             inline_tasks
                 .entry(task.name.clone())
                 .or_insert_with(|| task.clone());
@@ -4091,11 +4110,9 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
             if let Some(inline_task) = inline_tasks.get(&task.name) {
                 if seen_config_task_names.insert(task.name.clone()) {
                     if let Some(existing) = tasks.get_mut(&task.name) {
-                        let rediscovered_file = resolved_task_file(existing)
-                            .zip(resolved_task_file(&task))
-                            .is_some_and(|(left, right)| file::same_file(&left, &right));
-                        if rediscovered_file {
+                        if tasks_have_same_source(existing, &task) {
                             existing.merge_toml_overlay(inline_task.clone());
+                            existing.infer_auto_outputs();
                         }
                     } else {
                         tasks.insert(task.name.clone(), task);
@@ -4281,10 +4298,10 @@ async fn load_config_tasks(
     templates: &TaskDefinitions,
     monorepo_cf: Option<&Arc<dyn ConfigFile>>,
     task_config: &ResolvedTaskConfig,
-) -> Result<Vec<Task>> {
+) -> Result<Vec<LoadedConfigTask>> {
     let is_global = is_global_config(cf.get_path());
     let config_root = Arc::new(config_root.to_path_buf());
-    let mut tasks = vec![];
+    let mut loaded_tasks = vec![];
     for t in cf.tasks().into_iter() {
         let config_root = config_root.clone();
         let config = config.clone();
@@ -4300,6 +4317,9 @@ async fn load_config_tasks(
         }
         // Resolve template if the task extends one
         resolve_task_template(&mut t, templates)?;
+        let has_explicit_dir = t.dir.is_some();
+        let has_explicit_shell = t.shell.is_some();
+        let has_explicit_outputs = !t.outputs.is_empty();
         if t.dir.is_none() {
             t.dir = task_config.dir.clone();
         }
@@ -4308,11 +4328,36 @@ async fn load_config_tasks(
         }
         match t.render(&config, &config_root).await {
             Ok(()) => {
-                apply_task_config_inputs(&mut t, &config, &task_config.inputs).await?;
+                let resolved_task_inputs =
+                    resolve_task_config_inputs(&t, &config, &task_config.inputs).await?;
+                if let Some(task_inputs) = &resolved_task_inputs {
+                    apply_task_input_groups(&mut t, task_inputs)?;
+                }
+                let explicit_overlay = if is_global {
+                    let mut overlay = t.clone();
+                    if !has_explicit_dir {
+                        overlay.dir = None;
+                    }
+                    if !has_explicit_shell {
+                        overlay.shell = None;
+                    }
+                    if !has_explicit_outputs {
+                        overlay.outputs = TaskOutputs::default();
+                    }
+                    Some(overlay)
+                } else {
+                    None
+                };
+                if let Some(task_inputs) = &resolved_task_inputs {
+                    apply_task_global_inputs(&mut t, task_inputs)?;
+                }
                 apply_task_config_cache_default(&mut t, &task_config.cache);
                 apply_task_config_rust_cache_default(&mut t, &task_config.rust_cache);
                 task_config.environment.apply(&mut t)?;
-                tasks.push(t);
+                loaded_tasks.push(LoadedConfigTask {
+                    effective: t,
+                    explicit_overlay,
+                });
             }
             Err(e) => {
                 if monorepo_cf.is_some() {
@@ -4327,7 +4372,7 @@ async fn load_config_tasks(
             }
         }
     }
-    Ok(tasks)
+    Ok(loaded_tasks)
 }
 
 struct LoadTaskIncludesOptions<'a> {
@@ -4681,7 +4726,12 @@ async fn load_tasks_in_dir_with_definitions(
 
 struct TaskSources {
     file_tasks: Vec<Task>,
-    config_tasks: Vec<Task>,
+    config_tasks: Vec<LoadedConfigTask>,
+}
+
+struct LoadedConfigTask {
+    effective: Task,
+    explicit_overlay: Option<Task>,
 }
 
 #[derive(Clone)]
@@ -4800,7 +4850,12 @@ impl RenderedTaskCache {
 
 impl TaskSources {
     fn into_tasks(self) -> Vec<Task> {
-        let mut tasks = merge_file_and_config_tasks(self.file_tasks, self.config_tasks)
+        let config_tasks = self
+            .config_tasks
+            .into_iter()
+            .map(|task| task.effective)
+            .collect();
+        let mut tasks = merge_file_and_config_tasks(self.file_tasks, config_tasks)
             .into_iter()
             .sorted_by_cached_key(|t| t.name.clone())
             .collect::<Vec<_>>();
@@ -4915,7 +4970,7 @@ async fn load_task_sources_from_configs(
     for (precedence, cf) in configs.iter().enumerate() {
         let dir = dir.to_path_buf();
         let monorepo_cf = monorepo_context.then_some(*cf);
-        let mut loaded = load_config_tasks(
+        let loaded = load_config_tasks(
             config,
             (*cf).clone(),
             &dir,
@@ -4924,10 +4979,20 @@ async fn load_task_sources_from_configs(
             &task_config,
         )
         .await?;
-        for task in &mut loaded {
-            task.config_precedence = precedence;
+        for LoadedConfigTask {
+            mut effective,
+            mut explicit_overlay,
+        } in loaded
+        {
+            effective.config_precedence = precedence;
+            if let Some(overlay) = &mut explicit_overlay {
+                overlay.config_precedence = precedence;
+            }
+            config_tasks.push(LoadedConfigTask {
+                effective,
+                explicit_overlay,
+            });
         }
-        config_tasks.extend(loaded);
     }
 
     let mut file_tasks = vec![];

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4150,13 +4150,13 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
                         task: selected,
                         has_inline_definition,
                     } => {
-                        if let Some(inline_task) = inline_task {
-                            if !*has_inline_definition {
-                                *has_inline_definition = true;
-                                if tasks_have_same_source(selected, &task) {
-                                    selected.merge_toml_overlay(inline_task.clone());
-                                    selected.infer_auto_outputs();
-                                }
+                        if let Some(inline_task) = inline_task
+                            && !*has_inline_definition
+                        {
+                            *has_inline_definition = true;
+                            if tasks_have_same_source(selected, &task) {
+                                selected.merge_toml_overlay(inline_task.clone());
+                                selected.infer_auto_outputs();
                             }
                         }
                     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,7 +4,7 @@ use indexmap::{IndexMap, IndexSet};
 use itertools::{Either, Itertools};
 use path_absolutize::Absolutize;
 pub use settings::{CompilePurpose, Settings};
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::env::join_paths;
 use std::fmt::{Debug, Formatter};
 use std::iter::once;
@@ -924,12 +924,14 @@ impl Config {
             load_local_tasks_with_context(&config, ctx, &task_definitions).await?;
         let global_tasks = load_global_tasks(&config, &task_definitions).await?;
         local_tasks.retain(|local| {
-            !global_tasks
-                .iter()
-                .any(|global| tasks_have_same_source(local, global))
+            !local.suppress_if_global_duplicate
+                || !global_tasks
+                    .iter()
+                    .any(|global| tasks_have_same_source(&local.task, global))
         });
         let mut tasks: BTreeMap<String, Task> = local_tasks
             .into_iter()
+            .map(|local| local.task)
             .chain(global_tasks)
             .rev()
             .inspect(|t| {
@@ -3452,11 +3454,28 @@ fn dir_is_in_enclosing_monorepo(
         && !file::path_starts_with_resolved(dir, selected_root)
 }
 
+struct LoadedLocalTask {
+    task: Task,
+    suppress_if_global_duplicate: bool,
+}
+
+fn task_config_has_file_context(task_config: &TaskConfig) -> bool {
+    task_config.includes.is_some()
+        || task_config.dir.is_some()
+        || task_config.shell.is_some()
+        || task_config.cache.is_some()
+        || task_config.rust_cache.is_some()
+        || !task_config.global_env.is_empty()
+        || !task_config.global_pass_through_env.is_empty()
+        || !task_config.global_inputs.is_empty()
+        || !task_config.input_groups.is_empty()
+}
+
 async fn load_local_tasks_with_context(
     config: &Arc<Config>,
     ctx: Option<&crate::task::TaskLoadContext>,
     templates: &TaskDefinitions,
-) -> Result<Vec<Task>> {
+) -> Result<Vec<LoadedLocalTask>> {
     let mut tasks = vec![];
     let monorepo_config = find_monorepo_config(&config.config_files);
     let monorepo_root = monorepo_config.and_then(|cf| cf.project_root().map(|p| p.to_path_buf()));
@@ -3473,6 +3492,11 @@ async fn load_local_tasks_with_context(
         .as_deref()
         .map(|root| enclosing_monorepo_roots(&config.config_files, root))
         .unwrap_or_default();
+    let user_global_config_paths = global_config_files();
+    let has_user_global_config = config
+        .config_files
+        .values()
+        .any(|cf| config_set_contains(&user_global_config_paths, cf.get_path()));
     for d in all_dirs()? {
         if cfg!(test) && !d.starts_with(*dirs::HOME) {
             continue;
@@ -3487,14 +3511,55 @@ async fn load_local_tasks_with_context(
             );
             continue;
         }
-        let mut dir_tasks =
-            load_tasks_in_dir_with_definitions(config, &d, &local_config_files, templates).await?;
+        let local_configs = configs_at_root(&d, &local_config_files);
+        let cascaded_task_config = cascaded_task_config_for_dir(&d, &local_config_files)?;
+        let effective_cascaded_task_config =
+            if local_configs.iter().find_map(|cf| cf.task_config().cascade) == Some(false) {
+                None
+            } else {
+                cascaded_task_config.as_ref()
+            };
+        let mut dir_tasks = load_tasks_from_configs(
+            config,
+            &d,
+            local_configs.clone(),
+            templates,
+            false,
+            effective_cascaded_task_config,
+        )
+        .await?;
+
+        let mut suppress_if_global_duplicate = !has_user_global_config;
+        let mut local_inline_task_names = HashSet::new();
+        if has_user_global_config && file::same_file(&d, &env::MISE_GLOBAL_CONFIG_ROOT) {
+            let local_file_context = local_configs
+                .iter()
+                .any(|cf| task_config_has_file_context(cf.task_config()))
+                || effective_cascaded_task_config
+                    .is_some_and(|tc| task_config_has_file_context(&tc.task_config));
+            suppress_if_global_duplicate = false;
+            if !local_file_context {
+                local_inline_task_names = local_configs
+                    .iter()
+                    .flat_map(|cf| cf.tasks())
+                    .map(|task| task.name.clone())
+                    .collect();
+                // A user-global config owns the HOME include decision, so
+                // omitted defaults must not be resurrected by the local
+                // hierarchy walk.
+                dir_tasks.retain(|task| local_inline_task_names.contains(&task.name));
+            }
+        }
 
         if let Some(ref monorepo_root) = monorepo_root {
             prefix_monorepo_task_names(&mut dir_tasks, &d, monorepo_root);
         }
 
-        tasks.extend(dir_tasks);
+        tasks.extend(dir_tasks.into_iter().map(|task| LoadedLocalTask {
+            suppress_if_global_duplicate: suppress_if_global_duplicate
+                && !local_inline_task_names.contains(&task.name),
+            task,
+        }));
     }
 
     // Determine if we should load monorepo tasks from subdirectories
@@ -3620,7 +3685,10 @@ async fn load_local_tasks_with_context(
         }
 
         while let Some(result) = join_set.join_next().await {
-            tasks.extend(result??);
+            tasks.extend(result??.into_iter().map(|task| LoadedLocalTask {
+                task,
+                suppress_if_global_duplicate: !has_user_global_config,
+            }));
         }
     }
 

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -2637,15 +2637,19 @@ impl Task {
     }
 
     fn store_raw_render_inputs(&mut self) {
-        if !self.sources.is_empty() && self.outputs.is_empty() {
-            self.outputs = TaskOutputs::Auto;
-        }
+        self.infer_auto_outputs();
         self.raw_outputs = self.outputs.raw_templates_without_env();
         // Save unrendered dependency templates so they can be re-rendered later
         // with parent task args available (for passing args to dependencies).
         self.depends_raw = Some(self.depends.clone());
         self.depends_post_raw = Some(self.depends_post.clone());
         self.wait_for_raw = Some(self.wait_for.clone());
+    }
+
+    pub(crate) fn infer_auto_outputs(&mut self) {
+        if !self.sources.is_empty() && self.outputs.is_empty() {
+            self.outputs = TaskOutputs::Auto;
+        }
     }
 
     fn parse_plain_depends(&mut self) -> Result<()> {


### PR DESCRIPTION
Stacked on #12216, which is itself stacked on #12203. Review commits `98b310c40` and `6273a3b4f` for this layer only.

## Summary

- keep higher-priority metadata-only global task definitions pending until a lower execution- or include-backed definition supplies the task base
- merge multiple pending metadata layers onto the nearest lower base with the highest-priority fields winning
- treat dependency-only, post-dependency-only, and wait-only tasks as executable task definitions
- use the same execution-base rule for local and global `conf.d` composition

## Bug examples

- A higher config can define only `[tasks.build] description = "Build"`, while a lower `conf.d` fragment supplies `run = "make"`. First-wins aggregation previously retained the no-op metadata task and discarded the runnable task, so `mise run build` did nothing.
- A wrapper task may have no `run` command and only `depends = ["child"]`. It is still executable task behavior. Such a lower definition was previously mistaken for another metadata overlay, causing its dependency graph to disappear.
- With high and middle metadata fragments over a lower command, both layers should apply while conflicts keep the high value. The pending state now resolves that chain deterministically against the nearest runnable base.

## Testing

- `mise run lint-fix`
- `mise run test:e2e e2e/tasks/test_task_global_config_precedence e2e/tasks/test_task_global_source_context_precedence`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved global task configuration precedence across system, user, included, and project settings.
  * Enhanced task loading to preserve metadata, environments, dependencies, directories, shells, inputs, outputs, and scripts from the highest-priority sources.
  * Improved task listing and execution with custom global roots, cascading configuration, source resolution, and explicit task contexts.
  * Automatic output inference is now applied consistently for tasks with defined sources.

* **Bug Fixes**
  * Prevented duplicate task definitions and repeated template evaluation when loading global and monorepo configurations.

* **Tests**
  * Added comprehensive end-to-end coverage for global configuration, includes, precedence, deduplication, and task listing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
