### PR TITLE
fix(config): restore unconditional dotted conf.d fragments

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,10 +10,10 @@ Learn how to configure mise for your project with `mise.toml` files, environment
 - `mise.toml`
 - `mise/config.toml`
 - `.mise/config.toml`
-- `.mise/conf.d/*.toml` - all non-hidden TOML files in this directory are loaded in alphabetical order; dotted names are [being deprecated](/configuration/environments.html#conf-d-environments)
+- `.mise/conf.d/*.toml` - all non-hidden TOML files in this directory are loaded in alphabetical order; dotted names like `x.base.toml` are [being deprecated](/configuration/environments.html#conf-d-environments) and load only for the matching environment under `env_conf_d = true`
 - `.config/mise.toml` - use this in order to group config files into a common directory
 - `.config/mise/config.toml`
-- `.config/mise/conf.d/*.toml` - all non-hidden TOML files in this directory are loaded in alphabetical order
+- `.config/mise/conf.d/*.toml` - the same fragment loading and [deprecation](/configuration/environments.html#conf-d-environments) behavior under the grouped config directory
 
 ::: tip
 Run [`mise cfg`](/cli/config.html) to figure out what order mise is loading files on your particular setup. This is often

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,10 +10,10 @@ Learn how to configure mise for your project with `mise.toml` files, environment
 - `mise.toml`
 - `mise/config.toml`
 - `.mise/config.toml`
-- `.mise/conf.d/*.toml` - non-hidden TOML fragments, loaded in alphabetical order; environment suffixes such as `tools.development.toml` load only when that environment is active
+- `.mise/conf.d/*.toml` - all non-hidden TOML files in this directory are loaded in alphabetical order; dotted names are [being deprecated](/configuration/environments.html#conf-d-environments)
 - `.config/mise.toml` - use this in order to group config files into a common directory
 - `.config/mise/config.toml`
-- `.config/mise/conf.d/*.toml` - the same fragment and environment-suffix behavior under the grouped config directory
+- `.config/mise/conf.d/*.toml` - all non-hidden TOML files in this directory are loaded in alphabetical order
 
 ::: tip
 Run [`mise cfg`](/cli/config.html) to figure out what order mise is loading files on your particular setup. This is often

--- a/docs/configuration/environments.md
+++ b/docs/configuration/environments.md
@@ -70,8 +70,20 @@ If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, that will be used instead of all of 
 You can also use paths like `mise/config.{MISE_ENV}.toml` or `.config/mise.{MISE_ENV}.toml` Those rules
 follow the order in [Configuration](/configuration).
 
-Files in `.mise/conf.d` and `.config/mise/conf.d` use the same environment suffixes. This allows a
-configuration to stay split into named fragments:
+## conf.d environments
+
+::: warning Migration in progress
+Environment-specific `conf.d` filenames are opt-in until mise 2027.8.10. By default, all non-hidden
+TOML fragments still load unconditionally, including names such as `node.tools.toml`.
+
+Dots in unconditional fragment names are deprecated. Rename them to use hyphens, for example
+`node-tools.toml`, before mise 2027.8.10. At that point, the suffix after the first dot will select
+an environment.
+:::
+
+Set `env_conf_d = true` in `.miserc.toml`, or set `MISE_ENV_CONF_D=true`, to opt into the new
+behavior now. Files in `.mise/conf.d` and `.config/mise/conf.d` will then use the same environment
+suffixes as other config files:
 
 ```text
 .mise/conf.d/tools.toml                   # always loaded
@@ -80,8 +92,9 @@ configuration to stay split into named fragments:
 .mise/conf.d/tools.development.local.toml # MISE_ENV=development, usually gitignored
 ```
 
-An extra filename component before `.toml` is reserved for the environment, so use hyphens rather
-than dots inside an unconditional fragment name: `node-tools.toml`, not `node.tools.toml`.
+Because this setting controls config discovery, it must be set in `.miserc.toml` or the environment;
+setting it in `mise.toml` is too late. Set `env_conf_d = false` explicitly to retain the old behavior
+without the deprecation warning during the migration window.
 
 Use `mise config` to see which files are being used.
 

--- a/docs/configuration/environments.md
+++ b/docs/configuration/environments.md
@@ -81,8 +81,8 @@ Dots in unconditional fragment names are deprecated. Rename them to use hyphens,
 an environment.
 :::
 
-Set `env_conf_d = true` in `.miserc.toml`, or set `MISE_ENV_CONF_D=true`, to opt into the new
-behavior now. Files in `.mise/conf.d` and `.config/mise/conf.d` will then use the same environment
+Set `env_conf_d = true` in any `miserc.toml` file (the locations listed above), or set
+`MISE_ENV_CONF_D=true`, to opt into the new behavior now. Files in `.mise/conf.d` and `.config/mise/conf.d` will then use the same environment
 suffixes as other config files:
 
 ```text
@@ -92,8 +92,8 @@ suffixes as other config files:
 .mise/conf.d/tools.development.local.toml # MISE_ENV=development, usually gitignored
 ```
 
-Because this setting controls config discovery, it must be set in `.miserc.toml` or the environment;
-setting it in `mise.toml` is too late. Set `env_conf_d = false` explicitly to retain the old behavior
+Because this setting controls config discovery, it must be set in a `miserc.toml` file or the
+environment; setting it in `mise.toml` is too late. Set `env_conf_d = false` explicitly to retain the old behavior
 without the deprecation warning during the migration window.
 
 Use `mise config` to see which files are being used.

--- a/e2e/config/test_config_auto_env
+++ b/e2e/config/test_config_auto_env
@@ -26,6 +26,7 @@ echo 'env.CONF_D_AUTO = "base"' >.mise/conf.d/00-base.toml
 echo 'env.CONF_D_AUTO = "unix"' >.mise/conf.d/10-platform.unix.toml
 echo "env.CONF_D_AUTO = \"$os\"" >".mise/conf.d/20-platform.$os.toml"
 echo "env.CONF_D_AUTO = \"$os-$arch\"" >".mise/conf.d/30-platform.$os-$arch.toml"
+export MISE_ENV_CONF_D=true
 
 # default: off, platform configs are not loaded
 assert "mise env --json | jq -r .AAA" "base"

--- a/e2e/config/test_config_env
+++ b/e2e/config/test_config_env
@@ -11,7 +11,7 @@ MISE_ENV=ci assert "mise ls dummy" "dummy  3 (missing)  ~/workdir/mise.ci.toml  
 MISE_ENV=ci,test assert "mise ls dummy" "dummy  2.0.0 (missing)  ~/workdir/mise.test.toml  2"
 MISE_ENV=test,ci assert "mise ls dummy" "dummy  3 (missing)  ~/workdir/mise.ci.toml  3"
 
-# conf.d fragments follow the same environment and local filename conventions
+# Dotted conf.d fragments remain unconditional by default during migration.
 mkdir -p .mise/conf.d
 cat >.mise/conf.d/00-base.toml <<'EOF'
 [env]
@@ -40,9 +40,15 @@ cat >.mise/conf.d/99-inactive.inactive.toml <<'EOF'
 CONF_D_INACTIVE = "loaded"
 EOF
 
-assert "mise env --json | jq -r '[.CONF_D_COMMON, .CONF_D_ENV, .CONF_D_ALWAYS_LOCAL, .CONF_D_INACTIVE] | @tsv'" $'base\tbase\tlocal\t'
-MISE_ENV=test assert "mise env --json | jq -r '[.CONF_D_ENV, .CONF_D_ENV_LOCAL, .CONF_D_INACTIVE] | @tsv'" $'test\ttest-local\t'
-MISE_ENV=test,ci assert "mise env --json | jq -r '[.CONF_D_ENV, .CONF_D_ENV_LOCAL] | @tsv'" $'ci\ttest-local'
+assert_contains "mise env 2>&1" "deprecated [dotted_conf_d_filename]"
+assert_not_contains "MISE_ENV_CONF_D=false mise env 2>&1" "deprecated [dotted_conf_d_filename]"
+assert "mise env --json | jq -r '[.CONF_D_COMMON, .CONF_D_ENV, .CONF_D_ALWAYS_LOCAL, .CONF_D_INACTIVE] | @tsv'" $'base\tci\tlocal\tloaded'
+MISE_ENV=test assert "mise env --json | jq -r '[.CONF_D_ENV, .CONF_D_ENV_LOCAL, .CONF_D_INACTIVE] | @tsv'" $'ci\ttest-local\tloaded'
+
+# Users can opt into environment-specific conf.d filenames immediately.
+MISE_ENV_CONF_D=true assert "mise env --json | jq -r '[.CONF_D_COMMON, .CONF_D_ENV, .CONF_D_ALWAYS_LOCAL, .CONF_D_INACTIVE] | @tsv'" $'base\tbase\tlocal\t'
+MISE_ENV_CONF_D=true MISE_ENV=test assert "mise env --json | jq -r '[.CONF_D_ENV, .CONF_D_ENV_LOCAL, .CONF_D_INACTIVE] | @tsv'" $'test\ttest-local\t'
+MISE_ENV_CONF_D=true MISE_ENV=test,ci assert "mise env --json | jq -r '[.CONF_D_ENV, .CONF_D_ENV_LOCAL] | @tsv'" $'ci\ttest-local'
 
 # Environment names are matched literally and by the complete suffix after the first dot
 cat >'.mise/conf.d/30-literal.qa*.toml' <<'EOF'
@@ -62,6 +68,6 @@ cat >.mise/conf.d/41-prod.prod.toml <<'EOF'
 CONF_D_PROD = "prod"
 EOF
 
-MISE_ENV='qa*' assert "mise env --json | jq -r '[.CONF_D_LITERAL, .CONF_D_UNRELATED] | @tsv'" $'literal\t'
-MISE_ENV=prod assert "mise env --json | jq -r '[.CONF_D_DOTTED, .CONF_D_PROD] | @tsv'" $'\tprod'
-MISE_ENV=qa.prod assert "mise env --json | jq -r '[.CONF_D_DOTTED, .CONF_D_PROD] | @tsv'" $'dotted\t'
+MISE_ENV_CONF_D=true MISE_ENV='qa*' assert "mise env --json | jq -r '[.CONF_D_LITERAL, .CONF_D_UNRELATED] | @tsv'" $'literal\t'
+MISE_ENV_CONF_D=true MISE_ENV=prod assert "mise env --json | jq -r '[.CONF_D_DOTTED, .CONF_D_PROD] | @tsv'" $'\tprod'
+MISE_ENV_CONF_D=true MISE_ENV=qa.prod assert "mise env --json | jq -r '[.CONF_D_DOTTED, .CONF_D_PROD] | @tsv'" $'dotted\t'

--- a/e2e/config/test_global_config_precedence
+++ b/e2e/config/test_global_config_precedence
@@ -8,6 +8,12 @@ export MISE_CEILING_PATHS="$HOME"
 
 mkdir -p "$MISE_CONFIG_DIR/conf.d"
 
+cat >dotted-fragment-target.toml <<EOF
+[env]
+DOTTED_SYMLINK = "loaded"
+EOF
+ln -s "$PWD/dotted-fragment-target.toml" "$MISE_CONFIG_DIR/conf.d/x.base.toml"
+
 cat >"$MISE_CONFIG_DIR/conf.d/10-fragment.toml" <<EOF
 [settings]
 minimum_release_age_excludes = ["from-conf-d"]
@@ -34,6 +40,8 @@ EOF
 echo "dummy 1.0.0" >"$HOME/.tool-versions"
 
 assert "mise env | grep GLOBAL_PRECEDENCE" "export GLOBAL_PRECEDENCE=from-local"
+assert "mise env --json | jq -r .DOTTED_SYMLINK" "loaded"
+MISE_ENV_CONF_D=true assert "mise env --json | jq -r .DOTTED_SYMLINK" "null"
 assert "mise settings get minimum_release_age_excludes" '["from-local"]'
 # ~/.tool-versions joins the global group only under MISE_USE_TOML=0, and outranks
 # the config dir. Only the active version carries a source.

--- a/e2e/tasks/test_task_monorepo_mise_env
+++ b/e2e/tasks/test_task_monorepo_mise_env
@@ -59,6 +59,7 @@ EOF
 mkdir -p projects/frontend/.mise/conf.d
 echo 'env.DEV_CONF_D = "dev-conf-d"' >projects/frontend/.mise/conf.d/frontend.dev.toml
 echo 'env.PROD_CONF_D = "prod-conf-d"' >projects/frontend/.mise/conf.d/frontend.prod.toml
+export MISE_ENV_CONF_D=true
 
 # Create backend project
 mkdir -p projects/backend

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -829,6 +829,10 @@
           "description": "TTL for cached environments",
           "type": "string"
         },
+        "env_conf_d": {
+          "description": "Enable environment-specific filenames in conf.d directories.",
+          "type": "boolean"
+        },
         "env_file": {
           "description": "Path to a file containing environment variables to automatically load.",
           "type": "string"

--- a/schema/miserc.json
+++ b/schema/miserc.json
@@ -25,6 +25,10 @@
         "type": "string"
       }
     },
+    "env_conf_d": {
+      "description": "Enable environment-specific filenames in conf.d directories.",
+      "type": "boolean"
+    },
     "ignored_config_paths": {
       "default": [],
       "description": "This is a list of config paths that mise will ignore.",

--- a/settings.toml
+++ b/settings.toml
@@ -679,6 +679,27 @@ tool versions, settings, or watched files change.
 env = "MISE_ENV_CACHE_TTL"
 type = "Duration"
 
+[env_conf_d]
+description = "Enable environment-specific filenames in conf.d directories."
+docs = """
+When enabled, files in `.mise/conf.d` and `.config/mise/conf.d` use environment
+suffixes: `tools.development.toml` loads only when `development` is active, and
+`tools.development.local.toml` is its local variant.
+
+This behavior is opt-in during the migration period. When disabled or unset,
+all non-hidden TOML files in `conf.d` continue to load unconditionally. Dots in
+unconditional fragment names are deprecated; rename `node.tools.toml` to
+`node-tools.toml` before mise 2027.8.10.
+
+This is an early-init setting: it must be set in `.miserc.toml` or via the
+`MISE_ENV_CONF_D` environment variable. Setting it in `mise.toml` has no effect
+because config file discovery has already occurred by the time `mise.toml` is read.
+"""
+env = "MISE_ENV_CONF_D"
+optional = true
+rc = true
+type = "Bool"
+
 [env_file]
 description = "Path to a file containing environment variables to automatically load."
 env = "MISE_ENV_FILE"

--- a/settings.toml
+++ b/settings.toml
@@ -691,7 +691,7 @@ all non-hidden TOML files in `conf.d` continue to load unconditionally. Dots in
 unconditional fragment names are deprecated; rename `node.tools.toml` to
 `node-tools.toml` before mise 2027.8.10.
 
-This is an early-init setting: it must be set in `.miserc.toml` or via the
+This is an early-init setting: it must be set in a `miserc.toml` file or via the
 `MISE_ENV_CONF_D` environment variable. Setting it in `mise.toml` has no effect
 because config file discovery has already occurred by the time `mise.toml` is read.
 """

--- a/src/config/miserc.rs
+++ b/src/config/miserc.rs
@@ -67,6 +67,11 @@ pub fn get_auto_env() -> Option<bool> {
     get().auto_env
 }
 
+/// Get the env_conf_d value from miserc, if set.
+pub fn get_env_conf_d() -> Option<bool> {
+    get().env_conf_d
+}
+
 /// Get the ceiling_paths value from miserc, if set.
 pub fn get_ceiling_paths() -> Option<&'static BTreeSet<PathBuf>> {
     get().ceiling_paths.as_ref()
@@ -186,6 +191,9 @@ fn merge_settings(target: &mut MisercSettings, source: MisercSettings) {
     if source.auto_env.is_some() {
         target.auto_env = source.auto_env;
     }
+    if source.env_conf_d.is_some() {
+        target.env_conf_d = source.env_conf_d;
+    }
     if source.ceiling_paths.is_some() {
         target.ceiling_paths = source.ceiling_paths;
     }
@@ -266,23 +274,27 @@ mod tests {
     fn test_merge_settings() {
         let mut target = MisercSettings {
             env: Some(vec!["base".to_string()]),
+            env_conf_d: Some(false),
             ..Default::default()
         };
 
         let source = MisercSettings {
             env: Some(vec!["override".to_string()]),
+            env_conf_d: Some(true),
             ..Default::default()
         };
 
         merge_settings(&mut target, source);
 
         assert_eq!(target.env, Some(vec!["override".to_string()]));
+        assert_eq!(target.env_conf_d, Some(true));
     }
 
     #[test]
     fn test_parse_miserc() {
         let content = r#"
 env = ["development", "local"]
+env_conf_d = true
 ceiling_paths = ["/home/user"]
 "#;
         let settings: MisercSettings = toml::from_str(content).unwrap();
@@ -290,6 +302,7 @@ ceiling_paths = ["/home/user"]
             settings.env,
             Some(vec!["development".to_string(), "local".to_string()])
         );
+        assert_eq!(settings.env_conf_d, Some(true));
         assert!(settings.ceiling_paths.is_some());
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1700,6 +1700,8 @@ fn env_config_patterns(env: &str) -> Vec<String> {
     env_config_patterns_with_conf_d(env, env::env_conf_d())
 }
 
+/// `env_config_patterns` with the `env_conf_d` decision injected, so tests can
+/// cover both sides of the migration without touching global state.
 fn env_config_patterns_with_conf_d(env: &str, env_conf_d: bool) -> Vec<String> {
     let env = glob::Pattern::escape(env);
     let mut patterns = vec![
@@ -1841,16 +1843,21 @@ fn is_environment_conf_d_file(path: &Path) -> bool {
     conf_d_file_environment(path).is_some()
 }
 
+/// Warn about a dotted `conf.d` fragment whose name will become an environment
+/// selector once `env_conf_d` defaults to on. Only fires inside the migration
+/// window: the setting is unset (so the meaning is still going to change) and
+/// the version default is still legacy (so it hasn't changed yet).
 fn warn_on_dotted_conf_d_file(path: &Path) {
     if settings::is_loaded()
         && env::env_conf_d_setting().is_none()
+        && !env::env_conf_d()
         && is_environment_conf_d_file(path)
     {
         deprecated_at!(
             "2026.8.10",
             "2027.8.10",
             "dotted_conf_d_filename",
-            "dots in unconditional conf.d filenames are deprecated because the suffix will become an environment selector; rename fragments such as `node.tools.toml` to `node-tools.toml`, or set `env_conf_d = true` in .miserc.toml to opt in now"
+            "dots in unconditional conf.d filenames are deprecated because the suffix will become an environment selector; rename fragments such as `node.tools.toml` to `node-tools.toml`, or set `env_conf_d = true` in a miserc.toml file to opt in now"
         );
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1697,25 +1697,32 @@ static LOCAL_CONFIG_FILENAMES: Lazy<IndexSet<&'static str>> = Lazy::new(|| {
 /// Config filename patterns for a single MISE_ENV environment, in precedence order
 /// (later wins, matching LOCAL_CONFIG_FILENAMES ordering)
 fn env_config_patterns(env: &str) -> Vec<String> {
+    env_config_patterns_with_conf_d(env, env::env_conf_d())
+}
+
+fn env_config_patterns_with_conf_d(env: &str, env_conf_d: bool) -> Vec<String> {
     let env = glob::Pattern::escape(env);
-    vec![
-        format!(".config/mise/conf.d/*.{env}.toml"),
+    let mut patterns = vec![
         format!(".config/mise/config.{env}.toml"),
         format!(".config/mise.{env}.toml"),
         format!("mise/config.{env}.toml"),
         format!("mise.{env}.toml"),
-        format!(".mise/conf.d/*.{env}.toml"),
         format!(".mise/config.{env}.toml"),
         format!(".mise.{env}.toml"),
-        format!(".config/mise/conf.d/*.{env}.local.toml"),
         format!(".config/mise/config.{env}.local.toml"),
         format!(".config/mise.{env}.local.toml"),
         format!("mise/config.{env}.local.toml"),
         format!("mise.{env}.local.toml"),
-        format!(".mise/conf.d/*.{env}.local.toml"),
         format!(".mise/config.{env}.local.toml"),
         format!(".mise.{env}.local.toml"),
-    ]
+    ];
+    if env_conf_d {
+        patterns.insert(0, format!(".config/mise/conf.d/*.{env}.toml"));
+        patterns.insert(5, format!(".mise/conf.d/*.{env}.toml"));
+        patterns.insert(8, format!(".config/mise/conf.d/*.{env}.local.toml"));
+        patterns.insert(13, format!(".mise/conf.d/*.{env}.local.toml"));
+    }
+    patterns
 }
 
 pub static DEFAULT_CONFIG_FILENAMES: Lazy<Vec<String>> = Lazy::new(|| {
@@ -1834,8 +1841,29 @@ fn is_environment_conf_d_file(path: &Path) -> bool {
     conf_d_file_environment(path).is_some()
 }
 
+fn warn_on_dotted_conf_d_file(path: &Path) {
+    if settings::is_loaded()
+        && env::env_conf_d_setting().is_none()
+        && is_environment_conf_d_file(path)
+    {
+        deprecated_at!(
+            "2026.8.10",
+            "2027.8.10",
+            "dotted_conf_d_filename",
+            "dots in unconditional conf.d filenames are deprecated because the suffix will become an environment selector; rename fragments such as `node.tools.toml` to `node-tools.toml`, or set `env_conf_d = true` in .miserc.toml to opt in now"
+        );
+    }
+}
+
 fn load_config_glob(dir: &Path, pattern: &str) -> Vec<PathBuf> {
-    config_glob(dir, pattern)
+    let paths = config_glob(dir, pattern);
+    if !env::env_conf_d() {
+        for path in &paths {
+            warn_on_dotted_conf_d_file(path);
+        }
+        return paths;
+    }
+    paths
         .into_iter()
         .filter(|path| {
             if is_unconditional_conf_d_pattern(pattern) {
@@ -1873,8 +1901,9 @@ pub(crate) fn environments_for_config_path(path: &Path) -> Vec<String> {
             ["config", "mise", ".mise"].into_iter().any(|prefix| {
                 filename == format!("{prefix}.{environment}.toml")
                     || filename == format!("{prefix}.{environment}.local.toml")
-            }) || conf_d_file_environment(path)
-                .is_some_and(|(file_environment, _)| file_environment == environment.as_str())
+            }) || (env::env_conf_d()
+                && conf_d_file_environment(path)
+                    .is_some_and(|(file_environment, _)| file_environment == environment.as_str()))
         })
         .cloned()
         .collect()
@@ -2264,8 +2293,10 @@ fn detect_auto_env_candidate_files() -> Vec<PathBuf> {
     }
     for dir in [*dirs::CONFIG, *dirs::SYSTEM_CONFIG] {
         for env_name in &candidate_envs {
-            found.extend(conf_d_environment_files(dir, env_name, false));
-            found.extend(conf_d_environment_files(dir, env_name, true));
+            if env::env_conf_d() {
+                found.extend(conf_d_environment_files(dir, env_name, false));
+                found.extend(conf_d_environment_files(dir, env_name, true));
+            }
             for filename in [
                 format!("config.{env_name}.toml"),
                 format!("mise.{env_name}.toml"),
@@ -2494,14 +2525,17 @@ fn config_files_from_dir(dir: &Path) -> IndexSet<PathBuf> {
         if let Some(file_name) = p.file_name().map(|f| f.to_string_lossy().to_string())
             && !file_name.starts_with(".")
             && file_name.ends_with(".toml")
-            && !is_environment_conf_d_file(&p)
+            && (!env::env_conf_d() || !is_environment_conf_d_file(&p))
         {
+            warn_on_dotted_conf_d_file(&p);
             files.insert(p);
         }
     }
     files.extend([dir.join("config.toml"), dir.join("mise.toml")]);
     for environment in &*env::MISE_ENV_WITH_AUTO {
-        files.extend(conf_d_environment_files(dir, environment, false));
+        if env::env_conf_d() {
+            files.extend(conf_d_environment_files(dir, environment, false));
+        }
         files.extend([
             dir.join(format!("config.{environment}.toml")),
             dir.join(format!("mise.{environment}.toml")),
@@ -2509,7 +2543,9 @@ fn config_files_from_dir(dir: &Path) -> IndexSet<PathBuf> {
     }
     files.extend([dir.join("config.local.toml"), dir.join("mise.local.toml")]);
     for environment in &*env::MISE_ENV_WITH_AUTO {
-        files.extend(conf_d_environment_files(dir, environment, true));
+        if env::env_conf_d() {
+            files.extend(conf_d_environment_files(dir, environment, true));
+        }
         files.extend([
             dir.join(format!("config.{environment}.local.toml")),
             dir.join(format!("mise.{environment}.local.toml")),
@@ -2714,6 +2750,7 @@ async fn parse_config_file(
     f: &PathBuf,
     idiomatic_filenames: &BTreeMap<String, Vec<String>>,
 ) -> Result<Arc<dyn ConfigFile>> {
+    warn_on_dotted_conf_d_file(f);
     let plugins = matching_idiomatic_tools(f, idiomatic_filenames);
     if plugins.is_empty() {
         config_file::parse(f).await
@@ -5391,7 +5428,7 @@ mod tests {
     }
 
     #[test]
-    fn test_project_conf_d_environment_precedence() -> Result<()> {
+    fn test_project_conf_d_dotted_fragments_remain_unconditional() -> Result<()> {
         let tmp = TempDir::new()?;
         let confd = tmp.path().join(".mise/conf.d");
         fs::create_dir_all(&confd)?;
@@ -5405,11 +5442,7 @@ mod tests {
             fs::write(confd.join(filename), "[env]\n")?;
         }
 
-        let filenames = vec![
-            ".mise/conf.d/*.toml".to_string(),
-            ".mise/conf.d/*.dev.toml".to_string(),
-            ".mise/conf.d/*.dev.local.toml".to_string(),
-        ];
+        let filenames = vec![".mise/conf.d/*.toml".to_string()];
         let paths = config_paths_in_dir_with_filenames(tmp.path(), &filenames);
         let relative = paths
             .iter()
@@ -5418,6 +5451,9 @@ mod tests {
         assert_eq!(
             relative,
             vec![
+                Path::new(".mise/conf.d/05-ci.ci.toml"),
+                Path::new(".mise/conf.d/04-dev-local.dev.local.toml"),
+                Path::new(".mise/conf.d/03-dev.dev.toml"),
                 Path::new(".mise/conf.d/02-local.local.toml"),
                 Path::new(".mise/conf.d/01-base.toml"),
             ]
@@ -5768,7 +5804,7 @@ mod tests {
     #[test]
     fn test_env_config_patterns() {
         assert_eq!(
-            env_config_patterns("linux"),
+            env_config_patterns_with_conf_d("linux", true),
             vec![
                 ".config/mise/conf.d/*.linux.toml",
                 ".config/mise/config.linux.toml",
@@ -5788,6 +5824,11 @@ mod tests {
                 ".mise.linux.local.toml",
             ]
         );
+        assert!(
+            env_config_patterns_with_conf_d("linux", false)
+                .iter()
+                .all(|pattern| !pattern.contains("conf.d"))
+        );
     }
 
     #[test]
@@ -5798,7 +5839,7 @@ mod tests {
         fs::write(confd.join("tools.qa*.toml"), "[env]\n")?;
         fs::write(confd.join("tools.qa1.toml"), "[env]\n")?;
 
-        let pattern = env_config_patterns("qa*")
+        let pattern = env_config_patterns_with_conf_d("qa*", true)
             .into_iter()
             .find(|pattern| pattern.starts_with(".mise/conf.d/") && !pattern.contains(".local."))
             .unwrap();

--- a/src/env.rs
+++ b/src/env.rs
@@ -329,6 +329,8 @@ pub(crate) fn env_conf_d_default_for_version(v: &versions::Versioning) -> bool {
     *v >= versions::Versioning::new("2027.8.10").unwrap()
 }
 
+/// Whether `conf.d` filenames carry environment suffixes, resolving the
+/// setting against the version-gated default.
 pub fn env_conf_d() -> bool {
     env_conf_d_setting().unwrap_or_else(|| env_conf_d_default_for_version(&crate::cli::version::V))
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -313,6 +313,26 @@ pub fn auto_env_setting() -> Option<bool> {
     }
 }
 
+/// The tri-state env_conf_d setting: MISE_ENV_CONF_D env var > .miserc.toml > unset.
+pub fn env_conf_d_setting() -> Option<bool> {
+    if var_is_true("MISE_ENV_CONF_D") {
+        Some(true)
+    } else if var_is_false("MISE_ENV_CONF_D") {
+        Some(false)
+    } else {
+        miserc::get_env_conf_d()
+    }
+}
+
+/// Keep dotted conf.d fragments unconditional through the deprecation window.
+pub(crate) fn env_conf_d_default_for_version(v: &versions::Versioning) -> bool {
+    *v >= versions::Versioning::new("2027.8.10").unwrap()
+}
+
+pub fn env_conf_d() -> bool {
+    env_conf_d_setting().unwrap_or_else(|| env_conf_d_default_for_version(&crate::cli::version::V))
+}
+
 /// Default for auto_env when the setting is unset: off until mise 2027.6.0
 pub(crate) fn auto_env_default_for_version(v: &versions::Versioning) -> bool {
     *v >= versions::Versioning::new("2027.6.0").unwrap()
@@ -1223,6 +1243,14 @@ mod tests {
         assert!(!auto_env_default_for_version(&v("2027.5.9")));
         assert!(auto_env_default_for_version(&v("2027.6.0")));
         assert!(auto_env_default_for_version(&v("2028.1.0")));
+    }
+
+    #[test]
+    fn test_env_conf_d_default_for_version() {
+        let v = |s: &str| versions::Versioning::new(s).unwrap();
+        assert!(!env_conf_d_default_for_version(&v("2026.8.10")));
+        assert!(!env_conf_d_default_for_version(&v("2027.8.9")));
+        assert!(env_conf_d_default_for_version(&v("2027.8.10")));
     }
 
     #[test]


### PR DESCRIPTION
Fixes the regression reported in #12232.

## What broke

[#12151](https://github.com/jdx/mise/pull/12151) taught `conf.d` to read the filename component before `.toml` as an environment selector. That silently changed the meaning of every existing dotted fragment: as of 2026.8.9, `~/.config/mise/conf.d/x.base.toml` stopped loading unless `MISE_ENV` contained `base`. No warning, no migration window — tools just disappeared from the config stack.

That was my mistake. The new syntax is fine; shipping it as an immediate reinterpretation of filenames people already had on disk was not.

## What this does

- **Restores the old behavior as the default.** Every non-hidden `.toml` file in `.mise/conf.d` and `.config/mise/conf.d` loads unconditionally again, dots included.
- **Deprecates dotted unconditional names** via `deprecated_at!("2026.8.10", "2027.8.10", ...)`. The warning points at hyphenated names (`node-tools.toml` rather than `node.tools.toml`).
- **Adds an early-init `env_conf_d` setting** (`MISE_ENV_CONF_D`) so the new semantics are available immediately:
  - `env_conf_d = true` — opt into environment-specific `conf.d` filenames now.
  - `env_conf_d = false` — keep the legacy behavior and silence the deprecation warning.
  - unset — legacy behavior until 2027.8.10, then the new behavior becomes the default.

  It has to be set in `.miserc.toml` or the environment, since config discovery happens before `mise.toml` is read.

The dotted-name ambiguity is worth resolving eventually — that's what the 12-month window is for — but not by breaking working setups in a patch release.

## Testing

- `cargo test --bin mise` (3077 passed)
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean
- `mise run lint` clean
- `mise run test:e2e e2e/config/test_config_env e2e/config/test_config_auto_env e2e/config/test_global_config_precedence e2e/tasks/test_task_monorepo_mise_env`
- `test_global_config_precedence` now covers the exact reported case: a dotted **symlink** (`conf.d/x.base.toml`) in the global config dir loads by default, and drops out under `MISE_ENV_CONF_D=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which config files are discovered and merged, so a wrong default or setting would drop or reintroduce fragments. The change is gated and covered by e2e tests, but it still sits on the config-loading path.
> 
> **Overview**
> Restores loading every non-hidden `conf.d` TOML fragment by default, undoing the silent break where names like `x.base.toml` were treated as environment selectors.
> 
> Environment-specific `conf.d` suffixes are now opt-in via early-init `env_conf_d` / `MISE_ENV_CONF_D` (must be set in `miserc.toml` or the environment). Unset keeps the old behavior until **2027.8.10**; dotted unconditional names warn during the window. `env_conf_d = false` silences the warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46a51cc8fb76955946a9c2f9fa3278a9cd418bd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in support for environment-specific `conf.d` filenames via `env_conf_d` or `MISE_ENV_CONF_D`.
  * Added support for environment suffixes and local variants.
  * Added configuration schema support for the new setting.

* **Bug Fixes**
  * Improved `conf.d` loading, environment matching, and symlink handling.
  * Dotted fragments now load unconditionally by default, with deprecation warnings.

* **Documentation**
  * Documented configuration options, setting locations, behavior, and migration timeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->