### PR TITLE
fix(task): forward a file task's arguments through a -c shell

### DIFF
--- a/e2e-win/task_file_shell_command_mode.Tests.ps1
+++ b/e2e-win/task_file_shell_command_mode.Tests.ps1
@@ -1,0 +1,66 @@
+Describe 'file tasks whose shell is in -c mode' {
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        # Saved here, restored in AfterAll: Pester runs every suite in one process, so removing an
+        # inherited value would leave the next suite without it.
+        $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+        $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path (Join-Path $script:TestRoot "mise-tasks") | Out-Null
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:TestRoot
+        "[tools]" | Out-File -Encoding ascii (Join-Path $script:TestRoot "mise.toml")
+
+        function Write-Task {
+            param([string]$Name, [string]$Body)
+            $path = Join-Path $script:TestRoot "mise-tasks\$Name"
+            # LF, because this file's own line endings are CRLF and a stray `r would ride along
+            # into the script and reach bash as part of a command.
+            $lf = $Body -replace "`r`n", "`n"
+            [System.IO.File]::WriteAllText($path, $lf, (New-Object System.Text.UTF8Encoding $false))
+        }
+
+        # A file task hands its shell a script *path*. `bash -c` reads what follows as a command
+        # string, so here the path is the command -- and on Windows its backslashes are eaten as
+        # escapes before it is even looked up, leaving `command not found` and exit 127.
+        Write-Task -Name "bash_c" -Body @'
+#!/usr/bin/env bash
+#MISE shell="bash -c"
+printf 'bash -c: [%s] [%s]\n' "$1" "$2"
+'@
+
+        # Control: the same task without the override, taking its shell from the shebang. It has
+        # always worked, and pins that the fix left that shape alone.
+        Write-Task -Name "plain" -Body @'
+#!/usr/bin/env bash
+printf 'plain: [%s]\n' "$1"
+'@
+
+        Set-Location $script:TestRoot
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        if ($null -eq $script:OriginalTrusted) {
+            Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
+        } else {
+            [Environment]::SetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', $script:OriginalTrusted, 'Process')
+        }
+    }
+
+    It 'passes the task its arguments through a -c shell' {
+        $output = mise run bash_c ARG1 ARG2 2>&1 | Out-String
+        $output | Should -Match "bash -c: \[ARG1\] \[ARG2\]"
+    }
+
+    It 'does not mangle the script path on the way' {
+        # The failure this guards against ate every backslash out of the path, so the message named
+        # `C:UsersRunner...`. Asserted separately from the arguments because it is a different
+        # break with the same cause.
+        $output = mise run bash_c ARG1 ARG2 2>&1 | Out-String
+        $output | Should -Not -Match "command not found"
+    }
+
+    It 'still runs a task that takes its shell from the shebang' {
+        $output = mise run plain ARG1 | Out-String
+        $output | Should -Match "plain: \[ARG1\]"
+    }
+}

