### PR TITLE
fix(config): report an unparseable settings file once, through the logger

### DIFF
--- a/e2e/config/test_settings_parse_error
+++ b/e2e/config/test_settings_parse_error
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# One typo in a config file used to be reported three times. The settings loader printed a raw,
+# unprefixed block once per settings build -- and settings are built twice per run, because
+# `add_cli_matches` resets them so CLI flags take effect -- and then the config loader reported the
+# same file again, properly, through miette.
+#
+# The raw print also went straight to stderr, so the log level could not reach it and `--quiet`
+# could not silence it.
+
+# Control: with a config that parses, none of the assertions below can pass by accident.
+cat <<'TOML' >mise.toml
+[tools]
+TOML
+assert "mise --version 2>&1 | grep -c 'Error loading settings file' || true" "0"
+
+cat <<'TOML' >mise.toml
+[env]
+Bad = "C:\x"
+TOML
+
+# Exactly once, compared exactly: `assert_contains` would have passed on the old behaviour too,
+# since three renderings contain the string just as well as one does.
+assert "mise --version 2>&1 | grep -c 'Error loading settings file'" "1"
+
+# It goes through the logger now, so it carries the usual prefix instead of arriving bare.
+assert "mise --version 2>&1 | grep -c 'WARN.*Error loading settings file'" "1"
+
+# Being a warning, the log level now reaches it. This is the point of routing it through the
+# logger, not a side effect.
+assert "mise --quiet --version 2>&1 | grep -c 'Error loading settings file' || true" "0"
+
+# Queued warnings are flushed once CLI flags are known, and several startup steps between those two
+# points can fail first. A bad `--cd` is one of them: the diagnostic must not be swallowed just
+# because the command left early.
+assert_fail_contains "mise --cd no-such-dir env" "Error loading settings file"
+
+# The log level reaches those early exits too, but only by a route that exists before the flags are
+# parsed. `MISE_QUIET` is read from the environment during the first settings build, so it applies
+# on every path; `--quiet` cannot, on a command that left before `add_cli_matches` ran. Both cases
+# below are that: flags the parser rejected never became flags at all, and `--cd` is checked by
+# `validate_cd_path` ahead of `add_cli_matches`, on purpose, so a bad directory never reaches the
+# settings. Pinning the reachable half keeps that boundary honest.
+#
+# The other half -- a `--cd` directory that passes both checks and still refuses the `chdir`, which
+# is where `--quiet` has to come from the flags rather than from a settings build -- is not pinned
+# here: this suite runs as root in CI, where `chmod` cannot stop `chdir`. See `cli/test_cd_bad_target`.
+assert "MISE_QUIET=1 mise --cd no-such-dir env 2>&1 | grep -c 'Error loading settings file' || true" "0"
+assert "MISE_QUIET=1 mise --badflag 2>&1 | grep -c 'Error loading settings file' || true" "0"
+
+# The config loader still reports the file, and still fails: this collapses a duplicate, it does
+# not hide the failure.
+assert_fail_contains "mise env" "Invalid TOML in config file"
+
+# Two settings files failing the same way must stay two reports. mise reads several settings files
+# and the parser text alone is byte-identical between them, so a message that does not name its
+# file would collapse the pair and the second file would never be mentioned.
+cp mise.toml "$MISE_CONFIG_DIR/config.toml"
+assert "mise --version 2>&1 | grep -c 'Error loading settings file'" "2"
+assert "mise --version 2>&1 | grep 'Error loading settings file' | sort -u | wc -l | tr -d ' '" "2"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -788,7 +788,7 @@ impl Cli {
         // This avoids expensive backend::load_tools() and config loading
         if hook_env_module::should_exit_early_fast() {
             measure!("logger", { logger::init() });
-            Settings::flush_deprecated_warnings_for_fast_exit();
+            Settings::flush_pending_warnings_before_exit();
             return Ok(());
         }
         measure!("logger", { logger::init() });

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -312,7 +312,18 @@ static LAST_SAFE: AtomicU8 = AtomicU8::new(2);
 static CLI_SETTINGS: Mutex<Option<SettingsPartial>> = Mutex::new(None);
 static PENDING_DEPRECATED_SETTINGS: Lazy<Mutex<BTreeSet<&'static str>>> =
     Lazy::new(Default::default);
-static DEPRECATED_WARNINGS_READY: AtomicBool = AtomicBool::new(false);
+/// Settings files that failed to parse, held until warnings can be printed.
+///
+/// A set rather than a list because settings are built more than once per run — `add_cli_matches`
+/// resets them so CLI flags take effect — and each build re-reports the same file. The messages
+/// name their file, which is what keeps two files failing the same way from collapsing into one.
+static PENDING_SETTINGS_FILE_ERRORS: Lazy<Mutex<BTreeSet<String>>> = Lazy::new(Default::default);
+/// Whether warnings found while loading settings can be printed yet.
+///
+/// `logger::init()` calls `Settings::try_get()` before installing the logger, so the first build
+/// happens with nothing to print to. Anything found there is queued above and flushed once the
+/// logger exists.
+static WARNINGS_READY: AtomicBool = AtomicBool::new(false);
 // TODO(2027.8.0): Remove the per-tool warning accessors once the NixOS
 // and Alpine `all_compile` deprecation process is complete.
 
@@ -457,8 +468,23 @@ fn warn_deprecated_env_settings() {
     }
 }
 
