### PR TITLE
fix(bash): do not apply the environment at activation under --no-hook-env

### DIFF
--- a/e2e/env/test_bash_no_hook_env
+++ b/e2e/env/test_bash_no_hook_env
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# `--no-hook-env` means mise does not apply the environment. zsh, fish and pwsh all keep their
+# activation-time hook-env call inside the flag's guard; bash did too, until the script moved out
+# of bash.rs into src/assets/bash/activate.sh (#8920) and the call was left outside it. From then
+# on a bash shell activated with the flag had the config's env applied anyway — the one thing the
+# flag says it will not do.
+
+printf '[env]\nNO_HOOK_ENV_PROBE = "applied"\n' >mise.toml
+
+# An inherited value would be printed by the probe and read as the environment having been applied,
+# so the only value the probe can see is one activation set.
+unset NO_HOOK_ENV_PROBE
+
+# The activation script is captured, then eval'd, so that a `mise activate` that fails and emits
+# nothing is a failed probe rather than an empty eval that quietly prints "unset".
+probe() {
+  bash --noprofile --norc -c \
+    "activation=\"\$(mise activate bash $1)\" || exit \$?
+     eval \"\$activation\" || exit \$?
+     echo \"\${NO_HOOK_ENV_PROBE:-unset}\"" | tail -1
+}
+
+if ! with_flag="$(probe --no-hook-env)"; then
+  echo "activation with --no-hook-env failed"
+  exit 1
+fi
+if [ "$with_flag" != "unset" ]; then
+  echo "--no-hook-env applied the environment at activation: NO_HOOK_ENV_PROBE=$with_flag"
+  exit 1
+fi
+
+# The control. Without it the check above would also pass against a mise that never applies the
+# environment at all, or against a config that was never loaded.
+if ! without_flag="$(probe "")"; then
+  echo "activation without the flag failed"
+  exit 1
+fi
+if [ "$without_flag" != "applied" ]; then
+  echo "expected activation without the flag to apply the environment, got: $without_flag"
+  exit 1
+fi

--- a/src/assets/bash/activate.sh
+++ b/src/assets/bash/activate.sh
@@ -79,7 +79,13 @@ if [ "$__MISE_HOOK_ENABLED" = "1" ]; then
 	chpwd_functions+=(_mise_hook_chpwd)
 fi
 
-_mise_hook
+# `--no-hook-env` means mise does not apply the environment at activation -- zsh, fish and pwsh
+# all keep their equivalent call inside this guard, and bash did too until the script moved out
+# of bash.rs into this file (#8920), which left the call outside it. The skip flag exists because
+# the hook runs here, so the two belong under one condition; it is set first so the `$?` that
+# `_mise_hook` saves is not read straight off the guard's condition, where it is the test's
+# status rather than a command's (SC2319).
 if [ "$__MISE_HOOK_ENABLED" = "1" ]; then
 	__MISE_BASH_SKIP_FIRST_PROMPT=1
+	_mise_hook
 fi

--- a/src/shell/snapshots/mise__shell__bash__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__bash__tests__activate.snap
@@ -109,9 +109,15 @@ function __zsh_like_cd()
 	chpwd_functions+=(_mise_hook_chpwd)
 fi
 
-_mise_hook
+# `--no-hook-env` means mise does not apply the environment at activation -- zsh, fish and pwsh
+# all keep their equivalent call inside this guard, and bash did too until the script moved out
+# of bash.rs into this file (#8920), which left the call outside it. The skip flag exists because
+# the hook runs here, so the two belong under one condition; it is set first so the `$?` that
+# `_mise_hook` saves is not read straight off the guard's condition, where it is the test's
+# status rather than a command's (SC2319).
 if [ "$__MISE_HOOK_ENABLED" = "1" ]; then
 	__MISE_BASH_SKIP_FIRST_PROMPT=1
+	_mise_hook
 fi
 
 # shellcheck shell=bash


### PR DESCRIPTION
`mise activate bash --no-hook-env` applies the config's environment anyway. The other three shells do not.

Measured, one tool configured and installed, checking whether it lands on `PATH` at activation:

| shell | `--no-hook-env` | no flag (control) |
| --- | --- | --- |
| **bash** | **applied** | applied |
| zsh | not applied | applied |
| fish | not applied | applied |
| pwsh | not applied | applied |

And with an `[env]` entry rather than a tool, which is the plainer statement of it:

```
$ printf '[env]\nNO_HOOK_ENV_PROBE = "applied"\n' > mise.toml
$ bash --noprofile --norc -c 'eval "$(mise activate bash --no-hook-env)"; echo "${NO_HOOK_ENV_PROBE:-unset}"'
applied          # zsh, same config: unset
```

## Not a design choice — the call moved

bash used to match the others. Before `src/assets/bash/activate.sh` existed, `bash.rs` emitted the activation-time call **inside** the flag's guard:

```rust
if !opts.no_hook_env {
    out.push_str(&formatdoc! {r#"
    …PROMPT_COMMAND…
    chpwd_functions+=(_mise_hook)
    _mise_hook            // inside
    "#, …});
}
```

`48e5dd59ca7d` — **"fix(bash): avoid duplicate trust warning after cd" (#8920)** — extracted that script into the asset file, and the call came out from under the guard on the way. The subject of that change was duplicate trust warnings; `--no-hook-env` is not mentioned in it.

Nothing pins the current behaviour either: the test that same commit added, `e2e/env/test_bash_first_prompt_after_activate`, activates with `--status`, not with the flag, and no bash test covers `--no-hook-env` at all. `e2e/cli/test_activate_export` does use it, but only to check `__MISE_EXE`, which is exported at the top of the script outside any guard — unaffected by this change.

The flag's own summary line is "Do not automatically call hook-env". Applying the environment at activation is calling hook-env.

## The change

The call joins the guard that immediately follows it — the one already setting `__MISE_BASH_SKIP_FIRST_PROMPT`, which exists *because* `_mise_hook` just ran, so the two belong under one condition:

```bash
if [ "$__MISE_HOOK_ENABLED" = "1" ]; then
	_mise_hook
	__MISE_BASH_SKIP_FIRST_PROMPT=1
fi
```

## Test

`e2e/env/test_bash_no_hook_env` asserts an `[env]` entry is **not** applied with the flag, and — the control — that it **is** without it, so the first check cannot pass against a mise that never applies the environment at all. Verified against the current release: it fails there with `--no-hook-env applied the environment at activation: NO_HOOK_ENV_PROBE=applied`, which is the bug.

## Draft

Opened as a draft: this changes what an existing flag does for bash users. The history says the current behaviour is accidental, but somebody may have come to rely on activating with `--no-hook-env` and still getting their tools — worth your call before it lands.

**No local build was run** — this machine cannot build mise, so type checking and the snapshot are CI's. The measurements above are all from released binaries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Bash activation so the initial environment hook is skipped when hook processing is disabled.
  * Ensured the `--no-hook-env` option leaves configured environment variables unset while normal activation continues to apply them.

* **Tests**
  * Added end-to-end coverage for Bash activation with and without `--no-hook-env`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->