### PR TITLE
registry: add ori

### DIFF
--- a/registry/ori.toml
+++ b/registry/ori.toml
@@ -1,0 +1,5 @@
+backends = ["aqua:OpenRouterLabs/ori-releases"]
+bins = ["ori"]
+description = "The easiest way to use OpenRouter locally"
+test = { cmd = "ori --version", expected = '"name": "@ori-runtime/cli"' }
+version_order = "source"


### PR DESCRIPTION
## Summary
- add `ori` shorthand using the preferred `aqua:OpenRouterLabs/ori-releases` backend
- preserve upstream source ordering because Ori release versions include commit hashes
- declare the `ori` binary and a stable version-command check

## Popularity
- GitHub release repository: 3 stars, 1 fork; latest release `cli-0.10.1-b41708f` published 2026-08-24
- Available in the Aqua registry with checksum verification
- Used by: Omarchy as a mise-managed tool
- Maintainer-directed exception to the usual registry popularity threshold

## Testing
- `mise ls-remote aqua:OpenRouterLabs/ori-releases`
- `MISE_MINIMUM_RELEASE_AGE=0 mise x aqua:OpenRouterLabs/ori-releases@0.10.1-b41708f -- ori --version`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new registry manifest only; no changes to install logic, auth, or existing tools.
> 
> **Overview**
> Adds a new **mise registry shorthand** for **Ori** (`ori`), the OpenRouter local runtime CLI.
> 
> Installation is wired through **`aqua:OpenRouterLabs/ori-releases`**, with **`version_order = "source"`** so version lists follow upstream ordering (needed because Ori tags include commit hashes). The entry exposes the **`ori`** binary and a **`test`** hook that runs `ori --version` and checks for `"name": "@ori-runtime/cli"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a22864a1d0041d7e4770c095d40f76701dcb3b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ori CLI registry configuration, including executable details and version detection settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->