### PR TITLE
fix(task): give global task scopes default includes without a config file

### DIFF
--- a/docs/tasks/file-tasks.md
+++ b/docs/tasks/file-tasks.md
@@ -11,6 +11,10 @@ In addition to defining tasks through the configuration, they can also be define
 These are the default file-task directories. If [`task_config.includes`](/tasks/task-configuration.html#task_config.includes)
 is set for the current config scope, mise searches only the paths listed there instead.
 
+Global file tasks live in `$MISE_CONFIG_DIR/tasks` (default `~/.config/mise/tasks`) and system-wide
+file tasks in `$MISE_SYSTEM_DIR/tasks` (default `/etc/mise/tasks`). These directories are picked up
+even when the scope has no config file at all.
+
 Here is an example of a file task that builds a Rust CLI:
 
 ```bash [mise-tasks/build]

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -1484,6 +1484,12 @@ The default file-task directories are:
 - `.config/mise/tasks`
 - `mise/tasks`
 
+For the user-global scope, the `.config/mise/tasks` entry points at the actual config dir: when
+`MISE_CONFIG_DIR` is set to a non-default location, `$MISE_CONFIG_DIR/tasks` is used instead (and
+the default location is no longer treated as global). The system scope similarly uses
+`$MISE_SYSTEM_DIR/tasks` (default `/etc/mise/tasks`). Both directories are loaded even when no
+config file exists in that scope, so a scripts-only setup works without a `config.toml`.
+
 If you want to keep the defaults and add another directory, include the defaults explicitly:
 
 ```toml

--- a/e2e/tasks/test_task_global_default_includes
+++ b/e2e/tasks/test_task_global_default_includes
@@ -64,3 +64,56 @@ chmod +x ~/custom-tasks/custom-included
 assert "mise run custom-included" "custom-included"
 assert "mise tasks --global" "custom-included
 system-scripts-only"
+
+# glob metacharacters in the config dir path must not break discovery
+mkdir -p "$HOME/cfg [x]/tasks"
+cat <<'EOF' >"$HOME/cfg [x]/tasks/metachar-task"
+#!/usr/bin/env bash
+echo metachar-task
+EOF
+chmod +x "$HOME/cfg [x]/tasks/metachar-task"
+assert "MISE_CONFIG_DIR='$HOME/cfg [x]' mise run metachar-task" "metachar-task"
+
+unset MISE_CONFIG_DIR
+
+# with the default config dir, the config-dir entry still resolves relative to
+# a custom global root
+cat >~/.config/mise/config.toml <<'TOML'
+tasks.myglobal = { run = 'echo myglobal' }
+TOML
+mkdir -p ~/groot/.config/mise/tasks
+cat <<'EOF' >~/groot/.config/mise/tasks/groot-task
+#!/usr/bin/env bash
+echo groot-task
+EOF
+chmod +x ~/groot/.config/mise/tasks/groot-task
+assert "MISE_GLOBAL_CONFIG_ROOT=$HOME/groot mise tasks --global" "groot-task
+myglobal
+scripts-only
+system-scripts-only"
+
+# run from outside HOME so the ancestor walk cannot reach the global dirs and
+# only the global scopes themselves are observed
+mkdir -p "$TMPDIR/outside"
+
+# a nonexistent MISE_GLOBAL_CONFIG_FILE disables the user scope entirely
+assert "MISE_GLOBAL_CONFIG_FILE=$HOME/nope.toml mise -C '$TMPDIR/outside' tasks --global" "system-scripts-only"
+
+# a scope whose config file was consumed by the other scope stays disabled
+cat >"$HOME/shared-global.toml" <<'TOML'
+[task_config]
+includes = []
+TOML
+assert_empty "MISE_GLOBAL_CONFIG_FILE=$HOME/shared-global.toml MISE_SYSTEM_CONFIG_FILE=$HOME/shared-global.toml mise -C '$TMPDIR/outside' tasks --global"
+
+# --no-config disables global file-task discovery too
+assert_empty "MISE_NO_CONFIG=1 mise -C '$TMPDIR/outside' tasks --global"
+
+# a config dir inside a project keeps that project's task context
+mkdir -p "$HOME/proj/.config/mise/tasks"
+cat <<'EOF' >"$HOME/proj/.config/mise/tasks/proj-pwd"
+#!/usr/bin/env bash
+echo "PWD=$PWD"
+EOF
+chmod +x "$HOME/proj/.config/mise/tasks/proj-pwd"
+assert "MISE_CONFIG_DIR=$HOME/proj/.config/mise mise -C $HOME/proj run proj-pwd" "PWD=$HOME/proj"

--- a/e2e/tasks/test_task_global_default_includes
+++ b/e2e/tasks/test_task_global_default_includes
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+echo "tasks.mylocal = { run = 'echo mylocal' }" >mise.toml
+
+# the user-global scope owns its config dir's tasks/ even without a config file
+mkdir -p "$MISE_CONFIG_DIR/tasks"
+cat <<'EOF' >"$MISE_CONFIG_DIR/tasks/scripts-only"
+#!/usr/bin/env bash
+echo scripts-only
+EOF
+chmod +x "$MISE_CONFIG_DIR/tasks/scripts-only"
+
+assert "mise run scripts-only" "scripts-only"
+assert "mise tasks --global" "scripts-only"
+
+# the system scope owns its tasks dir even without a system config file
+mkdir -p "$MISE_SYSTEM_DIR/tasks"
+cat <<'EOF' >"$MISE_SYSTEM_DIR/tasks/system-scripts-only"
+#!/usr/bin/env bash
+echo system-scripts-only
+EOF
+chmod +x "$MISE_SYSTEM_DIR/tasks/system-scripts-only"
+
+assert "mise run system-scripts-only" "system-scripts-only"
+assert "mise tasks --global" "scripts-only
+system-scripts-only"
+
+# a relocated config dir owns its own tasks/; the default location is no
+# longer part of the global scope but stays discoverable as a HOME-local task
+mkdir -p ~/relocated-config/tasks
+cat <<'EOF' >~/relocated-config/tasks/relocated
+#!/usr/bin/env bash
+echo relocated
+EOF
+chmod +x ~/relocated-config/tasks/relocated
+
+export MISE_CONFIG_DIR="$HOME/relocated-config"
+assert "mise run relocated" "relocated"
+assert "mise tasks --global" "relocated
+system-scripts-only"
+assert "mise run scripts-only" "scripts-only"
+
+# a config file in the relocated dir keeps the same default include
+cat >"$MISE_CONFIG_DIR/config.toml" <<'TOML'
+tasks.myglobal = { run = 'echo myglobal' }
+TOML
+assert "mise run relocated" "relocated"
+assert "mise tasks --global" "myglobal
+relocated
+system-scripts-only"
+
+# explicit task_config.includes still replaces the default include
+cat >"$MISE_CONFIG_DIR/config.toml" <<'TOML'
+[task_config]
+includes = ["custom-tasks"]
+TOML
+mkdir -p ~/custom-tasks
+cat <<'EOF' >~/custom-tasks/custom-included
+#!/usr/bin/env bash
+echo custom-included
+EOF
+chmod +x ~/custom-tasks/custom-included
+
+assert "mise run custom-included" "custom-included"
+assert "mise tasks --global" "custom-included
+system-scripts-only"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3376,14 +3376,33 @@ async fn apply_task_config_inputs(
     Ok(())
 }
 
