### PR TITLE
feat(bootstrap): add package plugin uninstall support

### DIFF
--- a/crates/vfox/src/hooks/package.rs
+++ b/crates/vfox/src/hooks/package.rs
@@ -21,6 +21,11 @@ pub struct PackageActionContext {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageUninstallContext {
+    pub packages: Vec<PackageRequest>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InstalledPackage {
     pub name: String,
     pub state: String,
@@ -71,6 +76,18 @@ impl Plugin {
         })
         .await
     }
+
+    pub async fn package_uninstall(
+        &self,
+        ctx: PackageUninstallContext,
+    ) -> Result<PackageActionResponse> {
+        debug!("[vfox:{}] package_uninstall", self.name);
+        self.eval_async(chunk! {
+            require "hooks/package_uninstall"
+            return PLUGIN:PackageUninstall($ctx)
+        })
+        .await
+    }
 }
 
 fn packages_into_lua(packages: Vec<PackageRequest>, lua: &Lua) -> mlua::Result<Value> {
@@ -98,6 +115,14 @@ impl IntoLua for PackageActionContext {
         table.set("packages", packages_into_lua(self.packages, lua)?)?;
         table.set("dry_run", self.dry_run)?;
         table.set("update", self.update)?;
+        Ok(Value::Table(table))
+    }
+}
+
+impl IntoLua for PackageUninstallContext {
+    fn into_lua(self, lua: &Lua) -> mlua::Result<Value> {
+        let table = lua.create_table()?;
+        table.set("packages", packages_into_lua(self.packages, lua)?)?;
         Ok(Value::Table(table))
     }
 }
@@ -162,6 +187,67 @@ mod tests {
         let package = packages.get::<mlua::Table>(1).unwrap();
         assert_eq!(package.get::<String>("version").unwrap(), "nightly-2026.07");
         assert!(table.get::<bool>("dry_run").unwrap());
+    }
+
+    #[test]
+    fn package_uninstall_context_serializes_packages_without_action_flags() {
+        let lua = Lua::new();
+        let value = PackageUninstallContext {
+            packages: vec![PackageRequest {
+                name: "extension".into(),
+                version: Some("nightly-2026.07".into()),
+            }],
+        }
+        .into_lua(&lua)
+        .unwrap();
+        let table = value.as_table().unwrap();
+        let packages = table.get::<mlua::Table>("packages").unwrap();
+        let package = packages.get::<mlua::Table>(1).unwrap();
+        assert_eq!(package.get::<String>("name").unwrap(), "extension");
+        assert_eq!(package.get::<String>("version").unwrap(), "nightly-2026.07");
+        assert!(!table.contains_key("dry_run").unwrap());
+        assert!(!table.contains_key("update").unwrap());
+    }
+
+    #[tokio::test]
+    async fn package_uninstall_dispatches_to_hook() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("hooks")).unwrap();
+        std::fs::write(
+            tmp.path().join("metadata.lua"),
+            r#"PLUGIN = {
+                name = "fake",
+                version = "0.1.0",
+                homepage = "",
+                license = "MIT",
+                description = "fake",
+                minRuntimeVersion = "0.3.0",
+                notes = {},
+                legacyFilenames = {},
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.path().join("hooks/package_uninstall.lua"),
+            r#"function PLUGIN:PackageUninstall(ctx)
+                assert(#ctx.packages == 1)
+                assert(ctx.packages[1].name == "extension")
+                assert(ctx.packages[1].version == "release:edge")
+                assert(ctx.dry_run == nil)
+                return {}
+            end"#,
+        )
+        .unwrap();
+        let plugin = Plugin::from_dir(tmp.path()).unwrap();
+        plugin
+            .package_uninstall(PackageUninstallContext {
+                packages: vec![PackageRequest {
+                    name: "extension".into(),
+                    version: Some("release:edge".into()),
+                }],
+            })
+            .await
+            .unwrap();
     }
 
     #[test]

--- a/crates/vfox/src/lib.rs
+++ b/crates/vfox/src/lib.rs
@@ -12,7 +12,7 @@ pub use error::Result as VfoxResult;
 pub use error::VfoxError;
 pub use hooks::package::{
     PackageActionContext, PackageActionResponse, PackageInstalledContext, PackageInstalledResponse,
-    PackageRequest,
+    PackageRequest, PackageUninstallContext,
 };
 pub use hooks::pre_install::VerifiedAttestation;
 pub use metadata::{Metadata, SystemDependency};

--- a/crates/vfox/src/lua_mod/hooks.rs
+++ b/crates/vfox/src/lua_mod/hooks.rs
@@ -10,7 +10,7 @@ pub(super) struct HookFunc {
 }
 
 #[rustfmt::skip]
