### PR TITLE
perf(search): avoid allocating aqua registry ids

### DIFF
--- a/src/aqua/standard_registry.rs
+++ b/src/aqua/standard_registry.rs
@@ -23,9 +23,9 @@ static AQUA_STANDARD_REGISTRY_ALIASES: phf::Map<&'static str, &'static str> = in
     "/aqua_standard_registry_aliases.rs"
 ));
 
-/// Returns all package IDs from the baked-in aqua registry.
-pub fn package_ids() -> Vec<&'static str> {
-    AQUA_STANDARD_REGISTRY_FILES.keys().copied().collect()
+/// Returns all package IDs from the baked-in Aqua registry without allocating a collection.
+pub fn package_ids() -> impl Iterator<Item = &'static str> {
+    AQUA_STANDARD_REGISTRY_FILES.keys().copied()
 }
 
 pub fn package(package_id: &str) -> Option<Result<AquaPackage>> {

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -161,10 +161,8 @@ impl Search {
         }
 
         crate::aqua::standard_registry::package_ids()
-            .into_iter()
-            .map(|s| s.to_string())
             .filter_map(|id| {
-                let tool_name = id.rsplit_once('/').map_or(id.as_str(), |(_, name)| name);
+                let tool_name = id.rsplit_once('/').map_or(id, |(_, name)| name);
                 let score = match self.match_type {
                     MatchType::Equal => {
                         if tool_name == name || id == name || format!("aqua:{id}") == name {
@@ -185,11 +183,7 @@ impl Search {
                     }
                 }?;
 
-                Some((
-                    score,
-                    format!("aqua:{id}"),
-                    get_aqua_description(id.as_str()),
-                ))
+                Some((score, format!("aqua:{id}"), get_aqua_description(id)))
             })
             .collect()
     }


### PR DESCRIPTION
## Summary
- return a borrowed iterator from the baked Aqua registry instead of allocating a `Vec` of every package ID
- consume borrowed package IDs directly in `mise search`
- preserve existing search and not-found behavior

This is the allocation-only prerequisite for #12225. It contains no Cargo/Go translation, generated override map, or GoBuild policy.

Related discussion: https://github.com/jdx/mise/discussions/12224

## Validation
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Improved package ID handling to reduce unnecessary allocations during Aqua searches.
  - Preserved existing search matching and result output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->