### PR TITLE
fix(cli): report a cd target it cannot enter instead of panicking

### DIFF
--- a/e2e-win/cd_bad_target.Tests.ps1
+++ b/e2e-win/cd_bad_target.Tests.ps1
@@ -1,0 +1,52 @@
+Describe 'a cd target that cannot be entered' {
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        # Saved here, restored in AfterAll: Pester runs every suite in one process, so removing an
+        # inherited value would leave the next suite without it.
+        $script:OriginalCd = [Environment]::GetEnvironmentVariable('MISE_CD', 'Process')
+        $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:TestRoot | Out-Null
+        Set-Location $script:TestRoot
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        if ($null -eq $script:OriginalCd) {
+            Remove-Item Env:MISE_CD -ErrorAction Ignore
+        } else {
+            [Environment]::SetEnvironmentVariable('MISE_CD', $script:OriginalCd, 'Process')
+        }
+    }
+
+    It 'reports a missing cd target instead of aborting' {
+        # `validate_cd_path` only inspects the `--cd` flag, so the environment route reaches the
+        # `chdir` with no checks in front of it -- a missing directory is enough to get there.
+        $env:MISE_CD = Join-Path $script:TestRoot "not-here"
+        $out = mise env 2>&1 | Out-String
+        # Captured before anything else runs: a cmdlet does not touch $LASTEXITCODE, but the next
+        # native command would.
+        $status = $LASTEXITCODE
+        Remove-Item Env:MISE_CD -ErrorAction Ignore
+
+        $out | Should -Not -Match 'panicked'
+        $out | Should -Match 'failed to set current directory'
+        # It has to actually fail. An error message printed on a successful exit would satisfy the
+        # assertions above. "Not zero" rather than a specific code, which is all this pins.
+        $status | Should -Not -Be 0
+    }
+
+    It 'still runs when the cd target is real' {
+        # Control: the same variable pointing somewhere that exists, so the failure above is pinned
+        # on the target rather than on MISE_CD being set at all.
+        $env:MISE_CD = $script:TestRoot
+        $out = mise env 2>&1 | Out-String
+        $status = $LASTEXITCODE
+        Remove-Item Env:MISE_CD -ErrorAction Ignore
+
+        $out | Should -Not -Match 'panicked'
+        $out | Should -Not -Match 'failed to set current directory'
+        # The control has to succeed, not merely stay quiet -- otherwise it would still pass if
+        # MISE_CD broke the run for some entirely different reason.
+        $status | Should -Be 0
+    }
+}