+const CONFIG_DIR_DEFAULT_TASK_INCLUDE: &str = ".config/mise/tasks";
+
 fn default_task_includes() -> Vec<String> {
     vec![
         "mise-tasks".to_string(),
         ".mise-tasks".to_string(),
         ".mise/tasks".to_string(),
-        ".config/mise/tasks".to_string(),
+        CONFIG_DIR_DEFAULT_TASK_INCLUDE.to_string(),
         "mise/tasks".to_string(),
     ]
+}
+
+/// Default task includes for a global/system scope. The root-relative
+/// `.config/mise/tasks` entry is pinned to the scope's own config dir so a
+/// relocated `MISE_CONFIG_DIR` (or the system config dir) keeps owning its
+/// `tasks/` directory.
+fn scope_default_task_includes(scope_tasks_dir: &Path) -> Vec<String> {
+    default_task_includes()
+        .into_iter()
+        .map(|include| {
+            if include == CONFIG_DIR_DEFAULT_TASK_INCLUDE {
+                scope_tasks_dir.to_string_lossy().to_string()
+            } else {
+                include
+            }
+        })
+        .collect()
 }
 
 fn is_global_task_include_path(path: &Path) -> bool {
@@ -4077,10 +4096,16 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
     // Compose user-global and system configs as separate scopes so task_config
     // fields follow the same override semantics as local config files. Load the
     // user scope first so a user task replaces a same-named system task without
-    // inheriting metadata from it.
+    // inheriting metadata from it. Each scope owns its config dir's `tasks/`
+    // directory even when no config file exists in that scope, so scripts-only
+    // setups don't depend on the ancestor walk reaching the global root.
     let mut seen_configs = BTreeSet::new();
-    let mut config_groups = vec![];
-    for config_paths in [global_config_files(), system_config_files()] {
+    let mut tasks: IndexMap<String, Task> = IndexMap::new();
+    let mut rendered_file_tasks = RenderedTaskCache::default();
+    for (config_paths, scope_tasks_dir) in [
+        (global_config_files(), dirs::CONFIG.join("tasks")),
+        (system_config_files(), dirs::SYSTEM_CONFIG.join("tasks")),
+    ] {
         let configs = config_paths
             .iter()
             .rev()
@@ -4096,25 +4121,20 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
             })
             .filter(|cf| seen_configs.insert(file::desymlink_path(cf.get_path())))
             .collect::<Vec<_>>();
-        if !configs.is_empty() {
-            config_groups.push(configs);
-        }
-    }
-
-    // Aggregate the user and system scopes high-to-low. Each scope has already
-    // composed its file and inline tasks, so precedence between scopes is a
-    // simple first-wins replacement by task name.
-    let mut tasks: IndexMap<String, Task> = IndexMap::new();
-    let mut rendered_file_tasks = RenderedTaskCache::default();
-    for configs in config_groups {
+        // Aggregate the user and system scopes high-to-low. Each scope has
+        // already composed its file and inline tasks, so precedence between
+        // scopes is a simple first-wins replacement by task name.
         let sources = load_task_sources_from_configs(
             config,
             &env::MISE_GLOBAL_CONFIG_ROOT,
             configs,
             templates,
-            false,
-            None,
-            Some(&mut rendered_file_tasks),
+            TaskSourceLoadOptions {
+                monorepo_context: false,
+                cascaded_task_config: None,
+                rendered_file_tasks: Some(&mut rendered_file_tasks),
+                scope_default_tasks_dir: Some(scope_tasks_dir),
+            },
         )
         .await?;
         rendered_file_tasks.finish_config();
@@ -4881,12 +4901,25 @@ async fn load_tasks_from_configs(
         dir,
         configs,
         templates,
-        monorepo_context,
-        cascaded_task_config,
-        None,
+        TaskSourceLoadOptions {
+            monorepo_context,
+            cascaded_task_config,
+            rendered_file_tasks: None,
+            scope_default_tasks_dir: None,
+        },
     )
     .await?
     .into_tasks())
