### PR TITLE
fix(cli): default to an editor Windows has, and name the one that failed

### DIFF
--- a/e2e/cli/test_tasks_edit_editor
+++ b/e2e/cli/test_tasks_edit_editor
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# `mise tasks edit` launches $VISUAL/$EDITOR, falling back to a default. When that program cannot
+# be started the failure used to be std's bare `program not found`, which names neither the
+# program mise tried to run nor the variables that choose it. On Windows that was the whole of
+# what the command printed, because the default was `nano` and Windows ships no `nano`.
+
+cat <<EOF >mise.toml
+[env]
+E = "1"
+EOF
+
+# Control: an editor that can be started still works, and the task file is created for it. Without
+# this the assertions below would pass just as well on a command that was broken outright.
+assert "EDITOR=true mise tasks edit demo"
+assert "test -f mise-tasks/demo"
+
+# The failure names the program...
+assert_fail_contains "EDITOR=$PWD/no-such-editor mise tasks edit demo" "no-such-editor"
+# ...and the variables that would fix it.
+assert_fail_contains "EDITOR=$PWD/no-such-editor mise tasks edit demo" "EDITOR"
+assert_fail_contains "EDITOR=$PWD/no-such-editor mise tasks edit demo" "VISUAL"
+
+# VISUAL wins over EDITOR, so a broken VISUAL is what gets reported even when EDITOR is fine.
+assert_fail_contains "VISUAL=$PWD/no-such-visual EDITOR=true mise tasks edit demo" "no-such-visual"

