### PR TITLE
registry: add ghui

### DIFF
--- a/registry/ghui.toml
+++ b/registry/ghui.toml
@@ -1,0 +1,5 @@
+backends = ["npm:@kitlangton/ghui"]
+bins = ["ghui"]
+description = "Terminal UI for GitHub pull requests"
+test = { cmd = "ghui --version", expected = "{{version}}" }
+version_order = "semver"

--- a/registry/ghui.toml
+++ b/registry/ghui.toml
@@ -1,5 +1,11 @@
-backends = ["npm:@kitlangton/ghui"]
 bins = ["ghui"]
 description = "Terminal UI for GitHub pull requests"
 test = { cmd = "ghui --version", expected = "{{version}}" }
 version_order = "semver"
+
+[[backends]]
+full = "npm:@kitlangton/ghui"
+
+[backends.options]
+# Curated registry entry; explicitly permit the package below aube's threshold.
+allow_low_downloads = true


### PR DESCRIPTION
## Summary
- add `ghui` shorthand backed by `npm:@kitlangton/ghui`
- declare the `ghui` binary and version check

## Popularity
- GitHub: 1,079 stars, 74 forks; latest release `v0.9.0` published 2026-06-28
- npm: 9,378 downloads from 2025-08-24 through 2026-08-23
- Used by: Omarchy as a mise-managed tool
- Maintainer-directed exception to the usual popularity and Tier 3 backend thresholds

## Testing
- `mise ls-remote npm:@kitlangton/ghui`
- installed `npm:@kitlangton/ghui@0.9.0` after accepting the low-download prompt
- `mise x npm:@kitlangton/ghui@0.9.0 -- ghui --version`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a single registry TOML with no changes to install or security logic.
> 
> **Overview**
> Adds a new **mise registry shorthand** for **`ghui`**, a terminal UI for GitHub pull requests, installed via **`npm:@kitlangton/ghui`**.
> 
> The entry declares the **`ghui`** binary, a **`ghui --version`** install check against **`{{version}}`**, and **semver** version ordering. **`allow_low_downloads = true`** opts this curated package in despite npm download counts below the usual **aube** threshold.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e13b8fe928fb8efe59be5398473d32acbae48090. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated `ghui` package registry configuration with structured npm backend details.
  * Added support for including packages with low download counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->