### PR TITLE
registry: install oc from a channel directory

### DIFF
--- a/registry/oc.toml
+++ b/registry/oc.toml
@@ -15,19 +15,19 @@ version_list_url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"
 version_regex = 'href="(\d+\.\d+\.\d+)/"'
 
 [backends.options.platforms.linux-x64]
-url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-client-linux-{{ version }}.tar.gz"
+url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-client-linux.tar.gz"
 
 [backends.options.platforms.linux-arm64]
-url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-client-linux-arm64-{{ version }}.tar.gz"
+url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-client-linux-arm64.tar.gz"
 
 [backends.options.platforms.macos-x64]
-url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-client-mac-{{ version }}.tar.gz"
+url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-client-mac.tar.gz"
 
 [backends.options.platforms.macos-arm64]
-url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-client-mac-arm64-{{ version }}.tar.gz"
+url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-client-mac-arm64.tar.gz"
 
 [backends.options.platforms.windows-x64]
-url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-client-windows-{{ version }}.zip"
+url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-client-windows.zip"
 
 [[backends]]
 full = "conda:openshift-cli"


### PR DESCRIPTION
Addresses discussion #9642. Existing registry entry, so no popularity section — this is a fix, not a new tool.

## Problem

`oc = "stable"` 404s:

```
Failed to install http:oc@stable: HTTP status client error (404 Not Found)
for .../ocp/stable/openshift-client-mac-arm64-stable.tar.gz
```

The URL templates put the version in the **filename** as well as the path, so the alias became part of the file being asked for. Nothing named `*-stable.tar.gz` exists — but `stable/` itself does.

The report shows a conda solve instead; the entry has since been reordered so `http:oc` is tried first, and this is where it lands now.

## Fix

The mirror publishes each artifact under two names in every directory:

```
/ocp/stable/openshift-client-mac-arm64-4.22.9.tar.gz
/ocp/stable/openshift-client-mac-arm64.tar.gz
/ocp/4.22.9/openshift-client-mac-arm64-4.22.9.tar.gz
/ocp/4.22.9/openshift-client-mac-arm64.tar.gz
```

Dropping the version from the filename resolves in a channel directory and a versioned one alike. Five lines, no code change.

Checked before relying on it:

- **Checksums.** `sha256sum.txt` lists both names with the same hash, in channel and versioned directories, so verification is unaffected.
- **All five platforms** serve the unversioned name.
- **Old releases.** 4.14.0 and 4.10.0 serve it too. 4.10.0 has no linux-arm64 build under *either* name, so nothing regresses.
- **Release candidates.** `4.22.0-rc.5` still installs. This one matters: `version_regex` only scrapes `\d+\.\d+\.\d+`, so rc directories were never listed either, and they install by being passed through exactly the way `stable` is. Rejecting versions absent from the listing — the other obvious fix — would have broken them.

It is also not one special alias. The mirror carries `stable`, `fast`, `candidate`, and `latest`, plus 80-odd per-minor variants like `stable-4.22`, all the same shape.

## Verification

Against the released 2026.8.10 as a control, which reproduces the 404:

| | control | this entry |
| --- | --- | --- |
| `oc@stable` | 404 | installs, `Client Version: 4.22.9` |
| `oc@4.22.9` | installs | installs |
| `oc@4.22.0-rc.5` | installs | installs |

`taplo check` and `taplo fmt --check` clean against the registry schema.

## Two things left for you, deliberately not in this PR

- **Channels are still not listed.** `mise ls-remote oc` shows only `x.y.z`, so `stable` works but is not discoverable. Adding channels to `version_regex` would put non-semver strings under `version_order = "semver"` and `sortVersions`, which risks `mise latest oc` returning a channel name. Happy to do it if you want it, but it is a separate call.
- **A channel install never updates.** `oc@stable` records the version as `stable`, and the `http` backend has no rolling-channel concept, so mise will not notice when upstream `stable` moves. That is not a regression — today it cannot install at all — but it is the same shape as #10017.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OpenShift client download links across supported platforms.
  * Improved download URL handling while retaining version-specific directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->