### PR TITLE
fix(lockfile): include monorepo root requests in lockfile maintenance

### DIFF
--- a/e2e/lockfile/test_lockfile_version
+++ b/e2e/lockfile/test_lockfile_version
@@ -245,3 +245,46 @@ assert_succeed "cmp failed-multi-target-upgrade/mise.local.lock.before failed-mu
 assert_not_contains "cd failed-multi-target-upgrade && RTX_FAILURE=1 mise lock --upgrade --platform linux-x64 2>&1 || true" "Upgrading"
 assert_not_contains "cd failed-multi-target-upgrade && RTX_FAILURE=1 mise lock --upgrade --platform linux-x64 2>&1 || true" "Pruned"
 assert_not_contains "cd failed-multi-target-upgrade && RTX_FAILURE=1 mise lock --upgrade --platform linux-x64 2>&1 || true" "Lockfile written"
+
+echo "=== monorepo format upgrades retain shadowed root requests ==="
+mkdir -p shadowed-root/packages/b
+cat >shadowed-root/mise.toml <<'EOF'
+monorepo_root = true
+
+[tools]
+dummy = "1"
+
+[settings]
+lockfile = true
+
+[monorepo]
+lockfile = true
+config_roots = ["packages/*"]
+EOF
+cat >shadowed-root/packages/b/mise.toml <<'EOF'
+[tools]
+dummy = "2.0.0"
+EOF
+cat >shadowed-root/mise.lock <<'EOF'
+[[tools.dummy]]
+version = "1.1.0"
+backend = "asdf:dummy"
+
+[[tools.dummy]]
+version = "2.0.0"
+backend = "asdf:dummy"
+EOF
+
+assert_succeed "cd shadowed-root && mise install"
+assert_succeed "cd shadowed-root/packages/b && mise install"
+assert_succeed "cd shadowed-root && mise lock --upgrade --platform linux-x64"
+assert_contains "cat shadowed-root/mise.lock" 'specifiers = ["1"]'
+assert_contains "cat shadowed-root/mise.lock" 'specifiers = ["2.0.0"]'
+assert "cd shadowed-root && mise ls dummy --json --current | jq -r '.[0].version'" "1.1.0"
+assert "cd shadowed-root/packages/b && mise ls dummy --json --current | jq -r '.[0].version'" "2.0.0"
+
+echo "=== plain mise lock retains shadowed root entries ==="
+assert_succeed "cd shadowed-root && mise lock"
+assert_contains "cat shadowed-root/mise.lock" 'specifiers = ["1"]'
+assert_contains "cat shadowed-root/mise.lock" 'specifiers = ["2.0.0"]'
+assert "cd shadowed-root && mise ls dummy --json --current | jq -r '.[0].version'" "1.1.0"

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -272,7 +272,13 @@ impl Lock {
             ..Default::default()
         };
         let monorepo_union = if !self.global && config.monorepo_lockfile_root().is_some() {
-            Some(config.monorepo_union().await?)
+            // The plain union lets a sibling's request shadow the monorepo
+            // root's own request for the same short, so lock treated the
+            // root's entry as stale: plain `mise lock` pruned its version and
+            // binding, and `mise lock --upgrade` migrated v0 lockfiles
+            // without it. Lockfile maintenance needs the root-inclusive
+            // variant.
+            Some(config.monorepo_lockfile_union().await?)
         } else {
             None
         };

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -107,6 +107,25 @@ pub(crate) struct MonorepoUnion {
     pub repo_urls: HashMap<String, String>,
 }
 
