### PR TITLE
fix(aqua): suggest compatible package backends

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -37,6 +37,16 @@ struct AquaPackageRegistry {
     content: Vec<u8>,
     aliases: Vec<String>,
     search_backend: Option<String>,
+    search_overrides: Vec<AquaSearchOverrideRegistry>,
+}
+
+#[derive(Debug)]
+struct AquaSearchOverrideRegistry {
+    goos: Option<String>,
+    goarch: Option<String>,
+    envs: Vec<String>,
+    libc: Option<String>,
+    backend: Option<String>,
 }
 
 /// Generate a raw string literal that safely contains the given content.
@@ -482,7 +492,6 @@ fn codegen_aqua_standard_registry() -> Result<()> {
 fn aqua_package_registries(rows: &[RegistryPackageRow]) -> Result<Vec<AquaPackageRegistry>> {
     let mut registries = Vec::new();
     let mut canonical_ids = HashMap::new();
-    let (target_os, target_arch, target_libc) = aqua_target_platform();
     for (index, row) in rows.iter().enumerate() {
         let package = &row.package;
         let Some(id) = aqua_canonical_package_id(package) else {
@@ -497,23 +506,39 @@ fn aqua_package_registries(rows: &[RegistryPackageRow]) -> Result<Vec<AquaPackag
             ));
         }
         let content = encode_package_rkyv(package)?;
-        let effective_package = package.clone().with_unconditional_overrides_libc(
-            &target_os,
-            &target_arch,
-            target_libc.as_deref(),
-        );
-        let search_backend = aqua_search_backend(&effective_package);
+        let (effective_package, root_package) =
+            package.clone().with_unconditional_version_override();
+        let allow_go_repo_fallback = root_package;
+        let search_backend = aqua_search_backend(&effective_package, allow_go_repo_fallback);
+        let mut search_overrides = effective_package
+            .platform_overrides()
+            .into_iter()
+            .map(|package_override| AquaSearchOverrideRegistry {
+                goos: package_override.goos,
+                goarch: package_override.goarch,
+                envs: package_override.envs,
+                libc: package_override.libc,
+                backend: aqua_search_backend(&package_override.package, allow_go_repo_fallback),
+            })
+            .collect::<Vec<_>>();
+        if search_overrides
+            .iter()
+            .all(|package_override| package_override.backend == search_backend)
+        {
+            search_overrides.clear();
+        }
         registries.push(AquaPackageRegistry {
             id,
             content,
             aliases: row.aliases.clone(),
             search_backend,
+            search_overrides,
         });
     }
     Ok(registries)
 }
 
