### PR TITLE
fix(ui): stop padding the last table column past its content

### DIFF
--- a/e2e/cli/test_tool_alias
+++ b/e2e/cli/test_tool_alias
@@ -32,3 +32,19 @@ EOF
 mise i tiny@both
 # tool_alias should take precedence - should install 1.1.0
 assert_contains "mise ls tiny" "1.1.0"
+
+# Test 4: no row ends in the fill tabled adds to bring a cell up to its column's width. The two
+# targets differ in length on purpose -- with one row, or with equal-length targets, the widest
+# cell is the row itself and there is nothing to fill, so the assertion below would pass on the
+# unfixed code and prove nothing.
+cat >mise.toml <<'EOF2'
+[tool_alias.tiny.versions]
+short = "1.0.0"
+longer = "1.0.0-with-a-longer-target"
+EOF2
+
+# The fixture really does produce two rows of different width -- checked before the count below,
+# which is only meaningful if it does.
+assert_contains "mise tool-alias ls" "1.0.0-with-a-longer-target"
+assert_contains "mise tool-alias ls" "short"
+assert "mise tool-alias ls | grep -c '[[:space:]]$' || true" "0"

--- a/src/cli/outdated.rs
+++ b/src/cli/outdated.rs
@@ -144,8 +144,7 @@ impl Outdated {
         if !self.bump {
             table.with(Remove::column(ByColumnName::new("bump")));
         }
-        table::default_style(&mut table, self.no_header);
-        miseprintln!("{table}");
+        table::print(&mut table, self.no_header)?;
         Ok(())
     }
 

--- a/src/cli/plugins/ls.rs
+++ b/src/cli/plugins/ls.rs
@@ -131,8 +131,7 @@ impl PluginsLs {
                 info!("All plugins are up to date");
             } else {
                 let mut table = Table::new(data);
-                table::default_style(&mut table, false);
-                miseprintln!("{table}");
+                table::print(&mut table, false)?;
             }
         } else if self.urls || self.refs {
             let data = plugins
@@ -164,8 +163,7 @@ impl PluginsLs {
                 })
                 .collect::<Vec<_>>();
             let mut table = Table::new(data);
-            table::default_style(&mut table, false);
-            miseprintln!("{table}");
+            table::print(&mut table, false)?;
         } else {
             hint!("registry", "see available plugins with", "mise registry");
             for tool in plugins.values() {

--- a/src/cli/set.rs
+++ b/src/cli/set.rs
@@ -252,8 +252,7 @@ impl Set {
             }
         }
         let mut table = tabled::Table::new(env);
-        table::default_style(&mut table, false);
-        miseprintln!("{table}");
+        table::print(&mut table, false)?;
         Ok(())
     }
 

--- a/src/cli/settings/ls.rs
+++ b/src/cli/settings/ls.rs
@@ -107,8 +107,7 @@ impl SettingsLs {
             self.print_toml(rows)?;
         } else {
             let mut table = Table::new(rows);
-            table::default_style(&mut table, false);
-            miseprintln!("{}", table.to_string());
+            table::print(&mut table, false)?;
         }
         Ok(())
     }

--- a/src/cli/shell_alias/ls.rs
+++ b/src/cli/shell_alias/ls.rs
@@ -28,8 +28,7 @@ impl ShellAliasLs {
             })
             .collect::<Vec<_>>();
         let mut table = tabled::Table::new(rows);
-        table::default_style(&mut table, self.no_header);
-        miseprintln!("{table}");
+        table::print(&mut table, self.no_header)?;
         Ok(())
     }
 }

--- a/src/cli/tool.rs
+++ b/src/cli/tool.rs
@@ -275,8 +275,7 @@ impl Tool {
                 table.push(("Security:", security_str));
             }
             let mut table = tabled::Table::new(table);
-            table::default_style(&mut table, true);
-            miseprintln!("{table}");
+            table::print(&mut table, true)?;
         }
 
         Ok(())

--- a/src/cli/tool_alias/ls.rs
+++ b/src/cli/tool_alias/ls.rs
@@ -50,8 +50,7 @@ impl ToolAliasLs {
             })
             .collect::<Vec<_>>();
         let mut table = tabled::Table::new(rows);
-        table::default_style(&mut table, self.no_header);
-        miseprintln!("{table}");
+        table::print(&mut table, self.no_header)?;
         Ok(())
     }
 }

--- a/src/ui/table.rs
+++ b/src/ui/table.rs
@@ -23,7 +23,31 @@ pub(crate) fn term_size_settings() -> SettingMinWidth {
     // .with(Height::increase(*TERM_HEIGHT))
 }
 
