### PR TITLE
registry: add ticker (github:achannarasappa/ticker)

### DIFF
--- a/registry/ticker.toml
+++ b/registry/ticker.toml
@@ -1,0 +1,5 @@
+backends = ["github:achannarasappa/ticker"]
+bins = ["ticker"]
+description = "Terminal stock ticker with live updates and position tracking"
+test = { cmd = "ticker --version", expected = "ticker version {{version}}" }
+version_order = "semver"


### PR DESCRIPTION
registry: add ticker (github:achannarasappa/ticker)

Not in the aqua standard registry, so `github` is the tier 1 backend. Upstream
ships per-platform archives for linux/macos/windows on amd64 and arm64, so no
`asset_pattern`, `bin_path`, or `os` restriction is needed. All 71 release tags
are strict `MAJOR.MINOR.PATCH`, hence `version_order = "semver"`.

## Popularity

- GitHub: 6,213 stars, 340 forks; latest release v5.3.0 published 2026-06-21
- Active maintenance: latest repository push 2026-06-28
- Also packaged in nixpkgs, and as a Snap published by the upstream author

## Validation

- `mise test-tool ticker` -> `ticker: OK`
- `mise x github:achannarasappa/ticker@5.3.0 -- ticker --version` -> `ticker version 5.3.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added support for detecting and validating the GitHub-hosted `ticker` backend.
- Added semantic version ordering for `ticker` releases, enabling accurate version comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->