### PR TITLE
docs(env): fix cacheable source example

### DIFF
--- a/docs/cache-behavior.md
+++ b/docs/cache-behavior.md
@@ -57,7 +57,7 @@ Directives can opt out of caching by setting `cacheable = false`:
 ```toml
 [env]
 TIMESTAMP = { value = "{{ now() }}", cacheable = false }
-_.source = { file = "dynamic.sh", cacheable = false }
+_.source = { path = "dynamic.sh", cacheable = false }
 ```
 
 ## Cache auto-pruning


### PR DESCRIPTION
## Summary

- correct the cacheable `_.source` example to use the supported `path` field
- keep the example aligned with the current environment directive schema

## Problem

The cache behavior documentation used `file` inside `_.source`, but the source directive accepts `path`. Copying the documented example therefore fails configuration deserialization instead of sourcing `dynamic.sh`.

## Verification

- `mise exec -- prettier --check docs/cache-behavior.md` — passed
- `mise run docs:build` — blocked by an unrelated existing Vue compiler failure in `docs/cli/tool-alias/set.md`: `decode.fromCodePoint is not a function`
- `mise run lint` — blocked locally because hk could not detect the Git repository in this Sapling checkout

Addresses https://github.com/jdx/mise/discussions/8735

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `_.source` directive example to use the `path` attribute.
  * Clarified that `cacheable = false` remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->