### PR TITLE
feat(lock): version lockfiles and bind requests

### DIFF
--- a/docs/cli/lock.md
+++ b/docs/cli/lock.md
@@ -54,14 +54,6 @@ advances without installing anything. Config files are never modified:
 exactly pinned versions resolve to themselves and stay unchanged
 (use `mise upgrade --bump` to rewrite pins in mise.toml).
 
-### `--upgrade`
-
-Upgrade legacy lockfiles to the latest format
-
-Existing unversioned lockfiles use format version 0 and are otherwise
-preserved to avoid unexpected lockfile drift. This flag upgrades them
-to the latest format with request-specific version bindings.
-
 ### `--json`
 
 Output version changes as JSON
@@ -88,6 +80,16 @@ Supports absolute dates like "2024-06-01" and relative durations like "90d" or "
 This only affects fuzzy version matches like "20" or "latest".
 Explicitly pinned versions like "22.5.0" are not filtered.
 Existing matching lockfile entries are preserved and are not downgraded solely by this flag.
+
+### `--upgrade`
+
+Upgrade legacy lockfiles to the latest format
+
+Existing unversioned lockfiles use format version 0 and are otherwise
+preserved to avoid unexpected lockfile drift. This flag upgrades them
+to the latest format with request-specific version bindings.
+Format upgrades always process every configured tool and cannot be
+combined with tool arguments.
 
 Examples:
 

--- a/docs/cli/lock.md
+++ b/docs/cli/lock.md
@@ -54,6 +54,14 @@ advances without installing anything. Config files are never modified:
 exactly pinned versions resolve to themselves and stay unchanged
 (use `mise upgrade --bump` to rewrite pins in mise.toml).
 
+### `--upgrade`
+
+Upgrade legacy lockfiles to the latest format
+
+Existing unversioned lockfiles use format version 0 and are otherwise
+preserved to avoid unexpected lockfile drift. This flag upgrades them
+to the latest format with request-specific version bindings.
+
 ### `--json`
 
 Output version changes as JSON

--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -42,9 +42,12 @@ the config that owns the task.
 
 ```toml
 # Example mise.lock
+lockfile_version = 1
+
 [[tools.node]]
 version = "20.11.0"
 backend = "core:node"
+specifiers = ["20"]
 
 [tools.node.platforms.linux-x64]
 checksum = "sha256:a6c213b7a2c3b8b9c0aaf8d7f5b3a5c8d4e2f4a5b6c7d8e9f0a1b2c3d4e5f6a7"
@@ -54,6 +57,7 @@ url = "https://nodejs.org/dist/v20.11.0/node-v20.11.0-linux-x64.tar.xz"
 [[tools.python]]
 version = "3.11.7"
 backend = "core:python"
+specifiers = ["3.11"]
 
 [tools.python.platforms.linux-x64]
 checksum = "sha256:def456..."
@@ -71,6 +75,12 @@ size = 1234567
 
 ```
 
+New lockfiles use the current versioned format. Unversioned lockfiles are treated as
+version 0 and remain in that format during ordinary updates to avoid unexpected lockfile
+drift. Run `mise lock --upgrade` to deliberately upgrade legacy lockfiles. Version 1
+records each original tool request in the concrete entry it resolved to, so overlapping
+requests such as `"1"` and `"1.0.0"` can select different locked versions reliably.
+
 ### Platform Information
 
 Each platform in a tool's `[tools.name.platforms]` section uses a key format like `"os-arch"` (e.g., `"linux-x64"`, `"macos-arm64"`) and can contain:
@@ -85,6 +95,7 @@ Each tool entry (`[[tools.name]]`) can contain:
 
 - **`version`** (required): The exact version of the tool
 - **`backend`** (optional): The backend used to install the tool (e.g., `core:node`, `aqua:BurntSushi/ripgrep`)
+- **`specifiers`** (version 1): Original requests that resolve to this version and option variant
 - **`options`** (optional): Backend-specific options that identify the artifact (e.g., `{exe = "rg", matching = "musl"}`)
 - **`platforms`** (optional): Platform-specific metadata (checksums, URLs, sizes)
 

--- a/e2e/lockfile/test_lockfile_prune_stale_tools
+++ b/e2e/lockfile/test_lockfile_prune_stale_tools
@@ -67,6 +67,8 @@ assert_not_contains "echo \"$OUTPUT\"" "No tools configured to lock"
 # empty lockfile should just have header and tools section
 assert "cat mise.lock" "$LOCKFILE_HEADER
 
+lockfile_version = 1
+
 [tools]"
 
 echo "=== Cleanup ==="

--- a/e2e/lockfile/test_lockfile_version
+++ b/e2e/lockfile/test_lockfile_version
@@ -198,3 +198,34 @@ assert_fail_contains "cd failed-monorepo-upgrade && RTX_FAILURE=1 mise lock --up
 assert_succeed "test -f failed-monorepo-upgrade/packages/b/mise.lock"
 assert_succeed "cmp failed-monorepo-upgrade/packages/b/mise.lock.before failed-monorepo-upgrade/packages/b/mise.lock"
 assert_fail "test -f failed-monorepo-upgrade/mise.lock"
+
+echo "=== failed upgrades do not commit or report earlier targets ==="
+mkdir failed-multi-target-upgrade
+cat >failed-multi-target-upgrade/mise.toml <<'EOF'
+[tools]
+tiny = "1.0.0"
+EOF
+cat >failed-multi-target-upgrade/mise.local.toml <<'EOF'
+[tools]
+dummy = "3.0.0"
+EOF
+cat >failed-multi-target-upgrade/mise.lock <<'EOF'
+[[tools.tiny]]
+version = "1.0.0"
+backend = "asdf:tiny"
+EOF
+cat >failed-multi-target-upgrade/mise.local.lock <<'EOF'
+[[tools.dummy]]
+version = "1.0.0"
+backend = "asdf:dummy"
+EOF
+cp failed-multi-target-upgrade/mise.lock failed-multi-target-upgrade/mise.lock.before
+cp failed-multi-target-upgrade/mise.local.lock failed-multi-target-upgrade/mise.local.lock.before
+
+mise cache clear dummy
+assert_fail_contains "cd failed-multi-target-upgrade && RTX_FAILURE=1 mise lock --upgrade --platform linux-x64 2>&1" "failed to resolve"
+assert_succeed "cmp failed-multi-target-upgrade/mise.lock.before failed-multi-target-upgrade/mise.lock"
+assert_succeed "cmp failed-multi-target-upgrade/mise.local.lock.before failed-multi-target-upgrade/mise.local.lock"
+assert_not_contains "cd failed-multi-target-upgrade && RTX_FAILURE=1 mise lock --upgrade --platform linux-x64 2>&1 || true" "Upgrading"
+assert_not_contains "cd failed-multi-target-upgrade && RTX_FAILURE=1 mise lock --upgrade --platform linux-x64 2>&1 || true" "Pruned"
+assert_not_contains "cd failed-multi-target-upgrade && RTX_FAILURE=1 mise lock --upgrade --platform linux-x64 2>&1 || true" "Lockfile written"

--- a/e2e/lockfile/test_lockfile_version
+++ b/e2e/lockfile/test_lockfile_version
@@ -131,3 +131,50 @@ EOF
 assert_succeed "cd mixed-monorepo && mise lock --upgrade --platform linux-x64"
 assert_fail "test -f mixed-monorepo/packages/b/mise.lock"
 assert_contains "cat mixed-monorepo/mise.lock" 'specifiers = ["1.0.0"]'
+
+echo "=== unbound versioned entries use backend version order ==="
+mkdir unbound-versioned
+cat >unbound-versioned/mise.toml <<'EOF'
+[tools]
+dummy = "latest"
+EOF
+cat >unbound-versioned/mise.lock <<'EOF'
+lockfile_version = 1
+
+[[tools.dummy]]
+version = "1.0.0"
+backend = "asdf:dummy"
+
+[[tools.dummy]]
+version = "2.0.0"
+backend = "asdf:dummy"
+EOF
+
+assert "cd unbound-versioned && mise ls dummy --json --current | jq -r '.[0].version'" "2.0.0"
+
+echo "=== failed upgrades preserve legacy monorepo lockfiles ==="
+mkdir -p failed-monorepo-upgrade/packages/b
+cat >failed-monorepo-upgrade/mise.toml <<'EOF'
+monorepo_root = true
+
+[tools]
+dummy = "3.0.0"
+
+[monorepo]
+lockfile = true
+config_roots = ["packages/*"]
+EOF
+cat >failed-monorepo-upgrade/packages/b/mise.toml <<'EOF'
+[env]
+CHILD = "true"
+EOF
+cat >failed-monorepo-upgrade/packages/b/mise.lock <<'EOF'
+[[tools.tiny]]
+version = "1.0.0"
+backend = "asdf:tiny"
+EOF
+
+mise cache clear dummy
+assert_fail_contains "cd failed-monorepo-upgrade && RTX_FAILURE=1 mise lock --upgrade --platform linux-x64 2>&1" "failed to resolve"
+assert_succeed "test -f failed-monorepo-upgrade/packages/b/mise.lock"
+assert_fail "test -f failed-monorepo-upgrade/mise.lock"

--- a/e2e/lockfile/test_lockfile_version
+++ b/e2e/lockfile/test_lockfile_version
@@ -76,3 +76,58 @@ EOF
 
 assert_contains "cd legacy-dry-run && mise lock --upgrade --dry-run" "Would upgrade"
 assert_not_contains "cat legacy-dry-run/mise.lock" "lockfile_version"
+
+echo "=== format upgrades cannot be filtered ==="
+mkdir legacy-filtered
+cat >legacy-filtered/mise.toml <<'EOF'
+[tools]
+dummy = "1.0.0"
+tiny = "2.1.0"
+EOF
+cat >legacy-filtered/mise.lock <<'EOF'
+[[tools.dummy]]
+version = "1.0.0"
+backend = "asdf:dummy"
+
+[[tools.tiny]]
+version = "2.1.0"
+backend = "asdf:tiny"
+EOF
+
+assert_fail "cd legacy-filtered && mise lock --upgrade dummy"
+assert_not_contains "cat legacy-filtered/mise.lock" "lockfile_version"
+assert_contains "cat legacy-filtered/mise.lock" '[[tools.tiny]]'
+
+echo "=== mixed-format monorepo migration preserves bindings ==="
+mkdir -p mixed-monorepo/packages/b
+cat >mixed-monorepo/mise.toml <<'EOF'
+monorepo_root = true
+
+[tools]
+dummy = "1"
+
+[monorepo]
+lockfile = true
+config_roots = ["packages/*"]
+EOF
+cat >mixed-monorepo/packages/b/mise.toml <<'EOF'
+[tools]
+dummy = "1.0.0"
+EOF
+cat >mixed-monorepo/mise.lock <<'EOF'
+[[tools.dummy]]
+version = "1.1.0"
+backend = "asdf:dummy"
+EOF
+cat >mixed-monorepo/packages/b/mise.lock <<'EOF'
+lockfile_version = 1
+
+[[tools.dummy]]
+version = "1.0.0"
+backend = "asdf:dummy"
+specifiers = ["1.0.0"]
+EOF
+
+assert_succeed "cd mixed-monorepo && mise lock --upgrade --platform linux-x64"
+assert_fail "test -f mixed-monorepo/packages/b/mise.lock"
+assert_contains "cat mixed-monorepo/mise.lock" 'specifiers = ["1.0.0"]'

--- a/e2e/lockfile/test_lockfile_version
+++ b/e2e/lockfile/test_lockfile_version
@@ -61,6 +61,24 @@ assert_contains "cd legacy && mise lock 2>&1" "uses legacy lockfile format versi
 assert_not_contains "cat legacy/mise.lock" "lockfile_version"
 assert_not_contains "cat legacy/mise.lock" "specifiers"
 
+echo "=== missing variant lockfiles do not promote legacy lookups ==="
+mkdir legacy-argument
+cat >legacy-argument/mise.toml <<'EOF'
+[settings]
+lockfile = true
+EOF
+cat >legacy-argument/mise.lock <<'EOF'
+[[tools.dummy]]
+version = "2.0.0"
+backend = "asdf:dummy"
+
+[[tools.dummy]]
+version = "1.0.0"
+backend = "asdf:dummy"
+EOF
+
+assert "cd legacy-argument && mise x dummy@latest -- dummy --version" "This is Dummy 2.0.0! --version"
+
 assert_contains "cd legacy && mise lock --upgrade" "Upgrading"
 assert_contains "cat legacy/mise.lock" "lockfile_version = 1"
 assert_contains "cat legacy/mise.lock" 'specifiers = ["1.0.0"]'
@@ -173,8 +191,10 @@ cat >failed-monorepo-upgrade/packages/b/mise.lock <<'EOF'
 version = "1.0.0"
 backend = "asdf:tiny"
 EOF
+cp failed-monorepo-upgrade/packages/b/mise.lock failed-monorepo-upgrade/packages/b/mise.lock.before
 
 mise cache clear dummy
 assert_fail_contains "cd failed-monorepo-upgrade && RTX_FAILURE=1 mise lock --upgrade --platform linux-x64 2>&1" "failed to resolve"
 assert_succeed "test -f failed-monorepo-upgrade/packages/b/mise.lock"
+assert_succeed "cmp failed-monorepo-upgrade/packages/b/mise.lock.before failed-monorepo-upgrade/packages/b/mise.lock"
 assert_fail "test -f failed-monorepo-upgrade/mise.lock"

--- a/e2e/lockfile/test_lockfile_version
+++ b/e2e/lockfile/test_lockfile_version
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+echo "=== new lockfiles use request bindings ==="
+mkdir -p versioned/packages/b
+cat >versioned/mise.toml <<'EOF'
+monorepo_root = true
+
+[tools]
+dummy = "1"
+
+[settings]
+lockfile = true
+
+[monorepo]
+lockfile = true
+config_roots = ["packages/*"]
+EOF
+cat >versioned/packages/b/mise.toml <<'EOF'
+[tools]
+dummy = "1.0.0"
+EOF
+
+assert_succeed "cd versioned && mise install"
+assert_succeed "cd versioned/packages/b && mise install"
+assert_contains "cat versioned/mise.lock" "lockfile_version = 1"
+assert_contains "cat versioned/mise.lock" 'specifiers = ["1"]'
+assert_contains "cat versioned/mise.lock" 'specifiers = ["1.0.0"]'
+assert "cd versioned && mise ls dummy --json --current | jq -r '.[0].version'" "1.1.0"
+assert "cd versioned/packages/b && mise ls dummy --json --current | jq -r '.[0].version'" "1.0.0"
+
+echo "=== upgrades move only the matching request binding ==="
+mkdir -p upgrade/packages/b
+cp versioned/mise.toml upgrade/mise.toml
+cp versioned/packages/b/mise.toml upgrade/packages/b/mise.toml
+cat >upgrade/mise.lock <<'EOF'
+lockfile_version = 1
+
+[[tools.dummy]]
+version = "1.0.0"
+backend = "asdf:dummy"
+specifiers = ["1", "1.0.0"]
+EOF
+assert "cd upgrade && mise ls dummy --json --current | jq -r '.[0].version'" "1.0.0"
+assert_succeed "cd upgrade && mise upgrade dummy"
+assert "cd upgrade && mise ls dummy --json --current | jq -r '.[0].version'" "1.1.0"
+assert "cd upgrade/packages/b && mise ls dummy --json --current | jq -r '.[0].version'" "1.0.0"
+
+echo "=== legacy lockfiles require an explicit format upgrade ==="
+mkdir legacy
+cat >legacy/mise.toml <<'EOF'
+[tools]
+dummy = "1.0.0"
+EOF
+cat >legacy/mise.lock <<'EOF'
+[[tools.dummy]]
+version = "1.0.0"
+backend = "asdf:dummy"
+EOF
+
+assert_contains "cd legacy && mise lock 2>&1" "uses legacy lockfile format version 0"
+assert_not_contains "cat legacy/mise.lock" "lockfile_version"
+assert_not_contains "cat legacy/mise.lock" "specifiers"
+
+assert_contains "cd legacy && mise lock --upgrade" "Upgrading"
+assert_contains "cat legacy/mise.lock" "lockfile_version = 1"
+assert_contains "cat legacy/mise.lock" 'specifiers = ["1.0.0"]'
+
+echo "=== dry-run reports but does not upgrade legacy lockfiles ==="
+mkdir legacy-dry-run
+cp legacy/mise.toml legacy-dry-run/mise.toml
+cat >legacy-dry-run/mise.lock <<'EOF'
+[[tools.dummy]]
+version = "1.0.0"
+backend = "asdf:dummy"
+EOF
+
+assert_contains "cd legacy-dry-run && mise lock --upgrade --dry-run" "Would upgrade"
+assert_not_contains "cat legacy-dry-run/mise.lock" "lockfile_version"

