### PR TITLE
fix(migrate): use safe_eprintln! so an unwritable stderr can't abort mise

### DIFF
--- a/e2e/cli/test_broken_stderr
+++ b/e2e/cli/test_broken_stderr
@@ -13,3 +13,10 @@ fi
 # MISE_DEBUG=1 forces log output to stderr; the subshell keeps stderr pointed
 # at /dev/full since the assert helpers append their own 2>&1
 assert "(MISE_DEBUG=1 mise version >/dev/null 2>/dev/full && echo ok)" "ok"
+
+# The check above runs with no migration pending, so migrate.rs never reaches
+# one of its prints and passes vacuously. Give it a migration to announce: that
+# is the path a real user hits on the first run after an upgrade, and it is the
+# one that still aborted with SIGABRT.
+mkdir -p "$MISE_DATA_DIR/tracked-config-files"
+assert "(MISE_DEBUG=1 mise version >/dev/null 2>/dev/full && echo ok)" "ok"

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -23,7 +23,7 @@ pub(crate) async fn run() {
 
 async fn task(job: impl FnOnce() -> Result<()> + Send + 'static) {
     if let Err(err) = job() {
-        eprintln!("[WARN] migrate: {err}");
+        safe_eprintln!("[WARN] migrate: {err}");
     }
 }
 
@@ -42,7 +42,7 @@ fn migrate_trusted_configs() -> Result<()> {
 
 fn move_dirs(from: &Path, to: &Path) -> Result<bool> {
     if from.exists() && !to.exists() {
-        eprintln!("migrating {} to {}", from.display(), to.display());
+        safe_eprintln!("migrating {} to {}", from.display(), to.display());
         file::create_dir_all(to.parent().unwrap())?;
         file::rename(from, to)?;
         Ok(true)
@@ -58,7 +58,9 @@ fn remove_deprecated_plugin(name: &str, plugin_name: &str) -> Result<()> {
     if !gitconfig_body.contains(&format!("github.com/mise-plugins/{plugin_name}")) {
         return Ok(());
     }
-    eprintln!("removing deprecated plugin {plugin_name}, will use core {name} plugin from now on");
+    safe_eprintln!(
+        "removing deprecated plugin {plugin_name}, will use core {name} plugin from now on"
+    );
     file::remove_all(plugin_root)?;
     Ok(())
 }
@@ -71,7 +73,7 @@ async fn migrate_runtime_symlink_dirs() {
     }
 
     if let Err(err) = migrate_runtime_symlink_dirs_impl(&marker).await {
-        eprintln!("[WARN] migrate: {err}");
+        safe_eprintln!("[WARN] migrate: {err}");
     }
 }
 


### PR DESCRIPTION
### What happened

`mise` aborts with **SIGABRT** (and dumps core) whenever `src/migrate.rs` has a
message to print and stderr is unwritable.

This is the same class of bug fixed by #10773 ("fix(core): don't panic when
stderr is unwritable"), which added `safe_eprintln!` and converted `logger.rs`,
`main.rs`, `output.rs`, `task_results_display.rs` and `ui/progress_report.rs`.
`migrate.rs` was not converted and still has four bare `eprintln!` calls
(lines 26, 45, 61, 74 on `main`). Since `migrate::run()` is awaited from
`Cli::run_inner` on **every** invocation, this is on the hottest path there is.

I hit it in the wild: two `mise activate zsh` processes aborted seconds apart
when a terminal window was closed while the shell was still starting up. A pty
returns `EIO` once its master is gone, so the migration warning that mise was
about to print took the process down.

### Steps to reproduce

A pending migration plus an unwritable stderr is enough — no pty needed,
`/dev/full` reproduces it:

```bash
tmp=$(mktemp -d); mkdir -p "$tmp"/{d,s,c,cfg}/ "$tmp/work"
mkdir -p "$tmp/d/tracked-config-files"          # <- makes a migration pending

cd "$tmp/work" && env HOME="$tmp" \
  MISE_DATA_DIR="$tmp/d" MISE_STATE_DIR="$tmp/s" \
  MISE_CACHE_DIR="$tmp/c" MISE_CONFIG_DIR="$tmp/cfg" \
  mise version >/dev/null 2>/dev/full
echo "exit: $?"     # 134 = SIGABRT
```

Drop the `tracked-config-files` line and it exits 0.

### Why the existing e2e test doesn't catch this

`e2e/cli/test_broken_stderr` runs `mise version` against `/dev/full` in a clean
test home. With nothing to migrate, every path in `migrate.rs` returns without
printing, so the assertion passes vacuously. The bug only shows up in the state
a real user is in on the first run after an upgrade.

### What I expected

A broken stderr should drop the migration message, exactly as #10773 made it
drop log output — not abort the process.

### Mechanism

`eprintln!` panics on write failure; mise builds with `panic = "abort"` (the
`serious` profile), so the panic becomes SIGABRT rather than a clean exit.
Symbolized from the core dump (Arch debuginfod, build-id `8038b548…`):

```
#2  abort
#3  std::sys::pal::unix::abort_internal
#4  std::process::abort
#5  __rustc::__rust_abort
#6  __rustc::__rust_start_panic
#7  __rustc::rust_panic
#8  std::panicking::panic_with_hook
#11 __rustc::rust_begin_unwind
#12 core::panicking::panic_fmt
#13 mise::migrate::run::{closure#0}          <-- inlined eprintln!
#14 <mise::cli::Cli>::run_inner::{closure#0}
#16 mise::main_::{closure#0}                    src/main.rs:180
```

The panic payload recovered from the core:

```
failed printing to stderr: Input/output error (os error 5)
```

### Suggested fix

Swap the four `eprintln!` in `src/migrate.rs` for the existing `safe_eprintln!`
(already in scope — `mod output` is `#[macro_use]` and declared before
`mod migrate`), and give `e2e/cli/test_broken_stderr` a pending migration so the
path is actually exercised. Patch attached below; it applies cleanly to both
v2026.8.6 and the current release v2026.8.10, and the same four call sites are
unchanged on `main`.

### Version

```
mise 2026.8.6 linux-x64 (2026-08-15)   # Arch Linux, extra/mise 2026.8.6-1
```

Still present in v2026.8.10 (the four `eprintln!` are byte-identical there); the
Arch package builds with `--profile=serious`, which sets `panic = "abort"`.

---
Filed by Claude Opus 5 via Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration messages when standard error is unavailable or cannot be written.
  * Ensured migrations continue reporting progress and errors safely in restricted output environments.
  * Expanded coverage for migration scenarios involving unwritable error output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->