### PR TITLE
fix(config): say what a backslash does when a config fails to parse

### DIFF
--- a/e2e/config/test_toml_backslash_help
+++ b/e2e/config/test_toml_backslash_help
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# A backslash starts an escape inside a TOML basic string, so the most ordinary thing a Windows
+# user writes -- `"C:\Users\you"` -- fails with a complaint about unicode digits or an expected
+# escape character. Neither mentions the backslash that caused it. `docs/configuration.md` explains
+# the trap, but only under the `path:` tool scope, and nothing connected the error to it.
+
+# Control: the literal-string form the help recommends actually works, so the failure below is
+# about the quoting and not about the value.
+cat <<'TOML' >mise.toml
+[env]
+P = 'C:\Users\you'
+TOML
+assert_contains "mise env" 'C:\Users\you'
+
+cat <<'TOML' >mise.toml
+[env]
+P = "C:\Users\you"
+TOML
+# Matched on single words: miette wraps the help line, so a phrase can be split across lines.
+assert_fail_contains "mise env" "help:"
+assert_fail_contains "mise env" "backslash"
+assert_fail_contains "mise env" "literal"
+
+# The other escape error the toml crate produces for a Windows path. Different message, same cause,
+# so the advice has to reach it too.
+cat <<'TOML' >mise.toml
+[env]
+P = "C:\dev"
+TOML
+assert_fail_contains "mise env" "backslash"
+
+# Control that matters most: a parse error with no backslash on the failing line must not collect
+# the advice. Help that shows up everywhere is worth nothing where it belongs.
+cat <<'TOML' >mise.toml
+[env]
+fdsfads
+TOML
+assert_fail_contains "mise env" "Invalid TOML in config file"
+assert "mise env 2>&1 | grep -c 'help:' || true" "0"

--- a/src/config/config_file/diagnostic.rs
+++ b/src/config/config_file/diagnostic.rs
@@ -22,6 +22,46 @@ pub(crate) struct TomlParseError {
     #[label("{message}")]
     span: SourceSpan,
     message: String,
+    /// Rendered as a `help:` line, and only when set. See [`backslash_help`].
+    #[help]
+    help: Option<String>,
+}
+
+/// Advice for the way a Windows path most often breaks a config file.
+///
+/// A backslash starts an escape inside a TOML basic string, so `"C:\Users\you"` fails with a
+/// complaint about unicode digits or an expected escape character -- neither of which mentions the
+/// backslash that caused it. `docs/configuration.md` already explains this, but only under the
+/// `path:` tool scope, and nothing connects the error to it.
+///
+/// Two conditions, deliberately: the wording comes from the `toml` crate and could be reworded,
+/// while a backslash on the failing line is a fact about the user's file. Requiring both means a
+/// reworded message costs the advice rather than misplacing it.
+fn backslash_help(source: &str, span: &SourceSpan, message: &str) -> Option<String> {
+    if !(message.contains("escape") || message.contains("unicode")) {
+        return None;
+    }
+    if !failing_line(source, span.offset())?.contains('\\') {
+        return None;
+    }
+    Some(
+        "a backslash starts an escape inside a double-quoted TOML string. \
+         Write a Windows path as a literal string -- 'C:\\Users\\you' -- \
+         or double the backslashes: \"C:\\\\Users\\\\you\"."
+            .to_string(),
+    )
+}
+
+/// The line `offset` falls on, or `None` if it is not a character boundary.
+fn failing_line(source: &str, offset: usize) -> Option<&str> {
+    let offset = offset.min(source.len());
+    let before = source.get(..offset)?;
+    let start = before.rfind('\n').map_or(0, |i| i + 1);
+    let end = source
+        .get(offset..)?
+        .find('\n')
+        .map_or(source.len(), |i| offset + i);
+    source.get(start..end)
 }
 
 /// A diagnostic error that stores pre-rendered miette output.
@@ -66,10 +106,12 @@ pub(crate) fn toml_parse_error(err: &toml::de::Error, source: &str, path: &Path)
         .map(|r| SourceSpan::from((r.start, r.end.saturating_sub(r.start))))
         .unwrap_or_else(|| SourceSpan::from((0, 0)));
 
