### PR TITLE
docs(task): document that raw serializes execution

### DIFF
--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -382,12 +382,13 @@ run = "deploy.sh ${usage_environment}"
 - **Default**: `false`
 
 Connects the task directly to the shell's stdin/stdout/stderr. This is useful for tasks that need to
-accept input or output in a way that mise's normal task handling doesn't support. This is not recommended
-to use because it really screws up the output whenever mise runs tasks in parallel. Ensure when using
-this that no other tasks are running at the same time.
+accept input or output in a way that mise's normal task handling doesn't support.
 
-In the future we could have a property like `single = true` or something that prevents multiple tasks
-from running at the same time. If that sounds useful, search/file a ticket.
+A raw command holds an exclusive lock for as long as it runs, so mise will not run another command
+alongside it and you do not have to keep other tasks out of the way yourself. The lock is taken per
+command rather than per task, so two raw tasks can still take turns between their individual
+commands. If you need a whole task to run without interruption, search/file a ticket for a property
+like `single = true`.
 
 ### `raw_args`
 

--- a/settings.toml
+++ b/settings.toml
@@ -2310,6 +2310,14 @@ type = "Bool"
 
 [raw]
 description = "Connect stdin/stdout/stderr to child processes."
+docs = """
+Connect stdin/stdout/stderr to child processes.
+
+A raw command holds an exclusive lock for as long as it runs, so no other command runs alongside it.
+Enabling this globally therefore serializes task execution whatever `jobs` is set to: the parallel
+execution engine still schedules the tasks, but only one of them can be running a command at a time.
+`mise run --raw` goes further and sets the scheduler itself to a single job.
+"""
 env = "MISE_RAW"
 type = "Bool"
 


### PR DESCRIPTION
Addresses discussion #8797, where the reporter diagnosed this themselves and asked for a note on the setting's page.

## Problem

`raw` was documented only as "Connect stdin/stdout/stderr to child processes", which does not prepare anyone for tasks stopping running in parallel.

A raw command takes the write side of `RAW_LOCK` for its whole duration (`src/cmd.rs:992`) while non-raw commands take the read side, so nothing runs beside it. `mise run --raw` additionally builds the scheduler with a single job. The setting, `MISE_RAW`, and per-task `raw = true` all reach that lock (`src/task/task_executor.rs:1563`).

The task-level `raw` docs claimed the opposite — that it "screws up the output whenever mise runs tasks in parallel", that you must "ensure … no other tasks are running at the same time", and that a future `single = true` property could prevent overlap. The overlap it warns about cannot happen.

## Fix

Document the serialization on the `raw` setting, and correct the task-level page. The ticket invitation is kept for the one gap that remains: the lock is taken per command, not per task, so two raw tasks can still take turns between their individual commands.

Both files are touched together because they describe the same fact; fixing one alone would leave the two pages contradicting each other.

Docs only — no behavior change. `taplo check`, `prettier --check`, and `markdownlint` clean; `mise run render:schema` produces no diff.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that raw commands use an exclusive lock during execution, preventing concurrent commands while allowing separate raw tasks to alternate.
  - Removed outdated guidance about disrupted parallel output and manually preventing concurrent tasks.
  - Updated guidance for the future `single = true` option to direct users to file a ticket.

- **Configuration**
  - Added documentation for the `raw` setting, including how enabling it serializes command execution and how `mise run --raw` runs with a single job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->