### PR TITLE
fix(brew): stage bare cask pkg downloads

### DIFF
--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -1043,12 +1043,16 @@ fn extract_archive(cask: &Cask, archive: &Path, pr: Option<&dyn SingleReport>) -
     } else {
         let format = cask_extraction_format(archive, filename)?;
         if format == ExtractionFormat::Raw {
-            // Raw executable binary — copy it using the original URL filename so
-            // find_file_artifact can match against the binary stanza source name (e.g. "claude").
-            let url_filename = archive_filename(&cask.url).unwrap_or_else(|| filename.to_string());
-            let dest = extract_dir.join(&url_filename);
+            // A direct pkg download may have an opaque URL path while the response's
+            // Content-Disposition and the cask artifact supply its real name. Stage
+            // XAR installers under the declared artifact name; other raw downloads
+            // are executable binaries and retain the original URL filename.
+            let (stage_filename, executable) = raw_cask_artifact_name(cask, archive, filename)?;
+            let dest = extract_dir.join(stage_filename);
             file::copy(archive, &dest)?;
-            file::make_executable(&dest)?;
+            if executable {
+                file::make_executable(&dest)?;
+            }
         } else if !format.is_archive() {
             bail!(
                 "brew-cask:{}: unsupported archive type for {}",
@@ -1226,6 +1230,26 @@ fn detect_extraction_format(archive: &Path) -> Result<Option<ExtractionFormat>> 
         return Ok(Some(ExtractionFormat::Zip));
     }
     Ok(None)
+}
+
+fn raw_cask_artifact_name(cask: &Cask, archive: &Path, fallback: &str) -> Result<(String, bool)> {
+    let mut magic = [0; 4];
+    let len = std::fs::File::open(archive)?.read(&mut magic)?;
+    if magic[..len].starts_with(b"xar!") {
+        let pkgs = cask_artifacts(cask)?.pkgs;
+        if let [pkg] = pkgs.as_slice() {
+            let mut components = Path::new(&pkg.source).components();
+            if matches!(components.next(), Some(Component::Normal(_)))
+                && components.next().is_none()
+            {
+                return Ok((pkg.source.clone(), false));
+            }
+        }
+    }
+    Ok((
+        archive_filename(&cask.url).unwrap_or_else(|| fallback.to_string()),
+        true,
+    ))
 }
 
 fn install_app(
@@ -10978,6 +11002,40 @@ end
         assert_eq!(
             cask_extraction_format(&archive, "claude-1.0.0-claude")?,
             ExtractionFormat::Raw
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn stages_bare_pkg_using_declared_artifact_name() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let archive = tmp.path().join("2026.7.1343.0");
+        std::fs::write(&archive, b"xar!bare pkg")?;
+        let mut cask = test_cask("cloudflare-warp", "2026.7.1343.0");
+        cask.url = "https://example.com/version/2026.7.1343.0".to_string();
+        cask.artifacts = vec![
+            serde_json::json!({"pkg": ["Cloudflare_WARP_2026.7.1343.0.pkg"]}),
+            serde_json::json!({"uninstall": [{"pkgutil": "com.cloudflare.warp"}]}),
+        ];
+
+        assert_eq!(
+            raw_cask_artifact_name(&cask, &archive, "cached-name")?,
+            ("Cloudflare_WARP_2026.7.1343.0.pkg".to_string(), false)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn raw_executable_keeps_url_filename() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let archive = tmp.path().join("cached-name");
+        std::fs::write(&archive, b"#!/bin/sh\n")?;
+        let mut cask = test_cask("claude", "1.0.0");
+        cask.url = "https://example.com/claude".to_string();
+
+        assert_eq!(
+            raw_cask_artifact_name(&cask, &archive, "cached-name")?,
+            ("claude".to_string(), true)
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary
- detect direct XAR/pkg cask payloads instead of treating them as raw executables
- stage a single direct pkg under the artifact name declared by Homebrew metadata
- preserve the existing raw-executable behavior for non-pkg downloads

Fixes the failure reported in discussion #12367 for `cloudflare-warp`, whose download URL has an opaque basename while the cask declares `Cloudflare_WARP_2026.7.1343.0.pkg`.

## Testing
- `cargo test --locked --bin mise system::packages::brew::cask::tests`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow brew-cask extraction naming change with tests; no auth or security-sensitive paths.
> 
> **Overview**
> Fixes Homebrew cask installs for **direct XAR/pkg downloads** whose URL basename does not match the declared `.pkg` artifact (e.g. `cloudflare-warp`).
> 
> When a raw payload starts with `xar!` and the cask has a single simple `pkg` artifact, it is staged under that artifact name and **not** marked executable. Other raw downloads still use the URL filename and remain treated as binaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c08b515044192b32fe674cb679fb4724548324a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of direct package downloads during installation.
  - Package installers now use the correct declared filename instead of an opaque download URL.
  - Non-package downloads continue to be staged as executable files using an appropriate fallback filename.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->