### PR TITLE
fix(config): don't prompt for trust when stdin is not a tty

### DIFF
--- a/e2e/config/test_trust_prompt_non_interactive
+++ b/e2e/config/test_trust_prompt_non_interactive
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# The trust prompt is a `demand::Dialog`, which has no non-tty branch: it drives
+# `Term::stderr().read_key()` unconditionally. With a terminal on stderr but not on
+# stdin (`docker run -t` without `-i`, a `script`-wrapped CI step) `console` falls
+# back to /dev/tty and either blocks forever waiting for a keypress nobody is there
+# to type, or fails with an errno that replaces the actionable "not trusted" error.
+#
+# mise must fail the same way it does with plain pipes, and it must not record an
+# ignore marker -- that marker is sticky and silent, so the config would just stop
+# applying without the user ever having declined it.
+
+require_cmd script
+
+# A terminal on stderr is the whole point of this test, so it needs a pty. macOS's
+# script(1) additionally requires a terminal on its own stdin, which the harness
+# does not have, so skip where a pty cannot be allocated rather than fail.
+if ! script -qec true /dev/null >/dev/null 2>&1; then
+  echo "skipping: script(1) cannot allocate a pty here" >&2
+  exit 0
+fi
+
+export MISE_TRUSTED_CONFIG_PATHS=""
+
+cat <<'EOF' >mise.toml
+[env]
+TRUST_PROMPT_TEST = "1"
+EOF
+
+ignored_configs="$MISE_STATE_DIR/ignored-configs"
+
+# Gives mise a pty on stderr and /dev/null on stdin. Kept under a timeout because
+# the regression this guards against is a hang, not a failure. `-e` makes script(1)
+# exit with the child's status. 10s is well clear of the ~1s a passing run takes,
+# and keeps a regression under the harness's 20s "should be marked slow" warning.
+run_in_pty() {
+  timeout 10 script -qec "$1 </dev/null" /dev/null
+}
+
+marker_count() {
+  if [[ -d $ignored_configs ]]; then
+    find "$ignored_configs" -mindepth 1 | wc -l | tr -d ' '
+  else
+    echo 0
+  fi
+}
+
+# MISE_PARANOID=1 keeps the trust check deterministic by skipping the
+# implicitly-trust-active-config fast path.
+status=0
+output="$(run_in_pty 'MISE_YES=0 MISE_PARANOID=1 mise env' 2>&1)" || status=$?
+
+if [[ $status == 124 ]]; then
+  fail "mise blocked on a trust prompt that nothing could answer"
+fi
+if [[ $status == 0 ]]; then
+  fail "expected mise to fail on untrusted config, got: $output"
+fi
+assert_contains_text "$output" "not trusted"
+assert_contains_text "$output" "mise trust"
+
+if [[ $(marker_count) != 0 ]]; then
+  fail "an ignore marker was recorded without the user declining"
+fi
+ok "[trust] no ignore marker recorded when the prompt cannot be answered"
+
+# Same terminal shape while generating usage/completions. Before the fix this exited
+# 0 -- because it had just recorded the ignore marker -- so the marker is what
+# distinguishes the bug, not the exit status.
+status=0
+run_in_pty '__USAGE=1 MISE_YES=0 MISE_PARANOID=1 mise env' >/dev/null 2>&1 || status=$?
+
+if [[ $status == 124 ]]; then
+  fail "mise blocked while generating usage in an untrusted directory"
+fi
+if [[ $(marker_count) != 0 ]]; then
+  fail "generating usage recorded an ignore marker"
+fi
+ok "[trust] no ignore marker recorded while generating usage"

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -469,7 +469,12 @@ pub(crate) fn trust_check(path: &Path) -> eyre::Result<()> {
         if ans {
             trust(&config_root)?;
             return Ok(());
-        } else if console::user_attended_stderr() {
+        } else if prompt::can_prompt_dialog() {
+            // Only a real "no" is worth remembering. `confirm_with_all` also
+            // returns false when it could not ask at all -- while generating
+            // usage/completions, or with a terminal on stderr but not on stdin --
+            // and persisting an ignore marker there would silently stop the
+            // config from applying without the user ever declining it.
             add_ignored(config_root.to_path_buf())?;
         }
     }

--- a/src/ui/prompt.rs
+++ b/src/ui/prompt.rs
@@ -1,3 +1,4 @@
+use std::io::{BufRead, IsTerminal};
 use std::sync::Mutex;
 
 use demand::{Confirm, Dialog, DialogButton};
