### PR TITLE
fix(env): say why an age SSH identity could not be used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6390,6 +6390,7 @@ dependencies = [
  "rmcp",
  "rmp-serde",
  "rops",
+ "rust-embed",
  "same-file",
  "seccompiler",
  "self_update",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,6 +190,12 @@ rops = { version = "0.1", default-features = false, features = [
   "toml",
   "age",
 ] }
+# Not used directly. age renders its error messages through fluent, and
+# rust-embed only bakes the translations into the binary for release builds
+# unless `debug-embed` is on. Without it a debug mise that formats an age error
+# outside the crate's source tree — e2e inside a container — panics in age's
+# lazy_static instead of reporting the error.
+rust-embed = { version = "8", features = ["debug-embed"] }
 same-file = "1"
 serde = { version = "1", features = ["derive"] }
 serde_ignored = "0.1"
@@ -348,7 +354,14 @@ pkg-url = "{ repo }/releases/download/v{ version }/mise-v{version}-linux-x64{ ar
 pkg-url = "{ repo }/releases/download/v{ version }/mise-v{version}-linux-armv7{ archive-suffix }"
 
 [package.metadata.cargo-machete]
-ignored = ["aws-lc-rs", "built", "cfg_aliases", "openssl", "phf_codegen"]
+ignored = [
+  "aws-lc-rs",
+  "built",
+  "cfg_aliases",
+  "openssl",
+  "phf_codegen",
+  "rust-embed",
+]
 
 [package.metadata.release]
 pre-release-replacements = [

--- a/e2e/env/test_env_age_ssh_passphrase
+++ b/e2e/env/test_env_age_ssh_passphrase
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# A passphrase-protected SSH identity parses fine but can never match a stanza,
+# so age reports "No matching keys found" — blaming the recipient rather than
+# the key mise could not read. https://github.com/jdx/mise/discussions/10829
+
+if ! command -v ssh-keygen >/dev/null 2>&1; then
+  echo "skipping: no ssh-keygen on this host"
+  exit 0
+fi
+
+export MISE_EXPERIMENTAL=true
+keys="$PWD/keys"
+mkdir -p "$keys"
+ssh-keygen -t ed25519 -N '' -C plain -f "$keys/plain" -q
+ssh-keygen -t ed25519 -N 'hunter2' -C locked -f "$keys/locked" -q
+
+# Control: an identity mise can read decrypts as usual.
+cat >mise.toml <<TOML
+[settings.age]
+ssh_identity_files = ["$keys/plain"]
+TOML
+assert "mise set --age-encrypt --age-ssh-recipient \"$(cat "$keys/plain.pub")\" PLAIN_SECRET=works"
+assert_contains "mise env" "PLAIN_SECRET=works"
+
+# The reported case: identical except the identity needs a passphrase.
+cat >mise.toml <<TOML
+[settings.age]
+ssh_identity_files = ["$keys/locked"]
+TOML
+assert "mise set --age-encrypt --age-ssh-recipient \"$(cat "$keys/locked.pub")\" LOCKED_SECRET=nope"
+assert_fail_contains "mise env 2>&1" "is protected by a passphrase"
+assert_fail_contains "mise env 2>&1" "keys/locked"
+assert_fail_contains "mise env 2>&1" "settings.age.key_file"

--- a/src/agecrypt.rs
+++ b/src/agecrypt.rs
@@ -15,6 +15,74 @@ use crate::{dirs, env};
 const ZSTD_COMPRESSION_LEVEL: i32 = 3;
 const COMPRESSION_THRESHOLD: usize = 1024; // 1KB
 
+/// Why an SSH identity mise loaded cannot actually decrypt anything.
+///
+/// `ssh::Identity::from_buffer` succeeds for these keys, so they look loaded,
+/// but age maps them to `None` when matching stanzas. The decryptor then
+/// reports "No matching keys found", which blames the recipient when the real
+/// problem is that the identity could not be read at all.
+#[derive(Debug, PartialEq, Eq)]
+enum UnusableSshIdentity {
+    Passphrase,
+    EncryptedPem,
+    EncryptedCipher(String),
+    Hardware(String),
+    KeyType(String),
+}
+
+impl UnusableSshIdentity {
+    fn classify(identity: &ssh::Identity) -> Option<Self> {
+        match identity {
+            ssh::Identity::Unencrypted(_) => None,
+            ssh::Identity::Encrypted(_) => Some(Self::Passphrase),
+            ssh::Identity::Unsupported(key) => Some(match key {
+                ssh::UnsupportedKey::EncryptedPem => Self::EncryptedPem,
+                ssh::UnsupportedKey::EncryptedSsh(cipher) => Self::EncryptedCipher(cipher.clone()),
+                ssh::UnsupportedKey::Hardware(kind) => Self::Hardware(kind.clone()),
+                ssh::UnsupportedKey::Type(kind) => Self::KeyType(kind.clone()),
+            }),
+        }
+    }
+
+    fn reason(&self) -> String {
+        match self {
+            Self::Passphrase => {
+                "is protected by a passphrase, which mise does not prompt for".to_string()
+            }
+            Self::EncryptedPem => "is an encrypted PEM key, a format age cannot read".to_string(),
+            Self::EncryptedCipher(cipher) => {
+                format!("is encrypted with {cipher}, a cipher age does not support")
+            }
+            Self::Hardware(kind) => {
+                format!("is a {kind} key held on a hardware security key")
+            }
+            Self::KeyType(kind) => format!("is a {kind} key, a type age does not support"),
+        }
+    }
+}
+
+/// Explain identities that were loaded but could not participate in decryption.
+///
+/// Only worth saying once decryption has already failed: an unreadable key
+/// sitting beside a working one costs the user nothing.
+fn unusable_identity_hint(unusable: &[(PathBuf, UnusableSshIdentity)]) -> String {
+    if unusable.is_empty() {
+        return String::new();
+    }
+    let mut hint = String::new();
+    for (path, reason) in unusable {
+        hint.push_str(&format!(
+            "\nhint: {} {}, so it could not be used",
+            file::display_path(path),
+            reason.reason()
+        ));
+    }
+    hint.push_str(
+        "\nhint: use an identity mise can read, or set settings.age.key_file to an age key",
+    );
+    hint
+}
+
 pub(crate) async fn create_age_directive(
     key: String,
     value: &str,
@@ -69,7 +137,7 @@ pub(crate) async fn decrypt_age_directive(directive: &EnvDirective) -> Result<St
                 Some(AgeFormat::Raw) | None => decoded,
             };
 
-            let identities = load_all_identities().await?;
+            let (identities, unusable) = load_all_identities().await?;
             if identities.is_empty() {
                 return Err(eyre!(
                     "[experimental] No age identities found for decryption"
@@ -89,7 +157,10 @@ pub(crate) async fn decrypt_age_directive(directive: &EnvDirective) -> Result<St
                     reader.read_to_end(&mut decrypted)?;
                 }
                 Err(e) => {
-                    return Err(eyre!("[experimental] Failed to decrypt: {}", e));
+                    return Err(eyre!(
+                        "[experimental] Failed to decrypt: {e}{}",
+                        unusable_identity_hint(&unusable)
+                    ));
                 }
             }
 
@@ -252,13 +323,19 @@ async fn load_ssh_recipient_from_private_key(path: &Path) -> Result<String> {
     ))
 }
 
-async fn load_all_identities() -> Result<Vec<Box<dyn Identity + Send + Sync>>> {
+type LoadedIdentities = (
+    Vec<Box<dyn Identity + Send + Sync>>,
+    Vec<(PathBuf, UnusableSshIdentity)>,
+);
+
+async fn load_all_identities() -> Result<LoadedIdentities> {
     // Get identity files first
     let identity_files = get_all_identity_files().await;
     let ssh_identity_files = get_all_ssh_identity_files();
 
     // Now process identities without holding them across await points
     let mut identities: Vec<Box<dyn Identity + Send + Sync>> = Vec::new();
+    let mut unusable: Vec<(PathBuf, UnusableSshIdentity)> = Vec::new();
 
     // Check MISE_AGE_KEY environment variable
     if let Ok(age_key) = env::var("MISE_AGE_KEY")
@@ -313,6 +390,12 @@ async fn load_all_identities() -> Result<Vec<Box<dyn Identity + Send + Sync>>> {
                     match ssh::Identity::from_buffer(&mut reader, Some(path.display().to_string()))
                     {
                         Ok(identity) => {
+                            if let Some(reason) = UnusableSshIdentity::classify(&identity) {
+                                // Still keep it: dropping the only identity would
+                                // report "No age identities found" instead, which is
+                                // just as misleading as the message being fixed here.
+                                unusable.push((path.clone(), reason));
+                            }
                             identities.push(Box::new(identity));
                         }
                         Err(e) => {
@@ -333,7 +416,7 @@ async fn load_all_identities() -> Result<Vec<Box<dyn Identity + Send + Sync>>> {
         }
     }
 
-    Ok(identities)
+    Ok((identities, unusable))
 }
 
 async fn get_default_key_file() -> Option<PathBuf> {
@@ -400,6 +483,51 @@ fn get_default_ssh_key_paths() -> Vec<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_classify_unsupported_ssh_identities() {
+        // `Encrypted` needs a real parsed key, so it is covered end-to-end by
+        // e2e/env/test_env_age_ssh_passphrase instead. These variants carry
+        // only a string, so the mapping can be checked directly.
+        let cases = [
+            (
+                ssh::UnsupportedKey::EncryptedPem,
+                UnusableSshIdentity::EncryptedPem,
+            ),
+            (
+                ssh::UnsupportedKey::EncryptedSsh("aes256-cbc".into()),
+                UnusableSshIdentity::EncryptedCipher("aes256-cbc".into()),
+            ),
+            (
+                ssh::UnsupportedKey::Hardware("sk-ssh-ed25519".into()),
+                UnusableSshIdentity::Hardware("sk-ssh-ed25519".into()),
+            ),
+            (
+                ssh::UnsupportedKey::Type("ssh-dss".into()),
+                UnusableSshIdentity::KeyType("ssh-dss".into()),
+            ),
+        ];
+        for (key, expected) in cases {
+            let identity = ssh::Identity::Unsupported(key);
+            assert_eq!(UnusableSshIdentity::classify(&identity), Some(expected));
+        }
+    }
+
+    #[test]
+    fn test_unusable_identity_hint_stays_quiet_when_every_key_is_readable() {
+        assert_eq!(unusable_identity_hint(&[]), "");
+    }
+
+    #[test]
+    fn test_unusable_identity_hint_names_the_file_and_the_way_out() {
+        let path = PathBuf::from("/keys/id_ed25519");
+        let hint = unusable_identity_hint(&[(path.clone(), UnusableSshIdentity::Passphrase)]);
+        // Compare against the rendered form: display_path uses the host
+        // separator, so a literal "/keys/..." never matches on Windows.
+        assert!(hint.contains(&file::display_path(&path)), "{hint}");
+        assert!(hint.contains("passphrase"), "{hint}");
+        assert!(hint.contains("settings.age.key_file"), "{hint}");
+    }
 
     #[tokio::test]
     async fn test_age_x25519_round_trip_small() -> Result<()> {


### PR DESCRIPTION
Addresses discussion #10829.

## Problem

With `[settings.age] ssh_identity_files` pointing at a passphrase-protected key, decryption fails with:

```
[experimental] Failed to decrypt HOGE
[experimental] Failed to decrypt: No matching keys found
```

That blames the recipient, when the identity does match — mise just could not read it.

`ssh::Identity::from_buffer` **succeeds** for such a key and hands back `Identity::Encrypted`, which `src/agecrypt.rs` pushed into the identity list without looking. age then maps `Encrypted` and `Unsupported` to `None` while matching stanzas, so the key silently contributes nothing and the decryptor reports the one thing that is not wrong.

`age.strict` defaults to `true`, so this error — not the non-strict `debug!` — is what users hit.

## Fix

Classify each SSH identity as it is loaded and, when decryption fails, name the ones that could never have worked and why:

```
[experimental] Failed to decrypt: No matching keys found
hint: ~/.ssh/id_ed25519 is protected by a passphrase, which mise does not prompt for, so it could not be used
hint: use an identity mise can read, or set settings.age.key_file to an age key
```

`UnsupportedKey` separates encrypted PEM, an unsupported cipher, a hardware-backed key, and an unsupported key type, so each gets its own wording.

Two deliberate choices:

- Unusable identities are still added to the list. Dropping the only one would report "No age identities found" instead, trading one wrong diagnosis for another.
- **Not prompting for the passphrase.** age supports it via `DecryptableIdentity<C: Callbacks>`, but env resolution runs through `hook-env` on every shell prompt, so blocking there would be worse than the message. That belongs behind an explicit opt-in.

## Why this touches `Cargo.toml`

The new test turned up a second defect and could not pass without fixing it. age renders its error messages through fluent, and rust-embed only bakes the translations into the binary for release builds. A **debug** mise that formats an age error from outside the crate's source tree — which is exactly what e2e does inside a container — panicked in age's `lazy_static` instead of reporting anything:

```
called `Result::unwrap()` on an `Err` value: LanguageNotAvailable("en-US/age.ftl", …)
  at age-0.12.1/src/i18n.rs:19
```

Nothing depended on that path before: non-strict mode only formats the error behind `debug!`, and no test reached a strict-mode failure. Reproduced directly by running a debug build in a container without the cargo registry mounted, and confirmed fixed the same way.

age exposes no feature to flip this, so `rust-embed` is a direct dependency purely for feature unification, listed in cargo-machete's ignore list beside the five entries already there for the same reason. Happy to split it out if you would rather review it separately.

## Verification

New `e2e/env/test_env_age_ssh_passphrase` generates two ed25519 keys differing only in whether `ssh-keygen` got a passphrase and asserts the contrast; it skips where `ssh-keygen` is absent, since no other e2e test needs it. Three unit tests cover the classifier and hint formatting. Existing age and SOPS e2e tests pass. clippy clean with no exclusions.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved age SSH identity handling during decryption.
  * Added clearer, file-specific guidance when identities are passphrase-protected, encrypted, hardware-backed, or otherwise unsupported.
  * Preserved recognizable but unusable SSH identities so users receive more actionable diagnostics instead of generic failures.
  * Added support for more reliable handling of SSH key scenarios, including plain and passphrase-protected Ed25519 keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->