### PR TITLE
fix(config): name the config file once in a TOML parse error

### DIFF
--- a/e2e/config/test_miserc
+++ b/e2e/config/test_miserc
@@ -21,9 +21,13 @@ cat >"$MISE_CONFIG_DIR/miserc.toml" <<'EOF'
 ceiling_paths = ["{{ env.HOME }}"]
 fdsfads
 EOF
-assert_fail "mise config ls" "Invalid TOML in config file:"
+# The message no longer repeats the path: miette prints it above the snippet, and the two copies
+# used different forms of the same path -- raw in the message, `~`-shortened in the header. Counted
+# exactly, because a substring check cannot tell one naming from two.
+assert_fail "mise config ls" "Invalid TOML in config file"
 assert_fail "mise config ls" "~/.config/mise/miserc.toml:2:8"
 assert_fail "mise config ls" "key with no value, expected"
+assert "mise config ls 2>&1 | grep -oF 'miserc.toml' | wc -l | tr -d ' '" "1"
 rm -f "$MISE_CONFIG_DIR/miserc.toml"
 echo 'env = ["test"]' >.miserc.toml
 mkdir -p subdir

--- a/src/config/config_file/diagnostic.rs
+++ b/src/config/config_file/diagnostic.rs
@@ -3,15 +3,20 @@
 use crate::file::display_path;
 use miette::{Diagnostic, NamedSource, SourceSpan};
 use std::fmt;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use thiserror::Error;
 
 /// A TOML parsing error with source location information for rich display.
+///
+/// The message deliberately does not name the file. `src` already does, and miette prints it above
+/// the snippet, so repeating it here rendered the same path twice in two different forms -- raw
+/// from `Path::display` in the message, shortened by [`display_path`] in the snippet header. On
+/// Windows the duplicate was also the one that wrapped, mid drive letter. Every caller that shows
+/// this error without the snippet names the file itself.
 #[derive(Debug, Error, Diagnostic)]
-#[error("Invalid TOML in config file: {}", path.display())]
+#[error("Invalid TOML in config file")]
 #[diagnostic(code(mise::config::parse_error))]
 pub(crate) struct TomlParseError {
-    path: PathBuf,
     #[source_code]
     src: NamedSource<String>,
     #[label("{message}")]
@@ -62,7 +67,6 @@ pub(crate) fn toml_parse_error(err: &toml::de::Error, source: &str, path: &Path)
         .unwrap_or_else(|| SourceSpan::from((0, 0)));
 
     let diagnostic = TomlParseError {
-        path: path.to_path_buf(),
         src: NamedSource::new(display_path(path), source.to_string()),
         span,
         message,


### PR DESCRIPTION
A TOML parse error names the same file twice, in two different forms. Measured on Linux 2026.8.3:

```
  × Invalid TOML in config file: /home/jam/diagprobe/cfg/miserc.toml
   ╭─[~/diagprobe/cfg/miserc.toml:2:8]
```

The message uses `Path::display`; the snippet header uses `file::display_path`, which shortens
`$HOME` to `~`. Same file, two lines, two spellings.

On Windows the duplicate is also the copy that wraps — miette's line breaking finds an opportunity
right after the drive letter's colon:

```
  × Invalid TOML in config file: C:
  │ \Users\Jam\AppData\Local\Temp\…\mise.toml
   ╭─[C:\Users\Jam\AppData\Local\Temp\…\mise.toml:2:12]
```

The header is intact in both cases. **The wrap is the symptom; the duplicate is the defect**, and it
is not Windows-specific — Windows just makes it obvious.

### The change

The message drops the path. `NamedSource` already carries it and miette prints it above the snippet,
so the file is still named — once, in the form the rest of mise uses. The now-unread `path` field
goes with it.

### Why dropping it from `Display` is safe

`MiseDiagnostic`'s plain `Display` comes from this `#[error]`, so it matters wherever the snippet is
not rendered. Every such path names the file itself:

| path | how it names the file |
|---|---|
| `config/mod.rs` tracked configs | `warn!("error loading tracked config file {}: {err:#}", display_path(&path))` |
| `config/mod.rs` monorepo hierarchy | `warn!("Failed to parse config file {} in monorepo directory {} …")` |
| `config/mod.rs` config chain ×2 | `err.wrap_err(format!("error parsing config file: {}", display_path(f)))` |
| everything that `?`-propagates | reaches `handle_err`, which renders the snippet — header included |

The last row is the wide one, so it was checked rather than assumed: the callers of
`config_file::parse` / `MiseToml::from_file` outside tests either propagate with `?` — and
`handle_err` intercepts `MiseDiagnostic` before any plain rendering — or discard the error with
`unwrap_or_default`. Two of those propagating paths were run end to end (`mise config ls`,
`mise env`) and both produced the snippet with its header.

In the `wrap_err` cases this also removes a *third* naming of the same file.

### Tests

`e2e/config/test_miserc` already had the fixture and, tellingly, **already pinned the header**:
`~/.config/mise/miserc.toml:2:8`. The project was reading the file name from the snippet, not from
the message.

- The existing `"Invalid TOML in config file:"` assertion loses its trailing colon, which was there
  only because a path followed. Deliberate, and it would fail otherwise.
- A new assertion counts the file name in the output **exactly**: `assert_contains` cannot tell one
  naming from two, which is the entire subject here.

No Windows e2e: the defect reproduces on Linux and the fix is shared code — the wrap follows from
the duplicate, so pinning the cause is enough. No unit test: `diagnostic.rs` has no test module and
what is under test is miette's rendering, which the e2e drives for real.

### Verification

The count assertion is red on the released binary for the right reason — `2`, one per spelling. The
suite is green there before the change (`rc=0` on the unmodified file), so the baseline is
established rather than assumed.

`cargo fmt --all`, `shfmt -d` and `shellcheck -x` are clean. `cargo check` does not run on this
machine (`libz-ng-sys` wants `cmake`, not installed), so type-checking is left to CI — nothing here
is reported as having been compiled locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invalid configuration error messages by removing duplicated file paths.
  * Error messages continue to show the relevant location and parsing details.
  * Updated validation to ensure each file path appears only once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->