@@ -10,6 +11,41 @@ use crate::ui::theme::get_theme;
 static MUTEX: Mutex<()> = Mutex::new(());
 
 static SKIP_PROMPT: Mutex<bool> = Mutex::new(false);
+
+/// Whether a [`Dialog`] can actually be answered.
+///
+/// `demand` defines interactive as stdin *and* stderr ([`demand::tty::is_tty`]),
+/// and [`Confirm`] honors that -- but [`Dialog`] has no non-tty branch, so it
+/// drives `Term::stderr().read_key()` unconditionally. When stderr is a terminal
+/// and stdin is not (`docker run -t` without `-i`, a `script`-wrapped CI step,
+/// `mise env < /dev/null`), `console` falls back to `/dev/tty` and either fails
+/// with `ENXIO` -- burying the caller's real error under an errno -- or blocks
+/// forever on a keypress nobody is there to type. Checking both ends keeps a
+/// dialog from being drawn when nothing can answer it.
+///
+/// Callers that act on a "no" answer must consult this too, so that "nobody could
+/// be asked" is not mistaken for "the user declined".
+pub(crate) fn can_prompt_dialog() -> bool {
+    dialog_prompt_allowed(
+        console::user_attended_stderr(),
+        std::io::stdin().is_terminal(),
+        env::__USAGE.is_some(),
+    )
+}
+
+/// The decision behind [`can_prompt_dialog`], split out so it can be tested
+/// without manipulating the process's file descriptors.
+fn dialog_prompt_allowed(stderr_tty: bool, stdin_tty: bool, usage: bool) -> bool {
+    stderr_tty && stdin_tty && !usage
+}
+
+/// [`Dialog`] and [`Confirm`] hide the cursor while they render and restore it on
+/// submit and on Escape, but not when the read itself fails -- which leaves the
+/// terminal with an invisible cursor. Failures here are ignored: the error that
+/// got us here is the one worth reporting.
+fn restore_cursor() {
+    let _ = console::Term::stderr().show_cursor();
+}
 
 pub(crate) fn confirm<S: Into<String>>(message: S) -> eyre::Result<bool> {
     confirm_with_default(message, true)
@@ -25,20 +61,72 @@ pub(crate) fn confirm_with_default<S: Into<String>>(
     if !console::user_attended_stderr() || env::__USAGE.is_some() {
         return Ok(false);
     }
+    let message = message.into();
+    // Held across both branches below: a prompt written to stderr is just as
+    // easily overwritten by progress redraws when it is read from a pipe as when
+    // it is read from the terminal. The guard is a no-op when no report is active.
     let _progress_pause = MultiProgressReport::try_get().map(|report| report.pause_progress());
+    // Deliberately not `can_prompt_dialog()`: `Confirm` does have a non-tty
+    // branch, so `echo y | mise ...` is a supported way to answer. What it cannot
+    // do is tell EOF from a bare newline -- it discards the 0-byte return of
+    // `read_line` and applies the default -- so `mise implode < /dev/null` would
+    // answer "yes" to every deletion. Read the line here instead, so that no
+    // answer means no.
+    if !std::io::stdin().is_terminal() {
+        return read_confirm_from_stdin(&message, default_yes);
+    }
     let theme = get_theme();
     let result = Confirm::new(message)
         .selected(default_yes)
         .theme(&theme)
-        .run()?;
+        .run()
+        .inspect_err(|_| restore_cursor())?;
     Ok(result)
+}
+
+/// Prints `message` to stderr and reads a single answer from a non-terminal
+/// stdin, which is what makes `echo y | mise ...` work without letting an
+/// unanswered prompt (EOF) count as consent.
+fn read_confirm_from_stdin(message: &str, default_yes: bool) -> eyre::Result<bool> {
+    let hint = if default_yes { "[Y/n]" } else { "[y/N]" };
+    safe_eprintln!("{message} {hint}");
+    let mut line = String::new();
+    let read = std::io::stdin().lock().read_line(&mut line)?;
+    // A 0-byte read is EOF, which is the case `demand` cannot distinguish.
+    let answer = (read > 0).then_some(line.as_str());
+    parse_confirm_answer(answer, default_yes)
+}
+
+/// Interprets one typed answer, matching what `demand`'s own non-tty branch
+/// accepted: any prefix of "yes" or "no", an empty line for the default, and an
+/// error for anything else -- silently rereading what someone typed as "no" would
+/// be worse than telling them it was not understood.
+///
+/// `None` means stdin reached EOF without an answer, which is the one case
+/// `demand` gets wrong and the reason this exists.
+fn parse_confirm_answer(line: Option<&str>, default_yes: bool) -> eyre::Result<bool> {
+    let Some(line) = line else {
+        // Nobody answered, so nothing was consented to.
+        return Ok(false);
+    };
+    let answer = line.trim().to_lowercase();
+    if answer.is_empty() {
+        return Ok(default_yes);
+    }
+    if "yes".starts_with(&answer) {
+        Ok(true)
+    } else if "no".starts_with(&answer) {
+        Ok(false)
+    } else {
+        eyre::bail!("expected y/yes or n/no, got {:?}", line.trim())
+    }
 }
 
 pub(crate) fn confirm_with_all<S: Into<String>>(message: S) -> eyre::Result<bool> {
     let _lock = MUTEX.lock().unwrap(); // Prevent multiple prompts at once
     ctrlc::show_cursor_after_ctrl_c();
 
-    if !console::user_attended_stderr() || env::__USAGE.is_some() {
+    if !can_prompt_dialog() {
         return Ok(false);
     }
 
@@ -57,7 +145,8 @@ pub(crate) fn confirm_with_all<S: Into<String>>(message: S) -> eyre::Result<bool
         ])
         .selected_button(1)
         .theme(&theme)
-        .run()?;
+        .run()
+        .inspect_err(|_| restore_cursor())?;
 
     let result = match answer.as_str() {
         "Yes" => true,
@@ -69,4 +158,64 @@ pub(crate) fn confirm_with_all<S: Into<String>>(message: S) -> eyre::Result<bool
         _ => false,
     };
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dialog_needs_both_ends_of_the_terminal() {
+        // A dialog is drawn on stderr and read from the terminal, so anything
+        // less than both ends means nothing can answer it.
+        assert!(dialog_prompt_allowed(true, true, false));
+        assert!(!dialog_prompt_allowed(false, true, false));
+        assert!(!dialog_prompt_allowed(true, false, false));
+        assert!(!dialog_prompt_allowed(false, false, false));
+    }
+
+    #[test]
+    fn dialog_never_shown_while_generating_usage() {
+        // Completion/usage generation must never block on a prompt, even from a
+        // terminal.
+        assert!(!dialog_prompt_allowed(true, true, true));
+        assert!(!dialog_prompt_allowed(false, true, true));
+        assert!(!dialog_prompt_allowed(true, false, true));
+        assert!(!dialog_prompt_allowed(false, false, true));
+    }
+
+    #[test]
+    fn eof_is_not_consent() {
+        assert!(!parse_confirm_answer(None, true).unwrap());
+        assert!(!parse_confirm_answer(None, false).unwrap());
+    }
+
+    #[test]
+    fn empty_line_takes_the_default() {
+        for line in ["", "\n", "  \n"] {
+            assert!(parse_confirm_answer(Some(line), true).unwrap());
+            assert!(!parse_confirm_answer(Some(line), false).unwrap());
+        }
+    }
+
+    #[test]
+    fn explicit_answers_override_the_default() {
+        // Any prefix of the label answers, as `demand`'s own non-tty branch did.
+        for line in ["y\n", "Y", "ye", "yes", "YES\n"] {
+            assert!(parse_confirm_answer(Some(line), false).unwrap());
+        }
+        for line in ["n\n", "N", "no", "No\n"] {
+            assert!(!parse_confirm_answer(Some(line), true).unwrap());
+        }
+    }
+
+    #[test]
+    fn unrecognized_answers_are_an_error() {
+        // Not silently a "no": the user typed something, and guessing at it is
+        // how a decline gets attributed to someone who never made one.
+        for line in ["maybe", "1", "yep", "sure\n"] {
+            assert!(parse_confirm_answer(Some(line), true).is_err());
+            assert!(parse_confirm_answer(Some(line), false).is_err());
+        }
+    }
 }


