### PR TITLE
fix(generate): name a task stub after the task, not its file

### DIFF
--- a/e2e-win/task_stub_names.Tests.ps1
+++ b/e2e-win/task_stub_names.Tests.ps1
@@ -1,0 +1,47 @@
+Describe 'task stub names' {
+    BeforeAll {
+        # Outside the shared TestDrive config: this suite needs a project whose only tasks are the
+        # ones below, so the stub directory can be asserted file by file.
+        $script:OriginalDir = Get-Location
+        $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+        $script:Root = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path (Join-Path $script:Root 'mise-tasks') -Force | Out-Null
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:Root
+        '[tools]' | Out-File -FilePath (Join-Path $script:Root 'mise.toml') -Encoding utf8NoBOM
+        # A `.bat` file task. Windows will not run the `#!/bin/sh` stub itself, and naming that stub
+        # `.bat` used to make cmd.exe run the shebang script as a batch file, echoing each line.
+        @'
+@echo off
+echo from-bat
+'@ | Out-File -FilePath (Join-Path $script:Root 'mise-tasks\batTask.bat') -Encoding ascii
+        Set-Location $script:Root
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        if ($null -eq $script:OriginalTrusted) {
+            Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
+        } else {
+            [Environment]::SetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', $script:OriginalTrusted, 'Process')
+        }
+    }
+
+    It 'names the stub after the task, not after the file' {
+        mise generate task-stubs | Out-Null
+        $LASTEXITCODE | Should -Be 0
+        Test-Path 'bin\batTask' | Should -BeTrue
+        Test-Path 'bin\batTask.cmd' | Should -BeTrue
+        # The negative control: the old spelling is what cmd.exe mis-executed, so its absence is
+        # the point rather than a tidiness check.
+        Test-Path 'bin\batTask.bat' | Should -BeFalse
+    }
+
+    It 'produces a launcher Windows can actually run' {
+        # What the old naming cost: `bin\batTask.bat` held `#!/bin/sh` and cmd ran it line by line,
+        # reporting `'#!' is not recognized`. The launcher has to reach the task instead.
+        $out = & '.\bin\batTask.cmd' 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -BeLike '*from-bat*'
+        $out | Should -Not -BeLike '*is not recognized*'
+    }
+}

--- a/e2e/generate/test_generate_task_stubs
+++ b/e2e/generate/test_generate_task_stubs
@@ -151,3 +151,65 @@ assert_fail_contains \
   "relocated-blocked-bin/work/containers/_default is not a generated task stub"
 assert_contains "cat relocated-blocked-bin/work/containers/_default" "exec custom-tool run work:containers"
 test ! -e relocated-blocked-bin/xxx
+
+# A file task is named after its file, so the stub used to be too: `build.sh` produced
+# `bin/build.sh`, and on Windows `build.bat` produced a `#!/bin/sh` script called `bin/build.bat`,
+# which cmd.exe runs as a batch file line by line. The stub is named after the task now.
+#
+# Nothing is cleared first: the paths below (`bin/deploy*`, `bin/build*`) do not collide with what
+# the scenarios above leave in `bin/` (`xxx*`, `work/containers/*`), so a reset would only be
+# tidiness.
+mkdir -p mise-tasks
+cat >mise-tasks/deploy.sh <<'SH'
+#!/usr/bin/env sh
+echo deploying
+SH
+chmod +x mise-tasks/deploy.sh
+cat >mise.toml <<'EOF2'
+[tools]
+EOF2
+
+assert "mise generate task-stubs"
+assert_succeed "test -f bin/deploy"
+assert_succeed "test -f bin/deploy.cmd"
+# The negative control: without it the assertion above would hold even if both spellings were
+# written, which is the state this replaces.
+assert_fail "test -f bin/deploy.sh"
+assert "./bin/deploy" "deploying"
+
+# A stub written under the old spelling is migrated, launcher and all, rather than left beside the
+# new one still running the task.
+cp bin/deploy bin/deploy.sh
+cp bin/deploy.cmd bin/deploy.sh.cmd
+chmod +x bin/deploy.sh
+assert "mise generate task-stubs"
+assert_fail "test -e bin/deploy.sh"
+assert_fail "test -e bin/deploy.sh.cmd"
+assert_succeed "test -f bin/deploy"
+
+# ...but only a stub mise wrote. Anything else at that path stops the run, the same protection the
+# nested-stub migration already has.
+printf '#!/bin/sh\necho mine\n' >bin/deploy.sh
+chmod +x bin/deploy.sh
+assert_fail_contains "mise generate task-stubs" "is not the generated stub for task"
+assert_contains "cat bin/deploy.sh" "echo mine"
+# Not cleanup: this un-plants the file the two lines above deliberately planted. Left in place it
+# keeps failing validation, and the next scenario asserts a successful run.
+rm -f bin/deploy.sh
+
+# Two file tasks differing only by extension share a display name, and on this platform both
+# survive as separate tasks. They keep their file-named paths: renaming both onto `bin/build` would
+# take a project that generates two stubs today and fail the run instead.
+cat >mise-tasks/build.sh <<'SH'
+#!/usr/bin/env sh
+echo from-sh
+SH
+cat >mise-tasks/build.bat <<'SH'
+#!/usr/bin/env sh
+echo from-bat
+SH
+chmod +x mise-tasks/build.sh mise-tasks/build.bat
+assert "mise generate task-stubs"
+assert_succeed "test -f bin/build.sh"
+assert_succeed "test -f bin/build.bat"
+assert_fail "test -e bin/build"