--- a/e2e/lockfile/test_lockfile_version
+++ b/e2e/lockfile/test_lockfile_version
@@ -83,6 +83,22 @@ assert_contains "cd legacy && mise lock --upgrade" "Upgrading"
 assert_contains "cat legacy/mise.lock" "lockfile_version = 1"
 assert_contains "cat legacy/mise.lock" 'specifiers = ["1.0.0"]'
 
+echo "=== upgrades bind distinct requests resolving to the same version ==="
+mkdir same-version
+cat >same-version/mise.toml <<'EOF'
+[tools]
+dummy = ["1.0", "1.0.0"]
+EOF
+cat >same-version/mise.lock <<'EOF'
+[[tools.dummy]]
+version = "1.0.0"
+backend = "asdf:dummy"
+EOF
+
+assert_succeed "cd same-version && mise lock --upgrade --platform linux-x64"
+assert_contains "sed -n '/specifiers = \[/,/]/p' same-version/mise.lock" '"1.0",'
+assert_contains "sed -n '/specifiers = \[/,/]/p' same-version/mise.lock" '"1.0.0",'
+
 echo "=== dry-run reports but does not upgrade legacy lockfiles ==="
 mkdir legacy-dry-run
 cp legacy/mise.toml legacy-dry-run/mise.toml

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2649,6 +2649,15 @@ Supports absolute dates like "2024\-06\-01" and relative durations like "90d" or
 This only affects fuzzy version matches like "20" or "latest".
 Explicitly pinned versions like "22.5.0" are not filtered.
 Existing matching lockfile entries are preserved and are not downgraded solely by this flag.
+.TP
+\fB\-\-upgrade\fR
+Upgrade legacy lockfiles to the latest format
+
+Existing unversioned lockfiles use format version 0 and are otherwise
+preserved to avoid unexpected lockfile drift. This flag upgrades them
+to the latest format with request\-specific version bindings.
+Format upgrades always process every configured tool and cannot be
+combined with tool arguments.
 \fBArguments:\fR
 .PP
 .TP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -2285,15 +2285,6 @@ exactly pinned versions resolve to themselves and stay unchanged
 (use `mise upgrade --bump` to rewrite pins in mise.toml).
 """#
     }
-    flag --upgrade help="Upgrade legacy lockfiles to the latest format" {
-        long_help #"""
-Upgrade legacy lockfiles to the latest format
-
-Existing unversioned lockfiles use format version 0 and are otherwise
-preserved to avoid unexpected lockfile drift. This flag upgrades them
-to the latest format with request-specific version bindings.
-"""#
-    }
     flag --json help="Output version changes as JSON" {
         long_help #"""
 Output version changes as JSON
