### PR TITLE
fix(task): enforce global task scope precedence

### DIFF
--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -1503,7 +1503,10 @@ For local and monorepo task discovery, mise uses the nearest config file that de
 `task_config.includes`. When the parent has `task_config.cascade = true`, its includes are inherited
 until a child defines its own. A child config's `includes` replaces both the defaults and any
 inherited `includes` for that directory.
-Global config files are loaded independently, so each global config file uses its own `task_config.includes` or the default directories if `includes` is unset.
+User-global config files form one config scope, as do system config files. Within each scope, the
+highest-precedence config that defines `task_config.includes` replaces lower-precedence includes and
+the default directories. User-global and system scopes remain independent, so user includes do not
+remove tasks provided by the system config.
 
 Entries are evaluated in order, and when more than one include defines a task with the same name the **last** entry in the list wins.
 This applies uniformly to directory, toml-file, and `git::` includes, so to override a task coming from a `git::` include with a local one, list the local directory after the `git::` entry:

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -1505,8 +1505,9 @@ until a child defines its own. A child config's `includes` replaces both the def
 inherited `includes` for that directory.
 User-global config files form one config scope, as do system config files. Within each scope, the
 highest-precedence config that defines `task_config.includes` replaces lower-precedence includes and
-the default directories. User-global and system scopes remain independent, so user includes do not
-remove tasks provided by the system config.
+the default directories. User-global and system scopes remain independent. User-global tasks replace
+same-named system tasks without inheriting system task metadata, while system tasks with other names
+remain available.
 
 Entries are evaluated in order, and when more than one include defines a task with the same name the **last** entry in the list wins.
 This applies uniformly to directory, toml-file, and `git::` includes, so to override a task coming from a `git::` include with a local one, list the local directory after the `git::` entry:

--- a/e2e/tasks/test_task_global_config_dedup
+++ b/e2e/tasks/test_task_global_config_dedup
@@ -79,7 +79,7 @@ cat >"$HOME/global-config/include-order.toml" <<EOF
 includes = ["$HOME/first-global-tasks", "$HOME/second-global-tasks"]
 EOF
 
-# Reuse is limited to earlier global config units. Within one config the
+# Reuse is limited to earlier global scopes. Within one config scope the
 # documented later-include-wins rule still controls the task's source context.
 assert \
   "MISE_GLOBAL_CONFIG_FILE='$HOME/global-config/include-order.toml' MISE_SYSTEM_CONFIG_FILE='$HOME/global-config/missing.toml' mise run include-winner" \

--- a/e2e/tasks/test_task_global_config_dedup
+++ b/e2e/tasks/test_task_global_config_dedup
@@ -66,6 +66,29 @@ MISE_GLOBAL_CONFIG_FILE="$HOME/global-config/user.toml" \
 assert "wc -l < '$shared_marker' | tr -d ' '" "1"
 assert "wc -l < '$shared_toml_marker' | tr -d ' '" "1"
 
+cat >"$HOME/shared-global-tasks/scope-winner" <<'EOF'
+#!/usr/bin/env bash
+echo "SYSTEM_METADATA=${SYSTEM_METADATA:-unset}"
+EOF
+chmod +x "$HOME/shared-global-tasks/scope-winner"
+cat >"$HOME/global-config/user-scope.toml" <<EOF
+[task_config]
+includes = ["$HOME/shared-global-tasks"]
+EOF
+cat >"$HOME/global-config/system-scope.toml" <<EOF
+[task_config]
+includes = ["$HOME/shared-global-tasks"]
+
+[tasks.scope-winner]
+env = { SYSTEM_METADATA = "leaked" }
+EOF
+
+# User and system configs are separate scopes. A same-named user task replaces
+# the system task instead of inheriting the system scope's inline metadata.
+assert \
+  "MISE_GLOBAL_CONFIG_FILE='$HOME/global-config/user-scope.toml' MISE_SYSTEM_CONFIG_FILE='$HOME/global-config/system-scope.toml' mise run scope-winner" \
+  "SYSTEM_METADATA=unset"
+
 mkdir -p "$HOME/include-order-tasks"
 cat >"$HOME/include-order-tasks/include-winner" <<'EOF'
 #!/usr/bin/env bash