--- a/src/cli/generate/task_stubs.rs
+++ b/src/cli/generate/task_stubs.rs
@@ -4,7 +4,7 @@ use crate::file;
 use crate::file::display_path;
 use crate::task::Task;
 use eyre::bail;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
@@ -32,8 +32,12 @@ impl TaskStubs {
     pub(super) async fn run(self) -> eyre::Result<()> {
         let config = Config::get().await?;
         let tasks = config.tasks().await?;
+        // Two paths per task, and they differ only for a task that came from a file: `name` keeps
+        // the file's extension, `display_name` does not. The stub is named after the task, and the
+        // file-named path is kept so a stub written under the old spelling can be migrated away.
         let task_paths = tasks.values().map(Task::name_to_path).collect::<Vec<_>>();
-        let paths = resolve_stub_paths(&self.dir, &task_paths)?;
+        let base_paths = stub_base_paths(&tasks, &task_paths);
+        let paths = resolve_stub_paths(&self.dir, &base_paths)?;
         let stubs = tasks
             .values()
             .zip(task_paths)
@@ -158,6 +162,40 @@ fn remove_generated_launcher(stub_path: &Path) -> Result<()> {
 enum StubMigration {
     File(PathBuf),
     Directory(PathBuf),
+}
+
+/// The path each stub should take, named for the task, falling back where that is ambiguous.
+///
+/// A file task is *named* after its file — `build.sh` — while everything else about it, including
+/// the command the stub runs, uses the extensionless display name. Naming the stub after the file
+/// produced `bin/build.sh`, and on Windows a `#!/bin/sh` script called `bin/build.bat`, which
+/// cmd.exe runs as a batch file line by line.
+///
+/// Two file tasks that differ only by extension share a display name, and on platforms other than
+/// Windows both survive as separate tasks — `prefer_windows_file_task_siblings` collapses the pair
+/// only there. Those keep their file-named paths, because renaming both onto one path would take a
+/// working project and fail its `task-stubs` run. Windows never reaches that branch, so the case
+/// this exists to fix is always unambiguous.
+fn stub_base_paths(tasks: &BTreeMap<String, Task>, task_paths: &[PathBuf]) -> Vec<PathBuf> {
+    let display_paths = tasks
+        .values()
+        .map(Task::display_name_to_path)
+        .collect::<Vec<_>>();
+    let mut counts: HashMap<&PathBuf, usize> = HashMap::new();
+    for path in &display_paths {
+        *counts.entry(path).or_default() += 1;
+    }
+    display_paths
+        .iter()
+        .zip(task_paths)
+        .map(|(display_path, task_path)| {
+            if counts.get(display_path).copied().unwrap_or_default() > 1 {
+                task_path.clone()
+            } else {
+                display_path.clone()
+            }
+        })
+        .collect()
 }
 
 fn resolve_stub_paths(dir: &Path, task_paths: &[PathBuf]) -> Result<Vec<PathBuf>> {

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -2798,6 +2798,17 @@ impl Task {
         self.name.replace(':', path::MAIN_SEPARATOR_STR).into()
     }
 
+    /// Like [`Self::name_to_path`], but named for the task rather than for the file behind it.
+    ///
+    /// A file task's `name` keeps its file's extension while everything else about the task drops
+    /// it, so the two spellings disagree for exactly the tasks that come from a file. Anything
+    /// naming a file *after* the task -- a task stub, say -- wants this one.
+    pub(crate) fn display_name_to_path(&self) -> PathBuf {
+        self.display_name
+            .replace(':', path::MAIN_SEPARATOR_STR)
+            .into()
+    }
+
     pub(crate) async fn render_env(
         &self,
         config: &Arc<Config>,


### PR DESCRIPTION
A file task is *named* after its file, so its stub was too. Measured on Windows 2026.8.10 with three
tasks in `mise-tasks/`:

| task file | task | stub written | result |
|---|---|---|---|
| `shTask` | `shTask` | `bin/shTask` + `bin/shTask.cmd` | fine |
| `psTask.ps1` | `psTask` | `bin/psTask.ps1` + `bin/psTask.ps1.cmd` | typing `psTask` resolves neither — PATHEXT looks for `psTask.CMD` |
| `batTask.bat` | `batTask` | `bin/batTask.bat`, **no launcher** | cmd.exe runs the `#!/bin/sh` stub as a batch file |

The `.bat` case, run:

```
>#!/bin/sh
'#!' is not recognized as an internal or external command, operable program or batch file.
># generated by mise task-stubs
rc=1
```

### Root cause

`task_stubs.rs` mixes two spellings of the same task. The **path** comes from `Task::name_to_path`
— `name`, which keeps the file's extension — while the **body** it writes uses `display_name`,
which drops it, so the stub at `bin/batTask.bat` runs `mise run batTask`.

`windows_launcher_path` then declines to write a `.cmd` beside anything already ending in
`.bat`/`.cmd`/`.exe`, on the reasonable assumption that such a file is already something Windows
runs. A generated stub is a `#!/bin/sh` script whatever it is called, so that assumption does not
hold for it.

### The change

`Task::display_name_to_path` joins the existing `name_to_path`, and the stub path comes from the
first while `legacy_path` keeps using the second. **That is what makes the migration free**:
`validate_stub_paths` already compares the two, checks the file at the old path really is a
generated stub, and hands it to `StubMigration::File`, which removes it together with its launcher.
A file mise did not write still stops the run rather than being deleted — the protection the nested
`_default` migration already had, now covering this rename too.

### The fallback, and why it is not optional

Two file tasks differing only by extension share a display name, and on platforms other than
Windows **both survive as separate tasks** — `prefer_windows_file_task_siblings` collapses the pair
only on Windows. Measured on Linux today: `build.sh` + `build.bat` produce `bin/build.sh` and
`bin/build.bat`, and both work.

Naming both after the display name would put them on one path and `resolve_stub_paths` would fail
the run — turning a working project into an error. So a colliding group keeps its file-named paths.
Windows never reaches that branch, so the case this PR fixes is always unambiguous.

### Tests

Linux, appended to `e2e/generate/test_generate_task_stubs`: the new naming with
`assert_fail "test -f bin/deploy.sh"` as the **negative control**; the migration removing the old
stub *and* its launcher; a hand-written file at the old path still stopping the run; and the
collision keeping both extensioned stubs.

Windows, in a **new** `e2e-win/task_stub_names.Tests.ps1` — `e2e-win/task.Tests.ps1` is untouched
because #12324 is open against it and two PRs appending to one file is an avoidable conflict. That
suite asserts what only Windows can: `bin\batTask.cmd` **runs** and prints the task's output, with
`Should -Not -BeLike '*is not recognized*'` pinning the exact failure this replaces.

No unit test: what is under test is how files get named and migrated, which the e2e drives for real.

### Verification

Red first, measured on both platforms. Windows: `bin\batTask` and `bin\batTask.cmd` absent,
`bin\batTask.bat` present — the inverse of what the tests now expect. Linux: `Wrote to bin/deploy.sh`,
with `bin/deploy` absent.

The collision assertions are **green today and must stay green** — they guard the behaviour the
fallback preserves rather than reproducing a defect, and are reported as such.

`test_generate_task_stubs` **cannot be baselined on this box**: its Linux binary is 2026.8.3, which
predates the launcher, so the suite already fails at `test -f bin/xxx.cmd` before reaching anything
of mine. CI is its baseline.

`cargo fmt --all`, `shfmt -d`, `shellcheck -x` are clean and the Pester file parses. `cargo check`
does not run on this machine (`libz-ng-sys` wants `cmake`), so type-checking is left to CI — nothing
here is reported as having been compiled locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Task stub generation now uses cleaner extensionless names where possible.
  - Windows task stubs include both `.cmd` and extensionless launchers.
  - File-based tasks retain distinct paths when their names differ only by extension.

- **Bug Fixes**
  - Obsolete extension-based stubs are removed or migrated during regeneration.
  - Generation now detects conflicting existing files and avoids overwriting them.
  - Windows-generated task launchers execute successfully without command-recognition errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->