### PR TITLE
chore(ci): use github runners for fork prs

### DIFF
--- a/.github/actions/setup-mbx/action.yml
+++ b/.github/actions/setup-mbx/action.yml
@@ -1,0 +1,64 @@
+name: Set up mbx
+description: Install a pinned mbx release and optionally restore the main-branch GHA cache
+
+inputs:
+  restore-cache:
+    description: Restore the read-only GitHub Actions cache built from main
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      if: inputs.restore-cache == 'true'
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          ~/.cargo/.global-cache
+          ~/.cache/mbx
+        key: ${{ runner.os }}-${{ runner.arch }}-fork-pr-mbx-v0.1.0-${{ github.event.pull_request.base.sha }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-fork-pr-mbx-v0.1.0-
+    - name: Install mbx
+      shell: bash
+      env:
+        MBX_VERSION: v0.1.0
+      run: | # zizmor: ignore[github-env] PATH and cache paths use only runner-owned directories and pinned constants
+        case "${RUNNER_OS}-${RUNNER_ARCH}" in
+          Linux-X64)
+            target=x86_64-unknown-linux-musl
+            checksum=b6cfe4c5104f79cef94d7bfa0b1c3fd5448265f0e82da312b8ba8a2a1b13ed52
+            ;;
+          Linux-ARM64)
+            target=aarch64-unknown-linux-musl
+            checksum=21e83146163bb10346a7ed098f1a8887c980fed18f4ab8684ee4732587fa43b1
+            ;;
+          macOS-X64)
+            target=x86_64-apple-darwin
+            checksum=0a71cc73b84cf3b6844f96fa8eccba8bcf872a4a211ccf2ccde4e627681c7dee
+            ;;
+          macOS-ARM64)
+            target=aarch64-apple-darwin
+            checksum=013806932a12a97641a572e6d177daf8226d13aa792874abaf89c46eaed6f100
+            ;;
+          *)
+            echo "unsupported mbx runner: ${RUNNER_OS}-${RUNNER_ARCH}" >&2
+            exit 1
+            ;;
+        esac
+
+        install_dir="$RUNNER_TEMP/mbx-$MBX_VERSION"
+        archive="$RUNNER_TEMP/mbx-$MBX_VERSION-$target.tar.gz"
+        curl -fsSL --retry 3 \
+          "https://github.com/jdx/mr-boxington/releases/download/$MBX_VERSION/mbx-$target.tar.gz" \
+          -o "$archive"
+        actual_checksum="$(shasum -a 256 "$archive" | cut -d ' ' -f 1)"
+        if [ "$actual_checksum" != "$checksum" ]; then
+          echo "mbx checksum mismatch: expected $checksum, got $actual_checksum" >&2
+          exit 1
+        fi
+        mkdir -p "$install_dir"
+        tar -xzf "$archive" -C "$install_dir"
+        echo "$install_dir" >> "$GITHUB_PATH"
+        echo "MBX_CACHE_DIR=$HOME/.cache/mbx" >> "$GITHUB_ENV"

--- a/.github/actions/setup-mbx/action.yml
+++ b/.github/actions/setup-mbx/action.yml
@@ -1,5 +1,5 @@
 name: Set up mbx
-description: Install a pinned mbx release and optionally restore the main-branch GHA cache
+description: Install mbx from mise.toml and optionally restore the main-branch GHA cache
 
 inputs:
   restore-cache:
@@ -17,48 +17,16 @@ runs:
           ~/.cargo/git
           ~/.cargo/.global-cache
           ~/.cache/mbx
-        key: ${{ runner.os }}-${{ runner.arch }}-fork-pr-mbx-v0.1.0-${{ github.event.pull_request.base.sha }}
+        key: ${{ runner.os }}-${{ runner.arch }}-fork-pr-mbx-v0.2.0-${{ github.event.pull_request.base.sha }}
         restore-keys: |
-          ${{ runner.os }}-${{ runner.arch }}-fork-pr-mbx-v0.1.0-
+          ${{ runner.os }}-${{ runner.arch }}-fork-pr-mbx-v0.2.0-
     - name: Install mbx
       shell: bash
