### PR TITLE
refactor(cli): keep one copy of the task-flag escape rule

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -463,15 +463,22 @@ fn get_all_run_value_taking_short_flags(cmd: &usage_rs::Command<'_>) -> Vec<(Str
 /// Prefix used to escape flags that should be passed to tasks, not mise
 const TASK_ARG_ESCAPE_PREFIX: &str = "\x00MISE_TASK_ARG\x00";
 
+/// One task-side argument, with a leading flag hidden from the parser.
+///
+/// A lone `-` is the conventional stdin placeholder rather than a flag, so it passes through. That
+/// exception was written out at each of the three places that needed this rule; this is the only
+/// copy of it now.
+fn escape_flag_arg(arg: &str) -> String {
+    if arg.starts_with('-') && arg != "-" {
+        format!("{TASK_ARG_ESCAPE_PREFIX}{arg}")
+    } else {
+        arg.to_string()
+    }
+}
+
 fn escape_args_after_separator(args: &[String], separator_idx: usize) -> Vec<String> {
     let mut result = args[..=separator_idx].to_vec();
-    for arg in &args[separator_idx + 1..] {
-        if arg.starts_with('-') && arg != "-" {
-            result.push(format!("{}{}", TASK_ARG_ESCAPE_PREFIX, arg));
-        } else {
-            result.push(arg.clone());
-        }
-    }
+    result.extend(args[separator_idx + 1..].iter().map(|a| escape_flag_arg(a)));
     result
 }
 
@@ -619,14 +626,10 @@ fn escape_task_args(cmd: &usage_rs::Command<'_>, args: &[String]) -> Vec<String>
         // First protect task-side flags before the separator (`run TASK -q -- ...`),
         // then preserve the existing escaping for its tail.
         let mut result = escape_task_args(cmd, &args[..separator_idx]);
-        result.push("--".to_string());
-        for arg in &args[separator_idx + 1..] {
-            if arg.starts_with('-') && arg != "-" {
-                result.push(format!("{}{}", TASK_ARG_ESCAPE_PREFIX, arg));
-            } else {
-                result.push(arg.clone());
-            }
-        }
+        // `separator_idx` was found by matching `"--"`, so the slice starting there begins with it:
+        // `escape_args_after_separator(.., 0)` emits that element and then escapes the tail, which
+        // is what this branch used to build by hand.
+        result.extend(escape_args_after_separator(&args[separator_idx..], 0));
         return result;
     }
 
@@ -699,13 +702,8 @@ fn escape_task_args(cmd: &usage_rs::Command<'_>, args: &[String]) -> Vec<String>
                 in_task_args = true;
             }
         } else {
-            // In task args - escape flags so clap doesn't parse them
-            if arg.starts_with('-') && arg != "-" {
-                // Escape the flag
-                result.push(format!("{}{}", TASK_ARG_ESCAPE_PREFIX, arg));
-            } else {
-                result.push(arg.clone());
-            }
+            // In task args - escape flags so the parser doesn't take them
+            result.push(escape_flag_arg(arg));
         }
 
         i += 1;
@@ -1353,6 +1351,21 @@ mod tests {
         }
 
         check(Cli::command(), &mut Vec::new());
+    }
+
+    #[test]
+    fn test_escape_flag_arg_leaves_a_lone_hyphen_alone() {
+        // The exception the three copies of this rule each carried: `-` on its own is the
+        // conventional stdin placeholder, not a flag, and a task that reads stdin needs it to
+        // arrive unchanged. Now that the rule has one home, it is asserted there.
+        assert_eq!(escape_flag_arg("-"), "-");
+        assert_eq!(escape_flag_arg("plain"), "plain");
+        assert!(escape_flag_arg("--help").starts_with(TASK_ARG_ESCAPE_PREFIX));
+        assert!(escape_flag_arg("-q").starts_with(TASK_ARG_ESCAPE_PREFIX));
+        assert_eq!(
+            unescape_task_args(&[escape_flag_arg("--help")]),
+            vec!["--help".to_string()]
+        );
     }
 
     #[test]


### PR DESCRIPTION
`src/cli/mod.rs` carried the same rule three times: prefix an argument with `TASK_ARG_ESCAPE_PREFIX`
when it `starts_with('-') && arg != "-"`, otherwise pass it through.

| site | shape |
|---|---|
| `escape_args_after_separator` (466-476) | loop over a slice |
| `escape_task_args`, separator branch (621-629) | loop over a slice |
| the task-args loop (703-708) | **one element** |

**This came from review, not from me.** CodeRabbit raised it on #12327 and again on #12314. Both
times it fell outside the diff — those PRs change one hunk each in this file, ~200 lines away — so I
declined and said it wanted its own PR. **A finding that keeps landing on unrelated PRs is asking
for a home**, and the second report is what turned up the third copy, which the first had not
mentioned.

No behaviour change is intended.

### The shape

An iterator-returning helper covers the two slice sites but not the third, which applies the rule to
a single argument inside a larger `while`. A singular helper covers all three:

```rust
fn escape_flag_arg(arg: &str) -> String {
    if arg.starts_with('-') && arg != "-" {
        format!("{TASK_ARG_ESCAPE_PREFIX}{arg}")
    } else {
        arg.to_string()
    }
}
```

The separator branch then does not need it at all — it can delegate:

```rust
let mut result = escape_task_args(cmd, &args[..separator_idx]);
result.extend(escape_args_after_separator(&args[separator_idx..], 0));
```

**One correction to the review note**, which said `escape_args_after_separator` "cannot be reused
directly here". It can. `separator_idx` is found by matching `"--"`, so for the slice beginning
there, `escape_args_after_separator(.., 0)` emits `slice[..=0]` — exactly `["--"]` — and then runs
the same escape over the tail. That is what the branch built by hand, element for element.

The predicate now appears once. `grep -c` for it in the file returns `1`.

### Tests

Existing unit tests already reach all three sites, and they are in a `#[cfg(test)] mod tests` with
no `#[cfg(unix)]`, so they run on Windows CI too:

- `test_escape_task_args_preserves_task_separator_tail` — `run atask -q -- -- --help`. Asserts the
  `-q` before the separator (the task-args loop) *and* both elements after it (the separator
  branch).
- `test_escape_task_args_preserves_naked_task_separator_tail` — the form with no `run`, which enters
  `escape_args_after_separator` directly.
- `..._splits_attached_short_option_values_before_task`, `..._preserves_equals_attached_option_values`
  and `..._keeps_hyphen_prefixed_attached_value_bound_to_option` exercise the task-args loop.

One test is added, for the rule itself. The `-`-is-not-a-flag exception was carried by all three
copies and asserted by none; now that it has one home, it is pinned there — including that a lone
`-` survives, which is what a task reading stdin depends on.

No e2e: nothing observable changes.

### Verification

`cargo fmt --all` is clean. **Nothing here has been compiled or run locally** — `cargo check` does
not work on this machine (`libz-ng-sys` wants `cmake`, which is not installed), so for a refactor
this is thinner than I would like and CI is the first thing to type-check it. What stands in for it
is the existing coverage above, and the equivalence argument for the delegating branch, which is a
reading of `args[separator_idx] == "--"` rather than a run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line argument handling to correctly preserve standalone hyphens.
  * Ensured task flags and separator arguments are consistently escaped and restored.

* **Tests**
  * Added coverage for plain arguments, flag escaping, unescaping, and standalone hyphen behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->