### PR TITLE
fix(sandbox): allow macOS root path traversal

### DIFF
--- a/docs/sandboxing.md
+++ b/docs/sandboxing.md
@@ -125,6 +125,10 @@ If Landlock is unavailable or cannot apply filesystem restrictions, the command 
 
 Uses Apple's `sandbox-exec` (Seatbelt) with a generated profile. Supports all features including per-host network filtering.
 
+When reads are restricted, Seatbelt requires data access to the root directory for process startup.
+Sandboxed processes can enumerate names directly under `/`, but cannot read unallowed entries or
+their descendants.
+
 ### Windows
 
 Sandboxing is not currently supported on Windows. A warning is printed and the command runs unsandboxed.

--- a/src/sandbox/macos.rs
+++ b/src/sandbox/macos.rs
@@ -45,7 +45,8 @@ pub(crate) async fn generate_seatbelt_profile(config: &SandboxConfig) -> String 
     // Filesystem read restrictions
     if config.effective_deny_read() {
         rules.push("(deny file-read*)".to_string());
-        // Permit absolute path traversal without granting recursive access from the root.
+        // Seatbelt requires data access to the root vnode for process startup and getcwd.
+        // This exposes names directly under `/`, but descendants still obey the read rules.
         rules.push("(allow file-read-data (literal \"/\"))".to_string());
         for path in SYSTEM_READ_PATHS {
             rules.push(format!("(allow file-read* (subpath \"{path}\"))"));
@@ -182,7 +183,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_allow_read_executes_shell_without_exposing_siblings() {
+    async fn test_allow_read_executes_shell_without_reading_siblings() {
         let root = tempfile::tempdir().unwrap();
         let allowed_dir = root.path().join("allowed");
         fs::create_dir(&allowed_dir).unwrap();

--- a/src/sandbox/macos.rs
+++ b/src/sandbox/macos.rs
@@ -45,6 +45,8 @@ pub(crate) async fn generate_seatbelt_profile(config: &SandboxConfig) -> String 
     // Filesystem read restrictions
     if config.effective_deny_read() {
         rules.push("(deny file-read*)".to_string());
+        // Permit absolute path traversal without granting recursive access from the root.
+        rules.push("(allow file-read-data (literal \"/\"))".to_string());
         for path in SYSTEM_READ_PATHS {
             rules.push(format!("(allow file-read* (subpath \"{path}\"))"));
         }
@@ -112,7 +114,7 @@ pub(crate) async fn generate_seatbelt_profile(config: &SandboxConfig) -> String 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
+    use std::{fs, path::PathBuf, process::Command};
 
     #[tokio::test]
     async fn test_deny_write_profile() {
@@ -177,6 +179,43 @@ mod tests {
         assert!(profile.contains("(deny file-read*)"));
         assert!(profile.contains("(allow file-read* (subpath \"/usr\"))"));
         assert!(profile.contains("(allow file-read* (subpath \"/System\"))"));
+    }
+
+    #[tokio::test]
+    async fn test_allow_read_executes_shell_without_exposing_siblings() {
+        let root = tempfile::tempdir().unwrap();
+        let allowed_dir = root.path().join("allowed");
+        fs::create_dir(&allowed_dir).unwrap();
+        let allowed_file = allowed_dir.join("allowed.txt");
+        let denied_file = root.path().join("denied.txt");
+        fs::write(&allowed_file, "allowed").unwrap();
+        fs::write(&denied_file, "denied").unwrap();
+        let allowed_file = allowed_file.canonicalize().unwrap();
+        let denied_file = denied_file.canonicalize().unwrap();
+
+        let mut config = SandboxConfig {
+            deny_read: true,
+            allow_read: vec![allowed_dir],
+            ..Default::default()
+        };
+        config.resolve_paths();
+        let profile = generate_seatbelt_profile(&config).await;
+        let read = |path: &std::path::Path| {
+            Command::new("sandbox-exec")
+                .current_dir("/")
+                .args(["-p", &profile, "--", "/bin/sh", "-c", "cat \"$1\"", "sh"])
+                .arg(path)
+                .output()
+                .unwrap()
+        };
+
+        let allowed = read(&allowed_file);
+        assert!(
+            allowed.status.success(),
+            "sandboxed shell failed: {}",
+            String::from_utf8_lossy(&allowed.stderr)
+        );
+        assert!(!read(&denied_file).status.success());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- permit `file-read-data` on the literal filesystem root in macOS Seatbelt profiles so sandboxed commands can traverse allowed absolute paths
- add a macOS regression test that reads an allowed file through `/bin/sh` while confirming a sibling file remains denied

## Context
`mise exec --deny-all --allow-read=.` currently aborts on macOS before reading the allowed file, as reported in [the sandboxing announcement discussion](https://github.com/jdx/mise/discussions/8878#discussioncomment-16658034).

The rule uses `(literal "/")`, not `(subpath "/")`, and grants only `file-read-data`. A metadata-only rule was insufficient in the regression test; recursive access remains denied.

## Validation
- confirmed the new regression test fails before the profile change
- `cargo test --locked sandbox::macos::tests`
- `rustup run 1.97.1 cargo clippy --locked --bin mise --tests -- -D warnings`
- focused hk check for `src/sandbox/macos.rs` (cargo-fmt and cargo-check)

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS sandbox filesystem access by allowing safe traversal of the filesystem root while preserving restricted path access.
  * Prevented unauthorized sibling files and descendants from being read, even when their names are visible.
* **Documentation**
  * Clarified macOS sandbox behavior, including root-level name visibility and the access required for restricted reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->