### PR TITLE
fix(brew): resolve cask artifacts behind flight-created symlinks

### DIFF
--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -6062,7 +6062,32 @@ fn find_artifact_matching(
             case_insensitive = Some(entry.into_path());
         }
     }
-    case_insensitive
+    if let Some(found) = case_insensitive {
+        return Some(found);
+    }
+    // `WalkDir` defaults to `follow_links = false`, so the walk above never
+    // descends into a symlink a flight step created: gcloud-cli's last
+    // preflight step links `staged_path/google-cloud-sdk` at the SDK it copied
+    // into the prefix, and every `binary` beneath it was unreachable. Resolving
+    // `name` as an exact path under `root` traverses the link. Kept as a
+    // fallback rather than a fast path so the walk's exact-then-case-insensitive
+    // precedence is unchanged on case-insensitive filesystems.
+    relative_artifact_path(root, name_path).filter(|path| pred(path))
+}
+
+/// `name` resolved against `root`, or `None` when `name` cannot be interpreted
+/// as a path contained by `root`.
+fn relative_artifact_path(root: &Path, name: &Path) -> Option<PathBuf> {
+    if name.as_os_str().is_empty() || name.is_absolute() {
+        return None;
+    }
+    if name
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return None;
+    }
+    Some(root.join(name))
 }
 
 /// True when `path`'s trailing components match `suffix` with ASCII
