### PR TITLE
refactor(deps): centralize install dependency resolution

### DIFF
--- a/src/backend/asdf.rs
+++ b/src/backend/asdf.rs
@@ -434,8 +434,9 @@ impl Backend for AsdfBackend {
         // on the first install (#4384). Keep the existing active-tool paths after the
         // dependencies for compatibility, and preserve each toolset's path order.
         let dependency_paths = self
-            .install_dependency_toolset(&ctx.config, &tv)
+            .install_dependency_context(ctx, &tv)
             .await?
+            .toolset
             .list_paths(&ctx.config)
             .await;
         let active_paths = ctx.ts.list_paths(&ctx.config).await;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3248,7 +3248,7 @@ pub trait Backend: Debug + Send + Sync {
         // "{{ tools.python.path }}/bin/python3"`) for the tool-level `postinstall`
         // hook, resolved against this tool's already-installed dependencies. The
         // config env added above is resolved without tools (`NonToolsOnly`), so it
-        // omits these; `install_dependency_toolset` is fully resolved (offline) so
+        // omits these; `install_dependency_context` is fully resolved (offline) so
         // `{{ tools.<dep>.path }}` maps to a real install path — `ctx.ts` is the raw,
         // unresolved install toolset during a combined install. PATH stays owned by
         // `path_env` below. Best-effort: any resolution error leaves the tool-less

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3273,11 +3273,8 @@ pub trait Backend: Debug + Send + Sync {
                 .is_some_and(|deps| !deps.is_empty());
         if declares_deps {
             let base = env_vars.clone();
-            let tool_vals = match self
-                .install_dependency_toolset(&ctx.config, &tv_exact)
-                .await
-            {
-                Ok(dep_ts) => dep_ts.tool_val_env(&ctx.config, &base).await,
+            let tool_vals = match self.install_dependency_context(ctx, &tv_exact).await {
+                Ok(dependencies) => dependencies.toolset.tool_val_env(&ctx.config, &base).await,
                 Err(e) => Err(e),
             };
             match tool_vals {
@@ -3597,47 +3594,12 @@ pub trait Backend: Debug + Send + Sync {
         Ok(ts)
     }
 
-    /// Like [`Self::dependency_toolset`] but also includes this tool's per-instance
-    /// mise.toml `depends` option (`tv.request.options().depends`). `get_dependencies`
-    /// only covers backend/plugin-metadata deps, so a user-declared
-    /// `gcloud = { depends = ["python"] }` is invisible to `dependency_toolset`.
-    /// Used anywhere an install needs the concrete paths or values of its declared
-    /// dependencies, including `tools = true` `[env]` value templates and asdf
-    /// install scripts. Resolved offline; the declared deps are installed before the
-    /// dependent (depends ordering), so their install paths are present. (#10282,
-    /// #4384)
-    async fn install_dependency_toolset(
+    async fn install_dependency_context<'a>(
         &self,
-        config: &Arc<Config>,
+        ctx: &'a InstallContext,
         tv: &ToolVersion,
-    ) -> eyre::Result<Toolset> {
-        let mut names: std::collections::HashSet<String> = self
-            .get_all_dependencies(true)?
-            .into_iter()
-            .map(|ba| ba.short)
-            .collect();
-        let opts = tv.request.options();
-        if let Some(user_deps) = opts.core.depends {
-            names.extend(
-                user_deps
-                    .into_iter()
-                    .flat_map(|dep| BackendArg::from(dep).all_fulls()),
-            );
-        }
-        let mut ts: Toolset = config
-            .get_tool_request_set()
-            .await?
-            .filter_by_tool(names)
-            .into();
-        ts.resolve_with_opts(
-            config,
-            &ResolveOptions {
-                offline: true,
-                ..Default::default()
-            },
-        )
-        .await?;
-        Ok(ts)
+    ) -> eyre::Result<&'a crate::install_context::InstallDependencyContext> {
+        ctx.dependency_context(&tv.request).await
     }
 
     async fn dependency_which(&self, config: &Arc<Config>, bin: &str) -> Option<PathBuf> {

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -660,6 +660,7 @@ impl PIPXBackend {
                 dry_run: false,
                 locked: false,
                 before_date: None,
+                dependency_context: Default::default(),
             };
             b.install_version(ctx, tv).await?;
         }

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -294,8 +294,8 @@ impl Backend for VfoxBackend {
         // `dependency_env`. (#10282, follow-up to #10432)
         {
             let base: EnvMap = cmd_env.clone().into_iter().collect();
-            let tool_vals = match self.install_dependency_toolset(&ctx.config, &tv).await {
-                Ok(dep_ts) => dep_ts.tool_val_env(&ctx.config, &base).await,
+            let tool_vals = match self.install_dependency_context(ctx, &tv).await {
+                Ok(dependencies) => dependencies.toolset.tool_val_env(&ctx.config, &base).await,
                 Err(e) => Err(e),
             };
             match tool_vals {

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -285,7 +285,7 @@ impl Backend for VfoxBackend {
         // ctx.ts: ctx.ts is the raw install toolset (`Toolset::from(ToolRequestSet)`)
         // whose `.versions` are empty until `resolve()` runs *after* installs, so its
         // `tools.*` tera map is empty and `{{ tools.python.path }}` would render "".
-        // `install_dependency_toolset` is resolved offline and includes both backend deps
+        // `install_dependency_context` is resolved offline and includes both backend deps
         // and the per-tool mise.toml `depends` option (`gcloud = { depends =
         // ["python"] }`) with real install paths, and is install-safe (it uses
         // `get_tool_request_set()`, not the deadlock-prone `config.get_toolset()`).

--- a/src/cli/install_into.rs
+++ b/src/cli/install_into.rs
@@ -13,6 +13,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
+use tokio::sync::OnceCell;
 
 /// Install a tool version to a specific path
 ///
@@ -59,6 +60,7 @@ impl InstallInto {
             dry_run: false,
             locked: false, // install-into doesn't support locked mode
             before_date,
+            dependency_context: OnceCell::new(),
         };
         tv.install_path = Some(install_path.clone());
         tv.install_path_is_exact = true;

--- a/src/install_context.rs
+++ b/src/install_context.rs
@@ -133,11 +133,13 @@ impl InstallDependencyContext {
             requests,
             toolset,
         };
+        debug_assert_eq!(context.requests.tools.len(), context.toolset.versions.len());
         debug_assert!(
             context
-                .requests
-                .iter()
-                .all(|(ba, ..)| context.declarations.matches(ba))
+                .toolset
+                .versions
+                .keys()
+                .all(|backend| context.declarations.matches(backend))
         );
         Ok(context)
     }
@@ -152,10 +154,13 @@ pub struct InstallContext {
     /// require lockfile URLs to be present; fail if not
     pub locked: bool,
     pub before_date: Option<Timestamp>,
+    /// One install context belongs to exactly one tool request, so this cache is
+    /// intentionally unkeyed. Every caller must use that same request.
     pub(crate) dependency_context: OnceCell<InstallDependencyContext>,
 }
 
 impl InstallContext {
+    /// Resolve the dependency context for this install's single tool request.
     pub(crate) async fn dependency_context(
         &self,
         request: &ToolRequest,
@@ -243,5 +248,21 @@ mod tests {
         declarations.validate().unwrap();
         assert!(!declarations.matches(&BackendArg::from("cargo-binstall")));
         assert_eq!(names(&declarations), vec!["rust", "sccache"]);
+    }
+
+    #[tokio::test]
+    async fn metadata_errors_preserve_direct_dependencies() {
+        let _config = Config::get().await.unwrap();
+        let declarations =
+            install_dependency_declarations(&request("unknown:example", r#"depends=["node"]"#));
+        assert!(declarations.validate().is_err());
+        assert_eq!(names(&declarations), vec!["node"]);
+        assert_eq!(
+            declarations
+                .direct()
+                .map(|(raw, _)| raw)
+                .collect::<Vec<_>>(),
+            vec!["node"]
+        );
     }
 }

--- a/src/install_context.rs
+++ b/src/install_context.rs
@@ -1,9 +1,147 @@
 use std::sync::Arc;
 
+use eyre::{Result, eyre};
+use indexmap::IndexSet;
 use jiff::Timestamp;
+use tokio::sync::OnceCell;
 
+use crate::cli::args::BackendArg;
 use crate::ui::progress_report::SingleReport;
-use crate::{config::Config, toolset::Toolset};
+use crate::{
+    config::Config,
+    toolset::{ResolveOptions, ToolRequest, ToolRequestSet, Toolset},
+};
+
+/// The normalized dependency declarations that apply while installing one tool.
+///
+/// Backend/plugin dependencies (including optional and recursive dependencies) and
+/// direct per-tool `depends` entries share one ordered, deduplicated collection.
+/// Matching uses `BackendArg::all_fulls`, just like install scheduling, so aliases
+/// and explicit backend identities select the same configured tools.
+#[derive(Debug, Default)]
+pub(crate) struct InstallDependencyDeclarations {
+    dependencies: IndexSet<BackendArg>,
+    direct: Vec<(String, BackendArg)>,
+    metadata_error: Option<String>,
+}
+
+impl InstallDependencyDeclarations {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &BackendArg> {
+        self.dependencies.iter()
+    }
+
+    pub(crate) fn direct(&self) -> impl Iterator<Item = (&str, &BackendArg)> {
+        self.direct.iter().map(|(raw, ba)| (raw.as_str(), ba))
+    }
+
+    pub(crate) fn matches(&self, candidate: &BackendArg) -> bool {
+        self.dependencies
+            .iter()
+            .any(|dependency| backend_args_match(dependency, candidate))
+    }
+
+    fn validate(&self) -> Result<()> {
+        match &self.metadata_error {
+            Some(err) => Err(eyre!(err.clone())),
+            None => Ok(()),
+        }
+    }
+
+    fn insert(&mut self, target: &BackendArg, dependency: BackendArg) {
+        if backend_args_match(target, &dependency)
+            || self
+                .dependencies
+                .iter()
+                .any(|existing| backend_args_match(existing, &dependency))
+        {
+            return;
+        }
+        self.dependencies.insert(dependency);
+    }
+
+    fn matching_requests(&self, requests: &ToolRequestSet) -> ToolRequestSet {
+        requests
+            .iter()
+            .filter(|(ba, ..)| self.matches(ba))
+            .map(|(ba, requests, source)| (ba.clone(), requests.clone(), source.clone()))
+            .collect()
+    }
+}
+
+fn backend_args_match(left: &BackendArg, right: &BackendArg) -> bool {
+    let left = left.all_fulls();
+    let right = right.all_fulls();
+    left.iter().any(|identity| right.contains(identity))
+}
+
+/// Compute all install-time dependency declarations for a request.
+///
+/// The returned collection always includes direct user declarations. A backend
+/// metadata error is retained so strict consumers can propagate it while the install
+/// graph can preserve its historical behavior of ignoring that error.
+pub(crate) fn install_dependency_declarations(
+    request: &ToolRequest,
+) -> InstallDependencyDeclarations {
+    let mut declarations = InstallDependencyDeclarations::default();
+    match request
+        .backend()
+        .and_then(|backend| backend.get_all_dependencies(true))
+    {
+        Ok(dependencies) => {
+            for dependency in dependencies {
+                declarations.insert(request.ba(), dependency);
+            }
+        }
+        Err(err) => declarations.metadata_error = Some(format!("{err:#}")),
+    }
+
+    if let Some(dependencies) = request.options().core.depends {
+        for raw in dependencies {
+            let dependency = BackendArg::from(raw.as_str());
+            declarations.direct.push((raw, dependency.clone()));
+            declarations.insert(request.ba(), dependency);
+        }
+    }
+    declarations
+}
+
+/// The configured and offline-resolved view of one tool's install dependencies.
+#[derive(Debug)]
+pub(crate) struct InstallDependencyContext {
+    pub(crate) declarations: InstallDependencyDeclarations,
+    pub(crate) requests: ToolRequestSet,
+    pub(crate) toolset: Toolset,
+}
+
+impl InstallDependencyContext {
+    async fn resolve(config: &Arc<Config>, request: &ToolRequest) -> Result<Self> {
+        let declarations = install_dependency_declarations(request);
+        declarations.validate()?;
+        let requests = declarations.matching_requests(config.get_tool_request_set().await?);
+        let mut toolset: Toolset = requests.clone().into();
+        toolset
+            .resolve_with_opts(
+                config,
+                &ResolveOptions {
+                    offline: true,
+                    ..Default::default()
+                },
+            )
+            .await?;
+        let context = Self {
+            declarations,
+            requests,
+            toolset,
+        };
+        debug_assert!(
+            context
+                .requests
+                .iter()
+                .all(|(ba, ..)| context.declarations.matches(ba))
+        );
+        Ok(context)
+    }
+}
 
 pub struct InstallContext {
     pub config: Arc<Config>,
@@ -14,4 +152,96 @@ pub struct InstallContext {
     /// require lockfile URLs to be present; fail if not
     pub locked: bool,
     pub before_date: Option<Timestamp>,
+    pub(crate) dependency_context: OnceCell<InstallDependencyContext>,
+}
+
+impl InstallContext {
+    pub(crate) async fn dependency_context(
+        &self,
+        request: &ToolRequest,
+    ) -> Result<&InstallDependencyContext> {
+        self.dependency_context
+            .get_or_try_init(|| InstallDependencyContext::resolve(&self.config, request))
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::toolset::{ToolSource, parse_tool_options};
+
+    fn request(tool: &str, options: &str) -> ToolRequest {
+        ToolRequest::new_opts(
+            Arc::new(BackendArg::from(tool)),
+            "1.0.0",
+            parse_tool_options(options),
+            ToolSource::Argument,
+        )
+        .unwrap()
+    }
+
+    fn names(declarations: &InstallDependencyDeclarations) -> Vec<String> {
+        declarations.iter().map(|ba| ba.short.clone()).collect()
+    }
+
+    #[tokio::test]
+    async fn backend_dependencies_include_required_optional_and_recursive_collection() {
+        let _config = Config::get().await.unwrap();
+        let declarations = install_dependency_declarations(&request("cargo:eza", ""));
+        declarations.validate().unwrap();
+        let names = names(&declarations);
+        assert!(names.contains(&"rust".to_string()));
+        assert!(names.contains(&"cargo-binstall".to_string()));
+        assert!(names.contains(&"sccache".to_string()));
+    }
+
+    #[tokio::test]
+    async fn per_tool_dependencies_are_included() {
+        let _config = Config::get().await.unwrap();
+        let declarations = install_dependency_declarations(&request(
+            "http:example",
+            r#"depends=["node","python"]"#,
+        ));
+        declarations.validate().unwrap();
+        assert_eq!(names(&declarations), vec!["node", "python"]);
+    }
+
+    #[tokio::test]
+    async fn backend_and_per_tool_dependencies_are_unioned_deterministically() {
+        let _config = Config::get().await.unwrap();
+        let declarations = install_dependency_declarations(&request(
+            "cargo:eza",
+            r#"depends=["python","rust","python"]"#,
+        ));
+        declarations.validate().unwrap();
+        assert_eq!(
+            names(&declarations),
+            vec!["rust", "cargo-binstall", "sccache", "python"]
+        );
+    }
+
+    #[tokio::test]
+    async fn aliases_and_full_backend_identities_are_deduplicated() {
+        let _config = Config::get().await.unwrap();
+        let declarations = install_dependency_declarations(&request(
+            "http:example",
+            r#"depends=["nodejs","node","core:node"]"#,
+        ));
+        declarations.validate().unwrap();
+        assert_eq!(names(&declarations), vec!["node"]);
+        assert!(declarations.matches(&BackendArg::from("core:node")));
+    }
+
+    #[tokio::test]
+    async fn self_dependencies_are_removed_across_aliases() {
+        let _config = Config::get().await.unwrap();
+        let declarations = install_dependency_declarations(&request(
+            "cargo:cargo-binstall",
+            r#"depends=["cargo-binstall","cargo:cargo-binstall"]"#,
+        ));
+        declarations.validate().unwrap();
+        assert!(!declarations.matches(&BackendArg::from("cargo-binstall")));
+        assert_eq!(names(&declarations), vec!["rust", "sccache"]);
+    }
 }

--- a/src/install_context.rs
+++ b/src/install_context.rs
@@ -257,12 +257,5 @@ mod tests {
             install_dependency_declarations(&request("unknown:example", r#"depends=["node"]"#));
         assert!(declarations.validate().is_err());
         assert_eq!(names(&declarations), vec!["node"]);
-        assert_eq!(
-            declarations
-                .direct()
-                .map(|(raw, _)| raw)
-                .collect::<Vec<_>>(),
-            vec!["node"]
-        );
     }
 }

--- a/src/toolset/tool_deps.rs
+++ b/src/toolset/tool_deps.rs
@@ -1,10 +1,8 @@
-use std::collections::HashSet;
-
 use eyre::{Result, bail};
 use tokio::sync::mpsc;
 
-use crate::cli::args::BackendArg;
 use crate::deps_graph::DepsGraph;
+use crate::install_context::install_dependency_declarations;
 use crate::toolset::tool_request::ToolRequest;
 
 /// Unique key for a tool request (tool short name + version).
@@ -58,59 +56,39 @@ impl ToolDeps {
             .map(|tr| (tool_key(tr), tr.clone()))
             .collect();
 
-        // Build a set of all tool identifiers being installed for dependency lookup
-        let versions_hash: HashSet<String> =
-            requests.iter().flat_map(|tr| tr.ba().all_fulls()).collect();
-
-        // Compute edges from backend dependencies
+        // Compute edges from the shared backend/plugin and per-tool declarations.
+        // Metadata errors remain ignored here, matching the scheduler's historical
+        // behavior; strict consumers validate the same declaration object.
         let mut edges: Vec<(ToolKey, ToolKey)> = vec![];
         for tr in &requests {
             let tr_key = tool_key(tr);
-
-            if let Ok(backend) = tr.backend()
-                && let Ok(deps) = backend.get_all_dependencies(true)
-            {
-                for dep_ba in deps {
-                    let dep_fulls = dep_ba.all_fulls();
-                    if dep_fulls.iter().any(|full| versions_hash.contains(full)) {
-                        for other_tr in &requests {
-                            let other_fulls = other_tr.ba().all_fulls();
-                            if dep_fulls.iter().any(|f| other_fulls.contains(f)) {
-                                let other_key = tool_key(other_tr);
-                                if tr_key != other_key {
-                                    edges.push((tr_key.clone(), other_key));
-                                }
-                            }
+            let declarations = install_dependency_declarations(tr);
+            for dependency in declarations.iter() {
+                for other_tr in &requests {
+                    if dependency
+                        .all_fulls()
+                        .iter()
+                        .any(|identity| other_tr.ba().all_fulls().contains(identity))
+                    {
+                        let other_key = tool_key(other_tr);
+                        if tr_key != other_key {
+                            edges.push((tr_key.clone(), other_key));
                         }
                     }
                 }
             }
-        }
-
-        // Add edges from user-specified depends in tool options
-        for tr in &requests {
-            let tr_key = tool_key(tr);
-            if let Some(user_deps) = &tr.options().depends {
-                for dep_str in user_deps {
-                    let dep_ba = BackendArg::from(dep_str.as_str());
-                    let dep_fulls = dep_ba.all_fulls();
-                    let mut found = false;
-                    for other_tr in &requests {
-                        let other_fulls = other_tr.ba().all_fulls();
-                        if dep_fulls.iter().any(|f| other_fulls.contains(f)) {
-                            let other_key = tool_key(other_tr);
-                            if tr_key != other_key {
-                                edges.push((tr_key.clone(), other_key));
-                                found = true;
-                            }
-                        }
-                    }
-                    if !found {
-                        warn!(
-                            "tool '{}': depends on '{}' which is not in the current install set",
-                            tr_key, dep_str
-                        );
-                    }
+            for (raw, dependency) in declarations.direct() {
+                if !requests.iter().any(|other| {
+                    tr_key != tool_key(other)
+                        && dependency
+                            .all_fulls()
+                            .iter()
+                            .any(|identity| other.ba().all_fulls().contains(identity))
+                }) {
+                    warn!(
+                        "tool '{}': depends on '{}' which is not in the current install set",
+                        tr_key, raw
+                    );
                 }
             }
         }
@@ -145,6 +123,7 @@ mod tests {
     use super::*;
     use std::sync::Arc;
 
+    use crate::cli::args::BackendArg;
     use crate::config::Config;
     use crate::toolset::{CoreToolOptions, ToolSource, ToolVersionOptions, parse_tool_options};
 
@@ -254,6 +233,38 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("conflicting options for tiny@1.0.0")
+        );
+    }
+
+    fn request(tool: &str, options: &str) -> ToolRequest {
+        ToolRequest::new_opts(
+            Arc::new(BackendArg::from(tool)),
+            "1.0.0",
+            parse_tool_options(options),
+            ToolSource::Argument,
+        )
+        .unwrap()
+    }
+
+    fn assert_dependency_edge(dependent: ToolRequest, dependency: ToolRequest) {
+        let mut deps = ToolDeps::new(vec![dependent.clone(), dependency.clone()]).unwrap();
+        let mut rx = deps.subscribe();
+        assert_eq!(rx.try_recv().unwrap(), Some(dependency.clone()));
+        assert!(rx.try_recv().is_err());
+        deps.complete_success(&dependency);
+        assert_eq!(rx.try_recv().unwrap(), Some(dependent));
+    }
+
+    #[test]
+    fn backend_dependency_graph_edge_is_preserved() {
+        assert_dependency_edge(request("elixir", ""), request("erlang", ""));
+    }
+
+    #[test]
+    fn per_tool_dependency_graph_edge_is_preserved() {
+        assert_dependency_edge(
+            request("needs-dummy", "depends=dummy"),
+            request("dummy", ""),
         );
     }
 }

--- a/src/toolset/tool_deps.rs
+++ b/src/toolset/tool_deps.rs
@@ -255,13 +255,15 @@ mod tests {
         assert_eq!(rx.try_recv().unwrap(), Some(dependent));
     }
 
-    #[test]
-    fn backend_dependency_graph_edge_is_preserved() {
+    #[tokio::test]
+    async fn backend_dependency_graph_edge_is_preserved() {
+        let _config = Config::get().await.unwrap();
         assert_dependency_edge(request("elixir", ""), request("erlang", ""));
     }
 
-    #[test]
-    fn per_tool_dependency_graph_edge_is_preserved() {
+    #[tokio::test]
+    async fn per_tool_dependency_graph_edge_is_preserved() {
+        let _config = Config::get().await.unwrap();
         assert_dependency_edge(
             request("needs-dummy", "depends=dummy"),
             request("dummy", ""),

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use eyre::Result;
 use indexmap::IndexSet;
 use itertools::Itertools;
+use tokio::sync::OnceCell;
 use tokio::sync::{Mutex, Semaphore};
 use tokio::task::JoinSet;
 
@@ -585,6 +586,7 @@ impl Toolset {
             dry_run: opts.dry_run,
             locked: opts.locked || config.tool_config_locked(tr.source()),
             before_date,
+            dependency_context: OnceCell::new(),
         };
 
         backend.install_version(ctx, tv).await


### PR DESCRIPTION
## Summary
- centralize normalized backend/plugin and per-tool install dependency declarations
- add a reusable lazy install dependency context
- preserve existing scheduling, asdf PATH, vfox, and postinstall behavior

## Testing
- `mise run lint-fix`
- `mise run test:unit`
- `mise run test:e2e e2e/cli/test_tool_depends e2e/backend/test_asdf_install_dependency_path e2e/backend/test_vfox_install_tools_env_dep`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved dependency resolution during tool installation, including backend, direct, aliased, and recursive dependencies.
  * Dependencies are now ordered and deduplicated for more consistent installations.
  * Dependency results are cached and resolved offline when possible.
  * Direct dependencies remain available when metadata resolution fails.

* **Bug Fixes**
  * Self-dependencies are excluded, with improved validation of resolved versions.
  * Reinstall and post-install workflows now use consistent dependency resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->