### PR TITLE
fix(config): keep a config file's line endings when writing it back

### DIFF
--- a/e2e-win/config_line_endings.Tests.ps1
+++ b/e2e-win/config_line_endings.Tests.ps1
@@ -1,0 +1,64 @@
+Describe 'writing a config back keeps its line endings' {
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        # Saved here, restored in AfterAll: Pester runs every suite in one process, so removing an
+        # inherited value would leave the next suite without it.
+        $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+        $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:TestRoot | Out-Null
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:TestRoot
+        $script:Config = Join-Path $script:TestRoot "mise.toml"
+        Set-Location $script:TestRoot
+
+        # WriteAllText, not Out-File: the endings under test have to be the ones written here, not
+        # whatever a cmdlet decides to append.
+        function Set-Config {
+            param([string]$Text)
+            [IO.File]::WriteAllText($script:Config, $Text)
+        }
+
+        # Counted, not matched. A `\r$` pattern check reported every file on this machine as CRLF
+        # once; counting the bytes cannot be fooled that way, and it names a mixed file rather than
+        # rounding it to one answer.
+        function Get-Eol {
+            $bytes = [IO.File]::ReadAllBytes($script:Config)
+            $cr = @($bytes | Where-Object { $_ -eq 13 }).Count
+            $lf = @($bytes | Where-Object { $_ -eq 10 }).Count
+            if ($lf -eq 0) { "NONE" }
+            elseif ($cr -eq 0) { "LF" }
+            elseif ($cr -eq $lf) { "CRLF" }
+            else { "MIXED cr=$cr lf=$lf" }
+        }
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        if ($null -eq $script:OriginalTrusted) {
+            Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
+        } else {
+            [Environment]::SetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', $script:OriginalTrusted, 'Process')
+        }
+    }
+
+    It 'leaves a CRLF config on CRLF' {
+        # CRLF is what an editor on this platform writes by default, so this is the ordinary case
+        # here rather than an exotic one.
+        Set-Config "[env]`r`nA = `"1`"`r`n"
+        mise set B=2 | Out-Null
+        $LASTEXITCODE | Should -Be 0
+
+        Get-Eol | Should -Be 'CRLF'
+        # The edit still has to have happened -- a write that failed would also "keep" the endings.
+        (Get-Content $script:Config -Raw) | Should -Match 'B = "2"'
+    }
+
+    It 'leaves an LF config on LF' {
+        # Control: the fix restores what was there, so it must not push everything to CRLF either.
+        Set-Config "[env]`nA = `"1`"`n"
+        mise set B=2 | Out-Null
+        $LASTEXITCODE | Should -Be 0
+
+        Get-Eol | Should -Be 'LF'
+        (Get-Content $script:Config -Raw) | Should -Match 'B = "2"'
+    }
+}

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -20,7 +20,8 @@ use versions::Versioning;
 use crate::backend::unalias_backend;
 use crate::cli::args::BackendArg;
 use crate::config::config_file::{
-    ConfigFile, TaskConfig, ToolConfig, config_trust_root, is_ignored, trust, trust_check,
+    ConfigFile, TaskConfig, ToolConfig, config_trust_root, existing_line_ending, is_ignored, trust,
+    trust_check, with_line_ending,
 };
 use crate::config::config_file::{config_root, toml::deserialize_arr};
 use crate::config::env_directive::{
@@ -1416,7 +1417,9 @@ impl ConfigFile for MiseToml {
     }
 
     fn save(&self) -> eyre::Result<()> {
-        let contents = self.dump()?;
+        // Read before writing: what is on disk is still the file the user wrote, so it is what
+        // says which line ending to give back.
+        let contents = with_line_ending(self.dump()?, existing_line_ending(&self.path));
         if let Some(parent) = self.path.parent() {
             create_dir_all(parent)?;
         }
@@ -3091,6 +3094,47 @@ mod tests {
             before, after,
             "save() rewrote the config in place, so a concurrent reader can observe a torn file"
         );
+    }
+
+    /// Serialising the document returns `\n` whatever was parsed, while everything else about the
+    /// file survives the round trip. A config written on Windows would therefore come back with
+    /// every line changed, turning a one-line edit into a whole-file diff.
+    ///
+    /// Runs on unix only, because this whole module does. The Windows path — where CRLF is what an
+    /// editor writes by default, so this is the ordinary case rather than an exotic one — is
+    /// covered by `e2e-win/config_line_endings.Tests.ps1`.
+    #[test]
+    fn save_keeps_the_line_endings_the_file_already_had() {
+        let temp = tempfile::tempdir().unwrap();
+
+        // Counted rather than "contains a CRLF somewhere": a file that came back half converted
+        // would satisfy `any`, and half converted is its own defect.
+        let endings = |p: &Path| {
+            let bytes = std::fs::read(p).unwrap();
+            let lf = bytes.iter().filter(|b| **b == b'\n').count();
+            let crlf = bytes.windows(2).filter(|w| *w == b"\r\n").count();
+            (lf, crlf)
+        };
+
+        let crlf = temp.path().join("crlf.toml");
+        file::write(&crlf, "[tools]\r\nclaude = \"latest\"\r\n").unwrap();
+        MiseToml::from_file(&crlf).unwrap().save().unwrap();
+        let (lf_count, crlf_count) = endings(&crlf);
+        assert!(lf_count > 0, "the saved file has no newlines at all");
+        assert_eq!(
+            crlf_count,
+            lf_count,
+            "a CRLF config came back with {} of its {lf_count} newlines converted",
+            lf_count - crlf_count
+        );
+
+        // Control: putting back what was there must not turn into pushing everything to CRLF.
+        let lf = temp.path().join("lf.toml");
+        file::write(&lf, "[tools]\nclaude = \"latest\"\n").unwrap();
+        MiseToml::from_file(&lf).unwrap().save().unwrap();
+        let (lf_count, crlf_count) = endings(&lf);
+        assert!(lf_count > 0, "the saved file has no newlines at all");
+        assert_eq!(crlf_count, 0, "an LF config gained carriage returns");
     }
 
     #[tokio::test]

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -482,6 +482,44 @@ pub(crate) fn trust_active_config() -> Result<()> {
     Ok(())
 }
 
+/// The line ending a config file is written with.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LineEnding {
+    Lf,
+    Crlf,
+}
+
+/// What `path` is currently written with, or [`LineEnding::Lf`] when there is nothing to learn
+/// from — the file does not exist yet, is empty, or is a single line with no terminator.
+///
+/// Only the first line ending is consulted. A file with mixed endings is pathological either way,
+/// and "match the first line" is a rule that can be stated; taking a majority would silently
+/// rewrite the minority instead.
+pub(crate) fn existing_line_ending(path: &Path) -> LineEnding {
+    let Ok(body) = file::read_to_string(path) else {
+        return LineEnding::Lf;
+    };
+    match body.find('\n') {
+        Some(i) if body[..i].ends_with('\r') => LineEnding::Crlf,
+        _ => LineEnding::Lf,
+    }
+}
+
+/// `contents` rewritten to use `eol`.
+///
+/// Both config writers rebuild their text with `\n` — `mise.toml` because serialising the document
+/// returns `\n` whatever was parsed, `.tool-versions` because it re-joins `str::lines()`, which
+/// drops the `\r`. Everything else about either file survives, so the line endings are the one
+/// part that has to be put back by hand. Normalising before expanding keeps this safe to apply to
+/// a string that already uses CRLF.
+pub(crate) fn with_line_ending(contents: String, eol: LineEnding) -> String {
+    let lf = contents.replace("\r\n", "\n");
+    match eol {
+        LineEnding::Lf => lf,
+        LineEnding::Crlf => lf.replace('\n', "\r\n"),
+    }
+}
+
 pub(crate) fn trust_check(path: &Path) -> eyre::Result<()> {
     // In safe mode, config is inert (no code execution, no env injection — see
     // MISE_SAFE / the `safe` setting), so loading an untrusted config is
@@ -1236,6 +1274,56 @@ mod ignored_config_path_tests {
 
         assert!(matcher.is_match(&root.path().join("vendor/jj/mise.toml")));
         assert!(!matcher.is_match(&root.path().join("vendor-other/mise.toml")));
+    }
+
+    /// Every branch of the rule the doc comment states, each with its own fixture — the three that
+    /// fall back to LF are distinct situations, not one.
+    #[test]
+    fn existing_line_ending_reads_the_first_terminator() {
+        let root = tempfile::tempdir().unwrap();
+        let at = |name: &str, body: &str| {
+            let p = root.path().join(name);
+            crate::file::write(&p, body).unwrap();
+            p
+        };
+
+        assert_eq!(
+            existing_line_ending(&at("crlf", "a = 1\r\nb = 2\r\n")),
+            LineEnding::Crlf
+        );
+        assert_eq!(
+            existing_line_ending(&at("lf", "a = 1\nb = 2\n")),
+            LineEnding::Lf
+        );
+        // The first one decides, so a file that starts LF stays LF even with CRLF further down.
+        assert_eq!(
+            existing_line_ending(&at("mixed", "a = 1\nb = 2\r\n")),
+            LineEnding::Lf
+        );
+
+        // Nothing to learn from: each of these is its own case.
+        assert_eq!(existing_line_ending(&at("empty", "")), LineEnding::Lf);
+        assert_eq!(
+            existing_line_ending(&at("unterminated", "a = 1")),
+            LineEnding::Lf
+        );
+        assert_eq!(
+            existing_line_ending(&root.path().join("does-not-exist")),
+            LineEnding::Lf
+        );
+    }
+
+    #[test]
+    fn with_line_ending_is_idempotent_and_lossless() {
+        let lf = "a = 1\nb = 2\n".to_string();
+        let crlf = "a = 1\r\nb = 2\r\n".to_string();
+
+        assert_eq!(with_line_ending(lf.clone(), LineEnding::Lf), lf);
+        assert_eq!(with_line_ending(lf.clone(), LineEnding::Crlf), crlf);
+        // Normalising first is what makes this safe to run on a string that is already CRLF —
+        // without it the carriage returns would double up.
+        assert_eq!(with_line_ending(crlf.clone(), LineEnding::Crlf), crlf);
+        assert_eq!(with_line_ending(crlf, LineEnding::Lf), lf);
     }
 }
 

