### PR TITLE
fix(tasks): tell Windows users why a task file was skipped

### DIFF
--- a/e2e-win/task.Tests.ps1
+++ b/e2e-win/task.Tests.ps1
@@ -423,4 +423,92 @@ file = "scripts/thing"
             }
         }
     }
+
+    Context 'a task-directory file Windows will not run' {
+        BeforeAll {
+            # Deliberately outside $TestDrive: the config at the TestDrive root includes a tasks
+            # directory, and a project that inherits those tasks never reaches the two diagnostics
+            # that only fire when nothing resolved at all.
+            $script:skipRoot = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())
+            $script:aloneDir = Join-Path $script:skipRoot 'alone'
+            $script:besideDir = Join-Path $script:skipRoot 'beside'
+            New-Item -ItemType Directory -Path (Join-Path $script:aloneDir 'mise-tasks') -Force | Out-Null
+            New-Item -ItemType Directory -Path (Join-Path $script:besideDir 'mise-tasks') -Force | Out-Null
+
+            # No shebang and no known extension. There is no permission bit for `is_executable` to
+            # consult on this platform, so this file is simply not a task.
+            Set-Content (Join-Path $script:aloneDir 'mise-tasks\skipped') 'echo hi' -NoNewline
+            New-Item -ItemType File -Path (Join-Path $script:aloneDir 'mise.toml') | Out-Null
+
+            # The same file with a working task beside it, which sends `mise run` down its other
+            # branch -- the one that has a task list to suggest from. The warning is the only
+            # thing that names the file there.
+            Set-Content (Join-Path $script:besideDir 'mise-tasks\skipped') 'echo hi' -NoNewline
+            Set-Content (Join-Path $script:besideDir 'mise-tasks\works.bat') "@echo off`r`necho works"
+            New-Item -ItemType File -Path (Join-Path $script:besideDir 'mise.toml') | Out-Null
+
+            # Global tasks would also keep these projects from being empty, and this suite does
+            # not otherwise isolate them.
+            $script:originalConfigDir = [Environment]::GetEnvironmentVariable('MISE_CONFIG_DIR', 'Process')
+            $env:MISE_CONFIG_DIR = Join-Path $script:skipRoot 'config'
+            New-Item -ItemType Directory -Path $env:MISE_CONFIG_DIR | Out-Null
+            $script:describeTrusted = $env:MISE_TRUSTED_CONFIG_PATHS
+            $env:MISE_TRUSTED_CONFIG_PATHS = $script:skipRoot
+        }
+
+        AfterAll {
+            $env:MISE_TRUSTED_CONFIG_PATHS = $script:describeTrusted
+            if ($null -eq $script:originalConfigDir) {
+                Remove-Item -Path Env:\MISE_CONFIG_DIR -ErrorAction SilentlyContinue
+            } else {
+                $env:MISE_CONFIG_DIR = $script:originalConfigDir
+            }
+            Remove-Item -Recurse -Force $script:skipRoot -ErrorAction SilentlyContinue
+        }
+
+        It 'says why `mise tasks ls` found nothing' {
+            Push-Location $script:aloneDir
+            try {
+                $out = mise tasks ls 2>&1 | Out-String
+                $LASTEXITCODE | Should -Be 0
+                $out | Should -BeLike '*non-executable*'
+                $out | Should -BeLike '*shebang*'
+                # Being told to run chmod is why this diagnostic was switched off here at all.
+                $out | Should -Not -BeLike '*chmod*'
+            } finally {
+                Pop-Location
+            }
+        }
+
+        It 'names the file when the project has no other tasks' {
+            Push-Location $script:aloneDir
+            try {
+                $out = mise run skipped 2>&1 | Out-String
+                $LASTEXITCODE | Should -Not -Be 0
+                $out | Should -BeLike '*non-executable*'
+                $out | Should -BeLike '*mise-tasks*'
+                $out | Should -BeLike '*shebang*'
+                $out | Should -Not -BeLike '*chmod*'
+            } finally {
+                Pop-Location
+            }
+        }
+
+        It 'names the file when the project has other tasks' {
+            Push-Location $script:besideDir
+            try {
+                # The control: the sibling really is a task here, so the run below fails over the
+                # skipped file rather than over an empty project.
+                mise run works | Select -Last 1 | Should -Be 'works'
+                $out = mise run skipped 2>&1 | Out-String
+                $LASTEXITCODE | Should -Not -Be 0
+                $out | Should -BeLike '*non-executable*'
+                $out | Should -BeLike '*mise-tasks*'
+                $out | Should -BeLike '*shebang*'
+                $out | Should -Not -BeLike '*chmod*'
+            } finally {
+                Pop-Location
+            }
+        }
+    }
 }

