### PR TITLE
fix(deps): unify install dependency environments

### DIFF
--- a/docs/dev-tools/backends/asdf.md
+++ b/docs/dev-tools/backends/asdf.md
@@ -86,4 +86,6 @@ python = "3.12"
 ```
 
 This allows an asdf plugin to invoke an executable supplied by another mise-managed tool during
-the same `mise install`.
+the same `mise install`. Other active mise tools are not added implicitly; declare every
+mise-managed install requirement with `depends`. Executables already available on the ambient
+system or configuration `PATH` remain available.

--- a/docs/dev-tools/backends/asdf.md
+++ b/docs/dev-tools/backends/asdf.md
@@ -76,8 +76,9 @@ Set environment variables for asdf plugin install scripts:
 
 ### Install dependencies
 
-Tools declared with the [`depends` option](/dev-tools/#tool-dependencies) are installed before the
-asdf tool and added to the `PATH` used by its `bin/download` and `bin/install` scripts:
+Matching tools selected in the same install operation and declared with the
+[`depends` option](/dev-tools/#tool-dependencies) are installed before the asdf tool. Their paths
+are added to the `PATH` used by its `bin/download` and `bin/install` scripts:
 
 ```toml
 [tools]
@@ -89,3 +90,6 @@ This allows an asdf plugin to invoke an executable supplied by another mise-mana
 the same `mise install`. Other active mise tools are not added implicitly; declare every
 mise-managed install requirement with `depends`. Executables already available on the ambient
 system or configuration `PATH` remain available.
+
+The `depends` option does not add or install a missing tool. A configured dependency must already
+be installed or selected in the same install operation.

--- a/docs/dev-tools/backends/vfox.md
+++ b/docs/dev-tools/backends/vfox.md
@@ -148,3 +148,16 @@ use these variables directly.
 [tools]
 "vfox:version-fox/vfox-cmake" = { version = "latest", install_env = { HTTPS_PROXY = "http://proxy.example" } }
 ```
+
+### Install dependencies
+
+Plugin authors should declare intrinsic install requirements with `PLUGIN.depends` in
+`metadata.lua`. Users can supplement those declarations with the
+[`depends` tool option](/dev-tools/#tool-dependencies). Matching configured tools from both
+sources share one install dependency context: they are ordered before the dependent and their
+paths and `tools = true` values are available to install hooks launched through `os.execute` or
+`cmd.exec`.
+
+Declarations do not configure or automatically install a tool. A matching configured dependency
+must resolve and be installed; an unconfigured dependency can still be supplied by the existing
+system or configuration `PATH`. `io.popen` does not receive this install environment.

--- a/docs/dev-tools/index.md
+++ b/docs/dev-tools/index.md
@@ -265,7 +265,7 @@ The `depends` field accepts either a single string or an array of strings:
 "pipx:ruff" = { version = "latest", depends = ["python", "pipx"] }
 ```
 
-User-specified `depends` adds ordering constraints and makes matching tools available to install hooks. Backend declarations such as vfox `PLUGIN.depends` and `[tools].depends` are combined into the same install dependency context.
+User-specified `[tools].depends` adds ordering constraints and makes matching tools available to install hooks. Backend declarations such as vfox `PLUGIN.depends` are combined with these user declarations in the same install dependency context.
 
 Dependency declarations do not add tools to the configuration or install them automatically. When a matching tool is configured, its selected version must resolve and already be installed (or finish successfully earlier in the same install batch). A declaration with no matching configured tool may still be satisfied by an executable on the existing system or configuration `PATH`.
 

