### PR TITLE
fix(lockfile): attribute each new version to its own request source

### DIFF
--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1853,16 +1853,17 @@ fn merge_lockfile_preserving_root(root: &mut Lockfile, other: Lockfile) {
     }
 }
 
-pub(crate) fn update_lockfiles(
-    config: &Config,
+/// Groups the resolved toolset plus this session's newly installed versions by
+/// the config source that requested each of them.
+///
+/// Each new version must be attributed to its own request's source: one
+/// command can install versions of the same backend requested by different
+/// config files, and grouping them by backend attributed the whole group to
+/// the first request's source, writing entries into the wrong lockfile.
+fn tools_by_source_for_update(
     ts: &Toolset,
     new_versions: &[ToolVersion],
-    mode: LockfileUpdateMode,
-) -> Result<bool> {
-    if !Settings::get().lockfile_enabled() || (Settings::get().locked && !mode.allow_locked()) {
-        return Ok(false);
-    }
-
+) -> HashMap<ToolSource, HashMap<String, Vec<ToolVersion>>> {
     // Collect tools by source (config file)
     let mut tools_by_source: HashMap<ToolSource, HashMap<String, Vec<ToolVersion>>> =
         HashMap::new();
@@ -1877,18 +1878,32 @@ pub(crate) fn update_lockfiles(
         }
     }
 
-    // Add versions added within this session (from `mise use` or `mise up`)
-    for (backend, group) in &new_versions.iter().chunk_by(|tv| tv.ba()) {
-        let tvs = group.cloned().collect_vec();
-        let source = tvs[0].request.source().clone();
-        let source_tools = tools_by_source.entry(source.clone()).or_default();
-
-        let existing_versions = source_tools.entry(backend.short.to_string()).or_default();
-        for new_tv in tvs {
-            existing_versions.retain(|tv| tv.request.version() != new_tv.request.version());
-            existing_versions.push(new_tv);
-        }
+    // Add versions added within this session (from `mise use` or `mise up`),
+    // replacing the resolved entry for the same request within that source.
+    for new_tv in new_versions {
+        let existing_versions = tools_by_source
+            .entry(new_tv.request.source().clone())
+            .or_default()
+            .entry(new_tv.ba().short.to_string())
+            .or_default();
+        existing_versions.retain(|tv| tv.request.version() != new_tv.request.version());
+        existing_versions.push(new_tv.clone());
     }
+
+    tools_by_source
+}
+
+pub(crate) fn update_lockfiles(
+    config: &Config,
+    ts: &Toolset,
+    new_versions: &[ToolVersion],
+    mode: LockfileUpdateMode,
+) -> Result<bool> {
+    if !Settings::get().lockfile_enabled() || (Settings::get().locked && !mode.allow_locked()) {
+        return Ok(false);
+    }
+
+    let tools_by_source = tools_by_source_for_update(ts, new_versions);
 
     // Group config files by target lockfile path
     let mut lockfile_configs: HashMap<PathBuf, Vec<PathBuf>> = HashMap::new();
@@ -4089,6 +4104,50 @@ mod tests {
             source: ToolSource::Unknown,
         };
         ToolVersion::new(request, version.to_string())
+    }
+
+    fn basic_tv_from_source(
+        backend: &str,
+        request: &str,
+        version: &str,
+        source: ToolSource,
+    ) -> ToolVersion {
+        let prototype = basic_tv(backend, request);
+        let request =
+            crate::toolset::ToolRequest::new(prototype.request.ba().clone(), request, source)
+                .unwrap();
+        ToolVersion::new(request, version.to_string())
+    }
+
+    #[test]
+    fn test_tools_by_source_for_update_attributes_each_new_version_to_its_source() {
+        let source_a = ToolSource::MiseToml(PathBuf::from("/repo/packages/a/mise.toml"));
+        let source_b = ToolSource::MiseToml(PathBuf::from("/repo/packages/b/mise.toml"));
+        let new_versions = vec![
+            basic_tv_from_source("aqua:example/tool", "stable", "release-a", source_a.clone()),
+            basic_tv_from_source("aqua:example/tool", "stable", "release-b", source_b.clone()),
+        ];
+
+        let tools_by_source = tools_by_source_for_update(&Toolset::default(), &new_versions);
+
+        assert_eq!(tools_by_source[&source_a]["tool"].len(), 1);
+        assert_eq!(tools_by_source[&source_a]["tool"][0].version, "release-a");
+        assert_eq!(tools_by_source[&source_b]["tool"].len(), 1);
+        assert_eq!(tools_by_source[&source_b]["tool"][0].version, "release-b");
+    }
+
+    #[test]
+    fn test_tools_by_source_for_update_last_duplicate_request_version_wins() {
+        let source = ToolSource::MiseToml(PathBuf::from("/repo/mise.toml"));
+        let new_versions = vec![
+            basic_tv_from_source("aqua:example/tool", "stable", "release-old", source.clone()),
+            basic_tv_from_source("aqua:example/tool", "stable", "release-new", source.clone()),
+        ];
+
+        let tools_by_source = tools_by_source_for_update(&Toolset::default(), &new_versions);
+
+        assert_eq!(tools_by_source[&source]["tool"].len(), 1);
+        assert_eq!(tools_by_source[&source]["tool"][0].version, "release-new");
     }
 
     fn tool_with_conda_dep(


### PR DESCRIPTION

## Problem

`update_lockfiles` chunks the newly resolved versions by backend and files the whole chunk under `tvs[0].request.source()`. In any layout where two configs request the same short — a monorepo root and one of its packages, or a parent and a child config — every new version of that backend is written into the first request's lockfile, and the other lockfile never receives its entry.

## Example

Parent `mise.toml` requests `dummy = "1"`, child `sub/mise.toml` requests `dummy = "2.0.0"`, lockfiles enabled and present in both. Run `mise up` (or anything that resolves new versions for both configs).

Expected:

```toml
# mise.lock
lockfile_version = 1

[[tools.dummy]]
version = "1.1.0"
specifiers = ["1"]

# sub/mise.lock
lockfile_version = 1

[[tools.dummy]]
version = "2.0.0"
specifiers = ["2.0.0"]
```

Actual — both versions are attributed to the first request's source:

```toml
# mise.lock
lockfile_version = 1

[[tools.dummy]]
version = "1.1.0"
specifiers = ["1"]

[[tools.dummy]]
version = "2.0.0"
specifiers = ["2.0.0"]

# sub/mise.lock
lockfile_version = 1
# <missing tools.dummy>
```

## Fix

Extract the grouping into `tools_by_source_for_update` and attribute each new version to its own `request.source()`, still replacing the resolved entry for the same request version within that source. Mostly a lift-out of the existing loop; the behavioral change is the per-version source lookup. Single-source layouts produce the same lockfile bytes as before.

## Tests

Two unit tests: per-source attribution, and last-writer-wins for duplicate requests of the same version. Existing lockfile suite green; `cargo fmt` and `clippy -D warnings` clean.

## Future work

Replacement identity here — and in the later overlay inside `update_lockfiles` — keys on `request.version()` alone, so two same-source requests for the same version with different options (e.g. mutually exclusive `os = [...]` variants of one version) can lose the inactive variant's lockfile options. This predates this PR: the identical predicate exists on `main`, and this change deliberately keeps the single-source case behavior-identical. A proper fix would include backend identity and request options in the replacement key at both sites, with regression coverage for OS-variant pairs — flagged by CodeRabbit in review; worth a separate follow-up PR.

_AI-assisted (Claude). Reviewed and tested by hand._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UamPmwY9k6TRA36nvBrGcC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lockfile updates to accurately associate resolved and newly installed tool versions with their originating sources.
  * Prevented duplicate version requests from producing incorrect lockfile entries by consistently keeping the latest version.
  * Improved reliability when multiple sources request different versions of the same tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->