### PR TITLE
Add cloc to the registry using the GitHub backend

### DIFF
--- a/registry/cloc.toml
+++ b/registry/cloc.toml
@@ -1,0 +1,26 @@
+description = "Count Lines of Code"
+test = { cmd = "cloc --version", expected = "{{version}}" }
+version_order = "semver"
+
+bins = ["cloc"]
+
+[[backends]]
+full = "github:AlDanial/cloc"
+
+[backends.options]
+bin = "cloc"
+
+[backends.options.platforms.linux-x64]
+asset_pattern = "cloc-{{ version }}.pl"
+
+[backends.options.platforms.linux-arm64]
+asset_pattern = "cloc-{{ version }}.pl"
+
+[backends.options.platforms.macos-x64]
+asset_pattern = "cloc-{{ version }}.pl"
+
+[backends.options.platforms.macos-arm64]
+asset_pattern = "cloc-{{ version }}.pl"
+
+[backends.options.platforms.windows-x64]
+asset_pattern = "cloc-{{ version }}.exe"

--- a/registry/cloc.toml
+++ b/registry/cloc.toml
@@ -9,6 +9,7 @@ full = "github:AlDanial/cloc"
 
 [backends.options]
 bin = "cloc"
+depends = ["perl"]
 
 [backends.options.platforms.linux-x64]
 asset_pattern = "cloc-{{ version }}.pl"


### PR DESCRIPTION
cloc publishes a portable Perl script for Unix-like platforms and a Windows .exe release asset. The backend uses platform-specific asset patterns to select the correct release asset and exposes it as the cloc binary.

Repository popularity:
- GitHub stars: 23,458

https://github.com/AlDanial/cloc/releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added registry support for the `cloc` tool.
  * Added semantic version ordering and version verification.
  * Added platform-specific executable detection for Linux, macOS, and Windows.
  * Added support for retrieving `cloc` releases and selecting compatible versions across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->