### PR TITLE
feat(prune): explain why each version is prunable in --dry-run

### DIFF
--- a/e2e/cli/test_prune_dry_run_explains
+++ b/e2e/cli/test_prune_dry_run_explains
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# `mise prune` removes a version because *nothing* tracked resolved to it, so
+# the plain output has nothing to point at. --dry-run names the tracked configs
+# instead. https://github.com/jdx/mise/discussions/9045
+
+# Installed on its own, so no tracked config mentions dummy at all.
+assert "mise install dummy@1.0.0"
+assert_contains "mise prune --dry-run 2>&1" \
+  "dummy@1.0.0 is prunable: no tracked config or tool stub requires dummy"
+
+# Now a tracked config pins a different version: report that version and the
+# file it came from, which is the actual reason 1.0.0 is unreferenced. Match on
+# the directory name rather than the full path — macOS resolves the temporary
+# directory through /private, so the recorded path is not literally $project.
+project="$(mktemp -d)"
+cd "$project" || exit 1
+assert "mise use dummy@2.0.0"
+cd "$(mktemp -d)" || exit 1
+assert_contains "mise prune --dry-run 2>&1" \
+  "dummy@1.0.0 is prunable: dummy is required at 2.0.0 by "
+assert_contains "mise prune --dry-run 2>&1" "$(basename "$project")/mise.toml"
+
+# --dry-run-code previews the same removals, so it explains them too.
+assert_fail_contains "mise prune --dry-run-code 2>&1" "dummy@1.0.0 is prunable:"
+
+# A real prune is unchanged: it acts rather than explains.
+MISE_YES=1 assert_not_contains "mise prune 2>&1" "is prunable:"
+assert_fail "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
+assert "ls $MISE_DATA_DIR/installs/dummy/2.0.0"

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -1,12 +1,14 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::cli::args::{BackendArg, ToolArg};
 use crate::config::tracking::Tracker;
 use crate::config::{Config, Settings};
+use crate::file::display_path;
 use crate::runtime_symlinks;
 use crate::toolset::{
-    ToolVersion, ToolsetBuilder, get_versions_needed_by_tracked_configs,
+    NeededVersions, ToolVersion, ToolsetBuilder, get_versions_needed_by_tracked_configs,
     get_versions_needed_by_tracked_stubs,
 };
 use crate::ui::multi_progress_report::MultiProgressReport;