-pub(super) const HOOK_FUNCS: [HookFunc; 15] = [
+pub(super) const HOOK_FUNCS: [HookFunc; 16] = [
     HookFunc { _name: "Available", filename: "available" },
     HookFunc { _name: "PreInstall", filename: "pre_install" },
     HookFunc { _name: "EnvKeys", filename: "env_keys" },
@@ -28,6 +28,7 @@ pub(super) const HOOK_FUNCS: [HookFunc; 15] = [
     HookFunc { _name: "PackageInstalled", filename: "package_installed" },
     HookFunc { _name: "PackageInstall", filename: "package_install" },
     HookFunc { _name: "PackageUpgrade", filename: "package_upgrade" },
+    HookFunc { _name: "PackageUninstall", filename: "package_uninstall" },
 
     // mise
     HookFunc { _name: "MiseEnv", filename: "mise_env" },

--- a/crates/vfox/src/vfox.rs
+++ b/crates/vfox/src/vfox.rs
@@ -19,6 +19,7 @@ use crate::hooks::mise_env::{MiseEnvContext, MiseEnvResult};
 use crate::hooks::mise_path::MisePathContext;
 use crate::hooks::package::{
     PackageActionContext, PackageActionResponse, PackageInstalledContext, PackageInstalledResponse,
+    PackageUninstallContext,
 };
 use crate::hooks::parse_legacy_file::ParseLegacyFileResponse;
 use crate::hooks::post_install::PostInstallContext;
@@ -589,6 +590,14 @@ impl Vfox {
         ctx: PackageActionContext,
     ) -> Result<PackageActionResponse> {
         self.get_sdk_with_env(sdk)?.package_upgrade(ctx).await
+    }
+
+    pub async fn package_uninstall(
+        &self,
+        sdk: &str,
+        ctx: PackageUninstallContext,
+    ) -> Result<PackageActionResponse> {
+        self.get_sdk_with_env(sdk)?.package_uninstall(ctx).await
     }
 
     pub async fn mise_path<T: serde::Serialize>(

--- a/docs/bootstrap/packages/index.md
+++ b/docs/bootstrap/packages/index.md
@@ -86,8 +86,9 @@ declarative sections work the same way:
   keys. A project can add packages on top of the global list (and override a
   global entry's version pin) but not remove them. For Homebrew formulae,
   `mise bootstrap packages prune` is an explicit destructive command that
-  removes linked formulae or safely prunable mise-owned casks no longer needed
-  by the current config or by trusted, loadable tracked configs.
+  removes linked formulae, safely prunable mise-owned casks, or packages owned
+  by uninstall-capable package plugins when they are no longer needed by the
+  current config or by trusted, loadable tracked configs.
 - **OS-filtered** — entries whose `os` selector does not match and entries for
   a manager that isn't available on the current machine are not acted on, so
   the same config works across platforms: `apt` entries are ignored on macOS,
@@ -141,6 +142,8 @@ mise bootstrap packages prune --manager brew --dry-run
 mise bootstrap packages prune --manager brew --yes
 mise bootstrap packages prune --manager brew-cask # remove safely prunable mise casks
 mise bootstrap packages prune --manager brew-cask --dry-run
+mise bootstrap packages prune --manager vscode # remove mise-owned plugin packages
+mise bootstrap packages prune --manager vscode --dry-run
 
 mise bootstrap packages upgrade           # upgrade installed packages to current versions
 mise bootstrap packages upgrade --manager brew
@@ -177,6 +180,13 @@ fingerprints. It skips older receipts, Homebrew-owned casks, pkg and command
 wrapper artifacts, casks with lifecycle actions, changed or shared targets,
 and incomplete transactions. Skips include a reason, and `zap` metadata is
 never applied.
+
+For a package-plugin manager, prune considers only packages mise observed
+transition from missing to installed during `PackageInstall`. Existing or
+manually installed packages are never adopted. The plugin must implement
+`PackageUninstall`; dry runs print the approved removal batch without invoking
+the hook, and mise verifies removals with `PackageInstalled` before updating its
+ownership state.
 
 `mise bootstrap packages upgrade` refreshes package manager metadata and upgrades the
 configured packages that are already installed to the newest available

--- a/docs/bootstrap/packages/index.md
+++ b/docs/bootstrap/packages/index.md
@@ -84,11 +84,12 @@ declarative sections work the same way:
 - **Declarative and additive by default** — entries merge across the
   [config hierarchy](/configuration.html) (global → project) as a union of
   keys. A project can add packages on top of the global list (and override a
-  global entry's version pin) but not remove them. For Homebrew formulae,
-  `mise bootstrap packages prune` is an explicit destructive command that
-  removes linked formulae, safely prunable mise-owned casks, or packages owned
-  by uninstall-capable package plugins when they are no longer needed by the
-  current config or by trusted, loadable tracked configs.
+  global entry's version pin) but not remove them. Pruning is an explicit,
+  manager-scoped destructive operation: `mise bootstrap packages prune`
+  defaults to Homebrew, while plugin-owned packages require
+  `mise bootstrap packages prune --manager <plugin>`. It removes only packages
+  no longer needed by the current config or by trusted, loadable tracked
+  configs.
 - **OS-filtered** — entries whose `os` selector does not match and entries for
   a manager that isn't available on the current machine are not acted on, so
   the same config works across platforms: `apt` entries are ignored on macOS,

--- a/docs/bootstrap/packages/plugins.md
+++ b/docs/bootstrap/packages/plugins.md
@@ -32,6 +32,7 @@ mise bootstrap plugins status --missing
 mise bootstrap plugins apply
 mise bootstrap packages status
 mise bootstrap packages apply
+mise bootstrap packages prune --manager vscode --dry-run
 ```
 
 You can install a plugin without declaring it:
@@ -46,8 +47,12 @@ do not create mise installs or shims, never elevate with `sudo`, and are not
 affected by `system_packages.sudo`. The `system_packages.managers` setting is
 name-based and can include or exclude plugin managers just like built-ins.
 
-Package removal and pruning are not supported in the first version of this API.
-Removing a config entry does not uninstall host-managed state.
+Plugins may implement `PackageUninstall` to support the explicit destructive
+command `mise bootstrap packages prune --manager <plugin>`. mise removes only
+packages it observed transition from missing to installed during a plugin
+install; packages that were already present are never claimed. Prune also keeps
+packages referenced by the current config or trusted, loadable tracked configs.
+Removing a config entry alone does not uninstall host-managed state.
 
 See [Package Plugin Development](/package-plugin-development.html) to create a
 plugin.

--- a/docs/cli/bootstrap/packages/prune.md
+++ b/docs/cli/bootstrap/packages/prune.md
@@ -7,20 +7,17 @@
 
 Prune installed system packages no longer declared in `[bootstrap.packages]`
 
-Supports Homebrew formulae and conservatively removable, mise-owned casks.
+Supports Homebrew formulae, conservatively removable mise-owned casks, and
+packages installed by package plugins that implement `PackageUninstall`.
 Pruning keeps packages needed by the current config or by trusted, loadable
-tracked configs.
+tracked configs. Plugin packages that were already installed before mise
+first applied them are never claimed or removed.
 
 ## Flags
 
 ### `-m --manager <MANAGER>`
 
 Only prune packages for this manager
-
-**Choices:**
-
-- `brew`
-- `brew-cask`
 
 **Default:** `brew`
 
@@ -39,4 +36,5 @@ mise bootstrap packages prune --manager brew
 mise bootstrap packages prune --manager brew --dry-run
 mise bootstrap packages prune --manager brew --yes
 mise bootstrap packages prune --manager brew-cask --dry-run
+mise bootstrap packages prune --manager vscode --dry-run
 ```

--- a/docs/cli/generate/task-stubs.md
+++ b/docs/cli/generate/task-stubs.md
@@ -23,7 +23,7 @@ Directory to create task stubs inside of
 
 Path to a mise bin to use when running the task stub.
 
-Use `--mise-bin=./bin/mise` to use a mise bin generated from `mise generate bootstrap`
+Use `--mise-bin=./bin/mise` to use a mise bin generated from `mise generate install-script`
 
 **Default:** `mise`
 

--- a/docs/package-plugin-development.md
+++ b/docs/package-plugin-development.md
@@ -112,7 +112,9 @@ ledger persists across plugin removal and reinstallation. Explicit prune still
 works when the desired set is empty, including after the final declaration is
 removed. After the hook returns or fails, mise calls `PackageInstalled` to
 verify each removal when possible and retains ownership for anything still
-present.
+present. After confirmation, mise reloads the complete desired set before
+invoking the hook; newly declared packages are removed from the approved batch,
+and new removal candidates are never added without another confirmation.
 
 ## Hard contracts
 

--- a/docs/package-plugin-development.md
+++ b/docs/package-plugin-development.md
@@ -14,7 +14,8 @@ mise-vscode-extensions/
 └── hooks/
     ├── package_installed.lua
     ├── package_install.lua
-    └── package_upgrade.lua
+    ├── package_upgrade.lua
+    └── package_uninstall.lua
 ```
 
 The required `hooks/package_installed.lua` and `hooks/package_install.lua` pair
@@ -89,9 +90,29 @@ may target only a subset, and removing the final declaration for a manager
 produces no batch for that manager. A plugin must not infer that an identity
 should be removed merely because it is absent from `ctx.packages`.
 
-The name reserves room for a future `PackageUninstall` hook, but uninstall and
-prune are not part of v1. Removing a config entry does not invoke a hook or
-uninstall host-managed state.
+`PackageUninstall` is optional and is used only by the explicit destructive
+command `mise bootstrap packages prune --manager <plugin>`. mise passes the
+concrete, approved removal batch after protecting packages declared by the
+current config and trusted, loadable tracked configs:
+
+```lua
+function PLUGIN:PackageUninstall(ctx)
+  for _, package in ipairs(ctx.packages) do
+    -- uninstall package.name; package.version is the observed installed version
+  end
+  return {}
+end
+```
+
+Dry runs do not invoke this hook. mise records ownership only when a package
+reported missing before `PackageInstall` is present afterwards. Packages that
+were already installed, including installations made before ownership tracking
+was introduced, are never claimed or sent to `PackageUninstall`. The ownership
+ledger persists across plugin removal and reinstallation. Explicit prune still
+works when the desired set is empty, including after the final declaration is
+removed. After the hook returns or fails, mise calls `PackageInstalled` to
+verify each removal when possible and retains ownership for anything still
+present.
 
 ## Hard contracts
 
@@ -103,6 +124,8 @@ uninstall host-managed state.
   should be fast.
 - Hooks operate on phase-specific batches and must not treat absence from a
   batch as an uninstall request.
+- `PackageUninstall` removes only the identities provided by mise and must not
+  perform manager-wide orphan cleanup.
 - Declare every required host binary in `requires`.
 
 For a VS Code implementation, `PackageInstalled` can parse

--- a/docs/package-plugin-development.md
+++ b/docs/package-plugin-development.md
@@ -39,7 +39,19 @@ os = ["macos", "linux"]
 
 ## Hooks
 
-All hooks receive the complete package batch. Managers must be batch-oriented.
+Hooks are batch-oriented, but each hook receives the batch for its own phase:
+
+- `PackageInstalled` receives every request in the current invocation. This may
+  be the merged `[bootstrap.packages]` declarations or an explicit subset named
+  on the command line.
+- `PackageInstall` receives only requests mise selected for installation, such
+  as packages reported missing or at a mismatched requested version.
+- `PackageUpgrade` receives the actionable requests reported as present,
+  including packages that are already current so the manager can no-op them.
+  Requests reported missing or unavailable and unsupported version pins are
+  omitted.
+
+mise does not call an action hook when its action batch is empty.
 
 ```lua
 function PLUGIN:PackageInstalled(ctx)
@@ -70,8 +82,16 @@ end
 ```
 
 `PackageUpgrade` has the same context and response. It is optional; mise calls
-`PackageInstall` when the upgrade hook is absent. The name reserves room for a
-future `PackageUninstall` hook, but uninstall and prune are not part of v1.
+`PackageInstall` when the upgrade hook is absent.
+
+An action batch is not a complete desired-state snapshot. An explicit command
+may target only a subset, and removing the final declaration for a manager
+produces no batch for that manager. A plugin must not infer that an identity
+should be removed merely because it is absent from `ctx.packages`.
+
+The name reserves room for a future `PackageUninstall` hook, but uninstall and
+prune are not part of v1. Removing a config entry does not invoke a hook or
+uninstall host-managed state.
 
 ## Hard contracts
 
@@ -81,7 +101,8 @@ future `PackageUninstall` hook, but uninstall and prune are not part of v1.
   parse or sort them.
 - `PackageInstalled` is side-effect free, non-interactive, never elevates, and
   should be fast.
-- Hooks operate on the full request batch.
+- Hooks operate on phase-specific batches and must not treat absence from a
+  batch as an uninstall request.
 - Declare every required host binary in `requires`.
 
 For a VS Code implementation, `PackageInstalled` can parse

--- a/e2e/plugins/test_package_plugin
+++ b/e2e/plugins/test_package_plugin
@@ -50,6 +50,19 @@ function PLUGIN:PackageInstall(ctx)
 end
 EOF
 
+cat >fake-package-plugin/hooks/package_uninstall.lua <<'EOF'
+function PLUGIN:PackageUninstall(ctx)
+  local cmd = require("cmd")
+  for _, package in ipairs(ctx.packages) do
+    if package.name == "z-fails" then
+      error("intentional uninstall failure")
+    end
+    cmd.exec("rm -f " .. os.getenv("HOME") .. "/.fake-packages/" .. package.name)
+  end
+  return {}
+end
+EOF
+
 assert "mise plugin link -f fake $PWD/fake-package-plugin" ""
 assert_contains "mise plugin ls" "fake"
 
@@ -73,13 +86,98 @@ assert_contains "mise bootstrap packages status" "version mismatch"
 assert "mise bootstrap packages apply --yes" ""
 assert "cat $HOME/.fake-packages/extension" "2.0"
 
+# Packages already present before apply are not claimed by mise.
+printf 'manual' >"$HOME/.fake-packages/manual"
+cat >mise.toml <<'EOF'
+[bootstrap.packages]
+"fake:extension" = "2.0"
+"fake:manual" = "latest"
+EOF
+assert "mise bootstrap packages apply --yes" ""
+
+# A trusted tracked config protects an owned package from plugin pruning.
+mkdir -p tracked
+cat >tracked/mise.toml <<'EOF'
+[bootstrap.packages]
+"fake:extension" = "latest"
+EOF
+assert_succeed "mise -C tracked bootstrap packages status"
+cat >mise.toml <<'EOF'
+[bootstrap.packages]
+EOF
+assert_contains "mise bootstrap packages prune --manager fake --dry-run 2>&1" "nothing to prune"
+assert "cat $HOME/.fake-packages/extension" "2.0"
+
+# Once the final declaration disappears everywhere, dry-run reports the owned
+# package without invoking the hook and confirmed prune removes it. The manual
+# package is never included.
+cat >tracked/mise.toml <<'EOF'
+[bootstrap.packages]
+EOF
+assert_succeed "mise -C tracked bootstrap packages status"
+output=$(mise bootstrap packages prune --manager fake --dry-run)
+assert_contains "echo '$output'" "remove fake:extension@2.0"
+assert_not_contains "echo '$output'" "manual"
+assert "cat $HOME/.fake-packages/extension" "2.0"
+assert "mise bootstrap packages prune --manager fake --yes" ""
+assert_fail "test -e $HOME/.fake-packages/extension"
+assert "cat $HOME/.fake-packages/manual" "manual"
+
+# An owned candidate requires the optional uninstall hook.
+cat >mise.toml <<'EOF'
+[bootstrap.packages]
+"fake:nohook" = "latest"
+EOF
+assert "mise bootstrap packages apply --yes" ""
+cat >mise.toml <<'EOF'
+[bootstrap.packages]
+EOF
+mv fake-package-plugin/hooks/package_uninstall.lua fake-package-plugin/hooks/package_uninstall.lua.bak
+assert_fail \
+  "mise bootstrap packages prune --manager fake --yes" \
+  "does not support uninstall"
+assert_succeed "test -e $HOME/.fake-packages/nohook"
+mv fake-package-plugin/hooks/package_uninstall.lua.bak fake-package-plugin/hooks/package_uninstall.lua
+
+# Ownership state survives plugin removal and relinking.
+assert "mise plugin uninstall fake" ""
+assert "mise plugin link -f fake $PWD/fake-package-plugin" ""
+assert "mise bootstrap packages prune --manager fake --yes" ""
+assert_fail "test -e $HOME/.fake-packages/nohook"
+
+# Partial uninstall failures still reconcile packages verified as removed.
+cat >mise.toml <<'EOF'
+[bootstrap.packages]
+"fake:a-removed" = "latest"
+"fake:z-fails" = "latest"
+EOF
+assert "mise bootstrap packages apply --yes" ""
+cat >mise.toml <<'EOF'
+[bootstrap.packages]
+EOF
+assert_fail \
+  "mise bootstrap packages prune --manager fake --yes" \
+  "intentional uninstall failure"
+assert_fail "test -e $HOME/.fake-packages/a-removed"
+assert_succeed "test -e $HOME/.fake-packages/z-fails"
+output=$(mise bootstrap packages prune --manager fake --dry-run)
+assert_not_contains "echo '$output'" "a-removed"
+assert_contains "echo '$output'" "z-fails"
+rm -f "$HOME/.fake-packages/z-fails"
+assert_contains "mise bootstrap packages prune --manager fake --dry-run 2>&1" "nothing to prune"
+
 cat >fake-package-plugin/mise.plugin.toml <<'EOF'
 [package-manager]
 requires = ["definitely-not-a-real-binary"]
 EOF
+cat >mise.toml <<'EOF'
+[bootstrap.packages]
+"fake:unavailable" = "latest"
+EOF
 
 assert_contains "mise bootstrap packages status" "required binary"
 assert_fail "mise bootstrap packages apply --manager fake --yes" "not available"
+assert_fail "mise bootstrap packages prune --manager fake --yes" "not available"
 
 # Without plugin packages, post-packages retains its original position before
 # the tools phase.
@@ -108,6 +206,9 @@ run = "touch post-packages-ran"
 [bootstrap.hooks.pre-tools]
 run = "test -f post-packages-ran"
 EOF
+assert_fail \
+  "mise bootstrap packages prune --manager fake --yes" \
+  "excluded by the system_packages.managers setting"
 assert "mise bootstrap --yes" ""
 
 cp -R fake-package-plugin declared-package-plugin

--- a/e2e/plugins/test_package_plugin
+++ b/e2e/plugins/test_package_plugin
@@ -134,6 +134,9 @@ cat >mise.toml <<'EOF'
 EOF
 mv fake-package-plugin/hooks/package_uninstall.lua fake-package-plugin/hooks/package_uninstall.lua.bak
 assert_fail \
+  "mise bootstrap packages prune --manager fake --dry-run" \
+  "does not support uninstall"
+assert_fail \
   "mise bootstrap packages prune --manager fake --yes" \
   "does not support uninstall"
 assert_succeed "test -e $HOME/.fake-packages/nohook"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2360,7 +2360,7 @@ Directory to create task stubs inside of
 \fB\-m, \-\-mise\-bin\fR \fI<MISE_BIN>\fR
 Path to a mise bin to use when running the task stub.
 
-Use `\-\-mise\-bin=./bin/mise` to use a mise bin generated from `mise generate bootstrap`
+Use `\-\-mise\-bin=./bin/mise` to use a mise bin generated from `mise generate install\-script`
 .RS
 \fIDefault: \fRmise
 .RE

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1468,9 +1468,11 @@ Write to this config file or directory
 .SH "MISE BOOTSTRAP PACKAGES PRUNE"
 Prune installed system packages no longer declared in `[bootstrap.packages]`
 
-Supports Homebrew formulae and conservatively removable, mise\-owned casks.
+Supports Homebrew formulae, conservatively removable mise\-owned casks, and
+packages installed by package plugins that implement `PackageUninstall`.
 Pruning keeps packages needed by the current config or by trusted, loadable
-tracked configs.
+tracked configs. Plugin packages that were already installed before mise
+first applied them are never claimed or removed.
 .PP
 \fBUsage:\fR mise bootstrap packages prune [OPTIONS]
 .PP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1660,7 +1660,7 @@ When a parent and nested task both exist, the parent stub is written to `<parent
             long_help #"""
 Path to a mise bin to use when running the task stub.
 
-Use `--mise-bin=./bin/mise` to use a mise bin generated from `mise generate bootstrap`
+Use `--mise-bin=./bin/mise` to use a mise bin generated from `mise generate install-script`
 """#
             arg <MISE_BIN>
         }

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -778,15 +778,15 @@ Pass `--all` to import every linked formula, including dependencies.
             long_help #"""
 Prune installed system packages no longer declared in `[bootstrap.packages]`
 
-Supports Homebrew formulae and conservatively removable, mise-owned casks.
+Supports Homebrew formulae, conservatively removable mise-owned casks, and
+packages installed by package plugins that implement `PackageUninstall`.
 Pruning keeps packages needed by the current config or by trusted, loadable
-tracked configs.
+tracked configs. Plugin packages that were already installed before mise
+first applied them are never claimed or removed.
 """#
-            after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap packages prune --manager brew\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages prune --manager brew --dry-run\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages prune --manager brew --yes\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages prune --manager brew-cask --dry-run\u{1b}[22m\n"
+            after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap packages prune --manager brew\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages prune --manager brew --dry-run\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages prune --manager brew --yes\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages prune --manager brew-cask --dry-run\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages prune --manager vscode --dry-run\u{1b}[22m\n"
             flag "-m --manager" help="Only prune packages for this manager" default=brew {
-                arg <MANAGER> {
-                    choices brew brew-cask
-                }
+                arg <MANAGER>
             }
             flag "-n --dry-run" help="Print what would be removed without deleting anything"
             flag "-y --yes" help="Skip the confirmation prompt"

--- a/src/cli/generate/task_stubs.rs
+++ b/src/cli/generate/task_stubs.rs
@@ -23,7 +23,7 @@ pub(super) struct TaskStubs {
 
     /// Path to a mise bin to use when running the task stub.
     ///
-    /// Use `--mise-bin=./bin/mise` to use a mise bin generated from `mise generate bootstrap`
+    /// Use `--mise-bin=./bin/mise` to use a mise bin generated from `mise generate install-script`
     #[usage(long, short, verbatim_doc_comment, default = "mise")]
     mise_bin: PathBuf,
 }

--- a/src/cli/system/prune.rs
+++ b/src/cli/system/prune.rs
@@ -3,6 +3,7 @@ use eyre::{Result, bail};
 use crate::config::Config;
 use crate::config::Settings;
 use crate::system;
+#[cfg(unix)]
 use crate::system::packages::SystemPackageManager;
 #[cfg(unix)]
 use crate::system::packages::brew;
@@ -80,6 +81,12 @@ impl SystemPrune {
             }
             info!("{}: nothing to prune", self.manager);
             return Ok(());
+        }
+        if !manager.supports_uninstall() {
+            bail!(
+                "package plugin '{}' does not support uninstall; add hooks/package_uninstall.lua",
+                self.manager
+            );
         }
         let remove = plan
             .remove

--- a/src/cli/system/prune.rs
+++ b/src/cli/system/prune.rs
@@ -1,27 +1,26 @@
 use eyre::{Result, bail};
 
-#[cfg(unix)]
 use crate::config::Config;
 use crate::config::Settings;
-#[cfg(unix)]
 use crate::system;
-#[cfg(unix)]
 use crate::system::packages::SystemPackageManager;
 #[cfg(unix)]
 use crate::system::packages::brew;
-#[cfg(unix)]
+use crate::system::packages::plugin::PackagePluginManager;
 use crate::ui::prompt;
 
 /// Prune installed system packages no longer declared in `[bootstrap.packages]`
 ///
-/// Supports Homebrew formulae and conservatively removable, mise-owned casks.
+/// Supports Homebrew formulae, conservatively removable mise-owned casks, and
+/// packages installed by package plugins that implement `PackageUninstall`.
 /// Pruning keeps packages needed by the current config or by trusted, loadable
-/// tracked configs.
+/// tracked configs. Plugin packages that were already installed before mise
+/// first applied them are never claimed or removed.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(crate) struct SystemPrune {
     /// Only prune packages for this manager
-    #[usage(long, short, default = "brew", choices("brew", "brew-cask"))]
+    #[usage(long, short, default = "brew")]
     manager: String,
 
     /// Print what would be removed without deleting anything
@@ -49,8 +48,60 @@ impl SystemPrune {
         match self.manager.as_str() {
             "brew" => self.run_brew().await,
             "brew-cask" => self.run_brew_cask().await,
-            _ => unreachable!(),
+            _ => self.run_plugin().await,
         }
+    }
+
+    async fn run_plugin(self) -> Result<()> {
+        let discovered = system::packages::all_managers()
+            .into_iter()
+            .find(|manager| manager.name() == self.manager)
+            .ok_or_else(|| eyre::eyre!("unknown bootstrap package manager '{}'", self.manager))?;
+        if !discovered.is_plugin() {
+            bail!(
+                "package manager '{}' does not support pruning",
+                self.manager
+            );
+        }
+        if let Some(reason) = discovered.unavailable_reason_async().await {
+            bail!("{} is not available: {reason}", self.manager);
+        }
+        let manager = PackagePluginManager::new(self.manager.clone())?;
+        let config = Config::get().await?;
+        let configured = system::package_requests_for_manager_from_config_and_tracked_config_files(
+            &config,
+            &self.manager,
+        )
+        .await?;
+        let plan = manager.prune_plan(&configured).await?;
+        if plan.is_empty() {
+            if !self.dry_run {
+                manager.apply_prune_plan(&plan).await?;
+            }
+            info!("{}: nothing to prune", self.manager);
+            return Ok(());
+        }
+        let remove = plan
+            .remove
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        if self.dry_run {
+            for package in &remove {
+                miseprintln!("remove {}:{package}", self.manager);
+            }
+            return Ok(());
+        }
+        if !self.yes && !Settings::get().yes && console::user_attended_stderr() {
+            let msg = format!("{}: prune {}?", self.manager, remove.join(", "));
+            if !prompt::confirm(msg)?.is_yes() {
+                info!("{}: skipped", self.manager);
+                return Ok(());
+            }
+        }
+        let removed = manager.apply_prune_plan(&plan).await?;
+        info!("{}: pruned {removed} packages", self.manager);
+        Ok(())
     }
 
     #[cfg(unix)]
@@ -160,5 +211,6 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     $ <bold>mise bootstrap packages prune --manager brew --dry-run</bold>
     $ <bold>mise bootstrap packages prune --manager brew --yes</bold>
     $ <bold>mise bootstrap packages prune --manager brew-cask --dry-run</bold>
+    $ <bold>mise bootstrap packages prune --manager vscode --dry-run</bold>
 "#
 );

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -23,7 +23,6 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-#[cfg(unix)]
 use eyre::Result;
 use eyre::bail;
 use indexmap::IndexMap;
@@ -502,6 +501,34 @@ pub(crate) async fn packages_from_config_and_tracked_config_files(
 ) -> Result<Vec<ManagerPackages>> {
     let tracked_config_files = config.get_tracked_config_files().await?;
     packages_from_config_files_and_tracked_config_files(&config.config_files, &tracked_config_files)
+}
+
+/// Return requests for one manager from the current config and every trusted,
+/// loadable tracked config. This does not resolve unrelated managers, which
+/// keeps plugin pruning portable when shared configs contain host-specific
+/// package managers.
+pub(crate) async fn package_requests_for_manager_from_config_and_tracked_config_files(
+    config: &Arc<Config>,
+    manager: &str,
+) -> Result<Vec<PackageRequest>> {
+    let tracked = config.get_tracked_config_files().await?;
+    let mut requests = package_requests_from_config_files(&config.config_files, &IndexMap::new())
+        .0
+        .shift_remove(manager)
+        .unwrap_or_default();
+    for request in package_requests_from_config_files(&tracked, &IndexMap::new())
+        .0
+        .shift_remove(manager)
+        .unwrap_or_default()
+    {
+        if !requests
+            .iter()
+            .any(|existing| existing.name == request.name && existing.version == request.version)
+        {
+            requests.push(request);
+        }
+    }
+    Ok(requests)
 }
 
 #[cfg(unix)]

--- a/src/system/packages/mod.rs
+++ b/src/system/packages/mod.rs
@@ -209,7 +209,6 @@ pub(crate) trait SystemPackageManager: Send + Sync {
     }
 
     /// Whether this manager is supplied by a package plugin.
-    #[allow(dead_code)] // used by the stacked bootstrap orchestration change
     fn is_plugin(&self) -> bool {
         false
     }

--- a/src/system/packages/plugin.rs
+++ b/src/system/packages/plugin.rs
@@ -321,6 +321,19 @@ impl PackagePluginManager {
         changed
     }
 
+    fn reconcile_missing_ownership(
+        state: &mut PackagePluginState,
+        statuses: &[PackageStatus],
+    ) -> bool {
+        let mut changed = false;
+        for status in statuses {
+            if matches!(status.state, PackageState::Missing) {
+                changed |= state.packages.remove(&status.request.name).is_some();
+            }
+        }
+        changed
+    }
+
     pub(crate) async fn prune_plan(
         &self,
         configured: &[PackageRequest],
@@ -357,8 +370,20 @@ impl PackagePluginManager {
         let _lock = self.operation_lock()?;
         let mut state = self.load_state()?;
         let mut state_changed = false;
-        for name in &plan.stale {
-            state_changed |= state.packages.remove(name).is_some();
+        let stale_requests = plan
+            .stale
+            .iter()
+            .filter_map(|name| {
+                state.packages.get(name).map(|owned| PackageRequest {
+                    name: name.clone(),
+                    version: owned.version.clone(),
+                    tap_url: None,
+                })
+            })
+            .collect::<Vec<_>>();
+        if !stale_requests.is_empty() {
+            let stale_statuses = self.installed(&stale_requests).await?;
+            state_changed |= Self::reconcile_missing_ownership(&mut state, &stale_statuses);
         }
         let requests = plan
             .remove
@@ -383,11 +408,7 @@ impl PackagePluginManager {
                 })
             })
             .collect::<Vec<_>>();
-        for status in &before {
-            if matches!(status.state, PackageState::Missing) {
-                state.packages.remove(&status.request.name);
-            }
-        }
+        Self::reconcile_missing_ownership(&mut state, &before);
         self.save_state(&state)?;
         if present.is_empty() {
             return Ok(0);
@@ -719,5 +740,36 @@ mod tests {
             Some("nightly-2026.08")
         );
         assert!(!state.packages.contains_key("manual"));
+    }
+
+    #[test]
+    fn stale_reconciliation_rechecks_status_before_dropping_ownership() {
+        let mut state = state("fake");
+        let statuses = vec![
+            PackageStatus {
+                request: PackageRequest {
+                    name: "keep".to_string(),
+                    version: Some("nightly-2026.07".to_string()),
+                    tap_url: None,
+                },
+                state: PackageState::Installed {
+                    version: "nightly-2026.07".to_string(),
+                },
+            },
+            PackageStatus {
+                request: PackageRequest {
+                    name: "remove".to_string(),
+                    version: Some("release:edge".to_string()),
+                    tap_url: None,
+                },
+                state: PackageState::Missing,
+            },
+        ];
+
+        assert!(PackagePluginManager::reconcile_missing_ownership(
+            &mut state, &statuses
+        ));
+        assert!(state.packages.contains_key("keep"));
+        assert!(!state.packages.contains_key("remove"));
     }
 }

--- a/src/system/packages/plugin.rs
+++ b/src/system/packages/plugin.rs
@@ -1,13 +1,18 @@
+use std::collections::{BTreeMap, HashSet};
 use std::env::{join_paths, split_paths};
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use eyre::{WrapErr, bail};
+use eyre::{WrapErr, bail, eyre};
 use heck::ToKebabCase;
 use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
 use tokio::sync::OnceCell;
-use vfox::{PackageActionContext, PackageInstalledContext, PackageRequest as VfoxPackageRequest};
+use vfox::{
+    PackageActionContext, PackageInstalledContext, PackageRequest as VfoxPackageRequest,
+    PackageUninstallContext,
+};
 
 use super::{InstallOpts, PackageRequest, PackageState, PackageStatus, SystemPackageManager};
 use crate::config::Config;
@@ -15,6 +20,50 @@ use crate::plugins::mise_plugin_toml::{MisePluginToml, MisePluginTomlPackageMana
 use crate::plugins::vfox_plugin::VfoxPlugin;
 use crate::result::Result;
 use crate::toolset::{ConfigScope, ToolsetBuilder};
+
+const STATE_SCHEMA_VERSION: u8 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+struct PackagePluginState {
+    schema_version: u8,
+    manager: String,
+    packages: BTreeMap<String, OwnedPackage>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+struct OwnedPackage {
+    version: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PluginPrunePlan {
+    pub remove: Vec<PackageRequest>,
+    stale: Vec<String>,
+}
+
+impl PluginPrunePlan {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.remove.is_empty()
+    }
+}
+
+impl PackagePluginState {
+    fn prune_requests(&self, configured: &[PackageRequest]) -> Vec<PackageRequest> {
+        let keep = configured
+            .iter()
+            .map(|request| request.name.as_str())
+            .collect::<HashSet<_>>();
+        self.packages
+            .iter()
+            .filter(|(name, _)| !keep.contains(name.as_str()))
+            .map(|(name, owned)| PackageRequest {
+                name: name.clone(),
+                version: owned.version.clone(),
+                tap_url: None,
+            })
+            .collect()
+    }
+}
 
 #[derive(Debug)]
 pub(crate) struct PackagePluginManager {
@@ -43,6 +92,74 @@ impl PackagePluginManager {
             oses.iter()
                 .any(|os| os == crate::config::Settings::get().os())
         })
+    }
+
+    fn state_path_for(name: &str) -> PathBuf {
+        crate::dirs::STATE
+            .join("package-plugins")
+            .join(format!("{}.json", crate::hash::hash_sha256_to_str(name)))
+    }
+
+    fn state_path(&self) -> PathBuf {
+        Self::state_path_for(&self.name)
+    }
+
+    fn operation_lock(&self) -> Result<Option<fslock::LockFile>> {
+        crate::lock_file::get(&self.state_path(), false)
+    }
+
+    fn load_state_at(path: &std::path::Path, manager: &str) -> Result<PackagePluginState> {
+        if !path.exists() {
+            return Ok(PackagePluginState {
+                schema_version: STATE_SCHEMA_VERSION,
+                manager: manager.to_string(),
+                packages: BTreeMap::new(),
+            });
+        }
+        let state: PackagePluginState = serde_json::from_str(&crate::file::read_to_string(path)?)
+            .wrap_err_with(|| {
+            format!(
+                "failed to read package plugin ownership state {}",
+                crate::file::display_path(path)
+            )
+        })?;
+        if state.schema_version != STATE_SCHEMA_VERSION {
+            bail!(
+                "unsupported package plugin ownership state version {} in {}",
+                state.schema_version,
+                crate::file::display_path(path)
+            );
+        }
+        if state.manager != manager {
+            bail!(
+                "package plugin ownership state {} belongs to manager '{}', not '{manager}'",
+                crate::file::display_path(path),
+                state.manager
+            );
+        }
+        Ok(state)
+    }
+
+    fn load_state(&self) -> Result<PackagePluginState> {
+        Self::load_state_at(&self.state_path(), &self.name)
+    }
+
+    fn save_state_at(path: &std::path::Path, state: &PackagePluginState) -> Result<()> {
+        crate::file::create_dir_all(path.parent().expect("package plugin state parent"))?;
+        let mut contents = serde_json::to_vec_pretty(state)?;
+        contents.push(b'\n');
+        crate::file::write_atomic(path, contents)
+    }
+
+    fn save_state(&self, state: &PackagePluginState) -> Result<()> {
+        Self::save_state_at(&self.state_path(), state)
+    }
+
+    pub(crate) fn supports_uninstall(&self) -> bool {
+        self.plugin
+            .plugin_path
+            .join("hooks/package_uninstall.lua")
+            .exists()
     }
 
     fn sync_lookup_path() -> Vec<PathBuf> {
@@ -139,6 +256,171 @@ impl PackagePluginManager {
             vfox.package_install(&self.name, ctx).await?;
         }
         Ok(())
+    }
+
+    async fn uninstall_action(&self, pkgs: &[PackageRequest]) -> Result<()> {
+        let env = self.checked_hook_env().await?;
+        let ctx = PackageUninstallContext {
+            packages: Self::requests(pkgs),
+        };
+        self.vfox(env)?.package_uninstall(&self.name, ctx).await?;
+        Ok(())
+    }
+
+    fn status_version(status: &PackageStatus) -> Option<String> {
+        match &status.state {
+            PackageState::Installed { version }
+            | PackageState::NeedsRepair { installed: version }
+            | PackageState::VersionMismatch { installed: version } => Some(version.clone()),
+            #[cfg(unix)]
+            PackageState::InstalledAutoUpdates { version } => Some(version.clone()),
+            PackageState::Missing => None,
+            #[cfg(unix)]
+            PackageState::Unavailable { .. } => None,
+        }
+    }
+
+    fn reconcile_installed_ownership(
+        &self,
+        state: &mut PackagePluginState,
+        before: &[PackageStatus],
+        after: &[PackageStatus],
+    ) -> Result<()> {
+        let missing = before
+            .iter()
+            .filter(|status| matches!(status.state, PackageState::Missing))
+            .map(|status| status.request.name.as_str())
+            .collect::<HashSet<_>>();
+        for status in after {
+            if (missing.contains(status.request.name.as_str())
+                || state.packages.contains_key(&status.request.name))
+                && let Some(version) = Self::status_version(status)
+            {
+                state.packages.insert(
+                    status.request.name.clone(),
+                    OwnedPackage {
+                        version: Some(version),
+                    },
+                );
+            }
+        }
+        self.save_state(state)
+    }
+
+    pub(crate) async fn prune_plan(
+        &self,
+        configured: &[PackageRequest],
+    ) -> Result<PluginPrunePlan> {
+        let _lock = self.operation_lock()?;
+        let state = self.load_state()?;
+        let requests = state.prune_requests(configured);
+        if requests.is_empty() {
+            return Ok(PluginPrunePlan {
+                remove: vec![],
+                stale: vec![],
+            });
+        }
+        let statuses = self.installed(&requests).await?;
+        let mut remove = vec![];
+        let mut stale = vec![];
+        for status in statuses {
+            match Self::status_version(&status) {
+                Some(version) => remove.push(PackageRequest {
+                    name: status.request.name,
+                    version: Some(version),
+                    tap_url: None,
+                }),
+                None if matches!(status.state, PackageState::Missing) => {
+                    stale.push(status.request.name);
+                }
+                None => {}
+            }
+        }
+        Ok(PluginPrunePlan { remove, stale })
+    }
+
+    pub(crate) async fn apply_prune_plan(&self, plan: &PluginPrunePlan) -> Result<usize> {
+        let _lock = self.operation_lock()?;
+        let mut state = self.load_state()?;
+        let mut state_changed = false;
+        for name in &plan.stale {
+            state_changed |= state.packages.remove(name).is_some();
+        }
+        let requests = plan
+            .remove
+            .iter()
+            .filter(|request| state.packages.contains_key(&request.name))
+            .cloned()
+            .collect::<Vec<_>>();
+        if requests.is_empty() {
+            if state_changed {
+                self.save_state(&state)?;
+            }
+            return Ok(0);
+        }
+        let before = self.installed(&requests).await?;
+        let present = before
+            .iter()
+            .filter_map(|status| {
+                Self::status_version(status).map(|version| PackageRequest {
+                    name: status.request.name.clone(),
+                    version: Some(version),
+                    tap_url: None,
+                })
+            })
+            .collect::<Vec<_>>();
+        for status in &before {
+            if matches!(status.state, PackageState::Missing) {
+                state.packages.remove(&status.request.name);
+            }
+        }
+        self.save_state(&state)?;
+        if present.is_empty() {
+            return Ok(0);
+        }
+        if !self.supports_uninstall() {
+            bail!(
+                "package plugin '{}' does not support uninstall; add hooks/package_uninstall.lua",
+                self.name
+            );
+        }
+
+        let action_result = self.uninstall_action(&present).await;
+        let after = self.installed(&present).await;
+        let after = match after {
+            Ok(after) => after,
+            Err(status_err) => {
+                if let Err(action_err) = action_result {
+                    warn!(
+                        "{}: failed to verify uninstall after error: {status_err:#}",
+                        self.name
+                    );
+                    return Err(action_err);
+                }
+                return Err(status_err);
+            }
+        };
+        let mut removed = 0;
+        let mut remaining = vec![];
+        for status in after {
+            if matches!(status.state, PackageState::Missing) {
+                if state.packages.remove(&status.request.name).is_some() {
+                    removed += 1;
+                }
+            } else {
+                remaining.push(status.request.name);
+            }
+        }
+        self.save_state(&state)?;
+        action_result?;
+        if !remaining.is_empty() {
+            return Err(eyre!(
+                "package plugin '{}' did not uninstall: {}",
+                self.name,
+                remaining.join(", ")
+            ));
+        }
+        Ok(removed)
     }
 }
 
@@ -237,10 +519,48 @@ impl SystemPackageManager for PackagePluginManager {
     }
 
     async fn install(&self, pkgs: &[PackageRequest], opts: &InstallOpts) -> Result<()> {
-        self.action(pkgs, opts, false).await
+        if opts.dry_run {
+            return self.action(pkgs, opts, false).await;
+        }
+        let _lock = self.operation_lock()?;
+        let mut state = self.load_state()?;
+        let before = self.installed(pkgs).await?;
+        let action_result = self.action(pkgs, opts, false).await;
+        let after = self.installed(pkgs).await;
+        match after {
+            Ok(after) => {
+                if let Err(state_err) =
+                    self.reconcile_installed_ownership(&mut state, &before, &after)
+                {
+                    if let Err(action_err) = action_result {
+                        warn!(
+                            "{}: failed to save ownership after install error: {state_err:#}",
+                            self.name
+                        );
+                        return Err(action_err);
+                    }
+                    return Err(state_err);
+                }
+            }
+            Err(status_err) => {
+                if let Err(action_err) = action_result {
+                    warn!(
+                        "{}: failed to verify ownership after install error: {status_err:#}",
+                        self.name
+                    );
+                    return Err(action_err);
+                }
+                return Err(status_err);
+            }
+        }
+        action_result
     }
 
     async fn upgrade(&self, pkgs: &[PackageRequest], opts: &InstallOpts) -> Result<()> {
+        if opts.dry_run {
+            return self.action(pkgs, opts, true).await;
+        }
+        let _lock = self.operation_lock()?;
         self.action(pkgs, opts, true).await
     }
 
@@ -250,5 +570,75 @@ impl SystemPackageManager for PackagePluginManager {
 
     fn is_plugin(&self) -> bool {
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn state(manager: &str) -> PackagePluginState {
+        PackagePluginState {
+            schema_version: STATE_SCHEMA_VERSION,
+            manager: manager.to_string(),
+            packages: BTreeMap::from([
+                (
+                    "keep".to_string(),
+                    OwnedPackage {
+                        version: Some("nightly-2026.07".to_string()),
+                    },
+                ),
+                (
+                    "remove".to_string(),
+                    OwnedPackage {
+                        version: Some("release:edge".to_string()),
+                    },
+                ),
+            ]),
+        }
+    }
+
+    #[test]
+    fn ownership_state_round_trips_atomically() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let path = tmp.path().join("state/manager.json");
+        let expected = state("fake");
+        PackagePluginManager::save_state_at(&path, &expected)?;
+        assert_eq!(
+            PackagePluginManager::load_state_at(&path, "fake")?,
+            expected
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn ownership_state_rejects_invalid_json_and_schema() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let path = tmp.path().join("manager.json");
+        crate::file::write(&path, b"not json")?;
+        assert!(PackagePluginManager::load_state_at(&path, "fake").is_err());
+
+        let mut invalid = state("fake");
+        invalid.schema_version += 1;
+        PackagePluginManager::save_state_at(&path, &invalid)?;
+        assert!(PackagePluginManager::load_state_at(&path, "fake").is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn prune_candidates_match_names_and_preserve_opaque_versions() {
+        let configured = vec![PackageRequest {
+            name: "keep".to_string(),
+            version: Some("a-different-pin".to_string()),
+            tap_url: None,
+        }];
+        assert_eq!(
+            state("fake").prune_requests(&configured),
+            vec![PackageRequest {
+                name: "remove".to_string(),
+                version: Some("release:edge".to_string()),
+                tap_url: None,
+            }]
+        );
     }
 }

--- a/src/system/packages/plugin.rs
+++ b/src/system/packages/plugin.rs
@@ -307,6 +307,20 @@ impl PackagePluginManager {
         self.save_state(state)
     }
 
+    fn reconcile_owned_versions(state: &mut PackagePluginState, after: &[PackageStatus]) -> bool {
+        let mut changed = false;
+        for status in after {
+            if let Some(version) = Self::status_version(status)
+                && let Some(owned) = state.packages.get_mut(&status.request.name)
+            {
+                let version = Some(version);
+                changed |= owned.version != version;
+                owned.version = version;
+            }
+        }
+        changed
+    }
+
     pub(crate) async fn prune_plan(
         &self,
         configured: &[PackageRequest],
@@ -561,7 +575,36 @@ impl SystemPackageManager for PackagePluginManager {
             return self.action(pkgs, opts, true).await;
         }
         let _lock = self.operation_lock()?;
-        self.action(pkgs, opts, true).await
+        let mut state = self.load_state()?;
+        let action_result = self.action(pkgs, opts, true).await;
+        let after = self.installed(pkgs).await;
+        match after {
+            Ok(after) => {
+                if Self::reconcile_owned_versions(&mut state, &after)
+                    && let Err(state_err) = self.save_state(&state)
+                {
+                    if let Err(action_err) = action_result {
+                        warn!(
+                            "{}: failed to save ownership after upgrade error: {state_err:#}",
+                            self.name
+                        );
+                        return Err(action_err);
+                    }
+                    return Err(state_err);
+                }
+            }
+            Err(status_err) => {
+                if let Err(action_err) = action_result {
+                    warn!(
+                        "{}: failed to verify ownership after upgrade error: {status_err:#}",
+                        self.name
+                    );
+                    return Err(action_err);
+                }
+                return Err(status_err);
+            }
+        }
+        action_result
     }
 
     fn supports_version_pins(&self) -> bool {
@@ -640,5 +683,41 @@ mod tests {
                 tap_url: None,
             }]
         );
+    }
+
+    #[test]
+    fn upgrade_reconciliation_updates_only_owned_versions() {
+        let mut state = state("fake");
+        let statuses = vec![
+            PackageStatus {
+                request: PackageRequest {
+                    name: "keep".to_string(),
+                    version: Some("nightly-2026.08".to_string()),
+                    tap_url: None,
+                },
+                state: PackageState::Installed {
+                    version: "nightly-2026.08".to_string(),
+                },
+            },
+            PackageStatus {
+                request: PackageRequest {
+                    name: "manual".to_string(),
+                    version: None,
+                    tap_url: None,
+                },
+                state: PackageState::Installed {
+                    version: "release:edge".to_string(),
+                },
+            },
+        ];
+
+        assert!(PackagePluginManager::reconcile_owned_versions(
+            &mut state, &statuses
+        ));
+        assert_eq!(
+            state.packages["keep"].version.as_deref(),
+            Some("nightly-2026.08")
+        );
+        assert!(!state.packages.contains_key("manual"));
     }
 }

--- a/src/system/packages/plugin.rs
+++ b/src/system/packages/plugin.rs
@@ -63,6 +63,24 @@ impl PackagePluginState {
             })
             .collect()
     }
+
+    fn approved_prune_requests(
+        &self,
+        approved: &[PackageRequest],
+        configured: &[PackageRequest],
+    ) -> Vec<PackageRequest> {
+        let keep = configured
+            .iter()
+            .map(|request| request.name.as_str())
+            .collect::<HashSet<_>>();
+        approved
+            .iter()
+            .filter(|request| {
+                self.packages.contains_key(&request.name) && !keep.contains(request.name.as_str())
+            })
+            .cloned()
+            .collect()
+    }
 }
 
 #[derive(Debug)]
@@ -368,6 +386,12 @@ impl PackagePluginManager {
 
     pub(crate) async fn apply_prune_plan(&self, plan: &PluginPrunePlan) -> Result<usize> {
         let _lock = self.operation_lock()?;
+        let config = Config::reset().await?;
+        let configured =
+            crate::system::package_requests_for_manager_from_config_and_tracked_config_files(
+                &config, &self.name,
+            )
+            .await?;
         let mut state = self.load_state()?;
         let mut state_changed = false;
         let stale_requests = plan
@@ -385,12 +409,10 @@ impl PackagePluginManager {
             let stale_statuses = self.installed(&stale_requests).await?;
             state_changed |= Self::reconcile_missing_ownership(&mut state, &stale_statuses);
         }
-        let requests = plan
-            .remove
-            .iter()
-            .filter(|request| state.packages.contains_key(&request.name))
-            .cloned()
-            .collect::<Vec<_>>();
+        // The confirmed plan is an upper bound. Configuration may have changed
+        // while the confirmation prompt was open, so never remove an approved
+        // package that is now part of the desired set.
+        let requests = state.approved_prune_requests(&plan.remove, &configured);
         if requests.is_empty() {
             if state_changed {
                 self.save_state(&state)?;
@@ -703,6 +725,38 @@ mod tests {
                 version: Some("release:edge".to_string()),
                 tap_url: None,
             }]
+        );
+    }
+
+    #[test]
+    fn approved_prune_candidates_can_only_shrink_after_config_revalidation() {
+        let state = state("fake");
+        let approved = vec![
+            PackageRequest {
+                name: "remove".to_string(),
+                version: Some("release:edge".to_string()),
+                tap_url: None,
+            },
+            PackageRequest {
+                name: "not-owned".to_string(),
+                version: None,
+                tap_url: None,
+            },
+        ];
+        let configured = vec![PackageRequest {
+            name: "remove".to_string(),
+            version: Some("newly-declared".to_string()),
+            tap_url: None,
+        }];
+
+        assert_eq!(
+            state.approved_prune_requests(&approved, &[]),
+            vec![approved[0].clone()]
+        );
+        assert!(
+            state
+                .approved_prune_requests(&approved, &configured)
+                .is_empty()
         );
     }
 


### PR DESCRIPTION
## Summary
- add the optional `PackageUninstall` hook for package plugins
- track packages installed by mise so manually installed host state is never claimed
- support plugin managers in `mise bootstrap packages prune`
- protect packages referenced by current and trusted tracked configs
- document phase-specific hook batches and explicit prune semantics

## Design

Package removal remains an explicit destructive operation. `apply` and `upgrade`
never infer uninstall requests from packages absent from their action batches.

mise records only packages that transition from missing to installed during a
plugin install. During prune, it computes owned packages absent from the complete
keep-set, confirms the plan, invokes `PackageUninstall`, verifies removal through
`PackageInstalled`, and updates ownership state.

Existing packages and installations made before this feature are not adopted
automatically.

Addresses [Discussion #12315](https://github.com/jdx/mise/discussions/12315).

## Testing
- `mise run lint-fix`
- focused package-plugin and prune E2E tests
- vfox package-hook tests
- `cargo check --all-features`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a destructive prune path that uninstalls host-managed plugin packages and persists an ownership ledger. Risk is mitigated by opt-in `--manager`, confirmation/dry-run, and never claiming pre-existing installs.
> 
> **Overview**
> Enables **explicit prune** of package-plugin managers. Plugins can implement optional `PackageUninstall`; `mise bootstrap packages prune --manager <plugin>` is no longer Homebrew-only.
> 
> mise now records ownership only for packages that go from missing to installed during `PackageInstall`. Prune removes only those owned identities that are absent from the current config and trusted tracked configs. Pre-existing/manual installs are never claimed. Dry-run does not call the hook; after confirmation the keep-set is reloaded so newly declared packages cannot be removed without another prompt. Removals are verified with `PackageInstalled`, and partial hook failures still drop ownership for packages that are actually gone.
> 
> Docs clarify that install/upgrade batches are phase-specific and must not treat absence as uninstall.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c94e2d0c48c916df908c592eed6b727977b9cb78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added package pruning for package-plugin managers with uninstall support.
  * Added persistent ownership tracking to protect pre-existing, configured, and trusted packages.
  * Added dry-run previews, confirmation prompts, post-removal verification, arbitrary manager support, and safeguards for unavailable managers or partial failures.

* **Documentation**
  * Clarified package hook behavior, pruning rules, ownership protections, and dry-run usage.
  * Updated task-stub examples to reference `mise generate install-script`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->