### PR TITLE
fix(env): fold any spelling of PATH onto one key on Windows

### DIFF
--- a/e2e-win/env_path_case.Tests.ps1
+++ b/e2e-win/env_path_case.Tests.ps1
@@ -1,0 +1,97 @@
+Describe 'env names that differ only in case' {
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        # Saved here, restored in AfterAll: Pester runs every suite in one process, so removing an
+        # inherited value would leave the next suite without it.
+        $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+        $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:TestRoot | Out-Null
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:TestRoot
+
+        # `Path` is how Windows itself writes it, so it is the spelling a config is likely to use --
+        # and it names the same variable as `PATH`, which mise owns. `Temp` is the control: mise
+        # emits nothing of its own under that name, so it has never collided with anything.
+        @(
+            '[env]'
+            'Path = "C:/custom-from-mise"'
+            'Temp = "C:/mytemp"'
+        ) | Out-File -Encoding ascii (Join-Path $script:TestRoot "mise.toml")
+
+        Set-Location $script:TestRoot
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        if ($null -eq $script:OriginalTrusted) {
+            Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
+        } else {
+            [Environment]::SetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', $script:OriginalTrusted, 'Process')
+        }
+    }
+
+    It 'emits PATH once' {
+        # Two entries is the whole defect: the shell applies both, and the later one wins.
+        $count = mise env --json | jq -r '[to_entries[] | select(.key | ascii_upcase == "PATH")] | length'
+        $count | Should -Be 1
+    }
+
+    It 'does not let the declaration replace PATH' {
+        # Asserted on the value rather than an exit code -- this failed while exiting 0.
+        $path = mise env --json | jq -r 'to_entries[] | select(.key | ascii_upcase == "PATH") | .value'
+        $path | Should -Match 'system32'
+    }
+
+    It 'leaves a child process with a usable PATH' {
+        $path = mise exec -- pwsh -NoProfile -Command '$env:PATH' 2>&1 | Out-String
+        $path | Should -Match 'system32'
+    }
+
+    It 'still applies a declaration that collides with nothing' {
+        # Control: only a name mise emits itself can collide, so `Temp` has to keep working
+        # exactly as before. Without this, folding too much would look like a fix.
+        mise env --json | jq -r '.Temp' | Should -Be 'C:/mytemp'
+    }
+}
+
+Describe 'PATH spelled another way in required and unset' {
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+        $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:TestRoot | Out-Null
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:TestRoot
+        Set-Location $script:TestRoot
+
+        # Each case needs its own config, and `required` may not be combined with a value.
+        function Write-Config {
+            param([string[]]$Lines)
+            $Lines | Out-File -Encoding ascii (Join-Path $script:TestRoot "mise.toml")
+        }
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        if ($null -eq $script:OriginalTrusted) {
+            Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
+        } else {
+            [Environment]::SetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', $script:OriginalTrusted, 'Process')
+        }
+    }
+
+    It 'sees a required PATH that is spelled differently' {
+        # PATH is set -- it is always set -- but the lookup was on the literal name, so this
+        # reported it missing. The message is the assertion because that is what the user gets.
+        Write-Config @('[env]', 'Path = { required = true }')
+        $out = mise env 2>&1 | Out-String
+        $out | Should -Not -Match "Required environment variable 'Path' is not defined"
+    }
+
+    It 'leaves PATH usable after unsetting it by another spelling' {
+        # A guard rather than a reproduction: PATH survives either way, because mise writes its
+        # own after the directives are applied. It pins that folding `unset` did not turn into a
+        # way to lose PATH.
+        Write-Config @('[env]', 'Path = false')
+        $path = mise env --json | jq -r 'to_entries[] | select(.key | ascii_upcase == "PATH") | .value'
+        $path | Should -Match 'system32'
+    }
+}

