### PR TITLE
feat(task): add inferred sandbox reads

### DIFF
--- a/docs/sandboxing.md
+++ b/docs/sandboxing.md
@@ -72,6 +72,22 @@ allow_write = ["./node_modules"]
 allow_net = ["registry.npmjs.org"]
 ```
 
+Tasks can also opt in to inferred filesystem reads:
+
+```toml
+[tasks.build]
+run = "npm run build"
+depends = ["generate"]
+sources = ["src/**/*.ts"]
+outputs = ["dist/**"]
+sandbox = true
+```
+
+With `sandbox = true`, matched source files and the task file are readable, and outputs from all
+prerequisite dependencies are readable. Explicit `allow_read` paths extend those inferred reads;
+other sandbox settings, including `allow_write`, continue to compose normally. Declaring `sources`
+without `sandbox = true` does not enable sandboxing.
+
 CLI flags on `mise run` override task-level config:
 
 ```bash
@@ -101,6 +117,21 @@ When filesystem restrictions are active, certain paths remain accessible so tool
 
 - `--allow-write` paths are implicitly readable
 - `--allow-read` paths include system essentials above
+- With task `sandbox = true`, declared `sources` enable read restrictions and are automatically
+  readable
+- With task `sandbox = true`, declared outputs of all prerequisite dependencies enable read
+  restrictions and are automatically readable
+
+Explicit `allow_read` paths extend these inferred permissions. Output writes are not inferred; use
+`allow_write` when a task also needs write restrictions.
+
+Source globs are resolved to the files they match, including source exclusions. Dependency output
+globs grant read access to the static path before the first wildcard.
+
+Inferred permissions are an ergonomics feature, not a hermetic build boundary. Tools may need
+additional explicit access for configuration, caches, formatters, or undeclared inputs. The task
+working directory is not implicitly readable; add `allow_read = ["."]` when a tool needs to inspect
+it.
 
 ## Platform Support
 

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -1080,6 +1080,28 @@ When both a global timeout and a per-task timeout are set, the shorter of the tw
 timeout cannot extend beyond the global timeout. The `--timeout` CLI flag overrides the global
 setting.
 
+### `sandbox`
+
+- **Type**: `bool`
+- **Default**: `false`
+
+Infer filesystem sandbox reads from the task's declared inputs. Matched `sources` and the task file
+become readable, and outputs of all prerequisite dependencies become readable. Explicit
+`allow_read` paths extend the inferred reads; other sandbox settings continue to compose normally.
+
+```mise-toml
+[tasks.build]
+run = "npm run build"
+depends = ["generate"]
+sources = ["src/**/*.ts"]
+outputs = ["dist/**"]
+sandbox = true
+```
+
+Source globs resolve to the files they currently match. Dependency output globs grant read access
+to their static prefix. Output writes are not inferred; use `allow_write` when needed. See
+[Sandboxing](/sandboxing.html) for platform behavior and limitations.
+
 ### `deny_all`
 
 - **Type**: `bool`

--- a/docs/tasks/templates.md
+++ b/docs/tasks/templates.md
@@ -55,7 +55,7 @@ When a task extends a template, fields are merged according to these rules:
 | `dir`                                             | Local overrides; defaults to config_root if not in template |
 | `sources`, `outputs`, `cache`                     | Local overrides completely                                  |
 | `output`                                          | Local overrides template (if set)                           |
-| Sandbox deny fields                               | Compose with task-local settings                            |
+| `sandbox` and sandbox deny fields                 | Compose with task-local settings                            |
 | Sandbox allow fields                              | Template and task-local values are combined                 |
 | `description`, `shell`, `timeout`, etc.           | Local overrides template (if set)                           |
 | `quiet`, `hide`, `raw`, `interactive`, `raw_args` | Not supported on templates (set explicitly on each task)    |

