### PR TITLE
fix(task): flush a keep-order buffer instead of discarding it

### DIFF
--- a/e2e/tasks/test_task_keep_order_task_reference
+++ b/e2e/tasks/test_task_keep_order_task_reference
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Regression test for https://github.com/jdx/mise/discussions/12238
+#
+# keep-order holds a task's output until that task is eligible to stream. A task
+# started from a task reference is not registered up front, so its first line is
+# always held — and the held lines used to be dropped rather than printed. A
+# task emitting a single line never reaches a second line to become active, so
+# it lost everything.
+#
+# --jobs 1 keeps this deterministic. Block order across tasks is a separate
+# defect and is deliberately not asserted here.
+
+cat >mise.toml <<'TOML'
+[tasks.launch]
+run = { tasks = ["one", "two"] }
+
+[tasks.one]
+run = 'echo ONLY-LINE-ONE'
+
+[tasks.two]
+run = 'echo ONLY-LINE-TWO'
+TOML
+
+# Every line survives. Before the fix this printed nothing at all.
+out="$(mise run --quiet --jobs 1 --output keep-order launch 2>&1)"
+assert_contains "echo \"$out\"" "[one] ONLY-LINE-ONE"
+assert_contains "echo \"$out\"" "[two] ONLY-LINE-TWO"
+
+# A task's own lines stay in order. Flushing the held lines when the task
+# finishes instead of when it becomes active would print 2, 3, then 1.
+cat >mise.toml <<'TOML'
+[tasks.launch]
+run = { tasks = ["three"] }
+
+[tasks.three]
+run = '''
+echo L1
+echo L2
+echo L3
+'''
+TOML
+
+out="$(mise run --quiet --jobs 1 --output keep-order launch 2>&1)"
+assert "printf '%s\n' \"$out\"" "[three] L1
+[three] L2
+[three] L3"

