### PR TITLE
fix(task): map Rust cache paths to task root

### DIFF
--- a/e2e/tasks/test_task_rust_cache_restore
+++ b/e2e/tasks/test_task_rust_cache_restore
@@ -5,6 +5,7 @@ cat <<'EOF' >mise.toml
 experimental = true
 
 [tasks.restore]
+dir = "task"
 rust_cache = true
 run = '''
 invoke() {
@@ -26,6 +27,27 @@ if test -f cold-run; then
   test -f out/demo.d
   exit 0
 fi
+
+external_invoke() {
+  (
+    cd dependency
+    "$RUSTC_WRAPPER" "$PWD/../fake-rustc-external" \
+      --crate-name external \
+      --crate-type lib \
+      --emit=dep-info,link \
+      --out-dir "$PWD/../../external-out" \
+      "$PWD/lib.rs"
+  )
+}
+
+external_first="$(external_invoke 2>&1)"
+test "$external_first" = "external cached output"
+test "$(cat ../external-compile-count)" = 1
+rm -rf ../external-out
+external_second="$(external_invoke 2>&1)"
+test "$external_second" = "$external_first"
+test "$(cat ../external-compile-count)" = 1
+test "$(cat ../external-out/libexternal.rlib)" = 'external cached artifact'
 
 first="$(invoke 2>&1)"
 test "$first" = "$(printf 'cached stdout\ncached stderr')"
@@ -74,11 +96,12 @@ touch cold-run
 '''
 EOF
 
-cat <<'EOF' >lib.rs
+mkdir task
+cat <<'EOF' >task/lib.rs
 pub fn cached_library() -> usize { 42 }
 EOF
 
-cat <<'EOF' >fake-rustc
+cat <<'EOF' >task/fake-rustc
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -107,10 +130,48 @@ printf '# env-dep:CACHE_TEST_ENV=%s\n' "${CACHE_TEST_ENV-}" >>out/demo.d
 printf 'cached stdout\n'
 printf 'cached stderr\n' >&2
 EOF
-chmod +x fake-rustc
+chmod +x task/fake-rustc
 
-assert_contains "mise run restore 2>&1" "Action cache: 1 hits, 2 misses, 0 prefetched;"
-rm -rf out
+mkdir task/dependency
+cat <<'EOF' >task/dependency/lib.rs
+pub fn external_dependency() -> usize { 42 }
+EOF
+
+cat <<'EOF' >task/fake-rustc-external
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ${1:-} == -vV ]]; then
+  cat <<'IDENTITY'
+rustc 1.97.0 (cache-test 2026-08-01)
+binary: rustc
+commit-hash: cache-test
+commit-date: 2026-08-01
+host: x86_64-unknown-linux-gnu
+release: 1.97.0
+LLVM version: 22.0.0
+IDENTITY
+  exit 0
+fi
+
+root="$(cd ../.. && pwd)"
+count=0
+if [[ -f $root/external-compile-count ]]; then
+  count="$(cat "$root/external-compile-count")"
+fi
+printf '%s\n' "$((count + 1))" >"$root/external-compile-count"
+mkdir -p "$root/external-out"
+printf 'external cached artifact' >"$root/external-out/libexternal.rlib"
+printf '%s: %s\n' \
+  "$root/external-out/libexternal.rlib" \
+  "$root/task/dependency/lib.rs" \
+  >"$root/external-out/external.d"
+printf 'external cached output\n'
+EOF
+chmod +x task/fake-rustc-external
+
+assert_contains "mise run restore 2>&1" "Action cache: 2 hits, 2 misses, 0 prefetched;"
+rm -rf task/out
 assert_contains \
   "MISE_TASK_CACHE_STATS_REPORT=cache-stats.json mise run restore 2>&1" \
   "Action cache: 1 hits, 0 misses, 0 prefetched;"

--- a/src/cache/rustc.rs
+++ b/src/cache/rustc.rs
@@ -192,11 +192,18 @@ fn action_from_parsed_dep_info(
     Ok((action, discovered))
 }
 
+/// Builds a compiler action context with stable host path mappings.
 fn base_action_context(rustc: &OsStr, working_dir: &Path) -> Result<ActionContext> {
+    let task_root = std::env::var_os(session::TASK_ROOT_ENV).map(PathBuf::from);
+    let cargo_target_dir = std::env::var_os(session::CARGO_TARGET_ENV).map(PathBuf::from);
     Ok(ActionContext {
         compiler: compiler_identity(rustc)?,
         working_dir: working_dir.to_path_buf(),
-        path_mappings: path_mappings(working_dir),
+        path_mappings: path_mappings(
+            working_dir,
+            task_root.as_deref(),
+            cargo_target_dir.as_deref(),
+        ),
         environment: BTreeMap::new(),
         inputs: Vec::new(),
     })
@@ -646,7 +653,12 @@ fn identity_field<'a>(verbose: &'a str, field: &str) -> Result<&'a str> {
         .ok_or_else(|| eyre::eyre!("rustc identity is missing {field}"))
 }
 