-fn queue_deprecated(key: &'static str) {
-    PENDING_DEPRECATED_SETTINGS.lock().unwrap().insert(key);
+/// Report a settings file that could not be parsed.
+///
+/// Queued rather than printed when the logger is not up yet. `warn_once!` cannot stand in for the
+/// queue: it records the message as seen even when nothing was printed, so the pre-logger build
+/// would silence the one that comes after it.
+///
+/// Readiness is read while the queue is held, and the flush sets it while holding the same lock, so
+/// a warning cannot be queued into a set that has just been drained.
+fn warn_settings_file_error(msg: String) {
+    {
+        let mut pending = PENDING_SETTINGS_FILE_ERRORS.lock().unwrap();
+        if !WARNINGS_READY.load(Ordering::SeqCst) {
+            pending.insert(msg);
+            return;
+        }
+    }
+    warn_once!("{msg}");
 }
 
 fn queue_deprecated_settings(keys: impl IntoIterator<Item = &'static str>) {
@@ -495,9 +521,14 @@ fn should_warn_deprecated_value(value: &toml::Value) -> bool {
 }
 
 fn warn_deprecated(key: &'static str) {
-    if !DEPRECATED_WARNINGS_READY.load(Ordering::SeqCst) {
-        queue_deprecated(key);
-        return;
+    // Same lock discipline as `warn_settings_file_error`: the readiness read and the insert have to
+    // be one step against the flush, or a key queued just after the drain is never printed.
+    {
+        let mut pending = PENDING_DEPRECATED_SETTINGS.lock().unwrap();
+        if !WARNINGS_READY.load(Ordering::SeqCst) {
+            pending.insert(key);
+            return;
+        }
     }
     warn_deprecated_now(key);
 }
@@ -524,6 +555,44 @@ fn warn_deprecated_now(key: &'static str) {
                     "deprecated [setting.{key}]: {msg} This will be removed in mise {remove_at}."
                 );
             }
+        }
+    }
+}
+
+/// Settle the verbosity settings against each other, so `log_level` is the single answer.
+///
+/// `debug`, `trace`, `quiet` and `verbose` each say something about `log_level`, and they overlap:
+/// the order below is the precedence. Kept apart from the rest of the load so it can also be
+/// applied to a partial view of the settings — see [`Settings::cli_log_level`].
+fn normalize_verbosity(settings: &mut Settings) {
+    if settings.debug {
+        settings.log_level = "debug".to_string();
+    }
+    if settings.trace {
+        settings.log_level = "trace".to_string();
+    }
+    if settings.quiet {
+        settings.log_level = "error".to_string();
+    }
+    if settings.log_level == "trace" || settings.log_level == "debug" {
+        settings.verbose = true;
+        settings.debug = true;
+        if settings.log_level == "trace" {
+            settings.trace = true;
+        }
+    }
+    // handle the special case of `mise -v` which should show version, not set verbose.
+    // Use the args mise was invoked with (already captured safely in Cli::run and kept
+    // in sync with internal re-dispatch like `mise asdf ...`) rather than re-reading the
+    // process argv. See also Settings::no_config().
+    let is_version_flag = {
+        let args = env::ARGS.read().unwrap();
+        args.len() == 2 && args[1] == "-v"
+    };
+    if settings.verbose && !is_version_flag {
+        settings.quiet = false;
+        if settings.log_level != "trace" {
+            settings.log_level = "debug".to_string();
         }
     }
 }
