### PR TITLE
security(task): contain remote Git task paths

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -30,7 +30,9 @@ use crate::env::{MISE_DEFAULT_CONFIG_FILENAME, MISE_DEFAULT_TOOL_VERSIONS_FILENA
 use crate::file::display_path;
 use crate::remote_source::RemoteSource;
 use crate::shorthands::{Shorthands, get_shorthands};
-use crate::task::task_file_providers::{TaskFileArtifact, TaskFileProvidersBuilder};
+use crate::task::task_file_providers::{
+    TaskFileArtifact, TaskFileProvidersBuilder, validate_remote_git_path,
+};
 use crate::task::task_sources::TaskOutputs;
 use crate::task::{
     RunEntry, Task, TaskCacheConfig, TaskRustCacheConfig, TaskTemplate, monorepo_scope,
@@ -4551,13 +4553,7 @@ async fn resolve_git_url_to_path(git_url: &str) -> Result<TaskFileArtifact> {
         .await?;
 
     let artifact = checkout.with_path(checkout.path.join(source.path));
-    let metadata = artifact.path.symlink_metadata()?;
-    if !metadata.file_type().is_file() && !metadata.file_type().is_dir() {
-        bail!(
-            "remote task path is not a regular file or directory: {}",
-            display_path(&artifact.path)
-        );
-    }
+    validate_remote_git_path(&checkout.path, &artifact.path)?;
     Ok(artifact)
 }
 

--- a/src/remote_source.rs
+++ b/src/remote_source.rs
@@ -60,9 +60,13 @@ impl RemoteSource {
 fn parse_git_with(regex: &Regex, file: &str) -> Option<RemoteGitSource> {
     let captures = regex.captures(file)?;
     let path = captures.name("path").unwrap().as_str();
-    if path
-        .split('/')
-        .any(|component| component.is_empty() || component == "." || component == "..")
+    let mut components = path.split('/');
+    let first = components.next()?;
+    if path.contains('\\')
+        || is_windows_drive_component(first)
+        || std::iter::once(first)
+            .chain(components)
+            .any(|component| component.is_empty() || component == "." || component == "..")
     {
         return None;
     }
@@ -71,6 +75,11 @@ fn parse_git_with(regex: &Regex, file: &str) -> Option<RemoteGitSource> {
         path: path.to_string(),
         git_ref: captures.name("ref").map(|m| m.as_str().to_string()),
     })
+}
+
+fn is_windows_drive_component(component: &str) -> bool {
+    let bytes = component.as_bytes();
+    bytes.len() == 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
 }
 
 #[cfg(test)]
@@ -142,6 +151,15 @@ mod tests {
         assert!(
             RemoteSource::parse_git("git::https://myserver.com/example.git//plugin/./other")
                 .is_none()
+        );
+        assert!(
+            RemoteSource::parse_git("git::https://myserver.com/example.git//..\\outside").is_none()
+        );
+        assert!(
+            RemoteSource::parse_git("git::https://myserver.com/example.git//C:/outside").is_none()
+        );
+        assert!(
+            RemoteSource::parse_git("git::https://myserver.com/example.git//C:\\outside").is_none()
         );
     }
 

--- a/src/remote_source.rs
+++ b/src/remote_source.rs
@@ -77,9 +77,12 @@ fn parse_git_with(regex: &Regex, file: &str) -> Option<RemoteGitSource> {
     })
 }
 
+// Windows `Path::join` discards the base path when joining a drive-prefixed
+// path even without a root (e.g. `C:outside`), so any leading `<letter>:`
+// must be rejected, not just a bare `C:` component.
 fn is_windows_drive_component(component: &str) -> bool {
     let bytes = component.as_bytes();
-    bytes.len() == 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
+    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
 }
 
 #[cfg(test)]
@@ -160,6 +163,12 @@ mod tests {
         );
         assert!(
             RemoteSource::parse_git("git::https://myserver.com/example.git//C:\\outside").is_none()
+        );
+        assert!(
+            RemoteSource::parse_git("git::https://myserver.com/example.git//C:outside").is_none()
+        );
+        assert!(
+            RemoteSource::parse_git("git::https://myserver.com/example.git//C:dir/file").is_none()
         );
     }
 

--- a/src/task/task_file_providers/mod.rs
+++ b/src/task/task_file_providers/mod.rs
@@ -12,13 +12,9 @@ mod remote_task_http;
 use crate::Result;
 use async_trait::async_trait;
 use local_task::LocalTask;
-use remote_task_git::{RemoteTaskGit, RemoteTaskGitBuilder};
+use remote_task_git::RemoteTaskGitBuilder;
+pub(crate) use remote_task_git::validate_remote_git_path;
 use remote_task_http::RemoteTaskHttpBuilder;