-      env:
-        MBX_VERSION: v0.1.0
-      run: | # zizmor: ignore[github-env] PATH and cache paths use only runner-owned directories and pinned constants
-        case "${RUNNER_OS}-${RUNNER_ARCH}" in
-          Linux-X64)
-            target=x86_64-unknown-linux-musl
-            checksum=b6cfe4c5104f79cef94d7bfa0b1c3fd5448265f0e82da312b8ba8a2a1b13ed52
-            ;;
-          Linux-ARM64)
-            target=aarch64-unknown-linux-musl
-            checksum=21e83146163bb10346a7ed098f1a8887c980fed18f4ab8684ee4732587fa43b1
-            ;;
-          macOS-X64)
-            target=x86_64-apple-darwin
-            checksum=0a71cc73b84cf3b6844f96fa8eccba8bcf872a4a211ccf2ccde4e627681c7dee
-            ;;
-          macOS-ARM64)
-            target=aarch64-apple-darwin
-            checksum=013806932a12a97641a572e6d177daf8226d13aa792874abaf89c46eaed6f100
-            ;;
-          *)
-            echo "unsupported mbx runner: ${RUNNER_OS}-${RUNNER_ARCH}" >&2
-            exit 1
-            ;;
-        esac
-
-        install_dir="$RUNNER_TEMP/mbx-$MBX_VERSION"
-        archive="$RUNNER_TEMP/mbx-$MBX_VERSION-$target.tar.gz"
-        curl -fsSL --retry 3 \
-          "https://github.com/jdx/mr-boxington/releases/download/$MBX_VERSION/mbx-$target.tar.gz" \
-          -o "$archive"
-        actual_checksum="$(shasum -a 256 "$archive" | cut -d ' ' -f 1)"
-        if [ "$actual_checksum" != "$checksum" ]; then
-          echo "mbx checksum mismatch: expected $checksum, got $actual_checksum" >&2
-          exit 1
-        fi
-        mkdir -p "$install_dir"
-        tar -xzf "$archive" -C "$install_dir"
-        echo "$install_dir" >> "$GITHUB_PATH"
+      run:
+        | # zizmor: ignore[github-env] PATH and cache paths use only runner-owned directories
+        mise install github:jdx/mr-boxington
+        mise_bin="$(mise where github:jdx/mr-boxington)/bin"
+        echo "$mise_bin" >> "$GITHUB_PATH"
+        export PATH="$mise_bin:$PATH"
+        mbx --version
         echo "MBX_CACHE_DIR=$HOME/.cache/mbx" >> "$GITHUB_ENV"

--- a/.github/actions/setup-mbx/action.yml
+++ b/.github/actions/setup-mbx/action.yml
@@ -20,13 +20,13 @@ runs:
         key: ${{ runner.os }}-${{ runner.arch }}-fork-pr-mbx-v0.2.0-${{ github.event.pull_request.base.sha }}
         restore-keys: |
           ${{ runner.os }}-${{ runner.arch }}-fork-pr-mbx-v0.2.0-
-    - name: Install mbx
+    - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+      with:
+        cache: false
+        install_args: github:jdx/mr-boxington
+    - name: Verify mbx
       shell: bash
       run:
         | # zizmor: ignore[github-env] PATH and cache paths use only runner-owned directories
-        mise install github:jdx/mr-boxington
-        mise_bin="$(mise where github:jdx/mr-boxington)/bin"
-        echo "$mise_bin" >> "$GITHUB_PATH"
-        export PATH="$mise_bin:$PATH"
         mbx --version
         echo "MBX_CACHE_DIR=$HOME/.cache/mbx" >> "$GITHUB_ENV"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ env:
 jobs:
   docs:
     if: github.repository == 'jdx/mise'
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/github-runner-cache.yml
+++ b/.github/workflows/github-runner-cache.yml
@@ -20,6 +20,7 @@ env:
 
 jobs:
   warm:
+    if: github.ref == 'refs/heads/main'
     name: warm-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90

--- a/.github/workflows/github-runner-cache.yml
+++ b/.github/workflows/github-runner-cache.yml
@@ -38,12 +38,12 @@ jobs:
             ~/.cargo/git
             ~/.cargo/.global-cache
             ~/.cache/mbx
-          key: ${{ runner.os }}-${{ runner.arch }}-fork-pr-mbx-v0.1.0-${{ github.sha }}
+          key: ${{ runner.os }}-${{ runner.arch }}-fork-pr-mbx-v0.2.0-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-fork-pr-mbx-v0.1.0-
+            ${{ runner.os }}-${{ runner.arch }}-fork-pr-mbx-v0.2.0-
       - uses: ./.github/actions/setup-mbx
       - run: mbx build build --all-features --ignore-rust-version
-      # v0.1.0 predates automatic GC. Bound each immutable GHA cache entry so
-      # Linux and macOS can coexist within the repository cache quota.
+      # Bound each immutable GHA cache entry so Linux and macOS can coexist
+      # within the repository cache quota.
       - run: mbx gc --max-size 3GB
         if: always()

