### PR TITLE
fix(aqua): use crate names in cargo warnings

### DIFF
--- a/crates/aqua-registry/src/cache.rs
+++ b/crates/aqua-registry/src/cache.rs
@@ -7,7 +7,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
-const COMPILED_REGISTRY_CACHE_VERSION: &str = "v8";
+const COMPILED_REGISTRY_CACHE_VERSION: &str = "v9";
 
 #[derive(Debug, Clone)]
 pub struct RegistryCache {

--- a/crates/aqua-registry/src/codec.rs
+++ b/crates/aqua-registry/src/codec.rs
@@ -30,6 +30,7 @@ mod tests {
         let mut package = AquaPackage::default();
         package.repo_owner = "owner".into();
         package.repo_name = "repo".into();
+        package.crate_name = Some("example-crate".into());
         package.private = true;
         package.vars = vec![AquaVar {
             name: "channel".into(),
@@ -42,6 +43,7 @@ mod tests {
 
         assert_eq!(decoded.repo_owner, "owner");
         assert_eq!(decoded.repo_name, "repo");
+        assert_eq!(decoded.crate_name.as_deref(), Some("example-crate"));
         assert!(decoded.private);
         assert_eq!(decoded.vars[0].default.as_deref(), Some("beta"));
     }

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -57,6 +57,8 @@ pub struct AquaPackage {
     pub repo_owner: String,
     pub repo_name: String,
     pub name: Option<String>,
+    #[serde(rename = "crate")]
+    pub crate_name: Option<String>,
     pub asset: String,
     pub url: String,
     pub description: Option<String>,
@@ -1018,6 +1020,9 @@ fn apply_override(mut orig: AquaPackage, avo: &AquaPackage) -> AquaPackage {
     if !avo.repo_name.is_empty() {
         orig.repo_name = avo.repo_name.clone();
     }
+    if let Some(crate_name) = avo.crate_name.clone() {
+        orig.crate_name = Some(crate_name);
+    }
     if !avo.asset.is_empty() {
         orig.asset = avo.asset.clone();
     }
@@ -1561,6 +1566,25 @@ packages:
 
         assert_eq!(pkg.r#type, None);
         assert_eq!(pkg.package_type(), AquaPackageType::GithubRelease);
+    }
+
+    #[test]
+    fn test_cargo_crate_survives_version_override() {
+        let pkg = first_registry_package(
+            r#"
+packages:
+  - type: github_release
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        type: cargo
+        crate: example-crate
+"#,
+        )
+        .with_version(&["1.0.0"], "linux", "amd64");
+
+        assert_eq!(pkg.package_type(), AquaPackageType::Cargo);
+        assert_eq!(pkg.crate_name.as_deref(), Some("example-crate"));
     }
 
     #[test]

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -3567,6 +3567,7 @@ packages:
     repo_owner: example
     repo_name: tool
     name: crates.io/example-crate
+    crate: ""
 "#,
         )
         .unwrap();
@@ -3575,6 +3576,27 @@ packages:
         let error = validate(&pkg).unwrap_err().to_string();
 
         assert!(error.ends_with("Use the cargo backend instead: cargo:example-crate."));
+    }
+
+    #[test]
+    fn cargo_warning_escapes_terminal_control_characters() {
+        let registry = ParsedRegistry::parse_yaml(
+            r#"
+packages:
+  - type: cargo
+    repo_owner: example
+    repo_name: tool
+    crate: "example\u001b[2J\ncrate"
+"#,
+        )
+        .unwrap();
+        let pkg = registry.package("example/tool").unwrap();
+
+        let error = validate(&pkg).unwrap_err().to_string();
+
+        assert!(!error.contains('\u{1b}'));
+        assert!(!error.contains('\n'));
+        assert!(error.ends_with(r"Use the cargo backend instead: cargo:example\u{1b}[2J\ncrate."));
     }
 
     fn aqua_var(name: &str, required: bool) -> AquaVar {
@@ -4768,12 +4790,13 @@ fn validate(pkg: &AquaPackage) -> Result<()> {
                 "package type `cargo` is not supported in the aqua backend. Use the cargo backend instead{}.",
                 pkg.crate_name
                     .as_deref()
+                    .filter(|name| !name.is_empty())
                     .or_else(|| {
                         pkg.name
                             .as_deref()
                             .and_then(|s| s.strip_prefix("crates.io/"))
                     })
-                    .map(|name| format!(": cargo:{name}"))
+                    .map(|name| format!(": cargo:{}", name.escape_debug()))
                     .unwrap_or_default()
             )
         }

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -3539,6 +3539,44 @@ mod tests {
     use super::*;
     use aqua_registry::{AquaFile, AquaVar, ParsedRegistry};
 
+    #[test]
+    fn cargo_warning_uses_crate_name() {
+        let registry = ParsedRegistry::parse_yaml(
+            r#"
+packages:
+  - type: cargo
+    repo_owner: example
+    repo_name: tool
+    crate: example-crate
+"#,
+        )
+        .unwrap();
+        let pkg = registry.package("example/tool").unwrap();
+
+        let error = validate(&pkg).unwrap_err().to_string();
+
+        assert!(error.ends_with("Use the cargo backend instead: cargo:example-crate."));
+    }
+
+    #[test]
+    fn cargo_warning_falls_back_to_crates_io_name() {
+        let registry = ParsedRegistry::parse_yaml(
+            r#"
+packages:
+  - type: cargo
+    repo_owner: example
+    repo_name: tool
+    name: crates.io/example-crate
+"#,
+        )
+        .unwrap();
+        let pkg = registry.package("crates.io/example-crate").unwrap();
+
+        let error = validate(&pkg).unwrap_err().to_string();
+
+        assert!(error.ends_with("Use the cargo backend instead: cargo:example-crate."));
+    }
+
     fn aqua_var(name: &str, required: bool) -> AquaVar {
         AquaVar {
             name: name.to_string(),
@@ -4728,9 +4766,13 @@ fn validate(pkg: &AquaPackage) -> Result<()> {
         AquaPackageType::Cargo => {
             bail!(
                 "package type `cargo` is not supported in the aqua backend. Use the cargo backend instead{}.",
-                pkg.name
-                    .as_ref()
-                    .and_then(|s| s.strip_prefix("crates.io/"))
+                pkg.crate_name
+                    .as_deref()
+                    .or_else(|| {
+                        pkg.name
+                            .as_deref()
+                            .and_then(|s| s.strip_prefix("crates.io/"))
+                    })
                     .map(|name| format!(": cargo:{name}"))
                     .unwrap_or_default()
             )


### PR DESCRIPTION
## Summary
- deserialize the authoritative Aqua `crate:` field and preserve it through version and platform overrides
- persist the crate name in baked and custom compiled Aqua registries
- recommend `cargo:<crate>` from that field, while retaining the existing `crates.io/<name>` fallback
- treat empty crate metadata as absent and escape selected names in terminal diagnostics
- bump the compiled Aqua cache version because the serialized package layout changes
- keep this warning-only change independent from search behavior

## Example
Cargo overrides such as `rhit` and `tokei` specify `crate:` without a `name: crates.io/...` value. Their Aqua validation error can now recommend `cargo:rhit` or `cargo:tokei` instead of only saying to use the Cargo backend.

Related discussion: https://github.com/jdx/mise/discussions/12224

## Validation
- `cargo test -p aqua-registry` (129 passed)
- `cargo test --all-features cargo_warning` (3 passed)
- `mise run lint`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registry packages can retain explicit Cargo crate names from metadata and version overrides.
  * Cargo validation uses the declared crate name when available, with a compatibility fallback.
* **Bug Fixes**
  * Improved validation messages and safely escaped terminal control characters.
* **Maintenance**
  * Updated compiled registry cache versioning, triggering safe recompilation of existing caches.
* **Tests**
  * Added coverage for crate-name preservation, override resolution, serialization, and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->