### PR TITLE
chore: raise the crate recursion limit for nightly's trait solver

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,10 @@
 #![deny(dead_code_pub_in_binary, unreachable_pub)]
 // eyre 0.6.12 emits a trailing semicolon from bail!, which nightly rejects.
 #![allow(semicolon_in_expressions_from_macros)]
+// Boxing async fns into `Pin<Box<dyn Future>>` across the backend and core-plugin
+// traits overruns the default trait-solver depth on rustc 1.100 nightly, which is
+// slated to become a hard error (rust-lang/rust#159228).
+#![recursion_limit = "256"]
 
 use std::{
     panic,


### PR DESCRIPTION
The `nightly` job has been emitting 230 warnings since **rustc 1.100.0-nightly (c656540d6, 2026-08-21)**, all of one kind and all in this crate:

```
warning: overflow evaluating the requirement
  `Pin<Box<{async block@src/backend/aqua.rs:171}>>: CoerceUnsized<Pin<Box<dyn Future<…> + Send>>>`
    = help: consider increasing the recursion limit by adding a
            `#![recursion_limit = "256"]` attribute to your crate (`mise`)
    = warning: this was previously accepted by the compiler but is being phased out;
               it will become a hard error in a future release!
    = note: see rust-lang/rust#159228
```

From the job logs:

- All 230 belong to one cargo unit (`mise` bin). By location: 48 under `src/backend`, 46 under `src/plugins/core`, the rest across `src/cli`, `src/task`, `src/config`, `src/cache`. No workspace sub-crate is involved, so one crate-level attribute covers all of them.
- `recursion_limit` was not set anywhere in the repo.
- The immediately preceding nightly (`8925ea358`, 2026-08-20) emitted **zero** of these, so they arrived with the toolchain, not with a code change.

rustc names the fix in the diagnostic and says it becomes a hard error in a future release, so this is worth doing regardless of CI colour.

## Measured on this PR's CI: the warnings go, the failure does not

I had wondered whether these diagnostics were also what was killing the job. CI says no — worth recording so nobody re-tests it:

| | before | after |
|---|---|---|
| `overflow evaluating` warnings | 230 | **0** |
| total warnings | 230 | 1 |
| new `error[E…]` | 0 | 0 |
| job result | OOM (`signal 9`) | **still OOM** |

So the attribute does exactly what the diagnostic promised, and the OOM is independent of it. The remaining warning is `std::sync::atomic::Atomic::<u64>::fetch_update` at `crates/mise-cache-core/src/agent.rs:261`, renamed to `try_update`; that one has to wait, since `try_update` is nightly-only and the MSRV here is 1.93.

I'm leaving this at `256` rather than escalating — the warning count is already zero, so a larger limit would not buy anything.

**The `nightly` failure is separate and not specific to this PR.** It reproduces on the `release` branch and on several unrelated PRs, with the same `sccache: Compile terminated by signal 9` while compiling `mise (bin "mise" test)` under `--all-features`. (`main` itself I can't speak for: this workflow runs on pull requests to `main` and on pushes to `mise`/`release`/tags, not on pushes to `main`, and its last `nightly` run on `main` was 2026-08-19 — before the toolchain that introduced this.) That looks like plain memory pressure on the runner rather than anything in the source, so it likely needs a CI-side change — happy to look into it if you want, but it is out of scope for this PR.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the compiler’s recursion limit to improve build reliability for complex asynchronous code.
  * Added documentation explaining the related compilation constraint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

