### PR TITLE
refactor: distinguish "could not ask" from "no" in confirmation prompts

### DIFF
--- a/e2e/config/test_trust_prompt_declined
+++ b/e2e/config/test_trust_prompt_declined
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# The other half of test_trust_prompt_non_interactive: when the user actually
+# answers "No", mise must remember it by recording an ignore marker, so the same
+# directory stops asking on every command.
+#
+# Both halves matter together. The marker is written for a decline and withheld
+# when nobody could be asked, and a `bool` return cannot tell those apart -- which
+# is how a marker once got written for an answer no one gave. This test pins the
+# side that a fail-closed reading would quietly drop.
+
+require_cmd script
+
+# Needs a real pty: the answer is delivered as a keystroke to a `demand::Dialog`.
+# macOS's script(1) also wants a terminal on its own stdin, which the harness does
+# not have, so skip where a pty cannot be allocated rather than fail.
+if ! script -qec true /dev/null >/dev/null 2>&1; then
+  echo "skipping: script(1) cannot allocate a pty here" >&2
+  exit 0
+fi
+
+export MISE_TRUSTED_CONFIG_PATHS=""
+
+cat <<'EOF' >mise.toml
+[env]
+TRUST_PROMPT_TEST = "1"
+EOF
+
+ignored_configs="$MISE_STATE_DIR/ignored-configs"
+
+marker_count() {
+  if [[ -d $ignored_configs ]]; then
+    find "$ignored_configs" -mindepth 1 | wc -l | tr -d ' '
+  else
+    echo 0
+  fi
+}
+
+# The dialog's buttons are Yes/No/All and each is bound to its lowercased first
+# letter, so a bare `n` selects "No" and submits. Feeding keystrokes through
+# script(1) is the same pattern as e2e/tasks/test_task_run_all_picker.
+# MISE_PARANOID=1 keeps the trust check deterministic by skipping the
+# implicitly-trust-active-config fast path.
+status=0
+output="$(printf 'n' | timeout 10 script -qec 'MISE_YES=0 MISE_PARANOID=1 mise env' /dev/null 2>&1)" || status=$?
+
+if [[ $status == 124 ]]; then
+  fail "mise did not accept the answer and hung on the trust prompt"
+fi
+# The prompt was shown and answered.
+assert_contains_text "$output" "not trusted"
+
+if [[ $(marker_count) != 1 ]]; then
+  fail "declining the trust prompt did not record an ignore marker"
+fi
+ok "[trust] declining records an ignore marker"
+
+# Declining is not an error. Recording the marker makes the config *ignored*, and
+# an ignored config is skipped rather than fatal -- unlike an untrusted one, which
+# is what test_trust_prompt_non_interactive pins. So this run succeeds and simply
+# does not apply the config.
+if [[ $status != 0 ]]; then
+  fail "expected mise to succeed once the config was ignored, got status $status: $output"
+fi
+assert_not_contains_text "$output" "TRUST_PROMPT_TEST"
+ok "[trust] the declined config is skipped rather than fatal"
+
+# And the marker sticks: the next run neither prompts nor applies the config, with
+# no pty involved at all. Checking only that the config is absent would also pass
+# if mise had asked again and been declined, so assert the trust path is not
+# entered at all.
+status=0
+output="$(MISE_YES=0 MISE_PARANOID=1 mise env 2>&1)" || status=$?
+if [[ $status != 0 ]]; then
+  fail "expected the ignored config to be skipped, got status $status: $output"
+fi
+assert_not_contains_text "$output" "TRUST_PROMPT_TEST"
+assert_not_contains_text "$output" "not trusted"
+if [[ $(marker_count) != 1 ]]; then
+  fail "the ignore marker was not reused on the next run"
+fi
+ok "[trust] the recorded decline suppresses the next prompt"

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -1416,6 +1416,7 @@ impl aube::embed::InstallPromptHandler for AubePromptHandler {
     fn confirm(&self, prompt: aube::embed::InstallPrompt) -> aube::embed::InstallPromptFuture<'_> {
         Box::pin(async move {
             crate::ui::prompt::confirm_with_default(aube_prompt_message(&prompt), false)
+                .map(|answer| answer.is_yes())
                 .map_err(|err| miette::miette!("{err:#}"))
         })
     }