-pub(crate) fn default_style(table: &mut Table, no_headers: bool) {
+/// Style `table` and print it, with the fill taken off the end of each row.
+///
+/// `tabled` brings every cell up to its column's width, so the last column leaves trailing spaces
+/// on every row shorter than the widest one. The `Padding::zero()` below does not prevent that:
+/// padding is the space *around* a cell, and the fill that brings it up to the column width is
+/// added separately. [`MiseTable::print`] already trims the comfy_table side the same way.
+///
+/// The only entry point on purpose. `default_style` stays private so a table cannot be printed
+/// without this step, which is how the trailing spaces got there in the first place.
+pub(crate) fn print(table: &mut Table, no_headers: bool) -> Result<()> {
+    default_style(table, no_headers);
+    // One `miseprintln!`, not one per line: this way the newlines land exactly where
+    // `miseprintln!("{table}")` used to put them, including for a table with no rows, and the only
+    // difference is the trailing space.
+    let rendered = table.to_string();
+    let trimmed = rendered
+        .lines()
+        .map(str::trim_end)
+        .collect::<Vec<_>>()
+        .join("\n");
+    miseprintln!("{trimmed}");
+    Ok(())
+}
+
+fn default_style(table: &mut Table, no_headers: bool) {
     let header = |h: &_| style(h).italic().magenta().to_string();
 
     if no_headers || !console::user_attended() || cfg!(test) {


### PR DESCRIPTION
Every table mise draws with `tabled` pads its last column out to the widest cell, so shorter rows
end in spaces nobody can see. Measured on `mise settings`, three rows filled to exactly 150 columns:

```
len=150  trimmed=56   fill=94
len=150  trimmed=150  fill=0
len=150  trimmed=150  fill=0
```

`mise tool-alias ls` shows it in miniature — `25`, `20` and `24` filled out to the width of
`20.11.1`:

```
java  lts          25     $
node  a            20     $
node  b            20.11.1$
```

### Why the line that looks like it prevents this does not

`default_style` already ends with `Modify::new(Columns::last()).with(Padding::zero())`, which reads
as "no space after the last column". **Padding and width fill are different things.** Zeroing the
padding removes the space tabled puts *around* a cell; it does not remove the space that brings the
cell up to its column's width. Two concepts, one word, and only one of them was handled.

### The fix already exists in the same file

`MiseTable::print` — the comfy_table half of `ui/table.rs` — renders line by line and calls
`trim_end()` before printing. The `tabled` half had no equivalent: all **eight** call sites did
`table::default_style(&mut table, …); miseprintln!("{table}");` raw.

`table::print` now does both steps, and **`default_style` is private**. That is the part worth more
than the trim: with one entry point, a table cannot be printed without it, which is exactly how the
spaces got there. Eight call sites collapse to one line each.

One `miseprintln!`, not one per line, so the newlines land exactly where `miseprintln!("{table}")`
put them — including for a table with no rows. **The only difference in the output is the trailing
space.**

The leading-space handling `MiseTable::print` carries is deliberately not copied: `default_style`
sets the first column's padding to `(0, 1, 0, 0)`, so these rows do not start with one.

### Tests

Added to `e2e/cli/test_tool_alias`, chosen because it is green on the released binary and its last
column is an alias target, which is trivial to give two different lengths.

The **control comes first and is not optional**: the two targets differ in length on purpose,
because with one row — or with equal-length targets — the widest cell *is* the row, nothing is
filled, and the count assertion would pass on the unfixed code while proving nothing. Two
`assert_contains` pin that both rows are really there before the count runs.

No existing test relies on the old output: `e2e/` has exactly two lines ending in whitespace and
both are inside a TOML comment in a config fixture, not a table assertion.

No Windows e2e (the fill is platform-independent and the fix is shared code) and no unit test
(`table.rs` has no test module and what is under test is the rendered output).

### Verification

Red first, with the controls green: the two `assert_contains` pass on the released binary and the
count assertion fails with `14` where the fix expects `0`.

**One thing reasoned rather than measured**: header cells are coloured, and `default_style` removes
the header row entirely unless stdout is a terminal — so piped output carries no ANSI at all
(measured), and the `trim_end()` behaviour with colour is an inference. The grounds for it are that
`MiseTable::print` has shipped the same `trim_end()` on the comfy_table side.

`cargo fmt --all`, `shfmt -d` and `shellcheck -x` are clean. `cargo check` does not run on this
machine (`libz-ng-sys` wants `cmake`), so type-checking is left to CI — nothing here is reported as
having been compiled locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed trailing whitespace from command-line table output.
  * Improved consistency and reliability of tables displayed by plugin, tool, alias, settings, environment, and shell-alias commands.
  * Ensured table rendering errors are handled appropriately instead of being silently printed.

* **Tests**
  * Added coverage verifying tool alias listings contain all entries without trailing whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->