### PR TITLE
chore: release 2026.8.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,93 @@
 # Changelog
 
+## [2026.8.13](https://github.com/jdx/mise/compare/v2026.8.12..v2026.8.13) - 2026-08-25
+
+### 🚀 Features
+
+- **(bootstrap)** add skip-dirty repo updates by @jdx in [#12364](https://github.com/jdx/mise/pull/12364)
+- **(config)** support mise/conf.d fragments by @jdx in [#12395](https://github.com/jdx/mise/pull/12395)
+- **(task)** add task discovery exclusions by @jdx in [#12366](https://github.com/jdx/mise/pull/12366)
+
+### 🐛 Bug Fixes
+
+- **(backend)** resolve latest from system installs by @jdx in [#12406](https://github.com/jdx/mise/pull/12406)
+- **(brew)** stage bare cask pkg downloads by @jdx in [#12371](https://github.com/jdx/mise/pull/12371)
+- **(brew)** extract nested cask archives by @jdx in [#12373](https://github.com/jdx/mise/pull/12373)
+- **(cli)** default to an editor Windows has, and name the one that failed by @JamBalaya56562 in [#12375](https://github.com/jdx/mise/pull/12375)
+- **(completion)** restore dynamic completions by @jdx in [#12376](https://github.com/jdx/mise/pull/12376)
+- **(completion)** preserve runtime path fallback by @jdx in [#12379](https://github.com/jdx/mise/pull/12379)
+- **(config)** name the config file once in a TOML parse error by @JamBalaya56562 in [#12329](https://github.com/jdx/mise/pull/12329)
+- **(config)** report an unparseable settings file once, through the logger by @JamBalaya56562 in [#12327](https://github.com/jdx/mise/pull/12327)
+- **(config)** say what a backslash does when a config fails to parse by @JamBalaya56562 in [#12330](https://github.com/jdx/mise/pull/12330)
+- **(config)** truncate picker descriptions safely by @jdx in [#12422](https://github.com/jdx/mise/pull/12422)
+- **(elvish)** separate the prepended entry from the existing PATH by @NgoQuocViet2001 in [#12362](https://github.com/jdx/mise/pull/12362)
+- **(env)** strip a byte-order mark before parsing an env file by @JamBalaya56562 in [#12320](https://github.com/jdx/mise/pull/12320)
+- **(env)** preserve command environment overrides by @jdx in [#12390](https://github.com/jdx/mise/pull/12390)
+- **(generate)** name every file a generator writes by @JamBalaya56562 in [#12333](https://github.com/jdx/mise/pull/12333)
+- **(generate)** name a task stub after the task, not its file by @JamBalaya56562 in [#12341](https://github.com/jdx/mise/pull/12341)
+- **(github)** skip provenance API calls when lockfile has checksum but no provenance by @effati in [#12377](https://github.com/jdx/mise/pull/12377)
+- **(lockfile)** include monorepo root requests in lockfile maintenance by @pikeas in [#12382](https://github.com/jdx/mise/pull/12382)
+- **(lockfile)** attribute each new version to its own request source by @pikeas in [#12381](https://github.com/jdx/mise/pull/12381)
+- **(nushell)** unset __MISE_SESSION on deactivate by @NgoQuocViet2001 in [#12361](https://github.com/jdx/mise/pull/12361)
+- **(pipx)** track latest git revisions by @jdx in [#12407](https://github.com/jdx/mise/pull/12407)
+- **(pipx)** reject unavailable configured executable by @jdx in [#12416](https://github.com/jdx/mise/pull/12416)
+- **(prune)** remove tracked configs that cannot be a config file by @Marukome0743 in [#12380](https://github.com/jdx/mise/pull/12380)
+- **(self-update)** do not fail the command when updating plugins fails by @JamBalaya56562 in [#12363](https://github.com/jdx/mise/pull/12363)
+- **(task)** say which sandbox paths do not exist yet by @Marukome0743 in [#12309](https://github.com/jdx/mise/pull/12309)
+- **(task)** flush a keep-order buffer instead of discarding it by @Marukome0743 in [#12370](https://github.com/jdx/mise/pull/12370)
+- **(task)** anchor injected tasks at their parent's keep-order slot by @Marukome0743 in [#12397](https://github.com/jdx/mise/pull/12397)
+- **(task)** stop dropping #MISE header keys that need quoting by @Marukome0743 in [#12415](https://github.com/jdx/mise/pull/12415)
+- **(task)** reject negative template argument bounds by @jdx in [#12421](https://github.com/jdx/mise/pull/12421)
+- **(trust)** refuse a path that does not exist instead of trusting its parent by @JamBalaya56562 in [#12372](https://github.com/jdx/mise/pull/12372)
+- **(ui)** stop padding the last table column past its content by @JamBalaya56562 in [#12334](https://github.com/jdx/mise/pull/12334)
+
+### 📚 Documentation
+
+- **(security)** update paranoid mode behavior by @jdx in [#12394](https://github.com/jdx/mise/pull/12394)
+
+### 🧪 Testing
+
+- **(config)** assert the tracking entry itself is removed by @Marukome0743 in [#12396](https://github.com/jdx/mise/pull/12396)
+- make e2e harness compatible with BSD env by @Marukome0743 in [#12357](https://github.com/jdx/mise/pull/12357)
+- avoid pipefail race in trust e2e test by @Marukome0743 in [#12358](https://github.com/jdx/mise/pull/12358)
+
+### 📦️ Dependency Updates
+
+- lock file maintenance by @renovate[bot] in [#12356](https://github.com/jdx/mise/pull/12356)
+- bump usage to 6.4.0 by @jdx in [#12392](https://github.com/jdx/mise/pull/12392)
+- update ghcr.io/jdx/mise:rpm docker digest to 28f006d by @renovate[bot] in [#12411](https://github.com/jdx/mise/pull/12411)
+- update dependency go to v1.26.6 by @renovate[bot] in [#12412](https://github.com/jdx/mise/pull/12412)
+- update ghcr.io/jdx/mise:alpine docker digest to 0c43677 by @renovate[bot] in [#12409](https://github.com/jdx/mise/pull/12409)
+- update docker/dockerfile:1 docker digest to ecfaec9 by @renovate[bot] in [#12408](https://github.com/jdx/mise/pull/12408)
+- update ghcr.io/jdx/mise:deb docker digest to f220a26 by @renovate[bot] in [#12410](https://github.com/jdx/mise/pull/12410)
+- update jdx/mise-action action to v4.2.5 by @renovate[bot] in [#12413](https://github.com/jdx/mise/pull/12413)
+- update rust crate demand to v2.1.0 by @renovate[bot] in [#12423](https://github.com/jdx/mise/pull/12423)
+
+### 📦 Registry
+
+- add mr-boxington by @jdx in [#12384](https://github.com/jdx/mise/pull/12384)
+- add ori by @jdx in [#12388](https://github.com/jdx/mise/pull/12388)
+- add hey-cli by @jdx in [#12387](https://github.com/jdx/mise/pull/12387)
+- add playwright by @jdx in [#12385](https://github.com/jdx/mise/pull/12385)
+- add ghui by @jdx in [#12386](https://github.com/jdx/mise/pull/12386)
+- use aqua for claude-code on windows by @Marukome0743 in [#12399](https://github.com/jdx/mise/pull/12399)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (6)
+
+- [`crossplane/cli`](https://github.com/crossplane/cli)
+- [`jdx/fnox`](https://github.com/jdx/fnox)
+- [`rafaelespinoza/godfish`](https://github.com/rafaelespinoza/godfish)
+- [`re-taro/tsmcp`](https://github.com/re-taro/tsmcp)
+- [`skyhook-io/radar`](https://github.com/skyhook-io/radar)
+- [`zwasm/zwasm`](https://github.com/zwasm/zwasm)
+
+#### Updated Packages (2)
+
+- [`temporalio/temporal`](https://github.com/temporalio/temporal)
+- [`wasm-bindgen/wasm-pack`](https://github.com/wasm-bindgen/wasm-pack)
+
 ## [2026.8.12](https://github.com/jdx/mise/compare/v2026.8.11..v2026.8.12) - 2026-08-24
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6261,7 +6261,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.8.12"
+version = "2026.8.13"
 dependencies = [
  "age 0.12.1",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.8.12"
+version = "2026.8.13"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.8.12 macos-arm64 (2026-08-24)
+2026.8.13 macos-arm64 (2026-08-25)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.8.12";
+  version = "2026.8.13";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "32.9k",
+      stars: "33k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.8.12
+Version: 2026.8.13
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.8.12"
+version: "2026.8.13"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "2f018c979bf1b63b345864abe5976843f6adc849"
+  "tag": "b59b11f29f14a9eb93bef65a55084280acd8f0eb"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -30625,14 +30625,20 @@ packages:
           - amd64
   - type: http
     repo_owner: crossplane
-    repo_name: crossplane
-    format: raw
-    url: https://releases.crossplane.io/stable/{{.Version}}/bin/{{.OS}}_{{.Arch}}/crank
-    description: The Crossplane CLI extends kubectl with functionality to build, push, and install Crossplane packages
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
+    repo_name: cli
+    description: The CLI for Crossplane
+    aliases:
+      - name: crossplane/crossplane
+    files:
+      - name: crossplane
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("< 2.3.0")
+        url: https://releases.crossplane.io/stable/{{.Version}}/bin/{{.OS}}_{{.Arch}}/crank
+        windows_arm_emulation: true
+      - version_constraint: "true"
+        url: https://cli.crossplane.io/stable/{{.Version}}/bin/{{.OS}}_{{.Arch}}/crossplane
+        windows_arm_emulation: true
   - type: github_release
     repo_owner: cswank
     repo_name: kcli
@@ -52360,6 +52366,38 @@ packages:
           - windows
         github_artifact_attestations:
           signer_workflow: jdx/aube/\.github/workflows/release\.yml
+  - type: github_release
+    repo_owner: jdx
+    repo_name: fnox
+    description: encrypted/remote secret manager
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.27.0"
+        no_asset: true
+      - version_constraint: semver("<= 1.23.0")
+        asset: fnox-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: fnox-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: jdx
     repo_name: hk
@@ -78571,6 +78609,40 @@ packages:
           - name: raco
             src: racket/raco
   - type: github_release
+    repo_owner: rafaelespinoza
+    repo_name: godfish
+    description: a db migration management CLI for cassandra, mysql, postgres, sqlite, sqlserver
+    version_filter: semver(">= 0.18.0")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: godfish_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - darwin
+          - linux
+          - windows
+        files:
+          - name: godfish
+          - name: godfish-cassandra
+          - name: godfish-mysql
+          - name: godfish-postgres
+          - name: godfish-sqlite3
+          - name: godfish-sqlserver
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/rafaelespinoza/godfish/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
+  - type: github_release
     repo_owner: rajatjindal
     repo_name: krew-release-bot
     description: bot to bump version of plugin in krew-index on new releases
@@ -78996,6 +79068,22 @@ packages:
           linux: unknown-linux-musl
         supported_envs:
           - linux/amd64
+          - darwin
+  - type: github_release
+    repo_owner: re-taro
+    repo_name: tsmcp
+    description: MCP server specialized for the TypeScript 7 native language server (tsc --lsp)
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: tsmcp_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
           - darwin
   - type: github_release
     repo_owner: realm
@@ -85464,6 +85552,61 @@ packages:
             format: zip
             files:
               - name: sk
+  - type: github_release
+    repo_owner: skyhook-io
+    repo_name: radar
+    description: The missing open-source Kubernetes UI with a built-in MCP server for AI agents. See what's broken, why, and what changed. Issues, Topology, event timeline, Helm, GitOps, live service traffic, and cluster audits - all in one Go binary
+    files:
+      - name: kubectl-radar
+      - name: radar
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.6.3")
+        asset: explorer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: kubectl-radar
+            src: kubectl-explorer
+          - name: radar
+            src: kubectl-explorer
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.6.9")
+        asset: radar_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: kubectl-radar
+          - name: radar
+            src: kubectl-radar
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: kubectl-radar
+          - name: radar
+            src: kubectl-radar
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: sl1pm4t
     repo_name: k2tf
@@ -93608,6 +93751,12 @@ packages:
       - name: tdbg
     version_constraint: "false"
     version_overrides:
+      - version_constraint: Version in ["v0.10.0", "v1.0.1", "v1.1.2", "v1.2.3", "v1.3.3", "v1.20.5", "v1.21.6", "v1.22.3", "v1.28.3.1", "v1.29.4.1", "v1.29.6.1", "v1.30.4.1"]
+        no_asset: true
+      - version_constraint: semver("> 1.4.2, <= 1.4.4")
+        no_asset: true
+      - version_constraint: semver("> 1.5.1, <= 1.7.3")
+        no_asset: true
       - version_constraint: semver("<= 1.30.1")
         asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -100182,6 +100331,9 @@ packages:
       - name: rustwasm/wasm-pack
       - name: drager/wasm-pack
     description: your favorite rust -> wasm workflow tool
+    files:
+      - name: wasm-pack
+        src: "{{.AssetWithoutExt}}/wasm-pack"
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.2.0")
@@ -100190,9 +100342,6 @@ packages:
         asset: wasm-pack-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
-        files:
-          - name: wasm-pack
-            src: "{{.AssetWithoutExt}}/wasm-pack"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -100205,9 +100354,6 @@ packages:
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
-        files:
-          - name: wasm-pack
-            src: "{{.AssetWithoutExt}}/wasm-pack"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -100217,14 +100363,11 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.13.1")
         asset: wasm-pack-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
-        files:
-          - name: wasm-pack
-            src: "{{.AssetWithoutExt}}/wasm-pack"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -100234,6 +100377,16 @@ packages:
           - goos: linux
             replacements:
               arm64: aarch64
+      - version_constraint: "true"
+        asset: wasm-pack-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
   - name: wasmCloud/wasmCloud/wash
     type: github_release
     repo_owner: wasmCloud
@@ -103854,6 +104007,54 @@ packages:
           - darwin
           - windows
           - amd64
+  - type: github_release
+    repo_owner: zwasm
+    repo_name: zwasm
+    description: A fast, spec-compliant WebAssembly runtime written in Zig
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.11.1"
+        no_asset: true
+      - version_constraint: semver("<= 1.5.0")
+        asset: zwasm-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+        supported_envs:
+          - linux
+          - darwin/arm64
+      - version_constraint: "true"
+        asset: zwasm-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: amd64
+          - goos: windows
+            format: zip
+            replacements: {}
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64
   - type: github_release
     repo_owner: zyedidia
     repo_name: eget


### PR DESCRIPTION
### 🚀 Features

- **(bootstrap)** add skip-dirty repo updates by @jdx in [#12364](https://github.com/jdx/mise/pull/12364)
- **(config)** support mise/conf.d fragments by @jdx in [#12395](https://github.com/jdx/mise/pull/12395)
- **(task)** add task discovery exclusions by @jdx in [#12366](https://github.com/jdx/mise/pull/12366)

### 🐛 Bug Fixes

- **(backend)** resolve latest from system installs by @jdx in [#12406](https://github.com/jdx/mise/pull/12406)
- **(brew)** stage bare cask pkg downloads by @jdx in [#12371](https://github.com/jdx/mise/pull/12371)
- **(brew)** extract nested cask archives by @jdx in [#12373](https://github.com/jdx/mise/pull/12373)
- **(cli)** default to an editor Windows has, and name the one that failed by @JamBalaya56562 in [#12375](https://github.com/jdx/mise/pull/12375)
- **(completion)** restore dynamic completions by @jdx in [#12376](https://github.com/jdx/mise/pull/12376)
- **(completion)** preserve runtime path fallback by @jdx in [#12379](https://github.com/jdx/mise/pull/12379)
- **(config)** name the config file once in a TOML parse error by @JamBalaya56562 in [#12329](https://github.com/jdx/mise/pull/12329)
- **(config)** report an unparseable settings file once, through the logger by @JamBalaya56562 in [#12327](https://github.com/jdx/mise/pull/12327)
- **(config)** say what a backslash does when a config fails to parse by @JamBalaya56562 in [#12330](https://github.com/jdx/mise/pull/12330)
- **(config)** truncate picker descriptions safely by @jdx in [#12422](https://github.com/jdx/mise/pull/12422)
- **(elvish)** separate the prepended entry from the existing PATH by @NgoQuocViet2001 in [#12362](https://github.com/jdx/mise/pull/12362)
- **(env)** strip a byte-order mark before parsing an env file by @JamBalaya56562 in [#12320](https://github.com/jdx/mise/pull/12320)
- **(env)** preserve command environment overrides by @jdx in [#12390](https://github.com/jdx/mise/pull/12390)
- **(generate)** name every file a generator writes by @JamBalaya56562 in [#12333](https://github.com/jdx/mise/pull/12333)
- **(generate)** name a task stub after the task, not its file by @JamBalaya56562 in [#12341](https://github.com/jdx/mise/pull/12341)
- **(github)** skip provenance API calls when lockfile has checksum but no provenance by @effati in [#12377](https://github.com/jdx/mise/pull/12377)
- **(lockfile)** include monorepo root requests in lockfile maintenance by @pikeas in [#12382](https://github.com/jdx/mise/pull/12382)
- **(lockfile)** attribute each new version to its own request source by @pikeas in [#12381](https://github.com/jdx/mise/pull/12381)
- **(nushell)** unset __MISE_SESSION on deactivate by @NgoQuocViet2001 in [#12361](https://github.com/jdx/mise/pull/12361)
- **(pipx)** track latest git revisions by @jdx in [#12407](https://github.com/jdx/mise/pull/12407)
- **(pipx)** reject unavailable configured executable by @jdx in [#12416](https://github.com/jdx/mise/pull/12416)
- **(prune)** remove tracked configs that cannot be a config file by @Marukome0743 in [#12380](https://github.com/jdx/mise/pull/12380)
- **(self-update)** do not fail the command when updating plugins fails by @JamBalaya56562 in [#12363](https://github.com/jdx/mise/pull/12363)
- **(task)** say which sandbox paths do not exist yet by @Marukome0743 in [#12309](https://github.com/jdx/mise/pull/12309)
- **(task)** flush a keep-order buffer instead of discarding it by @Marukome0743 in [#12370](https://github.com/jdx/mise/pull/12370)
- **(task)** anchor injected tasks at their parent's keep-order slot by @Marukome0743 in [#12397](https://github.com/jdx/mise/pull/12397)
- **(task)** stop dropping #MISE header keys that need quoting by @Marukome0743 in [#12415](https://github.com/jdx/mise/pull/12415)
- **(task)** reject negative template argument bounds by @jdx in [#12421](https://github.com/jdx/mise/pull/12421)
- **(trust)** refuse a path that does not exist instead of trusting its parent by @JamBalaya56562 in [#12372](https://github.com/jdx/mise/pull/12372)
- **(ui)** stop padding the last table column past its content by @JamBalaya56562 in [#12334](https://github.com/jdx/mise/pull/12334)

### 📚 Documentation

- **(security)** update paranoid mode behavior by @jdx in [#12394](https://github.com/jdx/mise/pull/12394)

### 🧪 Testing

- **(config)** assert the tracking entry itself is removed by @Marukome0743 in [#12396](https://github.com/jdx/mise/pull/12396)
- make e2e harness compatible with BSD env by @Marukome0743 in [#12357](https://github.com/jdx/mise/pull/12357)
- avoid pipefail race in trust e2e test by @Marukome0743 in [#12358](https://github.com/jdx/mise/pull/12358)

### 📦️ Dependency Updates

- lock file maintenance by @renovate[bot] in [#12356](https://github.com/jdx/mise/pull/12356)
- bump usage to 6.4.0 by @jdx in [#12392](https://github.com/jdx/mise/pull/12392)
- update ghcr.io/jdx/mise:rpm docker digest to 28f006d by @renovate[bot] in [#12411](https://github.com/jdx/mise/pull/12411)
- update dependency go to v1.26.6 by @renovate[bot] in [#12412](https://github.com/jdx/mise/pull/12412)
- update ghcr.io/jdx/mise:alpine docker digest to 0c43677 by @renovate[bot] in [#12409](https://github.com/jdx/mise/pull/12409)
- update docker/dockerfile:1 docker digest to ecfaec9 by @renovate[bot] in [#12408](https://github.com/jdx/mise/pull/12408)
- update ghcr.io/jdx/mise:deb docker digest to f220a26 by @renovate[bot] in [#12410](https://github.com/jdx/mise/pull/12410)
- update jdx/mise-action action to v4.2.5 by @renovate[bot] in [#12413](https://github.com/jdx/mise/pull/12413)
- update rust crate demand to v2.1.0 by @renovate[bot] in [#12423](https://github.com/jdx/mise/pull/12423)

### 📦 Registry

- add mr-boxington by @jdx in [#12384](https://github.com/jdx/mise/pull/12384)
- add ori by @jdx in [#12388](https://github.com/jdx/mise/pull/12388)
- add hey-cli by @jdx in [#12387](https://github.com/jdx/mise/pull/12387)
- add playwright by @jdx in [#12385](https://github.com/jdx/mise/pull/12385)
- add ghui by @jdx in [#12386](https://github.com/jdx/mise/pull/12386)
- use aqua for claude-code on windows by @Marukome0743 in [#12399](https://github.com/jdx/mise/pull/12399)

## 📦 Aqua Registry Updates

### New Packages (6)

- [`crossplane/cli`](https://github.com/crossplane/cli)
- [`jdx/fnox`](https://github.com/jdx/fnox)
- [`rafaelespinoza/godfish`](https://github.com/rafaelespinoza/godfish)
- [`re-taro/tsmcp`](https://github.com/re-taro/tsmcp)
- [`skyhook-io/radar`](https://github.com/skyhook-io/radar)
- [`zwasm/zwasm`](https://github.com/zwasm/zwasm)

### Updated Packages (2)

- [`temporalio/temporal`](https://github.com/temporalio/temporal)
- [`wasm-bindgen/wasm-pack`](https://github.com/wasm-bindgen/wasm-pack)