### PR TITLE
fix(bootstrap): reject overlapping dotfile footprints

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -42,6 +42,9 @@ roots never acquire precedence from their order in `config_roots`.
 Same-target `symlink-each` declarations are the exception: their source trees
 compose when their leaf paths are disjoint, while overlapping leaves or
 file/directory collisions are reported with both declaring configs.
+Directory `copy` and `symlink-each` footprints are also checked against nested
+dotfile declarations. Disjoint leaves may share directories, but two entries
+cannot own the same leaf or place a file where another entry needs a directory.
 
 Other configuration such as tools, tasks, packages, hooks, and repos is not
 collected from these roots. Use their existing explicit workflows when those

--- a/e2e/cli/test_bootstrap_config_roots
+++ b/e2e/cli/test_bootstrap_config_roots
@@ -259,3 +259,30 @@ EOF
 assert_fail "mise bootstrap dotfiles add '$nested_leaf' --source '$root_b/nested.txt' --path '$root_b/mise.toml' --no-apply --yes" "conflicting dotfile declarations for $nested_leaf"
 assert_not_contains "cat '$root_b/mise.toml'" "$nested_leaf"
 assert_contains "cat '$root_b/mise.toml'" "keep = true"
+
+# A missing directory source has an unknown future shape. It still reserves
+# its target so filtering to a nested declaration cannot bypass validation.
+cat <<EOF >"$root_a/mise.toml"
+[dotfiles]
+"$nested_tree" = { source = "missing-tree", mode = "copy" }
+EOF
+cat <<EOF >"$root_b/mise.toml"
+[dotfiles]
+"$nested_leaf" = { source = "nested.txt", mode = "copy" }
+EOF
+assert_fail "mise bootstrap dotfiles apply --yes '$nested_leaf'" "conflicting dotfile declarations for $nested_tree"
+assert_fail "test -e $nested_leaf"
+
+# Refreshing an existing directory declaration retains its exclusions while
+# validating the prospective set.
+cat <<EOF >"$root_a/mise.toml"
+[dotfiles]
+"$nested_tree" = { source = "copy-tree", mode = "copy", exclude = ["collide.txt"] }
+EOF
+assert_succeed "mise bootstrap dotfiles add '$nested_tree' --path '$root_a/mise.toml' --no-apply --yes"
+
+# Repeated and aliased arguments resolve to one config target and therefore
+# produce one prospective filesystem operation rather than conflicting.
+duplicate_target="$PWD/duplicate.conf"
+echo duplicate >"$duplicate_target"
+assert_succeed "mise bootstrap dotfiles add '$duplicate_target' '$PWD/roots/../duplicate.conf' --path '$root_b/mise.toml' --no-apply --dry-run --yes"

--- a/e2e/cli/test_bootstrap_config_roots
+++ b/e2e/cli/test_bootstrap_config_roots
@@ -239,3 +239,23 @@ assert_fail "mise bootstrap dotfiles status" "$root_a/mise.toml"
 assert_fail "mise bootstrap dotfiles status" "$root_b/mise.toml"
 assert_fail "mise bootstrap dotfiles apply --yes '$nested_leaf'" "conflicting dotfile declarations for $nested_leaf"
 assert_fail "test -e $nested_tree"
+
+# edit --apply validates the complete set before opening the editor, rather
+# than editing a source and then applying only the selected conflicting leaf.
+cat <<EOF >"$PWD/editor-marker"
+#!/usr/bin/env bash
+touch "$PWD/editor-ran"
+EOF
+chmod +x "$PWD/editor-marker"
+assert_fail "EDITOR='$PWD/editor-marker' mise bootstrap dotfiles edit --apply '$nested_leaf'" "conflicting dotfile declarations for $nested_leaf"
+assert_fail "test -e $PWD/editor-ran"
+
+# add validates the prospective complete set before capturing a source or
+# writing the new declaration, including when automatic apply is disabled.
+cat <<EOF >"$root_b/mise.toml"
+[vars]
+keep = true
+EOF
+assert_fail "mise bootstrap dotfiles add '$nested_leaf' --source '$root_b/nested.txt' --path '$root_b/mise.toml' --no-apply --yes" "conflicting dotfile declarations for $nested_leaf"
+assert_not_contains "cat '$root_b/mise.toml'" "$nested_leaf"
+assert_contains "cat '$root_b/mise.toml'" "keep = true"