--- a/src/cli/dotfiles/edit.rs
+++ b/src/cli/dotfiles/edit.rs
@@ -46,7 +46,7 @@ impl DotfilesEdit {
 
         if let Some(path) = source_for_target(&config, &target, &self.target)? {
             open_or_create(&path)?;
-            super::open_in_editor(&path)?;
+            crate::cli::editor::open_in_editor(&path)?;
             if self.apply {
                 apply_target(&self.target).await?;
             }
@@ -83,7 +83,7 @@ impl DotfilesEdit {
             bail!("failed to add {}", self.target);
         };
         open_or_create(&path)?;
-        super::open_in_editor(&path)?;
+        crate::cli::editor::open_in_editor(&path)?;
         if self.apply {
             apply_target(&self.target).await?;
         }

--- a/src/cli/dotfiles/mod.rs
+++ b/src/cli/dotfiles/mod.rs
@@ -1,4 +1,4 @@
-use eyre::{Result, eyre};
+use eyre::Result;
 use std::path::Path;
 
 mod add;
@@ -89,21 +89,4 @@ pub(crate) fn warn_if_dotfiles_ignored() {
             .collect::<Vec<_>>()
             .join("\n")
     );
-}
-
-fn open_in_editor(file: &Path) -> Result<()> {
-    let (program, mut args) = split_editor_command(&crate::env::EDITOR)?;
-    args.push(file.as_os_str().into());
-    crate::cmd::cmd(&program, args).run()?;
-    Ok(())
-}
-
-fn split_editor_command(editor: &str) -> Result<(String, Vec<std::ffi::OsString>)> {
-    let mut parts = shell_words::split(editor)
-        .map_err(|e| eyre!("failed to parse EDITOR/VISUAL value {:?}: {}", editor, e))?
-        .into_iter();
-    let program = parts
-        .next()
-        .ok_or_else(|| eyre!("EDITOR/VISUAL is empty"))?;
-    Ok((program, parts.map(Into::into).collect()))
 }

--- a/src/cli/editor.rs
+++ b/src/cli/editor.rs
@@ -1,0 +1,96 @@
+use eyre::{Result, bail, eyre};
+use std::ffi::OsString;
+use std::path::Path;
+
+/// Open `file` in the user's editor and wait for it to exit.
+///
+/// The wait is part of the contract, not an accident of blocking IO: `mise dotfiles edit --apply`
+/// converges the target as soon as this returns, so an editor that detached would apply a file the
+/// user had not saved yet.
+pub(super) fn open_in_editor(file: &Path) -> Result<()> {
+    open_in_editor_with(&crate::env::EDITOR, file)
+}
+
+/// Takes the editor rather than reading it, so the failure path can be driven from a test.
+fn open_in_editor_with(editor: &str, file: &Path) -> Result<()> {
+    let (program, mut args) = split_editor_command(editor)?;
+    args.push(file.as_os_str().into());
+    if let Err(err) = crate::cmd::cmd(&program, args).run() {
+        // Name the program and the variables that choose it. A child that never starts comes back
+        // as std's bare "program not found" (see the note in `backend::which_spawnable`), which
+        // says neither what mise tried to run nor where the name came from — and the default is
+        // the name most likely to be missing.
+        bail!(
+            "failed to open the editor `{program}`: {err}\n\
+             Set $EDITOR or $VISUAL to an editor mise can run."
+        );
+    }
+    Ok(())
+}
+
+fn split_editor_command(editor: &str) -> Result<(String, Vec<OsString>)> {
+    let mut parts = shell_words::split(editor)
+        .map_err(|e| eyre!("failed to parse EDITOR/VISUAL value {:?}: {}", editor, e))?
+        .into_iter();
+    let program = parts
+        .next()
+        .ok_or_else(|| eyre!("EDITOR/VISUAL is empty"))?;
+
+    Ok((program, parts.map(Into::into).collect()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_editor_with_arguments() {
+        let (program, args) = split_editor_command("cat -n").unwrap();
+
+        assert_eq!(program, "cat");
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].as_os_str(), std::ffi::OsStr::new("-n"));
+    }
+
+    #[test]
+    fn parses_editor_with_quoted_path() {
+        let (program, args) =
+            split_editor_command(r#""/Applications/My Editor.app/editor" --wait"#).unwrap();
+
+        assert_eq!(program, "/Applications/My Editor.app/editor");
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0], "--wait");
+    }
+
+    #[test]
+    fn errors_on_empty_editor() {
+        assert!(split_editor_command("").is_err());
+    }
+
+    /// The failure this exists for: an editor that cannot be started. The bare error is std's
+    /// `program not found`, which names nothing — on Windows with neither variable set that is
+    /// the whole of what `mise tasks edit` used to print.
+    #[test]
+    fn an_editor_that_cannot_start_is_named_along_with_the_variables_that_choose_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("task");
+        std::fs::write(&file, "").unwrap();
+        let missing = dir.path().join("editor-that-is-not-there");
+
+        // Control: the spawn really does fail. Without it this test would pass just as well on an
+        // editor that started, and prove nothing about the message.
+        assert!(crate::cmd::cmd(&missing, [file.as_os_str()]).run().is_err());
+
+        let err = open_in_editor_with(&missing.to_string_lossy(), &file)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("editor-that-is-not-there"),
+            "the message has to name the program: {err}"
+        );
+        assert!(
+            err.contains("EDITOR") && err.contains("VISUAL"),
+            "and the variables that would fix it: {err}"
+        );
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -37,6 +37,7 @@ pub(crate) use hook_env::HookReason;
 mod command_effects;
 mod deps;
 pub(crate) mod edit;
+mod editor;
 mod implode;
 mod install;
 mod install_into;

--- a/src/cli/tasks/edit.rs
+++ b/src/cli/tasks/edit.rs
@@ -1,7 +1,7 @@
 use crate::config::Config;
 use crate::task::Task;
-use crate::{dirs, env, file};
-use eyre::{Result, eyre};
+use crate::{dirs, file};
+use eyre::Result;
 use indoc::formatdoc;
 use std::path::MAIN_SEPARATOR_STR;
 
@@ -44,30 +44,11 @@ impl TasksEdit {
         if self.path {
             miseprintln!("{}", file.display());
         } else {
-            open_in_editor(file.as_path())?;
+            crate::cli::editor::open_in_editor(file.as_path())?;
         }
 
         Ok(())
     }