--- a/src/cli/dotfiles/add.rs
+++ b/src/cli/dotfiles/add.rs
@@ -219,7 +219,8 @@ impl DotfilesAdd {
                             "dotfiles: overwrite source {} from {}?",
                             item.source.display_user(),
                             item.target.display_user()
-                        ))?;
+                        ))?
+                        .is_yes();
                         if !ok {
                             info!("dotfiles: skipped {}", item.target_raw);
                             continue;

--- a/src/cli/dotfiles/edit.rs
+++ b/src/cli/dotfiles/edit.rs
@@ -54,7 +54,7 @@ impl DotfilesEdit {
         }
 
         if !self.yes && console::user_attended_stderr() {
-            let ok = prompt::confirm(format!("dotfiles: add {}?", self.target))?;
+            let ok = prompt::confirm(format!("dotfiles: add {}?", self.target))?.is_yes();
             if !ok {
                 info!("dotfiles: skipped");
                 return Ok(());

--- a/src/cli/dotfiles/unapply.rs
+++ b/src/cli/dotfiles/unapply.rs
@@ -88,6 +88,7 @@ impl DotfilesUnapply {
                 file_plan.len(),
                 edit_plan.len()
             ))?
+            .is_yes()
         {
             info!("dotfiles: skipped");
             return Ok(());

--- a/src/cli/implode.rs
+++ b/src/cli/implode.rs
@@ -58,8 +58,7 @@ impl Implode {
         } else if settings.yes {
             Ok(true)
         } else {
-            let r = prompt::confirm(format!("remove {} ?", f.display()))?;
-            Ok(r)
+            Ok(prompt::confirm(format!("remove {} ?", f.display()))?.is_yes())
         }
     }
 }

--- a/src/cli/install_into.rs
+++ b/src/cli/install_into.rs
@@ -81,7 +81,8 @@ impl InstallInto {
                         display_path(&install_path)
                     ),
                     false,
-                )?;
+                )?
+                .is_yes();
             if !proceed {
                 bail!(
                     "refusing to overwrite non-empty directory {}; pass {} or choose an empty/new path",

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -169,7 +169,7 @@ async fn delete(
         }
         if !dry_run
             && !Settings::get().yes
-            && !prompt::confirm_with_all(format!("remove {} ?", tv))?
+            && !prompt::confirm_with_all(format!("remove {} ?", tv))?.is_yes()
         {
             continue;
         }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1386,7 +1386,7 @@ impl Run {
                 )
             }
             let msg = format!("Script `{dp}` is not executable. Make it executable?");
-            if ui::confirm(msg)? {
+            if ui::confirm(msg)?.is_yes() {
                 file::make_executable(path)?;
             } else {
                 bail!(

--- a/src/cli/system/driver.rs
+++ b/src/cli/system/driver.rs
@@ -166,7 +166,7 @@ pub(crate) async fn run(mgrs: Vec<ManagerPackages>, action: Action, d: &DriverOp
         let list = targets.iter().map(|r| r.to_string()).collect::<Vec<_>>();
         if !d.dry_run && !d.yes && console::user_attended_stderr() {
             let msg = format!("{name}: {} {}?", action.verb(), list.join(", "));
-            if !prompt::confirm(msg)? {
+            if !prompt::confirm(msg)?.is_yes() {
                 info!("{name}: skipped");
                 continue;
             }

--- a/src/cli/system/install.rs
+++ b/src/cli/system/install.rs
@@ -115,7 +115,7 @@ pub(crate) async fn apply_defaults_with_report(
     let list = targets.iter().map(|r| r.to_string()).collect::<Vec<_>>();
     if !dry_run && !yes && console::user_attended_stderr() {
         let msg = format!("defaults: write {}?", list.join(", "));
-        if !crate::ui::prompt::confirm(msg)? {
+        if !crate::ui::prompt::confirm(msg)?.is_yes() {
             info!("defaults: skipped");
             return Ok(BootstrapApplyReport::default());
         }
@@ -174,7 +174,7 @@ pub(crate) fn apply_login_shell_with_report(
     let needs_follow_up = status.state != LoginShellState::Set;
     if !dry_run && !yes && console::user_attended_stderr() {
         let msg = format!("login_shell: run `chsh -s {}`?", request.shell);
-        if !crate::ui::prompt::confirm(msg)? {
+        if !crate::ui::prompt::confirm(msg)?.is_yes() {
             info!("login_shell: skipped");
             return Ok(BootstrapApplyReport::default());
         }
@@ -299,7 +299,7 @@ fn mutate_repos(
         .collect::<Vec<_>>();
     if !dry_run && !yes && console::user_attended_stderr() {
         let msg = format!("repos: {} {}?", mutation.prompt_verb, list.join(", "));
-        if !crate::ui::prompt::confirm(msg)? {
+        if !crate::ui::prompt::confirm(msg)?.is_yes() {
             info!("repos: skipped");
             return Ok(());
         }
@@ -356,7 +356,7 @@ pub(crate) async fn apply_launchd_with_report(
     let list = targets.iter().map(|r| r.to_string()).collect::<Vec<_>>();
     if !dry_run && !yes && console::user_attended_stderr() {
         let msg = format!("launchd: install/load {}?", list.join(", "));
-        if !crate::ui::prompt::confirm(msg)? {
+        if !crate::ui::prompt::confirm(msg)?.is_yes() {
             info!("launchd: skipped");
             return Ok(BootstrapApplyReport::default());
         }
@@ -416,7 +416,7 @@ pub(crate) async fn apply_systemd_with_report(
     let list = targets.iter().map(|r| r.to_string()).collect::<Vec<_>>();
     if !dry_run && !yes && console::user_attended_stderr() {
         let msg = format!("systemd: apply {}?", list.join(", "));
-        if !crate::ui::prompt::confirm(msg)? {
+        if !crate::ui::prompt::confirm(msg)?.is_yes() {
             info!("systemd: skipped");
             return Ok(BootstrapApplyReport::default());
         }

--- a/src/cli/system/prune.rs
+++ b/src/cli/system/prune.rs
@@ -83,7 +83,7 @@ impl SystemPrune {
             .collect::<Vec<_>>();
         if !self.yes && !Settings::get().yes && console::user_attended_stderr() {
             let msg = format!("brew: prune {}?", remove.join(", "));
-            if !prompt::confirm(msg)? {
+            if !prompt::confirm(msg)?.is_yes() {
                 info!("brew: skipped");
                 return Ok(());
             }
@@ -130,7 +130,7 @@ impl SystemPrune {
             .collect::<Vec<_>>();
         if !self.yes && !Settings::get().yes && console::user_attended_stderr() {
             let msg = format!("brew-cask: prune {}?", remove.join(", "));
-            if !prompt::confirm(msg)? {
+            if !prompt::confirm(msg)?.is_yes() {
                 info!("brew-cask: skipped");
                 return Ok(());
             }

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -22,6 +22,7 @@ use crate::hooks::Hook;
 use crate::redactions::Redactions;
 use crate::task::{Task, TaskRustCacheConfig, TaskTemplate};
 use crate::toolset::{ToolRequest, ToolRequestSet, ToolSource, ToolVersionList, Toolset};
+use crate::ui::prompt::Confirmation;
 use crate::ui::{prompt, style};
 use crate::watch_files::WatchFile;
 use crate::{
@@ -460,22 +461,25 @@ pub(crate) fn trust_check(path: &Path) -> eyre::Result<()> {
         return Ok(());
     }
     if cmd != "hook-env" && !is_ignored(&config_root) && !is_ignored(path) {
-        let ans = (settings::is_loaded() && Settings::get().yes)
-            || prompt::confirm_with_all(format!(
+        let ans = if settings::is_loaded() && Settings::get().yes {
+            Confirmation::Yes
+        } else {
+            prompt::confirm_with_all(format!(
                 "{} config files in {} are not trusted. Trust them?",
                 style::eyellow("mise"),
                 style::epath(&config_root)
-            ))?;
-        if ans {
-            trust(&config_root)?;
-            return Ok(());
-        } else if prompt::can_prompt_dialog() {
-            // Only a real "no" is worth remembering. `confirm_with_all` also
-            // returns false when it could not ask at all -- while generating
-            // usage/completions, or with a terminal on stderr but not on stdin --
-            // and persisting an ignore marker there would silently stop the
-            // config from applying without the user ever declining it.
-            add_ignored(config_root.to_path_buf())?;
+            ))?
+        };
+        match ans {
+            Confirmation::Yes => {
+                trust(&config_root)?;
+                return Ok(());
+            }
+            // Only a real decline is worth remembering. An ignore marker is
+            // sticky and silent, so recording one for an answer nobody gave
+            // would stop the config from applying with nothing to explain why.
+            Confirmation::No => add_ignored(config_root.to_path_buf())?,
+            Confirmation::Unavailable => {}
         }
     }
     Err(UntrustedConfig(path.into()))?

--- a/src/plugins/asdf_plugin.rs
+++ b/src/plugins/asdf_plugin.rs
@@ -293,7 +293,9 @@ impl Plugin for AsdfPlugin {
                     if !prompt::confirm_with_all(format!(
                         "Would you like to install {}?",
                         self.name
-                    ))? {
+                    ))?
+                    .is_yes()
+                    {
                         Err(PluginNotInstalled(self.name.clone()))?
                     }
                 }

--- a/src/plugins/vfox_plugin.rs
+++ b/src/plugins/vfox_plugin.rs
@@ -277,7 +277,9 @@ impl Plugin for VfoxPlugin {
                     if !prompt::confirm_with_all(format!(
                         "Would you like to install {}?",
                         self.name
-                    ))? {
+                    ))?
+                    .is_yes()
+                    {
                         Err(PluginNotInstalled(self.name.clone()))?
                     }
                 }

--- a/src/system/accounts.rs
+++ b/src/system/accounts.rs
@@ -823,6 +823,7 @@ pub(crate) fn apply(requests: &AccountRequests, dry_run: bool, yes: bool) -> Res
     if !yes
         && console::user_attended_stderr()
         && !crate::ui::prompt::confirm(format!("accounts: apply {} change(s)?", actions.len()))?
+            .is_yes()
     {
         info!("accounts: skipped");
         return Ok(false);

--- a/src/system/compose.rs
+++ b/src/system/compose.rs
@@ -267,6 +267,7 @@ pub(crate) fn apply_with_dry_run_actions(
             "compose projects: apply {} change(s)?",
             changes.len()
         ))?
+        .is_yes()
     {
         info!("compose projects: skipped");
         return Ok(());

--- a/src/system/edits.rs
+++ b/src/system/edits.rs
@@ -679,7 +679,7 @@ pub(crate) fn apply(config: &Config, requests: &[EditRequest], opts: &ApplyOpts)
             .map(|(r, _)| format!("{} ({})", r.path_raw, r.describe_op()))
             .collect::<Vec<_>>()
             .join(", ");
-        if !prompt::confirm(format!("edits: apply {list}?"))? {
+        if !prompt::confirm(format!("edits: apply {list}?"))?.is_yes() {
             info!("edits: skipped");
             return Ok(false);
         }
@@ -843,7 +843,7 @@ pub(crate) fn execute_unapply(todo: &[UnapplyPlan<'_>], opts: &UnapplyOpts) -> R
             .map(|plan| format!("{} ({})", plan.req.path_raw, plan.req.describe_op()))
             .collect::<Vec<_>>()
             .join(", ");
-        if !prompt::confirm(format!("edits: unapply {list}?"))? {
+        if !prompt::confirm(format!("edits: unapply {list}?"))?.is_yes() {
             info!("edits: skipped");
             return Ok(());
         }

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -1245,7 +1245,7 @@ pub(crate) fn execute_apply(plan: ApplyPlan<'_>, opts: &ApplyOpts) -> Result<boo
             .map(|(r, _)| r.target_raw.clone())
             .collect::<Vec<_>>()
             .join(", ");
-        if !prompt::confirm(format!("files: apply {list}?"))? {
+        if !prompt::confirm(format!("files: apply {list}?"))?.is_yes() {
             info!("files: skipped");
             return Ok(false);
         }
@@ -1515,7 +1515,7 @@ pub(crate) fn execute_unapply(plans: &[UnapplyPlan<'_>], opts: &UnapplyOpts) -> 
             .iter()
             .map(|plan| plan.req.target_raw.clone())
             .join(", ");
-        if !prompt::confirm(format!("files: unapply {list}?"))? {
+        if !prompt::confirm(format!("files: unapply {list}?"))?.is_yes() {
             info!("files: skipped");
             return Ok(());
         }

--- a/src/system/firewall.rs
+++ b/src/system/firewall.rs
@@ -742,6 +742,7 @@ pub(crate) fn apply(request: &FirewallRequest, dry_run: bool, yes: bool) -> Resu
                 ""
             }
         ))?
+        .is_yes()
     {
         info!("firewall: skipped");
         return Ok(());

--- a/src/system/managed_files.rs
+++ b/src/system/managed_files.rs
@@ -804,6 +804,7 @@ pub(crate) fn apply_with_accounts(
             "system files: apply {} change(s)?",
             plan.actions.len()
         ))?
+        .is_yes()
     {
         info!("system files: skipped");
         return Ok(ApplyReport::default());

--- a/src/system/services.rs
+++ b/src/system/services.rs
@@ -578,6 +578,7 @@ pub(crate) fn apply_with_notifications(
         && !crate::ui::prompt::confirm(format!(
             "services: apply {independent_actions} change(s) not triggered by managed files?"
         ))?
+        .is_yes()
     {
         actions.retain(|action| action.dependency_changed);
         if actions.is_empty() {

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -27,6 +27,7 @@ use crate::task::{TaskCompletionState, TaskDependencyState};
 use crate::tera::{contains_template_syntax, render_str};
 use crate::toolset::Toolset;
 use crate::toolset::env_cache::CachedEnv;
+use crate::ui::prompt::Confirmation;
 use crate::ui::{style, time};
 use duct::IntoExecutablePath;
 use eyre::{Context, Report, Result, ensure, eyre};
@@ -1859,8 +1860,15 @@ impl TaskExecutor {
                 Some(default) => Self::parse_confirm_default(default)?,
                 None => true, // keep backwards compatible default of yes if not specified
             };
-            if !crate::ui::prompt::confirm_with_default(&message, default_yes).unwrap_or(false) {
-                return Err(eyre!("aborted by user"));
+            match crate::ui::prompt::confirm_with_default(&message, default_yes) {
+                Ok(Confirmation::Yes) => {}
+                Ok(Confirmation::No) => return Err(eyre!("aborted by user")),
+                Ok(Confirmation::Unavailable) => {
+                    return Err(eyre!(
+                        "task requires confirmation but there was nobody to ask; pass --yes to accept"
+                    ));
+                }
+                Err(err) => return Err(err),
             }
         }
         Ok(())

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -223,7 +223,8 @@ async fn make_task_executable(
         display_path(&path)
     );
     let confirmed = config::Settings::get().yes
-        || prompt::confirm("Mark this file as executable to allow it to be run as a task?")?;
+        || prompt::confirm("Mark this file as executable to allow it to be run as a task?")?
+            .is_yes();
     if !confirmed {
         return Ok(None);
     }

--- a/src/ui/prompt.rs
+++ b/src/ui/prompt.rs
@@ -12,6 +12,23 @@ static MUTEX: Mutex<()> = Mutex::new(());
 
 static SKIP_PROMPT: Mutex<bool> = Mutex::new(false);
 
+/// The outcome of a confirmation prompt.
+///
+/// A plain `bool` cannot say the difference between a user who declined and a
+/// prompt that was never answerable, so every caller that acted on "no" had to
+/// re-derive the difference for itself -- and one that forgot silently attributed
+/// a decision to someone who never made one. Carrying it in the return type is
+/// what keeps that from being expressible.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumIs)]
+pub(crate) enum Confirmation {
+    Yes,
+    No,
+    /// The question never reached anyone: nothing was drawable on stderr, or
+    /// mise is generating usage/completions. A prompt that *was* displayed and
+    /// then went unanswered is [`Confirmation::No`], not this.
+    Unavailable,
+}
+
 /// Whether a [`Dialog`] can actually be answered.
 ///
 /// `demand` defines interactive as stdin *and* stderr ([`demand::tty::is_tty`]),
@@ -23,9 +40,9 @@ static SKIP_PROMPT: Mutex<bool> = Mutex::new(false);
 /// forever on a keypress nobody is there to type. Checking both ends keeps a
 /// dialog from being drawn when nothing can answer it.
 ///
-/// Callers that act on a "no" answer must consult this too, so that "nobody could
-/// be asked" is not mistaken for "the user declined".
-pub(crate) fn can_prompt_dialog() -> bool {
+/// Deliberately private: callers learn that nobody could be asked from
+/// [`Confirmation::Unavailable`], never by re-deriving it here.
+fn can_prompt_dialog() -> bool {
     dialog_prompt_allowed(
         console::user_attended_stderr(),
         std::io::stdin().is_terminal(),
@@ -47,19 +64,19 @@ fn restore_cursor() {
     let _ = console::Term::stderr().show_cursor();
 }
 
-pub(crate) fn confirm<S: Into<String>>(message: S) -> eyre::Result<bool> {
+pub(crate) fn confirm<S: Into<String>>(message: S) -> eyre::Result<Confirmation> {
     confirm_with_default(message, true)
 }
 
 pub(crate) fn confirm_with_default<S: Into<String>>(
     message: S,
     default_yes: bool,
-) -> eyre::Result<bool> {
+) -> eyre::Result<Confirmation> {
     let _lock = MUTEX.lock().unwrap(); // Prevent multiple prompts at once
     ctrlc::show_cursor_after_ctrl_c();
 
     if !console::user_attended_stderr() || env::__USAGE.is_some() {
-        return Ok(false);
+        return Ok(Confirmation::Unavailable);
     }
     let message = message.into();
     // Held across both branches below: a prompt written to stderr is just as
@@ -81,13 +98,17 @@ pub(crate) fn confirm_with_default<S: Into<String>>(
         .theme(&theme)
         .run()
         .inspect_err(|_| restore_cursor())?;
-    Ok(result)
+    Ok(if result {
+        Confirmation::Yes
+    } else {
+        Confirmation::No
+    })
 }
 
 /// Prints `message` to stderr and reads a single answer from a non-terminal
 /// stdin, which is what makes `echo y | mise ...` work without letting an
 /// unanswered prompt (EOF) count as consent.
-fn read_confirm_from_stdin(message: &str, default_yes: bool) -> eyre::Result<bool> {
+fn read_confirm_from_stdin(message: &str, default_yes: bool) -> eyre::Result<Confirmation> {
     let hint = if default_yes { "[Y/n]" } else { "[y/N]" };
     safe_eprintln!("{message} {hint}");
     let mut line = String::new();
@@ -102,37 +123,49 @@ fn read_confirm_from_stdin(message: &str, default_yes: bool) -> eyre::Result<boo
 /// error for anything else -- silently rereading what someone typed as "no" would
 /// be worse than telling them it was not understood.
 ///
-/// `None` means stdin reached EOF without an answer, which is the one case
-/// `demand` gets wrong and the reason this exists.
-fn parse_confirm_answer(line: Option<&str>, default_yes: bool) -> eyre::Result<bool> {
+/// `None` means stdin reached EOF without an answer -- the one case `demand`
+/// gets wrong (it applies the default) and the reason this exists.
+fn parse_confirm_answer(line: Option<&str>, default_yes: bool) -> eyre::Result<Confirmation> {
     let Some(line) = line else {
-        // Nobody answered, so nothing was consented to.
-        return Ok(false);
+        // A decline, not `Unavailable`: the question *was* put on stderr and
+        // stdin ended without an answer, so nothing was consented to.
+        // `Unavailable` is reserved for the question never reaching anyone.
+        // Keeping it a decline is also what every caller already assumed, and
+        // leaves silence safe to read as "no" for any that come later.
+        return Ok(Confirmation::No);
     };
     let answer = line.trim().to_lowercase();
     if answer.is_empty() {
-        return Ok(default_yes);
+        return Ok(default_answer(default_yes));
     }
     if "yes".starts_with(&answer) {
-        Ok(true)
+        Ok(Confirmation::Yes)
     } else if "no".starts_with(&answer) {
-        Ok(false)
+        Ok(Confirmation::No)
     } else {
         eyre::bail!("expected y/yes or n/no, got {:?}", line.trim())
     }
 }
 
-pub(crate) fn confirm_with_all<S: Into<String>>(message: S) -> eyre::Result<bool> {
+fn default_answer(default_yes: bool) -> Confirmation {
+    if default_yes {
+        Confirmation::Yes
+    } else {
+        Confirmation::No
+    }
+}
+
+pub(crate) fn confirm_with_all<S: Into<String>>(message: S) -> eyre::Result<Confirmation> {
     let _lock = MUTEX.lock().unwrap(); // Prevent multiple prompts at once
     ctrlc::show_cursor_after_ctrl_c();
 
     if !can_prompt_dialog() {
-        return Ok(false);
+        return Ok(Confirmation::Unavailable);
     }
 
     let mut skip_prompt = SKIP_PROMPT.lock().unwrap();
     if *skip_prompt {
-        return Ok(true);
+        return Ok(Confirmation::Yes);
     }
 
     let _progress_pause = MultiProgressReport::try_get().map(|report| report.pause_progress());
@@ -148,16 +181,19 @@ pub(crate) fn confirm_with_all<S: Into<String>>(message: S) -> eyre::Result<bool
         .run()
         .inspect_err(|_| restore_cursor())?;
 
-    let result = match answer.as_str() {
-        "Yes" => true,
-        "No" => false,
-        "All" => {
-            *skip_prompt = true;
-            true
-        }
-        _ => false,
-    };
-    Ok(result)
+    if answer == "All" {
+        *skip_prompt = true;
+    }
+    Ok(dialog_answer(&answer))
+}
+
+/// Maps a [`Dialog`] button label to an answer. "All" is a "yes" that also
+/// latches [`SKIP_PROMPT`]; the latching is the caller's job so this stays pure.
+fn dialog_answer(answer: &str) -> Confirmation {
+    match answer {
+        "Yes" | "All" => Confirmation::Yes,
+        _ => Confirmation::No,
+    }
 }
 
 #[cfg(test)]
@@ -186,15 +222,24 @@ mod tests {
 
     #[test]
     fn eof_is_not_consent() {
-        assert!(!parse_confirm_answer(None, true).unwrap());
-        assert!(!parse_confirm_answer(None, false).unwrap());
+        // The prompt was displayed and stdin ended without an answer. That has
+        // to read as a decline, whichever way the default points -- callers
+        // that act only on an explicit "no" must not take it as permission.
+        assert_eq!(parse_confirm_answer(None, true).unwrap(), Confirmation::No);
+        assert_eq!(parse_confirm_answer(None, false).unwrap(), Confirmation::No);
     }
 
     #[test]
     fn empty_line_takes_the_default() {
         for line in ["", "\n", "  \n"] {
-            assert!(parse_confirm_answer(Some(line), true).unwrap());
-            assert!(!parse_confirm_answer(Some(line), false).unwrap());
+            assert_eq!(
+                parse_confirm_answer(Some(line), true).unwrap(),
+                Confirmation::Yes
+            );
+            assert_eq!(
+                parse_confirm_answer(Some(line), false).unwrap(),
+                Confirmation::No
+            );
         }
     }
 
@@ -202,11 +247,26 @@ mod tests {
     fn explicit_answers_override_the_default() {
         // Any prefix of the label answers, as `demand`'s own non-tty branch did.
         for line in ["y\n", "Y", "ye", "yes", "YES\n"] {
-            assert!(parse_confirm_answer(Some(line), false).unwrap());
+            assert_eq!(
+                parse_confirm_answer(Some(line), false).unwrap(),
+                Confirmation::Yes
+            );
         }
         for line in ["n\n", "N", "no", "No\n"] {
-            assert!(!parse_confirm_answer(Some(line), true).unwrap());
+            assert_eq!(
+                parse_confirm_answer(Some(line), true).unwrap(),
+                Confirmation::No
+            );
         }
+    }
+
+    #[test]
+    fn all_answers_yes() {
+        assert_eq!(dialog_answer("Yes"), Confirmation::Yes);
+        assert_eq!(dialog_answer("All"), Confirmation::Yes);
+        assert_eq!(dialog_answer("No"), Confirmation::No);
+        // Escape and anything unrecognized decline rather than proceed.
+        assert_eq!(dialog_answer(""), Confirmation::No);
     }
 
     #[test]


### PR DESCRIPTION
#12268 has landed, so the stacked-diff caveat that was here no longer applies: this is now one commit rebased onto `main`, and the diff below is only the refactor. Still a draft — say the word and I'll flip it.

Follow-up you asked for in #12268:

> Two call sites independently deriving "could we have asked?" is the trap, and `trust_check` consulting `can_prompt_dialog()` a second time to decide whether to remember a "no" is the shape of the bug you just fixed. Make it unrepresentable rather than fixed — separate PR is fine.

## The change

`confirm`, `confirm_with_default`, and `confirm_with_all` now return `Confirmation { Yes, No, Unavailable }` instead of `bool`, and **`can_prompt_dialog` is private**. That second part is the point: there is no longer any way for a caller to re-derive "could we have asked?", so the class of bug #12268 fixed cannot be written again. `trust_check` matches on the three variants and records an ignore marker only for `No`.

`Unavailable` means the question was never put to anyone — nothing drawable on stderr, or usage/completion generation. An EOF on a redirected stdin stays a **decline**: the prompt was displayed and nothing came back, and a caller that only stops on an explicit "no" must not read silence as permission.

## No behavior changes

Every call site keeps the guard it already had and gains only the predicate the new type requires — `.is_yes()` throughout. That covers both families without changing either:

- **Fail-closed sites**, unguarded and refusing on a non-yes today: `install_into` (guards an `rm -rf`), `implode`, `prune`, the asdf/vfox community-plugin prompts, aube's typosquat warnings, the task `confirm =` field, and the two "make this executable?" prompts.
- **`console::user_attended_stderr()`-guarded sites**, the `system` and `dotfiles` apply/prune paths. The guard stays. It answers "should we offer a prompt at all", which is a policy decision, not the "how do I read this answer" derivation that was the trap — and it is load-bearing: it is what makes these paths proceed unattended, while `Unavailable` inside the guard (usage generation) and a stdin EOF both still stop them.

I did try dropping those guards and keying purely off the answer. It changes behavior in the unsafe direction in two cells — a redirected-stdin EOF and `__USAGE` with a terminal on stderr both stop these paths today, and would have started letting destructive `system` mutations through. Greptile caught the first; the second only shows up in the matrix. Not worth a fourth enum variant to model, so the guards stay.

The one message change: the task `confirm =` field now reports that nobody could be asked instead of "aborted by user", which was untrue in unattended CI.

## Tests

- Unit tests updated for the new return type. Added `dialog_answer` as a pure function so the Yes/No/All mapping (including "All" being a yes) is covered without a terminal.
- **New e2e for the declined path**, which was untested end to end: `e2e/config/test_trust_prompt_declined` answers the dialog with `n` over a pty (same keystroke-through-`script` pattern as `e2e/tasks/test_task_run_all_picker`), asserts the ignore marker **is** written, and asserts it suppresses the next prompt. With `test_trust_prompt_non_interactive` from #12268 that pins both directions — marker written for a decline, withheld when nobody could be asked — which is what the `match` has to preserve.

`cargo clippy --workspace --all-features --all-targets -- -D warnings` is clean with no lint exclusions added.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Confirmation prompts now distinguish approval, rejection, and unavailable responses.
  * Non-interactive commands fail clearly without hanging and suggest using `--yes` when confirmation is required.
  * Declined trust prompts are remembered, preventing repeated prompts.
  * Destructive and system-management operations now proceed only after explicit approval.
  * Dotfile changes detect a broader range of file and directory conflicts.
  * End-of-file input is handled as a declined confirmation.

* **Tests**
  * Added end-to-end coverage for declined trust prompts and non-interactive confirmation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