--- a/e2e/tasks/test_task_ls_global
+++ b/e2e/tasks/test_task_ls_global
@@ -13,10 +13,15 @@ cat <<'EOF' >~/.config/mise/tasks/myglobalfile
 echo myglobalfile
 EOF
 chmod +x ~/.config/mise/tasks/myglobalfile
-mkdir -p ~/.config/mise/conf.d
+mkdir -p ~/.config/mise/conf.d ~/lower-global-tasks
+cat <<'EOF' >~/lower-global-tasks/lower-global-only
+#!/usr/bin/env bash
+echo lower-global-only
+EOF
+chmod +x ~/lower-global-tasks/lower-global-only
 cat <<'TOML' >~/.config/mise/conf.d/relative-overlay.toml
 [task_config]
-includes = ["empty-global-tasks"]
+includes = ["lower-global-tasks"]
 
 [tasks.relative-meta]
 file = ".config/mise/tasks/relative-meta"
@@ -79,3 +84,4 @@ assert "mise run customglobalfile" "PROJECT_ROOT=$PWD"
 assert "mise run systemglobalfile" "PROJECT_ROOT=$PWD"
 assert "mise run relative-meta" "RELATIVE_OVERLAY=applied"
 assert "mise run templated-meta" "TEMPLATED_OVERLAY=applied"
+assert_fail "mise run lower-global-only" "no task lower-global-only found"

--- a/e2e/tasks/test_task_source_comparison_no_exec
+++ b/e2e/tasks/test_task_source_comparison_no_exec
@@ -49,7 +49,7 @@ file = "{{ '/definitely/missing' | hash_file }}"
 [tasks.same-vars]
 file = "{{ vars.comparison_path }}"
 vars = { comparison_path = "$HOME/other-vars-script" }
-env = { LOWER_OVERLAY = "must-not-apply" }
+env = { LOWER_OVERLAY = "applied-from-lower-fragment" }
 EOF
 
 if ! mise tasks >/dev/null; then
@@ -59,7 +59,7 @@ if [[ -e $marker ]]; then
   fail "task source comparison executed a deferred file template"
 fi
 