-fn path_mappings(working_dir: &Path) -> Vec<PathMapping> {
+/// Returns stable path mappings with optional task and Cargo target roots.
+fn path_mappings(
+    working_dir: &Path,
+    task_root: Option<&Path>,
+    cargo_target_dir: Option<&Path>,
+) -> Vec<PathMapping> {
     let mut mappings = Vec::new();
     let mut roots = BTreeSet::new();
     add_mapping(
@@ -655,6 +667,17 @@ fn path_mappings(working_dir: &Path) -> Vec<PathMapping> {
         working_dir.to_path_buf(),
         "workspace",
     );
+    if let Some(root) = task_root.filter(|root| root.is_absolute()) {
+        add_mapping(&mut mappings, &mut roots, root.to_path_buf(), "task_root");
+    }
+    if let Some(root) = cargo_target_dir.filter(|root| root.is_absolute()) {
+        add_mapping(
+            &mut mappings,
+            &mut roots,
+            root.to_path_buf(),
+            "cargo_target",
+        );
+    }
     for (name, placeholder) in [
         ("CARGO_HOME", "cargo_home"),
         ("RUSTUP_HOME", "rustup_home"),
@@ -952,12 +975,39 @@ mod tests {
     #[test]
     fn mappings_do_not_duplicate_home_placeholders() {
         let directory = tempfile::tempdir().unwrap();
-        let mappings = path_mappings(directory.path());
+        let mappings = path_mappings(directory.path(), None, None);
         let placeholders = mappings
             .iter()
             .map(|mapping| &mapping.placeholder)
             .collect::<BTreeSet<_>>();
         assert_eq!(placeholders.len(), mappings.len());
+    }
+
+    #[test]
+    fn mappings_include_the_task_root() {
+        let directory = tempfile::tempdir().unwrap();
+        let dependency = directory.path().join("dependency");
+        let task = directory.path().join("task");
+        let mappings = path_mappings(&dependency, Some(&task), None);
+
+        assert!(
+            mappings
+                .iter()
+                .any(|mapping| mapping.root == task && mapping.placeholder == "task_root")
+        );
+    }
+
+    #[test]
+    fn mappings_include_the_cargo_target_directory() {
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("target");
+        let mappings = path_mappings(directory.path(), None, Some(&target));
+
+        assert!(
+            mappings
+                .iter()
+                .any(|mapping| mapping.root == target && mapping.placeholder == "cargo_target")
+        );
     }
 
     #[test]

--- a/src/cache/session.rs
+++ b/src/cache/session.rs
@@ -21,9 +21,11 @@ use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
 const RUSTC_SHIM_STEM: &str = "mise-cache-rustc";
+pub(super) const CARGO_TARGET_ENV: &str = "MISE_CACHE_CARGO_TARGET_DIR";
 const SOCKET_ENV: &str = "MISE_CACHE_SOCKET";
 pub(super) const STAGING_ENV: &str = "MISE_CACHE_STAGING_DIR";
 pub(super) const TASK_ENV: &str = "MISE_CACHE_TASK";
+pub(super) const TASK_ROOT_ENV: &str = "MISE_CACHE_TASK_ROOT";
 pub(super) const VERIFY_ENV: &str = "MISE_CACHE_RUST_VERIFY";
 const PREVIOUS_RUSTC_WRAPPER_ENV: &str = "MISE_CACHE_PREVIOUS_RUSTC_WRAPPER";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -37,9 +39,11 @@ pub(crate) struct CacheSessionEnvironment {
 }
 
 impl CacheSessionEnvironment {
+    /// Adds the Rust action-cache environment for an enabled task.
     pub(crate) async fn apply(
         &self,
         task: &Task,
+        task_root: &Path,
         environment: &mut BTreeMap<String, String>,
     ) -> Option<TaskActionRun> {
         if !task.rust_cache.as_ref().is_some_and(|cache| cache.enabled) {
@@ -62,6 +66,13 @@ impl CacheSessionEnvironment {
         environment.insert(SOCKET_ENV.into(), self.socket.clone());
         environment.insert(STAGING_ENV.into(), self.staging.clone());
         environment.insert(TASK_ENV.into(), protocol_task);
+        environment.insert(
+            TASK_ROOT_ENV.into(),
+            task_root.to_string_lossy().into_owned(),
+        );
+        if let Some(target) = environment.get("CARGO_TARGET_DIR").cloned() {
+            environment.insert(CARGO_TARGET_ENV.into(), target);
+        }
         if task.rust_cache.as_ref().is_some_and(|cache| cache.verify) {
             environment.insert(VERIFY_ENV.into(), "1".into());
         } else {
@@ -832,8 +843,13 @@ mod tests {
             agent: CacheAgent::new(cache.path(), VERSION),
         };
         let mut task = Task::default();
-        let mut values = BTreeMap::from([("RUSTC_WRAPPER".into(), "existing".into())]);
-        let run = environment.apply(&task, &mut values).await;
+        let mut values = BTreeMap::from([
+            ("CARGO_TARGET_DIR".into(), "target".into()),
+            ("RUSTC_WRAPPER".into(), "existing".into()),
+        ]);
+        let task_directory = tempfile::tempdir().unwrap();
+        let task_root = task_directory.path();
+        let run = environment.apply(&task, task_root, &mut values).await;
         assert!(run.is_none());
         assert_eq!(values.get("RUSTC_WRAPPER").unwrap(), "existing");
 
@@ -841,7 +857,7 @@ mod tests {
             enabled: false,
             ..TaskRustCacheConfig::default()
         });
-        let run = environment.apply(&task, &mut values).await;
+        let run = environment.apply(&task, task_root, &mut values).await;
         assert!(run.is_none());
         assert_eq!(values.get("RUSTC_WRAPPER").unwrap(), "existing");
 
@@ -849,11 +865,16 @@ mod tests {
             verify: true,
             ..TaskRustCacheConfig::default()
         });
-        let run = environment.apply(&task, &mut values).await;
+        let run = environment.apply(&task, task_root, &mut values).await;
         assert!(run.is_some());
         assert_eq!(values.get(SOCKET_ENV).unwrap(), "socket");
         assert_eq!(values.get(STAGING_ENV).unwrap(), "staging");
         assert_eq!(values.get(TASK_ENV).unwrap().len(), 64);
+        assert_eq!(values.get(CARGO_TARGET_ENV).unwrap(), "target");
+        assert_eq!(
+            values.get(TASK_ROOT_ENV).unwrap(),
+            &task_root.to_string_lossy()
+        );
         assert_eq!(values.get("RUSTC_WRAPPER").unwrap(), "shim");
         assert_eq!(values.get(PREVIOUS_RUSTC_WRAPPER_ENV).unwrap(), "existing");
         assert_eq!(values.get("CARGO_INCREMENTAL").unwrap(), "0");

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -3,7 +3,9 @@ use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings, env_directive::EnvDirective};
 use crate::duration;
 use crate::env_diff::EnvDiff;
-use crate::file::{can_execute_directly, display_path, replace_path, strip_utf8_bom};
+use crate::file::{
+    can_execute_directly, canonicalize_or_self, display_path, replace_path, strip_utf8_bom,
+};
 use crate::sandbox::SandboxConfig;
 use crate::task::TaskArtifactCache;
 use crate::task::task_cache::{
@@ -16,7 +18,7 @@ use crate::task::task_output_handler::OutputHandler;
 use crate::task::task_scheduler::SchedMsg;
 use crate::task::task_script_parser::subcommand_name_from_parse;
 use crate::task::task_source_checker::{
-    remove_auto_output, save_checksum, sources_are_fresh, task_cwd,
+    remove_auto_output, save_checksum, sources_are_fresh, task_cwd, task_source_match_root,
 };
 use crate::task::{
     Deps, FailedTasks, GetMatchingExt, Task, TaskCacheAudit, TaskCacheMode, TaskCacheOutput,
@@ -476,6 +478,8 @@ impl TaskExecutor {
                     "MISE_CACHE_SOCKET".into(),
                     "MISE_CACHE_STAGING_DIR".into(),
                     "MISE_CACHE_TASK".into(),
+                    "MISE_CACHE_CARGO_TARGET_DIR".into(),
+                    "MISE_CACHE_TASK_ROOT".into(),
                     "MISE_CACHE_RUST_VERIFY".into(),
                     "MISE_CACHE_PREVIOUS_RUSTC_WRAPPER".into(),
                     "RUSTC_WRAPPER".into(),
@@ -707,8 +711,12 @@ impl TaskExecutor {
             .as_ref()
             .filter(|_| self.task_cache.writes())
             .map(|_| Arc::new(StdMutex::new(Vec::new())));
-        let action_cache_run = if let Some(session) = self.cache_session.as_ref() {
-            session.apply(task, &mut env).await
+        let action_cache_run = if task.rust_cache.as_ref().is_some_and(|cache| cache.enabled)
+            && let Some(session) = self.cache_session.as_ref()
+        {
+            let task_cwd = task_cwd(task, config).await?;
+            let task_root = canonicalize_or_self(&task_source_match_root(&task_cwd, config));
+            session.apply(task, &task_root, &mut env).await
         } else {
             None
         };


### PR DESCRIPTION
## Summary

- map compiler paths against the outer task config root while preserving the compiler working directory as the most specific mapping
- carry an explicit `CARGO_TARGET_DIR` into the compiler shim as a stable mapping
- cover nested task roots, explicit Cargo target directories, and artifact restoration

## Verification

- `mise run lint`
- `cargo test --locked --bin mise mappings_include_the_task_root`
- `cargo test --locked --bin mise mappings_include_the_cargo_target_directory`
- `cargo test --locked --bin mise session_environment_is_scoped_to_selected_adapters`
- `TMPDIR=/tmp mise run test:e2e e2e/tasks/test_task_rust_cache_restore`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Rust task caching for compiler commands run from dependency directories.
  * Cached build artifacts are now restored correctly after output directories are removed.
  * Sandboxed tasks now recognize the task’s resolved working directory and Cargo target directory.

* **Bug Fixes**
  * Improved cache path handling for tasks executed outside the workspace root.
  * Fixed restoration of outputs generated by external compiler commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->