### PR TITLE
registry: fix usage version test

### DIFF
--- a/registry/usage.toml
+++ b/registry/usage.toml
@@ -8,5 +8,5 @@ backends = [
 ]
 bins = ["usage"]
 description = "A specification for CLIs"
-test = { cmd = "usage --version", expected = "usage-cli {{version}}" }
+test = { cmd = "usage --version", expected = "usage {{version}}" }
 version_order = "semver"


### PR DESCRIPTION
## Summary
- update the `usage --version` expectation for usage 6.1.0

## Verification
- `mise test-tool usage`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line registry test string change with no runtime or security impact.
> 
> **Overview**
> Updates the `usage` registry test so `usage --version` is expected to print `usage {{version}}` instead of `usage-cli {{version}}`, matching the 6.1.0 CLI output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0684726986b774afc6449d07c06c98a25aa6e693. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the usage version display expectation to show `usage {{version}}`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->