+}
+
+struct TaskSourceLoadOptions<'a> {
+    monorepo_context: bool,
+    cascaded_task_config: Option<&'a CascadedTaskConfig>,
+    rendered_file_tasks: Option<&'a mut RenderedTaskCache>,
+    /// For global/system scopes: the scope's own `tasks/` directory. It pins
+    /// the config-dir entry of the default includes to that scope's config dir
+    /// and is the sole default include when the scope has no config files.
+    scope_default_tasks_dir: Option<PathBuf>,
 }
 
 /// Load file and inline task sources without merging them.
@@ -4898,10 +4931,14 @@ async fn load_task_sources_from_configs(
     dir: &Path,
     configs: Vec<&Arc<dyn ConfigFile>>,
     templates: &TaskDefinitions,
-    monorepo_context: bool,
-    cascaded_task_config: Option<&CascadedTaskConfig>,
-    mut rendered_file_tasks: Option<&mut RenderedTaskCache>,
+    options: TaskSourceLoadOptions<'_>,
 ) -> Result<TaskSources> {
+    let TaskSourceLoadOptions {
+        monorepo_context,
+        cascaded_task_config,
+        mut rendered_file_tasks,
+        scope_default_tasks_dir,
+    } = options;
     let cascaded_task_config =
         if configs.iter().find_map(|cf| cf.task_config().cascade) == Some(false) {
             None
@@ -4929,7 +4966,19 @@ async fn load_task_sources_from_configs(
                     .map(|includes| (includes, tc.includes_root.clone(), configs.len()))
             })
         })