--- a/src/config/config_file/tool_versions.rs
+++ b/src/config/config_file/tool_versions.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 use tera::Context;
 
 use crate::cli::args::BackendArg;
-use crate::config::config_file::{ConfigFile, trust_check};
+use crate::config::config_file::{ConfigFile, existing_line_ending, trust_check, with_line_ending};
 use crate::file;
 use crate::file::display_path;
 use crate::tera::{BASE_CONTEXT, contains_template_syntax, get_tera, render_str};
@@ -184,7 +184,10 @@ impl ConfigFile for ToolVersions {
     }
 
     fn save(&self) -> Result<()> {
-        let s = self.dump()?;
+        // Read before writing: what is on disk is still the file the user wrote, so it is what
+        // says which line ending to give back. `dump()` rebuilds the text from `str::lines()`,
+        // which drops the `\r`, so without this a CRLF file comes back entirely LF.
+        let s = with_line_ending(self.dump()?, existing_line_ending(&self.path));
         file::write_atomic(&self.path, s)
     }
 
@@ -242,5 +245,54 @@ impl Clone for ToolVersions {
             plugins: Mutex::new(self.plugins.lock().unwrap().clone()),
             tools: Mutex::new(self.tools.lock().unwrap().clone()),
         }
+    }
+}
+
+#[cfg(test)]
+#[cfg(unix)]
+mod tests {
+    use super::*;
+
+    /// `dump()` rebuilds the file from `str::lines()`, which drops the `\r`, so a CRLF
+    /// `.tool-versions` came back entirely LF — a one-line edit landing as a whole-file diff.
+    ///
+    /// Gated to unix like every other test module under `config_file/`. The bug is
+    /// platform-neutral (mise's own re-join, not anything the OS does), and the shared helper is
+    /// exercised on Windows through `e2e-win/config_line_endings.Tests.ps1`.
+    #[test]
+    fn save_keeps_the_line_endings_the_file_already_had() {
+        let temp = tempfile::tempdir().unwrap();
+
+        // Counted rather than "contains a CRLF somewhere": a half-converted file would satisfy
+        // that, and half-converted is its own defect.
+        let endings = |p: &Path| {
+            let bytes = std::fs::read(p).unwrap();
+            let lf = bytes.iter().filter(|b| **b == b'\n').count();
+            let crlf = bytes.windows(2).filter(|w| *w == b"\r\n").count();
+            (lf, crlf)
+        };
+
+        let crlf = temp.path().join("crlf");
+        file::write(&crlf, "# a comment\r\nnode 20.0.0\r\n").unwrap();
+        ToolVersions::from_file(&crlf).unwrap().save().unwrap();
+        let (lf_count, crlf_count) = endings(&crlf);
+        assert!(lf_count > 0, "the saved file has no newlines at all");
+        assert_eq!(
+            crlf_count,
+            lf_count,
+            "a CRLF .tool-versions came back with {} of its {lf_count} newlines converted",
+            lf_count - crlf_count
+        );
+
+        // Control: putting back what was there must not turn into pushing everything to CRLF.
+        let lf = temp.path().join("lf");
+        file::write(&lf, "# a comment\nnode 20.0.0\n").unwrap();
+        ToolVersions::from_file(&lf).unwrap().save().unwrap();
+        let (lf_count, crlf_count) = endings(&lf);
+        assert!(lf_count > 0, "the saved file has no newlines at all");
+        assert_eq!(
+            crlf_count, 0,
+            "an LF .tool-versions gained carriage returns"
+        );
     }
 }


