### PR TITLE
docs(bootstrap): warn when brew-cask replaces apps (TCC)

### DIFF
--- a/docs/bootstrap/macos-defaults.md
+++ b/docs/bootstrap/macos-defaults.md
@@ -152,7 +152,16 @@ killall Finder
 killall SystemUIServer
 ```
 
-mise deliberately does not kill applications itself.
+mise deliberately does not kill applications itself. After `mise bootstrap`
+writes defaults, the follow-up summary reminds you to relaunch; a common
+`post-defaults` hook is:
+
+```toml
+[bootstrap.hooks.post-defaults]
+run = "killall Dock || true"
+```
+
+Without a relaunch, Dock/Finder preferences can look unset until the next login.
 
 ## Finding keys
 

--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -128,6 +128,34 @@ The `Current` column is the version recorded in the cask receipt; the live app
 may have updated itself to a different version. JSON status keeps the stable
 `"state": "installed"` value and adds `"auto_updates": true`.
 
+### macOS Privacy & Security (TCC)
+
+Replacing an app bundle under `/Applications` (or your configured appdir) is
+the same class of operation as `brew reinstall --cask`: macOS may revoke
+Privacy & Security grants for that app (Accessibility, Screen Recording, Full
+Disk Access, Automation, and similar). mise does not manage TCC; after a
+replace you may need to re-grant permissions in System Settings.
+
+When migrating a machine that already has casks installed (for example from
+Homebrew or a nix-darwin brew integration), prefer adoption so mise records
+ownership without swapping the live bundle:
+
+```toml
+[bootstrap.brew]
+adopt = true
+```
+
+Or adopt selectively:
+
+```toml
+[bootstrap.packages]
+"brew-cask:firefox" = { version = "latest", adopt = true }
+```
+
+mise prints a warning whenever it replaces an existing `.app`. Version
+upgrades still replace the bundle when upstream publishes a new cask version —
+expect to re-confirm TCC prompts after those upgrades, just as with Homebrew.
+
 On Linux, initial cask support is limited to font-only casks without lifecycle
 hooks or structured `preflight_steps` or `postflight_steps` — concepts from
 Homebrew's cask DSL, documented in the

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -140,6 +140,16 @@ run = "gh auth status || gh auth login"
 mise bootstrap --yes   # new laptop or container -> ready to work
 ```
 
+When taking over an existing Mac that already has Homebrew casks (or a
+nix-darwin brew integration), set `[bootstrap.brew] adopt = true` so mise
+records ownership without replacing `/Applications` bundles — replacing an
+`.app` can revoke macOS Privacy & Security grants. See
+[brew casks / TCC](/bootstrap/packages/brew.html#macos-privacy-security-tcc).
+
+After writing macOS defaults, relaunch Dock/Finder (or use a `post-defaults`
+hook) or prefs can look unset until restart — see
+[macOS Defaults](/bootstrap/macos-defaults.html#app-restarts).
+
 Everything is declarative and idempotent: re-running skips whatever is
 already in its desired state, `mise bootstrap packages status --missing` and
 `mise bootstrap dotfiles status --missing` make CI checks, and nothing is ever

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -1360,6 +1360,18 @@ fn activate_app_at(
     caskroom_app: &Path,
     logical_target: &Path,
 ) -> Result<()> {
+    if exists_at(&parent.fd, name)? {
+        // Same class of pain as `brew reinstall --cask`: TCC is keyed to the
+        // app identity at this path, so an atomic bundle swap clears grants.
+        warn!(
+            "brew-cask: replacing {} — macOS may revoke Privacy & Security \
+             permissions for this app (Accessibility, Screen Recording, Full \
+             Disk Access, etc.); re-grant them in System Settings if prompted. \
+             To take over an existing app without replacing it, set adopt = true \
+             or [bootstrap.brew] adopt = true",
+            logical_target.display()
+        );
+    }
     swap_app_at(parent, name, tmp_name, old_name)?;
     replace_caskroom_app_with_symlink(caskroom_app, logical_target)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Warn and document the macOS TCC side effect of replacing brew-cask app bundles, aimed at nix-darwin / Homebrew migrants.

## Changes

- Warn when mise atomically replaces an existing `.app` (same class of pain as `brew reinstall --cask`).
- Document Privacy & Security (TCC) behavior and recommend `[bootstrap.brew] adopt = true` when taking over an existing machine.
- Cross-link from tips-and-tricks; clarify `post-defaults` relaunch so Dock/Finder prefs do not look “lost.”

## Related

- Behavior fix for fingerprint-driven reinstalls: #12222

## Test plan

- [x] `mise run lint-fix`
- [ ] Reviewer (macOS): confirm replace path prints the TCC warning; adopt path does not replace and does not warn

*AI-assisted — Tool: Cursor Cloud Agent; model: Cursor/Composer; version: unavailable.*

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0200a-8af4-79ec-8527-3a4b4993309e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0200a-8af4-79ec-8527-3a4b4993309e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for adopting existing Homebrew cask applications without replacing their bundles.
  * Documented macOS Privacy & Security permission behavior, including potential revocation and reauthorization after replacements.
  * Added instructions for relaunching Dock and Finder after applying macOS defaults.
  * Clarified application restart behavior and provided a `post-defaults` hook example.

* **Bug Fixes**
  * Added a warning before replacing an existing application bundle, including guidance on avoiding permission loss through adoption mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->