### PR TITLE
registry: add rootle

### DIFF
--- a/registry/rootle.toml
+++ b/registry/rootle.toml
@@ -1,0 +1,6 @@
+backends = ["github:tknawara/rootle", "cargo:rootle"]
+bins = ["rootle"]
+description = "Modal TUI for browsing remote source-control systems (GitHub in-tree, any forge via stdio providers)"
+os = ["linux"]
+test = { cmd = "rootle --version", expected = "rootle {{version}}" }
+version_order = "semver"


### PR DESCRIPTION
Adds [rootle](https://github.com/tknawara/rootle) — a modal TUI for browsing remote source-control systems (GitHub in-tree, any forge via stdio providers).

- backend: `github` (Tier 1) — releases ship `rootle-<version>-x86_64-unknown-linux-musl.tar.gz` + `.sha256`, which the asset autodetector matches on linux/x64/musl; `cargo` as fallback backend
- `os = ["linux"]` — only linux x86_64 prebuilts are published for now
- test: `rootle --version` → `rootle {{version}}` (verified against v0.3.1 locally: install.sh + github asset layout)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project registry metadata, including GitHub and Cargo backends.
  * Declared the rootle command-line binary and Linux platform support.
  * Added version validation and semantic-version ordering configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->