### PR DESCRIPTION
## The bug

Editing a CRLF config rewrites it entirely to LF, so a one-line change arrives as a whole-file diff.
On Windows — where CRLF is what an editor writes by default — that is the ordinary case, not an
exotic one.

Measured on 2026.8.10, **both** config writers:

```
mise set B=2   on a CRLF mise.toml       ->  LF   (cr=2 lf=2  ->  cr=0 lf=3)
mise use ...   on a CRLF .tool-versions  ->  LF   (cr=2       ->  cr=0 lf=2)
```

## It is only the line endings

Run again with a comment and deliberately uneven spacing:

```
before:  # a comment the user wrote<CR><LF>
         A    =    "1"   # trailing note<CR><LF>

after:   # a comment the user wrote<LF>
         A    =    "1"   # trailing note<LF>
         B = "2"<LF>
```

The comment survives. `A    =    "1"` keeps its spacing. The trailing note is still there. **Only
the endings change** — so this is not "mise reformats the file", it is one specific thing being
dropped. Preserving shape is the *point* of the round trip: this file already carries
`insert_table_item_preserving_decor` and `insert_inline_value_preserving_decor` for exactly that.

**Same symptom, two different causes.** `mise.toml` loses them because serialising the document
returns `\n` whatever was parsed *(inferred — `read_to_string` is a plain pass-through and mise
never touches newlines there; I did not read `toml_edit` to confirm)*. `.tool-versions` loses them
in **mise's own code**: `parse_str` rebuilds the preamble with
`for line in s.lines() { pre.push_str(line); pre.push('\n') }`, and `str::lines()` drops the `\r`.

