### PR TITLE
fix(trust): refuse a path that does not exist instead of trusting its parent

### DIFF
--- a/e2e/cli/test_trust_missing_path
+++ b/e2e/cli/test_trust_missing_path
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# `mise trust <path>` does not record trust against the path as typed: it resolves it to a trust
+# root first, and that resolution is purely lexical -- `config_root` counts path components and
+# never looks at the filesystem. A path that does not exist therefore resolved to its *parent*,
+# which mise then trusted, reported as success, and exited 0 for. `mise untrust` did the same in
+# reverse. A typo granted (or revoked) trust for a directory the user never named.
+
+# The test harness pre-trusts the test dir via MISE_TRUSTED_CONFIG_PATHS; clear it so the configs
+# below actually start out untrusted.
+export MISE_TRUSTED_CONFIG_PATHS=""
+
+mkdir -p outer/inner
+cat <<EOF >mise.toml
+[env]
+ROOT = "1"
+EOF
+cat <<EOF >outer/inner/mise.toml
+[env]
+INNER = "1"
+EOF
+
+# Control: the directory that used to be trusted by accident starts out untrusted, so the
+# assertion at the end is about the failed command rather than about a directory that was never
+# trusted in the first place.
+assert_contains "cd outer/inner && mise trust --show" "outer/inner: untrusted"
+
+# All four routes go through one resolver, so all four are pinned: `mise trust`, its `--ignore`
+# and `--untrust` flags, and the separate `mise untrust` command.
+assert_fail_contains "mise trust $PWD/outer/inner/nope" "Path does not exist"
+assert_fail_contains "mise trust --ignore $PWD/outer/inner/nope" "Path does not exist"
+assert_fail_contains "mise trust --untrust $PWD/outer/inner/nope" "Path does not exist"
+assert_fail_contains "mise untrust $PWD/outer/inner/nope" "Path does not exist"
+
+# The error names the path it was given, not just the failure. The old message on the half of this
+# that did fail was the bare OS error, which named nothing at all.
+assert_fail_contains "mise trust $PWD/outer/inner/nope" "nope"
+
+# This is the point of the change: the failed command trusted nothing. Without it the test would
+# only pin that a typo errors, not that it stopped trusting the parent.
+assert_contains "cd outer/inner && mise trust --show" "outer/inner: untrusted"
+
+# Control: a path that exists still resolves and still works, so the check is about existence.
+assert_contains "mise trust $PWD/outer/inner/mise.toml 2>&1" "trusted"
+assert_contains "cd outer/inner && mise trust --show" "outer/inner: trusted"
+
+# Control: a directory with no config file in it yet is still trustable. Trust roots are
+# directories, so this is the case that stops "the path must exist" from becoming "the config file
+# must exist".
+mkdir -p empty-project
+assert_contains "mise trust $PWD/empty-project 2>&1" "trusted"

--- a/src/cli/trust.rs
+++ b/src/cli/trust.rs
@@ -8,7 +8,7 @@ use crate::config::{
 };
 use crate::file::{display_path, remove_file};
 use crate::{config, dirs, env, file};
-use eyre::Result;
+use eyre::{Result, bail};
 use itertools::Itertools;
 
 /// Marks a config file as trusted
