### PR TITLE
registry: add hey-cli

### DIFF
--- a/registry/hey-cli.toml
+++ b/registry/hey-cli.toml
@@ -1,0 +1,5 @@
+backends = ["github:basecamp/hey-cli"]
+bins = ["hey"]
+description = "A CLI and TUI for HEY"
+test = { cmd = "hey --version", expected = "hey version {{version}}" }
+version_order = "semver"


### PR DESCRIPTION
## Summary
- add `hey-cli` shorthand backed by `github:basecamp/hey-cli`
- declare the `hey` binary and version check

## Popularity
- GitHub: 137 stars, 24 forks; latest release `v0.2.2` published 2026-08-24
- Used by: Omarchy as a mise-managed tool
- Maintainer-directed exception to the usual registry popularity threshold

## Testing
- `mise ls-remote github:basecamp/hey-cli`
- `MISE_MINIMUM_RELEASE_AGE=0 mise x github:basecamp/hey-cli@0.2.2 -- hey --version`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only addition with no changes to install or runtime logic.
> 
> **Overview**
> Adds a new mise registry shorthand **`hey-cli`** so users can install HEY’s CLI/TUI via `github:basecamp/hey-cli` without typing the full backend path.
> 
> The entry wires the **`hey`** binary, semver ordering, and a smoke test that runs `hey --version` and expects `hey version {{version}}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ae675e46872ff1fc205425492595c695b404dc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `hey-cli` to the available tool registry.
  * Included its GitHub source, executable name, description, version check, and semantic version handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->