### PR TITLE
fix(env): strip a byte-order mark before parsing an env file

### DIFF
--- a/e2e/env/test_env_file
+++ b/e2e/env/test_env_file
@@ -108,3 +108,22 @@ mise.file = ['{{env.HOME}}/.home-test-env']
 EOF
 echo FOO_FROM_FILE=foo_from_file_home >~/.home-test-env
 assert "mise x -- env | grep FOO_FROM_FILE" "FOO_FROM_FILE=foo_from_file_home"
+
+# A byte-order mark is what Notepad, and PowerShell 5.1's `Out-File -Encoding utf8`, leave at the
+# front of a file. It is invisible in an editor, and it used to make the whole file unparseable:
+# every command that read this config failed, pointing at a character nobody can see.
+cat <<TOML >mise.toml
+[env]
+_.file = 'bom-env'
+TOML
+printf '\xef\xbb\xbfBOM_FOO=bar\n' >bom-env
+assert "mise env | grep '^export BOM_FOO='" "export BOM_FOO=bar"
+
+# Same mark, structured file. serde_json rejects it; yaml and toml were measured to accept it and
+# are left alone.
+cat <<TOML >mise.toml
+[env]
+_.file = 'bom.json'
+TOML
+printf '\xef\xbb\xbf{"BOM_BAZ": "qux"}\n' >bom.json
+assert "mise env | grep '^export BOM_BAZ='" "export BOM_BAZ=qux"

--- a/e2e/env/test_env_file_expand
+++ b/e2e/env/test_env_file_expand
@@ -54,3 +54,13 @@ cat >mise.toml <<'EOF'
 _.file = { path = 'chain.json', expand = true }
 EOF
 assert_contains "MISE_ENV_SHELL_EXPAND=false mise env -s bash" "export BIN='\${BASE}/bin'"
+
+# The expanded path reads the file itself rather than letting dotenvy open it, and it did not strip
+# the mark either -- same defect, the other branch.
+cat >mise.toml <<'TOML'
+[env]
+_.file = { path = ['bom-expand'], expand = true }
+TOML
+printf '\xef\xbb\xbfBOM_A=1\nBOM_B="${BOM_A}"\n' >bom-expand
+assert "mise env | grep '^export BOM_A='" "export BOM_A=1"
+assert "mise env | grep '^export BOM_B='" "export BOM_B=1"

