### PR TITLE
docs(task): note that tasks deps ignores run array refs

### DIFF
--- a/docs/cli/tasks/deps.md
+++ b/docs/cli/tasks/deps.md
@@ -8,9 +8,10 @@
 Display a tree visualization of a dependency graph
 
 The graph is built from declared dependencies: `depends`, `depends_post`,
-and `wait_for`. Task references inside a `run` array (`{ task = "..." }` or
-`{ tasks = [...] }`) are execution steps, not declared dependencies, so they
-do not appear here.
+and `wait_for`. Task references inside a `run` or `run_windows` array
+(`{ task = "..." }` or `{ tasks = [...] }`) are execution steps, not graph
+edges, so they do not appear here. Those nested tasks still run, including
+their own `depends`.
 
 ## Arguments
 

--- a/docs/cli/tasks/deps.md
+++ b/docs/cli/tasks/deps.md
@@ -7,6 +7,11 @@
 
 Display a tree visualization of a dependency graph
 
+The graph is built from declared dependencies: `depends`, `depends_post`,
+and `wait_for`. Task references inside a `run` array (`{ task = "..." }` or
+`{ tasks = [...] }`) are execution steps, not declared dependencies, so they
+do not appear here.
+
 ## Arguments
 
 ### `[TASKS]…`

--- a/docs/tasks/architecture.md
+++ b/docs/tasks/architecture.md
@@ -247,7 +247,7 @@ This automatically reruns tasks when their source files change.
 ### Visualize Dependencies
 
 ```bash
-mise tasks deps build           # Show build's dependencies
+mise tasks deps build           # Show build's declared dependencies
 mise tasks deps --dot > deps.dot # Generate graphviz diagram
 ```
 
@@ -279,7 +279,7 @@ Solution: Define the missing task or remove the dependency.
 **Slow Parallel Execution**:
 
 - Check if tasks have unnecessary dependencies
-- Use `mise tasks deps` to verify dependency graph
+- Use `mise tasks deps` to verify the declared dependency graph (`depends`, `wait_for`, `depends_post`)
 - Consider increasing `--jobs` if you have CPU cores available
 
 The task architecture is designed to scale from simple single-task projects to complex multi-service applications with intricate build dependencies.