--- a/e2e/tasks/test_task_file_shell_command_mode
+++ b/e2e/tasks/test_task_file_shell_command_mode
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# A file task hands its shell a script *path*. A shell left in `-c` mode reads that path as a
+# command string instead, so the task's own arguments land on `$0` onward and never reach the
+# script.
+#
+# An executable file task is spawned directly here, so the file shell is only reached at all
+# with this setting -- without it the `shell` below is never consulted.
+export MISE_USE_FILE_SHELL_FOR_EXECUTABLE_TASKS=1
+
+cat <<'EOF' >mise.toml
+[tasks]
+EOF
+
+mkdir -p mise-tasks
+
+cat <<'EOF' >mise-tasks/sh_c
+#!/usr/bin/env bash
+#MISE shell="sh -c"
+printf 'sh -c: [%s] [%s]\n' "$1" "$2"
+EOF
+
+# fish is not POSIX here: it has no `$0`/`$@` and rejects `$@` outright, so it needs its own
+# payload. Covered because `is_posix_shell_program` counts it, which makes it easy to reach for
+# the wrong one.
+cat <<'EOF' >mise-tasks/fish_c
+#!/usr/bin/env bash
+#MISE shell="fish -c"
+printf 'fish -c: [%s]\n' "$1"
+EOF
+
+# Control: no `shell`, so this takes the default file shell -- `sh`, with no `-c` -- which has
+# always forwarded arguments. It pins the shape that already worked.
+cat <<'EOF' >mise-tasks/plain
+#!/usr/bin/env bash
+printf 'plain: [%s]\n' "$1"
+EOF
+
+# A guard rather than a reproduction: this one passes before the fix too. The shebang chooses the
+# interpreter, and it has to keep doing so. `${a[1]}` is a bash array, which the `sh` named as the
+# task's shell cannot parse -- so dropping the `-c` and handing the script to `sh` to *interpret*,
+# rather than keeping `-c` and having it *run* the script, would turn this into a syntax error.
+cat <<'EOF' >mise-tasks/shebang_wins
+#!/usr/bin/env bash
+#MISE shell="sh -c"
+a=(x y)
+printf 'shebang wins: %s\n' "${a[1]}"
+EOF
+
+chmod +x mise-tasks/sh_c mise-tasks/fish_c mise-tasks/plain mise-tasks/shebang_wins
+
+assert "mise run plain ARG1" "plain: [ARG1]"
+assert "mise run sh_c ARG1 ARG2" "sh -c: [ARG1] [ARG2]"
+assert "mise run shebang_wins" "shebang wins: y"
+assert "mise run fish_c ARG1" "fish -c: [ARG1]"

