### PR TITLE
fix(elvish): separate the prepended entry from the existing PATH

### DIFF
--- a/src/shell/elvish.rs
+++ b/src/shell/elvish.rs
@@ -83,7 +83,11 @@ impl Shell for Elvish {
     fn prepend_env(&self, k: &str, v: &str) -> String {
         let k = shell_escape::unix::escape(k.into());
         let v = shell_escape::unix::escape(v.into());
-        format!("set-env {k} {v}(get-env {k})\n")
+        // The list separator is required: without it the new entry is glued
+        // onto the first existing one, so prepending /new/dir to
+        // /usr/bin:/bin produced /new/dir/usr/bin:/bin. bash and zsh hardcode
+        // ":" here for the same reason.
+        format!("set-env {k} {v}':'(get-env {k})\n")
     }
 
     fn unset_env(&self, k: &str) -> String {

--- a/src/shell/snapshots/mise__shell__elvish__tests__prepend_env.snap
+++ b/src/shell/snapshots/mise__shell__elvish__tests__prepend_env.snap
@@ -3,4 +3,4 @@ source: src/shell/elvish.rs
 expression: "replace_path(&sh.prepend_env(\"PATH\", \"/some/dir:/2/dir\"))"
 snapshot_kind: text
 ---
-set-env PATH '/some/dir:/2/dir'(get-env PATH)
+set-env PATH '/some/dir:/2/dir'':'(get-env PATH)


### PR DESCRIPTION
## The bug

`Elvish::prepend_env` emitted the new value immediately followed by the existing one, with nothing between them:

```rust
format!("set-env {k} {v}(get-env {k})\n")
```

```
set-env PATH '/new/dir'(get-env PATH)
```

So prepending `/new/dir` to `/usr/bin:/bin` yields:

```
/new/dir/usr/bin:/bin
```

One bogus entry where two were intended, and the first real entry loses its leading component. Since this is the call mise uses to put a tool's `bin` on `PATH`, every tool it activates is unreachable under elvish.

## Every other shell separates

| shell | emitted |
|---|---|
| bash / zsh | `export {k}="{v}:${k}"` |
| pwsh | `'{v}'+[IO.Path]::PathSeparator+${env:{k}}` |
| nushell | `$env.{k} \| prepend r#'{v}'#` (a list, so separation is implicit) |
| **elvish** | `set-env {k} {v}(get-env {k})` — **nothing** |

## The fix

Emit the separator:

```rust
format!("set-env {k} {v}':'(get-env {k})\n")
```

The quoting keeps it a literal `:` rather than a barewords parse, so it composes with the already-escaped `{v}` and the `(get-env …)` capture.

I hardcoded `:` to match what `bash` and `zsh` already do in this same trait. If you would rather it be platform-aware like the pwsh arm, `$path:list-separator` is the elvish equivalent — I left it out because it needs the `path:` module in scope in the activate script, which is a bigger change than this bug warrants. Happy to switch if you prefer.

## Verified

```
$ cargo test --bin mise shell::elvish
test result: ok. 5 passed; 0 failed
```

The snapshot had recorded the missing separator, so it is updated in the same commit — and it does guard the behaviour. Reverting `elvish.rs` while keeping the new snapshot fails:

```
    1       │-set-env PATH '/some/dir:/2/dir'':'(get-env PATH)
          1 │+set-env PATH '/some/dir:/2/dir'(get-env PATH)
test result: FAILED. 0 passed; 1 failed
```

Built with cmake installed for the `libz-ng-sys` build script, on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed environment variable updates in the Elvish shell so prepended entries are correctly separated from existing values.
  * Prevented newly added entries from being concatenated with the first existing entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->