--- a/docs/tasks/running-tasks.md
+++ b/docs/tasks/running-tasks.md
@@ -207,7 +207,8 @@ run = [
 
 `mise run one_by_one` runs that pipeline, but `mise tasks deps one_by_one` still
 shows a leaf. Those `{ task }` / `{ tasks }` entries are this task's own `run`
-steps, not `depends`. Rewriting them as `depends = ["example1", "example2", "example3"]`
+steps, not graph edges. The nested tasks still run, including their own
+`depends`. Rewriting them as `depends = ["example1", "example2", "example3"]`
 would put them in the graph, but it would also drop the sequential/parallel
 ordering above: `depends` only requires those tasks to finish first, with no
 order among them.

--- a/docs/tasks/running-tasks.md
+++ b/docs/tasks/running-tasks.md
@@ -2,7 +2,12 @@
 
 See available tasks with `mise tasks`. To show tasks hidden with property `hide=true`, use the option `--hidden`.
 
-List dependencies of tasks with `mise tasks deps [tasks]...`.
+List declared dependencies of tasks with `mise tasks deps [tasks]...`.
+That graph is built from [`depends`](/tasks/task-configuration.html#depends),
+[`wait_for`](/tasks/task-configuration.html#wait-for), and
+[`depends_post`](/tasks/task-configuration.html#depends-post).
+Task references inside a `run` array (`{ task = "..." }` / `{ tasks = [...] }`)
+are execution steps, so they do not appear there.
 
 Run a task with `mise tasks run <task>`, `mise run <task>`, `mise r <task>`, or just `mise <task>`—however
 that last one you should never put into scripts or documentation because if mise ever adds a command with that name in a
@@ -199,3 +204,10 @@ run = [
     { tasks = ["example2", "example3"] }, # these 2 are run in parallel
 ]
 ```
+
+`mise run one_by_one` runs that pipeline, but `mise tasks deps one_by_one` still
+shows a leaf. Those `{ task }` / `{ tasks }` entries are this task's own `run`
+steps, not `depends`. Rewriting them as `depends = ["example1", "example2", "example3"]`
+would put them in the graph, but it would also drop the sequential/parallel
+ordering above: `depends` only requires those tasks to finish first, with no
+order among them.

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -25,6 +25,10 @@ run = [
 ]
 ```
 
+`{ task }` and `{ tasks }` are execution steps for this task, not
+[`depends`](#depends). `mise tasks deps` therefore does not include them.
+See [`mise tasks deps`](/cli/tasks/deps.html).
+
 Simple forms still work and are equivalent:
 
 ```mise-toml
@@ -99,6 +103,9 @@ Tasks that must be run before this task. This is a list of task names or aliases
 passed to the task, e.g.: `depends = ["build --release"]`. If multiple tasks have the same dependency,
 that dependency will only be run once. mise will run whatever it can in parallel (up to [`--jobs`](/cli/run))
 through the use of `depends` and related properties.
+
+[`mise tasks deps`](/cli/tasks/deps.html) visualizes this declared graph
+(`depends`, `wait_for`, `depends_post`), not task references inside `run`.
 
 ```mise-toml
 [tasks.build]

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -26,7 +26,8 @@ run = [
 ```
 
 `{ task }` and `{ tasks }` are execution steps for this task, not
-[`depends`](#depends). `mise tasks deps` therefore does not include them.
+[`depends`](#depends). They still run with their own dependencies.
+`mise tasks deps` does not include them as graph edges.
 See [`mise tasks deps`](/cli/tasks/deps.html).
 
 Simple forms still work and are equivalent:

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -4103,6 +4103,11 @@ Do not print the command or its output
 Tasks name to add
 .SH "MISE TASKS DEPS"
 Display a tree visualization of a dependency graph
+
+The graph is built from declared dependencies: `depends`, `depends_post`,
+and `wait_for`. Task references inside a `run` array (`{ task = "..." }` or
+`{ tasks = [...] }`) are execution steps, not declared dependencies, so they
+do not appear here.
 .PP
 \fBUsage:\fR mise tasks deps [OPTIONS] [<TASKS>] ...
 .PP

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -4105,9 +4105,10 @@ Tasks name to add
 Display a tree visualization of a dependency graph
 
 The graph is built from declared dependencies: `depends`, `depends_post`,
-and `wait_for`. Task references inside a `run` array (`{ task = "..." }` or
-`{ tasks = [...] }`) are execution steps, not declared dependencies, so they
-do not appear here.
+and `wait_for`. Task references inside a `run` or `run_windows` array
+(`{ task = "..." }` or `{ tasks = [...] }`) are execution steps, not graph
+edges, so they do not appear here. Those nested tasks still run, including
+their own `depends`.
 .PP
 \fBUsage:\fR mise tasks deps [OPTIONS] [<TASKS>] ...
 .PP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3984,9 +3984,10 @@ Examples:
 Display a tree visualization of a dependency graph
 
 The graph is built from declared dependencies: `depends`, `depends_post`,
-and `wait_for`. Task references inside a `run` array (`{ task = "..." }` or
-`{ tasks = [...] }`) are execution steps, not declared dependencies, so they
-do not appear here.
+and `wait_for`. Task references inside a `run` or `run_windows` array
+(`{ task = "..." }` or `{ tasks = [...] }`) are execution steps, not graph
+edges, so they do not appear here. Those nested tasks still run, including
+their own `depends`.
 """#
         after_long_help #"""
 Examples:

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3980,6 +3980,14 @@ Examples:
         arg "[-- RUN]…" required=#false var=#true
     }
     cmd deps help="Display a tree visualization of a dependency graph" effect=read {
+        long_help #"""
+Display a tree visualization of a dependency graph
+
+The graph is built from declared dependencies: `depends`, `depends_post`,
+and `wait_for`. Task references inside a `run` array (`{ task = "..." }` or
+`{ tasks = [...] }`) are execution steps, not declared dependencies, so they
+do not appear here.
+"""#
         after_long_help #"""
 Examples:
 

--- a/src/cli/tasks/deps.rs
+++ b/src/cli/tasks/deps.rs
@@ -12,9 +12,10 @@ use petgraph::dot::Dot;
 /// Display a tree visualization of a dependency graph
 ///
 /// The graph is built from declared dependencies: `depends`, `depends_post`,
-/// and `wait_for`. Task references inside a `run` array (`{ task = "..." }` or
-/// `{ tasks = [...] }`) are execution steps, not declared dependencies, so they
-/// do not appear here.
+/// and `wait_for`. Task references inside a `run` or `run_windows` array
+/// (`{ task = "..." }` or `{ tasks = [...] }`) are execution steps, not graph
+/// edges, so they do not appear here. Those nested tasks still run, including
+/// their own `depends`.
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(super) struct TasksDeps {

--- a/src/cli/tasks/deps.rs
+++ b/src/cli/tasks/deps.rs
@@ -10,6 +10,11 @@ use itertools::Itertools;
 use petgraph::dot::Dot;
 
 /// Display a tree visualization of a dependency graph
+///
+/// The graph is built from declared dependencies: `depends`, `depends_post`,
+/// and `wait_for`. Task references inside a `run` array (`{ task = "..." }` or
+/// `{ tasks = [...] }`) are execution steps, not declared dependencies, so they
+/// do not appear here.
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(super) struct TasksDeps {


### PR DESCRIPTION
## Summary

Document that `mise tasks deps` shows the declared dependency graph only (`depends`, `wait_for`, `depends_post`). Task references inside a `run` array are execution steps, so they do not appear in that graph.

Addresses https://github.com/jdx/mise/discussions/11999.

## Problem

A task like this runs `a` and `b` in parallel, then `c`:

```toml
[tasks.check]
run = [
  { tasks = ["a", "b"] },
  { task = "c" },
]
```

`mise run check` does that. `mise tasks deps check` still prints a leaf, because `Deps::new` never reads `run`. That is intended: `{ task }` / `{ tasks }` are nested execution steps (`inject_and_wait`), not declared dependencies. Rewriting them as `depends = ["a", "b", "c"]` would put them in the graph, but would also drop the sequential/parallel ordering.

The surprise was that `tasks deps` looks like "what will run" while it only visualizes declared dependencies. The docs and CLI help did not say so.

## Changes

- CLI help / generated usage, CLI docs, and man page for `mise tasks deps`
- Running Tasks: what `tasks deps` includes, and a note on the `run` array example
- Task Configuration: `run` vs `depends`
- Architecture: debugging section

No scheduler or `Deps::new` change. Merging `run` into that graph would change execution.

*AI-assisted — Tool: Cursor; model: cursor-grok-4.6-xhigh; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that `mise tasks deps` displays declared `depends`, `depends_post`, and `wait_for` relationships.
  * Documented that task references in `run` and `run_windows` represent execution steps, not dependency-graph edges.
  * Clarified that nested tasks still execute and honor their own dependencies.
  * Updated CLI help and reference documentation with these distinctions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->