### PR TITLE
fix(brew-cask): recognize Homebrew-owned casks

### DIFF
--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -136,9 +136,8 @@ Privacy & Security grants for that app (Accessibility, Screen Recording, Full
 Disk Access, Automation, and similar). mise does not manage TCC; after a
 replace you may need to re-grant permissions in System Settings.
 
-When migrating a machine that already has casks installed (for example from
-Homebrew or a nix-darwin brew integration), prefer adoption so mise records
-ownership without swapping the live bundle:
+When migrating an unmanaged app bundle that has no Homebrew `.metadata`, prefer
+adoption so mise records ownership without swapping the live bundle:
 
 ```toml
 [bootstrap.brew]
@@ -206,18 +205,26 @@ error instead of delegating to Homebrew.
 
 Direct cask pours remain mise-owned. Their completed state is recorded in
 `.mise-cask.toml`; mise does not synthesize Homebrew's private `.metadata`
-receipts. If Homebrew metadata already exists for a cask, mise preserves it and
-fails before mutation rather than taking over Homebrew's lifecycle state.
-Status treats a cask as installed when its receipt and recorded targets are
-still present. App and font content fingerprints are kept for prune and adopt
-safety, but content drift inside an existing app or font does **not** mark the
-cask missing or trigger a reinstall on apply — replacing `/Applications/*.app`
-resets macOS Privacy & Security (TCC) grants. Binary and completion symlinks
-still require the recorded link destination (a cheap `readlink`) and a
-resolvable target, so dangling or retargeted links stay repairable. Missing or
-unknown receipts and pending transactions are still reported as unhealthy so
-the next apply can reconcile them. Version upgrades and an explicit remove +
-apply still replace the app when you want a fresh pour.
+receipts. A Homebrew-owned cask with `.metadata` and exactly one Caskroom version
+satisfies a matching `brew-cask:` entry without transferring ownership.
+Status reports it as installed, apply leaves it unchanged, and upgrade skips its
+lifecycle. mise does not create `.mise-cask.toml`, adopt the cask, or change its
+metadata, app targets, prefix binaries, or completion links; use Homebrew to
+upgrade, reinstall, or remove it.
+Homebrew metadata with no version or multiple versions fails with Homebrew
+repair guidance instead of guessing which installation is valid.
+
+For mise-owned casks, status treats a cask as installed when its receipt and
+recorded targets are still present. App and font content fingerprints are kept
+for prune and adopt safety, but content drift inside an existing app or font
+does **not** mark the cask missing or trigger a reinstall on apply — replacing
+`/Applications/*.app` resets macOS Privacy & Security (TCC) grants. Binary and
+completion symlinks still require the recorded link destination (a cheap
+`readlink`) and a resolvable target, so dangling or retargeted links stay
+repairable. Missing or unknown receipts and pending transactions are still
+reported as unhealthy so the next apply can reconcile them. Version upgrades
+and an explicit remove + apply still replace the app when you want a fresh
+pour.
 
 This exists because shared-library packages — postgres, ffmpeg, imagemagick,
 php — fundamentally can't be served by mise's per-project backends like

--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -124,9 +124,10 @@ self-updating apps are also tracked by receipt without a duplicate Caskroom app
 bundle, and ordinary mise upgrades skip them.
 
 `mise bootstrap status` marks these entries as `installed (auto-updates)`.
-The `Current` column is the version recorded in the cask receipt; the live app
-may have updated itself to a different version. JSON status keeps the stable
-`"state": "installed"` value and adds `"auto_updates": true`.
+For mise-owned casks, the `Current` column is the version recorded in the mise
+receipt; the live app may have updated itself to a different version. JSON
+status keeps the stable `"state": "installed"` value and adds
+`"auto_updates": true`.
 
 ### macOS Privacy & Security (TCC)
 
@@ -207,10 +208,11 @@ Direct cask pours remain mise-owned. Their completed state is recorded in
 `.mise-cask.toml`; mise does not synthesize Homebrew's private `.metadata`
 receipts. A Homebrew-owned cask with `.metadata` and exactly one Caskroom version
 satisfies a matching `brew-cask:` entry without transferring ownership.
-Status reports it as installed, apply leaves it unchanged, and upgrade skips its
-lifecycle. mise does not create `.mise-cask.toml`, adopt the cask, or change its
-metadata, app targets, prefix binaries, or completion links; use Homebrew to
-upgrade, reinstall, or remove it.
+Status reports it as installed and uses that Caskroom directory name for the
+`Current` version; apply leaves it unchanged, and upgrade skips its lifecycle.
+mise does not create `.mise-cask.toml`, adopt the cask, or change its metadata,
+app targets, prefix binaries, or completion links; use Homebrew to upgrade,
+reinstall, or remove it.
 Homebrew metadata with no version or multiple versions fails with Homebrew
 repair guidance instead of guessing which installation is valid.
 

--- a/e2e/cli/test_system_install_brew_cask_homebrew_owned
+++ b/e2e/cli/test_system_install_brew_cask_homebrew_owned
@@ -38,7 +38,9 @@ class Handler(BaseHTTPRequestHandler):
 
 
 server = HTTPServer(("127.0.0.1", 0), Handler)
-port_file.write_text(str(server.server_address[1]))
+port_file_tmp = port_file.with_suffix(".tmp")
+port_file_tmp.write_text(str(server.server_address[1]))
+port_file_tmp.replace(port_file)
 server.serve_forever()
 PY
 HTTP_SERVER_PID=$!

--- a/e2e/cli/test_system_install_brew_cask_homebrew_owned
+++ b/e2e/cli/test_system_install_brew_cask_homebrew_owned
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+if [[ "$(uname)" != "Darwin" && "$(uname)" != "Linux" ]]; then
+  exit 0
+fi
+
+HTTP_PORT_FILE="$TMPDIR/mise_brew_cask_http_port"
+python3 -u - "$HTTP_PORT_FILE" <<'PY' >/dev/null 2>&1 &
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+port_file = Path(sys.argv[1])
+cask = {
+    "token": "example-homebrew-owned",
+    "version": "current-2",
+    "url": "https://example.invalid/cask.zip",
+    "sha256": "no_check",
+    "artifacts": [{"future_artifact": ["unsupported"]}],
+}
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, format, *args):
+        return
+
+    def do_GET(self):
+        if self.path.split("?", 1)[0] != "/api/cask/example-homebrew-owned.json":
+            self.send_error(404)
+            return
+        body = json.dumps(cask).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+server = HTTPServer(("127.0.0.1", 0), Handler)
+port_file.write_text(str(server.server_address[1]))
+server.serve_forever()
+PY
+HTTP_SERVER_PID=$!
+trap 'kill "$HTTP_SERVER_PID" 2>/dev/null || true' EXIT
+wait_for_file "$HTTP_PORT_FILE" "brew-cask fixture server port file" 30 "$HTTP_SERVER_PID"
+HTTP_PORT="$(cat "$HTTP_PORT_FILE")"
+MISE_URL_REPLACEMENTS="$(printf '{"https://formulae.brew.sh":"http://127.0.0.1:%s"}' "$HTTP_PORT")"
+export MISE_URL_REPLACEMENTS
+
+export MISE_SYSTEM_BREW_PREFIX="$PWD/brew-prefix"
+token="example-homebrew-owned"
+token_dir="$MISE_SYSTEM_BREW_PREFIX/Caskroom/$token"
+version_dir="$token_dir/external-1"
+binary="$version_dir/bin/example"
+binary_target="$MISE_SYSTEM_BREW_PREFIX/bin/example"
+app_target="$MISE_SYSTEM_BREW_PREFIX/Applications/External.app"
+
+mkdir -p \
+  "$token_dir/.metadata" \
+  "$version_dir/bin" \
+  "$MISE_SYSTEM_BREW_PREFIX/bin" \
+  "$MISE_SYSTEM_BREW_PREFIX/etc/bash_completion.d" \
+  "$MISE_SYSTEM_BREW_PREFIX/share/fish/vendor_completions.d" \
+  "$MISE_SYSTEM_BREW_PREFIX/share/zsh/site-functions" \
+  "$app_target/Contents"
+printf '{"owned_by":"homebrew"}\n' >"$token_dir/.metadata/INSTALL_RECEIPT.json"
+printf '#!/bin/sh\necho external\n' >"$binary"
+chmod +x "$binary"
+ln -s "$binary" "$binary_target"
+printf 'bash completion\n' >"$MISE_SYSTEM_BREW_PREFIX/etc/bash_completion.d/example"
+printf 'fish completion\n' >"$MISE_SYSTEM_BREW_PREFIX/share/fish/vendor_completions.d/example.fish"
+printf 'zsh completion\n' >"$MISE_SYSTEM_BREW_PREFIX/share/zsh/site-functions/_example"
+printf 'external app\n' >"$app_target/Contents/payload"
+ln -s "$app_target" "$version_dir/External.app"
+
+write_config() {
+  cat >mise.toml <<EOF
+[bootstrap.packages]
+"brew-cask:$token" = "latest"
+EOF
+}
+
+clear_config() {
+  cat >mise.toml <<EOF
+[bootstrap.packages]
+EOF
+}
+
+snapshot_prefix() {
+  tar -cf - -C "$MISE_SYSTEM_BREW_PREFIX" . | cksum
+}
+
+write_config
+before="$(snapshot_prefix)"
+
+assert_contains "mise bootstrap packages status" "installed"
+assert_contains "mise bootstrap packages apply --yes 2>&1" "already installed"
+assert_contains "mise bootstrap packages upgrade --yes 2>&1" "managed by Homebrew"
+assert_succeed "mise bootstrap packages use brew-cask:$token"
+clear_config
+assert_contains "mise bootstrap packages prune --manager brew-cask --yes 2>&1" "Homebrew owns this cask"
+
+after="$(snapshot_prefix)"
+assert_succeed "test '$before' = '$after'"
+assert_fail "test -e $version_dir/.mise-cask.toml"
+assert "cat $token_dir/.metadata/INSTALL_RECEIPT.json" '{"owned_by":"homebrew"}'
+
+cat >"$version_dir/.mise-cask.toml" <<EOF
+schema_version = 3
+version = "external-1"
+EOF
+write_config
+dual_before="$(snapshot_prefix)"
+
+assert_contains "mise bootstrap packages status" "installed"
+assert_contains "mise bootstrap packages apply --yes 2>&1" "already installed"
+assert_contains "mise bootstrap packages upgrade --yes 2>&1" "managed by Homebrew"
+clear_config
+assert_contains "mise bootstrap packages prune --manager brew-cask --yes 2>&1" "Homebrew owns this cask"
+
+dual_after="$(snapshot_prefix)"
+assert_succeed "test '$dual_before' = '$dual_after'"
+assert "cat $version_dir/.mise-cask.toml" $'schema_version = 3\nversion = "external-1"'
+assert "cat $token_dir/.metadata/INSTALL_RECEIPT.json" '{"owned_by":"homebrew"}'

--- a/e2e/cli/test_system_install_brew_cask_homebrew_owned
+++ b/e2e/cli/test_system_install_brew_cask_homebrew_owned
@@ -5,20 +5,20 @@ if [[ "$(uname)" != "Darwin" && "$(uname)" != "Linux" ]]; then
 fi
 
 HTTP_PORT_FILE="$TMPDIR/mise_brew_cask_http_port"
-python3 -u - "$HTTP_PORT_FILE" <<'PY' >/dev/null 2>&1 &
-import json
+CASK_FIXTURE_FILE="$TMPDIR/mise_brew_cask_fixture.json"
+
+write_cask_fixture() {
+  printf '{"token":"example-homebrew-owned","version":"%s","auto_updates":%s,"url":"https://example.invalid/cask.zip","sha256":"no_check","artifacts":[{"future_artifact":["unsupported"]}]}\n' "$1" "$2" >"$CASK_FIXTURE_FILE"
+}
+
+write_cask_fixture "current-2" false
+python3 -u - "$HTTP_PORT_FILE" "$CASK_FIXTURE_FILE" <<'PY' >/dev/null 2>&1 &
 import sys
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
 port_file = Path(sys.argv[1])
-cask = {
-    "token": "example-homebrew-owned",
-    "version": "current-2",
-    "url": "https://example.invalid/cask.zip",
-    "sha256": "no_check",
-    "artifacts": [{"future_artifact": ["unsupported"]}],
-}
+fixture_file = Path(sys.argv[2])
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -29,7 +29,7 @@ class Handler(BaseHTTPRequestHandler):
         if self.path.split("?", 1)[0] != "/api/cask/example-homebrew-owned.json":
             self.send_error(404)
             return
-        body = json.dumps(cask).encode()
+        body = fixture_file.read_bytes()
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
@@ -51,7 +51,7 @@ export MISE_URL_REPLACEMENTS
 export MISE_SYSTEM_BREW_PREFIX="$PWD/brew-prefix"
 token="example-homebrew-owned"
 token_dir="$MISE_SYSTEM_BREW_PREFIX/Caskroom/$token"
-version_dir="$token_dir/external-1"
+version_dir="$token_dir/current-2"
 binary="$version_dir/bin/example"
 binary_target="$MISE_SYSTEM_BREW_PREFIX/bin/example"
 app_target="$MISE_SYSTEM_BREW_PREFIX/Applications/External.app"
@@ -108,7 +108,7 @@ assert "cat $token_dir/.metadata/INSTALL_RECEIPT.json" '{"owned_by":"homebrew"}'
 
 cat >"$version_dir/.mise-cask.toml" <<EOF
 schema_version = 3
-version = "external-1"
+version = "current-2"
 EOF
 write_config
 dual_before="$(snapshot_prefix)"
@@ -121,5 +121,29 @@ assert_contains "mise bootstrap packages prune --manager brew-cask --yes 2>&1" "
 
 dual_after="$(snapshot_prefix)"
 assert_succeed "test '$dual_before' = '$dual_after'"
-assert "cat $version_dir/.mise-cask.toml" $'schema_version = 3\nversion = "external-1"'
+assert "cat $version_dir/.mise-cask.toml" $'schema_version = 3\nversion = "current-2"'
+assert "cat $token_dir/.metadata/INSTALL_RECEIPT.json" '{"owned_by":"homebrew"}'
+
+write_cask_fixture "future-3" true
+write_config
+auto_before="$(snapshot_prefix)"
+
+assert_contains "mise bootstrap packages status" "auto-updates"
+assert_contains "mise bootstrap packages apply --yes 2>&1" "already installed"
+assert_contains "mise bootstrap packages upgrade --yes 2>&1" "managed by Homebrew"
+
+auto_after="$(snapshot_prefix)"
+assert_succeed "test '$auto_before' = '$auto_after'"
+assert "cat $version_dir/.mise-cask.toml" $'schema_version = 3\nversion = "current-2"'
+assert "cat $token_dir/.metadata/INSTALL_RECEIPT.json" '{"owned_by":"homebrew"}'
+
+mkdir "$token_dir/stale-1"
+malformed_before="$(snapshot_prefix)"
+
+assert_fail_contains "mise bootstrap packages status 2>&1" "multiple Caskroom versions"
+assert_fail_contains "mise bootstrap packages upgrade --yes 2>&1" "multiple Caskroom versions"
+
+malformed_after="$(snapshot_prefix)"
+assert_succeed "test '$malformed_before' = '$malformed_after'"
+assert "cat $version_dir/.mise-cask.toml" $'schema_version = 3\nversion = "current-2"'
 assert "cat $token_dir/.metadata/INSTALL_RECEIPT.json" '{"owned_by":"homebrew"}'

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -6380,7 +6380,7 @@ fn installed_versions(token: &str) -> Vec<String> {
             entry
                 .file_type()
                 .ok()
-                .filter(|ft| ft.is_dir() && name != ".metadata" && !name.starts_with(".mise-tmp-"))
+                .filter(|ft| ft.is_dir() && name != ".metadata" && !name.starts_with(".mise-"))
                 .map(|_| name)
         })
         .collect()
@@ -6415,7 +6415,7 @@ fn homebrew_installed_versions(token: &str) -> Result<Vec<String>> {
                 path.display()
             )
         })?;
-        if file_type.is_dir() && name != ".metadata" && !name.starts_with(".mise-tmp-") {
+        if file_type.is_dir() && name != ".metadata" && !name.starts_with(".mise-") {
             versions.push(name);
         }
     }
@@ -7866,7 +7866,7 @@ mod tests {
     }
 
     #[test]
-    fn recognizes_homebrew_installed_version() -> Result<()> {
+    fn homebrew_version_ignores_mise_working_directories() -> Result<()> {
         let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
@@ -7874,6 +7874,7 @@ mod tests {
         file::create_dir_all(token_dir.join(".metadata"))?;
         file::create_dir_all(token_dir.join("1.0.0"))?;
         file::create_dir_all(token_dir.join(".mise-tmp-interrupted"))?;
+        file::create_dir_all(token_dir.join(".mise-backup-interrupted"))?;
 
         assert_eq!(
             homebrew_installed_version("example")?,
@@ -14393,6 +14394,7 @@ end
         file::create_dir_all(token_dir.join("2.0.0"))?;
         file::create_dir_all(token_dir.join(".metadata/2.0.0/timestamp/Casks"))?;
         file::create_dir_all(token_dir.join(".mise-tmp-interrupted"))?;
+        file::create_dir_all(token_dir.join(".mise-backup-interrupted"))?;
 
         assert_eq!(installed_version("actual-token"), Some("2.0.0".to_string()));
         Ok(())

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -431,21 +431,22 @@ impl BrewCaskManager {
         }
         let mut ancestors = ancestors.clone();
         ancestors.insert(cask.token.clone());
-        let artifacts = cask_artifacts(&cask)?;
-        validate_platform_support(&cask, &artifacts)?;
-        if homebrew_metadata_present(&cask.token) {
-            bail!(
-                "brew-cask:{}: Homebrew owns this cask; remove it with Homebrew before installing it with mise",
-                cask.token
-            );
-        }
-        let installed_version = installed_cask_version(&cask, &artifacts)?;
+        let installed_version = mise_installed_cask_version(&cask)?;
         if let Some(version) = installed_version.as_ref()
             && (cask.auto_updates || version == &cask.version)
         {
             info!("brew-cask:{}: already installed", cask.token);
             return Ok(version.clone());
         }
+        if let Some(version) = homebrew_installed_version(&cask.token)? {
+            info!(
+                "brew-cask:{}: installed and managed by Homebrew; leaving unchanged",
+                cask.token
+            );
+            return Ok(version);
+        }
+        let artifacts = cask_artifacts(&cask)?;
+        validate_platform_support(&cask, &artifacts)?;
         for conflict in &cask.conflicts_with.cask {
             if !installed_versions(conflict).is_empty() {
                 bail!(
@@ -528,14 +529,8 @@ impl BrewCaskManager {
         }
         let _caskroom_lock = lock_caskroom()?;
         recover_flight_backups()?;
-        if homebrew_metadata_present(&cask.token) {
-            file::remove_all(&stage)?;
-            bail!(
-                "brew-cask:{}: Homebrew took ownership of this cask while installation was pending",
-                cask.token
-            );
-        }
-        if let Some(version) = installed_cask_version(&cask, &artifacts)?
+        ensure_homebrew_did_not_take_ownership(&cask.token, &stage)?;
+        if let Some(version) = mise_installed_cask_version(&cask)?
             && (cask.auto_updates || version == cask.version)
         {
             file::remove_all(stage)?;
@@ -848,6 +843,13 @@ impl SystemPackageManager for BrewCaskManager {
         let mut statuses = Vec::with_capacity(pkgs.len());
         for req in pkgs {
             let cask = fetch_cask(req).await?;
+            if let Some(state) = installed_state(req, &cask)? {
+                statuses.push(PackageStatus {
+                    request: req.clone(),
+                    state,
+                });
+                continue;
+            }
             let artifacts = cask_artifacts(&cask)?;
             if let Some(state) = platform_unavailable_state(&cask, &artifacts) {
                 statuses.push(PackageStatus {
@@ -856,20 +858,9 @@ impl SystemPackageManager for BrewCaskManager {
                 });
                 continue;
             }
-            let version = installed_cask_version(&cask, &artifacts)?;
-            let state = match version {
-                Some(version) => match &req.version {
-                    Some(requested) if version != *requested => {
-                        PackageState::VersionMismatch { installed: version }
-                    }
-                    _ if cask.auto_updates => PackageState::InstalledAutoUpdates { version },
-                    _ => PackageState::Installed { version },
-                },
-                None => PackageState::Missing,
-            };
             statuses.push(PackageStatus {
                 request: req.clone(),
-                state,
+                state: PackageState::Missing,
             });
         }
         Ok(statuses)
@@ -6410,6 +6401,35 @@ fn installed_versions(token: &str) -> Vec<String> {
         .collect()
 }
 
+fn homebrew_installed_version(token: &str) -> Result<Option<String>> {
+    if !homebrew_metadata_present(token) {
+        return Ok(None);
+    }
+
+    let mut versions = installed_versions(token);
+    versions.sort();
+    match versions.as_slice() {
+        [version] => Ok(Some(version.clone())),
+        [] => bail!(
+            "brew-cask:{token}: Homebrew metadata exists, but no installed Caskroom version was found; repair it with `brew reinstall --cask {token}`"
+        ),
+        versions => bail!(
+            "brew-cask:{token}: Homebrew metadata exists with multiple Caskroom versions ({}); repair it with Homebrew",
+            versions.join(", ")
+        ),
+    }
+}
+
+fn ensure_homebrew_did_not_take_ownership(token: &str, stage: &Path) -> Result<()> {
+    if homebrew_metadata_present(token) {
+        file::remove_all(stage)?;
+        bail!(
+            "brew-cask:{token}: Homebrew took ownership of this cask while installation was pending"
+        );
+    }
+    Ok(())
+}
+
 fn homebrew_metadata_present(token: &str) -> bool {
     caskroom_token_dir(token)
         .join(".metadata")
@@ -6564,20 +6584,21 @@ fn remove_obsolete_binary_links(
 }
 
 #[cfg(not(test))]
-fn installed_cask_version(cask: &Cask, artifacts: &CaskArtifacts) -> Result<Option<String>> {
-    installed_cask_version_in(cask, artifacts, &crate::dirs::STATE)
+fn mise_installed_cask_version(cask: &Cask) -> Result<Option<String>> {
+    installed_cask_version_in(cask, &crate::dirs::STATE)
 }
 
 #[cfg(test)]
-fn installed_cask_version(cask: &Cask, artifacts: &CaskArtifacts) -> Result<Option<String>> {
-    installed_cask_version_in(cask, artifacts, &prefix::prefix().join(".mise-test-state"))
+fn mise_installed_cask_version(cask: &Cask) -> Result<Option<String>> {
+    installed_cask_version_in(cask, &prefix::prefix().join(".mise-test-state"))
 }
 
-fn installed_cask_version_in(
-    cask: &Cask,
-    _artifacts: &CaskArtifacts,
-    state_dir: &Path,
-) -> Result<Option<String>> {
+#[cfg(test)]
+fn installed_cask_version(cask: &Cask, _artifacts: &CaskArtifacts) -> Result<Option<String>> {
+    mise_installed_cask_version(cask)
+}
+
+fn installed_cask_version_in(cask: &Cask, state_dir: &Path) -> Result<Option<String>> {
     if cask_journal_pending_in(state_dir, &cask.token) {
         return Ok(None);
     }
@@ -6614,6 +6635,24 @@ fn installed_cask_version_in(
         }
         None => Ok(None),
     }
+}
+
+fn state_for_version(req: &PackageRequest, cask: &Cask, version: String) -> PackageState {
+    match &req.version {
+        Some(requested) if version != *requested => {
+            PackageState::VersionMismatch { installed: version }
+        }
+        _ if cask.auto_updates => PackageState::InstalledAutoUpdates { version },
+        _ => PackageState::Installed { version },
+    }
+}
+
+fn installed_state(req: &PackageRequest, cask: &Cask) -> Result<Option<PackageState>> {
+    let version = match mise_installed_cask_version(cask)? {
+        Some(version) => Some(version),
+        None => homebrew_installed_version(&cask.token)?,
+    };
+    Ok(version.map(|version| state_for_version(req, cask, version)))
 }
 
 fn cask_prune_blocker(cask: &Cask, artifacts: &CaskArtifacts) -> Option<String> {
@@ -7781,6 +7820,146 @@ mod tests {
         file::remove_all(&metadata)?;
         crate::file::write(&metadata, "foreign")?;
         assert!(homebrew_metadata_present("example"));
+        Ok(())
+    }
+
+    #[test]
+    fn recognizes_homebrew_installed_version() -> Result<()> {
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let token_dir = caskroom_token_dir("example");
+        file::create_dir_all(token_dir.join(".metadata"))?;
+        file::create_dir_all(token_dir.join("1.0.0"))?;
+        file::create_dir_all(token_dir.join(".mise-tmp-interrupted"))?;
+
+        assert_eq!(
+            homebrew_installed_version("example")?,
+            Some("1.0.0".to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_version_without_homebrew_metadata() -> Result<()> {
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        file::create_dir_all(caskroom_version_dir("example", "1.0.0"))?;
+
+        assert_eq!(homebrew_installed_version("example")?, None);
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_homebrew_metadata_without_installed_version() -> Result<()> {
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        file::create_dir_all(caskroom_token_dir("example").join(".metadata"))?;
+
+        let error = homebrew_installed_version("example").unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("repair it with `brew reinstall --cask example`")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_homebrew_metadata_with_multiple_versions() -> Result<()> {
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let token_dir = caskroom_token_dir("example");
+        file::create_dir_all(token_dir.join(".metadata"))?;
+        file::create_dir_all(token_dir.join("2.0.0"))?;
+        file::create_dir_all(token_dir.join("1.0.0"))?;
+
+        let error = homebrew_installed_version("example").unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("multiple Caskroom versions (1.0.0, 2.0.0)")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn externally_managed_state_precedes_artifact_parsing() -> Result<()> {
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let token_dir = caskroom_token_dir("example");
+        file::create_dir_all(token_dir.join(".metadata"))?;
+        file::create_dir_all(token_dir.join("1.0.0"))?;
+        let mut cask = test_cask("example", "1.0.0");
+        cask.artifacts = vec![serde_json::json!({
+            "future_artifact": ["unsupported"]
+        })];
+        let request = PackageRequest {
+            name: cask.token.clone(),
+            version: None,
+            tap_url: None,
+        };
+
+        assert_eq!(
+            installed_state(&request, &cask)?,
+            Some(PackageState::Installed {
+                version: "1.0.0".to_string()
+            })
+        );
+        assert!(cask_artifacts(&cask).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn both_receipt_types_satisfy_installed_state_without_mutation() -> Result<()> {
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let cask = test_cask("example", "1.0.0");
+        write_test_app_receipt(&cask, "Example.app")?;
+        let metadata = caskroom_token_dir(&cask.token).join(".metadata/receipt.json");
+        file::create_dir_all(metadata.parent().unwrap())?;
+        file::write(&metadata, "homebrew")?;
+        let mise_receipt = caskroom_version_dir(&cask.token, &cask.version).join(".mise-cask.toml");
+        let receipt_before = file::read_to_string(&mise_receipt)?;
+        let request = PackageRequest {
+            name: cask.token.clone(),
+            version: None,
+            tap_url: None,
+        };
+
+        assert_eq!(
+            installed_state(&request, &cask)?,
+            Some(PackageState::Installed {
+                version: "1.0.0".to_string()
+            })
+        );
+        assert_eq!(file::read_to_string(mise_receipt)?, receipt_before);
+        assert_eq!(file::read_to_string(metadata)?, "homebrew");
+        Ok(())
+    }
+
+    #[test]
+    fn ownership_race_guard_removes_only_mise_stage() -> Result<()> {
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let stage = tmp.path().join("stage");
+        file::create_dir_all(&stage)?;
+        file::write(stage.join("download"), "mise")?;
+        let metadata = caskroom_token_dir("example").join(".metadata/receipt.json");
+        file::create_dir_all(metadata.parent().unwrap())?;
+        file::write(&metadata, "homebrew")?;
+
+        let error = ensure_homebrew_did_not_take_ownership("example", &stage).unwrap_err();
+
+        assert!(error.to_string().contains("Homebrew took ownership"));
+        assert!(!stage.exists());
+        assert_eq!(file::read_to_string(metadata)?, "homebrew");
         Ok(())
     }
 

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -431,13 +431,6 @@ impl BrewCaskManager {
         }
         let mut ancestors = ancestors.clone();
         ancestors.insert(cask.token.clone());
-        let installed_version = mise_installed_cask_version(&cask)?;
-        if let Some(version) = installed_version.as_ref()
-            && (cask.auto_updates || version == &cask.version)
-        {
-            info!("brew-cask:{}: already installed", cask.token);
-            return Ok(version.clone());
-        }
         if let Some(version) = homebrew_installed_version(&cask.token)? {
             info!(
                 "brew-cask:{}: installed and managed by Homebrew; leaving unchanged",
@@ -447,6 +440,13 @@ impl BrewCaskManager {
         }
         let artifacts = cask_artifacts(&cask)?;
         validate_platform_support(&cask, &artifacts)?;
+        let installed_version = mise_installed_cask_version(&cask)?;
+        if let Some(version) = installed_version.as_ref()
+            && (cask.auto_updates || version == &cask.version)
+        {
+            info!("brew-cask:{}: already installed", cask.token);
+            return Ok(version.clone());
+        }
         for conflict in &cask.conflicts_with.cask {
             if !installed_versions(conflict).is_empty() {
                 bail!(
@@ -843,24 +843,9 @@ impl SystemPackageManager for BrewCaskManager {
         let mut statuses = Vec::with_capacity(pkgs.len());
         for req in pkgs {
             let cask = fetch_cask(req).await?;
-            if let Some(state) = installed_state(req, &cask)? {
-                statuses.push(PackageStatus {
-                    request: req.clone(),
-                    state,
-                });
-                continue;
-            }
-            let artifacts = cask_artifacts(&cask)?;
-            if let Some(state) = platform_unavailable_state(&cask, &artifacts) {
-                statuses.push(PackageStatus {
-                    request: req.clone(),
-                    state,
-                });
-                continue;
-            }
             statuses.push(PackageStatus {
                 request: req.clone(),
-                state: PackageState::Missing,
+                state: package_state(req, &cask)?,
             });
         }
         Ok(statuses)
@@ -6401,13 +6386,48 @@ fn installed_versions(token: &str) -> Vec<String> {
         .collect()
 }
 
+fn homebrew_installed_versions(token: &str) -> Result<Vec<String>> {
+    let dir = caskroom_token_dir(token);
+    let entries = std::fs::read_dir(&dir).wrap_err_with(|| {
+        format!(
+            "brew-cask:{token}: failed to read Homebrew Caskroom directory '{}'",
+            dir.display()
+        )
+    })?;
+    let mut versions = Vec::new();
+    for entry in entries {
+        let entry = entry.wrap_err_with(|| {
+            format!(
+                "brew-cask:{token}: failed to read an entry in Homebrew Caskroom directory '{}'",
+                dir.display()
+            )
+        })?;
+        let path = entry.path();
+        let file_type = entry.file_type().wrap_err_with(|| {
+            format!(
+                "brew-cask:{token}: failed to read type of Homebrew Caskroom entry '{}'",
+                path.display()
+            )
+        })?;
+        let name = entry.file_name().into_string().map_err(|_| {
+            eyre!(
+                "brew-cask:{token}: Homebrew Caskroom entry name is not valid UTF-8: '{}'",
+                path.display()
+            )
+        })?;
+        if file_type.is_dir() && name != ".metadata" && !name.starts_with(".mise-tmp-") {
+            versions.push(name);
+        }
+    }
+    Ok(versions)
+}
+
 fn homebrew_installed_version(token: &str) -> Result<Option<String>> {
-    if !homebrew_metadata_present(token) {
+    if !homebrew_metadata_present(token)? {
         return Ok(None);
     }
 
-    let mut versions = installed_versions(token);
-    versions.sort();
+    let versions = homebrew_installed_versions(token)?;
     match versions.as_slice() {
         [version] => Ok(Some(version.clone())),
         [] => bail!(
@@ -6415,13 +6435,28 @@ fn homebrew_installed_version(token: &str) -> Result<Option<String>> {
         ),
         versions => bail!(
             "brew-cask:{token}: Homebrew metadata exists with multiple Caskroom versions ({}); repair it with Homebrew",
-            versions.join(", ")
+            {
+                let mut versions = versions.to_vec();
+                versions.sort();
+                versions.join(", ")
+            }
         ),
     }
 }
 
 fn ensure_homebrew_did_not_take_ownership(token: &str, stage: &Path) -> Result<()> {
-    if homebrew_metadata_present(token) {
+    let metadata_present = match homebrew_metadata_present(token) {
+        Ok(present) => present,
+        Err(err) => {
+            file::remove_all(stage).wrap_err_with(|| {
+                format!(
+                    "failed to remove mise stage after Homebrew ownership check failed: {err:#}"
+                )
+            })?;
+            return Err(err);
+        }
+    };
+    if metadata_present {
         file::remove_all(stage)?;
         bail!(
             "brew-cask:{token}: Homebrew took ownership of this cask while installation was pending"
@@ -6430,11 +6465,18 @@ fn ensure_homebrew_did_not_take_ownership(token: &str, stage: &Path) -> Result<(
     Ok(())
 }
 
-fn homebrew_metadata_present(token: &str) -> bool {
-    caskroom_token_dir(token)
-        .join(".metadata")
-        .symlink_metadata()
-        .is_ok()
+fn homebrew_metadata_present(token: &str) -> Result<bool> {
+    let path = caskroom_token_dir(token).join(".metadata");
+    match path.symlink_metadata() {
+        Ok(_) => Ok(true),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err).wrap_err_with(|| {
+            format!(
+                "brew-cask:{token}: failed to inspect Homebrew metadata at '{}'",
+                path.display()
+            )
+        }),
+    }
 }
 
 fn pkg_id_installed(pkg_id: &str) -> Result<bool> {
@@ -6593,11 +6635,6 @@ fn mise_installed_cask_version(cask: &Cask) -> Result<Option<String>> {
     installed_cask_version_in(cask, &prefix::prefix().join(".mise-test-state"))
 }
 
-#[cfg(test)]
-fn installed_cask_version(cask: &Cask, _artifacts: &CaskArtifacts) -> Result<Option<String>> {
-    mise_installed_cask_version(cask)
-}
-
 fn installed_cask_version_in(cask: &Cask, state_dir: &Path) -> Result<Option<String>> {
     if cask_journal_pending_in(state_dir, &cask.token) {
         return Ok(None);
@@ -6647,12 +6684,17 @@ fn state_for_version(req: &PackageRequest, cask: &Cask, version: String) -> Pack
     }
 }
 
-fn installed_state(req: &PackageRequest, cask: &Cask) -> Result<Option<PackageState>> {
-    let version = match mise_installed_cask_version(cask)? {
-        Some(version) => Some(version),
-        None => homebrew_installed_version(&cask.token)?,
-    };
-    Ok(version.map(|version| state_for_version(req, cask, version)))
+fn package_state(req: &PackageRequest, cask: &Cask) -> Result<PackageState> {
+    if let Some(version) = homebrew_installed_version(&cask.token)? {
+        return Ok(state_for_version(req, cask, version));
+    }
+    let artifacts = cask_artifacts(cask)?;
+    if let Some(state) = platform_unavailable_state(cask, &artifacts) {
+        return Ok(state);
+    }
+    Ok(mise_installed_cask_version(cask)?
+        .map(|version| state_for_version(req, cask, version))
+        .unwrap_or(PackageState::Missing))
 }
 
 fn cask_prune_blocker(cask: &Cask, artifacts: &CaskArtifacts) -> Option<String> {
@@ -7295,7 +7337,7 @@ fn validate_cask_prune_claims(candidate: &CaskPruneCandidate) -> Result<()> {
 }
 
 fn validate_cask_prune_candidate(candidate: &CaskPruneCandidate) -> Result<()> {
-    if homebrew_metadata_present(&candidate.token) {
+    if homebrew_metadata_present(&candidate.token)? {
         bail!("Homebrew now owns this cask");
     }
     let receipt = &candidate.receipt;
@@ -7814,12 +7856,12 @@ mod tests {
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let metadata = tmp.path().join("Caskroom/example/.metadata");
-        assert!(!homebrew_metadata_present("example"));
+        assert!(!homebrew_metadata_present("example")?);
         file::create_dir_all(&metadata)?;
-        assert!(homebrew_metadata_present("example"));
+        assert!(homebrew_metadata_present("example")?);
         file::remove_all(&metadata)?;
         crate::file::write(&metadata, "foreign")?;
-        assert!(homebrew_metadata_present("example"));
+        assert!(homebrew_metadata_present("example")?);
         Ok(())
     }
 
@@ -7837,6 +7879,56 @@ mod tests {
             homebrew_installed_version("example")?,
             Some("1.0.0".to_string())
         );
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn rejects_non_utf8_homebrew_version_name() -> Result<()> {
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let token_dir = caskroom_token_dir("example");
+        file::create_dir_all(token_dir.join(".metadata"))?;
+        file::create_dir_all(token_dir.join("1.0.0"))?;
+        file::create_dir_all(token_dir.join(Path::new(std::ffi::OsStr::from_bytes(b"\xff"))))?;
+
+        let error = homebrew_installed_version("example").unwrap_err();
+        assert!(error.to_string().contains("name is not valid UTF-8"));
+        assert!(error.to_string().contains("brew-cask:example"));
+        Ok(())
+    }
+
+    #[test]
+    fn homebrew_version_enumeration_error_includes_directory() -> Result<()> {
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let token_dir = caskroom_token_dir("example");
+        file::create_dir_all(token_dir.parent().unwrap())?;
+        file::write(&token_dir, "not a directory")?;
+
+        let error = homebrew_installed_versions("example").unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("failed to read Homebrew Caskroom directory"));
+        assert!(message.contains(&token_dir.display().to_string()));
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn homebrew_metadata_probe_error_is_not_absence() -> Result<()> {
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let token_dir = caskroom_token_dir("example");
+        file::create_dir_all(token_dir.parent().unwrap())?;
+        file::write(&token_dir, "not a directory")?;
+
+        let error = homebrew_metadata_present("example").unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("failed to inspect Homebrew metadata"));
+        assert!(message.contains(".metadata"));
         Ok(())
     }
 
@@ -7887,7 +7979,7 @@ mod tests {
     }
 
     #[test]
-    fn externally_managed_state_precedes_artifact_parsing() -> Result<()> {
+    fn externally_managed_version_precedes_artifact_parsing() -> Result<()> {
         let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
@@ -7905,10 +7997,10 @@ mod tests {
         };
 
         assert_eq!(
-            installed_state(&request, &cask)?,
-            Some(PackageState::Installed {
+            package_state(&request, &cask)?,
+            PackageState::Installed {
                 version: "1.0.0".to_string()
-            })
+            }
         );
         assert!(cask_artifacts(&cask).is_err());
         Ok(())
@@ -7933,13 +8025,64 @@ mod tests {
         };
 
         assert_eq!(
-            installed_state(&request, &cask)?,
-            Some(PackageState::Installed {
+            package_state(&request, &cask)?,
+            PackageState::Installed {
                 version: "1.0.0".to_string()
-            })
+            }
         );
-        assert_eq!(file::read_to_string(mise_receipt)?, receipt_before);
-        assert_eq!(file::read_to_string(metadata)?, "homebrew");
+        assert_eq!(file::read_to_string(&mise_receipt)?, receipt_before);
+        assert_eq!(file::read_to_string(&metadata)?, "homebrew");
+
+        file::create_dir_all(caskroom_version_dir(&cask.token, "2.0.0"))?;
+        let error = package_state(&request, &cask).unwrap_err();
+        assert!(error.to_string().contains("multiple Caskroom versions"));
+        assert_eq!(file::read_to_string(&mise_receipt)?, receipt_before);
+        assert_eq!(file::read_to_string(&metadata)?, "homebrew");
+        Ok(())
+    }
+
+    #[test]
+    fn mise_owned_state_validates_artifacts_before_receipt() -> Result<()> {
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let mut cask = test_cask("example", "1.0.0");
+        write_test_app_receipt(&cask, "Example.app")?;
+        cask.artifacts = vec![serde_json::json!({
+            "future_artifact": ["unsupported"]
+        })];
+        let request = PackageRequest {
+            name: cask.token.clone(),
+            version: None,
+            tap_url: None,
+        };
+
+        let error = package_state(&request, &cask).unwrap_err();
+        assert!(error.to_string().contains("unsupported artifact type"));
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn mise_owned_state_validates_platform_before_receipt() -> Result<()> {
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let mut cask = test_cask("example", "1.0.0");
+        write_test_app_receipt(&cask, "Example.app")?;
+        cask.artifacts = vec![serde_json::json!({
+            "app": ["Example.app"]
+        })];
+        let request = PackageRequest {
+            name: cask.token.clone(),
+            version: None,
+            tap_url: None,
+        };
+
+        assert!(matches!(
+            package_state(&request, &cask)?,
+            PackageState::Unavailable { .. }
+        ));
         Ok(())
     }
 
@@ -7960,6 +8103,30 @@ mod tests {
         assert!(error.to_string().contains("Homebrew took ownership"));
         assert!(!stage.exists());
         assert_eq!(file::read_to_string(metadata)?, "homebrew");
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ownership_race_probe_error_removes_mise_stage() -> Result<()> {
+        let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let stage = tmp.path().join("stage");
+        file::create_dir_all(&stage)?;
+        file::write(stage.join("download"), "mise")?;
+        let token_dir = caskroom_token_dir("example");
+        file::create_dir_all(token_dir.parent().unwrap())?;
+        file::write(&token_dir, "not a directory")?;
+
+        let error = ensure_homebrew_did_not_take_ownership("example", &stage).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("failed to inspect Homebrew metadata")
+        );
+        assert!(!stage.exists());
         Ok(())
     }
 
@@ -8053,14 +8220,14 @@ mod tests {
             &[],
         )?;
         assert_eq!(
-            installed_cask_version(&cask, &artifacts)?,
+            mise_installed_cask_version(&cask)?,
             Some(cask.version.clone())
         );
         crate::file::write(app_target.join("Contents/app"), "changed")?;
         // Content drift must not look like "missing" — that would reinstall the
         // app on the next apply and revoke macOS TCC grants.
         assert_eq!(
-            installed_cask_version(&cask, &artifacts)?,
+            mise_installed_cask_version(&cask)?,
             Some(cask.version.clone())
         );
         assert!(!cask_target_record_matches(
@@ -8102,7 +8269,7 @@ mod tests {
             &[],
         )?;
         file::remove_all(&app_target)?;
-        assert_eq!(installed_cask_version(&cask, &artifacts)?, None);
+        assert_eq!(mise_installed_cask_version(&cask)?, None);
         Ok(())
     }
 
@@ -8201,7 +8368,7 @@ mod tests {
         crate::file::write(app_target.join("Contents/app"), "updated by app")?;
         cask.version = "2.0.0".to_string();
         assert_eq!(
-            installed_cask_version(&cask, &artifacts)?,
+            mise_installed_cask_version(&cask)?,
             Some("1.0.0".to_string())
         );
         let receipt = read_receipt(&caskroom)?.unwrap();
@@ -12709,13 +12876,7 @@ end
         )?;
 
         assert_eq!(
-            installed_cask_version(
-                &cask,
-                &CaskArtifacts {
-                    apps: vec![app],
-                    ..Default::default()
-                }
-            )?,
+            mise_installed_cask_version(&cask)?,
             Some("1.0.0".to_string())
         );
         Ok(())
@@ -12750,10 +12911,7 @@ end
             toml::to_string_pretty(&receipt)?,
         )?;
 
-        assert_eq!(
-            installed_cask_version(&cask, &CaskArtifacts::default())?,
-            None
-        );
+        assert_eq!(mise_installed_cask_version(&cask)?, None);
         Ok(())
     }
 
@@ -13085,31 +13243,13 @@ end
         };
         file::create_dir_all(caskroom_version_dir(&cask.token, &cask.version))?;
 
-        assert_eq!(
-            installed_cask_version(
-                &cask,
-                &CaskArtifacts {
-                    binaries: vec![binary.clone()],
-                    ..Default::default()
-                }
-            )?,
-            None
-        );
+        assert_eq!(mise_installed_cask_version(&cask)?, None);
 
         let target = binary.target_path(Path::new("/Applications"))?;
         file::create_dir_all(target.parent().unwrap())?;
         crate::file::write(&target, "binary")?;
 
-        assert_eq!(
-            installed_cask_version(
-                &cask,
-                &CaskArtifacts {
-                    binaries: vec![binary],
-                    ..Default::default()
-                }
-            )?,
-            None
-        );
+        assert_eq!(mise_installed_cask_version(&cask)?, None);
         Ok(())
     }
 
@@ -13155,24 +13295,16 @@ end
             caskroom.join(".mise-cask.toml"),
             toml::to_string_pretty(&receipt)?,
         )?;
-        let artifacts = CaskArtifacts {
-            apps: vec![app],
-            command_wrappers: vec![wrapper.clone()],
-            ..Default::default()
-        };
 
         assert_eq!(
-            installed_cask_version(&cask, &artifacts)?,
+            mise_installed_cask_version(&cask)?,
             Some(cask.version.clone())
         );
 
         let target = wrapper.target_path()?;
         file::create_dir_all(target.parent().unwrap())?;
         file::write(target, "wrapper")?;
-        assert_eq!(
-            installed_cask_version(&cask, &artifacts)?,
-            Some(cask.version)
-        );
+        assert_eq!(mise_installed_cask_version(&cask)?, Some(cask.version));
         Ok(())
     }
 
@@ -14159,16 +14291,7 @@ end
         )?;
 
         assert_eq!(
-            installed_cask_version(
-                &cask,
-                &CaskArtifacts {
-                    pkgs: vec![PkgArtifact {
-                        source: "Example.pkg".to_string(),
-                    }],
-                    pkg_ids: vec!["com.example.missing".to_string()],
-                    ..Default::default()
-                }
-            )?,
+            mise_installed_cask_version(&cask)?,
             Some("1.0.0".to_string())
         );
         Ok(())
@@ -14186,28 +14309,10 @@ end
         };
         file::create_dir_all(caskroom_version_dir(&cask.token, &cask.version))?;
 
-        assert_eq!(
-            installed_cask_version(
-                &cask,
-                &CaskArtifacts {
-                    apps: vec![app.clone()],
-                    ..Default::default()
-                }
-            )?,
-            None
-        );
+        assert_eq!(mise_installed_cask_version(&cask)?, None);
 
         file::create_dir_all(app_target_path(app.target_name())?)?;
-        assert_eq!(
-            installed_cask_version(
-                &cask,
-                &CaskArtifacts {
-                    apps: vec![app],
-                    ..Default::default()
-                }
-            )?,
-            None
-        );
+        assert_eq!(mise_installed_cask_version(&cask)?, None);
         Ok(())
     }
 
@@ -14223,17 +14328,13 @@ end
             target: None,
         };
         file::create_dir_all(caskroom_version_dir(&cask.token, &cask.version))?;
-        let artifacts = CaskArtifacts {
-            completions: vec![completion.clone()],
-            ..Default::default()
-        };
 
-        assert_eq!(installed_cask_version(&cask, &artifacts)?, None);
+        assert_eq!(mise_installed_cask_version(&cask)?, None);
 
         let target = completion.target_path()?;
         file::create_dir_all(target.parent().unwrap())?;
         crate::file::write(target, "complete")?;
-        assert_eq!(installed_cask_version(&cask, &artifacts)?, None);
+        assert_eq!(mise_installed_cask_version(&cask)?, None);
         Ok(())
     }
 
@@ -14250,16 +14351,7 @@ end
         file::create_dir_all(caskroom_version_dir("configured-name", &cask.version))?;
         file::create_dir_all(app_target_path(app.target_name())?)?;
 
-        assert_eq!(
-            installed_cask_version(
-                &cask,
-                &CaskArtifacts {
-                    apps: vec![app],
-                    ..Default::default()
-                }
-            )?,
-            None
-        );
+        assert_eq!(mise_installed_cask_version(&cask)?, None);
 
         let caskroom = caskroom_version_dir(&cask.token, &cask.version);
         file::create_dir_all(&caskroom)?;
@@ -14286,16 +14378,7 @@ end
             toml::to_string_pretty(&receipt)?,
         )?;
         assert_eq!(
-            installed_cask_version(
-                &cask,
-                &CaskArtifacts {
-                    apps: vec![AppArtifact {
-                        source: "Example.app".to_string(),
-                        target: Some("$HOMEBREW_PREFIX/Applications/Example.app".to_string()),
-                    }],
-                    ..Default::default()
-                }
-            )?,
+            mise_installed_cask_version(&cask)?,
             Some("2.0.0".to_string())
         );
         Ok(())


### PR DESCRIPTION
## Problem

`brew-cask:` status only recognizes mise-owned `.mise-cask.toml` receipts. When a cask is already owned by Homebrew, status reports it missing and apply then fails at the ownership guard:

```text
Homebrew owns this cask; remove it with Homebrew before installing it with mise
```

This makes declarative bootstrap non-idempotent when the cask lifecycle should remain managed by Homebrew.

## Fix

Treat `.metadata` plus exactly one Caskroom version as a read-only Homebrew-owned installation.

- status recognizes the installed version after fetching cask metadata but before parsing artifacts
- apply and `use` leave the installation unchanged
- upgrade reports Homebrew ownership and performs no mutation
- prune retains its existing Homebrew-ownership skip
- zero or multiple Caskroom versions fail with deterministic Homebrew repair guidance
- the post-lock ownership recheck still aborts if `.metadata` appears during a mise install

Healthy mise receipts remain the preferred installed-state source. If both receipt types exist, Homebrew metadata remains a mutation fence.

## Safety boundary

This is read-side recognition only. mise does not parse or write Homebrew metadata, invoke `brew`, adopt the cask, synthesize a mise receipt, or mutate app targets, binaries, completions, or Caskroom contents.

This follows the ownership boundary established by #11215 and #11012. Existing Homebrew-owned prune behavior from #11810 remains unchanged.

## Verification

- `cargo test --all-features system::packages::brew::cask::tests -- --test-threads=1`
- `mise run test:unit`
- `mise run test:e2e e2e/cli/test_system_install_brew_cask_homebrew_owned e2e/cli/test_system_prune_brew_cask`
- `mise run lint-fix`
- `mise run lint`
- `git diff --check`

The deterministic E2E test uses a local cask API and fake Homebrew prefix. It covers status, apply, use, upgrade, and prune while proving metadata, version contents, app target, binary link, and completion files remain unchanged. It also covers unsupported future artifact metadata and dual-receipt state.

Manual validation used Homebrew-owned `1password-cli`; Caskroom contents, `op`, completions, and `.metadata` checksums remained unchanged across bootstrap apply and upgrade.

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Homebrew cask detection and status reporting.
  * Homebrew-managed casks are recognized without changing files, creating metadata, or taking ownership.
  * Added validation for missing, duplicate, or malformed Homebrew installations.
  * Preserved ownership and existing files during install, upgrade, use, and prune operations.
  * Improved recognition of auto-updating casks and version reporting.
  * Excluded temporary mise working directories from installed-version detection.

* **Documentation**
  * Clarified migration guidance for unmanaged app bundles.
  * Documented coexistence with Homebrew-managed applications, health checks, and supported content differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->