### PR TITLE
fix(env): name the key and file behind an unexpanded $VAR

### DIFF
--- a/e2e/env/test_env_shell_expand
+++ b/e2e/env/test_env_shell_expand
@@ -122,6 +122,11 @@ cat <<'EOF' >mise.toml
 BAR = "$UNDEFINED_VAR"
 EOF
 assert_contains "mise env -s bash 2>&1" "env var 'UNDEFINED_VAR' is not defined"
+# The warning has to say what referenced it. A missing variable is by definition
+# absent from `mise env`, so naming it alone left the reporter in discussion
+# #8232 with nothing to grep for.
+assert_contains "mise env -s bash 2>&1" 'referenced by `BAR`'
+assert_contains "mise env -s bash 2>&1" "mise.toml"
 
 # Test ${VAR:-} suppresses warning for undefined var
 cat <<'EOF' >mise.toml

--- a/src/config/env_directive/file.rs
+++ b/src/config/env_directive/file.rs
@@ -31,7 +31,7 @@ impl EnvResults {
         expand: bool,
     ) -> Result<IndexMap<PathBuf, EnvMap>> {
         let mut out = IndexMap::new();
-        let s = ctx.parse_template(&input)?;
+        let s = ctx.parse_template("_.file", &input)?;
         let expand = expand && crate::config::Settings::get().env_shell_expand;
         // Accumulate loaded vars so opted-in expansion can reference values from
         // an earlier file in the same directive or an earlier env block.
@@ -39,7 +39,10 @@ impl EnvResults {
         for p in xx::file::glob(ctx.normalize_path(s.into())).unwrap_or_default() {
             let config = ctx.config;
             let exec_env = ctx.exec_env;
-            let parse_template = |s: String| ctx.parse_template(&s);
+            // The loaders expand templates in values read from the file and do
+            // not carry the key from inside it, so label by the file itself.
+            let origin = display_path(&p);
+            let parse_template = |s: String| ctx.parse_template(&origin, &s);
             let ext = p
                 .extension()
                 .map(|e| e.to_string_lossy().to_string())
@@ -57,13 +60,7 @@ impl EnvResults {
                 for (k, v) in loaded.iter_mut() {
                     let mut missing = Vec::new();
                     let expanded = super::shell_expand_env(&*v, &acc, &mut missing);
-                    for var in missing {
-                        warn_once!(
-                            "env var '{var}' is not defined and will be left unexpanded. \
-                             Use ${{{var}:-}} to default to an empty string and suppress \
-                             this warning."
-                        );
-                    }
+                    super::warn_unexpanded_vars(missing, k, &p);
                     *v = expanded;
                     acc.insert(k.clone(), v.clone());
                 }

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -352,9 +352,15 @@ pub(super) struct EnvDirectiveContext<'a> {
 }
 
 impl EnvDirectiveContext<'_> {
-    fn parse_template(&mut self, input: &str) -> eyre::Result<String> {
-        self.results
-            .parse_template(self.tera_ctx, self.tera, self.source, self.exec_env, input)
+    fn parse_template(&mut self, origin: &str, input: &str) -> eyre::Result<String> {
+        self.results.parse_template(
+            self.tera_ctx,
+            self.tera,
+            self.source,
+            self.exec_env,
+            origin,
+            input,
+        )
     }
 
     fn normalize_path(&self, path: PathBuf) -> PathBuf {
@@ -540,7 +546,7 @@ impl EnvResults {
                         crate::env::normalize_path_key(k)
                     };
                     r.track_redaction_override(&k, redact);
-                    let v = r.parse_template(&ctx, &mut tera, &source, &env_vars, &v)?;
+                    let v = r.parse_template(&ctx, &mut tera, &source, &env_vars, &k, &v)?;
 
                     if resolve_opts.vars {
                         if redact.unwrap_or(false) {
@@ -587,7 +593,7 @@ impl EnvResults {
                     }
 
                     r.track_redaction_override(&k, redact);
-                    let v = r.parse_template(&ctx, &mut tera, &source, &env_vars, &v)?;
+                    let v = r.parse_template(&ctx, &mut tera, &source, &env_vars, &k, &v)?;
 
                     if resolve_opts.vars {
                         if redact.unwrap_or(false) {
@@ -651,7 +657,7 @@ impl EnvResults {
                     let decrypted_v = match res {
                         Ok(decrypted_v) => {
                             // Parse as template after decryption
-                            r.parse_template(&ctx, &mut tera, &source, &env_vars, &decrypted_v)?
+                            r.parse_template(&ctx, &mut tera, &source, &env_vars, k, &decrypted_v)?
                         }
                         Err(e) if Settings::get().age.strict => {
                             return Err(e)
@@ -1016,6 +1022,7 @@ impl EnvResults {
         tera: &mut Option<TeraEngine>,
         path: &Path,
         exec_env: &EnvMap,
+        origin: &str,
         input: &str,
     ) -> eyre::Result<String> {
         let mut output = input.to_string();
@@ -1055,13 +1062,7 @@ impl EnvResults {
                 .unwrap_or_default();
             let mut missing_vars = Vec::new();
             output = shell_expand_env(&output, &env_vars, &mut missing_vars);
-            for var in missing_vars {
-                warn_once!(
-                    "env var '{var}' is not defined and will be left unexpanded. \
-                     Use ${{{var}:-}} to default to an empty string and suppress \
-                     this warning."
-                );
-            }
+            warn_unexpanded_vars(missing_vars, origin, path);
         }
 
         Ok(output)
@@ -1075,6 +1076,33 @@ impl EnvResults {
             && self.env_paths.is_empty()
             && self.env_scripts.is_empty()
             && self.tool_add_paths.is_empty()
+    }
+}
+
+/// The warning for a `$VAR` that `shell_expand_env` could not expand.
+///
+/// Built as a string rather than warned in place so it can be tested without
+/// `warn_once!`'s process-global dedup set, which would make any test asserting
+/// on emitted output depend on whatever ran before it.
+///
+/// Naming the missing variable alone was not actionable. The reporter in
+/// discussion #8232 could see *which* variable was missing but not which value
+/// referenced it, and `mise env` cannot show that: a missing variable is by
+/// definition absent from the environment. `origin` is the referencing `[env]`
+/// key where one exists, and the directive otherwise.
+fn unexpanded_var_warning(var: &str, origin: &str, path: &Path) -> String {
+    format!(
+        "env var '{var}' is not defined and will be left unexpanded, \
+         referenced by `{origin}` in {}. \
+         Use ${{{var}:-}} to default to an empty string and suppress this warning.",
+        display_path(path)
+    )
+}
+
+/// Warn once for each variable left unexpanded, naming what referenced it.
+pub(crate) fn warn_unexpanded_vars(missing: Vec<String>, origin: &str, path: &Path) {
+    for var in missing {
+        warn_once!("{}", unexpanded_var_warning(&var, origin, path));
     }
 }
 
@@ -1263,6 +1291,19 @@ mod tests {
     use crate::config::Config;
     use crate::env_diff::EnvMap;
     use crate::tera::BASE_CONTEXT;
+
+    /// Naming the missing variable was never the hard part — finding what
+    /// referenced it was. See discussion #8232.
+    #[test]
+    fn test_unexpanded_var_warning_names_the_reference() {
+        let path = Path::new("/p/mise.toml");
+        let msg = unexpanded_var_warning("DB_HOST", "DATABASE_URL", path);
+        assert!(msg.contains("'DB_HOST'"), "{msg}");
+        assert!(msg.contains("`DATABASE_URL`"), "{msg}");
+        assert!(msg.contains(&display_path(path)), "{msg}");
+        // The existing escape hatch has to survive the rewording.
+        assert!(msg.contains("${DB_HOST:-}"), "{msg}");
+    }
 
     /// `ToolsFilter::ToolsOnlyVals` must select only `tools = true` `Val`
     /// directives — excluding `tools = false` vars and `tools = true` *modules*

--- a/src/config/env_directive/path.rs
+++ b/src/config/env_directive/path.rs
@@ -7,7 +7,7 @@ impl EnvResults {
         ctx: &mut EnvDirectiveContext<'_>,
         input: String,
     ) -> result::Result<PathBuf> {
-        ctx.parse_template(&input).map(PathBuf::from)
+        ctx.parse_template("_.path", &input).map(PathBuf::from)
     }
 }
 

--- a/src/config/env_directive/source.rs
+++ b/src/config/env_directive/source.rs
@@ -14,7 +14,7 @@ impl EnvResults {
         // Note: in safe mode `_.source` directives are dropped during env
         // resolution (see EnvResults::resolve), so this is never reached.
         let mut out = IndexMap::new();
-        let s = ctx.parse_template(&input)?;
+        let s = ctx.parse_template("_.source", &input)?;
         let orig_path = ctx
             .exec_env
             .get(&*env::PATH_KEY)

--- a/src/config/env_directive/venv.rs
+++ b/src/config/env_directive/venv.rs
@@ -258,7 +258,7 @@ impl EnvResults {
             return Ok(());
         }
         trust_check(ctx.source)?;
-        let venv = ctx.parse_template(&path)?;
+        let venv = ctx.parse_template("python.venv", &path)?;
         let venv = ctx.normalize_path(venv.into());
         let venv_lock = LockFile::new(&venv).lock()?;
         // Record whichever python the caller actually has active. The toolset rebuilt below comes

--- a/src/deps/rule.rs
+++ b/src/deps/rule.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use eyre::{Result, WrapErr};
 use serde::{Deserialize, Serialize};
@@ -86,7 +86,7 @@ impl DepsProviderConfig {
         rendered.render_strings(|field, input, shell_expand| {
             let mut output = render_template_field(template, field, input, &context)?;
             if shell_expand && output.contains('$') && Settings::get().env_shell_expand {
-                output = expand_shell_vars(&output, &env_vars);
+                output = expand_shell_vars(&output, &env_vars, field, &template.config_path);
             }
             Ok(output)
         })?;
@@ -182,7 +182,7 @@ impl DepsProviderConfig {
                 let field = format!("env.{key}");
                 let mut output = render_template_field(template, &field, input, &context)?;
                 if output.contains('$') && Settings::get().env_shell_expand {
-                    output = expand_shell_vars(&output, &env_vars);
+                    output = expand_shell_vars(&output, &env_vars, &field, &template.config_path);
                 }
                 Ok((key.clone(), output))
             })
@@ -212,16 +212,15 @@ fn template_error_context(template: &DepsTemplateContext, field: &str) -> String
     )
 }
 
-fn expand_shell_vars(input: &str, env_vars: &BTreeMap<String, String>) -> String {
+fn expand_shell_vars(
+    input: &str,
+    env_vars: &BTreeMap<String, String>,
+    field: &str,
+    config_path: &Path,
+) -> String {
     let mut missing_vars = Vec::new();
     let output = shell_expand_env(input, env_vars, &mut missing_vars);
-    for var in missing_vars {
-        warn_once!(
-            "env var '{var}' is not defined and will be left unexpanded. \
-             Use ${{{var}:-}} to default to an empty string and suppress \
-             this warning."
-        );
-    }
+    crate::config::env_directive::warn_unexpanded_vars(missing_vars, field, config_path);
     output
 }
 


### PR DESCRIPTION
Addresses discussion #8232.

## Problem

The warning named the variable that was missing and nothing else:

```
env var 'X' is not defined and will be left unexpanded.
Use ${X:-} to default to an empty string and suppress this warning.
```

The report is one question about exactly that:

> I get this warning, but `mise env` doesn't show any such variable. How do I figure out what mise is complaining about?

`mise env` cannot help, and the reporter had already tried — a missing variable is by definition absent from the environment. What they needed was the *other* end: the value that referenced it. In a config with dozens of `[env]` entries there is nothing to grep for.

Every site that warns already had the answer in scope. None of it reached the message.

## Fix

```
env var 'DB_HOST' is not defined and will be left unexpanded,
referenced by `DATABASE_URL` in ~/p/mise.toml.
Use ${DB_HOST:-} to default to an empty string and suppress this warning.
```

The three copies of the text collapse into one builder so the wording cannot drift again. It returns the string rather than warning in place, because `warn_once!` dedupes through a process-global set and a test asserting on emitted output would otherwise depend on whatever ran before it.

What each site can name:

| origin | label |
| --- | --- |
| `[env]` values, including age-encrypted ones | the key |
| `_.file`, `_.path`, `_.source`, `python.venv` | the directive |
| values inside a structured env file | the key within that file |
| `[deps]` provider fields | the `field` it already builds as `env.{key}` |

Coarser than a key in some cases, still enough to find the line.

The `${VAR:-}` escape hatch is unchanged, and the message keeps its original prefix, so `e2e/env/test_env_shell_expand`'s existing assertion on this warning still holds — it is extended rather than replaced.

## Verification

- Unit test on the builder, including that the `${VAR:-}` hint survived the rewording.
- `e2e/env/test_env_shell_expand` extended to assert the key and the file are named; `test_env_file_expand` and `cli/test_deps_templates` re-run for the two other paths touched.
- clippy clean with no exclusions, `cargo fmt --check` clean.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved warnings for unexpanded environment variables.
  - Warnings now identify the missing variable, the setting or directive that referenced it, and the relevant configuration file.
  - Applied consistent diagnostics across environment, dependency, path, source, and virtual-environment settings.
  - Preserved guidance for escaping variables that should remain unexpanded.
- **Tests**
  - Added coverage verifying warning details, including the referencing variable and configuration file path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->