### PR TITLE
fix(task): resolve trusted remote metadata in task commands

### DIFF
--- a/e2e/helpers/scripts/git_http_backend_server.py
+++ b/e2e/helpers/scripts/git_http_backend_server.py
@@ -135,6 +135,18 @@ def create_test_repo(repo_path, server_port):
 
     remote_task_dir = Path(repo_path) / 'xtasks' / 'remote'
     remote_task_dir.mkdir(parents=True)
+    remote_metadata_file = remote_task_dir / 'remote_metadata.toml'
+    remote_metadata_file.write_text(
+        '#!/usr/bin/env bash\n'
+        '#MISE description="remote git metadata"\n'
+        '#MISE tools={dummy="1.0.0"}\n'
+        '#MISE env._.file="remote.env"\n'
+        'echo "remote path: $0"\n'
+        'echo "$REMOTE_RELATIVE_ENV"\n'
+        'dummy\n'
+    )
+    remote_metadata_file.chmod(0o755)
+    (remote_task_dir / 'remote.env').write_text('REMOTE_RELATIVE_ENV="relative env loaded"\n')
     nested_remote_file = remote_task_dir / 'nested'
     nested_remote_file.write_text(
         '#!/usr/bin/env bash\n'

--- a/e2e/helpers/scripts/git_http_backend_server.py
+++ b/e2e/helpers/scripts/git_http_backend_server.py
@@ -14,8 +14,9 @@ import socketserver
 from pathlib import Path
 
 class GitHTTPHandler(http.server.BaseHTTPRequestHandler):
-    def __init__(self, *args, repo_dir=None, upload_pack_count_file=None, **kwargs):
+    def __init__(self, *args, repo_dir=None, request_log=None, upload_pack_count_file=None, **kwargs):
         self.repo_dir = repo_dir
+        self.request_log = request_log
         self.upload_pack_count_file = upload_pack_count_file
         super().__init__(*args, **kwargs)
 
@@ -26,6 +27,10 @@ class GitHTTPHandler(http.server.BaseHTTPRequestHandler):
         self.handle_git_request()
 
     def handle_git_request(self):
+        if self.request_log:
+            with open(self.request_log, 'a') as log:
+                log.write(f'{self.command} {self.path}\n')
+
         # Set up environment for git-http-backend
         env = os.environ.copy()
         env['GIT_PROJECT_ROOT'] = str(self.repo_dir)
@@ -111,7 +116,7 @@ class GitHTTPHandler(http.server.BaseHTTPRequestHandler):
         except Exception as e:
             self.send_error(500, f"Server error: {str(e)}")
 
-def create_test_repo(repo_path):
+def create_test_repo(repo_path, server_port):
     """Create a minimal test repository"""
     # Create a regular (non-bare) repository
     subprocess.run(['git', 'init', repo_path], check=True)
@@ -127,6 +132,15 @@ def create_test_repo(repo_path):
     remote_task_file = xtasks_dir / 'remote-task'
     remote_task_file.write_text('#!/usr/bin/env bash\necho "remote task executed"\n')
     remote_task_file.chmod(0o755)
+
+    remote_task_dir = Path(repo_path) / 'xtasks' / 'remote'
+    remote_task_dir.mkdir(parents=True)
+    nested_remote_file = remote_task_dir / 'nested'
+    nested_remote_file.write_text(
+        '#!/usr/bin/env bash\n'
+        'echo "nested remote task executed"\n'
+    )
+    nested_remote_file.chmod(0o755)
 
     snapshot_root = Path(repo_path) / 'xtasks' / 'snapshot'
     snapshot_parent = snapshot_root / 'parent' / 'snapshot_parent'
@@ -165,6 +179,9 @@ def create_test_repo(repo_path):
         '[toml_table_task]\n'
         'run = "echo toml_table_task executed"\n'
         'description = "TOML task with table form"\n'
+        '\n'
+        '[nested_remote]\n'
+        f'file = "git::http://localhost:{server_port}/repo.git//xtasks/remote/nested"\n'
     )
 
     # A standalone toml file in a sibling directory to test the
@@ -203,18 +220,17 @@ def start_server(port=0):
     repo_path = temp_dir / 'repo'
     upload_pack_count_path = os.environ.get('MISE_GIT_HTTP_UPLOAD_PACK_COUNT_FILE')
     upload_pack_count_file = Path(upload_pack_count_path) if upload_pack_count_path else None
+    request_log = os.environ.get('MISE_GIT_HTTP_REQUEST_LOG')
     if upload_pack_count_file is not None:
         upload_pack_count_file.parent.mkdir(parents=True, exist_ok=True)
         upload_pack_count_file.write_text('')
-
-    print(f"Creating test repository at {repo_path}")
-    create_test_repo(str(repo_path))
 
     # Create handler with repo directory
     def handler(*args, **kwargs):
         return GitHTTPHandler(
             *args,
             repo_dir=temp_dir,
+            request_log=request_log,
             upload_pack_count_file=upload_pack_count_file,
             **kwargs,
         )
@@ -223,6 +239,8 @@ def start_server(port=0):
     # This avoids race conditions between finding and binding
     with socketserver.TCPServer(("", port), handler) as httpd:
         actual_port = httpd.server_address[1]
+        print(f"Creating test repository at {repo_path}")
+        create_test_repo(str(repo_path), actual_port)
         print(f"Git HTTP server running on port {actual_port}")
         print(f"Repository URL: http://localhost:{actual_port}/repo.git")
 

--- a/e2e/helpers/scripts/http_test_server.py
+++ b/e2e/helpers/scripts/http_test_server.py
@@ -48,6 +48,52 @@ class TestFileHandler(http.server.SimpleHTTPRequestHandler):
                 'echo "remote template task ran"\n'
             )
             self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-deferred-template':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE confirm="\\u007b\\u007b exec(command=\'touch $MISE_REMOTE_DEFERRED_MARKER\') \\u007d\\u007d"\n'
+                '#MISE env={REMOTE_DEFERRED="\\u007b\\u007b exec(command=\'touch $MISE_REMOTE_DEFERRED_MARKER\') \\u007d\\u007d"}\n'
+                'echo "remote deferred task ran"\n'
+            )
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-source':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            source_path = json.dumps(os.environ['MISE_REMOTE_SOURCE_SCRIPT'])
+            venv_path = json.dumps(os.environ['MISE_REMOTE_VENV'])
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE confirm="run remote source task?"\n'
+                '#MISE env={_={source=%s,python={venv={path=%s}}}}\n'
+                'echo "remote source task ran: VIRTUAL_ENV=$VIRTUAL_ENV"\n'
+            ) % (source_path, venv_path)
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-sops-file':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            sops_file = json.dumps(os.environ['MISE_REMOTE_SOPS_FILE'])
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE env={_={file=%s}}\n'
+                'echo "remote sops task ran: $REMOTE_SOPS_VALUE"\n'
+            ) % sops_file
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-tools':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE alias="remote-tools-alias"\n'
+                '#MISE tools={dummy="1.0.0"}\n'
+                'if command -v dummy >/dev/null 2>&1; then dummy; else echo "dummy not installed"; fi\n'
+            )
+            self.wfile.write(content.encode('utf-8'))
         elif self.path == '/test/remote-changing':
             TestFileHandler.changing_remote_revision += 1
             revision = TestFileHandler.changing_remote_revision

--- a/e2e/helpers/scripts/http_test_server.py
+++ b/e2e/helpers/scripts/http_test_server.py
@@ -34,6 +34,20 @@ class TestFileHandler(http.server.SimpleHTTPRequestHandler):
             self.end_headers()
             content = '#!/usr/bin/env bash\necho "running mytask"\n'
             self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-template':
+            if marker := os.environ.get('MISE_HTTP_REQUEST_MARKER'):
+                Path(marker).touch()
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE description="{{ exec(command=\'touch $MISE_REMOTE_TEMPLATE_MARKER\') }}"\n'
+                '#MISE depends=["remote_dep"]\n'
+                '#USAGE flag "--remote-flag" help="Remote usage flag"\n'
+                'echo "remote template task ran"\n'
+            )
+            self.wfile.write(content.encode('utf-8'))
         elif self.path == '/test/remote-changing':
             TestFileHandler.changing_remote_revision += 1
             revision = TestFileHandler.changing_remote_revision

--- a/e2e/helpers/scripts/http_test_server.py
+++ b/e2e/helpers/scripts/http_test_server.py
@@ -22,6 +22,8 @@ HEADERS_LOG_DIR = None
 
 class TestFileHandler(http.server.SimpleHTTPRequestHandler):
     changing_remote_revision = 0
+    changing_alias_revision = 0
+    raw_help_revision = 0
 
     def do_GET(self):
         """Handle GET requests for test files"""
@@ -46,6 +48,18 @@ class TestFileHandler(http.server.SimpleHTTPRequestHandler):
                 '#MISE depends=["remote_dep"]\n'
                 '#USAGE flag "--remote-flag" help="Remote usage flag"\n'
                 'echo "remote template task ran"\n'
+            )
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-raw-help':
+            TestFileHandler.raw_help_revision += 1
+            revision = TestFileHandler.raw_help_revision
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE raw_args=true\n'
+                f'echo "remote raw help revision {revision}"\n'
             )
             self.wfile.write(content.encode('utf-8'))
         elif self.path == '/test/remote-deferred-template':
@@ -92,6 +106,30 @@ class TestFileHandler(http.server.SimpleHTTPRequestHandler):
                 '#MISE alias="remote-tools-alias"\n'
                 '#MISE tools={dummy="1.0.0"}\n'
                 'if command -v dummy >/dev/null 2>&1; then dummy; else echo "dummy not installed"; fi\n'
+            )
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-changing-alias':
+            TestFileHandler.changing_alias_revision += 1
+            revision = TestFileHandler.changing_alias_revision
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            alias = '#MISE alias="remote-changing-alias"\n' if revision == 1 else ''
+            content = (
+                '#!/usr/bin/env bash\n'
+                f'{alias}'
+                f'echo "remote changing alias revision {revision}"\n'
+            )
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-hidden':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE hide=true\n'
+                '#MISE description="hidden remote metadata"\n'
+                'echo "hidden remote task ran"\n'
             )
             self.wfile.write(content.encode('utf-8'))
         elif self.path == '/test/remote-changing':

--- a/e2e/tasks/test_task_remote_git_includes
+++ b/e2e/tasks/test_task_remote_git_includes
@@ -200,6 +200,23 @@ assert_contains "mise tasks" "standalone_task"
 assert_contains "mise run standalone_task" "standalone_task executed"
 
 #################################################################################
+# Test config-declared remote Git task metadata and tool installation
+#################################################################################
+
+cat <<EOF >mise.toml
+[tasks.remote_metadata_a]
+file = "git::${LOCAL_GIT_URL}//xtasks/remote/remote_metadata.toml"
+
+[tasks.remote_metadata_b]
+file = "git::${LOCAL_GIT_URL}//xtasks/remote/remote_metadata.toml"
+EOF
+
+mise trust
+assert_contains "mise tasks info remote_metadata_a" "remote git metadata"
+assert_contains "mise run remote_metadata_a" "This is Dummy 1.0.0!"
+assert_contains "mise run remote_metadata_a" "relative env loaded"
+
+#################################################################################
 # Test no-cache Git task snapshots
 #################################################################################
 