## The fix

`save()` on both now reads what is still on disk — at that moment still the file the user wrote —
and restores its ending. `mise use` and `mise set` share `MiseToml::save()`, so one change covers
both of those; `.tool-versions` has its own `save()` and gets the same two lines.

A file that does not exist yet, is empty, or has no terminator keeps the previous default of LF.
Only the **first** line ending is consulted: mixed files are pathological either way, and "match the
first line" is a rule that can be stated, where a majority vote would silently rewrite the minority.

The helpers live in `config_file/mod.rs` because both writers use them.

### Deliberately not included

**`mise fmt`** writes through `file::write` rather than `save()`, so it is untouched. A formatter
normalising is defensible; the argument here is narrower — a command editing *one line* should not
rewrite the others.

## Tests

**Unit, `config_file/mod.rs`** — every branch of the rule the doc comment states, each with its own
fixture: CRLF, LF, mixed (first one wins), empty, unterminated, missing. Plus `with_line_ending`
both ways, including that it is safe to apply to a string that is already CRLF.

**Unit, `mise_toml.rs` and `tool_versions.rs`** — the round trip through each `save()`. Endings are
**counted**, not sampled: `crlf_count == lf_count` rather than "contains a CRLF somewhere", because a
half-converted file would satisfy the latter and half-converted is its own defect.

Those modules are `#[cfg(unix)]`, as every test module under `config_file/` is, so they do not run
on Windows — which is where this bites. That is what the e2e test is for.

**`e2e-win/config_line_endings.Tests.ps1`** — `mise set` against a CRLF config on the platform where
CRLF is the default. Red against 2026.8.10 for the right reason:

```
[-] leaves a CRLF config on CRLF
    Expected: 'CRLF'   But was: 'LF'
[+] leaves an LF config on LF
```

It also asserts the edit landed (`B = "2"` present) — a write that failed outright would otherwise
"keep" the endings and pass. Endings are decided by counting CR and LF bytes, not by matching a
`\r$` pattern: that pattern once reported every file on this machine as CRLF, and a count also names
a mixed file rather than rounding it to one answer.

## Checks

**I have not built this locally**: `cargo check` cannot run on this machine (`libz-ng-sys` needs
`cmake`, which is not installed), so the type check and the unit tests are for CI. Everything
reported above as measured was measured against a released binary.

Draft: the fix is small, but it changes what mise writes to a user's file, which is worth a
maintainer's eye before it goes ready.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated `mise set` to preserve the existing line-ending format when editing configuration files.
  - Configurations using CRLF line endings remain CRLF after changes.
  - Configurations using LF line endings, empty files, or files without existing endings continue to use LF-compatible formatting.
  - Tool version files now preserve their original line-ending format when updated.
  - Prevents unnecessary formatting changes and reduces noisy diffs across supported environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->