### PR TITLE
fix(ruby): skip glibc precompiled binaries on musl linux

### DIFF
--- a/docs/lang/ruby.md
+++ b/docs/lang/ruby.md
@@ -32,11 +32,16 @@ Precompiled binaries are sourced from [jdx/ruby](https://github.com/jdx/ruby) an
 for the following platforms:
 
 - macOS (arm64/Apple Silicon only)
-- Linux arm64
-- Linux x86_64
+- Linux arm64 (glibc/manylinux2014 only)
+- Linux x86_64 (glibc/manylinux2014 only)
 
 If a precompiled binary is not available for your platform or Ruby version, mise automatically
 falls back to compiling from source using ruby-build.
+
+jdx/ruby has no musl builds, so on musl-based distros such as Alpine mise always compiles Ruby
+from source (unless you set `ruby.compile=false`, in which case installs error out). If you host
+your own musl binaries via `ruby.precompiled_url`, set `ruby.precompiled_arch` and
+`ruby.precompiled_os` explicitly to opt back in to precompiled installs.
 
 ### Precompiled binaries only
 

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -455,34 +455,7 @@ impl RubyPlugin {
     /// Get platform identifier for precompiled binaries
     /// Returns platform in jdx/ruby format: "macos", "arm64_linux", or "x86_64_linux"
     fn precompiled_platform(&self) -> Option<String> {
-        let settings = Settings::get();
-
-        // Check for user overrides first
-        if let (Some(arch), Some(os)) = (
-            settings.ruby.precompiled_arch.as_deref(),
-            settings.ruby.precompiled_os.as_deref(),
-        ) {
-            return Some(format!("{}_{}", arch, os));
-        }
-
-        // Auto-detect platform
-        if cfg!(target_os = "macos") {
-            // macOS only supports arm64 and uses "macos" without arch prefix
-            match settings.arch() {
-                "arm64" | "aarch64" => Some("macos".to_string()),
-                _ => None,
-            }
-        } else if cfg!(target_os = "linux") {
-            // Linux uses arch_linux format
-            let arch = match settings.arch() {
-                "arm64" | "aarch64" => "arm64",
-                "x64" | "x86_64" => "x86_64",
-                _ => return None,
-            };
-            Some(format!("{}_linux", arch))
-        } else {
-            None
-        }
+        self.precompiled_platform_for_target(&PlatformTarget::from_current())
     }
 
     /// Get platform identifier for a specific target (used for lockfiles)
@@ -507,6 +480,11 @@ impl RubyPlugin {
                 }
             }
             "linux" => {
+                // jdx/ruby Linux binaries are glibc-only (manylinux2014); there is no
+                // musl build, so a glibc tarball would fail at runtime on Alpine etc.
+                if target.libc() == Some("musl") {
+                    return None;
+                }
                 // Linux uses arch_linux format
                 let arch = match target.arch_name() {
                     "arm64" | "aarch64" => "arm64",
@@ -1588,6 +1566,70 @@ mod tests {
         assert!(!ruby_precompiled_only(None));
         assert!(!ruby_precompiled_only(Some(true)));
         assert!(ruby_precompiled_only(Some(false)));
+    }
+
+    fn ruby_precompiled_platform_for_target(
+        configure_settings: impl FnOnce(&mut SettingsPartial),
+        platform: &str,
+    ) -> Option<String> {
+        with_ruby_settings(configure_settings, |backend| {
+            backend.precompiled_platform_for_target(&PlatformTarget::new(
+                Platform::parse(platform).unwrap(),
+            ))
+        })
+    }
+
+    #[test]
+    fn test_ruby_precompiled_platform_skips_musl_linux() {
+        assert_eq!(
+            ruby_precompiled_platform_for_target(|_| {}, "linux-x64").as_deref(),
+            Some("x86_64_linux")
+        );
+        assert_eq!(
+            ruby_precompiled_platform_for_target(|_| {}, "linux-arm64").as_deref(),
+            Some("arm64_linux")
+        );
+        assert_eq!(
+            ruby_precompiled_platform_for_target(|_| {}, "macos-arm64").as_deref(),
+            Some("macos")
+        );
+
+        // jdx/ruby has no musl builds, so a musl target has no precompiled platform;
+        // installs fall back to ruby-build and lockfiles record the source tarball
+        assert_eq!(
+            ruby_precompiled_platform_for_target(|_| {}, "linux-x64-musl"),
+            None
+        );
+        assert_eq!(
+            ruby_precompiled_platform_for_target(|_| {}, "linux-arm64-musl"),
+            None
+        );
+
+        // Explicit overrides bypass auto-detection, including the musl skip
+        assert_eq!(
+            ruby_precompiled_platform_for_target(
+                |settings| {
+                    settings.ruby.precompiled_arch = Some("x86_64".to_string());
+                    settings.ruby.precompiled_os = Some("linux".to_string());
+                },
+                "linux-x64-musl"
+            )
+            .as_deref(),
+            Some("x86_64_linux")
+        );
+    }
+
+    #[test]
+    fn test_ruby_precompiled_platform_skips_musl_current() {
+        let platform = with_ruby_settings(
+            |settings| {
+                settings.os = Some("linux".to_string());
+                settings.arch = Some("x64".to_string());
+                settings.libc = Some("musl".to_string());
+            },
+            |backend| backend.precompiled_platform(),
+        );
+        assert_eq!(platform, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

[jdx/ruby](https://github.com/jdx/ruby) Linux assets (`ruby-*.x86_64_linux.tar.gz`, `ruby-*.arm64_linux.tar.gz`) are glibc-only (manylinux2014); there is no musl build. mise still treated any Linux host as a precompiled platform, so on musl distros (Alpine, etc.) it would download a glibc MRI that fails at runtime with `ld-linux`/GLIBC errors.

Today this is hidden on Alpine because of the implicit `all_compile = true` distro default, but that default is being deprecated (#12287), which makes precompiled the default path there.

This follows the same model as Erlang, which already refuses precompiled binaries on musl and falls back to compiling:

- `precompiled_platform_for_target()` now returns `None` for Linux targets with `libc == musl` (detected via the existing `Platform`/`PlatformTarget` libc logic, which respects `settings.libc` and runtime musl detection)
- `precompiled_platform()` now delegates to `precompiled_platform_for_target(&PlatformTarget::from_current())` so install, `ls-remote` (with `ruby.compile=false`), and lockfile resolution cannot diverge
- Explicit `ruby.precompiled_arch` + `ruby.precompiled_os` overrides still bypass auto-detection, including the musl skip (for gcompat users or custom `ruby.precompiled_url` sources that do host musl builds)

Resulting behavior on musl Linux:

- `ruby.compile` unset: precompiled is skipped, mise compiles with ruby-build (existing fallback path)
- `ruby.compile=false`: installs error with `no precompiled ruby is available for this platform` instead of installing a broken binary
- `ruby.compile=true`: unchanged (ruby-build)

glibc Linux, macOS, and Windows are unchanged.

## Lockfile changes

For musl platform targets, `mise.lock` now records the **source tarball** instead of the unusable glibc jdx/ruby asset. `resolve_lock_info` already fell back to the source tarball whenever no precompiled platform existed; musl targets now take that path.

Before (broken — glibc binary pinned for a musl target):

```toml
[tools.ruby.platforms.linux-x64-musl]
url = "https://github.com/jdx/ruby/releases/download/3.4.9-1/ruby-3.4.9.x86_64_linux.tar.gz"
```

After:

```toml
[tools.ruby.platforms.linux-x64-musl]
url = "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.9.tar.gz"
checksum = "sha256:7bb4d4f5e807cc27251d14d9d6086d182c5b25875191e44ab15b709cd7a7dd9c"
```

Non-musl platform entries (`linux-x64`, `linux-arm64`, `macos-arm64`, `windows-*`) are unaffected. Lockfile `options` are also unaffected — they are derived from settings, not from the target platform.

## Test plan

- [x] `cargo test --bin mise plugins::core::ruby` — new unit tests cover: glibc targets keep `x86_64_linux`/`arm64_linux`, musl targets (`linux-x64-musl`, `linux-arm64-musl`) return no precompiled platform (the gate `resolve_lock_info` and `install_precompiled` use), explicit `precompiled_arch`/`precompiled_os` overrides still win on musl, and the current-platform path honors `settings.libc = "musl"`
- [x] `mise run test:e2e e2e/core/test_ruby_precompiled e2e/core/test_ruby_precompiled_only` — pass on glibc
- [x] `mise run lint-fix` — clean

Related: #12287

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ruby platform detection for Linux systems.
  * Prevented incompatible precompiled Ruby binaries from being selected on musl-based systems.
  * Added support for target-specific platform mapping and explicit custom binary overrides.

* **Documentation**
  * Clarified glibc/manylinux2014 requirements for precompiled Ruby binaries.
  * Documented musl compilation behavior and configuration options for custom binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->