-}
-
-fn open_in_editor(file: &std::path::Path) -> Result<()> {
-    let (program, mut args) = split_editor_command(&env::EDITOR)?;
-    args.push(file.as_os_str().into());
-
-    crate::cmd::cmd(&program, args).run()?;
-    Ok(())
-}
-
-fn split_editor_command(editor: &str) -> Result<(String, Vec<std::ffi::OsString>)> {
-    let mut parts = shell_words::split(editor)
-        .map_err(|e| eyre!("failed to parse EDITOR/VISUAL value {:?}: {}", editor, e))?
-        .into_iter();
-    let program = parts
-        .next()
-        .ok_or_else(|| eyre!("EDITOR/VISUAL is empty"))?;
-
-    Ok((program, parts.map(Into::into).collect()))
 }
 
 fn default_task() -> String {
@@ -86,32 +67,3 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     $ <bold>mise tasks edit test</bold>
 "#
 );
-
-#[cfg(test)]
-mod tests {
-    use super::split_editor_command;
-
-    #[test]
-    fn parses_editor_with_arguments() {
-        let (program, args) = split_editor_command("cat -n").unwrap();
-
-        assert_eq!(program, "cat");
-        assert_eq!(args.len(), 1);
-        assert_eq!(args[0].as_os_str(), std::ffi::OsStr::new("-n"));
-    }
-
-    #[test]
-    fn parses_editor_with_quoted_path() {
-        let (program, args) =
-            split_editor_command(r#""/Applications/My Editor.app/editor" --wait"#).unwrap();
-
-        assert_eq!(program, "/Applications/My Editor.app/editor");
-        assert_eq!(args.len(), 1);
-        assert_eq!(args[0], "--wait");
-    }
-
-    #[test]
-    fn errors_on_empty_editor() {
-        assert!(split_editor_command("").is_err());
-    }
-}

--- a/src/env.rs
+++ b/src/env.rs
@@ -80,8 +80,27 @@ pub(crate) static HOME: Lazy<PathBuf> = Lazy::new(|| {
         .unwrap_or_else(|| PathBuf::from("/"))
 });
 
-pub(crate) static EDITOR: Lazy<String> =
-    Lazy::new(|| var("VISUAL").unwrap_or_else(|_| var("EDITOR").unwrap_or_else(|_| "nano".into())));
+pub(crate) static EDITOR: Lazy<String> = Lazy::new(|| {
+    var("VISUAL")
+        .or_else(|_| var("EDITOR"))
+        .unwrap_or_else(|_| DEFAULT_EDITOR.to_string())
+});
+
+/// The editor to fall back on when neither `VISUAL` nor `EDITOR` is set.
+///
+/// `nano` everywhere but Windows, which ships none of it — not `nano`, `vi`, `vim`, or anything
+/// else POSIX — so the shared default left `mise tasks edit` there with nothing to run at all.
+/// `notepad` is the one editor Windows can be relied on to have.
+///
+/// It also has to *wait*, because `mise dotfiles edit --apply` converges the target as soon as the
+/// editor returns. Measured on Windows 11 26200, where `System32\notepad.exe` no longer exists and
+/// `notepad` resolves to a zero-byte app-execution alias under `WindowsApps`: spawned the way
+/// `Command::status` does it, the parent was still waiting five seconds later, so the alias hands
+/// back the real process rather than detaching from it.
+#[cfg(windows)]
+const DEFAULT_EDITOR: &str = "notepad";
+#[cfg(not(windows))]
+const DEFAULT_EDITOR: &str = "nano";
 
 #[cfg(macos)]
 pub(crate) static XDG_CACHE_HOME: Lazy<PathBuf> =


### PR DESCRIPTION
`mise tasks edit` and `mise dotfiles edit` launch `$VISUAL`, then `$EDITOR`, then fall back to
`nano`. Windows ships no `nano`, so on Windows the fallback is a program that does not exist — and
when it fails, the error names nothing at all:

```
> mise task edit hello
mise ERROR program not found
```

Measured on Windows 11 26200 (mise 2026.8.12): with neither variable set that is the entire output.
`vi`, `vim`, `nano` and `code` are **none of them** on PATH there; the only editors this machine
has are `notepad` and the new `System32\edit.exe`.

`program not found` is std's own wording for a Windows spawn whose PATH lookup fails — the repo
already records this, in `src/backend/mod.rs`: *"std only ever appends `.exe` to a bare name and
then reports \"program not found\""*. It carries no program name, so nothing downstream can
recover one. duct passes it through untouched.

## The change

**A default Windows actually has.** `notepad`, gated to Windows; `nano` stays everywhere else.

**The error names what failed and what to set:**

```
mise ERROR failed to open the editor `nano`: program not found
Set $EDITOR or $VISUAL to an editor mise can run.
```

## Why `notepad`, and the measurement that nearly stopped it

The editor has to **block**. `mise dotfiles edit --apply` (`src/cli/dotfiles/edit.rs`) calls
`open_in_editor()` and then `apply_target()` on the next line — an editor that detached would apply
a file the user had not saved yet.

That is not obviously true of `notepad` any more. On this machine:

- `System32\notepad.exe` **does not exist**;
- `notepad` on PATH resolves to `%LOCALAPPDATA%\Microsoft\WindowsApps\notepad.exe`, a **zero-byte
  reparse point** — an app-execution alias for the packaged Notepad.

So it was measured rather than assumed. Spawned the way `Command::status()` does it
(`UseShellExecute = false`, then wait on the returned handle):

```
started pid=13552
WaitForExit(5s) returned: exited=False after 5291 ms
notepad processes now: 2
VERDICT: the spawned process is STILL RUNNING -> the parent waits on the real editor
```

The alias hands back the real process rather than detaching from it, so the wait `dotfiles edit
--apply` depends on still holds. Had it detached, this PR would have shipped the error message
alone.

**The Unix default is unchanged.** `nano` is missing on plenty of minimal Linux images too, but
that is not something I measured, and the error above now says so clearly wherever it happens.

## One copy of the launcher

`open_in_editor` and `split_editor_command` existed **verbatim in two files** —
`src/cli/tasks/edit.rs` and `src/cli/dotfiles/mod.rs` — identical apart from whitespace and
`env::` vs `crate::env::`. The fix lands squarely in the duplicated code, so it moves to one
`src/cli/editor.rs` rather than being written twice. The three existing `split_editor_command`
tests move with it.

## Tests

**Unit** (`src/cli/editor.rs`) — the three moved parser tests, plus one for the failure: an editor
path that cannot be started is named in the message along with both variables. It opens with a
**control** asserting that the raw `cmd(...).run()` for that path really does fail — without it the
test would pass just as well on an editor that started, and prove nothing about the message.

The seam that makes it testable is `open_in_editor_with(editor, file)`, which takes the editor
instead of reading `env::EDITOR`; the public entry point is a one-line wrapper. No process
environment is mutated by the test.

**e2e** (`e2e/cli/test_tasks_edit_editor`) — the harness already sets `MISE_EXPERIMENTAL=1`, so
`mise tasks edit` runs. A control first (`EDITOR=true` succeeds and the task file is created),
then the program name, both variable names, and that `VISUAL` outranks `EDITOR` when reporting.

## Verification

`cargo fmt --all`, `shellcheck -x` and `shfmt -l -s` are clean. **Nothing was compiled or run
locally** — `cargo check` needs `cmake` for `libz-ng-sys`, which is not installed on this machine —
so CI is the first thing to type-check it. The bash e2e does not run on Windows, so the Windows
default itself rests on the unit test and the measurement above rather than on CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved editor selection for task and dotfile editing, including support for commands with arguments.
  * Added platform-specific default editors: Notepad on Windows and Nano on other platforms.
  * VISUAL continues to take precedence over EDITOR.

* **Bug Fixes**
  * Added clearer error messages when an editor cannot be started, parsed, or configured.
  * Editor commands now correctly wait for completion and handle quoted paths.
  * Task editing now reports which editor configuration variables are being used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->