### PR DESCRIPTION
Fixes the remaining half of #8940.

## Problem

`src/ui/prompt.rs` decided whether it could prompt from `console::user_attended_stderr()` alone — stdin was never checked. `demand` defines interactive as stdin **and** stderr (`demand::tty::is_tty`), and `Confirm` honors that, but `Dialog` has no non-tty branch: it drives `Term::stderr().read_key()` unconditionally.

So with a terminal on stderr but not on stdin — `docker run -t` without `-i`, a `script`-wrapped CI step, `mise env < /dev/null` — mise painted the trust dialog even though nothing could answer it. `console` then fell back to `/dev/tty` and either blocked forever waiting for a keypress nobody was there to type, or failed outright:

```
Error:
   0: error parsing config file: /tmp/proj/mise.toml
   1: Device not configured (os error 6)

Location:
   src/ui/prompt.rs:49
```

That errno **replaced** the actionable `Config files in … are not trusted. Trust them with 'mise trust'` message. It also emitted `ESC[?25l` without ever pairing it, leaving the terminal with an invisible cursor. With both streams piped the same command already failed correctly, so only this one fd shape was broken.

Investigating turned up two more defects with the same root cause:

**A completion keystroke could silently disable a config.** `trust_check` gated `add_ignored()` on `console::user_attended_stderr()`, but `confirm_with_all` also returns `false` when it *could not ask* — including when `__USAGE` is set. With stderr a terminal, `__USAGE=1 MISE_YES=0 mise env` in an untrusted directory exited 0 and persisted `state/ignored-configs/<root> -> <root>`. That marker is sticky and silent, so the config simply stopped applying with no message. Reproduced; the piped control run creates no marker.