--- a/e2e/env/test_env_path_case
+++ b/e2e/env/test_env_path_case
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# A guard, not a reproduction: this passes before the fix too.
+#
+# On Windows `Path` and `PATH` are one variable, and mise owns it, so a config declaring either
+# spelling has to land on the single key the toolset later overwrites. Here names are
+# case-sensitive and `Path` is a variable in its own right — folding it onto PATH the way Windows
+# needs would silently drop a variable the user asked for.
+
+cat <<'EOF' >mise.toml
+[env]
+Path = "/custom-from-mise"
+EOF
+
+# `Path` survives as itself...
+assert "mise env --json | jq -r '.Path'" "/custom-from-mise"
+
+# ...and PATH is not the thing that was declared.
+assert_not_contains "mise env --json | jq -r '.PATH'" "/custom-from-mise"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3474,12 +3474,7 @@ pub(crate) trait Backend: Debug + Send + Sync {
                 Ok(vals) => {
                     for (k, v) in vals {
                         // PATH is owned by path_env; exclude any casing on Windows.
-                        let is_path = if cfg!(windows) {
-                            k.eq_ignore_ascii_case(env::PATH_KEY.as_str())
-                        } else {
-                            k.as_str() == env::PATH_KEY.as_str()
-                        };
-                        if !is_path {
+                        if !env::is_path_key(&k) {
                             env_vars.insert(k, v);
                         }
                     }

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -298,15 +298,8 @@ impl Backend for VfoxBackend {
             match tool_vals {
                 Ok(vals) => {
                     for (k, v) in vals {
-                        // PATH stays owned by dependency_env. On Windows env var
-                        // names are case-insensitive, so exclude any casing
-                        // (e.g. a lowercase `path`); on unix only exact `PATH`.
-                        let is_path = if cfg!(windows) {
-                            k.eq_ignore_ascii_case(crate::env::PATH_KEY.as_str())
-                        } else {
-                            k.as_str() == crate::env::PATH_KEY.as_str()
-                        };
-                        if !is_path {
+                        // PATH stays owned by dependency_env, under any casing on Windows.
+                        if !crate::env::is_path_key(&k) {
                             set_env_var(&mut cmd_env, k, v);
                         }
                     }

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -532,6 +532,13 @@ impl EnvResults {
             // trace!("resolve: ctx.get('env'): {:#?}", &ctx.get("env"));
             match directive {
                 EnvDirective::Val(k, v, _opts) => {
+                    // `[vars]` are template variables rather than environment variables, so the
+                    // PATH rule does not apply to them.
+                    let k = if resolve_opts.vars {
+                        k
+                    } else {
+                        crate::env::normalize_path_key(k)
+                    };
                     r.track_redaction_override(&k, redact);
                     let v = r.parse_template(&ctx, &mut tera, &source, &env_vars, &v)?;
 
@@ -550,6 +557,12 @@ impl EnvResults {
                     }
                 }
                 EnvDirective::Default(k, v, _opts) => {
+                    // Same fold as `Val` above, and for the same reason.
+                    let k = if resolve_opts.vars {
+                        k
+                    } else {
+                        crate::env::normalize_path_key(k)
+                    };
                     if resolve_opts.vars {
                         if let Some((v, _)) = r.vars.get(&k).filter(|(v, _)| !v.is_empty()) {
                             if redact.unwrap_or(false) {
@@ -590,6 +603,13 @@ impl EnvResults {
                     }
                 }
                 EnvDirective::Rm(k, _opts) => {
+                    // The same fold as `Val`, so that `_.unset` naming another spelling of PATH
+                    // reaches the key `Val` stored it under rather than missing silently.
+                    let k = if resolve_opts.vars {
+                        k
+                    } else {
+                        crate::env::normalize_path_key(k)
+                    };
                     env.shift_remove(&k);
                     r.redaction_exclusions.remove(&k);
                     // The key is gone from the environment, so its caller value is no longer
@@ -920,24 +940,34 @@ impl EnvResults {
 
         // Check if required variables are defined
         for (var_name, declaring_source, required_value) in required_vars {
+            // Looked up under the folded name, reported under the one the config wrote. On
+            // Windows `Path = { required = true }` asks after the variable that is spelled
+            // `PATH` in the environment, and `Val`/`Default` store it folded, so a lookup on
+            // the literal name reads a variable that is set as missing.
+            let lookup = if vars_mode {
+                var_name.clone()
+            } else {
+                env::normalize_path_key(var_name.clone())
+            };
+
             // Variable must be defined either:
             // 1. In the initial environment (before mise runs), OR
             // 2. In a config file processed later than the one declaring it as required
-            let is_predefined = initial.contains_key(&var_name);
+            let is_predefined = initial.contains_key(&lookup);
 
             let resolved_values = if vars_mode {
                 &env_results.vars
             } else {
                 &env_results.env
             };
-            let is_defined_later = if let Some((_, var_source)) = resolved_values.get(&var_name) {
+            let is_defined_later = if let Some((_, var_source)) = resolved_values.get(&lookup) {
                 // Check if the variable comes from a different config file
                 var_source != &declaring_source
             } else {
                 false
             };
             let is_defined_in_context =
-                vars_mode && context_vars.get(&var_name).is_some_and(|v| !v.is_empty());
+                vars_mode && context_vars.get(&lookup).is_some_and(|v| !v.is_empty());
 
             if !is_predefined && !is_defined_later && !is_defined_in_context {
                 let variable_kind = if vars_mode {

--- a/src/env.rs
+++ b/src/env.rs
@@ -729,6 +729,34 @@ fn path_key_from_env(keys: impl IntoIterator<Item = String>) -> String {
         .find(|k| k.eq_ignore_ascii_case("PATH"))
         .unwrap_or("PATH".into())
 }
+
+/// Whether `key` names PATH.
+///
+/// Windows environment variable names are case-insensitive, so every spelling is the same
+/// variable there — including `Path`, which is how Windows itself writes it. On unix only the
+/// exact [`PATH_KEY`] is PATH, and a `Path` beside it is a variable of its own.
+pub(crate) fn is_path_key(key: &str) -> bool {
+    if cfg!(windows) {
+        key.eq_ignore_ascii_case(&PATH_KEY)
+    } else {
+        key == *PATH_KEY
+    }
+}
+
+/// Fold any spelling of PATH onto [`PATH_KEY`], leaving every other name alone.
+///
+/// mise owns PATH: it writes its own value under `PATH_KEY` after everything else has been
+/// collected. A key that means PATH but is spelled differently would survive that write as a
+/// second entry, and the two would then both be applied — so it has to be folded before it is
+/// stored, not filtered afterwards. The identity on unix, where the only spelling that is PATH
+/// is `PATH_KEY` already.
+pub(crate) fn normalize_path_key(key: String) -> String {
+    if is_path_key(&key) {
+        PATH_KEY.to_string()
+    } else {
+        key
+    }
+}
 pub(crate) static PATH: Lazy<Vec<PathBuf>> = Lazy::new(|| match PRISTINE_ENV.get(&*PATH_KEY) {
     Some(path) => split_paths(path).collect(),
     None => vec![],
@@ -1375,6 +1403,36 @@ mod tests {
             "PATH"
         );
         assert_eq!(path_key_from_env(vec!["TEMP".into()]), "PATH");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_is_path_key_accepts_any_casing_on_windows() {
+        for spelling in ["PATH", "Path", "path", "pAtH"] {
+            assert!(is_path_key(spelling), "{spelling}");
+            assert_eq!(normalize_path_key(spelling.to_string()), *PATH_KEY);
+        }
+
+        assert!(!is_path_key("PATHEXT"));
+        assert!(!is_path_key("TEMP"));
+        assert!(!is_path_key(""));
+        // A name that is not PATH keeps the spelling the config gave it.
+        assert_eq!(normalize_path_key("Temp".to_string()), "Temp");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_is_path_key_is_exact_on_unix() {
+        assert!(is_path_key("PATH"));
+        assert_eq!(normalize_path_key("PATH".to_string()), "PATH");
+
+        // `Path` is a variable of its own here, so folding it would drop what was asked for.
+        assert!(!is_path_key("Path"));
+        assert!(!is_path_key("path"));
+        assert_eq!(normalize_path_key("Path".to_string()), "Path");
+
+        assert!(!is_path_key("PATHEXT"));
+        assert!(!is_path_key(""));
     }
 
     #[test]


### PR DESCRIPTION
## The bug

A `mise.toml` containing this destroys PATH on Windows:

```toml
[env]
Path = "C:/custom"
```

`Path` is how Windows itself writes the variable, so it is a natural thing to type — and it names
the same variable as `PATH`. mise emitted **two assignments to it**:

```
${Env:PATH}='C:\Users\...\mise\installs\go\1.26.7\bin;C:\WINDOWS\system32;...'
${Env:Path}='C:/custom-from-mise'
```

The later one wins, and takes the system directories and every mise tool path with it. Measured on
2026.8.10, both ways a process can inherit the environment:

| route | the child's PATH |
| --- | --- |
| `mise exec` | `C:\Program Files\PowerShell\7;C:/custom-from-mise` |
| eval `mise env` (the activate path) | `C:/custom-from-mise` |

Exit 0 both times. Nothing reports that PATH was replaced.

## The two spellings behaved oppositely

| declaration | assignments emitted | result |
| --- | --- | --- |
| `[env] PATH = "x"` | 1 | PATH intact; the declaration is ignored |
| `[env] Path = "x"` | 2 | **PATH replaced by `x`** |

`[env] PATH` is a single assignment that mise's own PATH write overwrites — mise owns PATH, and
`_.path` is how you add to it. **Unix does the same**: measured there, `[env] PATH = "/custom-only"`
is ignored and the child gets the normal system PATH. `[env] Path` only escaped that write by being
a different key.

**Unix is correct as it stands** and is unchanged by this: `Path` there is a variable of its own, so
`export PATH=…` and `export Path=/custom` coexist and PATH survives. Measured.

**Only names mise emits itself can collide.** `[env] Temp = "C:/mytemp"` emits one assignment and
the child gets `TEMP=C:/mytemp` — correct before and after. There is a test for that, so folding too
much would not pass as a fix.

## The rule was already in the codebase, twice

Both places guard *tool* env values, and both spell the check out inline:

```rust
// src/backend/mod.rs — "PATH is owned by path_env; exclude any casing on Windows."
// src/backend/vfox.rs — "On Windows env var names are case-insensitive, so exclude any
//                        casing (e.g. a lowercase `path`); on unix only exact `PATH`."
let is_path = if cfg!(windows) {
    k.eq_ignore_ascii_case(env::PATH_KEY.as_str())
} else {
    k.as_str() == env::PATH_KEY.as_str()
};
```

The config `[env]` path never got it. This names the rule once in `src/env.rs` and has all three
call sites use it, so the copies go away rather than becoming three.

## The fix

`env::normalize_path_key` folds any spelling onto `PATH_KEY` **as the key is stored**, in
`EnvDirective::Val` and `Default`. Folding at storage rather than filtering afterwards is what makes
it one change: `env.insert(PATH_KEY, …)` appears at fifteen-odd sites across `toolset_env.rs`,
`task/`, and `tool_stub.rs`, and every one of them is fixed by the key being right before it gets
there.

After this, `[env] Path` is **exactly** `[env] PATH`: ignored, with PATH intact.

`[vars]` are template variables rather than environment variables, so the fold does not apply to
them. `Rm` (`[env] Path = false`) and the `required` lookup fold the same way, so every directive
agrees on what PATH is.

## A second bug the review turned up

Folding the `required` lookup fixes something that **predates this PR**. Measured on 2026.8.10:

```
[env] Path = { required = true }
  mise ERROR Required environment variable 'Path' is not defined.

[env] PATH = { required = true }
  (no error)
```

PATH is set — it is always set — and only the spelling differs. The lookup now uses the folded
name while the message still reports the name the config wrote.

## Test

Run against the **unfixed** 2026.8.10 first, to check the new cases fail for the right reason:

```
Describing env names that differ only in case
  [-] emits PATH once                                        Expected 1, but got '2'
  [-] does not let the declaration replace PATH              'C:/custom-from-mise'
  [-] leaves a child process with a usable PATH              'C:\Program Files\PowerShell\7;C:/custom-from-mise'
  [+] still applies a declaration that collides with nothing

Describing PATH spelled another way in required and unset
  [-] sees a required PATH that is spelled differently
      "Required environment variable 'Path' is not defined"
  [+] leaves PATH usable after unsetting it by another spelling
Tests Passed: 2, Failed: 4
```

Four reproductions and two guards. The two passing cases are labelled as guards in the files: the
`Temp` one so that folding too much would not pass as a fix, and the `unset` one so that folding
`unset` could not quietly become a way to drop PATH.

`e2e/env/test_env_path_case` is a **guard, not a reproduction**, and says so in the file: it passes
before and after, and exists so that folding `Path` onto PATH on unix — where it is a real,
separate variable — would be caught. Verified green through `e2e/run_test` (on 2026.8.3, which is
what is installed in the Linux box here).

**I have not built this locally**: `cargo check` cannot run on this machine (`libz-ng-sys` needs
`cmake`, which is not installed), so the type check and the post-fix behaviour are for CI.
Everything reported above as measured was measured against released binaries, not against a build
of this branch.

Independent of #12277 — different files, no overlap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows `PATH` handling regardless of capitalization.
  * Prevented duplicate `PATH` entries while preserving the system PATH.
  * Ensured child processes receive a usable PATH.
  * Preserved case-sensitive variables such as `Path` on Unix systems.
  * Continued applying unrelated variables, such as `Temp`, correctly.
  * Improved required-variable lookup when `PATH` uses different capitalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->