### PR TITLE
docs(install): clarify --system is shared storage, not a mise-free install

### DIFF
--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -89,6 +89,11 @@ Install tool(s) to the system-wide shared directory
 Installs to /usr/local/share/mise/installs (or MISE_SYSTEM_DATA_DIR/installs).
 May require elevated permissions (e.g. sudo).
 
+This shares the install location between users; it does not put binaries on
+PATH for use without mise. Every user still needs mise to run these tools.
+For binaries usable without mise, see `mise install-into` or
+`[bootstrap.packages]`.
+
 Examples:
 
 ```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -351,7 +351,57 @@ Things mise does **not** do:
 - Handle system-level dependencies that tools need to compile
 
 If a mise-installed tool needs a system library, install that library with your OS package
-manager first.
+manager first. You can declare those packages in
+[`[bootstrap.packages]`](/bootstrap/packages/) so `mise bootstrap` installs them: through
+apt/dnf/pacman where the platform's package manager owns them, or through mise's built-in
+Homebrew installers for `brew:` and `brew-cask:` entries, which do not require Homebrew
+itself. Either way they are host packages, not `[tools]` entries.
+
+## How do I install tools other users can run without mise?
+
+Two features install binaries that work on `PATH` with no mise involved at runtime.
+
+Use [`[bootstrap.packages]`](/bootstrap/packages/) with `brew:` entries for tools that have
+a Homebrew formula:
+
+```toml
+[bootstrap.packages]
+"brew:ffmpeg" = "latest"
+"brew:jq" = "latest"
+```
+
+mise pours bottles into the canonical prefix (`/home/linuxbrew/.linuxbrew` on Linux,
+`/opt/homebrew` on arm64 macOS) with the usual `<prefix>/bin` links, and does not require
+Homebrew itself to be installed. Once `<prefix>/bin` is on `PATH`, the binaries behave like
+any other Homebrew install.
+[Keg-only](https://docs.brew.sh/FAQ#what-does-keg-only-mean) formulae are the exception:
+like brew, mise leaves them out of the prefix, so their binaries stay at
+`<prefix>/opt/<name>/bin`.
+
+On arm64 macOS and x86_64/arm64 Linux, where mise's brew manager runs,
+`mise bootstrap packages import --manager brew` snapshots an existing Homebrew or Linuxbrew
+setup into your config — the formulae you installed on request, or every linked formula
+with `--all`.
+
+Use [`mise install-into`](/cli/install-into.html) for any backend mise supports. It installs
+one tool version into a directory you pick, for use outside of mise:
+
+```sh
+mise install-into node@22 /opt/node
+/opt/node/bin/node -v
+```
+
+Point it at a new or empty directory: `install-into` deletes whatever is already at the
+destination, after a confirmation prompt that defaults to no, or without asking under
+`--yes`. It only writes to that directory, so add its `bin` to `PATH` yourself the way you
+would the brew prefix above. Tools that expect environment variables such as `JAVA_HOME`,
+or other configuration mise normally applies at runtime, still need those set up by hand.
+
+Both approaches make the same trade Homebrew makes: one version on `PATH` for everyone,
+with no per-project version selection. When you want that selection, keep the tools in
+`[tools]` and let [`mise bootstrap`](/bootstrap.html) converge each user's activation,
+config, and tools in one command — or across many hosts with
+[`mise bootstrap remote`](/bootstrap/remote.html).
 
 ## How does mise versioning work?
 

--- a/docs/mise-cookbook/docker.md
+++ b/docs/mise-cookbook/docker.md
@@ -39,6 +39,10 @@ For toolbox containers or bastion hosts where tools should be pre-installed for 
 use `mise install --system` to install tools into `/usr/local/share/mise/installs`.
 Each user's mise will automatically find these system-level tools without any configuration.
 
+`--system` shares the install location between users; it does not put binaries on `PATH`
+for use without mise. If you want tools other users can run with no mise involved, see
+[How do I install tools other users can run without mise?](/faq.html#how-do-i-install-tools-other-users-can-run-without-mise)
+
 The following example also shows installing using `extrepo` on Debian/Ubuntu image.
 With this approach you cannot specify `MISE_VERSION` or `MISE_INSTALL_PATH`.
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2503,6 +2503,11 @@ Install tool(s) to the system\-wide shared directory
 
 Installs to /usr/local/share/mise/installs (or MISE_SYSTEM_DATA_DIR/installs).
 May require elevated permissions (e.g. sudo).
+
+This shares the install location between users; it does not put binaries on
+PATH for use without mise. Every user still needs mise to run these tools.
+For binaries usable without mise, see `mise install\-into` or
+`[bootstrap.packages]`.
 \fBArguments:\fR
 .PP
 .TP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -2043,6 +2043,11 @@ Install tool(s) to the system-wide shared directory
 
 Installs to /usr/local/share/mise/installs (or MISE_SYSTEM_DATA_DIR/installs).
 May require elevated permissions (e.g. sudo).
+
+This shares the install location between users; it does not put binaries on
+PATH for use without mise. Every user still needs mise to run these tools.
+For binaries usable without mise, see `mise install-into` or
+`[bootstrap.packages]`.
 """#
     }
     arg "[TOOL@VERSION]…" help="Tool(s) to install e.g.: node@20" required=#false var=#true

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -103,6 +103,11 @@ pub struct Install {
     ///
     /// Installs to /usr/local/share/mise/installs (or MISE_SYSTEM_DATA_DIR/installs).
     /// May require elevated permissions (e.g. sudo).
+    ///
+    /// This shares the install location between users; it does not put binaries on
+    /// PATH for use without mise. Every user still needs mise to run these tools.
+    /// For binaries usable without mise, see `mise install-into` or
+    /// `[bootstrap.packages]`.
     #[clap(long, verbatim_doc_comment, conflicts_with = "shared")]
     system: bool,
 


### PR DESCRIPTION
## Problem

In [discussion #8596](https://github.com/jdx/mise/discussions/8596) more than one person has read `mise install --system` as a Homebrew-style system-wide install, then been surprised that other users still need mise activated to run the tools. The [most recent comment](https://github.com/jdx/mise/discussions/8596#discussioncomment-18108357) abandoned a Linuxbrew → mise migration over it:

> To me, a system-wide installation means that once an administrator installs a tool, it should be usable by other users through the normal system `PATH`, without requiring mise-specific shell activation, user-level shims, caches, or configuration. […] requiring mise at runtime makes `--system` feel more like a shared download/install cache than a true system-wide installation.

That reading is accurate — `--system` only redirects the install dir to `MISE_SYSTEM_DATA_DIR/installs` so N users don't download N copies; version resolution still happens through mise. Nothing in the flag help or docs said so, and nothing pointed at the features that *do* install binaries usable without mise.

## Changes

- `--system` flag help and the docker cookbook now say plainly that the flag shares the install location and does not put binaries on `PATH` for use without mise.
- New FAQ entry, **How do I install tools other users can run without mise?**, covering the two features that do:
  - `[bootstrap.packages]` with `brew:` entries — pours bottles into the canonical prefix with the usual `<prefix>/bin` links and needs no Homebrew installed, plus `mise bootstrap packages import --manager brew` to migrate an existing Linuxbrew setup.
  - `mise install-into` — one tool version into a directory you pick, any backend.

  It also names the trade both make (one version on `PATH`, no per-project selection) and points at `mise bootstrap` / `bootstrap remote` for converging per-user setup when you want the mise model instead.
- The "mise is for dev tools, not applications or system packages" FAQ said to install OS libraries by hand; it now notes `[bootstrap.packages]` can declare them, while keeping the `[tools]` boundary intact.

Docs-only; no behavior change. `docs/cli/install.md`, `mise.usage.kdl`, and `man/man1/mise.1` are regenerated from the help-text change.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and clap help text only; no runtime or install behavior changes.
> 
> **Overview**
> Clarifies that `mise install --system` is a **shared install cache**, not a Homebrew-style system PATH install. Users still need mise at runtime.
> 
> Adds a FAQ on installing tools others can run without mise: `[bootstrap.packages]` `brew:` entries (canonical prefix, no Homebrew required) and `mise install-into`. Also notes `[bootstrap.packages]` for OS libraries while keeping them out of `[tools]`.
> 
> The same `--system` wording is mirrored in clap help, generated CLI/man docs, and the Docker cookbook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af549f5c33b6e4a0aa31259f30a665f0eeda6436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that system-wide installations share files between users but do not add tool binaries directly to `PATH`.
  * Explained that `mise` is still required to run tools installed with the system option.
  * Documented `mise install-into` and `[bootstrap.packages]` as alternatives for standalone tools usable without `mise`.
  * Added FAQ guidance on declaring OS dependencies and making a single tool version available system-wide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->