--- a/e2e/tasks/test_task_remote_git_includes
+++ b/e2e/tasks/test_task_remote_git_includes
@@ -8,15 +8,17 @@ PORT_FILE="$TMPDIR/mise_git_http_port"
 READY_FILE="$TMPDIR/mise_git_http_ready"
 INFO_FILE="$TMPDIR/mise_git_http_info"
 UPLOAD_PACK_COUNT_FILE="$TMPDIR/mise_git_http_upload_pack_count"
+REQUEST_LOG="$TMPDIR/mise_git_http_requests"
 
 # Clean up any previous server files
-rm -f "$PORT_FILE" "$READY_FILE" "$INFO_FILE" "$UPLOAD_PACK_COUNT_FILE"
+rm -f "$PORT_FILE" "$READY_FILE" "$INFO_FILE" "$UPLOAD_PACK_COUNT_FILE" "$REQUEST_LOG"
 
 # Start local git HTTP server with OS-assigned port to avoid race conditions
 MISE_GIT_HTTP_PORT_FILE="$PORT_FILE" \
   MISE_GIT_HTTP_READY_FILE="$READY_FILE" \
   MISE_GIT_HTTP_INFO_FILE="$INFO_FILE" \
   MISE_GIT_HTTP_UPLOAD_PACK_COUNT_FILE="$UPLOAD_PACK_COUNT_FILE" \
+  MISE_GIT_HTTP_REQUEST_LOG="$REQUEST_LOG" \
   python3 "${TEST_ROOT}/helpers/scripts/git_http_backend_server.py" 0 &
 SERVER_PID=$!
 
@@ -52,7 +54,7 @@ git init
 # Ensure cleanup on exit
 cleanup() {
   kill "$SERVER_PID" 2>/dev/null || true
-  rm -f "$PORT_FILE" "$READY_FILE" "$INFO_FILE" "$UPLOAD_PACK_COUNT_FILE"
+  rm -f "$PORT_FILE" "$READY_FILE" "$INFO_FILE" "$UPLOAD_PACK_COUNT_FILE" "$REQUEST_LOG"
 }
 trap cleanup EXIT
 
@@ -66,6 +68,11 @@ includes = [
     "git::${LOCAL_GIT_URL}//xtasks/lint"
 ]
 EOF
+
+# Safe-mode parsing must reject an untrusted remote include before cloning it.
+: >"$REQUEST_LOG"
+assert_fail "MISE_SAFE=1 MISE_TRUSTED_CONFIG_PATHS=$TMPDIR/not-trusted MISE_YES=0 mise tasks"
+assert_fail "test -s '$REQUEST_LOG'"
 
 # The xtasks/lint directory contains multiple task files
 # We should be able to see and run them
@@ -163,6 +170,18 @@ assert_contains "mise tasks" "toml_task"
 assert_contains "mise tasks" "toml_table_task"
 assert_contains "mise run toml_task" "toml_task executed"
 assert_contains "mise run toml_table_task" "toml_table_task executed"
+
+# A remote TOML include may declare another remote file task. Preserve the
+# local config as trust provenance through both remote layers.
+NESTED_ARTIFACT_TMPDIR="$TMPDIR/nested-remote-git-artifacts"
+mkdir -p "$NESTED_ARTIFACT_TMPDIR"
+assert_contains "TMPDIR=$NESTED_ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run nested_remote" "nested remote task executed"
+assert_directory_empty "$NESTED_ARTIFACT_TMPDIR"
+
+PROVENANCE_STATE_DIR="$TMPDIR/remote-git-provenance-state"
+mkdir -p "$PROVENANCE_STATE_DIR"
+assert_contains "MISE_STATE_DIR=$PROVENANCE_STATE_DIR MISE_TRUSTED_CONFIG_PATHS='' MISE_YES=1 mise run nested_remote" "nested remote task executed"
+assert "find '$PROVENANCE_STATE_DIR/trusted-configs' -mindepth 1 \\( -type f -o -type l \\) 2>/dev/null | wc -l | tr -d ' '" "1"
 
 mise cache clear # Clear cache to force redownload
 

--- a/e2e/tasks/test_task_remote_metadata_trust
+++ b/e2e/tasks/test_task_remote_metadata_trust
@@ -5,9 +5,35 @@
 
 HTTP_PORT_FILE="$TMPDIR/mise_http_test_port"
 MARKER="$TMPDIR/remote-template-executed"
+DEFERRED_MARKER="$TMPDIR/remote-deferred-template-executed"
+SOURCE_MARKER="$TMPDIR/remote-source-executed"
+SOURCE_SCRIPT="$TMPDIR/remote-source.sh"
+REMOTE_VENV="$TMPDIR/remote-venv"
+SOPS_MARKER="$TMPDIR/remote-sops-executed"
+SOPS_FILE="$TMPDIR/remote-sops.yaml"
+FAKE_SOPS_BIN="$TMPDIR/remote-fake-sops-bin"
 REQUEST_MARKER="$TMPDIR/remote-template-requested"
+mkdir -p "$REMOTE_VENV/bin"
+cat <<'EOF' >"$SOURCE_SCRIPT"
+touch "$MISE_REMOTE_SOURCE_MARKER"
+EOF
+mkdir -p "$FAKE_SOPS_BIN"
+cat <<'EOF' >"$FAKE_SOPS_BIN/sops"
+#!/usr/bin/env bash
+touch "$MISE_REMOTE_SOPS_MARKER"
+cat
+EOF
+chmod +x "$FAKE_SOPS_BIN/sops"
+cat <<'EOF' >"$SOPS_FILE"
+sops:
+  version: "3.8.1"
+REMOTE_SOPS_VALUE: decrypted
+EOF
 MISE_HTTP_TEST_PORT_FILE="$HTTP_PORT_FILE" \
   MISE_HTTP_REQUEST_MARKER="$REQUEST_MARKER" \
+  MISE_REMOTE_SOURCE_SCRIPT="$SOURCE_SCRIPT" \
+  MISE_REMOTE_VENV="$REMOTE_VENV" \
+  MISE_REMOTE_SOPS_FILE="$SOPS_FILE" \
   python3 "${TEST_ROOT}/helpers/scripts/http_test_server.py" 0 &
 HTTP_SERVER_PID=$!
 
@@ -19,7 +45,7 @@ trap cleanup EXIT
 wait_for_file "$HTTP_PORT_FILE" "HTTP test server port file" 30 "$HTTP_SERVER_PID"
 HTTP_PORT=$(cat "$HTTP_PORT_FILE")
 
-UNTRUSTED_ENV="env -u CI -u GITHUB_ACTION -u GITHUB_ACTIONS MISE_PARANOID=1 MISE_TRUSTED_CONFIG_PATHS=$TMPDIR/not-trusted MISE_YES=0 MISE_REMOTE_TEMPLATE_MARKER=$MARKER"
+UNTRUSTED_ENV="env -u CI -u GITHUB_ACTION -u GITHUB_ACTIONS MISE_PARANOID=1 MISE_TRUSTED_CONFIG_PATHS=$TMPDIR/not-trusted MISE_YES=0 MISE_REMOTE_TEMPLATE_MARKER=$MARKER MISE_REMOTE_DEFERRED_MARKER=$DEFERRED_MARKER MISE_REMOTE_SOURCE_MARKER=$SOURCE_MARKER MISE_REMOTE_SOURCE_SCRIPT=$SOURCE_SCRIPT MISE_REMOTE_VENV=$REMOTE_VENV MISE_REMOTE_SOPS_MARKER=$SOPS_MARKER"
 
 cat <<EOF >mise.toml
 [tasks.remote_template]
@@ -63,3 +89,71 @@ assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
 assert_contains "$UNTRUSTED_ENV mise tasks info included_remote_template" "remote_dep"
 assert_contains "$UNTRUSTED_ENV MISE_TASK_REMOTE_NO_CACHE=true mise tasks info included_remote_template" "remote_dep"
 assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
+
+# Deferred metadata (confirmation and task env) can render after initial task
+# discovery, so decoded header templates must still require the defining
+# config's trust before either path gets a chance to execute.
+cat <<EOF >mise.toml
+[tasks.remote_deferred]
+file = "http://localhost:${HTTP_PORT}/test/remote-deferred-template"
+EOF
+
+assert_fail "$UNTRUSTED_ENV mise run remote_deferred" "not trusted"
+[[ ! -e $DEFERRED_MARKER ]] || fail "deferred remote metadata template executed before trust"
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_contains "$UNTRUSTED_ENV MISE_YES=1 mise run remote_deferred" "remote deferred task ran"
+[[ -e $DEFERRED_MARKER ]] || fail "trusted remote task env template did not render"
+assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
+
+# Template-free env metadata can still execute code or install tooling. It must
+# require the defining config's trust before resolution and before confirmation.
+cat <<EOF >mise.toml
+[tasks.remote_source]
+file = "http://localhost:${HTTP_PORT}/test/remote-source"
+EOF
+
+assert_fail "$UNTRUSTED_ENV mise run --dry-run remote_source" "not trusted"
+[[ ! -e $SOURCE_MARKER ]] || fail "remote source directive executed before trust"
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_contains "$UNTRUSTED_ENV MISE_YES=1 mise run remote_source" "remote source task ran: VIRTUAL_ENV=$REMOTE_VENV"
+[[ -e $SOURCE_MARKER ]] || fail "trusted remote source directive did not execute"
+assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
+
+# Static file directives read outside the task sandbox, and structured SOPS
+# files can execute the configured sops binary. Neither may happen before the
+# defining config is trusted, including during dry-run.
+cat <<EOF >mise.toml
+[tasks.remote_sops_file]
+file = "http://localhost:${HTTP_PORT}/test/remote-sops-file"
+EOF
+
+assert_fail "$UNTRUSTED_ENV PATH=$FAKE_SOPS_BIN:$PATH MISE_SOPS_ROPS=0 mise run --dry-run remote_sops_file" "not trusted"
+[[ ! -e $SOPS_MARKER ]] || fail "remote sops file executed a tool before trust"
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_contains "$UNTRUSTED_ENV PATH=$FAKE_SOPS_BIN:$PATH MISE_SOPS_ROPS=0 mise run remote_sops_file" "remote sops task ran: decrypted"
+[[ -e $SOPS_MARKER ]] || fail "trusted remote sops file did not execute the configured tool"
+assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
+
+# Tool metadata is consumed for runtime activation even when installation is
+# disabled, so every consumption path must require trust. Disabled modes still
+# remain authoritative after trust and must not install the missing fixture.
+cat <<EOF >mise.toml
+[tasks.remote_tools]
+file = "http://localhost:${HTTP_PORT}/test/remote-tools"
+EOF
+
+assert_fail "$UNTRUSTED_ENV mise run remote_tools" "not trusted"
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
+assert_fail "$UNTRUSTED_ENV mise run --skip-tools remote_tools" "not trusted"
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
+assert_fail "$UNTRUSTED_ENV MISE_TASK_RUN_AUTO_INSTALL=0 mise run remote_tools" "not trusted"
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
+assert_fail "$UNTRUSTED_ENV MISE_AUTO_INSTALL=0 mise run remote_tools" "not trusted"
+assert_fail "$UNTRUSTED_ENV mise run --dry-run --skip-tools remote_tools" "not trusted"
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
+
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_contains "$UNTRUSTED_ENV mise run --skip-tools remote_tools" "dummy not installed"
+assert_contains "$UNTRUSTED_ENV MISE_TASK_RUN_AUTO_INSTALL=0 mise run remote_tools" "dummy not installed"
+assert_contains "$UNTRUSTED_ENV MISE_AUTO_INSTALL=0 mise run remote_tools" "dummy not installed"
+assert_contains "$UNTRUSTED_ENV mise run remote_tools" "This is Dummy 1.0.0!"

