### PR TITLE
feat(task): add task discovery exclusions

### DIFF
--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -1602,6 +1602,29 @@ When `path` points at a directory, mise loads both executable file tasks and any
 
 Included `.toml` files use the [task toml file format](#task_config.includes) (the keys are task names — there is no `[tasks.…]` prefix). The repository will be cloned and cached in `MISE_CACHE_DIR/remote-git-tasks-cache`. Tasks from the include will be loaded as if they were local. You can disable caching with `MISE_TASK_REMOTE_NO_CACHE=true` or the `--no-cache` flag.
 
+### `task_config.excludes` {#task_config.excludes}
+
+Set paths or glob patterns to exclude from file-task discovery. Relative entries resolve from the
+config root and may exclude a file, an entire directory, or files matched by a glob:
+
+```toml
+[task_config]
+excludes = [
+    ".mise/tasks/python/pyproject.toml",
+    ".mise/tasks/generated",
+    ".mise/tasks/**/fixtures/*.toml",
+]
+```
+
+The closest config that defines `task_config.excludes` replaces inherited exclusions. Set it to an
+empty array to clear exclusions inherited through `task_config.cascade = true`. Exclusions apply to
+both the default task directories and paths selected by `task_config.includes`.
+
+Task directories are searched recursively. Executable files are loaded as file tasks, and every
+`.toml` file that is not a mise configuration file is loaded using the
+[included task TOML format](#task_config.includes). Use `task_config.excludes` when other TOML files,
+such as `pyproject.toml` or `Cargo.toml`, must live inside a task directory.
+
 ## Monorepo Support
 
 mise supports monorepo-style task organization with target path syntax. Enable it by setting `monorepo_root = true` in your root `mise.toml`.

--- a/e2e/tasks/test_task_excludes
+++ b/e2e/tasks/test_task_excludes
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+mkdir -p .mise/tasks/problem .mise/tasks/generated .mise/tasks/keep
+
+cat <<'EOF' >.mise/tasks/problem/_default
+#!/usr/bin/env bash
+echo problem
+EOF
+chmod +x .mise/tasks/problem/_default
+
+cat <<'EOF' >.mise/tasks/problem/pyproject.toml
+[project]
+name = "problem"
+version = "0.1.0"
+EOF
+
+cat <<'EOF' >.mise/tasks/keep/_default
+#!/usr/bin/env bash
+echo keep
+EOF
+chmod +x .mise/tasks/keep/_default
+
+cat <<'EOF' >.mise/tasks/generated/hidden.toml
+[generated]
+run = "echo generated"
+EOF
+
+cat <<'EOF' >standalone.toml
+[standalone]
+run = "echo standalone"
+EOF
+
+# Config-defined task.disable_paths entries resolve from the declaring config root.
+cat <<'EOF' >.mise/config.toml
+[settings.task]
+disable_paths = [".mise/tasks/problem"]
+EOF
+
+assert_contains "mise tasks" "keep"
+assert_not_contains "mise tasks" "problem"
+
+# Scoped excludes support directories, globs, and direct TOML includes.
+cat <<'EOF' >.mise/config.toml
+[task_config]
+includes = [".mise/tasks", "standalone.toml"]
+excludes = [
+  ".mise/tasks/problem",
+  ".mise/tasks/generated/*.toml",
+  "standalone.toml",
+]
+EOF
+
+assert_contains "mise tasks" "keep"
+assert_not_contains "mise tasks" "problem"
+assert_not_contains "mise tasks" "generated"
+assert_not_contains "mise tasks" "standalone"
+assert "mise run keep" "keep"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2500,6 +2500,13 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "excludes": {
+          "description": "config-root-relative paths or glob patterns to exclude from file-task discovery",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       }
     },

--- a/settings.toml
+++ b/settings.toml
@@ -3006,6 +3006,9 @@ description = "Paths that mise will not look for tasks in."
 docs = """
 Paths that mise will not look for tasks in.
 
+Relative paths set in a config file are resolved from that file's config root. Relative paths from
+the environment are resolved from the invocation's working directory.
+
 Paths are separated by the OS path separator when using the environment variable,
 `mise settings set`, or `mise settings add` (`:` on Unix, `;` on Windows).
 """

--- a/src/cli/tasks/ls.rs
+++ b/src/cli/tasks/ls.rs
@@ -168,10 +168,11 @@ impl TasksLs {
             && let Some(cwd) = &*dirs::CWD
         {
             let includes = config::task_includes_for_dir(cwd, &config.config_files)?;
+            let excludes = config::task_excludes_for_dir(cwd, &config.config_files)?;
             // One file is enough to act on, and `make_executable_hint` is the only thing that
             // knows what "make it executable" means on this platform. Bound to a local because
             // under edition 2024 an `if let` scrutinee temporary is dropped before the body runs.
-            let non_executable = find_non_executable_task_files(&includes);
+            let non_executable = find_non_executable_task_files(&includes, &excludes);
             if let Some(path) = non_executable.first() {
                 warn!(
                     "no tasks found, but non-executable files exist in task directories.\nFiles must be executable to be detected as tasks. {}",

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -1615,6 +1615,19 @@ impl ConfigFile for MiseToml {
             .transpose()
     }
 
+    fn task_config_excludes(&self) -> eyre::Result<Option<Vec<String>>> {
+        self.task_config
+            .excludes
+            .as_ref()
+            .map(|excludes| {
+                excludes
+                    .iter()
+                    .map(|exclude| self.parse_template(exclude))
+                    .collect()
+            })
+            .transpose()
+    }
+
     fn monorepo_root(&self) -> Option<bool> {
         self.monorepo_root
     }

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -158,6 +158,10 @@ pub(crate) trait ConfigFile: Debug + Send + Sync {
         Ok(self.task_config().includes.clone())
     }
 
+    fn task_config_excludes(&self) -> eyre::Result<Option<Vec<String>>> {
+        Ok(self.task_config().excludes.clone())
+    }
+
     fn task_templates(&self) -> IndexMap<String, TaskTemplate> {
         IndexMap::new()
     }
@@ -1112,6 +1116,7 @@ impl Hash for dyn ConfigFile {
 pub(crate) struct TaskConfig {
     pub cascade: Option<bool>,
     pub includes: Option<Vec<String>>,
+    pub excludes: Option<Vec<String>>,
     pub dir: Option<String>,
     pub shell: Option<String>,
     pub cache: Option<crate::task::TaskCacheConfig>,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4361,14 +4361,30 @@ struct LoadTaskIncludesOptions<'a> {
     monorepo_cf: Option<&'a Arc<dyn ConfigFile>>,
     require_trust: bool,
     rendered_file_tasks: Option<&'a mut RenderedTaskCache>,
+    excludes: &'a [PathBuf],
 }
 
-fn collect_task_files(root: &Path) -> Result<Vec<PathBuf>> {
+pub(crate) fn is_task_path_excluded(path: &Path, excludes: &[PathBuf]) -> bool {
+    Settings::get()
+        .task
+        .disable_paths
+        .iter()
+        .chain(excludes)
+        .any(|exclude| file::path_starts_with_resolved(path, exclude))
+}
+
+fn collect_task_files(root: &Path, excludes: &[PathBuf]) -> Result<Vec<PathBuf>> {
     WalkDir::new(root)
         .follow_links(true)
         .into_iter()
         // skip hidden directories (if the root is hidden that's ok)
-        .filter_entry(|e| e.path() == root || !e.file_name().to_string_lossy().starts_with('.'))
+        .filter_entry(|entry| {
+            entry.path() == root
+                || (!entry.file_name().to_string_lossy().starts_with('.')
+                    && !excludes
+                        .iter()
+                        .any(|exclude| file::path_starts_with_resolved(entry.path(), exclude)))
+        })
         .filter_map(|entry| match entry {
             Ok(entry) if entry.file_type().is_file() => Some(Ok(entry.path().to_path_buf())),
             Ok(_) => None,
@@ -4398,7 +4414,11 @@ async fn load_tasks_includes(
         monorepo_cf,
         require_trust,
         mut rendered_file_tasks,
+        excludes,
     } = options;
+    if is_task_path_excluded(root, excludes) {
+        return Ok(vec![]);
+    }
     if root.is_file() && root.extension().map(|e| e == "toml").unwrap_or(false) {
         trust_check_task_include(root, require_trust)?;
         load_task_file(
@@ -4412,16 +4432,14 @@ async fn load_tasks_includes(
         )
         .await
     } else if root.is_dir() {
-        let all_files = collect_task_files(root)?
-            .into_iter()
-            .filter(|p| {
-                !Settings::get()
-                    .task
-                    .disable_paths
-                    .iter()
-                    .any(|d| p.starts_with(d))
-            })
+        let all_excludes = Settings::get()
+            .task
+            .disable_paths
+            .iter()
+            .chain(excludes)
+            .cloned()
             .collect::<Vec<_>>();
+        let all_files = collect_task_files(root, &all_excludes)?;
         let is_toml = |p: &Path| p.extension().map(|e| e == "toml").unwrap_or(false);
         let (toml_files, exec_files): (Vec<_>, Vec<_>) = all_files
             .into_iter()
@@ -4612,6 +4630,25 @@ fn expand_task_include(dir: &Path, pattern: &str) -> Vec<PathBuf> {
     }
 }
 
+fn resolve_task_excludes(dir: &Path, patterns: &[String]) -> Vec<PathBuf> {
+    patterns
+        .iter()
+        .flat_map(|pattern| {
+            if is_glob_pattern(pattern) {
+                expand_task_include(dir, pattern)
+            } else {
+                let path = file::replace_path(pattern);
+                if path.is_absolute() {
+                    vec![path]
+                } else {
+                    vec![dir.join(path)]
+                }
+            }
+        })
+        .unique()
+        .collect()
+}
+
 fn task_include_patterns_for_dir(
     dir: &Path,
     config_files: &ConfigMap,
@@ -4664,6 +4701,33 @@ pub(crate) fn task_includes_for_dir(dir: &Path, config_files: &ConfigMap) -> Res
         })
         .unique()
         .collect::<Vec<_>>())
+}
+
+pub(crate) fn task_excludes_for_dir(dir: &Path, config_files: &ConfigMap) -> Result<Vec<PathBuf>> {
+    let configs = configs_at_root(dir, config_files);
+    let cascaded_task_config =
+        if configs.iter().find_map(|cf| cf.task_config().cascade) == Some(false) {
+            None
+        } else {
+            cascaded_task_config_for_dir(dir, config_files)?
+        };
+    let (excludes, resolve_dir) = configs
+        .iter()
+        .find_map(|cf| match cf.task_config_excludes() {
+            Ok(Some(excludes)) => Some(Ok((excludes, cf.config_root()))),
+            Ok(None) => None,
+            Err(err) => Some(Err(err)),
+        })
+        .transpose()?
+        .or_else(|| {
+            cascaded_task_config.and_then(|tc| {
+                tc.task_config
+                    .excludes
+                    .map(|excludes| (excludes, tc.excludes_root))
+            })
+        })
+        .unwrap_or_default();
+    Ok(resolve_task_excludes(&resolve_dir, &excludes))
 }
 
 /// Returns the directory where a new file task should be created.
@@ -4740,6 +4804,7 @@ struct TaskSources {
 struct CascadedTaskConfig {
     task_config: TaskConfig,
     includes_root: PathBuf,
+    excludes_root: PathBuf,
 }
 
 fn merge_cascaded_task_config(
@@ -4785,6 +4850,18 @@ fn merge_cascaded_task_config(
         cascaded.task_config.includes = Some(includes);
         cascaded.includes_root = root;
     }
+    if let Some((excludes, root)) = configs
+        .iter()
+        .find_map(|cf| match cf.task_config_excludes() {
+            Ok(Some(excludes)) => Some(Ok((excludes, cf.config_root()))),
+            Ok(None) => None,
+            Err(err) => Some(Err(err)),
+        })
+        .transpose()?
+    {
+        cascaded.task_config.excludes = Some(excludes);
+        cascaded.excludes_root = root;
+    }
     Ok(())
 }
 
@@ -4812,7 +4889,8 @@ fn cascaded_task_config_for_dir(
             Some(true) if cascaded.is_none() => {
                 cascaded = Some(CascadedTaskConfig {
                     task_config: TaskConfig::default(),
-                    includes_root: root,
+                    includes_root: root.clone(),
+                    excludes_root: root,
                 });
             }
             _ => {}
@@ -4935,6 +5013,24 @@ async fn load_task_sources_from_configs(
             })
         })
         .unwrap_or_else(|| (default_task_includes(), dir.to_path_buf(), configs.len()));
+    let (excludes, excludes_root) = configs
+        .iter()
+        .find_map(|cf| match cf.task_config_excludes() {
+            Ok(Some(excludes)) => Some(Ok((excludes, cf.config_root()))),
+            Ok(None) => None,
+            Err(err) => Some(Err(err)),
+        })
+        .transpose()?
+        .or_else(|| {
+            cascaded_task_config.and_then(|tc| {
+                tc.task_config
+                    .excludes
+                    .clone()
+                    .map(|excludes| (excludes, tc.excludes_root.clone()))
+            })
+        })
+        .unwrap_or_default();
+    let excludes = resolve_task_excludes(&excludes_root, &excludes);
 
     // Resolve task defaults once for the config root so inline tasks from
     // lower-precedence overlay files use the same defaults as file tasks.
@@ -5008,6 +5104,7 @@ async fn load_task_sources_from_configs(
                     monorepo_cf,
                     require_trust: require_task_include_trust,
                     rendered_file_tasks: rendered_file_tasks.as_deref_mut(),
+                    excludes: &excludes,
                 },
             )
             .await?;
@@ -5219,7 +5316,24 @@ mod tests {
         fs::write(&task, "echo ok")?;
         std::os::unix::fs::symlink("missing", tmp.path().join("dangling"))?;
 
-        assert_eq!(collect_task_files(tmp.path())?, vec![task]);
+        assert_eq!(collect_task_files(tmp.path(), &[])?, vec![task]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_collect_task_files_prunes_excluded_directories() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let excluded = tmp.path().join("excluded");
+        fs::create_dir(&excluded)?;
+        fs::write(excluded.join("pyproject.toml"), "[project]")?;
+        let task = tmp.path().join("task");
+        fs::write(&task, "echo ok")?;
+
+        assert_eq!(
+            collect_task_files(tmp.path(), std::slice::from_ref(&excluded))?,
+            vec![task]
+        );
 
         Ok(())
     }
@@ -5234,7 +5348,10 @@ mod tests {
         fs::create_dir(&root)?;
         std::os::unix::fs::symlink(&target, root.join("linked"))?;
 
-        assert_eq!(collect_task_files(&root)?, vec![root.join("linked/task")]);
+        assert_eq!(
+            collect_task_files(&root, &[])?,
+            vec![root.join("linked/task")]
+        );
 
         Ok(())
     }
@@ -5244,7 +5361,7 @@ mod tests {
         let tmp = TempDir::new()?;
         std::os::unix::fs::symlink("loop", tmp.path().join("loop"))?;
 
-        assert!(collect_task_files(tmp.path()).is_err());
+        assert!(collect_task_files(tmp.path(), &[]).is_err());
 
         Ok(())
     }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -2085,7 +2085,7 @@ mod tests {
             format!(
                 r#"
                 [settings.task]
-                disable_paths = ["tasks/generated", "{}"]
+                disable_paths = ["tasks/generated", '{}']
                 "#,
                 absolute.display()
             ),

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -678,6 +678,45 @@ fn resolve_aqua_registry_paths(settings: &mut toml::Table, path: &Path) {
     }
 }
 
+/// Resolve task discovery exclusions while the settings file that declared them is still known.
+/// Once settings layers are merged, a relative `PathBuf` no longer carries enough information to
+/// distinguish two config roots.
+fn resolve_task_disable_paths(settings: &mut toml::Table, path: &Path) {
+    let config_root = crate::config::config_file::config_root::config_root(path);
+    let resolve = |paths: &mut Vec<toml::Value>| {
+        for entry in paths {
+            let Some(value) = entry.as_str() else {
+                continue;
+            };
+            let value = Path::new(value);
+            if value.is_absolute() || value == Path::new("~") || value.starts_with("~/") {
+                continue;
+            }
+            let joined = config_root.join(value);
+            let resolved = joined
+                .absolutize()
+                .map(|path| path.into_owned())
+                .unwrap_or(joined);
+            *entry = toml::Value::String(resolved.to_string_lossy().into_owned());
+        }
+    };
+
+    if let Some(paths) = settings
+        .get_mut("task")
+        .and_then(toml::Value::as_table_mut)
+        .and_then(|task| task.get_mut("disable_paths"))
+        .and_then(toml::Value::as_array_mut)
+    {
+        resolve(paths);
+    }
+    if let Some(paths) = settings
+        .get_mut("task_disable_paths")
+        .and_then(toml::Value::as_array_mut)
+    {
+        resolve(paths);
+    }
+}
+
 /// Resolve age identity paths while the settings file that declared them is
 /// still known. Once settings layers are merged, a relative `PathBuf` no
 /// longer carries enough information to distinguish two config roots.
@@ -1134,6 +1173,7 @@ impl Settings {
             // never rewritten.
             resolve_aqua_registry_paths(settings, path);
             resolve_age_paths(settings, path)?;
+            resolve_task_disable_paths(settings, path);
         }
         let deprecated = deprecated_settings_in_toml_config(&raw);
         let settings_file: SettingsFile = raw.try_into()?;
@@ -2031,6 +2071,36 @@ mod tests {
 
         assert_eq!(partial.default_config_filename, None);
         assert_eq!(partial.default_tool_versions_filename, None);
+    }
+
+    #[test]
+    fn test_parse_settings_file_resolves_task_disable_paths_from_config_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_dir = dir.path().join(".mise");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        let path = config_dir.join("config.toml");
+        let absolute = dir.path().join("absolute");
+        std::fs::write(
+            &path,
+            format!(
+                r#"
+                [settings.task]
+                disable_paths = ["tasks/generated", "{}"]
+                "#,
+                absolute.display()
+            ),
+        )
+        .unwrap();
+
+        let partial = Settings::parse_settings_file(&path).unwrap();
+
+        assert_eq!(
+            partial.task.disable_paths,
+            Some(BTreeSet::from([
+                dir.path().join("tasks/generated"),
+                absolute,
+            ]))
+        );
     }
 
     /// Unlike `global_only`, being in the *global* config does not rescue these — the loader

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -23,7 +23,10 @@ const MAX_AVAILABLE_TASKS_IN_ERROR: usize = 20;
 /// Find non-executable files in task include directories.
 /// These are files that likely should be tasks but are missing the executable bit.
 /// Skips hidden files (e.g., .gitkeep, .DS_Store) to match load_tasks_includes behavior.
-pub(crate) fn find_non_executable_task_files(includes: &[PathBuf]) -> Vec<PathBuf> {
+pub(crate) fn find_non_executable_task_files(
+    includes: &[PathBuf],
+    excludes: &[PathBuf],
+) -> Vec<PathBuf> {
     includes
         .iter()
         .filter(|d| d.is_dir())
@@ -36,7 +39,11 @@ pub(crate) fn find_non_executable_task_files(includes: &[PathBuf]) -> Vec<PathBu
                     e.path() == root || !e.file_name().to_string_lossy().starts_with('.')
                 })
                 .filter_map(|e| e.ok())
-                .filter(|e| e.file_type().is_file() && !file::is_executable(e.path()))
+                .filter(|e| {
+                    e.file_type().is_file()
+                        && !file::is_executable(e.path())
+                        && !config::is_task_path_excluded(e.path(), excludes)
+                })
                 .map(|e| e.path().to_path_buf())
         })
         .collect()
@@ -204,8 +211,9 @@ async fn make_task_executable(
         (cwd.clone(), name.strip_prefix(':').unwrap_or(name))
     };
     let includes = config::task_includes_for_dir(&task_dir, &config.config_files)?;
+    let excludes = config::task_excludes_for_dir(&task_dir, &config.config_files)?;
     let Some(path) = includes.iter().find_map(|root| {
-        find_non_executable_task_files(std::slice::from_ref(root))
+        find_non_executable_task_files(std::slice::from_ref(root), &excludes)
             .into_iter()
             .find(|path| {
                 Task::new(path, root, &task_dir).is_ok_and(|task| task.is_match(task_name))
@@ -319,7 +327,8 @@ async fn err_no_task(
         // Check if there are non-executable files in task include directories
         if let Some(cwd) = &*dirs::CWD {
             let includes = config::task_includes_for_dir(cwd, &config.config_files)?;
-            let non_exec_files = find_non_executable_task_files(&includes);
+            let excludes = config::task_excludes_for_dir(cwd, &config.config_files)?;
+            let non_exec_files = find_non_executable_task_files(&includes, &excludes);
             // The remedy differs by platform and `make_executable_hint` is the only thing that
             // knows how, so it gets one file to name rather than the list. The count and the
             // directories below still say how much is affected.


### PR DESCRIPTION
## Summary
- resolve config-defined `task.disable_paths` entries relative to the declaring config root before settings layers are merged
- add config-root-relative `task_config.excludes` paths and glob patterns with normal task config precedence and cascading
- prune excluded task directories and apply exclusions to direct TOML includes and non-executable task suggestions
- document recursive TOML task discovery and add schema/test coverage

## Testing
- `mise run lint-fix`
- `cargo check --all-features --quiet`
- `cargo test --bin mise test_parse_settings_file_resolves_task_disable_paths_from_config_root`
- `cargo test --bin mise test_collect_task_files_prunes_excluded_directories`
- `mise run test:e2e e2e/tasks/test_task_excludes`
- `mise run render:schema`

Context: https://github.com/jdx/mise/discussions/12359#discussioncomment-18132334

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how tasks are discovered and which files are treated as tasks, including path resolution across config layers. Incorrect excludes could hide tasks or skip intended includes, but this is not auth or data-handling.
> 
> **Overview**
> Adds **`task_config.excludes`** so file-task discovery can skip config-root-relative paths, directories, and globs (including accidental TOML like `pyproject.toml` inside task dirs). The closest config that sets `excludes` replaces inherited values; an empty list clears cascade. Exclusions apply to default task dirs, `includes`, and non-executable-file hints.
> 
> Also resolves relative **`task.disable_paths`** from the declaring config root before settings merge (env-relative paths still use CWD), and prunes excluded directories during WalkDir instead of filtering after the fact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04b4d7d924fb75cd19be5f26300f9a9c2571d953. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `task_config.excludes` support for excluding files, directories, and glob patterns from recursive task discovery.
  - Exclusions apply to default and explicitly included paths, support nested configuration, and can be cleared with an empty list.
  - Added schema support and documented path-resolution behavior for task exclusions and disabled paths.

- **Bug Fixes**
  - Excluded task files are now omitted from task listings, recovery, and missing-task diagnostics.
  - Relative disabled paths now resolve consistently from their declaring configuration file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->