--- a/e2e/tasks/test_task_sandbox_inferred_io
+++ b/e2e/tasks/test_task_sandbox_inferred_io
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+# https://github.com/jdx/mise/discussions/12264
+# Filesystem sandboxing is unavailable on Windows and on Linux kernels without Landlock.
+case "$(uname -s)" in
+  Darwin) ;;
+  Linux)
+    if ! mise x --deny-read -- true >/dev/null 2>&1; then
+      echo "skipping: task sandbox inference requires Landlock"
+      return 0
+    fi
+    ;;
+  *)
+    echo "skipping: task sandbox inference is unsupported on this platform"
+    return 0
+    ;;
+esac
+
+mkdir -p input work/scratch seed-output dep-output output
+echo source >input/source.txt
+echo private >input/private.md
+
+cat <<'EOF' >source-task.sh
+#!/usr/bin/env bash
+echo source-file
+EOF
+chmod +x source-task.sh
+
+cat <<'EOF' >mise.toml
+[tasks.seed]
+dir = "work"
+run = "echo seed > ../seed-output/result.txt"
+outputs = ["../seed-output/**"]
+
+[tasks.prepare]
+dir = "work"
+run = "echo dependency > ../dep-output/result.txt"
+depends = ["seed"]
+outputs = ["../dep-output/**"]
+
+[tasks.build]
+dir = "work"
+run = "cat ../input/source.txt ../seed-output/result.txt ../dep-output/result.txt > ../output/result.txt && echo explicit > scratch/result.txt"
+depends = ["prepare"]
+sources = ["../input/*.txt"]
+outputs = ["../output/**"]
+sandbox = true
+allow_read = ["."]
+allow_write = ["../output", "scratch"]
+
+[tasks.undeclared-read]
+dir = "work"
+run = "cat ../input/private.md"
+sources = ["../input/*.txt"]
+sandbox = true
+allow_read = ["."]
+
+[tasks.not-sandboxed]
+dir = "work"
+run = "cat ../input/private.md"
+sources = ["../input/*.txt"]
+
+[tasks.source-file]
+file = "source-task.sh"
+dir = "work"
+sandbox = true
+allow_read = ["."]
+EOF
+
+assert "mise run build" ""
+assert "cat output/result.txt" $'source\nseed\ndependency'
+assert "cat work/scratch/result.txt" "explicit"
+assert_fail "mise run undeclared-read"
+assert "mise run --force not-sandboxed" "private"
+assert "mise run source-file" "source-file"

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -341,6 +341,11 @@
           "description": "timeout for this task",
           "type": "string"
         },
+        "sandbox": {
+          "default": false,
+          "description": "infer filesystem reads from sources and prerequisite outputs",
+          "type": "boolean"
+        },
         "deny_all": {
           "default": false,
           "description": "block reads, writes, network, and env vars",

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -3347,6 +3347,11 @@
           "description": "timeout for this task",
           "type": "string"
         },
