### PR TITLE
fix(doctor): report the new-version warning in JSON output too

### DIFF
--- a/e2e/cli/test_doctor
+++ b/e2e/cli/test_doctor
@@ -33,3 +33,18 @@ assert_contains "mise doctor" "(none)"
 echo "DOCTOR_VAR=1" >.doctor-test-env
 assert_contains "MISE_ENV_FILE=.doctor-test-env mise doctor" ".doctor-test-env"
 assert_contains "MISE_ENV_FILE=.doctor-test-env mise doctor -J" ".doctor-test-env"
+
+# Both outputs render the same warnings, so a check that only one path runs is a hole in the other.
+# Seeding the version cache makes this deterministic: no network, and no waiting for a release.
+# Asked of mise rather than assembled here, so the file is written wherever the version check
+# will look for it.
+# Kept last — the seeded version adds a warning to every doctor run after this point.
+cache_dir="$(mise cache path)"
+mkdir -p "$cache_dir"
+echo "2099.1.0" >"$cache_dir/latest-version"
+assert_contains "mise doctor" "new mise version 2099.1.0 available"
+# Structure rather than substring on the JSON side: what this PR is about is the warning reaching
+# `warnings`, not the text appearing somewhere in the document. `pipefail` because the helper runs
+# this through its own `bash -c`, where the pipeline's status is jq's alone — a `mise doctor` that
+# printed the right JSON and then exited non-zero would pass unnoticed.
+assert_succeed "set -o pipefail; mise doctor -J | jq -e '.warnings | map(contains(\"new mise version 2099.1.0 available\")) | any'"

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -164,6 +164,7 @@ impl Doctor {
         self.analyze_plugins();
         self.analyze_backend_mismatches();
         self.analyze_system_deps(ts).await;
+        self.analyze_new_version().await;
         #[cfg(windows)]
         self.analyze_self_update_leftovers();
         self.check_path_ordering(ts, &config).await;
@@ -313,13 +314,7 @@ impl Doctor {
         }
         self.analyze_settings()?;
 
-        if let Some(latest) = version::check_for_new_version(duration::HOURLY).await {
-            version::show_latest().await;
-            self.warnings.push(format!(
-                "new mise version {latest} available, currently on {}",
-                *version::V
-            ));
-        }
+        self.analyze_new_version().await;
         #[cfg(windows)]
         self.analyze_self_update_leftovers();
 
@@ -397,6 +392,22 @@ impl Doctor {
                 };
                 self.warnings.push(msg);
             }
+        }
+    }
+
+    /// Both outputs render `self.warnings`, so a check only one path runs is a hole in the other.
+    ///
+    /// The stderr notice is presentation rather than diagnosis, and `-J` is asked for by something
+    /// reading the JSON: it gets the warning below instead of a message aimed at a person.
+    async fn analyze_new_version(&mut self) {
+        if let Some(latest) = version::check_for_new_version(duration::HOURLY).await {
+            if !self.json {
+                version::show_latest().await;
+            }
+            self.warnings.push(format!(
+                "new mise version {latest} available, currently on {}",
+                *version::V
+            ));
         }
     }
 


### PR DESCRIPTION
`mise doctor` and `mise doctor -J` render the same `warnings` list, but only the text path runs the new-version check. Anyone gating CI on the JSON output never hears that their mise is out of date.

Same machine, same moment:

| | warnings |
| --- | --- |
| `mise doctor` | 2 — a backend mismatch, **and `new mise version 2026.8.10 available, currently on 2026.8.9`** |
| `mise doctor -J` | 1 — the backend mismatch only |

## Reproducing it without waiting for a release

The check reads a cached version file, so the condition can be created directly:

```console
$ echo "2099.1.0" > "$(mise cache path)/latest-version"

$ mise doctor | grep 'new mise version'
2. new mise version 2099.1.0 available, currently on 2026.8.9

$ mise doctor -J | jq -r '.warnings[]'
tool 'aube' installed with explicit backend 'github:endevco/aube' …          # and nothing else
```

`get_latest_version` returns the cached value whenever the file's mtime is inside the TTL, so a freshly written file is used as-is and no request is made.

## Why only this one

I counted the `analyze_*` calls on both paths rather than assuming the rest were fine. The other differences are not lost diagnostics:

- `analyze_toolset`'s error push — the JSON path has its own tool loop pushing the same error
- `analyze_settings`'s error push — the JSON path loads settings with `?`, so a failure propagates
- `analyze_paths` — pushes nothing

The new-version warning is the only check whose output one path emits and the other silently drops.

There is precedent for the fix being parity rather than a JSON-specific addition: #12205 added `analyze_self_update_leftovers` to **both** paths for exactly this reason.

## The change

The block becomes an `analyze_*` method like its neighbours, called from both paths:

```rust
async fn analyze_new_version(&mut self) {
    if let Some(latest) = version::check_for_new_version(duration::HOURLY).await {
        if !self.json {
            version::show_latest().await;
        }
        self.warnings.push(format!(
            "new mise version {latest} available, currently on {}",
            *version::V
        ));
    }
}
```

`show_latest()` writes through `warn!`, so calling it under `-J` would not corrupt stdout — it is skipped because it is a message aimed at a person, and `-J` was asked for by something reading the JSON. The warning itself, which is the diagnosis, goes to both. `self.json` is the same field `run()` dispatches on, so the branch and the output path cannot drift apart.

## Test

Appended to `e2e/cli/test_doctor`, which already checks text/JSON parity this way (`env_files`, `.doctor-test-env`). Seeding the cache makes it deterministic — no network, no waiting for a release:

```bash
cache_dir="$(mise cache path)"
echo "2099.1.0" >"$cache_dir/latest-version"
assert_contains "mise doctor" "new mise version 2099.1.0 available"
assert_contains "mise doctor -J" "new mise version 2099.1.0 available"
```

Three details worth stating: `2099.1.0` rather than the usual `99.0.0`, because mise's versions are calendar-shaped and `99` sorts *below* `2026`; `mise cache path` rather than `$MISE_CACHE_DIR`, which `run_test` does not export; and it goes last in the file, since the seeded version adds a warning to every `doctor` run after it.

`show_latest()` returns early under `ci_info::is_ci()`, but the warning push is outside that guard, so the text assertion holds in CI too.

## Verification

The measurements above are from the current release on this machine. **No local build was run** — this box cannot build mise, so the fixed behaviour is CI's to confirm; I have not claimed a measurement of it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `mise doctor` version-update reporting for more consistent results.
  * Text output now displays the latest available version notice.
  * JSON output records available-update warnings in the structured warnings list without including text-only notices.
  * The command continues to succeed when an available update is detected.

* **Tests**
  * Added deterministic coverage verifying version-update warnings appear consistently in both text and JSON `mise doctor` output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->