### PR TITLE
feat(bootstrap): install mise on remote targets

### DIFF
--- a/docs/bootstrap/remote.md
+++ b/docs/bootstrap/remote.md
@@ -232,11 +232,9 @@ staged — the local binary or the checksum-verified official release artifact �
 and it is what runs the bootstrap, so the host converges with the mise version
 that orchestrated it. Mise writes a temporary file beside the target and renames
 it into place, so replacing a mise that is currently running cannot truncate it.
-When the target already holds a byte-identical executable, nothing is uploaded,
-and after an install mise checks the target's digest before running it, so a
-path another account can write cannot silently substitute the executable. A dry
-run never writes to the host: `--dry-run` reports the path it would install to
-and stages the executable as usual.
+When the target already holds a byte-identical executable, nothing is uploaded.
+A dry run never writes to the host: `--dry-run` reports the path it would
+install to and stages the executable as usual.
 
 `install_mise` composes with `mise_bin`, which installs a locally built
 executable. It cannot be combined with `remote_mise` or `bootstrap_command`,
@@ -246,7 +244,15 @@ right choice when the host should own the install through a system package,
 
 The SSH user must be able to write the install path; mise does not elevate for
 it, so a path such as `/usr/local/bin/mise` needs a user who already owns that
-directory.
+directory. Keep that directory writable only by that user. After installing,
+mise compares the target's digest with what it wrote and fails rather than
+running something else, but that check is best-effort — it is skipped when the
+host provides neither `sha256sum` nor `shasum`, and it cannot cover the window
+between the check and the run. Anyone who can write the install directory
+controls what that account runs as `mise` on every later invocation regardless,
+so the directory's permissions are the real boundary. The staging directory used
+without `install_mise` is created by `mktemp -d` and is private to the SSH
+account.
 
 Installing mise does not put it on the host's `PATH`. Mise warns when the
 install directory is missing from the login `PATH`, and the bootstrap project

--- a/docs/bootstrap/remote.md
+++ b/docs/bootstrap/remote.md
@@ -85,7 +85,8 @@ For each target, mise:
 2. creates a validated `/tmp/mise-bootstrap.*` directory;
 3. archives the source directory locally and extracts it into the staging
    directory;
-4. provisions the exact mise executable used for the remote run;
+4. provisions the exact mise executable used for the remote run, staging it
+   unless `install_mise` keeps it on the host;
 5. executes `mise bootstrap` in the staged project; and
 6. removes the staging directory, including after a failed bootstrap.
 
@@ -191,6 +192,61 @@ bootstrap_command = "nix profile install nixpkgs#mise"
 
 Mise verifies every uploaded or selected remote command by running
 `mise version` before bootstrap.
