### PR TITLE
chore(ci): remove nightly Rust job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,41 +177,6 @@ jobs:
       - run: sccache --show-stats
         if: always()
 
-  nightly:
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux-nightly
-    timeout-minutes: 15
-    # Track rolling nightly for early rustc regressions without blocking PRs on upstream compiler ICEs.
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.head_ref }}
-      - run: rustup default nightly
-      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/.global-cache
-            ~/.cache/sccache
-      - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
-        with: { tool: sccache }
-      - name: Configure sccache
-        run: |
-          export RUSTC_WRAPPER=sccache
-          export SCCACHE_DIR="$HOME/.cache/sccache"
-          export SCCACHE_CACHE_SIZE=20G
-          {
-            echo "RUSTC_WRAPPER=$RUSTC_WRAPPER"
-            echo "SCCACHE_DIR=$SCCACHE_DIR"
-            echo "SCCACHE_CACHE_SIZE=$SCCACHE_CACHE_SIZE"
-          } >> "$GITHUB_ENV"
-          sccache --zero-stats
-      - run: cargo test --all-features
-      - run: sccache --show-stats
-        if: always()
-
   lint:
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
     timeout-minutes: 80
@@ -487,7 +452,6 @@ jobs:
       - build-ubuntu
       - build-windows
       - unit
-      - nightly
       - lint
       - e2e
       - bootstrap-linux-host


### PR DESCRIPTION
## Summary
- remove the non-blocking Rust nightly test job
- remove the nightly job from the aggregate CI dependency list

## Testing
- `mise run lint-fix`
- `actionlint .github/workflows/test.yml`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that removes an already non-blocking compiler-canary job; it does not alter product code or required test coverage.
> 
> **Overview**
> Drops the non-blocking `nightly` job from `test.yml` that ran `cargo test --all-features` on rolling rustc nightly (with `continue-on-error`). Also removes it from the `test-ci` aggregate `needs` list so the gate no longer waits on that job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4796b4b530725e34f1ad7656ea4897f725aeccc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the nightly continuous integration job.
  * Streamlined test validation by eliminating the nightly job dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->