### PR TITLE
fix(npm): filter deprecated versions during resolution

### DIFF
--- a/e2e/backend/test_npm_install_before
+++ b/e2e/backend/test_npm_install_before
@@ -25,6 +25,16 @@ unset MISE_MINIMUM_RELEASE_AGE
 # Test: `mise latest --minimum-release-age` CLI flag should filter by date
 assert_contains "mise latest npm:prettier --minimum-release-age 2023-06-01" "2.8.8"
 
+# Test: selectively deprecated releases are excluded from date-aware latest
+# resolution. aws-cdk 3.0.0 was published accidentally and deprecated in favor
+# of 2.x; 2.1007.0 is the newest usable release before this cutoff.
+assert "mise latest npm:aws-cdk --minimum-release-age 2025-04-10" "2.1007.0"
+
+# The npm CLI metadata path needs an additional query for deprecated releases.
+assert \
+  "MISE_CACHE_DIR='$PWD/npm-shell-out-cache' MISE_NPM_SHELL_OUT=1 mise latest npm:aws-cdk --minimum-release-age 2025-04-10" \
+  "2.1007.0"
+
 # Test: CLI --minimum-release-age flag overrides the global minimum_release_age setting
 # Global is 2024-01-01 (would give 3.1.0), CLI is 2023-06-01 (gives 2.8.8)
 export MISE_MINIMUM_RELEASE_AGE="2024-01-01"

--- a/e2e/backend/test_npm_install_before
+++ b/e2e/backend/test_npm_install_before
@@ -35,6 +35,12 @@ assert \
   "MISE_CACHE_DIR='$PWD/npm-shell-out-cache' MISE_NPM_SHELL_OUT=1 mise latest npm:aws-cdk --minimum-release-age 2025-04-10" \
   "2.1007.0"
 
+# Fully deprecated packages have no automatically resolvable latest version.
+# Every release of request is deprecated on npm.
+assert_empty "MISE_CACHE_DIR='$PWD/npm-request-cache' mise latest npm:request"
+assert_empty \
+  "MISE_CACHE_DIR='$PWD/npm-request-shell-out-cache' MISE_NPM_SHELL_OUT=1 mise latest npm:request"
+
 # Test: CLI --minimum-release-age flag overrides the global minimum_release_age setting
 # Global is 2024-01-01 (would give 3.1.0), CLI is 2023-06-01 (gives 2.8.8)
 export MISE_MINIMUM_RELEASE_AGE="2024-01-01"

--- a/e2e/backend/test_npm_install_before
+++ b/e2e/backend/test_npm_install_before
@@ -35,11 +35,12 @@ assert \
   "MISE_CACHE_DIR='$PWD/npm-shell-out-cache' MISE_NPM_SHELL_OUT=1 mise latest npm:aws-cdk --minimum-release-age 2025-04-10" \
   "2.1007.0"
 
-# Fully deprecated packages have no automatically resolvable latest version.
-# Every release of request is deprecated on npm.
-assert_empty "MISE_CACHE_DIR='$PWD/npm-request-cache' mise latest npm:request"
-assert_empty \
-  "MISE_CACHE_DIR='$PWD/npm-request-shell-out-cache' MISE_NPM_SHELL_OUT=1 mise latest npm:request"
+# A package whose entire version history is deprecated remains resolvable. npm
+# treats that as package-level deprecation and warns during installation.
+assert "MISE_CACHE_DIR='$PWD/npm-request-cache' mise latest npm:request" "2.88.2"
+assert \
+  "MISE_CACHE_DIR='$PWD/npm-request-shell-out-cache' MISE_NPM_SHELL_OUT=1 mise latest npm:request" \
+  "2.88.2"
 
 # Test: CLI --minimum-release-age flag overrides the global minimum_release_age setting
 # Global is 2024-01-01 (would give 3.1.0), CLI is 2023-06-01 (gives 2.8.8)

--- a/e2e/backend/test_npm_install_before
+++ b/e2e/backend/test_npm_install_before
@@ -32,7 +32,7 @@ assert "mise latest npm:aws-cdk --minimum-release-age 2025-04-10" "2.1007.0"
 
 # The npm CLI metadata path needs an additional query for deprecated releases.
 assert \
-  "MISE_CACHE_DIR='$PWD/npm-shell-out-cache' MISE_NPM_SHELL_OUT=1 mise latest npm:aws-cdk --minimum-release-age 2025-04-10" \
+  "MISE_CACHE_DIR='$PWD/npm-shell-out-cache' MISE_NPM_SHELL_OUT=1 NPM_CONFIG_JSON=true mise latest npm:aws-cdk --minimum-release-age 2025-04-10" \
   "2.1007.0"
 
 # A package whose entire version history is deprecated remains resolvable. npm

--- a/e2e/cli/test_use_pin_exact
+++ b/e2e/cli/test_use_pin_exact
@@ -69,6 +69,9 @@ if [[ $1 == view && $3 == versions ]]; then
   echo '{"versions":["1.0.1"],"time":{}}'
   exit 0
 fi
+if [[ $1 == view && $3 == version && $4 == deprecated ]]; then
+  exit 0
+fi
 echo "unexpected npm invocation: $*" >&2
 exit 1
 EOF

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -37,10 +37,6 @@ use tokio::sync::Mutex as TokioMutex;
 const BEFORE_DATE_TOLERANCE_SECS: u64 = 60;
 const NPM_ALLOW_SCRIPTS_VERSION: &str = "11.16.0";
 const NPM_MIN_RELEASE_AGE_VERSION: &str = "11.10.0";
-// npm is normally a .cmd shim on Windows, where cmd.exe limits the entire
-// command line to 8,191 characters. Keep this argument well below that limit
-// to leave room for the executable, fields, prefix, quoting, and expansion.
-const NPM_DEPRECATED_QUERY_MAX_LEN: usize = 4096;
 const AUBE_PROGRAM: &str = if cfg!(windows) { "aube.exe" } else { "aube" };
 const BUN_MIN_RELEASE_AGE_VERSION: &str = "1.3.0";
 const NPM_IGNORE_SCRIPTS_ARG: &str = "--ignore-scripts=true";
@@ -884,14 +880,13 @@ impl NPMBackend {
         versions: &[VersionInfo],
     ) -> eyre::Result<HashSet<String>> {
         let package = self.tool_name();
-        let mut deprecated_versions = HashSet::new();
-        for query in npm_deprecated_queries(&package, versions) {
-            let raw = self
-                .npm_view(config, query, &["version", "deprecated"], false)
-                .await?;
-            deprecated_versions.extend(npm_view_deprecated_versions(&package, &raw));
-        }
-        Ok(deprecated_versions)
+        let Some(query) = npm_deprecated_query(&package, versions) else {
+            return Ok(HashSet::new());
+        };
+        let raw = self
+            .npm_view(config, query, &["version", "deprecated"], false)
+            .await?;
+        Ok(npm_view_deprecated_versions(&package, &raw))
     }
 
     /// Check dependencies for version checking (always needs npm)
@@ -1601,13 +1596,12 @@ fn npm_view_deprecated_versions(package: &str, output: &str) -> HashSet<String> 
         .collect()
 }
 
-/// Build bounded npm ranges that collectively cover every stable release plus
-/// every prerelease core returned by the versions query. npm ranges exclude
-/// prereleases unless a comparator in the same set names their
-/// major/minor/patch tuple.
-fn npm_deprecated_queries(package: &str, versions: &[VersionInfo]) -> Vec<String> {
+/// Build one npm range that covers every stable release plus every prerelease
+/// core returned by the versions query. npm ranges exclude prereleases unless
+/// a comparator in the same set names their major/minor/patch tuple.
+fn npm_deprecated_query(package: &str, versions: &[VersionInfo]) -> Option<String> {
     if versions.is_empty() {
-        return Vec::new();
+        return None;
     }
 
     let prerelease_cores = versions
@@ -1616,26 +1610,13 @@ fn npm_deprecated_queries(package: &str, versions: &[VersionInfo]) -> Vec<String
         .filter_map(|version| semver::Version::parse(&version.version).ok())
         .map(|version| (version.major, version.minor, version.patch))
         .collect::<BTreeSet<_>>();
-    let ranges = std::iter::once(">=0.0.0-0".to_string()).chain(prerelease_cores.into_iter().map(
-        |(major, minor, patch)| format!(">={major}.{minor}.{patch}-0 <{major}.{minor}.{patch}"),
-    ));
-    let prefix = format!("{package}@");
-    let mut queries = Vec::new();
-    let mut query = prefix.clone();
-    for range in ranges {
-        let separator = if query == prefix { "" } else { " || " };
-        if query != prefix
-            && query.len() + separator.len() + range.len() > NPM_DEPRECATED_QUERY_MAX_LEN
-        {
-            queries.push(query);
-            query = format!("{prefix}{range}");
-        } else {
-            query.push_str(separator);
-            query.push_str(&range);
-        }
-    }
-    queries.push(query);
-    queries
+    let ranges = std::iter::once(">=0.0.0-0".to_string())
+        .chain(prerelease_cores.into_iter().map(|(major, minor, patch)| {
+            format!(">={major}.{minor}.{patch}-0 <{major}.{minor}.{patch}")
+        }))
+        .collect::<Vec<_>>()
+        .join(" || ");
+    Some(format!("{package}@{ranges}"))
 }
 
 /// Exclude individually deprecated releases while retaining a package whose
@@ -2184,7 +2165,7 @@ pkg@1.2.0 '1.2.0'
     }
 
     #[test]
