### PR TITLE
fix(lock): point at --global when only global config has tools

### DIFF
--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -144,6 +144,23 @@ This design means CI environments that don't set `MISE_ENV` only depend on `mise
 
 Both `mise.lock` and `mise.<env>.lock` files should be committed to version control. `mise.local.lock` and `mise.<env>.local.lock` should be gitignored alongside their corresponding config files.
 
+## Global Lockfiles
+
+Tools declared in the global config (`~/.config/mise/config.toml`) are never locked by a
+plain `mise lock`, which only targets the active project config root. Use `mise lock --global`:
+
+```sh
+mise lock --global              # update global (and system) config lockfiles
+```
+
+::: tip
+This also applies when your global config is a symlink into a dotfiles repo, for example
+`~/.config/mise/config.toml` -> `~/dotfiles/mise.toml`. mise reaches the same file through
+both paths and treats it as the global config, so `mise lock` run from the repo reports that
+nothing is configured in project scope. Run `mise lock --global` instead; the lockfile is
+written next to the symlink target (`~/dotfiles/mise.lock`).
+:::
+
 ## Local Lockfiles
 
 Tools defined in `mise.local.toml` (which is typically gitignored) use a separate `mise.local.lock` file. This keeps local tool configurations separate from the committed lockfile.

--- a/e2e/cli/test_lock_global
+++ b/e2e/cli/test_lock_global
@@ -74,8 +74,31 @@ ln -sf "$PWD/dotfiles/mise.toml" "$MISE_CONFIG_DIR/config.toml"
   assert_contains "cat mise.lock" "mikefarah/yq"
 )
 
-echo "=== Testing mise lock with nothing configured anywhere ==="
+echo "=== Testing the hint honors tool selectors ==="
+# Drop the symlink before its target, so the global config path is a real file again
 rm -f "$MISE_CONFIG_DIR/config.toml"
+rm -rf dotfiles
+# Global declares jq; a project config with no tools keeps project scope empty.
+cat >"$MISE_CONFIG_DIR/config.toml" <<EOF
+[tools]
+"aqua:jqlang/jq" = "1.7.1"
+EOF
+cat >mise.toml <<EOF
+[env]
+FOO = "bar"
+EOF
+
+# A selector naming a tool that is not in global config must not point at --global
+output=$(mise lock "aqua:mikefarah/yq" 2>&1)
+assert_contains "echo '$output'" "No tools configured to lock"
+assert_not_contains "echo '$output'" "mise lock --global"
+
+# A selector naming a tool that *is* in global config should
+output=$(mise lock "aqua:jqlang/jq" 2>&1)
+assert_contains "echo '$output'" "mise lock --global"
+
+echo "=== Testing mise lock with nothing configured anywhere ==="
+rm -f "$MISE_CONFIG_DIR/config.toml" mise.toml
 rm -rf dotfiles
 
 output=$(mise lock 2>&1)

--- a/e2e/cli/test_lock_global
+++ b/e2e/cli/test_lock_global
@@ -43,6 +43,45 @@ assert "test -f system-config/mise.lock"
 assert_contains "cat $MISE_CONFIG_DIR/mise.lock" "jqlang/jq"
 assert_contains "cat system-config/mise.lock" "cli/cli"
 
+echo "=== Testing mise lock points at --global when only global config has tools ==="
+rm -rf mise.toml mise.lock "$MISE_CONFIG_DIR/mise.lock" system-config
+
+# jq is still declared in the global config, so `mise lock` has nothing in project
+# scope but `mise lock --global` does. Say so instead of "No tools configured".
+output=$(mise lock 2>&1)
+assert_contains "echo '$output'" "mise lock --global"
+assert "test ! -f mise.lock"
+
+echo "=== Testing the dotfiles layout that symlinks the global config to a project config ==="
+# A config reached through both the global path and the project path is merged into
+# a single global entry, so plain `mise lock` finds no project-scoped tools.
+mkdir -p dotfiles
+cat >dotfiles/mise.toml <<EOF
+[tools]
+"aqua:mikefarah/yq" = "4.44.6"
+EOF
+ln -sf "$PWD/dotfiles/mise.toml" "$MISE_CONFIG_DIR/config.toml"
+
+( # subshell to avoid cd'ing back (SC2103)
+  cd dotfiles
+
+  output=$(mise lock 2>&1)
+  assert_contains "echo '$output'" "mise lock --global"
+  assert "test ! -f mise.lock"
+
+  # --global locks it, writing the lockfile beside the symlink target
+  assert "mise lock --global --platform linux-x64"
+  assert_contains "cat mise.lock" "mikefarah/yq"
+)
+
+echo "=== Testing mise lock with nothing configured anywhere ==="
+rm -f "$MISE_CONFIG_DIR/config.toml"
+rm -rf dotfiles
+
+output=$(mise lock 2>&1)
+assert_contains "echo '$output'" "No tools configured to lock"
+assert_not_contains "echo '$output'" "mise lock --global"
+
 echo "=== Cleanup ==="
 rm -rf mise.toml mise.lock "$MISE_CONFIG_DIR/config.toml" "$MISE_CONFIG_DIR/mise.lock" system-config
 

