### PR TITLE
fix(completion): restore dynamic completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4264,7 +4264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a791e6620676a875f362f3156ed213e73ca099a09bf992c18812abe65cc37b1"
 dependencies = [
  "bstr",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -6424,6 +6424,7 @@ dependencies = [
  "ubi",
  "url",
  "urlencoding",
+ "usage-cli",
  "usage-lib",
  "usage-rs",
  "versions",
@@ -7250,7 +7251,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "argon2",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitfields",
  "block-padding",
  "blowfish",
@@ -9533,7 +9534,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.2.8",
+ "errno 0.3.14",
  "libc",
 ]
 
@@ -11055,6 +11056,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "857c0a155957d220665b2257ac7c58e168476ff7de09286940055ff78f622fb0"
 
 [[package]]
+name = "usage-cli"
+version = "6.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f327bbf6a72a7ce13a8a9158f4fc6c1d8a99b9b7cb53feb5f5caca810092787"
+dependencies = [
+ "env_logger",
+ "exec",
+ "indexmap 2.14.0",
+ "itertools 0.15.0",
+ "kdl",
+ "log",
+ "miette",
+ "regex",
+ "rmcp",
+ "schemars 1.2.2",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "shell-words",
+ "tera 2.1.1",
+ "thiserror 2.0.20",
+ "tokio",
+ "usage-lib",
+ "usage-rs",
+]
+
+[[package]]
 name = "usage-derive"
 version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11085,6 +11113,7 @@ dependencies = [
  "strum 0.28.0",
  "tera 2.1.1",
  "thiserror 2.0.20",
+ "usage-validation",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ usage_rs = { package = "usage-rs", version = "6", features = [
   "diagnostics",
   "validation",
 ] }
+usage-cli = "6"
 color-eyre = "0.6"
 color-print = "0.3"
 comfy-table = "8"

--- a/e2e/cli/test_completion_dynamic
+++ b/e2e/cli/test_completion_dynamic
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+cat >mise.toml <<'EOF'
+[tasks.test]
+description = "Run the test task"
+usage = '''
+flag "--environment <name>" {
+  choices "dev" "production"
+}
+'''
+run = 'echo works'
+EOF
+
+fish_tasks="$(mise __complete_word__ --shell fish --line 'mise run ')"
+assert_contains_text "$fish_tasks" $'test\tRun the test task'
+assert_not_contains_text "$fish_tasks" $'\001files'
+
+zsh_tasks="$(mise __complete_word__ --shell zsh --line 'mise run ')"
+assert_contains_text "$zsh_tasks" $'test\tRun the test task\ttest'
+assert_not_contains_text "$zsh_tasks" $'\001files'
+
+naked_tasks="$(mise __complete_word__ --shell fish --line 'mise te')"
+assert_contains_text "$naked_tasks" $'test\tRun the test task'
+
+task_flags="$(mise __complete_word__ --shell fish --line 'mise run test --')"
+assert_contains_text "$task_flags" '--environment'
+assert_not_contains_text "$task_flags" '--silent'
+
+task_values="$(mise __complete_word__ --shell fish --line 'mise run test --environment ')"
+assert_contains_text "$task_values" 'dev'
+assert_contains_text "$task_values" 'production'
+assert_not_contains_text "$task_values" $'\001files'
+
+tools="$(mise __complete_word__ --shell fish --line 'mise install actionl')"
+assert_contains_text "$tools" 'actionlint@'
+assert_not_contains_text "$tools" $'\001files'

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -1,6 +1,50 @@
 use crate::cli::Cli;
 use eyre::Result;
+use std::ffi::OsString;
 use strum::EnumString;
+
+/// Answer mise's hidden completion protocol with its runtime completion metadata.
+///
+/// The tables compiled by usage-rs cover static commands, flags, choices, and path hints. mise
+/// also augments those tables at runtime with `run=` completers and task commands mounted from
+/// `mise tasks --usage`; those only exist in [`super::usage::completion_spec`]. Try that richer
+/// spec first, then leave static and path completion to usage-rs so the shell retains its native
+/// path handling.
+pub(crate) fn completion_request(argv: &[OsString]) -> Option<String> {
+    let request = usage_rs::complete::CompletionRequest::parse(argv)?;
+    if request.candidates_for.is_some() {
+        return Cli::completion_request(argv);
+    }
+
+    let spec = super::usage::completion_spec();
+    let answer = usage_cli::complete_answer(
+        &spec,
+        &request.split.words,
+        request.split.cword,
+        request.shell.as_str(),
+    );
+    match answer {
+        Ok(answer) if !answer.files => {
+            let candidates = answer
+                .candidates
+                .into_iter()
+                .map(|(value, description)| {
+                    if description.is_empty() {
+                        usage_rs::complete::Candidate::new(value)
+                    } else {
+                        usage_rs::complete::Candidate::described(value, description)
+                    }
+                })
+                .collect();
+            let answer = usage_rs::complete::Completions {
+                candidates,
+                files: None,
+            };
+            Some(usage_rs::complete::render(&answer, request.shell))
+        }
+        _ => Cli::completion_request(argv),
+    }
+}
 
 /// Generate shell completions
 #[derive(Debug, usage_rs::Args)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -772,7 +772,7 @@ impl Cli {
         // Handle the hidden completion protocol here, before config or tools load.
         let completion_argv: Vec<std::ffi::OsString> =
             args.iter().skip(1).map(std::ffi::OsString::from).collect();
-        if let Some(answer) = Cli::completion_request(&completion_argv) {
+        if let Some(answer) = completion::completion_request(&completion_argv) {
             print!("{answer}");
             return Ok(());
         }


### PR DESCRIPTION
## Summary
- complete against mise's augmented usage spec so runtime `run=` completers work again
- restore mounted task names, task-specific flags, and task value choices
- retain usage-rs rendering and native path fallback for the self-contained shell scripts
- add fish and zsh regression coverage for discussion #12374

## Tests
- `mise run test:e2e e2e/cli/test_completion_dynamic`
- `mise run lint-fix`
- `mise run build`
- `cargo check --locked`

Addresses https://github.com/jdx/mise/discussions/12374

*AI-assisted — Tool: Codex; model: unavailable/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the completion protocol path for all shells, so regressions could break tab-complete. File/path fallback is preserved and covered by e2e tests.
> 
> **Overview**
> Restores dynamic shell completions that were lost when the hidden protocol only used usage-rs's static tables.
> 
> Hidden `__complete_word__` requests now try `usage_cli::complete_answer` against `completion_spec()` (mounted tasks, `run=` completers, extra KDL metadata). If that yields non-file candidates, they are rendered with usage-rs; otherwise it falls back to `Cli::completion_request` so native path completion still works.
> 
> Adds fish/zsh e2e coverage for task names, task-specific flags/choices, naked-run tasks, and tool names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc23c9923814fa09c1117bca9d9ff2da7039248b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved dynamic shell completion for Fish and Zsh.
  * Added completion support for task names, command-line flags, flag values, and tool names.
  * File-based completions continue to work where applicable.

* **Bug Fixes**
  * Prevented irrelevant file suggestions from appearing in task completion.
  * Removed the default `--silent` option from completion suggestions when it is not applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->