-
-pub(crate) fn validate_remote_git_path(checkout_root: &Path, path: &Path) -> Result<()> {
-    RemoteTaskGit::validate_remote_path(checkout_root, path)?;
-    Ok(())
-}
 
 #[async_trait]
 pub(crate) trait TaskFileProvider: Debug + Send + Sync {

--- a/src/task/task_file_providers/mod.rs
+++ b/src/task/task_file_providers/mod.rs
@@ -12,8 +12,13 @@ mod remote_task_http;
 use crate::Result;
 use async_trait::async_trait;
 use local_task::LocalTask;
-use remote_task_git::RemoteTaskGitBuilder;
+use remote_task_git::{RemoteTaskGit, RemoteTaskGitBuilder};
 use remote_task_http::RemoteTaskHttpBuilder;
+
+pub(crate) fn validate_remote_git_path(checkout_root: &Path, path: &Path) -> Result<()> {
+    RemoteTaskGit::validate_remote_path(checkout_root, path)?;
+    Ok(())
+}
 
 #[async_trait]
 pub(crate) trait TaskFileProvider: Debug + Send + Sync {

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -1,5 +1,5 @@
 use crate::Result;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 
@@ -68,14 +68,21 @@ impl GitRepoStructure {
 }
 
 impl RemoteTaskGit {
-    /// Make fetched task files executable while leaving task include directories intact.
-    fn prepare_remote_path(path: &PathBuf) -> Result<()> {
+    pub(super) fn validate_remote_path(
+        checkout_root: &Path,
+        path: &Path,
+    ) -> Result<std::fs::Metadata> {
         let metadata = path.symlink_metadata()?;
-        if metadata.file_type().is_file() {
-            return file::make_executable(path);
+        let checkout_root = checkout_root.canonicalize()?;
+        let canonical_path = path.canonicalize()?;
+        if !canonical_path.starts_with(&checkout_root) {
+            eyre::bail!(
+                "remote task path escapes its Git checkout: {}",
+                display_path(path)
+            );
         }
-        if metadata.file_type().is_dir() {
-            return Ok(());
+        if metadata.file_type().is_file() || metadata.file_type().is_dir() {
+            return Ok(metadata);
         }
         eyre::bail!(
             "remote task path is not a regular file or directory: {}",
@@ -83,12 +90,21 @@ impl RemoteTaskGit {
         )
     }
 
-    fn prepare_cached_path(path: &PathBuf, destination: &PathBuf) -> Result<()> {
-        if let Err(err) = Self::prepare_remote_path(path) {
-            if let Err(cleanup_err) = crate::file::remove_all(destination) {
+    /// Make fetched task files executable while leaving task include directories intact.
+    fn prepare_remote_path(checkout_root: &Path, path: &Path) -> Result<()> {
+        let metadata = Self::validate_remote_path(checkout_root, path)?;
+        if metadata.file_type().is_file() {
+            file::make_executable(path)?;
+        }
+        Ok(())
+    }
+
+    fn prepare_cached_path(checkout_root: &Path, path: &Path) -> Result<()> {
+        if let Err(err) = Self::prepare_remote_path(checkout_root, path) {
+            if let Err(cleanup_err) = crate::file::remove_all(checkout_root) {
                 warn!(
                     "failed to remove unusable remote Git task checkout {}: {cleanup_err:#}",
-                    display_path(destination)
+                    display_path(checkout_root)
                 );
             }
             return Err(err);
@@ -151,7 +167,7 @@ impl RemoteTaskGit {
 
         if reuse_existing && full_path.exists() {
             debug!("Using cached file: {:?}", full_path);
-            Self::prepare_cached_path(&full_path, destination)?;
+            Self::prepare_cached_path(destination, &full_path)?;
             return Ok(full_path);
         }
 
@@ -184,7 +200,7 @@ impl RemoteTaskGit {
             }
         }
 
-        Self::prepare_cached_path(&full_path, destination)?;
+        Self::prepare_cached_path(destination, &full_path)?;
         Ok(full_path)
     }
 }
@@ -220,7 +236,7 @@ impl TaskFileProvider for RemoteTaskGit {
         let artifact = TaskFileArtifact::temporary(artifact_root.clone(), artifact_root.clone());
         Self::clone_to(&repo_structure, &artifact_root)?;
         let path = artifact_root.join(repo_structure.path);
-        Self::prepare_remote_path(&path)?;
+        Self::prepare_remote_path(&artifact_root, &path)?;
         Ok(artifact.with_path(path))
     }
 }
@@ -263,7 +279,7 @@ mod tests {
         fs::write(&task_file, "#!/usr/bin/env bash\necho ok\n").unwrap();
         fs::set_permissions(&task_file, fs::Permissions::from_mode(0o644)).unwrap();
 
-        RemoteTaskGit::prepare_remote_path(&task_file).unwrap();
+        RemoteTaskGit::prepare_remote_path(temp_dir.path(), &task_file).unwrap();
 
         assert!(file::is_executable(&task_file));
     }
@@ -281,7 +297,7 @@ mod tests {
         fs::set_permissions(&target, fs::Permissions::from_mode(0o644)).unwrap();
         symlink(&target, &task_file).unwrap();
 
-        let error = RemoteTaskGit::prepare_remote_path(&task_file).unwrap_err();
+        let error = RemoteTaskGit::prepare_remote_path(temp_dir.path(), &task_file).unwrap_err();
 
         assert!(error.to_string().contains("not a regular file"));
         assert_eq!(
@@ -294,7 +310,53 @@ mod tests {
     fn test_prepare_remote_path_allows_task_include_directory() {
         let temp_dir = tempfile::tempdir().unwrap();
 
-        RemoteTaskGit::prepare_remote_path(&temp_dir.path().to_path_buf()).unwrap();
+        RemoteTaskGit::prepare_remote_path(temp_dir.path(), temp_dir.path()).unwrap();
+    }
+
+    #[test]
+    fn test_prepare_remote_path_rejects_path_outside_checkout() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let checkout = temp_dir.path().join("checkout");
+        let outside = temp_dir.path().join("outside-task");
+        std::fs::create_dir(&checkout).unwrap();
+        std::fs::write(&outside, "#!/usr/bin/env bash\necho outside\n").unwrap();
+
+        let escaped_path = checkout.join("..").join("outside-task");
+        let error = RemoteTaskGit::prepare_remote_path(&checkout, &escaped_path).unwrap_err();
+
+        assert!(error.to_string().contains("escapes its Git checkout"));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_prepare_remote_path_rejects_windows_backslash_escape() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let checkout = temp_dir.path().join("checkout");
+        let outside = temp_dir.path().join("outside-task");
+        std::fs::create_dir(&checkout).unwrap();
+        std::fs::write(&outside, "echo outside\n").unwrap();
+
+        let escaped_path = checkout.join(r"..\outside-task");
+        let error = RemoteTaskGit::prepare_remote_path(&checkout, &escaped_path).unwrap_err();
+
+        assert!(error.to_string().contains("escapes its Git checkout"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_prepare_remote_path_rejects_intermediate_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let checkout = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let outside_task = outside.path().join("task");
+        std::fs::write(&outside_task, "#!/usr/bin/env bash\necho outside\n").unwrap();
+        symlink(outside.path(), checkout.path().join("linked-dir")).unwrap();
+
+        let escaped_path = checkout.path().join("linked-dir/task");
+        let error = RemoteTaskGit::prepare_remote_path(checkout.path(), &escaped_path).unwrap_err();
+
+        assert!(error.to_string().contains("escapes its Git checkout"));
     }
 
     #[test]
@@ -310,9 +372,9 @@ mod tests {
         std::fs::write(&target, "#!/usr/bin/env bash\necho ok\n").unwrap();
         symlink(&target, &task_file).unwrap();
 
-        let error = RemoteTaskGit::prepare_cached_path(&task_file, &destination).unwrap_err();
+        let error = RemoteTaskGit::prepare_cached_path(&destination, &task_file).unwrap_err();
 
-        assert!(error.to_string().contains("not a regular file"));
+        assert!(error.to_string().contains("escapes its Git checkout"));
         assert!(!destination.exists());
     }
 

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -74,9 +74,10 @@ pub(crate) fn validate_remote_git_path(
     path: &Path,
 ) -> Result<std::fs::Metadata> {
     let metadata = path.symlink_metadata()?;
-    let checkout_root = checkout_root.canonicalize()?;
-    let canonical_path = path.canonicalize()?;
-    if !canonical_path.starts_with(&checkout_root) {
+    if !path
+        .canonicalize()?
+        .starts_with(checkout_root.canonicalize()?)
+    {
         eyre::bail!(
             "remote task path escapes its Git checkout: {}",
             display_path(path)
@@ -94,8 +95,10 @@ pub(crate) fn validate_remote_git_path(
 impl RemoteTaskGit {
     /// Make fetched task files executable while leaving task include directories intact.
     fn prepare_remote_path(checkout_root: &Path, path: &Path) -> Result<()> {
-        let metadata = validate_remote_git_path(checkout_root, path)?;
-        if metadata.file_type().is_file() {
+        if validate_remote_git_path(checkout_root, path)?
+            .file_type()
+            .is_file()
+        {
             file::make_executable(path)?;
         }
         Ok(())

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -67,32 +67,34 @@ impl GitRepoStructure {
     }
 }
 
-impl RemoteTaskGit {
-    pub(super) fn validate_remote_path(
-        checkout_root: &Path,
-        path: &Path,
-    ) -> Result<std::fs::Metadata> {
-        let metadata = path.symlink_metadata()?;
-        let checkout_root = checkout_root.canonicalize()?;
-        let canonical_path = path.canonicalize()?;
-        if !canonical_path.starts_with(&checkout_root) {
-            eyre::bail!(
-                "remote task path escapes its Git checkout: {}",
-                display_path(path)
-            );
-        }
-        if metadata.file_type().is_file() || metadata.file_type().is_dir() {
-            return Ok(metadata);
-        }
+/// Ensure a remote task path resolves inside its Git checkout and points at a
+/// regular file or directory.
+pub(crate) fn validate_remote_git_path(
+    checkout_root: &Path,
+    path: &Path,
+) -> Result<std::fs::Metadata> {
+    let metadata = path.symlink_metadata()?;
+    let checkout_root = checkout_root.canonicalize()?;
+    let canonical_path = path.canonicalize()?;
+    if !canonical_path.starts_with(&checkout_root) {
         eyre::bail!(
-            "remote task path is not a regular file or directory: {}",
+            "remote task path escapes its Git checkout: {}",
             display_path(path)
-        )
+        );
     }
+    if metadata.file_type().is_file() || metadata.file_type().is_dir() {
+        return Ok(metadata);
+    }
+    eyre::bail!(
+        "remote task path is not a regular file or directory: {}",
+        display_path(path)
+    )
+}
 
+impl RemoteTaskGit {
     /// Make fetched task files executable while leaving task include directories intact.
     fn prepare_remote_path(checkout_root: &Path, path: &Path) -> Result<()> {
-        let metadata = Self::validate_remote_path(checkout_root, path)?;
+        let metadata = validate_remote_git_path(checkout_root, path)?;
         if metadata.file_type().is_file() {
             file::make_executable(path)?;
         }


### PR DESCRIPTION
## Work order

1. This PR — contain remote Git task paths (independent)
2. #12202 — require trust before remote metadata discovery
3. #12256 — guard remote metadata side effects
4. #12257 — resolve trusted metadata in task commands
5. #12206 — harden cache lifecycle after the trust stack is merged and rebased

This PR is independent of the trust stack and may merge separately; the list above is the recommended review order.

## Summary

- reject traversal, Windows absolute/backslash, and drive-qualified remote Git task paths
- canonicalize checkout roots and targets before use
- reject intermediate symlink escapes and non-file task targets
- apply the same containment policy to direct Git tasks and Git task includes

## Root cause

Remote Git task paths were joined to a checkout after parser-only validation. Platform-specific absolute forms and intermediate symlinks could therefore resolve outside the checkout root.

## Example attack

The task path (the part after `//`) is attacker-controlled: it comes from the config that references the remote task, and mise appends it to the checkout directory with `checkout.join(path)` before making the target executable and running it. Before this PR, validation only inspected the string for `..` segments, so several forms escaped the checkout:

- **Intermediate symlink escape (Unix).** A repo commits `linked-dir -> /` (or any absolute target) and a config points at `git::https://evil.example/repo.git//linked-dir/etc/cron.d/x`. No `..` appears in the path, so the old check passed; `checkout.join("linked-dir/...")` then resolves through the symlink to an arbitrary location outside the checkout — mise `chmod +x`'s and executes a file the attacker chose, anywhere the process can read.
- **Drive-relative Windows path.** `git::https://evil.example/repo.git//C:outside\payload`. On Windows, `Path::join` throws the base path away when the joined component carries a drive prefix without a root (`C:outside`), so the result is `C:outside\payload` — entirely outside the checkout. The original two-byte-only drive check (`len == 2`) matched a bare `C:` but not `C:outside`/`C:dir/file`, so this slipped through until the fix in this PR.
- **Non-file target.** Pointing the path at a directory or a device/FIFO node caused mise to treat it as a task file and make it executable.

The fix canonicalizes both the checkout root and the resolved target and requires the target to stay under the root (`canonical_path.starts_with(&checkout_root)`), which closes the intermediate-symlink case that a pure string check cannot, and tightens the parser to reject drive-qualified and backslash forms up front, plus rejects non-regular-file targets.

## Validation

- mise run lint-fix
- mise run test:unit remote_source::tests
- mise run test:unit task::task_file_providers::remote_task_git::tests

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for files retrieved from remote Git sources.
  * Blocked path traversal attempts, Windows-style paths, backslash-based escapes, and symlink-based escapes.
  * Prevented directories and other non-file paths from being treated as executable task files.
  * Applied consistent validation to cached and newly cloned task sources.
  * Improved cleanup when invalid cached paths are detected.
  * Added consistent protection against unsafe remote task paths across supported workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