--- a/e2e/cli/test_lock_global
+++ b/e2e/cli/test_lock_global
@@ -97,6 +97,12 @@ assert_not_contains "echo '$output'" "mise lock --global"
 output=$(mise lock "aqua:jqlang/jq" 2>&1)
 assert_contains "echo '$output'" "mise lock --global"
 
+echo "=== Testing the hint stays out of --local runs ==="
+# --local asks for mise.local.lock; there is no global equivalent to point at
+output=$(mise lock --local 2>&1)
+assert_contains "echo '$output'" "No tools configured to lock"
+assert_not_contains "echo '$output'" "mise lock --global"
+
 echo "=== Testing mise lock with nothing configured anywhere ==="
 rm -f "$MISE_CONFIG_DIR/config.toml" mise.toml
 rm -rf dotfiles

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -406,7 +406,7 @@ impl Lock {
         }
 
         if !has_lock_targets && !self.json {
-            if !self.global && Self::global_config_declares_tools(ts) {
+            if !self.global && self.global_config_declares_tools(ts) {
                 miseprintln!(
                     "{} No tools configured to lock in this project, but global config declares tools. Run {} to lock those.",
                     style("!").yellow(),
@@ -856,14 +856,25 @@ impl Lock {
         })
     }
 
-    /// Whether any resolved tool comes from a global mise.toml, meaning `--global`
-    /// would have something to lock even though the project scope is empty.
+    /// Whether any tool this run asked for comes from a global mise.toml, meaning
+    /// `--global` would have something to lock even though the project scope is empty.
     ///
     /// This also covers a config reached through two paths, such as a dotfiles repo
     /// that symlinks ~/.config/mise/config.toml to its own mise.toml: the single
     /// merged config counts as global, so plain `mise lock` finds nothing.
-    fn global_config_declares_tools(toolset: &Toolset) -> bool {
-        toolset.list_current_versions().iter().any(|(_, tv)| {
+    ///
+    /// Tool selectors are honored so `mise lock node` never points at `--global`
+    /// for some unrelated tool that happens to live in the global config.
+    fn global_config_declares_tools(&self, toolset: &Toolset) -> bool {
+        toolset.list_current_versions().iter().any(|(backend, tv)| {
+            if !self.tool.is_empty()
+                && !self
+                    .tool
+                    .iter()
+                    .any(|requested| requested.ba.short == backend.ba().short)
+            {
+                return false;
+            }
             matches!(tv.request.source(), ToolSource::MiseToml(path) if crate::config::is_global_config(path))
         })
     }

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -406,7 +406,9 @@ impl Lock {
         }
 
         if !has_lock_targets && !self.json {
-            if !self.global && self.global_config_declares_tools(ts) {
+            // --local asks for mise.local.lock specifically, and there is no global
+            // equivalent, so don't redirect that run to global scope.
+            if !self.global && !self.local && self.global_config_declares_tools(ts) {
                 miseprintln!(
                     "{} No tools configured to lock in this project, but global config declares tools. Run {} to lock those.",
                     style("!").yellow(),

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -406,7 +406,15 @@ impl Lock {
         }
 
         if !has_lock_targets && !self.json {
-            miseprintln!("{} No tools configured to lock", style("!").yellow());
+            if !self.global && Self::global_config_declares_tools(ts) {
+                miseprintln!(
+                    "{} No tools configured to lock in this project, but global config declares tools. Run {} to lock those.",
+                    style("!").yellow(),
+                    style("mise lock --global").cyan()
+                );
+            } else {
+                miseprintln!("{} No tools configured to lock", style("!").yellow());
+            }
         }
 
         // Update config files when a specific version is requested that doesn't match
@@ -845,6 +853,18 @@ impl Lock {
                     cf.source().is_mise_toml() && !crate::config::is_global_config(path)
                 })
                 .map(|(_, cf)| cf.config_root())
+        })
+    }
+
+    /// Whether any resolved tool comes from a global mise.toml, meaning `--global`
+    /// would have something to lock even though the project scope is empty.
+    ///
+    /// This also covers a config reached through two paths, such as a dotfiles repo
+    /// that symlinks ~/.config/mise/config.toml to its own mise.toml: the single
+    /// merged config counts as global, so plain `mise lock` finds nothing.
+    fn global_config_declares_tools(toolset: &Toolset) -> bool {
+        toolset.list_current_versions().iter().any(|(_, tv)| {
+            matches!(tv.request.source(), ToolSource::MiseToml(path) if crate::config::is_global_config(path))
         })
     }
 


### PR DESCRIPTION
Closes the confusion in #12250.

## Problem

`mise lock` scopes to the active project config root and filters out every global config path ([src/cli/lock.rs](src/cli/lock.rs) `config_paths_in_lock_scope`). When the only configs in scope are global, there are no lockfile targets and it prints a bare `! No tools configured to lock` — with no hint that `mise lock --global` is the command that works.

This is most confusing in the dotfiles layout from the discussion, where `~/.config/mise/config.toml` is a symlink to the repo's own `mise.toml`:

- Both paths reach one file, so mise merges them into a single config entry keyed by the project path.
- `is_global_config` still matches it, via the `desymlink_path` comparison in `config_set_contains` (added for symlinked prefixes like Fedora Atomic's `/home` -> `/var/home`). That's the right call — the file genuinely *is* the global config, and it needs global-only settings honored.
- So `mise lock` run from inside the repo reports nothing to lock, while `mise ls` resolves the tools fine. The reporter had to fall back to `MISE_CONFIG_DIR="$(mktemp -d)" mise lock`.

## Change

Detect the case from the resolved toolset and name the command that works:

```
! No tools configured to lock in this project, but global config declares tools. Run mise lock --global to lock those.
```

Global lockfiles stay explicit via `--global`, as documented — no scoping behavior changes. The message also improves the plain case of standing in a directory with no project config while the real global config declares tools.

Verified `mise lock --global` writes the lockfile beside the symlink target (`~/dotfiles/mise.lock`) with concrete versions, checksums, URLs, and provenance, so the reporter's stale-entry problem is fixed without the `MISE_CONFIG_DIR` workaround.

## Tests

Four cases added to `e2e/cli/test_lock_global`, all passing:

- tools only in a real global config, cwd has no project config -> hint
- global config symlinked to a project `mise.toml`, run from the repo -> hint, then `--global` locks it to `dotfiles/mise.lock`
- nothing configured anywhere -> unchanged bare message, no `--global` hint
- project config with tools -> unchanged happy path (pre-existing assertions)

`cargo clippy --workspace --all-features --all-targets -- -D warnings` and `cargo test --bin mise cli::lock` are clean.

Docs get a short "Global Lockfiles" section covering the symlinked-dotfiles case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI messaging and docs only; lockfile scoping and writes are unchanged. Risk is limited to a misleading hint in edge cases, which the new e2e coverage targets.
> 
> **Overview**
> When `mise lock` finds nothing in project scope, it now tells you to run `mise lock --global` if tools actually live in global (or system) config. Locking behavior is unchanged; this is a message-only fix for the empty-project and symlinked-dotfiles cases.
> 
> The hint is skipped for `--local`/`--global` runs, when nothing is configured anywhere, and when a tool selector does not match a globally declared tool. Docs add a short **Global Lockfiles** section covering `mise lock --global` and writing the lockfile next to a symlink target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 703d1b8cb6f399f5d397004577fff3a3d4d6c34e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer guidance when tools are configured globally but excluded from standard lock operations.
  * Global tools can now be locked using `mise lock --global`.
  * Locking provides relevant guidance based on selected global tools.

* **Bug Fixes**
  * Corrected `mise lock --local` behavior when no local tools are configured.

* **Documentation**
  * Documented global lockfile behavior, including symlinked configurations and lockfile locations.

* **Tests**
  * Added coverage for global-only configurations, selectors, symlinked setups, lockfile creation, and unconfigured scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->