### PR TITLE
docs(tasks): point extensionless pwsh tasks at MISE_TASK_DIR

### DIFF
--- a/docs/tasks/file-tasks.md
+++ b/docs/tasks/file-tasks.md
@@ -162,8 +162,13 @@ mise runs it from a `.ps1` copy in the temp directory and removes the copy when 
 
 Only the script's view of its own location changes: `$PSScriptRoot` and `$PSCommandPath` name the
 copy rather than the task file. The working directory, `$args`, and the environment are untouched.
-A task that needs to find files sitting next to it should carry a `.ps1` extension, which is run
-in place.
+
+A task that needs to find files next to itself has two ways out, and the first works everywhere:
+
+- Read [`MISE_TASK_DIR`](/tasks/#environment-variables-passed-to-tasks), which names the directory
+  the task file is in. mise sets it from the task rather than from whatever is executing, so the
+  copy does not move it — and it reads the same on Linux and macOS, where nothing is copied at all.
+- Give the task a `.ps1` extension, which is run in place.
 
 ### Writing one task for both platforms
 


### PR DESCRIPTION
## What this changes

The note added by #12274 about staging a `.ps1` copy offered exactly one way out for a task that
needs to read files sitting beside it:

> A task that needs to find files sitting next to it should carry a `.ps1` extension, which is run
> in place.

There is a better answer already in the product, and it was not mentioned:
[`MISE_TASK_DIR`](https://mise.jdx.dev/tasks/#environment-variables-passed-to-tasks). It costs the
task nothing — no rename, no extension — and it **reads the same on Linux and macOS**, where no copy
is ever made. `$PSScriptRoot` does not.

Measured, from a pwsh task with a `config.psd1` next to it:

```
PSScriptRoot   = ...\mise-tasks
MISE_TASK_DIR  = ...\mise-tasks
MISE_TASK_FILE = ...\mise-tasks\where.ps1
sibling resolved via MISE_TASK_DIR: yes
```

Docs only — no code changes, and no new explanation: it links the canonical list in
`docs/tasks/index.md`, using the same anchor this file already uses further up.

## Where it came from

Raised by a reviewer on #12277, against #12274's code. The suggestion there was to stage the copy in
the task's **own directory** rather than temp, so `$PSScriptRoot` would be right.

That was measured and **rejected**: a `.ps1` in a task directory is discovered by extension, so the
staged copy becomes a task.

```
$ mise task ls
hello

# after placing a staged copy where the suggestion proposes
$ mise task ls
hello
mise-task-hello-a1b2c3
```

A phantom task in the user's project for the length of every run, plus writing into the working tree
— which fails on a read-only checkout and leaves the debris in the repository rather than temp if
mise is killed. The observation behind the comment was still worth acting on, which is what this is.

## On the measurement

The numbers above were taken from a `.ps1` task, which is **not** staged. A release containing
#12274 does not exist yet, so the staged case cannot be measured against a released binary.

What can be said without measuring it: `MISE_TASK_DIR` and `MISE_TASK_FILE` are built in the task
context builder from `task.file_path()`, before `exec` stages anything, and every file task goes
through that one path regardless of platform or extension. So the value's origin is the same in both
cases — that part is read from the code, not measured, and is stated here as such.

## Checks

`prettier --check` passes, run the way `hk.pkl` invokes it so it uses the pinned 3.9.6:

```
$ mise x prettier -- prettier --check docs/tasks/file-tasks.md
All matched files use Prettier code style!
```

markdownlint could not be run here — the `npm:markdownlint-cli` install on this machine fails with
`ERR_MODULE_NOT_FOUND` before reaching any file. Instead the new list was matched against the bullet
list already in this file (same `-` marker, same two-space continuation), and `MD013` is disabled in
`.markdownlint.json`, so the ~100-column lines match the surrounding text. CI has the real check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PowerShell task guidance to explain how to locate files relative to the task across platforms.
  * Documented support for running PowerShell tasks with a `.ps1` extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->