### PR TITLE
fix(bootstrap): match brew cask pkgutil patterns

### DIFF
--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -6419,15 +6419,27 @@ fn pkg_id_installed(pkg_id: &str) -> Result<bool> {
     bail!("brew-cask: pkgutil receipt check for '{pkg_id}' is only available on macOS");
 
     #[cfg(target_os = "macos")]
+    // Homebrew's pkgutil metadata is a regular expression, not a literal ID.
+    // Match it with pkgutil itself to preserve its nonstandard regexp semantics.
     let output = std::process::Command::new("pkgutil")
-        .arg("--pkg-info")
-        .arg(pkg_id)
+        .arg(format!("--pkgs={pkg_id}"))
         .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
-        .status()?;
+        .output()?;
     #[cfg(target_os = "macos")]
-    Ok(output.success())
+    if !output.status.success() {
+        bail!(
+            "brew-cask: pkgutil receipt query for '{pkg_id}' failed with {}",
+            output.status
+        );
+    }
+    #[cfg(target_os = "macos")]
+    Ok(pkgutil_output_has_match(&output.stdout))
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn pkgutil_output_has_match(output: &[u8]) -> bool {
+    output.iter().any(|byte| !byte.is_ascii_whitespace())
 }
 
 fn pkg_ids_installed(pkg_ids: &[String]) -> Result<bool> {
@@ -12013,6 +12025,15 @@ end
             }
         );
         Ok(())
+    }
+
+    #[test]
+    fn detects_pkgutil_query_matches() {
+        assert!(pkgutil_output_has_match(
+            b"com.pioneer.rekordbox.7.2.14.0323\n"
+        ));
+        assert!(!pkgutil_output_has_match(b""));
+        assert!(!pkgutil_output_has_match(b"\n"));
     }
 
     #[test]

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -6055,10 +6055,13 @@ fn collect_pkg_receipt_ids(value: &Value, pkg_ids: &mut Vec<String>) {
             continue;
         };
         match pkgutil {
-            Value::String(id) => pkg_ids.push(id.clone()),
-            Value::Array(ids) => {
-                pkg_ids.extend(ids.iter().filter_map(Value::as_str).map(str::to_string))
-            }
+            Value::String(id) if !id.trim().is_empty() => pkg_ids.push(id.clone()),
+            Value::Array(ids) => pkg_ids.extend(
+                ids.iter()
+                    .filter_map(Value::as_str)
+                    .filter(|id| !id.trim().is_empty())
+                    .map(str::to_string),
+            ),
             _ => {}
         }
     }
@@ -6421,18 +6424,13 @@ fn pkg_id_installed(pkg_id: &str) -> Result<bool> {
     #[cfg(target_os = "macos")]
     // Homebrew's pkgutil metadata is a regular expression, not a literal ID.
     // Match it with pkgutil itself to preserve its nonstandard regexp semantics.
+    // Like Homebrew, use the returned IDs rather than the exit status because a
+    // query with no matches may exit unsuccessfully.
     let output = std::process::Command::new("pkgutil")
         .arg(format!("--pkgs={pkg_id}"))
         .stdin(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .output()?;
-    #[cfg(target_os = "macos")]
-    if !output.status.success() {
-        bail!(
-            "brew-cask: pkgutil receipt query for '{pkg_id}' failed with {}",
-            output.status
-        );
-    }
     #[cfg(target_os = "macos")]
     Ok(pkgutil_output_has_match(&output.stdout))
 }
@@ -12065,6 +12063,24 @@ end
 
         let err = cask_artifacts(&cask).unwrap_err().to_string();
         assert!(err.contains("pkg artifacts require pkgutil ids"));
+    }
+
+    #[test]
+    fn rejects_empty_pkgutil_patterns() {
+        for pkgutil in [
+            serde_json::json!(""),
+            serde_json::json!(" \n\t"),
+            serde_json::json!(["", " \t"]),
+        ] {
+            let mut cask = test_cask("example", "1.0.0");
+            cask.artifacts = vec![
+                serde_json::json!({"uninstall": [{"pkgutil": pkgutil}]}),
+                serde_json::json!({"pkg": ["Example.pkg"]}),
+            ];
+
+            let err = cask_artifacts(&cask).unwrap_err().to_string();
+            assert!(err.contains("pkg artifacts require pkgutil ids"));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- query pkgutil receipt expressions with `pkgutil --pkgs=<regexp>` to match Homebrew semantics
- determine matches from returned receipt IDs, including when a no-match query exits unsuccessfully
- reject empty or whitespace-only expressions so they cannot match unrelated receipts
- add regression coverage using the rekordbox package ID from discussion #12292

## Tests
- `mise run lint-fix`
- `cargo test --locked --bin mise detects_pkgutil_query_matches`
- `cargo test --locked --bin mise parses_uninstall_pkgutil_ids`
- `cargo test --locked --bin mise rejects_empty_pkgutil_patterns`
- `cargo fmt --check`

Addresses https://github.com/jdx/mise/discussions/12292

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow macOS brew-cask receipt check; no auth or data-handling changes. Worst case is a wrong installed/not-installed result for pkg casks.
> 
> **Overview**
> Fixes brew cask pkg receipt detection so Homebrew `pkgutil` values are queried as regexes (`pkgutil --pkgs=<pattern>`), matching Homebrew instead of treating them as literal IDs.
> 
> Installed is now based on nonempty `pkgutil` stdout (not exit status), since unmatched queries can fail. Empty/whitespace `pkgutil` IDs are ignored so they no longer count as valid receipts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 627aa543ea68d6837be10793d28e725d880208b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of installed Homebrew packages on macOS, including regular-expression package matching.
  * Empty or whitespace-only package results are no longer treated as installed packages.
  * Package detection now handles unsuccessful system queries more accurately.
* **Tests**
  * Added coverage for successful matches, empty results, whitespace-only output, and unsuccessful queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->