### PR TITLE
fix(config): strip a byte-order mark before reading a version file

### DIFF
--- a/e2e/config/test_config_file_bom
+++ b/e2e/config/test_config_file_bom
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# A UTF-8 byte-order mark is what Notepad and PowerShell 5.1's `Out-File -Encoding utf8` leave at
+# the front of a file. It is invisible in an editor, and mise used to either drop the declaration
+# silently or carry the mark into the version -- and from there into a download URL, which 404s
+# while naming nothing the user can see.
+#
+# Each case is paired with the same file without a mark. Without that control an assertion could
+# pass because the reader never worked, rather than because the mark is handled.
+#
+# `requested_version` is compared exactly rather than with `assert_contains`: a version that still
+# carries the mark *contains* the expected one, so a substring check would pass unfixed.
+
+mise settings set idiomatic_version_file_enable_tools "node,pnpm,earthly"
+
+# .tool-versions: the first whitespace-separated token on a line is the tool name, so the mark
+# lands in the name and the entry resolves to nothing at all.
+echo 'tiny 3.1.0' >.tool-versions
+assert "mise ls --current --json | jq -r '.tiny[0].requested_version'" "3.1.0"
+printf '\xef\xbb\xbftiny 3.1.0\n' >.tool-versions
+assert "mise ls --current --json | jq -r '.tiny[0].requested_version'" "3.1.0"
+
+# A plain-text idiomatic file: the mark used to become part of the version itself.
+echo '20.0.0' >.node-version
+assert "mise ls --current --json | jq -r '.node[0].requested_version'" "20.0.0"
+printf '\xef\xbb\xbf20.0.0\n' >.node-version
+assert "mise ls --current --json | jq -r '.node[0].requested_version'" "20.0.0"
+
+# package.json is read by serde_json, which rejects a leading mark outright.
+echo '{"packageManager": "pnpm@9.0.0"}' >package.json
+assert "mise ls --current --json | jq -r '.pnpm[0].requested_version'" "9.0.0"
+printf '\xef\xbb\xbf{"packageManager": "pnpm@9.0.0"}\n' >package.json
+assert "mise ls --current --json | jq -r '.pnpm[0].requested_version'" "9.0.0"
+
+# A registry file read by regex. Earthly's pattern is line-anchored, so the mark stops it matching
+# and the tool disappears without a word.
+echo 'VERSION 0.8.15' >Earthfile
+assert "mise ls --current --json | jq -r '.earthly[0].requested_version'" "0.8.15"
+printf '\xef\xbb\xbfVERSION 0.8.15\n' >Earthfile
+assert "mise ls --current --json | jq -r '.earthly[0].requested_version'" "0.8.15"

--- a/src/backend/asdf.rs
+++ b/src/backend/asdf.rs
@@ -86,7 +86,26 @@ impl AsdfBackend {
             return Ok(None);
         }
 
