### PR TITLE
docs(lockfile): say which backends strict mode skips

### DIFF
--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -233,6 +233,8 @@ mise lock                    # generate URLs for all platforms
 mise lock --platform linux-x64,macos-arm64  # or specific platforms
 ```
 
+The check only covers backends that can record a URL. `asdf`, `cargo`, `gem`, `go`, `npm`, `pipx`, `ubi`, `core:dotnet`, `core:rust`, and `core:swift` install through an external tool or resolve their download at install time, and vfox _backend_ plugins cannot yet report one, so strict mode skips them instead of failing — a config that mixes them with lockable tools still installs. vfox _tool_ plugins do record a URL and are checked like any other lockable backend. Tools resolved from a [tool stub](/dev-tools/tool-stubs) are skipped as well. See [Backend Support](#backend-support) for what each backend records.
+
 This is useful for CI environments where you want to guarantee reproducible builds without any external API dependencies.
 
 ## Workflow


### PR DESCRIPTION
Addresses discussion #8586.

## Problem

The Strict Lockfile Mode section promised only that `mise install` "will fail if a tool doesn't have a URL for the current platform in the lockfile", which reads as though every tool must be lockable.

The check is guarded by `supports_lockfile_url()` (`src/backend/mod.rs:3221`), so backends that cannot record a URL are **skipped rather than failed**, and a config mixing them with lockable tools installs fine. Tools resolved from a tool stub are skipped too. Neither was documented.

## Fix

One paragraph naming both exemptions and pointing at the existing Backend Support table.

The backends that return `false` are `asdf`, `cargo`, `gem`, `go`, `npm`, `pipx`, `ubi`, `core:dotnet`, `core:rust`, and `core:swift`. Worth noting for review: `pkgx` returns `true`, the `dotnet:` backend uses the default `true` (only the core tool opts out), and vfox opts out only for backend plugins (`!self.is_backend_plugin()`).

Docs only — no behavior change. `prettier --check` and `markdownlint` clean.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that strict lockfile URL checks apply only to URL-capable backends.
  * Documented that external-install sources, install-time resolution, unsupported backend plugins, and tool stubs are skipped without causing installation failures.
  * Confirmed that supported tool plugins remain subject to strict URL checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->