### PR TITLE
registry: add hugo-extended-withdeploy (aqua:gohugoio/hugo/hugo-extended-withdeploy)

### DIFF
--- a/registry/hugo-extended-withdeploy.toml
+++ b/registry/hugo-extended-withdeploy.toml
@@ -1,0 +1,5 @@
+backends = ["aqua:gohugoio/hugo/hugo-extended-withdeploy"]
+bins = ["hugo"]
+description = "The world’s fastest framework for building websites"
+test = { cmd = "hugo version | sed -E 's/-[0-9a-f]+//'", expected = "hugo v{{version}}+extended+withdeploy" }
+version_order = "source"


### PR DESCRIPTION
This PR adds the `hugo-extended-withdeploy` tool to the registry. The `+withdeploy` variant was introduced in Hugo [v0.137.0](https://github.com/gohugoio/hugo/releases/tag/v0.137.0), released on Nov 4, 2024.

The Hugo GitHub repo star count at the time of writing is 89.5k.

Full disclosure: I added the `+withdeploy` package a few days ago https://github.com/aquaproj/aqua-registry/pull/59006. Before that, you couldn't use aqua or mise to get a recent version of Hugo that could deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added registry support for Hugo Extended with Deploy.
- Configured its Aqua backend, executable, description, and source-based version ordering.
- Improved version recognition by handling commit-hash suffixes and identifying extended-withdeploy releases correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->