### PR TITLE
fix(config): deprecate minimum-version idiomatic files

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -263,7 +263,7 @@ fn codegen_registry() {
                     .iter()
                     .map(|f| match f {
                         toml::Value::String(path) => format!(
-                            "RegistryIdiomaticFile {{ path: {}, version_regex: None, version_json_path: None, version_expr: None }}",
+                            "RegistryIdiomaticFile {{ path: {}, version_regex: None, version_json_path: None, version_expr: None, deprecated: None }}",
                             raw_string_literal(path)
                         ),
                         toml::Value::Table(spec) => {
@@ -275,6 +275,7 @@ fn codegen_registry() {
                                             | "version_regex"
                                             | "version_json_path"
                                             | "version_expr"
+                                            | "deprecated"
                                     ),
                                     "[{short}] unknown idiomatic file field: {key}"
                                 );
@@ -302,11 +303,12 @@ fn codegen_registry() {
                                     .unwrap_or_else(|| "None".to_string())
                             };
                             format!(
-                                "RegistryIdiomaticFile {{ path: {}, version_regex: {}, version_json_path: {}, version_expr: {} }}",
+                                "RegistryIdiomaticFile {{ path: {}, version_regex: {}, version_json_path: {}, version_expr: {}, deprecated: {} }}",
                                 raw_string_literal(required("path")),
                                 optional("version_regex"),
                                 optional("version_json_path"),
                                 optional("version_expr"),
+                                optional("deprecated"),
                             )
                         }
                         _ => panic!(

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -498,10 +498,34 @@ idiomatic files. Registry entries may use the same `version_regex`, `version_jso
 This lets tools installed through backends such as `aqua:` and `github:` support JSON manifests
 and other tool-specific version files without requiring an asdf or vfox plugin.
 
-Some files declare a minimum compatible version or a configuration-format major rather than an
-exact binary release. mise treats that value as a normal version request, so a value such as
-`3.25` selects the latest matching CMake 3.25 release and a GoReleaser config `version: 2` selects
-the latest GoReleaser 2.x release.
+### Which fields mise reads
+
+An idiomatic version file is only read for fields that declare **the version the project is built
+with**. Fields that declare a **minimum compatible version** — a floor for whoever consumes the
+project — are not version requests and mise does not install from them. A floor says nothing about
+which version the project is developed and tested against: a library that still supports Node 18
+or CMake 3.25 is almost certainly not built with it, so resolving the floor either pins everyone to
+the oldest supported release or, read as a range, just means "latest".
+
+A configuration-format major is different and is still read: a GoReleaser config `version: 2` is a
+schema selector deliberately coupled to the CLI major, not a compatibility floor, so it selects the
+latest GoReleaser 2.x.
+
+::: warning
+mise used to treat two floors as version requests. Both are deprecated, warn when they resolve a
+version, and will be removed in mise 2026.11.0: `go.mod`'s `go X.Y` directive (add a
+`toolchain goX.Y.Z` line to `go.mod`, or use `.go-version` or `mise.toml`) and `CMakeLists.txt`'s
+`cmake_minimum_required` (use `mise.toml`).
+
+A project that has already migrated can opt into the final behavior — floors ignored, no warning —
+before then:
+
+```sh
+mise settings set idiomatic_version_file_ignore_minimum_versions true
+```
+
+That setting is removed in 2026.11.0 along with the behavior it guards.
+:::
 
 For `package.json` (supported by `node`, `deno`, `bun`, `npm`, `pnpm`, and `yarn`):
 
@@ -509,9 +533,21 @@ For `package.json` (supported by `node`, `deno`, `bun`, `npm`, `pnpm`, and `yarn
 - Package managers (`npm`, `pnpm`, and `yarn`) read `devEngines.packageManager` or top-level `packageManager` (e.g. `pnpm@9.1.0` or `npm@10.0.0`).
 - For `bun`, mise checks `devEngines.runtime` first, falling back to `devEngines.packageManager` and top-level `packageManager` (e.g. `bun@1.2.0`).
 
-For `go.mod`, the `toolchain goX.Y.Z` directive (an exact toolchain pin) is used when present.
-Otherwise the `go X.Y` directive is used; because it declares only the _minimum_ required Go
-version, mise resolves it to the latest matching patch (e.g. `go 1.22` → latest `1.22.x`).
+The `engines` field is **not** read, and this is the clearest case of the rule above. `engines`
+declares the range of Node versions a package is _compatible_ with — npm uses it to warn or fail
+when someone installs the package on an unsupported runtime. It is a statement about consumers, and
+it is routinely a wide range (`>=18`) that no one develops against. `devEngines`, added by npm
+precisely to fill this gap, states the version the project's own developers use, which is what mise
+needs. If you only have `engines`, pin the real version explicitly:
+
+```sh
+mise use node@22
+```
+
+For `go.mod`, the `toolchain goX.Y.Z` directive is used — an exact pin of the toolchain the module
+builds and tests with. The `go X.Y` directive is a minimum and is deprecated (see above).
+
+### Enabling idiomatic version files
 
 In mise, these are disabled by default, see <https://github.com/jdx/mise/discussions/4345> for rationale.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -782,10 +782,17 @@ The supported parser fields are:
 These parsers are evaluated in-process and cannot run shell commands. Plain string entries remain
 compatible with existing registry entries and backend-native parsers.
 
-Only extract a value that determines compatibility with the tool binary. Good candidates include
-an exact version, a minimum/required version, or a configuration-format major that is intentionally
-coupled to the CLI major. Do not extract unrelated project versions, dependency versions, lockfile
-schema revisions, or generic `version` fields that do not constrain the tool itself.
+Only extract a value that states the version the project is built with. Good candidates are an
+exact version or a configuration-format major that is intentionally coupled to the CLI major. Do
+not extract a **minimum compatible version** — a floor such as `cmake_minimum_required` or
+`package.json`'s `engines` describes what a consumer needs, not what the project is developed
+against, and resolving it pins users to the oldest supported release (see
+[which fields mise reads](/configuration.html#which-fields-mise-reads)).
+Also do not extract unrelated project versions, dependency versions, lockfile schema revisions, or
+generic `version` fields that do not constrain the tool itself.
+
+An existing entry that reads a floor can be retired with `deprecated = "<reason>"` on the file,
+which keeps it resolving while warning users to move the version into `mise.toml`.
 
 Include all filenames that the tool officially searches, including documented nested paths such as
 `.config/tool.yml`. When suffixes overlap, mise uses the most specific matching path.

--- a/e2e/backend/test_registry_idiomatic_version_files
+++ b/e2e/backend/test_registry_idiomatic_version_files
@@ -34,11 +34,21 @@ assert_contains "mise tool task" "3.17"
 echo "v2.71.1" >.chezmoiversion
 assert_contains "mise tool chezmoi" "2.71.1"
 
+# `cmake_minimum_required` is a floor, not the version the project is built with.
+# Deprecated: it still resolves but warns. Removed in mise 2026.11.0 along with this
+# block and the registry entry's parser.
 cat >CMakeLists.txt <<'EOF'
 cmake_minimum_required(VERSION 3.25...3.28)
 project(example)
 EOF
 assert_contains "mise tool cmake" "3.25"
+assert_contains "mise tool cmake 2>&1" "deprecated [CMakeLists.txt]"
+
+# opting into the final behavior now drops the version and the warning
+export MISE_IDIOMATIC_VERSION_FILE_IGNORE_MINIMUM_VERSIONS=1
+assert_not_contains "mise tool cmake" "3.25"
+assert_not_contains "mise tool cmake 2>&1" "deprecated"
+unset MISE_IDIOMATIC_VERSION_FILE_IGNORE_MINIMUM_VERSIONS
 
 cat >Earthfile <<'EOF'
 VERSION --pass-args 0.8

--- a/e2e/core/test_go_from_gomod
+++ b/e2e/core/test_go_from_gomod
@@ -5,24 +5,63 @@
 # Enable idiomatic version files for go
 mise settings set idiomatic_version_file_enable_tools go
 
-# the `toolchain` directive is an exact pin and takes precedence over the
-# `go` directive (which is only a minimum version)
-cat >go.mod <<EOF
+# the `toolchain` directive is an exact pin of the toolchain the module builds
+# with, and takes precedence over the `go` directive. A `go` directive alongside
+# it is not read at all, so this must not warn -- `go` + `toolchain` together is
+# what `go mod tidy` writes, and it is the shape users should end up with.
+cat >go.mod <<GOMOD
 module example.com/m
 
 go 1.21
 toolchain go1.21.4
-EOF
+GOMOD
 assert "mise current go" "1.21.4"
+assert_not_contains "mise current go 2>&1" "deprecated"
 
-# `toolchain default` is ignored; the `go` directive is used, resolved to the
-# latest matching patch (a minimum version -> latest 1.21.x). Derive the expected
-# patch the same way resolution does, so the assertion tracks "latest matching".
-cat >go.mod <<EOF
+# a `toolchain` pin alone is enough, and also does not warn
+cat >go.mod <<GOMOD
+module example.com/m
+
+toolchain go1.21.4
+GOMOD
+assert "mise current go" "1.21.4"
+assert_not_contains "mise current go 2>&1" "deprecated"
+
+# the `go` directive is only a minimum compatible version. Deprecated: it still
+# resolves (to the latest matching patch) but warns. Removed in mise 2026.11.0,
+# along with this block.
+cat >go.mod <<GOMOD
 module example.com/m
 
 go 1.21
-toolchain default
-EOF
+GOMOD
 latest_121="$(mise ls-remote go@1.21 | tail -1)"
 assert "mise current go" "$latest_121"
+assert_contains "mise current go 2>&1" "deprecated [idiomatic.go.mod.go-directive]"
+
+# no usable directive at all -> the file is skipped
+cat >go.mod <<GOMOD
+module example.com/m
+GOMOD
+assert "mise current go" ""
+
+# projects can opt into the final behavior now: the `go` directive is not read and
+# nothing warns
+mise settings set idiomatic_version_file_ignore_minimum_versions true
+
+cat >go.mod <<GOMOD
+module example.com/m
+
+go 1.21
+GOMOD
+assert "mise current go" ""
+assert_not_contains "mise current go 2>&1" "deprecated"
+
+# ...and `toolchain` still resolves
+cat >go.mod <<GOMOD
+module example.com/m
+
+go 1.21
+toolchain go1.21.4
+GOMOD
+assert "mise current go" "1.21.4"

--- a/registry/cmake.toml
+++ b/registry/cmake.toml
@@ -6,7 +6,7 @@ backends = [
 bins = ["ccmake", "cmake", "cmake-gui", "cpack", "ctest"]
 description = "CMake is a tool to manage building of source code. Originally, CMake was designed as a generator for various dialects of Makefile, today CMake generates modern buildsystems such as Ninja as well as project files for IDEs such as Visual Studio and Xcode"
 idiomatic_files = [
-  { path = "CMakeLists.txt", version_regex = '''(?im)^\s*cmake_minimum_required\s*\(\s*VERSION\s+v?([0-9]+(?:\.[0-9]+){0,3})''' },
+  { path = "CMakeLists.txt", version_regex = '''(?im)^\s*cmake_minimum_required\s*\(\s*VERSION\s+v?([0-9]+(?:\.[0-9]+){0,3})''', deprecated = "`cmake_minimum_required` declares only the minimum CMake version the project is compatible with, not the version it is built with." },
 ]
 test = { cmd = "cmake --version", expected = """
 cmake version {{version}}

--- a/schema/mise-registry-tool.json
+++ b/schema/mise-registry-tool.json
@@ -178,6 +178,10 @@
               "version_expr": {
                 "type": "string",
                 "description": "expr-lang expression used to extract or post-process versions"
+              },
+              "deprecated": {
+                "type": "string",
+                "description": "Reason this file is no longer read; emits a deprecation warning when it resolves a version"
               }
             },
             "required": ["path"],

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1132,6 +1132,11 @@
             "type": "string"
           }
         },
+        "idiomatic_version_file_ignore_minimum_versions": {
+          "default": false,
+          "description": "Ignore idiomatic version file fields that only declare a minimum compatible version.",
+          "type": "boolean"
+        },
         "ignored_config_paths": {
           "default": [],
           "description": "This is a list of config paths that mise will ignore.",

--- a/settings.toml
+++ b/settings.toml
@@ -1336,6 +1336,28 @@ parse_env = "set_by_comma"
 rust_type = "BTreeSet<String>"
 type = "SetString"
 
+[idiomatic_version_file_ignore_minimum_versions]
+default = false
+description = "Ignore idiomatic version file fields that only declare a minimum compatible version."
+docs = """
+Some idiomatic version files carry a *minimum* compatible version rather than the version the
+project is built with. mise used to resolve those, which is wrong -- a floor says nothing about
+which version a project is developed against. They are deprecated and warn; set this to opt into
+the final behavior now, which ignores them and silences the warning:
+
+    mise settings set idiomatic_version_file_ignore_minimum_versions true
+
+Affects `go.mod`'s `go X.Y` directive (`toolchain goX.Y.Z` is still read) and `CMakeLists.txt`'s
+`cmake_minimum_required`.
+
+This is a temporary migration setting. In mise 2026.11.0 the behavior becomes unconditional and
+this setting is removed. See
+[Idiomatic Version Files](/configuration.html#which-fields-mise-reads).
+"""
+env = "MISE_IDIOMATIC_VERSION_FILE_IGNORE_MINIMUM_VERSIONS"
+hide = true
+type = "Bool"
+
 [ignored_config_paths]
 default = []
 description = "This is a list of config paths that mise will ignore."

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -630,7 +630,35 @@ fn parse_matching_registry_idiomatic_file(
         .max_by_key(|spec| Path::new(spec.path).components().count())
         .filter(|spec| spec.has_parser())
     {
-        Some(spec) => parse_registry_idiomatic_file(path, spec),
+        Some(spec) => match spec.deprecated {
+            // The file's only parser reads a value mise should not be installing from.
+            // Opting in early means it yields nothing -- `Some(vec![])` rather than
+            // `None`, so the backend's plain-text fallback doesn't read the whole file.
+            Some(_) if Settings::get().idiomatic_version_file_ignore_minimum_versions => {
+                Ok(Some(vec![]))
+            }
+            Some(reason) => {
+                let versions = parse_registry_idiomatic_file(path, spec)?;
+                // Only warn when the file actually resolved something, so a project
+                // that merely has the file lying around stays quiet.
+                if versions
+                    .as_ref()
+                    .is_some_and(|versions| !versions.is_empty())
+                {
+                    // The path is the id so two deprecated files can't silence each
+                    // other, and it already names the file in the warning.
+                    let id = spec.path;
+                    deprecated_at!(
+                        "2026.8.10",
+                        "2026.11.0",
+                        id,
+                        "{reason} mise will stop reading it as an idiomatic version file; set the version in mise.toml instead."
+                    );
+                }
+                Ok(versions)
+            }
+            None => parse_registry_idiomatic_file(path, spec),
+        },
         None => Ok(None),
     }
 }
@@ -974,6 +1002,7 @@ mod tests {
             version_regex: None,
             version_json_path: Some(".releases[?channel=stable].version"),
             version_expr: None,
+            deprecated: None,
         };
 
         assert_eq!(
@@ -993,6 +1022,7 @@ mod tests {
             version_regex: None,
             version_json_path: Some(".version"),
             version_expr: None,
+            deprecated: None,
         }];
 
         assert_eq!(
@@ -1011,6 +1041,7 @@ mod tests {
             version_regex: None,
             version_json_path: Some(".tool.version"),
             version_expr: None,
+            deprecated: None,
         }];
 
         assert_eq!(
@@ -1026,6 +1057,7 @@ mod tests {
             version_regex: None,
             version_json_path: None,
             version_expr: None,
+            deprecated: None,
         };
 
         assert_eq!(

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -282,7 +282,10 @@ impl Backend for GoPlugin {
     }
     async fn _parse_idiomatic_file(&self, path: &Path) -> eyre::Result<Vec<String>> {
         let v = match path.file_name() {
-            Some(name) if name == "go.mod" => parse_gomod(&file::read_to_string(path)?),
+            Some(name) if name == "go.mod" => parse_gomod(
+                &file::read_to_string(path)?,
+                Settings::get().idiomatic_version_file_ignore_minimum_versions,
+            ),
             _ => {
                 // .go-version
                 let body = normalize_idiomatic_contents(&file::read_to_string(path)?);
@@ -416,25 +419,28 @@ fn is_go_directive_version(v: &str) -> bool {
 /// A `toolchain` version: a fully-qualified Go release `major.minor.patch` (e.g.
 /// `1.22.5`). Go toolchain names always carry the patch (`go1.22.5`, never `go1.22`),
 /// and pre-releases are excluded from resolution, so anything else falls back to the
-/// `go` directive rather than being used as an exact pin.
+/// deprecated `go` directive rather than being used as an exact pin.
 fn is_go_toolchain_version(v: &str) -> bool {
     regex!(r"^[0-9]+\.[0-9]+\.[0-9]+$").is_match(v)
 }
 
 /// Parse a `go.mod` file into a Go version request for idiomatic version resolution.
 ///
-/// go.mod carries two relevant directives with different semantics:
-/// - `toolchain goX.Y.Z` is the *exact* toolchain the module builds/tests with (what
-///   `go version` reports in the repo), so it takes precedence and resolves exactly.
-/// - `go X.Y` is the *minimum* required Go version. mise materializes it as a prefix,
-///   resolving to the latest matching patch (e.g. `go 1.22` -> latest `1.22.x`), which
-///   is consistent with how every other idiomatic version file (`.go-version`, etc.) is
-///   resolved and picks up patch/security updates.
+/// `toolchain goX.Y.Z` is the *exact* toolchain the module builds and tests with (what
+/// `go version` reports inside the repo), so it is a real version declaration and is
+/// what mise reads.
+///
+/// `go X.Y` declares only the *minimum* Go version the module is compatible with. That
+/// is a consumer compatibility floor, the same kind of declaration as `package.json`'s
+/// `engines` field, which mise ignores — it says nothing about which version the project
+/// is developed with, so it should never have selected a version to install. It is
+/// deprecated and still resolves (as a prefix, to the latest matching patch) until
+/// 2026.11.0, or until `ignore_minimums` opts a project into the final behavior early.
 ///
 /// Returns an empty string when no usable version is found (malformed, pre-release, or
 /// missing directive) so the caller skips the file rather than erroring or pinning a
 /// wrong version.
-fn parse_gomod(body: &str) -> String {
+fn parse_gomod(body: &str, ignore_minimums: bool) -> String {
     // Value of the first `<keyword> <value>` directive, ignoring `//` line comments.
     let directive_value = |keyword: &str| -> Option<String> {
         body.lines().find_map(|line| {
@@ -448,15 +454,33 @@ fn parse_gomod(body: &str) -> String {
         })
     };
 
-    // Prefer a fully-qualified `toolchain goX.Y.Z` pin; otherwise fall back to the `go`
-    // minimum. A malformed/partial/pre-release toolchain (e.g. `toolchain default`,
-    // `toolchain go1.22`, `toolchain go1.22rc1`) falls through to the `go` directive
-    // rather than discarding the file.
-    directive_value("toolchain")
+    // A fully-qualified `toolchain goX.Y.Z` pin is the only non-deprecated source. A
+    // malformed/partial/pre-release toolchain (e.g. `toolchain default`,
+    // `toolchain go1.22`, `toolchain go1.22rc1`) is not a real toolchain name, so it
+    // falls through to the `go` directive rather than discarding the file.
+    if let Some(toolchain) = directive_value("toolchain")
         .and_then(|v| v.strip_prefix("go").map(|s| s.to_string()))
         .filter(|v| is_go_toolchain_version(v))
-        .or_else(|| directive_value("go").filter(|v| is_go_directive_version(v)))
-        .unwrap_or_default()
+    {
+        return toolchain;
+    }
+
+    if ignore_minimums {
+        return String::new();
+    }
+
+    match directive_value("go").filter(|v| is_go_directive_version(v)) {
+        Some(minimum) => {
+            deprecated_at!(
+                "2026.8.10",
+                "2026.11.0",
+                "idiomatic.go.mod.go-directive",
+                "the `go` directive in go.mod is only a minimum compatible version, not the version this project is built with, so mise will stop reading it. Add a `toolchain goX.Y.Z` line to go.mod, or set the version in .go-version or mise.toml."
+            );
+            minimum
+        }
+        None => String::new(),
+    }
 }
 
 #[cfg(test)]
@@ -467,50 +491,96 @@ mod tests {
 
     #[test]
     fn test_parse_gomod() {
+        // a fully-qualified `toolchain` pin is used
+        assert_eq!(
+            parse_gomod(
+                indoc! {r#"
+                module example.com/m
+                go 1.22
+                toolchain go1.22.5
+            "#},
+                false
+            ),
+            "1.22.5"
+        );
+        // a `toolchain` pin with no `go` directive is still usable
+        assert_eq!(parse_gomod("toolchain go1.22.0\n", false), "1.22.0");
+        // inline `//` comments and extra whitespace are ignored
+        assert_eq!(
+            parse_gomod("toolchain   go1.20.3   // set by go mod tidy\n", false),
+            "1.20.3"
+        );
+        // no version directive -> empty (file skipped)
+        assert_eq!(parse_gomod("module example.com/m\n", false), "");
+    }
+
+    /// The `go` directive is a minimum, not a version to install. It is deprecated and
+    /// still resolves until 2026.11.0; every case here goes away with it.
+    #[test]
+    fn test_parse_gomod_deprecated_go_directive() {
         // bare `go` directive -> minor version (mise resolves to the latest patch)
         assert_eq!(
-            parse_gomod(indoc! {r#"
+            parse_gomod(
+                indoc! {r#"
                 module example.com/mymodule
                 go 1.14
                 require (
                     example.com/othermodule v1.2.3
                 )
-            "#}),
+            "#},
+                false
+            ),
             "1.14"
         );
         // `toolchain` (exact pin) takes precedence over `go` (minimum)
         assert_eq!(
-            parse_gomod(indoc! {r#"
+            parse_gomod(
+                indoc! {r#"
                 module example.com/m
                 go 1.22
                 toolchain go1.22.5
-            "#}),
+            "#},
+                false
+            ),
             "1.22.5"
         );
         // `toolchain default` is ignored -> fall back to the `go` directive
         assert_eq!(
-            parse_gomod(indoc! {r#"
+            parse_gomod(
+                indoc! {r#"
                 go 1.22
                 toolchain default
-            "#}),
+            "#},
+                false
+            ),
             "1.22"
         );
         // full patch version in the `go` directive is used as-is (resolves exactly)
-        assert_eq!(parse_gomod("go 1.21.4\n"), "1.21.4");
+        assert_eq!(parse_gomod("go 1.21.4\n", false), "1.21.4");
         // inline `//` comments and extra whitespace are ignored
-        assert_eq!(parse_gomod("go   1.20   // set by go mod tidy\n"), "1.20");
+        assert_eq!(
+            parse_gomod("go   1.20   // set by go mod tidy\n", false),
+            "1.20"
+        );
         // pre-releases are not resolvable -> skip the file
-        assert_eq!(parse_gomod("go 1.22rc1\n"), "");
+        assert_eq!(parse_gomod("go 1.22rc1\n", false), "");
         // an invalid pre-release toolchain falls back to a valid `go` line
-        assert_eq!(parse_gomod("go 1.21\ntoolchain go1.21rc1\n"), "1.21");
+        assert_eq!(parse_gomod("go 1.21\ntoolchain go1.21rc1\n", false), "1.21");
         // a partial (not fully-qualified) toolchain is not a real toolchain name;
         // fall back to the `go` directive
-        assert_eq!(parse_gomod("go 1.22\ntoolchain go1.22\n"), "1.22");
-        // a fully-qualified toolchain with no `go` directive is still usable
-        assert_eq!(parse_gomod("toolchain go1.22.0\n"), "1.22.0");
+        assert_eq!(parse_gomod("go 1.22\ntoolchain go1.22\n", false), "1.22");
         // a bare major-only directive is rejected (would resolve to the newest Go)
-        assert_eq!(parse_gomod("go 1\n"), "");
-        // no version directive -> empty (file skipped)
-        assert_eq!(parse_gomod("module example.com/m\n"), "");
+        assert_eq!(parse_gomod("go 1\n", false), "");
+    }
+
+    /// `idiomatic_version_file_ignore_minimum_versions` opts a project into the final
+    /// behavior early: the `go` directive is not read, and `toolchain` is unaffected.
+    #[test]
+    fn test_parse_gomod_ignore_minimum_versions() {
+        assert_eq!(parse_gomod("go 1.21\n", true), "");
+        assert_eq!(parse_gomod("go 1.21.4\n", true), "");
+        assert_eq!(parse_gomod("go 1.21\ntoolchain default\n", true), "");
+        assert_eq!(parse_gomod("go 1.21\ntoolchain go1.21.4\n", true), "1.21.4");
+        assert_eq!(parse_gomod("toolchain go1.21.4\n", true), "1.21.4");
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -142,6 +142,11 @@ pub struct RegistryIdiomaticFile {
     pub version_regex: Option<&'static str>,
     pub version_json_path: Option<&'static str>,
     pub version_expr: Option<&'static str>,
+    /// Set when this file should no longer be read. The value is the reason, shown in
+    /// the deprecation warning emitted when the file still resolves a version. Used for
+    /// files that only declare a minimum compatible version rather than the version the
+    /// project is built with.
+    pub deprecated: Option<&'static str>,
 }
 
 impl RegistryIdiomaticFile {
@@ -428,13 +433,18 @@ fn parse_registry_idiomatic_file(value: &toml::Value) -> Result<RegistryIdiomati
             version_regex: None,
             version_json_path: None,
             version_expr: None,
+            deprecated: None,
         }),
         toml::Value::Table(table) => {
             for key in table.keys() {
                 ensure!(
                     matches!(
                         key.as_str(),
-                        "path" | "version_regex" | "version_json_path" | "version_expr"
+                        "path"
+                            | "version_regex"
+                            | "version_json_path"
+                            | "version_expr"
+                            | "deprecated"
                     ),
                     "unknown idiomatic file field: {key}"
                 );
@@ -457,6 +467,7 @@ fn parse_registry_idiomatic_file(value: &toml::Value) -> Result<RegistryIdiomati
                 version_regex: string("version_regex")?,
                 version_json_path: string("version_json_path")?,
                 version_expr: string("version_expr")?,
+                deprecated: string("deprecated")?,
             })
         }
         _ => Err(eyre::eyre!(
@@ -835,6 +846,7 @@ idiomatic_files = [
   ".example-version",
   { path = "example.json", version_json_path = ".tool.version" },
   { path = "example.txt", version_regex = 'version=(\S+)', version_expr = "versions[0]" },
+  { path = "example.conf", version_regex = 'minimum=(\S+)', deprecated = "it declares a minimum." },
 ]
 test = { cmd = "example --version", expected = "{{version}}", tools = ["node"] }
 "#
@@ -873,6 +885,12 @@ test = { cmd = "example --version", expected = "{{version}}", tools = ["node"] }
             Some(r"version=(\S+)")
         );
         assert_eq!(tool.idiomatic_files[2].version_expr, Some("versions[0]"));
+        assert_eq!(tool.idiomatic_files[2].deprecated, None);
+        assert_eq!(tool.idiomatic_files[3].path, "example.conf");
+        assert_eq!(
+            tool.idiomatic_files[3].deprecated,
+            Some("it declares a minimum.")
+        );
         assert_eq!(tool.test.as_ref().unwrap().tools, &["node"]);
         assert!(!registry.missing_version_order);
     }


### PR DESCRIPTION
An idiomatic version file should only be read for fields that state **the version a project is
built with**. A *minimum compatible version* is a floor for whoever consumes the project — it says
nothing about what the project is developed and tested against, so resolving it either pins users
to the oldest release still supported or, read as a range, just means "latest". `package.json`'s
`engines` is the clearest case, and mise has always ignored it in favor of `devEngines`.

Two floors were being read anyway. Both are deprecated here, warn immediately, and are removed in
**2026.11.0** (3 months, accelerated from the usual 12):

| Floor | Behavior today | After 2026.11.0 |
|---|---|---|
| `go.mod` `go X.Y` (added in #11213) | resolves as a prefix → latest `1.22.x`; a patch-level minimum like `go 1.21.4` pins exactly | not read |
| `CMakeLists.txt` `cmake_minimum_required` | resolves the floor as a version request | not read |

`toolchain goX.Y.Z` in `go.mod` is **unaffected** — it names the exact toolchain the module builds
and tests with, which is a real version declaration.

Both only affect users who opted in: `idiomatic_version_file_enable_tools` defaults to `[]`.

## Mechanism

Registry idiomatic files can now carry `deprecated = "<reason>"`:

```toml
idiomatic_files = [
  { path = "CMakeLists.txt", version_regex = '...', deprecated = "`cmake_minimum_required` declares only the minimum CMake version…" },
]
```

The parser keeps working and the warning is emitted only when the file actually resolved a version,
so a project with the file lying around and no match stays quiet. The warning is keyed by path
rather than a single shared id, so marking a second file later can't silence the first.

## Docs

- `configuration.md` gains a **Which fields mise reads** section stating the rule, replacing a
  paragraph that said the opposite ("mise treats that value as a normal version request, so a value
  such as `3.25` selects the latest matching CMake 3.25 release"). That paragraph is what #11213
  cited.
- Spells out why `engines` is not read, and what to do instead — this had never been written down
  anywhere, which is why it keeps coming up (most recently #12258).
- `contributing.md` no longer lists "a minimum/required version" as a good thing for a registry
  entry to extract, and documents the `deprecated` field.

## Other floors in the registry, not touched

Found while writing the e2e test — flagging rather than expanding scope, since each needs a call:

| Tool | Field | Notes |
|---|---|---|
| `chezmoi` | `.chezmoiversion` | chezmoi refuses to run below it — a floor |
| `lefthook` | `min_version` | a floor |
| `pre-commit` | `minimum_pre_commit_version` | a floor |
| `pixi` | `requires-pixi` | a version requirement, effectively a floor |
| `ruff` | `required-version` | borderline — ruff *enforces* it, so closer to a pin than a floor |

Say the word and I'll deprecate the clear four the same way, on the same timeline.

## Testing

- `cargo test --bin mise plugins::core::go registry:: backend::tests`
- `mise run test:e2e e2e/core/test_go_from_gomod e2e/backend/test_registry_idiomatic_version_files`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean, `mise run lint` clean

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how opted-in idiomatic files resolve Go and CMake versions, which can alter installed tool versions after the deprecation window. Migration is opt-in today and only affects users who enabled those files.
> 
> **Overview**
> Stops treating **minimum compatible versions** as install requests. Idiomatic files should only pin the version a project is built with; floors like `go.mod`'s `go X.Y` and `CMakeLists.txt`'s `cmake_minimum_required` now warn and will stop resolving in **2026.11.0**. `toolchain goX.Y.Z` is unchanged.
> 
> Registry idiomatic files can set `deprecated = "<reason>"`. When a match still yields a version, mise warns (keyed by path). `idiomatic_version_file_ignore_minimum_versions` opts into the final behavior early: floors are ignored and the warning is silent.
> 
> Docs now state this rule (including why `package.json` `engines` is not read) and how to migrate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 520d5c2e4535cf2f0ffd1d0f6ba34abf7816d13e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Changes**
  * Go versions can now be detected from exact `toolchain goX.Y.Z` directives.
  * Legacy `go` directives remain supported temporarily and emit deprecation warnings.
  * Deprecated version sources, including CMake compatibility declarations, warn when successfully used.
  * Minimum-version detection can be disabled through the idiomatic version-file setting.

* **Documentation**
  * Clarified the difference between project tool versions and minimum compatibility versions.
  * Added migration guidance for deprecated Go and CMake version detection.
  * Documented ignored package-manager engine fields and explicit version pinning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->