### PR TITLE
feat(config): deprecate alpine all_compile default

### DIFF
--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -125,12 +125,10 @@ _mise lives in
 the [community repository](https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/mise/APKBUILD)._
 
 ::: warning Alpine source-build default is deprecated
-Alpine currently compiles Node, Python, Erlang, and Ruby from source by default. This automatic
-behavior is deprecated: affected source installs warn beginning in mise 2026.8.0, and the default
-will switch to precompiled binaries in mise 2027.8.0. Set
-[`all_compile = false`](/configuration/settings.html#all_compile) (or a per-tool `compile = false`)
-to use musl precompiled binaries now. To keep compiling from source, set `all_compile = true`
-explicitly.
+Alpine currently compiles tools from source by default. This automatic behavior is deprecated:
+affected source installs warn beginning in mise 2026.8.0, and the default will switch to
+precompiled binaries in mise 2027.8.0. To keep compiling from source, set
+[`all_compile = true`](/configuration/settings.html#all_compile) explicitly.
 :::
 
 ### apt

--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -124,6 +124,15 @@ apk add mise
 _mise lives in
 the [community repository](https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/mise/APKBUILD)._
 
+::: warning Alpine source-build default is deprecated
+Alpine currently compiles Node, Python, Erlang, and Ruby from source by default. This automatic
+behavior is deprecated: affected source installs warn beginning in mise 2026.8.0, and the default
+will switch to precompiled binaries in mise 2027.8.0. Set
+[`all_compile = false`](/configuration/settings.html#all_compile) (or a per-tool `compile = false`)
+to use musl precompiled binaries now. To keep compiling from source, set `all_compile = true`
+explicitly.
+:::
+
 ### apt
 
 On Ubuntu 26.04+, mise is available via a PPA:

--- a/docs/lang/node.md
+++ b/docs/lang/node.md
@@ -172,6 +172,18 @@ mise settings node.flavor=glibc-217
 For the common musl case, `mise settings libc=musl` also selects Node's `musl`
 flavor when `node.flavor` is unset.
 
+On Alpine, `all_compile` currently defaults to `true`, which skips precompiled Node
+(including musl unofficial builds) and compiles from source instead. Disable that to use
+`node.flavor=musl`:
+
+```toml
+[settings]
+all_compile = false
+```
+
+or `[settings.node] compile = false`. This Alpine default is deprecated and will be removed
+in mise 2027.8.0.
+
 ## Settings
 
 <script setup>

--- a/docs/lang/node.md
+++ b/docs/lang/node.md
@@ -172,18 +172,6 @@ mise settings node.flavor=glibc-217
 For the common musl case, `mise settings libc=musl` also selects Node's `musl`
 flavor when `node.flavor` is unset.
 
-On Alpine, `all_compile` currently defaults to `true`, which skips precompiled Node
-(including musl unofficial builds) and compiles from source instead. Disable that to use
-`node.flavor=musl`:
-
-```toml
-[settings]
-all_compile = false
-```
-
-or `[settings.node] compile = false`. This Alpine default is deprecated and will be removed
-in mise 2027.8.0.
-
 ## Settings
 
 <script setup>

--- a/settings.toml
+++ b/settings.toml
@@ -67,8 +67,7 @@ mise 2027.8.0. Afterward, users who require source builds must set `all_compile 
 explicitly.
 
 Do not use precompiled binaries for all languages. Useful if running on a Linux distribution
-like Alpine that does not use glibc and therefore likely won't be able to run precompiled
-glibc binaries. Prefer musl or static precompiled binaries when they exist.
+like Alpine that does not use glibc and therefore likely won't be able to run precompiled binaries.
 
 Note that this needs to be setup for each language. File a ticket if you notice a language that is
 not

--- a/settings.toml
+++ b/settings.toml
@@ -61,13 +61,14 @@ type = "Bool"
 [all_compile]
 description = "do not use precompiled binaries for any tool"
 docs = """
-Default: false unless running Alpine. NixOS also defaults to true temporarily, but that automatic
-default is deprecated: affected source installs warn beginning in mise 2026.8.0, and the default
-will be removed in mise 2027.8.0. Afterward, NixOS users who require source builds must set
-`all_compile = true` explicitly.
+Default: false unless running Alpine or NixOS. Both automatic defaults are deprecated:
+affected source installs warn beginning in mise 2026.8.0, and the defaults will be removed in
+mise 2027.8.0. Afterward, users who require source builds must set `all_compile = true`
+explicitly.
 
 Do not use precompiled binaries for all languages. Useful if running on a Linux distribution
-like Alpine that does not use glibc and therefore likely won't be able to run precompiled binaries.
+like Alpine that does not use glibc and therefore likely won't be able to run precompiled
+glibc binaries. Prefer musl or static precompiled binaries when they exist.
 
 Note that this needs to be setup for each language. File a ticket if you notice a language that is
 not

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -252,42 +252,66 @@ static PENDING_DEPRECATED_SETTINGS: Lazy<Mutex<BTreeSet<&'static str>>> =
     Lazy::new(Default::default);
 static DEPRECATED_WARNINGS_READY: AtomicBool = AtomicBool::new(false);
 // TODO(2027.8.0): Remove the per-tool warning accessors once the NixOS
-// `all_compile` deprecation process is complete.
+// and Alpine `all_compile` deprecation process is complete.
 
 fn default_all_compile(linux_distro: Option<&str>) -> bool {
     matches!(linux_distro, Some("alpine" | "nixos"))
 }
 
-fn compile_inherits_nixos_all_compile_default(
+fn compile_inherits_distro_all_compile_default(
     linux_distro: Option<&str>,
+    distro: &str,
     explicit_all_compile: Option<bool>,
     compile: Option<bool>,
 ) -> bool {
-    linux_distro == Some("nixos") && explicit_all_compile.is_none() && compile.is_none()
+    linux_distro == Some(distro) && explicit_all_compile.is_none() && compile.is_none()
 }
 
 fn effective_compile_setting(all_compile: bool, compile: Option<bool>) -> Option<bool> {
     compile.or_else(|| all_compile.then_some(true))
 }
 
-fn warn_nixos_all_compile_default_deprecated(
+fn distro_all_compile_deprecation_id(distro: &str, tool: &str) -> Option<&'static str> {
+    match (distro, tool) {
+        ("nixos", "node") => Some("nixos.node_all_compile_default"),
+        ("nixos", "python") => Some("nixos.python_all_compile_default"),
+        ("nixos", "erlang") => Some("nixos.erlang_all_compile_default"),
+        ("nixos", "ruby") => Some("nixos.ruby_all_compile_default"),
+        ("alpine", "node") => Some("alpine.node_all_compile_default"),
+        ("alpine", "python") => Some("alpine.python_all_compile_default"),
+        ("alpine", "erlang") => Some("alpine.erlang_all_compile_default"),
+        ("alpine", "ruby") => Some("alpine.ruby_all_compile_default"),
+        _ => None,
+    }
+}
+
+fn warn_implicit_all_compile_default_deprecated(
     tool: &str,
-    id: &'static str,
     all_compile: Option<bool>,
     compile: Option<bool>,
 ) {
-    if !cfg!(test)
-        && compile_inherits_nixos_all_compile_default(
-            env::LINUX_DISTRO.as_deref(),
-            all_compile,
-            compile,
-        )
+    if cfg!(test) {
+        return;
+    }
+    let distro = env::LINUX_DISTRO.as_deref();
+    if compile_inherits_distro_all_compile_default(distro, "nixos", all_compile, compile)
+        && let Some(id) = distro_all_compile_deprecation_id("nixos", tool)
     {
         deprecated_at!(
             "2026.8.0",
             "2027.8.0",
             id,
             "The automatic all_compile=true default on NixOS caused {tool} to compile from source. Enable nix-ld to use precompiled binaries, or configure all_compile=true explicitly to keep compiling tools from source."
+        );
+    }
+    if compile_inherits_distro_all_compile_default(distro, "alpine", all_compile, compile)
+        && let Some(id) = distro_all_compile_deprecation_id("alpine", tool)
+    {
+        deprecated_at!(
+            "2026.8.0",
+            "2027.8.0",
+            id,
+            "The automatic all_compile=true default on Alpine caused {tool} to compile from source. Set all_compile=false to use precompiled musl binaries when available, or configure all_compile=true explicitly to keep compiling tools from source."
         );
     }
 }
@@ -698,50 +722,29 @@ impl Settings {
         &self,
         purpose: CompilePurpose,
         tool: &str,
-        id: &'static str,
         compile: Option<bool>,
     ) -> Option<bool> {
         if matches!(purpose, CompilePurpose::Install) {
-            warn_nixos_all_compile_default_deprecated(tool, id, self.all_compile, compile);
+            warn_implicit_all_compile_default_deprecated(tool, self.all_compile, compile);
         }
         effective_compile_setting(self.all_compile(), compile)
     }
 
     pub(crate) fn node_compile(&self, purpose: CompilePurpose) -> Option<bool> {
-        self.compile_setting(
-            purpose,
-            "node",
-            "nixos.node_all_compile_default",
-            self.node.compile,
-        )
+        self.compile_setting(purpose, "node", self.node.compile)
     }
 
     pub(crate) fn python_compile(&self, purpose: CompilePurpose) -> Option<bool> {
-        self.compile_setting(
-            purpose,
-            "python",
-            "nixos.python_all_compile_default",
-            self.python.compile,
-        )
+        self.compile_setting(purpose, "python", self.python.compile)
     }
 
     pub(crate) fn erlang_compile(&self, purpose: CompilePurpose) -> Option<bool> {
-        self.compile_setting(
-            purpose,
-            "erlang",
-            "nixos.erlang_all_compile_default",
-            self.erlang.compile,
-        )
+        self.compile_setting(purpose, "erlang", self.erlang.compile)
     }
 
     #[cfg(not(windows))]
     pub(crate) fn ruby_compile(&self, purpose: CompilePurpose) -> Option<bool> {
-        self.compile_setting(
-            purpose,
-            "ruby",
-            "nixos.ruby_all_compile_default",
-            self.ruby.compile,
-        )
+        self.compile_setting(purpose, "ruby", self.ruby.compile)
     }
 
     pub(crate) fn try_get() -> Result<Arc<Self>> {
@@ -1712,39 +1715,84 @@ mod tests {
     }
 
     #[test]
-    fn compile_warning_only_applies_to_implicit_nixos_values() {
-        assert!(compile_inherits_nixos_all_compile_default(
+    fn compile_warning_only_applies_to_implicit_distro_values() {
+        assert!(compile_inherits_distro_all_compile_default(
             Some("nixos"),
+            "nixos",
             None,
             None
         ));
-        assert!(!compile_inherits_nixos_all_compile_default(
+        assert!(!compile_inherits_distro_all_compile_default(
             Some("nixos"),
+            "nixos",
             Some(true),
             None
         ));
-        assert!(!compile_inherits_nixos_all_compile_default(
+        assert!(!compile_inherits_distro_all_compile_default(
             Some("nixos"),
+            "nixos",
             Some(false),
             None
         ));
-        assert!(!compile_inherits_nixos_all_compile_default(
+        assert!(!compile_inherits_distro_all_compile_default(
             Some("nixos"),
+            "nixos",
             None,
             Some(true)
         ));
-        assert!(!compile_inherits_nixos_all_compile_default(
+        assert!(!compile_inherits_distro_all_compile_default(
             Some("nixos"),
+            "nixos",
             None,
             Some(false)
         ));
-        assert!(!compile_inherits_nixos_all_compile_default(
+        assert!(!compile_inherits_distro_all_compile_default(
             Some("alpine"),
+            "nixos",
             None,
             None
         ));
-        assert!(!compile_inherits_nixos_all_compile_default(
-            None, None, None
+        assert!(compile_inherits_distro_all_compile_default(
+            Some("alpine"),
+            "alpine",
+            None,
+            None
+        ));
+        assert!(!compile_inherits_distro_all_compile_default(
+            Some("alpine"),
+            "alpine",
+            Some(true),
+            None
+        ));
+        assert!(!compile_inherits_distro_all_compile_default(
+            Some("alpine"),
+            "alpine",
+            Some(false),
+            None
+        ));
+        assert!(!compile_inherits_distro_all_compile_default(
+            Some("alpine"),
+            "alpine",
+            None,
+            Some(true)
+        ));
+        assert!(!compile_inherits_distro_all_compile_default(
+            Some("alpine"),
+            "alpine",
+            None,
+            Some(false)
+        ));
+        assert!(!compile_inherits_distro_all_compile_default(
+            Some("nixos"),
+            "alpine",
+            None,
+            None
+        ));
+        assert!(!compile_inherits_distro_all_compile_default(
+            None, "nixos", None, None
+        ));
+        assert!(!compile_inherits_distro_all_compile_default(
+            None, "alpine", None, None
         ));
     }
 


### PR DESCRIPTION
## Summary
- deprecate the automatic `all_compile = true` default on Alpine
- warn immediately in mise 2026.8.0 and schedule removal for 2027.8.0
- keep the same deprecation window as NixOS in #11956

## Why

The distro-wide Alpine default unexpectedly forces source builds for Node, Python, Erlang, and Ruby even when precompiled musl binaries exist. This preserves the current behavior for a full deprecation window while giving users an immediate, actionable warning.

## Requires #12289

Removing the Alpine default makes precompiled binaries the default path there, and the other affected tools already work well on musl without setting `compile=false` or any other compile settings:

- **Node**: musl hosts are routed to musl tarballs from unofficial-builds.nodejs.org
- **Python**: precompiled python-build-standalone ships musl builds
- **Erlang**: refuses precompiled binaries on musl and falls back to source builds

Ruby is the exception: it would download a glibc-only jdx/ruby binary that cannot run on musl. #12289 fixes that by skipping precompiled Ruby on musl and falling back to ruby-build, and is required for this deprecation to be safe on Alpine.

## Test plan
- [x] `cargo test --bin mise config::settings::tests`
- [ ] On Alpine, unset `all_compile` still compiles from source and now warns
- [ ] Explicit `all_compile = true` keeps compiling and does not warn
- [ ] Explicit `all_compile = false` uses precompiled binaries

*AI-assisted — Tool: Cursor; model: SpaceXAI/Cursor Grok 4.6; version: unavailable.*
*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Deprecation**
  - Alpine Linux and NixOS currently enable source compilation automatically, but this behavior is deprecated.
  - Warnings identify the affected platform and tool.
  - Warnings begin in mise 2026.8.0; automatic source compilation defaults are removed in mise 2027.8.0.
  - Set `all_compile = true` to retain source compilation explicitly.

- **Documentation**
  - Updated installation and configuration guidance with platform-specific defaults, deprecation timelines, and migration steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
