### PR TITLE
docs(hooks): clarify cross-file execution order

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -4,6 +4,13 @@ You can have mise automatically execute scripts during a `mise activate` session
 without the `mise activate` shell hook installed in your shell—except the `preinstall` and `postinstall` hooks.
 The configuration goes into `mise.toml`.
 
+When the same hook type is defined in multiple loaded config files, mise runs every matching hook
+rather than overriding hooks from lower-precedence files. Hooks run from the highest-precedence
+config file to the lowest-precedence config file. Within a single config file, hooks defined as an
+array run in the order listed. For example, hooks in `conf.d/a.toml`, `conf.d/b.toml`, and
+`conf.d/c.toml` run as `c`, `b`, then `a` because later alphabetical fragments have higher
+precedence. Put order-dependent hooks in one array when they need to run in alphabetical order.
+
 ## CD hook
 
 This hook is run anytime the directory is changed.


### PR DESCRIPTION
## Summary
- clarify that matching hooks from multiple config files are additive
- document highest-to-lowest precedence execution order
- add a `conf.d` example and recommend arrays for order-dependent hooks

Context: https://github.com/jdx/mise/discussions/12276

## Validation
- `git diff --check`
- `hk run --check --safe --format json` scoped to `docs/hooks.md`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only clarification of hook execution order; no code or behavior changes.
> 
> **Overview**
> Documents that matching hooks from multiple config files are **additive**, not overridden, and run from **highest- to lowest-precedence** files (arrays keep listed order within a file).
> 
> Adds a `conf.d` example (`c`, then `b`, then `a`) and recommends putting order-dependent hooks in one array.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3c28217420255e33ca03b1c42e6784f824cea0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented hook execution order across multiple configuration files.
  * Clarified precedence rules and ordering for hook entries and configuration fragments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->