### PR TITLE
registry: add nushell (aqua:nushell/nushell)

### DIFF
--- a/registry/nushell.toml
+++ b/registry/nushell.toml
@@ -1,0 +1,6 @@
+aliases = ["nu"]
+backends = ["aqua:nushell/nushell", "github:nushell/nushell"]
+bins = ["nu"]
+description = "A new type of shell"
+test = { cmd = "nu --version", expected = "{{version}}" }
+version_order = "semver"


### PR DESCRIPTION
In the aqua standard registry, so `aqua` is the preferred backend, with `github` as a tier 1 fallback. The binary is `nu` rather than `nushell`, so `bins` and a `nu` alias are set; `mise search nu` currently returns no nushell result. All 100 release tags are strict `MAJOR.MINOR.PATCH`, hence `version_order = "semver"`.

## Popularity

- GitHub: 40,315 stars, 2,214 forks; latest release 0.115.0 published 2026-08-15
- Active maintenance: latest repository push 2026-08-21
- crates.io `nu`: 448,911 downloads
- Also packaged in Homebrew, nixpkgs, and winget

## Validation

- `mise test-tool nushell` -> `nushell: OK`
- `mise x aqua:nushell/nushell@0.115.0 -- nu --version` -> `0.115.0`
- `mise x github:nushell/nushell@0.115.0 -- nu --version` -> `0.115.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Nushell registry support, including version detection and semantic version ordering.
  * Configured metadata and download sources for the Nushell binary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->