--- a/src/cli/tasks/ls.rs
+++ b/src/cli/tasks/ls.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::config::{self, Config};
 use crate::dirs;
+use crate::file;
 use crate::file::display_rel_path;
 use crate::task::Task;
 use crate::task::task_fetcher::TaskFetcher;
@@ -164,13 +165,17 @@ impl TasksLs {
         // Warn about non-executable files only when there are truly no tasks at all
         // (not just filtered out by --hidden/--local/--global)
         if all_tasks.is_empty()
-            && !cfg!(windows)
             && let Some(cwd) = &*dirs::CWD
         {
             let includes = config::task_includes_for_dir(cwd, &config.config_files)?;
-            if !find_non_executable_task_files(&includes).is_empty() {
+            // One file is enough to act on, and `make_executable_hint` is the only thing that
+            // knows what "make it executable" means on this platform. Bound to a local because
+            // under edition 2024 an `if let` scrutinee temporary is dropped before the body runs.
+            let non_executable = find_non_executable_task_files(&includes);
+            if let Some(path) = non_executable.first() {
                 warn!(
-                    "no tasks found, but non-executable files exist in task directories.\nFiles must be executable to be detected as tasks. Run `chmod +x` on the task files to fix this."
+                    "no tasks found, but non-executable files exist in task directories.\nFiles must be executable to be detected as tasks. {}",
+                    file::make_executable_hint(path)
                 );
             }
         }

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -184,9 +184,6 @@ async fn make_task_executable(
     name: &str,
     task_context: Option<&TaskLoadContext>,
 ) -> Result<Option<Task>> {
-    if cfg!(windows) {
-        return Ok(None);
-    }
     let Some(cwd) = &*dirs::CWD else {
         return Ok(None);
     };
@@ -217,11 +214,24 @@ async fn make_task_executable(
         return Ok(None);
     };
 
+    // The prompt below is the only part Windows cannot use: `make_executable` does not change
+    // whether Windows will run a file, so a "yes" would be taken and change nothing. The warning
+    // itself is still wanted -- when the project has other tasks this is the only place that names
+    // the file at all -- so on Windows it carries the remedy instead of handing off to a prompt.
+    let windows_has_no_prompt = cfg!(windows);
+    let remedy = if windows_has_no_prompt {
+        format!(" {}", file::make_executable_hint(&path))
+    } else {
+        String::new()
+    };
     warn!(
-        "no task {} found, but a non-executable file exists at {}",
+        "no task {} found, but a non-executable file exists at {}{remedy}",
         style::ered(name),
         display_path(&path)
     );
+    if windows_has_no_prompt {
+        return Ok(None);
+    }
     let confirmed = config::Settings::get().yes
         || prompt::confirm("Mark this file as executable to allow it to be run as a task?")?
             .is_yes();
@@ -307,12 +317,13 @@ async fn err_no_task(
         }
 
         // Check if there are non-executable files in task include directories
-        if !cfg!(windows)
-            && let Some(cwd) = &*dirs::CWD
-        {
+        if let Some(cwd) = &*dirs::CWD {
             let includes = config::task_includes_for_dir(cwd, &config.config_files)?;
             let non_exec_files = find_non_executable_task_files(&includes);
-            if !non_exec_files.is_empty() {
+            // The remedy differs by platform and `make_executable_hint` is the only thing that
+            // knows how, so it gets one file to name rather than the list. The count and the
+            // directories below still say how much is affected.
+            if let Some(first) = non_exec_files.first() {
                 let dirs_with_files: Vec<String> = includes
                     .iter()
                     .filter(|d| d.is_dir())
@@ -321,16 +332,11 @@ async fn err_no_task(
                 bail!(
                     "no tasks defined in {}, but found {} non-executable file(s) in {}.\n\
                         Files must be executable to be detected as tasks.\n\
-                        Run `chmod +x` on the task files to fix this, e.g.:\n  chmod +x {}",
+                        {}",
                     display_path(dirs::CWD.clone().unwrap_or_default()),
                     non_exec_files.len(),
                     dirs_with_files.join(", "),
-                    non_exec_files
-                        .iter()
-                        .take(5)
-                        .map(display_path)
-                        .collect::<Vec<_>>()
-                        .join(" "),
+                    file::make_executable_hint(first),
                 );
             }
         }


### PR DESCRIPTION
On Windows a task file with neither a known extension nor a shebang is skipped — correctly, since
`is_executable` has no permission bit to consult there — but **nothing says so**. Measured on
Windows 2026.8.10 against Linux 2026.8.3 as the control:

| | Linux (control) | Windows |
|---|---|---|
| `mise tasks ls` | `no tasks found, but non-executable files exist … Run chmod +x …` | **no output at all** |
| `mise run <name>`, no other tasks | names the file and the directory | `no tasks defined in …. Are you in a project directory?` |
| `mise run <name>`, other tasks present | `no task X found, but a non-executable file exists at <path>` | that line is absent |

Three diagnostics, all excluded on Windows by `cfg!(windows)`.

### The exclusion is left-over, and the correct wording already exists

- **2026-03-22, #8705** added all three. Their text was a hardcoded `chmod +x`, which is meaningless
  on Windows, so Windows was excluded from the start.
- **2026-08-14, #11923** ("stop telling Windows users to run chmod +x") added
  `file::make_executable_hint` — the one place that knows the remedy per platform — and applied it
  in `cli/run.rs` and `cli/tasks/validate.rs`.

**#11923 was mine and it did not touch `cli/tasks/ls.rs` or `task/task_list.rs`.** It removed the
reason for the exclusion and left the exclusion. `find_non_executable_task_files` already works on
Windows (`is_executable` has a Windows arm), so all that was missing was dropping the gates and
using the wording that is already there.

"not executable" stays as the phrasing: #11923 already settled on it as platform-neutral, and
`e2e-win/task.Tests.ps1` pins it. Only the remedy clause changes.

### What changed

- **`cli/tasks/ls.rs`** — gate dropped; the `chmod +x` sentence becomes `make_executable_hint` for
  the first offending file.
- **`task/task_list.rs`, the no-tasks-at-all error** — same. **One deliberate trade on unix:** the
  old text listed up to five files (`e.g.:\n  chmod +x a b c`) and now names one. The count and the
  directories are still reported, and keeping a single owner of the remedy is worth more than the
  list.
- **`task/task_list.rs`, `make_task_executable`** — the function returned early on Windows before
  doing anything. Only the *prompt* is genuinely inapplicable (`make_executable` cannot change
  whether Windows runs a file, so a "yes" would be accepted and change nothing), so the early
  return moved below the warning, and on Windows the warning carries the hint instead of handing
  off to a prompt. This matters most: when the project has other tasks, that warning is the only
  thing that names the file.

  Cost: Windows now walks the task directories on a failed task lookup. That is the error path
  only, and the same walk `err_no_task` already does elsewhere.

### Tests

`e2e-win/task.Tests.ps1` gets one new `Context` covering all three sites. The existing
`a task file Windows cannot execute` context is a *different* path — a TOML `file =` task, which
resolves and is then rejected by `validate_task` (what #11923 fixed). Here nothing resolves at all.

The fixture lives outside `$TestDrive` on purpose: the config at the TestDrive root includes a
tasks directory, and a project that inherits those tasks never reaches the two diagnostics that
only fire when nothing resolved. `MISE_CONFIG_DIR` is pointed at an empty directory for the same
reason — this suite does not otherwise isolate global tasks. Each case also asserts
`-Not -BeLike '*chmod*'`, which is the original defect.

The third case runs the working sibling first as a control, so a failure there cannot be mistaken
for an empty project.

No unix e2e was added. `e2e/tasks/test_task_non_executable_error` and `e2e/tasks/test_task_validate`
are the regression net; both assert `non-executable` and `chmod +x`, which `Run: chmod +x <path>`
still satisfies, and neither pins the five-file listing.

### Verification

The three new cases were run against the released 2026.8.10 binary first and fail for exactly the
reported reasons — empty output, the generic "Are you in a project directory?", and the missing
warning line. The two unix suites were run against the released Linux binary to establish the
before-state; both pass.

`cargo fmt --all` is clean. `cargo check` does not run on this machine (`libz-ng-sys` wants `cmake`,
not installed), so type-checking and the full `e2e-win` run are left to CI — nothing here is
reported as having been compiled locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics for non-executable task files on Windows.
  * Added platform-appropriate guidance for making task files executable.
  * Removed outdated `chmod` advice from Windows messages.
  * Improved error reporting when no tasks are found.
  * Enhanced task discovery messages across supported platforms.

* **Tests**
  * Added Windows end-to-end coverage for task discovery, listing, and execution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->