-fn aqua_search_backend(package: &AquaPackage) -> Option<String> {
+fn aqua_search_backend(package: &AquaPackage, allow_go_repo_fallback: bool) -> Option<String> {
     match package.package_type() {
         AquaPackageType::Cargo => package
             .crate_name
@@ -532,6 +557,14 @@ fn aqua_search_backend(package: &AquaPackage) -> Option<String> {
             .as_deref()
             .filter(|path| !is_aqua_template(path))
             .map(|path| format!("go:{path}"))
+            .or_else(|| {
+                (allow_go_repo_fallback
+                    && !package.repo_owner.is_empty()
+                    && !package.repo_name.is_empty()
+                    && !is_aqua_template(&package.repo_owner)
+                    && !is_aqua_template(&package.repo_name))
+                .then(|| format!("go:github.com/{}/{}", package.repo_owner, package.repo_name))
+            })
             .or(Some(String::new())),
         AquaPackageType::GoBuild => Some(String::new()),
         AquaPackageType::GithubArchive
@@ -543,32 +576,6 @@ fn aqua_search_backend(package: &AquaPackage) -> Option<String> {
 
 fn is_aqua_template(value: &str) -> bool {
     value.contains("{{") || value.contains("}}")
-}
-
-fn aqua_target_platform() -> (String, String, Option<String>) {
-    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_else(|_| env::consts::OS.to_string());
-    let target_os = match target_os.as_str() {
-        "macos" => "darwin",
-        other => other,
-    }
-    .to_string();
-
-    let target_arch =
-        env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| env::consts::ARCH.to_string());
-    let target_arch = match target_arch.as_str() {
-        "x86" => "386",
-        "x86_64" => "amd64",
-        "aarch64" => "arm64",
-        "powerpc64" => "ppc64",
-        other => other,
-    }
-    .to_string();
-
-    let target_libc = env::var("CARGO_CFG_TARGET_ENV")
-        .ok()
-        .filter(|target_env| !target_env.is_empty());
-
-    (target_os, target_arch, target_libc)
 }
 
 fn aqua_registry_files_code(
@@ -657,13 +664,47 @@ fn aqua_registry_search_code(registries: &[AquaPackageRegistry]) -> String {
     let entries = registries
         .iter()
         .filter_map(|registry| {
-            registry
-                .search_backend
-                .as_ref()
-                .map(|backend| (registry.id.clone(), backend.clone()))
+            if registry.search_backend.is_none() && registry.search_overrides.is_empty() {
+                return None;
+            }
+            let overrides = registry
+                .search_overrides
+                .iter()
+                .map(|package_override| {
+                    let envs = package_override
+                        .envs
+                        .iter()
+                        .map(|env| format!("{env:?}"))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    format!(
+                        "AquaSearchBackendOverride {{ goos: {}, goarch: {}, envs: &[{envs}], libc: {}, backend: {} }}",
+                        rust_option_str(package_override.goos.as_deref()),
+                        rust_option_str(package_override.goarch.as_deref()),
+                        rust_option_str(package_override.libc.as_deref()),
+                        rust_option_str(package_override.backend.as_deref()),
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            Some((
+                registry.id.clone(),
+                format!(
+                    "AquaSearchBackends {{ default: {}, overrides: &[{overrides}] }}",
+                    rust_option_str(registry.search_backend.as_deref()),
+                ),
+            ))
         })
         .collect::<Vec<_>>();
-    aqua_registry_string_map_code(&entries)
+    let mut map = phf_codegen::Map::new();
+    for (key, value) in &entries {
+        map.entry(key, value);
+    }
+    map.build().to_string()
+}
+
+fn rust_option_str(value: Option<&str>) -> String {
+    value.map_or_else(|| "None".to_string(), |value| format!("Some({value:?})"))
 }
 
 fn aqua_registry_string_map_code(entries: &[(String, String)]) -> String {

--- a/build.rs
+++ b/build.rs
@@ -482,6 +482,7 @@ fn codegen_aqua_standard_registry() -> Result<()> {
 fn aqua_package_registries(rows: &[RegistryPackageRow]) -> Result<Vec<AquaPackageRegistry>> {
     let mut registries = Vec::new();
     let mut canonical_ids = HashMap::new();
+    let (target_os, target_arch, target_libc) = aqua_target_platform();
     for (index, row) in rows.iter().enumerate() {
         let package = &row.package;
         let Some(id) = aqua_canonical_package_id(package) else {
@@ -496,19 +497,12 @@ fn aqua_package_registries(rows: &[RegistryPackageRow]) -> Result<Vec<AquaPackag
             ));
         }
         let content = encode_package_rkyv(package)?;
-        let search_backend = match package.package_type() {
-            AquaPackageType::Cargo => package
-                .name
-                .as_deref()
-                .and_then(|name| name.strip_prefix("crates.io/"))
-                .map(|name| format!("cargo:{name}")),
-            AquaPackageType::GoInstall => package.path.as_ref().map(|path| format!("go:{path}")),
-            AquaPackageType::GoBuild => Some(String::new()),
-            AquaPackageType::GithubArchive
-            | AquaPackageType::GithubContent
-            | AquaPackageType::GithubRelease
-            | AquaPackageType::Http => None,
-        };
+        let effective_package = package.clone().with_unconditional_overrides_libc(
+            &target_os,
+            &target_arch,
+            target_libc.as_deref(),
+        );
+        let search_backend = aqua_search_backend(&effective_package);
         registries.push(AquaPackageRegistry {
             id,
             content,
@@ -517,6 +511,64 @@ fn aqua_package_registries(rows: &[RegistryPackageRow]) -> Result<Vec<AquaPackag
         });
     }
     Ok(registries)
+}
+
+fn aqua_search_backend(package: &AquaPackage) -> Option<String> {
+    match package.package_type() {
+        AquaPackageType::Cargo => package
+            .crate_name
+            .as_deref()
+            .or_else(|| {
+                package
+                    .name
+                    .as_deref()
+                    .and_then(|name| name.strip_prefix("crates.io/"))
+            })
+            .filter(|name| !is_aqua_template(name))
+            .map(|name| format!("cargo:{name}"))
+            .or(Some(String::new())),
+        AquaPackageType::GoInstall => package
+            .path
+            .as_deref()
+            .filter(|path| !is_aqua_template(path))
+            .map(|path| format!("go:{path}"))
+            .or(Some(String::new())),
+        AquaPackageType::GoBuild => Some(String::new()),
+        AquaPackageType::GithubArchive
+        | AquaPackageType::GithubContent
+        | AquaPackageType::GithubRelease
+        | AquaPackageType::Http => None,
+    }
+}
+
+fn is_aqua_template(value: &str) -> bool {
+    value.contains("{{") || value.contains("}}")
+}
+
+fn aqua_target_platform() -> (String, String, Option<String>) {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_else(|_| env::consts::OS.to_string());
+    let target_os = match target_os.as_str() {
+        "macos" => "darwin",
+        other => other,
+    }
+    .to_string();
+
+    let target_arch =
+        env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| env::consts::ARCH.to_string());
+    let target_arch = match target_arch.as_str() {
+        "x86" => "386",
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        "powerpc64" => "ppc64",
+        other => other,
+    }
+    .to_string();
+
+    let target_libc = env::var("CARGO_CFG_TARGET_ENV")
+        .ok()
+        .filter(|target_env| !target_env.is_empty());
+
+    (target_os, target_arch, target_libc)
 }
 
 fn aqua_registry_files_code(

--- a/build.rs
+++ b/build.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use std::{env, fs};
 
 use aqua_registry::encode_package_rkyv;
-use aqua_registry::types::{AquaPackage, RegistryPackageRow, RegistryYaml};
+use aqua_registry::types::{AquaPackage, AquaPackageType, RegistryPackageRow, RegistryYaml};
 use eyre::{Result, eyre};
 use serde_yaml::Value;
 
@@ -36,6 +36,7 @@ struct AquaPackageRegistry {
     id: String,
     content: Vec<u8>,
     aliases: Vec<String>,
+    search_backend: Option<String>,
 }
 
 /// Generate a raw string literal that safely contains the given content.
@@ -428,6 +429,7 @@ fn codegen_aqua_standard_registry() -> Result<()> {
     let out_dir = env::var("OUT_DIR")?;
     let files_dest_path = Path::new(&out_dir).join("aqua_standard_registry_files.rs");
     let aliases_dest_path = Path::new(&out_dir).join("aqua_standard_registry_aliases.rs");
+    let search_dest_path = Path::new(&out_dir).join("aqua_standard_registry_search.rs");
     let metadata_dest_path = Path::new(&out_dir).join("aqua_standard_registry_metadata.rs");
     let packages_dir = Path::new(&out_dir).join("aqua_standard_registry_packages");
 
@@ -453,6 +455,7 @@ fn codegen_aqua_standard_registry() -> Result<()> {
         aqua_registry_files_code(&registries, &packages_dir)?,
     )?;
     fs::write(aliases_dest_path, aqua_registry_aliases_code(&registries)?)?;
+    fs::write(search_dest_path, aqua_registry_search_code(&registries))?;
 
     let metadata = serde_yaml::from_str::<Value>(&fs::read_to_string(metadata_file)?)?;
     let repository = yaml_string_field(&metadata, "repository").ok_or_else(|| {
@@ -493,10 +496,24 @@ fn aqua_package_registries(rows: &[RegistryPackageRow]) -> Result<Vec<AquaPackag
             ));
         }
         let content = encode_package_rkyv(package)?;
+        let search_backend = match package.package_type() {
+            AquaPackageType::Cargo => package
+                .name
+                .as_deref()
+                .and_then(|name| name.strip_prefix("crates.io/"))
+                .map(|name| format!("cargo:{name}")),
+            AquaPackageType::GoInstall => package.path.as_ref().map(|path| format!("go:{path}")),
+            AquaPackageType::GoBuild => Some(String::new()),
+            AquaPackageType::GithubArchive
+            | AquaPackageType::GithubContent
+            | AquaPackageType::GithubRelease
+            | AquaPackageType::Http => None,
+        };
         registries.push(AquaPackageRegistry {
             id,
             content,
             aliases: row.aliases.clone(),
+            search_backend,
         });
     }
     Ok(registries)
@@ -582,6 +599,19 @@ fn aqua_registry_aliases_code(registries: &[AquaPackageRegistry]) -> Result<Stri
     let entries = aliases.into_iter().collect::<Vec<_>>();
 
     Ok(aqua_registry_string_map_code(&entries))
+}
+
+fn aqua_registry_search_code(registries: &[AquaPackageRegistry]) -> String {
+    let entries = registries
+        .iter()
+        .filter_map(|registry| {
+            registry
+                .search_backend
+                .as_ref()
+                .map(|backend| (registry.id.clone(), backend.clone()))
+        })
+        .collect::<Vec<_>>();
+    aqua_registry_string_map_code(&entries)
 }
 
 fn aqua_registry_string_map_code(entries: &[(String, String)]) -> String {

--- a/build.rs
+++ b/build.rs
@@ -506,9 +506,8 @@ fn aqua_package_registries(rows: &[RegistryPackageRow]) -> Result<Vec<AquaPackag
             ));
         }
         let content = encode_package_rkyv(package)?;
-        let (effective_package, root_package) =
+        let (effective_package, allow_go_repo_fallback) =
             package.clone().with_unconditional_version_override();
-        let allow_go_repo_fallback = root_package;
         let search_backend = aqua_search_backend(&effective_package, allow_go_repo_fallback);
         let mut search_overrides = effective_package
             .platform_overrides()

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -57,7 +57,6 @@ pub struct AquaPackage {
     pub repo_owner: String,
     pub repo_name: String,
     pub name: Option<String>,
-    /// Cargo package name used when Aqua delegates installation to Cargo.
     #[serde(rename = "crate")]
     pub crate_name: Option<String>,
     pub asset: String,
@@ -135,15 +134,10 @@ struct AquaRuntime<'a> {
 /// A platform-specific package override with selectors mise can evaluate at runtime.
 #[derive(Debug, Clone)]
 pub struct AquaPackagePlatformOverride {
-    /// Package after applying this platform override.
     pub package: AquaPackage,
-    /// Aqua GOOS selector.
     pub goos: Option<String>,
-    /// Aqua GOARCH selector.
     pub goarch: Option<String>,
-    /// Aqua environment selectors.
     pub envs: Vec<String>,
-    /// Normalized libc selector, when present.
     pub libc: Option<String>,
 }
 

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -132,6 +132,21 @@ struct AquaRuntime<'a> {
     libc: Option<&'a str>,
 }
 
+/// A platform-specific package override with selectors mise can evaluate at runtime.
+#[derive(Debug, Clone)]
+pub struct AquaPackagePlatformOverride {
+    /// Package after applying this platform override.
+    pub package: AquaPackage,
+    /// Aqua GOOS selector.
+    pub goos: Option<String>,
+    /// Aqua GOARCH selector.
+    pub goarch: Option<String>,
+    /// Aqua environment selectors.
+    pub envs: Vec<String>,
+    /// Normalized libc selector, when present.
+    pub libc: Option<String>,
+}
+
 /// Variable definition for Aqua templates
 #[derive(Debug, Deserialize, Archive, RkyvDeserialize, RkyvSerialize, Clone, Default)]
 pub struct AquaVar {
@@ -418,25 +433,68 @@ impl AquaPackage {
         self.with_unconditional_overrides_runtime(os, arch, AquaRuntime { libc })
     }
 
+    /// Apply a catch-all version fallback when the root package is explicitly disabled.
+    ///
+    /// The boolean indicates whether the root package remains the effective
+    /// package. Conditional roots are preserved because determining whether
+    /// they match requires a concrete version.
+    pub fn with_unconditional_version_override(mut self) -> (AquaPackage, bool) {
+        if self.version_constraint.trim() != "false" {
+            return (self, true);
+        }
+        if let Some(version_override) = self
+            .version_overrides
+            .iter()
+            .find(|version_override| {
+                matches!(version_override.version_constraint.trim(), "" | "true")
+            })
+            .cloned()
+        {
+            self = apply_override(self, &version_override);
+            (self, false)
+        } else {
+            (self, false)
+        }
+    }
+
+    /// Return platform overrides after applying them to this package.
+    ///
+    /// Overrides containing runtime variants mise does not understand are
+    /// omitted because they can never match in the Aqua resolver either.
+    pub fn platform_overrides(&self) -> Vec<AquaPackagePlatformOverride> {
+        self.overrides
+            .iter()
+            .filter_map(|package_override| {
+                let mut libc = None;
+                for variant in &package_override.variants {
+                    if variant.key != "libc" {
+                        return None;
+                    }
+                    let variant_libc = normalize_libc(Some(&variant.value))?.to_string();
+                    if libc.as_ref().is_some_and(|libc| libc != &variant_libc) {
+                        return None;
+                    }
+                    libc = Some(variant_libc);
+                }
+                Some(AquaPackagePlatformOverride {
+                    package: apply_override(self.clone(), &package_override.pkg),
+                    goos: package_override.goos.clone(),
+                    goarch: package_override.goarch.clone(),
+                    envs: package_override.envs.clone(),
+                    libc,
+                })
+            })
+            .collect()
+    }
+
     fn with_unconditional_overrides_runtime(
-        mut self,
+        self,
         os: &str,
         arch: &str,
         runtime: AquaRuntime<'_>,
     ) -> AquaPackage {
-        let root_is_unconditional = matches!(self.version_constraint.trim(), "" | "true");
-        if !root_is_unconditional
-            && let Some(version_override) = self
-                .version_overrides
-                .iter()
-                .find(|version_override| {
-                    matches!(version_override.version_constraint.trim(), "" | "true")
-                })
-                .cloned()
-        {
-            self = apply_override(self, &version_override);
-        }
-        self.with_platform_runtime(os, arch, runtime)
+        let (package, _) = self.with_unconditional_version_override();
+        package.with_platform_runtime(os, arch, runtime)
     }
 
     fn with_version_runtime(
@@ -2872,6 +2930,50 @@ packages:
 
         assert_eq!(pkg.package_type(), AquaPackageType::GithubRelease);
         assert_eq!(pkg.crate_name, None);
+    }
+
+    #[test]
+    fn test_conditional_root_does_not_apply_version_fallback_without_version() {
+        let yml = r#"
+packages:
+  - type: go_install
+    version_constraint: semver(">= 1.2.0")
+    version_overrides:
+      - version_constraint: "true"
+        type: github_release
+"#;
+        let (pkg, root_package) = first_registry_package(yml).with_unconditional_version_override();
+
+        assert_eq!(pkg.package_type(), AquaPackageType::GoInstall);
+        assert!(root_package);
+    }
+
+    #[test]
+    fn test_platform_overrides_expose_normalized_libc_selector() {
+        let yml = r#"
+packages:
+  - type: github_release
+    overrides:
+      - goos: linux
+        variants:
+          - key: libc
+            value: glibc
+        type: cargo
+        crate: platform-tool
+"#;
+        let pkg = first_registry_package(yml);
+        let package_override = pkg.platform_overrides().into_iter().next().unwrap();
+
+        assert_eq!(package_override.goos.as_deref(), Some("linux"));
+        assert_eq!(package_override.libc.as_deref(), Some("gnu"));
+        assert_eq!(
+            package_override.package.package_type(),
+            AquaPackageType::Cargo
+        );
+        assert_eq!(
+            package_override.package.crate_name.as_deref(),
+            Some("platform-tool")
+        );
     }
 
     #[test]

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -415,9 +415,10 @@ impl AquaPackage {
 
     /// Apply a catch-all version fallback when the root package is explicitly disabled.
     ///
-    /// The boolean indicates whether the root package remains the effective
-    /// package. Conditional roots are preserved because determining whether
-    /// they match requires a concrete version.
+    /// The boolean is false when the root package is explicitly disabled,
+    /// even if no catch-all override exists to replace it. Conditional roots
+    /// are preserved because determining whether they match requires a
+    /// concrete version.
     pub fn with_unconditional_version_override(mut self) -> (AquaPackage, bool) {
         if self.version_constraint.trim() != "false" {
             return (self, true);
@@ -431,10 +432,8 @@ impl AquaPackage {
             .cloned()
         {
             self = apply_override(self, &version_override);
-            (self, false)
-        } else {
-            (self, false)
         }
+        (self, false)
     }
 
     /// Return platform overrides after applying them to this package.
@@ -481,15 +480,6 @@ impl AquaPackage {
         {
             self = apply_override(self, &version_override);
         }
-        self.with_platform_runtime(os, arch, runtime)
-    }
-
-    fn with_platform_runtime(
-        mut self,
-        os: &str,
-        arch: &str,
-        runtime: AquaRuntime<'_>,
-    ) -> AquaPackage {
         self.apply_format_override(os);
         if let Some(pkg) = self
             .overrides

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -413,26 +413,6 @@ impl AquaPackage {
         self.with_version_runtime(versions, os, arch, AquaRuntime { libc })
     }
 
-    /// Apply Aqua's unconditional version fallback and platform overrides.
-    ///
-    /// This resolves the package shape that can be determined without knowing a
-    /// concrete version. It is intended for offline metadata consumers, not for
-    /// installing a particular version.
-    pub fn with_unconditional_overrides(self, os: &str, arch: &str) -> AquaPackage {
-        self.with_unconditional_overrides_runtime(os, arch, AquaRuntime::default())
-    }
-
-    /// Apply Aqua's unconditional version fallback and platform overrides for
-    /// a libc runtime variant.
-    pub fn with_unconditional_overrides_libc(
-        self,
-        os: &str,
-        arch: &str,
-        libc: Option<&str>,
-    ) -> AquaPackage {
-        self.with_unconditional_overrides_runtime(os, arch, AquaRuntime { libc })
-    }
-
     /// Apply a catch-all version fallback when the root package is explicitly disabled.
     ///
     /// The boolean indicates whether the root package remains the effective
@@ -485,16 +465,6 @@ impl AquaPackage {
                 })
             })
             .collect()
-    }
-
-    fn with_unconditional_overrides_runtime(
-        self,
-        os: &str,
-        arch: &str,
-        runtime: AquaRuntime<'_>,
-    ) -> AquaPackage {
-        let (package, _) = self.with_unconditional_version_override();
-        package.with_platform_runtime(os, arch, runtime)
     }
 
     fn with_version_runtime(
@@ -2910,10 +2880,11 @@ packages:
       - version_constraint: "true"
         type: go_build
 "#;
-        let pkg = first_registry_package(yml).with_unconditional_overrides("linux", "amd64");
+        let (pkg, root_package) = first_registry_package(yml).with_unconditional_version_override();
 
         assert_eq!(pkg.package_type(), AquaPackageType::GoBuild);
         assert_eq!(pkg.crate_name, None);
+        assert!(!root_package);
     }
 
     #[test]
@@ -2926,10 +2897,11 @@ packages:
         type: cargo
         crate: tool
 "#;
-        let pkg = first_registry_package(yml).with_unconditional_overrides("linux", "amd64");
+        let (pkg, root_package) = first_registry_package(yml).with_unconditional_version_override();
 
         assert_eq!(pkg.package_type(), AquaPackageType::GithubRelease);
         assert_eq!(pkg.crate_name, None);
+        assert!(root_package);
     }
 
     #[test]
@@ -2991,14 +2963,22 @@ packages:
             type: cargo
             crate: platform-tool
 "#;
-        let pkg = first_registry_package(yml);
-        let linux = pkg.clone().with_unconditional_overrides("linux", "amd64");
-        let darwin = pkg.with_unconditional_overrides("darwin", "arm64");
+        let (effective, _) = first_registry_package(yml).with_unconditional_version_override();
 
-        assert_eq!(linux.package_type(), AquaPackageType::GithubRelease);
-        assert_eq!(linux.crate_name, None);
-        assert_eq!(darwin.package_type(), AquaPackageType::Cargo);
-        assert_eq!(darwin.crate_name.as_deref(), Some("platform-tool"));
+        assert_eq!(effective.package_type(), AquaPackageType::GithubRelease);
+        let package_override = effective.platform_overrides().into_iter().next().unwrap();
+        assert_eq!(
+            package_override.envs,
+            vec!["darwin".to_string(), "windows".to_string()]
+        );
+        assert_eq!(
+            package_override.package.package_type(),
+            AquaPackageType::Cargo
+        );
+        assert_eq!(
+            package_override.package.crate_name.as_deref(),
+            Some("platform-tool")
+        );
     }
 
     #[test]

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -57,6 +57,7 @@ pub struct AquaPackage {
     pub repo_owner: String,
     pub repo_name: String,
     pub name: Option<String>,
+    /// Cargo package name used when Aqua delegates installation to Cargo.
     #[serde(rename = "crate")]
     pub crate_name: Option<String>,
     pub asset: String,
@@ -397,6 +398,47 @@ impl AquaPackage {
         self.with_version_runtime(versions, os, arch, AquaRuntime { libc })
     }
 
+    /// Apply Aqua's unconditional version fallback and platform overrides.
+    ///
+    /// This resolves the package shape that can be determined without knowing a
+    /// concrete version. It is intended for offline metadata consumers, not for
+    /// installing a particular version.
+    pub fn with_unconditional_overrides(self, os: &str, arch: &str) -> AquaPackage {
+        self.with_unconditional_overrides_runtime(os, arch, AquaRuntime::default())
+    }
+
+    /// Apply Aqua's unconditional version fallback and platform overrides for
+    /// a libc runtime variant.
+    pub fn with_unconditional_overrides_libc(
+        self,
+        os: &str,
+        arch: &str,
+        libc: Option<&str>,
+    ) -> AquaPackage {
+        self.with_unconditional_overrides_runtime(os, arch, AquaRuntime { libc })
+    }
+
+    fn with_unconditional_overrides_runtime(
+        mut self,
+        os: &str,
+        arch: &str,
+        runtime: AquaRuntime<'_>,
+    ) -> AquaPackage {
+        let root_is_unconditional = matches!(self.version_constraint.trim(), "" | "true");
+        if !root_is_unconditional
+            && let Some(version_override) = self
+                .version_overrides
+                .iter()
+                .find(|version_override| {
+                    matches!(version_override.version_constraint.trim(), "" | "true")
+                })
+                .cloned()
+        {
+            self = apply_override(self, &version_override);
+        }
+        self.with_platform_runtime(os, arch, runtime)
+    }
+
     fn with_version_runtime(
         mut self,
         versions: &[&str],
@@ -411,6 +453,15 @@ impl AquaPackage {
         {
             self = apply_override(self, &version_override);
         }
+        self.with_platform_runtime(os, arch, runtime)
+    }
+
+    fn with_platform_runtime(
+        mut self,
+        os: &str,
+        arch: &str,
+        runtime: AquaRuntime<'_>,
+    ) -> AquaPackage {
         self.apply_format_override(os);
         if let Some(pkg) = self
             .overrides
@@ -2786,6 +2837,66 @@ packages:
             musl.url("1.0.0", "linux", "amd64").unwrap(),
             "https://example.com/tool-1.0.0-linux-amd64-musl"
         );
+    }
+
+    #[test]
+    fn test_unconditional_override_resolves_package_type_without_version() {
+        let yml = r#"
+packages:
+  - type: github_release
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.0.0"
+        type: cargo
+        crate: historical-tool
+      - version_constraint: "true"
+        type: go_build
+"#;
+        let pkg = first_registry_package(yml).with_unconditional_overrides("linux", "amd64");
+
+        assert_eq!(pkg.package_type(), AquaPackageType::GoBuild);
+        assert_eq!(pkg.crate_name, None);
+    }
+
+    #[test]
+    fn test_unconditional_root_does_not_apply_version_fallback() {
+        let yml = r#"
+packages:
+  - type: github_release
+    version_overrides:
+      - version_constraint: "true"
+        type: cargo
+        crate: tool
+"#;
+        let pkg = first_registry_package(yml).with_unconditional_overrides("linux", "amd64");
+
+        assert_eq!(pkg.package_type(), AquaPackageType::GithubRelease);
+        assert_eq!(pkg.crate_name, None);
+    }
+
+    #[test]
+    fn test_unconditional_override_applies_matching_platform_type() {
+        let yml = r#"
+packages:
+  - type: github_release
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        overrides:
+          - envs:
+              - darwin
+              - windows
+            type: cargo
+            crate: platform-tool
+"#;
+        let pkg = first_registry_package(yml);
+        let linux = pkg.clone().with_unconditional_overrides("linux", "amd64");
+        let darwin = pkg.with_unconditional_overrides("darwin", "arm64");
+
+        assert_eq!(linux.package_type(), AquaPackageType::GithubRelease);
+        assert_eq!(linux.crate_name, None);
+        assert_eq!(darwin.package_type(), AquaPackageType::Cargo);
+        assert_eq!(darwin.crate_name.as_deref(), Some("platform-tool"));
     }
 
     #[test]

--- a/e2e/cli/test_did_you_mean
+++ b/e2e/cli/test_did_you_mean
@@ -17,6 +17,8 @@ assert_not_contains "mise use broot 2>&1 || true" "aqua:crates.io/broot"
 assert_fail "mise use broot" "cargo:broot"
 assert_not_contains "mise use benchstat 2>&1 || true" "aqua:golang.org/x/perf/cmd/benchstat"
 assert_fail "mise use benchstat" "go:golang.org/x/perf/cmd/benchstat"
+assert_fail "mise use mapotf" "go:github.com/Azure/mapotf"
+assert_fail "mise use ifacemaker" "go:github.com/vburenin/ifacemaker"
 
 # Test: Aqua GoBuild packages should not appear in suggestions
 assert_not_contains "mise use ycat 2>&1 || true" "aqua:goccy/go-yaml/ycat"

--- a/e2e/cli/test_did_you_mean
+++ b/e2e/cli/test_did_you_mean
@@ -12,5 +12,15 @@ assert_fail "mise use nod" "node"
 # Test: Typo of python should suggest python
 assert_fail "mise use pythn" "python"
 
+# Test: Aqua Cargo and GoInstall packages should use runnable backend suggestions
+assert_not_contains "mise use broot 2>&1 || true" "aqua:crates.io/broot"
+assert_fail "mise use broot" "cargo:broot"
+assert_not_contains "mise use benchstat 2>&1 || true" "aqua:golang.org/x/perf/cmd/benchstat"
+assert_fail "mise use benchstat" "go:golang.org/x/perf/cmd/benchstat"
+
+# Test: Aqua GoBuild packages should not appear in suggestions
+assert_not_contains "mise use ycat 2>&1 || true" "aqua:goccy/go-yaml/ycat"
+assert_not_contains "mise use ycat 2>&1 || true" "go:github.com/goccy/go-yaml"
+
 # Test: Completely unrelated name should not show suggestions
 assert_fail "mise use somethingnonexistent" "not found in mise tool registry"

--- a/e2e/cli/test_did_you_mean
+++ b/e2e/cli/test_did_you_mean
@@ -21,6 +21,7 @@ assert_fail "mise use benchstat" "go:golang.org/x/perf/cmd/benchstat"
 # Test: Aqua GoBuild packages should not appear in suggestions
 assert_not_contains "mise use ycat 2>&1 || true" "aqua:goccy/go-yaml/ycat"
 assert_not_contains "mise use ycat 2>&1 || true" "go:github.com/goccy/go-yaml"
+assert_not_contains "mise use kics 2>&1 || true" "aqua:Checkmarx/kics"
 
 # Test: Completely unrelated name should not show suggestions
 assert_fail "mise use somethingnonexistent" "not found in mise tool registry"

--- a/e2e/cli/test_search
+++ b/e2e/cli/test_search
@@ -15,3 +15,16 @@ assert "mise search --match-type equal jq" "jq  Command-line JSON processor. htt
 assert_contains "mise search 7zip" "aqua:ip7z/7zip"
 assert_contains "mise search --match-type contains 7zip" "aqua:ip7z/7zip"
 assert_contains "mise search --match-type equal 7zip" "aqua:ip7z/7zip"
+
+# Backend prefixes are identifiers, not broad search terms
+assert_not_contains "mise search cargo" "cargo:broot"
+assert_not_contains "mise search aqua" "aqua:"
+
+# Aqua Cargo and GoInstall packages use runnable backends in search results
+assert_contains "mise search --match-type equal broot" "cargo:broot"
+assert_not_contains "mise search --match-type equal broot" "aqua:crates.io/broot"
+assert_contains "mise search --match-type equal benchstat" "go:golang.org/x/perf/cmd/benchstat"
+assert_not_contains "mise search --match-type equal benchstat" "aqua:golang.org/x/perf/cmd/benchstat"
+
+# Aqua GoBuild packages are excluded from search
+assert_fail "mise search --match-type equal ycat" "not found in registry"

--- a/e2e/cli/test_search
+++ b/e2e/cli/test_search
@@ -28,3 +28,12 @@ assert_not_contains "mise search --match-type equal benchstat" "aqua:golang.org/
 
 # Aqua GoBuild packages are excluded from search
 assert_fail "mise search --match-type equal ycat" "not found in registry"
+assert_fail "mise search --match-type equal kics" "not found in registry"
+
+# A standard shorthand still takes precedence over a translated Cargo fallback
+assert_contains "mise search --match-type equal tokei" "tokei  Count your code"
+assert_not_contains "mise search --match-type equal tokei" "aqua:XAMPPRocky/tokei"
+assert_not_contains "mise search --match-type equal tokei" "cargo:tokei"
+
+# Version-templated GoInstall paths cannot form runnable suggestions
+assert_fail "mise search --match-type equal mosint" "not found in registry"

--- a/e2e/cli/test_search
+++ b/e2e/cli/test_search
@@ -17,7 +17,7 @@ assert_contains "mise search --match-type contains 7zip" "aqua:ip7z/7zip"
 assert_contains "mise search --match-type equal 7zip" "aqua:ip7z/7zip"
 assert_contains "mise search aqua:ip7z/7zip" "aqua:ip7z/7zip"
 
-# Backend prefixes are identifiers, not broad search terms
+# Backend prefixes matching a shorthand do not dump translated aqua packages
 assert_not_contains "mise search cargo" "cargo:broot"
 assert_not_contains "mise search aqua" "aqua:"
 
@@ -37,6 +37,13 @@ assert_contains "mise search --match-type equal ifacemaker" "go:github.com/vbure
 assert_contains "MISE_OS=macos mise search --match-type equal rhit" "cargo:rhit"
 assert_contains "MISE_OS=macos mise search --match-type equal dockfmt" "go:github.com/jessfraz/dockfmt"
 
+# Names are searchable by the aqua id even when the backend path tail differs
+assert_contains "mise search --match-type equal mock" "go:go.uber.org/mock/mockgen"
+assert_contains "mise search --match-type equal playwright-go" "go:github.com/playwright-community/playwright-go/cmd/playwright"
+
+# The aqua id form still finds entries whose current platform has a backend override
+assert_contains "MISE_OS=macos mise search aqua:eza-community/eza" "cargo:eza"
+
 # Aqua GoBuild packages are excluded from search
 assert_fail "mise search --match-type equal ycat" "not found in registry"
 assert_fail "mise search --match-type equal kics" "not found in registry"
@@ -48,4 +55,6 @@ assert_not_contains "mise search --match-type equal tokei" "cargo:tokei"
 
 # Version-templated GoInstall paths cannot form runnable suggestions
 assert_fail "mise search --match-type equal mosint" "not found in registry"
+
+# Disabled roots whose catch-all override is an error message are excluded
 assert_fail "mise search --match-type equal gorename" "not found in registry"

--- a/e2e/cli/test_search
+++ b/e2e/cli/test_search
@@ -15,6 +15,7 @@ assert "mise search --match-type equal jq" "jq  Command-line JSON processor. htt
 assert_contains "mise search 7zip" "aqua:ip7z/7zip"
 assert_contains "mise search --match-type contains 7zip" "aqua:ip7z/7zip"
 assert_contains "mise search --match-type equal 7zip" "aqua:ip7z/7zip"
+assert_contains "mise search aqua:ip7z/7zip" "aqua:ip7z/7zip"
 
 # Backend prefixes are identifiers, not broad search terms
 assert_not_contains "mise search cargo" "cargo:broot"
@@ -23,8 +24,18 @@ assert_not_contains "mise search aqua" "aqua:"
 # Aqua Cargo and GoInstall packages use runnable backends in search results
 assert_contains "mise search --match-type equal broot" "cargo:broot"
 assert_not_contains "mise search --match-type equal broot" "aqua:crates.io/broot"
+assert_contains "mise search cargo:broot" "cargo:broot"
 assert_contains "mise search --match-type equal benchstat" "go:golang.org/x/perf/cmd/benchstat"
 assert_not_contains "mise search --match-type equal benchstat" "aqua:golang.org/x/perf/cmd/benchstat"
+assert_contains "mise search go:golang.org/x/perf/cmd/benchstat" "go:golang.org/x/perf/cmd/benchstat"
+
+# Pathless and conditional-root GoInstall packages use the repository fallback
+assert_contains "mise search --match-type equal mapotf" "go:github.com/Azure/mapotf"
+assert_contains "mise search --match-type equal ifacemaker" "go:github.com/vburenin/ifacemaker"
+
+# Runtime platform settings select precomputed platform overrides
+assert_contains "MISE_OS=macos mise search --match-type equal rhit" "cargo:rhit"
+assert_contains "MISE_OS=macos mise search --match-type equal dockfmt" "go:github.com/jessfraz/dockfmt"
 
 # Aqua GoBuild packages are excluded from search
 assert_fail "mise search --match-type equal ycat" "not found in registry"
@@ -37,3 +48,4 @@ assert_not_contains "mise search --match-type equal tokei" "cargo:tokei"
 
 # Version-templated GoInstall paths cannot form runnable suggestions
 assert_fail "mise search --match-type equal mosint" "not found in registry"
+assert_fail "mise search --match-type equal gorename" "not found in registry"

--- a/src/aqua/aqua_registry_wrapper.rs
+++ b/src/aqua/aqua_registry_wrapper.rs
@@ -487,16 +487,9 @@ pub(crate) struct AquaSearchEntry {
 }
 
 impl AquaSearchEntry {
+    /// Tool name users search by: the last path segment of the Aqua package id.
     pub(crate) fn name(&self) -> &'static str {
-        let searchable_id = self.backend_override.unwrap_or(self.id);
-        searchable_id.rsplit_once('/').map_or_else(
-            || {
-                searchable_id
-                    .split_once(':')
-                    .map_or(searchable_id, |(_, name)| name)
-            },
-            |(_, name)| name,
-        )
+        self.id.rsplit_once('/').map_or(self.id, |(_, name)| name)
     }
 
     pub(crate) fn backend(&self) -> String {
@@ -506,10 +499,8 @@ impl AquaSearchEntry {
     }
 
     pub(crate) fn backend_matches(&self, query: &str) -> bool {
-        self.backend_override.map_or_else(
-            || query.strip_prefix("aqua:") == Some(self.id),
-            |b| b == query,
-        )
+        query.strip_prefix("aqua:") == Some(self.id)
+            || self.backend_override.is_some_and(|b| b == query)
     }
 }
 
@@ -520,11 +511,9 @@ pub(crate) struct AquaSuggestion {
 }
 
 pub(crate) fn aqua_search_entries() -> impl Iterator<Item = AquaSearchEntry> {
-    super::standard_registry::search_entries().filter_map(|(id, backend_override)| {
-        (backend_override != Some("")).then_some(AquaSearchEntry {
-            id,
-            backend_override,
-        })
+    super::standard_registry::search_entries().map(|(id, backend_override)| AquaSearchEntry {
+        id,
+        backend_override,
     })
 }
 
@@ -552,9 +541,18 @@ pub(crate) fn aqua_suggest(query: &str) -> Vec<AquaSuggestion> {
     for matched_name in &similar_names {
         if let Some(entries) = cache.name_to_entries.get(matched_name.as_str()) {
             for entry in entries {
+                let backend = entry.backend();
+                // Distinct aqua packages can translate to the same backend
+                // (e.g. crates.io/eza and eza-community/eza both to cargo:eza)
+                if results
+                    .iter()
+                    .any(|suggestion: &AquaSuggestion| suggestion.backend == backend)
+                {
+                    continue;
+                }
                 results.push(AquaSuggestion {
                     name: matched_name.clone(),
-                    backend: entry.backend(),
+                    backend,
                 });
                 if results.len() >= 5 {
                     return results;

--- a/src/aqua/aqua_registry_wrapper.rs
+++ b/src/aqua/aqua_registry_wrapper.rs
@@ -476,36 +476,86 @@ fn github_repo_slug(registry_url: &str) -> Option<(String, String)> {
 }
 
 struct AquaSuggestionsCache {
-    name_to_ids: HashMap<&'static str, Vec<&'static str>>,
+    name_to_entries: HashMap<&'static str, Vec<AquaSearchEntry>>,
     names: Vec<&'static str>,
 }
 
-static AQUA_SUGGESTIONS_CACHE: Lazy<AquaSuggestionsCache> = Lazy::new(|| {
-    let ids = super::standard_registry::package_ids();
-    let mut name_to_ids: HashMap<&'static str, Vec<&'static str>> = HashMap::new();
-    for id in ids {
-        if let Some((_, name)) = id.rsplit_once('/') {
-            name_to_ids.entry(name).or_default().push(id);
-        }
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct AquaSearchEntry {
+    pub id: &'static str,
+    backend_override: Option<&'static str>,
+}
+
+impl AquaSearchEntry {
+    pub(crate) fn name(&self) -> &'static str {
+        let searchable_id = self.backend_override.unwrap_or(self.id);
+        searchable_id.rsplit_once('/').map_or_else(
+            || {
+                searchable_id
+                    .split_once(':')
+                    .map_or(searchable_id, |(_, name)| name)
+            },
+            |(_, name)| name,
+        )
     }
-    let names = name_to_ids.keys().copied().collect();
-    AquaSuggestionsCache { name_to_ids, names }
+
+    pub(crate) fn backend(&self) -> String {
+        self.backend_override
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("aqua:{}", self.id))
+    }
+
+    pub(crate) fn backend_matches(&self, query: &str) -> bool {
+        self.backend_override.map_or_else(
+            || query.strip_prefix("aqua:") == Some(self.id),
+            |b| b == query,
+        )
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct AquaSuggestion {
+    pub name: String,
+    pub backend: String,
+}
+
+pub(crate) fn aqua_search_entries() -> impl Iterator<Item = AquaSearchEntry> {
+    super::standard_registry::search_entries().filter_map(|(id, backend_override)| {
+        (backend_override != Some("")).then_some(AquaSearchEntry {
+            id,
+            backend_override,
+        })
+    })
+}
+
+static AQUA_SUGGESTIONS_CACHE: Lazy<AquaSuggestionsCache> = Lazy::new(|| {
+    let mut name_to_entries: HashMap<&'static str, Vec<AquaSearchEntry>> = HashMap::new();
+    for entry in aqua_search_entries() {
+        name_to_entries.entry(entry.name()).or_default().push(entry);
+    }
+    let names = name_to_entries.keys().copied().collect();
+    AquaSuggestionsCache {
+        name_to_entries,
+        names,
+    }
 });
 
-/// Search aqua packages by tool name, returning "owner/name" IDs
-/// where the name part is similar to the query.
-pub(crate) fn aqua_suggest(query: &str) -> Vec<String> {
+/// Search Aqua packages by tool name, returning runnable mise backend suggestions.
+pub(crate) fn aqua_suggest(query: &str) -> Vec<AquaSuggestion> {
     let cache = &*AQUA_SUGGESTIONS_CACHE;
 
     // Use a higher threshold (0.8) to avoid noisy suggestions
     let similar_names = xx::suggest::similar_n_with_threshold(query, &cache.names, 5, 0.8);
 
-    // Map back to full IDs
+    // Map back to runnable backend identifiers.
     let mut results = Vec::new();
     for matched_name in &similar_names {
-        if let Some(full_ids) = cache.name_to_ids.get(matched_name.as_str()) {
-            for full_id in full_ids {
-                results.push(full_id.to_string());
+        if let Some(entries) = cache.name_to_entries.get(matched_name.as_str()) {
+            for entry in entries {
+                results.push(AquaSuggestion {
+                    name: matched_name.clone(),
+                    backend: entry.backend(),
+                });
                 if results.len() >= 5 {
                     return results;
                 }

--- a/src/aqua/aqua_registry_wrapper.rs
+++ b/src/aqua/aqua_registry_wrapper.rs
@@ -487,7 +487,6 @@ pub(crate) struct AquaSearchEntry {
 }
 
 impl AquaSearchEntry {
-    /// Tool name users search by: the last path segment of the Aqua package id.
     pub(crate) fn name(&self) -> &'static str {
         self.id.rsplit_once('/').map_or(self.id, |(_, name)| name)
     }
@@ -536,7 +535,6 @@ pub(crate) fn aqua_suggest(query: &str) -> Vec<AquaSuggestion> {
     // Use a higher threshold (0.8) to avoid noisy suggestions
     let similar_names = xx::suggest::similar_n_with_threshold(query, &cache.names, 5, 0.8);
 
-    // Map back to runnable backend identifiers.
     let mut results = Vec::new();
     for matched_name in &similar_names {
         if let Some(entries) = cache.name_to_entries.get(matched_name.as_str()) {

--- a/src/aqua/standard_registry.rs
+++ b/src/aqua/standard_registry.rs
@@ -83,6 +83,7 @@ static AQUA_STANDARD_REGISTRY_SEARCH: phf::Map<&'static str, AquaSearchBackends>
 );
 
 /// Returns searchable Aqua package IDs and any precomputed backend override.
+/// Packages without a runnable mise backend on the current platform are omitted.
 pub(crate) fn search_entries() -> impl Iterator<Item = (&'static str, Option<&'static str>)> {
     let current_platform = Platform::current();
     let os = match current_platform.os.as_str() {
@@ -98,11 +99,11 @@ pub(crate) fn search_entries() -> impl Iterator<Item = (&'static str, Option<&'s
     let libc = (os == "linux").then(|| current_platform.libc().unwrap_or("gnu").to_string());
     let platform = AquaSearchPlatform { os, arch, libc };
 
-    AQUA_STANDARD_REGISTRY_FILES.keys().map(move |id| {
+    AQUA_STANDARD_REGISTRY_FILES.keys().filter_map(move |id| {
         let backend = AQUA_STANDARD_REGISTRY_SEARCH
             .get(id)
             .and_then(|backends| backends.backend(&platform));
-        (*id, backend)
+        (backend != Some("")).then_some((*id, backend))
     })
 }
 
@@ -152,7 +153,7 @@ mod tests {
             entries.get("golang.org/x/perf/cmd/benchstat"),
             Some(&Some("go:golang.org/x/perf/cmd/benchstat"))
         );
-        assert_eq!(entries.get("goccy/go-yaml/ycat"), Some(&Some("")));
+        assert_eq!(entries.get("goccy/go-yaml/ycat"), None);
         assert_eq!(
             entries.get("Azure/mapotf"),
             Some(&Some("go:github.com/Azure/mapotf"))
@@ -161,7 +162,7 @@ mod tests {
             entries.get("vburenin/ifacemaker"),
             Some(&Some("go:github.com/vburenin/ifacemaker"))
         );
-        assert_eq!(entries.get("golang/tools/gorename"), Some(&Some("")));
+        assert_eq!(entries.get("golang/tools/gorename"), None);
         assert_eq!(entries.get("cli/cli"), Some(&None));
     }
 

--- a/src/aqua/standard_registry.rs
+++ b/src/aqua/standard_registry.rs
@@ -23,9 +23,18 @@ static AQUA_STANDARD_REGISTRY_ALIASES: phf::Map<&'static str, &'static str> = in
     "/aqua_standard_registry_aliases.rs"
 ));
 
-/// Returns all package IDs from the baked-in Aqua registry without allocating a collection.
-pub(crate) fn package_ids() -> impl Iterator<Item = &'static str> {
-    AQUA_STANDARD_REGISTRY_FILES.keys().copied()
+/// Baked exceptions to the default `aqua:<id>` search backend.
+/// An empty value marks a package that cannot be represented by a runnable mise backend.
+static AQUA_STANDARD_REGISTRY_SEARCH: phf::Map<&'static str, &'static str> = include!(concat!(
+    env!("OUT_DIR"),
+    "/aqua_standard_registry_search.rs"
+));
+
+/// Returns searchable Aqua package IDs and any precomputed backend override.
+pub(crate) fn search_entries() -> impl Iterator<Item = (&'static str, Option<&'static str>)> {
+    AQUA_STANDARD_REGISTRY_FILES
+        .keys()
+        .map(|id| (*id, AQUA_STANDARD_REGISTRY_SEARCH.get(id).copied()))
 }
 
 pub(crate) fn package(package_id: &str) -> Option<Result<AquaPackage>> {
@@ -63,6 +72,19 @@ mod tests {
             package.path.as_deref(),
             Some("golang.org/x/perf/cmd/benchstat")
         );
+    }
+
+    #[test]
+    fn test_baked_registry_search_entries() {
+        let entries = search_entries().collect::<std::collections::HashMap<_, _>>();
+
+        assert_eq!(entries.get("crates.io/broot"), Some(&Some("cargo:broot")));
+        assert_eq!(
+            entries.get("golang.org/x/perf/cmd/benchstat"),
+            Some(&Some("go:golang.org/x/perf/cmd/benchstat"))
+        );
+        assert_eq!(entries.get("goccy/go-yaml/ycat"), Some(&Some("")));
+        assert_eq!(entries.get("cli/cli"), Some(&None));
     }
 
     #[test]

--- a/src/aqua/standard_registry.rs
+++ b/src/aqua/standard_registry.rs
@@ -1,5 +1,7 @@
 use aqua_registry::{AquaPackage, Result, decode_package_rkyv};
 
+use crate::platform::Platform;
+
 /// Metadata for the baked aqua registry snapshot.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct AquaRegistryMetadata {
@@ -23,18 +25,85 @@ static AQUA_STANDARD_REGISTRY_ALIASES: phf::Map<&'static str, &'static str> = in
     "/aqua_standard_registry_aliases.rs"
 ));
 
+#[derive(Debug)]
+struct AquaSearchBackends {
+    default: Option<&'static str>,
+    overrides: &'static [AquaSearchBackendOverride],
+}
+
+#[derive(Debug)]
+struct AquaSearchBackendOverride {
+    goos: Option<&'static str>,
+    goarch: Option<&'static str>,
+    envs: &'static [&'static str],
+    libc: Option<&'static str>,
+    backend: Option<&'static str>,
+}
+
+#[derive(Debug)]
+struct AquaSearchPlatform {
+    os: String,
+    arch: String,
+    libc: Option<String>,
+}
+
+impl AquaSearchBackends {
+    fn backend(&self, platform: &AquaSearchPlatform) -> Option<&'static str> {
+        self.overrides
+            .iter()
+            .find(|package_override| package_override.matches(platform))
+            .map_or(self.default, |package_override| package_override.backend)
+    }
+}
+
+impl AquaSearchBackendOverride {
+    fn matches(&self, platform: &AquaSearchPlatform) -> bool {
+        self.goos.is_none_or(|goos| goos == platform.os.as_str())
+            && self
+                .goarch
+                .is_none_or(|goarch| goarch == platform.arch.as_str())
+            && (self.envs.is_empty()
+                || self.envs.iter().any(|env| {
+                    *env == "all"
+                        || *env == platform.os.as_str()
+                        || *env == platform.arch.as_str()
+                        || env.split_once('/')
+                            == Some((platform.os.as_str(), platform.arch.as_str()))
+                }))
+            && self
+                .libc
+                .is_none_or(|libc| Some(libc) == platform.libc.as_deref())
+    }
+}
+
 /// Baked exceptions to the default `aqua:<id>` search backend.
-/// An empty value marks a package that cannot be represented by a runnable mise backend.
-static AQUA_STANDARD_REGISTRY_SEARCH: phf::Map<&'static str, &'static str> = include!(concat!(
-    env!("OUT_DIR"),
-    "/aqua_standard_registry_search.rs"
-));
+/// An empty backend marks a package that cannot be represented by a runnable mise backend.
+static AQUA_STANDARD_REGISTRY_SEARCH: phf::Map<&'static str, AquaSearchBackends> = include!(
+    concat!(env!("OUT_DIR"), "/aqua_standard_registry_search.rs")
+);
 
 /// Returns searchable Aqua package IDs and any precomputed backend override.
 pub(crate) fn search_entries() -> impl Iterator<Item = (&'static str, Option<&'static str>)> {
-    AQUA_STANDARD_REGISTRY_FILES
-        .keys()
-        .map(|id| (*id, AQUA_STANDARD_REGISTRY_SEARCH.get(id).copied()))
+    let current_platform = Platform::current();
+    let os = match current_platform.os.as_str() {
+        "macos" => "darwin",
+        other => other,
+    }
+    .to_string();
+    let arch = match current_platform.arch.as_str() {
+        "x64" => "amd64",
+        other => other,
+    }
+    .to_string();
+    let libc = (os == "linux").then(|| current_platform.libc().unwrap_or("gnu").to_string());
+    let platform = AquaSearchPlatform { os, arch, libc };
+
+    AQUA_STANDARD_REGISTRY_FILES.keys().map(move |id| {
+        let backend = AQUA_STANDARD_REGISTRY_SEARCH
+            .get(id)
+            .and_then(|backends| backends.backend(&platform));
+        (*id, backend)
+    })
 }
 
 pub(crate) fn package(package_id: &str) -> Option<Result<AquaPackage>> {
@@ -84,7 +153,70 @@ mod tests {
             Some(&Some("go:golang.org/x/perf/cmd/benchstat"))
         );
         assert_eq!(entries.get("goccy/go-yaml/ycat"), Some(&Some("")));
+        assert_eq!(
+            entries.get("Azure/mapotf"),
+            Some(&Some("go:github.com/Azure/mapotf"))
+        );
+        assert_eq!(
+            entries.get("vburenin/ifacemaker"),
+            Some(&Some("go:github.com/vburenin/ifacemaker"))
+        );
+        assert_eq!(entries.get("golang/tools/gorename"), Some(&Some("")));
         assert_eq!(entries.get("cli/cli"), Some(&None));
+    }
+
+    #[test]
+    fn test_baked_registry_search_platform_overrides() {
+        let darwin = AquaSearchPlatform {
+            os: "darwin".to_string(),
+            arch: "arm64".to_string(),
+            libc: None,
+        };
+        let linux = AquaSearchPlatform {
+            os: "linux".to_string(),
+            arch: "amd64".to_string(),
+            libc: Some("gnu".to_string()),
+        };
+
+        let rhit = AQUA_STANDARD_REGISTRY_SEARCH.get("Canop/rhit").unwrap();
+        assert_eq!(rhit.backend(&darwin), Some("cargo:rhit"));
+        assert_eq!(rhit.backend(&linux), None);
+
+        let dockfmt = AQUA_STANDARD_REGISTRY_SEARCH
+            .get("jessfraz/dockfmt")
+            .unwrap();
+        assert_eq!(
+            dockfmt.backend(&darwin),
+            Some("go:github.com/jessfraz/dockfmt")
+        );
+        assert_eq!(dockfmt.backend(&linux), None);
+    }
+
+    #[test]
+    fn test_search_backend_libc_override_selection() {
+        let backends = AquaSearchBackends {
+            default: None,
+            overrides: &[AquaSearchBackendOverride {
+                goos: Some("linux"),
+                goarch: None,
+                envs: &[],
+                libc: Some("musl"),
+                backend: Some("cargo:example"),
+            }],
+        };
+        let gnu = AquaSearchPlatform {
+            os: "linux".to_string(),
+            arch: "amd64".to_string(),
+            libc: Some("gnu".to_string()),
+        };
+        let musl = AquaSearchPlatform {
+            os: "linux".to_string(),
+            arch: "amd64".to_string(),
+            libc: Some("musl".to_string()),
+        };
+
+        assert_eq!(backends.backend(&gnu), None);
+        assert_eq!(backends.backend(&musl), Some("cargo:example"));
     }
 
     #[test]

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -361,7 +361,6 @@ impl BackendArg {
 
             let mise_names: HashSet<String> = suggestions.iter().cloned().collect();
             for aqua in crate::aqua::aqua_registry_wrapper::aqua_suggest(&self.short) {
-                // Skip backend suggestions whose tool name matches an existing mise suggestion
                 if !mise_names.contains(&aqua.name) {
                     suggestions.push(aqua.backend);
                 }

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -360,13 +360,10 @@ impl BackendArg {
                     .collect();
 
             let mise_names: HashSet<String> = suggestions.iter().cloned().collect();
-            for aqua_id in crate::aqua::aqua_registry_wrapper::aqua_suggest(&self.short) {
-                // Skip aqua suggestions whose tool name matches an existing mise suggestion
-                let name = aqua_id
-                    .rsplit_once('/')
-                    .map_or(aqua_id.as_str(), |(_, n)| n);
-                if !mise_names.contains(name) {
-                    suggestions.push(format!("aqua:{aqua_id}"));
+            for aqua in crate::aqua::aqua_registry_wrapper::aqua_suggest(&self.short) {
+                // Skip backend suggestions whose tool name matches an existing mise suggestion
+                if !mise_names.contains(&aqua.name) {
+                    suggestions.push(aqua.backend);
                 }
             }
 

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -192,6 +192,9 @@ impl Search {
 
                 Some((score, search_backend, description))
             })
+            // Distinct aqua packages can translate to the same backend
+            // (e.g. crates.io/eza and eza-community/eza both to cargo:eza)
+            .unique_by(|(_score, search_backend, _description)| search_backend.clone())
             .collect()
     }
 
@@ -258,16 +261,21 @@ fn get_backends(backends: Vec<&'static str>) -> Vec<String> {
             let prefix = backend.split(':').next().unwrap_or("");
             let slug = backend.split(':').next_back().unwrap_or("");
             let slug = regex!(r"^(.*?)\[.*\]$").replace_all(slug, "$1");
-            match prefix {
-                "core" => format!("https://mise.jdx.dev/lang/{slug}.html"),
-                "cargo" => format!("https://crates.io/crates/{slug}"),
-                "go" => format!("https://pkg.go.dev/{slug}"),
-                "pipx" => format!("https://pypi.org/project/{slug}"),
-                "npm" => format!("https://www.npmjs.com/package/{slug}"),
-                _ => format!("https://github.com/{slug}"),
-            }
+            backend_homepage_url(prefix, &slug)
+                .unwrap_or_else(|| format!("https://github.com/{slug}"))
         })
         .collect()
+}
+
+fn backend_homepage_url(prefix: &str, slug: &str) -> Option<String> {
+    match prefix {
+        "core" => Some(format!("https://mise.jdx.dev/lang/{slug}.html")),
+        "cargo" => Some(format!("https://crates.io/crates/{slug}")),
+        "go" => Some(format!("https://pkg.go.dev/{slug}")),
+        "pipx" => Some(format!("https://pypi.org/project/{slug}")),
+        "npm" => Some(format!("https://www.npmjs.com/package/{slug}")),
+        _ => None,
+    }
 }
 
 fn get_aqua_description(id: &str, search_backend: &str) -> String {
@@ -282,11 +290,7 @@ fn get_aqua_description(id: &str, search_backend: &str) -> String {
         format!("https://github.com/{}/{}", pkg.repo_owner, pkg.repo_name)
     } else {
         let (backend_type, tool) = search_backend.split_once(':').unwrap_or_default();
-        match backend_type {
-            "cargo" => format!("https://crates.io/crates/{tool}"),
-            "go" => format!("https://pkg.go.dev/{tool}"),
-            _ => fallback,
-        }
+        backend_homepage_url(backend_type, tool).unwrap_or(fallback)
     };
 
     match pkg.description.as_deref().filter(|d| !d.is_empty()) {

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -160,19 +160,19 @@ impl Search {
             return vec![];
         }
 
-        crate::aqua::standard_registry::package_ids()
-            .filter_map(|id| {
-                let tool_name = id.rsplit_once('/').map_or(id, |(_, name)| name);
+        crate::aqua::aqua_registry_wrapper::aqua_search_entries()
+            .filter_map(|entry| {
+                let tool_name = entry.name();
                 let score = match self.match_type {
                     MatchType::Equal => {
-                        if tool_name == name || id == name || format!("aqua:{id}") == name {
+                        if tool_name == name || entry.id == name || entry.backend_matches(name) {
                             Some(0)
                         } else {
                             None
                         }
                     }
                     MatchType::Contains => {
-                        if tool_name.contains(name) || id.contains(name) {
+                        if tool_name.contains(name) || entry.id.contains(name) {
                             Some(0)
                         } else {
                             None
@@ -183,7 +183,10 @@ impl Search {
                     }
                 }?;
 
-                Some((score, format!("aqua:{id}"), get_aqua_description(id)))
+                let search_backend = entry.backend();
+                let description = get_aqua_description(entry.id, &search_backend);
+
+                Some((score, search_backend, description))
             })
             .collect()
     }
@@ -263,8 +266,8 @@ fn get_backends(backends: Vec<&'static str>) -> Vec<String> {
         .collect()
 }
 
-fn get_aqua_description(id: &str) -> String {
-    let fallback = format!("aqua:{id}");
+fn get_aqua_description(id: &str, search_backend: &str) -> String {
+    let fallback = search_backend.to_string();
     let Ok(pkg) =
         crate::aqua::standard_registry::package(id).unwrap_or_else(|| Ok(Default::default()))
     else {
@@ -274,7 +277,12 @@ fn get_aqua_description(id: &str) -> String {
     let backend = if !pkg.repo_owner.is_empty() && !pkg.repo_name.is_empty() {
         format!("https://github.com/{}/{}", pkg.repo_owner, pkg.repo_name)
     } else {
-        fallback
+        let (backend_type, tool) = search_backend.split_once(':').unwrap_or_default();
+        match backend_type {
+            "cargo" => format!("https://crates.io/crates/{tool}"),
+            "go" => format!("https://pkg.go.dev/{tool}"),
+            _ => fallback,
+        }
     };
 
     match pkg.description.as_deref().filter(|d| !d.is_empty()) {

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -163,23 +163,27 @@ impl Search {
         crate::aqua::aqua_registry_wrapper::aqua_search_entries()
             .filter_map(|entry| {
                 let tool_name = entry.name();
-                let score = match self.match_type {
-                    MatchType::Equal => {
-                        if tool_name == name || entry.id == name || entry.backend_matches(name) {
-                            Some(0)
-                        } else {
-                            None
+                let score = if entry.backend_matches(name) {
+                    Some(0)
+                } else {
+                    match self.match_type {
+                        MatchType::Equal => {
+                            if tool_name == name || entry.id == name {
+                                Some(0)
+                            } else {
+                                None
+                            }
                         }
-                    }
-                    MatchType::Contains => {
-                        if tool_name.contains(name) || entry.id.contains(name) {
-                            Some(0)
-                        } else {
-                            None
+                        MatchType::Contains => {
+                            if tool_name.contains(name) || entry.id.contains(name) {
+                                Some(0)
+                            } else {
+                                None
+                            }
                         }
-                    }
-                    MatchType::Fuzzy => {
-                        fuzzy_matcher.score_pattern(&tool_name.to_lowercase(), fuzzy_pattern)
+                        MatchType::Fuzzy => {
+                            fuzzy_matcher.score_pattern(&tool_name.to_lowercase(), fuzzy_pattern)
+                        }
                     }
                 }?;
 


### PR DESCRIPTION
## Summary
- precompute a compact map of Aqua backend exceptions while embedding the vendored registry
- translate effective Aqua Cargo packages to `cargo:<crate>` and GoInstall packages to `go:<path>`
- use Aqua's GitHub repository fallback for pathless root GoInstall packages
- exclude GoBuild packages and compile-backed packages without a literal runnable backend identifier
- preserve conditional version roots; only apply a catch-all version fallback offline when the root is explicitly disabled
- precompute the small set of platform-dependent backend variants and select them at runtime using the same OS, architecture, and libc settings as Aqua installation
- keep classification offline: builds and searches do not resolve `latest`, traverse the registry, or call the GitHub API
- use the same translated entries for search and not-found suggestions
- accept an exact runnable backend identifier in the default search mode without treating prefixes such as `cargo` or `aqua` as broad search terms
- preserve standard registry shorthand precedence so overlapping entries still produce one result

## Examples
- `mise search broot` and `mise search cargo:broot` show `cargo:broot`, not `aqua:crates.io/broot`
- `mise use broot` suggests `cargo:broot`
- `mise search benchstat` shows `go:golang.org/x/perf/cmd/benchstat`
- `mise search mapotf` shows `go:github.com/Azure/mapotf`, using Aqua's pathless GoInstall fallback
- `MISE_OS=macos mise search rhit` shows `cargo:rhit`; the default platform keeps the Aqua backend
- `mise search tokei` shows only the existing `tokei` shorthand
- `mise search cargo` does not dump Cargo-backed Aqua packages
- GoBuild packages and version-templated GoInstall paths without a runnable identifier are omitted

Related discussion: https://github.com/jdx/mise/discussions/12224

## Validation
- `mise run lint`
- `cargo test -p aqua-registry` (133 passed)
- `cargo test --all-features aqua::standard_registry::tests` (8 passed)
- `mise run build`
- `mise run test:e2e e2e/cli/test_search e2e/cli/test_did_you_mean`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Aqua search recognizes runnable Cargo and Go backend identifiers.
  * Search supports platform-specific backend resolution, including macOS and Linux libc variants.
  * Search results and CLI suggestions use executable package targets instead of Aqua source identifiers.
  * Cargo and Go results can include direct package links when repository details are unavailable.

* **Bug Fixes**
  * Improved duplicate filtering and exact-match behavior for Aqua suggestions.
  * Unsupported packages and version-templated paths no longer appear in inappropriate results.
  * Standard package shortcuts take precedence over translated backend identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->