--- a/e2e/tasks/test_task_remote_metadata_trust
+++ b/e2e/tasks/test_task_remote_metadata_trust
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# Remote task discovery must trust the defining config before it fetches or
+# renders metadata, including through explicitly included task files.
+
+HTTP_PORT_FILE="$TMPDIR/mise_http_test_port"
+MARKER="$TMPDIR/remote-template-executed"
+REQUEST_MARKER="$TMPDIR/remote-template-requested"
+MISE_HTTP_TEST_PORT_FILE="$HTTP_PORT_FILE" \
+  MISE_HTTP_REQUEST_MARKER="$REQUEST_MARKER" \
+  python3 "${TEST_ROOT}/helpers/scripts/http_test_server.py" 0 &
+HTTP_SERVER_PID=$!
+
+cleanup() {
+  kill "$HTTP_SERVER_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+wait_for_file "$HTTP_PORT_FILE" "HTTP test server port file" 30 "$HTTP_SERVER_PID"
+HTTP_PORT=$(cat "$HTTP_PORT_FILE")
+
+UNTRUSTED_ENV="env -u CI -u GITHUB_ACTION -u GITHUB_ACTIONS MISE_PARANOID=1 MISE_TRUSTED_CONFIG_PATHS=$TMPDIR/not-trusted MISE_YES=0 MISE_REMOTE_TEMPLATE_MARKER=$MARKER"
+
+cat <<EOF >mise.toml
+[tasks.remote_template]
+file = "http://localhost:${HTTP_PORT}/test/remote-template"
+
+[tasks.remote_dep]
+run = "echo remote dependency"
+EOF
+
+# Safe mode makes config parsing inert, but it must not turn remote discovery
+# into an SSRF-capable trust bypass.
+assert_fail "$UNTRUSTED_ENV MISE_SAFE=1 mise tasks ls" "not trusted"
+[[ ! -e $REQUEST_MARKER ]] || fail "safe-mode discovery fetched an untrusted remote task"
+
+assert_fail "$UNTRUSTED_ENV mise tasks ls" "not trusted"
+assert_fail "$UNTRUSTED_ENV mise tasks deps remote_template" "not trusted"
+[[ ! -e $REQUEST_MARKER ]] || fail "remote task was fetched during untrusted passive discovery"
+[[ ! -e $MARKER ]] || fail "remote metadata template executed before trust"
+
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_succeed "$UNTRUSTED_ENV mise tasks ls"
+[[ -e $REQUEST_MARKER ]] || fail "trusted passive discovery did not fetch the remote task"
+[[ -e $MARKER ]] || fail "trusted remote metadata template did not render"
+assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
+
+# A trusted config vouches for an explicitly included task file even when that
+# file is outside the config's trust root. Preserve that provenance when the
+# include declares a remote task, including for temporary no-cache snapshots.
+INCLUDED_TASK_DIR="$TMPDIR/included-remote-tasks"
+mkdir -p "$INCLUDED_TASK_DIR"
+cat <<EOF >"$INCLUDED_TASK_DIR/tasks.toml"
+[included_remote_template]
+file = "http://localhost:${HTTP_PORT}/test/remote-template"
+EOF
+cat <<EOF >mise.toml
+[task_config]
+includes = ["$INCLUDED_TASK_DIR/tasks.toml"]
+EOF
+
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_contains "$UNTRUSTED_ENV mise tasks info included_remote_template" "remote_dep"
+assert_contains "$UNTRUSTED_ENV MISE_TASK_REMOTE_NO_CACHE=true mise tasks info included_remote_template" "remote_dep"
+assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"

--- a/e2e/tasks/test_task_remote_metadata_trust
+++ b/e2e/tasks/test_task_remote_metadata_trust
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# Remote task discovery must trust the defining config before it fetches or
-# renders metadata, including through explicitly included task files.
+# Remote task metadata can render Tera templates during discovery and install
+# tools before execution. Both actions must respect the defining config's trust.
 
 HTTP_PORT_FILE="$TMPDIR/mise_http_test_port"
 MARKER="$TMPDIR/remote-template-executed"
@@ -62,11 +62,13 @@ assert_fail "$UNTRUSTED_ENV MISE_SAFE=1 mise tasks ls" "not trusted"
 
 assert_fail "$UNTRUSTED_ENV mise tasks ls" "not trusted"
 assert_fail "$UNTRUSTED_ENV mise tasks deps remote_template" "not trusted"
+assert_fail "$UNTRUSTED_ENV mise run remote_template --help" "not trusted"
 [[ ! -e $REQUEST_MARKER ]] || fail "remote task was fetched during untrusted passive discovery"
 [[ ! -e $MARKER ]] || fail "remote metadata template executed before trust"
-
 assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
 assert_succeed "$UNTRUSTED_ENV mise tasks ls"
+assert_contains "$UNTRUSTED_ENV mise tasks deps remote_template" "remote_dep"
+assert_contains "$UNTRUSTED_ENV mise run remote_template --help" "--remote-flag"
 [[ -e $REQUEST_MARKER ]] || fail "trusted passive discovery did not fetch the remote task"
 [[ -e $MARKER ]] || fail "trusted remote metadata template did not render"
 assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
@@ -134,12 +136,47 @@ assert_contains "$UNTRUSTED_ENV PATH=$FAKE_SOPS_BIN:$PATH MISE_SOPS_ROPS=0 mise 
 [[ -e $SOPS_MARKER ]] || fail "trusted remote sops file did not execute the configured tool"
 assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
 
+# Remote visibility is metadata too: ordinary listings must apply hide after
+# fetching, while --hidden still exposes the task and its remote description.
+cat <<EOF >mise.toml
+[tasks.remote_hidden]
+file = "http://localhost:${HTTP_PORT}/test/remote-hidden"
+EOF
+
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_not_contains "$UNTRUSTED_ENV mise tasks ls" "remote_hidden"
+assert_contains "$UNTRUSTED_ENV mise tasks ls --hidden" "hidden remote metadata"
+assert_not_contains "$UNTRUSTED_ENV mise tasks deps" "remote_hidden"
+assert_contains "$UNTRUSTED_ENV mise tasks deps --hidden" "remote_hidden"
+assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
+
+# Locally known hidden metadata is monotonic, so passive listings must not
+# fetch that task merely to discard it afterward.
+rm -f "$REQUEST_MARKER"
+cat <<EOF >mise.toml
+[tasks.locally_hidden_remote]
+file = "http://localhost:${HTTP_PORT}/test/remote-template"
+hide = true
+EOF
+
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_not_contains "$UNTRUSTED_ENV mise tasks deps" "locally_hidden_remote"
+[[ ! -e $REQUEST_MARKER ]] || fail "tasks deps fetched a locally hidden remote task"
+assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
+
 # Tool metadata is consumed for runtime activation even when installation is
 # disabled, so every consumption path must require trust. Disabled modes still
 # remain authoritative after trust and must not install the missing fixture.
 cat <<EOF >mise.toml
 [tasks.remote_tools]
 file = "http://localhost:${HTTP_PORT}/test/remote-tools"
+
+[tasks.remote_alias_parent]
+depends = ["remote-tools-alias"]
+run = "echo remote alias parent ran"
+
+[tasks.remote_alias_delegate]
+run = [{ task = "remote-tools-alias" }]
 EOF
 
 assert_fail "$UNTRUSTED_ENV mise run remote_tools" "not trusted"
@@ -153,7 +190,85 @@ assert_fail "$UNTRUSTED_ENV mise run --dry-run --skip-tools remote_tools" "not t
 assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
 
 assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
-assert_contains "$UNTRUSTED_ENV mise run --skip-tools remote_tools" "dummy not installed"
+assert_contains "$UNTRUSTED_ENV mise tasks info remote-tools-alias" "remote-tools-alias"
+assert_contains "$UNTRUSTED_ENV mise tasks deps remote-tools-alias" "remote_tools"
+assert_contains "$UNTRUSTED_ENV mise run --skip-tools remote-tools-alias" "dummy not installed"
+assert_contains "$UNTRUSTED_ENV MISE_TASK_RUN_AUTO_INSTALL=0 mise remote-tools-alias" "dummy not installed"
+assert_contains "$UNTRUSTED_ENV mise run --skip-tools remote_alias_parent" "remote alias parent ran"
+assert_contains "$UNTRUSTED_ENV mise run --skip-tools remote_alias_delegate" "dummy not installed"
 assert_contains "$UNTRUSTED_ENV MISE_TASK_RUN_AUTO_INSTALL=0 mise run remote_tools" "dummy not installed"
 assert_contains "$UNTRUSTED_ENV MISE_AUTO_INSTALL=0 mise run remote_tools" "dummy not installed"
 assert_contains "$UNTRUSTED_ENV mise run remote_tools" "This is Dummy 1.0.0!"
+
+# A prefixed alias already known from local metadata must not trigger remote
+# alias discovery for unrelated tasks.
+cat <<EOF >mise.toml
+monorepo_root = true
+
+[monorepo]
+config_roots = ["projects/*"]
+
+[tasks.local_prefixed_alias]
+alias = "local-alias"
+run = "echo local prefixed alias ran"
+
+[tasks.unrelated_remote]
+file = "http://localhost:${HTTP_PORT}/test/remote-template"
+EOF
+
+rm -f "$REQUEST_MARKER"
+assert_contains "mise //:local-alias" "local prefixed alias ran"
+[[ ! -e $REQUEST_MARKER ]] || fail "known local prefixed alias fetched unrelated remote metadata"
+
+# Prefixed monorepo aliases must use the same synthesized alias map in bare
+# dispatch and dynamic task delegation as normal `mise run` resolution.
+cat <<EOF >mise.toml
+monorepo_root = true
+
+[monorepo]
+config_roots = ["projects/*"]
+
+[tasks.remote_tools]
+file = "http://localhost:${HTTP_PORT}/test/remote-tools"
+
+[tasks.remote_prefixed_alias_delegate]
+run = [{ task = "//:remote-tools-alias" }]
+EOF
+
+assert_contains "MISE_TASK_RUN_AUTO_INSTALL=0 mise //:remote-tools-alias" "This is Dummy 1.0.0!"
+assert_contains "mise run --skip-tools remote_prefixed_alias_delegate" "This is Dummy 1.0.0!"
+
+# Bare remote-alias dispatch must retain the snapshot whose header established
+# the alias, rather than selecting revision 1 and executing a second download.
+cat <<EOF >mise.toml
+[tasks.remote_changing_alias]
+file = "http://localhost:${HTTP_PORT}/test/remote-changing-alias"
+EOF
+
+assert_contains "MISE_TASK_REMOTE_NO_CACHE=true mise remote-changing-alias" "remote changing alias revision 1"
+
+# A remote raw-args task must execute the same snapshot used to decide that
+# --help should pass through, rather than fetching a mutable source twice.
+cat <<EOF >mise.toml
+[tasks.remote_raw_help]
+file = "http://localhost:${HTTP_PORT}/test/remote-raw-help"
+EOF
+
+assert_contains "MISE_TASK_REMOTE_NO_CACHE=true mise run remote_raw_help --help" "remote raw help revision 1"
+
+# Two no-cache tasks using the same mutable URL must retain the exact body that
+# was parsed for each Task instead of both executing the final download path.
+cat <<EOF >mise.toml
+[tasks.remote_revision_a]
+file = "http://localhost:${HTTP_PORT}/test/remote-changing"
+
+[tasks.remote_revision_b]
+file = "http://localhost:${HTTP_PORT}/test/remote-changing"
+EOF
+
+ARTIFACT_TMPDIR="$TMPDIR/remote-artifacts"
+mkdir -p "$ARTIFACT_TMPDIR"
+output=$(quiet_assert_succeed "TMPDIR=$ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run remote_revision_a ::: remote_revision_b")
+assert_contains_text "$output" "remote revision 1"
+assert_contains_text "$output" "remote revision 2"
+assert_fail "find '$ARTIFACT_TMPDIR' -mindepth 1 -print -quit | grep -q ."

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,5 @@
 use crate::config::{Config, Settings, config_file};
-use crate::task::TaskOutput;
+use crate::task::{GetMatchingExt, TaskOutput};
 use crate::ui::{self, ctrlc};
 use crate::{Result, backend, request_exit};
 use crate::{cli::args::ToolArg, path::PathExt};
@@ -838,7 +838,25 @@ impl Cli {
                 } else {
                     config.tasks().await?
                 };
-                if tasks.iter().any(|(_, t)| t.is_match(&task)) {
+                let task_refs = crate::task::build_task_ref_map(tasks.iter());
+                let task_exists = if tasks.iter().any(|(_, candidate)| candidate.is_match(&task))
+                    || !task_refs.get_matching(&task)?.is_empty()
+                {
+                    true
+                } else {
+                    // Bare remote aliases exist only after parsing their headers.
+                    // Reuse is guaranteed by the command-scoped artifact map.
+                    let resolved_tasks = crate::task::task_fetcher::TaskFetcher::new(false)
+                        .require_trust_before_fetch()
+                        .fetch_task_map(&config, &tasks)
+                        .await?;
+                    let resolved_refs = crate::task::build_task_ref_map(resolved_tasks.iter());
+                    resolved_tasks
+                        .values()
+                        .any(|candidate| candidate.is_match(&task))
+                        || !resolved_refs.get_matching(&task)?.is_empty()
+                };
+                if task_exists {
                     return Ok(Commands::Run(Box::new(run::Run {
                         task: Some(task),
                         args: self.task_args.unwrap_or_default(),

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -601,7 +601,13 @@ impl Run {
                 )
                 .collect_vec();
 
-            let task_list = get_task_lists(&config, &args, false, false, false).await?;
+            let mut task_list = get_task_lists(&config, &args, false, false, false).await?;
+            // Help is passive discovery, but remote usage and metadata must be
+            // fetched before display. Require trust before that network/Git work.
+            crate::task::task_fetcher::TaskFetcher::new(self.no_cache)
+                .require_trust_before_fetch()
+                .fetch_tasks(&config, &mut task_list)
+                .await?;
 
             if let Some(task) = task_list.first() {
                 // raw_args tasks act as proxies for tools that handle their

--- a/src/cli/tasks/deps.rs
+++ b/src/cli/tasks/deps.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashSet, sync::Arc};
 
 use crate::config::Config;
+use crate::task::task_fetcher::TaskFetcher;
 use crate::task::{Deps, GetMatchingExt, Task, build_task_ref_map};
 use crate::ui::style::{self};
 use crate::ui::tree::{print_tree, print_tree_compact};
@@ -53,9 +54,19 @@ impl TasksDeps {
     async fn get_all_tasks(&self, config: &Arc<Config>) -> Result<Vec<Task>> {
         // Use TaskLoadContext::all() to load tasks from entire monorepo
         let ctx = crate::task::TaskLoadContext::all();
-        Ok(config
-            .tasks_with_context(Some(&ctx))
-            .await?
+        let tasks = config.tasks_with_context(Some(&ctx)).await?;
+        let visible_tasks = tasks
+            .iter()
+            // A local/overlay hide=true survives remote metadata merging, so
+            // do not fetch tasks that cannot appear in ordinary output.
+            .filter(|(_, task)| self.hidden || !task.hide)
+            .map(|(name, task)| (name.clone(), task.clone()))
+            .collect();
+        let resolved = TaskFetcher::new(false)
+            .require_trust_before_fetch()
+            .fetch_task_map(config, &visible_tasks)
+            .await?;
+        Ok(resolved
             .values()
             .filter(|t| self.hidden || !t.hide)
             .cloned()
@@ -78,26 +89,76 @@ impl TasksDeps {
             .filter(|t| t.starts_with("//"))
             .map(|s| s.as_str())
             .collect();
-        let monorepo_tasks = if !monorepo_patterns.is_empty() {
+        let mut monorepo_tasks = if !monorepo_patterns.is_empty() {
             let ctx = crate::task::TaskLoadContext::from_patterns(monorepo_patterns.into_iter());
-            Some(config.tasks_with_context(Some(&ctx)).await?)
+            Some(
+                config
+                    .tasks_with_context(Some(&ctx))
+                    .await?
+                    .as_ref()
+                    .clone(),
+            )
         } else {
             None
         };
 
         // Load non-monorepo tasks once (only if needed)
         let has_regular = task_names.iter().any(|t| !t.starts_with("//"));
-        let regular_tasks = if has_regular {
-            Some(config.tasks().await?)
+        let mut regular_tasks = if has_regular {
+            Some(config.tasks().await?.as_ref().clone())
         } else {
             None
         };
 
-        // Build task ref maps once (not per-task)
+        let monorepo_needs_remote = if let Some(tasks) = &monorepo_tasks {
+            let refs = build_task_ref_map(tasks.iter());
+            task_names
+                .iter()
+                .filter(|name| name.starts_with("//"))
+                .map(|name| refs.get_matching(name))
+                .collect::<Result<Vec<_>>>()?
+                .iter()
+                .any(Vec::is_empty)
+        } else {
+            false
+        };
+        if monorepo_needs_remote && let Some(tasks) = &monorepo_tasks {
+            monorepo_tasks = Some(
+                TaskFetcher::new(false)
+                    .require_trust_before_fetch()
+                    .fetch_task_map(config, tasks)
+                    .await?,
+            );
+        }
+
+        let regular_needs_remote = if let Some(tasks) = &regular_tasks {
+            let refs = build_task_ref_map(tasks.iter());
+            task_names
+                .iter()
+                .filter(|name| !name.starts_with("//"))
+                .map(|name| refs.get_matching(name))
+                .collect::<Result<Vec<_>>>()?
+                .iter()
+                .any(Vec::is_empty)
+        } else {
+            false
+        };
+        if regular_needs_remote && let Some(tasks) = &regular_tasks {
+            regular_tasks = Some(
+                TaskFetcher::new(false)
+                    .require_trust_before_fetch()
+                    .fetch_task_map(config, tasks)
+                    .await?,
+            );
+        }
+
+        // Build task ref maps once (not per-task), after any remote-alias retry.
         let monorepo_ref_map = monorepo_tasks
             .as_ref()
-            .map(|t| build_task_ref_map(t.iter()));
-        let regular_ref_map = regular_tasks.as_ref().map(|t| build_task_ref_map(t.iter()));
+            .map(|tasks| build_task_ref_map(tasks.iter()));
+        let regular_ref_map = regular_tasks
+            .as_ref()
+            .map(|tasks| build_task_ref_map(tasks.iter()));
 
         // Look up each task from the appropriate cache
         let mut tasks = vec![];

--- a/src/cli/tasks/deps.rs
+++ b/src/cli/tasks/deps.rs
@@ -142,7 +142,7 @@ impl TasksDeps {
     /// ```
     ///
     async fn print_deps_tree(&self, config: &Arc<Config>, tasks: Vec<Task>) -> Result<()> {
-        let deps = Deps::new(config, tasks.clone()).await?;
+        let deps = Deps::new_for_display(config, tasks.clone()).await?;
         // filter out nodes that are not selected
         let start_indexes = deps.graph.node_indices().filter(|&idx| {
             let task = &deps.graph[idx];
@@ -181,7 +181,7 @@ impl TasksDeps {
     /// ```
     //
     async fn print_deps_dot(&self, config: &Arc<Config>, tasks: Vec<Task>) -> Result<()> {
-        let deps = Deps::new(config, tasks).await?;
+        let deps = Deps::new_for_display(config, tasks).await?;
         miseprintln!(
             "{:?}",
             Dot::with_attr_getters(

--- a/src/cli/tasks/info.rs
+++ b/src/cli/tasks/info.rs
@@ -43,7 +43,23 @@ impl TasksInfo {
 
         use crate::task::GetMatchingExt;
         let matching = tasks_with_aliases.get_matching(&task_name).ok();
-        let task = matching.and_then(|m| m.first().cloned().cloned());
+        let mut task =
+            matching.and_then(|matching| matching.into_iter().next().map(|task| (**task).clone()));
+
+        // A remote task's aliases only become available after its #MISE header
+        // is fetched. Avoid fetching every remote task for ordinary name hits,
+        // but retry a miss against trusted, resolved remote metadata.
+        if task.is_none() {
+            let resolved_tasks = TaskFetcher::new(false)
+                .require_trust_before_fetch()
+                .fetch_task_map(&config, &tasks)
+                .await?;
+            let resolved_with_aliases = crate::task::build_task_ref_map(resolved_tasks.iter());
+            task = resolved_with_aliases
+                .get_matching(&task_name)
+                .ok()
+                .and_then(|matching| matching.into_iter().next().map(|task| (**task).clone()));
+        }
 
         if let Some(task) = task {
             // Resolve remote task files before displaying task info

--- a/src/cli/tasks/info.rs
+++ b/src/cli/tasks/info.rs
@@ -51,6 +51,7 @@ impl TasksInfo {
             // always pass no_cache=false as the command doesn't take no-cache argument
             // MISE_TASK_REMOTE_NO_CACHE env var is still respected if set
             TaskFetcher::new(false)
+                .require_trust_before_fetch()
                 .fetch_tasks(&config, &mut tasks)
                 .await?;
             let task = &tasks[0];

--- a/src/cli/tasks/ls.rs
+++ b/src/cli/tasks/ls.rs
@@ -158,6 +158,7 @@ impl TasksLs {
         // always pass no_cache=false as the command doesn't take no-cache argument
         // MISE_TASK_REMOTE_NO_CACHE env var is still respected if set
         TaskFetcher::new(false)
+            .require_trust_before_fetch()
             .fetch_tasks(&config, &mut tasks)
             .await?;
 

--- a/src/cli/tasks/ls.rs
+++ b/src/cli/tasks/ls.rs
@@ -144,23 +144,27 @@ impl TasksLs {
 
         let all_tasks = config.tasks_with_context(ctx.as_ref()).await?;
 
-        let tasks = all_tasks
+        let mut tasks = all_tasks
             .values()
+            // A local/overlay hide=true is monotonic when remote metadata is
+            // merged, so avoid fetching tasks that can never become visible.
             .filter(|t| self.hidden || !t.hide)
             .filter(|t| !self.local || !t.global)
             .filter(|t| !self.global || t.global)
             .cloned()
-            .sorted_by(|a, b| self.sort(a, b))
             .collect::<Vec<Task>>();
 
         // Resolve remote task files before any operation that may need them
-        let mut tasks = tasks;
         // always pass no_cache=false as the command doesn't take no-cache argument
         // MISE_TASK_REMOTE_NO_CACHE env var is still respected if set
         TaskFetcher::new(false)
             .require_trust_before_fetch()
             .fetch_tasks(&config, &mut tasks)
             .await?;
+        // Remote #MISE headers can contribute hide/alias/description metadata,
+        // so visibility and metadata-based sorting must happen after fetching.
+        tasks.retain(|task| self.hidden || !task.hide);
+        tasks.sort_by(|a, b| self.sort(a, b));
 
         // Warn about non-executable files only when there are truly no tasks at all
         // (not just filtered out by --hidden/--local/--global)

--- a/src/cli/tasks/validate.rs
+++ b/src/cli/tasks/validate.rs
@@ -70,6 +70,7 @@ impl TasksValidate {
         // always no_cache=false as the command doesn't take no-cache argument
         // MISE_TASK_REMOTE_NO_CACHE env var is still respected if set
         TaskFetcher::new(false)
+            .require_trust_before_fetch()
             .fetch_tasks(&config, &mut resolved_tasks)
             .await?;
         let all_tasks: BTreeMap<String, Task> = resolved_tasks

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -454,6 +454,23 @@ pub fn trust_check(path: &Path) -> eyre::Result<()> {
     Err(UntrustedConfig(path.into()))?
 }
 
+/// Require trust before configuration can cause remote network or Git work.
+///
+/// Safe mode makes ordinary config parsing trust-exempt because its executable
+/// features are disabled. A remote fetch is still an external side effect,
+/// though, so safe mode only permits it when the owner was already trusted.
+/// Outside safe mode this preserves the normal interactive trust prompt.
+pub fn trust_check_remote_fetch(path: &Path) -> eyre::Result<()> {
+    if !remote_fetch_trust_allows(Settings::safe_mode(), is_path_trusted(path)) {
+        Err(UntrustedConfig(path.into()))?
+    }
+    trust_check(path)
+}
+
+fn remote_fetch_trust_allows(safe_mode: bool, is_trusted: bool) -> bool {
+    !safe_mode || is_trusted
+}
+
 pub fn is_trusted(path: &Path) -> bool {
     let canonicalized_path = match path.canonicalize() {
         Ok(p) => p,
@@ -1273,5 +1290,13 @@ mod tests {
             result2,
             Path::new("/tmp/trusted/infra-mise.toml-a1b2c3d4e5f67890.monorepo")
         );
+    }
+
+    #[test]
+    fn test_remote_fetch_trust_policy() {
+        assert!(!remote_fetch_trust_allows(true, false));
+        assert!(remote_fetch_trust_allows(true, true));
+        assert!(remote_fetch_trust_allows(false, false));
+        assert!(remote_fetch_trust_allows(false, true));
     }
 }

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -240,6 +240,17 @@ impl EnvDirective {
             | EnvDirective::Module(_, _, opts) => opts,
         }
     }
+
+    /// Whether resolving this directive can execute code or install tooling.
+    fn requires_remote_trust(&self) -> bool {
+        matches!(
+            self,
+            EnvDirective::File(..)
+                | EnvDirective::Source(..)
+                | EnvDirective::PythonVenv { .. }
+                | EnvDirective::Module(..)
+        )
+    }
 }
 
 impl From<(String, String)> for EnvDirective {
@@ -332,6 +343,7 @@ pub struct EnvResults {
     pub watch_files: Vec<PathBuf>,
     /// True if any directive declared cacheable=false or is a dynamic module
     pub has_uncacheable: bool,
+    pub(crate) trust_source: Option<PathBuf>,
 }
 
 pub(super) struct EnvDirectiveContext<'a> {
@@ -359,6 +371,10 @@ impl EnvDirectiveContext<'_> {
 
     fn normalize_path(&self, path: PathBuf) -> PathBuf {
         (self.normalize_path)(self.config_root, path)
+    }
+
+    fn trust_check_source(&self) -> eyre::Result<()> {
+        self.results.trust_check_source(self.source)
     }
 }
 
@@ -418,25 +434,80 @@ impl EnvResults {
         input: Vec<(EnvDirective, PathBuf)>,
         resolve_opts: EnvResolveOptions,
     ) -> eyre::Result<Self> {
-        Self::resolve_with_toolset(config, ctx, initial, input, resolve_opts, None).await
+        Self::resolve_with_toolset_and_trust_source(
+            config,
+            ctx,
+            initial,
+            input,
+            resolve_opts,
+            None,
+            None,
+        )
+        .await
+    }
+
+    /// Resolve directives relative to their source paths while checking trust
+    /// against separate provenance for remote task metadata.
+    pub async fn resolve_with_trust_source(
+        config: &Arc<Config>,
+        ctx: tera::Context,
+        initial: &EnvMap,
+        input: Vec<(EnvDirective, PathBuf)>,
+        resolve_opts: EnvResolveOptions,
+        trust_source: Option<&Path>,
+    ) -> eyre::Result<Self> {
+        Self::resolve_with_toolset_and_trust_source(
+            config,
+            ctx,
+            initial,
+            input,
+            resolve_opts,
+            None,
+            trust_source,
+        )
+        .await
     }
 
     /// [`Self::resolve`] for callers that already have a resolved toolset. See
     /// [`EnvDirectiveContext::toolset`] for why a directive would want it.
     pub async fn resolve_with_toolset(
         config: &Arc<Config>,
+        ctx: tera::Context,
+        initial: &EnvMap,
+        input: Vec<(EnvDirective, PathBuf)>,
+        resolve_opts: EnvResolveOptions,
+        toolset: Option<&Toolset>,
+    ) -> eyre::Result<Self> {
+        Self::resolve_with_toolset_and_trust_source(
+            config,
+            ctx,
+            initial,
+            input,
+            resolve_opts,
+            toolset,
+            None,
+        )
+        .await
+    }
+
+    async fn resolve_with_toolset_and_trust_source(
+        config: &Arc<Config>,
         mut ctx: tera::Context,
         initial: &EnvMap,
         input: Vec<(EnvDirective, PathBuf)>,
         resolve_opts: EnvResolveOptions,
         toolset: Option<&Toolset>,
+        trust_source: Option<&Path>,
     ) -> eyre::Result<Self> {
         // trace!("resolve: input: {:#?}", &input);
         let mut env = initial
             .iter()
             .map(|(k, v)| (k.clone(), (v.clone(), None)))
             .collect::<IndexMap<_, _>>();
-        let mut r = Self::default();
+        let mut r = Self {
+            trust_source: trust_source.map(Path::to_path_buf),
+            ..Default::default()
+        };
         let normalize_path = |config_root: &Path, p: PathBuf| {
             let p = p.strip_prefix("./").unwrap_or(&p);
             match p.strip_prefix("~/") {
@@ -508,6 +579,13 @@ impl EnvResults {
 
         for (directive, source) in filtered_input {
             let mut tera = None;
+            if directive.requires_remote_trust() && r.trust_source.is_some() {
+                r.trust_check_source(&source).wrap_err_with(|| {
+                    format!(
+                        "remote task environment directive {directive} requires its defining config to be trusted"
+                    )
+                })?;
+            }
             // trace!(
             //     "resolve: directive: {:?}, source: {:?}",
             //     &directive,
@@ -992,7 +1070,7 @@ impl EnvResults {
 
         // Step 1: Tera template expansion
         if contains_template_syntax(input) {
-            trust_check(path)?;
+            self.trust_check_source(path)?;
             let tera = tera.get_or_insert_with(|| {
                 let mut tera = get_tera(path.parent());
                 // Re-bind exec() to the accumulated env vars — but never in safe
@@ -1035,6 +1113,10 @@ impl EnvResults {
         }
 
         Ok(output)
+    }
+
+    fn trust_check_source(&self, fallback: &Path) -> eyre::Result<()> {
+        trust_check(self.trust_source.as_deref().unwrap_or(fallback))
     }
 
     pub fn is_empty(&self) -> bool {

--- a/src/config/env_directive/venv.rs
+++ b/src/config/env_directive/venv.rs
@@ -1,7 +1,6 @@
 use crate::Result;
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
-use crate::config::config_file::trust_check;
 use crate::config::env_directive::{EnvDirectiveContext, EnvResults};
 use crate::config::{Config, Settings};
 use crate::env_diff::EnvMap;
@@ -257,7 +256,7 @@ impl EnvResults {
             debug!("python venv skipped: the python tool is disabled");
             return Ok(());
         }
-        trust_check(ctx.source)?;
+        ctx.trust_check_source()?;
         let venv = ctx.parse_template(&path)?;
         let venv = ctx.normalize_path(venv.into());
         let venv_lock = LockFile::new(&venv).lock()?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1211,6 +1211,7 @@ impl Config {
                 tool_add_paths: Vec::new(),
                 watch_files: cached.watch_files.clone(),
                 has_uncacheable: false,
+                trust_source: None,
             };
             let redact_keys = self
                 .redaction_keys()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4558,6 +4558,39 @@ async fn resolve_git_url_to_path(git_url: &str) -> Result<TaskFileArtifact> {
     Ok(artifact)
 }
 
+fn trust_check_remote_task_include(owner: &Path, include: &str) -> Result<()> {
+    config_file::trust_check_remote_fetch(owner).wrap_err_with(|| {
+        format!(
+            "fetching remote task include {include} requires its defining config {} to be trusted",
+            display_path(owner)
+        )
+    })
+}
+
+fn trust_check_remote_task_includes(owner: &Path, includes: &[String]) -> Result<bool> {
+    let mut found_remote = false;
+    for include in includes
+        .iter()
+        .filter(|include| include.starts_with("git::"))
+    {
+        trust_check_remote_task_include(owner, include)?;
+        found_remote = true;
+    }
+    Ok(found_remote)
+}
+
+fn preserve_remote_task_trust_source(tasks: &mut [Task], source: &Path) {
+    for task in tasks {
+        if task.file.as_ref().is_some_and(|file| {
+            let file = file.to_string_lossy();
+            file.starts_with("git::") || file.starts_with("http://") || file.starts_with("https://")
+        }) {
+            task.remote_config_source
+                .get_or_insert_with(|| source.to_path_buf());
+        }
+    }
+}
+
 /// Check if a pattern contains glob metacharacters
 fn is_glob_pattern(pattern: &str) -> bool {
     // Check for unescaped glob metacharacters: *, ?, [, ], {, }
@@ -4732,6 +4765,7 @@ struct TaskSources {
 struct CascadedTaskConfig {
     task_config: TaskConfig,
     includes_root: PathBuf,
+    includes_source: Option<PathBuf>,
 }
 
 fn merge_cascaded_task_config(
@@ -4765,10 +4799,14 @@ fn merge_cascaded_task_config(
     }) {
         cascaded.task_config.global_pass_through_env = global_pass_through_env;
     }
-    if let Some((includes, root)) = configs
+    if let Some((includes, root, source)) = configs
         .iter()
         .find_map(|cf| match cf.task_config_includes() {
-            Ok(Some(includes)) => Some(Ok((includes, cf.config_root()))),
+            Ok(Some(includes)) => Some(Ok((
+                includes,
+                cf.config_root(),
+                cf.get_path().to_path_buf(),
+            ))),
             Ok(None) => None,
             Err(err) => Some(Err(err)),
         })
@@ -4776,6 +4814,7 @@ fn merge_cascaded_task_config(
     {
         cascaded.task_config.includes = Some(includes);
         cascaded.includes_root = root;
+        cascaded.includes_source = Some(source);
     }
     Ok(())
 }
@@ -4805,6 +4844,7 @@ fn cascaded_task_config_for_dir(
                 cascaded = Some(CascadedTaskConfig {
                     task_config: TaskConfig::default(),
                     includes_root: root,
+                    includes_source: None,
                 });
             }
             _ => {}
@@ -4907,27 +4947,63 @@ async fn load_task_sources_from_configs(
             cascaded_task_config
         };
     let is_global = configs.iter().any(|cf| is_global_config(cf.get_path()));
-    // a config can only vouch for task include files when it was actually
-    // trusted — safe configs load without trust and cannot vouch for anything
-    let require_task_include_trust = !configs.iter().any(|cf| is_path_trusted(cf.get_path()));
-    let (includes, resolve_dir, include_config_precedence) = configs
+    let (includes, resolve_dir, include_config_precedence, include_owner) = configs
         .iter()
         .enumerate()
         .find_map(|(precedence, cf)| match cf.task_config_includes() {
-            Ok(Some(includes)) => Some(Ok((includes, cf.config_root(), precedence))),
+            Ok(Some(includes)) => Some(Ok((
+                includes,
+                cf.config_root(),
+                precedence,
+                Some(cf.get_path().to_path_buf()),
+            ))),
             Ok(None) => None,
             Err(err) => Some(Err(err)),
         })
         .transpose()?
         .or_else(|| {
             cascaded_task_config.and_then(|tc| {
-                tc.task_config
-                    .includes
-                    .clone()
-                    .map(|includes| (includes, tc.includes_root.clone(), configs.len()))
+                tc.task_config.includes.clone().map(|includes| {
+                    (
+                        includes,
+                        tc.includes_root.clone(),
+                        configs.len(),
+                        tc.includes_source.clone(),
+                    )
+                })
             })
         })
-        .unwrap_or_else(|| (default_task_includes(), dir.to_path_buf(), configs.len()));
+        .unwrap_or_else(|| {
+            (
+                default_task_includes(),
+                dir.to_path_buf(),
+                configs.len(),
+                None,
+            )
+        });
+
+    let remote_includes_authorized = match include_owner.as_deref() {
+        Some(owner) => trust_check_remote_task_includes(owner, &includes)?,
+        None if includes.iter().any(|include| include.starts_with("git::")) => {
+            bail!("remote task include has no defining config provenance")
+        }
+        None => false,
+    };
+
+    let vouching_config_source = include_owner
+        .as_ref()
+        .filter(|owner| remote_includes_authorized || is_path_trusted(owner))
+        .cloned()
+        .or_else(|| {
+            if include_owner.is_some() {
+                return None;
+            }
+            configs
+                .iter()
+                .find(|cf| is_path_trusted(cf.get_path()))
+                .map(|cf| cf.get_path().to_path_buf())
+        });
+    let require_task_include_trust = vouching_config_source.is_none();
 
     // Resolve task defaults once for the config root so inline tasks from
     // lower-precedence overlay files use the same defaults as file tasks.
@@ -5012,6 +5088,9 @@ async fn load_task_sources_from_configs(
                 apply_task_config_cache_default(task, &task_config.cache);
                 apply_task_config_rust_cache_default(task, &task_config.rust_cache);
                 task_config.environment.apply(task)?;
+            }
+            if let Some(source) = &vouching_config_source {
+                preserve_remote_task_trust_source(&mut loaded, source);
             }
             if is_global || is_global_task_include_path(&p) {
                 mark_tasks_as_global(&mut loaded);

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -127,20 +127,27 @@ fn same_task_without_phase(task: &Task, other: &Task) -> bool {
 /// manages a dependency graph of tasks so `mise run` knows what to run next
 impl Deps {
     pub async fn new(config: &Arc<Config>, tasks: Vec<Task>) -> eyre::Result<Self> {
-        Self::new_with_cycle_limit(config, tasks, Some(1)).await
+        Self::new_with_options(config, tasks, Some(1), false).await
     }
 
     pub(crate) async fn new_for_validation(
         config: &Arc<Config>,
         tasks: Vec<Task>,
     ) -> eyre::Result<Self> {
-        Self::new_with_cycle_limit(config, tasks, None).await
+        Self::new_with_options(config, tasks, None, true).await
     }
 
-    async fn new_with_cycle_limit(
+    /// Build a dependency graph for passive display without allowing remote
+    /// providers to perform network or Git work from an untrusted config.
+    pub async fn new_for_display(config: &Arc<Config>, tasks: Vec<Task>) -> eyre::Result<Self> {
+        Self::new_with_options(config, tasks, Some(1), true).await
+    }
+
+    async fn new_with_options(
         config: &Arc<Config>,
         tasks: Vec<Task>,
         cycle_limit: Option<usize>,
+        trust_before_fetch: bool,
     ) -> eyre::Result<Self> {
         let mut graph = DiGraph::new();
         let mut indexes = HashMap::new();
@@ -165,7 +172,11 @@ impl Deps {
         }
         let all_tasks_to_run = resolve_depends(config, tasks).await?;
         let no_cache = Settings::get().task.remote_no_cache.unwrap_or(false);
-        let fetcher = TaskFetcher::new(no_cache);
+        let fetcher = if trust_before_fetch {
+            TaskFetcher::new(no_cache).require_trust_before_fetch()
+        } else {
+            TaskFetcher::new(no_cache)
+        };
         while let Some(mut a) = stack.pop() {
             if seen.contains(&a) {
                 // prevent infinite loop

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -38,6 +38,17 @@ pub(crate) fn reset() {
     TASK_ENV_CACHE.lock().unwrap().clear();
 }
 
+#[derive(Debug)]
+pub(crate) struct TaskNotFoundError(String);
+
+impl Display for TaskNotFoundError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for TaskNotFoundError {}
+
 /// Type alias for tracking failed tasks with their exit codes
 pub type FailedTasks = Arc<std::sync::Mutex<Vec<(Task, Option<i32>)>>>;
 
@@ -1679,7 +1690,7 @@ impl Task {
         config: &Arc<Config>,
         tasks_to_run: &[Task],
     ) -> Result<ResolvedTaskDependencies> {
-        use crate::task::TaskLoadContext;
+        use crate::task::{TaskLoadContext, task_fetcher::TaskFetcher};
 
         if let Some(err) = &self.workspace_dependency_error {
             bail!("{err}");
@@ -1712,62 +1723,76 @@ impl Task {
         };
 
         let all_tasks = config.tasks_with_context(ctx.as_ref()).await?;
-        let tasks = build_task_ref_map(all_tasks.iter());
-        // Skip deps with unresolved {{usage.*}} references — they'll be resolved
-        // later when render_depends_with_usage() is called with actual arg values.
-        let depends = self
-            .depends
-            .iter()
-            .filter(|td| !dep_has_usage_ref(td))
-            .map(|td| match_tasks_with_context(&tasks, td, Some(self)))
-            .flatten_ok()
-            .collect_vec();
-        let wait_for = self
-            .wait_for
-            .iter()
-            .filter(|td| !dep_has_usage_ref(td))
-            .map(|td| {
-                match_tasks_with_context(&tasks, td, Some(self))
-                    .map(|tasks| tasks.into_iter().map(|t| (t, td)).collect_vec())
+        let resolve = |all_tasks: &BTreeMap<String, Task>| -> Result<_> {
+            let tasks = build_task_ref_map(all_tasks.iter());
+            // Skip deps with unresolved {{usage.*}} references — they'll be resolved
+            // later when render_depends_with_usage() is called with actual arg values.
+            let depends = self
+                .depends
+                .iter()
+                .filter(|td| !dep_has_usage_ref(td))
+                .map(|td| match_tasks_with_context(&tasks, td, Some(self)))
+                .flatten_ok()
+                .collect_vec();
+            let wait_for = self
+                .wait_for
+                .iter()
+                .filter(|td| !dep_has_usage_ref(td))
+                .map(|td| {
+                    match_tasks_with_context(&tasks, td, Some(self))
+                        .map(|tasks| tasks.into_iter().map(|t| (t, td)).collect_vec())
+                })
+                .flatten_ok()
+                .filter_map_ok(|(t, td)| {
+                    if td.env.is_empty() && td.args.is_empty() {
+                        // Name-based matching: wait for any running instance of this task
+                        // regardless of env/args variant (e.g., "VERBOSE=1 setup" matches "setup").
+                        // Return the actual task from tasks_to_run so the dependency graph
+                        // gets the correct env/args-variant node.
+                        tasks_to_run
+                            .iter()
+                            .find(|tr| tr.name == t.name)
+                            .map(|tr| (*tr).clone())
+                    } else {
+                        // Full identity matching: user explicitly wants a specific env/args variant
+                        tasks_to_run.contains(&t).then_some(t)
+                    }
+                })
+                .collect_vec();
+            let depends_post = self
+                .depends_post
+                .iter()
+                .filter(|td| !dep_has_usage_ref(td))
+                .map(|td| match_tasks_with_context(&tasks, td, Some(self)))
+                .flatten_ok()
+                .filter_ok(|t| t.name != self.name)
+                .collect::<Result<Vec<_>>>()?;
+            let depends = depends
+                .into_iter()
+                .filter_ok(|t| t.name != self.name)
+                .collect::<Result<_>>()?;
+            let wait_for = wait_for
+                .into_iter()
+                .filter_ok(|t| t.name != self.name)
+                .collect::<Result<_>>()?;
+            Ok(ResolvedTaskDependencies {
+                depends,
+                wait_for,
+                depends_post,
             })
-            .flatten_ok()
-            .filter_map_ok(|(t, td)| {
-                if td.env.is_empty() && td.args.is_empty() {
-                    // Name-based matching: wait for any running instance of this task
-                    // regardless of env/args variant (e.g., "VERBOSE=1 setup" matches "setup").
-                    // Return the actual task from tasks_to_run so the dependency graph
-                    // gets the correct env/args-variant node.
-                    tasks_to_run
-                        .iter()
-                        .find(|tr| tr.name == t.name)
-                        .map(|tr| (*tr).clone())
-                } else {
-                    // Full identity matching: user explicitly wants a specific env/args variant
-                    tasks_to_run.contains(&t).then_some(t)
-                }
-            })
-            .collect_vec();
-        let depends_post = self
-            .depends_post
-            .iter()
-            .filter(|td| !dep_has_usage_ref(td))
-            .map(|td| match_tasks_with_context(&tasks, td, Some(self)))
-            .flatten_ok()
-            .filter_ok(|t| t.name != self.name)
-            .collect::<Result<Vec<_>>>()?;
-        let depends = depends
-            .into_iter()
-            .filter_ok(|t| t.name != self.name)
-            .collect::<Result<_>>()?;
-        let wait_for = wait_for
-            .into_iter()
-            .filter_ok(|t| t.name != self.name)
-            .collect::<Result<_>>()?;
-        Ok(ResolvedTaskDependencies {
-            depends,
-            wait_for,
-            depends_post,
-        })
+        };
+
+        match resolve(&all_tasks) {
+            Ok(dependencies) => Ok(dependencies),
+            Err(err) if err.downcast_ref::<TaskNotFoundError>().is_some() => {
+                let all_tasks = TaskFetcher::new(false)
+                    .require_trust_before_fetch()
+                    .fetch_task_map(config, &all_tasks)
+                    .await?;
+                resolve(&all_tasks)
+            }
+            Err(err) => Err(err),
+        }
     }
 
     /// Expands `^task` dependencies to the matching task in every upstream workspace project.
@@ -3127,7 +3152,7 @@ fn match_tasks_with_context(
             }
         }
 
-        return Err(eyre!(err_msg));
+        return Err(TaskNotFoundError(err_msg).into());
     };
 
     Ok(matches)

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -781,6 +781,15 @@ pub struct Task {
     #[serde(skip)]
     pub remote_file_source: Option<String>,
 
+    /// Config file that declared a remote task. The fetched task's local path
+    /// is not the trust authority for its metadata.
+    #[serde(skip)]
+    pub remote_config_source: Option<PathBuf>,
+
+    /// Whether the fetched remote header contributed tool requirements.
+    #[serde(skip)]
+    pub remote_metadata_has_tools: bool,
+
     /// Block reads, writes, network, and env vars
     #[serde(default)]
     pub deny_all: bool,
@@ -1050,6 +1059,16 @@ pub(crate) fn file_has_decoded_template(path: &Path, body: &str) -> bool {
             .filter_map(|entry| entry.parse_toml().ok())
             .any(|value| toml_value_has_template(&value))
     }
+}
+
+/// Check decoded remote script header values regardless of the fetched path's
+/// extension. A remote script may legitimately end in `.toml`.
+pub(crate) fn script_header_has_decoded_template(body: &str) -> bool {
+    use crate::config::config_file::mise_toml::toml_value_has_template;
+    scan_mise_header_entries(file::strip_utf8_bom(body))
+        .into_iter()
+        .filter_map(|entry| entry.parse_toml().ok())
+        .any(|value| toml_value_has_template(&value))
 }
 
 fn parse_task_script_usage(file: &Path) -> usage::Result<usage::Spec> {
@@ -3147,6 +3166,8 @@ impl Default for Task {
             usage: "".to_string(),
             timeout: None,
             remote_file_source: None,
+            remote_config_source: None,
+            remote_metadata_has_tools: false,
             deny_all: false,
             deny_read: false,
             deny_write: false,

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -9,7 +9,7 @@ use crate::tera::{TeraEngine, contains_template_syntax, get_tera, render_str};
 use crate::ui::tree::TreeItem;
 use crate::{dirs, env, file};
 use console::{measure_text_width, truncate_str};
-use eyre::{Result, bail, eyre};
+use eyre::{Result, WrapErr, bail, eyre};
 use globset::{GlobBuilder, GlobMatcher};
 use indexmap::IndexMap;
 use itertools::Itertools;
@@ -107,7 +107,7 @@ impl Task {
     }
 }
 
-use crate::config::config_file::ConfigFile;
+use crate::config::config_file::{ConfigFile, trust_check};
 use crate::env_diff::EnvMap;
 use crate::file::display_path;
 use crate::fuzzy::{FuzzyMatcher, FuzzyPattern};
@@ -1309,6 +1309,21 @@ impl Task {
     }
 
     pub(crate) fn tool_args(&self) -> Result<Vec<ToolArg>> {
+        if self.remote_metadata_has_tools {
+            let remote_source = self.remote_file_source.as_deref().unwrap_or(&self.name);
+            let config_source = self.remote_config_source.as_deref().ok_or_else(|| {
+                eyre!(
+                    "remote task {remote_source} has tool metadata without defining config provenance"
+                )
+            })?;
+            trust_check(config_source).wrap_err_with(|| {
+                format!(
+                    "tool metadata from remote task {} requires its defining config {} to be trusted",
+                    remote_source,
+                    display_path(config_source)
+                )
+            })?;
+        }
         self.tools
             .iter()
             .map(|(tool, value)| value.to_tool_arg(tool))
@@ -2835,7 +2850,7 @@ impl Task {
         env_directives.extend(self.overlay_env.iter().cloned());
 
         // Resolve environment directives using the same system as global env
-        let env_results = EnvResults::resolve(
+        let env_results = EnvResults::resolve_with_trust_source(
             config,
             tera_ctx.clone(),
             &env,
@@ -2845,6 +2860,7 @@ impl Task {
                 tools: ToolsFilter::Both,
                 warn_on_missing_required: false,
             },
+            self.remote_config_source.as_deref(),
         )
         .await?;
         // Register task-specific redactions with the global redactor

--- a/src/task/task_context_builder.rs
+++ b/src/task/task_context_builder.rs
@@ -9,7 +9,7 @@ use crate::toolset::{Toolset, ToolsetBuilder};
 use eyre::Result;
 use indexmap::IndexMap;
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
 type EnvResolutionResult = (
@@ -252,7 +252,7 @@ impl TaskContextBuilder {
 
         // Resolve config-level env from ALL config files, not just task_cf
         let config_env_results = self
-            .resolve_env_directives(config, &tera_ctx, &env, all_config_env_entries)
+            .resolve_env_directives(config, &tera_ctx, &env, all_config_env_entries, None)
             .await?;
         Self::apply_env_results(&mut env, &config_env_results);
 
@@ -267,7 +267,13 @@ impl TaskContextBuilder {
 
         let task_env_directives = self.build_task_env_directives(task);
         let task_env_results = self
-            .resolve_env_directives(config, &tera_ctx, &env, task_env_directives)
+            .resolve_env_directives(
+                config,
+                &tera_ctx,
+                &env,
+                task_env_directives,
+                task.remote_config_source.as_deref(),
+            )
             .await?;
 
         let task_env = self.extract_task_env(&task_env_results);
@@ -418,8 +424,9 @@ impl TaskContextBuilder {
         tera_ctx: &tera::Context,
         env: &BTreeMap<String, String>,
         directives: Vec<(EnvDirective, PathBuf)>,
+        trust_source: Option<&Path>,
     ) -> Result<EnvResults> {
-        EnvResults::resolve(
+        EnvResults::resolve_with_trust_source(
             config,
             tera_ctx.clone(),
             env,
@@ -429,6 +436,7 @@ impl TaskContextBuilder {
                 tools: ToolsFilter::Both,
                 warn_on_missing_required: false,
             },
+            trust_source,
         )
         .await
     }

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -1012,16 +1012,21 @@ impl TaskExecutor {
             name
         }));
         let tasks = config.tasks_with_context(Some(&ctx)).await?;
-        let tasks_map: BTreeMap<String, Task> = tasks
-            .values()
-            .flat_map(|t| {
-                t.aliases
-                    .iter()
-                    .map(|a| (a.to_string(), t.clone()))
-                    .chain(once((t.name.clone(), t.clone())))
-                    .collect::<Vec<_>>()
-            })
-            .collect();
+        let mut resolved_tasks = tasks.as_ref().clone();
+        let needs_remote_aliases = {
+            let tasks_map = crate::task::build_task_ref_map(resolved_tasks.iter());
+            specs.iter().try_fold(false, |missing, spec| {
+                let (name, _) = split_task_spec(spec);
+                Ok::<_, eyre::Report>(missing || tasks_map.get_matching(name)?.is_empty())
+            })?
+        };
+        if needs_remote_aliases {
+            resolved_tasks = crate::task::task_fetcher::TaskFetcher::new(false)
+                .require_trust_before_fetch()
+                .fetch_task_map(config, &resolved_tasks)
+                .await?;
+        }
+        let tasks_map = crate::task::build_task_ref_map(resolved_tasks.iter());
         let mut to_run: Vec<Task> = vec![];
         for spec in specs {
             let (name, args) = split_task_spec(spec);

--- a/src/task/task_fetcher.rs
+++ b/src/task/task_fetcher.rs
@@ -1,8 +1,9 @@
+use crate::config::config_file::{trust_check, trust_check_remote_fetch};
 use crate::config::{Config, Settings};
-use crate::task::Task;
 use crate::task::task_file_providers::{TaskFileArtifact, TaskFileProvidersBuilder};
+use crate::task::{Task, script_header_has_decoded_template};
 use dashmap::DashMap;
-use eyre::Result;
+use eyre::{Result, WrapErr};
 use std::{
     path::PathBuf,
     sync::{Arc, LazyLock, Mutex},
@@ -65,11 +66,21 @@ fn take_remote_task_artifacts() -> Vec<Arc<OnceCell<TaskFileArtifact>>> {
 /// Handles fetching remote task files and converting them to local paths
 pub struct TaskFetcher {
     no_cache: bool,
+    trust_before_fetch: bool,
 }
 
 impl TaskFetcher {
     pub fn new(no_cache: bool) -> Self {
-        Self { no_cache }
+        Self {
+            no_cache,
+            trust_before_fetch: false,
+        }
+    }
+
+    /// Require trust before a remote provider performs network or Git work.
+    pub fn require_trust_before_fetch(mut self) -> Self {
+        self.trust_before_fetch = true;
+        self
     }
 
     /// Fetch remote task files, converting remote paths to local cached paths
@@ -89,6 +100,24 @@ impl TaskFetcher {
                 }
 
                 let original = t.clone();
+                let defining_cf = original
+                    .cf
+                    .clone()
+                    .or_else(|| config.config_files.get(&original.config_source).cloned());
+                let defining_config_source = original
+                    .remote_config_source
+                    .clone()
+                    .or_else(|| defining_cf.as_ref().map(|cf| cf.get_path().to_path_buf()))
+                    .unwrap_or_else(|| original.config_source.clone());
+
+                if self.trust_before_fetch {
+                    trust_check_remote_fetch(&defining_config_source).wrap_err_with(|| {
+                        format!(
+                            "fetching remote task {source} requires its defining config to be trusted"
+                        )
+                    })?;
+                }
+
                 let provider = task_file_providers
                     .get_provider(&source)
                     .ok_or_else(|| eyre::eyre!("No provider found for file: {}", source))?;
@@ -123,12 +152,25 @@ impl TaskFetcher {
                 // Parse the downloaded script as a regular file task so all #MISE
                 // metadata is honored. The inline TOML task remains the higher-
                 // precedence overlay, matching local file-task behavior.
+                let body = crate::file::read_to_string(&local_path).wrap_err_with(|| {
+                    format!("failed to read remote task metadata from {source}")
+                })?;
+                let header_has_templates = script_header_has_decoded_template(&body);
                 let mut remote = Task::from_path_unrendered_with_cf(
                     &local_path,
                     prefix,
                     &config_root,
                     original.cf.clone(),
-                )?;
+                )
+                .wrap_err_with(|| format!("failed to parse remote task metadata from {source}"))?;
+                if header_has_templates {
+                    trust_check(&defining_config_source).wrap_err_with(|| {
+                        format!(
+                            "remote task metadata from {source} requires its defining config to be trusted"
+                        )
+                    })?;
+                }
+                let remote_metadata_has_tools = !remote.tools.is_empty();
                 remote.name.clone_from(&original.name);
                 remote.display_name.clone_from(&original.display_name);
 
@@ -141,13 +183,20 @@ impl TaskFetcher {
                 remote.inherited_env.clone_from(&original.inherited_env);
                 remote.overlay_env.clone_from(&original.overlay_env);
                 remote.overlay_vars.clone_from(&original.overlay_vars);
-                remote.render(config, &config_root).await?;
+                remote
+                    .render(config, &config_root)
+                    .await
+                    .wrap_err_with(|| {
+                        format!("failed to render remote task metadata from {source}")
+                    })?;
                 remote.merge_toml_overlay(original.clone());
 
                 // Preserve runtime state that is not task metadata and therefore is
                 // intentionally not handled by merge_toml_overlay().
                 remote.global = original.global;
                 remote.remote_file_source = Some(source);
+                remote.remote_config_source = Some(defining_config_source);
+                remote.remote_metadata_has_tools = remote_metadata_has_tools;
                 *t = remote;
             }
         }

--- a/src/task/task_fetcher.rs
+++ b/src/task/task_fetcher.rs
@@ -5,6 +5,7 @@ use crate::task::{Task, script_header_has_decoded_template};
 use dashmap::DashMap;
 use eyre::{Result, WrapErr};
 use std::{
+    collections::BTreeMap,
     path::PathBuf,
     sync::{Arc, LazyLock, Mutex},
 };
@@ -202,6 +203,21 @@ impl TaskFetcher {
         }
 
         Ok(())
+    }
+
+    /// Clone and resolve a task map so consumers can retry alias/dependency
+    /// matching against metadata that only exists in remote headers.
+    pub async fn fetch_task_map(
+        &self,
+        config: &Arc<Config>,
+        tasks: &BTreeMap<String, Task>,
+    ) -> Result<BTreeMap<String, Task>> {
+        let mut resolved = tasks.values().cloned().collect::<Vec<_>>();
+        self.fetch_tasks(config, &mut resolved).await?;
+        Ok(resolved
+            .into_iter()
+            .map(|task| (task.name.clone(), task))
+            .collect())
     }
 
     /// Check if a source path is a remote task file (git or http/https)

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -1,5 +1,6 @@
 use crate::config::{self, Config};
 use crate::file::display_path;
+use crate::task::task_fetcher::TaskFetcher;
 use crate::task::{
     GetMatchingExt, Task, TaskLoadContext, extract_monorepo_path, is_workspace_project_task,
     resolve_task_pattern,
@@ -524,25 +525,38 @@ pub async fn get_task_lists(
             config.tasks().await?
         };
 
-        let tasks_with_aliases = crate::task::build_task_ref_map(all_tasks.iter());
+        let find_matching_tasks =
+            |tasks_with_aliases: &BTreeMap<String, &Task>| -> Result<Vec<Task>> {
+                let mut matches = tasks_with_aliases
+                    .get_matching(&t)?
+                    .into_iter()
+                    .map(|task| (**task).clone())
+                    .collect_vec();
+                if matches.is_empty()
+                    && t != original_name
+                    && !original_name.starts_with("//")
+                    && !original_name.starts_with(':')
+                {
+                    matches = tasks_with_aliases
+                        .get_matching(&original_name)?
+                        .into_iter()
+                        .map(|task| (**task).clone())
+                        .collect_vec();
+                }
+                Ok(matches)
+            };
 
-        let mut cur_tasks = tasks_with_aliases
-            .get_matching(&t)?
-            .into_iter()
-            .cloned()
-            .collect_vec();
-        // If the task name was auto-expanded to monorepo syntax (e.g., "hello" -> "//:hello")
-        // but no monorepo task matched, fall back to the original bare name to find global tasks
-        if cur_tasks.is_empty()
-            && t != original_name
-            && !original_name.starts_with("//")
-            && !original_name.starts_with(':')
-        {
-            cur_tasks = tasks_with_aliases
-                .get_matching(&original_name)?
-                .into_iter()
-                .cloned()
-                .collect_vec();
+        let tasks_with_aliases = crate::task::build_task_ref_map(all_tasks.iter());
+        let mut cur_tasks = find_matching_tasks(&tasks_with_aliases)?;
+        if cur_tasks.is_empty() {
+            // Remote aliases exist only after parsing their headers. A miss is
+            // passive discovery, so require trust before fetching them.
+            let resolved_tasks = TaskFetcher::new(false)
+                .require_trust_before_fetch()
+                .fetch_task_map(config, &all_tasks)
+                .await?;
+            let resolved_with_aliases = crate::task::build_task_ref_map(resolved_tasks.iter());
+            cur_tasks = find_matching_tasks(&resolved_with_aliases)?;
         }
         if cur_tasks.is_empty() {
             // Check if this is a "default" task (either plain "default" or monorepo syntax like "//:default")
@@ -639,12 +653,31 @@ pub async fn resolve_depends(config: &Arc<Config>, tasks: Vec<Task>) -> Result<V
 
     let all_tasks = config.tasks_with_context(ctx.as_ref()).await?;
 
-    tasks
-        .into_iter()
-        .map(|t| {
-            let depends = t.all_depends(&all_tasks)?;
-            Ok(once(t).chain(depends).collect::<Vec<_>>())
-        })
-        .flatten_ok()
-        .collect()
+    let resolve = |all_tasks: &BTreeMap<String, Task>| {
+        tasks
+            .iter()
+            .cloned()
+            .map(|task| {
+                let depends = task.all_depends(all_tasks)?;
+                Ok(once(task).chain(depends).collect::<Vec<_>>())
+            })
+            .flatten_ok()
+            .collect::<Result<Vec<_>>>()
+    };
+
+    match resolve(&all_tasks) {
+        Ok(tasks) => Ok(tasks),
+        Err(error)
+            if error
+                .downcast_ref::<crate::task::TaskNotFoundError>()
+                .is_some() =>
+        {
+            let resolved_tasks = TaskFetcher::new(false)
+                .require_trust_before_fetch()
+                .fetch_task_map(config, &all_tasks)
+                .await?;
+            resolve(&resolved_tasks)
+        }
+        Err(error) => Err(error),
+    }
 }

--- a/src/task/task_tool_installer.rs
+++ b/src/task/task_tool_installer.rs
@@ -225,6 +225,7 @@ impl<'a> TaskToolInstaller<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::task::Task;
 
     #[test]
     fn test_task_tool_installer_new() {
@@ -232,5 +233,23 @@ mod tests {
         let cli_tools: Vec<ToolArg> = vec![];
         let installer = TaskToolInstaller::new(&context_builder, &cli_tools);
         assert_eq!(installer.cli_tools.len(), 0);
+    }
+
+    #[test]
+    fn test_remote_tool_metadata_without_provenance_fails_closed() {
+        let task = Task {
+            name: "remote".into(),
+            remote_file_source: Some("https://example.com/task".into()),
+            remote_metadata_has_tools: true,
+            ..Default::default()
+        };
+
+        let error = task.tool_args().unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("tool metadata without defining config provenance")
+        );
     }
 }


### PR DESCRIPTION
Stacked on #12256.

## Work order

1. #12254 — contain remote Git task paths (independent)
2. #12202 — require trust before remote metadata discovery
3. #12256 — guard remote metadata side effects
4. This PR — resolve trusted metadata in task commands
5. #12206 — harden cache lifecycle after the trust stack is merged and rebased

GitHub shows the cumulative stack diff against main because the branches live in a fork. The incremental review diff is #12256 through this PR.

## Summary

- resolve aliases and visibility supplied by trusted remote headers
- use remote metadata consistently in run, bare dispatch, info, deps, validation, and listing paths
- retry dependency resolution after trusted remote metadata discovery
- retain the exact no-cache artifact whose metadata selected execution behavior

## Validation

- mise run lint-fix
- mise run test:e2e e2e/tasks/test_task_remote_metadata_trust e2e/tasks/test_task_remote_git_includes

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote task aliases and references are now discovered across task execution, listing, information, dependency, and validation commands.
  * Remote metadata can control task visibility, ordering, help output, tools, and environment settings.
  * Nested and inherited remote task configurations retain their trust context.

* **Security**
  * Safe mode now requires trusted configuration ownership before fetching or processing remote tasks, templates, tools, and environment directives.

* **Bug Fixes**
  * Improved resolution of remote tasks when no local match is found.
  * Added clearer errors for unavailable or improperly configured remote task metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->