--- a/docs/dev-tools/index.md
+++ b/docs/dev-tools/index.md
@@ -265,13 +265,13 @@ The `depends` field accepts either a single string or an array of strings:
 "pipx:ruff" = { version = "latest", depends = ["python", "pipx"] }
 ```
 
-User-specified `depends` adds ordering constraints for tools already in the current install set. Use it when one configured tool install must finish before another configured tool install starts, especially when installs would otherwise run in parallel.
+User-specified `depends` adds ordering constraints and makes matching tools available to install hooks. Backend declarations such as vfox `PLUGIN.depends` and `[tools].depends` are combined into the same install dependency context.
+
+Dependency declarations do not add tools to the configuration or install them automatically. When a matching tool is configured, its selected version must resolve and already be installed (or finish successfully earlier in the same install batch). A declaration with no matching configured tool may still be satisfied by an executable on the existing system or configuration `PATH`.
 
 ### vfox plugin hook dependencies
 
-`depends` in `[tools]` only adds install graph ordering. It does not by itself declare hook-time dependencies or add those tools to the `PATH` used while vfox install hooks run.
-
-For vfox plugins, declare install-hook tool requirements on the `PLUGIN` table in `metadata.lua`:
+Vfox plugin authors should declare requirements intrinsic to the plugin on the `PLUGIN` table in `metadata.lua`:
 
 ```lua
 PLUGIN = {
@@ -281,7 +281,7 @@ PLUGIN = {
 }
 ```
 
-Use tool names as they would appear in `mise.toml`. When matching tools are configured, mise uses those metadata entries to order current install jobs and to build the hook environment. See [Tool plugin development](/tool-plugin-development#_2-metadata-lua).
+Use tool names as they would appear in `mise.toml`. Users can supplement plugin declarations with `[tools].depends`; both forms affect install ordering, the `PATH` visible to `os.execute` and `cmd.exec`, and `tools = true` environment values. They do not affect `io.popen`. See [Tool plugin development](/tool-plugin-development#_2-metadata-lua).
 
 ## Caching and Performance
 

--- a/e2e/backend/test_asdf_install_dependency_path
+++ b/e2e/backend/test_asdf_install_dependency_path
@@ -53,8 +53,8 @@ mkdir -p "$ASDF_INSTALL_PATH/bin"
 cp "$ASDF_DOWNLOAD_PATH/dependency-path" "$ASDF_INSTALL_PATH/download-dependency-path"
 command -v node >"$ASDF_INSTALL_PATH/install-dependency-path"
 node install >/dev/null
-if command -v legacy-active >/dev/null 2>&1; then
-  legacy-active >"$ASDF_INSTALL_PATH/legacy-active-output"
+if command -v undeclared-active >/dev/null 2>&1; then
+  undeclared-active >"$ASDF_INSTALL_PATH/undeclared-active-output"
 fi
 printf '%s\n' "$PATH" >"$ASDF_INSTALL_PATH/install-path"
 cat >"$ASDF_INSTALL_PATH/bin/asdf-path-dependent" <<'SCRIPT'
@@ -86,36 +86,35 @@ assert "cat '$DEPENDENT_PATH/install-dependency-path'" "$DEPENDENCY_BIN"
 assert "tr ':' '\n' <'$DEPENDENT_PATH/install-path' | grep -Fxc '$(dirname "$DEPENDENCY_BIN")'" "1"
 assert "mise exec -- asdf-path-dependent" "installed"
 
-# Keep the asdf-only compatibility fallback for an already-installed active
-# tool that was not declared as a dependency.
-LEGACY_PLUGIN_DIR="$MISE_DATA_DIR/plugins/asdf-legacy-active"
-mkdir -p "$LEGACY_PLUGIN_DIR/bin"
-cat >"$LEGACY_PLUGIN_DIR/bin/list-all" <<'EOF'
+# An already-installed active tool is not exposed unless it is declared as an
+# install dependency or is already present on the ambient PATH.
+UNDECLARED_PLUGIN_DIR="$MISE_DATA_DIR/plugins/asdf-undeclared-active"
+mkdir -p "$UNDECLARED_PLUGIN_DIR/bin"
+cat >"$UNDECLARED_PLUGIN_DIR/bin/list-all" <<'EOF'
 #!/usr/bin/env bash
 echo 1.0.0
 EOF
-cat >"$LEGACY_PLUGIN_DIR/bin/install" <<'EOF'
+cat >"$UNDECLARED_PLUGIN_DIR/bin/install" <<'EOF'
 #!/usr/bin/env bash
 set -eu
 mkdir -p "$ASDF_INSTALL_PATH/bin"
-cat >"$ASDF_INSTALL_PATH/bin/legacy-active" <<'SCRIPT'
+cat >"$ASDF_INSTALL_PATH/bin/undeclared-active" <<'SCRIPT'
 #!/usr/bin/env bash
-echo legacy-active
+echo undeclared-active
 SCRIPT
-chmod +x "$ASDF_INSTALL_PATH/bin/legacy-active"
+chmod +x "$ASDF_INSTALL_PATH/bin/undeclared-active"
 EOF
-chmod +x "$LEGACY_PLUGIN_DIR/bin/list-all" "$LEGACY_PLUGIN_DIR/bin/install"
+chmod +x "$UNDECLARED_PLUGIN_DIR/bin/list-all" "$UNDECLARED_PLUGIN_DIR/bin/install"
 
-mise install asdf:legacy-active@1.0.0
+mise install asdf:undeclared-active@1.0.0
 cat >mise.toml <<'EOF'
 [tools]
 "asdf:asdf-path-dependent" = { version = "1.0.0", depends = ["nodejs"] }
 node = "1.0.0"
-"asdf:legacy-active" = "1.0.0"
+"asdf:undeclared-active" = "1.0.0"
 EOF
 rm -rf "$DEPENDENT_PATH"
-legacy_output="$(mise exec -- mise install asdf:asdf-path-dependent 2>&1)"
-assert_not_contains_text "$legacy_output" "deprecated"
+mise install asdf:asdf-path-dependent
 
 DEPENDENT_PATH="$(mise where asdf:asdf-path-dependent)"
-assert "cat '$DEPENDENT_PATH/legacy-active-output'" "legacy-active"
+assert_fail "test -f '$DEPENDENT_PATH/undeclared-active-output'"

--- a/e2e/backend/test_asdf_install_dependency_path
+++ b/e2e/backend/test_asdf_install_dependency_path
@@ -53,6 +53,9 @@ mkdir -p "$ASDF_INSTALL_PATH/bin"
 cp "$ASDF_DOWNLOAD_PATH/dependency-path" "$ASDF_INSTALL_PATH/download-dependency-path"
 command -v node >"$ASDF_INSTALL_PATH/install-dependency-path"
 node install >/dev/null
+if command -v legacy-active >/dev/null 2>&1; then
+  legacy-active >"$ASDF_INSTALL_PATH/legacy-active-output"
+fi
 printf '%s\n' "$PATH" >"$ASDF_INSTALL_PATH/install-path"
 cat >"$ASDF_INSTALL_PATH/bin/asdf-path-dependent" <<'SCRIPT'
 #!/usr/bin/env bash
@@ -82,3 +85,37 @@ assert "cat '$DEPENDENT_PATH/download-dependency-path'" "$DEPENDENCY_BIN"
 assert "cat '$DEPENDENT_PATH/install-dependency-path'" "$DEPENDENCY_BIN"
 assert "tr ':' '\n' <'$DEPENDENT_PATH/install-path' | grep -Fxc '$(dirname "$DEPENDENCY_BIN")'" "1"
 assert "mise exec -- asdf-path-dependent" "installed"
+
+# Keep the asdf-only compatibility fallback for an already-installed active
+# tool that was not declared as a dependency.
+LEGACY_PLUGIN_DIR="$MISE_DATA_DIR/plugins/asdf-legacy-active"
+mkdir -p "$LEGACY_PLUGIN_DIR/bin"
+cat >"$LEGACY_PLUGIN_DIR/bin/list-all" <<'EOF'
+#!/usr/bin/env bash
+echo 1.0.0
+EOF
+cat >"$LEGACY_PLUGIN_DIR/bin/install" <<'EOF'
+#!/usr/bin/env bash
+set -eu
+mkdir -p "$ASDF_INSTALL_PATH/bin"
+cat >"$ASDF_INSTALL_PATH/bin/legacy-active" <<'SCRIPT'
+#!/usr/bin/env bash
+echo legacy-active
+SCRIPT
+chmod +x "$ASDF_INSTALL_PATH/bin/legacy-active"
+EOF
+chmod +x "$LEGACY_PLUGIN_DIR/bin/list-all" "$LEGACY_PLUGIN_DIR/bin/install"
+
+mise install asdf:legacy-active@1.0.0
+cat >mise.toml <<'EOF'
+[tools]
+"asdf:asdf-path-dependent" = { version = "1.0.0", depends = ["nodejs"] }
+node = "1.0.0"
+"asdf:legacy-active" = "1.0.0"
+EOF
+rm -rf "$DEPENDENT_PATH"
+legacy_output="$(mise exec -- mise install asdf:asdf-path-dependent 2>&1)"
+assert_not_contains_text "$legacy_output" "deprecated"
+
+DEPENDENT_PATH="$(mise where asdf:asdf-path-dependent)"
+assert "cat '$DEPENDENT_PATH/legacy-active-output'" "legacy-active"

--- a/e2e/backend/test_vfox_install_tools_env_dep
+++ b/e2e/backend/test_vfox_install_tools_env_dep
@@ -16,6 +16,10 @@
 PLUGIN_DIR="$PWD/vfox-tools-env-dep"
 INSTALL_MARKER="$PWD/tools-env-install-marker"
 POSTINSTALL_MARKER="$PWD/tools-env-postinstall-marker"
+PLUGIN_DEP_MARKER="$PWD/plugin-dependency-marker"
+USER_DEP_MARKER="$PWD/user-dependency-marker"
+POSTINSTALL_EXEC_MARKER="$PWD/postinstall-dependency-marker"
+UNRELATED_MARKER="$PWD/unrelated-dependency-marker"
 
 mkdir -p "$PLUGIN_DIR/hooks"
 
@@ -26,6 +30,7 @@ PLUGIN.version = "0.1.0"
 PLUGIN.homepage = "https://example.com/tools-env-dep"
 PLUGIN.license = "MIT"
 PLUGIN.description = "tools=true dependency-path env test plugin"
+PLUGIN.depends = { "dummy" }
 LUA
 
 cat >"$PLUGIN_DIR/hooks/available.lua" <<'LUA'
@@ -48,6 +53,9 @@ LUA
 # env value, mirroring how vfox-gcloud runs its install.sh.
 cat >"$PLUGIN_DIR/hooks/post_install.lua" <<LUA
 function PLUGIN:PostInstall(ctx)
+	os.execute("dummy plugin > \"$PLUGIN_DEP_MARKER\"")
+	os.execute("per-tool-dep > \"$USER_DEP_MARKER\"")
+	os.execute("if command -v unrelated-sibling >/dev/null 2>&1; then echo exposed > \"$UNRELATED_MARKER\"; else echo hidden > \"$UNRELATED_MARKER\"; fi")
 	os.execute("printf '%s' \"\$MISE_TEST_TOOLS_PATH\" > \"$INSTALL_MARKER\"")
 end
 LUA
@@ -62,6 +70,26 @@ git -C "$PLUGIN_DIR" init
 git -C "$PLUGIN_DIR" add .
 git -C "$PLUGIN_DIR" -c user.name="mise" -c user.email="mise@example.com" commit -m "initial plugin"
 
+for dependency in per-tool-dep unrelated-sibling; do
+  dependency_plugin="$MISE_DATA_DIR/plugins/asdf-$dependency"
+  mkdir -p "$dependency_plugin/bin"
+  cat >"$dependency_plugin/bin/list-all" <<'EOF'
+#!/usr/bin/env bash
+echo 1.0.0
+EOF
+  cat >"$dependency_plugin/bin/install" <<EOF
+#!/usr/bin/env bash
+set -eu
+mkdir -p "\$ASDF_INSTALL_PATH/bin"
+cat >"\$ASDF_INSTALL_PATH/bin/$dependency" <<'SCRIPT'
+#!/usr/bin/env bash
+echo $dependency
+SCRIPT
+chmod +x "\$ASDF_INSTALL_PATH/bin/$dependency"
+EOF
+  chmod +x "$dependency_plugin/bin/list-all" "$dependency_plugin/bin/install"
+done
+
 # The vfox tool depends on `dummy`; the tools=true [env] value references the
 # dependency's resolved path. The tool-level `postinstall` writes the same value
 # to a second marker.
@@ -70,14 +98,16 @@ cat >mise.toml <<EOF
 unix_default_inline_shell_args = "sh -c"
 
 [tools]
+"vfox:file://$PLUGIN_DIR" = { version = "1.0.0", depends = ["asdf:per-tool-dep"], postinstall = "per-tool-dep > '$POSTINSTALL_EXEC_MARKER'; printf '%s' \"\$MISE_TEST_TOOLS_PATH\" > '$POSTINSTALL_MARKER'" }
 dummy = "1.0.0"
-"vfox:file://$PLUGIN_DIR" = { version = "1.0.0", depends = ["dummy"], postinstall = "printf '%s' \"\$MISE_TEST_TOOLS_PATH\" > \"$POSTINSTALL_MARKER\"" }
+"asdf:per-tool-dep" = "1.0.0"
+"asdf:unrelated-sibling" = "1.0.0"
 
 [env]
 MISE_TEST_TOOLS_PATH = { value = "{{ tools.dummy.path | default(value='') }}", tools = true }
 EOF
 
-mise install
+MISE_JOBS=4 mise install
 
 DUMMY_PATH="$(mise where dummy)"
 
@@ -85,3 +115,9 @@ DUMMY_PATH="$(mise where dummy)"
 assert "cat '$INSTALL_MARKER'" "$DUMMY_PATH"
 # tool-level postinstall hook saw the resolved dependency path (Step 2)
 assert "cat '$POSTINSTALL_MARKER'" "$DUMMY_PATH"
+# Plugin and user dependency declarations were unioned for vfox os.execute.
+assert_contains "cat '$PLUGIN_DEP_MARKER'" "This is Dummy 1.0.0"
+assert "cat '$USER_DEP_MARKER'" "per-tool-dep"
+assert "cat '$UNRELATED_MARKER'" "hidden"
+# The same per-tool dependency is callable from generic postinstall.
+assert "cat '$POSTINSTALL_EXEC_MARKER'" "per-tool-dep"

--- a/e2e/cli/test_install_postinstall_bin_path
+++ b/e2e/cli/test_install_postinstall_bin_path
@@ -23,3 +23,153 @@ else
   echo "Output: $output"
   exit 1
 fi
+
+create_dependency_plugin() {
+  local name="$1"
+  local list_paths_mode="$2"
+  local plugin_dir="$MISE_DATA_DIR/plugins/asdf-$name"
+  mkdir -p "$plugin_dir/bin"
+  cat >"$plugin_dir/bin/list-all" <<'EOF'
+#!/usr/bin/env bash
+echo 1.0.0
+EOF
+  cat >"$plugin_dir/bin/install" <<EOF
+#!/usr/bin/env bash
+set -eu
+mkdir -p "\$ASDF_INSTALL_PATH"
+touch "\$ASDF_INSTALL_PATH/installed"
+if [ "$list_paths_mode" = normal ]; then
+  mkdir -p "\$ASDF_INSTALL_PATH/bin"
+  cat >"\$ASDF_INSTALL_PATH/bin/$name" <<'SCRIPT'
+#!/usr/bin/env bash
+echo managed
+SCRIPT
+  chmod +x "\$ASDF_INSTALL_PATH/bin/$name"
+fi
+EOF
+  if [ "$list_paths_mode" = error ]; then
+    cat >"$plugin_dir/bin/list-bin-paths" <<'EOF'
+#!/usr/bin/env bash
+echo "list-bin-paths failed on purpose" >&2
+exit 1
+EOF
+  elif [ "$list_paths_mode" = zero ]; then
+    cat >"$plugin_dir/bin/list-bin-paths" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  fi
+  chmod +x "$plugin_dir/bin/"*
+}
+
+create_dependency_plugin strict-dependency normal
+mkdir -p "$HOME/bin"
+cat >"$HOME/bin/strict-dependency" <<'EOF'
+#!/usr/bin/env bash
+echo ambient
+EOF
+chmod +x "$HOME/bin/strict-dependency"
+export PATH="$HOME/bin:$PATH"
+
+# A configured dependency must be installed even when a same-named ambient
+# executable exists, and validation occurs before the target path is created.
+cat >mise.toml <<'EOF'
+[tools]
+dummy = { version = "1.0.0", depends = ["asdf:strict-dependency"] }
+"asdf:strict-dependency" = "1.0.0"
+EOF
+rm -rf "$MISE_DATA_DIR/installs/dummy/1.0.0"
+rm -rf "$MISE_DATA_DIR/installs/strict-dependency/1.0.0"
+assert_fail_contains "mise install dummy" "selected version is not installed"
+assert_fail_contains "mise install dummy" "mise install asdf:strict-dependency@1.0.0"
+assert_directory_not_exists "$MISE_DATA_DIR/installs/dummy/1.0.0"
+
+# Offline resolution failures are strict and also precede target mutation.
+cat >mise.toml <<'EOF'
+[tools]
+dummy = { version = "1.0.0", depends = ["asdf:strict-dependency"] }
+"asdf:strict-dependency" = "latest"
+EOF
+assert_fail_contains "mise install dummy" "failed to resolve configured install dependency"
+assert_directory_not_exists "$MISE_DATA_DIR/installs/dummy/1.0.0"
+
+# An unconfigured declaration can be satisfied by the existing system PATH.
+SYSTEM_MARKER="$PWD/system-dependency-marker"
+cat >"$HOME/bin/system-only-dependency" <<'EOF'
+#!/usr/bin/env bash
+echo system
+EOF
+chmod +x "$HOME/bin/system-only-dependency"
+cat >mise.toml <<EOF
+[tools]
+dummy = { version = "1.0.0", depends = ["system-only-dependency"], postinstall = "system-only-dependency > '$SYSTEM_MARKER'" }
+EOF
+rm -rf "$MISE_DATA_DIR/installs/dummy/1.0.0"
+mise install dummy
+assert "cat '$SYSTEM_MARKER'" "system"
+
+# Backend list-bin-paths errors from an installed dependency are fatal and name
+# both sides of the relationship.
+create_dependency_plugin path-error error
+mise install asdf:path-error@1.0.0
+cat >mise.toml <<'EOF'
+[tools]
+dummy = { version = "1.0.0", depends = ["asdf:path-error"] }
+"asdf:path-error" = "1.0.0"
+EOF
+rm -rf "$MISE_DATA_DIR/installs/dummy/1.0.0"
+assert_fail_contains "mise install dummy" "failed to list bin paths for install dependency"
+assert_fail_contains "mise install dummy" "dummy@1.0.0"
+assert_directory_not_exists "$MISE_DATA_DIR/installs/dummy/1.0.0"
+
+# An installed dependency may intentionally contribute no executable paths.
+create_dependency_plugin zero-paths zero
+mise install asdf:zero-paths@1.0.0
+cat >mise.toml <<'EOF'
+[tools]
+dummy = { version = "1.0.0", depends = ["asdf:zero-paths"] }
+"asdf:zero-paths" = "1.0.0"
+EOF
+rm -rf "$MISE_DATA_DIR/installs/dummy/1.0.0"
+mise install dummy
+assert_contains "mise ls --installed dummy" "1.0.0"
+
+# Generic postinstall PATH ordering is target, declared dependencies, then the
+# existing PATH, with the first exact occurrence winning.
+create_dependency_plugin path-order normal
+cat >"$MISE_DATA_DIR/plugins/asdf-path-order/bin/install" <<'EOF'
+#!/usr/bin/env bash
+set -eu
+mkdir -p "$ASDF_INSTALL_PATH/bin"
+cat >"$ASDF_INSTALL_PATH/bin/dummy" <<'SCRIPT'
+#!/usr/bin/env bash
+echo dependency-dummy
+SCRIPT
+cat >"$ASDF_INSTALL_PATH/bin/dependency-command" <<'SCRIPT'
+#!/usr/bin/env bash
+echo managed-dependency
+SCRIPT
+chmod +x "$ASDF_INSTALL_PATH/bin/dummy" "$ASDF_INSTALL_PATH/bin/dependency-command"
+EOF
+cat >"$HOME/bin/dummy" <<'EOF'
+#!/usr/bin/env bash
+echo ambient-dummy
+EOF
+cat >"$HOME/bin/dependency-command" <<'EOF'
+#!/usr/bin/env bash
+echo ambient-dependency
+EOF
+chmod +x "$HOME/bin/dummy" "$HOME/bin/dependency-command"
+mise install asdf:path-order@1.0.0
+
+TARGET_ORDER_MARKER="$PWD/target-order-marker"
+DEPENDENCY_ORDER_MARKER="$PWD/dependency-order-marker"
+cat >mise.toml <<EOF
+[tools]
+dummy = { version = "1.0.0", depends = ["asdf:path-order"], postinstall = "dummy > '$TARGET_ORDER_MARKER'; dependency-command > '$DEPENDENCY_ORDER_MARKER'" }
+"asdf:path-order" = "1.0.0"
+EOF
+rm -rf "$MISE_DATA_DIR/installs/dummy/1.0.0"
+mise install dummy
+assert_contains "cat '$TARGET_ORDER_MARKER'" "This is Dummy 1.0.0"
+assert "cat '$DEPENDENCY_ORDER_MARKER'" "managed-dependency"

--- a/e2e/cli/test_install_postinstall_bin_path
+++ b/e2e/cli/test_install_postinstall_bin_path
@@ -93,6 +93,25 @@ EOF
 assert_fail_contains "mise install dummy" "failed to resolve configured install dependency"
 assert_directory_not_exists "$MISE_DATA_DIR/installs/dummy/1.0.0"
 
+# A lockfile-resolved opaque version is resolved even when it has no dotted
+# release shape. If it is absent, report the actionable missing-install error.
+cat >mise.toml <<'EOF'
+[tools]
+dummy = { version = "1.0.0", depends = ["asdf:strict-dependency"] }
+"asdf:strict-dependency" = "latest"
+
+[settings]
+lockfile = true
+EOF
+cat >mise.lock <<'EOF'
+[[tools."asdf:strict-dependency"]]
+version = "20260822"
+EOF
+locked_output="$(quiet_assert_fail "mise install dummy")"
+assert_contains_text "$locked_output" "selected version is not installed"
+assert_contains_text "$locked_output" "mise install asdf:strict-dependency@latest"
+assert_directory_not_exists "$MISE_DATA_DIR/installs/dummy/1.0.0"
+
 # An unconfigured declaration can be satisfied by the existing system PATH.
 SYSTEM_MARKER="$PWD/system-dependency-marker"
 cat >"$HOME/bin/system-only-dependency" <<'EOF'
@@ -118,8 +137,10 @@ dummy = { version = "1.0.0", depends = ["asdf:path-error"] }
 "asdf:path-error" = "1.0.0"
 EOF
 rm -rf "$MISE_DATA_DIR/installs/dummy/1.0.0"
-assert_fail_contains "mise install dummy" "failed to list bin paths for install dependency"
-assert_fail_contains "mise install dummy" "dummy@1.0.0"
+path_error_output="$(quiet_assert_fail "mise install dummy")"
+assert_contains_text "$path_error_output" "failed to list bin paths for install dependency"
+assert_contains_text "$path_error_output" "path-error@1.0.0"
+assert_contains_text "$path_error_output" "dummy@1.0.0"
 assert_directory_not_exists "$MISE_DATA_DIR/installs/dummy/1.0.0"
 
 # An installed dependency may intentionally contribute no executable paths.

--- a/e2e/cli/test_tool_depends
+++ b/e2e/cli/test_tool_depends
@@ -19,6 +19,15 @@ assert "MISE_JOBS=1 mise install"
 assert_contains "mise ls --installed dummy" "2.0.0"
 assert_contains "mise ls --installed needs-dummy" "1.0.0"
 
+# A dependency installed in an earlier command is valid and must not produce the
+# old current-install-set warning when only the dependent is installed later.
+rm -rf "$MISE_DATA_DIR/installs/dummy"
+rm -rf "$MISE_DATA_DIR/installs/needs-dummy"
+assert "mise install dummy"
+separate_output="$(mise install needs-dummy 2>&1)"
+assert_not_contains_text "$separate_output" "not in the current install set"
+assert_contains "mise ls --installed needs-dummy" "1.0.0"
+
 # Bracket syntax should populate the same core `depends` option as table syntax.
 rm -rf "$MISE_DATA_DIR/installs/dummy"
 rm -rf "$MISE_DATA_DIR/installs/needs-dummy"
@@ -41,3 +50,15 @@ rm -rf "$MISE_DATA_DIR/installs/dummy"
 rm -rf "$MISE_DATA_DIR/installs/needs-dummy"
 
 assert_fail "mise install"
+
+# A dependency that fails in the same batch continues to block its dependent.
+cat <<EOF >mise.toml
+[tools]
+needs-dummy = { version = "1.0.0", depends = ["dummy"] }
+dummy = "other-dummy"
+EOF
+
+rm -rf "$MISE_DATA_DIR/installs/dummy"
+rm -rf "$MISE_DATA_DIR/installs/needs-dummy"
+assert_fail "mise install"
+assert_directory_not_exists "$MISE_DATA_DIR/installs/needs-dummy/1.0.0"

--- a/src/backend/asdf.rs
+++ b/src/backend/asdf.rs
@@ -436,9 +436,8 @@ impl Backend for AsdfBackend {
         let dependency_paths = self
             .install_dependency_context(ctx, &tv)
             .await?
-            .toolset
-            .list_paths(&ctx.config)
-            .await;
+            .paths
+            .clone();
         let active_paths = ctx.ts.list_paths(&ctx.config).await;
         let mut seen = HashSet::new();
         let paths: Vec<_> = dependency_paths

--- a/src/backend/asdf.rs
+++ b/src/backend/asdf.rs
@@ -428,17 +428,14 @@ impl Backend for AsdfBackend {
     async fn install_version_(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion> {
         let mut sm = self.script_man_for_tv(&ctx.config, &tv).await?;
 
-        // `ctx.ts` is the unresolved install toolset during a combined install, so it
-        // does not expose tools that just finished installing. Resolve this tool's
-        // declared dependencies separately so asdf install scripts can execute them
-        // on the first install (#4384). Keep the existing active-tool paths after the
-        // dependencies for compatibility, and preserve each toolset's path order.
+        // Resolve this tool's declared dependencies separately so asdf install scripts
+        // can execute them on the first install. Do not expose unrelated active tools:
+        // install requirements must be declared or already available on the script's
+        // ambient PATH.
         let dependency_paths = ctx.dependency_context(&tv.request).await?.paths.clone();
-        let active_paths = ctx.ts.list_paths(&ctx.config).await;
         let mut seen = HashSet::new();
         let paths: Vec<_> = dependency_paths
             .into_iter()
-            .chain(active_paths)
             .filter(|path| seen.insert(path.clone()))
             .collect();
         for p in paths.into_iter().rev() {

--- a/src/backend/asdf.rs
+++ b/src/backend/asdf.rs
@@ -433,11 +433,7 @@ impl Backend for AsdfBackend {
         // declared dependencies separately so asdf install scripts can execute them
         // on the first install (#4384). Keep the existing active-tool paths after the
         // dependencies for compatibility, and preserve each toolset's path order.
-        let dependency_paths = self
-            .install_dependency_context(ctx, &tv)
-            .await?
-            .paths
-            .clone();
+        let dependency_paths = ctx.dependency_context(&tv.request).await?.paths.clone();
         let active_paths = ctx.ts.list_paths(&ctx.config).await;
         let mut seen = HashSet::new();
         let paths: Vec<_> = dependency_paths

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3924,10 +3924,7 @@ pub(crate) trait Backend: Debug + Send + Sync {
         tv: &ToolVersion,
     ) -> eyre::Result<BTreeMap<String, String>> {
         let dependencies = ctx.dependency_context(&tv.request).await?;
-        let mut env = dependencies
-            .toolset
-            .full_env_without_tools_with_paths(&ctx.config, &dependencies.paths)
-            .await?;
+        let mut env = dependencies.base_env_for_install(&ctx.config).await?;
         self.remove_dependency_shims(&mut env)?;
         Ok(env)
     }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3290,6 +3290,16 @@ pub(crate) trait Backend: Debug + Send + Sync {
         let will_uninstall =
             (ctx.force || rolling_reinstall) && self.is_version_installed(&ctx.config, &tv, true);
 
+        if install_satisfied && !will_uninstall {
+            return Ok(tv);
+        }
+
+        // The scheduler has released this tool only after its in-batch dependencies
+        // succeeded. Validate configured dependencies before replacing the target or
+        // creating any of its install directories, then reuse the stored context in
+        // backend and tool-level hooks.
+        self.install_dependency_context(&ctx, &tv).await?;
+
         // Query backend for operation count and set up progress tracking
         let install_ops = self.install_operation_count(&tv, &ctx).await;
         let total_ops = if will_uninstall {
@@ -3303,8 +3313,6 @@ pub(crate) trait Backend: Debug + Send + Sync {
             self.uninstall_version_unlocked(&ctx.config, &tv, ctx.pr.as_ref(), false)
                 .await?;
             ctx.pr.next_operation();
-        } else if install_satisfied {
-            return Ok(tv);
         }
 
         // Track the installation asynchronously (fire-and-forget)
@@ -3392,16 +3400,17 @@ pub(crate) trait Backend: Debug + Send + Sync {
                 }
             }
         }
+        let dependencies = self.install_dependency_context(ctx, &tv_exact).await?;
 
         // Surface `tools = true` `[env]` *value* directives (e.g. `CLOUDSDK_PYTHON =
         // "{{ tools.python.path }}/bin/python3"`) for the tool-level `postinstall`
         // hook, resolved against this tool's already-installed dependencies. The
         // config env added above is resolved without tools (`NonToolsOnly`), so it
-        // omits these; `install_dependency_context` is fully resolved (offline) so
+        // omits these; the install dependency context is fully resolved (offline) so
         // `{{ tools.<dep>.path }}` maps to a real install path — `ctx.ts` is the raw,
         // unresolved install toolset during a combined install. PATH stays owned by
-        // `path_env` below. Best-effort: any resolution error leaves the tool-less
-        // env untouched.
+        // `path_env` below. Best-effort: a `tools = true` value evaluation error
+        // leaves the tool-less env untouched.
         //
         // Gated on the tool declaring dependencies. Only a `tools = true` value that
         // can reference a dependency (installed first, by depends ordering) is
@@ -3410,22 +3419,9 @@ pub(crate) trait Backend: Debug + Send + Sync {
         // (#6418, e2e/config/test_hooks_postinstall_env) — since a *static*
         // `tools = true` value (no `{{ tools.* }}` reference) would otherwise leak in.
         // (#10282, follow-up to #10432)
-        let declares_deps = self
-            .get_all_dependencies(true)
-            .map(|deps| !deps.is_empty())
-            .unwrap_or(false)
-            || tv_exact
-                .request
-                .options()
-                .core
-                .depends
-                .is_some_and(|deps| !deps.is_empty());
-        if declares_deps {
+        if !dependencies.declarations.is_empty() {
             let base = env_vars.clone();
-            let tool_vals = match self.install_dependency_context(ctx, &tv_exact).await {
-                Ok(dependencies) => dependencies.toolset.tool_val_env(&ctx.config, &base).await,
-                Err(e) => Err(e),
-            };
+            let tool_vals = dependencies.toolset.tool_val_env(&ctx.config, &base).await;
             match tool_vals {
                 Ok(vals) => {
                     for (k, v) in vals {
@@ -3448,9 +3444,15 @@ pub(crate) trait Backend: Debug + Send + Sync {
         // instead of hardcoding install_path/bin, which may not match the actual
         // binary location for backends like aqua.
         let bin_paths = self.list_bin_paths(&ctx.config, &tv_exact).await?;
-        let mut path_env = PathEnv::from_iter(env::PATH.clone());
+        let mut path_env = PathEnv::new();
         for p in bin_paths {
             path_env.add(p);
+        }
+        for p in &dependencies.paths {
+            path_env.add(p.clone());
+        }
+        for p in env::PATH.iter() {
+            path_env.add(p.clone());
         }
 
         // Render tera template variables (e.g. {{tools.ripgrep.path}})
@@ -3919,6 +3921,26 @@ pub(crate) trait Backend: Debug + Send + Sync {
         // filtering only one used to leak recursion through the other (#8475
         // closed the user dir for `dependency_env`, this PR closes the system dir
         // and aligns with the dual-dir guard already in `which_shim` (#8816)).
+        self.remove_dependency_shims(&mut env)?;
+
+        Ok(env)
+    }
+
+    async fn dependency_env_for_install(
+        &self,
+        ctx: &InstallContext,
+        tv: &ToolVersion,
+    ) -> eyre::Result<BTreeMap<String, String>> {
+        let dependencies = self.install_dependency_context(ctx, tv).await?;
+        let mut env = dependencies
+            .toolset
+            .full_env_without_tools_with_paths(&ctx.config, &dependencies.paths)
+            .await?;
+        self.remove_dependency_shims(&mut env)?;
+        Ok(env)
+    }
+
+    fn remove_dependency_shims(&self, env: &mut BTreeMap<String, String>) -> eyre::Result<()> {
         if let Some(path_val) = env.get(&*env::PATH_KEY) {
             let paths: Vec<_> = env::split_paths(path_val).collect();
             let original_len = paths.len();
@@ -3934,8 +3956,7 @@ pub(crate) trait Backend: Debug + Send + Sync {
                 );
             }
         }
-
-        Ok(env)
+        Ok(())
     }
 
     /// Default fuzzy-match. `filter_prereleases = true` applies the historical

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3298,7 +3298,7 @@ pub(crate) trait Backend: Debug + Send + Sync {
         // succeeded. Validate configured dependencies before replacing the target or
         // creating any of its install directories, then reuse the stored context in
         // backend and tool-level hooks.
-        self.install_dependency_context(&ctx, &tv).await?;
+        ctx.dependency_context(&tv.request).await?;
 
         // Query backend for operation count and set up progress tracking
         let install_ops = self.install_operation_count(&tv, &ctx).await;
@@ -3400,7 +3400,7 @@ pub(crate) trait Backend: Debug + Send + Sync {
                 }
             }
         }
-        let dependencies = self.install_dependency_context(ctx, &tv_exact).await?;
+        let dependencies = ctx.dependency_context(&tv_exact.request).await?;
 
         // Surface `tools = true` `[env]` *value* directives (e.g. `CLOUDSDK_PYTHON =
         // "{{ tools.python.path }}/bin/python3"`) for the tool-level `postinstall`
@@ -3745,14 +3745,6 @@ pub(crate) trait Backend: Debug + Send + Sync {
         Ok(ts)
     }
 
-    async fn install_dependency_context<'a>(
-        &self,
-        ctx: &'a InstallContext,
-        tv: &ToolVersion,
-    ) -> eyre::Result<&'a crate::install_context::InstallDependencyContext> {
-        ctx.dependency_context(&tv.request).await
-    }
-
     async fn dependency_which(&self, config: &Arc<Config>, bin: &str) -> Option<PathBuf> {
         if let Some(bin) = which_non_pristine_executable(bin) {
             return Some(bin);
@@ -3931,7 +3923,7 @@ pub(crate) trait Backend: Debug + Send + Sync {
         ctx: &InstallContext,
         tv: &ToolVersion,
     ) -> eyre::Result<BTreeMap<String, String>> {
-        let dependencies = self.install_dependency_context(ctx, tv).await?;
+        let dependencies = ctx.dependency_context(&tv.request).await?;
         let mut env = dependencies
             .toolset
             .full_env_without_tools_with_paths(&ctx.config, &dependencies.paths)

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -293,7 +293,7 @@ impl Backend for VfoxBackend {
         // the strict install dependency environment. (#10282, follow-up to #10432)
         {
             let base: EnvMap = cmd_env.clone().into_iter().collect();
-            let dependencies = self.install_dependency_context(ctx, &tv).await?;
+            let dependencies = ctx.dependency_context(&tv.request).await?;
             let tool_vals = dependencies.toolset.tool_val_env(&ctx.config, &base).await;
             match tool_vals {
                 Ok(vals) => {

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -256,9 +256,8 @@ impl Backend for VfoxBackend {
         let (mut vfox, log_rx) = self.plugin.vfox()?;
         Self::forward_plugin_logs(log_rx);
         let mut cmd_env: indexmap::IndexMap<String, String> = self
-            .dependency_env(&ctx.config)
-            .await
-            .unwrap_or_default()
+            .dependency_env_for_install(ctx, &tv)
+            .await?
             .into_iter()
             .collect();
         let tool_options = self.tool_options_for_tv(&ctx.config, &tv).await;
@@ -285,19 +284,17 @@ impl Backend for VfoxBackend {
         // ctx.ts: ctx.ts is the raw install toolset (`Toolset::from(ToolRequestSet)`)
         // whose `.versions` are empty until `resolve()` runs *after* installs, so its
         // `tools.*` tera map is empty and `{{ tools.python.path }}` would render "".
-        // `install_dependency_context` is resolved offline and includes both backend deps
+        // The install dependency context is resolved offline and includes both backend deps
         // and the per-tool mise.toml `depends` option (`gcloud = { depends =
         // ["python"] }`) with real install paths, and is install-safe (it uses
         // `get_tool_request_set()`, not the deadlock-prone `config.get_toolset()`).
         // Best-effort: env *modules* are excluded via `ToolsFilter::ToolsOnlyVals`,
-        // any resolution error falls back to the tool-less env, and PATH is left to
-        // `dependency_env`. (#10282, follow-up to #10432)
+        // any value evaluation error falls back to the tool-less env, and PATH is left to
+        // the strict install dependency environment. (#10282, follow-up to #10432)
         {
             let base: EnvMap = cmd_env.clone().into_iter().collect();
-            let tool_vals = match self.install_dependency_context(ctx, &tv).await {
-                Ok(dependencies) => dependencies.toolset.tool_val_env(&ctx.config, &base).await,
-                Err(e) => Err(e),
-            };
+            let dependencies = self.install_dependency_context(ctx, &tv).await?;
+            let tool_vals = dependencies.toolset.tool_val_env(&ctx.config, &base).await;
             match tool_vals {
                 Ok(vals) => {
                     for (k, v) in vals {

--- a/src/install_context.rs
+++ b/src/install_context.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use eyre::{Result, eyre};
+use eyre::{Result, WrapErr, bail, eyre};
 use indexmap::IndexSet;
 use jiff::Timestamp;
 use tokio::sync::OnceCell;
@@ -21,7 +21,6 @@ use crate::{
 #[derive(Debug, Default)]
 pub(crate) struct InstallDependencyDeclarations {
     dependencies: IndexSet<BackendArg>,
-    direct: Vec<(String, BackendArg)>,
     metadata_error: Option<String>,
 }
 
@@ -30,8 +29,8 @@ impl InstallDependencyDeclarations {
         self.dependencies.iter()
     }
 
-    pub(crate) fn direct(&self) -> impl Iterator<Item = (&str, &BackendArg)> {
-        self.direct.iter().map(|(raw, ba)| (raw.as_str(), ba))
+    pub(crate) fn is_empty(&self) -> bool {
+        self.dependencies.is_empty()
     }
 
     pub(crate) fn matches(&self, candidate: &BackendArg) -> bool {
@@ -98,7 +97,6 @@ pub(crate) fn install_dependency_declarations(
     if let Some(dependencies) = request.options().core.depends {
         for raw in dependencies {
             let dependency = BackendArg::from(raw.as_str());
-            declarations.direct.push((raw, dependency.clone()));
             declarations.insert(request.ba(), dependency);
         }
     }
@@ -111,6 +109,7 @@ pub(crate) struct InstallDependencyContext {
     pub(crate) declarations: InstallDependencyDeclarations,
     pub(crate) requests: ToolRequestSet,
     pub(crate) toolset: Toolset,
+    pub(crate) paths: Vec<std::path::PathBuf>,
 }
 
 impl InstallDependencyContext {
@@ -119,19 +118,59 @@ impl InstallDependencyContext {
         declarations.validate()?;
         let requests = declarations.matching_requests(config.get_tool_request_set().await?);
         let mut toolset: Toolset = requests.clone().into();
-        toolset
-            .resolve_with_opts(
-                config,
-                &ResolveOptions {
-                    offline: true,
-                    ..Default::default()
-                },
-            )
-            .await?;
+        let resolve_options = ResolveOptions {
+            offline: true,
+            ..Default::default()
+        };
+        for (dependency, versions) in &mut toolset.versions {
+            versions
+                .resolve(config, &resolve_options)
+                .await
+                .wrap_err_with(|| {
+                    format!(
+                        "failed to resolve configured install dependency '{}' for '{}'",
+                        dependency, request
+                    )
+                })?;
+        }
+        for (backend, dependency) in toolset.list_current_versions() {
+            if !backend.is_version_installed(config, &dependency, true) {
+                let unresolved = match &dependency.request {
+                    ToolRequest::Prefix { .. } | ToolRequest::Sub { .. } => {
+                        dependency.version.matches('.').count() < 2
+                            && !backend.is_exact_version(&dependency.version)
+                    }
+                    ToolRequest::Version { .. } => {
+                        dependency.version.matches('.').count() < 2
+                            && !backend.is_exact_version(&dependency.version)
+                    }
+                    ToolRequest::Ref { .. }
+                    | ToolRequest::Path { .. }
+                    | ToolRequest::System { .. } => false,
+                };
+                if unresolved {
+                    bail!(
+                        "failed to resolve configured install dependency '{}' for '{}' while offline",
+                        dependency.request,
+                        request
+                    );
+                }
+                bail!(
+                    "tool '{}' requires configured install dependency '{}', but its selected version is not installed\n\
+                     hint: Run `mise install {}` before installing '{}'. Remove the dependency from configuration to allow the install hook to rely on system PATH instead.",
+                    request,
+                    dependency.request,
+                    dependency.request,
+                    request,
+                );
+            }
+        }
+        let paths = toolset.list_paths_strict(config, request).await?;
         let context = Self {
             declarations,
             requests,
             toolset,
+            paths,
         };
         debug_assert_eq!(context.requests.tools.len(), context.toolset.versions.len());
         debug_assert!(

--- a/src/install_context.rs
+++ b/src/install_context.rs
@@ -136,11 +136,9 @@ impl InstallDependencyContext {
         for (backend, dependency) in toolset.list_current_versions() {
             if !backend.is_version_installed(config, &dependency, true) {
                 let unresolved = match &dependency.request {
-                    ToolRequest::Prefix { .. } | ToolRequest::Sub { .. } => {
-                        dependency.version.matches('.').count() < 2
-                            && !backend.is_exact_version(&dependency.version)
-                    }
-                    ToolRequest::Version { .. } => {
+                    ToolRequest::Prefix { .. }
+                    | ToolRequest::Sub { .. }
+                    | ToolRequest::Version { .. } => {
                         dependency.version.matches('.').count() < 2
                             && !backend.is_exact_version(&dependency.version)
                     }

--- a/src/install_context.rs
+++ b/src/install_context.rs
@@ -135,17 +135,16 @@ impl InstallDependencyContext {
         }
         for (backend, dependency) in toolset.list_current_versions() {
             if !backend.is_version_installed(config, &dependency, true) {
-                let unresolved = match &dependency.request {
-                    ToolRequest::Prefix { .. }
-                    | ToolRequest::Sub { .. }
-                    | ToolRequest::Version { .. } => {
-                        dependency.version.matches('.').count() < 2
-                            && !backend.is_exact_version(&dependency.version)
-                    }
-                    ToolRequest::Ref { .. }
-                    | ToolRequest::Path { .. }
-                    | ToolRequest::System { .. } => false,
-                };
+                let unresolved = !dependency.resolved_from_lockfile()
+                    && match &dependency.request {
+                        ToolRequest::Prefix { .. } | ToolRequest::Sub { .. } => true,
+                        ToolRequest::Version { version, .. } => {
+                            version == "latest" || backend.is_rolling_channel(version)
+                        }
+                        ToolRequest::Ref { .. }
+                        | ToolRequest::Path { .. }
+                        | ToolRequest::System { .. } => false,
+                    };
                 if unresolved {
                     bail!(
                         "failed to resolve configured install dependency '{}' for '{}' while offline",

--- a/src/toolset/tool_deps.rs
+++ b/src/toolset/tool_deps.rs
@@ -77,20 +77,6 @@ impl ToolDeps {
                     }
                 }
             }
-            for (raw, dependency) in declarations.direct() {
-                if !requests.iter().any(|other| {
-                    tr_key != tool_key(other)
-                        && dependency
-                            .all_fulls()
-                            .iter()
-                            .any(|identity| other.ba().all_fulls().contains(identity))
-                }) {
-                    warn!(
-                        "tool '{}': depends on '{}' which is not in the current install set",
-                        tr_key, raw
-                    );
-                }
-            }
         }
 
         let inner = DepsGraph::new(nodes, edges, tool_key)?;

--- a/src/toolset/toolset_env.rs
+++ b/src/toolset/toolset_env.rs
@@ -46,6 +46,34 @@ impl Toolset {
         Ok(env)
     }
 
+    /// Build the install-hook base environment with already-validated dependency
+    /// paths ahead of ambient alternatives. `tools = true` directives remain
+    /// excluded because a partial install context cannot evaluate arbitrary modules.
+    pub(crate) async fn full_env_without_tools_with_paths(
+        &self,
+        config: &Arc<Config>,
+        tool_paths: &[PathBuf],
+    ) -> Result<EnvMap> {
+        let mut full_env = env::PRISTINE_ENV.clone().into_iter().collect::<EnvMap>();
+        let (mut env, add_paths) = self.env(config).await?;
+        let mut path_env = PathEnv::new();
+        for path in tool_paths {
+            path_env.add(path.clone());
+        }
+        for path in config.path_dirs().await?.clone() {
+            path_env.add(path);
+        }
+        for path in add_paths {
+            path_env.add(path);
+        }
+        for path in pristine_path_without_install_dirs() {
+            path_env.add(path);
+        }
+        env.insert(PATH_KEY.to_string(), path_env.to_string());
+        full_env.extend(env);
+        Ok(full_env)
+    }
+
     /// Like env_with_path but skips `tools=true` env directives.
     /// Used during tool installation where tool-dependent env vars
     /// may reference tools that aren't installed yet, and in

--- a/src/toolset/toolset_env.rs
+++ b/src/toolset/toolset_env.rs
@@ -9,6 +9,7 @@ use crate::config::env_directive::{EnvResolveOptions, EnvResults, ToolsFilter};
 use crate::config::{Config, Settings};
 use crate::env::{PATH_KEY, WARN_ON_MISSING_REQUIRED_ENV};
 use crate::env_diff::EnvMap;
+use crate::install_context::InstallDependencyContext;
 use crate::path_env::PathEnv;
 use crate::toolset::Toolset;
 use crate::toolset::env_cache::{CachedEnv, compute_settings_hash, get_file_mtime};
@@ -45,19 +46,18 @@ impl Toolset {
         env.extend(self.env_with_path_without_tools(config).await?);
         Ok(env)
     }
+}
 
-    /// Build the install-hook base environment with already-validated dependency
-    /// paths ahead of ambient alternatives. `tools = true` directives remain
-    /// excluded because a partial install context cannot evaluate arbitrary modules.
-    pub(crate) async fn full_env_without_tools_with_paths(
-        &self,
-        config: &Arc<Config>,
-        tool_paths: &[PathBuf],
-    ) -> Result<EnvMap> {
+impl InstallDependencyContext {
+    /// Build an install-hook base environment from this context's resolved
+    /// dependency toolset and its already-validated paths. `tools = true`
+    /// directives remain excluded because a partial install context cannot
+    /// evaluate arbitrary modules.
+    pub(crate) async fn base_env_for_install(&self, config: &Arc<Config>) -> Result<EnvMap> {
         let mut full_env = env::PRISTINE_ENV.clone().into_iter().collect::<EnvMap>();
-        let (mut env, add_paths) = self.env(config).await?;
+        let (mut env, add_paths) = self.toolset.env(config).await?;
         let mut path_env = PathEnv::new();
-        for path in tool_paths {
+        for path in &self.paths {
             path_env.add(path.clone());
         }
         for path in config.path_dirs().await?.clone() {
@@ -73,7 +73,9 @@ impl Toolset {
         full_env.extend(env);
         Ok(full_env)
     }
+}
 
+impl Toolset {
     /// Like env_with_path but skips `tools=true` env directives.
     /// Used during tool installation where tool-dependent env vars
     /// may reference tools that aren't installed yet, and in

--- a/src/toolset/toolset_paths.rs
+++ b/src/toolset/toolset_paths.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use dashmap::DashMap;
-use eyre::Result;
+use eyre::{Result, WrapErr};
 use std::sync::LazyLock as Lazy;
 
 use crate::config::Config;
@@ -16,6 +16,37 @@ use itertools::Itertools;
 pub(super) static LIST_PATHS_CACHE: Lazy<DashMap<String, Vec<PathBuf>>> = Lazy::new(DashMap::new);
 
 impl Toolset {
+    /// Enumerate install dependency paths without swallowing backend errors.
+    ///
+    /// This deliberately mirrors `list_paths` ordering while leaving that public,
+    /// forgiving API unchanged for existing callers.
+    pub(crate) async fn list_paths_strict(
+        &self,
+        config: &Arc<Config>,
+        dependent: &crate::toolset::ToolRequest,
+    ) -> Result<Vec<PathBuf>> {
+        let mut installed = self.list_current_installed_versions(config);
+        Self::sort_by_overrides(&mut installed)?;
+
+        let mut paths = Vec::new();
+        for (backend, dependency) in installed {
+            let new_paths = backend
+                .list_bin_paths(config, &dependency)
+                .await
+                .wrap_err_with(|| {
+                    format!(
+                        "failed to list bin paths for install dependency '{}' of '{}'",
+                        dependency.request, dependent
+                    )
+                })?;
+            paths.extend(new_paths);
+        }
+        Ok(paths
+            .into_iter()
+            .filter(|path| path.parent().is_some())
+            .collect())
+    }
+
     pub(crate) async fn list_paths(&self, config: &Arc<Config>) -> Vec<PathBuf> {
         // Build a stable cache key based on project_root and current installed versions
         let mut key_parts = vec![];


### PR DESCRIPTION
## Summary

- Builds on source PR #12233 and reuses its shared install dependency context.
- Validates configured dependencies before mutating the dependent install, with actionable failures for offline resolution, missing installs, and bin-path enumeration.
- Makes backend and per-tool dependency paths available consistently to asdf and vfox install commands and generic postinstall hooks.
- Limits asdf install scripts to declared mise-managed dependencies plus their existing ambient system/config PATH; unrelated active mise tools are no longer injected.
- Removes the inaccurate current-install-set warning and documents the unified contract.

This is the implementation follow-up to [Discussion #12219](https://github.com/jdx/mise/discussions/12219).

## Inconsistent behavior on main

| Surface | Behavior on `main` before this PR | Behavior in this PR |
| --- | --- | --- |
| Install scheduling | Backend/plugin declarations and `[tools].depends` both create graph edges, but only a direct user dependency missing from the current command emits the misleading current-install-set warning—even if it is already installed. | Both declaration sources use the same graph; the batch-only warning is removed and availability is decided by the validated context. |
| asdf `bin/download` / `bin/install` PATH | Declared dependencies are added, followed by every active mise tool and then the ambient script PATH. This exposes unrelated sibling tools. | Only declared dependency paths are injected ahead of the ambient PATH. Unrelated active tools are excluded. |
| vfox `os.execute` / `cmd.exec` PATH | Only backend `PLUGIN.depends` affects PATH; user `[tools].depends` is ignored. Base environment construction errors silently fall back to an empty dependency environment. | Backend and user declarations are unioned through the shared context, and environment/path construction errors are fatal. |
| Generic tool-level `postinstall` PATH | Contains the newly installed tool followed by the ambient PATH; declared dependency paths are absent. | Contains the newly installed tool, then declared dependency paths, then the ambient PATH. |
| `tools = true` values | vfox and generic postinstall resolve values against the union of declarations on a best-effort basis, even though their command PATHs expose a different dependency set. | Both reuse the same dependency toolset as PATH construction. Value evaluation intentionally remains best-effort. |
| Configured dependency availability | A configured but unresolved or uninstalled dependency can contribute no mise path and silently fall through to a similarly named ambient executable; bin-path errors may also be swallowed. | Configured dependencies must resolve offline and be installed; strict bin-path errors propagate before the dependent install is mutated. |
| Unconfigured declaration | Contributes no mise-managed path and may be satisfied by the ambient PATH. | Unchanged: declarations do not synthesize or install tools, and an unconfigured requirement may use the ambient PATH. |
| vfox `io.popen` | Does not receive the vfox install command environment. | Unchanged and explicitly outside this PR. |

## asdf compatibility change

Before this PR, asdf `bin/download` and `bin/install` scripts received paths for every active tool in the install toolset, even when the plugin or user had not declared those tools as dependencies. This implicit active-tool fallback is removed. Mise-managed install requirements must now come from backend/plugin dependency metadata or `[tools].depends`; executables already present on the ambient system/config `PATH` remain available.

The confirmed legacy consumer is `mise-plugins/mise-poetry`/`asdf-community/asdf-poetry`, whose install script invokes `python3` without declaring Python, as reported in [Discussion #4384](https://github.com/jdx/mise/discussions/4384). The current Poetry registry entry uses vfox and pipx rather than asdf. Users who explicitly retain the legacy asdf plugin should declare `depends = ["python"]` in `mise.toml`, or provide `python3` on the ambient PATH. Because `.tool-versions` cannot express per-tool dependencies, those users must migrate that entry to `mise.toml` or provide the prerequisite externally.

This removes accidental sibling-tool visibility and gives asdf the same explicit install dependency boundary as the other hook environments in this PR.

## Non-goals

- Automatically installing dependency declarations.
- Changing vfox `io.popen` environments.
- Changing direct Tera rendering of postinstall scripts.
- Managing or changing system packages.
- Extending `.tool-versions` with dependency declarations.

## Testing

- `mise run lint-fix`
- `mise run test:unit`
- `mise run test:e2e e2e/cli/test_tool_depends e2e/backend/test_asdf_install_dependency_path e2e/backend/test_vfox_install_tools_env_dep e2e/cli/test_install_postinstall_bin_path`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dependency resolution across separate and combined installations.
  - Added clearer errors for unavailable, uninstalled, or offline dependencies.
  - Restricted installation and postinstall environments to declared dependencies.
  - Fixed dependency visibility and PATH ordering for backend and tool hooks.
  - Prevented undeclared active tools from being exposed during installation.

- **Documentation**
  - Clarified dependency ordering, PATH behavior, environment handling, and vfox declarations.

- **Tests**
  - Expanded coverage for dependency installation, PATH resolution, postinstall behavior, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->