### PR TITLE
fix(task): preserve string type for usage value flags

### DIFF
--- a/e2e/tasks/test_task_usage_map_tera
+++ b/e2e/tasks/test_task_usage_map_tera
@@ -235,6 +235,20 @@ basename=file.txt
 extname=txt
 file_stem=file"
 
+# Path filters work with value flags that do not declare a default
+cat <<'EOF' >mise.toml
+[tasks.usage-tera-flag-path-filter]
+usage = '''
+arg "<name>"
+flag "-f --file <file>"
+'''
+run = '''
+echo "dirname={{ usage.file | dirname }}"
+'''
+EOF
+
+assert "mise run usage-tera-flag-path-filter -- test -f data/cmp.csv" "dirname=data"
+
 # Count flag renders as integer (e.g. -vvv -> 3)
 cat <<'EOF' >mise.toml
 [tasks.usage-tera-count]

--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -911,6 +911,8 @@ impl TaskScriptParser {
                     tera::Value::from(flag.default.clone())
                 } else if flag.count {
                     tera::Value::from(0)
+                } else if flag.arg.is_some() {
+                    tera::Value::from(flag.default.first().cloned().unwrap_or_default())
                 } else if let Some(default) = flag.default.first() {
                     default
                         .parse::<bool>()
@@ -1784,6 +1786,16 @@ mod tests {
             )
             .await,
             "echo bob"
+        );
+        // Value flags use a string placeholder during the initial template render.
+        assert_eq!(
+            render_usage(
+                r#"flag "-f --file <file>""#,
+                "echo {{ usage.file | dirname }}",
+                &["--file", "data/cmp.csv"]
+            )
+            .await,
+            "echo data"
         );
         // Default value
         assert_eq!(


### PR DESCRIPTION
## Summary
- keep value-taking usage flags string-typed during the initial Tera render
- preserve boolean fallbacks for switch flags and integer fallbacks for count flags
- add unit and end-to-end coverage for path filters on value flags without defaults

Fixes the behavior reported in https://github.com/jdx/mise/discussions/12352.

## Tests
- `cargo test --locked --bin mise task::task_script_parser::tests::test_usage_flag_renders`
- `mise run test:e2e e2e/tasks/test_task_usage_map_tera`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested typing fix in task template defaults; switch/count flag behavior is unchanged.
> 
> **Overview**
> Fixes initial Tera rendering of task `usage` maps so **value-taking flags** (e.g. `--file <file>`) stay **strings**, not booleans, when they have no default.
> 
> That lets path filters like `dirname` work on those flags. Switch flags still default to bools and count flags still default to `0`. Adds unit and e2e coverage for the no-default value-flag case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4549d490dd9a9b9f37e3fcc43db93016c1a47db2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed task templates using value-based command-line flags without defaults, ensuring they render as text values rather than being misinterpreted as booleans.
  * Path filters now work correctly with file arguments, including when deriving directory names during initial task rendering.

* **Tests**
  * Added end-to-end coverage for value flags and path filtering to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->