### PR TITLE
registry: add skim

### DIFF
--- a/registry/skim.toml
+++ b/registry/skim.toml
@@ -1,4 +1,4 @@
-backends = ["aqua:skim-rs/skim"]
+backends = ["aqua:skim-rs/skim", "github:skim-rs/skim"]
 bins = ["sk"]
 description = "Fuzzy Finder in rust"
 test = { cmd = "sk --version", expected = "sk {{version}}" }

--- a/registry/skim.toml
+++ b/registry/skim.toml
@@ -1,0 +1,5 @@
+backends = ["aqua:skim-rs/skim"]
+bins = ["sk"]
+description = "Fuzzy Finder in rust"
+test = { cmd = "sk --version", expected = "sk {{version}}" }
+version_order = "semver"

--- a/registry/skim.toml
+++ b/registry/skim.toml
@@ -1,4 +1,4 @@
-backends = ["aqua:skim-rs/skim", "github:skim-rs/skim"]
+backends = ["aqua:skim-rs/skim", "github:skim-rs/skim", "cargo:skim"]
 bins = ["sk"]
 description = "Fuzzy Finder in rust"
 test = { cmd = "sk --version", expected = "sk {{version}}" }


### PR DESCRIPTION
## Summary
- add a `skim` shorthand with Aqua as the primary backend, followed by GitHub releases and Cargo fallbacks
- register the `sk` binary and its version check
- collapse multiple backend-specific search results into one registry shorthand

## Motivation

The Aqua standard registry contains two separate packages for skim: the normal GitHub release package and a Cargo package. Today this produces two Aqua suggestions:

```console
$ mise search skim
Tool                              Description
aqua:skim-rs/skim                 Fuzzy Finder in rust. https://github.com/skim-rs/skim
aqua:crates.io/skim               Fuzzy Finder in rust!. https://github.com/skim-rs/skim
```

After #12225 translates Aqua registry package types into usable mise backends, the second result becomes `cargo:skim`, but the search remains duplicated:

```text
aqua:skim-rs/skim
cargo:skim
```

Adding the `skim` registry shorthand merges those installation choices under one tool name:

```console
$ mise search skim
skim  Fuzzy Finder in rust. https://github.com/skim-rs/skim
```

This is the same behavior already provided for overlapping Aqua/Cargo entries such as `eza`, `bat`, `gitu`, and `zizmor`: search shows the shorthand once, while its registry entry retains the ordered backend choices.

## Popularity
- GitHub: 6,930 stars, 256 forks; latest release v5.6.5 published 2026-08-16
- crates.io: 1,928,676 total downloads and 159,415 recent downloads
- Active maintenance: latest repository push 2026-08-17

## Validation
- `mise run lint-fix`
- `mise run build`
- `mise ls-remote aqua:skim-rs/skim`
- `mise ls-remote github:skim-rs/skim`
- `mise ls-remote cargo:skim`
- `target/debug/mise search --match-type equal skim`
- `mise x aqua:skim-rs/skim@5.6.5 -- sk --version`
- `mise x github:skim-rs/skim@5.6.5 -- sk --version`
- `mise x cargo:skim@5.6.5 -- sk --version`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `cargo:skim` installation backend for the Skim package.
  * Preserved existing binary, description, version-check, and version-ordering details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->