--- a/.github/workflows/github-runner-cache.yml
+++ b/.github/workflows/github-runner-cache.yml
@@ -1,0 +1,49 @@
+name: github runner cache
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 0"
+  workflow_dispatch:
+
+concurrency:
+  group: github-runner-cache-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  warm:
+    name: warm-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/.global-cache
+            ~/.cache/mbx
+          key: ${{ runner.os }}-${{ runner.arch }}-fork-pr-mbx-v0.1.0-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-fork-pr-mbx-v0.1.0-
+      - uses: ./.github/actions/setup-mbx
+      - run: mbx build build --all-features --ignore-rust-version
+      # v0.1.0 predates automatic GC. Bound each immutable GHA cache entry so
+      # Linux and macOS can coexist within the repository cache quota.
+      - run: mbx gc --max-size 3GB
+        if: always()

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -16,6 +16,13 @@ name: perf-pr
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    # These files change the repository's development environment rather than
+    # the mise binary. In particular, root mise.toml tools are inherited by the
+    # benchmark fixture and would make the head and base inputs differ.
+    paths-ignore:
+      - ".github/**"
+      - "mise.lock"
+      - "mise.toml"
 
 permissions:
   contents: read

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   check-changes:
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
     timeout-minutes: 5
     outputs:
       registry-changed: ${{ steps.check.outputs.registry-changed }}
@@ -51,7 +51,7 @@ jobs:
 
   build:
     timeout-minutes: 20
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
     needs: check-changes
     if: needs.check-changes.outputs.registry-changed == 'true'
     env:
@@ -59,36 +59,27 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             ~/.cargo/.global-cache
-            ~/.cache/sccache
-      - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
-        with: { tool: sccache }
-      - name: Configure sccache
-        run: |
-          export RUSTC_WRAPPER=sccache
-          export SCCACHE_DIR="$HOME/.cache/sccache"
-          export SCCACHE_CACHE_SIZE=20G
-          {
-            echo "RUSTC_WRAPPER=$RUSTC_WRAPPER"
-            echo "SCCACHE_DIR=$SCCACHE_DIR"
-            echo "SCCACHE_CACHE_SIZE=$SCCACHE_CACHE_SIZE"
-          } >> "$GITHUB_ENV"
-          sccache --zero-stats
-      - run: cargo build --all-features --ignore-rust-version
+            ~/.cache/mbx
+      - uses: ./.github/actions/setup-mbx
+        with:
+          restore-cache: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+      - run: mbx build build --all-features --ignore-rust-version
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mise
           path: target/debug/mise
-      - run: sccache --show-stats
+      - run: mbx cache stats
         if: always()
 
   list-changed-tools:
     timeout-minutes: 10
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
     needs: check-changes
     if: github.event_name == 'pull_request' && needs.check-changes.outputs.registry-changed == 'true'
     outputs:
@@ -142,7 +133,7 @@ jobs:
           fi
 
   validate-new-tools:
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
     timeout-minutes: 5
     needs: list-changed-tools
     if: |
@@ -171,7 +162,7 @@ jobs:
   test-tool:
     name: test-tool-${{ matrix.tranche }}
     timeout-minutes: 90
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
     needs:
       - build
       - list-changed-tools
@@ -356,7 +347,7 @@ jobs:
         run: mise run test-tool-retry --check-only --grace-period ${{ steps.retry.outputs.failed_tools }}
 
   registry-ci:
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
     timeout-minutes: 1
     needs:
       - check-changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,7 +274,7 @@ jobs:
       - build-tarball-linux
       - build-tarball-macos
       - build-tarball-windows
-    if: ${{ !cancelled() && !failure() }}
+    if: ${{ !cancelled() && !failure() && (github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)) }}
     steps:
       - name: Verify all build targets succeeded
         if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
@@ -322,11 +322,6 @@ jobs:
             echo "No release found for $VERSION"
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
-      - name: Skip release for untrusted or non-release PRs
-        if: github.event_name == 'pull_request' && (github.head_ref != 'release' || github.event.pull_request.head.repo.full_name != github.repository)
-        run: |
-          echo "Skipping release steps for untrusted or non-release PR"
-          echo "All release operations will be skipped"
       - uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
         if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
   build-tarball-linux:
     if: github.event_name != 'pull_request' || github.head_ref == 'release'
     name: build-tarball-${{matrix.name}}