--- a/src/task/task_output_handler.rs
+++ b/src/task/task_output_handler.rs
@@ -63,7 +63,7 @@ impl KeepOrderState {
     /// Called when a stdout line is produced by a task's process.
     pub(crate) fn on_stdout(&mut self, task: &Task, prefix: String, line: String) {
         if self.done || self.is_active(task) {
-            self.active = Some(task.clone());
+            self.activate(task);
             print_stdout(&prefix, &line);
         } else {
             self.buffers
@@ -77,7 +77,7 @@ impl KeepOrderState {
     /// or when metadata (command echo, timing) is emitted for a task.
     pub(crate) fn on_stderr(&mut self, task: &Task, prefix: String, line: String) {
         if self.done || self.is_active(task) {
-            self.active = Some(task.clone());
+            self.activate(task);
             print_stderr(&prefix, &line);
         } else {
             self.buffers
@@ -95,7 +95,13 @@ impl KeepOrderState {
         if self.is_active(task) {
             // Active task finished — clear it, flush waiting tasks, promote next
             self.active = None;
-            self.buffers.shift_remove(task);
+            // `activate` empties the buffer on the way in, so there should be
+            // nothing here. Print whatever is anyway: no removal in this type is
+            // allowed to drop lines, and losing output silently is the failure
+            // this guards against.
+            if let Some(lines) = self.buffers.shift_remove(task) {
+                Self::print_lines(&lines);
+            }
             self.flush_finished();
             self.promote_next();
         } else {
@@ -121,16 +127,30 @@ impl KeepOrderState {
         self.finished.extend(finished);
     }
 
-    /// Promote the next buffered (still-running) task to active and
-    /// flush its current buffer so it can stream live going forward.
+    /// Promote the next buffered (still-running) task to active so it can
+    /// stream live going forward.
     fn promote_next(&mut self) {
         if let Some((task, _)) = self.buffers.first() {
             let task = task.clone();
-            self.active = Some(task.clone());
-            if let Some(lines) = self.buffers.get_mut(&task) {
-                let lines = std::mem::take(lines);
-                Self::print_lines(&lines);
-            }
+            self.activate(&task);
+        }
+    }
+
+    /// Make `task` the live one, printing whatever it buffered before it got
+    /// here.
+    ///
+    /// A task reaches this with a non-empty buffer whenever it produced output
+    /// before it was eligible to stream: `is_active` only lets the first entry
+    /// in `buffers` claim the stream, and a task started from a task reference
+    /// is not in `buffers` at all until its own first line creates the entry.
+    /// Those buffered lines came *before* the one being printed now, so they
+    /// have to go out first — flushing them at finish instead would reorder the
+    /// task's own output, and dropping them is how #12238 lost it.
+    fn activate(&mut self, task: &Task) {
+        self.active = Some(task.clone());
+        if let Some(lines) = self.buffers.get_mut(task) {
+            let lines = std::mem::take(lines);
+            Self::print_lines(&lines);
         }
     }
 
@@ -493,6 +513,51 @@ mod tests {
         ] {
             assert!(!displays_colored_task_prefix(output));
         }
+    }
+
+    fn task_named(name: &str) -> Task {
+        Task {
+            name: name.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn buffered(state: &KeepOrderState, task: &Task) -> usize {
+        state.buffers.get(task).map(Vec::len).unwrap_or(0)
+    }
+
+    #[test]
+    fn activating_a_task_flushes_what_it_buffered() {
+        // A task started from a task reference is not in `buffers`, so its first
+        // line is held; from the second on it is `buffers.first()` and streams
+        // live. Those held lines came first and must go out with it, not be
+        // stranded for `on_task_finished` to drop (#12238).
+        let mut state = KeepOrderState::new();
+        let task = task_named("one");
+
+        state.on_stdout(&task, "one".into(), "first".into());
+        assert_eq!(buffered(&state, &task), 1, "first line should be held");
+
+        state.on_stdout(&task, "one".into(), "second".into());
+        assert_eq!(
+            buffered(&state, &task),
+            0,
+            "becoming active must flush what was held"
+        );
+    }
+
+    #[test]
+    fn activating_through_stderr_flushes_too() {
+        // stderr carries the command echo and timing lines, and reaches the same
+        // branch, so it has to flush on the way in as well.
+        let mut state = KeepOrderState::new();
+        let task = task_named("one");
+
+        state.on_stderr(&task, "one".into(), "first".into());
+        assert_eq!(buffered(&state, &task), 1);
+
+        state.on_stderr(&task, "one".into(), "second".into());
+        assert_eq!(buffered(&state, &task), 0);
     }
 
     #[test]


### PR DESCRIPTION
Addresses discussion #12238.

## Problem

`--output keep-order` silently drops output from tasks started through a task reference. With each task emitting a single line, it drops all of it:

```toml
[tasks.launch]
run = { tasks = ["one", "two"] }

[tasks.one]
run = 'echo ONLY-LINE-ONE'

[tasks.two]
run = 'echo ONLY-LINE-TWO'
```

```console
$ mise run --quiet --jobs 1 --output keep-order launch
                                        # nothing at all, 4 runs out of 4

$ mise run --quiet --jobs 1 --output prefix launch
[one] ONLY-LINE-ONE
[two] ONLY-LINE-TWO
```

Reported from pwsh, but **not Windows-specific** — reproduced on macOS arm64 with plain `sh` on 2026.8.12. Multi-line tasks lose exactly their first line. `--jobs 1` removes the run-to-run variation and leaves the loss intact, so this is not a race.

## Mechanism

`KeepOrderState` has two ways for a task holding buffered lines to start streaming, and only one of them printed what was held:

- `promote_next` — took the buffer, printed it, then streamed. Correct.
- the `on_stdout`/`on_stderr` branch — set `active` and printed the new line only, leaving the held lines stranded.

`on_task_finished` then removed the entry with `shift_remove` and dropped the result. That was the one place in the type that removed a buffer without printing it: `flush_finished` removes then prints, `flush_all` drains then prints.

A task reaches that state because `is_active` only lets the first entry in `buffers` claim the stream, and a task started from a task reference is not in `buffers` at all — `init_task` runs over `tasks.all()`, the graph known up front. Its first line creates the entry and is held; from the second line on it *is* the first entry, so it streams live and the held line is stranded.

The single-line case falls out of that: such a task never reaches a second line, so nothing ever streams and the whole task disappears. I predicted that from the mechanism before testing it, and it reproduced exactly — which is what convinced me this reading is right.

## Fix

Flush on the way in, not at finish. The held lines came *before* the line being printed now, so flushing them at finish would reorder the task's own output — `2`, `3`, then `1`. `promote_next` already did the right thing, so both paths now share one `activate`.

`on_task_finished` prints whatever it removes. With `activate` in place that buffer should always be empty; printing anyway keeps a single rule in the type — no removal drops lines — and if some future path leaves lines there, showing them late beats losing them.

No double printing: a buffer in that branch only ever holds lines from before the task became active, and `activate` empties it on the way in.

## Still wrong, deliberately left alone

Block ordering. These tasks appear in the order they first produced output rather than definition order, because they are not registered up front. Fixing that means the executor telling the output handler where a dynamically started task belongs, which is a different change from "stop throwing lines away" — happy to look at it separately if you want it.

## Why the existing tests missed this

`e2e/tasks/test_task_sequence_keep_order` does exercise task references, but through the array form (`run = [{ task = "a" }, ...]`, which registers the children) and it only checks that `A1` appears before `B1`. Nothing asserted that every line survived.

`e2e/tasks/test_task_keep_order_task_reference` uses the bare mapping form that loses lines, single-line tasks for the total-loss case, and `--jobs 1` for determinism. It asserts both lines survive and, separately, that a three-line task keeps `L1, L2, L3` in order — that second one fails if you flush at finish instead of on activation.

Two unit tests pin the flush for stdout and stderr by asserting the task's buffer is empty once it starts streaming. I dropped a third that asserted the entry is gone after finish: `shift_remove` removes it either way, so it passed unpatched and pinned nothing.

`test_task_keep_order`, `test_task_sequence_keep_order`, `test_task_output_style_decoupling`, `test_task_raw_output` and `test_task_prefix_color` all still pass. `cargo fmt --check`, `shellcheck` and `shfmt` are clean.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keep-order task output so buffered messages are flushed when tasks become active or complete.
  * Preserved single-line task output when tasks are launched through references.
  * Ensured multi-line output maintains emission order when running with a single job.
  * Improved consistent handling of both standard output and error output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->