### PR TITLE
fix(prune): remove tracked configs that cannot be a config file

### DIFF
--- a/e2e/cli/test_prune_tracked_config_dev_null
+++ b/e2e/cli/test_prune_tracked_config_dev_null
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Regression test for a tracked config that cannot be a config file.
+#
+# `MISE_GLOBAL_CONFIG_FILE=/dev/null` used to be a way to disable the global
+# config, so older versions tracked it. mise now rejects unknown config file
+# types, and the leftover entry survived every `mise prune` — cleaning asked
+# whether the *entry* existed, and a symlink to /dev/null does exist — so every
+# run that loads tracked configs warned about it forever.
+
+tracked="$MISE_STATE_DIR/tracked-configs"
+mkdir -p "$tracked"
+ln -s /dev/null "$tracked/deadbeefdeadbeef"
+
+out="$(mise prune 2>&1)"
+assert_contains "echo '$out'" "pruned configuration links"
+assert_not_contains "echo '$out'" "unknown config file type"
+
+# The entry is gone, so it cannot come back on the next command either.
+assert_fail "test -e '$tracked/deadbeefdeadbeef'"
+assert_not_contains "mise ls 2>&1" "unknown config file type"

--- a/src/config/tracking.rs
+++ b/src/config/tracking.rs
@@ -41,20 +41,34 @@ impl Tracker {
         if !dir.exists() {
             return Ok(output);
         }
-        for path in read_dir(dir)? {
-            let mut path = path?.path();
-            if path.is_symlink() {
-                path = fs::read_link(path)?;
-            } else if cfg!(target_os = "windows") {
-                path = PathBuf::from(fs::read_to_string(&path)?.trim());
-            } else {
+        for entry in read_dir(dir)? {
+            let Some(path) = Self::tracked_path(&entry?.path())? else {
                 continue;
-            }
-            if path.exists() {
+            };
+            // Only a regular file can be one of these. A tracked path that is a
+            // device or a directory is left-over state that every reader would
+            // fail on, so it is not handed out (#12246).
+            if path.is_file() {
                 output.push(path);
             }
         }
         Ok(output)
+    }
+
+    /// The path an entry records, or `None` when it is not one mise wrote.
+    ///
+    /// Entries are symlinks on unix and, since Windows symlinks need a
+    /// privilege mise does not require, plain files holding the path there —
+    /// see `file::make_symlink_or_file`. Both forms have to be resolved before
+    /// anything can be decided about what they point at.
+    fn tracked_path(entry: &Path) -> Result<Option<PathBuf>> {
+        if entry.is_symlink() {
+            Ok(Some(fs::read_link(entry)?))
+        } else if cfg!(target_os = "windows") {
+            Ok(Some(PathBuf::from(fs::read_to_string(entry)?.trim())))
+        } else {
+            Ok(None)
+        }
     }
 
     pub(crate) fn clean() -> Result<()> {
@@ -64,13 +78,79 @@ impl Tracker {
 
     fn clean_in(dir: &Path) -> Result<()> {
         if dir.is_dir() {
-            for path in read_dir(dir)? {
-                let path = path?.path();
-                if !path.exists() {
-                    remove_file(&path)?;
+            for entry in read_dir(dir)? {
+                let entry = entry?.path();
+                // Resolve first. Asking whether the *entry* exists answers the
+                // wrong question: a symlink to `/dev/null` exists, so it
+                // survived every prune while every reader kept failing on it,
+                // and on Windows the entry is a plain file that always exists
+                // no matter what it records.
+                let keep = match Self::tracked_path(&entry)? {
+                    Some(path) => path.is_file(),
+                    None => false,
+                };
+                if !keep {
+                    remove_file(&entry)?;
                 }
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `track_in` writes a symlink on unix and a plain file on Windows, so going
+    /// through it keeps these tests meaningful on both.
+    fn track(dir: &Path, target: &Path) -> PathBuf {
+        Tracker::track_in(dir, target).unwrap();
+        dir.join(hash_to_str(&target))
+    }
+
+    #[test]
+    fn keeps_an_entry_pointing_at_a_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("tracked");
+        let config = tmp.path().join("mise.toml");
+        fs::write(&config, "[tools]\n").unwrap();
+
+        let entry = track(&dir, &config);
+        Tracker::clean_in(&dir).unwrap();
+
+        assert!(entry.exists(), "a real config file must survive a clean");
+        assert_eq!(Tracker::list_all_in(&dir).unwrap(), vec![config]);
+    }
+
+    #[test]
+    fn removes_an_entry_pointing_at_something_that_is_not_a_file() {
+        // Stands in for the `/dev/null` entries older versions left behind: the
+        // target exists, so asking `entry.exists()` kept them forever while
+        // every reader failed on them. A directory reproduces that portably.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("tracked");
+        let not_a_config = tmp.path().join("somewhere");
+        fs::create_dir(&not_a_config).unwrap();
+
+        let entry = track(&dir, &not_a_config);
+        assert!(Tracker::list_all_in(&dir).unwrap().is_empty());
+
+        Tracker::clean_in(&dir).unwrap();
+        assert!(!entry.exists());
+    }
+
+    #[test]
+    fn removes_an_entry_whose_target_is_gone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("tracked");
+        let config = tmp.path().join("mise.toml");
+        fs::write(&config, "[tools]\n").unwrap();
+
+        let entry = track(&dir, &config);
+        fs::remove_file(&config).unwrap();
+
+        Tracker::clean_in(&dir).unwrap();
+        assert!(!entry.exists());
     }
 }


### PR DESCRIPTION
Found on a real machine, not from a discussion — `mise prune` warns on every run and cannot clear what it is warning about:

```console
$ mise prune
mise pruned configuration links
mise WARN  error loading tracked config file /dev/null: unknown config file type: /dev/null
```

The culprit is a symlink to `/dev/null` sitting in `tracked-configs`, left behind by a version where `MISE_GLOBAL_CONFIG_FILE=/dev/null` was the way to disable the global config (discussions#12246). mise rejects unknown config file types now, so **nothing creates these any more** — I measured that: pointing the setting at `/dev/null` errors out before anything is tracked, and only real files land in the directory. What remains is state older versions wrote, and prune refuses to remove it.

Reproduced in isolation on 2026.8.12:

```console
before: deadbeefdeadbeef -> /dev/null
$ mise prune
mise pruned configuration links
mise WARN  error loading tracked config file /dev/null: unknown config file type: /dev/null
after:  deadbeefdeadbeef          # still there
```

## Cause

The two halves of `src/config/tracking.rs` disagreed about what an entry *is*.

`list_all_in` resolves it — a symlink on unix, and on Windows a plain file holding the path, since symlinks there need a privilege mise does not require (`file::make_symlink_or_file`).

`clean_in` did not resolve at all. It asked whether the **entry** existed, which answers the wrong question twice:

- a symlink to `/dev/null` exists, so the entry survived every prune while every reader kept failing on it;
- on Windows the entry is a file that exists whatever it records, so **stale entries were never removed there either** — the same bug, hiding as a second symptom.

## Fix

Both now share one resolver and one rule: **an entry is meaningful only when it resolves to a regular file.** `clean_in` removes the rest; `list_all_in` stops handing them out, so the warning stops before a prune rather than only after one.

A malformed `mise.toml` is a regular file, so it still warns — that is a real problem worth surfacing, and since no config file can be a device or a directory, the rule cannot silence one.

## What I could not verify

**The Windows half is reasoned from `make_symlink_or_file`, not measured on Windows.** The unix half is measured end to end. If you would rather I split the Windows behaviour out, say so — it falls out of the same resolver, which is why it is here rather than in its own change.

## Tests

Three unit tests, in a module that had none. They go through `track_in`, so they exercise the symlink form on unix and the file form on Windows rather than hard-coding either:

- an entry pointing at a file survives `clean_in` and appears in `list_all_in`
- an entry pointing at a **directory** is removed and never listed — the same "not a regular file" case as `/dev/null`, without needing a device node
- an entry whose target was deleted is removed, pinning the behaviour that already worked

`e2e/cli/test_prune_tracked_config_dev_null` covers the reported shape directly: plant the symlink, run `mise prune`, assert the warning is gone, the entry is gone, and a following command stays quiet.

All four pass locally, as do the three unit tests. `cargo fmt --check`, `shellcheck` and `shfmt` are clean.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*