-        .unwrap_or_else(|| (default_task_includes(), dir.to_path_buf(), configs.len()));
+        .unwrap_or_else(|| {
+            let includes = match &scope_default_tasks_dir {
+                // A global/system scope without any config file still owns its
+                // config dir's tasks/ directory, but does not claim the
+                // root-relative defaults a config at the root would.
+                Some(tasks_dir) if configs.is_empty() => {
+                    vec![tasks_dir.to_string_lossy().to_string()]
+                }
+                Some(tasks_dir) => scope_default_task_includes(tasks_dir),
+                None => default_task_includes(),
+            };
+            (includes, dir.to_path_buf(), configs.len())
+        });
 
     // Resolve task defaults once for the config root so inline tasks from
     // lower-precedence overlay files use the same defaults as file tasks.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3376,33 +3376,25 @@ async fn apply_task_config_inputs(
     Ok(())
 }
 
-const CONFIG_DIR_DEFAULT_TASK_INCLUDE: &str = ".config/mise/tasks";
-
 fn default_task_includes() -> Vec<String> {
+    default_task_includes_with_config_dir(".config/mise/tasks".to_string())
+}
+
+/// Default task includes for a global/system scope. The config-dir entry is
+/// pinned to the scope's own config dir so a relocated `MISE_CONFIG_DIR` (or
+/// the system config dir) keeps owning its `tasks/` directory.
+fn scope_default_task_includes(scope_tasks_dir: &Path) -> Vec<String> {
+    default_task_includes_with_config_dir(scope_tasks_dir.to_string_lossy().to_string())
+}
+
+fn default_task_includes_with_config_dir(config_dir_tasks: String) -> Vec<String> {
     vec![
         "mise-tasks".to_string(),
         ".mise-tasks".to_string(),
         ".mise/tasks".to_string(),
-        CONFIG_DIR_DEFAULT_TASK_INCLUDE.to_string(),
+        config_dir_tasks,
         "mise/tasks".to_string(),
     ]
-}
-
-/// Default task includes for a global/system scope. The root-relative
-/// `.config/mise/tasks` entry is pinned to the scope's own config dir so a
-/// relocated `MISE_CONFIG_DIR` (or the system config dir) keeps owning its
-/// `tasks/` directory.
-fn scope_default_task_includes(scope_tasks_dir: &Path) -> Vec<String> {
-    default_task_includes()
-        .into_iter()
-        .map(|include| {
-            if include == CONFIG_DIR_DEFAULT_TASK_INCLUDE {
-                scope_tasks_dir.to_string_lossy().to_string()
-            } else {
-                include
-            }
-        })
-        .collect()
 }
 
 fn is_global_task_include_path(path: &Path) -> bool {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -982,9 +982,19 @@ impl Config {
             load_local_tasks_with_context(&config, ctx, &task_definitions).await?;
         let global_tasks = load_global_tasks(&config, &task_definitions).await?;
         local_tasks.retain(|local| {
-            !global_tasks
-                .iter()
-                .any(|global| tasks_have_same_source(local, global))
+            !global_tasks.iter().any(|global| {
+                // Drop a local rediscovery of a global source only when both
+                // readings share a config root. A differing root (e.g.
+                // MISE_CONFIG_DIR pointing inside a project) is a genuinely
+                // different context, and the local reading keeps shadowing the
+                // global one by name.
+                tasks_have_same_source(local, global)
+                    && local
+                        .config_root
+                        .as_ref()
+                        .zip(global.config_root.as_ref())
+                        .is_none_or(|(l, g)| file::desymlink_path(l) == file::desymlink_path(g))
+            })
         });
         let mut tasks: BTreeMap<String, Task> = local_tasks
             .into_iter()
@@ -3377,33 +3387,34 @@ async fn apply_task_config_inputs(
 }
 
 fn default_task_includes() -> Vec<String> {
-    default_task_includes_with_config_dir(".config/mise/tasks".to_string())
+    let mut includes = default_task_includes_without_config_dir();
+    includes.insert(3, ".config/mise/tasks".to_string());
+    includes
 }
 
-/// Default task includes for a global/system scope. The config-dir entry is
-/// pinned to the scope's own config dir so a relocated `MISE_CONFIG_DIR` (or
-/// the system config dir) keeps owning its `tasks/` directory.
-fn scope_default_task_includes(scope_tasks_dir: &Path) -> Vec<String> {
-    default_task_includes_with_config_dir(scope_tasks_dir.to_string_lossy().to_string())
-}
-
-fn default_task_includes_with_config_dir(config_dir_tasks: String) -> Vec<String> {
+fn default_task_includes_without_config_dir() -> Vec<String> {
     vec![
         "mise-tasks".to_string(),
         ".mise-tasks".to_string(),
         ".mise/tasks".to_string(),
-        config_dir_tasks,
         "mise/tasks".to_string(),
     ]
 }
 
-fn is_global_task_include_path(path: &Path) -> bool {
+/// The user-global and system scopes' own `tasks/` directories, in scope
+/// order. Both the global task loader and the global include marking/trust
+/// exemption derive from this list so they cannot drift apart.
+fn global_scope_tasks_dirs() -> [PathBuf; 2] {
     [
         dirs::CONFIG.join("tasks"),
         dirs::SYSTEM_CONFIG.join("tasks"),
     ]
-    .iter()
-    .any(|prefix| file::path_starts_with_resolved(path, prefix))
+}
+
+fn is_global_task_include_path(path: &Path) -> bool {
+    global_scope_tasks_dirs()
+        .iter()
+        .any(|prefix| file::path_starts_with_resolved(path, prefix))
 }
 
 #[async_backtrace::framed]
@@ -4094,10 +4105,16 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
     let mut seen_configs = BTreeSet::new();
     let mut tasks: IndexMap<String, Task> = IndexMap::new();
     let mut rendered_file_tasks = RenderedTaskCache::default();
-    for (config_paths, scope_tasks_dir) in [
-        (global_config_files(), dirs::CONFIG.join("tasks")),
-        (system_config_files(), dirs::SYSTEM_CONFIG.join("tasks")),
+    let [user_tasks_dir, system_tasks_dir] = global_scope_tasks_dirs();
+    for (config_paths, scope_tasks_dir, pin_config_dir_include) in [
+        (
+            global_config_files(),
+            user_tasks_dir,
+            *env::MISE_CONFIG_DIR_OVERRIDDEN,
+        ),
+        (system_config_files(), system_tasks_dir, true),
     ] {
+        let scope_has_candidates = !config_paths.is_empty();
         let configs = config_paths
             .iter()
             .rev()
@@ -4113,6 +4130,32 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
             })
             .filter(|cf| seen_configs.insert(file::desymlink_path(cf.get_path())))
             .collect::<Vec<_>>();
+        let scope_task_defaults = if configs.is_empty() {
+            // Only a scope with no config files at all claims its own tasks
+            // dir. A scope whose candidates did not load (a nonexistent
+            // MISE_GLOBAL_CONFIG_FILE, --no-config) or were consumed by the
+            // other scope keeps that explicit configuration authoritative.
+            if scope_has_candidates || Settings::no_config() {
+                continue;
+            }
+            ScopeTaskDefaults {
+                includes: vec![],
+                pinned_dir: Some(scope_tasks_dir),
+            }
+        } else if pin_config_dir_include {
+            // The scope's config dir is not where the root-relative default
+            // include points, so pin the config-dir entry to the scope's own
+            // tasks dir instead.
+            ScopeTaskDefaults {
+                includes: default_task_includes_without_config_dir(),
+                pinned_dir: Some(scope_tasks_dir),
+            }
+        } else {
+            ScopeTaskDefaults {
+                includes: default_task_includes(),
+                pinned_dir: None,
+            }
+        };
         // Aggregate the user and system scopes high-to-low. Each scope has
         // already composed its file and inline tasks, so precedence between
         // scopes is a simple first-wins replacement by task name.
@@ -4125,7 +4168,7 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
                 monorepo_context: false,
                 cascaded_task_config: None,
                 rendered_file_tasks: Some(&mut rendered_file_tasks),
-                scope_default_tasks_dir: Some(scope_tasks_dir),
+                scope_task_defaults: Some(scope_task_defaults),
             },
         )
         .await?;
@@ -4897,21 +4940,29 @@ async fn load_tasks_from_configs(
             monorepo_context,
             cascaded_task_config,
             rendered_file_tasks: None,
-            scope_default_tasks_dir: None,
+            scope_task_defaults: None,
         },
     )
     .await?
     .into_tasks())
 }
 
