### PR TITLE
chore(ci): prevent cache warmer starvation

### DIFF
--- a/.github/workflows/github-runner-cache.yml
+++ b/.github/workflows/github-runner-cache.yml
@@ -9,7 +9,9 @@ on:
 
 concurrency:
   group: github-runner-cache-${{ github.ref }}
-  cancel-in-progress: true
+  # Let the active warmer publish a usable cache when several commits land on
+  # main in quick succession. GitHub still keeps only the newest pending run.
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- let an active GitHub-runner cache warmer finish when newer main pushes arrive
- retain the newest pending warmer while avoiding repeated cold-build cancellation

## Validation
- actionlint on .github/workflows/github-runner-cache.yml
- git diff --check
- observed cache run 32681499827 complete on Ubuntu and macOS after two earlier runs were canceled by rapid main pushes
- confirmed published caches: Linux 667 MiB and macOS 650 MiB

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI concurrency tweak only; no application, auth, or data-handling changes.
> 
> **Overview**
> Stops the GitHub runner cache warmer from being canceled when several commits land on `main` in a short window.
> 
> Sets `cancel-in-progress: false` so an in-flight warmer can finish and publish a usable cache. GitHub still queues only the newest pending run for the same concurrency group.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 297d35bd4d5b112a7d442b2a4d1925e919445756. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->