### PR TITLE
fix(doctor): report installs that provide no executables

### DIFF
--- a/e2e/cli/test_doctor_empty_install
+++ b/e2e/cli/test_doctor_empty_install
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# An interrupted download can leave the install directory in place but empty.
+# `is_version_installed` decides on path existence alone, so mise reports the
+# tool as installed and doctor used to say nothing about it.
+# https://github.com/jdx/mise/discussions/9324
+
+mise use dummy@1.0.0
+
+# `mise doctor` exits non-zero whenever it finds any problem, and this harness
+# has unrelated ones (mise is not activated here), so assert on the text only.
+assert_not_contains "mise doctor 2>&1 || true" "directory is empty"
+
+# Empty the install directory, leaving the directory itself in place.
+find "$MISE_DATA_DIR/installs/dummy/1.0.0" -mindepth 1 -delete
+assert "test -d $MISE_DATA_DIR/installs/dummy/1.0.0"
+
+assert_contains "mise doctor 2>&1 || true" "is installed but its directory is empty"
+assert_contains "mise doctor 2>&1 || true" "mise install --force dummy@1.0.0"
+
+# Both outputs have to classify it the same way; a check that only runs on one
+# path is a hole in the other.
+assert "mise doctor -J 2>/dev/null | jq -e '.errors | map(contains(\"directory is empty\")) | any' >/dev/null"
+assert "mise doctor -J 2>/dev/null | jq -e '.toolset.dummy[0].empty == true' >/dev/null"
+
+# Reinstalling clears it, so the check tracks the real state rather than latching.
+assert "mise install --force dummy@1.0.0"
+assert_not_contains "mise doctor 2>&1 || true" "directory is empty"
+
+# `@system` points at a tool mise did not install, so a stray directory under
+# installs/ says nothing about its health and `--force` would be nonsense advice.
+mise use dummy@system
+mkdir -p "$MISE_DATA_DIR/installs/dummy/system"
+assert_not_contains "mise doctor 2>&1 || true" "directory is empty"

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -17,7 +17,7 @@ use crate::plugins::PluginType;
 use crate::plugins::core::CORE_PLUGINS;
 use crate::registry::REGISTRY;
 use crate::toolset::install_state;
-use crate::toolset::{ToolVersion, Toolset, ToolsetBuilder};
+use crate::toolset::{ToolRequest, ToolVersion, Toolset, ToolsetBuilder};
 use crate::ui::{info, style};
 use crate::{backend, dirs, duration, env, file, shims};
 use console::{Alignment, pad_str, style};
