### PR TITLE
test: forward GitHub token vars to e2e only when they are set

### DIFF
--- a/e2e/run_test
+++ b/e2e/run_test
@@ -71,6 +71,17 @@ within_isolated_env() {
   [[ -n ${no_proxy:-} ]] && proxy_vars+=(no_proxy="$no_proxy")
   [[ -n ${NO_PROXY:-} ]] && proxy_vars+=(NO_PROXY="$NO_PROXY")
 
+  # Forward the token vars only when they hold something. Passing an unset
+  # variable through as "" is not the same as leaving it unset: mise reads the
+  # first token variable that *exists* and only then rejects empty values, so an
+  # empty MISE_GITHUB_TOKEN means "no token" and hides a real GITHUB_TOKEN (see
+  # get_token in src/env.rs). An empty GITHUB_TOKEN is worse than useless on its
+  # own too: the ubi crate reads it directly, sends an empty bearer, and turns
+  # a request that would have worked unauthenticated into a 401.
+  local token_vars=()
+  [[ -n ${MISE_GITHUB_TOKEN:-} ]] && token_vars+=(MISE_GITHUB_TOKEN="$MISE_GITHUB_TOKEN")
+  [[ -n ${GITHUB_TOKEN:-} ]] && token_vars+=(GITHUB_TOKEN="$GITHUB_TOKEN")
+
   env \
     -i \
     -C "$TEST_WORKDIR" \
@@ -84,8 +95,7 @@ within_isolated_env() {
     GIT_COMMITTER_NAME="test" \
     GIT_COMMITTER_EMAIL="test@test.com" \
     GITHUB_ACTION="${GITHUB_ACTION:-}" \
-    MISE_GITHUB_TOKEN="${MISE_GITHUB_TOKEN:-}" \
-    GITHUB_TOKEN="${GITHUB_TOKEN:-}" \
+    ${token_vars[@]+"${token_vars[@]}"} \
     GOPROXY="${GOPROXY:-}" \
     HOME="$TEST_HOME" \
     LANG="${LANG:-C.UTF-8}" \
@@ -224,8 +234,6 @@ run_in_docker() {
     -e ROOT=/mise-src
     -e CI="${CI:-}"
     -e GITHUB_ACTION="${GITHUB_ACTION:-}"
-    -e MISE_GITHUB_TOKEN="${MISE_GITHUB_TOKEN:-}"
-    -e GITHUB_TOKEN="${GITHUB_TOKEN:-}"
     -e MISE_DEBUG="${MISE_DEBUG:-0}"
     -e MISE_TRACE="${MISE_TRACE:-0}"
     -e MISE_LOG_LEVEL="${MISE_LOG_LEVEL:-}"
@@ -233,6 +241,9 @@ run_in_docker() {
     -e MISE_E2E_INSIDE_DOCKER=1
     -e CARGO_TARGET_DIR=/usr/local/lib/mise
   )
+  # Same rule as the non-docker path: an empty token var is not an absent one.
+  [[ -n ${MISE_GITHUB_TOKEN:-} ]] && docker_args+=(-e MISE_GITHUB_TOKEN="$MISE_GITHUB_TOKEN")
+  [[ -n ${GITHUB_TOKEN:-} ]] && docker_args+=(-e GITHUB_TOKEN="$GITHUB_TOKEN")
 
   local rc=0
   "${docker_args[@]}" "$image" bash /mise-src/e2e/run_test "$TEST" || rc=$?


### PR DESCRIPTION
## Problem

`e2e/run_test` forwarded the token variables unconditionally:

```bash
MISE_GITHUB_TOKEN="${MISE_GITHUB_TOKEN:-}" \
GITHUB_TOKEN="${GITHUB_TOKEN:-}" \
```

On a machine that exports neither, that turns "unset" into "set but empty", which is not the same thing and breaks two ways.

**An empty `GITHUB_TOKEN` is worse than no token.** mise itself rejects it — `get_token` and `github::resolve_token` both filter empty values — but the `ubi` crate reads the variable directly with no such check, sends `Authorization: Bearer` with nothing after it, and GitHub answers 401 where an unauthenticated request would have succeeded. That is why `e2e/cli/test_upgrade` fails locally on `ubi:bazelbuild/buildtools`.

**An empty `MISE_GITHUB_TOKEN` also hides a real `GITHUB_TOKEN`.** `get_token` takes the first variable that *exists* and only then rejects empties, so an empty one deliberately means "no token" and stops the walk — the behavior `test_token_overwrite` pins down. A developer who exports only `GITHUB_TOKEN` lost it inside e2e for every `env::GITHUB_TOKEN` consumer.

## Fix

Forward each variable only when it holds something, using the array idiom already used for the proxy variables just above, and the same rule for the docker path.

CI is unaffected: `test.yml` and `registry.yml` always supply non-empty values, so this is a local-developer-only failure.

## Verification

A temporary probe inside the isolated environment confirmed both shapes:

| exported | before | after |
| --- | --- | --- |
| neither | two empty token vars | none |
| `GITHUB_TOKEN` only | plus an empty `MISE_GITHUB_TOKEN` that suppressed it | `GITHUB_TOKEN` intact, no `MISE_GITHUB_TOKEN` |

`mise run test:e2e e2e/cli/test_upgrade` then passes with no token exported. `shellcheck -x` clean.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication token handling in isolated and Docker-based environments.
  * Empty GitHub token values are no longer forwarded, preserving the expected unset state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->