+
+### Leaving mise installed on the host
+
+By default the provisioned executable lives in the staging directory and is
+removed with it, so a target keeps the tools installed under
+`~/.local/share/mise` but not the mise that installed them. Set `install_mise`
+to keep mise on the machine:
+
+```toml
+[bootstrap.remote]
+install_mise = true
+
+[bootstrap.remote.hosts.cache]
+host = "cache.example.com"
+install_mise = "/usr/local/bin/mise"
+```
+
+`true` installs to `~/.local/bin/mise`, the same path used by
+[mise.run](https://mise.run). A string installs to that path instead; it must be
+absolute or start with `~/`, and it names the executable rather than a directory.
+A host-level value replaces `[bootstrap.remote].install_mise`, so
+`install_mise = false` opts one host out of a project-wide default.
+
+```sh
+mise bootstrap remote cache --install-mise
+mise bootstrap remote cache --install-mise=/usr/local/bin/mise
+mise bootstrap remote cache --no-install-mise
+```
+
+`--install-mise` requires `=` before a path so that a bare flag cannot consume a
+target name.
+
+What gets installed is the same executable the default strategy would have
+staged — the local binary or the checksum-verified official release artifact —
+and it is what runs the bootstrap, so the host converges with the mise version
+that orchestrated it. Mise writes a temporary file beside the target and renames
+it into place, so replacing a mise that is currently running cannot truncate it.
+When the target already holds a byte-identical executable, nothing is uploaded.
+A dry run never writes to the host: `--dry-run` reports the path it would
+install to and stages the executable as usual.
+
+`install_mise` composes with `mise_bin`, which installs a locally built
+executable. It cannot be combined with `remote_mise` or `bootstrap_command`,
+because both already provide mise on the host. `bootstrap_command` remains the
+right choice when the host should own the install through a system package,
+`nix profile install`, or a site-specific installer.
+
+The SSH user must be able to write the install path; mise does not elevate for
+it, so a path such as `/usr/local/bin/mise` needs a user who already owns that
+directory.
+
+Installing mise does not put it on the host's `PATH`. Mise warns when the
+install directory is missing from the login `PATH`, and the bootstrap project
+can declare [`[bootstrap.mise_shell_activate]`](/bootstrap/shell.html) so the
+same run writes activation or shims into the host's shell startup files.
 
 ## Bootstrap controls and secrets
 

--- a/docs/bootstrap/remote.md
+++ b/docs/bootstrap/remote.md
@@ -211,7 +211,9 @@ install_mise = "/usr/local/bin/mise"
 
 `true` installs to `~/.local/bin/mise`, the same path used by
 [mise.run](https://mise.run). A string installs to that path instead; it must be
-absolute or start with `~/`, and it names the executable rather than a directory.
+absolute or start with `~/`, and it names the executable rather than a directory
+— a path that already holds a directory is rejected instead of receiving the
+executable as a child entry.
 A host-level value replaces `[bootstrap.remote].install_mise`, so
 `install_mise = false` opts one host out of a project-wide default.
 
@@ -222,7 +224,8 @@ mise bootstrap remote cache --no-install-mise
 ```
 
 `--install-mise` requires `=` before a path so that a bare flag cannot consume a
-target name.
+target name. Like the other command-line provisioning options, it replaces a
+`remote_mise` or `bootstrap_command` declared by a selected inventory host.
 
 What gets installed is the same executable the default strategy would have
 staged — the local binary or the checksum-verified official release artifact —

--- a/docs/bootstrap/remote.md
+++ b/docs/bootstrap/remote.md
@@ -232,9 +232,11 @@ staged â€” the local binary or the checksum-verified official release artifact â
 and it is what runs the bootstrap, so the host converges with the mise version
 that orchestrated it. Mise writes a temporary file beside the target and renames
 it into place, so replacing a mise that is currently running cannot truncate it.
-When the target already holds a byte-identical executable, nothing is uploaded.
-A dry run never writes to the host: `--dry-run` reports the path it would
-install to and stages the executable as usual.
+When the target already holds a byte-identical executable, nothing is uploaded,
+and after an install mise checks the target's digest before running it, so a
+path another account can write cannot silently substitute the executable. A dry
+run never writes to the host: `--dry-run` reports the path it would install to
+and stages the executable as usual.
 
 `install_mise` composes with `mise_bin`, which installs a locally built
 executable. It cannot be combined with `remote_mise` or `bootstrap_command`,

--- a/docs/cli/bootstrap/remote.md
+++ b/docs/cli/bootstrap/remote.md
@@ -61,6 +61,12 @@ SSH identity file override
 
 Print the remote bootstrap changes without applying them
 
+### `--install-mise <PATH>`
+
+Install the provisioned mise on each host instead of only staging it
+
+Defaults to `~/.local/bin/mise`; pass `--install-mise=<PATH>` for another path.
+
 ### `--keep-staging`
 
 Keep the remote staging directory for debugging
@@ -68,6 +74,10 @@ Keep the remote staging directory for debugging
 ### `--mise-bin <MISE_BIN>`
 
 Local mise binary to upload (escape hatch for custom architectures)
+
+### `--no-install-mise`
+
+Do not install mise on the host, even when the selected hosts configure it
 
 ### `--only… <ONLY>`
 

--- a/e2e/cli/test_bootstrap_remote
+++ b/e2e/cli/test_bootstrap_remote
@@ -249,6 +249,50 @@ assert_fail "mise bootstrap remote cross --dry-run --yes --skip tools"
 assert_contains "cat $ssh_log" "uname -s"
 assert_fail "test -d $remote_stage"
 
+# install_mise keeps the provisioned executable after the staging directory is
+# removed. The target lives outside the archived source so the installed binary
+# is not sent back to the host on the next run.
+install_target="$HOME/installed bin/mise"
+
+: >"$ssh_log"
+assert_contains \
+  "mise bootstrap remote --host install.test --source . --mise-bin bin/mise --install-mise='$install_target' --dry-run --yes 2>&1" \
+  "would install mise to $install_target"
+assert_fail "test -e '$install_target'"
+
+: >"$ssh_log"
+assert_succeed "mise bootstrap remote --host install.test --source . --mise-bin bin/mise --install-mise='$install_target' --yes --skip tools"
+assert_succeed "test -x '$install_target'"
+assert_succeed "'$install_target' version"
+assert_contains "cat $ssh_log" "mise-install"
+assert_contains "cat $ssh_log" "'$install_target' --cd"
+assert_fail "test -d $remote_stage"
+
+: >"$ssh_log"
+assert_succeed "mise bootstrap remote --host install.test --source . --mise-bin bin/mise --install-mise='$install_target' --yes --skip tools"
+assert_not_contains "cat $ssh_log" "mise-install"
+assert_contains "cat $ssh_log" "'$install_target' --cd"
+
+assert_fail "mise bootstrap remote --host install.test --source . --mise-bin bin/mise --install-mise=relative/mise --yes"
+assert_fail "mise bootstrap remote --host install.test --source . --install-mise --remote-mise mise --yes"
+
+cat >>mise.toml <<'EOF'
+
+[bootstrap.remote.hosts.self-install]
+host = "self-install.test"
+install_mise = true
+mise_bin = "bin/mise"
+EOF
+
+: >"$ssh_log"
+assert_succeed "mise bootstrap remote self-install --yes --skip tools"
+assert_succeed "cmp -s bin/mise $HOME/.local/bin/mise"
+assert_contains "cat $ssh_log" "$HOME/.local/bin/mise --cd"
+
+: >"$ssh_log"
+assert_succeed "mise bootstrap remote self-install --no-install-mise --dry-run --yes"
+assert_contains "cat $ssh_log" "$remote_stage/mise version"
+
 cat >>"$HOME/.config/mise/config.toml" <<'EOF'
 
 [bootstrap.remote.hosts.stale]

--- a/e2e/cli/test_bootstrap_remote
+++ b/e2e/cli/test_bootstrap_remote
@@ -78,11 +78,14 @@ chmod +x fakebin/uname
 
 cat >fakebin/mktemp <<'EOF'
 #!/bin/sh
-# only the staging directory is faked; every other caller gets the real mktemp
-if test "${1:-}" != -d; then
+# only the bootstrap staging directory is faked; other callers get real mktemp
+case "${2:-}" in
+/tmp/mise-bootstrap.*) ;;
+*)
   PATH=/usr/bin:/bin command mktemp "$@"
   exit $?
-fi
+  ;;
+esac
 if test "${MISE_TEST_BAD_STAGE:-}" = 1; then
   mkdir -p "$BAD_REMOTE_STAGE"
   printf '%s\n' "$BAD_REMOTE_STAGE"

--- a/e2e/cli/test_bootstrap_remote
+++ b/e2e/cli/test_bootstrap_remote
@@ -78,6 +78,11 @@ chmod +x fakebin/uname
 
 cat >fakebin/mktemp <<'EOF'
 #!/bin/sh
+# only the staging directory is faked; every other caller gets the real mktemp
+if test "${1:-}" != -d; then
+  PATH=/usr/bin:/bin command mktemp "$@"
+  exit $?
+fi
 if test "${MISE_TEST_BAD_STAGE:-}" = 1; then
   mkdir -p "$BAD_REMOTE_STAGE"
   printf '%s\n' "$BAD_REMOTE_STAGE"
@@ -275,6 +280,13 @@ assert_contains "cat $ssh_log" "'$install_target' --cd"
 
 assert_fail "mise bootstrap remote --host install.test --source . --mise-bin bin/mise --install-mise=relative/mise --yes"
 assert_fail "mise bootstrap remote --host install.test --source . --install-mise --remote-mise mise --yes"
+assert_fail "mise bootstrap remote --host install.test --source . --mise-bin bin/mise --install-mise='$HOME/installed bin' --yes --skip tools"
+
+# a command-line install replaces the strategy the inventory host declared
+: >"$ssh_log"
+assert_contains \
+  "mise bootstrap remote cache --mise-bin bin/mise --install-mise='$install_target' --dry-run --yes --skip tools 2>&1" \
+  "would install mise to $install_target"
 
 cat >>mise.toml <<'EOF'
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1612,11 +1612,19 @@ SSH identity file override
 \fB\-n, \-\-dry\-run\fR
 Print the remote bootstrap changes without applying them
 .TP
+\fB\-\-install\-mise\fR \fI<PATH>\fR
+Install the provisioned mise on each host instead of only staging it
+
+Defaults to `~/.local/bin/mise`; pass `\-\-install\-mise=<PATH>` for another path.
+.TP
 \fB\-\-keep\-staging\fR
 Keep the remote staging directory for debugging
 .TP
 \fB\-\-mise\-bin\fR \fI<MISE_BIN>\fR
 Local mise binary to upload (escape hatch for custom architectures)
+.TP
+\fB\-\-no\-install\-mise\fR
+Do not install mise on the host, even when the selected hosts configure it
 .TP
 \fB\-\-only\fR \fI<ONLY>\fR
 Run only one or more remote bootstrap parts

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -854,10 +854,19 @@ Examples:
             arg <IDENTITY_FILE>
         }
         flag "-n --dry-run" help="Print the remote bootstrap changes without applying them"
+        flag --install-mise help="Install the provisioned mise on each host instead of only staging it" {
+            long_help #"""
+Install the provisioned mise on each host instead of only staging it
+
+Defaults to `~/.local/bin/mise`; pass `--install-mise=<PATH>` for another path.
+"""#
+            arg <PATH>
+        }
         flag --keep-staging help="Keep the remote staging directory for debugging"
         flag --mise-bin help="Local mise binary to upload (escape hatch for custom architectures)" {
             arg <MISE_BIN>
         }
+        flag --no-install-mise help="Do not install mise on the host, even when the selected hosts configure it"
         flag --only help="Run only one or more remote bootstrap parts" var=#true {
             arg <ONLY> {
                 choices plugins packages accounts files services firewall compose repos dotfiles mise-shell-activate shell macos-defaults defaults macos-launchd-agents launchd linux-systemd-units systemd user tools task final-hook

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -3525,6 +3525,18 @@
           "additionalProperties": false
         }
       ]
+    },
+    "bootstrap_remote_install_mise": {
+      "oneOf": [
+        {
+          "type": "boolean",
+          "description": "install the provisioned mise to ~/.local/bin/mise, or do not install it"
+        },
+        {
+          "type": "string",
+          "description": "absolute or ~/-relative remote path to install the provisioned mise to"
+        }
+      ]
     }
   },
   "unevaluatedProperties": false,
@@ -3905,6 +3917,10 @@
                 "type": "string"
               }
             },
+            "install_mise": {
+              "$ref": "#/$defs/bootstrap_remote_install_mise",
+              "description": "install the provisioned mise on inventory hosts instead of only staging it"
+            },
             "copy_links": {
               "type": "boolean",
               "description": "dereference every symbolic link in the source archive"
@@ -3990,6 +4006,10 @@
                     "items": {
                       "type": "string"
                     }
+                  },
+                  "install_mise": {
+                    "$ref": "#/$defs/bootstrap_remote_install_mise",
+                    "description": "install the provisioned mise on this host instead of only staging it"
                   },
                   "mise_bin": {
                     "type": "string",

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -652,7 +652,7 @@ struct BootstrapRemote {
         value_name = "PATH",
         num_args = 0..=1,
         require_equals = true,
-        default_missing_value = "~/.local/bin/mise",
+        default_missing_value = system::remote::DEFAULT_INSTALL_MISE_PATH,
         conflicts_with_all = ["remote_mise", "bootstrap_command", "no_install_mise"]
     )]
     install_mise: Option<String>,

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -603,7 +603,7 @@ struct BootstrapRemote {
     #[clap(
         long,
         value_name = "COMMAND",
-        conflicts_with_all = ["mise_bin", "remote_mise"]
+        conflicts_with_all = ["mise_bin", "remote_mise", "install_mise"]
     )]
     bootstrap_command: Option<String>,
 
@@ -643,6 +643,20 @@ struct BootstrapRemote {
     #[clap(long, short = 'n')]
     dry_run: bool,
 
+    /// Install the provisioned mise on each host instead of only staging it
+    ///
+    /// Defaults to `~/.local/bin/mise`; pass `--install-mise=<PATH>` for another
+    /// path.
+    #[clap(
+        long,
+        value_name = "PATH",
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "~/.local/bin/mise",
+        conflicts_with_all = ["remote_mise", "bootstrap_command", "no_install_mise"]
+    )]
+    install_mise: Option<String>,
+
     /// Keep the remote staging directory for debugging
     #[clap(long)]
     keep_staging: bool,
@@ -654,6 +668,10 @@ struct BootstrapRemote {
         conflicts_with_all = ["remote_mise", "bootstrap_command"]
     )]
     mise_bin: Option<std::path::PathBuf>,
+
+    /// Do not install mise on the host, even when the selected hosts configure it
+    #[clap(long)]
+    no_install_mise: bool,
 
     /// Run only one or more remote bootstrap parts
     #[clap(long, value_enum, value_delimiter = ',', conflicts_with = "skip")]
@@ -675,7 +693,7 @@ struct BootstrapRemote {
     #[clap(
         long,
         value_name = "COMMAND",
-        conflicts_with_all = ["mise_bin", "bootstrap_command"]
+        conflicts_with_all = ["mise_bin", "bootstrap_command", "install_mise"]
     )]
     remote_mise: Option<String>,
 
@@ -2380,6 +2398,8 @@ impl BootstrapRemote {
             identity_file: self.identity_file,
             exclude: self.exclude,
             ssh_options: self.ssh_option,
+            install_mise: self.install_mise,
+            no_install_mise: self.no_install_mise,
             mise_bin: self.mise_bin,
             remote_mise: self.remote_mise,
             bootstrap_command: self.bootstrap_command,

--- a/src/system/remote.rs
+++ b/src/system/remote.rs
@@ -14,7 +14,7 @@ use crate::ui::multi_progress_report::MultiProgressReport;
 const RELEASE_BASE_URL: &str = "https://github.com/jdx/mise/releases/download";
 /// Where `install_mise = true` puts the executable. This matches the default
 /// used by <https://mise.run> and is already searched by remote mise discovery.
-const DEFAULT_INSTALL_MISE_PATH: &str = "~/.local/bin/mise";
+pub(crate) const DEFAULT_INSTALL_MISE_PATH: &str = "~/.local/bin/mise";
 
 #[derive(Clone, Debug, Default, Deserialize)]
 pub(crate) struct RemoteTomlConfig {
@@ -292,6 +292,10 @@ impl RemoteHost {
             }
         }
         if let Some(install_mise) = &overrides.install_mise {
+            // Both of these provide their own mise, so an explicit install
+            // replaces them the same way a command-line strategy would.
+            self.remote_mise = None;
+            self.bootstrap_command = None;
             self.install_mise = Some(install_mise.clone());
         } else if overrides.no_install_mise {
             self.install_mise = None;
@@ -778,13 +782,20 @@ fn install_remote_mise(session: &SshSession<'_>, binary: &Path, target: &str) ->
 }
 
 /// Writes beside the target and renames, so a replaced executable is never
-/// truncated in place and a busy binary cannot fail with ETXTBSY.
+/// truncated in place and a busy binary cannot fail with ETXTBSY. `mktemp`
+/// creates that file exclusively, so a symbolic link planted in a shared
+/// writable install directory cannot capture the write.
 fn install_mise_script(target: &str) -> String {
     format!(
         r#"set -eu
 target={}
-mkdir -p {}
-temporary="$target.mise-install.$$"
+directory={}
+mkdir -p "$directory"
+if [ -d "$target" ]; then
+  printf 'mise install path is a directory: %s\n' "$target" >&2
+  exit 1
+fi
+temporary=$(mktemp "$directory/.mise-install.XXXXXXXXXX")
 trap 'rm -f "$temporary"' EXIT
 cat > "$temporary"
 chmod 755 "$temporary"
@@ -2176,13 +2187,35 @@ mod tests {
         .unwrap();
         assert!(host.install_mise.is_none());
         assert_eq!(host.remote_mise.as_deref(), Some("mise"));
+
+        host.apply_overrides(&RemoteOverrides {
+            install_mise: Some(DEFAULT_INSTALL_MISE_PATH.to_string()),
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(
+            host.install_mise.as_deref(),
+            Some(DEFAULT_INSTALL_MISE_PATH)
+        );
+        assert!(host.remote_mise.is_none());
+
+        host.bootstrap_command = Some("curl https://mise.run | sh".to_string());
+        host.install_mise = None;
+        host.apply_overrides(&RemoteOverrides {
+            install_mise: Some(DEFAULT_INSTALL_MISE_PATH.to_string()),
+            ..Default::default()
+        })
+        .unwrap();
+        assert!(host.bootstrap_command.is_none());
     }
 
     #[test]
     fn install_script_quotes_the_target_and_renames_into_place() {
         let script = install_mise_script("/home/deploy dir/.local/bin/mise");
         assert!(script.contains("target='/home/deploy dir/.local/bin/mise'"));
-        assert!(script.contains("mkdir -p '/home/deploy dir/.local/bin'"));
+        assert!(script.contains("directory='/home/deploy dir/.local/bin'"));
+        assert!(script.contains(r#"temporary=$(mktemp "$directory/.mise-install.XXXXXXXXXX")"#));
+        assert!(script.contains(r#"if [ -d "$target" ]; then"#));
         assert_eq!(remote_parent_directory("/mise"), "/");
         assert!(script.contains(r#"mv -f "$temporary" "$target""#));
     }

--- a/src/system/remote.rs
+++ b/src/system/remote.rs
@@ -779,13 +779,16 @@ fn install_remote_mise(session: &SshSession<'_>, binary: &Path, target: &str) ->
     session.status_with_stdin(&["sh", "-c", &install_mise_script(target)], file)?;
     // An install path can be writable by more than the SSH account, so confirm
     // the executable about to run is the one that was just written.
-    if let Some(installed) = remote_executable_sha256(session, target)?
-        && installed != expected
-    {
-        bail!(
+    match remote_executable_sha256(session, target)? {
+        Some(installed) if installed != expected => bail!(
             "{target} on '{}' changed after it was installed; another writer owns that path",
             session.host.name
-        );
+        ),
+        Some(_) => {}
+        None => warn!(
+            "cannot verify the mise installed at {target} on {}; the host returned no SHA-256 digest",
+            session.host.name
+        ),
     }
     info!("installed mise to {target} on {}", session.host.name);
     Ok(())

--- a/src/system/remote.rs
+++ b/src/system/remote.rs
@@ -766,8 +766,11 @@ fn resolve_remote_install_path(session: &SshSession<'_>, path: &str) -> Result<S
 /// Installs the provisioned executable at a persistent remote path so the host
 /// keeps a usable mise once the staging directory is removed.
 fn install_remote_mise(session: &SshSession<'_>, binary: &Path, target: &str) -> Result<()> {
-    let local = crate::hash::file_hash_sha256(binary, None)?;
-    if remote_executable_sha256(session, target)?.is_some_and(|remote| remote == local) {
+    // The remote digest comes first so a first install does not hash the local
+    // executable for nothing.
+    if let Some(installed) = remote_executable_sha256(session, target)?
+        && installed == crate::hash::file_hash_sha256(binary, None)?
+    {
         info!(
             "mise is already installed at {target} on {}",
             session.host.name
@@ -784,7 +787,10 @@ fn install_remote_mise(session: &SshSession<'_>, binary: &Path, target: &str) ->
 /// Writes beside the target and renames, so a replaced executable is never
 /// truncated in place and a busy binary cannot fail with ETXTBSY. `mktemp`
 /// creates that file exclusively, so a symbolic link planted in a shared
-/// writable install directory cannot capture the write.
+/// writable install directory cannot capture the write. A directory at the
+/// target is refused before the rename, and again after it in case one appears
+/// in between — `mv` would otherwise move the executable inside it and report
+/// success.
 fn install_mise_script(target: &str) -> String {
     format!(
         r#"set -eu
@@ -799,7 +805,12 @@ temporary=$(mktemp "$directory/.mise-install.XXXXXXXXXX")
 trap 'rm -f "$temporary"' EXIT
 cat > "$temporary"
 chmod 755 "$temporary"
-mv -f "$temporary" "$target""#,
+mv -f "$temporary" "$target"
+if [ ! -f "$target" ]; then
+  rm -f "$target/${{temporary##*/}}"
+  printf 'mise install path is not a regular file: %s\n' "$target" >&2
+  exit 1
+fi"#,
         shell_quote(target),
         shell_quote(remote_parent_directory(target)),
     )
@@ -2207,6 +2218,56 @@ mod tests {
         })
         .unwrap();
         assert!(host.bootstrap_command.is_none());
+    }
+
+    /// Runs the real script rather than asserting on its text, so the install,
+    /// replace, and refuse-a-directory paths are covered end to end.
+    #[test]
+    #[cfg(unix)]
+    fn install_script_installs_replaces_and_refuses_a_directory() -> Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir()?;
+        let directory = temp.path().join("bin");
+        let target = directory.join("mise");
+        let payload = temp.path().join("payload");
+        let install = |target: &Path, contents: &str| -> Result<Output> {
+            fs::write(&payload, contents)?;
+            Ok(Command::new("sh")
+                .arg("-c")
+                .arg(install_mise_script(
+                    target.to_str().expect("a utf-8 temporary path"),
+                ))
+                .stdin(Stdio::from(File::open(&payload)?))
+                .output()?)
+        };
+
+        // `sh -n` parses every branch, including the post-rename guard that a
+        // deterministic test cannot reach.
+        let script = install_mise_script(target.to_str().expect("a utf-8 temporary path"));
+        assert!(
+            Command::new("sh")
+                .args(["-n", "-c", &script])
+                .output()?
+                .status
+                .success()
+        );
+
+        assert!(install(&target, "first")?.status.success());
+        assert_eq!(fs::read_to_string(&target)?, "first");
+        assert_eq!(fs::metadata(&target)?.permissions().mode() & 0o777, 0o755);
+
+        assert!(install(&target, "second")?.status.success());
+        assert_eq!(fs::read_to_string(&target)?, "second");
+        assert_eq!(fs::read_dir(&directory)?.count(), 1);
+
+        let occupied = directory.join("occupied");
+        fs::create_dir(&occupied)?;
+        let refused = install(&occupied, "third")?;
+        assert!(!refused.status.success());
+        assert!(String::from_utf8_lossy(&refused.stderr).contains("is a directory"));
+        assert_eq!(fs::read_dir(&occupied)?.count(), 0);
+        Ok(())
     }
 
     #[test]

--- a/src/system/remote.rs
+++ b/src/system/remote.rs
@@ -12,11 +12,15 @@ use crate::http::HTTP;
 use crate::ui::multi_progress_report::MultiProgressReport;
 
 const RELEASE_BASE_URL: &str = "https://github.com/jdx/mise/releases/download";
+/// Where `install_mise = true` puts the executable. This matches the default
+/// used by <https://mise.run> and is already searched by remote mise discovery.
+const DEFAULT_INSTALL_MISE_PATH: &str = "~/.local/bin/mise";
 
 #[derive(Clone, Debug, Default, Deserialize)]
 pub(crate) struct RemoteTomlConfig {
     pub source: Option<PathBuf>,
     pub mise_env: Option<Vec<String>>,
+    pub install_mise: Option<InstallMiseTomlConfig>,
     #[serde(default)]
     pub copy_links: bool,
     #[serde(default)]
@@ -44,9 +48,28 @@ pub(crate) struct RemoteHostTomlConfig {
     pub ssh_options: Vec<String>,
     #[serde(default)]
     pub tags: Vec<String>,
+    pub install_mise: Option<InstallMiseTomlConfig>,
     pub mise_bin: Option<PathBuf>,
     pub remote_mise: Option<String>,
     pub bootstrap_command: Option<String>,
+}
+
+/// `install_mise = true` or `install_mise = "~/bin/mise"`.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum InstallMiseTomlConfig {
+    Enabled(bool),
+    Path(String),
+}
+
+impl InstallMiseTomlConfig {
+    fn path(self) -> Option<String> {
+        match self {
+            Self::Enabled(false) => None,
+            Self::Enabled(true) => Some(DEFAULT_INSTALL_MISE_PATH.to_string()),
+            Self::Path(path) => Some(path),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -63,6 +86,9 @@ pub(crate) struct RemoteHost {
     pub exclude: Vec<String>,
     pub ssh_options: Vec<String>,
     pub tags: IndexSet<String>,
+    /// Remote path the provisioned executable is installed to, keeping mise on
+    /// the host after the staging directory is removed.
+    pub install_mise: Option<String>,
     pub mise_bin: Option<PathBuf>,
     pub remote_mise: Option<String>,
     pub bootstrap_command: Option<String>,
@@ -78,6 +104,8 @@ pub(crate) struct RemoteOverrides {
     pub identity_file: Option<PathBuf>,
     pub exclude: Vec<String>,
     pub ssh_options: Vec<String>,
+    pub install_mise: Option<String>,
+    pub no_install_mise: bool,
     pub mise_bin: Option<PathBuf>,
     pub remote_mise: Option<String>,
     pub bootstrap_command: Option<String>,
@@ -129,6 +157,7 @@ pub(crate) fn hosts_from_config(
         let base = cf.get_path().parent().unwrap_or_else(|| Path::new("."));
         let default_source = resolve_local_path(base, remote.source.as_deref())?;
         let default_mise_env = remote.mise_env;
+        let default_install_mise = remote.install_mise.and_then(InstallMiseTomlConfig::path);
         let default_copy_links = remote.copy_links;
         let default_copy_link = remote.copy_link;
         for (name, host) in remote.hosts {
@@ -162,6 +191,10 @@ pub(crate) fn hosts_from_config(
                 exclude: dedupe(exclude),
                 ssh_options: dedupe(host.ssh_options),
                 tags: host.tags.into_iter().collect(),
+                install_mise: match host.install_mise {
+                    Some(install_mise) => install_mise.path(),
+                    None => default_install_mise.clone(),
+                },
                 mise_bin,
                 remote_mise: host.remote_mise,
                 bootstrap_command: host.bootstrap_command,
@@ -208,6 +241,7 @@ pub(crate) fn ad_hoc_host(
         ),
         ssh_options: vec![],
         tags: IndexSet::new(),
+        install_mise: None,
         mise_bin: None,
         remote_mise: None,
         bootstrap_command: None,
@@ -251,6 +285,16 @@ impl RemoteHost {
             self.remote_mise.clone_from(&overrides.remote_mise);
             self.bootstrap_command
                 .clone_from(&overrides.bootstrap_command);
+            // A command-line strategy that provides its own mise replaces a
+            // configured install rather than conflicting with it.
+            if overrides.remote_mise.is_some() || overrides.bootstrap_command.is_some() {
+                self.install_mise = None;
+            }
+        }
+        if let Some(install_mise) = &overrides.install_mise {
+            self.install_mise = Some(install_mise.clone());
+        } else if overrides.no_install_mise {
+            self.install_mise = None;
         }
         self.validate()
     }
@@ -315,6 +359,17 @@ impl RemoteHost {
                 "remote host '{}' must set at most one of mise_bin, remote_mise, or bootstrap_command",
                 self.name
             );
+        }
+        if let Some(install_mise) = &self.install_mise {
+            if self.remote_mise.is_some() || self.bootstrap_command.is_some() {
+                bail!(
+                    "remote host '{}' cannot combine install_mise with remote_mise or bootstrap_command, which already provide mise on the host",
+                    self.name
+                );
+            }
+            validate_install_mise_path(install_mise).wrap_err_with(|| {
+                format!("remote host '{}' has an invalid install_mise", self.name)
+            })?;
         }
         for option in &self.ssh_options {
             validate_value("SSH option", option)?;
@@ -658,15 +713,137 @@ async fn provision_mise(
                 })?
         }
     };
-    let remote = format!("{staging}/mise");
-    session.upload_executable(&binary, &remote)?;
+    let remote = match &session.host.install_mise {
+        // A dry run stays inside the staging directory it already cleans up.
+        Some(install_mise) if dry_run => {
+            info!(
+                "would install mise to {} on {}",
+                resolve_remote_install_path(session, install_mise)?,
+                session.host.name
+            );
+            stage_mise(session, &binary, staging)?
+        }
+        Some(install_mise) => {
+            let target = resolve_remote_install_path(session, install_mise)?;
+            install_remote_mise(session, &binary, &target)?;
+            target
+        }
+        None => stage_mise(session, &binary, staging)?,
+    };
     session.status(&[&remote, "version"], false).wrap_err_with(|| {
         format!(
-            "uploaded local mise cannot run on remote host '{}'; set mise_bin, remote_mise, or bootstrap_command",
+            "provisioned mise cannot run on remote host '{}'; set mise_bin, remote_mise, or bootstrap_command",
             session.host.name
         )
     })?;
+    if session.host.install_mise.is_some() && !dry_run {
+        warn_when_installed_mise_is_off_login_path(session, &remote);
+    }
     Ok(remote)
+}
+
+fn stage_mise(session: &SshSession<'_>, binary: &Path, staging: &str) -> Result<String> {
+    let remote = format!("{staging}/mise");
+    session.upload_executable(binary, &remote)?;
+    Ok(remote)
+}
+
+fn resolve_remote_install_path(session: &SshSession<'_>, path: &str) -> Result<String> {
+    let Some(suffix) = path.strip_prefix("~/") else {
+        return Ok(path.to_string());
+    };
+    let output = session.output(&["sh", "-lc", "printf '%s\\n' \"$HOME\""])?;
+    let home = validated_absolute_remote_path_output(&output, "remote login home")?;
+    let target = format!("{}/{suffix}", home.trim_end_matches('/'));
+    validate_install_mise_path(&target)?;
+    Ok(target)
+}
+
+/// Installs the provisioned executable at a persistent remote path so the host
+/// keeps a usable mise once the staging directory is removed.
+fn install_remote_mise(session: &SshSession<'_>, binary: &Path, target: &str) -> Result<()> {
+    let local = crate::hash::file_hash_sha256(binary, None)?;
+    if remote_executable_sha256(session, target)?.is_some_and(|remote| remote == local) {
+        info!(
+            "mise is already installed at {target} on {}",
+            session.host.name
+        );
+        return Ok(());
+    }
+    let file = File::open(binary)
+        .wrap_err_with(|| format!("failed to open mise binary {}", binary.display()))?;
+    session.status_with_stdin(&["sh", "-c", &install_mise_script(target)], file)?;
+    info!("installed mise to {target} on {}", session.host.name);
+    Ok(())
+}
+
+/// Writes beside the target and renames, so a replaced executable is never
+/// truncated in place and a busy binary cannot fail with ETXTBSY.
+fn install_mise_script(target: &str) -> String {
+    format!(
+        r#"set -eu
+target={}
+mkdir -p {}
+temporary="$target.mise-install.$$"
+trap 'rm -f "$temporary"' EXIT
+cat > "$temporary"
+chmod 755 "$temporary"
+mv -f "$temporary" "$target""#,
+        shell_quote(target),
+        shell_quote(remote_parent_directory(target)),
+    )
+}
+
+fn remote_parent_directory(target: &str) -> &str {
+    match target.rsplit_once('/') {
+        Some(("", _)) | None => "/",
+        Some((directory, _)) => directory,
+    }
+}
+
+/// `None` when the path is missing or the host cannot compute SHA-256, which
+/// only costs an upload that would otherwise have been skipped.
+fn remote_executable_sha256(session: &SshSession<'_>, target: &str) -> Result<Option<String>> {
+    let script = format!(
+        r#"target={}
+if [ ! -f "$target" ]; then
+  exit 0
+fi
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256sum "$target" | cut -d' ' -f1
+elif command -v shasum >/dev/null 2>&1; then
+  shasum -a 256 "$target" | cut -d' ' -f1
+fi"#,
+        shell_quote(target)
+    );
+    let digest = session.output(&["sh", "-c", &script])?.trim().to_string();
+    if digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Ok(None);
+    }
+    Ok(Some(digest.to_ascii_lowercase()))
+}
+
+/// An installed executable is only reachable later when its directory is on the
+/// login PATH, so report that once instead of leaving a silent surprise.
+fn warn_when_installed_mise_is_off_login_path(session: &SshSession<'_>, target: &str) {
+    let script = format!(
+        r#"case ":$PATH:" in
+  *:{}:*) printf 'yes\n' ;;
+  *) printf 'no\n' ;;
+esac"#,
+        shell_quote(remote_parent_directory(target))
+    );
+    match session.output(&["sh", "-lc", &script]) {
+        Ok(output) if output.trim() == "no" => warn!(
+            "{target} is not on {}'s login PATH; add its directory to PATH or declare [bootstrap.mise_shell_activate] in the bootstrap project",
+            session.host.name
+        ),
+        Ok(_) => {}
+        Err(error) => debug!(
+            "failed to read the login PATH on {}: {error:#}",
+            session.host.name
+        ),
+    }
 }
 
 fn resolve_remote_mise(session: &SshSession<'_>) -> Result<String> {
@@ -1661,6 +1838,26 @@ fn validated_absolute_remote_path_output(output: &str, kind: &str) -> Result<Str
     Ok(path.to_string())
 }
 
+fn validate_install_mise_path(path: &str) -> Result<()> {
+    validate_value("mise install path", path)?;
+    if path.contains(['\n', '\r']) {
+        bail!("install_mise must not contain a newline: {path:?}");
+    }
+    if !path.starts_with('/') && !path.starts_with("~/") {
+        bail!("install_mise must be an absolute path or start with ~/: {path:?}");
+    }
+    if path.split('/').any(|component| component == "..") {
+        bail!("install_mise must not contain '..': {path:?}");
+    }
+    if matches!(
+        path.rsplit('/').next(),
+        None | Some("") | Some(".") | Some("~")
+    ) {
+        bail!("install_mise must name an executable file: {path:?}");
+    }
+    Ok(())
+}
+
 fn validate_remote_executable(command: &str) -> Result<()> {
     validate_value("mise command", command)?;
     let is_path = command.contains('/');
@@ -1903,6 +2100,91 @@ mod tests {
 
         host.bootstrap_command = Some("install-mise".to_string());
         assert!(host.validate().is_err());
+    }
+
+    #[test]
+    fn parses_install_mise_as_a_flag_or_a_path() {
+        let enabled: RemoteTomlConfig = toml::from_str("install_mise = true").unwrap();
+        assert_eq!(
+            enabled.install_mise.unwrap().path().as_deref(),
+            Some(DEFAULT_INSTALL_MISE_PATH)
+        );
+        let disabled: RemoteTomlConfig = toml::from_str("install_mise = false").unwrap();
+        assert!(disabled.install_mise.unwrap().path().is_none());
+        let path: RemoteTomlConfig =
+            toml::from_str(r#"install_mise = "/usr/local/bin/mise""#).unwrap();
+        assert_eq!(
+            path.install_mise.unwrap().path().as_deref(),
+            Some("/usr/local/bin/mise")
+        );
+    }
+
+    #[test]
+    fn validates_install_mise_paths() {
+        assert!(validate_install_mise_path("~/.local/bin/mise").is_ok());
+        assert!(validate_install_mise_path("/usr/local/bin/mise").is_ok());
+        assert!(validate_install_mise_path("bin/mise").is_err());
+        assert!(validate_install_mise_path("./mise").is_err());
+        assert!(validate_install_mise_path("~/bin/../../mise").is_err());
+        assert!(validate_install_mise_path("~/.local/bin/").is_err());
+        assert!(validate_install_mise_path("~/").is_err());
+        assert!(validate_install_mise_path("/usr/local/bin/mise\nrm -rf /").is_err());
+        assert!(validate_install_mise_path("").is_err());
+    }
+
+    #[test]
+    fn install_mise_composes_only_with_an_uploaded_binary() {
+        let mut host = ad_hoc_host("example.com", std::env::current_dir().unwrap(), &[]).unwrap();
+        host.install_mise = Some(DEFAULT_INSTALL_MISE_PATH.to_string());
+        host.validate().unwrap();
+
+        host.mise_bin = Some(std::env::current_exe().unwrap());
+        host.validate().unwrap();
+
+        host.mise_bin = None;
+        host.remote_mise = Some("mise".to_string());
+        assert!(host.validate().is_err());
+
+        host.remote_mise = None;
+        host.bootstrap_command = Some("curl https://mise.run | sh".to_string());
+        assert!(host.validate().is_err());
+    }
+
+    #[test]
+    fn install_mise_overrides_replace_and_clear_the_configured_path() {
+        let mut host = ad_hoc_host("example.com", std::env::current_dir().unwrap(), &[]).unwrap();
+        host.install_mise = Some(DEFAULT_INSTALL_MISE_PATH.to_string());
+        host.apply_overrides(&RemoteOverrides {
+            install_mise: Some("/usr/local/bin/mise".to_string()),
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(host.install_mise.as_deref(), Some("/usr/local/bin/mise"));
+
+        host.apply_overrides(&RemoteOverrides {
+            no_install_mise: true,
+            ..Default::default()
+        })
+        .unwrap();
+        assert!(host.install_mise.is_none());
+
+        host.install_mise = Some(DEFAULT_INSTALL_MISE_PATH.to_string());
+        host.apply_overrides(&RemoteOverrides {
+            remote_mise: Some("mise".to_string()),
+            ..Default::default()
+        })
+        .unwrap();
+        assert!(host.install_mise.is_none());
+        assert_eq!(host.remote_mise.as_deref(), Some("mise"));
+    }
+
+    #[test]
+    fn install_script_quotes_the_target_and_renames_into_place() {
+        let script = install_mise_script("/home/deploy dir/.local/bin/mise");
+        assert!(script.contains("target='/home/deploy dir/.local/bin/mise'"));
+        assert!(script.contains("mkdir -p '/home/deploy dir/.local/bin'"));
+        assert_eq!(remote_parent_directory("/mise"), "/");
+        assert!(script.contains(r#"mv -f "$temporary" "$target""#));
     }
 
     #[test]

--- a/src/system/remote.rs
+++ b/src/system/remote.rs
@@ -766,11 +766,8 @@ fn resolve_remote_install_path(session: &SshSession<'_>, path: &str) -> Result<S
 /// Installs the provisioned executable at a persistent remote path so the host
 /// keeps a usable mise once the staging directory is removed.
 fn install_remote_mise(session: &SshSession<'_>, binary: &Path, target: &str) -> Result<()> {
-    // The remote digest comes first so a first install does not hash the local
-    // executable for nothing.
-    if let Some(installed) = remote_executable_sha256(session, target)?
-        && installed == crate::hash::file_hash_sha256(binary, None)?
-    {
+    let expected = crate::hash::file_hash_sha256(binary, None)?;
+    if remote_executable_sha256(session, target)?.is_some_and(|installed| installed == expected) {
         info!(
             "mise is already installed at {target} on {}",
             session.host.name
@@ -780,6 +777,16 @@ fn install_remote_mise(session: &SshSession<'_>, binary: &Path, target: &str) ->
     let file = File::open(binary)
         .wrap_err_with(|| format!("failed to open mise binary {}", binary.display()))?;
     session.status_with_stdin(&["sh", "-c", &install_mise_script(target)], file)?;
+    // An install path can be writable by more than the SSH account, so confirm
+    // the executable about to run is the one that was just written.
+    if let Some(installed) = remote_executable_sha256(session, target)?
+        && installed != expected
+    {
+        bail!(
+            "{target} on '{}' changed after it was installed; another writer owns that path",
+            session.host.name
+        );
+    }
     info!("installed mise to {target} on {}", session.host.name);
     Ok(())
 }

--- a/src/system/remote.rs
+++ b/src/system/remote.rs
@@ -795,12 +795,13 @@ fn install_remote_mise(session: &SshSession<'_>, binary: &Path, target: &str) ->
 }
 
 /// Writes beside the target and renames, so a replaced executable is never
-/// truncated in place and a busy binary cannot fail with ETXTBSY. `mktemp`
-/// creates that file exclusively, so a symbolic link planted in a shared
-/// writable install directory cannot capture the write. A directory at the
-/// target is refused before the rename, and again after it in case one appears
-/// in between — `mv` would otherwise move the executable inside it and report
-/// success.
+/// truncated in place and a busy binary cannot fail with ETXTBSY. The write
+/// goes into a `mktemp -d` directory rather than a named sibling file: that
+/// directory is private to the SSH account, so nobody else can swap the path
+/// out from under `cat` in a shared writable install directory. A directory at
+/// the target is refused before the rename, and again after it in case one
+/// appears in between — `mv` would otherwise move the executable inside it and
+/// report success.
 fn install_mise_script(target: &str) -> String {
     format!(
         r#"set -eu
@@ -811,13 +812,14 @@ if [ -d "$target" ]; then
   printf 'mise install path is a directory: %s\n' "$target" >&2
   exit 1
 fi
-temporary=$(mktemp "$directory/.mise-install.XXXXXXXXXX")
-trap 'rm -f "$temporary"' EXIT
+staging=$(mktemp -d "$directory/.mise-install.XXXXXXXXXX")
+trap 'rm -rf -- "$staging"' EXIT
+temporary="$staging/mise"
 cat > "$temporary"
 chmod 755 "$temporary"
 mv -f "$temporary" "$target"
 if [ ! -f "$target" ]; then
-  rm -f "$target/${{temporary##*/}}"
+  rm -f "$target/mise"
   printf 'mise install path is not a regular file: %s\n' "$target" >&2
   exit 1
 fi"#,
@@ -2285,7 +2287,7 @@ mod tests {
         let script = install_mise_script("/home/deploy dir/.local/bin/mise");
         assert!(script.contains("target='/home/deploy dir/.local/bin/mise'"));
         assert!(script.contains("directory='/home/deploy dir/.local/bin'"));
-        assert!(script.contains(r#"temporary=$(mktemp "$directory/.mise-install.XXXXXXXXXX")"#));
+        assert!(script.contains(r#"staging=$(mktemp -d "$directory/.mise-install.XXXXXXXXXX")"#));
         assert!(script.contains(r#"if [ -d "$target" ]; then"#));
         assert_eq!(remote_parent_directory("/mise"), "/");
         assert!(script.contains(r#"mv -f "$temporary" "$target""#));


### PR DESCRIPTION
## Problem

`mise bootstrap remote` provisions mise into the `/tmp/mise-bootstrap.*` staging
directory and removes that directory when the run ends. The target keeps the
tools installed under `~/.local/share/mise`, but not the mise that installed
them, so the tools are unusable afterwards. Today the only way to leave mise
behind is `bootstrap_command = "curl https://mise.run | sh"`, which hands the
install to a third party, re-runs on every bootstrap, and is skipped by
`--dry-run`.

It is also possible today to bootstrap a host into writing
`eval "$(mise activate zsh)"` into its `.zshrc` with no mise on the machine.

## Solution

`install_mise` installs the executable that was already provisioned for the run
at a persistent remote path:

```toml
[bootstrap.remote]
install_mise = true

[bootstrap.remote.hosts.cache]
host = "cache.example.com"
install_mise = "/usr/local/bin/mise"
```

```sh
mise bootstrap remote cache --install-mise
mise bootstrap remote cache --install-mise=/usr/local/bin/mise
mise bootstrap remote cache --no-install-mise
```

- `true` installs to `~/.local/bin/mise` (the mise.run default, already in
  mise's remote discovery list); a string sets the path and must be absolute or
  `~/`-relative and name a file.
- A host-level value replaces `[bootstrap.remote].install_mise`, so
  `install_mise = false` opts one host out of a project-wide default.
- What gets installed is the same executable the default strategy would have
  staged — the local binary or the checksum-verified official release artifact —
  and it is what runs the bootstrap, so the host converges with the mise version
  that orchestrated it.
- Composes with `mise_bin`; rejected with `remote_mise` or `bootstrap_command`,
  which already provide mise on the host. A command-line `--remote-mise` or
  `--bootstrap-command` clears a configured `install_mise` rather than
  conflicting with it, matching the documented override behavior.
- Writes into a `mktemp -d` directory inside the install directory and renames
  into place, so replacing a mise that is currently running cannot truncate it,
  and nothing but the final rename touches a path other accounts might write.
- Skips the upload when the target already holds a byte-identical executable,
  and compares the target's digest with what it wrote before running it. That
  check is best-effort — skipped when the host has neither `sha256sum` nor
  `shasum`, and it cannot cover the window between check and run — so the docs
  say plainly that the install directory's permissions are the real boundary.
- `--dry-run` never writes to the host: it reports the path it would install to
  and stages the executable as before.
- Warns when the install directory is missing from the host's login `PATH`, and
  points at `[bootstrap.mise_shell_activate]` for activation.
- `--install-mise` requires `=` before a path so a bare flag cannot swallow a
  positional target name.

## Testing

- `cargo test --all-features` (3122 unit tests), including new coverage for the
  bool-or-path config form, path validation, strategy conflicts, override
  precedence, and the install script's quoting.
- `mise run test:e2e e2e/cli/test_bootstrap_remote` — extended with dry-run
  (nothing written), install to a path containing a space, the installed
  executable being used for the bootstrap run, idempotent re-run with no second
  upload, `install_mise = true` resolving `~/` on the host, a directory at the
  install path being refused, a command-line install replacing a host's
  configured strategy, `--no-install-mise`, and the rejected combinations. 76
  assertions pass; the test goes from 20s to ~30s.
- The generated install script is covered by running it (install, replace,
  refuse a directory, `sh -n` over every branch) rather than by asserting on
  its text.
- `mise run lint`, `cargo clippy --workspace --all-features --all-targets -- -D warnings`.
- `mise run render`; unrelated local render drift in nine `docs/cli/*.md` pages
  and two `man/man1/mise.1` lines was reverted and the committed artifacts were
  verified against the committed `mise.usage.kdl`.

The `nightly` check fails here, but it is failing on every open PR right now
(rustc OOM-killed under sccache), not from this change.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*