-        Ok(Some(fs::read_to_string(fp)?.trim().into()))
+        Ok(Self::cached_idiomatic_version(&fs::read_to_string(fp)?))
+    }
+
+    /// A cached idiomatic version, or `None` when the entry has to be parsed again.
+    ///
+    /// The cache holds the output of `normalize_idiomatic_contents`, and an entry written before
+    /// that stripped the byte-order mark still carries it. Nothing retires such an entry on its
+    /// own: it is compared only against the source file's modification time, and upgrading mise
+    /// moves neither. So the mark is treated as a miss — the file is re-read through the current
+    /// normaliser and the entry rewritten clean, once.
+    ///
+    /// A miss rather than a strip, because stripping repairs only the simpler shape. The old
+    /// normaliser also failed to recognise a commented first line with a mark in front of the `#`
+    /// (`starts_with('#')` is false there) and cached the comment itself as a version; only a
+    /// re-parse fixes that.
+    fn cached_idiomatic_version(cached: &str) -> Option<String> {
+        if cached.contains('\u{feff}') {
+            return None;
+        }
+        Some(cached.trim().to_string())
     }
 
     fn idiomatic_cache_file_path(&self, idiomatic_file: &Path) -> PathBuf {
@@ -556,6 +575,32 @@ mod tests {
 
     use super::*;
     use std::ffi::OsString;
+
+    #[test]
+    fn an_idiomatic_cache_entry_written_before_the_bom_was_stripped_is_a_miss() {
+        assert_eq!(
+            AsdfBackend::cached_idiomatic_version("20.0.0\n"),
+            Some("20.0.0".to_string())
+        );
+        // The mark is what `normalize_idiomatic_contents` used to leave in the cache. Modification
+        // time is the entry's only invalidation and upgrading mise moves neither file's, so
+        // without this the stale version outlives the fix indefinitely.
+        assert_eq!(
+            AsdfBackend::cached_idiomatic_version("\u{feff}20.0.0\n"),
+            None
+        );
+        // The shape a strip on read would not repair: with the mark in front, `starts_with('#')`
+        // was false, so the old normaliser cached the comment line as if it were a version.
+        assert_eq!(
+            AsdfBackend::cached_idiomatic_version("\u{feff}# only a comment\n3.12.0"),
+            None
+        );
+        // Nothing else changes: the trim the cache read has always done still happens.
+        assert_eq!(
+            AsdfBackend::cached_idiomatic_version("  3.12.0  \n"),
+            Some("3.12.0".to_string())
+        );
+    }
 
     #[test]
     fn test_verify_install_script_output() {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -675,7 +675,11 @@ pub(crate) fn is_install_time_option_key_for_type(backend_type: &BackendType, ke
 /// Normalize idiomatic file contents by removing comments and empty lines.
 /// Full-line and inline comments are supported by .python-version, .nvmrc, etc.
 pub(crate) fn normalize_idiomatic_contents(contents: &str) -> String {
-    contents
+    // Dropping a byte-order mark is normalisation too, and this is the only place every
+    // plain-text idiomatic reader passes through. `trim` below does not do it: U+FEFF does not
+    // carry the Unicode `White_Space` property, so the mark would ride along into the version and
+    // out into a download URL. See `file::strip_utf8_bom`.
+    file::strip_utf8_bom(contents)
         .lines()
         .filter_map(|line| {
             let trimmed = line.trim();
@@ -720,8 +724,11 @@ fn parse_registry_idiomatic_file(
         return Ok(None);
     }
     let contents = file::read_to_string(path)?;
+    // These parsers see the raw body rather than `normalize_idiomatic_contents`, so the mark has
+    // to come off here: an anchored pattern such as `(?m)^\s*version\s*:` simply stops matching.
+    let contents = file::strip_utf8_bom(&contents);
     version_list::parse_version_list(
-        &contents,
+        contents,
         spec.version_regex,
         spec.version_json_path,
         spec.version_expr,
@@ -934,6 +941,14 @@ mod tests {
         assert_eq!(
             normalize_idiomatic_contents("# full line comment\n3.14.2 # inline comment\n   \n\n"),
             "3.14.2"
+        );
+        // A byte-order mark is what Notepad leaves at the front of a file. `trim` does not remove
+        // it, so without the strip the version below carries the mark into a download URL.
+        assert_eq!(normalize_idiomatic_contents("\u{feff}20.0.0"), "20.0.0");
+        // Only a *leading* mark is a mark; anywhere else it is content and must survive.
+        assert_eq!(
+            normalize_idiomatic_contents("20.0.0\n\u{feff}18.0.0"),
+            "20.0.0\n\u{feff}18.0.0"
         );
     }
 

--- a/src/config/config_file/idiomatic_version/package_json.rs
+++ b/src/config/config_file/idiomatic_version/package_json.rs
@@ -57,7 +57,9 @@ where
 impl PackageJsonData {
     fn parse(path: &Path) -> Result<Self> {
         let contents = file::read_to_string(path)?;
-        let pkg: PackageJsonData = serde_json::from_str(&contents)?;
+        // serde_json rejects a leading byte-order mark outright, which would fail the whole file
+        // rather than just the version it declares.
+        let pkg: PackageJsonData = serde_json::from_str(file::strip_utf8_bom(&contents))?;
         Ok(pkg)
     }
 
@@ -206,6 +208,16 @@ mod tests {
 
         assert_eq!(parse(&path, "yarn").unwrap(), vec!["1.22.19".to_string()]);
         assert_eq!(parse(&path, "node").unwrap(), vec!["20.0.0".to_string()]);
+    }
+
+    #[test]
+    fn test_parse_package_json_with_byte_order_mark() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("package.json");
+        // serde_json rejects the mark, which used to fail the file rather than the field.
+        fs::write(&path, "\u{feff}{\"packageManager\": \"pnpm@9.0.0\"}").unwrap();
+
+        assert_eq!(parse(&path, "pnpm").unwrap(), vec!["9.0.0".to_string()]);
     }
 
     #[test]

--- a/src/config/config_file/tool_versions.rs
+++ b/src/config/config_file/tool_versions.rs
@@ -52,12 +52,15 @@ impl ToolVersions {
 
     pub(crate) fn from_file(path: &Path) -> Result<Self> {
         trace!("parsing tool-versions: {}", path.display());
-        Self::parse_str(&file::read_to_string(path)?, path.to_path_buf())
+        let body = file::read_to_string(path)?;
+        // The first whitespace-separated token on a line is the tool name, so a leading
+        // byte-order mark becomes part of it and the entry silently resolves to nothing.
+        Self::parse_str(file::strip_utf8_bom(&body), path.to_path_buf())
     }
 
     pub(crate) fn path_requires_trust(path: &Path) -> bool {
         match file::read_to_string(path) {
-            Ok(body) => contains_template_syntax(&body),
+            Ok(body) => contains_template_syntax(file::strip_utf8_bom(&body)),
             Err(_) => true,
         }
     }

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -547,6 +547,10 @@ impl Backend for JavaPlugin {
 
     async fn _parse_idiomatic_file(&self, path: &Path) -> Result<Vec<String>> {
         let contents = file::read_to_string(path)?;
+        // The `.sdkmanrc` branch matches on the start of a line without going through
+        // `normalize_idiomatic_contents`, so a leading mark defeats `starts_with("java")` and the
+        // fallback yields an empty version.
+        let contents = file::strip_utf8_bom(&contents);
         if path.file_name() == Some(".sdkmanrc".as_ref()) {
             let version = contents
                 .lines()
@@ -578,7 +582,7 @@ impl Backend for JavaPlugin {
             }
             Ok(vec![format!("{vendor}-{version}")])
         } else {
-            Ok(normalize_idiomatic_contents(&contents)
+            Ok(normalize_idiomatic_contents(contents)
                 .lines()
                 .map(|s| s.to_string())
                 .collect())


### PR DESCRIPTION
A UTF-8 byte-order mark at the front of a version-declaring file makes mise either drop the
declaration without a word or carry the mark into the version itself. Measured on Windows
2026.8.10, with the same file minus the mark as the control:

| reader | control | with a BOM |
|---|---|---|
| `.tool-versions` | `node 20.0.0` | **entry silently vanishes**; `mise install` → `﻿node not found in mise tool registry` |
| `.node-version` and the other plain-text idiomatic files | `20.0.0` | version becomes `﻿20.0.0`, so the download URL becomes `node-v%EF%BB%BF20.0.0-win-x64.zip` → **404**, and nothing in the error mentions a mark |
| `package.json` `packageManager` | `pnpm 9.0.0` | **silently vanishes** |
| line-anchored registry regex (`Earthfile`, `.golangci.yml`, …) | `earthly 0.8.15` | **silently vanishes** |
| `.sdkmanrc` | `temurin-21.0.2` | **version becomes empty** |
| `mise.toml`, `rust-toolchain.toml` | ok | ok — the toml crate accepts a mark, so these are **left alone** |

The trigger is ordinary: Notepad and PowerShell 5.1's `Out-File -Encoding utf8` write a mark by
default. The bug is not Windows-specific, only its provenance is.

### Why not strip inside `file::read_to_string`

That was the obvious upstream fix — 180 call sites in `src/`, one place to change — so it was
checked rather than assumed:

- **Config writers already drop the mark today.** Measured: after `mise fmt` or `mise use` on a
  BOM'd `mise.toml`, byte 0 is `[`. So "it would silently delete the user's mark" does not apply
  to config files.
- **All eight content-equality call sites read files mise itself wrote** — generated stubs, the
  launcher check, the install fingerprint, the cask shim, the task-cache key. The two exceptions
  (`is_trust_exempt`, the Gemfile parsers) would be *helped*.
- **Hash sites** read `SHASUMS256.txt` and the trust hash; `aqua.rs` already uses
  `read_to_string_bom` for checksums.
- **But `src/system/edits.rs` has six read-then-write-back sites** (plus one in `system/files.rs`)
  that edit *user* files and put them back. Stripping in the primitive would silently delete a mark
  from, say, a PowerShell `$PROFILE`. That is outside the failure reported here, and one such path
  is enough to make changing a 180-site primitive the wrong trade.

No new helper either: `file::strip_utf8_bom` is already the named rule, and a new read-helper would
sit one word away from the existing `read_to_string_bom`, which additionally decodes UTF-16 — two
near-identical names with different behaviour is a trap for whoever reads next.

### Where the strip went instead — four places

- **`normalize_idiomatic_contents`** — the one function every plain-text idiomatic reader passes
  through, so one line covers `_parse_idiomatic_file` plus the node, java, go, ruby and asdf
  readers. `trim` cannot do this: U+FEFF does not carry the Unicode `White_Space` property.
  **The measured failure behind this line is `.node-version`.** go.mod, `Gemfile` and
  `.java-version` come along because they share the function; they were read, not measured, and
  are not claimed as fixed defects.
- **`parse_registry_idiomatic_file`** — these parsers see the raw body, and a pattern like
  `(?m)^\s*version\s*:` simply stops matching.
- **`package_json::PackageJsonData::parse`** — serde_json rejects a leading mark outright.
- **`ToolVersions::from_file`** (and `path_requires_trust` alongside it) — the first token on a line
  is the tool name.
- **`java.rs`'s `.sdkmanrc` branch** — it matches `starts_with("java")` before normalising, so it
  bypasses all of the above. This one was found by reading and then **measured** before being
  fixed: with a mark the version comes back empty.

### Tests

`e2e/config/test_config_file_bom` is new: the four readers live in four different subsystems, so a
dedicated file keeps the subject in one place. **Every case is paired with the same file without a
mark**, because otherwise an assertion could pass by the reader never having worked.

`requested_version` is compared **exactly** rather than with `assert_contains` — a version that
still carries the mark *contains* the expected one, so a substring check passes on the unfixed
code. This is not hypothetical: unfixed, `.node-version` returns `﻿20.0.0`.

Unit tests: `normalize_idiomatic_contents` gains a leading-mark case and a case asserting that a
mark **elsewhere in the file stays**, since only a leading one is a mark; `package_json.rs` gains a
BOM'd `packageManager`. Both test modules are `#[cfg(test)]` without `#[cfg(unix)]`, so they run on
Windows CI too.

### Verification

Each of the four e2e cases was run against the unfixed binary first: every control returned the
expected version and every BOM case returned `null` — except `.node-version`, which returned
`﻿20.0.0`, which is what motivated the exact comparison.

Regression net: `test_tool_versions_alt` passes on the released binary. The other two candidates
(`test_registry_idiomatic_version_files`, `test_idiomatic_version_file_plugin_gate`) **cannot** be
baselined here — the first asserts a deprecation introduced in 2026.8.10 and this box's Linux
binary is 2026.8.3 — so CI is their baseline. `strip_utf8_bom` is a no-op on input without a mark,
so non-BOM behaviour is unchanged by construction.

`cargo fmt --all`, `shfmt -d` and `shellcheck -x` are clean. `cargo check` does not run on this
machine (`libz-ng-sys` wants `cmake`, not installed), so type-checking and the unit tests are left
to CI — nothing here is reported as having been compiled locally.


### Follow-up from review — the cache would have outlived the fix

`src/backend/asdf.rs` caches the **output** of `normalize_idiomatic_contents`, and validates the
entry only against the source file's modification time. An entry an older mise wrote from a marked
file therefore keeps the mark, and upgrading mise moves neither timestamp — so a user who had
already resolved that file once would never see this fix take effect.

Such an entry is now treated as a miss, so it is re-parsed through the current normaliser and
rewritten clean. A miss rather than a strip, because the old normaliser could also cache a
*comment* as a version: with the mark in front, `trimmed.starts_with('#')` is false and the line
was never skipped. Only a re-parse repairs that one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added support for UTF-8 BOM-prefixed version files, including `.tool-versions`, `.node-version`, `package.json`, `Earthfile`, and `.sdkmanrc`.
  - BOM-prefixed files now parse and resolve versions consistently with BOM-free files.
  - Preserved BOM characters appearing later in file content.
  - Improved handling of cached version data and unreadable files.

- **Tests**
  - Added regression and end-to-end coverage for BOM handling across supported configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