--- a/e2e/cli/test_cd_bad_target
+++ b/e2e/cli/test_cd_bad_target
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# mise's `cd` setting is applied after `--cd`'s two checks have run, and the `chdir` it performs can
+# still fail. That failure was dropped at the call site and met an unwrap further on, so it aborted
+# the process instead of being reported.
+#
+# Driven through `MISE_CD` rather than `--cd`, for two reasons. `validate_cd_path` only inspects the
+# CLI flag, so the environment route reaches the `chdir` with nothing in front of it and a plain
+# missing directory is enough to get there. And it needs no permission tricks: this suite runs in a
+# container as root in CI, where `chmod` cannot stop `chdir` and a permission-based reproduction
+# would quietly test nothing.
+
+target="$PWD/not-here"
+
+set +e
+out="$(MISE_CD="$target" mise env 2>&1)"
+status=$?
+set -e
+
+assert_not_contains_text "$out" "panicked"
+assert_contains_text "$out" "failed to set current directory"
+assert_contains_text "$out" "not-here"
+# The number rather than the sentence in front of it: Rust appends `os error N` itself, while the
+# text comes from the OS and is localised.
+assert_contains_text "$out" "os error 2"
+# It has to actually fail. An error message printed on a successful exit would satisfy every
+# assertion above. Written as "not zero" rather than a specific code, which is all this pins.
+assert_not_contains_text "exit=$status" "exit=0"
+
+# Control: the same variable pointing somewhere real, so the failure above is pinned on the target
+# rather than on MISE_CD being set at all.
+assert "MISE_CD='$PWD' mise env >/dev/null && echo entered" "entered"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -829,7 +829,12 @@ impl Cli {
         // Validate --cd path BEFORE Settings processes it and changes the directory
         validate_cd_path(&cli.cd)?;
         measure!("add_cli_matches", { Settings::add_cli_matches(&cli) });
-        let _ = measure!("settings", { Settings::try_get() });
+        // Propagated, not discarded: this is where `--cd` is actually applied, and a directory
+        // that passed the checks above can still refuse the `chdir` — no execute permission, or a
+        // path past the length `SetCurrentDirectory` accepts. Dropping the error here does not
+        // avoid it, it only defers it: `BASE_SETTINGS` stays empty, so the next `Settings::get()`
+        // repeats the same failure and unwraps it.
+        measure!("settings", { Settings::try_get() })?;
         let auto_update_command_eligible = !print_version
             && cli
                 .command


### PR DESCRIPTION
## The bug

Applying mise's `cd` setting can fail, and the failure aborted the process.

```
$ MISE_CD=/does/not/exist mise env
The application panicked (crashed).
Message:  called `Result::unwrap()` on an `Err` value:
   0: failed to set current directory to /does/not/exist
   1: No such file or directory (os error 2)
```

`--cd` checks two things before Settings applies it and reports both cleanly:

| given | today |
| --- | --- |
| a path that does not exist | ✅ `Directory specified with --cd does not exist: …` |
| a path that is not a directory | ✅ `Path specified with --cd is not a directory: …` |
| **anything the `chdir` itself rejects** | ❌ **abort** |

Two ways to land in the third row:

- **`MISE_CD` skips the checks entirely.** `validate_cd_path` reads `cli.cd`, so the environment
  route reaches the `chdir` with nothing in front of it — a *missing directory* is enough, the same
  input `-C` reports cleanly.
- **`--cd` still reaches it** when both checks pass and the `chdir` fails anyway: `exists()` and
  `is_dir()` need only the *parent* to be traversable, while `chdir` needs the directory itself.

**Measured on both platforms:**

| | trigger | result |
| --- | --- | --- |
| Linux 2026.8.3 | `MISE_CD` at a missing path, or `-C` at a `chmod 000` directory | abort, **SIGABRT (134)** |
| Windows 2026.8.10 | the same, or `-C` at a 309-character path — `SetCurrentDirectory` is capped at `MAX_PATH` whatever the long-path setting says | abort, **0xC0000409 / 127** |

## Why it crashed

```
cli/mod.rs   validate_cd_path(&cli.cd)?          only sees the flag, and only two conditions
cli/mod.rs   let _ = measure!("settings", …)     ← the Err is dropped here
             (inside: env::set_current_dir(cd)? had failed and propagated)
later        Settings::get() runs the load again, fails the same way, and
settings.rs  Self::try_get().unwrap()            ← panic
```

The comment directly above the call already states the contract — *"Validate --cd path BEFORE
Settings processes it and changes the directory"*.

## The fix

Propagate the error the call site was discarding. It is already produced, and already names the path
and the OS reason.

**This cannot break a case that worked.** If `try_get` fails there, `BASE_SETTINGS` is left empty,
so every later `Settings::get()` repeats the same load, fails identically, and unwraps. Dropping the
error never avoided the failure — it deferred it into a crash.

`--version` prints before this line and exits after it, so it does pass through. Checked whether
anything it used to tolerate now fails: `MISE_JOBS=abc` is rejected by **clap**, before Settings
(`rc=2`, unchanged); `MISE_HTTP_TIMEOUT=abc`, `MISE_RAW=maybe`, `MISE_ALL_COMPILE=xyz` are tolerated
by the loader (`rc=0`, unchanged); and the one failure that does reach the line already aborts today
(`mise -C <unenterable> --version` → `rc=134`). No tolerated case was found.

**A malformed config file does not reach this.** `all_settings_files()` skips files it cannot parse
rather than failing the load, so `mise --version` still works with a broken `mise.toml` — measured.

### What this deliberately does not do

**`validate_cd_path` is left alone**, and is not extended to `MISE_CD`. A pre-check for "can this be
entered" is wrong in both directions — on unix `chdir` wants `+x` while `read_dir` wants `+r`, so a
`chmod 111` directory is enterable but would be **rejected**; on Windows `SetCurrentDirectory` is
capped at `MAX_PATH` regardless of long-path support and `read_dir` is not, so the long path would be
**missed**. The only reliable probe is the `chdir` itself, which is process-global and would run
before `try_get` resolves a relative `cd`. Reporting the real failure is the smaller change.

The consequence is that `MISE_CD` gets the generic message rather than one of the two friendly ones.
That is a reasonable follow-up, and deliberately not bundled here.

## Tests

Driven through `MISE_CD` rather than `--cd`, because it needs **no permission tricks**: this suite
runs in a container as root in CI (`MISE_E2E_DOCKER: "1"`, and `run_in_docker` bind-mounts `/root`),
where `chmod` cannot stop `chdir` and a permission-based reproduction would quietly test nothing.

Both files are red on released binaries for the right reason:

```
e2e/cli/test_cd_bad_target        ERROR: expected 'panicked' not to be in output   (2026.8.3)
e2e-win/cd_bad_target.Tests.ps1   [-] reports a missing cd target instead of aborting  (2026.8.10)
```

Each has a control — the same variable pointing somewhere real — so the failure is pinned on the
target rather than on `MISE_CD` being set at all.

Assertion tokens were picked by reading the actual output rather than guessing:

- the **leaf** of the path, not the variable: `display_path` rewrites `$HOME` as `~`, so the
  absolute path does not appear when the target is under home;
- **`os error 2`**, not the sentence in front of it: Rust appends the number itself, while the text
  comes from the OS and is localised — the Windows run of this very test prints
  `指定されたファイルが見つかりません。`;
- **the exit status, on both platforms**: non-zero for the failure — written as "not zero" rather
  than a specific code, since nothing here defines one — and strictly `0` for each control, because
  that is the claim being made. An error message
  printed on a successful exit would satisfy everything else.

`shfmt -d` (without `-s`, which disables `.editorconfig` and would switch the file to tabs) and
`shellcheck -x` are clean.

## Checks

**I have not built this locally**: `cargo check` cannot run on this machine (`libz-ng-sys` needs
`cmake`, which is not installed), so the type check is for CI. `measure!` yields its block's value in
all three of its branches, so `?` applies to the `Result<Arc<Settings>>` — read, not compiled.
Everything reported above as measured was measured against released binaries.

Draft: the change turns a previously-ignored error into a fatal one at startup. Small, but worth a
maintainer's eye before it is marked ready.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved command-line parsing, help output, completions, aliases, and command validation.
  * Added the `bs` alias for bootstrap commands.
  * Root-level `--yes` and `--dry-run` options now apply consistently to applicable commands.

* **Bug Fixes**
  * Invalid directory targets no longer cause an unexpected panic.
  * Errors now appear immediately and include the missing path and operating system details.

* **Tests**
  * Added coverage for directory changes across Windows and other supported environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->