### PR TITLE
fix(github): skip provenance API calls when lockfile has checksum but no provenance

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -636,11 +636,18 @@ impl Backend for AquaBackend {
             }
         }
 
+        // Snapshot before verify_checksum can generate a new checksum.
+        let lockfile_had_checksum = tv
+            .lock_platforms
+            .get(&self.get_platform_key())
+            .is_some_and(|p| p.checksum.is_some());
+
         // Advance to checksum operation if applicable
         if pkg.checksum.as_ref().is_some_and(|c| c.enabled()) || api_digest.is_some() {
             ctx.pr.next_operation();
         }
-        self.verify(ctx, &mut tv, &pkg, &v, &filename).await?;
+        self.verify(ctx, &mut tv, &pkg, &v, &filename, lockfile_had_checksum)
+            .await?;
 
         // Advance to extraction operation if applicable
         if needs_extraction(format, &pkg.package_type()) {
@@ -2422,6 +2429,7 @@ impl AquaBackend {
         pkg: &AquaPackage,
         v: &str,
         filename: &str,
+        lockfile_has_checksum: bool,
     ) -> Result<()> {
         // Skip provenance verification if the lockfile already has both a checksum and
         // provenance entry for this platform — the artifact integrity is already guaranteed
@@ -2440,10 +2448,6 @@ impl AquaBackend {
             .lock_platforms
             .get(&platform_key)
             .is_some_and(PlatformInfo::has_checksum_and_verified_provenance);
-        let lockfile_has_checksum = tv
-            .lock_platforms
-            .get(&platform_key)
-            .is_some_and(|p| p.checksum.is_some());
         let locked_provenance = tv
             .lock_platforms
             .get(&platform_key)

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -619,12 +619,14 @@ impl Backend for AquaBackend {
         let download_url = select_github_download_url(pkg.private, &url, url_api.as_deref()).await;
         self.download(ctx, &tv, &download_url, &filename).await?;
 
+        // Snapshot before any mutation so verify() knows whether the lockfile
+        // originally contained a checksum (vs. one we just wrote from api_digest).
+        let lockfile_has_checksum = tv
+            .lock_platforms
+            .get(&platform_key)
+            .is_some_and(|p| p.checksum.is_some());
+
         if validated_url.is_none() {
-            // Store the asset URL and digest (if available) in the tool version
-            let lockfile_has_checksum = tv
-                .lock_platforms
-                .get(&platform_key)
-                .is_some_and(|p| p.checksum.is_some());
             let platform_info = tv.lock_platforms.entry(platform_key).or_default();
             platform_info.url = Some(url.clone());
             platform_info.url_api = url_api.clone();
@@ -636,17 +638,11 @@ impl Backend for AquaBackend {
             }
         }
 
-        // Snapshot before verify_checksum can generate a new checksum.
-        let lockfile_had_checksum = tv
-            .lock_platforms
-            .get(&self.get_platform_key())
-            .is_some_and(|p| p.checksum.is_some());
-
         // Advance to checksum operation if applicable
         if pkg.checksum.as_ref().is_some_and(|c| c.enabled()) || api_digest.is_some() {
             ctx.pr.next_operation();
         }
-        self.verify(ctx, &mut tv, &pkg, &v, &filename, lockfile_had_checksum)
+        self.verify(ctx, &mut tv, &pkg, &v, &filename, lockfile_has_checksum)
             .await?;
 
         // Advance to extraction operation if applicable

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -621,10 +621,16 @@ impl Backend for AquaBackend {
 
         if validated_url.is_none() {
             // Store the asset URL and digest (if available) in the tool version
+            let lockfile_has_checksum = tv
+                .lock_platforms
+                .get(&platform_key)
+                .is_some_and(|p| p.checksum.is_some());
             let platform_info = tv.lock_platforms.entry(platform_key).or_default();
             platform_info.url = Some(url.clone());
             platform_info.url_api = url_api.clone();
-            if let Some(digest) = api_digest.clone() {
+            if let Some(digest) = api_digest.clone()
+                && !lockfile_has_checksum
+            {
                 debug!("using GitHub API digest for checksum verification");
                 platform_info.checksum = Some(digest);
             }
@@ -2434,8 +2440,22 @@ impl AquaBackend {
             .lock_platforms
             .get(&platform_key)
             .is_some_and(PlatformInfo::has_checksum_and_verified_provenance);
+        let lockfile_has_checksum = tv
+            .lock_platforms
+            .get(&platform_key)
+            .is_some_and(|p| p.checksum.is_some());
+        let locked_provenance = tv
+            .lock_platforms
+            .get(&platform_key)
+            .and_then(|p| p.provenance.clone());
         if has_lockfile_integrity && !force_verify {
             self.ensure_provenance_setting_enabled(tv, &platform_key)?;
+        } else if !force_verify && locked_provenance.is_none() && lockfile_has_checksum {
+            debug!(
+                "skipping provenance detection for {} \
+                 (lockfile has checksum but no provenance)",
+                tv.style()
+            );
         } else {
             self.verify_provenance(ctx, tv, pkg, v, filename).await?;
         }

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -1386,12 +1386,18 @@ impl UnifiedGitBackend {
 
         // Store the asset URL and digest (if available) in the tool version
         let platform_key = self.get_platform_key();
+        let lockfile_has_checksum = tv
+            .lock_platforms
+            .get(&platform_key)
+            .is_some_and(|p| p.checksum.is_some());
         let platform_info = tv.lock_platforms.entry(platform_key).or_default();
         platform_info.url = Some(asset.url.clone());
         platform_info.url_api = (!asset.url_api.is_empty()).then(|| asset.url_api.clone());
         if let Some(digest) = &asset.digest {
-            debug!("using GitHub API digest for checksum verification");
-            platform_info.checksum = Some(digest.clone());
+            if !lockfile_has_checksum {
+                debug!("using GitHub API digest for checksum verification");
+                platform_info.checksum = Some(digest.clone());
+            }
         }
 
         let url = if asset.url_api.is_empty() {
@@ -1442,10 +1448,6 @@ impl UnifiedGitBackend {
             .lock_platforms
             .get(&platform_key)
             .and_then(|platform| platform.provenance.clone());
-        let lockfile_has_checksum = tv
-            .lock_platforms
-            .get(&platform_key)
-            .is_some_and(|p| p.checksum.is_some());
 
         self.verify_checksum(ctx, tv, &file_path)?;
 
@@ -1517,12 +1519,14 @@ impl UnifiedGitBackend {
             .cloned()
             .unwrap_or_default();
         let lockfile_has_checksum = artifact_info.checksum.is_some();
+        let has_lockfile_integrity = artifact_info.has_checksum_and_verified_provenance();
         artifact_info.url = asset.url.clone();
         artifact_info.url_api = (!asset.url_api.is_empty()).then(|| asset.url_api.clone());
         if let Some(digest) = &asset.digest {
-            artifact_info.checksum = Some(digest.clone());
+            if !lockfile_has_checksum {
+                artifact_info.checksum = Some(digest.clone());
+            }
         }
-        let has_lockfile_integrity = artifact_info.has_checksum_and_verified_provenance();
 
         let url = if asset.url_api.is_empty() {
             asset.url.clone()

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -1445,12 +1445,24 @@ impl UnifiedGitBackend {
 
         self.verify_checksum(ctx, tv, &file_path)?;
 
+        let lockfile_has_checksum = tv
+            .lock_platforms
+            .get(&platform_key)
+            .is_some_and(|p| p.checksum.is_some());
+
         let settings = Settings::get();
         let force_verify = settings.force_provenance_verify();
         if has_lockfile_integrity && !force_verify {
             // Still check that the recorded provenance type's setting is enabled —
             // disabling a verification setting with a provenance-bearing lockfile is a downgrade.
             self.ensure_provenance_setting_enabled(tv, &platform_key)?;
+        } else if ctx.locked && !force_verify && locked_provenance.is_none() && lockfile_has_checksum
+        {
+            debug!(
+                "locked mode: skipping provenance detection for {} \
+                 (lockfile has checksum but no provenance)",
+                tv.style()
+            );
         } else {
             let provenance_result = self
                 .verify_attestations_or_slsa(
@@ -1532,12 +1544,23 @@ impl UnifiedGitBackend {
             .await?;
         ctx.pr.next_operation();
 
+        let lockfile_has_checksum = artifact_info.checksum.is_some();
         self.verify_additional_artifact_checksum(ctx, &file_path, &mut artifact_info)?;
         let expected_provenance = artifact_info.provenance.clone();
         if has_lockfile_integrity && !Settings::get().force_provenance_verify() {
             if let Some(provenance) = expected_provenance.as_ref() {
                 self.ensure_provenance_type_setting_enabled(tv, opts, provenance)?;
             }
+        } else if ctx.locked
+            && !Settings::get().force_provenance_verify()
+            && expected_provenance.is_none()
+            && lockfile_has_checksum
+        {
+            debug!(
+                "locked mode: skipping provenance detection for additional asset {} \
+                 (lockfile has checksum but no provenance)",
+                asset.name
+            );
         } else {
             let provenance = self
                 .verify_attestations_or_slsa(

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -1455,7 +1455,10 @@ impl UnifiedGitBackend {
             // Still check that the recorded provenance type's setting is enabled —
             // disabling a verification setting with a provenance-bearing lockfile is a downgrade.
             self.ensure_provenance_setting_enabled(tv, &platform_key)?;
-        } else if ctx.locked && !force_verify && locked_provenance.is_none() && lockfile_has_checksum
+        } else if ctx.locked
+            && !force_verify
+            && locked_provenance.is_none()
+            && lockfile_has_checksum
         {
             debug!(
                 "locked mode: skipping provenance detection for {} \

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -1457,13 +1457,9 @@ impl UnifiedGitBackend {
             // Still check that the recorded provenance type's setting is enabled —
             // disabling a verification setting with a provenance-bearing lockfile is a downgrade.
             self.ensure_provenance_setting_enabled(tv, &platform_key)?;
-        } else if ctx.locked
-            && !force_verify
-            && locked_provenance.is_none()
-            && lockfile_has_checksum
-        {
+        } else if !force_verify && locked_provenance.is_none() && lockfile_has_checksum {
             debug!(
-                "locked mode: skipping provenance detection for {} \
+                "skipping provenance detection for {} \
                  (lockfile has checksum but no provenance)",
                 tv.style()
             );
@@ -1557,13 +1553,12 @@ impl UnifiedGitBackend {
             if let Some(provenance) = expected_provenance.as_ref() {
                 self.ensure_provenance_type_setting_enabled(tv, opts, provenance)?;
             }
-        } else if ctx.locked
-            && !Settings::get().force_provenance_verify()
+        } else if !Settings::get().force_provenance_verify()
             && expected_provenance.is_none()
             && lockfile_has_checksum
         {
             debug!(
-                "locked mode: skipping provenance detection for additional asset {} \
+                "skipping provenance detection for additional asset {} \
                  (lockfile has checksum but no provenance)",
                 asset.name
             );

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -1393,11 +1393,11 @@ impl UnifiedGitBackend {
         let platform_info = tv.lock_platforms.entry(platform_key).or_default();
         platform_info.url = Some(asset.url.clone());
         platform_info.url_api = (!asset.url_api.is_empty()).then(|| asset.url_api.clone());
-        if let Some(digest) = &asset.digest {
-            if !lockfile_has_checksum {
-                debug!("using GitHub API digest for checksum verification");
-                platform_info.checksum = Some(digest.clone());
-            }
+        if let Some(digest) = &asset.digest
+            && !lockfile_has_checksum
+        {
+            debug!("using GitHub API digest for checksum verification");
+            platform_info.checksum = Some(digest.clone());
         }
 
         let url = if asset.url_api.is_empty() {
@@ -1522,10 +1522,10 @@ impl UnifiedGitBackend {
         let has_lockfile_integrity = artifact_info.has_checksum_and_verified_provenance();
         artifact_info.url = asset.url.clone();
         artifact_info.url_api = (!asset.url_api.is_empty()).then(|| asset.url_api.clone());
-        if let Some(digest) = &asset.digest {
-            if !lockfile_has_checksum {
-                artifact_info.checksum = Some(digest.clone());
-            }
+        if let Some(digest) = &asset.digest
+            && !lockfile_has_checksum
+        {
+            artifact_info.checksum = Some(digest.clone());
         }
 
         let url = if asset.url_api.is_empty() {

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -1442,13 +1442,12 @@ impl UnifiedGitBackend {
             .lock_platforms
             .get(&platform_key)
             .and_then(|platform| platform.provenance.clone());
-
-        self.verify_checksum(ctx, tv, &file_path)?;
-
         let lockfile_has_checksum = tv
             .lock_platforms
             .get(&platform_key)
             .is_some_and(|p| p.checksum.is_some());
+
+        self.verify_checksum(ctx, tv, &file_path)?;
 
         let settings = Settings::get();
         let force_verify = settings.force_provenance_verify();
@@ -1514,6 +1513,7 @@ impl UnifiedGitBackend {
             .and_then(|platform| platform.additional_artifacts.get(index))
             .cloned()
             .unwrap_or_default();
+        let lockfile_has_checksum = artifact_info.checksum.is_some();
         artifact_info.url = asset.url.clone();
         artifact_info.url_api = (!asset.url_api.is_empty()).then(|| asset.url_api.clone());
         if let Some(digest) = &asset.digest {
@@ -1544,7 +1544,6 @@ impl UnifiedGitBackend {
             .await?;
         ctx.pr.next_operation();
 
-        let lockfile_has_checksum = artifact_info.checksum.is_some();
         self.verify_additional_artifact_checksum(ctx, &file_path, &mut artifact_info)?;
         let expected_provenance = artifact_info.provenance.clone();
         if has_lockfile_integrity && !Settings::get().force_provenance_verify() {


### PR DESCRIPTION
When the lockfile records a checksum but no provenance for a tool (because it
doesn't publish SLSA attestations), install-time should not probe the GitHub
releases API to detect provenance. The lockfile checksum already guarantees
artifact integrity.

These redundant API calls fail under rate limiting since
`provenance_api_failures_fatal` defaults to `true`, causing hard install failures
in CI environments with many concurrent jobs.

The skip applies whenever the lockfile has a checksum and no provenance,
regardless of whether `--locked` is passed. `force_provenance_verify` still
forces detection.

Also fixes a pre-existing issue where `asset.digest` / `api_digest` from release
metadata could overwrite a lockfile checksum. The lockfile checksum now takes
priority when present.

Both fixes are applied to the `github` and `aqua` backends.

## Security

Only tools where the lockfile records no provenance skip detection. Tools with
recorded provenance still verify it. The `force_provenance_verify` setting
overrides this and forces API verification regardless. The lockfile checksum
remains the primary integrity guarantee.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-4-6; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved locked-mode installation behavior when checksum information lacks provenance.
  - Installations now correctly evaluate existing lockfile checksums before verification.
  - Preserved validation for lockfiles that already include provenance details.
  - Improved checksum validation consistency for primary and additional downloaded assets.
  - Prevented verification settings from incorrectly affecting checksum provenance decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->