### PR TITLE
feat(env): decrypt SOPS-encrypted dotenv files

### DIFF
--- a/docs/environments/secrets/sops.md
+++ b/docs/environments/secrets/sops.md
@@ -2,7 +2,7 @@
 
 mise reads encrypted secret files and makes values available as environment variables via `env._.file`.
 
-- **Formats**: `.env.json`, `.env.yaml`, `.env.toml`
+- **Formats**: `.env.json`, `.env.yaml`, `.env.toml`, and dotenv (any other extension `env._.file` accepts, such as `.env` or `secrets.sops.env`)
 - **Encryption**: [sops](https://getsops.io), using the built-in age support or the external `sops` CLI
 
 ## Example
@@ -33,6 +33,24 @@ and PGP.
 :::: warning
 The external `sops` CLI does not currently support TOML input/output. mise can decrypt SOPS-encrypted `.env.toml` files only with the default `sops.rops = true` setting. If you set `sops.rops = false`, mise shells out to the `sops` CLI and encrypted TOML env files fail with a configuration error. Use `.env.json` or `.env.yaml` when you need the external CLI path.
 ::::
+:::: warning
+rops has no dotenv support ([gibbz00/rops#99](https://github.com/gibbz00/rops/issues/99)), so mise decrypts SOPS dotenv files by shelling out to the `sops` CLI even under the default `sops.rops = true`. Install it with `mise use sops` — without it, decryption fails in strict mode. Everything else about a dotenv file works the way `.env.json` does, including `redact = true` and re-reading the file when it changes.
+::::
+
+## Dotenv
+
+A dotenv file is detected by its content, not its name: mise looks for the `sops_version=` line SOPS writes together with a `sops_mac=ENC[` line, so any name `env._.file` accepts works. All of that is required, so a plain dotenv file that happens to define `sops_version` — or even both key names — is still read as plain text unless the MAC actually holds SOPS output.
+
+```sh
+sops encrypt -i --input-type dotenv --output-type dotenv --age "<public key>" secrets.sops.env
+```
+
+```toml [mise.toml]
+[env]
+_.file = "secrets.sops.env"
+```
+
+This keeps a single encrypted file usable by both mise and tools that require dotenv input, such as Kustomize's `secretGenerator`.
 
 1. Install tools: `mise use -g sops age`
 

--- a/e2e/secrets/test_sops_dotenv
+++ b/e2e/secrets/test_sops_dotenv
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -x
+
+# rops has no dotenv FileFormat, so mise decrypts dotenv through the sops CLI
+# even though sops.rops defaults to true.
+mise use sops age
+age="$(mise x -- age-keygen 2>&1)"
+age_pub="$(echo "$age" | grep -E "(Public key:|# public key:)" | head -1 | awk '{print $(NF)}')"
+MISE_SOPS_AGE_KEY="$(echo "$age" | grep "AGE-SECRET-KEY")"
+export MISE_SOPS_AGE_KEY
+
+printf 'SECRET=mysecret\nOTHER="two words"\n' >.env
+mise x -- sops encrypt -i --input-type dotenv --output-type dotenv --age "$age_pub" .env
+
+# The file really is encrypted and really does carry the marker mise looks for.
+assert_not_contains "cat .env" "SECRET=mysecret"
+assert_contains "cat .env" "sops_version="
+
+assert "mise set _.file=.env"
+assert_contains "mise env" "export SECRET=mysecret"
+assert_contains "mise env" "export OTHER='two words'"
+
+# The sops metadata keys are not exported.
+assert_not_contains "mise env" "sops_version"
+assert_not_contains "mise env" "sops_mac"
+
+# Rotating the file is picked up without clearing the cache, which _.source
+# with a decrypt script cannot do.
+printf 'SECRET=rotated\n' >.env
+mise x -- sops encrypt -i --input-type dotenv --output-type dotenv --age "$age_pub" .env
+assert_contains "mise env" "export SECRET=rotated"
+
+# Asking for the sops CLI explicitly takes the same path.
+mise settings set sops.rops 0
+assert_contains "mise env" "export SECRET=rotated"
+
+# A plain dotenv file is untouched by any of this.
+mise settings set sops.rops 1
+printf 'PLAIN=yes\n' >plain.env
+assert "mise set _.file=plain.env"
+assert_contains "mise env" "export PLAIN=yes"

--- a/e2e/secrets/test_sops_dotenv_cli
+++ b/e2e/secrets/test_sops_dotenv_cli
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -x
+
+# Which sops invocation mise makes for a dotenv file, without real crypto.
+cat >"$HOME/bin/sops" <<'SOPS'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"$HOME/sops-invocations"
+cat >/dev/null
+
+if [[ ${FAKE_SOPS_FAIL:-0} == 1 ]]; then
+  exit 42
+fi
+
+echo 'SECRET=cli-secret'
+SOPS
+chmod +x "$HOME/bin/sops"
+
+cat >.env <<'ENV'
+SECRET=ENC[AES256_GCM,data:ZmFrZQ==,iv:ZmFrZQ==,tag:ZmFrZQ==,type:str]
+sops_lastmodified=2026-08-23T11:10:00Z
+sops_mac=ENC[AES256_GCM,data:ZmFrZQ==,iv:ZmFrZQ==,tag:ZmFrZQ==,type:str]
+sops_version=3.13.3
+ENV
+
+cat >mise.toml <<'TOML'
+[env]
+_.file = ".env"
+TOML
+
+export MISE_SOPS_STRICT=0
+unset MISE_SOPS_AGE_KEY MISE_SOPS_AGE_KEY_FILE SOPS_AGE_KEY SOPS_AGE_KEY_FILE
+
+# sops.rops defaults to true, and dotenv still goes to the CLI because rops has
+# no dotenv format.
+export MISE_SOPS_ROPS=1
+assert_contains "mise env" "export SECRET=cli-secret"
+assert_contains "cat \"$HOME/sops-invocations\"" "decrypt --input-type dotenv --output-type dotenv"
+
+# Non-strict mode skips the file when the CLI fails.
+export FAKE_SOPS_FAIL=1
+assert_not_contains "mise env" "SECRET"
+
+# Strict mode propagates the failure.
+export MISE_SOPS_STRICT=1
+assert_fail "mise env"
+
+# A plain dotenv file never reaches sops at all — not even one that defines both
+# metadata key names itself, because the MAC has to hold SOPS output.
+export FAKE_SOPS_FAIL=0
+export MISE_SOPS_STRICT=1
+printf 'PLAIN=yes\nsops_version=3.13.3\nsops_mac=not-sops-output\n' >plain.env
+cat >mise.toml <<'TOML'
+[env]
+_.file = "plain.env"
+TOML
+before="$(wc -l <"$HOME/sops-invocations")"
+assert_contains "mise env" "export PLAIN=yes"
+assert_contains "mise env" "export sops_version=3.13.3"
+assert_contains "mise env" "export sops_mac=not-sops-output"
+after="$(wc -l <"$HOME/sops-invocations")"
+assert "test \"$before\" = \"$after\""

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1717,7 +1717,7 @@
             },
             "rops": {
               "default": true,
-              "description": "Use rops to decrypt sops files. Disable to shell out to `sops` which will slow down mise but sops may offer features not available in rops. Required for TOML SOPS files because the sops CLI does not support TOML.",
+              "description": "Use rops to decrypt sops files. Disable to shell out to `sops` which will slow down mise but sops may offer features not available in rops. Required for TOML SOPS files because the sops CLI does not support TOML. Ignored for dotenv SOPS files, which always use the sops CLI because rops has no dotenv support.",
               "type": "boolean"
             },
             "strict": {

--- a/settings.toml
+++ b/settings.toml
@@ -2641,7 +2641,7 @@ type = "String"
 
 [sops.rops]
 default = true
-description = "Use rops to decrypt sops files. Disable to shell out to `sops` which will slow down mise but sops may offer features not available in rops. Required for TOML SOPS files because the sops CLI does not support TOML."
+description = "Use rops to decrypt sops files. Disable to shell out to `sops` which will slow down mise but sops may offer features not available in rops. Required for TOML SOPS files because the sops CLI does not support TOML. Ignored for dotenv SOPS files, which always use the sops CLI because rops has no dotenv support."
 env = "MISE_SOPS_ROPS"
 type = "Bool"
 

--- a/src/config/env_directive/file.rs
+++ b/src/config/env_directive/file.rs
@@ -48,7 +48,7 @@ impl EnvResults {
                 "json" => Self::json(config, exec_env, &p, parse_template).await?,
                 "yaml" => Self::yaml(config, exec_env, &p, parse_template).await?,
                 "toml" => Self::toml(config, exec_env, &p, parse_template).await?,
-                _ => Self::dotenv(&p, &acc, expand).await?,
+                _ => Self::dotenv(config, exec_env, &p, parse_template, &acc, expand).await?,
             };
             // Structured files are literal by default. With `expand = true`, run
             // their values through the same `$VAR` engine used by `[env]` values
@@ -215,8 +215,30 @@ impl EnvResults {
         }
     }
 
-    async fn dotenv(p: &Path, acc: &TeraEnvMap, expand: bool) -> Result<EnvMap> {
+    async fn dotenv<PT>(
+        config: &Arc<Config>,
+        exec_env: &TeraEnvMap,
+        p: &Path,
+        parse_template: PT,
+        acc: &TeraEnvMap,
+        expand: bool,
+    ) -> Result<EnvMap>
+    where
+        PT: FnMut(String) -> Result<String>,
+    {
         let errfn = || eyre!("failed to parse dotenv file: {}", display_path(p));
+        // Reading ahead only to look for the SOPS marker, so a plain dotenv file
+        // still reaches dotenvy exactly the way it did before.
+        if let Ok(raw) = file::read_to_string(p)
+            && is_sops_dotenv(&raw)
+        {
+            let decrypted = sops::decrypt_dotenv(config, exec_env, &raw, parse_template).await?;
+            if decrypted.is_empty() {
+                // Non-strict mode skipped it, same as the structured formats.
+                return Ok(EnvMap::new());
+            }
+            return Self::parse_dotenv(&decrypted, p, acc, expand);
+        }
         if !expand {
             // Preserve dotenvy's normal behavior unless cross-file expansion was
             // explicitly requested.
@@ -229,12 +251,26 @@ impl EnvResults {
             }
             return Ok(env);
         }
-        // dotenvy substitutes `${VAR}` only against the process env + vars defined
-        // earlier in the same file and has no API for a custom map. Seed the parse
-        // with accumulated values, then retain only keys defined by this file.
         let Ok(content) = file::read_to_string(p) else {
             return Ok(EnvMap::new());
         };
+        Self::parse_dotenv(&content, p, acc, expand)
+    }
+
+    /// Parse dotenv text that is already in hand, decrypted or not.
+    fn parse_dotenv(content: &str, p: &Path, acc: &TeraEnvMap, expand: bool) -> Result<EnvMap> {
+        let errfn = || eyre!("failed to parse dotenv file: {}", display_path(p));
+        if !expand {
+            let mut env = EnvMap::new();
+            for item in dotenvy::from_read_iter(content.as_bytes()) {
+                let (k, v) = item.wrap_err_with(errfn)?;
+                env.insert(k, v);
+            }
+            return Ok(env);
+        }
+        // dotenvy substitutes `${VAR}` only against the process env + vars defined
+        // earlier in the same file and has no API for a custom map. Seed the parse
+        // with accumulated values, then retain only keys defined by this file.
         let mut own_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
         for item in dotenvy::from_read_iter(content.as_bytes()) {
             let (k, _v) = item.wrap_err_with(errfn)?;
@@ -263,6 +299,40 @@ impl EnvResults {
         }
         Ok(env)
     }
+}
+
+/// Does this dotenv text carry SOPS metadata?
+///
+/// SOPS's dotenv store flattens its metadata into `sops_`-prefixed keys. Match
+/// two of them at the start of a line, and require the MAC to carry a SOPS
+/// ciphertext rather than any value at all.
+///
+/// The bar is set there because a false positive is expensive: a plain file read
+/// as encrypted fails the whole config in strict mode and silently drops every
+/// variable in it otherwise. Nothing stops a dotenv file from defining its own
+/// `sops_version`, or even both key names, but `sops_mac=ENC[` additionally
+/// requires it to hold something shaped like SOPS output.
+///
+/// `sops_version` and `sops_mac` are the pair because SOPS writes both in every
+/// mode measured — default, `--unencrypted-suffix`, `--encrypted-regex`,
+/// `mac_only_encrypted`, and a single-key file — always with the MAC encrypted.
+/// `sops_unencrypted_suffix` looks like a candidate until `--encrypted-regex`
+/// drops it.
+///
+/// Sniffing the content rather than the file name is deliberate: `_.file` sends
+/// every extension it does not recognise down the dotenv path, including files
+/// with no extension at all, so there is no name to key off.
+fn is_sops_dotenv(raw: &str) -> bool {
+    let mut version = false;
+    let mut mac = false;
+    for line in raw.lines() {
+        version |= line.starts_with("sops_version=");
+        mac |= line.starts_with("sops_mac=ENC[");
+        if version && mac {
+            return true;
+        }
+    }
+    false
 }
 
 fn is_env_key(k: &str) -> bool {
@@ -313,6 +383,71 @@ mod tests {
             .encrypt::<AES256GCM, SHA512>()
             .unwrap()
             .to_string()
+    }
+
+    #[test]
+    fn detects_sops_metadata_in_dotenv() {
+        // Trimmed from a real `sops encrypt --input-type dotenv` result.
+        let raw = concat!(
+            "SECRET=ENC[AES256_GCM,data:PEpqNWS5S1k=,iv:xEPy,tag:ZE+F,type:str]\n",
+            "sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\\n...\n",
+            "sops_lastmodified=2026-08-23T11:10:00Z\n",
+            "sops_mac=ENC[AES256_GCM,data:vzLw,iv:RJNu,tag:4+mn,type:str]\n",
+            "sops_unencrypted_suffix=_unencrypted\n",
+            "sops_version=3.13.3\n",
+        );
+        assert!(is_sops_dotenv(raw));
+    }
+
+    #[test]
+    fn plain_dotenv_is_not_sops() {
+        assert!(!is_sops_dotenv("SECRET=mysecret\nOTHER=\"two words\"\n"));
+        assert!(!is_sops_dotenv(""));
+    }
+
+    #[test]
+    fn a_value_mentioning_the_marker_is_not_sops() {
+        // The marker only counts at the start of a line, so a file that merely
+        // talks about sops keeps its plain-dotenv path.
+        assert!(!is_sops_dotenv("NOTE=\"sops_version=3.13.3\"\n"));
+        assert!(!is_sops_dotenv("MY_sops_version=3.13.3\n"));
+    }
+
+    #[test]
+    fn a_plain_file_defining_sops_version_is_not_sops() {
+        // Nothing stops a dotenv file from having its own `sops_version`
+        // variable. One marker alone would send it to the decrypter, which
+        // fails the config in strict mode and drops every variable otherwise.
+        assert!(!is_sops_dotenv("sops_version=3.13.3\nSECRET=mysecret\n"));
+        assert!(!is_sops_dotenv(
+            "sops_mac=ENC[AES256_GCM,data:x]\nSECRET=s\n"
+        ));
+    }
+
+    #[test]
+    fn both_key_names_without_a_sops_mac_value_is_not_sops() {
+        // Even a file that defines both names is plain text unless the MAC
+        // holds something shaped like SOPS output.
+        assert!(!is_sops_dotenv(
+            "sops_version=3.13.3\nsops_mac=whatever\nSECRET=mysecret\n"
+        ));
+        assert!(is_sops_dotenv(
+            "sops_version=3.13.3\nsops_mac=ENC[AES256_GCM,data:x,type:str]\n"
+        ));
+    }
+
+    #[test]
+    fn parse_dotenv_reads_decrypted_text() {
+        // What the sops CLI hands back: no metadata left to strip.
+        let env = EnvResults::parse_dotenv(
+            "SECRET=mysecret\nOTHER=\"two words\"\n",
+            Path::new(".env"),
+            &TeraEnvMap::new(),
+            false,
+        )
+        .unwrap();
+        assert_eq!(env.get("SECRET").map(String::as_str), Some("mysecret"));
+        assert_eq!(env.get("OTHER").map(String::as_str), Some("two words"));
     }
 
     fn restore_env_var(key: &str, prev: Option<String>) {

--- a/src/sops.rs
+++ b/src/sops.rs
@@ -40,6 +40,33 @@ impl ResolvedAgeKey {
     }
 }
 
+/// The `--input-type`/`--output-type` value for SOPS dotenv files.
+pub(crate) const DOTENV: &str = "dotenv";
+
+/// Decrypt a SOPS dotenv file.
+///
+/// rops cannot represent dotenv (gibbz00/rops#99), so this always shells out to
+/// the sops CLI. The `F` type parameter is only read on the rops path, which
+/// this never takes.
+pub(crate) async fn decrypt_dotenv<PT>(
+    config: &Arc<Config>,
+    exec_env: &EnvMap,
+    input: &str,
+    parse_template: PT,
+) -> result::Result<String>
+where
+    PT: FnMut(String) -> result::Result<String>,
+{
+    decrypt::<_, rops::file::format::JsonFileFormat>(
+        config,
+        exec_env,
+        input,
+        parse_template,
+        DOTENV,
+    )
+    .await
+}
+
 pub(crate) async fn decrypt<PT, F>(
     config: &Arc<Config>,
     exec_env: &EnvMap,
@@ -53,7 +80,10 @@ where
 {
     static MUTEX: Mutex<()> = Mutex::const_new(());
 
-    let use_rops = Settings::get().sops.rops;
+    // rops has no dotenv FileFormat (gibbz00/rops#99), so a SOPS dotenv file
+    // always goes through the sops CLI, whatever sops.rops says. This is the
+    // mirror of the TOML case below, which the CLI cannot read.
+    let use_rops = Settings::get().sops.rops && format != DOTENV;
     if !use_rops && format == "toml" {
         return Err(eyre!(
             "sops.rops=false is not supported for TOML SOPS files because the sops CLI does not support TOML; set sops.rops=true or use a JSON/YAML SOPS file"
@@ -129,7 +159,13 @@ where
                     } else {
                         env::remove_var("SOPS_AGE_KEY_FILE");
                     }
-                    return Err(eyre!("sops command not found"));
+                    return Err(if format == DOTENV {
+                        eyre!(
+                            "sops command not found; SOPS dotenv files need it because the built-in rops decrypter has no dotenv support. Install it with `mise use sops`, or use a JSON/YAML SOPS file"
+                        )
+                    } else {
+                        eyre!("sops command not found")
+                    });
                 } else {
                     debug!("sops command not found, skipping decryption in non-strict mode");
                     None


### PR DESCRIPTION
Addresses discussion #9926.

## The gap

`env._.file` decrypts SOPS `.json`, `.yaml`, and `.toml` files. A dotenv file goes straight to the parser as ciphertext:

```
failed to parse dotenv file: secrets.sops.env
Error parsing line: '-----BEGIN AGE ENCRYPTED FILE-----\n...'
```

It matters because some consumers only take dotenv. Kustomize's `secretGenerator` is the reported one — converting the file to JSON to please mise breaks the single source of truth. The workaround is `_.source` with a decrypt script, which works but leaves mise unaware that the encrypted file is an input, so the env cache does not invalidate when secrets are rotated. That is the reporter's actual ask.

## Approach, and the part that is a judgement call

**rops cannot do this.** It has no dotenv `FileFormat`, and upstream [gibbz00/rops#99](https://github.com/gibbz00/rops/issues/99) describes the flattened-dotenv representation as non-trivial. The sops CLI can.

So dotenv ignores `sops.rops` and always shells out. This is the mirror of the TOML case, which already errors under `sops.rops = false` because the CLI cannot read TOML. When the CLI is missing, the error now says why it is needed instead of just `sops command not found`.

**This is the honest limitation and I would rather you decide it than have it slip through:** with this change, dotenv is the one format that does not work with the built-in decrypter. A user on the default `sops.rops = true` who has never installed `sops` gets a failure in strict mode. The alternatives I considered:

- **Wait for rops.** Correct, but #99 has been open since 2024 and dotenv support is not close.
- **Convert the dotenv metadata to YAML in memory and feed rops.** Possible in principle — the `sops_*` keys are a flattened nesting — but it means a second SOPS document model inside mise, tracking upstream's flattening rules by hand, with the MAC to get right. I do not think that belongs here.
- **Refuse unless `sops.rops = false` is set explicitly.** Worse: that setting is global, so opting into dotenv would drag every other SOPS file onto the CLI too.

If you would rather this waited for rops, say so and I will close it.

## Detection

By content, not file name. `_.file` sends every extension it does not recognise down the dotenv path — including files with no extension — so there is no name to key off.

It takes `sops_version=` **and** `sops_mac=ENC[`, both at the start of a line.

The bar is set there because a false positive is expensive: a plain file read as encrypted fails the whole config in strict mode and silently drops every variable in it otherwise. Nothing stops a dotenv file from defining its own `sops_version`, or even both key names, so the MAC also has to hold something shaped like SOPS output.

Those two keys are the pair because SOPS writes both in every mode I could produce — default, `--unencrypted-suffix`, `--encrypted-regex`, `mac_only_encrypted`, and a single-key file — always with the MAC encrypted:

```
default              sops_..._map_enc sops_..._map_recipient sops_lastmodified sops_mac=ENC[ sops_unencrypted_suffix sops_version
--unencrypted-suffix sops_..._map_enc sops_..._map_recipient sops_lastmodified sops_mac=ENC[ sops_unencrypted_suffix sops_version
--encrypted-regex    sops_..._map_enc sops_..._map_recipient sops_encrypted_regex sops_lastmodified sops_mac=ENC[ sops_version
mac_only_encrypted   sops_mac=ENC[ sops_version
single key           sops_..._map_enc sops_..._map_recipient sops_lastmodified sops_mac=ENC[ sops_unencrypted_suffix sops_version
```

`sops_unencrypted_suffix` looks like a candidate until `--encrypted-regex` drops it.

A file that does not match takes exactly the path it took before, still through `dotenvy::from_path_iter`. Only a detected SOPS file switches to parsing text already in hand.

## Verified against real crypto before relying on it

Two things I did not want to assume:

- `sops decrypt --input-type dotenv --output-type dotenv` returns the plain values with the `sops_*` metadata **already stripped**, so nothing needs filtering. (Had it not, `sops_mac` and friends would have been exported as env vars.)
- The metadata keys are the flattened `sops_age__list_0__map_enc`, `sops_age__list_0__map_recipient`, `sops_lastmodified`, `sops_mac`, `sops_unencrypted_suffix`, `sops_version` set.

End to end with an age-encrypted file: values decrypt under the default settings, no `sops_*` key is exported, `redact = true` works, and **rotating the encrypted file is picked up with no `mise cache clear`** — watching and redaction needed no work, because the `_.file` directive pushes every file it loads to `env_files` and applies `redact` regardless of format.

## Tests

- `e2e/secrets/test_sops_dotenv` — real `sops` + `age` round trip: encrypt, decrypt through `mise env`, assert no metadata leaks, rotate the file and see the new value, then `sops.rops = 0`, then a plain dotenv file for the untouched path.
- `e2e/secrets/test_sops_dotenv_cli` — the fake-`sops` pattern from `test_sops_cli_without_age`: asserts the invocation is `decrypt --input-type dotenv --output-type dotenv`, that it happens under `sops.rops = 1`, the strict/non-strict split, and that a plain dotenv file never reaches sops at all — including, under strict mode, one that defines both `sops_version` and `sops_mac` itself; all of its variables are exported normally and the sops invocation count does not move.
- Unit tests for the markers: a plain file whose *value* mentions `sops_version`, one that genuinely defines `sops_version` as a variable, and one that defines **both** key names with a MAC that is not SOPS output.
- `test_secrets`, `test_secrets_non_strict`, `test_sops_multiple_age_keys`, `test_sops_cli_without_age`, `test_age_secrets_non_strict` all still pass.

`cargo clippy --workspace --all-features --all-targets -- -D warnings`, `cargo fmt --check`, `shellcheck`, `shfmt`, `taplo`, `prettier`, and `markdownlint` are clean. `schema/mise.json` is regenerated from the one-line `settings.toml` description change and contains nothing else.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for loading SOPS-encrypted dotenv files with any supported filename.
  * Automatically detects and decrypts encrypted dotenv files through the SOPS CLI.
  * Supports refreshing rotated encrypted secrets without clearing the cache.
  * Plain dotenv files continue to work unchanged.

* **Documentation**
  * Added encryption, configuration, interoperability, redaction, reload, and strict-mode guidance.
  * Clarified that encrypted dotenv files always require the SOPS CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->