### PR TITLE
fix(go): don't hand go install a GOROOT from another Go

### DIFF
--- a/e2e/backend/test_go_backend_goroot
+++ b/e2e/backend/test_go_backend_goroot
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Regression test for https://github.com/jdx/mise/discussions/8261
+# (and https://github.com/jdx/mise/discussions/8877, the same failure).
+#
+# mise exports GOROOT for the Go it manages, and `mise activate` carries it
+# into the shell. On unix the go backend spawns the bare name `go`, so which
+# Go actually runs is up to PATH. If a different Go runs while that GOROOT is
+# still in the environment, every compile fails with
+# `compile: version "..." does not match go tool version "..."`.
+
+# A stand-in for `go` that refuses to run with an inherited GOROOT, which is
+# what a real Go effectively does once GOROOT names someone else's tree.
+cat >"$HOME/bin/go" <<'GO'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'GOROOT=%s\n' "${GOROOT:-<unset>}" >>"$HOME/go-invocations"
+
+if [[ -n ${GOROOT:-} ]]; then
+  echo "compile: GOROOT from another Go leaked: $GOROOT" >&2
+  exit 1
+fi
+
+# Stand in for a successful `go install`.
+mkdir -p "$GOBIN"
+printf '#!/usr/bin/env bash\necho go-example\n' >"$GOBIN/go-example"
+chmod +x "$GOBIN/go-example"
+GO
+chmod +x "$HOME/bin/go"
+export PATH="$HOME/bin:$PATH"
+
+# The environment a user gets from `mise activate` with a mise-managed Go,
+# while the `go` that PATH resolves belongs to a different installation.
+export GOROOT="$HOME/some-other-go"
+
+cat >mise.toml <<'TOML'
+[settings]
+experimental = true
+TOML
+
+# An exact version keeps this off the `go list` path, which needs the network.
+assert "mise install go:github.com/jdx/go-example@0.1.0"
+assert_contains "cat \"$HOME/go-invocations\"" "GOROOT=<unset>"
+assert_not_contains "cat \"$HOME/go-invocations\"" "some-other-go"
+
+# An explicitly configured GOROOT is still the user's call.
+rm -f "$HOME/go-invocations"
+mise uninstall "go:github.com/jdx/go-example@0.1.0"
+cat >mise.toml <<'TOML'
+[settings]
+experimental = true
+
+[tools]
+"go:github.com/jdx/go-example" = { version = "0.1.0", install_env = { GOROOT = "/explicitly/set" } }
+TOML
+assert_fail "mise install"
+assert_contains "cat \"$HOME/go-invocations\"" "GOROOT=/explicitly/set"

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -170,6 +170,16 @@ impl Backend for GoBackend {
             cmd.arg(format!("{}@{v}", self.tool_name()))
                 .with_pr(ctx.pr.as_ref())
                 .envs(self.dependency_env(&ctx.config).await?)
+                // `go` derives GOROOT from where its own executable lives, so it
+                // does not need one. An inherited GOROOT does harm: mise exports
+                // one for the Go it manages and `mise activate` carries it into
+                // the shell, and on unix `spawn_program` hands back the bare name
+                // `go`, so which Go actually runs is up to the child's PATH. The
+                // moment that is a different Go, every compile fails with
+                // `compile: version "..." does not match go tool version "..."`
+                // (#8261, #8877). Dropped before `install_env` so a GOROOT set
+                // there deliberately still wins.
+                .env_remove("GOROOT")
                 .env_values(tv.install_env())
                 .env("GOBIN", tv.install_path().join("bin"))
                 .execute()


### PR DESCRIPTION
Addresses discussions #8261 and #8877, which are the same failure.

## The report

`mise use -g go:<pkg>` fails with a wall of:

```
compile: version "go1.26.0" does not match go tool version "go1.25.6 X:nodwarf5"
```

That message means **GOROOT and the running `go` come from different Go trees**: `compile` reports the version stamped into `$GOROOT/pkg/tool`, `go tool version` reports the running binary. The `X:nodwarf5` suffix does not appear on dl.google.com tarballs, so the 1.25.6 was a distro build — two Go installs were in play. In #8877 the reporter confirmed that renaming `/usr/bin/go` made it go away.

## mise is what puts that GOROOT there

`go.set_goroot` defaults to true, so mise exports `GOROOT=<mise go>`, and `mise activate` carries it into the shell.

On unix `spawn_program` hands the backend the bare name `go`, so **which Go actually runs is up to the child's PATH** — mise cannot know it is the one GOROOT describes. Passing it along is a guess, and when the guess is wrong every compile fails.

`go` derives GOROOT from where its own executable lives, so it does not need one. Dropping it is a no-op when mise's Go runs and a fix when another one does. It is removed before `install_env`, so a GOROOT set there deliberately still wins.

## Isolated

Under docker on linux-arm64: a system go 1.25.6 on PATH, no `go` in the toolset, GOROOT exported for a mise go 1.27.0.

| | `mise use -g go:github.com/bokwoon95/wgo@v0.6.3` |
| --- | --- |
| GOROOT exported | mismatch lines → `Failed to install, trying again without added 'v' prefix` → `ERROR go failed` |
| identical, GOROOT unset | `✓ installed` |

GOROOT is the only differentiator, and the failing output matches the reports line for line.

## What this does *not* fix, and I would rather say so

**I could not reproduce why a system Go ran in the reporters' setups.** With `go` in the toolset, both current mise and the reporter's 2026.2.17 use their own Go and succeed even with an older system go first on PATH. I said as much on #8877 back in August and never got the traces I asked for.

So this fixes the layer that turns "some other go ran" into a hard failure, not the selection itself. If the selection is also wrong somewhere, that is a separate bug — but this one is real on its own: mise should not hand a `go` it did not resolve a GOROOT belonging to a different Go.

## One decision worth your call

I remove GOROOT unconditionally. The narrower alternative is to strip only an *ambient* GOROOT and keep one the toolset supplied — `.env_remove` before `.envs` rather than after. I did not do that because it cannot help #8877's shape, where `go` **is** in the toolset and a different binary ran anyway. If you would rather keep the toolset's value, say so and I will flip the ordering.

## Scope check

The `go list` path needs nothing. It goes through `cmd_read_async`, which already calls `env_clear`, so it never inherits an ambient GOROOT — only `go_list_env`, which is correct by construction. Left alone deliberately.

## Tests

`e2e/backend/test_go_backend_goroot` plants a `go` that records the GOROOT it was given and refuses to run with one, which is what a real Go effectively does once GOROOT names someone else's tree. It asserts the install succeeds with an ambient `GOROOT` exported, that the stand-in saw `GOROOT=<unset>`, and — second half — that an explicit `install_env = { GOROOT = ... }` still reaches it. No second real toolchain needed, so it is not `_slow`.

`test_go_install`, `test_go_shim_recursion`, `test_install_before_explicit_go_backend`, and `test_install_system_go_backend_slow` all pass. The last one matters most here: it is the #9526 regression test for `cannot find GOROOT directory`, and it still installs a `go:` tool through the system-installed Go.

`cargo fmt --check`, `shellcheck`, and `shfmt` are clean.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Go installations failing when an inherited `GOROOT` environment variable is present.
  * Installation now clears the inherited setting while preserving any explicitly configured `GOROOT` value.
* **Tests**
  * Added regression coverage for inherited and explicitly configured `GOROOT` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->