--- a/e2e/cli/test_bootstrap_config_roots
+++ b/e2e/cli/test_bootstrap_config_roots
@@ -216,3 +216,26 @@ assert_fail "mise bootstrap dotfiles status" "$root_b/mise.toml"
 assert_fail "mise bootstrap dotfiles apply --yes '$shared_tree'" "conflicting symlink-each declarations for $shared_tree/conf.d/a.toml"
 assert "readlink $shared_tree/conf.d/a.toml" "$root_a/tree/conf.d/a.toml"
 assert "readlink $shared_tree/conf.d/b.toml" "$root_b/tree/conf.d/b.toml"
+
+# A directory copy and a nested whole-file entry may share the target tree,
+# but they cannot own the same expanded leaf. Validate all entries even when
+# apply is filtered to only the nested target, and reject before mutation.
+nested_tree="$PWD/nested-tree"
+nested_leaf="$nested_tree/collide.txt"
+mkdir -p "$root_a/copy-tree"
+echo "from a" >"$root_a/copy-tree/collide.txt"
+echo "a only" >"$root_a/copy-tree/own-a.txt"
+echo "from b" >"$root_b/nested.txt"
+cat <<EOF >"$root_a/mise.toml"
+[dotfiles]
+"$nested_tree" = { source = "copy-tree", mode = "copy" }
+EOF
+cat <<EOF >"$root_b/mise.toml"
+[dotfiles]
+"$nested_leaf" = { source = "nested.txt", mode = "copy" }
+EOF
+assert_fail "mise bootstrap dotfiles status" "conflicting dotfile declarations for $nested_leaf"
+assert_fail "mise bootstrap dotfiles status" "$root_a/mise.toml"
+assert_fail "mise bootstrap dotfiles status" "$root_b/mise.toml"
+assert_fail "mise bootstrap dotfiles apply --yes '$nested_leaf'" "conflicting dotfile declarations for $nested_leaf"
+assert_fail "test -e $nested_tree"

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -2913,7 +2913,7 @@ impl BootstrapStatus {
     ) -> Result<()> {
         let mut json_files = vec![];
         let files = system::files::files_from_config(config)?;
-        system::files::validate_composed_symlink_each(&files)?;
+        system::files::validate_composed_file_footprints(&files)?;
         for req in files {
             let state = match system::files::check(config, &req) {
                 Ok(state) => state,

--- a/src/cli/dotfiles/add.rs
+++ b/src/cli/dotfiles/add.rs
@@ -134,7 +134,7 @@ impl DotfilesAdd {
                     mode.name()
                 );
             }
-            planned.push(PlannedAdd {
+            let item = PlannedAdd {
                 target_raw: normalized_target_raw(&target),
                 target,
                 source,
@@ -142,7 +142,16 @@ impl DotfilesAdd {
                 implied_source: self.source.is_none(),
                 explicit_mode: self.mode.is_some(),
                 already_managed: existing.cloned(),
-            });
+            };
+            // Wildcard expansion and equivalent spellings can resolve more
+            // than one argument to the same config key. The eventual config
+            // write is unique by target, so plan its filesystem work once too.
+            if !planned
+                .iter()
+                .any(|planned: &PlannedAdd| planned.target == item.target)
+            {
+                planned.push(item);
+            }
         }
 
         let mut prospective = managed.clone();
@@ -314,7 +323,7 @@ impl DotfilesAdd {
                     updated_targets.push(item.target_raw.as_str());
                 }
                 accepted.push(item);
-                apply_requests.push(item.as_request(&config_path));
+                apply_requests.push(item.managed_request(&config_path));
             }
 
             let apply_opts = system::files::ApplyOpts {
@@ -400,7 +409,7 @@ impl PlannedAdd {
     /// Build the request that will exist after capture, using the live target
     /// as the future source footprint when add is about to copy or move it.
     fn validation_request(&self, config_path: &std::path::Path) -> FileRequest {
-        let mut request = self.as_request(config_path);
+        let mut request = self.managed_request(config_path);
         if self.target.exists() && !same_file(&self.target, &self.source) {
             request.source = self.target.clone();
         } else if !self.source.exists() && self.mode != FileMode::SymlinkEach {
@@ -412,6 +421,15 @@ impl PlannedAdd {
         request
     }
 
+    /// Preserve an existing declaration's options when an add refreshes its
+    /// source; newly added declarations use the command-derived request.
+    fn managed_request(&self, config_path: &std::path::Path) -> FileRequest {
+        self.already_managed
+            .clone()
+            .unwrap_or_else(|| self.as_request(config_path))
+    }
+
+    /// Convert a newly added target into its configured file request.
     fn as_request(&self, config_path: &std::path::Path) -> FileRequest {
         FileRequest {
             target_raw: self.target_raw.clone(),

--- a/src/cli/dotfiles/add.rs
+++ b/src/cli/dotfiles/add.rs
@@ -66,6 +66,7 @@ pub(crate) struct DotfilesAdd {
 }
 
 impl DotfilesAdd {
+    /// Validate and capture the requested targets as one transactional update.
     pub(crate) async fn run(self) -> Result<()> {
         if self.source.is_some() && self.targets.len() != 1 {
             bail!("--source can only be used with one target");
@@ -143,6 +144,22 @@ impl DotfilesAdd {
                 already_managed: existing.cloned(),
             });
         }
+
+        let mut prospective = managed.clone();
+        for item in &planned {
+            if let Some(existing) = &item.already_managed
+                && let Some(index) = prospective.iter().position(|request| {
+                    request.target == existing.target
+                        && request.source == existing.source
+                        && request.mode == existing.mode
+                        && request.origin.config == existing.origin.config
+                })
+            {
+                prospective.remove(index);
+            }
+            prospective.push(item.validation_request(&config_path));
+        }
+        system::files::validate_composed_file_footprints(&prospective)?;
 
         if self.dry_run {
             for item in &planned {
@@ -380,6 +397,21 @@ struct PlannedAdd {
 }
 
 impl PlannedAdd {
+    /// Build the request that will exist after capture, using the live target
+    /// as the future source footprint when add is about to copy or move it.
+    fn validation_request(&self, config_path: &std::path::Path) -> FileRequest {
+        let mut request = self.as_request(config_path);
+        if self.target.exists() && !same_file(&self.target, &self.source) {
+            request.source = self.target.clone();
+        } else if !self.source.exists() && self.mode != FileMode::SymlinkEach {
+            // Add creates an empty source file in this case. Content mode gives
+            // the validator that known leaf shape without touching the disk.
+            request.mode = FileMode::Content;
+            request.content = Some(String::new());
+        }
+        request
+    }
+
     fn as_request(&self, config_path: &std::path::Path) -> FileRequest {
         FileRequest {
             target_raw: self.target_raw.clone(),

--- a/src/cli/dotfiles/apply.rs
+++ b/src/cli/dotfiles/apply.rs
@@ -42,6 +42,7 @@ impl DotfilesApply {
         Vec<system::edits::EditRequest>,
     )> {
         let all_files = system::files::files_from_config(config)?;
+        system::files::validate_composed_file_footprints(&all_files)?;
         let files = all_files
             .iter()
             .filter(|req| {

--- a/src/cli/dotfiles/edit.rs
+++ b/src/cli/dotfiles/edit.rs
@@ -35,9 +35,14 @@ pub(crate) struct DotfilesEdit {
 }
 
 impl DotfilesEdit {
+    /// Open the managed source and optionally converge its target afterward.
     pub(crate) async fn run(self) -> Result<()> {
         let mut config = Config::get().await?;
         let target = system::files::resolve_target_arg(&self.target);
+        if self.apply {
+            let files = system::files::files_from_config(&config)?;
+            system::files::validate_composed_file_footprints(&files)?;
+        }
 
         if let Some(path) = source_for_target(&config, &target, &self.target)? {
             open_or_create(&path)?;
@@ -140,10 +145,13 @@ fn open_or_create(path: &std::path::Path) -> Result<()> {
     Ok(())
 }
 
+/// Apply a selected target after validating the complete composed footprint.
 async fn apply_target(target: &str) -> Result<()> {
     let config = Config::reset().await?;
     let targets = vec![target.to_string()];
-    let files = system::files::files_from_config(&config)?
+    let all_files = system::files::files_from_config(&config)?;
+    system::files::validate_composed_file_footprints(&all_files)?;
+    let files = all_files
         .into_iter()
         .filter(|req| system::files::matches_target(&req.target, &req.target_raw, &targets))
         .collect::<Vec<_>>();

--- a/src/cli/dotfiles/status.rs
+++ b/src/cli/dotfiles/status.rs
@@ -31,7 +31,7 @@ impl DotfilesStatus {
         let mut any_missing = false;
 
         let all_files = system::files::files_from_config(&config)?;
-        system::files::validate_composed_symlink_each(&all_files)?;
+        system::files::validate_composed_file_footprints(&all_files)?;
         let files = all_files
             .iter()
             .filter(|req| {

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -190,15 +190,18 @@ pub(crate) fn validate_composed_file_footprints(requests: &[FileRequest]) -> Res
 
     for request in requests {
         // A missing source has an unknown eventual shape, but it still claims
-        // its target. Model that conservatively as a leaf so target-filtered
-        // operations cannot mutate a path inside the unresolved footprint.
+        // its target. Whole-resource modes reserve a leaf; symlink-each has a
+        // known directory-shaped target even before its children are known.
         let source_unavailable = request.mode != FileMode::Content
             && (!request.source.exists()
                 || request.mode == FileMode::SymlinkEach && !request.source.is_dir());
         let directory_walker = !source_unavailable
             && matches!(request.mode, FileMode::Copy | FileMode::SymlinkEach)
             && request.source.is_dir();
-        let request_leaves = if directory_walker {
+        let unresolved_directory = source_unavailable && request.mode == FileMode::SymlinkEach;
+        let request_leaves = if unresolved_directory {
+            vec![]
+        } else if directory_walker {
             walk_source_files(request)?
                 .into_iter()
                 .map(|(_, target)| target)
@@ -210,7 +213,7 @@ pub(crate) fn validate_composed_file_footprints(requests: &[FileRequest]) -> Res
         for leaf in &request_leaves {
             request_directories.extend(leaf.ancestors().skip(1).map(Path::to_path_buf));
         }
-        if directory_walker {
+        if directory_walker || unresolved_directory {
             request_directories.insert(request.target.clone());
             request_directories.extend(request.target.ancestors().skip(1).map(Path::to_path_buf));
         }
@@ -2456,6 +2459,24 @@ mod tests {
             err.to_string()
                 .contains(&target.to_string_lossy().to_string())
         );
+        Ok(())
+    }
+
+    /// An unavailable symlink-each contributor reserves the shared target as
+    /// a directory, allowing a sibling's known leaves to remain composable.
+    #[test]
+    fn composed_file_footprints_keep_missing_symlink_each_directory_shaped() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let missing = dir.path().join("missing");
+        let source_tree = dir.path().join("tree");
+        let target = dir.path().join("target");
+        file::create_dir_all(&source_tree)?;
+        file::write(source_tree.join("known"), "known")?;
+
+        validate_composed_file_footprints(&[
+            link_req(&missing, &target, FileMode::SymlinkEach),
+            link_req(&source_tree, &target, FileMode::SymlinkEach),
+        ])?;
         Ok(())
     }
 

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -189,16 +189,14 @@ pub(crate) fn validate_composed_file_footprints(requests: &[FileRequest]) -> Res
     let mut directories: IndexMap<PathBuf, &FileRequest> = IndexMap::new();
 
     for request in requests {
-        // Preserve the normal source-missing/type diagnostic. Apply will not
-        // mutate anything when any source is invalid, and its footprint cannot
-        // be determined reliably until the source exists with the right type.
-        if request.mode == FileMode::SymlinkEach && !request.source.is_dir()
-            || request.mode != FileMode::Content && !request.source.exists()
-        {
-            continue;
-        }
-
-        let directory_walker = matches!(request.mode, FileMode::Copy | FileMode::SymlinkEach)
+        // A missing source has an unknown eventual shape, but it still claims
+        // its target. Model that conservatively as a leaf so target-filtered
+        // operations cannot mutate a path inside the unresolved footprint.
+        let source_unavailable = request.mode != FileMode::Content
+            && (!request.source.exists()
+                || request.mode == FileMode::SymlinkEach && !request.source.is_dir());
+        let directory_walker = !source_unavailable
+            && matches!(request.mode, FileMode::Copy | FileMode::SymlinkEach)
             && request.source.is_dir();
         let request_leaves = if directory_walker {
             walk_source_files(request)?
@@ -2427,6 +2425,29 @@ mod tests {
 
         let err = validate_composed_file_footprints(&[
             link_req(&source_tree, &target, FileMode::Symlink),
+            link_req(&source_file, &target.join("nested"), FileMode::Copy),
+        ])
+        .unwrap_err();
+        assert!(err.to_string().contains("conflicting dotfile declarations"));
+        assert!(
+            err.to_string()
+                .contains(&target.to_string_lossy().to_string())
+        );
+        Ok(())
+    }
+
+    /// A declaration whose source is unavailable still reserves its target,
+    /// preventing a filtered apply from writing a nested declaration there.
+    #[test]
+    fn composed_file_footprints_reserve_missing_source_target() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let missing = dir.path().join("missing");
+        let source_file = dir.path().join("nested");
+        let target = dir.path().join("target");
+        file::write(&source_file, "nested")?;
+
+        let err = validate_composed_file_footprints(&[
+            link_req(&missing, &target, FileMode::Copy),
             link_req(&source_file, &target.join("nested"), FileMode::Copy),
         ])
         .unwrap_err();

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -239,6 +239,8 @@ pub(crate) fn validate_composed_file_footprints(requests: &[FileRequest]) -> Res
     Ok(())
 }
 
+/// Describe a footprint collision while preserving the established
+/// `symlink-each` diagnostic for two contributors in that mode.
 fn composed_file_footprint_conflict(
     path: &Path,
     first: &FileRequest,
@@ -2361,6 +2363,8 @@ mod tests {
         Ok(())
     }
 
+    /// Nested declarations may share directories when their concrete leaves
+    /// remain disjoint.
     #[test]
     fn composed_file_footprints_allow_disjoint_nested_leaves() -> Result<()> {
         let dir = tempfile::tempdir()?;
@@ -2382,6 +2386,8 @@ mod tests {
         Ok(())
     }
 
+    /// A nested whole-file declaration cannot also be owned by a directory
+    /// copy, regardless of declaration order.
     #[test]
     fn composed_file_footprints_reject_directory_copy_nested_leaf() -> Result<()> {
         let dir = tempfile::tempdir()?;
@@ -2408,6 +2414,8 @@ mod tests {
         Ok(())
     }
 
+    /// A whole-resource leaf cannot occupy a path another declaration needs
+    /// as a directory.
     #[test]
     fn composed_file_footprints_reject_leaf_required_as_directory() -> Result<()> {
         let dir = tempfile::tempdir()?;

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -180,57 +180,77 @@ pub(crate) fn files_from_config(config: &Config) -> Result<Vec<FileRequest>> {
     Ok(composed)
 }
 
-/// Same-target `symlink-each` declarations compose by their expanded target
-/// paths. Shared directories are fine, but two sources cannot own the same
-/// leaf or require a directory where another source places a leaf.
-pub(crate) fn validate_composed_symlink_each(requests: &[FileRequest]) -> Result<()> {
-    let mut groups: IndexMap<&Path, Vec<&FileRequest>> = IndexMap::new();
-    for request in requests
-        .iter()
-        .filter(|request| request.mode == FileMode::SymlinkEach)
-    {
-        groups.entry(&request.target).or_default().push(request);
-    }
+/// Validate the complete paths claimed by composed `[dotfiles]` entries.
+/// Directory copies and `symlink-each` entries may share directories, but no
+/// two entries may own the same leaf or require a directory where another
+/// entry places a leaf.
+pub(crate) fn validate_composed_file_footprints(requests: &[FileRequest]) -> Result<()> {
+    let mut leaves: IndexMap<PathBuf, &FileRequest> = IndexMap::new();
+    let mut directories: IndexMap<PathBuf, &FileRequest> = IndexMap::new();
 
-    for siblings in groups.into_values().filter(|siblings| siblings.len() > 1) {
-        let mut leaves: IndexMap<PathBuf, &FileRequest> = IndexMap::new();
-        let mut directories: IndexMap<PathBuf, &FileRequest> = IndexMap::new();
-        for request in siblings {
-            // Preserve the normal source-missing/type diagnostic. Once every
-            // source directory exists its complete composed footprint can be
-            // checked before status or apply performs any mutation.
-            if !request.source.is_dir() {
-                continue;
-            }
-            for (_, target) in walk_source_files(request)? {
-                if let Some(existing) = leaves.get(&target).or_else(|| directories.get(&target)) {
-                    return Err(composed_symlink_each_conflict(&target, existing, request));
-                }
-                leaves.insert(target, request);
-            }
-            for directory in needed_dirs(request)?
+    for request in requests {
+        // Preserve the normal source-missing/type diagnostic. Apply will not
+        // mutate anything when any source is invalid, and its footprint cannot
+        // be determined reliably until the source exists with the right type.
+        if request.mode == FileMode::SymlinkEach && !request.source.is_dir()
+            || request.mode != FileMode::Content && !request.source.exists()
+        {
+            continue;
+        }
+
+        let directory_walker = matches!(request.mode, FileMode::Copy | FileMode::SymlinkEach)
+            && request.source.is_dir();
+        let request_leaves = if directory_walker {
+            walk_source_files(request)?
                 .into_iter()
-                .filter(|directory| *directory != request.target)
-            {
-                if let Some(existing) = leaves.get(&directory) {
-                    return Err(composed_symlink_each_conflict(
-                        &directory, existing, request,
-                    ));
-                }
-                directories.entry(directory).or_insert(request);
+                .map(|(_, target)| target)
+                .collect::<Vec<_>>()
+        } else {
+            vec![request.target.clone()]
+        };
+        let mut request_directories = indexmap::IndexSet::new();
+        for leaf in &request_leaves {
+            request_directories.extend(leaf.ancestors().skip(1).map(Path::to_path_buf));
+        }
+        if directory_walker {
+            request_directories.insert(request.target.clone());
+            request_directories.extend(request.target.ancestors().skip(1).map(Path::to_path_buf));
+        }
+
+        for leaf in &request_leaves {
+            if let Some(existing) = leaves.get(leaf).or_else(|| directories.get(leaf)) {
+                return Err(composed_file_footprint_conflict(leaf, existing, request));
             }
+        }
+        for directory in &request_directories {
+            if let Some(existing) = leaves.get(directory) {
+                return Err(composed_file_footprint_conflict(
+                    directory, existing, request,
+                ));
+            }
+        }
+        for leaf in request_leaves {
+            leaves.insert(leaf, request);
+        }
+        for directory in request_directories {
+            directories.entry(directory).or_insert(request);
         }
     }
     Ok(())
 }
 
-fn composed_symlink_each_conflict(
+fn composed_file_footprint_conflict(
     path: &Path,
     first: &FileRequest,
     second: &FileRequest,
 ) -> eyre::Report {
+    let kind = if first.mode == FileMode::SymlinkEach && second.mode == FileMode::SymlinkEach {
+        "symlink-each"
+    } else {
+        "dotfile"
+    };
     eyre::eyre!(
-        "conflicting symlink-each declarations for {}\n\n  first:\n    {}\n\n  second:\n    {}",
+        "conflicting {kind} declarations for {}\n\n  first:\n    {}\n\n  second:\n    {}",
         path.display(),
         first.origin.conflict_description(),
         second.origin.conflict_description(),
@@ -1257,7 +1277,7 @@ pub(crate) fn plan_apply<'a>(
     requests: &'a [FileRequest],
     opts: &ApplyOpts,
 ) -> Result<ApplyPlan<'a>> {
-    validate_composed_symlink_each(requests)?;
+    validate_composed_file_footprints(requests)?;
     // pre-rendered template output rides along so it's written as compared,
     // and exec() in templates runs once per apply
     let mut todo: Vec<(&FileRequest, Option<String>)> = vec![];
@@ -2288,7 +2308,7 @@ mod tests {
         file::write(source_a.join("conf.d/a.toml"), "a")?;
         file::write(source_b.join("conf.d/b.toml"), "b")?;
 
-        validate_composed_symlink_each(&[
+        validate_composed_file_footprints(&[
             link_req(&source_a, &target, FileMode::SymlinkEach),
             link_req(&source_b, &target, FileMode::SymlinkEach),
         ])?;
@@ -2306,7 +2326,7 @@ mod tests {
         file::write(source_a.join("shared"), "a")?;
         file::write(source_b.join("shared"), "b")?;
 
-        let err = validate_composed_symlink_each(&[
+        let err = validate_composed_file_footprints(&[
             link_req(&source_a, &target, FileMode::SymlinkEach),
             link_req(&source_b, &target, FileMode::SymlinkEach),
         ])
@@ -2329,7 +2349,7 @@ mod tests {
         file::write(source_a.join("shared"), "a")?;
         file::write(source_b.join("shared/nested"), "b")?;
 
-        let err = validate_composed_symlink_each(&[
+        let err = validate_composed_file_footprints(&[
             link_req(&source_a, &target, FileMode::SymlinkEach),
             link_req(&source_b, &target, FileMode::SymlinkEach),
         ])
@@ -2337,6 +2357,75 @@ mod tests {
         assert!(
             err.to_string()
                 .contains(&target.join("shared").to_string_lossy().to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn composed_file_footprints_allow_disjoint_nested_leaves() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let source_tree = dir.path().join("tree");
+        let source_file = dir.path().join("nested");
+        let target = dir.path().join("target");
+        file::create_dir_all(&source_tree)?;
+        file::write(source_tree.join("owned-by-tree"), "tree")?;
+        file::write(&source_file, "nested")?;
+
+        validate_composed_file_footprints(&[
+            link_req(&source_tree, &target, FileMode::Copy),
+            link_req(
+                &source_file,
+                &target.join("owned-separately"),
+                FileMode::Copy,
+            ),
+        ])?;
+        Ok(())
+    }
+
+    #[test]
+    fn composed_file_footprints_reject_directory_copy_nested_leaf() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let source_tree = dir.path().join("tree");
+        let source_file = dir.path().join("nested");
+        let target = dir.path().join("target");
+        file::create_dir_all(&source_tree)?;
+        file::write(source_tree.join("shared"), "tree")?;
+        file::write(&source_file, "nested")?;
+        let tree = link_req(&source_tree, &target, FileMode::Copy);
+        let nested = link_req(&source_file, &target.join("shared"), FileMode::Copy);
+
+        for requests in [
+            [tree.clone(), nested.clone()],
+            [nested.clone(), tree.clone()],
+        ] {
+            let err = validate_composed_file_footprints(&requests).unwrap_err();
+            assert!(err.to_string().contains("conflicting dotfile declarations"));
+            assert!(
+                err.to_string()
+                    .contains(&target.join("shared").to_string_lossy().to_string())
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn composed_file_footprints_reject_leaf_required_as_directory() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let source_tree = dir.path().join("tree");
+        let source_file = dir.path().join("nested");
+        let target = dir.path().join("target");
+        file::create_dir_all(&source_tree)?;
+        file::write(&source_file, "nested")?;
+
+        let err = validate_composed_file_footprints(&[
+            link_req(&source_tree, &target, FileMode::Symlink),
+            link_req(&source_file, &target.join("nested"), FileMode::Copy),
+        ])
+        .unwrap_err();
+        assert!(err.to_string().contains("conflicting dotfile declarations"));
+        assert!(
+            err.to_string()
+                .contains(&target.to_string_lossy().to_string())
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary

- generalize composed dotfile validation to compare directory-copy and `symlink-each` leaves with nested whole-file declarations
- reject duplicate leaves and file/directory footprint collisions before status or apply, including target-filtered apply
- preserve disjoint additive directory composition and existing `symlink-each` diagnostics
- document the footprint rules and add unit/e2e regression coverage

Fixes the behavior reported in https://github.com/jdx/mise/discussions/12282.

## Validation

- `mise run format`
- `cargo test --bin mise system::files::tests::composed_`
- `mise run test:e2e e2e/cli/test_bootstrap_config_roots`
- `mise run lint`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches bootstrap/dotfile apply and add validation, so mis-modeled footprints could block valid configs or still miss collisions. Behavior is otherwise additive and covered by unit/e2e tests.
> 
> **Overview**
> Stops composed `[dotfiles]` from claiming the same leaf (or a file where another entry needs a directory) across **directory `copy`**, **`symlink-each`**, and nested whole-file entries.
> 
> Validation now runs on the **full composed set** before `status`, `apply`, `edit --apply`, and `add`—even when the command is filtered to one nested target—so a conflict cannot mutate disk or open the editor. Missing sources still reserve their target. Disjoint leaves may still share directories, and two `symlink-each` conflicts keep the existing diagnostic.
> 
> `dotfiles add` also dedupes aliased/repeated targets and validates the prospective set (preserving existing excludes on refresh) before capturing a source or writing config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5f9dc089b3fa37214c135b2d307432a8da0e806. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dotfile configuration validation across file, directory-copy, and `symlink-each` entries.
  * Conflicting declarations, duplicate target leaves, and file-versus-directory collisions are now detected consistently.
  * Valid shared-directory configurations with distinct leaf paths remain supported.
  * Validation now occurs before editing, filtering, or applying changes, preventing partial updates.
  * Repeated or aliased add arguments are consolidated without creating conflicts.

* **Tests**
  * Added coverage for nested conflicts, cross-mode collisions, missing sources, preserved exclusions, and disjoint footprints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->