@@ -77,9 +79,10 @@ impl Prune {
                 .as_ref()
                 .map(|it| it.iter().map(|ta| ta.ba.as_ref()).collect());
             let tools = backends.unwrap_or_default();
-            let to_delete = prunable_tools(&config, tools).await?;
+            let (to_delete, needed) = prunable_tools_with_sources(&config, tools).await?;
             let has_work = !to_delete.is_empty();
-            delete(&config, self.is_dry_run(), to_delete).await?;
+            let explain = self.is_dry_run().then_some(&needed);
+            delete(&config, self.is_dry_run(), to_delete, explain).await?;
             if self.dry_run_code && has_work {
                 return Err(exit::request(1));
             }
@@ -115,6 +118,17 @@ pub(super) async fn prunable_tools(
     config: &Arc<Config>,
     tools: Vec<&BackendArg>,
 ) -> Result<Vec<(Arc<dyn Backend>, ToolVersion)>> {
+    Ok(prunable_tools_with_sources(config, tools).await?.0)
+}
+
+/// Like [`prunable_tools`], but also returns what the tracked configs and stubs
+/// still need. Pruning removes what none of them named, so the versions that
+/// were kept — and the files that kept them — are the only evidence available
+/// for explaining a removal.
+async fn prunable_tools_with_sources(
+    config: &Arc<Config>,
+    tools: Vec<&BackendArg>,
+) -> Result<(Vec<(Arc<dyn Backend>, ToolVersion)>, NeededVersions)> {
     let ts = ToolsetBuilder::new().build(config).await?;
     let mut to_delete = ts
         .list_installed_versions(config)
@@ -133,18 +147,18 @@ pub(super) async fn prunable_tools(
     }
 
     // Remove versions that are still needed by tracked configs
-    let needed_versions = get_versions_needed_by_tracked_configs(config, true, true).await?;
-    for key in needed_versions {
-        to_delete.remove(&key);
-    }
+    let mut needed = get_versions_needed_by_tracked_configs(config, true, true).await?;
 
     // Remove versions that are still needed by tracked tool stubs
-    let needed_by_stubs = get_versions_needed_by_tracked_stubs(config).await?;
-    for key in needed_by_stubs {
-        to_delete.remove(&key);
+    for (key, sources) in get_versions_needed_by_tracked_stubs(config).await? {
+        needed.entry(key).or_default().extend(sources);
     }
 
-    Ok(to_delete.into_values().collect())
+    for key in needed.keys() {
+        to_delete.remove(key);
+    }
+
+    Ok((to_delete.into_values().collect(), needed))
 }
 
 pub(super) async fn prune(
@@ -153,16 +167,20 @@ pub(super) async fn prune(
     dry_run: bool,
 ) -> Result<()> {
     let to_delete = prunable_tools(config, tools).await?;
-    delete(config, dry_run, to_delete).await
+    delete(config, dry_run, to_delete, None).await
 }
 
 async fn delete(
     config: &Arc<Config>,
     dry_run: bool,
     to_delete: Vec<(Arc<dyn Backend>, ToolVersion)>,
+    explain: Option<&NeededVersions>,
 ) -> Result<()> {
     let mpr = MultiProgressReport::get();
     for (p, tv) in to_delete {
+        if let Some(needed) = explain {
+            explain_removal(&tv, needed);
+        }
         let mut prefix = tv.style();
         if dry_run {
             prefix = format!("{} {} ", prefix, style("[dryrun]").bold());
@@ -182,6 +200,42 @@ async fn delete(
         pr.finish();
     }
     Ok(())
+}
+
+/// Say why `tv` is up for removal.
+///
+/// Pruning decides by absence — a version goes because nothing among the
+/// tracked configs and stubs resolved to it — so there is no file to point at
+/// as the cause, and the output leaves the user nothing to check against.
+/// Report the other side instead: the versions of the same tool that were kept
+/// and the files that kept them. An empty list is itself the answer, and the
+/// common one: nothing tracked mentions this tool at all.
+fn explain_removal(tv: &ToolVersion, needed: &NeededVersions) {
+    let short = &tv.ba().short;
+    // `needed` is a HashMap; collect into a BTreeMap so the order is stable.
+    let kept: BTreeMap<&String, &BTreeSet<PathBuf>> = needed
+        .iter()
+        .filter(|((s, _), _)| s == short)
+        .map(|((_, version), sources)| (version, sources))
+        .collect();
+    // Match the short form the progress line below uses, not the fully
+    // qualified `backend:name@version` that `Display` renders.
+    let style = tv.style();
+    if kept.is_empty() {
+        info!("{style} is prunable: no tracked config or tool stub requires {short}");
+        return;
+    }
+    let kept = kept
+        .into_iter()
+        .map(|(version, sources)| {
+            let sources = sources.iter().map(display_path).collect::<Vec<_>>();
+            format!("{version} by {}", sources.join(", "))
+        })
+        .collect::<Vec<_>>();
+    info!(
+        "{style} is prunable: {short} is required at {}",
+        kept.join("; ")
+    );
 }
 
 static AFTER_LONG_HELP: &str = color_print::cstr!(

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -15,8 +15,9 @@ use crate::toolset::is_outdated_version;
 use crate::toolset::outdated_info::OutdatedInfo;
 use crate::toolset::outdated_info::prefixed_latest_query;
 use crate::toolset::{
-    ConfigScope, InstallOptions, ResolveOptions, ToolSource, ToolVersion, ToolsetBuilder,
-    get_versions_needed_by_tracked_configs_excluding_locks, get_versions_needed_by_tracked_stubs,
+    ConfigScope, InstallOptions, NeededVersions, ResolveOptions, ToolSource, ToolVersion,
+    ToolsetBuilder, get_versions_needed_by_tracked_configs_excluding_locks,
+    get_versions_needed_by_tracked_stubs,
 };
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::progress_report::SingleReport;
@@ -514,7 +515,7 @@ impl Upgrade {
         // actually up for removal — with --no-prune, or when every upgrade was in-place,
         // the answer would be discarded.
         let versions_needed_by_tracked = if to_remove.is_empty() {
-            HashSet::new()
+            NeededVersions::new()
         } else {
             let mut needed = get_versions_needed_by_tracked_configs_excluding_locks(
                 config,
@@ -541,7 +542,7 @@ impl Upgrade {
                 // on the toolset version would give the wrong key.
                 let old_tv = ToolVersion::new(o.tool_version.request.clone(), old_version.clone());
                 let version_key = (old_tv.ba().short.to_string(), old_tv.tv_pathname());
-                if versions_needed_by_tracked.contains(&version_key) {
+                if versions_needed_by_tracked.contains_key(&version_key) {
                     debug!(
                         "Keeping {}@{} because it's still needed by a tracked config or tool stub",
                         o.name, old_version

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -22,9 +22,9 @@ pub(crate) use outdated_info::is_outdated_version;
 use petgraph::Direction;
 use petgraph::graphmap::DiGraphMap;
 use serde::Serialize;
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 use std::fmt::{Display, Formatter};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{
     cmp::Reverse,
@@ -702,15 +702,23 @@ impl From<ToolRequestSet> for Toolset {
     }
 }
 
+/// Tool versions that some tracked file still needs, keyed by
+/// (short_name, tv_pathname) and mapped to the files that need them.
+///
+/// `mise prune` and `mise upgrade` only ask whether a key is present. The paths
+/// exist so `mise prune --dry-run` can say *which* config keeps a version
+/// alive, since the decision to remove one is otherwise made by absence and
+/// leaves nothing to point at (discussion #9045).
+pub(crate) type NeededVersions = HashMap<(String, String), BTreeSet<PathBuf>>;
+
 /// Get all tool versions that are needed by tracked config files.
-/// Returns a set of (short_name, tv_pathname) pairs.
 /// This is used by both `mise prune` and `mise upgrade` to avoid
 /// uninstalling versions that other projects still need.
 pub(crate) async fn get_versions_needed_by_tracked_configs(
     config: &Arc<Config>,
     use_locked_version: bool,
     offline: bool,
-) -> Result<HashSet<(String, String)>> {
+) -> Result<NeededVersions> {
     get_versions_needed_by_tracked_configs_excluding_locks(
         config,
         use_locked_version,
@@ -727,8 +735,8 @@ pub(crate) async fn get_versions_needed_by_tracked_configs_excluding_locks(
     use_locked_version: bool,
     offline: bool,
     exclude_locked_config_paths: &HashSet<PathBuf>,
-) -> Result<HashSet<(String, String)>> {
-    let mut needed = HashSet::new();
+) -> Result<NeededVersions> {
+    let mut needed = NeededVersions::new();
     // `mise prune` should keep versions pinned by lockfiles. `mise upgrade`
     // also protects lockfiles for other tracked projects, but excludes configs
     // it just upgraded so stale locks there do not keep the old version alive.
@@ -749,9 +757,15 @@ pub(crate) async fn get_versions_needed_by_tracked_configs_excluding_locks(
                     for (short, tools) in lockfile.tools() {
                         for tool in tools {
                             let version = tool.version.replace([':', '/'], "-");
-                            needed.insert((short.clone(), version.clone()));
+                            needed
+                                .entry((short.clone(), version.clone()))
+                                .or_default()
+                                .insert(lockfile_path.clone());
                             if let Some(backend) = &tool.backend {
-                                needed.insert((backend.clone(), version));
+                                needed
+                                    .entry((backend.clone(), version))
+                                    .or_default()
+                                    .insert(lockfile_path.clone());
                             }
                         }
                     }
@@ -764,7 +778,7 @@ pub(crate) async fn get_versions_needed_by_tracked_configs_excluding_locks(
         }
         let mut ts = Toolset::from(cf.to_tool_request_set()?);
         ts.resolve_with_opts(config, &opts).await?;
-        collect_needed_versions(&ts, offline, &mut needed);
+        collect_needed_versions(&ts, offline, &path, &mut needed);
     }
     Ok(needed)
 }
@@ -776,8 +790,8 @@ pub(crate) async fn get_versions_needed_by_tracked_configs_excluding_locks(
 /// `mise upgrade` do not delete versions still referenced by a stub.
 pub(crate) async fn get_versions_needed_by_tracked_stubs(
     config: &Arc<Config>,
-) -> Result<HashSet<(String, String)>> {
-    let mut needed = HashSet::new();
+) -> Result<NeededVersions> {
+    let mut needed = NeededVersions::new();
     // Like prune's tracked-config resolution, only installed versions need
     // protecting, so resolve offline to avoid pointless remote lookups.
     let opts = ResolveOptions {
@@ -817,14 +831,22 @@ pub(crate) async fn get_versions_needed_by_tracked_stubs(
             );
             continue;
         }
-        collect_needed_versions(&ts, true, &mut needed);
+        collect_needed_versions(&ts, true, &path, &mut needed);
     }
     Ok(needed)
 }
 
-fn collect_needed_versions(ts: &Toolset, offline: bool, needed: &mut HashSet<(String, String)>) {
+fn collect_needed_versions(
+    ts: &Toolset,
+    offline: bool,
+    source: &Path,
+    needed: &mut NeededVersions,
+) {
     for (_, tv) in ts.list_current_versions() {
-        needed.insert((tv.ba().short.to_string(), tv.tv_pathname()));
+        needed
+            .entry((tv.ba().short.to_string(), tv.tv_pathname()))
+            .or_default()
+            .insert(source.to_path_buf());
         // Offline can't resolve `sub-N:latest` to a concrete version
         // (no remote latest available). Conservatively protect every
         // installed version of this backend so we don't delete the
@@ -836,7 +858,10 @@ fn collect_needed_versions(ts: &Toolset, offline: bool, needed: &mut HashSet<(St
         {
             let short = tv.ba().short.to_string();
             for v in backend.list_installed_versions() {
-                needed.insert((short.clone(), v));
+                needed
+                    .entry((short.clone(), v))
+                    .or_default()
+                    .insert(source.to_path_buf());
             }
         }
     }


### PR DESCRIPTION
Addresses discussion #9045, where jdx asked for exactly this: "do we have a --dry-run for prune that shows config locations? if not we should include that".

## Problem

`prune` decides by *absence*. A version goes because nothing among the tracked configs and tool stubs resolved to it, so there is no file to point at as the cause and the output has nothing to check against:

```
java@21.0.1 [dryrun]
```

The report is a JDK proposed for removal on every run, with no way to see which configs were consulted.

## Fix

Report the other side instead. `--dry-run` now names, for each prunable version, either the versions of the same tool that were kept and the files keeping them, or the fact that nothing tracked mentions the tool at all:

```
mise java@21.0.1 is prunable: java is required at 17.0.9 by ~/b/mise.toml
mise jdk@1.8.0 is prunable: no tracked config or tool stub requires jdk
```

To carry the paths, `get_versions_needed_by_tracked_configs` and `get_versions_needed_by_tracked_stubs` return a map from (short name, version) to the files needing it rather than a bare set. `upgrade` only asks whether a key is present, so it is unchanged.

Two deliberate choices:

- The explanation is confined to the dry-run path. A real prune and `mise unuse` print exactly what they did before.
- `prunable_tools` was kept as a thin wrapper so `mise ls --prunable` is untouched. The comment at `src/cli/ls.rs:270` explicitly warns that behavior pushed down into it would make the two disagree.

## Verification

- New `e2e/cli/test_prune_dry_run_explains` covers both branches and asserts a real prune stays silent.
- Existing prune e2e tests pass.
- clippy clean with no exclusions; `cargo fmt --check` clean.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `mise prune --dry-run` now explains why each unused tool version can be removed.
  * Explanations identify the tracked configuration or stub requiring versions that are being kept.
  * `--dry-run-code` provides the same pruning details.
* **Bug Fixes**
  * Pruning now preserves all versions required by tracked configurations and stubs, including offline fallback versions.
  * Normal pruning removes only versions confirmed to be unreferenced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->