**`prompt::confirm()` failed open on EOF.** `demand::Confirm`'s non-tty branch discards the 0-byte return of `read_line`, so EOF is indistinguishable from a bare newline and applies the default. `confirm()` defaults to `true`, so `mise implode < /dev/null` in a terminal auto-confirmed every deletion (verified — it removed the first path it asked about).

## Fix

- `confirm_with_all` requires a terminal on both ends, via a new `can_prompt_dialog()`. This restores `demand`'s own contract rather than inventing a new rule.
- `trust_check` gates `add_ignored` on the same predicate, so only a real "no" is remembered.
- `confirm_with_default` reads the line itself when stdin is not a terminal: EOF → `false`, empty line → the default, any prefix of `yes`/`no` answers, and anything else is an error rather than a silent "no". `echo y | mise …` keeps working.
- Prompt errors restore the cursor before propagating.

The other `confirm_with_all` callers now get `Ok(false)` instead of an errno, which matches what they already do when fully piped: `asdf_plugin`/`vfox_plugin` return `PluginNotInstalled`, `prune` skips the entry rather than deleting it.

## Behavior change worth calling out

Dialog prompts no longer reach the controlling terminal through `/dev/tty` when stdin is redirected. This is broader than one command: `foo | mise install`, `mise x -- cmd < file`, or `mise prune < /dev/null` from a live terminal all used to prompt and now fail closed with the actionable error instead.

Reading `/dev/tty` under a redirect is normal for terminal programs — `sudo` and `ssh` do it — so this is a genuine capability being given up, not just the removal of a quirk. The trade is deliberate: discussions#8940 is precisely the case where that dialog is unanswerable, and `Dialog` cannot consume a piped answer anyway, so the alternatives are an actionable "run `mise trust`" error or a hang. `confirm_with_default` is unaffected — it still answers from piped stdin.

## Tests

- Unit tests in `src/ui/prompt.rs` for the predicate and the answer parsing. `trust_check` returns early under `cfg!(test)`, so this is the only unit-level seam.
- `e2e/config/test_trust_prompt_non_interactive` runs mise under a pty with `/dev/null` on stdin and asserts the actionable error, no hang, and no ignore marker — for both the plain and `__USAGE` shapes. It skips where `script(1)` cannot allocate a pty (macOS needs a terminal on its own stdin, which the harness lacks).

Verified locally with a `pty.openpty()` harness: the errno is gone, the cursor is no longer left hidden, no ignore marker is written in either shape, and a real terminal still shows the Yes/No/All dialog. `cargo clippy --workspace --all-features --all-targets -- -D warnings` is clean (no lint exclusions added).

## Possible follow-up

If you would prefer it, `confirm_with_all` could return a tri-state so "couldn't ask" is structurally distinct from "the user declined", instead of two call sites consulting `can_prompt_dialog()` independently. That would make the `add_ignored` bug unrepresentable rather than merely fixed, at the cost of touching all four callers. Happy to do that instead.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Trust prompts now behave correctly in non-interactive environments.
  * Failed or unavailable prompts no longer create persistent ignore entries.
  * Usage and completion generation no longer attempt interactive dialogs.
  * Prompts handle EOF, invalid input, input errors, and cursor restoration more reliably.
  * Recognized responses and default choices are handled consistently.

* **Tests**
  * Added coverage for non-interactive trust prompts and confirmation behavior, including EOF, default responses, explicit answers, and invalid input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
