### PR TITLE
fix(bootstrap): suspend progress display while sudo prompts

### DIFF
--- a/src/system/sudo.rs
+++ b/src/system/sudo.rs
@@ -73,38 +73,22 @@ pub(crate) fn subprocess_mode() -> &'static str {
     }
 }
 
-/// Whether an elevated child that inherits the terminal must first suspend the
-/// progress display. True exactly when sudo may prompt on the controlling TTY.
-///
-/// Already root: no sudo, no prompt. Elevation disabled: the call fails before
-/// spawning anything. Unattended: [`ensure_elevation_available`] has already
-/// required passwordless sudo, so no prompt can appear — and there is no
-/// animated renderer to collide with either.
-fn should_pause_progress(is_root: bool, sudo_enabled: bool, attended: bool) -> bool {
-    !is_root && sudo_enabled && attended
-}
-
-/// Suspend the animated progress display while an elevated child owns the
-/// terminal.
+/// Suspend the animated progress display for as long as the returned guard is
+/// held, because the child about to be spawned owns the terminal.
 ///
 /// Every elevated helper here inherits stdio so that sudo's `Password:` prompt
-/// reaches the user. The progress renderer repaints on its own interval, though,
-/// so without this it overwrites the prompt on the next frame and the command
-/// reads as hung — stdin is connected and typing the password blind works, but
-/// nothing on screen says mise is waiting.
+/// reaches the user. The progress renderer repaints on its own interval,
+/// though, so without this it overwrites the prompt on the next frame and the
+/// command reads as hung — stdin is connected and typing the password blind
+/// works, but nothing on screen says mise is waiting.
 ///