-# The active config's vars must not resolve a different task's deferred file
-# path. The task-local value points elsewhere, so treating this as the same
-# source would incorrectly apply the lower overlay to the discovered script.
-assert "mise run same-vars" "LOWER_OVERLAY=<unset>"
+# Global fragments compose like project-local fragments. The higher effective
+# include selects the executable file, while the lower same-name inline task
+# decorates it without evaluating or replacing it with its deferred file path.
+assert "mise run same-vars" "LOWER_OVERLAY=applied-from-lower-fragment"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3969,49 +3969,56 @@ fn discover_monorepo_subdirs(
 }
 
 async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) -> Result<Vec<Task>> {
-    // User-global config overrides system config. Within each group the path
-    // lists are lowest-first, so reverse them before applying first-wins task
-    // precedence.
-    let config_paths = global_config_files()
-        .into_iter()
-        .rev()
-        .chain(system_config_files().into_iter().rev())
-        .collect::<Vec<_>>();
-    let configs = config_paths
-        .iter()
-        .filter_map(|path| {
-            config.config_files.get(path).or_else(|| {
-                let path = file::desymlink_path(path);
-                config
-                    .config_files
-                    .iter()
-                    .find(|(loaded, _)| file::desymlink_path(loaded) == path)
-                    .map(|(_, cf)| cf)
+    // User-global config overrides system config. Compose each group as one
+    // config scope so task_config fields follow the same override semantics as
+    // local config files. Keep the groups separate so a user include does not
+    // remove tasks provided by the system config.
+    let mut seen_configs = BTreeSet::new();
+    let mut config_groups = vec![];
+    for config_paths in [global_config_files(), system_config_files()] {
+        let configs = config_paths
+            .iter()
+            .rev()
+            .filter_map(|path| {
+                config.config_files.get(path).or_else(|| {
+                    let path = file::desymlink_path(path);
+                    config
+                        .config_files
+                        .iter()
+                        .find(|(loaded, _)| file::desymlink_path(loaded) == path)
+                        .map(|(_, cf)| cf)
+                })
             })
-        })
-        .unique_by(|cf| file::desymlink_path(cf.get_path()))
-        .collect::<Vec<_>>();
+            .filter(|cf| seen_configs.insert(file::desymlink_path(cf.get_path())))
+            .collect::<Vec<_>>();
+        if !configs.is_empty() {
+            config_groups.push(configs);
+        }
+    }
 
-    // Global config files keep independent task include sets. Aggregate their
-    // results high-to-low. When a lower config supplies the first inline
-    // definition for a script already rediscovered by a higher config, apply
-    // only that inline metadata to the higher script so its config context is
-    // preserved.
+    // Aggregate the user and system scopes high-to-low. When the lower scope
+    // supplies the first inline definition for a script rediscovered by the
+    // higher scope, apply only that inline metadata to the higher script so its
+    // config context is preserved.
     let mut tasks: IndexMap<String, Task> = IndexMap::new();
     let mut seen_config_task_names = BTreeSet::new();
     let mut rendered_file_tasks = RenderedTaskCache::default();
-    for cf in configs {
+    for configs in config_groups {
+        let config_root = configs
+            .first()
+            .expect("global config group should not be empty")
+            .config_root();
         let sources = load_task_sources_from_configs(
             config,
-            &cf.config_root(),
-            vec![cf],
+            &config_root,
+            configs,
             templates,
             false,
             None,
             Some(&mut rendered_file_tasks),
         )
         .await?;
-        rendered_file_tasks.finish_config();
+        rendered_file_tasks.finish_scope();
         let mut inline_tasks = IndexMap::new();
         for task in &sources.config_tasks {
             inline_tasks
@@ -4723,7 +4730,7 @@ impl RenderedTaskCache {
         self.current_config.insert(key, task);
     }
 
-    fn finish_config(&mut self) {
+    fn finish_scope(&mut self) {
         for (key, task) in self.current_config.drain() {
             self.previous_configs.entry(key).or_insert(task);
         }
@@ -4776,9 +4783,9 @@ async fn load_tasks_from_configs(
 
 /// Load file and inline task sources without merging them.
 ///
-/// Global configs use this boundary because each config has independent file
-/// includes, while inline metadata may still need to decorate a script selected
-/// from a higher-precedence config.
+/// Global user and system scopes use this boundary because inline metadata from
+/// the lower scope may still need to decorate a script selected from the
+/// higher-precedence scope.
 async fn load_task_sources_from_configs(
     config: &Arc<Config>,
     dir: &Path,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3969,10 +3969,10 @@ fn discover_monorepo_subdirs(
 }
 
 async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) -> Result<Vec<Task>> {
-    // User-global config overrides system config. Compose each group as one
-    // config scope so task_config fields follow the same override semantics as
-    // local config files. Keep the groups separate so a user include does not
-    // remove tasks provided by the system config.
+    // Compose user-global and system configs as separate scopes so task_config
+    // fields follow the same override semantics as local config files. Load the
+    // user scope first so a user task replaces a same-named system task without
+    // inheriting metadata from it.
     let mut seen_configs = BTreeSet::new();
     let mut config_groups = vec![];
     for config_paths in [global_config_files(), system_config_files()] {
@@ -3996,12 +3996,10 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
         }
     }
 
-    // Aggregate the user and system scopes high-to-low. When the lower scope
-    // supplies the first inline definition for a script rediscovered by the
-    // higher scope, apply only that inline metadata to the higher script so its
-    // config context is preserved.
+    // Aggregate the user and system scopes high-to-low. Each scope has already
+    // composed its file and inline tasks, so precedence between scopes is a
+    // simple first-wins replacement by task name.
     let mut tasks: IndexMap<String, Task> = IndexMap::new();
-    let mut seen_config_task_names = BTreeSet::new();
     let mut rendered_file_tasks = RenderedTaskCache::default();
     for configs in config_groups {
         let config_root = configs
@@ -4019,30 +4017,8 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
         )
         .await?;
         rendered_file_tasks.finish_scope();
-        let mut inline_tasks = IndexMap::new();
-        for task in &sources.config_tasks {
-            inline_tasks
-                .entry(task.name.clone())
-                .or_insert_with(|| task.clone());
-        }
-        let loaded = sources.into_tasks();
-        for task in loaded {
-            if let Some(inline_task) = inline_tasks.get(&task.name) {
-                if seen_config_task_names.insert(task.name.clone()) {
-                    if let Some(existing) = tasks.get_mut(&task.name) {
-                        let rediscovered_file = resolved_task_file(existing)
-                            .zip(resolved_task_file(&task))
-                            .is_some_and(|(left, right)| file::same_file(&left, &right));
-                        if rediscovered_file {
-                            existing.merge_toml_overlay(inline_task.clone());
-                        }
-                    } else {
-                        tasks.insert(task.name.clone(), task);
-                    }
-                }
-            } else {
-                tasks.entry(task.name.clone()).or_insert(task);
-            }
+        for task in sources.into_tasks() {
+            tasks.entry(task.name.clone()).or_insert(task);
         }
     }
     Ok(tasks.into_values().collect())
@@ -4783,9 +4759,8 @@ async fn load_tasks_from_configs(
 
 /// Load file and inline task sources without merging them.
 ///
-/// Global user and system scopes use this boundary because inline metadata from
-/// the lower scope may still need to decorate a script selected from the
-/// higher-precedence scope.
+/// Global user and system scopes use this boundary so they can share rendered
+/// file tasks without merging task definitions across the scope boundary.
 async fn load_task_sources_from_configs(
     config: &Arc<Config>,
     dir: &Path,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4012,7 +4012,7 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
             Some(&mut rendered_file_tasks),
         )
         .await?;
-        rendered_file_tasks.finish_scope();
+        rendered_file_tasks.finish_config();
         for task in sources.into_tasks() {
             tasks.entry(task.name.clone()).or_insert(task);
         }
@@ -4685,8 +4685,8 @@ fn cascaded_task_config_for_dir(
 
 #[derive(Default)]
 struct RenderedTaskCache {
-    previous_scopes: HashMap<(PathBuf, String), Task>,
-    current_scope: HashMap<(PathBuf, String), Task>,
+    previous_configs: HashMap<(PathBuf, String), Task>,
+    current_config: HashMap<(PathBuf, String), Task>,
 }
 
 fn rendered_task_cache_key(task: &Task) -> (PathBuf, String) {
@@ -4695,16 +4695,16 @@ fn rendered_task_cache_key(task: &Task) -> (PathBuf, String) {
 
 impl RenderedTaskCache {
     fn get(&self, key: &(PathBuf, String)) -> Option<&Task> {
-        self.previous_scopes.get(key)
+        self.previous_configs.get(key)
     }
 
     fn insert(&mut self, key: (PathBuf, String), task: Task) {
-        self.current_scope.insert(key, task);
+        self.current_config.insert(key, task);
     }
 
-    fn finish_scope(&mut self) {
-        for (key, task) in self.current_scope.drain() {
-            self.previous_scopes.entry(key).or_insert(task);
+    fn finish_config(&mut self) {
+        for (key, task) in self.current_config.drain() {
+            self.previous_configs.entry(key).or_insert(task);
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4689,8 +4689,8 @@ fn cascaded_task_config_for_dir(
 
 #[derive(Default)]
 struct RenderedTaskCache {
-    previous_configs: HashMap<(PathBuf, String), Task>,
-    current_config: HashMap<(PathBuf, String), Task>,
+    previous_scopes: HashMap<(PathBuf, String), Task>,
+    current_scope: HashMap<(PathBuf, String), Task>,
 }
 
 fn rendered_task_cache_key(task: &Task) -> (PathBuf, String) {
@@ -4699,16 +4699,16 @@ fn rendered_task_cache_key(task: &Task) -> (PathBuf, String) {
 
 impl RenderedTaskCache {
     fn get(&self, key: &(PathBuf, String)) -> Option<&Task> {
-        self.previous_configs.get(key)
+        self.previous_scopes.get(key)
     }
 
     fn insert(&mut self, key: (PathBuf, String), task: Task) {
-        self.current_config.insert(key, task);
+        self.current_scope.insert(key, task);
     }
 
     fn finish_scope(&mut self) {
-        for (key, task) in self.current_config.drain() {
-            self.previous_configs.entry(key).or_insert(task);
+        for (key, task) in self.current_scope.drain() {
+            self.previous_scopes.entry(key).or_insert(task);
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4002,13 +4002,9 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
     let mut tasks: IndexMap<String, Task> = IndexMap::new();
     let mut rendered_file_tasks = RenderedTaskCache::default();
     for configs in config_groups {
-        let config_root = configs
-            .first()
-            .expect("global config group should not be empty")
-            .config_root();
         let sources = load_task_sources_from_configs(
             config,
-            &config_root,
+            &env::MISE_GLOBAL_CONFIG_ROOT,
             configs,
             templates,
             false,


### PR DESCRIPTION
This intentionally changes two legacy additive behaviors in global task loading: independently loaded `task_config.includes` per fragment, and system task metadata decorating a user-global task. If either compatibility break is not acceptable without deprecation, I will revise the approach.

## Summary

- compose user-global task configuration files as one precedence scope
- compose system task configuration files as a separate precedence scope
- use the highest-precedence `task_config.includes` within each scope instead of aggregating every include set
- make user-global tasks cleanly replace same-named system tasks without inheriting system metadata
- keep differently named system tasks available

## Behavior changes

### Global config fragments

Global config files currently load their task include sets independently. A lower-precedence `conf.d` fragment can therefore keep contributing tasks even when a higher-precedence `config.toml` defines a replacement `task_config.includes` list.

For example, if `config.toml` includes `~/dotfiles/tasks` and `conf.d/machine.toml` includes `~/machine/tasks`, the old loader discovers tasks from both directories. This PR uses only the higher-precedence include list. Users who want both directories should list both in the higher-precedence config.

Because the files now compose like project-local fragments, a lower-precedence same-name `[tasks.*]` block can still decorate a file task selected by the effective include list. Its metadata such as `env` applies to that selected script; an alternate `file` value in the inline block does not replace the selected file-task base or get evaluated merely for source comparison.

### User and system scopes

The old loader can also apply lower-precedence system inline metadata to a user-global task when both scopes discover the same physical script. For example, a system `[tasks.build] env = { TARGET = "system" }` block can modify the `build` script selected by the user-global config.

This PR treats the scope boundary as replacement instead: the user-global `build` task wins unchanged. System tasks with other names remain available.

This PR is limited to global task-scope composition. It does not change HOME-local ancestor traversal or duplicate-source ownership.

## Maintainer question

@jdx, is it acceptable to make these behavior changes immediately without a deprecation period?

I am sorry that I previously retained the independently loaded global behavior without reconsidering the overall configuration semantics carefully, and then documented it in #8905. Your earlier suggestion in #8740 to make global tasks use the same override semantics as local tasks was the cleaner direction. I also found that system-to-user task decoration was an incidental consequence of the generic aggregation introduced in #11103 rather than a separately designed policy.

If an immediate change is not acceptable, I will revise the approach based on your preference.

## Testing

- `mise run lint-fix`
- `mise run test:e2e e2e/tasks/test_task_global_config_dedup e2e/tasks/test_task_ls_global`
- `mise run test:e2e e2e/tasks/test_task_source_comparison_no_exec`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Global task configurations maintain separate user and system scopes.
  - User-defined tasks with matching names replace system tasks without inheriting their metadata.
  - Differently named system tasks remain available.
  - Relative task includes resolve within their configured scope.
  - Same-name task definitions can compose across global fragments, with higher-priority files determining execution and lower-priority definitions contributing supported metadata.

- **Bug Fixes**
  - Prevented unintended metadata inheritance between task scopes.
  - Preserved predictable ordering when multiple includes appear in the same configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->