### PR TITLE
fix(nushell): unset __MISE_SESSION on deactivate

### DIFF
--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -130,7 +130,7 @@ impl Shell for Nushell {
         [
             self.unset_env("MISE_SHELL"),
             self.unset_env("__MISE_DIFF"),
-            self.unset_env("__MISE_DIFF"),
+            self.unset_env("__MISE_SESSION"),
         ]
         .join("")
     }

--- a/src/shell/snapshots/mise__shell__nushell__tests__deactivate.snap
+++ b/src/shell/snapshots/mise__shell__nushell__tests__deactivate.snap
@@ -5,4 +5,4 @@ snapshot_kind: text
 ---
 hide,MISE_SHELL,
 hide,__MISE_DIFF,
-hide,__MISE_DIFF,
+hide,__MISE_SESSION,


### PR DESCRIPTION
## The bug

`Nushell::deactivate` lists `__MISE_DIFF` twice and never unsets `__MISE_SESSION`:

```rust
fn deactivate(&self) -> String {
    [
        self.unset_env("MISE_SHELL"),
        self.unset_env("__MISE_DIFF"),
        self.unset_env("__MISE_DIFF"),   // <- __MISE_SESSION
    ]
    .join("")
}
```

So `mise deactivate` leaves the session marker set in nushell, and only in nushell.

## Every other shell unsets all three

| shell | unsets |
|---|---|
| zsh | `MISE_SHELL`, `__MISE_DIFF`, `__MISE_SESSION` |
| fish | `MISE_SHELL`, `__MISE_DIFF`, `__MISE_SESSION` |
| xonsh | `MISE_SHELL`, `__MISE_DIFF`, `__MISE_SESSION` |
| elvish | `MISE_SHELL`, `__MISE_DIFF`, `__MISE_SESSION` |
| pwsh | `MISE_SHELL`, `__MISE_DIFF`, `__MISE_SESSION` |
| **nushell** | `MISE_SHELL`, `__MISE_DIFF`, **`__MISE_DIFF`** |

That consistency is what makes this a plain copy-paste slip rather than an intentional difference.

## Snapshot

The checked-in snapshot recorded the duplicate, so it is updated in the same commit:

```diff
 hide,MISE_SHELL,
 hide,__MISE_DIFF,
-hide,__MISE_DIFF,
+hide,__MISE_SESSION,
```

## Verified

```
$ cargo test --bin mise shell::nushell
test result: ok. 5 passed; 0 failed
```

And the snapshot genuinely guards it — reverting `nushell.rs` while keeping the updated snapshot fails:

```
Snapshot: deactivate
    3       │-hide,__MISE_SESSION,
snapshot assertion for 'deactivate' failed in line 203
test result: FAILED. 0 passed; 1 failed
```

The wider `shell::` suite is green too: `54 passed; 0 failed`.

Built with cmake installed for the `libz-ng-sys` build script, on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Nushell deactivation now properly clears the session environment variable.
  * Prevented redundant cleanup of the environment difference variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->