-/// Held for the child's whole lifetime rather than just the prompt: with stdio
-/// inherited the child owns the terminal, so its own output would corrupt the
-/// display too. This is what `--raw` already does by disabling the renderer
-/// outright.
-fn pause_progress_for_tty() -> Option<ProgressPauseGuard> {
-    if !should_pause_progress(
-        is_root(),
-        Settings::get().system_packages.sudo,
-        console::user_attended_stderr(),
-    ) {
-        return None;
-    }
+/// Unconditional, and held for the child's whole lifetime rather than just the
+/// prompt. Whether sudo will prompt is not the deciding question: the child has
+/// the terminal either way, so its own output would corrupt the display too.
+/// This is what `--raw` already achieves by disabling the renderer outright.
+/// [`MultiProgressReport::pause_progress`] is reference-counted and already
+/// no-ops when no renderer is animating, so there is nothing to pre-filter.
+fn pause_progress_for_child() -> Option<ProgressPauseGuard> {
     MultiProgressReport::try_get().map(|report| report.pause_progress())
 }
 
@@ -129,7 +113,7 @@ pub(crate) fn run(program: &str, args: &[String], envs: &[(String, String)]) -> 
     manual.extend(args.iter().cloned());
     let manual_cmd = manual.join(" ");
     ensure_elevation_available(&manual_cmd)?;
-    let _progress_pause = pause_progress_for_tty();
+    let _progress_pause = pause_progress_for_child();
     info!("$ {}", argv.join(" "));
     let mut cmd = CmdLineRunner::new(&argv[0]);
     for arg in &argv[1..] {
@@ -173,7 +157,7 @@ pub(crate) fn run_in_dir<Fd: std::os::fd::AsFd>(
         .collect::<Vec<_>>()
         .join(" ");
     ensure_elevation_available(&manual_cmd)?;
-    let _progress_pause = pause_progress_for_tty();
+    let _progress_pause = pause_progress_for_child();
     info!("$ {}", argv.join(" "));
     let raw = dir.as_fd().as_raw_fd();
     let mut cmd = Command::new(&argv[0]);
@@ -214,7 +198,7 @@ pub(crate) fn output(program: &str, args: &[String], envs: &[(String, String)]) 
         .join(" ");
     ensure_elevation_available(&manual_cmd)?;
     if !is_root() && Settings::get().system_packages.sudo && console::user_attended_stderr() {
-        let _progress_pause = pause_progress_for_tty();
+        let _progress_pause = pause_progress_for_child();
         CmdLineRunner::new("sudo").arg("-v").raw(true).execute()?;
     }
     info!("$ {}", argv.join(" "));
@@ -236,7 +220,7 @@ pub(crate) fn run_with_input(program: &str, args: &[String], input: &[u8]) -> Re
         .collect::<Vec<_>>()
         .join(" ");
     ensure_elevation_available(&manual_cmd)?;
-    let _progress_pause = pause_progress_for_tty();
+    let _progress_pause = pause_progress_for_child();
     info!("$ {}", argv.join(" "));
     let mut child = Command::new(&argv[0])
         .args(&argv[1..])
@@ -270,7 +254,7 @@ pub(crate) fn run_with_input_output(
         .collect::<Vec<_>>()
         .join(" ");
     ensure_elevation_available(&manual_cmd)?;
-    let _progress_pause = pause_progress_for_tty();
+    let _progress_pause = pause_progress_for_child();
     info!("$ {}", argv.join(" "));
     let mut child = Command::new(&argv[0])
         .args(&argv[1..])
@@ -321,23 +305,4 @@ fn ensure_elevation_available(manual_cmd: &str) -> Result<()> {
         }
     }
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// The tiers mirror [`subprocess_mode`]: only the "interactive" case where
-    /// mise itself does the elevating can produce a password prompt that the
-    /// progress renderer would paint over.
-    #[test]
-    fn progress_is_suspended_only_when_sudo_can_prompt() {
-        assert!(should_pause_progress(false, true, true));
-        // already root: the command runs directly, sudo is never invoked
-        assert!(!should_pause_progress(true, true, true));
-        // elevation disabled: the call errors out before spawning anything
-        assert!(!should_pause_progress(false, false, true));
-        // unattended: passwordless sudo was already required, so no prompt
-        assert!(!should_pause_progress(false, true, false));
-    }
 }

--- a/src/system/sudo.rs
+++ b/src/system/sudo.rs
@@ -2,8 +2,9 @@
 //!
 //! System package managers and declarative system mutations that require
 //! root use this. Every elevated command logs its full argv before running,
-//! never prompts for a password without a TTY, and can be disabled entirely
-//! with `system_packages.sudo = false`.
+//! never prompts for a password without a TTY, suspends the progress display
+//! while it owns the terminal, and can be disabled entirely with
+//! `system_packages.sudo = false`.
 
 use std::io::Write;
 use std::process::{Command, Output, Stdio};
@@ -13,6 +14,7 @@ use eyre::bail;
 use crate::cmd::CmdLineRunner;
 use crate::config::Settings;
 use crate::result::Result;
+use crate::ui::multi_progress_report::{MultiProgressReport, ProgressPauseGuard};
 
 pub(crate) fn is_root() -> bool {
     #[cfg(unix)]
@@ -71,6 +73,41 @@ pub(crate) fn subprocess_mode() -> &'static str {
     }
 }
 
+/// Whether an elevated child that inherits the terminal must first suspend the
+/// progress display. True exactly when sudo may prompt on the controlling TTY.
+///
+/// Already root: no sudo, no prompt. Elevation disabled: the call fails before
+/// spawning anything. Unattended: [`ensure_elevation_available`] has already
+/// required passwordless sudo, so no prompt can appear — and there is no
+/// animated renderer to collide with either.
+fn should_pause_progress(is_root: bool, sudo_enabled: bool, attended: bool) -> bool {
+    !is_root && sudo_enabled && attended
+}
+
+/// Suspend the animated progress display while an elevated child owns the
+/// terminal.
+///
+/// Every elevated helper here inherits stdio so that sudo's `Password:` prompt
+/// reaches the user. The progress renderer repaints on its own interval, though,
+/// so without this it overwrites the prompt on the next frame and the command
+/// reads as hung — stdin is connected and typing the password blind works, but
+/// nothing on screen says mise is waiting.
+///
+/// Held for the child's whole lifetime rather than just the prompt: with stdio
+/// inherited the child owns the terminal, so its own output would corrupt the
+/// display too. This is what `--raw` already does by disabling the renderer
+/// outright.
+fn pause_progress_for_tty() -> Option<ProgressPauseGuard> {
+    if !should_pause_progress(
+        is_root(),
+        Settings::get().system_packages.sudo,
+        console::user_attended_stderr(),
+    ) {
+        return None;
+    }
+    MultiProgressReport::try_get().map(|report| report.pause_progress())
+}
+
 /// Run `program args...`, elevating with sudo when not running as root.
 ///
 /// - root: runs the command directly (containers/CI)
@@ -92,6 +129,7 @@ pub(crate) fn run(program: &str, args: &[String], envs: &[(String, String)]) -> 
     manual.extend(args.iter().cloned());
     let manual_cmd = manual.join(" ");
     ensure_elevation_available(&manual_cmd)?;
+    let _progress_pause = pause_progress_for_tty();
     info!("$ {}", argv.join(" "));
     let mut cmd = CmdLineRunner::new(&argv[0]);
     for arg in &argv[1..] {
@@ -135,6 +173,7 @@ pub(crate) fn run_in_dir<Fd: std::os::fd::AsFd>(
         .collect::<Vec<_>>()
         .join(" ");
     ensure_elevation_available(&manual_cmd)?;
+    let _progress_pause = pause_progress_for_tty();
     info!("$ {}", argv.join(" "));
     let raw = dir.as_fd().as_raw_fd();
     let mut cmd = Command::new(&argv[0]);
@@ -175,6 +214,7 @@ pub(crate) fn output(program: &str, args: &[String], envs: &[(String, String)]) 
         .join(" ");
     ensure_elevation_available(&manual_cmd)?;
     if !is_root() && Settings::get().system_packages.sudo && console::user_attended_stderr() {
+        let _progress_pause = pause_progress_for_tty();
         CmdLineRunner::new("sudo").arg("-v").raw(true).execute()?;
     }
     info!("$ {}", argv.join(" "));
@@ -196,6 +236,7 @@ pub(crate) fn run_with_input(program: &str, args: &[String], input: &[u8]) -> Re
         .collect::<Vec<_>>()
         .join(" ");
     ensure_elevation_available(&manual_cmd)?;
+    let _progress_pause = pause_progress_for_tty();
     info!("$ {}", argv.join(" "));
     let mut child = Command::new(&argv[0])
         .args(&argv[1..])
@@ -229,6 +270,7 @@ pub(crate) fn run_with_input_output(
         .collect::<Vec<_>>()
         .join(" ");
     ensure_elevation_available(&manual_cmd)?;
+    let _progress_pause = pause_progress_for_tty();
     info!("$ {}", argv.join(" "));
     let mut child = Command::new(&argv[0])
         .args(&argv[1..])
@@ -279,4 +321,23 @@ fn ensure_elevation_available(manual_cmd: &str) -> Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The tiers mirror [`subprocess_mode`]: only the "interactive" case where
+    /// mise itself does the elevating can produce a password prompt that the
+    /// progress renderer would paint over.
+    #[test]
+    fn progress_is_suspended_only_when_sudo_can_prompt() {
+        assert!(should_pause_progress(false, true, true));
+        // already root: the command runs directly, sudo is never invoked
+        assert!(!should_pause_progress(true, true, true));
+        // elevation disabled: the call errors out before spawning anything
+        assert!(!should_pause_progress(false, false, true));
+        // unattended: passwordless sudo was already required, so no prompt
+        assert!(!should_pause_progress(false, true, false));
+    }
 }

--- a/src/system/sudo.rs
+++ b/src/system/sudo.rs
@@ -306,3 +306,35 @@ fn ensure_elevation_available(manual_cmd: &str) -> Result<()> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Each elevated helper binds the guard for the rest of its body, so the
+    /// renderer stays suspended until the child exits rather than only while
+    /// the guard is constructed. Nested acquisitions — a `with_sudo_fallback`
+    /// retry inside a flight step — must not resume it early either.
+    #[test]
+    fn pause_progress_for_child_suspends_until_every_guard_drops() {
+        let report = MultiProgressReport::get();
+        let baseline = report.progress_suspension_depth();
+
+        let outer = pause_progress_for_child();
+        assert!(outer.is_some(), "a live report must hand back a guard");
+        assert_eq!(report.progress_suspension_depth(), baseline + 1);
+
+        let inner = pause_progress_for_child();
+        assert_eq!(report.progress_suspension_depth(), baseline + 2);
+
+        drop(inner);
+        assert_eq!(
+            report.progress_suspension_depth(),
+            baseline + 1,
+            "the outer child still owns the terminal"
+        );
+
+        drop(outer);
+        assert_eq!(report.progress_suspension_depth(), baseline);
+    }
+}

--- a/src/ui/multi_progress_report.rs
+++ b/src/ui/multi_progress_report.rs
@@ -142,6 +142,16 @@ impl MultiProgressReport {
         }
     }
 
+    /// Depth of overlapping progress suspensions.
+    ///
+    /// For tests that need to observe that a caller holds its guard for a whole
+    /// scope — such as an elevated child's lifetime in [`crate::system::sudo`] —
+    /// rather than only that it constructed one.
+    #[cfg(test)]
+    pub(crate) fn progress_suspension_depth(&self) -> usize {
+        self.pause_state.lock().unwrap().count
+    }
+
     fn resume_progress(&self) {
         let mut state = self.pause_state.lock().unwrap();
         if state.release() {


### PR DESCRIPTION
Reported in [discussions#10582](https://github.com/jdx/mise/discussions/10582#discussioncomment-18104588): a pkg cask install that needs sudo looks hung.

```
$ mise bootstrap packages apply -y brew-cask:blackhole-2ch
mise $ sudo installer -pkg ~/Library/Caches/mise/system-brew/cask-extract/blackhole-2ch-0.7.1/BlackHole2ch-0.7.1.pkg -target /
Password:brew-cask:blackhole-2ch                                            ◟
```

## Cause

Not cask specific — it's a gap in `system::sudo`, the single elevation path.

Every elevated helper there inherits stdio precisely so sudo's `Password:` prompt reaches the user (`run` does this via `.raw(true)` → `execute_raw`). But nothing suspends the progress renderer, and clx repaints on its own interval, so the spinner overwrites the prompt on the next frame. stdin really is connected — typing the password blind works — but nothing on screen says mise is waiting.

The spinner is live for the whole call: `install_with_manager_options` holds `mpr.add("brew-cask:<token>")` across `install_one` → `install_pkg` → `sudo::run("installer", …)`. `--raw` works as a workaround only because `settings.raw` makes `use_progress_ui` false, so there is no renderer to collide with.

Blast radius is every elevated call made under an active progress bar: apt, dnf, pacman, apk, services, accounts, firewall, compose, login_shell, managed_files, and brew all route through `system::sudo`.

## Fix

The mechanism already existed and just wasn't wired up. `MultiProgressReport::pause_progress` returns a reference-counted guard that calls `clx::progress::pause()`, which clears the rendered lines and stops repainting until the last guard drops. Its only callers were the confirmation prompts in `ui::prompt`.

Acquire it in all five elevated entry points: `run`, `run_in_dir`, `output`'s inherited `sudo -v` pre-auth, and both `run_with_input` helpers.

Unconditionally, and for the child's whole lifetime rather than just the prompt. Whether sudo will prompt is not the deciding question — these helpers inherit stdio, so the child owns the terminal either way and its own output would corrupt the display too. This is what `--raw` already achieves by disabling the renderer outright. `pause_progress` computes `renderer_is_paused` from `!use_progress_ui || progress::is_paused()` and skips `progress::pause()` in that case, so it already no-ops when nothing is animating; there is nothing worth pre-filtering, and a predicate would only narrow the fix. (The first revision had one, gated on `user_attended_stderr`, and CodeRabbit correctly pointed out it missed `MISE_FORCE_PROGRESS=1`.)

Two consequences beyond the reported bug:

- `sudo mise bootstrap` on a TTY is also fixed — no prompt appears there, but `installer`/`apt-get` output previously interleaved with the spinner.
- There is now no spinner during a long `installer` or `apt-get` run, matching what `--raw` already gave you.

No CI impact: `settings.ci` already forces `ProgressOutput::Text`, so the guard no-ops there.

The reporter's other suggestion, printing an explicit "waiting for sudo password" line, doesn't work on its own: that line gets repainted over by the same renderer.

## Tests

`pause_progress_for_child_suspends_until_every_guard_drops` covers the part with behavior: the helper hands back a held suspension, and overlapping acquisitions keep the renderer down until the last guard drops — that last part is what stops a nested `with_sudo_fallback` retry inside a flight step from resuming the display while the outer child still owns the terminal. Observing the suspension needed a way to see its depth, so `MultiProgressReport` grew a `#[cfg(test)]` accessor; the test asserts deltas from the depth it sees on entry, since the report is a process-global shared with the rest of the suite. `cargo test --bin mise` passes (3085 tests); clippy and `mise run lint` are clean.

Not covered: that each of the five helpers spans its own child. Driving them for real is environment-dependent (as non-root they shell out to `sudo`; with `system_packages.sudo = false` they bail before spawning; whether CI runs as root flips the branch), the calls block so observing "paused *during* the child" needs a second polling thread, and anything else needs a test-only seam between guard acquisition and spawn — not worth threading test scaffolding through the one path in mise that elevates privileges. Placement rests on the binding instead: each helper holds `let _progress_pause = …` for the rest of its body, so the guard covers the child by construction. `output` is the deliberate exception — its guard is scoped to the inherited `sudo -v` pre-auth, because the captured run that follows owns no terminal.

What is *not* verified here: the visual result. Confirming the prompt stays on screen needs an interactive TTY plus a password-requiring sudo, which unit tests can't provide. The mechanism is verified by construction — `clx::progress::pause()` clears the display and halts repainting, and the guard now spans the child — but a real `mise bootstrap packages apply` against a pkg cask is the confirming run.

*AI-assisted — Tool: Claude Code; model: Anthropic/claude-opus-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Progress output now pauses consistently while elevated commands are running, including when they request passwords or control the terminal.
  - Improved behavior across elevated execution modes, including commands with input or captured output.

- **Documentation**
  - Clarified that progress output is suspended while elevated commands own the terminal.
  - Documented interactive terminal requirements for password prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only wiring of an existing progress-pause guard around sudo; elevation policy and command execution are unchanged.
> 
> **Overview**
> Stops the progress spinner from overwriting sudo password prompts (and other inherited-stdio output) during elevated commands.
> 
> All elevation helpers in `system::sudo` now hold a `pause_progress` guard for the child's full lifetime, using the existing reference-counted pause so nested retries do not resume the renderer early. The pause is unconditional: the child owns the terminal whether or not sudo will prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 472d950a714256622533eead4f3f14b85fb6a73a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