--- a/src/path.rs
+++ b/src/path.rs
@@ -228,11 +228,33 @@ pub(crate) fn program_stem(program: &Path) -> Option<String> {
 /// child's PATH before spawning.
 #[cfg_attr(not(windows), allow(dead_code))]
 pub(crate) fn is_posix_shell_program(program: &Path) -> bool {
-    const POSIX_SHELLS: &[&str] = &["bash", "sh", "zsh", "fish", "ksh", "dash"];
+    // `ash` is here because it is what `/bin/sh` is on Alpine, which mise ships musl builds
+    // for — a task written against it reaches this by name, not through the `sh` symlink.
+    const POSIX_SHELLS: &[&str] = &["bash", "sh", "zsh", "fish", "ksh", "dash", "ash"];
     let Some(stem) = program_stem(program) else {
         return false;
     };
     POSIX_SHELLS.iter().any(|name| *name == stem)
+}
+
+/// The `-c` payload that makes a shell *run* the path which follows it, treating the
+/// arguments after that as the script's own.
+///
+/// A file task hands its shell a script path, and a shell left in `-c` mode reads whatever
+/// follows as a command string instead. Without this in front of the path, the path *is* that
+/// string: the task's own arguments land on `$0` onward and never reach the script, and on
+/// Windows the backslashes are eaten as escapes before the path is even looked up.
+///
+/// `None` for the shells this does not apply to — `cmd`, whose `/c` already takes a program and
+/// forwards its arguments, and PowerShell, which has no `$0`/`$@` and already works.
+pub(crate) fn command_mode_script_payload(program: &Path) -> Option<&'static str> {
+    // fish counts as POSIX for [`is_posix_shell_program`]'s question (it wants a Unix-style
+    // PATH) but not for this one: it has no `$0`/`$@` and rejects `$@` outright. `$argv` is the
+    // whole argument list, and running it runs its first element with the rest as arguments.
+    if program_stem(program).as_deref() == Some("fish") {
+        return Some("$argv");
+    }
+    is_posix_shell_program(program).then_some(r#""$0" "$@""#)
 }
 
 /// Returns true if `program` is `cmd` / `cmd.exe`, the Windows command
@@ -994,6 +1016,7 @@ mod tests {
         assert!(is_posix_shell_program(Path::new("sh")));
         assert!(is_posix_shell_program(Path::new("zsh")));
         assert!(is_posix_shell_program(Path::new("fish")));
+        assert!(is_posix_shell_program(Path::new("ash")));
 
         assert!(!is_posix_shell_program(Path::new("cmd")));
         assert!(!is_posix_shell_program(Path::new("cmd.exe")));
@@ -1001,6 +1024,37 @@ mod tests {
         assert!(!is_posix_shell_program(Path::new("pwsh.exe")));
         assert!(!is_posix_shell_program(Path::new("rustc")));
         assert!(!is_posix_shell_program(Path::new("")));
+    }
+
+    #[test]
+    fn test_command_mode_script_payload() {
+        let payload = |p: &str| command_mode_script_payload(Path::new(p));
+
+        for posix in [
+            "bash",
+            "sh",
+            "zsh",
+            "ksh",
+            "dash",
+            // Alpine's `/bin/sh`. Measured in an alpine container: `ash -c <path> ARG1` drops
+            // the argument exactly as the others do, and the payload restores it.
+            "ash",
+            "/usr/bin/bash",
+            "BASH.EXE",
+        ] {
+            assert_eq!(payload(posix), Some(r#""$0" "$@""#), "{posix}");
+        }
+
+        // The whole reason this is not just `is_posix_shell_program`: fish answers true there
+        // and cannot use `$@`.
+        for fish in ["fish", "fish.exe", "/usr/bin/fish"] {
+            assert_eq!(payload(fish), Some("$argv"), "{fish}");
+        }
+
+        // cmd forwards arguments after `/c` already; PowerShell has no `$0`/`$@`.
+        for other in ["cmd", "cmd.exe", "pwsh", "powershell.exe", "rustc", ""] {
+            assert_eq!(payload(other), None, "{other}");
+        }
     }
 
     #[test]

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -1259,6 +1259,15 @@ impl TaskExecutor {
         let program = program.to_string();
         trace!("using shell: {}", shell.join(" "));
         let mut full_args = shell;
+        // What follows a `-c` is a command string, so the script path alone would *be* the
+        // command and the task's arguments would land on `$0` onward. The payload restores the
+        // shape the rest of this function assumes: a program, then its arguments. Only an exact
+        // `-c` is recognised — a combined `-ec` keeps the old behaviour rather than guessing.
+        if let Some(payload) = crate::path::command_mode_script_payload(Path::new(&program))
+            && let Some(i) = full_args.iter().position(|arg| arg == "-c")
+        {
+            full_args.insert(i + 1, payload.to_string());
+        }
         full_args.push(file.display().to_string());
         if !args.is_empty() {
             full_args.extend(args.iter().cloned());


### PR DESCRIPTION
## The bug

A file task hands its shell a script **path**. A shell left in `-c` mode reads what follows as a
**command string** instead, so the path becomes the command and the task's own arguments land on
`$0` onward — where the script never sees them.

```bash
# mise-tasks/args
#!/usr/bin/env bash
#MISE shell="sh -c"
printf 'got: [%s]\n' "$1"
```

```
$ mise run args ARG1
got: []
```

Exit 0. Nothing says an argument was dropped.

On Windows the same shape loses the path as well, because bash eats its backslashes as escapes
before looking it up:

```
$ mise run args ARG1
ARG1: line 1: C:UsersJamAppDataLocalTemp...mise-tasksargs: command not found
[args] ERROR task failed        (exit 127)
```

## Measured

All on 2026.8.10, with a path and arguments containing spaces as well:

| shell | today | with the fix |
| --- | --- | --- |
| `sh`, `dash`, `zsh` (Linux) | `ran: []` — argument dropped | ✅ `ran: [ARG1]` |
| `ash` (alpine container) | `ran: [] []` — arguments dropped | ✅ `ran: [ARG1] [ARG2]` |
| `bash` (Git Bash, Windows) | exit 127, path mangled | ✅ `ran: [ARG1]` |
| `fish` | `ran: []` — argument dropped | ✅ `ran: [ARG1]`, via `$argv` |
| `sh` with no `-c` (the unix default) | ✅ already correct | unchanged |
| `cmd /c` (the Windows default) | ✅ already correct | unchanged |
| `pwsh -c` | ✅ already correct | unchanged |

`ksh` was not measured — it is not installed here. `"$0" "$@"` is POSIX, so it should behave as
the others do, but I have not run it.

**The defaults are what say this is a contract rather than a preference.**
`unix_default_file_shell_args` is a bare **`sh`**, described as *"For example, `sh` for sh."* — a
program that takes a script path and its arguments. `cmd /c` is not a counter-example: `/c` is
cmd's only way to start anything, and it forwards arguments correctly.

## Why a payload rather than dropping the `-c`

Dropping the flag — `sh <path> <args>` — was measured and **rejected**. It makes the named shell
*interpret* the script instead of running it, so the shebang stops choosing the interpreter:

```
sh -c <path>                  → bash-array ok: y []      shebang honoured, argument lost
sh -c '"$0" "$@"' <path> ARG1 → bash-array ok: y [ARG1]  shebang honoured, argument kept
sh <path> ARG1                → Syntax error: "(" unexpected
```

The third line is a bash array being fed to `sh`. So the fix restores the arguments and changes
nothing else — same interpreter, same working directory.

## fish

fish answers **true** to `is_posix_shell_program`, which asks a different question (does it want a
Unix-style `PATH`). For this one it is not POSIX:

```
$ fish -c '"$0" "$@"' <path> ARG1
fish: $@ is not supported. In fish, please use $argv.
```

It gets `$argv` instead — the whole argument list, whose first element is run as the command with
the rest as its arguments. Measured on fish 3.7.0, including the no-extra-arguments case.

## Changes

- `src/path.rs` — `ash` joins `is_posix_shell_program`'s list (it is Alpine's `/bin/sh`, and a task
  naming it directly never reaches the list through the `sh` symlink), and
  `command_mode_script_payload`, the one place that knows which payload a shell
  needs. Built on the existing `program_stem` and `is_posix_shell_program` rather than a second
  list of shell names, with fish branching first.
- `src/task/task_executor.rs` — insert that payload immediately after the `-c` when assembling a
  file task's command line. Only an exact `-c` is recognised; a combined `-ec` keeps today's
  behaviour rather than being guessed at.

Inline tasks go through `get_cmd_program_and_args` and are untouched — including
`e2e/tasks/test_task_config_shell`, whose `shell = '"…/wrapper" -c'` is an inline shell.

## Test

Both suites were run against the **unfixed** 2026.8.10 first.

Linux, through `e2e/run_test`:

```
SUCCESS: [mise run plain ARG1] output is equal to 'plain: [ARG1]'
ERROR: E2E assertion failed: [mise run sh_c ARG1 ARG2]
       expected 'sh -c: [ARG1] [ARG2]' but got 'sh -c: [] []'
```

Windows, through Pester:

```
  [-] passes the task its arguments through a -c shell
  [-] does not mangle the script path on the way
      ARG1: line 1: C:UsersJamAppDataLocalTempPester_...mise-tasksbash_c: command not found
  [+] still runs a task that takes its shell from the shebang
Tests Passed: 1, Failed: 2
```

One assertion in the Linux test is a **guard, not a reproduction**, and is labelled as such: the
bash-array case passes before and after, and exists so that forcing the script through `sh` would
be caught.

## Rebased onto #12274

#12274 landed first and changed the signature of the same function, so this branch has been
rebased onto it. The conflict was in the argument assembly of `get_file_program_and_args`;
resolved by keeping #12274's shape (the shell arrives already resolved) and inserting the payload
into it.

The two changes stay independent: `command_mode_script_payload` returns `None` for PowerShell, so
nothing here touches the `.ps1` staging #12274 added, and nothing there reaches a POSIX shell.

**I have not built this locally**: `cargo check` cannot run on this machine (`libz-ng-sys` needs
`cmake`, which is not installed), so the type check and the post-fix behaviour are for CI.
Everything reported above as measured was measured against released binaries and the shells
themselves, not against a build of this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - File-based tasks now support shell command mode with Bash, Fish, POSIX shells, and Alpine’s `ash`.
  - Task arguments are forwarded correctly, while script paths and shebang-selected interpreters are preserved.
  - Extensionless Windows scripts can execute through PowerShell.

- **Bug Fixes**
  - Improved handling of exact `-c` options and combined shell flags.
  - Added safeguards to avoid unsupported interpreters during shell command execution.
  - Expanded end-to-end coverage for shell selection, argument forwarding, and shebang execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->