### PR TITLE
fix(completion): preserve runtime path fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11012,7 +11012,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "shell-words",
- "tera 2.1.1",
+ "tera 2.2.0",
  "thiserror 2.0.20",
  "tokio",
  "usage-lib",

--- a/e2e/cli/test_completion_dynamic
+++ b/e2e/cli/test_completion_dynamic
@@ -9,6 +9,11 @@ flag "--environment <name>" {
 }
 '''
 run = 'echo works'
+
+[tasks.paths]
+description = "Accept a path"
+usage = 'arg "<value>"'
+run = 'true'
 EOF
 
 fish_tasks="$(mise __complete_word__ --shell fish --line 'mise run ')"
@@ -34,3 +39,6 @@ assert_not_contains_text "$task_values" $'\001files'
 tools="$(mise __complete_word__ --shell fish --line 'mise install actionl')"
 assert_contains_text "$tools" 'actionlint@'
 assert_not_contains_text "$tools" $'\001files'
+
+task_paths="$(mise __complete_word__ --shell fish --line 'mise run paths ')"
+assert_contains_text "$task_paths" $'\001files'

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -8,8 +8,8 @@ use strum::EnumString;
 /// The tables compiled by usage-rs cover static commands, flags, choices, and path hints. mise
 /// also augments those tables at runtime with `run=` completers and task commands mounted from
 /// `mise tasks --usage`; those only exist in [`super::usage::completion_spec`]. Try that richer
-/// spec first, then leave static and path completion to usage-rs so the shell retains its native
-/// path handling.
+/// spec first, preserving its path fallback marker, then leave only unsupported requests to the
+/// compiled usage-rs tables.
 pub(crate) fn completion_request(argv: &[OsString]) -> Option<String> {
     let request = usage_rs::complete::CompletionRequest::parse(argv)?;
     if request.candidates_for.is_some() {
@@ -24,21 +24,25 @@ pub(crate) fn completion_request(argv: &[OsString]) -> Option<String> {
         request.shell.as_str(),
     );
     match answer {
-        Ok(answer) if !answer.files => {
-            let candidates = answer
-                .candidates
-                .into_iter()
-                .map(|(value, description)| {
-                    if description.is_empty() {
-                        usage_rs::complete::Candidate::new(value)
-                    } else {
-                        usage_rs::complete::Candidate::described(value, description)
-                    }
-                })
-                .collect();
+        Ok(answer) => {
+            let candidates = if answer.files {
+                vec![]
+            } else {
+                answer
+                    .candidates
+                    .into_iter()
+                    .map(|(value, description)| {
+                        if description.is_empty() {
+                            usage_rs::complete::Candidate::new(value)
+                        } else {
+                            usage_rs::complete::Candidate::described(value, description)
+                        }
+                    })
+                    .collect()
+            };
             let answer = usage_rs::complete::Completions {
                 candidates,
-                files: None,
+                files: answer.files.then_some(usage_rs::complete::Files::Any),
             };
             Some(usage_rs::complete::render(&answer, request.shell))
         }


### PR DESCRIPTION
## Summary
- preserve the runtime completion engine's native file fallback marker
- avoid duplicating eagerly enumerated paths when native completion takes over
- cover filesystem fallback for a runtime-mounted task
- repair the rebased usage-cli lockfile reference to the existing tera package

Follow-up to #12376 and addresses [Bugbot feedback](https://github.com/jdx/mise/pull/12376#discussion_r3843744332).

## Tests
- `mise run test:e2e e2e/cli/test_completion_dynamic`
- `mise run lint-fix`
- `cargo check --locked`

*AI-assisted — Tool: Codex; model: unavailable/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small completion-protocol change plus an e2e assertion; no auth, data, or command-execution behavior is affected.
> 
> **Overview**
> Runtime completion now forwards the usage engine’s **file fallback** instead of dropping it. When `complete_answer` marks a slot as files, mise emits `Files::Any` with no candidate list so the shell can complete paths natively.
> 
> Previously those answers were treated as “not handled” and fell through to static usage-rs tables, so task args that expect a path never got filesystem completion.
> 
> Adds an e2e case for `mise run paths` expecting the `\001files` marker. Also pins `tera` to 2.2.0 in `Cargo.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b61e68dc520d554add1b98be475a94d3833ac10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file and path completion for task arguments in Fish shell.
  * Shell-native file candidates are now preserved when a task requests path completion.

* **Bug Fixes**
  * Improved completion handling for unsupported or mixed completion responses by falling back appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->