### PR TITLE
chore: release 2026.8.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## [2026.8.12](https://github.com/jdx/mise/compare/v2026.8.11..v2026.8.12) - 2026-08-24
+
+### 🚀 Features
+
+- **(bootstrap)** add package plugin uninstall support by @jdx in [#12332](https://github.com/jdx/mise/pull/12332)
+
+### 🐛 Bug Fixes
+
+- **(brew-cask)** recognize Homebrew-owned casks by @donbeave in [#12346](https://github.com/jdx/mise/pull/12346)
+- **(cli)** report a cd target it cannot enter instead of panicking by @JamBalaya56562 in [#12314](https://github.com/jdx/mise/pull/12314)
+- **(config)** skip disabled idiomatic tracked configs by @xqm32 in [#12194](https://github.com/jdx/mise/pull/12194)
+- **(config)** keep comments when saving from mise edit by @Marukome0743 in [#12319](https://github.com/jdx/mise/pull/12319)
+- **(config)** strip a byte-order mark before reading a version file by @JamBalaya56562 in [#12325](https://github.com/jdx/mise/pull/12325)
+- **(doctor)** report installs that provide no executables by @Marukome0743 in [#12321](https://github.com/jdx/mise/pull/12321)
+- **(env)** say why an age SSH identity could not be used by @Marukome0743 in [#12339](https://github.com/jdx/mise/pull/12339)
+- **(env)** name the key and file behind an unexpanded $VAR by @Marukome0743 in [#12316](https://github.com/jdx/mise/pull/12316)
+- **(go)** don't hand go install a GOROOT from another Go by @Marukome0743 in [#12342](https://github.com/jdx/mise/pull/12342)
+- **(task)** treat a SIGINT-killed child as an interruption by @Marukome0743 in [#12323](https://github.com/jdx/mise/pull/12323)
+- **(task)** preserve string type for usage value flags by @jdx in [#12355](https://github.com/jdx/mise/pull/12355)
+- **(tasks)** tell Windows users why a task file was skipped by @JamBalaya56562 in [#12324](https://github.com/jdx/mise/pull/12324)
+- **(tool-stub)** keep env_with_path instead of rebuilding PATH by @tmkx in [#12322](https://github.com/jdx/mise/pull/12322)
+- **(watch)** restore the controlling terminal from a drop guard by @Marukome0743 in [#12328](https://github.com/jdx/mise/pull/12328)
+
+### 🚜 Refactor
+
+- **(cli)** keep one copy of the task-flag escape rule by @JamBalaya56562 in [#12343](https://github.com/jdx/mise/pull/12343)
+
+### 📚 Documentation
+
+- **(tasks)** point extensionless pwsh tasks at MISE_TASK_DIR by @JamBalaya56562 in [#12313](https://github.com/jdx/mise/pull/12313)
+
+### 📦️ Dependency Updates
+
+- update rust crate aube-registry to v2.1.0 by @renovate[bot] in [#12348](https://github.com/jdx/mise/pull/12348)
+- bump aube to 2.1.0 by @jdx in [#12351](https://github.com/jdx/mise/pull/12351)
+- bump usage to 6.2.0 by @jdx in [#12354](https://github.com/jdx/mise/pull/12354)
+
+### 📦 Registry
+
+- fix usage version test by @jdx in [#12349](https://github.com/jdx/mise/pull/12349)
+- install oc from a channel directory by @Marukome0743 in [#12326](https://github.com/jdx/mise/pull/12326)
+
+### Chore
+
+- **(ci)** use github runners for fork prs by @jdx in [#12345](https://github.com/jdx/mise/pull/12345)
+- **(ci)** prevent cache warmer starvation by @jdx in [#12350](https://github.com/jdx/mise/pull/12350)
+
+### New Contributors
+
+- @tmkx made their first contribution in [#12322](https://github.com/jdx/mise/pull/12322)
+
 ## [2026.8.11](https://github.com/jdx/mise/compare/v2026.8.10..v2026.8.11) - 2026-08-23
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6292,7 +6292,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.8.11"
+version = "2026.8.12"
 dependencies = [
  "age 0.12.1",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.8.11"
+version = "2026.8.12"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.8.11 macos-arm64 (2026-08-23)
+2026.8.12 macos-arm64 (2026-08-24)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.8.11";
+  version = "2026.8.12";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.8.11
+Version: 2026.8.12
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.8.11"
+version: "2026.8.12"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "15a82331294e4a3077a4c408477e15199c8090d9"
+  "tag": "2f018c979bf1b63b345864abe5976843f6adc849"
 }


### PR DESCRIPTION
### 🚀 Features

- **(bootstrap)** add package plugin uninstall support by @jdx in [#12332](https://github.com/jdx/mise/pull/12332)

### 🐛 Bug Fixes

- **(brew-cask)** recognize Homebrew-owned casks by @donbeave in [#12346](https://github.com/jdx/mise/pull/12346)
- **(cli)** report a cd target it cannot enter instead of panicking by @JamBalaya56562 in [#12314](https://github.com/jdx/mise/pull/12314)
- **(config)** skip disabled idiomatic tracked configs by @xqm32 in [#12194](https://github.com/jdx/mise/pull/12194)
- **(config)** keep comments when saving from mise edit by @Marukome0743 in [#12319](https://github.com/jdx/mise/pull/12319)
- **(config)** strip a byte-order mark before reading a version file by @JamBalaya56562 in [#12325](https://github.com/jdx/mise/pull/12325)
- **(doctor)** report installs that provide no executables by @Marukome0743 in [#12321](https://github.com/jdx/mise/pull/12321)
- **(env)** say why an age SSH identity could not be used by @Marukome0743 in [#12339](https://github.com/jdx/mise/pull/12339)
- **(env)** name the key and file behind an unexpanded $VAR by @Marukome0743 in [#12316](https://github.com/jdx/mise/pull/12316)
- **(go)** don't hand go install a GOROOT from another Go by @Marukome0743 in [#12342](https://github.com/jdx/mise/pull/12342)
- **(task)** treat a SIGINT-killed child as an interruption by @Marukome0743 in [#12323](https://github.com/jdx/mise/pull/12323)
- **(task)** preserve string type for usage value flags by @jdx in [#12355](https://github.com/jdx/mise/pull/12355)
- **(tasks)** tell Windows users why a task file was skipped by @JamBalaya56562 in [#12324](https://github.com/jdx/mise/pull/12324)
- **(tool-stub)** keep env_with_path instead of rebuilding PATH by @tmkx in [#12322](https://github.com/jdx/mise/pull/12322)
- **(watch)** restore the controlling terminal from a drop guard by @Marukome0743 in [#12328](https://github.com/jdx/mise/pull/12328)

### 🚜 Refactor

- **(cli)** keep one copy of the task-flag escape rule by @JamBalaya56562 in [#12343](https://github.com/jdx/mise/pull/12343)

### 📚 Documentation

- **(tasks)** point extensionless pwsh tasks at MISE_TASK_DIR by @JamBalaya56562 in [#12313](https://github.com/jdx/mise/pull/12313)

### 📦️ Dependency Updates

- update rust crate aube-registry to v2.1.0 by @renovate[bot] in [#12348](https://github.com/jdx/mise/pull/12348)
- bump aube to 2.1.0 by @jdx in [#12351](https://github.com/jdx/mise/pull/12351)
- bump usage to 6.2.0 by @jdx in [#12354](https://github.com/jdx/mise/pull/12354)

### 📦 Registry

- fix usage version test by @jdx in [#12349](https://github.com/jdx/mise/pull/12349)
- install oc from a channel directory by @Marukome0743 in [#12326](https://github.com/jdx/mise/pull/12326)

### Chore

- **(ci)** use github runners for fork prs by @jdx in [#12345](https://github.com/jdx/mise/pull/12345)
- **(ci)** prevent cache warmer starvation by @jdx in [#12350](https://github.com/jdx/mise/pull/12350)

### New Contributors

- @tmkx made their first contribution in [#12322](https://github.com/jdx/mise/pull/12322)