### PR TITLE
registry: add pkgx (github:pkgxdev/pkgx)

### DIFF
--- a/registry/pkgx.toml
+++ b/registry/pkgx.toml
@@ -1,0 +1,5 @@
+backends = ["aqua:pkgxdev/pkgx", "github:pkgxdev/pkgx"]
+bins = ["pkgx"]
+description = "Run Anything"
+test = { cmd = "pkgx --version", expected = "pkgx {{version}}" }
+version_order = "semver"


### PR DESCRIPTION
In the aqua standard registry, so `aqua` is the preferred backend, with `github` as a tier 1 fallback. All 96 release tags are strict `MAJOR.MINOR.PATCH`, hence `version_order = "semver"`.

The shorthand name does not collide with the existing `pkgx` backend prefix: a bare tool name is resolved through the registry, while `pkgx:<pkg>` still selects the backend. `registry/npm.toml`, `registry/go.toml`, and `registry/aqua.toml` already coexist with their backend prefixes the same way.

## Popularity

- GitHub: 9,901 stars, 1,390 forks; latest release v2.11.0 published 2026-07-22
- Active maintenance: latest repository push 2026-08-17
- Also packaged in Homebrew
- https://github.com/pkgxdev/pkgx

## Validation

- `mise test-tool pkgx` -> `pkgx: OK`
- `mise x aqua:pkgxdev/pkgx@2.11.0 -- pkgx --version` -> `pkgx 2.11.0`
- `mise x github:pkgxdev/pkgx@2.11.0 -- pkgx --version` -> `pkgx 2.11.0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added package registry metadata, including Aqua and GitHub sources.
  * Added package description, version validation, and semantic-version ordering.
  * Improved package discovery and version handling across supported registry integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->