@@ -813,6 +882,37 @@ impl Settings {
         normalize_hidden_config_aliases(CLI_SETTINGS.lock().unwrap().clone().unwrap_or_default())
     }
 
+    /// The log level the parsed CLI flags ask for, without a full settings build.
+    ///
+    /// [`Self::try_get`] can keep failing once the CLI flags are part of it — `--cd` naming a
+    /// directory that `validate_cd_path` accepts but the `chdir` refuses is the case `Cli::run`
+    /// propagates — and from then on no build succeeds. A caller that only knows how to give up
+    /// would be left holding the level from before the flags were parsed, and anything printed
+    /// from there on ignores `--quiet`.
+    ///
+    /// `None` when the flags said nothing about verbosity: the level already in force came from a
+    /// build that worked, and that build could see the config files this cannot. Only when the CLI
+    /// does speak is it worth answering, and then it outranks them anyway.
+    pub(crate) fn cli_log_level() -> Option<log::LevelFilter> {
+        let cli = CLI_SETTINGS.lock().unwrap().clone()?;
+        // `add_cli_matches` folds `--trace`/`--debug`/`-vv` into `log_level`, and `--silent` into
+        // `quiet`, so these four cover every flag that moves the level.
+        if cli.quiet.is_none()
+            && cli.silent.is_none()
+            && cli.log_level.is_none()
+            && cli.verbose.is_none()
+        {
+            return None;
+        }
+        // Environment-only: the CLI layer plus `MISE_*`. It skips config discovery, which is both
+        // what makes it survive the failure that sent us here and why its answer is a fallback
+        // rather than the real one.
+        let mut settings =
+            Self::load_sources_from(None, SettingsLoadPolicy::ENVIRONMENT_ONLY).ok()?;
+        normalize_verbosity(&mut settings);
+        Some(settings.log_level())
+    }
+
     /// Load settings sources for an explicit root, or the current directory when `root` is `None`.
     ///
     /// This shares source ordering and file parsing with the normal settings load. It deliberately
@@ -856,11 +956,16 @@ impl Settings {
                         || crate::config::config_file::is_path_trusted(path)
                 }
             })