+/// A global/system scope's default task includes, applied only when no config
+/// supplies explicit `task_config.includes`.
+struct ScopeTaskDefaults {
+    /// Relative default patterns, resolved against the global root.
+    includes: Vec<String>,
+    /// The scope's own `tasks/` directory, loaded as a literal path so glob
+    /// metacharacters or non-UTF-8 bytes in the directory path cannot break
+    /// discovery.
+    pinned_dir: Option<PathBuf>,
+}
+
 struct TaskSourceLoadOptions<'a> {
     monorepo_context: bool,
     cascaded_task_config: Option<&'a CascadedTaskConfig>,
     rendered_file_tasks: Option<&'a mut RenderedTaskCache>,
-    /// For global/system scopes: the scope's own `tasks/` directory. It pins
-    /// the config-dir entry of the default includes to that scope's config dir
-    /// and is the sole default include when the scope has no config files.
-    scope_default_tasks_dir: Option<PathBuf>,
+    scope_task_defaults: Option<ScopeTaskDefaults>,
 }
 
 /// Load file and inline task sources without merging them.
@@ -4929,7 +4980,7 @@ async fn load_task_sources_from_configs(
         monorepo_context,
         cascaded_task_config,
         mut rendered_file_tasks,
-        scope_default_tasks_dir,
+        scope_task_defaults,
     } = options;
     let cascaded_task_config =
         if configs.iter().find_map(|cf| cf.task_config().cascade) == Some(false) {
@@ -4941,6 +4992,7 @@ async fn load_task_sources_from_configs(
     // a config can only vouch for task include files when it was actually
     // trusted — safe configs load without trust and cannot vouch for anything
     let require_task_include_trust = !configs.iter().any(|cf| is_path_trusted(cf.get_path()));
+    let mut pinned_scope_dir = None;
     let (includes, resolve_dir, include_config_precedence) = configs
         .iter()
         .enumerate()
@@ -4959,14 +5011,11 @@ async fn load_task_sources_from_configs(
             })
         })
         .unwrap_or_else(|| {
-            let includes = match &scope_default_tasks_dir {
-                // A global/system scope without any config file still owns its
-                // config dir's tasks/ directory, but does not claim the
-                // root-relative defaults a config at the root would.
-                Some(tasks_dir) if configs.is_empty() => {
-                    vec![tasks_dir.to_string_lossy().to_string()]
+            let includes = match scope_task_defaults {
+                Some(defaults) => {
+                    pinned_scope_dir = defaults.pinned_dir;
+                    defaults.includes
                 }
-                Some(tasks_dir) => scope_default_task_includes(tasks_dir),
                 None => default_task_includes(),
             };
             (includes, dir.to_path_buf(), configs.len())
@@ -5023,14 +5072,35 @@ async fn load_task_sources_from_configs(
     } else {
         None
     };
-    for include in &includes {
-        let artifacts = if include.starts_with("git::") {
-            vec![resolve_git_url_to_path(include).await?]
-        } else {
-            expand_task_include(&resolve_dir, include)
+    enum TaskIncludeEntry<'a> {
+        Pattern(&'a str),
+        /// A literal directory bypassing glob expansion, so metacharacters or
+        /// non-UTF-8 bytes in the path cannot break discovery.
+        Dir(&'a Path),
+    }
+    let mut include_entries = includes
+        .iter()
+        .map(|include| TaskIncludeEntry::Pattern(include))
+        .collect::<Vec<_>>();
+    if let Some(dir_path) = &pinned_scope_dir {
+        // Keep the config-dir entry's position from default_task_includes()
+        // so later-include-wins precedence among the defaults is unchanged.
+        let pos = include_entries.len().min(3);
+        include_entries.insert(pos, TaskIncludeEntry::Dir(dir_path));
+    }
+    for entry in include_entries {
+        let artifacts = match entry {
+            TaskIncludeEntry::Pattern(include) if include.starts_with("git::") => {
+                vec![resolve_git_url_to_path(include).await?]
+            }
+            TaskIncludeEntry::Pattern(include) => expand_task_include(&resolve_dir, include)
                 .into_iter()
                 .map(TaskFileArtifact::persistent)
-                .collect()
+                .collect(),
+            TaskIncludeEntry::Dir(path) if path.exists() => {
+                vec![TaskFileArtifact::persistent(path.to_path_buf())]
+            }
+            TaskIncludeEntry::Dir(_) => vec![],
         };
         for artifact in artifacts {
             let p = artifact.path;


### PR DESCRIPTION
## Summary

- the user-global task scope always contributes `MISE_CONFIG_DIR/tasks` as its default task include, and the system scope `MISE_SYSTEM_DIR/tasks`, even when no config file exists in that scope
- when `MISE_CONFIG_DIR` is set to a non-default location, pin the config-dir entry of the user scope's default includes to that directory (the system scope always pins `MISE_SYSTEM_DIR/tasks`); with the default config dir, the root-relative `.config/mise/tasks` entry keeps resolving against `MISE_GLOBAL_CONFIG_ROOT` as before

## Bug examples

- A scripts-only setup (`~/.config/mise/tasks/*` with no global config file) was only discovered because the local ancestor walk happens to reach `$HOME`, so those tasks were invisible whenever the working directory was outside `$HOME`. They now load through the global pass from anywhere.
- With `MISE_CONFIG_DIR` relocated, `<config_dir>/tasks` was never discovered: without a config file the global pass produced nothing, and with one it resolved the default includes relative to the global root, still reading `~/.config/mise/tasks`. The scope now reads its own `tasks/` directory instead of the abandoned default location.
- With a system config file and no explicit includes, the system scope resolved the HOME-relative defaults and read the user's `~/.config/mise/tasks` as system tasks instead of its own `MISE_SYSTEM_DIR/tasks`, which was not discovered at all.

## Guard rails

- Explicit `task_config.includes` in a global or system config still replaces the defaults.
- A scope without any config file claims only its own `tasks/` directory, not the root-relative defaults a config at the global root would.
- A scope whose configured file did not load (nonexistent `MISE_GLOBAL_CONFIG_FILE`, `--no-config`) or whose candidates were consumed by the other scope is skipped entirely, so explicit configuration such as `includes = []` stays authoritative.
- The pinned scope directory is loaded as a literal path, so glob metacharacters or non-UTF-8 bytes in `HOME`/`MISE_CONFIG_DIR`/`MISE_SYSTEM_DIR` cannot break discovery.
- Same-source deduplication between the local walk and the global pass now compares config roots: when `MISE_CONFIG_DIR` points inside a project, the project-rooted reading keeps its context instead of silently running at the global root.
- The scope directories and the global include marking/trust exemption derive from one shared helper (`global_scope_tasks_dirs`).

Known gaps left for follow-ups: the task-not-found executable hint still only inspects cwd-relative include dirs, and `MISE_GLOBAL_CONFIG_FILE` does not claim a sibling `tasks/` dir (unchanged behavior).

This is groundwork for follow-up fixes to global/local task duplication (#12203).

## Testing

- `mise run lint`
- `cargo test --bin mise -- task` / `cargo test --bin mise -- config::tests`
- `mise run test:e2e e2e/tasks/test_task_global_default_includes e2e/tasks/test_task_ls_global e2e/tasks/test_task_global_config_dedup e2e/tasks/test_task_global_config_root e2e/tasks/test_task_monorepo_config_dedup e2e/tasks/test_task_monorepo_global_tasks e2e/tasks/test_task_toml_include_inline_precedence e2e/tasks/test_task_includes_env_precedence e2e/tasks/test_task_include_trust`
- The new e2e covers: scripts-only user/system scopes, relocated `MISE_CONFIG_DIR` (with and without a config file), explicit includes overriding defaults, glob metacharacters in the config dir path, custom `MISE_GLOBAL_CONFIG_ROOT` resolution, nonexistent `MISE_GLOBAL_CONFIG_FILE`, a scope consumed by cross-scope dedup with `includes = []`, `MISE_NO_CONFIG`, and `MISE_CONFIG_DIR` inside a project keeping the project's task context.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*
