### PR TITLE
fix(bootstrap): do not reinstall brew casks on content drift

### DIFF
--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -180,9 +180,14 @@ Direct cask pours remain mise-owned. Their completed state is recorded in
 `.mise-cask.toml`; mise does not synthesize Homebrew's private `.metadata`
 receipts. If Homebrew metadata already exists for a cask, mise preserves it and
 fails before mutation rather than taking over Homebrew's lifecycle state.
-Status uses recorded installation facts rather than reconstructing them from a
-newer cask definition; missing or unknown receipts and pending transactions are
-reported as unhealthy so the next apply can reconcile them.
+Status treats a cask as installed when its receipt and recorded targets are
+still present (directory / file / symlink kind). Content fingerprints are kept
+for prune and adopt safety, but content drift inside an existing app bundle
+does **not** mark the cask missing or trigger a reinstall on apply — replacing
+`/Applications/*.app` resets macOS Privacy & Security (TCC) grants. Missing or
+unknown receipts and pending transactions are still reported as unhealthy so
+the next apply can reconcile them. Version upgrades and an explicit remove +
+apply still replace the app when you want a fresh pour.
 
 This exists because shared-library packages — postgres, ffmpeg, imagemagick,
 php — fundamentally can't be served by mise's per-project backends like

--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -181,10 +181,12 @@ Direct cask pours remain mise-owned. Their completed state is recorded in
 receipts. If Homebrew metadata already exists for a cask, mise preserves it and
 fails before mutation rather than taking over Homebrew's lifecycle state.
 Status treats a cask as installed when its receipt and recorded targets are
-still present (directory / file / symlink kind). Content fingerprints are kept
-for prune and adopt safety, but content drift inside an existing app bundle
-does **not** mark the cask missing or trigger a reinstall on apply — replacing
-`/Applications/*.app` resets macOS Privacy & Security (TCC) grants. Missing or
+still present. App and font content fingerprints are kept for prune and adopt
+safety, but content drift inside an existing app or font does **not** mark the
+cask missing or trigger a reinstall on apply — replacing `/Applications/*.app`
+resets macOS Privacy & Security (TCC) grants. Binary and completion symlinks
+still require the recorded link destination (a cheap `readlink`) and a
+resolvable target, so dangling or retargeted links stay repairable. Missing or
 unknown receipts and pending transactions are still reported as unhealthy so
 the next apply can reconcile them. Version upgrades and an explicit remove +
 apply still replace the app when you want a fresh pour.

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -6486,23 +6486,13 @@ fn installed_cask_version_in(
                 return Ok(None);
             }
             if receipt.schema_version >= 2 {
-                let targets_match = receipt
-                    .targets
-                    .iter()
-                    .map(|record| {
-                        if (cask.auto_updates || receipt.auto_updates)
-                            && receipt.apps.contains(&record.path)
-                        {
-                            Ok(record.path.is_dir())
-                        } else {
-                            cask_target_record_matches(record)
-                        }
-                    })
-                    .collect::<Result<Vec<_>>>()?
-                    .into_iter()
-                    .all(|matches| matches);
+                // Presence only. Content fingerprints are for prune/adopt safety
+                // and must not mark a cask "missing": replacing an .app because a
+                // file inside it changed resets macOS TCC grants, and hashing
+                // every app tree on status/apply is expensive.
+                let targets_present = receipt.targets.iter().all(cask_target_present);
                 let pkgs_installed = pkg_ids_installed(&receipt.pkg_ids)?;
-                return Ok((targets_match && pkgs_installed).then_some(receipt.version));
+                return Ok((targets_present && pkgs_installed).then_some(receipt.version));
             }
 
             // Legacy receipts remain usable only from the historical facts they
@@ -6640,6 +6630,21 @@ fn cask_target_record_matches(record: &CaskTargetRecord) -> Result<bool> {
         return Ok(false);
     };
     Ok(actual == record.fingerprint)