--- a/src/config/env_directive/file.rs
+++ b/src/config/env_directive/file.rs
@@ -85,12 +85,16 @@ impl EnvResults {
     {
         let errfn = || eyre!("failed to parse json file: {}", display_path(p));
         if let Ok(raw) = file::read_to_string(p) {
-            let mut f: Env<serde_json::Value> = serde_json::from_str(&raw).wrap_err_with(errfn)?;
+            // serde_json rejects a leading byte-order mark, so an env file saved by an editor that
+            // writes one fails the whole config. Measured: yaml and toml accept it and are left
+            // alone; json does not.
+            let raw = file::strip_utf8_bom(&raw);
+            let mut f: Env<serde_json::Value> = serde_json::from_str(raw).wrap_err_with(errfn)?;
             if !f.sops.is_empty() {
                 let decrypted = sops::decrypt::<_, JsonFileFormat>(
                     config,
                     exec_env,
-                    &raw,
+                    raw,
                     parse_template,
                     "json",
                 )
@@ -214,24 +218,29 @@ impl EnvResults {
 
     async fn dotenv(p: &Path, acc: &TeraEnvMap, expand: bool) -> Result<EnvMap> {
         let errfn = || eyre!("failed to parse dotenv file: {}", display_path(p));
+        // Read here rather than letting dotenvy open the file, so a byte-order mark can be taken
+        // off before the parser sees it. A mark belongs to the first key's name as far as dotenvy
+        // is concerned, and one bad line fails the whole file — so a `.env` saved by an editor
+        // that writes one is rejected entirely, naming a character nobody can see. An unreadable
+        // file still yields nothing rather than an error, which is what the previous
+        // `if let Ok(..)` did.
+        let Ok(content) = file::read_to_string(p) else {
+            return Ok(EnvMap::new());
+        };
+        let content = file::strip_utf8_bom(&content);
         if !expand {
             // Preserve dotenvy's normal behavior unless cross-file expansion was
             // explicitly requested.
             let mut env = EnvMap::new();
-            if let Ok(dotenv) = dotenvy::from_path_iter(p) {
-                for item in dotenv {
-                    let (k, v) = item.wrap_err_with(errfn)?;
-                    env.insert(k, v);
-                }
+            for item in dotenvy::from_read_iter(content.as_bytes()) {
+                let (k, v) = item.wrap_err_with(errfn)?;
+                env.insert(k, v);
             }
             return Ok(env);
         }
         // dotenvy substitutes `${VAR}` only against the process env + vars defined
         // earlier in the same file and has no API for a custom map. Seed the parse
         // with accumulated values, then retain only keys defined by this file.
-        let Ok(content) = file::read_to_string(p) else {
-            return Ok(EnvMap::new());
-        };
         let mut own_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
         for item in dotenvy::from_read_iter(content.as_bytes()) {
             let (k, _v) = item.wrap_err_with(errfn)?;


### PR DESCRIPTION
A UTF-8 byte-order mark at the front of an env file makes mise reject the whole config, so every
command that reads it fails:

```
mise ERROR failed to parse dotenv file: …/.env
mise ERROR Error parsing line: '﻿FOO=bar', error at line index: 0
```

Measured on both platforms, with a no-BOM control through the same command:

| file | no BOM (control) | with BOM |
| --- | --- | --- |
| `.env` (Windows 2026.8.10) | rc=0, `FOO=bar` | **rc=1** |
| `.env` (Linux 2026.8.3) | rc=0 | **rc=1** |
| `.json` (Linux 2026.8.3) | rc=0, `export BOM_BAZ=qux` | **rc=1**, `expected value at line 1 column 1` |
| `.yaml` | rc=0 | rc=0 — serde_yaml accepts it |
| `.toml` | rc=0 | rc=0 — the toml crate accepts it |

So two of the five readers are affected, and this fixes those two. `yaml` and `toml` are left
untouched because they were measured to work, not because they were assumed to.

The trigger is ordinary: Notepad and PowerShell 5.1's `Out-File -Encoding utf8` both write a BOM by
default. The file looks correct in an editor and the error points at a character nobody can see, so
there is nothing for a user to go on.

### mise already has the rule and the tool; these paths just did not use them

| existing | |
| --- | --- |
| `file::strip_utf8_bom` | its doc says the writers that leave one there are ordinary on Windows — and it is **not** `#[cfg(windows)]`-gated |
| `task/mod.rs`, `task_executor.rs` | strip it in task bodies and in shebang parsing |
| `aqua.rs` ×2 | `read_to_string_bom` for checksums |
| `e2e-win/task_bom.Tests.ps1` | tasks already have a dedicated BOM test |

### What changed

**`dotenv()`** read the file twice, by two different routes, and neither stripped:

- default: `dotenvy::from_path_iter(p)` opened the file itself, so the BOM went straight to the parser
- `expand = true`: `file::read_to_string(p)` → `content.as_bytes()`, same passthrough

The read is now done once at the top and stripped before either branch sees it; the default branch
becomes `dotenvy::from_read_iter(content.as_bytes())`.

**Behaviour for an unreadable file is unchanged.** It used to fall through `if let Ok(dotenv) = …`
to an empty map, and now falls through `let Ok(content) = … else { return Ok(EnvMap::new()) }` to the
same place. `e2e/env/test_env_file` already asserts `mise env` does not error on
`_.file = 'not_present'`.

**`json()`** strips after reading, so both `serde_json::from_str` and the sops path get the
stripped text.

### `read_to_string_bom` was not used

That one also decodes UTF-16, which is a wider behaviour change than the failure reported here.
`strip_utf8_bom` closes the measured hole and nothing else.

### Tests

Cases were added to the existing dotenv/env-file suites rather than in a new file, so the subject
stays in one place:

- `e2e/env/test_env_file` — the default dotenv branch, and the json reader
- `e2e/env/test_env_file_expand` — the `expand = true` branch, both of its paths

The four existing dotenv suites (`test_env_dotenv`, `test_env_file`, `test_env_file_expand`,
`test_env_file_glob`) are the regression net for the `from_path_iter` → `from_read_iter` change; all
four were run against the unfixed binary first to establish that baseline, and the new cases were
confirmed red for the right reason before the fix went in.

No Windows-specific e2e was added: the bug is platform-independent (only the BOM's provenance is
Windows-flavoured) and the fix is shared code, so the Linux e2e exercises the actual path.

### Verification

`cargo fmt --all`, `shfmt -d`, and `shellcheck -x` were run locally and are clean. `cargo check` does
not run on this machine (`libz-ng-sys` wants `cmake`, which is not installed), so type-checking is
left to CI — nothing here is reported as having been compiled locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Environment files beginning with a UTF-8 byte-order mark are now parsed correctly.
  * Variables from BOM-prefixed files are exported as expected.
  * Variable expansion now works reliably when using explicitly expanded environment file paths.
  * Malformed environment entries report parsing errors consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->