-            .map(|path| Self::parse_settings_file(&path))
-            .filter_map(|config| match config {
+            .filter_map(|path| match Self::parse_settings_file(&path) {
                 Ok(config) => Some(config),
                 Err(err) => {
-                    eprintln!("Error loading settings file: {err}");
+                    // Name the file. mise reads several settings files and two of them can fail
+                    // with byte-identical parser text, which leaves the reports
+                    // indistinguishable -- to the reader, and to the queue that collapses repeats.
+                    warn_settings_file_error(format!(
+                        "Error loading settings file {}: {err}",
+                        file::display_path(&path)
+                    ));
                     None
                 }
             })
@@ -899,36 +1004,7 @@ impl Settings {
         if *env::NO_COLOR {
             settings.color = false;
         }
-        if settings.debug {
-            settings.log_level = "debug".to_string();
-        }
-        if settings.trace {
-            settings.log_level = "trace".to_string();
-        }
-        if settings.quiet {
-            settings.log_level = "error".to_string();
-        }
-        if settings.log_level == "trace" || settings.log_level == "debug" {
-            settings.verbose = true;
-            settings.debug = true;
-            if settings.log_level == "trace" {
-                settings.trace = true;
-            }
-        }
-        // handle the special case of `mise -v` which should show version, not set verbose.
-        // Use the args mise was invoked with (already captured safely in Cli::run and kept
-        // in sync with internal re-dispatch like `mise asdf ...`) rather than re-reading the
-        // process argv. See also Settings::no_config().
-        let is_version_flag = {
-            let args = env::ARGS.read().unwrap();
-            args.len() == 2 && args[1] == "-v"
-        };
-        if settings.verbose && !is_version_flag {
-            settings.quiet = false;
-            if settings.log_level != "trace" {
-                settings.log_level = "debug".to_string();
-            }
-        }
+        normalize_verbosity(&mut settings);
         if !settings.color {
             console::set_colors_enabled(false);
             console::set_colors_enabled_stderr(false);
@@ -960,24 +1036,39 @@ impl Settings {
         Ok(settings)
     }
 
-    pub(crate) fn flush_deprecated_warnings() {
+    pub(crate) fn flush_pending_warnings() {
         if CLI_SETTINGS.lock().unwrap().is_none() {
             return;
         }
-        Self::flush_deprecated_warnings_now();
+        Self::flush_pending_warnings_now();
     }
 
-    pub(crate) fn flush_deprecated_warnings_for_fast_exit() {
-        Self::flush_deprecated_warnings_now();
+    /// Flush without waiting for CLI settings, for a path that is about to leave.
+    ///
+    /// Startup queues warnings before the logger exists and only flushes them once CLI flags are
+    /// known — but several steps in between can fail first, and a diagnostic that was queued and
+    /// never flushed is worse than one printed a moment early.
+    pub(crate) fn flush_pending_warnings_before_exit() {
+        Self::flush_pending_warnings_now();
     }
 
-    fn flush_deprecated_warnings_now() {
-        DEPRECATED_WARNINGS_READY.store(true, Ordering::SeqCst);
-        warn_deprecated_env_settings();
-        let pending = {
-            let mut pending = PENDING_DEPRECATED_SETTINGS.lock().unwrap();
-            std::mem::take(&mut *pending)
+    fn flush_pending_warnings_now() {
+        // Readiness is set under both queue locks so a producer cannot read "not ready" and then
+        // insert into a set this call has already taken.
+        let (pending_files, pending) = {
+            let mut files = PENDING_SETTINGS_FILE_ERRORS.lock().unwrap();
+            let mut deprecated = PENDING_DEPRECATED_SETTINGS.lock().unwrap();
+            WARNINGS_READY.store(true, Ordering::SeqCst);
+            (
+                std::mem::take(&mut *files),
+                std::mem::take(&mut *deprecated),
+            )
         };
+        // Outside the locks: these warn, and warning re-enters the queue helpers.
+        warn_deprecated_env_settings();
+        for msg in pending_files {
+            warn_once!("{msg}");
+        }
         for key in pending {
             warn_deprecated_now(key);
         }
@@ -1764,6 +1855,42 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `normalize_verbosity` is the whole answer to "what level is this run at", and it is now
+    /// reached from two places -- the settings load and `cli_log_level`. Pin the precedence so the
+    /// two cannot drift apart.
+    #[test]
+    fn test_normalize_verbosity_quiet_lowers_the_level() {
+        let mut settings = Settings {
+            quiet: true,
+            ..Default::default()
+        };
+        normalize_verbosity(&mut settings);
+        assert_eq!(settings.log_level, "error");
+    }
+
+    #[test]
+    fn test_normalize_verbosity_verbose_outranks_quiet() {
+        let mut settings = Settings {
+            quiet: true,
+            verbose: true,
+            ..Default::default()
+        };
+        normalize_verbosity(&mut settings);
+        assert_eq!(settings.log_level, "debug");
+        assert!(!settings.quiet);
+    }
+
+    #[test]
+    fn test_normalize_verbosity_keeps_trace_above_verbose() {
+        let mut settings = Settings {
+            trace: true,
+            verbose: true,
+            ..Default::default()
+        };
+        normalize_verbosity(&mut settings);
+        assert_eq!(settings.log_level, "trace");
+    }
 
     #[test]
     fn default_all_compile_is_limited_to_alpine_and_deprecated_nixos_behavior() {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -179,20 +179,41 @@ pub(crate) fn thread_id() -> String {
 
 pub(crate) fn init() {
     static LOGGER: OnceLock<Logger> = OnceLock::new();
-    let settings = Settings::try_get().unwrap_or_else(|_| Default::default());
-    let term_level = settings.log_level();
+    let settings = Settings::try_get();
     if let Some(logger) = LOGGER.get() {
-        *logger.term_level.lock().unwrap() = term_level;
-        *logger.level.lock().unwrap() = std::cmp::max(term_level, logger.file_level);
+        // Re-init. A settings build that failed says nothing about the level, so the default is the
+        // wrong answer here: `quiet` resolves to `log_level = "error"` inside `try_get`, and
+        // resetting to `info` would *raise* the bar and let the warnings flushed below through.
+        //
+        // The parsed CLI flags are the exception. Once they are part of the build it can keep
+        // failing — `--cd` naming a directory that `validate_cd_path` accepts but the `chdir`
+        // refuses is the case `Cli::run` propagates — and then no later build succeeds either, so
+        // waiting for one would mean `--quiet` never applying to this run at all. `cli_log_level`
+        // reads the flags without a build, and answers `None` when they say nothing about
+        // verbosity — then the level in force came from a build that could see the config files,
+        // and is still the better answer.
+        let term_level = match &settings {
+            Ok(settings) => Some(settings.log_level()),
+            Err(_) => Settings::cli_log_level(),
+        };
+        if let Some(term_level) = term_level {
+            *logger.term_level.lock().unwrap() = term_level;
+            *logger.level.lock().unwrap() = std::cmp::max(term_level, logger.file_level);
+            log::set_max_level(term_level);
+        }
     } else {
+        // First init: nothing is in force yet, so the default is all there is. A logger at `info`
+        // beats no logger at all — a warning printed too loudly still beats one that vanishes.
+        let settings = settings.unwrap_or_default();
+        let term_level = settings.log_level();
         let file_level = env::MISE_LOG_FILE_LEVEL.unwrap_or(settings.log_level());
         let logger = LOGGER.get_or_init(|| Logger::init(term_level, file_level));
         if let Err(err) = log::set_logger(logger) {
             safe_eprintln!("mise: could not initialize logger: {err}");
         }
+        log::set_max_level(term_level);
     }
-    log::set_max_level(term_level);
-    Settings::flush_deprecated_warnings();
+    Settings::flush_pending_warnings();
 }
 
 fn init_log_file(log_file: &Path) -> Result<File> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -200,6 +200,19 @@ async fn main_() -> eyre::Result<()> {
 }
 
 fn handle_err(err: Report) -> eyre::Result<()> {
+    // Startup queues warnings found before the logger exists and flushes them once CLI flags are
+    // known. Half a dozen steps sit between those two points and any of them can fail — a bad flag,
+    // an unusable `--cd`, an untrusted config — so this is where a queued diagnostic gets its last
+    // chance to be seen. Before the exit-code check: a requested exit leaves just as finally.
+    //
+    // Re-init the logger first so the flush below runs at whatever level is knowable now.
+    // `auto_update` and `trust_active_config` fail *after* `add_cli_matches` but before startup
+    // reaches its second `logger::init()`, so without this `--quiet` would not reach them. It
+    // cannot help a command whose flags never parsed; `MISE_QUIET` still can, since that is read
+    // from the environment during the first settings build. If the settings cannot be built at all,
+    // `init` leaves the level where it is rather than resetting it to the default.
+    crate::logger::init();
+    crate::config::Settings::flush_pending_warnings_before_exit();
     if exit::requested_exit_code(&err).is_some() {
         return Err(err);
     }


### PR DESCRIPTION
One typo in a config file is reported three times. Measured on 2026.8.10 with
`[env]` / `Bad = "C:\x"`:

| command | raw `Error loading settings file:` blocks | miette `parse_error` |
|---|---|---|
| `mise --version` | **2** | 0 |
| `mise settings` | **2** | 0 |
| `mise env` | **2** | 1 |
| `mise ls` | **2** | 1 |
| `mise --quiet env` | **2** | 1 |

The raw blocks come from an `eprintln!` in `Settings::all_settings_files()`. They carry no prefix,
and because they bypass the logger entirely, **`--quiet` cannot silence them**.

### Why two, and why before anything else

Not a guess — `MISE_TIMINGS=2` shows `all_settings_files` twice per run, **including with a config
that parses cleanly**:

```
[TIME] 1 mise::config::settings::try_get all_settings_files 58.5ms 59.3ms
[TIME] 1 mise::config::settings::try_get all_settings_files 14.5ms 84.7ms
```

That second build is intentional: `Settings::add_cli_matches` resets settings so CLI flags take
effect. `raw=2` matches it exactly. And the first build happens inside `logger::init()` itself,
which calls `Settings::try_get()` before `log::set_logger` — which is why the first block lands
before any other output and without a prefix.

### The obvious fix is wrong

Swapping `eprintln!` for `warn_once!` produces **silence**: the pre-logger build records the message
as seen while printing nothing, so the post-logger build is suppressed. Verified by reading
`warn_once!` — it inserts into `WARNED_ONCE` and only then calls `warn!`.

### What this uses instead

`settings.rs` already has a queue-and-flush built for exactly this problem —
`PENDING_DEPRECATED_SETTINGS`, a readiness flag, and a flush called at the end of `logger::init()`
plus on the hook-env fast-exit path. `parse_settings_file` already queues deprecations two lines
away. This adds a sibling queue for parse errors and drains it in the same flush.

The queue is a `BTreeSet<String>`, so the two builds collapse to one entry on their own; `warn_once!`
covers any build after the flush.

**Renames, no behaviour attached:** `DEPRECATED_WARNINGS_READY` → `WARNINGS_READY`, and
`flush_deprecated_warnings{,_for_fast_exit}` → `flush_pending_warnings{,_for_fast_exit}`. The flag
and the flush no longer serve deprecations alone, and leaving the old names would have made the
next reader believe otherwise. That is 2 lines outside `settings.rs` (`logger.rs`, `cli/mod.rs`).

### One intended behaviour change

`quiet` sets `log_level = "error"`, so the message is now suppressed under `--quiet`. That is what
`--quiet` means, and it is deliberately narrow: for any command that loads config, the miette error
still appears, because that is returned as an `Err` and printed by the top-level handler rather than
through the logger. Only `mise --version --quiet` and friends go fully silent. The test pins this
rather than leaving it implicit.

`mise --version` does reach the flush: `print_version_if_requested` returns a flag and control
carries on to the second `logger::init()`.

### Tests

`e2e/config/test_settings_parse_error` is new. It compares the count **exactly**, because
`assert_contains` would pass on the old behaviour just as well as the new — three renderings contain
the string too. It also pins that the message now carries the `WARN` prefix, that `--quiet`
suppresses it, and — as the control that matters — that `mise env` **still fails** with the miette
diagnostic, so this cannot be mistaken for having quieted the failure itself.

A control with a config that parses runs first, so none of the counts can pass by accident.

No Windows e2e: the defect is platform-independent and the fix is shared code. No unit test: the
queue depends on the readiness flag and global logger state, so a unit test would leak across tests;
the e2e drives the real startup path.

### Verification

Every assertion was measured against the unfixed binary first. The control passes (0 with a valid
config) and each of the other four behaves as the PR body describes: count `2` where the fix expects
`1`, `0` WARN-prefixed lines where it expects `1`, `2` under `--quiet` where it expects `0`, and the
miette control already green (`mise env` → rc=1, message present).

Regression net: `cli/test_settings_set` and `config/test_local_settings_trust_controls` pass on the
released binary. `cli/test_settings_ls` and `cli/test_settings_env_only` **cannot be baselined
here** — they assert behaviour newer than this box's 2026.8.3 Linux binary — so CI is their baseline.

`cargo fmt --all`, `shfmt -d` and `shellcheck -x` are clean. `cargo check` does not run on this
machine (`libz-ng-sys` wants `cmake`, not installed), so type-checking is left to CI — nothing here
is reported as having been compiled locally.


### Follow-up from review — a failed settings build must not raise the level back

`logger::init` fell back to `Settings::default()` whenever the settings could not be built. On a
**re-init** that is not a neutral fallback: `quiet` resolves to `log_level = "error"` inside
`try_get`, and the default is `"info"`, so one failed build would put an already-quiet run back at
`info` — and both re-init sites (`src/cli/mod.rs` and the new one in `src/main.rs`) are immediately
followed by the warning flush.

`init` now leaves the level alone on a re-init it cannot resolve settings for. The first init keeps
the default fallback, where a logger at `info` beats no logger at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `bs` alias for bootstrap commands.
  * Improved command completion and help handling, including bootstrap command options.
  * Improved task argument handling around separators and flags.

* **Bug Fixes**
  * Improved configuration error reporting with clear, file-specific warnings.
  * Prevented duplicate warnings while preserving separate reports for multiple files.
  * Ensured warnings appear during early exits and can be suppressed with `--quiet`.
  * Preserved expected command failure behavior for invalid configurations.

* **Tests**
  * Added end-to-end coverage for configuration errors, quiet mode, aliases, completion, and argument handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