@@ -65,7 +65,7 @@ impl Trust {
             return self.show();
         }
         if self.untrust {
-            untrust_config_file(self.config_file())
+            untrust_config_file(self.config_file()?)
         } else if self.ignore {
             self.ignore()
         } else if self.all {
@@ -141,22 +141,42 @@ pub(super) fn untrust_config_file(config_file: Option<PathBuf>) -> Result<()> {
     Ok(())
 }
 
-pub(super) fn resolve_config_file(config_file: Option<&PathBuf>) -> Option<PathBuf> {
-    config_file.map(|config_file| {
-        if config_file.is_dir() {
-            config_files_in_dir(config_file)
-                .last()
-                .cloned()
-                .unwrap_or(config_file.join(&*env::MISE_DEFAULT_CONFIG_FILENAME))
-        } else {
-            config_file.clone()
-        }
-    })
+/// The config file a user-supplied path refers to, or `None` when none was given.
+///
+/// The path has to exist. Trusting is not done against the path as typed: it is resolved to a
+/// trust root first, and `config_root` does that by counting path components, never by looking at
+/// the filesystem. A path that is not there therefore used to resolve to its *parent*, and mise
+/// would trust or untrust that instead — exit 0, `trusted <parent>`, and a typo silently granting
+/// trust to a directory nobody named.
+///
+/// Existence is the whole check. A directory with no config file in it yet still resolves, since
+/// its trust root is the directory itself and trusting a project before writing its `mise.toml`
+/// is a real thing to want.
+pub(super) fn resolve_config_file(config_file: Option<&PathBuf>) -> Result<Option<PathBuf>> {
+    let Some(config_file) = config_file else {
+        return Ok(None);
+    };
+    if !config_file.exists() {
+        bail!(
+            "Path does not exist: {}\n\
+             mise resolves this to a trust root before recording anything, and that resolution is \
+             lexical — a path that is not there would act on its parent directory instead.",
+            display_path(config_file)
+        );
+    }
+    Ok(Some(if config_file.is_dir() {
+        config_files_in_dir(config_file)
+            .last()
+            .cloned()
+            .unwrap_or(config_file.join(&*env::MISE_DEFAULT_CONFIG_FILENAME))
+    } else {
+        config_file.clone()
+    }))
 }
 
 impl Trust {
     fn ignore(&self) -> Result<()> {
-        let path = match self.config_file() {
+        let path = match self.config_file()? {
             Some(filename) => filename,
             None => match self.get_next() {
                 Some(path) => path,
@@ -183,7 +203,7 @@ impl Trust {
         Ok(())
     }
     fn trust(&self) -> Result<()> {
-        let path = match self.config_file() {
+        let path = match self.config_file()? {
             Some(filename) => config_trust_root(&filename),
             None => match self.get_next_untrusted() {
                 Some(path) => path,
@@ -199,7 +219,7 @@ impl Trust {
         Ok(())
     }
 
-    fn config_file(&self) -> Option<PathBuf> {
+    fn config_file(&self) -> Result<Option<PathBuf>> {
         resolve_config_file(self.config_file.as_ref())
     }
 
@@ -320,3 +340,50 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     $ <bold>mise trust</bold>
 "#
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_path_that_does_not_exist_is_refused_and_named() {
+        let dir = tempfile::tempdir().unwrap();
+        let existing = dir.path().join("mise.toml");
+        std::fs::write(&existing, "").unwrap();
+
+        // Control: the same call resolves rather than erroring when the path is there, so the
+        // assertion below is about existence and not about a function that always fails.
+        assert_eq!(
+            resolve_config_file(Some(&existing)).unwrap(),
+            Some(existing.clone())
+        );
+
+        let missing = dir.path().join("nope");
+        let err = resolve_config_file(Some(&missing)).unwrap_err().to_string();
+        // The path is the whole point of the message: what used to happen instead was that this
+        // resolved to `dir` and mise trusted that, reporting success.
+        assert!(
+            err.contains("nope"),
+            "the message has to name the path: {err}"
+        );
+    }
+
+    #[test]
+    fn a_directory_with_no_config_in_it_yet_still_resolves() {
+        // The case the existence check must not break. Trusting a project before its `mise.toml`
+        // exists is a real thing to want, and it works because the trust root is the directory —
+        // which is exactly why "the path must exist" cannot be tightened to "the file must exist".
+        let dir = tempfile::tempdir().unwrap();
+        let resolved = resolve_config_file(Some(&dir.path().to_path_buf()))
+            .unwrap()
+            .unwrap();
+        assert_eq!(resolved.parent(), Some(dir.path()));
+    }
+
+    #[test]
+    fn no_argument_is_still_no_argument() {
+        // `mise trust` with no path falls back to config discovery further up; this must stay a
+        // `None` rather than becoming an error.
+        assert_eq!(resolve_config_file(None).unwrap(), None);
+    }
+}

--- a/src/cli/untrust.rs
+++ b/src/cli/untrust.rs
@@ -15,10 +15,10 @@ pub(crate) struct Untrust {
 
 impl Untrust {
     pub(crate) fn run(self) -> Result<()> {
-        trust::untrust_config_file(self.config_file())
+        trust::untrust_config_file(self.config_file()?)
     }
 
-    fn config_file(&self) -> Option<PathBuf> {
+    fn config_file(&self) -> Result<Option<PathBuf>> {
         trust::resolve_config_file(self.config_file.as_ref())
     }
 }


### PR DESCRIPTION
`mise trust <path>` does not record trust against the path as typed. It resolves the path to a
trust root first, and that resolution is **purely lexical** — `config_root`
(`src/config/config_file/config_root.rs`) counts path components and never touches the filesystem.
Nothing else checks the path either: `resolve_config_file` only asks `is_dir()`, which is `false`
for a path that is not there and returns it unchanged.

So a path that does not exist resolves to its **parent**, and mise trusts that instead — and says
it did, and exits 0.

## Measured

Windows 11, mise 2026.8.12, `MISE_STATE_DIR` pointed at a scratch directory:

| command | rc | output |
|---|---|---|
| `mise trust <sp>\mise.toml` *(control)* | 0 | `trusted ...\probe14` |
| `mise trust <sp>\outer\inner\nope` | **0** | **`trusted ...\outer\inner`** |
| `mise trust <sp>\nope\mise.toml` | 1 | `mise ERROR 指定されたファイルが見つかりません。 (os error 2)` |
| `mise trust --ignore <sp>\nope\mise.toml` | 1 | same |
| `mise untrust <sp>\nope\mise.toml` | 1 | same |

Row 2 is the one that matters. The trust store afterwards contained a real entry —
`trusted-configs\outer-inner-3c04af8520dd05dc` — for a directory that was never named on the
command line. **`mise trust ~/work/projet`** (one letter short) **trusts `~/work` and reports
success.**

`untrust` is the same defect in reverse, measured separately:

```
$ mise trust                     # in outer/inner
mise trusted .../outer/inner
$ mise trust --show
.../outer/inner: trusted

$ mise untrust .../outer/inner/nope
mise untrusted .../outer/inner          # rc=0
$ mise trust --show
.../outer/inner: untrusted              # the entry really was removed
```

Rows 3–5 are the same root cause from the other side: when the *parent* does not exist either, the
bare `canonicalize()?` inside `rm_ignored`/`add_ignored` fails, and the error names neither the
path nor the operation. On Windows the OS string is localized, so there is not even something to
search for.

Trust is a security boundary. Granting it to a directory the user did not name, silently, on a
typo, is the wrong direction for that boundary to fail in.

## The change

`resolve_config_file` is the single funnel every user-supplied path goes through — `mise trust`,
its `--ignore` and `--untrust` flags, and the separate `mise untrust` command are four call sites
on one function. The check goes there:

```rust
if !config_file.exists() {
    bail!(
        "Path does not exist: {}\n\
         mise resolves this to a trust root before recording anything, and that resolution is \
         lexical — a path that is not there would act on its parent directory instead.",
        display_path(config_file)
    );
}
```

Same shape as `validate_cd_path` from #12314: check what the user named, and name it back.

**Existence is the whole check** — a directory is as valid as a file. That is deliberate, and the
case it protects is trusting a project *before* writing its `mise.toml`: the trust root is the
directory either way, so tightening this to "the config file must exist" would break a real
workflow. There is a test for it.

### One behaviour change

**A path that does not exist now exits 1 where it used to exit 0** (row 2). Worth stating plainly
rather than filing under "better error message". The previous zero was reporting success for an
action the user had not asked for.

`--all` and the no-argument forms are unaffected: their paths come from config discovery and exist
by construction.

### Left out on purpose

- `hashed_path_filename` (`src/config/config_file/mod.rs`) does `path.canonicalize().unwrap()`. With
  this check in place it is reachable only if the path disappears between the check and the hash,
  but it is still an `unwrap` on a filesystem call. Making it fallible ripples through
  `trust_path`/`ignore_path` and their callers, so it wants its own PR rather than a widened diff
  here.
- The five bare `canonicalize()?` sites are in the same position — reachable only via that race
  now. Untouched.
- `mise trust README.md` trusting the containing directory is unchanged. That is the same rule as
  `mise trust foo/mise.toml` trusting `foo`, and it is a separate judgement from existence.

## Tests

**Unit** (`src/cli/trust.rs`) — three, on the resolver:

- a missing path is refused and the message names it, with a **control** asserting the same call
  resolves when the path exists (otherwise a function that always failed would pass);
- a directory with no config file in it still resolves — the case the check must not break;
- no argument is still `Ok(None)`, so discovery still takes over.

**e2e** (`e2e/cli/test_trust_missing_path`) — pins all four routes, and then the part that
actually matters:

```bash
assert_contains "cd outer/inner && mise trust --show" "outer/inner: untrusted"   # control, before
assert_fail_contains "mise trust $PWD/outer/inner/nope" "Path does not exist"
...
assert_contains "cd outer/inner && mise trust --show" "outer/inner: untrusted"   # nothing trusted
```

Asserting only that a typo now errors would pin rows 3–5 and miss row 2 entirely. The second
`--show` is what says the failed command trusted nothing. It closes with two controls: a path that
exists still works, and an empty directory is still trustable.

`MISE_TRUSTED_CONFIG_PATHS` is cleared first, the way `e2e/cli/test_trust_all` does, because the
harness pre-trusts the test directory.

## Verification

`cargo fmt --all`, `shellcheck -x` and `shfmt -l -s` are clean. **Nothing was compiled or run
locally** — `cargo check` needs `cmake` for `libz-ng-sys`, which is not installed on this machine —
so CI is the first thing to type-check it. Every measurement above was taken with the released
2026.8.12 binary before the change; none of them is a prediction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trust, untrust, and ignore commands now clearly reject nonexistent paths.
  * Prevented commands from accidentally trusting a nonexistent path’s parent directory.
  * Improved error reporting for invalid path inputs.
  * Confirmed trust operations continue to work for existing configuration files and directories without configuration files.
* **Tests**
  * Added end-to-end coverage for missing paths, existing directories, and trust-state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->