### PR TITLE
fix(task): treat a SIGINT-killed child as an interruption

### DIFF
--- a/e2e/tasks/test_task_child_sigint
+++ b/e2e/tasks/test_task_child_sigint
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# A terminal delivers Ctrl-C to the foreground process group. A task that puts
+# itself in another group therefore takes the signal while mise never sees it,
+# and the same keypress became a failure instead of an interruption.
+# https://github.com/jdx/mise/discussions/9482
+
+cat <<'TOML' >mise.toml
+[tasks.serve]
+run = """
+echo $$ > "$CHILD_PID_FILE"
+exec sleep 30
+"""
+TOML
+
+pid_file="$TMPDIR/task-child-sigint-pid"
+output_file="$TMPDIR/task-child-sigint-output"
+rm -f "$pid_file" "$output_file"
+
+CHILD_PID_FILE="$pid_file" mise run serve >"$output_file" 2>&1 &
+mise_pid=$!
+wait_for_file "$pid_file" "task child" 30 "$mise_pid"
+
+# Signal the child only. mise keeps running, so its own Ctrl-C handler never
+# fires — which is the whole point of the report.
+kill -INT "$(cat "$pid_file")"
+
+status=0
+wait "$mise_pid" || status=$?
+output="$(cat "$output_file")"
+
+if [[ $status -ne 130 ]]; then
+  fail "expected exit code 130 after the child took SIGINT, got $status: $output"
+fi
+if [[ $output == *ERROR* ]]; then
+  fail "interruption reported as an error: $output"
+fi
+
+# `--continue-on-error` still means what it says. Only the user interrupting
+# mise overrides it; one task's child taking a signal is not a reason to drop
+# work the user asked to keep going.
+cat <<'TOML' >mise.toml
+[tasks.first]
+run = """
+echo $$ > "$CHILD_PID_FILE"
+exec sleep 30
+"""
+[tasks.second]
+run = 'echo ran > "$SECOND_MARKER"'
+TOML
+
+second_marker="$TMPDIR/task-child-sigint-second"
+rm -f "$pid_file" "$second_marker" "$output_file"
+
+CHILD_PID_FILE="$pid_file" SECOND_MARKER="$second_marker" \
+  mise run --jobs 1 --continue-on-error first ::: second >"$output_file" 2>&1 &
+mise_pid=$!
+wait_for_file "$pid_file" "task child" 30 "$mise_pid"
+kill -INT "$(cat "$pid_file")"
+
+status=0
+wait "$mise_pid" || status=$?
+if [[ $status -ne 130 ]]; then
+  fail "expected 130 with --continue-on-error, got $status: $(cat "$output_file")"
+fi
+if [[ ! -e $second_marker ]]; then
+  fail "--continue-on-error dropped the queued task: $(cat "$output_file")"
+fi

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -912,7 +912,11 @@ impl Run {
                 &mut main_done_rx,
                 main_deps.clone(),
                 || this.is_stopping(),
-                || this.is_interrupted(),
+                // What overrides `continue_on_error` is the *user* interrupting
+                // mise, not any task being interrupted. A child that took SIGINT
+                // on its own stops that task; it is not a reason to drop work the
+                // user asked to keep going.
+                ctrlc::is_cancelled,
                 this.continue_on_error,
                 |task, deps_for_remove, allow_during_interruption| {
                     let this = this.clone();
@@ -1060,7 +1064,22 @@ impl Run {
                 }
             }
             let interrupted = result.as_ref().is_err_and(|err| {
-                !panicked && ctrlc::is_cancelled() && Error::is_task_interrupted(err)
+                if panicked {
+                    return false;
+                }
+                // A child killed by SIGINT is the kernel reporting an
+                // interruption, so it stands on its own: the terminal delivers
+                // Ctrl-C to the foreground group, and a task that put itself in
+                // another group means mise's own handler never runs. Requiring
+                // `is_cancelled()` here made the same keypress a failure
+                // depending on which process happened to receive the signal
+                // (discussion #9482).
+                //
+                // `TaskInterrupted` still needs it: that variant means mise
+                // abandoned the task before starting it, which only happens
+                // when mise itself was cancelled.
+                Error::is_sigint(err)
+                    || (ctrlc::is_cancelled() && Error::is_task_interrupted_before_start(err))
             });
             if let Err(err) = &result {
                 if interrupted {
@@ -1133,7 +1152,7 @@ impl Run {
         inherited_allow_during_interruption: bool,
     ) -> bool {
         if !this.is_stopping()
-            || (this.continue_on_error && !this.is_interrupted())
+            || (this.continue_on_error && !ctrlc::is_cancelled())
             || inherited_allow_during_interruption
         {
             return false;

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -2081,7 +2081,7 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert!(crate::errors::Error::is_task_interrupted(&err));
+        assert!(crate::errors::Error::is_task_interrupted_before_start(&err));
     }
 
     #[tokio::test]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -41,10 +41,22 @@ pub(crate) enum Error {
 }
 
 fn render_exit_status(exit_status: &Option<ExitStatus>) -> String {
-    match exit_status.and_then(|s| s.code()) {
-        Some(exit_status) => format!("exit code {exit_status}"),
-        None => "no exit status".into(),
+    if let Some(code) = exit_status.and_then(|s| s.code()) {
+        return format!("exit code {code}");
     }
+    // No code means the process was signalled, and the signal is right there.
+    // Reporting "no exit status" threw it away and left nothing to act on.
+    #[cfg(unix)]
+    if let Some(signal) = exit_status.and_then(|s| {
+        use std::os::unix::process::ExitStatusExt;
+        s.signal()
+    }) {
+        return match nix::sys::signal::Signal::try_from(signal) {
+            Ok(signal) => format!("killed by {signal}"),
+            Err(_) => format!("killed by signal {signal}"),
+        };
+    }
+    "no exit status".into()
 }
 
 fn format_install_failures(failed_installations: &[(ToolRequest, Report)]) -> String {
@@ -140,10 +152,6 @@ impl Error {
         false
     }
 
-    pub(crate) fn is_task_interrupted(err: &Report) -> bool {
-        Self::is_task_interrupted_before_start(err) || Self::is_sigint(err)
-    }
-
     pub(crate) fn is_task_interrupted_before_start(err: &Report) -> bool {
         matches!(err.downcast_ref::<Error>(), Some(Error::TaskInterrupted))
     }
@@ -194,9 +202,26 @@ mod tests {
     }
 
     #[test]
+    fn renders_the_signal_that_killed_the_process() {
+        // "no exit status" threw away the one fact that explains the failure.
+        let status = ExitStatus::from_raw(nix::sys::signal::SIGINT as i32);
+        assert_eq!(render_exit_status(&Some(status)), "killed by SIGINT");
+
+        let status = ExitStatus::from_raw(nix::sys::signal::SIGTERM as i32);
+        assert_eq!(render_exit_status(&Some(status)), "killed by SIGTERM");
+    }
+
+    #[test]
+    fn renders_an_exit_code_unchanged() {
+        let status = ExitStatus::from_raw(2 << 8);
+        assert_eq!(render_exit_status(&Some(status)), "exit code 2");
+        assert_eq!(render_exit_status(&None), "no exit status");
+    }
+
+    #[test]
     fn detects_interruption_before_process_start() {
         let err = Report::new(Error::TaskInterrupted);
 
-        assert!(Error::is_task_interrupted(&err));
+        assert!(Error::is_task_interrupted_before_start(&err));
     }
 }


### PR DESCRIPTION
Addresses discussion #9482. **This one changes behavior on a judgement call — see the last section before merging.**

## Problem

Ctrl-C on a task reports a failure whenever the signal reaches the child but not mise:

```console
^C[//frontend:dev] ERROR sh exited with non-zero status: no exit status
[//frontend:dev] ERROR task failed
$ echo $?
1
```

Reproduced against the released 2026.8.10, verbatim, by signalling only the task's child.

A terminal delivers Ctrl-C to the foreground process group. A task that puts itself in another group takes the signal alone, and mise's own handler never runs — so the same keypress was a clean exit or a failure depending on which process happened to receive it:

| what got the signal | before | after |
| --- | --- | --- |
| the process group (plain Ctrl-C) | 130, no error | unchanged |
| the child only | **1**, two ERROR lines | 130, no error |
| nothing — task returns 130 itself | fails, exit 130 | unchanged |

## What was actually wrong

The detection already existed. `Error::is_sigint` reads `ExitStatus::signal()` and has had unit tests for a while. What blocked it was the condition in `run.rs`:

```rust
!panicked && ctrlc::is_cancelled() && Error::is_task_interrupted(err)
```

`is_cancelled()` asks whether *mise* saw an interrupt, and it was required for both halves of `is_task_interrupted`. Only one half needs it — `TaskInterrupted` means mise abandoned the task before starting it, which cannot happen unless mise was cancelled. A child killed by SIGINT is the kernel reporting an interruption and stands on its own.

The two are now asked separately, and the combined `is_task_interrupted` is gone: conflating them is what let an unrelated condition attach to the wrong one. clippy found it dead immediately after the split.

## Also: the message stops throwing the signal away

`render_exit_status` rendered a signalled process as "no exit status" while the signal sat right there in the status:

```
killed by SIGINT      (was: no exit status)
killed by SIGTERM
exit code 2           (unchanged)
```

This matters for the cases that stay failures — a SIGTERM from an OOM kill still fails, it just says so now. Unix only; other platforms keep the old string.

## The judgement call

A task whose child dies of SIGINT no longer counts as failed, exits 130 instead of 1, and does not take its siblings down. A tool that sends itself `SIGINT` is now read as interrupted.

Two limits keep it narrow, but say the word if you want it drawn elsewhere:

- **SIGINT only.** A task killed by SIGTERM is not a user cancelling anything, so OOM kills and `systemctl stop` still fail.
- **A signal, not an exit code.** A task that *returns* 130 without dying of a signal still fails: an exit code is whatever the program chose to say, while a signal is the kernel's own report.

## Verification

- Unit tests for `render_exit_status` over both signal and exit-code cases; the existing `is_sigint` tests still pass.
- New `e2e/tasks/test_task_child_sigint` signals **only the child** — the existing `test_task_interrupt_cleanup` signals mise itself, which is the half that already worked.
- `test_task_interrupt_cleanup` and `cli/test_exit_status` re-run; the latter pins the exit-code contract directly.
- Control run against the released binary to confirm the test detects the difference rather than passing either way.
- clippy clean with no exclusions, `cargo fmt --check`, `shellcheck` and `shfmt` clean on the new script.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated command-line help output with consistent subcommand formatting and improved option handling.

* **Bug Fixes**
  * Improved Ctrl+C handling for child processes while allowing subsequent tasks to continue when configured.
  * Tasks interrupted before starting now report a more specific status.
  * Exit messages now display Unix signal names or numeric signal values when applicable.
  * Prevented panics from being incorrectly classified as task interruptions.

* **Tests**
  * Added end-to-end coverage for child-process SIGINT handling.
  * Added coverage for signal-based exit status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->