-    runs-on: namespace-profile-endev-linux-amd64-xlarge
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64-xlarge' }}
     # PGO and cross-built release tarballs can exceed 90 minutes on
     # loaded runners, especially once archive generation is included.
     timeout-minutes: 150
@@ -94,7 +94,7 @@ jobs:
   build-tarball-macos:
     if: github.event_name != 'pull_request' || github.head_ref == 'release'
     name: build-tarball-${{matrix.name}}
-    runs-on: namespace-profile-endev-macos-arm64
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'macos-14' || 'namespace-profile-endev-macos-arm64' }}
     timeout-minutes: 300
     env:
       MINIO_AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   build-tarball-linux:
-    if: github.event_name != 'pull_request' || github.head_ref == 'release'
+    if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
     name: build-tarball-${{matrix.name}}
     runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64-xlarge' }}
     # PGO and cross-built release tarballs can exceed 90 minutes on
@@ -92,7 +92,7 @@ jobs:
             dist/mise-*.tar.zst
           if-no-files-found: error
   build-tarball-macos:
-    if: github.event_name != 'pull_request' || github.head_ref == 'release'
+    if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
     name: build-tarball-${{matrix.name}}
     runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'macos-14' || 'namespace-profile-endev-macos-arm64' }}
     timeout-minutes: 300
@@ -141,7 +141,7 @@ jobs:
             dist/mise-*.tar.zst
           if-no-files-found: error
   build-tarball-windows:
-    if: github.event_name != 'pull_request' || github.head_ref == 'release'
+    if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
     name: build-tarball-windows-${{matrix.arch}}
     runs-on: windows-latest
     # Matches the Linux tarball job. 60 was sized for a non-LTO build; the fat-LTO