+        "sandbox": {
+          "default": false,
+          "description": "infer filesystem reads from sources and prerequisite outputs",
+          "type": "boolean"
+        },
         "deny_all": {
           "default": false,
           "description": "block reads, writes, network, and env vars",

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -69,8 +69,10 @@ impl fmt::Display for TaskCycleError {
 impl std::error::Error for TaskCycleError {}
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-/// State contributed by a task's completed direct dependencies.
+/// State contributed by a task's completed dependencies.
 pub(crate) struct TaskDependencyState {
+    /// Prerequisite tasks whose declared outputs may be read by this task.
+    pub(crate) dependencies: Vec<Task>,
     /// Stable artifact identities to include in the task's cache key.
     pub cache_keys: Vec<String>,
     /// Whether any dependency executed or restored outputs.
@@ -104,6 +106,7 @@ pub(crate) struct Deps {
     executed: HashSet<TaskKey>, // tasks that actually began executing (not just scheduled)
     did_work: HashSet<TaskKey>, // tasks that executed or restored outputs (not freshness-skipped)
     cache_keys: HashMap<TaskKey, String>, // stable artifact identities published by completed tasks
+    tasks: HashMap<TaskKey, Task>, // resolved definitions retained after graph nodes are removed
     dep_edges: HashMap<TaskKey, HashSet<TaskKey>>, // maps each task to its direct dependency task keys
     post_dep_parents: HashMap<TaskKey, HashSet<TaskKey>>, // maps each post-subtree task to its triggering parents
     tx: mpsc::UnboundedSender<Option<Task>>,
@@ -306,6 +309,10 @@ impl Deps {
         let executed = HashSet::new();
         let did_work = HashSet::new();
         let cache_keys = HashMap::new();
+        let tasks = graph
+            .node_indices()
+            .map(|idx| (task_key(&graph[idx]), graph[idx].clone()))
+            .collect();
         Ok(Self {
             graph,
             tx,
@@ -314,6 +321,7 @@ impl Deps {
             executed,
             did_work,
             cache_keys,
+            tasks,
             dep_edges,
             post_dep_parents,
         })
@@ -450,7 +458,23 @@ impl Deps {
             .collect::<Vec<_>>();
         cache_keys.sort();
         cache_keys.dedup();
+        let mut prerequisite_keys = deps.clone();
+        let mut pending = deps.iter().copied().collect_vec();
+        while let Some(key) = pending.pop() {
+            for dependency in self.dep_edges.get(key).into_iter().flatten() {
+                if prerequisite_keys.insert(dependency) {
+                    pending.push(dependency);
+                }
+            }
+        }
+        let mut dependencies = prerequisite_keys
+            .iter()
+            .filter_map(|key| self.tasks.get(*key).cloned())
+            .collect_vec();
+        dependencies.sort();
+        dependencies.dedup();
         TaskDependencyState {
+            dependencies,
             cache_keys,
             any_did_work: deps.iter().any(|dep_key| self.did_work.contains(dep_key)),
             any_unkeyed_did_work: deps.iter().any(|dep_key| {
@@ -669,6 +693,7 @@ mod tests {
             executed: HashSet::new(),
             did_work: HashSet::new(),
             cache_keys: HashMap::new(),
+            tasks: HashMap::new(),
             dep_edges,
             post_dep_parents,
             tx,
@@ -706,6 +731,7 @@ mod tests {
         assert_eq!(
             deps.dependency_state(&c),
             TaskDependencyState {
+                dependencies: vec![],
                 cache_keys: vec![],
                 any_did_work: true,
                 any_unkeyed_did_work: true,
@@ -716,11 +742,54 @@ mod tests {
         assert_eq!(
             deps.dependency_state(&c),
             TaskDependencyState {
+                dependencies: vec![],
                 cache_keys: vec!["b-key".to_string()],
                 any_did_work: true,
                 any_unkeyed_did_work: false,
             }
         );
+    }
+
+    // https://github.com/jdx/mise/discussions/12264
+    #[test]
+    fn dependency_state_retains_direct_dependency_tasks() {
+        let dependency = Task {
+            outputs: crate::task::TaskOutputs::Files(vec!["dist".to_string()]),
+            ..task("dependency")
+        };
+        let parent = task("parent");
+        let mut deps = deps_with_relationships(
+            HashMap::from([(task_key(&parent), HashSet::from([task_key(&dependency)]))]),
+            HashMap::new(),
+        );
+        deps.tasks.insert(task_key(&dependency), dependency.clone());
+
+        assert_eq!(deps.dependency_state(&parent).dependencies, [dependency]);
+    }
+
+    // https://github.com/jdx/mise/discussions/12264
+    #[test]
+    fn dependency_state_retains_transitive_prerequisite_tasks() {
+        let first = Task {
+            outputs: crate::task::TaskOutputs::Files(vec!["first-output".to_string()]),
+            ..task("first")
+        };
+        let second = Task {
+            outputs: crate::task::TaskOutputs::Files(vec!["second-output".to_string()]),
+            ..task("second")
+        };
+        let parent = task("parent");
+        let mut deps = deps_with_relationships(
+            HashMap::from([
+                (task_key(&parent), HashSet::from([task_key(&second)])),
+                (task_key(&second), HashSet::from([task_key(&first)])),
+            ]),
+            HashMap::new(),
+        );
+        deps.tasks.insert(task_key(&first), first.clone());
+        deps.tasks.insert(task_key(&second), second.clone());
+
+        assert_eq!(deps.dependency_state(&parent).dependencies, [first, second]);
     }
 
     #[test]
@@ -737,6 +806,7 @@ mod tests {
         assert_eq!(
             deps.dependency_state(&post),
             TaskDependencyState {
+                dependencies: vec![],
                 cache_keys: vec!["parent-key".to_string()],
                 any_did_work: true,
                 any_unkeyed_did_work: false,

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -89,6 +89,33 @@ pub(crate) enum TaskRunPhase {
     Post,
 }
 
+/// Selects how a task derives filesystem sandbox read permissions.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(from = "bool")]
+pub(crate) enum TaskSandboxMode {
+    /// Use only explicitly configured sandbox permissions.
+    #[default]
+    Disabled,
+    /// Infer reads from task sources and prerequisite outputs.
+    Inferred,
+}
+
+impl TaskSandboxMode {
+    pub(crate) fn is_inferred(self) -> bool {
+        matches!(self, Self::Inferred)
+    }
+}
+
+impl From<bool> for TaskSandboxMode {
+    fn from(enabled: bool) -> Self {
+        if enabled {
+            Self::Inferred
+        } else {
+            Self::Disabled
+        }
+    }
+}
+
 pub(crate) struct ResolvedTaskDependencies {
     pub depends: Vec<Task>,
     pub wait_for: Vec<Task>,
@@ -787,6 +814,9 @@ pub(crate) struct Task {
     #[serde(skip)]
     pub remote_file_source: Option<String>,
 
+    /// Infer filesystem reads from sources and prerequisite outputs.
+    #[serde(default)]
+    pub sandbox: TaskSandboxMode,
     /// Block reads, writes, network, and env vars
     #[serde(default)]
     pub deny_all: bool,
@@ -1421,6 +1451,7 @@ impl Task {
             })
             .transpose()?;
         task.outputs = p.get_raw("outputs").map(|to| to.into()).unwrap_or_default();
+        task.sandbox = p.parse_bool("sandbox").unwrap_or_default().into();
         task.cache = p
             .get_raw("cache")
             .map(|v| {
@@ -2591,7 +2622,10 @@ impl Task {
         if !other.usage.is_empty() {
             self.usage = other.usage;
         }
-        // Sandbox fields — deny is OR (any deny wins), allow lists extend.
+        // Sandbox fields — restrictions compose and allow lists extend.
+        if other.sandbox.is_inferred() {
+            self.sandbox = TaskSandboxMode::Inferred;
+        }
         self.deny_all |= other.deny_all;
         self.deny_read |= other.deny_read;
         self.deny_write |= other.deny_write;
@@ -3156,6 +3190,7 @@ impl Default for Task {
             usage: "".to_string(),
             timeout: None,
             remote_file_source: None,
+            sandbox: TaskSandboxMode::Disabled,
             deny_all: false,
             deny_read: false,
             deny_write: false,
@@ -5082,6 +5117,7 @@ echo "hello world"
 #MISE sources=["src1.txt", "src2.txt"]
 #MISE watch={no_vcs_ignore=true}
 #MISE outputs=["out1.txt"]
+#MISE sandbox=true
 #MISE cache={enabled=true,env=["PROFILE"]}
 #MISE rust_cache=true
 #MISE pass_through_env=["DEPLOY_TOKEN"]
@@ -5128,6 +5164,7 @@ echo "test"
             })
         );
         assert_eq!(task.rust_cache, Some(TaskRustCacheConfig::default()));
+        assert!(task.sandbox.is_inferred());
         assert_eq!(task.pass_through_env, ["DEPLOY_TOKEN"]);
         assert_eq!(task.shell, Some("bash -c".to_string()));
         assert_eq!(task.quiet, true);

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -18,7 +18,8 @@ use crate::task::task_output_handler::OutputHandler;
 use crate::task::task_scheduler::SchedMsg;
 use crate::task::task_script_parser::subcommand_name_from_parse;
 use crate::task::task_source_checker::{
-    remove_auto_output, save_checksum, sources_are_fresh, task_cwd, task_source_match_root,
+    expand_glob_braces, output_glob_patterns, remove_auto_output, resolve_task_source_paths,
+    save_checksum, sources_are_fresh, task_cwd, task_source_match_root,
 };
 use crate::task::{
     Deps, FailedTasks, GetMatchingExt, Task, TaskCacheAudit, TaskCacheMode, TaskCacheOutput,
@@ -70,6 +71,7 @@ pub(crate) struct TaskRunContext<'a> {
 #[derive(Clone, Copy)]
 struct TaskExecContext<'a> {
     task: &'a Task,
+    dependencies: &'a [Task],
     env: &'a BTreeMap<String, String>,
     prefix: &'a str,
     output_capture: Option<&'a TaskOutputCapture>,
@@ -150,6 +152,34 @@ fn resolve_task_sandbox_path(p: &Path, task_base: Option<&Path>) -> PathBuf {
     } else {
         p
     }
+}
+
+fn resolve_task_sandbox_pattern(pattern: &str, task_base: &Path) -> PathBuf {
+    let mut prefix = PathBuf::new();
+    for component in Path::new(pattern).components() {
+        if component
+            .as_os_str()
+            .to_string_lossy()
+            .contains(['*', '?', '[', '{'])
+        {
+            break;
+        }
+        prefix.push(component);
+    }
+    if prefix.as_os_str().is_empty() {
+        task_base.to_path_buf()
+    } else {
+        resolve_task_sandbox_path(&prefix, Some(task_base))
+    }
+}
+
+fn resolve_task_sandbox_patterns(patterns: &[String], task_base: &Path) -> Result<Vec<PathBuf>> {
+    patterns
+        .iter()
+        .map(|pattern| expand_glob_braces(pattern))
+        .flatten_ok()
+        .map_ok(|pattern| resolve_task_sandbox_pattern(&pattern, task_base))
+        .collect()
 }
 
 /// Build the single-line command shown in a task's header (the `$ ...` line).
@@ -415,6 +445,7 @@ impl TaskExecutor {
     async fn build_sandbox_for_task(
         &self,
         task: &Task,
+        dependencies: &[Task],
         config: &Arc<Config>,
     ) -> Result<SandboxConfig> {
         let task_base = task.dir(config).await?;
@@ -464,6 +495,30 @@ impl TaskExecutor {
                 .cloned()
                 .collect(),
         };
+        if task.sandbox.is_inferred() {
+            let source_paths = resolve_task_source_paths(task, config).await?;
+            let dependency_outputs = dependencies
+                .iter()
+                .map(|dependency| output_glob_patterns(&dependency.outputs.patterns()))
+                .collect_vec();
+            if !task.sources.is_empty()
+                || !source_paths.is_empty()
+                || dependency_outputs.iter().any(|outputs| !outputs.is_empty())
+            {
+                sandbox.deny_read = true;
+                sandbox.allow_read.extend(source_paths);
+            }
+            for (dependency, output_patterns) in dependencies.iter().zip(dependency_outputs) {
+                if output_patterns.is_empty() {
+                    continue;
+                }
+                let dependency_base = task_cwd(dependency, config).await?;
+                sandbox.allow_read.extend(resolve_task_sandbox_patterns(
+                    &output_patterns,
+                    &dependency_base,
+                )?);
+            }
+        }
         if task.rust_cache.as_ref().is_some_and(|cache| cache.enabled)
             && let Some(session) = &self.cache_session
         {
@@ -586,7 +641,12 @@ impl TaskExecutor {
                 }
                 Some(prepared) => {
                     let command_inputs = self
-                        .resolve_cache_command_inputs(task, config, &env)
+                        .resolve_cache_command_inputs(
+                            task,
+                            &dependency_state.dependencies,
+                            config,
+                            &env,
+                        )
                         .await?;
                     let cache = prepared
                         .finish(TaskCacheContext {
@@ -722,6 +782,7 @@ impl TaskExecutor {
         };
         let exec_ctx = TaskExecContext {
             task,
+            dependencies: &dependency_state.dependencies,
             env: &env,
             prefix: &prefix,
             output_capture: output_capture.as_ref(),
@@ -1339,6 +1400,7 @@ impl TaskExecutor {
     async fn resolve_cache_command_inputs(
         &self,
         task: &Task,
+        dependencies: &[Task],
         config: &Arc<Config>,
         resolved_env: &BTreeMap<String, String>,
     ) -> Result<Vec<CommandInput>> {
@@ -1347,7 +1409,9 @@ impl TaskExecutor {
             return Ok(Vec::new());
         }
         let root = task_cwd(task, config).await?;
-        let sandbox = self.build_sandbox_for_task(task, config).await?;
+        let sandbox = self
+            .build_sandbox_for_task(task, dependencies, config)
+            .await?;
         let filtered_env = if sandbox.is_active() {
             sandbox.filter_env(resolved_env)
         } else {
@@ -1492,6 +1556,7 @@ impl TaskExecutor {
     ) -> Result<()> {
         let TaskExecContext {
             task,
+            dependencies,
             env,
             prefix,
             output_capture,
@@ -1509,7 +1574,9 @@ impl TaskExecutor {
         let program = program.to_executable();
         let redactions = config.redactions();
         let raw = self.raw(Some(task));
-        let sandbox = self.build_sandbox_for_task(task, &config).await?;
+        let sandbox = self
+            .build_sandbox_for_task(task, dependencies, &config)
+            .await?;
         let env = if sandbox.is_active() {
             &sandbox.filter_env(env)
         } else {
@@ -2590,6 +2657,28 @@ mod tests {
         let resolved = resolve_task_sandbox_path(Path::new(""), Some(Path::new("/task/base")));
 
         assert_eq!(resolved, PathBuf::new());
+    }
+
+    // https://github.com/jdx/mise/discussions/12264
+    #[test]
+    fn dependency_output_patterns_resolve_to_static_prefixes() {
+        let base = Path::new("/task/base");
+
+        assert_eq!(
+            resolve_task_sandbox_pattern("src/**/*.rs", base),
+            PathBuf::from("/task/base/src")
+        );
+        assert_eq!(
+            resolve_task_sandbox_pattern("*.rs", base),
+            PathBuf::from("/task/base")
+        );
+        assert_eq!(
+            resolve_task_sandbox_patterns(&["{src,tests}/**/*.rs".to_string()], base).unwrap(),
+            [
+                PathBuf::from("/task/base/src"),
+                PathBuf::from("/task/base/tests")
+            ]
+        );
     }
 
     #[test]

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -557,6 +557,24 @@ pub(crate) fn task_source_match_root(root: &Path, config: &Config) -> PathBuf {
         .unwrap_or_else(|| root.to_path_buf())
 }
 
+/// Resolve a task's declared source patterns to the files they currently match.
+pub(crate) async fn resolve_task_source_paths(
+    task: &Task,
+    config: &Arc<Config>,
+) -> Result<Vec<PathBuf>> {
+    let root = task_cwd(task, config).await?;
+    let match_root = task_source_match_root(&root, config);
+    let matcher = build_source_matcher(&match_root, &root, &task.sources);
+    let mut paths = get_file_metadatas(&root, &source_glob_patterns(&task.sources), &matcher)?
+        .into_iter()
+        .map(|(path, _)| path)
+        .collect::<std::collections::BTreeSet<_>>();
+    if let Some(path) = task.file_path(config).await? {
+        paths.insert(path);
+    }
+    Ok(paths.into_iter().collect())
+}
+
 /// Collect source file metadatas for a task, anchored at the correct workspace root.
 async fn collect_source_metadatas(
     task: &Task,

--- a/src/task/task_template.rs
+++ b/src/task/task_template.rs
@@ -3,7 +3,7 @@ use crate::config::config_file::toml::deserialize_arr;
 use crate::task::task_sources::TaskOutputs;
 use crate::task::{
     RunEntry, Silent, Task, TaskCacheConfig, TaskConfirm, TaskDep, TaskOutput, TaskRustCacheConfig,
-    TaskToolValue, TaskWatchOptions,
+    TaskSandboxMode, TaskToolValue, TaskWatchOptions,
 };
 use indexmap::IndexMap;
 use serde::Deserialize;
@@ -58,6 +58,9 @@ pub(crate) struct TaskTemplate {
     pub run_windows: Vec<RunEntry>,
     #[serde(default)]
     pub file: Option<String>,
+    /// Infer filesystem reads from sources and prerequisite outputs.
+    #[serde(default)]
+    pub sandbox: TaskSandboxMode,
     /// Block reads, writes, network, and env vars
     #[serde(default)]
     pub deny_all: bool,
@@ -231,6 +234,9 @@ impl Task {
 
         // sandbox: restrictions compose with task-local settings, matching how
         // task and global sandbox config are combined in the executor.
+        if template.sandbox.is_inferred() {
+            self.sandbox = TaskSandboxMode::Inferred;
+        }
         self.deny_all |= template.deny_all;
         self.deny_read |= template.deny_read;
         self.deny_write |= template.deny_write;
@@ -514,6 +520,7 @@ mod tests {
             ..Default::default()
         };
         let template = TaskTemplate {
+            sandbox: TaskSandboxMode::Inferred,
             deny_all: true,
             deny_read: true,
             deny_write: true,
@@ -528,6 +535,7 @@ mod tests {
 
         task.merge_template(&template);
 
+        assert!(task.sandbox.is_inferred());
         assert!(task.deny_all);
         assert!(task.deny_read);
         assert!(task.deny_write);


### PR DESCRIPTION
## Summary
- add opt-in `sandbox = true` task read inference; declaring `sources` alone does not activate sandboxing
- resolve source globs to concrete matched files, honor exclusions, and include file-backed task scripts
- make declared outputs from all prerequisite dependencies readable
- keep explicit `allow_read` and other sandbox settings, including `allow_write`, composable with inferred reads
- leave current-task output writes entirely explicit

Implements https://github.com/jdx/mise/discussions/12264.

## Dependency
Built on #12263, which merged first as expected. Its macOS sandbox traversal fix is inherited from `main`.

## Limitations
This is an ergonomics feature, not a hermetic build boundary. Dependency output globs grant their static prefix. Tools may still need explicit access for configuration, caches, formatters, or the task working directory. Output writes are not inferred.

## Validation
- `cargo test --bin mise sandbox`
- `cargo test --bin mise dependency_state_retains_transitive_prerequisite_tasks`
- `cargo test --bin mise dependency_output_patterns_resolve_to_static_prefixes`
- `mise run test:e2e e2e/tasks/test_task_sandbox_inferred_io`
- `mise run lint-fix`
- `mise run lint`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added opt-in inferred filesystem permissions for sandboxed tasks.
  - Sandboxes allow reading declared sources and prerequisite outputs, plus writing declared task outputs.
  - Supports glob and brace patterns, explicit permission extensions, and automatic output-directory preparation.
  - Added the `sandbox` task configuration option and schema support.

- **Documentation**
  - Documented permission inference, exclusions, caching, freshness, and platform behavior.

- **Tests**
  - Added end-to-end coverage for declared and undeclared sandbox access, including inferred sources and outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->