### PR TITLE
fix(self-update): do not fail the command when updating plugins fails

### DIFF
--- a/e2e/cli/test_self_update_plugins_failure
+++ b/e2e/cli/test_self_update_plugins_failure
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# `self-update` replaces the binary and then refreshes plugins in a subprocess. That subprocess
+# failing used to take the whole command down, so a completed update printed `Updated mise to X`
+# and then exited non-zero -- which reads as "the update failed" for a mise that is in fact
+# installed and working. See discussions/8827.
+#
+# The version mise reports is what `do_update` compares against, so passing it explicitly is what
+# keeps this test offline: the comparison returns `UpToDate` before any release is looked up, and
+# nothing is downloaded or replaced. Debug builds append `-DEBUG`, which is not part of the version
+# the comparison uses. The banner only prints on a tty, so take the last line rather than the first.
+version="$(mise version | tail -n1 | awk '{print $1}' | sed 's/-DEBUG$//')"
+
+# Control: with the plugins step skipped the command is clean. This also pins that the version
+# above really did take the up-to-date path -- had it not matched, this would have gone to the
+# network to look up a release and failed here instead.
+assert_contains "mise self-update $version --no-plugins 2>&1" "mise is already up to date"
+assert_not_contains "mise self-update $version --no-plugins 2>&1" "Failed to update plugins"
+
+# A mise that cannot be spawned at all. That is the shape Windows produces when an AV scanner is
+# still holding the binary self-update just wrote, and discussions/8827 is the same step failing
+# for a different reason -- a plugin whose git remote is unreachable. Either way the update itself
+# has already happened, so the command has to succeed: `assert_contains` requires a zero exit,
+# which is the whole bug.
+assert_contains "__MISE_BIN=$PWD/no-such-mise mise self-update $version 2>&1" "Failed to update plugins"

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -365,6 +365,27 @@ fn current_exe_stem() -> Option<String> {
     exe.file_stem().and_then(|s| s.to_str()).map(str::to_owned)
 }
 