+    let help = backslash_help(source, &span, &message);
     let diagnostic = TomlParseError {
         src: NamedSource::new(display_path(path), source.to_string()),
         span,
         message,
+        help,
     };
 
     eyre::Report::new(MiseDiagnostic::new(diagnostic))


### PR DESCRIPTION
A backslash starts an escape inside a TOML basic string, so the most ordinary line a Windows user
writes fails with a message that never mentions backslashes. Measured on 2026.8.10:

| config line | result |
|---|---|
| `P = "C:\Users\Jam"` | rc=1 — `too few unicode value digits, expected unicode hexadecimal value` |
| `P = "C:\dev"`, `"C:\q"`, `"C:\Program Files"` | rc=1 — ``missing escaped value, expected `b`, `e`, `f`, …`` |
| `P = "C:\temp"` | **rc=0** — the value silently becomes `C:<TAB>emp` |
| `P = 'C:\temp'` (literal string) | rc=0, correct |
| `P = "C:/temp"` | rc=0, correct |

The trap is TOML's, not mise's, and it is platform-independent — only the impact is Windows-shaped,
since backslash paths are where people meet it.

### The project already knows this

`docs/configuration.md` explains it precisely, down to the silent case: *"`"C:\tools\node"` is not
rejected — TOML reads `\t` as a tab — so the path silently becomes something else."* But that lives
under the `path:` tool scope, while the trap applies to every string in the config, `[env]`
included, and nothing connects the error to it.

### The change

`TomlParseError` gains an optional `#[help]`. It is offered on **two** conditions:

1. the message is escape-related (`contains("escape") || contains("unicode")` — covering both forms
   above), and
2. the **failing line actually has a backslash**.

The second is the point. The wording belongs to the `toml` crate and could be reworded at any time;
a backslash on the line is a fact about the user's file. Requiring both means a reworded message
costs the advice rather than misplacing it.

```
  help: a backslash starts an escape inside a double-quoted TOML string. Write a
        Windows path as a literal string -- 'C:\Users\you' -- or double the
        backslashes: "C:\Users\you".
```

### Not attempted: the silent case

`"C:\temp"` is valid TOML. Detecting it means guessing that a tab in a value was meant as `\t`-the-
path-separator rather than `\t`-the-tab, and `"a\tb"` is a legitimate way to write one. **Half of
this trap can be caught exactly and half only by heuristic; this closes the exact half** and leaves
the other named rather than half-guessed.

### Tests

`e2e/config/test_toml_backslash_help` is new:

- a control that the recommended literal form works, so the failure below is about quoting rather
  than the value;
- both escape-error forms, matched on **single words** because miette wraps the help line and a
  phrase can be split across it;
- the control that matters most — a parse error with **no** backslash must not collect the advice.
  Help that appears everywhere is worth nothing where it belongs.

No Windows e2e (platform-independent defect, shared fix) and no unit test (`diagnostic.rs` has no
test module and what is under test is miette's rendering, which the e2e drives for real).

### Verification

Measured against the released binary first: the control passes, `help:` and `backslash` are absent
for both escape forms, and the no-backslash control already reports `0` occurrences of `help:` — so
that guard is green now and must stay green.

`cargo fmt --all`, `shfmt -d` and `shellcheck -x` are clean. **The rendered help line has not been
seen locally** — `cargo check` does not run on this machine (`libz-ng-sys` wants `cmake`), so the
`#[help]` derive form was confirmed by reading miette 7.6's source (`miette-derive/src/help.rs`
handles a field-level `#[help]` through `OptionalWrapper`, and `handlers/graphical.rs` prints it as
`  help: `) rather than by running it. CI is the first place the output is actually produced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added helpful guidance when Windows-style paths use backslashes incorrectly in TOML configuration files.
  * Guidance appears only for relevant escape-sequence errors and not for unrelated TOML syntax issues.

* **Bug Fixes**
  * Improved invalid TOML diagnostics with clearer path presentation and consistent error messages.
  * Ensured configuration file paths are displayed correctly and only once.
  * Clarified configuration error messages without duplicating file path information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->