@@ -171,7 +171,7 @@ jobs:
           path: dist/*.zip
           if-no-files-found: error
   e2e-linux:
-    if: github.event_name != 'pull_request' || github.head_ref == 'release'
+    if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
     name: e2e-linux-${{matrix.tranche}}
     needs: [build-tarball-linux]
     runs-on: ubuntu-latest
@@ -213,7 +213,7 @@ jobs:
           max_attempts: 3
           command: ./e2e/run_all_tests
   rpm:
-    if: github.event_name != 'pull_request' || github.head_ref == 'release'
+    if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     needs: [build-tarball-linux]
     timeout-minutes: 10
@@ -238,7 +238,7 @@ jobs:
           path: dist/rpmrepo
           if-no-files-found: error
   deb:
-    if: github.event_name != 'pull_request' || github.head_ref == 'release'
+    if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     needs: [build-tarball-linux]
     container: ghcr.io/jdx/mise:deb@sha256:bf1cd854cde9a3c97c274c86a8fb164ea90811892999fe7a50ee42dcd54f2de8
@@ -277,7 +277,7 @@ jobs:
     if: ${{ !cancelled() && !failure() }}
     steps:
       - name: Verify all build targets succeeded
-        if: github.event_name != 'pull_request' || github.head_ref == 'release'
+        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
         run: |
           failed=""
           for result in \
@@ -322,23 +322,23 @@ jobs:
             echo "No release found for $VERSION"
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
-      - name: Skip release for non-release branch PRs
-        if: github.event_name == 'pull_request' && github.head_ref != 'release'
+      - name: Skip release for untrusted or non-release PRs
+        if: github.event_name == 'pull_request' && (github.head_ref != 'release' || github.event.pull_request.head.repo.full_name != github.repository)
         run: |
-          echo "Skipping release steps for PR from non-release branch"
+          echo "Skipping release steps for untrusted or non-release PR"
           echo "All release operations will be skipped"
       - uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
-        if: github.event_name != 'pull_request' || github.head_ref == 'release'
+        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
         with:
           gpg_private_key: ${{ secrets.MISE_GPG_KEY }}
           git_user_signingkey: true
           git_commit_gpgsign: true
       - run: ./scripts/setup-zipsign.sh
-        if: github.event_name != 'pull_request' || github.head_ref == 'release'
+        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
         env:
           ZIPSIGN: ${{ secrets.ZIPSIGN }}
       - name: Install fd-find
-        if: github.event_name != 'pull_request' || github.head_ref == 'release'
+        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
         run: |
           sudo apt-get update
           sudo apt-get install fd-find minisign
@@ -346,12 +346,12 @@ jobs:
           ln -s "$(which fdfind)" "$HOME/.local/bin/fd"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        if: github.event_name != 'pull_request' || github.head_ref == 'release'
+        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
         with: { path: artifacts }
       - run: ls -R artifacts
-        if: github.event_name != 'pull_request' || github.head_ref == 'release'
+        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        if: github.event_name != 'pull_request' || github.head_ref == 'release'
+        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
         with:
           path: artifacts
           pattern: |
@@ -361,22 +361,22 @@ jobs:
             mise-v*.zip
           merge-multiple: true
       - run: echo "${{ secrets.MINISIGN_KEY }}" >minisign.key
-        if: github.event_name != 'pull_request' || github.head_ref == 'release'
+        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
       - run: ls -R artifacts
-        if: github.event_name != 'pull_request' || github.head_ref == 'release'
+        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        if: github.event_name != 'pull_request' || github.head_ref == 'release'
+        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
         with:
           name: tarball-x86_64-unknown-linux-gnu
           path: dist
       - run: tar -C "$HOME" -xvf "dist/mise-$(./scripts/get-version.sh)-linux-x64.tar.zst"
-        if: github.event_name != 'pull_request' || github.head_ref == 'release'
+        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
       - run: echo "$HOME/mise/bin" >> "$GITHUB_PATH"
-        if: github.event_name != 'pull_request' || github.head_ref == 'release'
+        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
       - run: which mise && mise -v && mise i
-        if: github.event_name != 'pull_request' || github.head_ref == 'release'
+        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
       - run: mise x -- scripts/release.sh
-        if: github.event_name != 'pull_request' || github.head_ref == 'release'
+        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
       - name: Generate release notes
         if: startsWith(github.ref, 'refs/tags/v') && steps.check-release.outputs.exists != 'true'
         run: |

--- a/.github/workflows/test-vfox.yml
+++ b/.github/workflows/test-vfox.yml
@@ -21,35 +21,28 @@ env:
 
 jobs:
   "test-vfox":
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             ~/.cargo/.global-cache
-            ~/.cache/sccache
-      - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
-        with: { tool: sccache }
-      - name: Configure sccache
-        run: |
-          export RUSTC_WRAPPER=sccache
-          export SCCACHE_DIR="$HOME/.cache/sccache"
-          export SCCACHE_CACHE_SIZE=20G
-          {
-            echo "RUSTC_WRAPPER=$RUSTC_WRAPPER"
-            echo "SCCACHE_DIR=$SCCACHE_DIR"
-            echo "SCCACHE_CACHE_SIZE=$SCCACHE_CACHE_SIZE"
-          } >> "$GITHUB_ENV"
-          sccache --zero-stats
+            ~/.cache/mbx
+      - uses: ./.github/actions/setup-mbx
+        with:
+          restore-cache: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
       - run: |
-          cargo build --all-features --ignore-rust-version
+          mbx build build --all-features --ignore-rust-version
           echo "$PWD/target/debug" >> "$GITHUB_PATH"
       - run: mise -v
-      - run: mise --cd crates/vfox run build
+      - run: mbx build build
+        working-directory: crates/vfox
       - run: mise --cd crates/vfox run lint
-      - run: mise --cd crates/vfox run test
-      - run: sccache --show-stats
+      - run: mbx build test
+        working-directory: crates/vfox
+      - run: mbx cache stats
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,32 +60,23 @@ jobs:
           fi
 
   build-ubuntu:
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             ~/.cargo/.global-cache
-            ~/.cache/sccache
-      - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
-        with: { tool: sccache }
-      - name: Configure sccache
-        run: |
-          export RUSTC_WRAPPER=sccache
-          export SCCACHE_DIR="$HOME/.cache/sccache"
-          export SCCACHE_CACHE_SIZE=20G
-          {
-            echo "RUSTC_WRAPPER=$RUSTC_WRAPPER"
-            echo "SCCACHE_DIR=$SCCACHE_DIR"
-            echo "SCCACHE_CACHE_SIZE=$SCCACHE_CACHE_SIZE"
-          } >> "$GITHUB_ENV"
-          sccache --zero-stats
+            ~/.cache/mbx
+      - uses: ./.github/actions/setup-mbx
+        with:
+          restore-cache: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
       - run: |
-          cargo build --all-features --ignore-rust-version
+          mbx build build --all-features --ignore-rust-version
           echo "$PWD/target/debug" >> "$GITHUB_PATH"
       - run: mise -v
       # Downstream jobs only execute this binary, so keep full debug symbols in
@@ -98,7 +89,7 @@ jobs:
         with:
           name: mise-ubuntu-latest
           path: target/ci-artifacts/mise
-      - run: sccache --show-stats
+      - run: mbx cache stats
         if: always()
 
   build-windows:
@@ -131,7 +122,7 @@ jobs:
 
   unit:
     name: unit-macos
-    runs-on: namespace-profile-endev-macos-arm64;overrides.cache-tag=mise-pr-rust-macos
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'macos-14' || 'namespace-profile-endev-macos-arm64;overrides.cache-tag=mise-pr-rust-macos' }}
     timeout-minutes: 90
     needs: [classify-changes]
     if: needs.classify-changes.outputs.full-ci == 'true'
@@ -143,44 +134,35 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             ~/.cargo/.global-cache
-            ~/.cache/sccache
-      - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
-        with: { tool: sccache }
-      - name: Configure sccache
-        run: |
-          export RUSTC_WRAPPER=sccache
-          export SCCACHE_DIR="$HOME/.cache/sccache"
-          export SCCACHE_CACHE_SIZE=20G
-          {
-            echo "RUSTC_WRAPPER=$RUSTC_WRAPPER"
-            echo "SCCACHE_DIR=$SCCACHE_DIR"
-            echo "SCCACHE_CACHE_SIZE=$SCCACHE_CACHE_SIZE"
-          } >> "$GITHUB_ENV"
-          sccache --zero-stats
+            ~/.cache/mbx
+      - uses: ./.github/actions/setup-mbx
+        with:
+          restore-cache: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
       - name: Install test tools
         run: brew install fd tmux
       - run: |
-          cargo build --all-features --ignore-rust-version
+          mbx build build --all-features --ignore-rust-version
           echo "$PWD/target/debug" >> "$GITHUB_PATH"
       - uses: ./.github/actions/mise-tools
-      - run: mise x -- cargo test --all-features --ignore-rust-version
+      - run: mise x -- mbx build test --all-features --ignore-rust-version
       # `cargo test` above resolves to the root package, so the workspace members are built as
       # dependencies but never tested. Run them separately rather than adding --workspace to the
       # line above, which would extend --all-features to members whose features are exclusive.
       - name: cargo test (workspace members)
-        run: cargo test --workspace --exclude mise --ignore-rust-version
+        run: mbx build test --workspace --exclude mise --ignore-rust-version
       - run: mise run test:e2e e2e/cli/test_system_install_brew_macos_slow
       - run: mise run test:e2e e2e/tasks/test_task_zsh_process_substitution_tmux_macos
-      - run: sccache --show-stats
+      - run: mbx cache stats
         if: always()
 
   lint:
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
     timeout-minutes: 80
     needs: [build-ubuntu]
     steps:
@@ -192,12 +174,26 @@ jobs:
             with:
               tool: cargo-deny,cargo-msrv,cargo-machete,sccache
           - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
+            if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
             with:
               path: |
                 ~/.cargo/registry
                 ~/.cargo/git
                 ~/.cargo/.global-cache
                 ~/.cache/sccache
+          # Clippy is not cacheable by mbx yet, but it can still reuse the
+          # Cargo downloads bundled with the same read-only main cache.
+          - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+            if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+            with:
+              path: |
+                ~/.cargo/registry
+                ~/.cargo/git
+                ~/.cargo/.global-cache
+                ~/.cache/mbx
+              key: ${{ runner.os }}-${{ runner.arch }}-fork-pr-mbx-v0.1.0-${{ github.event.pull_request.base.sha }}
+              restore-keys: |
+                ${{ runner.os }}-${{ runner.arch }}-fork-pr-mbx-v0.1.0-
           - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
             with:
               name: mise-ubuntu-latest
@@ -263,7 +259,7 @@ jobs:
     # The release PR runs the full suite against the packaged release tarball.
     # Keep that stronger signal instead of also testing the debug artifact.
     if: ${{ needs.classify-changes.outputs.full-ci == 'true' && (github.event_name != 'pull_request' || github.head_ref != 'release' || github.base_ref != 'main') }}
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
     needs: [build-ubuntu, classify-changes]
     timeout-minutes: 125
     steps:
@@ -383,7 +379,7 @@ jobs:
             with: *e2e-retry
 
   bootstrap-linux-host:
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
     timeout-minutes: 20
     needs: [build-ubuntu, classify-changes]
     if: needs.classify-changes.outputs.full-ci == 'true'
@@ -452,7 +448,7 @@ jobs:
           command: pwsh e2e-win\run.ps1
 
   test-ci:
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
     timeout-minutes: 1
     needs:
       - classify-changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,9 +191,9 @@ jobs:
                 ~/.cargo/git
                 ~/.cargo/.global-cache
                 ~/.cache/mbx
-              key: ${{ runner.os }}-${{ runner.arch }}-fork-pr-mbx-v0.1.0-${{ github.event.pull_request.base.sha }}
+              key: ${{ runner.os }}-${{ runner.arch }}-fork-pr-mbx-v0.2.0-${{ github.event.pull_request.base.sha }}
               restore-keys: |
-                ${{ runner.os }}-${{ runner.arch }}-fork-pr-mbx-v0.1.0-
+                ${{ runner.os }}-${{ runner.arch }}-fork-pr-mbx-v0.2.0-
           - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
             with:
               name: mise-ubuntu-latest

--- a/.github/workflows/vendored-file-warning.yml
+++ b/.github/workflows/vendored-file-warning.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   warn:
     if: github.event.pull_request.user.login != 'jdx' && github.event.pull_request.user.login != 'mise-en-dev'
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
     steps:
       - name: Fail on vendored file changes
         run: |

--- a/mise.lock
+++ b/mise.lock
@@ -521,11 +521,6 @@ checksum = "sha256:a8428b18eaf2240c47f36c628219d02a405cca4f65de5b3c649af481d6778
 url = "https://github.com/jdx/mr-boxington/releases/download/v0.2.0/mbx-aarch64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526595246"
 
-[tools."github:jdx/mr-boxington"."platforms.macos-x64"]
-checksum = "sha256:569c70e2b84e38c2bfda2ec8f936244393e2a84e74d8799e74d211dc024c2c9b"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.2.0/mbx-x86_64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526595242"
-
 [tools."github:jdx/mr-boxington"."platforms.windows-x64"]
 checksum = "sha256:24e44ab08896284b207fece614fe461db8c9399467cf934b115ef796ebf467e0"
 url = "https://github.com/jdx/mr-boxington/releases/download/v0.2.0/mbx-x86_64-pc-windows-msvc.zip"

--- a/mise.lock
+++ b/mise.lock
@@ -482,6 +482,60 @@ checksum = "sha256:3ae3a5549e85c7ad5b20192ebcfee4371269deca51255f6f2f2e051c6541f
 url = "https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.13.1-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/orhun/git-cliff/releases/assets/405851866"
 
+[[tools."github:jdx/mr-boxington"]]
+version = "0.2.0"
+backend = "github:jdx/mr-boxington"
+
+[tools."github:jdx/mr-boxington"."platforms.linux-arm64"]
+checksum = "sha256:8ed75a027ae0f8e28a76868ba1ad649bb55ece2ac731c06b25ef5750e9e844ca"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.2.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526595248"
+
+[tools."github:jdx/mr-boxington"."platforms.linux-arm64-musl"]
+checksum = "sha256:8ed75a027ae0f8e28a76868ba1ad649bb55ece2ac731c06b25ef5750e9e844ca"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.2.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526595248"
+
+[tools."github:jdx/mr-boxington"."platforms.linux-x64"]
+checksum = "sha256:5a83aa55e6f83eb6c77ac4e0397b345d3eb4cf5cb6f7430185469d02e4c0f409"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.2.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526595259"
+
+[tools."github:jdx/mr-boxington"."platforms.linux-x64-baseline"]
+checksum = "sha256:5a83aa55e6f83eb6c77ac4e0397b345d3eb4cf5cb6f7430185469d02e4c0f409"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.2.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526595259"
+
+[tools."github:jdx/mr-boxington"."platforms.linux-x64-musl"]
+checksum = "sha256:5a83aa55e6f83eb6c77ac4e0397b345d3eb4cf5cb6f7430185469d02e4c0f409"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.2.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526595259"
+
+[tools."github:jdx/mr-boxington"."platforms.linux-x64-musl-baseline"]
+checksum = "sha256:5a83aa55e6f83eb6c77ac4e0397b345d3eb4cf5cb6f7430185469d02e4c0f409"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.2.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526595259"
+
+[tools."github:jdx/mr-boxington"."platforms.macos-arm64"]
+checksum = "sha256:a8428b18eaf2240c47f36c628219d02a405cca4f65de5b3c649af481d6778b8f"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.2.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526595246"
+
+[tools."github:jdx/mr-boxington"."platforms.macos-x64"]
+checksum = "sha256:569c70e2b84e38c2bfda2ec8f936244393e2a84e74d8799e74d211dc024c2c9b"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.2.0/mbx-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526595242"
+
+[tools."github:jdx/mr-boxington"."platforms.windows-x64"]
+checksum = "sha256:24e44ab08896284b207fece614fe461db8c9399467cf934b115ef796ebf467e0"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.2.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526595245"
+
+[tools."github:jdx/mr-boxington"."platforms.windows-x64-baseline"]
+checksum = "sha256:24e44ab08896284b207fece614fe461db8c9399467cf934b115ef796ebf467e0"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.2.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526595245"
+
 [[tools."github:jdx/tak"]]
 version = "0.0.5"
 backend = "github:jdx/tak"

--- a/mise.toml
+++ b/mise.toml
@@ -51,8 +51,9 @@ includes = ["tasks.toml", "xtasks"]
 dir = "{{config_root}}"
 # MISE_OFFLINE keeps `ls`, `env` and `hook-env` off the network. Without it they
 # log HTTP warnings and their instruction counts move with whatever the registry
-# happened to answer.
-env = { MISE_OFFLINE = "1" }
+# happened to answer. Ignoring the repository config keeps its development tools
+# out of the fixture so editing this file does not change a benchmark's input.
+env = { MISE_OFFLINE = "1", MISE_IGNORED_CONFIG_PATHS = "{{config_root}}/mise.toml" }
 run = ["cargo build --release", "tak run"]
 
 # Same measurement, appended to refs/notes/tak for this commit. Run by the
@@ -60,7 +61,7 @@ run = ["cargo build --release", "tak run"]
 # locally — nothing leaves the machine until `tak push`.
 [tasks."perf:record"]
 dir = "{{config_root}}"
-env = { MISE_OFFLINE = "1" }
+env = { MISE_OFFLINE = "1", MISE_IGNORED_CONFIG_PATHS = "{{config_root}}/mise.toml" }
 run = ["cargo build --release", "tak run --record"]
 
 # End-to-end task artifact cache phases. The harness generates an isolated

--- a/mise.toml
+++ b/mise.toml
@@ -6,6 +6,7 @@ _.path = ["./target/debug", "./node_modules/.bin"]
 
 [tools]
 actionlint = "latest"
+"github:jdx/mr-boxington" = "0.2.0"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
 # in mise's numbers, indistinguishable from a real regression. Bump


### PR DESCRIPTION
## Summary
- route fork pull requests to GitHub-hosted Linux and macOS runners while keeping same-repository pull requests on Namespace
- install pinned mr-boxington v0.2.0 from `mise.toml` and its checksum-locked release metadata for Rust build and test jobs
- warm a bounded mbx local CAS from trusted main builds and store it in GitHub Actions cache
- let fork pull requests restore the main cache without permission to save it or access the private mise cache host
- retain sccache for Clippy because released mbx currently bypasses Clippy compilations

## Cache safety
- cache keys include mbx v0.2.0 and the trusted main SHA
- fork workflows use actions/cache/restore only
- the main warmer caps the mbx store at 3 GB per platform before saving
- no mbx remote URL or private cache credential is exposed

## Testing
- mise run lint-fix
- mise run render
- actionlint on the changed workflows
- action-validator on the setup-mbx composite action
- zizmor on the cache-warming workflow
- `mise install github:jdx/mr-boxington` verification against the published v0.2.0 Linux asset, GitHub attestation, and SLSA provenance
- local mbx smoke tests for dependency hits and sccache/Clippy compatibility boundaries
- git diff --check

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI runner selection, cache restore vs save, and release job gates for forks. Mis-routing or cache poisoning would affect untrusted PRs and build performance, not product auth.
> 
> **Overview**
> Fork pull requests now run on GitHub-hosted Linux/macOS runners instead of Namespace. Same-repo PRs stay on Namespace. Release jobs only run for trusted `release` PRs, not forks.
> 
> Rust build/test jobs install pinned **mbx 0.2.0** via a new `setup-mbx` action and `mbx build` instead of `cargo` + sccache (Clippy still uses sccache). A main-branch warmer writes a 3GB-capped GHA cache; forks restore it read-only and never get Namespace cache.
> 
> Perf jobs skip `.github` / `mise.toml` / `mise.lock` changes, and perf tasks ignore the repo `mise.toml` so tool pins do not skew benchmarks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe2c9528fecc4936ee559b5eab607702a63304f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Fork-based pull requests now run reliably on standard hosted runners, improving compatibility and security.
  - Build, test, lint, documentation, and release workflows use safer cache handling for external contributions.
  - Added automated Rust build-cache warming for scheduled, main-branch, and manually triggered runs.
  - Improved cross-platform build and test caching with clearer cache diagnostics.
  - Standardized project build tooling across supported Linux and macOS environments.
  - Performance checks now avoid running for configuration-only changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->