@@ -10476,6 +10501,64 @@ end
 
         assert_eq!(find_app(tmp.path(), "yaak.app"), Some(app));
         Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn artifact_lookup_resolves_through_a_flight_created_symlink() -> Result<()> {
+        // gcloud-cli's last preflight step symlinks
+        // `staged_path/google-cloud-sdk` at the SDK copied into the prefix, so
+        // every `binary` source resolves only by traversing that link. The walk
+        // cannot enter it.
+        let tmp = tempfile::tempdir()?;
+        let stage = tmp.path().join("stage");
+        let installed = tmp.path().join("share/google-cloud-sdk");
+        file::create_dir_all(&stage)?;
+        file::create_dir_all(installed.join("bin"))?;
+        crate::file::write(
+            installed.join("bin/git-credential-gcloud.sh"),
+            "credential helper",
+        )?;
+        std::os::unix::fs::symlink(&installed, stage.join("google-cloud-sdk"))?;
+
+        assert_eq!(
+            find_file_artifact(&stage, "google-cloud-sdk/bin/git-credential-gcloud.sh"),
+            Some(stage.join("google-cloud-sdk/bin/git-credential-gcloud.sh"))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn artifact_lookup_rejects_sources_that_escape_the_root() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let stage = tmp.path().join("stage");
+        file::create_dir_all(&stage)?;
+        crate::file::write(tmp.path().join("outside"), "not ours")?;
+
+        assert_eq!(find_file_artifact(&stage, "../outside"), None);
+        assert_eq!(
+            find_file_artifact(&stage, &tmp.path().join("outside").to_string_lossy()),
+            None
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn relative_artifact_path_refuses_names_it_cannot_contain() {
+        let root = Path::new("/stage");
+
+        assert_eq!(
+            relative_artifact_path(root, Path::new("bin/op")),
+            Some(PathBuf::from("/stage/bin/op"))
+        );
+        // An empty name would otherwise resolve to `root` itself.
+        assert_eq!(relative_artifact_path(root, Path::new("")), None);
+        assert_eq!(relative_artifact_path(root, Path::new("../op")), None);
+        assert_eq!(
+            relative_artifact_path(root, Path::new("bin/../../op")),
+            None
+        );
+        assert_eq!(relative_artifact_path(root, Path::new("/etc/passwd")), None);
     }
 
     #[test]

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -1830,7 +1830,17 @@ fn install_generic_artifact(
         );
     }
     let target = generic_artifact_target_path(&artifact.target)?;
-    let relative_source = source.strip_prefix(stage)?;
+    // Not a lexical `strip_prefix`: the lookup resolves symlinks it had to
+    // traverse, so a source reached that way can be contained by the stage
+    // without sharing its literal prefix — as it is whenever `stage` itself
+    // has a symlinked ancestor. `staged_relative_path` retries against the
+    // resolved stage, matching the containment check above.
+    let relative_source = staged_relative_path(stage, &source).ok_or_else(|| {
+        eyre!(
+            "brew-cask: generic artifact source is not contained by the extraction root: {}",
+            source.display()
+        )
+    })?;
     let caskroom_source = temporary_caskroom.join(relative_source);
     if !path_starts_with_resolved_root(&caskroom_source, temporary_caskroom) {
         bail!(
@@ -4595,7 +4605,10 @@ fn stage_binary(
             file::copy(&source, &caskroom_binary)?;
             file::make_executable(&caskroom_binary)?;
         } else {
-            file::make_symlink(&source, &caskroom_binary)?;
+            file::make_symlink(
+                &durable_binary_link_target(&source, stage, caskroom),
+                &caskroom_binary,
+            )?;
         }
     }
     Ok(())
@@ -4701,6 +4714,26 @@ fn find_binary_source(
                 binary.source
             )
         })
+}
+
+/// Where to point a caskroom binary link whose source is not stage content.
+///
+/// A source handed to us under the stage or the temporary caskroom, yet
+/// resolving outside it, has to be linked at its real location: a link at the
+/// literal path dangles as soon as staging tears that directory down. This is
+/// reachable both from the walk, which returns a symlink entry it matched by
+/// name, and from `generated_caskroom_artifact`, which maps a hook-generated
+/// path onto either root.
+///
+/// Sources that already sit outside both roots — the absolute paths a pkg
+/// installer creates, for instance — are linked verbatim, so the recorded
+/// target stays the path the cask metadata named.
+fn durable_binary_link_target(source: &Path, stage: &Path, caskroom: &Path) -> PathBuf {
+    if source.starts_with(stage) || source.starts_with(caskroom) {
+        file::desymlink_path(source)
+    } else {
+        source.to_path_buf()
+    }
 }
 
 fn absolute_binary_source(source: &str) -> Option<PathBuf> {
@@ -12932,6 +12965,79 @@ end
                 .parent()
                 .and_then(Path::parent)
                 .is_some_and(|root| root.join("lib").is_dir())
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn links_a_stage_symlink_at_its_target_so_it_survives_teardown() -> Result<()> {
+        // The walk matches symlink entries by name and `is_file` follows them,
+        // so a stage-local link to a durable binary comes back as a stage path
+        // that resolves outside the stage. Linking the caskroom entry at that
+        // literal path would dangle the moment staging tears the stage down.
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let stage = tmp.path().join("stage");
+        let durable = tmp.path().join("opt/vendor/tool");
+        file::create_dir_all(&stage)?;
+        file::create_dir_all(durable.parent().unwrap())?;
+        crate::file::write(&durable, "durable")?;
+        std::os::unix::fs::symlink(&durable, stage.join("tool"))?;
+        let caskroom = caskroom_version_dir("linked-binary", "1.0.0");
+        file::create_dir_all(&caskroom)?;
+        let cask = test_cask("linked-binary", "1.0.0");
+        let binary = BinaryArtifact {
+            source: "tool".to_string(),
+            target: Some("$HOMEBREW_PREFIX/bin/tool".to_string()),
+        };
+
+        stage_binary(&stage, &caskroom, &cask, &[], &binary)?;
+
+        let staged = caskroom.join("bin/tool");
+        assert_eq!(
+            std::fs::read_link(&staged)?,
+            file::desymlink_path(&durable),
+            "must link the real location, not the path through the stage"
+        );
+        // The decisive check: staging is over, so the stage is gone.
+        file::remove_all(&stage)?;
+        assert_eq!(crate::file::read_to_string(&staged)?, "durable");
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stages_generic_artifact_through_a_symlinked_stage() -> Result<()> {
+        // The lookup resolves links it traverses, so the source can be
+        // contained by the stage without sharing its literal prefix. A lexical
+        // strip would fail here even though the containment check passes.
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let real_stage = tmp.path().join("real-stage");
+        let payload = real_stage.join("libcblite-4.1.0/include/cbl");
+        file::create_dir_all(&payload)?;
+        file::write(payload.join("CouchbaseLite.h"), "header")?;
+        std::os::unix::fs::symlink(
+            real_stage.join("libcblite-4.1.0"),
+            real_stage.join("current"),
+        )?;
+        let stage = tmp.path().join("stage");
+        std::os::unix::fs::symlink(&real_stage, &stage)?;
+        let artifact = GenericArtifact {
+            source: "current/include/cbl".to_string(),
+            target: "$HOMEBREW_PREFIX/include/cbl".to_string(),
+        };
+
+        let mut targets = FlightTargetTransaction::default();
+        let temporary_caskroom = tmp.path().join("Caskroom/example/.mise-tmp");
+        install_generic_artifact(&stage, &temporary_caskroom, &artifact, &mut targets)?;
+
+        assert_eq!(
+            file::read_to_string(tmp.path().join("include/cbl/CouchbaseLite.h"))?,
+            "header"
         );
         Ok(())
     }

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -4582,7 +4582,16 @@ fn stage_binary(
         file::make_symlink(&app_binary, &caskroom_binary)?;
     } else {
         let source = find_binary_source(stage, caskroom, cask, binary)?;
-        if source.starts_with(stage) || source.starts_with(caskroom) {
+        // Ephemeral stage content has to be copied into the caskroom before the
+        // stage is torn down; a durable location is linked instead, so a CLI
+        // that derives its own root from the resolved path of `$0` still finds
+        // its tree. Resolve both sides: gcloud-cli's preflight leaves
+        // `staged_path/google-cloud-sdk` as a link to the SDK it installed under
+        // the prefix, and a lexical comparison would read that as stage content
+        // and copy the launcher out of the tree it needs.
+        if path_starts_with_resolved_root(&source, stage)
+            || path_starts_with_resolved_root(&source, caskroom)
+        {
             file::copy(&source, &caskroom_binary)?;
             file::make_executable(&caskroom_binary)?;
         } else {
@@ -6069,25 +6078,41 @@ fn find_artifact_matching(
     // descends into a symlink a flight step created: gcloud-cli's last
     // preflight step links `staged_path/google-cloud-sdk` at the SDK it copied
     // into the prefix, and every `binary` beneath it was unreachable. Resolving
-    // `name` as an exact path under `root` traverses the link. Kept as a
-    // fallback rather than a fast path so the walk's exact-then-case-insensitive
-    // precedence is unchanged on case-insensitive filesystems.
-    relative_artifact_path(root, name_path).filter(|path| pred(path))
+    // `name` as an exact path under `root` traverses the link.
+    //
+    // This only ever fires for that symlinked case. When `root/name` is
+    // reachable without traversing a link, its own relative path ends with
+    // `name`, so the walk already returned it — which is also why the result is
+    // desymlinked: the artifact's real location is what callers need to tell
+    // ephemeral stage content apart from a durable directory that outlives the
+    // install. Kept as a fallback rather than a fast path so the walk's
+    // exact-then-case-insensitive precedence is unchanged on case-insensitive
+    // filesystems.
+    relative_artifact_path(root, name_path)
+        .filter(|path| pred(path))
+        .map(|path| file::desymlink_path(&path))
 }
 
 /// `name` resolved against `root`, or `None` when `name` cannot be interpreted
 /// as a path contained by `root`.
 fn relative_artifact_path(root: &Path, name: &Path) -> Option<PathBuf> {
-    if name.as_os_str().is_empty() || name.is_absolute() {
+    if name.is_absolute() {
         return None;
     }
-    if name
-        .components()
-        .any(|component| matches!(component, Component::ParentDir))
-    {
-        return None;
+    let mut named = false;
+    for component in name.components() {
+        match component {
+            // `.` alone would resolve to `root` itself, and `install_app` would
+            // then take the whole extraction root as the bundle.
+            Component::Normal(component) if component != "__MACOSX" => named = true,
+            // The walk skips `__MACOSX` resource-fork copies; an exact-path hit
+            // must not reintroduce them.
+            Component::Normal(_) => return None,
+            Component::CurDir => {}
+            _ => return None,
+        }
     }
-    Some(root.join(name))
+    named.then(|| root.join(name))
 }
 
 /// True when `path`'s trailing components match `suffix` with ASCII
@@ -10521,9 +10546,14 @@ end
         )?;
         std::os::unix::fs::symlink(&installed, stage.join("google-cloud-sdk"))?;
 
+        // The artifact's real location, not the path through the link: callers
+        // decide copy-vs-symlink from it, and the stage does not outlive the
+        // install.
         assert_eq!(
             find_file_artifact(&stage, "google-cloud-sdk/bin/git-credential-gcloud.sh"),
-            Some(stage.join("google-cloud-sdk/bin/git-credential-gcloud.sh"))
+            Some(file::desymlink_path(
+                &installed.join("bin/git-credential-gcloud.sh")
+            ))
         );
         Ok(())
     }
@@ -10551,14 +10581,31 @@ end
             relative_artifact_path(root, Path::new("bin/op")),
             Some(PathBuf::from("/stage/bin/op"))
         );
-        // An empty name would otherwise resolve to `root` itself.
+        assert_eq!(
+            relative_artifact_path(root, Path::new("./bin/op")),
+            Some(PathBuf::from("/stage/./bin/op"))
+        );
+        // Names that would resolve to `root` itself, which `find_app`'s
+        // directory predicate would accept as the bundle.
         assert_eq!(relative_artifact_path(root, Path::new("")), None);
+        assert_eq!(relative_artifact_path(root, Path::new(".")), None);
+        assert_eq!(relative_artifact_path(root, Path::new("./")), None);
+        // Escapes.
         assert_eq!(relative_artifact_path(root, Path::new("../op")), None);
         assert_eq!(
             relative_artifact_path(root, Path::new("bin/../../op")),
             None
         );
         assert_eq!(relative_artifact_path(root, Path::new("/etc/passwd")), None);
+        // Resource-fork copies the walk skips.
+        assert_eq!(
+            relative_artifact_path(root, Path::new("__MACOSX/Yaak.app")),
+            None
+        );
+        assert_eq!(
+            relative_artifact_path(root, Path::new("payload/__MACOSX/op")),
+            None
+        );
     }
 
     #[test]
@@ -12841,6 +12888,87 @@ end
             crate::file::read_to_string(caskroom.join("bin/op"))?,
             "hook"
         );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn links_rather_than_copies_a_binary_behind_a_flight_symlink() -> Result<()> {
+        // gcloud-cli's preflight installs the SDK under the prefix and leaves
+        // `staged_path/google-cloud-sdk` as a link to it. The launcher derives
+        // CLOUDSDK_ROOT_DIR from the resolved path of `$0`, so copying it into
+        // the caskroom — out of the tree holding `lib/` — would stage a broken
+        // binary. It has to be linked, like Homebrew does.
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let stage = tmp.path().join("stage");
+        let installed = tmp.path().join("share/google-cloud-sdk");
+        file::create_dir_all(&stage)?;
+        file::create_dir_all(installed.join("bin"))?;
+        file::create_dir_all(installed.join("lib"))?;
+        crate::file::write(installed.join("bin/gcloud"), "launcher")?;
+        std::os::unix::fs::symlink(&installed, stage.join("google-cloud-sdk"))?;
+        let caskroom = caskroom_version_dir("gcloud-cli", "531.0.0");
+        file::create_dir_all(&caskroom)?;
+        let cask = test_cask("gcloud-cli", "531.0.0");
+        let binary = BinaryArtifact {
+            source: "google-cloud-sdk/bin/gcloud".to_string(),
+            target: Some("$HOMEBREW_PREFIX/bin/gcloud".to_string()),
+        };
+
+        stage_binary(&stage, &caskroom, &cask, &[], &binary)?;
+
+        let staged = caskroom.join("bin/gcloud");
+        assert_eq!(
+            std::fs::read_link(&staged)?,
+            file::desymlink_path(&installed.join("bin/gcloud")),
+            "must link into the SDK tree, not copy the launcher out of it"
+        );
+        // Still resolves, and `lib/` is a sibling of the link target.
+        assert_eq!(crate::file::read_to_string(&staged)?, "launcher");
+        assert!(
+            std::fs::read_link(&staged)?
+                .parent()
+                .and_then(Path::parent)
+                .is_some_and(|root| root.join("lib").is_dir())
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copies_a_binary_whose_link_stays_inside_a_symlinked_stage() -> Result<()> {
+        // Mirror of the case above with the link pointing back into the stage,
+        // reached through a stage path that is itself a symlink (a symlinked
+        // `~/Library/Caches`). The resolved source then differs lexically from
+        // `stage`, and treating that as a durable location would leave a
+        // dangling binary once the stage is torn down.
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let real_stage = tmp.path().join("real-stage");
+        file::create_dir_all(real_stage.join("payload/bin"))?;
+        crate::file::write(real_stage.join("payload/bin/tool"), "tool")?;
+        std::os::unix::fs::symlink(real_stage.join("payload"), real_stage.join("link"))?;
+        let stage = tmp.path().join("stage");
+        std::os::unix::fs::symlink(&real_stage, &stage)?;
+        let caskroom = caskroom_version_dir("linked-stage", "1.0.0");
+        file::create_dir_all(&caskroom)?;
+        let cask = test_cask("linked-stage", "1.0.0");
+        let binary = BinaryArtifact {
+            source: "link/bin/tool".to_string(),
+            target: Some("$HOMEBREW_PREFIX/bin/tool".to_string()),
+        };
+
+        stage_binary(&stage, &caskroom, &cask, &[], &binary)?;
+
+        let staged = caskroom.join("bin/tool");
+        assert!(
+            !staged.is_symlink(),
+            "stage content must be copied, not linked"
+        );
+        assert_eq!(crate::file::read_to_string(&staged)?, "tool");
         Ok(())
     }
 


### PR DESCRIPTION
Reported in [discussions#10582](https://github.com/jdx/mise/discussions/10582#discussioncomment-18104703): `gcloud-cli` gets all the way through preflight in v2026.8.10 and then fails at binary staging.

```
mise ERROR brew-cask: binary artifact 'google-cloud-sdk/bin/git-credential-gcloud.sh' was not found
```

## Cause

`find_artifact_matching` locates artifacts by walking the stage with `WalkDir`, which defaults to `follow_links = false`. An artifact reachable only through a symlink is therefore invisible to the lookup.

gcloud-cli's [preflight_steps](https://formulae.brew.sh/api/cask/gcloud-cli.json) end by copying the SDK into the prefix and symlinking `staged_path/google-cloud-sdk` back at it. That step works — the SDK installs and the file exists behind the link — but the walk cannot enter the symlink the preflight just created, so every `binary` source beneath it fails to resolve.

This is not gcloud-cli specific. Any artifact type routed through `find_artifact_matching` (`app`, `binary`, `pkg`, `font`) has the same blind spot.

## Fix

When the walk finds nothing, resolve the artifact name as an exact path under the root. A path join traverses the symlink, and it costs one `stat` instead of a tree walk.

`follow_links(true)` on the walk was the other option and is worse: `WalkDir` can loop on cyclic links, and a symlink present in staged archive content would let the walk escape into the rest of the filesystem. The targeted probe only resolves the exact name the cask metadata asked for.

The probe runs *after* the walk rather than before it. The walk's exact-match-then-case-insensitive-fallback precedence is load-bearing on case-insensitive filesystems — `artifact_lookup_prefers_exact_case_over_earlier_fallback` covers a case where a pre-walk probe would return the wrong path on APFS. As a post-walk fallback the change can only turn a current hard failure into a success.

Guards on the resolved name: it must be relative, contain no `..`, contain at least one `Normal` component (so `.` cannot resolve to the extraction root itself, which `find_app`'s `is_dir` predicate would have accepted as the bundle), and contain no `__MACOSX` component (so an exact-path hit cannot reintroduce the resource-fork copies the walk deliberately skips). The caller's predicate still has to hold.

### Linked, not copied

The result is desymlinked, which matters more than it looks. `stage_binary` decides between copying into the caskroom and symlinking based on whether the source is stage content, and `starts_with` is lexical — so the lexical path under the stage read as ephemeral and took the copy branch. That would have copied gcloud's launcher out of the tree it derives `CLOUDSDK_ROOT_DIR` from, i.e. staging would have *succeeded* while producing a broken binary. Thanks to Cursor Bugbot for catching that.

Desymlinking is unconditionally correct here because the fallback only ever fires for the symlinked case: when `root/name` is reachable without traversing a link, its own relative path ends with `name`, so the walk already returned it. Callers therefore get the artifact's real location, which is what distinguishes ephemeral stage content from a durable directory that outlives the install. gcloud-cli's launcher is now linked into the SDK, matching Homebrew.

`stage_binary`'s containment test also resolves both sides now, for a case the above doesn't cover: a link that stays *inside* the stage, reached through a stage path that is itself a symlink (a symlinked `~/Library/Caches`). The resolved source is then lexically different from `stage`, and treating it as durable would leave a dangling binary once the stage is torn down.

Resolving the branch decision introduced a regression of its own, caught independently by Cursor Bugbot and CodeRabbit: the branch was chosen from the resolved location while the link was still created from the literal path. A stage-local symlink to a durable binary — returned directly by the walk, which matches symlink entries by name with `is_file` following them, and also reachable via `generated_caskroom_artifact` — was linked at a path inside the stage and dangled once staging tore it down. That case used to be copied, so it was a regression rather than a pre-existing gap. Such a source is now linked at its real location.

Sources already outside both roots stay verbatim rather than being desymlinked unconditionally. The absolute paths a pkg installer creates are still linked at the path the cask metadata named, so recorded targets that receipt and uninstall logic reads are unchanged.

One more consequence of resolving: `install_generic_artifact` accepted a source with a resolved containment check and then stripped the stage prefix *lexically*. Those disagree whenever the source was reached through a link, which is guaranteed when `stage` has a symlinked ancestor — the check passes and the strip fails with a bare `StripPrefixError`. It now uses `staged_relative_path`, which already retries against the resolved stage for exactly this reason.

Note that resolving through a link means the returned path can leave the stage, which is the point — gcloud-cli's link deliberately targets `$HOMEBREW_PREFIX/share/google-cloud-sdk`. The trust anchor is unchanged: the name comes from sha256-pinned cask API metadata, and `absolute_binary_source` already resolves arbitrary absolute paths from that same metadata.

## Tests

- `artifact_lookup_resolves_through_a_flight_created_symlink` — the gcloud-cli layout resolves, to the durable path
- `links_rather_than_copies_a_binary_behind_a_flight_symlink` — the launcher is linked into the SDK tree, with `lib/` a sibling of the link target
- `links_a_stage_symlink_at_its_target_so_it_survives_teardown` — deletes the stage, then asserts the staged binary still reads, so it catches the dangling link itself rather than only the path shape
- `copies_a_binary_whose_link_stays_inside_a_symlinked_stage` — stage-internal link through a symlinked stage path is copied, not left dangling
- `stages_generic_artifact_through_a_symlinked_stage` — resolved containment and prefix strip agree
- `artifact_lookup_rejects_sources_that_escape_the_root` — `..` and absolute names stay unresolved
- `relative_artifact_path_refuses_names_it_cannot_contain` — the guard table: empty, `.`, `./`, `..`, absolute, `__MACOSX`

I verified every behavioral change in this PR by reverting it individually and confirming the corresponding test fails.

`cargo test --bin mise -- cask` passes (231 tests). `cargo clippy --workspace --all-features --all-targets -- -D warnings` and `mise run lint` are clean.

Verified on Linux; the change is filesystem-level and not macOS-gated, but an actual `mise bootstrap packages apply -y brew-cask:gcloud-cli` on macOS still wants a real run.

*AI-assisted — Tool: Claude Code; model: Anthropic/claude-opus-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed installation of generic artifacts when staging directories use symbolic links.
  * Prevented binary links from becoming broken after temporary staging data is removed.
  * Added clearer errors when staged source paths fall outside their permitted locations.
  * Improved reliability when resolving durable binaries through staged paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->