@@ -2322,6 +2313,17 @@ Explicitly pinned versions like "22.5.0" are not filtered.
 Existing matching lockfile entries are preserved and are not downgraded solely by this flag.
 """#
         arg <MINIMUM_RELEASE_AGE>
+    }
+    flag --upgrade help="Upgrade legacy lockfiles to the latest format" {
+        long_help #"""
+Upgrade legacy lockfiles to the latest format
+
+Existing unversioned lockfiles use format version 0 and are otherwise
+preserved to avoid unexpected lockfile drift. This flag upgrades them
+to the latest format with request-specific version bindings.
+Format upgrades always process every configured tool and cannot be
+combined with tool arguments.
+"""#
     }
     arg "[TOOL]…" help=#"""
 Tool(s) to update in lockfile

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -2285,6 +2285,15 @@ exactly pinned versions resolve to themselves and stay unchanged
 (use `mise upgrade --bump` to rewrite pins in mise.toml).
 """#
     }
+    flag --upgrade help="Upgrade legacy lockfiles to the latest format" {
+        long_help #"""
+Upgrade legacy lockfiles to the latest format
+
+Existing unversioned lockfiles use format version 0 and are otherwise
+preserved to avoid unexpected lockfile drift. This flag upgrades them
+to the latest format with request-specific version bindings.
+"""#
+    }
     flag --json help="Output version changes as JSON" {
         long_help #"""
 Output version changes as JSON

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -136,7 +136,7 @@ impl Install {
     pub async fn run(self) -> Result<()> {
         let config = Config::get().await?;
         if !self.is_dry_run() {
-            crate::lockfile::migrate_monorepo_lockfiles(&config)?;
+            crate::lockfile::migrate_monorepo_lockfiles(&config, false)?;
         }
         let task_requests = self.collect_task_tool_requests(&config).await?;
         match &self.tool {

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -231,6 +231,8 @@ impl Lock {
         let mut all_resolution_errors: Vec<String> = Vec::new();
         let mut all_platform_regressions: Vec<String> = Vec::new();
         let mut all_changes: Vec<LockChange> = Vec::new();
+        let mut staged_upgrade_writes: Vec<(PathBuf, Lockfile, Option<(usize, usize)>)> =
+            Vec::new();
         let collection_context = LockCollectionContext {
             config: &config,
             toolset: ts,
@@ -319,7 +321,11 @@ impl Lock {
                         false
                     };
                     if format_changed || !pruned_tools.is_empty() {
-                        lockfile.write(&lockfile_path)?;
+                        if self.upgrade {
+                            staged_upgrade_writes.push((lockfile_path.clone(), lockfile, None));
+                        } else {
+                            lockfile.write(&lockfile_path)?;
+                        }
                         self.show_stale_prune_message(&lockfile_path, &pruned_tools, false)?;
                         has_lock_targets = true;
                     }
@@ -424,17 +430,26 @@ impl Lock {
             self.prune_stale_versions(&mut lockfile, &tools);
             self.show_stale_version_prune_message(&lockfile_path, &stale_versions, false)?;
 
-            // Save lockfile before raising resolution errors so non-regressing
-            // tools' entries are preserved
-            lockfile.write(&lockfile_path)?;
+            let successful = results
+                .iter()
+                .filter(|result| matches!(result.status, LockTaskStatus::Updated))
+                .count();
+            let skipped = results.len() - successful;
+            if self.upgrade {
+                staged_upgrade_writes.push((
+                    lockfile_path.clone(),
+                    lockfile,
+                    Some((successful, skipped)),
+                ));
+            } else {
+                // Normal lock runs preserve successful updates even if another
+                // target reports a non-regressing resolution error.
+                lockfile.write(&lockfile_path)?;
+            }
 
-            // Print summary
-            if !self.json {
-                let successful = results
-                    .iter()
-                    .filter(|result| matches!(result.status, LockTaskStatus::Updated))
-                    .count();
-                let skipped = results.len() - successful;
+            // Print summaries for normal writes now. Upgrade summaries are
+            // deferred with their writes until every target succeeds.
+            if !self.json && !self.upgrade {
                 miseprintln!(
                     "{} Updated {} platform entries ({} skipped)",
                     style("✓").green(),
@@ -510,10 +525,31 @@ impl Lock {
             return Err(eyre::eyre!(all_platform_regressions.join("\n")));
         }
 
-        // Format upgrades are transactional with respect to legacy monorepo
-        // lockfiles: do not merge or delete them until every requested
-        // resolution and binding update has succeeded.
+        // Format upgrades are committed as a batch only after every target has
+        // resolved and bound successfully. This also keeps legacy monorepo
+        // lockfiles untouched on failure.
         if !self.dry_run && self.upgrade {
+            for (lockfile_path, lockfile, summary) in staged_upgrade_writes {
+                let _lock = crate::lock_file::LockFile::new(&lockfile_path)
+                    .with_callback(|l| debug!("waiting for lock on {}", display_path(l)))
+                    .lock()?;
+                lockfile.write(&lockfile_path)?;
+                if !self.json
+                    && let Some((successful, skipped)) = summary
+                {
+                    miseprintln!(
+                        "{} Updated {} platform entries ({} skipped)",
+                        style("✓").green(),
+                        successful,
+                        skipped
+                    );
+                    miseprintln!(
+                        "{} Lockfile written to {}",
+                        style("✓").green(),
+                        style(display_path(&lockfile_path)).cyan()
+                    );
+                }
+            }
             lockfile::migrate_monorepo_lockfiles(&config, true)?;
         }
 

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -196,8 +196,10 @@ fn prepare_lockfile_rollback(
                 .as_ref()
                 .map(|content| crate::file::prepare_atomic_write(&snapshot.path, content))
                 .transpose()?;
-            let path = crate::file::atomic_write_target(&snapshot.path)?;
-            Ok(PreparedLockfileRollback { path, replacement })
+            Ok(PreparedLockfileRollback {
+                path: snapshot.path.clone(),
+                replacement,
+            })
         })
         .collect()
 }
@@ -1783,6 +1785,28 @@ mod tests {
 
         assert_eq!(fs::read_to_string(replaced).unwrap(), "original");
         assert!(!created.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rollback_removes_file_that_replaced_dangling_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let lockfile = temp.path().join("mise.lock");
+        symlink("missing.lock", &lockfile).unwrap();
+        let snapshots = vec![LockfileSnapshot {
+            path: lockfile.clone(),
+            content: None,
+        }];
+        let rollbacks = prepare_lockfile_rollback(&snapshots).unwrap();
+
+        fs::remove_file(&lockfile).unwrap();
+        fs::write(&lockfile, "created").unwrap();
+        restore_lockfile_snapshots(rollbacks).unwrap();
+
+        assert!(fs::symlink_metadata(lockfile).is_err());
+        assert!(!temp.path().join("missing.lock").exists());
     }
 
     fn lock_cmd(tool_filters: &[&str]) -> Lock {

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -1,4 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -157,11 +159,48 @@ struct LockTaskResult {
 
 struct StagedUpgradeWrite {
     path: PathBuf,
+    original_content: Option<Vec<u8>>,
     lockfile: Lockfile,
     summary: Option<(usize, usize)>,
     format_changed: bool,
     stale_tools: BTreeSet<String>,
     stale_versions: BTreeMap<String, Vec<String>>,
+}
+
+struct LockfileSnapshot {
+    path: PathBuf,
+    content: Option<Vec<u8>>,
+}
+
+fn read_optional_file(path: &Path) -> Result<Option<Vec<u8>>> {
+    match fs::read(path) {
+        Ok(content) => Ok(Some(content)),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn restore_lockfile_snapshots(snapshots: &[LockfileSnapshot]) -> Result<()> {
+    let mut errors = Vec::new();
+    for snapshot in snapshots.iter().rev() {
+        let result = match &snapshot.content {
+            Some(content) => crate::file::write_atomic(&snapshot.path, content),
+            None => match fs::remove_file(&snapshot.path) {
+                Ok(()) => Ok(()),
+                Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+                Err(err) => Err(err.into()),
+            },
+        };
+        if let Err(err) = result {
+            errors.push(format!("{}: {err:?}", display_path(&snapshot.path)));
+        }
+    }
+    lockfile::invalidate_caches();
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        bail!("{}", errors.join("\n"))
+    }
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -303,6 +342,7 @@ impl Lock {
                     let _lock = crate::lock_file::LockFile::new(&lockfile_path)
                         .with_callback(|l| debug!("waiting for lock on {}", display_path(l)))
                         .lock()?;
+                    let original_content = read_optional_file(&lockfile_path)?;
                     let mut lockfile = Lockfile::read(&lockfile_path)?;
                     if self.json {
                         all_changes.extend(self.compute_version_changes(
@@ -332,6 +372,7 @@ impl Lock {
                         if self.upgrade {
                             staged_upgrade_writes.push(StagedUpgradeWrite {
                                 path: lockfile_path.clone(),
+                                original_content,
                                 lockfile,
                                 summary: None,
                                 format_changed,
@@ -403,6 +444,7 @@ impl Lock {
             let _lock = crate::lock_file::LockFile::new(&lockfile_path)
                 .with_callback(|l| debug!("waiting for lock on {}", display_path(l)))
                 .lock()?;
+            let original_content = read_optional_file(&lockfile_path)?;
             let mut lockfile = Lockfile::read(&lockfile_path)?;
             if !self.upgrade {
                 self.report_lockfile_format(&lockfile_path, &lockfile, false)?;
@@ -461,6 +503,7 @@ impl Lock {
             if self.upgrade {
                 staged_upgrade_writes.push(StagedUpgradeWrite {
                     path: lockfile_path.clone(),
+                    original_content,
                     lockfile,
                     summary: Some((successful, skipped)),
                     format_changed,
@@ -551,11 +594,60 @@ impl Lock {
         // resolved and bound successfully. This also keeps legacy monorepo
         // lockfiles untouched on failure.
         if !self.dry_run && self.upgrade {
-            for staged in staged_upgrade_writes {
-                let _lock = crate::lock_file::LockFile::new(&staged.path)
-                    .with_callback(|l| debug!("waiting for lock on {}", display_path(l)))
-                    .lock()?;
-                staged.lockfile.write(&staged.path)?;
+            let migration_paths = lockfile::monorepo_lockfile_migration_paths(&config);
+            let transaction_paths: BTreeSet<PathBuf> = staged_upgrade_writes
+                .iter()
+                .map(|staged| staged.path.clone())
+                .chain(
+                    migration_paths
+                        .iter()
+                        .flat_map(|(source, target)| [source.clone(), target.clone()]),
+                )
+                .collect();
+            let mut transaction_locks = Vec::with_capacity(transaction_paths.len());
+            for path in &transaction_paths {
+                transaction_locks.push(
+                    crate::lock_file::LockFile::new(path)
+                        .with_callback(|l| debug!("waiting for lock on {}", display_path(l)))
+                        .lock()?,
+                );
+            }
+
+            for staged in &staged_upgrade_writes {
+                if read_optional_file(&staged.path)? != staged.original_content {
+                    bail!(
+                        "lockfile {} changed while the format upgrade was being prepared; retry `mise lock --upgrade`",
+                        display_path(&staged.path)
+                    );
+                }
+            }
+
+            let snapshots = transaction_paths
+                .iter()
+                .map(|path| {
+                    Ok(LockfileSnapshot {
+                        path: path.clone(),
+                        content: read_optional_file(path)?,
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let commit_result = (|| -> Result<()> {
+                for staged in &staged_upgrade_writes {
+                    staged.lockfile.write(&staged.path)?;
+                }
+                lockfile::migrate_monorepo_lockfiles_already_locked(&config, true, &migration_paths)
+            })();
+            if let Err(err) = commit_result {
+                if let Err(rollback_err) = restore_lockfile_snapshots(&snapshots) {
+                    return Err(err.wrap_err(format!(
+                        "failed to roll back lockfile format upgrade: {rollback_err:?}"
+                    )));
+                }
+                return Err(err);
+            }
+            drop(transaction_locks);
+
+            for staged in &staged_upgrade_writes {
                 if staged.format_changed {
                     self.show_lockfile_upgrade_message(&staged.path)?;
                 }
@@ -577,7 +669,6 @@ impl Lock {
                     );
                 }
             }
-            lockfile::migrate_monorepo_lockfiles(&config, true)?;
         }
 
         if self.json {
@@ -1629,15 +1720,42 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 #[cfg(test)]
 mod tests {
     use super::{
-        Lock, LockTaskResult, LockTaskStatus, classify_lock_result, push_unique_lock_tool,
+        Lock, LockTaskResult, LockTaskStatus, LockfileSnapshot, classify_lock_result,
+        push_unique_lock_tool, restore_lockfile_snapshots,
     };
     use crate::cli::args::{BackendArg, ToolArg};
     use crate::lockfile::{Lockfile, PlatformInfo, apply_lock_result};
     use crate::platform::Platform;
     use crate::toolset::{ToolRequest, ToolSource, ToolVersion, ToolVersionOptions};
     use std::collections::BTreeMap;
+    use std::fs;
     use std::str::FromStr;
     use std::sync::Arc;
+
+    #[test]
+    fn rollback_restores_replaced_files_and_removes_created_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let replaced = temp.path().join("mise.lock");
+        let created = temp.path().join("mise.local.lock");
+        fs::write(&replaced, "original").unwrap();
+        let snapshots = vec![
+            LockfileSnapshot {
+                path: replaced.clone(),
+                content: Some(b"original".to_vec()),
+            },
+            LockfileSnapshot {
+                path: created.clone(),
+                content: None,
+            },
+        ];
+        fs::write(&replaced, "upgraded").unwrap();
+        fs::write(&created, "created").unwrap();
+
+        restore_lockfile_snapshots(&snapshots).unwrap();
+
+        assert_eq!(fs::read_to_string(replaced).unwrap(), "original");
+        assert!(!created.exists());
+    }
 
     fn lock_cmd(tool_filters: &[&str]) -> Lock {
         Lock {

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -38,6 +38,7 @@ fn request_matches(a: &ToolRequest, b: &ToolRequest) -> bool {
 fn lock_tool_matches(a: &LockTool, b: &LockTool) -> bool {
     a.0.full() == b.0.full()
         && a.1.version == b.1.version
+        && a.1.request.version() == b.1.request.version()
         && a.1.request.options() == b.1.request.options()
 }
 
@@ -1931,7 +1932,8 @@ mod tests {
     fn lock_tool_with_options(
         short: &str,
         backend: &str,
-        version: &str,
+        request: &str,
+        resolved_version: &str,
         option: Option<(&str, &str)>,
     ) -> (BackendArg, ToolVersion) {
         let ba = BackendArg::new(short.to_string(), Some(backend.to_string()));
@@ -1942,9 +1944,9 @@ mod tests {
                 .unwrap();
         }
         let request =
-            ToolRequest::new_opts(Arc::new(ba.clone()), version, options, ToolSource::Argument)
+            ToolRequest::new_opts(Arc::new(ba.clone()), request, options, ToolSource::Argument)
                 .unwrap();
-        let tv = ToolVersion::new(request, version.to_string());
+        let tv = ToolVersion::new(request, resolved_version.to_string());
         (ba, tv)
     }
 
@@ -1953,25 +1955,31 @@ mod tests {
         let mut tools = Vec::new();
         push_unique_lock_tool(
             &mut tools,
-            lock_tool_with_options("dummy", "http:one", "1.0.0", Some(("exe", "one"))),
+            lock_tool_with_options("dummy", "http:one", "1.0.0", "1.0.0", Some(("exe", "one"))),
         );
         push_unique_lock_tool(
             &mut tools,
-            lock_tool_with_options("dummy", "http:one", "1.0.0", Some(("exe", "one"))),
+            lock_tool_with_options("dummy", "http:one", "1.0.0", "1.0.0", Some(("exe", "one"))),
         );
         push_unique_lock_tool(
             &mut tools,
-            lock_tool_with_options("dummy", "http:one", "1.0.0", Some(("exe", "two"))),
+            lock_tool_with_options("dummy", "http:one", "1.0.0", "1.0.0", Some(("exe", "two"))),
         );
         push_unique_lock_tool(
             &mut tools,
-            lock_tool_with_options("dummy", "http:two", "1.0.0", Some(("exe", "one"))),
+            lock_tool_with_options("dummy", "http:two", "1.0.0", "1.0.0", Some(("exe", "one"))),
+        );
+        push_unique_lock_tool(
+            &mut tools,
+            lock_tool_with_options("dummy", "http:one", "1", "1.0.0", Some(("exe", "one"))),
         );
 
-        assert_eq!(tools.len(), 3);
+        assert_eq!(tools.len(), 4);
         assert_eq!(tools[0].0.full(), "http:one");
         assert_eq!(tools[1].0.full(), "http:one");
         assert_eq!(tools[2].0.full(), "http:two");
+        assert_eq!(tools[3].1.request.version(), "1");
+        assert_eq!(tools[3].1.version, "1.0.0");
         assert_ne!(tools[0].1.request.options(), tools[1].1.request.options());
     }
 

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -12,7 +12,7 @@ use crate::toolset::{ResolveOptions, ToolRequest, ToolSource, Toolset, ToolsetBu
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::{cli::args::ToolArg, config::Settings};
 use console::style;
-use eyre::Result;
+use eyre::{Result, bail};
 use jiff::Timestamp;
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
@@ -95,14 +95,6 @@ pub(crate) struct Lock {
     #[clap(long, verbatim_doc_comment)]
     pub bump: bool,
 
-    /// Upgrade legacy lockfiles to the latest format
-    ///
-    /// Existing unversioned lockfiles use format version 0 and are otherwise
-    /// preserved to avoid unexpected lockfile drift. This flag upgrades them
-    /// to the latest format with request-specific version bindings.
-    #[clap(long, verbatim_doc_comment)]
-    pub upgrade: bool,
-
     /// Output version changes as JSON
     ///
     /// Prints an array of objects describing lockfile version changes:
@@ -134,6 +126,16 @@ pub(crate) struct Lock {
         verbatim_doc_comment
     )]
     pub minimum_release_age: Option<String>,
+
+    /// Upgrade legacy lockfiles to the latest format
+    ///
+    /// Existing unversioned lockfiles use format version 0 and are otherwise
+    /// preserved to avoid unexpected lockfile drift. This flag upgrades them
+    /// to the latest format with request-specific version bindings.
+    /// Format upgrades always process every configured tool and cannot be
+    /// combined with tool arguments.
+    #[clap(long, verbatim_doc_comment)]
+    pub upgrade: bool,
 }
 
 /// A lockfile version change reported by `--json`
@@ -177,6 +179,9 @@ fn classify_lock_result(
 
 impl Lock {
     pub(crate) async fn run(self) -> Result<()> {
+        if self.upgrade && !self.tool.is_empty() {
+            bail!("`mise lock --upgrade` cannot be combined with tool arguments");
+        }
         let settings = Settings::get();
         let config = Config::get().await?;
         if !self.dry_run {
@@ -289,8 +294,6 @@ impl Lock {
                         .with_callback(|l| debug!("waiting for lock on {}", display_path(l)))
                         .lock()?;
                     let mut lockfile = Lockfile::read(&lockfile_path)?;
-                    let format_changed =
-                        self.prepare_lockfile_format(&lockfile_path, &mut lockfile)?;
                     if self.json {
                         all_changes.extend(self.compute_version_changes(
                             &lockfile,
@@ -302,6 +305,19 @@ impl Lock {
                         &mut lockfile,
                         configured_selectors.as_ref(),
                     );
+                    let format_changed = if self.upgrade {
+                        if lockfile.tools().is_empty() {
+                            self.prepare_lockfile_format(&lockfile_path, &mut lockfile)?
+                        } else {
+                            bail!(
+                                "cannot upgrade {} because no configured tools were resolved",
+                                display_path(&lockfile_path)
+                            );
+                        }
+                    } else {
+                        self.report_lockfile_format(&lockfile_path, &lockfile, false)?;
+                        false
+                    };
                     if format_changed || !pruned_tools.is_empty() {
                         lockfile.write(&lockfile_path)?;
                         self.show_stale_prune_message(&lockfile_path, &pruned_tools, false)?;
@@ -365,7 +381,9 @@ impl Lock {
                 .with_callback(|l| debug!("waiting for lock on {}", display_path(l)))
                 .lock()?;
             let mut lockfile = Lockfile::read(&lockfile_path)?;
-            self.prepare_lockfile_format(&lockfile_path, &mut lockfile)?;
+            if !self.upgrade {
+                self.report_lockfile_format(&lockfile_path, &lockfile, false)?;
+            }
             if self.json {
                 all_changes.extend(self.compute_version_changes(&lockfile, &tools, &lockfile_path));
             }
@@ -380,7 +398,7 @@ impl Lock {
             let (results, resolution_errors) = self
                 .process_tools(&settings, &tools, &target_platforms, &mut lockfile)
                 .await?;
-            self.bind_requests(&mut lockfile, &tools, &target_platforms);
+            let resolution_succeeded = resolution_errors.is_empty();
             all_resolution_errors.extend(resolution_errors);
 
             let platform_regressions =
@@ -388,6 +406,18 @@ impl Lock {
             if !platform_regressions.is_empty() {
                 all_platform_regressions.extend(platform_regressions);
                 continue;
+            }
+
+            if self.upgrade && lockfile.lockfile_version() == 0 && resolution_succeeded {
+                self.prepare_lockfile_format(&lockfile_path, &mut lockfile)?;
+                if !self.bind_requests(&mut lockfile, &tools, &target_platforms) {
+                    bail!(
+                        "cannot upgrade {} because not every request binding was resolved",
+                        display_path(&lockfile_path)
+                    );
+                }
+            } else {
+                self.bind_requests(&mut lockfile, &tools, &target_platforms);
             }
 
             // Prune stale versions AFTER provenance checks complete
@@ -595,12 +625,19 @@ impl Lock {
         }
     }
 
-    fn bind_requests(&self, lockfile: &mut Lockfile, tools: &[LockTool], platforms: &[Platform]) {
+    fn bind_requests(
+        &self,
+        lockfile: &mut Lockfile,
+        tools: &[LockTool],
+        platforms: &[Platform],
+    ) -> bool {
         if !lockfile.uses_request_bindings() {
-            return;
+            return false;
         }
+        let mut all_bound = true;
         for (ba, tv) in tools {
             let Ok(backend) = tv.request.backend() else {
+                all_bound = false;
                 continue;
             };
             for platform in platforms {
@@ -609,12 +646,19 @@ impl Lock {
                         &tv.request,
                         &crate::backend::platform_target::PlatformTarget::new(variant),
                     ) else {
+                        all_bound = false;
                         continue;
                     };
-                    lockfile.bind_request(&ba.short, &tv.request.version(), &tv.version, &options);
+                    all_bound &= lockfile.bind_request(
+                        &ba.short,
+                        &tv.request.version(),
+                        &tv.version,
+                        &options,
+                    );
                 }
             }
         }
+        all_bound
     }
 
     fn prune_stale_entries_if_needed(

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -184,7 +184,7 @@ impl Lock {
         }
         let settings = Settings::get();
         let config = Config::get().await?;
-        if !self.dry_run {
+        if !self.dry_run && !self.upgrade {
             lockfile::migrate_monorepo_lockfiles(&config, self.upgrade)?;
         }
         let before_date = self.get_before_date()?;
@@ -508,6 +508,13 @@ impl Lock {
         all_platform_regressions.extend(all_resolution_errors);
         if !all_platform_regressions.is_empty() {
             return Err(eyre::eyre!(all_platform_regressions.join("\n")));
+        }
+
+        // Format upgrades are transactional with respect to legacy monorepo
+        // lockfiles: do not merge or delete them until every requested
+        // resolution and binding update has succeeded.
+        if !self.dry_run && self.upgrade {
+            lockfile::migrate_monorepo_lockfiles(&config, true)?;
         }
 
         Ok(())

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -172,6 +172,11 @@ struct LockfileSnapshot {
     content: Option<Vec<u8>>,
 }
 
+struct PreparedLockfileRollback {
+    path: PathBuf,
+    replacement: Option<crate::file::PreparedAtomicWrite>,
+}
+
 fn read_optional_file(path: &Path) -> Result<Option<Vec<u8>>> {
     match fs::read(path) {
         Ok(content) => Ok(Some(content)),
@@ -180,19 +185,36 @@ fn read_optional_file(path: &Path) -> Result<Option<Vec<u8>>> {
     }
 }
 
-fn restore_lockfile_snapshots(snapshots: &[LockfileSnapshot]) -> Result<()> {
+fn prepare_lockfile_rollback(
+    snapshots: &[LockfileSnapshot],
+) -> Result<Vec<PreparedLockfileRollback>> {
+    snapshots
+        .iter()
+        .map(|snapshot| {
+            let replacement = snapshot
+                .content
+                .as_ref()
+                .map(|content| crate::file::prepare_atomic_write(&snapshot.path, content))
+                .transpose()?;
+            let path = crate::file::atomic_write_target(&snapshot.path)?;
+            Ok(PreparedLockfileRollback { path, replacement })
+        })
+        .collect()
+}
+
+fn restore_lockfile_snapshots(rollbacks: Vec<PreparedLockfileRollback>) -> Result<()> {
     let mut errors = Vec::new();
-    for snapshot in snapshots.iter().rev() {
-        let result = match &snapshot.content {
-            Some(content) => crate::file::write_atomic(&snapshot.path, content),
-            None => match fs::remove_file(&snapshot.path) {
+    for rollback in rollbacks.into_iter().rev() {
+        let result = match rollback.replacement {
+            Some(replacement) => replacement.commit(),
+            None => match fs::remove_file(&rollback.path) {
                 Ok(()) => Ok(()),
                 Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
                 Err(err) => Err(err.into()),
             },
         };
         if let Err(err) = result {
-            errors.push(format!("{}: {err:?}", display_path(&snapshot.path)));
+            errors.push(format!("{}: {err:?}", display_path(&rollback.path)));
         }
     }
     lockfile::invalidate_caches();
@@ -631,6 +653,11 @@ impl Lock {
                     })
                 })
                 .collect::<Result<Vec<_>>>()?;
+            // Materialize and sync every rollback replacement before the first
+            // mutation. Recovery then only needs same-directory renames, so a
+            // later disk-full failure cannot prevent restoration by requiring
+            // more file data to be written.
+            let rollbacks = prepare_lockfile_rollback(&snapshots)?;
             let commit_result = (|| -> Result<()> {
                 for staged in &staged_upgrade_writes {
                     staged.lockfile.write(&staged.path)?;
@@ -638,7 +665,7 @@ impl Lock {
                 lockfile::migrate_monorepo_lockfiles_already_locked(&config, true, &migration_paths)
             })();
             if let Err(err) = commit_result {
-                if let Err(rollback_err) = restore_lockfile_snapshots(&snapshots) {
+                if let Err(rollback_err) = restore_lockfile_snapshots(rollbacks) {
                     return Err(err.wrap_err(format!(
                         "failed to roll back lockfile format upgrade: {rollback_err:?}"
                     )));
@@ -1721,7 +1748,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 mod tests {
     use super::{
         Lock, LockTaskResult, LockTaskStatus, LockfileSnapshot, classify_lock_result,
-        push_unique_lock_tool, restore_lockfile_snapshots,
+        prepare_lockfile_rollback, push_unique_lock_tool, restore_lockfile_snapshots,
     };
     use crate::cli::args::{BackendArg, ToolArg};
     use crate::lockfile::{Lockfile, PlatformInfo, apply_lock_result};
@@ -1748,10 +1775,11 @@ mod tests {
                 content: None,
             },
         ];
+        let rollbacks = prepare_lockfile_rollback(&snapshots).unwrap();
         fs::write(&replaced, "upgraded").unwrap();
         fs::write(&created, "created").unwrap();
 
-        restore_lockfile_snapshots(&snapshots).unwrap();
+        restore_lockfile_snapshots(rollbacks).unwrap();
 
         assert_eq!(fs::read_to_string(replaced).unwrap(), "original");
         assert!(!created.exists());

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -95,6 +95,14 @@ pub(crate) struct Lock {
     #[clap(long, verbatim_doc_comment)]
     pub bump: bool,
 
+    /// Upgrade legacy lockfiles to the latest format
+    ///
+    /// Existing unversioned lockfiles use format version 0 and are otherwise
+    /// preserved to avoid unexpected lockfile drift. This flag upgrades them
+    /// to the latest format with request-specific version bindings.
+    #[clap(long, verbatim_doc_comment)]
+    pub upgrade: bool,
+
     /// Output version changes as JSON
     ///
     /// Prints an array of objects describing lockfile version changes:
@@ -172,7 +180,7 @@ impl Lock {
         let settings = Settings::get();
         let config = Config::get().await?;
         if !self.dry_run {
-            lockfile::migrate_monorepo_lockfiles(&config)?;
+            lockfile::migrate_monorepo_lockfiles(&config, self.upgrade)?;
         }
         let before_date = self.get_before_date()?;
         let lock_resolve_options = ResolveOptions {
@@ -262,6 +270,7 @@ impl Lock {
                 // For unfiltered runs (`mise lock`), this means "prune all stale lockfile entries".
                 if self.dry_run {
                     let lockfile = Lockfile::read(&lockfile_path)?;
+                    self.report_lockfile_format(&lockfile_path, &lockfile, true)?;
                     if self.json {
                         all_changes.extend(self.compute_version_changes(
                             &lockfile,
@@ -280,6 +289,8 @@ impl Lock {
                         .with_callback(|l| debug!("waiting for lock on {}", display_path(l)))
                         .lock()?;
                     let mut lockfile = Lockfile::read(&lockfile_path)?;
+                    let format_changed =
+                        self.prepare_lockfile_format(&lockfile_path, &mut lockfile)?;
                     if self.json {
                         all_changes.extend(self.compute_version_changes(
                             &lockfile,
@@ -291,7 +302,7 @@ impl Lock {
                         &mut lockfile,
                         configured_selectors.as_ref(),
                     );
-                    if !pruned_tools.is_empty() {
+                    if format_changed || !pruned_tools.is_empty() {
                         lockfile.write(&lockfile_path)?;
                         self.show_stale_prune_message(&lockfile_path, &pruned_tools, false)?;
                         has_lock_targets = true;
@@ -331,6 +342,7 @@ impl Lock {
             if self.dry_run {
                 self.show_dry_run(&tools, &target_platforms)?;
                 let lockfile = Lockfile::read(&lockfile_path)?;
+                self.report_lockfile_format(&lockfile_path, &lockfile, true)?;
                 if self.json {
                     all_changes.extend(self.compute_version_changes(
                         &lockfile,
@@ -353,6 +365,7 @@ impl Lock {
                 .with_callback(|l| debug!("waiting for lock on {}", display_path(l)))
                 .lock()?;
             let mut lockfile = Lockfile::read(&lockfile_path)?;
+            self.prepare_lockfile_format(&lockfile_path, &mut lockfile)?;
             if self.json {
                 all_changes.extend(self.compute_version_changes(&lockfile, &tools, &lockfile_path));
             }
@@ -367,6 +380,7 @@ impl Lock {
             let (results, resolution_errors) = self
                 .process_tools(&settings, &tools, &target_platforms, &mut lockfile)
                 .await?;
+            self.bind_requests(&mut lockfile, &tools, &target_platforms);
             all_resolution_errors.extend(resolution_errors);
 
             let platform_regressions =
@@ -540,6 +554,67 @@ impl Lock {
 
     fn is_unfiltered_lock_run(&self) -> bool {
         self.tool.is_empty()
+    }
+
+    fn report_lockfile_format(
+        &self,
+        path: &Path,
+        lockfile: &Lockfile,
+        dry_run: bool,
+    ) -> Result<()> {
+        if !path.exists() || lockfile.lockfile_version() != 0 || self.json {
+            return Ok(());
+        }
+        if self.upgrade {
+            let prefix = if dry_run {
+                "Would upgrade"
+            } else {
+                "Upgrading"
+            };
+            miseprintln!(
+                "{} {prefix} {} from lockfile version 0 to 1",
+                style("→").yellow(),
+                style(display_path(path)).cyan()
+            );
+        } else {
+            warn!(
+                "{} uses legacy lockfile format version 0; run `mise lock --upgrade` to enable request-specific version bindings",
+                display_path(path)
+            );
+        }
+        Ok(())
+    }
+
+    fn prepare_lockfile_format(&self, path: &Path, lockfile: &mut Lockfile) -> Result<bool> {
+        self.report_lockfile_format(path, lockfile, false)?;
+        if path.exists() && lockfile.lockfile_version() == 0 && self.upgrade {
+            lockfile.upgrade();
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn bind_requests(&self, lockfile: &mut Lockfile, tools: &[LockTool], platforms: &[Platform]) {
+        if !lockfile.uses_request_bindings() {
+            return;
+        }
+        for (ba, tv) in tools {
+            let Ok(backend) = tv.request.backend() else {
+                continue;
+            };
+            for platform in platforms {
+                for variant in backend.platform_variants(platform) {
+                    let Ok(options) = backend.resolve_lockfile_options(
+                        &tv.request,
+                        &crate::backend::platform_target::PlatformTarget::new(variant),
+                    ) else {
+                        continue;
+                    };
+                    lockfile.bind_request(&ba.short, &tv.request.version(), &tv.version, &options);
+                }
+            }
+        }
     }
 
     fn prune_stale_entries_if_needed(
@@ -1448,6 +1523,7 @@ mod tests {
             global: false,
             minimum_release_age: None,
             bump: false,
+            upgrade: false,
             json: false,
         }
     }

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -155,6 +155,15 @@ struct LockTaskResult {
     status: LockTaskStatus,
 }
 
+struct StagedUpgradeWrite {
+    path: PathBuf,
+    lockfile: Lockfile,
+    summary: Option<(usize, usize)>,
+    format_changed: bool,
+    stale_tools: BTreeSet<String>,
+    stale_versions: BTreeMap<String, Vec<String>>,
+}
+
 #[derive(Debug, Eq, PartialEq)]
 enum LockTaskStatus {
     Updated,
@@ -231,8 +240,7 @@ impl Lock {
         let mut all_resolution_errors: Vec<String> = Vec::new();
         let mut all_platform_regressions: Vec<String> = Vec::new();
         let mut all_changes: Vec<LockChange> = Vec::new();
-        let mut staged_upgrade_writes: Vec<(PathBuf, Lockfile, Option<(usize, usize)>)> =
-            Vec::new();
+        let mut staged_upgrade_writes: Vec<StagedUpgradeWrite> = Vec::new();
         let collection_context = LockCollectionContext {
             config: &config,
             toolset: ts,
@@ -309,7 +317,7 @@ impl Lock {
                     );
                     let format_changed = if self.upgrade {
                         if lockfile.tools().is_empty() {
-                            self.prepare_lockfile_format(&lockfile_path, &mut lockfile)?
+                            self.prepare_lockfile_format(&lockfile_path, &mut lockfile)
                         } else {
                             bail!(
                                 "cannot upgrade {} because no configured tools were resolved",
@@ -322,11 +330,20 @@ impl Lock {
                     };
                     if format_changed || !pruned_tools.is_empty() {
                         if self.upgrade {
-                            staged_upgrade_writes.push((lockfile_path.clone(), lockfile, None));
+                            staged_upgrade_writes.push(StagedUpgradeWrite {
+                                path: lockfile_path.clone(),
+                                lockfile,
+                                summary: None,
+                                format_changed,
+                                stale_tools: pruned_tools.clone(),
+                                stale_versions: BTreeMap::new(),
+                            });
                         } else {
                             lockfile.write(&lockfile_path)?;
                         }
-                        self.show_stale_prune_message(&lockfile_path, &pruned_tools, false)?;
+                        if !self.upgrade {
+                            self.show_stale_prune_message(&lockfile_path, &pruned_tools, false)?;
+                        }
                         has_lock_targets = true;
                     }
                 }
@@ -395,7 +412,9 @@ impl Lock {
             }
             let stale_tools =
                 self.prune_stale_entries_if_needed(&mut lockfile, configured_selectors.as_ref());
-            self.show_stale_prune_message(&lockfile_path, &stale_tools, false)?;
+            if !self.upgrade {
+                self.show_stale_prune_message(&lockfile_path, &stale_tools, false)?;
+            }
 
             // Compute stale versions BEFORE process_tools so provenance checks can
             // compare against old version entries. Actual pruning happens after.
@@ -414,8 +433,10 @@ impl Lock {
                 continue;
             }
 
-            if self.upgrade && lockfile.lockfile_version() == 0 && resolution_succeeded {
-                self.prepare_lockfile_format(&lockfile_path, &mut lockfile)?;
+            let format_changed =
+                self.upgrade && lockfile.lockfile_version() == 0 && resolution_succeeded;
+            if format_changed {
+                self.prepare_lockfile_format(&lockfile_path, &mut lockfile);
                 if !self.bind_requests(&mut lockfile, &tools, &target_platforms) {
                     bail!(
                         "cannot upgrade {} because not every request binding was resolved",
@@ -428,7 +449,9 @@ impl Lock {
 
             // Prune stale versions AFTER provenance checks complete
             self.prune_stale_versions(&mut lockfile, &tools);
-            self.show_stale_version_prune_message(&lockfile_path, &stale_versions, false)?;
+            if !self.upgrade {
+                self.show_stale_version_prune_message(&lockfile_path, &stale_versions, false)?;
+            }
 
             let successful = results
                 .iter()
@@ -436,11 +459,14 @@ impl Lock {
                 .count();
             let skipped = results.len() - successful;
             if self.upgrade {
-                staged_upgrade_writes.push((
-                    lockfile_path.clone(),
+                staged_upgrade_writes.push(StagedUpgradeWrite {
+                    path: lockfile_path.clone(),
                     lockfile,
-                    Some((successful, skipped)),
-                ));
+                    summary: Some((successful, skipped)),
+                    format_changed,
+                    stale_tools,
+                    stale_versions,
+                });
             } else {
                 // Normal lock runs preserve successful updates even if another
                 // target reports a non-regressing resolution error.
@@ -516,10 +542,6 @@ impl Lock {
             }
         }
 
-        if self.json {
-            miseprintln!("{}", serde_json::to_string_pretty(&all_changes)?);
-        }
-
         all_platform_regressions.extend(all_resolution_errors);
         if !all_platform_regressions.is_empty() {
             return Err(eyre::eyre!(all_platform_regressions.join("\n")));
@@ -529,13 +551,18 @@ impl Lock {
         // resolved and bound successfully. This also keeps legacy monorepo
         // lockfiles untouched on failure.
         if !self.dry_run && self.upgrade {
-            for (lockfile_path, lockfile, summary) in staged_upgrade_writes {
-                let _lock = crate::lock_file::LockFile::new(&lockfile_path)
+            for staged in staged_upgrade_writes {
+                let _lock = crate::lock_file::LockFile::new(&staged.path)
                     .with_callback(|l| debug!("waiting for lock on {}", display_path(l)))
                     .lock()?;
-                lockfile.write(&lockfile_path)?;
+                staged.lockfile.write(&staged.path)?;
+                if staged.format_changed {
+                    self.show_lockfile_upgrade_message(&staged.path)?;
+                }
+                self.show_stale_prune_message(&staged.path, &staged.stale_tools, false)?;
+                self.show_stale_version_prune_message(&staged.path, &staged.stale_versions, false)?;
                 if !self.json
-                    && let Some((successful, skipped)) = summary
+                    && let Some((successful, skipped)) = staged.summary
                 {
                     miseprintln!(
                         "{} Updated {} platform entries ({} skipped)",
@@ -546,11 +573,15 @@ impl Lock {
                     miseprintln!(
                         "{} Lockfile written to {}",
                         style("✓").green(),
-                        style(display_path(&lockfile_path)).cyan()
+                        style(display_path(&staged.path)).cyan()
                     );
                 }
             }
             lockfile::migrate_monorepo_lockfiles(&config, true)?;
+        }
+
+        if self.json {
+            miseprintln!("{}", serde_json::to_string_pretty(&all_changes)?);
         }
 
         Ok(())
@@ -658,14 +689,25 @@ impl Lock {
         Ok(())
     }
 
-    fn prepare_lockfile_format(&self, path: &Path, lockfile: &mut Lockfile) -> Result<bool> {
-        self.report_lockfile_format(path, lockfile, false)?;
+    fn prepare_lockfile_format(&self, path: &Path, lockfile: &mut Lockfile) -> bool {
         if path.exists() && lockfile.lockfile_version() == 0 && self.upgrade {
             lockfile.upgrade();
-            Ok(true)
+            true
         } else {
-            Ok(false)
+            false
         }
+    }
+
+    fn show_lockfile_upgrade_message(&self, path: &Path) -> Result<()> {
+        if self.json {
+            return Ok(());
+        }
+        miseprintln!(
+            "{} Upgrading {} from lockfile version 0 to 1",
+            style("→").yellow(),
+            style(display_path(path)).cyan()
+        );
+        Ok(())
     }
 
     fn bind_requests(

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -164,7 +164,7 @@ impl Upgrade {
         }
         let mut config = Config::get().await?;
         if !self.is_dry_run() {
-            crate::lockfile::migrate_monorepo_lockfiles(&config)?;
+            crate::lockfile::migrate_monorepo_lockfiles(&config, false)?;
         }
         let ts = ToolsetBuilder::new()
             .with_args(&self.tool)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3412,7 +3412,7 @@ pub(crate) async fn rebuild_shims_and_runtime_symlinks(
             .await
             .wrap_err("failed to rebuild shims")?;
     });
-    lockfile::migrate_monorepo_lockfiles(config)?;
+    lockfile::migrate_monorepo_lockfiles(config, false)?;
     // Snapshot the lockfiles' platform keys BEFORE update_lockfiles writes
     // current-platform entries — auto-lock uses this to tell a curated lockfile
     // (existing entries are authoritative) from a fresh one (expand to common).

--- a/src/file.rs
+++ b/src/file.rs
@@ -443,13 +443,44 @@ pub(crate) fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> Res
     fs::write(path, contents).wrap_err_with(|| format!("failed write: {}", display_path(path)))
 }
 
-/// Writes a complete replacement beside `path`, then atomically renames it into place.
+pub(crate) struct PreparedAtomicWrite {
+    temporary: tempfile::NamedTempFile,
+    target: PathBuf,
+    parent: PathBuf,
+}
+
+impl PreparedAtomicWrite {
+    /// Atomically renames this already-written replacement into place.
+    pub(crate) fn commit(self) -> Result<()> {
+        // The hint matters most here. `tempfile`'s persist does not get the extended-length path
+        // handling `std::fs` applies, so this is the operation that fails first as a path
+        // approaches `MAX_PATH` -- measured breaking at a 253-character target while `fs::rename`
+        // on the same tree succeeded at 415.
+        persist_atomic(self.temporary, &self.target).map_err(|e| {
+            let msg = format!("failed atomic write: {}", display_path(&self.target));
+            // Resolve the hint before `wrap_err` takes `e` by value: `downcast_ref` borrows it,
+            // and doing both in one expression leaves the borrow alive across the move.
+            let msg = match e.downcast_ref::<std::io::Error>() {
+                Some(io) => with_io_hint(msg, &self.target, io),
+                None => msg,
+            };
+            e.wrap_err(msg)
+        })?;
+        sync_dir(&self.parent)?;
+        Ok(())
+    }
+}
+
+/// Writes and syncs a complete replacement beside `path` without changing `path` yet.
 ///
 /// New files use ordinary write permissions subject to the process umask. Replacements preserve
 /// the destination's existing Unix permissions.
-pub(crate) fn write_atomic<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> Result<()> {
+pub(crate) fn prepare_atomic_write<P: AsRef<Path>, C: AsRef<[u8]>>(
+    path: P,
+    contents: C,
+) -> Result<PreparedAtomicWrite> {
     let path = path.as_ref();
-    trace!("write_atomic {}", display_path(path));
+    trace!("prepare_atomic_write {}", display_path(path));
     let target = atomic_write_target(path)?;
     let path = target.as_path();
     let parent = path
@@ -484,22 +515,19 @@ pub(crate) fn write_atomic<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C)
     temporary.write_all(contents.as_ref())?;
 
     temporary.as_file_mut().sync_all()?;
-    // The hint matters most here. `tempfile`'s persist does not get the extended-length path
-    // handling `std::fs` applies, so this is the operation that fails first as a path approaches
-    // `MAX_PATH` -- measured breaking at a 253-character target while `fs::rename` on the same
-    // tree succeeded at 415.
-    persist_atomic(temporary, path).map_err(|e| {
-        let msg = format!("failed atomic write: {}", display_path(path));
-        // Resolve the hint before `wrap_err` takes `e` by value: `downcast_ref` borrows it, and
-        // doing both in one expression leaves the borrow alive across the move.
-        let msg = match e.downcast_ref::<std::io::Error>() {
-            Some(io) => with_io_hint(msg, path, io),
-            None => msg,
-        };
-        e.wrap_err(msg)
-    })?;
-    sync_dir(parent)?;
-    Ok(())
+    let parent = parent.to_path_buf();
+    Ok(PreparedAtomicWrite {
+        temporary,
+        target,
+        parent,
+    })
+}
+
+/// Writes a complete replacement beside `path`, then atomically renames it into place.
+pub(crate) fn write_atomic<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> Result<()> {
+    let path = path.as_ref();
+    trace!("write_atomic {}", display_path(path));
+    prepare_atomic_write(path, contents)?.commit()
 }
 
 pub(crate) fn atomic_write_target(path: &Path) -> Result<PathBuf> {

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1599,6 +1599,37 @@ pub(crate) fn migrate_monorepo_lockfiles(
     config: &Config,
     allow_format_upgrade: bool,
 ) -> Result<()> {
+    migrate_monorepo_lockfiles_inner(config, allow_format_upgrade, true, None)
+}
+
+pub(crate) fn monorepo_lockfile_migration_paths(config: &Config) -> Vec<(PathBuf, PathBuf)> {
+    let Some(monorepo_root) = config.monorepo_lockfile_root() else {
+        return Vec::new();
+    };
+    monorepo_legacy_lockfile_paths(config)
+        .into_iter()
+        .filter_map(|source| {
+            let filename = source.file_name()?;
+            let target = monorepo_root.join(filename);
+            (source != target).then_some((source, target))
+        })
+        .collect()
+}
+
+pub(crate) fn migrate_monorepo_lockfiles_already_locked(
+    config: &Config,
+    allow_format_upgrade: bool,
+    migration_paths: &[(PathBuf, PathBuf)],
+) -> Result<()> {
+    migrate_monorepo_lockfiles_inner(config, allow_format_upgrade, false, Some(migration_paths))
+}
+
+fn migrate_monorepo_lockfiles_inner(
+    config: &Config,
+    allow_format_upgrade: bool,
+    acquire_target_locks: bool,
+    migration_paths: Option<&[(PathBuf, PathBuf)]>,
+) -> Result<()> {
     if !Settings::get().lockfile_enabled() {
         return Ok(());
     }
@@ -1607,24 +1638,29 @@ pub(crate) fn migrate_monorepo_lockfiles(
     };
     let mut migrated = 0usize;
 
-    for source in monorepo_legacy_lockfile_paths(config) {
+    let discovered_paths;
+    let migration_paths = match migration_paths {
+        Some(paths) => paths,
+        None => {
+            discovered_paths = monorepo_lockfile_migration_paths(config);
+            &discovered_paths
+        }
+    };
+    for (source, target) in migration_paths {
         if !source.exists() {
             continue;
         }
-        let Some(filename) = source.file_name() else {
-            continue;
-        };
-        let target = monorepo_root.join(filename);
-        if source == target {
-            continue;
-        }
-        let _lock = crate::lock_file::LockFile::new(&target)
-            .with_callback(|l| debug!("waiting for lock on {}", display_path(l)))
-            .lock()?;
+        let _lock = acquire_target_locks
+            .then(|| {
+                crate::lock_file::LockFile::new(target)
+                    .with_callback(|l| debug!("waiting for lock on {}", display_path(l)))
+                    .lock()
+            })
+            .transpose()?;
         let target_existed = target.exists();
         let mut root_lockfile =
-            Lockfile::read(&target).unwrap_or_else(|err| handle_lockfile_read_error(err, &target));
-        let subproject_lockfile = match Lockfile::read(&source) {
+            Lockfile::read(target).unwrap_or_else(|err| handle_lockfile_read_error(err, target));
+        let subproject_lockfile = match Lockfile::read(source) {
             Ok(lockfile) => lockfile,
             Err(err) if is_not_found_report(&err) => continue,
             Err(err) => return Err(err),
@@ -1650,8 +1686,8 @@ pub(crate) fn migrate_monorepo_lockfiles(
             );
         }
         merge_lockfile_preserving_root(&mut root_lockfile, subproject_lockfile);
-        root_lockfile.save(&target)?;
-        if let Err(err) = fs::remove_file(&source)
+        root_lockfile.save(target)?;
+        if let Err(err) = fs::remove_file(source)
             && err.kind() != ErrorKind::NotFound
         {
             return Err(err.into());
@@ -3267,10 +3303,14 @@ fn read_all_lockfiles(config: &Config) -> Arc<Lockfile> {
 }
 
 fn push_existing_lockfile(lockfiles: &mut Vec<Lockfile>, path: &Path) {
-    if path.exists()
-        && let Ok(lockfile) = Lockfile::read(path)
-    {
-        lockfiles.push(lockfile);
+    if !path.exists() {
+        return;
+    }
+    match Lockfile::read(path) {
+        Ok(lockfile) => lockfiles.push(lockfile),
+        Err(err) => {
+            handle_lockfile_read_error(err, path);
+        }
     }
 }
 

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1756,16 +1756,31 @@ fn legacy_lockfile_path_for_config(config_path: &Path, monorepo_root: &Path) -> 
     (source.parent() != Some(monorepo_root)).then_some(source)
 }
 
-fn merge_legacy_lockfile_if_present(lockfile: &mut Lockfile, legacy_path: &Path) -> Result<()> {
+fn merge_legacy_lockfile_if_present(
+    lockfile: &mut Lockfile,
+    legacy_path: &Path,
+    primary_exists: bool,
+) -> Result<()> {
     match Lockfile::read(legacy_path) {
         Ok(legacy) => {
-            lockfile.lockfile_version = lockfile.lockfile_version.min(legacy.lockfile_version);
-            merge_lockfile_preserving_root(lockfile, legacy);
+            if primary_exists {
+                merge_lockfile_for_lookup(lockfile, legacy);
+            } else {
+                *lockfile = legacy;
+            }
             Ok(())
         }
         Err(err) if is_not_found_report(&err) => Ok(()),
         Err(err) => Err(err),
     }
+}
+
+fn merge_lockfile_for_lookup(root: &mut Lockfile, other: Lockfile) {
+    // A mixed-format read must keep request bindings enabled. Version-0 entries
+    // have no specifiers and remain available through the versioned lockfile's
+    // unbound-entry fallback.
+    root.lockfile_version = root.lockfile_version.max(other.lockfile_version);
+    merge_lockfile_preserving_root(root, other);
 }
 
 fn merge_lockfile_preserving_root(root: &mut Lockfile, other: Lockfile) {
@@ -3109,6 +3124,9 @@ where
                     platforms: BTreeMap::new(),
                 });
                 target
+                    .specifiers
+                    .extend(existing_tool.specifiers.iter().cloned());
+                target
                     .platforms
                     .entry(platform_key.clone())
                     .and_modify(|fresh| *fresh = fresh.merge_with(info))
@@ -3247,21 +3265,7 @@ fn read_all_lockfiles(config: &Config) -> Arc<Lockfile> {
         let Some(mut acc) = acc else {
             return Some(l);
         };
-        acc.lockfile_version = acc.lockfile_version.min(l.lockfile_version);
-        for (short, tools) in l.tools {
-            let existing = acc.tools.entry(short).or_default();
-            for tool in tools {
-                // Avoid duplicates (same version+options)
-                if let Some(entry) = existing
-                    .iter_mut()
-                    .find(|t| t.version == tool.version && t.options == tool.options)
-                {
-                    entry.specifiers.extend(tool.specifiers);
-                } else {
-                    existing.push(tool);
-                }
-            }
-        }
+        merge_lockfile_for_lookup(&mut acc, l);
         Some(acc)
     });
 
@@ -3295,10 +3299,12 @@ fn read_lockfile_at(lockfile_path: PathBuf, legacy_path: Option<PathBuf>) -> Arc
         return Arc::clone(cached);
     }
 
+    let primary_exists = lockfile_path.exists();
     let mut lockfile = Lockfile::read(&lockfile_path)
         .unwrap_or_else(|err| handle_lockfile_read_error(err, &lockfile_path));
     if let Some(legacy_path) = &legacy_path
-        && let Err(err) = merge_legacy_lockfile_if_present(&mut lockfile, legacy_path)
+        && let Err(err) =
+            merge_legacy_lockfile_if_present(&mut lockfile, legacy_path, primary_exists)
     {
         warn!(
             "failed to read legacy monorepo lockfile {} (possible corruption): {err:?}",
@@ -4670,7 +4676,7 @@ options = { exe = "rg" }
         let existing = vec![LockfileTool {
             version: "26.0.1".to_string(),
             backend: Some("core:java".to_string()),
-            specifiers: BTreeSet::new(),
+            specifiers: BTreeSet::from(["latest".to_string()]),
             options: BTreeMap::new(),
             platforms: existing_platforms,
         }];
@@ -4689,7 +4695,7 @@ options = { exe = "rg" }
         let fresh = vec![LockfileTool {
             version: "26.0.1".to_string(),
             backend: Some("core:java".to_string()),
-            specifiers: BTreeSet::new(),
+            specifiers: BTreeSet::from(["26".to_string()]),
             options: new_options.clone(),
             platforms: fresh_platforms,
         }];
@@ -4705,6 +4711,10 @@ options = { exe = "rg" }
         );
         let tool = &merged[0];
         assert_eq!(tool.options, new_options);
+        assert_eq!(
+            tool.specifiers,
+            BTreeSet::from(["26".to_string(), "latest".to_string()])
+        );
         assert_eq!(tool.platforms.len(), 2);
         assert_eq!(
             tool.platforms["linux-x64"].checksum.as_deref(),
@@ -5196,6 +5206,81 @@ options = { exe = "rg" }
         assert_eq!(tools[0].version, "20.0.0");
         assert_eq!(tools[0].backend.as_deref(), Some("core:node"));
         assert_eq!(tools[1].version, "22.0.0");
+    }
+
+    #[test]
+    fn test_merge_lockfile_for_lookup_keeps_request_bindings_enabled() {
+        for (root_version, other_version) in [(0, 1), (1, 0)] {
+            let mut root = Lockfile::default();
+            root.lockfile_version = root_version;
+            root.tools.insert(
+                "node".to_string(),
+                vec![LockfileTool {
+                    version: "20.0.0".to_string(),
+                    backend: Some("core:node".to_string()),
+                    specifiers: BTreeSet::from(["20".to_string()]),
+                    options: BTreeMap::new(),
+                    platforms: BTreeMap::new(),
+                }],
+            );
+            let mut other = Lockfile::default();
+            other.lockfile_version = other_version;
+            other
+                .tools
+                .insert("node".to_string(), vec![basic_tool("22.0.0", "core:node")]);
+
+            merge_lockfile_for_lookup(&mut root, other);
+
+            assert_eq!(root.lockfile_version(), 1);
+            assert!(root.uses_request_bindings());
+            assert!(root.tools["node"][0].specifiers.contains("20"));
+            assert!(root.tools["node"][1].specifiers.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_read_lockfile_at_only_promotes_when_primary_exists() {
+        let temp = tempfile::tempdir().unwrap();
+        let primary_path = temp.path().join("mise.lock");
+        let legacy_path = temp.path().join("package.lock");
+
+        let mut legacy = Lockfile::default();
+        legacy.lockfile_version = 0;
+        legacy
+            .tools
+            .insert("node".to_string(), vec![basic_tool("20.0.0", "core:node")]);
+        legacy.save(&legacy_path).unwrap();
+
+        let legacy_only = read_lockfile_at(primary_path.clone(), Some(legacy_path.clone()));
+        assert_eq!(legacy_only.lockfile_version(), 0);
+
+        let mut primary = Lockfile::default();
+        primary.tools.insert(
+            "node".to_string(),
+            vec![LockfileTool {
+                version: "22.0.0".to_string(),
+                backend: Some("core:node".to_string()),
+                specifiers: BTreeSet::from(["latest".to_string()]),
+                options: BTreeMap::new(),
+                platforms: BTreeMap::new(),
+            }],
+        );
+        primary.save(&primary_path).unwrap();
+        invalidate_caches();
+
+        let mixed = read_lockfile_at(primary_path, Some(legacy_path));
+        assert_eq!(mixed.lockfile_version(), 1);
+        assert!(mixed.uses_request_bindings());
+        assert!(
+            mixed.tools["node"]
+                .iter()
+                .any(|tool| { tool.version == "22.0.0" && tool.specifiers.contains("latest") })
+        );
+        assert!(
+            mixed.tools["node"]
+                .iter()
+                .any(|tool| { tool.version == "20.0.0" && tool.specifiers.is_empty() })
+        );
     }
 
     #[test]

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -61,9 +61,13 @@ pub(crate) fn invalidate_caches() {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+const CURRENT_LOCKFILE_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Lockfile {
+    #[serde(skip)]
+    lockfile_version: u32,
     #[serde(skip)]
     generated_header_url: Option<String>,
     #[serde(skip)]
@@ -81,10 +85,24 @@ pub(crate) struct Lockfile {
 pub(crate) struct LockfileTool {
     pub version: String,
     pub backend: Option<String>,
+    #[serde(skip_serializing_if = "BTreeSet::is_empty", default)]
+    pub specifiers: BTreeSet<String>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
     pub options: BTreeMap<String, String>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
     pub platforms: BTreeMap<String, PlatformInfo>,
+}
+
+impl Default for Lockfile {
+    fn default() -> Self {
+        Self {
+            lockfile_version: CURRENT_LOCKFILE_VERSION,
+            generated_header_url: None,
+            tools: BTreeMap::new(),
+            conda_packages: BTreeMap::new(),
+            pkgx_packages: BTreeMap::new(),
+        }
+    }
 }
 
 type LockfileToolKey = (String, BTreeMap<String, String>);
@@ -863,6 +881,42 @@ fn existing_lockfile_doc_url_from_path(path: &Path) -> Option<String> {
 }
 
 impl Lockfile {
+    pub(crate) fn lockfile_version(&self) -> u32 {
+        self.lockfile_version
+    }
+
+    pub(crate) fn upgrade(&mut self) {
+        self.lockfile_version = CURRENT_LOCKFILE_VERSION;
+    }
+
+    pub(crate) fn uses_request_bindings(&self) -> bool {
+        self.lockfile_version > 0
+    }
+
+    pub(crate) fn bind_request(
+        &mut self,
+        short: &str,
+        specifier: &str,
+        version: &str,
+        options: &BTreeMap<String, String>,
+    ) {
+        if !self.uses_request_bindings() {
+            return;
+        }
+        let Some(tools) = self.tools.get_mut(short) else {
+            return;
+        };
+        for tool in tools.iter_mut().filter(|tool| &tool.options == options) {
+            tool.specifiers.remove(specifier);
+        }
+        if let Some(tool) = tools
+            .iter_mut()
+            .find(|tool| tool.version == version && &tool.options == options)
+        {
+            tool.specifiers.insert(specifier.to_string());
+        }
+    }
+
     pub(crate) fn read<P: AsRef<Path>>(path: P) -> Result<Self> {
         let path = path.as_ref();
         if !path.exists() {
@@ -872,6 +926,16 @@ impl Lockfile {
         let content = file::read_to_string(path)?;
         let generated_header_url = existing_lockfile_doc_url(&content);
         let mut table: toml::Table = toml::from_str(&content)?;
+        let lockfile_version = table
+            .remove("lockfile_version")
+            .map(|value| value.try_into())
+            .transpose()?
+            .unwrap_or(0);
+        if lockfile_version > CURRENT_LOCKFILE_VERSION {
+            bail!(
+                "unsupported lockfile version {lockfile_version}; this mise supports up to version {CURRENT_LOCKFILE_VERSION}"
+            );
+        }
 
         let tools: toml::Table = table
             .remove("tools")
@@ -879,6 +943,7 @@ impl Lockfile {
             .try_into()?;
 
         let mut lockfile = Lockfile {
+            lockfile_version,
             generated_header_url,
             ..Default::default()
         };
@@ -934,6 +999,13 @@ impl Lockfile {
     fn save<P: AsRef<Path>>(&self, path: P) -> Result<()> {
         let path = path.as_ref();
         let mut lockfile = toml::Table::new();
+
+        if self.lockfile_version > 0 {
+            lockfile.insert(
+                "lockfile_version".to_string(),
+                i64::from(self.lockfile_version).into(),
+            );
+        }
 
         // Write conda-packages section first (before tools for nicer ordering)
         if !self.conda_packages.is_empty() {
@@ -994,7 +1066,7 @@ impl Lockfile {
             let value: toml::Value = versions
                 .iter()
                 .cloned()
-                .map(|version| version.into_toml_value())
+                .map(|version| version.into_toml_value(self.lockfile_version > 0))
                 .collect::<Vec<toml::Value>>()
                 .into();
             tools.insert(short.clone(), value);
@@ -1364,6 +1436,7 @@ impl Lockfile {
             tools.push(LockfileTool {
                 version: version.to_string(),
                 backend: backend.map(|s| s.to_string()),
+                specifiers: BTreeSet::new(),
                 options: options.clone(),
                 platforms,
             });
@@ -1519,7 +1592,10 @@ impl LockfileUpdateMode {
     }
 }
 
-pub(crate) fn migrate_monorepo_lockfiles(config: &Config) -> Result<()> {
+pub(crate) fn migrate_monorepo_lockfiles(
+    config: &Config,
+    allow_format_upgrade: bool,
+) -> Result<()> {
     if !Settings::get().lockfile_enabled() {
         return Ok(());
     }
@@ -1542,6 +1618,7 @@ pub(crate) fn migrate_monorepo_lockfiles(config: &Config) -> Result<()> {
         let _lock = crate::lock_file::LockFile::new(&target)
             .with_callback(|l| debug!("waiting for lock on {}", display_path(l)))
             .lock()?;
+        let target_existed = target.exists();
         let mut root_lockfile =
             Lockfile::read(&target).unwrap_or_else(|err| handle_lockfile_read_error(err, &target));
         let subproject_lockfile = match Lockfile::read(&source) {
@@ -1549,6 +1626,24 @@ pub(crate) fn migrate_monorepo_lockfiles(config: &Config) -> Result<()> {
             Err(err) if is_not_found_report(&err) => continue,
             Err(err) => return Err(err),
         };
+        if !target_existed {
+            root_lockfile.lockfile_version = subproject_lockfile.lockfile_version;
+        } else if root_lockfile.lockfile_version != subproject_lockfile.lockfile_version
+            && allow_format_upgrade
+        {
+            // `mise lock --upgrade` immediately rebuilds the merged root from the
+            // authoritative monorepo union. Use legacy semantics for the merge so
+            // neither side's concrete entries become temporarily unreachable.
+            root_lockfile.lockfile_version = 0;
+        } else if root_lockfile.lockfile_version != subproject_lockfile.lockfile_version {
+            bail!(
+                "cannot merge lockfile version {} from {} into lockfile version {} at {}; run `mise lock --upgrade` at the monorepo root",
+                subproject_lockfile.lockfile_version,
+                display_path(&source),
+                root_lockfile.lockfile_version,
+                display_path(&target)
+            );
+        }
         merge_lockfile_preserving_root(&mut root_lockfile, subproject_lockfile);
         root_lockfile.save(&target)?;
         if let Err(err) = fs::remove_file(&source)
@@ -1668,6 +1763,7 @@ fn merge_legacy_lockfile_if_present(lockfile: &mut Lockfile, legacy_path: &Path)
 }
 
 fn merge_lockfile_preserving_root(root: &mut Lockfile, other: Lockfile) {
+    root.lockfile_version = root.lockfile_version.min(other.lockfile_version);
     for (short, tools) in other.tools {
         let root_tools = root.tools.entry(short).or_default();
         let mut keys: HashSet<(String, BTreeMap<String, String>)> = root_tools
@@ -1676,7 +1772,11 @@ fn merge_lockfile_preserving_root(root: &mut Lockfile, other: Lockfile) {
             .collect();
         for tool in tools {
             let key = (tool.version.clone(), tool.options.clone());
-            if keys.insert(key) {
+            if let Some(existing) = root_tools.iter_mut().find(|existing| {
+                existing.version == tool.version && existing.options == tool.options
+            }) {
+                existing.specifiers.extend(tool.specifiers);
+            } else if keys.insert(key) {
                 root_tools.push(tool);
             }
         }
@@ -1953,6 +2053,24 @@ pub(crate) fn update_lockfiles(
             // stale baseline self-heals on the next update once the new version is locked.
             reinsert_deferred_baselines(&mut merged_tools, &deferred_baselines, &short);
             existing_lockfile.tools.insert(short, merged_tools);
+            if existing_lockfile.uses_request_bindings() {
+                for tv in versions {
+                    let options = if let Ok(backend) = tv.request.backend() {
+                        backend.resolve_lockfile_options(
+                            &tv.request,
+                            &PlatformTarget::from_current(),
+                        )?
+                    } else {
+                        BTreeMap::new()
+                    };
+                    existing_lockfile.bind_request(
+                        tv.short(),
+                        &tv.request.version(),
+                        &tv.version,
+                        &options,
+                    );
+                }
+            }
         }
 
         // Merge conda packages from new_versions into the lockfile
@@ -2918,6 +3036,7 @@ where
     for tool in entries {
         let key = (tool.version.clone(), tool.options.clone());
         let entry = by_key.entry(key).or_insert_with(|| tool.clone());
+        entry.specifiers.extend(tool.specifiers.clone());
 
         // Merge platforms - properly combine platform info to preserve URLs and prefer sha256
         for (platform, info) in tool.platforms {
@@ -2935,6 +3054,9 @@ where
     if let Some(existing) = existing_tools {
         for existing_tool in existing {
             let key = (existing_tool.version.clone(), existing_tool.options.clone());
+            if let Some(entry) = by_key.get_mut(&key) {
+                entry.specifiers.extend(existing_tool.specifiers.clone());
+            }
             if !existing_tool.options.is_empty() {
                 if let Some(entry) = by_key.get_mut(&key) {
                     // Preserve platform data only for an exact non-empty option
@@ -2947,6 +3069,7 @@ where
                             .and_modify(|existing| *existing = existing.merge_with(info))
                             .or_insert(info.clone());
                     }
+                    entry.specifiers.extend(existing_tool.specifiers.clone());
                 }
                 continue;
             }
@@ -2964,6 +3087,7 @@ where
                         .or_insert_with(|| LockfileTool {
                             version: existing_tool.version.clone(),
                             backend: existing_tool.backend.clone(),
+                            specifiers: existing_tool.specifiers.clone(),
                             options: existing_tool.options.clone(),
                             platforms: BTreeMap::new(),
                         })
@@ -2976,6 +3100,7 @@ where
                 let target = by_key.entry(target_key).or_insert_with(|| LockfileTool {
                     version: existing_tool.version.clone(),
                     backend: existing_tool.backend.clone(),
+                    specifiers: existing_tool.specifiers.clone(),
                     options: resolved_options,
                     platforms: BTreeMap::new(),
                 });
@@ -3114,21 +3239,29 @@ fn read_all_lockfiles(config: &Config) -> Arc<Lockfile> {
         }
     }
 
-    let result = all.into_iter().fold(Lockfile::default(), |mut acc, l| {
+    let result = all.into_iter().fold(None, |acc: Option<Lockfile>, l| {
+        let Some(mut acc) = acc else {
+            return Some(l);
+        };
+        acc.lockfile_version = acc.lockfile_version.min(l.lockfile_version);
         for (short, tools) in l.tools {
             let existing = acc.tools.entry(short).or_default();
             for tool in tools {
                 // Avoid duplicates (same version+options)
-                if !existing
-                    .iter()
-                    .any(|t| t.version == tool.version && t.options == tool.options)
+                if let Some(entry) = existing
+                    .iter_mut()
+                    .find(|t| t.version == tool.version && t.options == tool.options)
                 {
+                    entry.specifiers.extend(tool.specifiers);
+                } else {
                     existing.push(tool);
                 }
             }
         }
-        acc
+        Some(acc)
     });
+
+    let result = result.unwrap_or_default();
 
     let result = Arc::new(result);
     cache.insert(discovery.cache_key.clone(), Arc::clone(&result));
@@ -3212,6 +3345,7 @@ pub(crate) fn get_locked_version(
     config: &Config,
     path: Option<&Path>,
     short: &str,
+    specifier: &str,
     prefix: &str,
     require_prefix_boundary: bool,
     request_options: &BTreeMap<String, String>,
@@ -3237,6 +3371,24 @@ pub(crate) fn get_locked_version(
     };
 
     if let Some(tools) = lockfile.tools.get(short) {
+        if lockfile.uses_request_bindings() {
+            let matching = tools
+                .iter()
+                .filter(|tool| {
+                    tool.specifiers.contains(specifier) && &tool.options == request_options
+                })
+                .collect_vec();
+            return match matching.as_slice() {
+                [] => Ok(None),
+                [found] => {
+                    trace!("[{short}@{specifier}] found {} in lockfile", found.version);
+                    Ok(Some((*found).clone()))
+                }
+                _ => bail!(
+                    "lockfile contains multiple resolutions for {short}@{specifier} with the same options"
+                ),
+            };
+        }
         let version_matches = |v: &LockfileTool| {
             lockfile_version_matches(prefix, &v.version)
                 && (!require_prefix_boundary
@@ -3413,6 +3565,7 @@ impl TryFrom<toml::Value> for LockfileTool {
             toml::Value::String(v) => LockfileTool {
                 version: v,
                 backend: Default::default(),
+                specifiers: Default::default(),
                 options: Default::default(),
                 platforms: Default::default(),
             },
@@ -3446,6 +3599,11 @@ impl TryFrom<toml::Value> for LockfileTool {
                         }
                     }
                 }
+                let specifiers = t
+                    .remove("specifiers")
+                    .map(|value| value.try_into())
+                    .transpose()?
+                    .unwrap_or_default();
                 // Silently discard env field from old lockfiles for backwards compat
                 t.remove("env");
                 LockfileTool {
@@ -3459,6 +3617,7 @@ impl TryFrom<toml::Value> for LockfileTool {
                         .map(|v| v.try_into())
                         .transpose()?
                         .unwrap_or_default(),
+                    specifiers,
                     options,
                     platforms,
                 }
@@ -3470,11 +3629,17 @@ impl TryFrom<toml::Value> for LockfileTool {
 }
 
 impl LockfileTool {
-    fn into_toml_value(self) -> toml::Value {
+    fn into_toml_value(self, include_specifiers: bool) -> toml::Value {
         let mut table = toml::Table::new();
         table.insert("version".to_string(), self.version.into());
         if let Some(backend) = self.backend {
             table.insert("backend".to_string(), backend.into());
+        }
+        if include_specifiers && !self.specifiers.is_empty() {
+            table.insert(
+                "specifiers".to_string(),
+                self.specifiers.into_iter().collect::<Vec<_>>().into(),
+            );
         }
         if !self.options.is_empty() {
             let opts_table: toml::Table = self
@@ -3510,6 +3675,7 @@ fn lockfile_tool_from_tool_version(tv: &ToolVersion) -> Result<LockfileTool> {
     Ok(LockfileTool {
         version: tv.version.clone(),
         backend: Some(tv.ba().stored_full()),
+        specifiers: BTreeSet::from([tv.request.version()]),
         options,
         platforms,
     })
@@ -3576,9 +3742,96 @@ mod tests {
         LockfileTool {
             version: version.to_string(),
             backend: Some(backend.to_string()),
+            specifiers: BTreeSet::new(),
             options: BTreeMap::new(),
             platforms: BTreeMap::new(),
         }
+    }
+
+    #[test]
+    fn new_lockfiles_write_current_version_and_request_bindings() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("mise.lock");
+        let mut lockfile = Lockfile::default();
+        lockfile.tools.insert(
+            "dummy".to_string(),
+            vec![LockfileTool {
+                version: "1.1.0".to_string(),
+                backend: Some("asdf:dummy".to_string()),
+                specifiers: BTreeSet::from(["1".to_string()]),
+                options: BTreeMap::new(),
+                platforms: BTreeMap::new(),
+            }],
+        );
+
+        lockfile.save(&path).unwrap();
+        let contents = file::read_to_string(&path).unwrap();
+        assert!(contents.contains("lockfile_version = 1"));
+        assert!(contents.contains("specifiers = [\"1\"]"));
+
+        let reloaded = Lockfile::read(&path).unwrap();
+        assert_eq!(reloaded.lockfile_version(), 1);
+        assert_eq!(
+            reloaded.tools["dummy"][0].specifiers,
+            BTreeSet::from(["1".to_string()])
+        );
+    }
+
+    #[test]
+    fn legacy_lockfiles_remain_unversioned_when_rewritten() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("mise.lock");
+        file::write(
+            &path,
+            "[[tools.dummy]]\nversion = \"1.0.0\"\nbackend = \"asdf:dummy\"\n",
+        )
+        .unwrap();
+
+        let lockfile = Lockfile::read(&path).unwrap();
+        assert_eq!(lockfile.lockfile_version(), 0);
+        lockfile.save(&path).unwrap();
+        let contents = file::read_to_string(&path).unwrap();
+        assert!(!contents.contains("lockfile_version"));
+        assert!(!contents.contains("specifiers"));
+    }
+
+    #[test]
+    fn future_lockfile_versions_are_rejected() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("mise.lock");
+        file::write(&path, "lockfile_version = 2\n[tools]\n").unwrap();
+
+        let err = Lockfile::read(&path).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("unsupported lockfile version 2; this mise supports up to version 1")
+        );
+    }
+
+    #[test]
+    fn request_binding_moves_between_versions_with_matching_options() {
+        let mut lockfile = Lockfile::default();
+        lockfile.tools.insert(
+            "dummy".to_string(),
+            vec![
+                LockfileTool {
+                    version: "1.0.0".to_string(),
+                    backend: Some("asdf:dummy".to_string()),
+                    specifiers: BTreeSet::from(["1".to_string()]),
+                    options: BTreeMap::new(),
+                    platforms: BTreeMap::new(),
+                },
+                basic_tool("1.1.0", "asdf:dummy"),
+            ],
+        );
+
+        lockfile.bind_request("dummy", "1", "1.1.0", &BTreeMap::new());
+
+        assert!(lockfile.tools["dummy"][0].specifiers.is_empty());
+        assert_eq!(
+            lockfile.tools["dummy"][1].specifiers,
+            BTreeSet::from(["1".to_string()])
+        );
     }
 
     #[test]
@@ -3682,6 +3935,7 @@ mod tests {
         LockfileTool {
             version: version.to_string(),
             backend: Some(backend.to_string()),
+            specifiers: BTreeSet::new(),
             options: BTreeMap::new(),
             platforms,
         }
@@ -3827,6 +4081,7 @@ backend = "core:python"
         let tool = LockfileTool {
             version: "20.10.0".to_string(),
             backend: Some("core:node".to_string()),
+            specifiers: BTreeSet::new(),
             options: BTreeMap::new(),
             platforms,
         };
@@ -3965,6 +4220,7 @@ checksum = "blake3:abc123"
         let tool = LockfileTool {
             version: "14.0.0".to_string(),
             backend: Some("ubi:BurntSushi/ripgrep".to_string()),
+            specifiers: BTreeSet::new(),
             options: BTreeMap::new(), // Empty options
             platforms: BTreeMap::new(),
         };
@@ -3992,6 +4248,7 @@ checksum = "blake3:abc123"
         let tool = LockfileTool {
             version: "14.0.0".to_string(),
             backend: Some("ubi:BurntSushi/ripgrep".to_string()),
+            specifiers: BTreeSet::new(),
             options,
             platforms: BTreeMap::new(),
         };
@@ -4215,6 +4472,7 @@ options = { exe = "rg" }
         let existing = vec![LockfileTool {
             version: "26.0.1".to_string(),
             backend: Some("core:java".to_string()),
+            specifiers: BTreeSet::new(),
             options: BTreeMap::new(),
             platforms,
         }];
@@ -4231,6 +4489,7 @@ options = { exe = "rg" }
             vec![LockfileTool {
                 version: "26.0.1".to_string(),
                 backend: Some("core:java".to_string()),
+                specifiers: BTreeSet::new(),
                 options: options.clone(),
                 platforms: fresh_platforms,
             }],
@@ -4254,6 +4513,7 @@ options = { exe = "rg" }
         fragmented.push(LockfileTool {
             version: "26.0.1".to_string(),
             backend: Some("core:java".to_string()),
+            specifiers: BTreeSet::new(),
             options: BTreeMap::from([("shorthand_vendor".to_string(), "openjdk".to_string())]),
             platforms: BTreeMap::new(),
         });
@@ -4292,6 +4552,7 @@ options = { exe = "rg" }
         let existing = vec![LockfileTool {
             version: "26.0.1".to_string(),
             backend: Some("core:java".to_string()),
+            specifiers: BTreeSet::new(),
             options: BTreeMap::new(),
             platforms: existing_platforms,
         }];
@@ -4310,6 +4571,7 @@ options = { exe = "rg" }
         let fresh = vec![LockfileTool {
             version: "26.0.1".to_string(),
             backend: Some("core:java".to_string()),
+            specifiers: BTreeSet::new(),
             options: new_options.clone(),
             platforms: fresh_platforms,
         }];
@@ -4343,6 +4605,7 @@ options = { exe = "rg" }
             LockfileTool {
                 version: "3.4.2".to_string(),
                 backend: Some("core:ruby".to_string()),
+                specifiers: BTreeSet::new(),
                 options: unix_options.clone(),
                 platforms: BTreeMap::from([(
                     "linux-x64".to_string(),
@@ -4355,6 +4618,7 @@ options = { exe = "rg" }
             LockfileTool {
                 version: "3.4.2".to_string(),
                 backend: Some("core:ruby".to_string()),
+                specifiers: BTreeSet::new(),
                 options: BTreeMap::new(),
                 platforms: BTreeMap::from([(
                     "windows-x64".to_string(),
@@ -4369,6 +4633,7 @@ options = { exe = "rg" }
             LockfileTool {
                 version: "3.4.2".to_string(),
                 backend: Some("core:ruby".to_string()),
+                specifiers: BTreeSet::new(),
                 options: unix_options,
                 platforms: BTreeMap::from([(
                     "linux-x64".to_string(),
@@ -4381,6 +4646,7 @@ options = { exe = "rg" }
             LockfileTool {
                 version: "3.4.2".to_string(),
                 backend: Some("core:ruby".to_string()),
+                specifiers: BTreeSet::new(),
                 options: BTreeMap::new(),
                 platforms: BTreeMap::from([(
                     "windows-x64".to_string(),
@@ -4439,6 +4705,7 @@ options = { exe = "rg" }
         let existing = vec![LockfileTool {
             version: "1.0.0".to_string(),
             backend: Some("example:tool".to_string()),
+            specifiers: BTreeSet::new(),
             options: old_options,
             platforms: BTreeMap::from([(
                 "linux-x64".to_string(),
@@ -4451,6 +4718,7 @@ options = { exe = "rg" }
         let fresh = vec![LockfileTool {
             version: "1.0.0".to_string(),
             backend: Some("example:tool".to_string()),
+            specifiers: BTreeSet::new(),
             options: new_options.clone(),
             platforms: BTreeMap::from([(
                 "linux-x64".to_string(),
@@ -4477,6 +4745,7 @@ options = { exe = "rg" }
         let existing = vec![LockfileTool {
             version: "26.0.1".to_string(),
             backend: Some("core:java".to_string()),
+            specifiers: BTreeSet::new(),
             options: BTreeMap::new(),
             platforms: BTreeMap::from([(
                 "linux-x64".to_string(),
@@ -4489,6 +4758,7 @@ options = { exe = "rg" }
         let fresh = vec![LockfileTool {
             version: "26.0.1".to_string(),
             backend: Some("core:java".to_string()),
+            specifiers: BTreeSet::new(),
             options: BTreeMap::from([("shorthand_vendor".to_string(), "openjdk".to_string())]),
             platforms: BTreeMap::new(),
         }];
@@ -4534,6 +4804,7 @@ options = { exe = "rg" }
             LockfileTool {
                 version: "3.4.2".to_string(),
                 backend: Some("core:ruby".to_string()),
+                specifiers: BTreeSet::new(),
                 options: BTreeMap::new(),
                 platforms: BTreeMap::from([(
                     "linux-x64".to_string(),
@@ -4546,6 +4817,7 @@ options = { exe = "rg" }
             LockfileTool {
                 version: "3.4.2".to_string(),
                 backend: Some("core:ruby".to_string()),
+                specifiers: BTreeSet::new(),
                 options: unix_options.clone(),
                 platforms: BTreeMap::from([(
                     "linux-x64".to_string(),
@@ -4559,6 +4831,7 @@ options = { exe = "rg" }
         let fresh = vec![LockfileTool {
             version: "3.4.2".to_string(),
             backend: Some("core:ruby".to_string()),
+            specifiers: BTreeSet::new(),
             options: unix_options.clone(),
             platforms: BTreeMap::from([(
                 "linux-x64".to_string(),
@@ -4587,12 +4860,14 @@ options = { exe = "rg" }
         let existing = vec![LockfileTool {
             version: "1.0.0".to_string(),
             backend: Some("example:tool".to_string()),
+            specifiers: BTreeSet::new(),
             options: other_options.clone(),
             platforms: BTreeMap::new(),
         }];
         let fresh = vec![LockfileTool {
             version: "1.0.0".to_string(),
             backend: Some("example:tool".to_string()),
+            specifiers: BTreeSet::new(),
             options: current_options,
             platforms: BTreeMap::new(),
         }];
@@ -4656,6 +4931,7 @@ options = { exe = "rg" }
             LockfileTool {
                 version: "3.4.2".to_string(),
                 backend: Some("core:ruby".to_string()),
+                specifiers: BTreeSet::new(),
                 options: unix_options.clone(),
                 platforms: BTreeMap::from([(
                     "linux-x64".to_string(),
@@ -4669,6 +4945,7 @@ options = { exe = "rg" }
             LockfileTool {
                 version: "3.4.2".to_string(),
                 backend: Some("core:ruby".to_string()),
+                specifiers: BTreeSet::new(),
                 options: BTreeMap::new(),
                 platforms: BTreeMap::from([(
                     "windows-x64".to_string(),
@@ -4882,6 +5159,7 @@ backend = "conda:jq"
             vec![LockfileTool {
                 version: "1.7.1".to_string(),
                 backend: Some("conda:jq".to_string()),
+                specifiers: BTreeSet::new(),
                 options: BTreeMap::new(),
                 platforms,
             }],
@@ -4969,6 +5247,7 @@ backend = "conda:jq"
             vec![LockfileTool {
                 version: "1.0.0".to_string(),
                 backend: Some("conda:mytool".to_string()),
+                specifiers: BTreeSet::new(),
                 options: BTreeMap::new(),
                 platforms,
             }],
@@ -5081,6 +5360,7 @@ backend = "conda:jq"
             vec![LockfileTool {
                 version: "1.7.1".to_string(),
                 backend: Some("aqua:jqlang/jq".to_string()),
+                specifiers: BTreeSet::new(),
                 options: BTreeMap::new(),
 
                 platforms: BTreeMap::new(),

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -899,22 +899,24 @@ impl Lockfile {
         specifier: &str,
         version: &str,
         options: &BTreeMap<String, String>,
-    ) {
+    ) -> bool {
         if !self.uses_request_bindings() {
-            return;
+            return false;
         }
         let Some(tools) = self.tools.get_mut(short) else {
-            return;
+            return false;
+        };
+        let Some(target_idx) = tools
+            .iter()
+            .position(|tool| tool.version == version && &tool.options == options)
+        else {
+            return false;
         };
         for tool in tools.iter_mut().filter(|tool| &tool.options == options) {
             tool.specifiers.remove(specifier);
         }
-        if let Some(tool) = tools
-            .iter_mut()
-            .find(|tool| tool.version == version && &tool.options == options)
-        {
-            tool.specifiers.insert(specifier.to_string());
-        }
+        tools[target_idx].specifiers.insert(specifier.to_string());
+        true
     }
 
     pub(crate) fn read<P: AsRef<Path>>(path: P) -> Result<Self> {
@@ -1631,10 +1633,12 @@ pub(crate) fn migrate_monorepo_lockfiles(
         } else if root_lockfile.lockfile_version != subproject_lockfile.lockfile_version
             && allow_format_upgrade
         {
-            // `mise lock --upgrade` immediately rebuilds the merged root from the
-            // authoritative monorepo union. Use legacy semantics for the merge so
-            // neither side's concrete entries become temporarily unreachable.
-            root_lockfile.lockfile_version = 0;
+            // Keep the newer format so request bindings from either input remain
+            // serialized if the subsequent rebuild fails. Entries imported from
+            // version 0 remain reachable through the unbound-entry fallback.
+            root_lockfile.lockfile_version = root_lockfile
+                .lockfile_version
+                .max(subproject_lockfile.lockfile_version);
         } else if root_lockfile.lockfile_version != subproject_lockfile.lockfile_version {
             bail!(
                 "cannot merge lockfile version {} from {} into lockfile version {} at {}; run `mise lock --upgrade` at the monorepo root",
@@ -1754,6 +1758,7 @@ fn legacy_lockfile_path_for_config(config_path: &Path, monorepo_root: &Path) -> 
 fn merge_legacy_lockfile_if_present(lockfile: &mut Lockfile, legacy_path: &Path) -> Result<()> {
     match Lockfile::read(legacy_path) {
         Ok(legacy) => {
+            lockfile.lockfile_version = lockfile.lockfile_version.min(legacy.lockfile_version);
             merge_lockfile_preserving_root(lockfile, legacy);
             Ok(())
         }
@@ -1763,7 +1768,6 @@ fn merge_legacy_lockfile_if_present(lockfile: &mut Lockfile, legacy_path: &Path)
 }
 
 fn merge_lockfile_preserving_root(root: &mut Lockfile, other: Lockfile) {
-    root.lockfile_version = root.lockfile_version.min(other.lockfile_version);
     for (short, tools) in other.tools {
         let root_tools = root.tools.entry(short).or_default();
         let mut keys: HashSet<(String, BTreeMap<String, String>)> = root_tools
@@ -2019,6 +2023,18 @@ pub(crate) fn update_lockfiles(
                 continue;
             }
             let versions = &tool_versions_by_short[&short];
+            let bindings = entries
+                .iter()
+                .flat_map(|entry| {
+                    entry.specifiers.iter().map(|specifier| {
+                        (
+                            specifier.clone(),
+                            entry.version.clone(),
+                            entry.options.clone(),
+                        )
+                    })
+                })
+                .collect_vec();
             // Normal monorepo installs load only the current config hierarchy,
             // not every sibling project. Consensus among those visible requests
             // is therefore not authoritative for the shared root lockfile. Fail
@@ -2052,23 +2068,10 @@ pub(crate) fn update_lockfiles(
             // gone before auto-lock runs, letting a genuine regression slip through. The
             // stale baseline self-heals on the next update once the new version is locked.
             reinsert_deferred_baselines(&mut merged_tools, &deferred_baselines, &short);
-            existing_lockfile.tools.insert(short, merged_tools);
+            existing_lockfile.tools.insert(short.clone(), merged_tools);
             if existing_lockfile.uses_request_bindings() {
-                for tv in versions {
-                    let options = if let Ok(backend) = tv.request.backend() {
-                        backend.resolve_lockfile_options(
-                            &tv.request,
-                            &PlatformTarget::from_current(),
-                        )?
-                    } else {
-                        BTreeMap::new()
-                    };
-                    existing_lockfile.bind_request(
-                        tv.short(),
-                        &tv.request.version(),
-                        &tv.version,
-                        &options,
-                    );
+                for (specifier, version, options) in bindings {
+                    existing_lockfile.bind_request(&short, &specifier, &version, &options);
                 }
             }
         }
@@ -3378,16 +3381,77 @@ pub(crate) fn get_locked_version(
                     tool.specifiers.contains(specifier) && &tool.options == request_options
                 })
                 .collect_vec();
-            return match matching.as_slice() {
-                [] => Ok(None),
+            match matching.as_slice() {
+                [] => {}
                 [found] => {
                     trace!("[{short}@{specifier}] found {} in lockfile", found.version);
-                    Ok(Some((*found).clone()))
+                    return Ok(Some((*found).clone()));
                 }
-                _ => bail!(
-                    "lockfile contains multiple resolutions for {short}@{specifier} with the same options"
-                ),
+                _ => {
+                    bail!(
+                        "lockfile contains multiple resolutions for {short}@{specifier} with the same options"
+                    )
+                }
+            }
+
+            if legacy_options_fallback && !request_options.is_empty() {
+                let legacy = tools
+                    .iter()
+                    .filter(|tool| tool.specifiers.contains(specifier) && tool.options.is_empty())
+                    .collect_vec();
+                match legacy.as_slice() {
+                    [] => {}
+                    [found] => {
+                        trace!(
+                            "[{short}@{specifier}] found {} in lockfile without options, keeping the version pin and dropping its artifact data",
+                            found.version
+                        );
+                        return Ok(Some(lockfile_tool_with_request_options(
+                            found,
+                            request_options,
+                        )));
+                    }
+                    _ => bail!(
+                        "lockfile contains multiple optionless resolutions for {short}@{specifier}"
+                    ),
+                }
+            }
+
+            // Mixed-format monorepo migration can temporarily place legacy
+            // entries without bindings in a version-1 file. Keep those pins
+            // reachable until a successful full format upgrade binds them.
+            let version_matches = |v: &LockfileTool| {
+                v.specifiers.is_empty()
+                    && lockfile_version_matches(prefix, &v.version)
+                    && (!require_prefix_boundary
+                        || lockfile_version_matches_prefix_boundary(prefix, &v.version))
             };
+            if let Some(found) = tools
+                .iter()
+                .find(|v| version_matches(v) && &v.options == request_options)
+            {
+                trace!(
+                    "[{short}@{specifier}] found legacy unbound {} in versioned lockfile",
+                    found.version
+                );
+                return Ok(Some(found.clone()));
+            }
+            if legacy_options_fallback
+                && !request_options.is_empty()
+                && let Some(found) = tools
+                    .iter()
+                    .find(|v| version_matches(v) && v.options.is_empty())
+            {
+                trace!(
+                    "[{short}@{specifier}] found legacy unbound {} without options in versioned lockfile",
+                    found.version
+                );
+                return Ok(Some(lockfile_tool_with_request_options(
+                    found,
+                    request_options,
+                )));
+            }
+            return Ok(None);
         }
         let version_matches = |v: &LockfileTool| {
             lockfile_version_matches(prefix, &v.version)
@@ -3429,20 +3493,30 @@ pub(crate) fn get_locked_version(
                     "[{short}@{prefix}] found {} in lockfile without options, keeping the version pin and dropping its artifact data",
                     found.version
                 );
-                let mut found = (*found).clone();
-                found.options = request_options.clone();
-                found.platforms = found
-                    .platforms
-                    .into_iter()
-                    .map(|(key, info)| (key, info.without_artifact_data()))
-                    .filter(|(_, info)| !info.is_empty())
-                    .collect();
-                return Ok(Some(found));
+                return Ok(Some(lockfile_tool_with_request_options(
+                    found,
+                    request_options,
+                )));
             }
         }
     }
 
     Ok(None)
+}
+
+fn lockfile_tool_with_request_options(
+    found: &LockfileTool,
+    request_options: &BTreeMap<String, String>,
+) -> LockfileTool {
+    let mut found = found.clone();
+    found.options = request_options.clone();
+    found.platforms = found
+        .platforms
+        .into_iter()
+        .map(|(key, info)| (key, info.without_artifact_data()))
+        .filter(|(_, info)| !info.is_empty())
+        .collect();
+    found
 }
 
 fn lockfile_version_matches(prefix: &str, version: &str) -> bool {
@@ -3825,11 +3899,32 @@ mod tests {
             ],
         );
 
-        lockfile.bind_request("dummy", "1", "1.1.0", &BTreeMap::new());
+        assert!(lockfile.bind_request("dummy", "1", "1.1.0", &BTreeMap::new()));
 
         assert!(lockfile.tools["dummy"][0].specifiers.is_empty());
         assert_eq!(
             lockfile.tools["dummy"][1].specifiers,
+            BTreeSet::from(["1".to_string()])
+        );
+    }
+
+    #[test]
+    fn failed_request_binding_preserves_the_existing_binding() {
+        let mut lockfile = Lockfile::default();
+        lockfile.tools.insert(
+            "dummy".to_string(),
+            vec![LockfileTool {
+                version: "1.0.0".to_string(),
+                backend: Some("asdf:dummy".to_string()),
+                specifiers: BTreeSet::from(["1".to_string()]),
+                options: BTreeMap::new(),
+                platforms: BTreeMap::new(),
+            }],
+        );
+
+        assert!(!lockfile.bind_request("dummy", "1", "2.0.0", &BTreeMap::new()));
+        assert_eq!(
+            lockfile.tools["dummy"][0].specifiers,
             BTreeSet::from(["1".to_string()])
         );
     }

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1,3 +1,4 @@
+use crate::backend::Backend;
 use crate::backend::backend_type::BackendType;
 use crate::backend::conda::CondaBackend;
 use crate::backend::pkgx::PkgxBackend;
@@ -8,7 +9,7 @@ use crate::file;
 use crate::file::display_path;
 use crate::path::PathExt;
 use crate::platform::Platform;
-use crate::toolset::{ToolSource, ToolVersion, Toolset};
+use crate::toolset::{ToolSource, ToolVersion, ToolVersionOptions, Toolset};
 use eyre::{Report, Result, bail, eyre};
 use indexmap::IndexSet;
 use itertools::Itertools;
@@ -3353,6 +3354,8 @@ pub(crate) fn get_locked_version(
     require_prefix_boundary: bool,
     request_options: &BTreeMap<String, String>,
     legacy_options_fallback: bool,
+    backend: Option<&dyn Backend>,
+    selection_options: &ToolVersionOptions,
 ) -> Result<Option<LockfileTool>> {
     let settings = Settings::get();
     if !settings.lockfile_enabled() {
@@ -3426,9 +3429,11 @@ pub(crate) fn get_locked_version(
                     && (!require_prefix_boundary
                         || lockfile_version_matches_prefix_boundary(prefix, &v.version))
             };
-            if let Some(found) = tools
+            let matching = tools
                 .iter()
-                .find(|v| version_matches(v) && &v.options == request_options)
+                .filter(|v| version_matches(v) && &v.options == request_options)
+                .collect_vec();
+            if let Some(found) = select_unbound_lockfile_tool(matching, backend, selection_options)?
             {
                 trace!(
                     "[{short}@{specifier}] found legacy unbound {} in versioned lockfile",
@@ -3436,20 +3441,23 @@ pub(crate) fn get_locked_version(
                 );
                 return Ok(Some(found.clone()));
             }
-            if legacy_options_fallback
-                && !request_options.is_empty()
-                && let Some(found) = tools
+            if legacy_options_fallback && !request_options.is_empty() {
+                let matching = tools
                     .iter()
-                    .find(|v| version_matches(v) && v.options.is_empty())
-            {
-                trace!(
-                    "[{short}@{specifier}] found legacy unbound {} without options in versioned lockfile",
-                    found.version
-                );
-                return Ok(Some(lockfile_tool_with_request_options(
-                    found,
-                    request_options,
-                )));
+                    .filter(|v| version_matches(v) && v.options.is_empty())
+                    .collect_vec();
+                if let Some(found) =
+                    select_unbound_lockfile_tool(matching, backend, selection_options)?
+                {
+                    trace!(
+                        "[{short}@{specifier}] found legacy unbound {} without options in versioned lockfile",
+                        found.version
+                    );
+                    return Ok(Some(lockfile_tool_with_request_options(
+                        found,
+                        request_options,
+                    )));
+                }
             }
             return Ok(None);
         }
@@ -3502,6 +3510,21 @@ pub(crate) fn get_locked_version(
     }
 
     Ok(None)
+}
+
+fn select_unbound_lockfile_tool<'a>(
+    matching: Vec<&'a LockfileTool>,
+    backend: Option<&dyn Backend>,
+    selection_options: &ToolVersionOptions,
+) -> Result<Option<&'a LockfileTool>> {
+    let Some(backend) = backend else {
+        return Ok(matching.first().copied());
+    };
+    Ok(backend
+        .version_order(selection_options)?
+        .order_by(matching, |tool| tool.version.as_str())
+        .last()
+        .copied())
 }
 
 fn lockfile_tool_with_request_options(

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1680,9 +1680,9 @@ fn migrate_monorepo_lockfiles_inner(
             bail!(
                 "cannot merge lockfile version {} from {} into lockfile version {} at {}; run `mise lock --upgrade` at the monorepo root",
                 subproject_lockfile.lockfile_version,
-                display_path(&source),
+                display_path(source),
                 root_lockfile.lockfile_version,
-                display_path(&target)
+                display_path(target)
             );
         }
         merge_lockfile_preserving_root(&mut root_lockfile, subproject_lockfile);
@@ -3389,18 +3389,33 @@ pub(crate) fn read_lockfile_for_tool_source(
 /// entry written before those options existed. The version pin is honored — it
 /// is the only record of what this project resolved to — but the artifact data
 /// is dropped, since there's no way to tell which variant it describes.
+pub(crate) struct LockedVersionQuery<'a> {
+    pub(crate) path: Option<&'a Path>,
+    pub(crate) short: &'a str,
+    pub(crate) specifier: &'a str,
+    pub(crate) prefix: &'a str,
+    pub(crate) require_prefix_boundary: bool,
+    pub(crate) request_options: &'a BTreeMap<String, String>,
+    pub(crate) legacy_options_fallback: bool,
+    pub(crate) backend: Option<&'a dyn Backend>,
+    pub(crate) selection_options: &'a ToolVersionOptions,
+}
+
 pub(crate) fn get_locked_version(
     config: &Config,
-    path: Option<&Path>,
-    short: &str,
-    specifier: &str,
-    prefix: &str,
-    require_prefix_boundary: bool,
-    request_options: &BTreeMap<String, String>,
-    legacy_options_fallback: bool,
-    backend: Option<&dyn Backend>,
-    selection_options: &ToolVersionOptions,
+    query: LockedVersionQuery<'_>,
 ) -> Result<Option<LockfileTool>> {
+    let LockedVersionQuery {
+        path,
+        short,
+        specifier,
+        prefix,
+        require_prefix_boundary,
+        request_options,
+        legacy_options_fallback,
+        backend,
+        selection_options,
+    } = query;
     let settings = Settings::get();
     if !settings.lockfile_enabled() {
         return Ok(None);
@@ -5249,8 +5264,10 @@ options = { exe = "rg" }
     #[test]
     fn test_merge_lockfile_for_lookup_keeps_request_bindings_enabled() {
         for (root_version, other_version) in [(0, 1), (1, 0)] {
-            let mut root = Lockfile::default();
-            root.lockfile_version = root_version;
+            let mut root = Lockfile {
+                lockfile_version: root_version,
+                ..Default::default()
+            };
             root.tools.insert(
                 "node".to_string(),
                 vec![LockfileTool {
@@ -5261,8 +5278,10 @@ options = { exe = "rg" }
                     platforms: BTreeMap::new(),
                 }],
             );
-            let mut other = Lockfile::default();
-            other.lockfile_version = other_version;
+            let mut other = Lockfile {
+                lockfile_version: other_version,
+                ..Default::default()
+            };
             other
                 .tools
                 .insert("node".to_string(), vec![basic_tool("22.0.0", "core:node")]);
@@ -5282,8 +5301,10 @@ options = { exe = "rg" }
         let primary_path = temp.path().join("mise.lock");
         let legacy_path = temp.path().join("package.lock");
 
-        let mut legacy = Lockfile::default();
-        legacy.lockfile_version = 0;
+        let mut legacy = Lockfile {
+            lockfile_version: 0,
+            ..Default::default()
+        };
         legacy
             .tools
             .insert("node".to_string(), vec![basic_tool("20.0.0", "core:node")]);

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -3236,29 +3236,19 @@ fn read_all_lockfiles(config: &Config) -> Arc<Lockfile> {
         // to read the most specific (e.g. macos-arm64) first.
         for env_name in env::MISE_ENV.iter().chain(env::AUTO_ENV_NAMES.iter().rev()) {
             let p = root.join(format!("mise.{env_name}.local.lock"));
-            if let Ok(l) = Lockfile::read(&p) {
-                all.push(l);
-            }
+            push_existing_lockfile(&mut all, &p);
         }
         let local_path = root.join("mise.local.lock");
-        if let Ok(local) = Lockfile::read(&local_path) {
-            all.push(local);
-        }
+        push_existing_lockfile(&mut all, &local_path);
         for env_name in env::MISE_ENV.iter().chain(env::AUTO_ENV_NAMES.iter().rev()) {
             let p = root.join(format!("mise.{env_name}.lock"));
-            if let Ok(l) = Lockfile::read(&p) {
-                all.push(l);
-            }
+            push_existing_lockfile(&mut all, &p);
         }
         let main_path = root.join("mise.lock");
-        if let Ok(main) = Lockfile::read(&main_path) {
-            all.push(main);
-        }
+        push_existing_lockfile(&mut all, &main_path);
     }
     for legacy_path in legacy_lockfiles {
-        if let Ok(legacy) = Lockfile::read(legacy_path) {
-            all.push(legacy);
-        }
+        push_existing_lockfile(&mut all, legacy_path);
     }
 
     let result = all.into_iter().fold(None, |acc: Option<Lockfile>, l| {
@@ -3274,6 +3264,14 @@ fn read_all_lockfiles(config: &Config) -> Arc<Lockfile> {
     let result = Arc::new(result);
     cache.insert(discovery.cache_key.clone(), Arc::clone(&result));
     result
+}
+
+fn push_existing_lockfile(lockfiles: &mut Vec<Lockfile>, path: &Path) {
+    if path.exists()
+        && let Ok(lockfile) = Lockfile::read(path)
+    {
+        lockfiles.push(lockfile);
+    }
 }
 
 fn read_lockfile_for(config: &Config, path: &Path) -> Arc<Lockfile> {

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -426,6 +426,7 @@ impl ToolRequest {
             config,
             path.map(|p| p.as_path()),
             &self.ba().short,
+            &self.version(),
             prefix,
             require_prefix_boundary,
             &request_options,

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -425,15 +425,17 @@ impl ToolRequest {
         };
         lockfile::get_locked_version(
             config,
-            path.map(|p| p.as_path()),
-            &self.ba().short,
-            &self.version(),
-            prefix,
-            require_prefix_boundary,
-            &request_options,
-            legacy_options_fallback,
-            backend.as_deref(),
-            &self.options(),
+            lockfile::LockedVersionQuery {
+                path: path.map(|p| p.as_path()),
+                short: &self.ba().short,
+                specifier: &self.version(),
+                prefix,
+                require_prefix_boundary,
+                request_options: &request_options,
+                legacy_options_fallback,
+                backend: backend.as_deref(),
+                selection_options: &self.options(),
+            },
         )
     }
 

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -409,7 +409,8 @@ impl ToolRequest {
         prefix: &str,
         require_prefix_boundary: bool,
     ) -> Result<Option<LockfileTool>> {
-        let (request_options, legacy_options_fallback) = if let Ok(backend) = self.backend() {
+        let backend = self.backend().ok();
+        let (request_options, legacy_options_fallback) = if let Some(backend) = &backend {
             let target = PlatformTarget::from_current();
             (
                 backend.resolve_lockfile_options(self, &target)?,
@@ -431,6 +432,8 @@ impl ToolRequest {
             require_prefix_boundary,
             &request_options,
             legacy_options_fallback,
+            backend.as_deref(),
+            &self.options(),
         )
     }
 

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -1072,6 +1072,7 @@ mod tests {
         let lt = LockfileTool {
             version: "11.17.0".to_string(),
             backend: Some("npm:npm".to_string()),
+            specifiers: Default::default(),
             options: BTreeMap::from([("registry".to_string(), "lockfile-value".to_string())]),
             platforms: Default::default(),
         };


### PR DESCRIPTION
## Summary

- write `lockfile_version = 1` and request-specific `specifiers` in newly created lockfiles
- treat unversioned lockfiles as version 0 and preserve their existing matching behavior during ordinary updates
- add `mise lock --upgrade` for explicit migration, with a warning from normal `mise lock`
- reject unsupported future formats and safely handle monorepo lockfile migration

This addresses the overlapping loose/exact request behavior described in [discussion #12298](https://github.com/jdx/mise/discussions/12298) without causing automatic lockfile drift for existing users.

## Testing

- `cargo check --all-features --all-targets`
- `cargo test --all-features --bin mise lockfile::tests:: --no-fail-fast`
- `mise run test:e2e e2e/lockfile/test_lockfile_version`
- `mise run test:e2e e2e/lockfile/test_lockfile_monorepo`
- `mise run test:e2e e2e/lockfile/test_lockfile_prefix e2e/lockfile/test_lockfile_upgrade_prune`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lockfile resolution and write paths, including monorepo merges and transactional upgrades. Legacy v0 behavior is preserved unless `--upgrade` is used, but incorrect bindings could pin the wrong versions.
> 
> **Overview**
> New lockfiles write **`lockfile_version = 1`** and bind each original request (`specifiers`) to the concrete entry it resolved to, so overlapping requests like `"1"` and `"1.0.0"` can lock different versions.
> 
> Unversioned lockfiles stay **format 0** on ordinary `mise lock`/`install`/`upgrade` to avoid surprise drift; they warn and keep prefix-based matching. **`mise lock --upgrade`** migrates to v1 (all tools, no tool filters), stages writes, and rolls back on failure so monorepo/local lockfiles are not partially upgraded.
> 
> Lookup prefers specifier+options matches, with fallbacks for unbound mixed-format entries. Future versions are rejected. Docs and e2e cover upgrade, dry-run, and failed-migration cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 417e14caaeae8a9a12898b669343971ce19dad9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `mise lock --upgrade` to migrate legacy lockfiles to the latest format.
  * Lockfiles now preserve request-specific version bindings, including across monorepos.
  * Dry-run mode reports pending upgrades without modifying files.
  * Upgrades process all configured tools and cannot be combined with tool arguments.

* **Bug Fixes**
  * Failed or partially unsuccessful upgrades now preserve the original lockfiles without misleading completion messages.

* **Documentation**
  * Updated command and lockfile format documentation with versioning, migration, and upgrade guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->