### PR TITLE
test(windows): stop pinning the usage version banner

### DIFF
--- a/e2e-win/exec_inactive_tool.Tests.ps1
+++ b/e2e-win/exec_inactive_tool.Tests.ps1
@@ -47,6 +47,11 @@ Describe 'exec_inactive_tool' {
 
     It 'suggests a command that works' {
         $out = (& $script:miseExe exec usage -- usage --version 2>&1 | Out-String)
-        $out | Should -Match "usage-cli"
+        # Assert that the suggested command ran the tool, not what the tool calls
+        # itself: usage 6.0.0 changed its banner from "usage-cli <ver>" to
+        # "usage <ver>" and broke this on a release with no mise change in it.
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match "usage"
+        $out | Should -Match "\d+\.\d+\.\d+"
     }
 }


### PR DESCRIPTION
`windows-e2e` is failing on every open PR, with no mise change behind it:

```
[-] exec_inactive_tool.suggests a command that works
Expected regular expression 'usage-cli' to match 'usage 6.0.0'
```

usage 6.0.0 renamed its version banner from `usage-cli <version>` to `usage <version>`. The assertion pinned the old text, so a release of an unrelated tool turned the whole matrix red. Reproduced by version: a local `usage` 5.1.0 still prints `usage-cli 5.1.0`, while CI now installs 6.0.0.

The test exists to prove the command mise *suggests* is runnable — it is the third case in a regression test for discussion #4407, where `mise exec` gave no hint that the tool it had just installed was not on PATH. What the tool calls itself is not the subject. So assert the thing it is actually about: exit 0, the output names the tool, and it looks like a version. That survives the next rename.

Opened ready rather than draft because it unblocks the matrix for everything else; happy to convert if you would rather it wait.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Windows end-to-end test coverage for inactive tools.
  * The test now verifies that the suggested command succeeds, displays the tool name, and includes a semantic-version pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->