### PR TITLE
registry: add mr-boxington

### DIFF
--- a/registry/mr-boxington.toml
+++ b/registry/mr-boxington.toml
@@ -1,0 +1,5 @@
+backends = ["github:jdx/mr-boxington"]
+bins = ["mbx"]
+description = "A Cargo wrapper with a shared, self-pruning compilation cache"
+test = { cmd = "mbx --version", expected = "mbx {{version}}" }
+version_order = "semver"


### PR DESCRIPTION
## Summary
- add `mr-boxington` shorthand backed by `github:jdx/mr-boxington`
- declare the `mbx` binary, version check, and semver release ordering

## Popularity
- GitHub: 5 stars, 0 forks
- Activity: latest release `v0.3.0` published 2026-08-23; repository last pushed 2026-08-24
- Maintainer-directed exception to the usual registry popularity threshold

## Testing
- `mise run lint-fix`
- `mise run build`
- `target/debug/mise ls-remote mr-boxington`
- `target/debug/mise x mr-boxington@0.1.0 -- mbx --version`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only metadata with no changes to install logic or core runtime behavior.
> 
> **Overview**
> Adds a new mise registry shorthand **`mr-boxington`** so users can install **`mbx`** from `github:jdx/mr-boxington`.
> 
> The entry wires the GitHub backend, declares the `mbx` binary, uses semver for release ordering, and validates installs with `mbx --version` against `mbx {{version}}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02a79d57e70dbb9f04e11166654ae1b36c03099a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added registry support for the `mr-boxington` command-line tool.
  * Added installation metadata, including its `mbx` executable name, GitHub source, version verification, and semantic version ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->