-    fn test_npm_deprecated_queries_and_filter_include_prereleases() {
+    fn test_npm_deprecated_query_and_filter_include_prereleases() {
         let versions = [
             ("1.0.0", false),
             ("2.0.0-beta.1", true),
@@ -2198,8 +2179,8 @@ pkg@1.2.0 '1.2.0'
         });
 
         assert_eq!(
-            npm_deprecated_queries("pkg", &versions),
-            ["pkg@>=0.0.0-0 || >=2.0.0-0 <2.0.0 || >=3.1.4-0 <3.1.4"]
+            npm_deprecated_query("pkg", &versions),
+            Some("pkg@>=0.0.0-0 || >=2.0.0-0 <2.0.0 || >=3.1.4-0 <3.1.4".into())
         );
 
         let deprecated_versions = npm_view_deprecated_versions(
@@ -2218,45 +2199,8 @@ pkg@1.2.0 '1.2.0'
     }
 
     #[test]
-    fn test_npm_deprecated_queries_skip_empty_version_history() {
-        assert!(npm_deprecated_queries("pkg", &[]).is_empty());
-    }
-
-    #[test]
-    fn test_npm_deprecated_queries_bound_large_prerelease_histories() {
-        let versions = (0..300)
-            .map(|patch| VersionInfo {
-                version: format!("1.0.{patch}-beta.1"),
-                prerelease: true,
-                ..Default::default()
-            })
-            .collect::<Vec<_>>();
-
-        let queries = npm_deprecated_queries("pkg", &versions);
-
-        assert!(queries.len() > 1);
-        assert!(
-            queries
-                .iter()
-                .all(|query| query.len() <= NPM_DEPRECATED_QUERY_MAX_LEN)
-        );
-        assert_eq!(
-            queries
-                .iter()
-                .filter(|query| query.contains(">=0.0.0-0"))
-                .count(),
-            1
-        );
-        for patch in 0..300 {
-            let comparator = format!(">=1.0.{patch}-0 <1.0.{patch}");
-            assert_eq!(
-                queries
-                    .iter()
-                    .filter(|query| query.contains(&comparator))
-                    .count(),
-                1
-            );
-        }
+    fn test_npm_deprecated_query_skips_empty_version_history() {
+        assert_eq!(npm_deprecated_query("pkg", &[]), None);
     }
 
     #[test]

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -508,7 +508,7 @@ impl Backend for NPMBackend {
                     NpmOptions::npm_lifecycle_script_args(allow_builds, supports_allow_scripts);
                 let skipped_lifecycle_scripts =
                     Self::effective_npm_ignore_scripts(default_ignore_scripts, &npm_args);
-                let mut cmd =
+                let mut cmd = Self::npm_command(
                     CmdLineRunner::new(self.spawn_program(&ctx.config, Some(&ctx.ts), "npm").await)
                         .arg("install")
                         .arg("-g")
@@ -519,14 +519,14 @@ impl Backend for NPMBackend {
                         .with_pr(ctx.pr.as_ref())
                         .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
                         .env_values(tv.install_env())
-                        .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
                         .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
                         .prepend_path(
                             self.dependency_toolset(&ctx.config)
                                 .await?
                                 .list_paths(&ctx.config)
                                 .await,
-                        )?;
+                        )?,
+                );
                 cmd = cmd.args(lifecycle_script_args);
                 if let Some(args) = &npm_args {
                     cmd = cmd.args(args);
@@ -613,23 +613,9 @@ impl NPMBackend {
         self.ensure_npm_for_version_check(config).await;
         timeout::run_with_timeout_async(
             async || {
-                let env = self.dependency_env(config).await?;
-                let prefix = Self::npm_meta_prefix()?;
-                let npm = self.spawn_program(config, None, "npm").await;
-
-                let raw = cmd!(
-                    &npm,
-                    "view",
-                    self.tool_name(),
-                    "versions",
-                    "time",
-                    "--json",
-                    "--prefix",
-                    &prefix
-                )
-                .full_env(&env)
-                .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
-                .read()?;
+                let raw = self
+                    .npm_view(config, self.tool_name(), &["versions", "time"], true)
+                    .await?;
                 let data: Value = serde_json::from_str(&raw)?;
                 let versions = npm_view_versions_time(&data)?;
 
@@ -638,19 +624,9 @@ impl NPMBackend {
                 // intentionally pays for a second query so its resolution
                 // semantics match the default HTTP registry client.
                 let deprecated_query = npm_deprecated_query(&self.tool_name(), &versions);
-                let deprecated_raw = cmd!(
-                    &npm,
-                    "view",
-                    deprecated_query,
-                    "version",
-                    "deprecated",
-                    "--json=false",
-                    "--prefix",
-                    &prefix
-                )
-                .full_env(&env)
-                .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
-                .read()?;
+                let deprecated_raw = self
+                    .npm_view(config, deprecated_query, &["version", "deprecated"], false)
+                    .await?;
                 let deprecated_versions =
                     npm_view_deprecated_versions(&self.tool_name(), &deprecated_raw);
 
@@ -663,39 +639,17 @@ impl NPMBackend {
 
     /// Legacy `npm view` dist-tags lookup, see [`Self::list_remote_versions_npm_view`].
     async fn latest_dist_tag_npm_view(&self, config: &Arc<Config>) -> eyre::Result<Option<String>> {
-        let prefix = Self::npm_meta_prefix()?;
-        let npm = self.spawn_program(config, None, "npm").await;
-        let raw = cmd!(
-            &npm,
-            "view",
-            self.tool_name(),
-            "versions",
-            "dist-tags",
-            "--json",
-            "--prefix",
-            &prefix
-        )
-        .full_env(self.dependency_env(config).await?)
-        .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
-        .read()?;
+        let raw = self
+            .npm_view(config, self.tool_name(), &["versions", "dist-tags"], true)
+            .await?;
         let data: Value = serde_json::from_str(&raw)?;
         let versions = npm_view_versions_time(&data)?;
         let latest = npm_view_latest_dist_tag(&data)?;
 
         let deprecated_query = npm_deprecated_query(&self.tool_name(), &versions);
-        let deprecated_raw = cmd!(
-            &npm,
-            "view",
-            deprecated_query,
-            "version",
-            "deprecated",
-            "--json=false",
-            "--prefix",
-            &prefix
-        )
-        .full_env(self.dependency_env(config).await?)
-        .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
-        .read()?;
+        let deprecated_raw = self
+            .npm_view(config, deprecated_query, &["version", "deprecated"], false)
+            .await?;
         let deprecated_versions = npm_view_deprecated_versions(&self.tool_name(), &deprecated_raw);
 
         Ok(filter_deprecated_latest_dist_tag(
@@ -861,10 +815,14 @@ impl NPMBackend {
             }
         };
         let npm = self.spawn_program(config, None, "npm").await;
-        let output = match cmd!(npm, "--version")
-            .full_env(env)
-            .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
-            .read()
+        let output = match Self::npm_command(
+            CmdLineRunner::new(npm)
+                .arg("--version")
+                .env_clear()
+                .envs(env),
+        )
+        .read()
+        .await
         {
             Ok(s) => s,
             Err(e) => {
@@ -883,6 +841,35 @@ impl NPMBackend {
         let dir = crate::dirs::CACHE.join("npm-meta");
         crate::file::create_dir_all(&dir)?;
         Ok(dir)
+    }
+
+    /// Apply environment required by every npm subprocess.
+    fn npm_command<'a>(cmd: CmdLineRunner<'a>) -> CmdLineRunner<'a> {
+        cmd.env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
+    }
+
+    /// Run an isolated `npm view` query with mise's required npm environment.
+    async fn npm_view(
+        &self,
+        config: &Arc<Config>,
+        package: impl AsRef<std::ffi::OsStr>,
+        fields: &[&str],
+        json: bool,
+    ) -> eyre::Result<String> {
+        let npm = self.spawn_program(config, None, "npm").await;
+        Self::npm_command(
+            CmdLineRunner::new(npm)
+                .arg("view")
+                .arg(package)
+                .args(fields)
+                .arg(format!("--json={json}"))
+                .arg("--prefix")
+                .arg(Self::npm_meta_prefix()?)
+                .env_clear()
+                .envs(self.dependency_env(config).await?),
+        )
+        .read()
+        .await
     }
 
     /// Check dependencies for version checking (always needs npm)

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -37,6 +37,10 @@ use tokio::sync::Mutex as TokioMutex;
 const BEFORE_DATE_TOLERANCE_SECS: u64 = 60;
 const NPM_ALLOW_SCRIPTS_VERSION: &str = "11.16.0";
 const NPM_MIN_RELEASE_AGE_VERSION: &str = "11.10.0";
+// npm is normally a .cmd shim on Windows, where cmd.exe limits the entire
+// command line to 8,191 characters. Keep this argument well below that limit
+// to leave room for the executable, fields, prefix, quoting, and expansion.
+const NPM_DEPRECATED_QUERY_MAX_LEN: usize = 4096;
 const AUBE_PROGRAM: &str = if cfg!(windows) { "aube.exe" } else { "aube" };
 const BUN_MIN_RELEASE_AGE_VERSION: &str = "1.3.0";
 const NPM_IGNORE_SCRIPTS_ARG: &str = "--ignore-scripts=true";
@@ -625,12 +629,7 @@ impl NPMBackend {
                 // deprecation metadata. The shell-out compatibility path
                 // intentionally pays for a second query so its resolution
                 // semantics match the default HTTP registry client.
-                let deprecated_query = npm_deprecated_query(&self.tool_name(), &versions);
-                let deprecated_raw = self
-                    .npm_view(config, deprecated_query, &["version", "deprecated"], false)
-                    .await?;
-                let deprecated_versions =
-                    npm_view_deprecated_versions(&self.tool_name(), &deprecated_raw);
+                let deprecated_versions = self.npm_deprecated_versions(config, &versions).await?;
 
                 Ok(filter_deprecated_versions(versions, &deprecated_versions))
             },
@@ -648,11 +647,7 @@ impl NPMBackend {
         let versions = npm_view_versions_time(&data)?;
         let latest = npm_view_latest_dist_tag(&data)?;
 
-        let deprecated_query = npm_deprecated_query(&self.tool_name(), &versions);
-        let deprecated_raw = self
-            .npm_view(config, deprecated_query, &["version", "deprecated"], false)
-            .await?;
-        let deprecated_versions = npm_view_deprecated_versions(&self.tool_name(), &deprecated_raw);
+        let deprecated_versions = self.npm_deprecated_versions(config, &versions).await?;
 
         Ok(filter_deprecated_latest_dist_tag(
             latest,
@@ -879,6 +874,24 @@ impl NPMBackend {
         .await
         .read()
         .await
+    }
+
+    /// Fetch deprecation metadata in bounded queries. An empty version history
+    /// needs no query; npm exits non-zero when a range matches no versions.
+    async fn npm_deprecated_versions(
+        &self,
+        config: &Arc<Config>,
+        versions: &[VersionInfo],
+    ) -> eyre::Result<HashSet<String>> {
+        let package = self.tool_name();
+        let mut deprecated_versions = HashSet::new();
+        for query in npm_deprecated_queries(&package, versions) {
+            let raw = self
+                .npm_view(config, query, &["version", "deprecated"], false)
+                .await?;
+            deprecated_versions.extend(npm_view_deprecated_versions(&package, &raw));
+        }
+        Ok(deprecated_versions)
     }
 
     /// Check dependencies for version checking (always needs npm)
@@ -1588,23 +1601,41 @@ fn npm_view_deprecated_versions(package: &str, output: &str) -> HashSet<String> 
         .collect()
 }
 
-/// Build one npm range that covers every stable release plus every prerelease
-/// core returned by the versions query. npm ranges exclude prereleases unless
-/// a comparator in the same set names their major/minor/patch tuple.
-fn npm_deprecated_query(package: &str, versions: &[VersionInfo]) -> String {
+/// Build bounded npm ranges that collectively cover every stable release plus
+/// every prerelease core returned by the versions query. npm ranges exclude
+/// prereleases unless a comparator in the same set names their
+/// major/minor/patch tuple.
+fn npm_deprecated_queries(package: &str, versions: &[VersionInfo]) -> Vec<String> {
+    if versions.is_empty() {
+        return Vec::new();
+    }
+
     let prerelease_cores = versions
         .iter()
         .filter(|version| version.prerelease)
         .filter_map(|version| semver::Version::parse(&version.version).ok())
         .map(|version| (version.major, version.minor, version.patch))
         .collect::<BTreeSet<_>>();
-    let ranges = std::iter::once(">=0.0.0-0".to_string())
-        .chain(prerelease_cores.into_iter().map(|(major, minor, patch)| {
-            format!(">={major}.{minor}.{patch}-0 <{major}.{minor}.{patch}")
-        }))
-        .collect::<Vec<_>>()
-        .join(" || ");
-    format!("{package}@{ranges}")
+    let ranges = std::iter::once(">=0.0.0-0".to_string()).chain(prerelease_cores.into_iter().map(
+        |(major, minor, patch)| format!(">={major}.{minor}.{patch}-0 <{major}.{minor}.{patch}"),
+    ));
+    let prefix = format!("{package}@");
+    let mut queries = Vec::new();
+    let mut query = prefix.clone();
+    for range in ranges {
+        let separator = if query == prefix { "" } else { " || " };
+        if query != prefix
+            && query.len() + separator.len() + range.len() > NPM_DEPRECATED_QUERY_MAX_LEN
+        {
+            queries.push(query);
+            query = format!("{prefix}{range}");
+        } else {
+            query.push_str(separator);
+            query.push_str(&range);
+        }
+    }
+    queries.push(query);
+    queries
 }
 
 /// Exclude individually deprecated releases while retaining a package whose
@@ -1641,9 +1672,8 @@ fn filter_deprecated_latest_dist_tag(
         .all(|version| deprecated_versions.contains(&version.version));
     latest.filter(|latest| {
         all_versions_deprecated
-            || versions.iter().all(|version| {
-                version.version != *latest || !deprecated_versions.contains(&version.version)
-            })
+            || !versions.iter().any(|version| version.version == *latest)
+            || !deprecated_versions.contains(latest)
     })
 }
 
@@ -2154,7 +2184,7 @@ pkg@1.2.0 '1.2.0'
     }
 
     #[test]
-    fn test_npm_deprecated_query_and_filter_include_prereleases() {
+    fn test_npm_deprecated_queries_and_filter_include_prereleases() {
         let versions = [
             ("1.0.0", false),
             ("2.0.0-beta.1", true),
@@ -2168,8 +2198,8 @@ pkg@1.2.0 '1.2.0'
         });
 
         assert_eq!(
-            npm_deprecated_query("pkg", &versions),
-            "pkg@>=0.0.0-0 || >=2.0.0-0 <2.0.0 || >=3.1.4-0 <3.1.4"
+            npm_deprecated_queries("pkg", &versions),
+            ["pkg@>=0.0.0-0 || >=2.0.0-0 <2.0.0 || >=3.1.4-0 <3.1.4"]
         );
 
         let deprecated_versions = npm_view_deprecated_versions(
@@ -2185,6 +2215,48 @@ pkg@1.2.0 '1.2.0'
                 .collect::<Vec<_>>(),
             ["1.0.0", "2.0.0-rc.1", "3.1.4-dev.1"]
         );
+    }
+
+    #[test]
+    fn test_npm_deprecated_queries_skip_empty_version_history() {
+        assert!(npm_deprecated_queries("pkg", &[]).is_empty());
+    }
+
+    #[test]
+    fn test_npm_deprecated_queries_bound_large_prerelease_histories() {
+        let versions = (0..300)
+            .map(|patch| VersionInfo {
+                version: format!("1.0.{patch}-beta.1"),
+                prerelease: true,
+                ..Default::default()
+            })
+            .collect::<Vec<_>>();
+
+        let queries = npm_deprecated_queries("pkg", &versions);
+
+        assert!(queries.len() > 1);
+        assert!(
+            queries
+                .iter()
+                .all(|query| query.len() <= NPM_DEPRECATED_QUERY_MAX_LEN)
+        );
+        assert_eq!(
+            queries
+                .iter()
+                .filter(|query| query.contains(">=0.0.0-0"))
+                .count(),
+            1
+        );
+        for patch in 0..300 {
+            let comparator = format!(">=1.0.{patch}-0 <1.0.{patch}");
+            assert_eq!(
+                queries
+                    .iter()
+                    .filter(|query| query.contains(&comparator))
+                    .count(),
+                1
+            );
+        }
     }
 
     #[test]

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -872,8 +872,8 @@ impl NPMBackend {
         .await
     }
 
-    /// Fetch deprecation metadata in bounded queries. An empty version history
-    /// needs no query; npm exits non-zero when a range matches no versions.
+    /// Fetch deprecation metadata in one combined query, or skip the lookup for
+    /// an empty version history because npm rejects ranges matching no versions.
     async fn npm_deprecated_versions(
         &self,
         config: &Arc<Config>,

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -2158,7 +2158,7 @@ pkg@1.2.0 '1.2.0'
     }
 
     #[test]
-    fn test_npm_deprecated_query_includes_every_prerelease_core() {
+    fn test_npm_deprecated_query_and_filter_include_prereleases() {
         let versions = [
             ("1.0.0", false),
             ("2.0.0-beta.1", true),
@@ -2174,6 +2174,20 @@ pkg@1.2.0 '1.2.0'
         assert_eq!(
             npm_deprecated_query("pkg", &versions),
             "pkg@>=0.0.0-0 || >=2.0.0-0 <2.0.0 || >=3.1.4-0 <3.1.4"
+        );
+
+        let deprecated_versions = npm_view_deprecated_versions(
+            "pkg",
+            "pkg@2.0.0-beta.1 deprecated = 'published accidentally'\n",
+        );
+        let filtered = filter_deprecated_versions(versions.into(), &deprecated_versions);
+
+        assert_eq!(
+            filtered
+                .iter()
+                .map(|version| version.version.as_str())
+                .collect::<Vec<_>>(),
+            ["1.0.0", "2.0.0-rc.1", "3.1.4-dev.1"]
         );
     }
 

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -642,6 +642,7 @@ impl NPMBackend {
                     &npm,
                     "view",
                     deprecated_query,
+                    "version",
                     "deprecated",
                     "--prefix",
                     &prefix
@@ -685,6 +686,7 @@ impl NPMBackend {
             &npm,
             "view",
             deprecated_query,
+            "version",
             "deprecated",
             "--prefix",
             &prefix
@@ -1572,8 +1574,16 @@ fn npm_view_deprecated_versions(package: &str, output: &str) -> HashSet<String> 
     output
         .lines()
         .filter_map(|line| line.strip_prefix(&prefix))
-        .filter_map(|line| line.split_whitespace().next())
-        .map(str::to_string)
+        .filter_map(|line| line.split_once(' '))
+        .filter_map(|(version, field)| {
+            // With both fields requested npm prefixes each matched version and
+            // labels deprecation metadata. npm sometimes renders version-only
+            // entries without a `version =` label, so match the field name
+            // positively rather than treating every other line as deprecated.
+            field
+                .starts_with("deprecated = ")
+                .then_some(version.to_string())
+        })
         .collect()
 }
 
@@ -2058,8 +2068,10 @@ mod tests {
     #[test]
     fn test_npm_view_deprecated_versions_extracts_versions() {
         let output = "\
-aws-cdk@1.0.0 'use 1.2.0'
-aws-cdk@2.0.0 'published accidentally'
+aws-cdk@1.0.0 version = '1.0.0'
+aws-cdk@1.0.0 deprecated = 'use 1.2.0'
+aws-cdk@2.0.0 version = '2.0.0'
+aws-cdk@2.0.0 deprecated = 'published accidentally'
 ";
         assert_eq!(
             npm_view_deprecated_versions("aws-cdk", output),
@@ -2070,9 +2082,11 @@ aws-cdk@2.0.0 'published accidentally'
     #[test]
     fn test_npm_view_deprecated_versions_handles_scoped_packages_and_multiline_messages() {
         let output = "\
-@scope/pkg@1.0.0 'first line\n' +
+@scope/pkg@1.0.0 version = '1.0.0'
+@scope/pkg@1.0.0 deprecated = 'first line\n' +
   'second line'
-@scope/pkg@2.0.0 'use a newer version'
+@scope/pkg@2.0.0 version = '2.0.0'
+@scope/pkg@2.0.0 deprecated = 'use a newer version'
 ";
         assert_eq!(
             npm_view_deprecated_versions("@scope/pkg", output),
@@ -2083,6 +2097,21 @@ aws-cdk@2.0.0 'published accidentally'
     #[test]
     fn test_npm_view_deprecated_versions_accepts_empty_output() {
         assert!(npm_view_deprecated_versions("prettier", "").is_empty());
+    }
+
+    #[test]
+    fn test_npm_view_deprecated_versions_preserves_a_single_deprecated_release() {
+        let output = "\
+pkg@1.0.0 '1.0.0'
+pkg@1.1.0 version = '1.1.0'
+pkg@1.1.0 deprecated = 'published accidentally'
+pkg@1.2.0 '1.2.0'
+";
+
+        assert_eq!(
+            npm_view_deprecated_versions("pkg", output),
+            HashSet::from(["1.1.0".into()])
+        );
     }
 
     #[test]

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -631,7 +631,7 @@ impl NPMBackend {
                 .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
                 .read()?;
                 let data: Value = serde_json::from_str(&raw)?;
-                let versions = npm_view_versions_time(&data)?;
+                let mut versions = npm_view_versions_time(&data)?;
 
                 // `npm view <package> versions time` omits per-version
                 // deprecation metadata. The shell-out compatibility path
@@ -651,11 +651,9 @@ impl NPMBackend {
                 .read()?;
                 let deprecated_versions =
                     npm_view_deprecated_versions(&self.tool_name(), &deprecated_raw);
+                versions.retain(|version| !deprecated_versions.contains(&version.version));
 
-                Ok(npm_registry::filter_deprecated_versions(
-                    versions,
-                    &deprecated_versions,
-                ))
+                Ok(versions)
             },
             Settings::get().fetch_remote_versions_timeout(),
         )
@@ -671,6 +669,7 @@ impl NPMBackend {
             "view",
             self.tool_name(),
             "dist-tags",
+            "deprecated",
             "--json",
             "--prefix",
             &prefix
@@ -1562,7 +1561,17 @@ fn npm_view_deprecated_versions(package: &str, output: &str) -> HashSet<String> 
 }
 
 fn npm_view_latest_dist_tag(data: &Value) -> eyre::Result<Option<String>> {
-    Ok(match npm_view_json(data)?["latest"] {
+    let data = npm_view_json(data)?;
+    let deprecated = match data.get("deprecated") {
+        Some(Value::String(message)) => !message.trim().is_empty(),
+        Some(Value::Bool(deprecated)) => *deprecated,
+        _ => false,
+    };
+    if deprecated {
+        return Ok(None);
+    }
+    let dist_tags = data.get("dist-tags").unwrap_or(data);
+    Ok(match dist_tags["latest"] {
         Value::String(ref s) => Some(s.clone()),
         _ => None,
     })
@@ -2062,6 +2071,29 @@ aws-cdk@2.0.0 'published accidentally'
     fn test_npm_view_latest_dist_tag_accepts_npm12_array() {
         let data = serde_json::json!([{
             "latest": "1.0.0"
+        }]);
+
+        assert_eq!(
+            npm_view_latest_dist_tag(&data).unwrap(),
+            Some("1.0.0".into())
+        );
+    }
+
+    #[test]
+    fn test_npm_view_latest_dist_tag_returns_none_when_deprecated() {
+        let data = serde_json::json!([{
+            "dist-tags": { "latest": "1.0.0" },
+            "deprecated": "use another package"
+        }]);
+
+        assert_eq!(npm_view_latest_dist_tag(&data).unwrap(), None);
+    }
+
+    #[test]
+    fn test_npm_view_latest_dist_tag_accepts_nested_dist_tags() {
+        let data = serde_json::json!([{
+            "dist-tags": { "latest": "1.0.0" },
+            "deprecated": ""
         }]);
 
         assert_eq!(

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -508,25 +508,27 @@ impl Backend for NPMBackend {
                     NpmOptions::npm_lifecycle_script_args(allow_builds, supports_allow_scripts);
                 let skipped_lifecycle_scripts =
                     Self::effective_npm_ignore_scripts(default_ignore_scripts, &npm_args);
-                let mut cmd = Self::npm_command(
-                    CmdLineRunner::new(self.spawn_program(&ctx.config, Some(&ctx.ts), "npm").await)
-                        .arg("install")
-                        .arg("-g")
-                        .arg(&package)
-                        .arg("--prefix")
-                        .arg(tv.install_path())
-                        .args(install_before_args)
-                        .with_pr(ctx.pr.as_ref())
-                        .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
-                        .env_values(tv.install_env())
-                        .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
-                        .prepend_path(
-                            self.dependency_toolset(&ctx.config)
-                                .await?
-                                .list_paths(&ctx.config)
-                                .await,
-                        )?,
-                );
+                let install_env = ctx.ts.env_with_path_without_tools(&ctx.config).await?;
+                let mut cmd = self
+                    .npm_command(&ctx.config, Some(&ctx.ts), |cmd| {
+                        cmd.arg("install")
+                            .arg("-g")
+                            .arg(&package)
+                            .arg("--prefix")
+                            .arg(tv.install_path())
+                            .args(install_before_args)
+                            .with_pr(ctx.pr.as_ref())
+                            .envs(install_env)
+                            .env_values(tv.install_env())
+                    })
+                    .await
+                    .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
+                    .prepend_path(
+                        self.dependency_toolset(&ctx.config)
+                            .await?
+                            .list_paths(&ctx.config)
+                            .await,
+                    )?;
                 cmd = cmd.args(lifecycle_script_args);
                 if let Some(args) = &npm_args {
                     cmd = cmd.args(args);
@@ -814,15 +816,13 @@ impl NPMBackend {
                 return false;
             }
         };
-        let npm = self.spawn_program(config, None, "npm").await;
-        let output = match Self::npm_command(
-            CmdLineRunner::new(npm)
-                .arg("--version")
-                .env_clear()
-                .envs(env),
-        )
-        .read()
-        .await
+        let output = match self
+            .npm_command(config, None, |cmd| {
+                cmd.arg("--version").env_clear().envs(env)
+            })
+            .await
+            .read()
+            .await
         {
             Ok(s) => s,
             Err(e) => {
@@ -843,9 +843,17 @@ impl NPMBackend {
         Ok(dir)
     }
 
-    /// Apply environment required by every npm subprocess.
-    fn npm_command<'a>(cmd: CmdLineRunner<'a>) -> CmdLineRunner<'a> {
-        cmd.env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
+    /// Resolve npm and apply environment required by every npm subprocess.
+    /// Caller configuration runs first so its environment cannot override
+    /// mise-owned npm settings.
+    async fn npm_command<'a>(
+        &self,
+        config: &Arc<Config>,
+        ts: Option<&Toolset>,
+        configure: impl FnOnce(CmdLineRunner<'a>) -> CmdLineRunner<'a>,
+    ) -> CmdLineRunner<'a> {
+        let npm = self.spawn_program(config, ts, "npm").await;
+        configure(CmdLineRunner::new(npm)).env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
     }
 
     /// Run an isolated `npm view` query with mise's required npm environment.
@@ -856,18 +864,19 @@ impl NPMBackend {
         fields: &[&str],
         json: bool,
     ) -> eyre::Result<String> {
-        let npm = self.spawn_program(config, None, "npm").await;
-        Self::npm_command(
-            CmdLineRunner::new(npm)
-                .arg("view")
+        let prefix = Self::npm_meta_prefix()?;
+        let env = self.dependency_env(config).await?;
+        self.npm_command(config, None, |cmd| {
+            cmd.arg("view")
                 .arg(package)
                 .args(fields)
                 .arg(format!("--json={json}"))
                 .arg("--prefix")
-                .arg(Self::npm_meta_prefix()?)
+                .arg(prefix)
                 .env_clear()
-                .envs(self.dependency_env(config).await?),
-        )
+                .envs(env)
+        })
+        .await
         .read()
         .await
     }

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -644,6 +644,7 @@ impl NPMBackend {
                     deprecated_query,
                     "version",
                     "deprecated",
+                    "--json=false",
                     "--prefix",
                     &prefix
                 )
@@ -688,6 +689,7 @@ impl NPMBackend {
             deprecated_query,
             "version",
             "deprecated",
+            "--json=false",
             "--prefix",
             &prefix
         )
@@ -695,9 +697,12 @@ impl NPMBackend {
         .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
         .read()?;
         let deprecated_versions = npm_view_deprecated_versions(&self.tool_name(), &deprecated_raw);
-        let versions = filter_deprecated_versions(versions, &deprecated_versions);
 
-        Ok(latest.filter(|latest| versions.iter().any(|version| version.version == *latest)))
+        Ok(filter_deprecated_latest_dist_tag(
+            latest,
+            &versions,
+            &deprecated_versions,
+        ))
     }
 
     async fn build_transitive_release_age_args(
@@ -1608,6 +1613,25 @@ fn filter_deprecated_versions(
         .collect()
 }
 
+/// Reject a selectively deprecated latest target. Preserve a missing target
+/// because npm registries can briefly publish a dist-tag before its version
+/// metadata, matching the direct registry path's behavior.
+fn filter_deprecated_latest_dist_tag(
+    latest: Option<String>,
+    versions: &[VersionInfo],
+    deprecated_versions: &HashSet<String>,
+) -> Option<String> {
+    let all_versions_deprecated = versions
+        .iter()
+        .all(|version| deprecated_versions.contains(&version.version));
+    latest.filter(|latest| {
+        all_versions_deprecated
+            || versions.iter().all(|version| {
+                version.version != *latest || !deprecated_versions.contains(&version.version)
+            })
+    })
+}
+
 fn npm_view_latest_dist_tag(data: &Value) -> eyre::Result<Option<String>> {
     let data = npm_view_json(data)?;
     let dist_tags = data.get("dist-tags").unwrap_or(data);
@@ -2190,6 +2214,42 @@ pkg@1.2.0 '1.2.0'
                 .map(|version| version.version.as_str())
                 .collect::<Vec<_>>(),
             ["1.0.0", "1.1.0"]
+        );
+    }
+
+    #[test]
+    fn test_filter_deprecated_latest_dist_tag_rejects_selective_deprecation() {
+        let versions = ["1.0.0", "2.0.0"].map(|version| VersionInfo {
+            version: version.into(),
+            ..Default::default()
+        });
+        let deprecated_versions = HashSet::from(["2.0.0".into()]);
+
+        assert_eq!(
+            filter_deprecated_latest_dist_tag(
+                Some("2.0.0".into()),
+                &versions,
+                &deprecated_versions
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn test_filter_deprecated_latest_dist_tag_preserves_missing_target() {
+        let versions = [VersionInfo {
+            version: "1.0.0".into(),
+            ..Default::default()
+        }];
+        let deprecated_versions = HashSet::from(["2.0.0".into()]);
+
+        assert_eq!(
+            filter_deprecated_latest_dist_tag(
+                Some("2.0.0".into()),
+                &versions,
+                &deprecated_versions
+            ),
+            Some("2.0.0".into())
         );
     }
 

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -631,7 +631,7 @@ impl NPMBackend {
                 .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
                 .read()?;
                 let data: Value = serde_json::from_str(&raw)?;
-                let mut versions = npm_view_versions_time(&data)?;
+                let versions = npm_view_versions_time(&data)?;
 
                 // `npm view <package> versions time` omits per-version
                 // deprecation metadata. The shell-out compatibility path
@@ -651,9 +651,8 @@ impl NPMBackend {
                 .read()?;
                 let deprecated_versions =
                     npm_view_deprecated_versions(&self.tool_name(), &deprecated_raw);
-                versions.retain(|version| !deprecated_versions.contains(&version.version));
 
-                Ok(versions)
+                Ok(filter_deprecated_versions(versions, &deprecated_versions))
             },
             Settings::get().fetch_remote_versions_timeout(),
         )
@@ -665,11 +664,11 @@ impl NPMBackend {
         let prefix = Self::npm_meta_prefix()?;
         let npm = self.spawn_program(config, None, "npm").await;
         let raw = cmd!(
-            npm,
+            &npm,
             "view",
             self.tool_name(),
+            "versions",
             "dist-tags",
-            "deprecated",
             "--json",
             "--prefix",
             &prefix
@@ -677,8 +676,26 @@ impl NPMBackend {
         .full_env(self.dependency_env(config).await?)
         .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
         .read()?;
-        let dist_tags: Value = serde_json::from_str(&raw)?;
-        npm_view_latest_dist_tag(&dist_tags)
+        let data: Value = serde_json::from_str(&raw)?;
+        let versions = npm_view_versions_time(&data)?;
+        let latest = npm_view_latest_dist_tag(&data)?;
+
+        let deprecated_query = format!("{}@>=0.0.0-0", self.tool_name());
+        let deprecated_raw = cmd!(
+            &npm,
+            "view",
+            deprecated_query,
+            "deprecated",
+            "--prefix",
+            &prefix
+        )
+        .full_env(self.dependency_env(config).await?)
+        .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
+        .read()?;
+        let deprecated_versions = npm_view_deprecated_versions(&self.tool_name(), &deprecated_raw);
+        let versions = filter_deprecated_versions(versions, &deprecated_versions);
+
+        Ok(latest.filter(|latest| versions.iter().any(|version| version.version == *latest)))
     }
 
     async fn build_transitive_release_age_args(
@@ -1560,16 +1577,29 @@ fn npm_view_deprecated_versions(package: &str, output: &str) -> HashSet<String> 
         .collect()
 }
 
+/// Exclude individually deprecated releases while retaining a package whose
+/// entire version history is deprecated. npm uses that all-versions state for
+/// package-level deprecation and still permits the package to be installed.
+fn filter_deprecated_versions(
+    versions: Vec<VersionInfo>,
+    deprecated_versions: &HashSet<String>,
+) -> Vec<VersionInfo> {
+    if deprecated_versions.is_empty()
+        || versions
+            .iter()
+            .all(|version| deprecated_versions.contains(&version.version))
+    {
+        return versions;
+    }
+
+    versions
+        .into_iter()
+        .filter(|version| !deprecated_versions.contains(&version.version))
+        .collect()
+}
+
 fn npm_view_latest_dist_tag(data: &Value) -> eyre::Result<Option<String>> {
     let data = npm_view_json(data)?;
-    let deprecated = match data.get("deprecated") {
-        Some(Value::String(message)) => !message.trim().is_empty(),
-        Some(Value::Bool(deprecated)) => *deprecated,
-        _ => false,
-    };
-    if deprecated {
-        return Ok(None);
-    }
     let dist_tags = data.get("dist-tags").unwrap_or(data);
     Ok(match dist_tags["latest"] {
         Value::String(ref s) => Some(s.clone()),
@@ -2080,25 +2110,57 @@ aws-cdk@2.0.0 'published accidentally'
     }
 
     #[test]
-    fn test_npm_view_latest_dist_tag_returns_none_when_deprecated() {
-        let data = serde_json::json!([{
-            "dist-tags": { "latest": "1.0.0" },
-            "deprecated": "use another package"
-        }]);
-
-        assert_eq!(npm_view_latest_dist_tag(&data).unwrap(), None);
-    }
-
-    #[test]
     fn test_npm_view_latest_dist_tag_accepts_nested_dist_tags() {
         let data = serde_json::json!([{
-            "dist-tags": { "latest": "1.0.0" },
-            "deprecated": ""
+            "versions": ["1.0.0"],
+            "dist-tags": { "latest": "1.0.0" }
         }]);
 
         assert_eq!(
             npm_view_latest_dist_tag(&data).unwrap(),
             Some("1.0.0".into())
+        );
+    }
+
+    #[test]
+    fn test_filter_deprecated_versions_excludes_individual_releases() {
+        let versions = ["1.0.0", "1.1.0", "2.0.0"]
+            .map(|version| VersionInfo {
+                version: version.into(),
+                ..Default::default()
+            })
+            .into();
+        let deprecated_versions = HashSet::from(["1.1.0".into(), "2.0.0".into()]);
+
+        let filtered = filter_deprecated_versions(versions, &deprecated_versions);
+
+        assert_eq!(
+            filtered
+                .iter()
+                .map(|version| version.version.as_str())
+                .collect::<Vec<_>>(),
+            ["1.0.0"]
+        );
+    }
+
+    #[test]
+    fn test_filter_deprecated_versions_retains_package_level_deprecation() {
+        let versions = ["1.0.0", "1.1.0"]
+            .map(|version| VersionInfo {
+                version: version.into(),
+                ..Default::default()
+            })
+            .into();
+        let deprecated_versions = HashSet::from(["1.0.0".into(), "1.1.0".into()]);
+
+        let filtered = filter_deprecated_versions(versions, &deprecated_versions);
+
+        assert_eq!(
+            filtered
+                .iter()
+                .map(|version| version.version.as_str())
+                .collect::<Vec<_>>(),
+            ["1.0.0", "1.1.0"]
         );
     }
 

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -23,7 +23,7 @@ use aube::embed::{EmbedderInstallOverrides, EmbedderRuntime};
 use bytesize::ByteSize;
 use jiff::Timestamp;
 use serde_json::Value;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::{fmt::Debug, sync::Arc};
@@ -637,7 +637,7 @@ impl NPMBackend {
                 // deprecation metadata. The shell-out compatibility path
                 // intentionally pays for a second query so its resolution
                 // semantics match the default HTTP registry client.
-                let deprecated_query = format!("{}@>=0.0.0-0", self.tool_name());
+                let deprecated_query = npm_deprecated_query(&self.tool_name(), &versions);
                 let deprecated_raw = cmd!(
                     &npm,
                     "view",
@@ -682,7 +682,7 @@ impl NPMBackend {
         let versions = npm_view_versions_time(&data)?;
         let latest = npm_view_latest_dist_tag(&data)?;
 
-        let deprecated_query = format!("{}@>=0.0.0-0", self.tool_name());
+        let deprecated_query = npm_deprecated_query(&self.tool_name(), &versions);
         let deprecated_raw = cmd!(
             &npm,
             "view",
@@ -1592,6 +1592,25 @@ fn npm_view_deprecated_versions(package: &str, output: &str) -> HashSet<String> 
         .collect()
 }
 
+/// Build one npm range that covers every stable release plus every prerelease
+/// core returned by the versions query. npm ranges exclude prereleases unless
+/// a comparator in the same set names their major/minor/patch tuple.
+fn npm_deprecated_query(package: &str, versions: &[VersionInfo]) -> String {
+    let prerelease_cores = versions
+        .iter()
+        .filter(|version| version.prerelease)
+        .filter_map(|version| semver::Version::parse(&version.version).ok())
+        .map(|version| (version.major, version.minor, version.patch))
+        .collect::<BTreeSet<_>>();
+    let ranges = std::iter::once(">=0.0.0-0".to_string())
+        .chain(prerelease_cores.into_iter().map(|(major, minor, patch)| {
+            format!(">={major}.{minor}.{patch}-0 <{major}.{minor}.{patch}")
+        }))
+        .collect::<Vec<_>>()
+        .join(" || ");
+    format!("{package}@{ranges}")
+}
+
 /// Exclude individually deprecated releases while retaining a package whose
 /// entire version history is deprecated. npm uses that all-versions state for
 /// package-level deprecation and still permits the package to be installed.
@@ -2135,6 +2154,26 @@ pkg@1.2.0 '1.2.0'
         assert_eq!(
             npm_view_deprecated_versions("pkg", output),
             HashSet::from(["1.1.0".into()])
+        );
+    }
+
+    #[test]
+    fn test_npm_deprecated_query_includes_every_prerelease_core() {
+        let versions = [
+            ("1.0.0", false),
+            ("2.0.0-beta.1", true),
+            ("2.0.0-rc.1", true),
+            ("3.1.4-dev.1", true),
+        ]
+        .map(|(version, prerelease)| VersionInfo {
+            version: version.into(),
+            prerelease,
+            ..Default::default()
+        });
+
+        assert_eq!(
+            npm_deprecated_query("pkg", &versions),
+            "pkg@>=0.0.0-0 || >=2.0.0-0 <2.0.0 || >=3.1.4-0 <3.1.4"
         );
     }
 

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -1581,10 +1581,10 @@ fn npm_view_deprecated_versions(package: &str, output: &str) -> HashSet<String> 
         .filter_map(|line| line.strip_prefix(&prefix))
         .filter_map(|line| line.split_once(' '))
         .filter_map(|(version, field)| {
-            // With both fields requested npm prefixes each matched version and
-            // labels deprecation metadata. npm sometimes renders version-only
-            // entries without a `version =` label, so match the field name
-            // positively rather than treating every other line as deprecated.
+            // When `deprecated` is absent, npm collapses the remaining
+            // `version` field to `<package>@<version> '<version>'` without a
+            // `version =` label. Match `deprecated =` positively so the
+            // shorthand version-only line is not treated as deprecated.
             field
                 .starts_with("deprecated = ")
                 .then_some(version.to_string())

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -23,7 +23,7 @@ use aube::embed::{EmbedderInstallOverrides, EmbedderRuntime};
 use bytesize::ByteSize;
 use jiff::Timestamp;
 use serde_json::Value;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::{fmt::Debug, sync::Arc};
@@ -618,7 +618,7 @@ impl NPMBackend {
                 let npm = self.spawn_program(config, None, "npm").await;
 
                 let raw = cmd!(
-                    npm,
+                    &npm,
                     "view",
                     self.tool_name(),
                     "versions",
@@ -631,9 +631,31 @@ impl NPMBackend {
                 .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
                 .read()?;
                 let data: Value = serde_json::from_str(&raw)?;
-                let version_info = npm_view_versions_time(&data)?;
+                let versions = npm_view_versions_time(&data)?;
 
-                Ok(version_info)
+                // `npm view <package> versions time` omits per-version
+                // deprecation metadata. The shell-out compatibility path
+                // intentionally pays for a second query so its resolution
+                // semantics match the default HTTP registry client.
+                let deprecated_query = format!("{}@>=0.0.0-0", self.tool_name());
+                let deprecated_raw = cmd!(
+                    &npm,
+                    "view",
+                    deprecated_query,
+                    "deprecated",
+                    "--prefix",
+                    &prefix
+                )
+                .full_env(&env)
+                .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
+                .read()?;
+                let deprecated_versions =
+                    npm_view_deprecated_versions(&self.tool_name(), &deprecated_raw);
+
+                Ok(npm_registry::filter_deprecated_versions(
+                    versions,
+                    &deprecated_versions,
+                ))
             },
             Settings::get().fetch_remote_versions_timeout(),
         )
@@ -1529,6 +1551,16 @@ fn npm_view_versions_time(data: &Value) -> eyre::Result<Vec<VersionInfo>> {
         .collect())
 }
 
+fn npm_view_deprecated_versions(package: &str, output: &str) -> HashSet<String> {
+    let prefix = format!("{package}@");
+    output
+        .lines()
+        .filter_map(|line| line.strip_prefix(&prefix))
+        .filter_map(|line| line.split_whitespace().next())
+        .map(str::to_string)
+        .collect()
+}
+
 fn npm_view_latest_dist_tag(data: &Value) -> eyre::Result<Option<String>> {
     Ok(match npm_view_json(data)?["latest"] {
         Value::String(ref s) => Some(s.clone()),
@@ -1982,6 +2014,36 @@ mod tests {
             error,
             "expected npm view --json to return one result, got 2"
         );
+    }
+
+    #[test]
+    fn test_npm_view_deprecated_versions_extracts_versions() {
+        let output = "\
+aws-cdk@1.0.0 'use 1.2.0'
+aws-cdk@2.0.0 'published accidentally'
+";
+        assert_eq!(
+            npm_view_deprecated_versions("aws-cdk", output),
+            HashSet::from(["1.0.0".into(), "2.0.0".into()])
+        );
+    }
+
+    #[test]
+    fn test_npm_view_deprecated_versions_handles_scoped_packages_and_multiline_messages() {
+        let output = "\
+@scope/pkg@1.0.0 'first line\n' +
+  'second line'
+@scope/pkg@2.0.0 'use a newer version'
+";
+        assert_eq!(
+            npm_view_deprecated_versions("@scope/pkg", output),
+            HashSet::from(["1.0.0".into(), "2.0.0".into()])
+        );
+    }
+
+    #[test]
+    fn test_npm_view_deprecated_versions_accepts_empty_output() {
+        assert!(npm_view_deprecated_versions("prettier", "").is_empty());
     }
 
     #[test]

--- a/src/backend/npm_registry.rs
+++ b/src/backend/npm_registry.rs
@@ -77,10 +77,13 @@ async fn fetch_packument(name: &str) -> Result<aube_registry::Packument> {
 /// stable position at the end.
 pub async fn list_versions(name: &str) -> Result<Vec<VersionInfo>> {
     let packument = fetch_packument(name).await?;
-    let versions = packument
+    let all_versions_deprecated = packument
         .versions
-        .iter()
-        .filter_map(|(version, metadata)| metadata.deprecated.is_none().then_some(version));
+        .values()
+        .all(|metadata| metadata.deprecated.is_some());
+    let versions = packument.versions.iter().filter_map(|(version, metadata)| {
+        (all_versions_deprecated || metadata.deprecated.is_none()).then_some(version)
+    });
     Ok(sort_versions(versions)
         .into_iter()
         .map(|version| VersionInfo {
@@ -111,14 +114,19 @@ fn sort_versions<'a>(versions: impl Iterator<Item = &'a String>) -> Vec<&'a Stri
 /// Resolve the `latest` dist-tag for a package, if the registry publishes one.
 pub async fn latest_dist_tag(name: &str) -> Result<Option<String>> {
     let packument = fetch_packument(name).await?;
+    let all_versions_deprecated = packument
+        .versions
+        .values()
+        .all(|metadata| metadata.deprecated.is_some());
     Ok(packument
         .dist_tags
         .get("latest")
         .filter(|version| {
-            packument
-                .versions
-                .get(*version)
-                .is_none_or(|metadata| metadata.deprecated.is_none())
+            all_versions_deprecated
+                || packument
+                    .versions
+                    .get(*version)
+                    .is_none_or(|metadata| metadata.deprecated.is_none())
         })
         .cloned())
 }

--- a/src/backend/npm_registry.rs
+++ b/src/backend/npm_registry.rs
@@ -12,8 +12,8 @@
 //! authenticate mise-owned metadata queries. User-level `~/.npmrc` (or
 //! `NPM_CONFIG_USERCONFIG`) and `NPM_CONFIG_*` env vars still apply.
 
-use std::path::Path;
-use std::path::PathBuf;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 use std::sync::LazyLock as Lazy;
 
 use aube_registry::NetworkMode;
@@ -78,7 +78,12 @@ async fn fetch_packument(name: &str) -> Result<aube_registry::Packument> {
 /// stable position at the end.
 pub async fn list_versions(name: &str) -> Result<Vec<VersionInfo>> {
     let packument = fetch_packument(name).await?;
-    Ok(sort_versions(packument.versions.keys())
+    let deprecated_versions = packument
+        .versions
+        .iter()
+        .filter_map(|(version, metadata)| metadata.deprecated.as_ref().map(|_| version.clone()))
+        .collect();
+    let versions = sort_versions(packument.versions.keys())
         .into_iter()
         .map(|version| VersionInfo {
             version: version.clone(),
@@ -86,7 +91,29 @@ pub async fn list_versions(name: &str) -> Result<Vec<VersionInfo>> {
             prerelease: is_semver_prerelease(version),
             ..Default::default()
         })
-        .collect())
+        .collect();
+    Ok(filter_deprecated_versions(versions, &deprecated_versions))
+}
+
+/// Exclude selectively deprecated releases from fuzzy/latest resolution. If a
+/// package deprecated every release, retain them all so the package remains
+/// installable and npm can display its package-level deprecation warning.
+pub(super) fn filter_deprecated_versions(
+    versions: Vec<VersionInfo>,
+    deprecated_versions: &HashSet<String>,
+) -> Vec<VersionInfo> {
+    if deprecated_versions.is_empty()
+        || versions
+            .iter()
+            .all(|version| deprecated_versions.contains(&version.version))
+    {
+        return versions;
+    }
+
+    versions
+        .into_iter()
+        .filter(|version| !deprecated_versions.contains(&version.version))
+        .collect()
 }
 
 fn sort_versions<'a>(versions: impl Iterator<Item = &'a String>) -> Vec<&'a String> {
@@ -125,7 +152,10 @@ pub async fn download_tarball(name: &str, version: &str, path: &Path) -> Result<
 
 #[cfg(test)]
 mod tests {
-    use super::sort_versions;
+    use std::collections::HashSet;
+
+    use super::{filter_deprecated_versions, sort_versions};
+    use crate::backend::VersionInfo;
 
     #[test]
     fn sort_versions_supports_npm_safe_integer_components() {
@@ -154,6 +184,48 @@ mod tests {
                 "0.1.0",
                 "0.52.0",
             ]
+        );
+    }
+
+    #[test]
+    fn deprecated_versions_are_filtered_when_usable_versions_remain() {
+        let versions = ["1.0.0", "1.1.0", "2.0.0"]
+            .map(|version| VersionInfo {
+                version: version.into(),
+                ..Default::default()
+            })
+            .into();
+        let deprecated_versions = HashSet::from(["1.1.0".into(), "2.0.0".into()]);
+
+        let filtered = filter_deprecated_versions(versions, &deprecated_versions);
+
+        assert_eq!(
+            filtered
+                .iter()
+                .map(|version| version.version.as_str())
+                .collect::<Vec<_>>(),
+            ["1.0.0"]
+        );
+    }
+
+    #[test]
+    fn fully_deprecated_packages_remain_installable() {
+        let versions = ["1.0.0", "1.1.0"]
+            .map(|version| VersionInfo {
+                version: version.into(),
+                ..Default::default()
+            })
+            .into();
+        let deprecated_versions = HashSet::from(["1.0.0".into(), "1.1.0".into()]);
+
+        let filtered = filter_deprecated_versions(versions, &deprecated_versions);
+
+        assert_eq!(
+            filtered
+                .iter()
+                .map(|version| version.version.as_str())
+                .collect::<Vec<_>>(),
+            ["1.0.0", "1.1.0"]
         );
     }
 }

--- a/src/backend/npm_registry.rs
+++ b/src/backend/npm_registry.rs
@@ -78,12 +78,14 @@ async fn fetch_packument(name: &str) -> Result<aube_registry::Packument> {
 /// stable position at the end.
 pub async fn list_versions(name: &str) -> Result<Vec<VersionInfo>> {
     let packument = fetch_packument(name).await?;
-    let deprecated_versions = packument
+    let all_versions_deprecated = packument
         .versions
-        .iter()
-        .filter_map(|(version, metadata)| metadata.deprecated.as_ref().map(|_| version.clone()))
-        .collect();
-    let versions = sort_versions(packument.versions.keys())
+        .values()
+        .all(|metadata| metadata.deprecated.is_some());
+    let versions = packument.versions.iter().filter_map(|(version, metadata)| {
+        (all_versions_deprecated || metadata.deprecated.is_none()).then_some(version)
+    });
+    Ok(sort_versions(versions)
         .into_iter()
         .map(|version| VersionInfo {
             version: version.clone(),
@@ -91,8 +93,7 @@ pub async fn list_versions(name: &str) -> Result<Vec<VersionInfo>> {
             prerelease: is_semver_prerelease(version),
             ..Default::default()
         })
-        .collect();
-    Ok(filter_deprecated_versions(versions, &deprecated_versions))
+        .collect())
 }
 
 /// Exclude selectively deprecated releases from fuzzy/latest resolution. If a

--- a/src/backend/npm_registry.rs
+++ b/src/backend/npm_registry.rs
@@ -12,7 +12,6 @@
 //! authenticate mise-owned metadata queries. User-level `~/.npmrc` (or
 //! `NPM_CONFIG_USERCONFIG`) and `NPM_CONFIG_*` env vars still apply.
 
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock as Lazy;
 
@@ -78,13 +77,10 @@ async fn fetch_packument(name: &str) -> Result<aube_registry::Packument> {
 /// stable position at the end.
 pub async fn list_versions(name: &str) -> Result<Vec<VersionInfo>> {
     let packument = fetch_packument(name).await?;
-    let all_versions_deprecated = packument
+    let versions = packument
         .versions
-        .values()
-        .all(|metadata| metadata.deprecated.is_some());
-    let versions = packument.versions.iter().filter_map(|(version, metadata)| {
-        (all_versions_deprecated || metadata.deprecated.is_none()).then_some(version)
-    });
+        .iter()
+        .filter_map(|(version, metadata)| metadata.deprecated.is_none().then_some(version));
     Ok(sort_versions(versions)
         .into_iter()
         .map(|version| VersionInfo {
@@ -94,27 +90,6 @@ pub async fn list_versions(name: &str) -> Result<Vec<VersionInfo>> {
             ..Default::default()
         })
         .collect())
-}
-
-/// Exclude selectively deprecated releases from fuzzy/latest resolution. If a
-/// package deprecated every release, retain them all so the package remains
-/// installable and npm can display its package-level deprecation warning.
-pub(super) fn filter_deprecated_versions(
-    versions: Vec<VersionInfo>,
-    deprecated_versions: &HashSet<String>,
-) -> Vec<VersionInfo> {
-    if deprecated_versions.is_empty()
-        || versions
-            .iter()
-            .all(|version| deprecated_versions.contains(&version.version))
-    {
-        return versions;
-    }
-
-    versions
-        .into_iter()
-        .filter(|version| !deprecated_versions.contains(&version.version))
-        .collect()
 }
 
 fn sort_versions<'a>(versions: impl Iterator<Item = &'a String>) -> Vec<&'a String> {
@@ -136,7 +111,16 @@ fn sort_versions<'a>(versions: impl Iterator<Item = &'a String>) -> Vec<&'a Stri
 /// Resolve the `latest` dist-tag for a package, if the registry publishes one.
 pub async fn latest_dist_tag(name: &str) -> Result<Option<String>> {
     let packument = fetch_packument(name).await?;
-    Ok(packument.dist_tags.get("latest").cloned())
+    Ok(packument
+        .dist_tags
+        .get("latest")
+        .filter(|version| {
+            packument
+                .versions
+                .get(*version)
+                .is_none_or(|metadata| metadata.deprecated.is_none())
+        })
+        .cloned())
 }
 
 /// Download the exact npm registry tarball for a package version, honoring
@@ -153,10 +137,7 @@ pub async fn download_tarball(name: &str, version: &str, path: &Path) -> Result<
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
-
-    use super::{filter_deprecated_versions, sort_versions};
-    use crate::backend::VersionInfo;
+    use super::sort_versions;
 
     #[test]
     fn sort_versions_supports_npm_safe_integer_components() {
@@ -185,48 +166,6 @@ mod tests {
                 "0.1.0",
                 "0.52.0",
             ]
-        );
-    }
-
-    #[test]
-    fn deprecated_versions_are_filtered_when_usable_versions_remain() {
-        let versions = ["1.0.0", "1.1.0", "2.0.0"]
-            .map(|version| VersionInfo {
-                version: version.into(),
-                ..Default::default()
-            })
-            .into();
-        let deprecated_versions = HashSet::from(["1.1.0".into(), "2.0.0".into()]);
-
-        let filtered = filter_deprecated_versions(versions, &deprecated_versions);
-
-        assert_eq!(
-            filtered
-                .iter()
-                .map(|version| version.version.as_str())
-                .collect::<Vec<_>>(),
-            ["1.0.0"]
-        );
-    }
-
-    #[test]
-    fn fully_deprecated_packages_remain_installable() {
-        let versions = ["1.0.0", "1.1.0"]
-            .map(|version| VersionInfo {
-                version: version.into(),
-                ..Default::default()
-            })
-            .into();
-        let deprecated_versions = HashSet::from(["1.0.0".into(), "1.1.0".into()]);
-
-        let filtered = filter_deprecated_versions(versions, &deprecated_versions);
-
-        assert_eq!(
-            filtered
-                .iter()
-                .map(|version| version.version.as_str())
-                .collect::<Vec<_>>(),
-            ["1.0.0", "1.1.0"]
         );
     }
 }

--- a/src/backend/npm_registry.rs
+++ b/src/backend/npm_registry.rs
@@ -69,6 +69,13 @@ async fn fetch_packument(name: &str) -> Result<aube_registry::Packument> {
         .await?)
 }
 
+fn all_versions_deprecated(packument: &aube_registry::Packument) -> bool {
+    packument
+        .versions
+        .values()
+        .all(|metadata| metadata.deprecated.is_some())
+}
+
 /// List a package's versions as [`VersionInfo`], semver-ascending with publish
 /// timestamps. npm registry versions are strict semver (the registry enforces
 /// it) but the packument's `versions` map is keyed lexically, so the keys are
@@ -77,10 +84,7 @@ async fn fetch_packument(name: &str) -> Result<aube_registry::Packument> {
 /// stable position at the end.
 pub async fn list_versions(name: &str) -> Result<Vec<VersionInfo>> {
     let packument = fetch_packument(name).await?;
-    let all_versions_deprecated = packument
-        .versions
-        .values()
-        .all(|metadata| metadata.deprecated.is_some());
+    let all_versions_deprecated = all_versions_deprecated(&packument);
     let versions = packument.versions.iter().filter_map(|(version, metadata)| {
         (all_versions_deprecated || metadata.deprecated.is_none()).then_some(version)
     });
@@ -114,10 +118,7 @@ fn sort_versions<'a>(versions: impl Iterator<Item = &'a String>) -> Vec<&'a Stri
 /// Resolve the `latest` dist-tag for a package, if the registry publishes one.
 pub async fn latest_dist_tag(name: &str) -> Result<Option<String>> {
     let packument = fetch_packument(name).await?;
-    let all_versions_deprecated = packument
-        .versions
-        .values()
-        .all(|metadata| metadata.deprecated.is_some());
+    let all_versions_deprecated = all_versions_deprecated(&packument);
     Ok(packument
         .dist_tags
         .get("latest")


### PR DESCRIPTION
## Summary

- exclude individually deprecated npm releases from automatic fuzzy and latest resolution
- retain every version when the package maintainer deprecated the entire package by deprecating all published versions
- apply the same policy to the default HTTP metadata path and the opt-in `npm.shell_out` compatibility path

## Resolution policy

npm does not publish a separate package-level deprecation flag. Deprecating a package means marking all of its published versions deprecated. This PR therefore distinguishes these cases:

| Registry metadata | Automatic resolution behavior |
| --- | --- |
| No versions deprecated | Keep all versions |
| Some versions deprecated | Exclude only those versions; ignore `latest` if it targets one of them |
| Every version deprecated | Keep all versions and honor `latest`, preserving npm package-level deprecation behavior |

This filtering affects automatic discovery and fuzzy/latest requests. Explicit full SemVer requests remain installable because exact npm requests intentionally bypass remote discovery; npm can then display the upstream deprecation warning.

Concretely, if every v3 release is deprecated but at least one release outside v3 remains non-deprecated, `npm:pkg@3` has no discoverable match while `npm:pkg@3.1.0` remains installable as an explicit full SemVer. If every release of the entire package is deprecated, the package-level fallback applies instead, so both `npm:pkg@3` and `npm:pkg@3.1.0` remain resolvable.

## Root cause

The default npm registry adapter copied version, timestamp, and prerelease metadata from the aube packument but ignored its per-version `deprecated` field. The shell-out path queried only `versions` and `time`, which do not include deprecation metadata.

When `minimum_release_age` rejects the npm `latest` dist-tag target, resolution falls back to the highest eligible version. For `aws-cdk`, that selected accidentally published and deprecated `3.0.0` instead of the newest eligible 2.x release.

The HTTP path filters metadata from its existing packument before sorting, with no additional registry request. The opt-in shell-out path makes a second `npm view` query for the complete deprecated-version set; its latest lookup also compares `dist-tags` against that set. This intentionally accepts the shell compatibility mode performance cost to keep both paths consistent.

## Regression coverage

- With a cutoff of 2025-04-10, both metadata paths resolve `aws-cdk` to `2.1007.0`, skipping individually deprecated `3.0.0`.
- Both metadata paths still resolve fully deprecated `request` to its `latest` version, `2.88.2`.
- The shell metadata lookup covers all discovered prerelease core tuples in one range query, rather than spawning once per version, and skips the extra query for an empty version history.
- Unit tests cover selective filtering, all-versions fallback, prerelease range construction, npm CLI output variants, scoped packages, and multiline deprecation messages.

Supersedes #9605 and addresses the case reported in https://github.com/jdx/mise/discussions/12220.

## Validation

- `mise run lint-fix`
- `cargo test --locked --bin mise backend::npm::tests`
- `cargo test --locked --bin mise backend::npm_registry::tests`
- `mise run test:e2e e2e/backend/test_npm_install_before e2e/cli/test_use_pin_exact`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added checksum-verified npm package installation using exact-version tarballs.
  * Added support for downloading package archives for installation.
* **Bug Fixes**
  * Improved handling of deprecated npm releases, including prereleases and package-level deprecations.
  * Latest-version resolution now excludes deprecated releases while preserving valid tags and fallback behavior.
  * Corrected latest-version results in standard and JSON output.
  * Exact-version pinning now supports syntactically valid versions not listed remotely.
  * Improved reliability when resolving packages with large or incomplete version histories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




