### PR TITLE
registry: fix yazi version test

### DIFF
--- a/registry/yazi.toml
+++ b/registry/yazi.toml
@@ -1,5 +1,5 @@
 backends = ["aqua:sxyazi/yazi", "cargo:yazi-fm"]
 bins = ["ya", "yazi"]
 description = "Blazing fast terminal file manager written in Rust, based on async I/O"
-test = { cmd = "yazi --version", expected = "Yazi {{version}}" }
+test = { cmd = "yazi --version", expected = "Version: {{version}}" }
 version_order = "semver"


### PR DESCRIPTION
## Summary
- update the Yazi version assertion for its multiline version banner
- restore the registry smoke test after the upstream output change

## Testing
- `target/debug/mise test-tool yazi`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line registry test expectation change with no runtime or security impact.
> 
> **Overview**
> Updates the `yazi` registry smoke test so `yazi --version` is matched against `Version: {{version}}` instead of `Yazi {{version}}`, matching the current multiline version banner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dda9939259b09743cc919c9b63298e7a573f691. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the Yazi version check to match the current `Version: {{version}}` command output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->