+/// Refresh the installed plugins, best effort.
+///
+/// This runs after the binary has already been replaced, so a failure here says nothing about
+/// whether the update worked. Propagating it made a successful update print `Updated mise to X`
+/// and then exit non-zero, which reads as "the update failed" — on Windows that is a bad enough
+/// misreading to send someone looking for a mise that is not broken. Warned about instead, the way
+/// the two housekeeping steps above it already are.
+///
+/// The message names the step because the error often cannot. `duct` attaches the command only
+/// when the child exits non-zero; a child that never starts comes back as the bare OS error, so an
+/// `ACCESS_DENIED` from spawning the freshly written binary arrives as nothing but
+/// "Access is denied. (os error 5)".
+///
+/// Takes the binary to run rather than reading [`env::MISE_BIN`] itself, so a test can drive the
+/// failure without a real update.
+fn update_plugins(bin: &std::path::Path) {
+    if let Err(err) = cmd!(bin, "plugins", "update").run() {
+        warn!("Failed to update plugins: {err}");
+    }
+}
+
 impl SelfUpdate {
     pub(crate) async fn run(self) -> Result<()> {
         if !Self::is_available() && !self.force {
@@ -408,7 +429,7 @@ impl SelfUpdate {
         }
         crate::cli::version::show_auto_update_hint();
         if !self.no_plugins {
-            cmd!(&*env::MISE_BIN, "plugins", "update").run()?;
+            update_plugins(&env::MISE_BIN);
         }
 
         Ok(())
@@ -734,6 +755,30 @@ mod auto_update_tests {
         std::fs::write(&marker, "").unwrap();
         assert!(!auto_update_check_due(&marker, Duration::from_secs(60)));
         assert!(auto_update_check_due(&marker, Duration::ZERO));
+    }
+}
+
+#[cfg(test)]
+mod post_update_tests {
+    use super::*;
+
+    /// By the time plugins are refreshed the new binary is already in place, so a failure there
+    /// must not turn a successful update into a failed command. Driving a real spawn failure
+    /// rather than a stub: a binary that cannot be started is what Windows produces while an AV
+    /// scanner still holds the file mise just wrote, and what discussion #8827 produces over SSH.
+    #[test]
+    fn a_plugins_update_that_cannot_run_is_not_fatal() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("mise-that-is-not-there");
+
+        // Control: without this the test would pass just as well on a spawn that quietly
+        // succeeded, and prove nothing. `run()` has to actually fail for the line below to mean
+        // anything.
+        assert!(cmd!(&missing, "plugins", "update").run().is_err());
+
+        // And the step swallows it. There is no error here to propagate — which is exactly what
+        // the `?` this replaces used to do.
+        update_plugins(&missing);
     }
 }
 


### PR DESCRIPTION
`self-update` replaces the binary, then refreshes plugins in a subprocess. When that subprocess
fails, the failure is propagated and the whole command exits non-zero — **after the update has
already completed successfully**.

```
Checking target-arch... mise-v2026.8.11-windows-x64.zip
Checking current version... v2026.8.10
Looking for tag: v2026.8.11
...
Downloading...
[00:00:31] [========================================] 31.80 MiB/31.80 MiB (0s) Done
Verifying downloaded file...
Extracting archive... Done
Replacing binary file... Done
Updated mise to 2026.8.11
mise ERROR アクセスが拒否されました。 (os error 5)
mise ERROR Version: 2026.8.10 windows-x64 (2026-08-20)
mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information
```

`Replacing binary file... Done` and `Updated mise to 2026.8.11` are both printed, and the install
was in fact fine afterwards: the new `mise.exe` (2026.8.11, 92,489,216 B) in place, `mise-shim.exe`
refreshed, no leftovers in `TEMP`. The exit code was still non-zero, and the error footer reports
`Version: 2026.8.10` — the *running* process is still the old binary, which makes it read even more
like a failed update. mise can leave an install with no binary at all when a self-update genuinely
fails, so this is a message people act on.

The `ACCESS_DENIED` came from spawning `mise plugins update`. `env::MISE_BIN` is mise's own path —
the 92MB executable that had just been written — and on a machine with Defender for Endpoint its
first launch is refused until the scan finishes. Measured on that box: launching the freshly
written 92MB binary failed 5 times out of 5; the same file 5 seconds later launched fine with an
identical hash; a 222KB executable written the same way launched immediately.

**The AV is not the interesting part.** A post-update subprocess can fail for any number of
reasons, and it already has:

## This is already reported: [discussions/8827](https://github.com/jdx/mise/discussions/8827)

Same defect, different trigger — there the subprocess *starts* and exits 1, because a private
plugin's git remote is unreachable over SSH:

```
~/.local/bin/mise self-update --quiet --yes
mise is already up to date
mise ERROR [node] plugin update
mise ERROR git failed: ...
mise ERROR command ["/home/<snip>/.local/bin/mise", "plugins", "update"] exited with code 1
```

That report is from 2026-03-31 and has no replies. It points at the same line. Both shapes are the
same thing: **something that runs after the update decides whether the update "failed".**

## The change

```rust
 if !self.no_plugins {
-    cmd!(&*env::MISE_BIN, "plugins", "update").run()?;
+    update_plugins(&env::MISE_BIN);
 }
```

This is the odd one out rather than a new policy. The two housekeeping steps immediately above it
are already best-effort:

```rust
match Self::update_mise_shim(&version).await {
    Ok(()) => {
        if let Err(e) = Self::reshim_after_update().await {
            warn!("Failed to reshim after self-update: {e}");
        }
    }
    Err(e) => warn!("Failed to update mise-shim.exe: {e}"),
}
```

Same nature, same position, same consequence if they fail — and only the plugin refresh used `?`.
Now it warns like its neighbours and `self-update` exits 0.

### Why the message needed the step name

The old output was `アクセスが拒否されました。 (os error 5)` and nothing else: no subject, no verb.
That is not mise dropping context, it is where `duct` puts it. `ChildHandle::start`
(duct-1.1.1 `src/lib.rs:1271`) returns the raw `io::Error` from `SharedChild::spawn`, and the
`command [...] exited with code N` wording is built only for a non-zero exit
(`src/lib.rs:1706`). So the failure mode that says least about itself is exactly the one that gets
no command attached. The warning names the step:

```
mise WARN  Failed to update plugins: Access is denied. (os error 5)
```

Kept to the `Failed to <step>: {e}` shape the two neighbours already use. Not
"…after self-update", because this step also runs on the `mise is already up to date` path, where
that wording would be wrong.

## What I deliberately did not change

- **Where the step sits.** `plugins update` runs outside `if status.updated()`, so it happens even
  when nothing was updated — that is #8827's transcript. It has been written that way since
  d714d4c ([#1069](https://github.com/jdx/mise/pull/1069), 2023-12-03), which placed it after the
  `if`/`else` in the same hunk that introduced it, and the doc comment is unconditional: "By
  default, this will also update any installed plugins". `731bde2` only restored the `?` while
  reverting miette. Deliberate, so left alone.
- **`--no-plugins`.** Its behaviour and its help text ("Disable auto-updating plugins") are
  unchanged, so `docs/cli/self-update.md` and `docs/mise.usage.kdl` do not need regenerating.
- **A spawn retry on Windows.** Sleeping and retrying would paper over the AV case specifically and
  add a timing knob to a path that should just not be fatal. Considered and dropped.
- No flag, public API, or other-platform behaviour changes.

## Tests

**Unit** — `a_plugins_update_that_cannot_run_is_not_fatal`. Drives a real spawn failure against a
path that does not exist, which is the Windows shape without needing an AV. It opens with a control
asserting that `cmd!(…).run()` for that path really does return `Err` — without it the test would
pass just as well on a spawn that quietly succeeded and would prove nothing.

**e2e** — `e2e/cli/test_self_update_plugins_failure`, and it needs no network and replaces no
binary:

- Passing the current version explicitly makes `do_update_blocking` return `Status::UpToDate`
  *before* it looks up a release, so nothing is downloaded and nothing is replaced.
- `__MISE_BIN` overrides `env::MISE_BIN` (`src/env.rs`), pointed at a file that does not exist.
  `e2e/cli/test_reshim_with_shims_on_path` already uses that override.
- With `status.updated()` false, the plugin spawn is the only thing on that path that reads
  `MISE_BIN` — the shim refresh and the macOS signature check are both inside the updated branch.
- `assert_contains` requires a zero exit, so the assertion *is* the bug.

It also runs the same command with `--no-plugins` as a control, which pins that the version really
did take the up-to-date path: had it not matched, that line would have gone to the network and
failed there instead.

## Verification

`cargo fmt --all`, `shfmt -l -s` and `shellcheck -x` are clean. **Nothing here was compiled or run
locally** — `cargo check` needs `cmake` for `libz-ng-sys`, which is not installed on this machine —
so CI is the first thing to type-check it. The e2e is a bash test and therefore runs on Linux and
macOS; the reported symptom is Windows-only, but the defect and the fix are not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Self-update now completes successfully even if the optional plugin refresh cannot start or fails.
  - Plugin refresh failures are reported clearly without incorrectly marking the overall mise update as failed.
  - Added coverage for plugin-refresh failures, including cases where the executable cannot be launched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->