+fn extend_monorepo_tool_request_set(union: &mut ToolRequestSet, requests: &ToolRequestSet) {
+    union
+        .unknown_tools
+        .extend(requests.unknown_tools.iter().cloned());
+    for (_ba, tool_requests, source) in requests.iter() {
+        for request in tool_requests {
+            let already_present = union.tools.get(request.ba()).is_some_and(|existing| {
+                existing.iter().any(|existing| {
+                    existing.version() == request.version()
+                        && existing.options() == request.options()
+                })
+            });
+            if !already_present {
+                union.add_version(request.clone(), source);
+            }
+        }
+    }
+}
+
 /// One independently composed bootstrap hierarchy and its scoped template context.
 #[derive(Clone)]
 struct BootstrapConfigMap {
@@ -782,7 +801,27 @@ impl Config {
         Ok(self.monorepo_union().await?.tool_request_set)
     }
 
+    /// Loads the union plus the monorepo root directory's own effective
+    /// requests, for lockfile maintenance of the shared root lockfile.
+    ///
+    /// `monorepo_union` merges the root's configs underneath each declared
+    /// config root, so a sibling's request for a short shadows the monorepo
+    /// root's own request for it. Treating the union as the set of live
+    /// requests for the root lockfile would then drop the root's request:
+    /// `mise lock --upgrade` migrated a v0 monorepo lockfile without binding
+    /// the root's request and pruned its locked version.
+    pub(crate) async fn monorepo_lockfile_union(self: &Arc<Self>) -> Result<MonorepoUnion> {
+        self.monorepo_union_with_root_toolset(true).await
+    }
+
     pub(crate) async fn monorepo_union(self: &Arc<Self>) -> Result<MonorepoUnion> {
+        self.monorepo_union_with_root_toolset(false).await
+    }
+
+    async fn monorepo_union_with_root_toolset(
+        self: &Arc<Self>,
+        include_root_toolset: bool,
+    ) -> Result<MonorepoUnion> {
         let idiomatic_filenames = load_idiomatic_filenames().await;
         let config_filenames = idiomatic_filenames
             .keys()
@@ -820,19 +859,20 @@ impl Config {
                 .without_runtime_args()
                 .build(self)
                 .await?;
-            union.unknown_tools.extend(root_trs.unknown_tools.clone());
-            for (_ba, requests, source) in root_trs.iter() {
-                for request in requests {
-                    let already_present = union.tools.get(request.ba()).is_some_and(|existing| {
-                        existing.iter().any(|r| {
-                            r.version() == request.version() && r.options() == request.options()
-                        })
-                    });
-                    if !already_present {
-                        union.add_version(request.clone(), source);
-                    }
-                }
-            }
+            extend_monorepo_tool_request_set(&mut union, &root_trs);
+        }
+
+        if include_root_toolset {
+            // Each declared root overlays base_config_files, so its request
+            // for a short can shadow the monorepo root's own request. Lockfile
+            // maintenance needs the root directory as an additional effective
+            // hierarchy so its requests stay live.
+            let root_trs = ToolRequestSetBuilder::new()
+                .with_config_files(base_config_files)
+                .without_runtime_args()
+                .build(self)
+                .await?;
+            extend_monorepo_tool_request_set(&mut union, &root_trs);
         }
 
         union.unknown_tools = union.unknown_tools.into_iter().unique().collect();


### PR DESCRIPTION

## Problem

`monorepo_union` merges the monorepo root's configs underneath each config root, so a package's request for a short shadows the root's request for the same short — the union never contains the root's. Both `mise lock` paths treat that union as the complete set of live requests for the shared root lockfile (lockfile v1, #12299), so the root's own entry looks stale.

## Example

```toml
# mise.toml
monorepo_root = true

[tools]
dummy = "1"

[settings]
lockfile = true

[monorepo]
lockfile = true
config_roots = ["packages/*"]


# packages/b/mise.toml
[tools]
dummy = "2.0.0"
```

With the root `mise.lock` holding both rows, run `mise lock`. Expected — nothing to do, the file is already correct:

```toml
lockfile_version = 1

[[tools.dummy]]
version = "1.1.0"
specifiers = ["1"]

[[tools.dummy]]
version = "2.0.0"
specifiers = ["2.0.0"]
```

Actual — `Pruned 1 stale version entry`, and the root's version and request binding are gone:

```toml
lockfile_version = 1

[[tools.dummy]]
version = "2.0.0"
specifiers = ["2.0.0"]
```

`mise lock --upgrade` has the same blind spot: migrating a v0 monorepo lockfile to v1 binds `packages/b`'s request but not the root's.

## Fix

Add `Config::monorepo_lockfile_union`, which overlays the monorepo root directory's own toolset as an additional effective hierarchy (sharing the merge logic with `monorepo_union` via an extracted helper), and use it from both `mise lock` paths. The plain `monorepo_union` and its other consumers are unchanged.

## Tests

- 2 new e2e cases in `e2e/lockfile/test_lockfile_version`: the shadowed root request survives plain `mise lock`, and survives `mise lock --upgrade` v0→v1 migration with its binding intact.
- Existing lockfile/config suites green; `cargo fmt` and `cargo clippy --all-targets -- -D warnings` clean.

## Future work

A related hygiene issue, deliberately not fixed here: after `mise upgrade` moves a request binding onto a new version, monorepo root lockfiles preserve the superseded row forever (non-monorepo lockfiles self-clean). The rows are inert for selection under v1 bindings, but they accumulate. Pruning them safely requires a complete liveness model for the shared lockfile — task-scoped tools (`[tasks.*.tools]`), `MISE_<TOOL>_VERSION` env requests, nested configs below declared config roots, and per-root template rendering all contribute rows that naive union-based liveness misses. Will file an issue with the details rather than ship a prune that can delete live rows.

_AI-assisted (Claude). Reviewed and tested by hand._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved monorepo lockfile handling so root and child tool requests are preserved during locking and lockfile format upgrades.
  * Prevented sibling configurations from incorrectly overriding root tool versions or options.
  * Preserved runtime versions for both root and child configurations.

* **Tests**
  * Added end-to-end coverage for lockfile upgrades and standard locking in monorepos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->