+}
+
+/// Whether a receipt target still exists at the recorded path and kind.
+/// Unlike [`cask_target_record_matches`], this ignores content drift so status
+/// and apply stay cheap and do not reinstall apps that have updated themselves
+/// or written into their bundle.
+fn cask_target_present(record: &CaskTargetRecord) -> bool {
+    let Ok(metadata) = record.path.symlink_metadata() else {
+        return false;
+    };
+    match record.fingerprint.kind {
+        CaskTargetKind::Symlink => metadata.file_type().is_symlink(),
+        CaskTargetKind::File => metadata.is_file(),
+        CaskTargetKind::Directory => metadata.is_dir(),
+    }
 }
 
 fn cask_target_fingerprint(path: &Path) -> Result<CaskTargetFingerprint> {
@@ -7720,7 +7725,7 @@ mod tests {
     }
 
     #[test]
-    fn completed_receipt_detects_app_bundle_drift() -> Result<()> {
+    fn completed_receipt_ignores_app_bundle_content_drift() -> Result<()> {
         let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
@@ -7752,6 +7757,51 @@ mod tests {
             Some(cask.version.clone())
         );
         crate::file::write(app_target.join("Contents/app"), "changed")?;
+        // Content drift must not look like "missing" — that would reinstall the
+        // app on the next apply and revoke macOS TCC grants.
+        assert_eq!(
+            installed_cask_version(&cask, &artifacts)?,
+            Some(cask.version.clone())
+        );
+        assert!(!cask_target_record_matches(
+            read_receipt(&caskroom)?
+                .expect("receipt")
+                .targets
+                .first()
+                .expect("app target")
+        )?);
+        Ok(())
+    }
+
+    #[test]
+    fn completed_receipt_missing_app_is_not_installed() -> Result<()> {
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let cask = test_cask("example", "1.0.0");
+        let app = AppArtifact {
+            source: "Example.app".to_string(),
+            target: Some("$HOMEBREW_PREFIX/Applications/Example.app".to_string()),
+        };
+        let artifacts = CaskArtifacts {
+            apps: vec![app.clone()],
+            ..Default::default()
+        };
+        let app_target = app_target_path(app.target_name())?;
+        file::create_dir_all(app_target.join("Contents"))?;
+        crate::file::write(app_target.join("Contents/app"), "original")?;
+        let caskroom = caskroom_version_dir(&cask.token, &cask.version);
+        file::create_dir_all(&caskroom)?;
+        write_receipt_with_flight_targets(
+            &caskroom,
+            &cask,
+            &artifacts,
+            &[],
+            &BTreeMap::new(),
+            &[],
+            &[],
+        )?;
+        file::remove_all(&app_target)?;
         assert_eq!(installed_cask_version(&cask, &artifacts)?, None);
         Ok(())
     }

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -6633,15 +6633,31 @@ fn cask_target_record_matches(record: &CaskTargetRecord) -> Result<bool> {
 }
 
 /// Whether a receipt target still exists at the recorded path and kind.
-/// Unlike [`cask_target_record_matches`], this ignores content drift so status
-/// and apply stay cheap and do not reinstall apps that have updated themselves
-/// or written into their bundle.
+///
+/// Directory and file targets ignore content drift so status/apply stay cheap
+/// and do not reinstall app bundles (which resets macOS TCC grants). Symlink
+/// targets still compare the recorded link destination — that is a cheap
+/// `readlink` — and require the link to resolve, so dangling or retargeted
+/// binaries/completions stay repairable on apply.
 fn cask_target_present(record: &CaskTargetRecord) -> bool {
     let Ok(metadata) = record.path.symlink_metadata() else {
         return false;
     };
     match record.fingerprint.kind {
-        CaskTargetKind::Symlink => metadata.file_type().is_symlink(),
+        CaskTargetKind::Symlink => {
+            if !metadata.file_type().is_symlink() {
+                return false;
+            }
+            let Ok(target) = std::fs::read_link(&record.path) else {
+                return false;
+            };
+            let digest = hex::encode(Sha256::digest(target.as_os_str().as_encoded_bytes()));
+            if digest != record.fingerprint.digest {
+                return false;
+            }
+            // Follow the link so a dangling binary/completion is not "present".
+            std::fs::metadata(&record.path).is_ok()
+        }
         CaskTargetKind::File => metadata.is_file(),
         CaskTargetKind::Directory => metadata.is_dir(),
     }
@@ -7803,6 +7819,68 @@ mod tests {
         )?;
         file::remove_all(&app_target)?;
         assert_eq!(installed_cask_version(&cask, &artifacts)?, None);
+        Ok(())
+    }
+
+    #[test]
+    fn cask_target_present_checks_symlink_destination_and_kinds() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let dest = tmp.path().join("bin/tool");
+        file::create_dir_all(dest.parent().unwrap())?;
+        crate::file::write(&dest, "tool")?;
+        let link = tmp.path().join("prefix/bin/tool");
+        file::create_dir_all(link.parent().unwrap())?;
+        file::make_symlink(&dest, &link)?;
+        let record = CaskTargetRecord {
+            path: link.clone(),
+            fingerprint: cask_target_fingerprint(&link)?,
+            uninstall: None,
+        };
+        assert!(cask_target_present(&record));
+
+        file::remove_file(&dest)?;
+        assert!(
+            !cask_target_present(&record),
+            "dangling symlink must not count as present"
+        );
+
+        crate::file::write(&dest, "tool")?;
+        let other = tmp.path().join("bin/other");
+        crate::file::write(&other, "other")?;
+        file::remove_file(&link)?;
+        file::make_symlink(&other, &link)?;
+        assert!(
+            !cask_target_present(&record),
+            "retargeted symlink must not count as present"
+        );
+
+        file::remove_file(&link)?;
+        crate::file::write(&link, "not a symlink")?;
+        assert!(
+            !cask_target_present(&record),
+            "file replacing a symlink must not count as present"
+        );
+
+        let font = tmp.path().join("fonts/Example.ttf");
+        file::create_dir_all(font.parent().unwrap())?;
+        crate::file::write(&font, "font")?;
+        let file_record = CaskTargetRecord {
+            path: font.clone(),
+            fingerprint: cask_target_fingerprint(&font)?,
+            uninstall: None,
+        };
+        assert!(cask_target_present(&file_record));
+        crate::file::write(&font, "changed font bytes")?;
+        assert!(
+            cask_target_present(&file_record),
+            "file content drift is ignored for install health"
+        );
+        file::remove_file(&font)?;
+        file::create_dir_all(&font)?;
+        assert!(
+            !cask_target_present(&file_record),
+            "directory replacing a file must not count as present"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`mise bootstrap packages apply` no longer treats content changes inside an already-installed brew-cask app as "missing."

Previously, schema-2+ receipts compared full content fingerprints on every status/apply. Any drift (self-update without `auto_updates`, writing into the bundle, etc.) made the cask look missing, so the next apply re-swapped `/Applications/*.app` and macOS revoked TCC grants (Accessibility, Screen Recording, …). Fingerprinting large app trees also made converge slow even when nothing needed installing.

## Changes

- Install health for schema-2+ receipts is **presence-based** for apps/fonts (directory / file kind at the recorded path).
- **Symlinks** (binaries/completions) still compare the recorded link destination via cheap `readlink` and require the link to resolve, so dangling or retargeted links stay repairable (addresses review feedback).
- Content fingerprints remain for **prune** and **adopt** safety.
- Version upgrades and remove+apply still replace apps when a fresh pour is intentional.
- Docs updated to describe the TCC / performance rationale.
- Tests: content drift stays installed; missing app is missing; dangling/retargeted/wrong-kind symlink and file cases.

## Test plan

- [x] `cargo test --all-features --bin mise receipt`
- [x] `cargo test --all-features --bin mise cask_target_present`
- [ ] Reviewer: optional macOS check that a non-`auto_updates` cask with a touched file inside `.app` stays `installed` on `mise bootstrap packages status` / `apply`

*AI-assisted — Tool: Cursor Cloud Agent; model: Cursor/Composer; version: unavailable.*

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0200a-8af4-79ec-8527-3a4b4993309e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0200a-8af4-79ec-8527-3a4b4993309e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Modified contents within installed app bundles and fonts no longer incorrectly mark casks as missing or trigger unnecessary reinstalls.
  * Cask status now correctly detects missing applications and validates recorded filesystem targets.
  * Symlinks must retain their recorded destinations and resolve successfully.
  * Missing or unrecognized receipts and pending transactions continue to be reported as unhealthy.
  * Upgrades and explicit remove-and-apply operations still replace applications as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->