@@ -210,6 +210,11 @@ impl Doctor {
                 .map(|tv: &ToolVersion| {
                     let mut tool = serde_json::Map::new();
                     match f.is_version_installed(&config, tv, true) {
+                        true if install_is_empty(tv) => {
+                            tool.insert("version".into(), tv.version.to_string().into());
+                            tool.insert("empty".into(), true.into());
+                            self.errors.push(empty_install_error(tv));
+                        }
                         true => {
                             tool.insert("version".into(), tv.version.to_string().into());
                         }
@@ -787,6 +792,10 @@ impl Doctor {
             .list_current_versions()
             .into_iter()
             .map(|(f, tv)| match f.is_version_installed(&config, &tv, true) {
+                true if install_is_empty(&tv) => {
+                    self.errors.push(empty_install_error(&tv));
+                    (tv.to_string(), style::ndim("(empty)"))
+                }
                 true => (tv.to_string(), style::nstyle("")),
                 false => {
                     self.errors.push(format!(
@@ -1270,3 +1279,71 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     [WARN] plugin node is not installed
 "#
 );
+
+/// An install directory that is there but holds nothing.
+///
+/// `Backend::is_version_installed` decides on path existence alone, so an
+/// interrupted download leaves a directory that passes it while providing
+/// nothing to run: `mise install` then reports "all tools are installed" and
+/// `mise ls` lists the version. `mise which` already notices; doctor did not
+/// (discussions #9324 and #9826).
+///
+/// Deliberately only the empty case. A directory holding files but no runnable
+/// binary cannot be told apart from a tool that legitimately ships none, and
+/// calling a healthy install broken is worse than missing one.
+/// Whether an install is present but has nothing in it.
+///
+/// `@system` is excluded: it points at a tool mise did not install, so a stray
+/// directory under `installs/` says nothing about its health, and
+/// `mise install --force <tool>@system` would be nonsense advice.
+fn install_is_empty(tv: &ToolVersion) -> bool {
+    if matches!(tv.request, ToolRequest::System { .. }) {
+        return false;
+    }
+    install_dir_is_empty(&tv.install_path())
+}
+
+/// One wording for an empty install, so the text and JSON paths cannot drift.
+fn empty_install_error(tv: &ToolVersion) -> String {
+    format!(
+        "tool {tv} is installed but its directory is empty, reinstall with \
+         `mise install --force {}@{}`",
+        tv.ba(),
+        tv.version
+    )
+}
+
+fn install_dir_is_empty(path: &Path) -> bool {
+    match std::fs::read_dir(path) {
+        Ok(mut entries) => entries.next().is_none(),
+        // Unreadable, and missing, are not the same as empty. Say nothing.
+        Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::install_dir_is_empty;
+
+    #[test]
+    fn empty_directory_is_reported() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(install_dir_is_empty(dir.path()));
+    }
+
+    #[test]
+    fn directory_with_anything_in_it_is_not() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("jq"), "").unwrap();
+        assert!(!install_dir_is_empty(dir.path()));
+    }
+
+    #[test]
+    fn missing_directory_is_not_reported() {
+        // A path that is not there means "not installed", which
+        // `is_version_installed` already covers. Claiming it is empty would
+        // duplicate that as a second, wronger message.
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!install_dir_is_empty(&dir.path().join("nope")));
+    }
+}


### PR DESCRIPTION
Addresses discussions #9324 and #9826 (the same symptom, reported twice).

## Problem

An interrupted download leaves the install directory in place but empty. `Backend::is_version_installed` decides on path existence alone, so mise treats that as installed:

```console
$ mise install
all tools are installed
$ mise ls
jq  1.8.2
$ mise doctor
2 problems found:      # neither of them jq
```

Reproduced on `main` by emptying an install directory and leaving it there.

`mise which jq` already notices and suggests `mise install --force jq@1.8.2`. `doctor` was the one place that walks the toolset and still said nothing — which is precisely what #9324 complained about. What it *did* report, "unused shims are present", is a symptom of the same breakage pointing somewhere else entirely.

## Fix

`analyze_toolset` already walks the installed versions and calls `is_version_installed`, so the check goes there:

```
tool aqua:jqlang/jq@1.8.2 is installed but its directory is empty,
reinstall with `mise install --force jq@1.8.2`
```

and the toolset listing marks it `(empty)` beside the existing `(missing)`.

## Two things kept deliberately narrow

**Not in `is_version_installed`.** 30 call sites reach that predicate; a directory scan inside it would be paid on every resolve. `doctor` is where a user asks for a diagnosis, so it is the one place worth paying for one — and no extra traversal is added, since the existing loop already visits each version.

**Only the empty case.** A directory holding files but no runnable binary is also broken, but it cannot be told apart from a tool that legitimately ships no executables. Calling a healthy install broken is worse than missing one, so that case stays unreported, as does a directory that cannot be read. Happy to widen it if you have a way to distinguish the two that I have missed.

## Verification

- Three unit tests on the rule: empty, non-empty, and missing. The missing case must *not* report — a path that is not there means "not installed", which `is_version_installed` already covers, and a second, less accurate message for the same state would be worse than none.
- New `e2e/cli/test_doctor_empty_install` covers all three states in sequence: silent when healthy, reported once emptied, silent again after `mise install --force`. The last step is there so a latching implementation cannot pass.
- `cli/test_doctor` and `cli/test_doctor_shim_shadowing` re-run for regressions.
- clippy clean with no exclusions, `cargo fmt --check` clean, `shellcheck` and `shfmt` clean on the new script.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `mise doctor` now detects installed tools with unexpectedly empty installation directories.
  * Added clear text and JSON diagnostics, including guidance to reinstall affected tools with `mise install --force`.
  * Diagnostics clear after a successful forced reinstall.
  * System tools and unrelated system directories are excluded from these warnings.

* **Tests**
  * Added coverage for empty, populated, missing, and recovered installation directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->