### PR TITLE
fix(env): preserve command environment overrides

### DIFF
--- a/e2e/env/test_command_env_overrides
+++ b/e2e/env/test_command_env_overrides
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cat >mise.toml <<'EOF'
+[env]
+TMPL = '{{ get_env(name="TMPL", default="tmpl-default") }}'
+DEFAULT = { default = "default-default" }
+PLAIN = "plain-value"
+
+[tasks.probe]
+run = 'printf "%s|%s|%s" "$TMPL" "$DEFAULT" "$PLAIN"'
+EOF
+
+eval "$(mise activate bash)"
+eval "$(mise hook-env -s bash --reason precmd)"
+
+assert \
+  "TMPL=override DEFAULT=override PLAIN=override mise env -J | jq -r '[.TMPL, (if has(\"DEFAULT\") then .DEFAULT else \"omitted\" end), .PLAIN] | join(\"|\")'" \
+  "override|omitted|plain-value"
+assert \
+  "TMPL=override DEFAULT=override PLAIN=override mise run probe" \
+  "override|override|plain-value"

--- a/src/env.rs
+++ b/src/env.rs
@@ -944,7 +944,7 @@ fn env_map_key<'a>(env: &'a EnvMap, key: &str) -> Option<&'a String> {
 #[cfg(windows)]
 fn env_map_key<'a>(env: &'a EnvMap, key: &str) -> Option<&'a String> {
     env.keys()
-        .find(|candidate| candidate.eq_ignore_ascii_case(key))
+        .find(|candidate| windows_env_key_eq(candidate, key))
 }
 
 fn env_map_get<'a>(env: &'a EnvMap, key: &str) -> Option<&'a String> {
@@ -959,8 +959,24 @@ fn env_diff_get<'a>(env: &'a IndexMap<String, String>, key: &str) -> Option<&'a 
 #[cfg(windows)]
 fn env_diff_get<'a>(env: &'a IndexMap<String, String>, key: &str) -> Option<&'a String> {
     env.iter()
-        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(key))
+        .find(|(candidate, _)| windows_env_key_eq(candidate, key))
         .map(|(_, value)| value)
+}
+
+#[cfg(windows)]
+fn windows_env_key_eq(left: &str, right: &str) -> bool {
+    use windows_sys::Win32::Globalization::{CSTR_EQUAL, CompareStringOrdinal};
+
+    let left = left.encode_utf16().collect::<Vec<_>>();
+    let right = right.encode_utf16().collect::<Vec<_>>();
+    let (Ok(left_len), Ok(right_len)) = (i32::try_from(left.len()), i32::try_from(right.len()))
+    else {
+        return false;
+    };
+
+    unsafe {
+        CompareStringOrdinal(left.as_ptr(), left_len, right.as_ptr(), right_len, 1) == CSTR_EQUAL
+    }
 }
 
 fn offline(args: &[String]) -> bool {
@@ -1319,10 +1335,15 @@ mod tests {
     #[test]
     fn test_reverse_diff_matches_environment_keys_case_insensitively_on_windows() {
         let diff = EnvDiff {
-            old: [("Changed".into(), "before".into())].into(),
+            old: [
+                ("Changed".into(), "before".into()),
+                ("MÎSE_FOO".into(), "before-unicode".into()),
+            ]
+            .into(),
             new: [
                 ("Added".into(), "managed".into()),
                 ("Changed".into(), "managed".into()),
+                ("MÎSE_FOO".into(), "managed-unicode".into()),
             ]
             .into(),
             ..Default::default()
@@ -1330,12 +1351,17 @@ mod tests {
         let current = [
             ("ADDED".into(), "managed".into()),
             ("CHANGED".into(), "managed".into()),
+            ("mîse_foo".into(), "managed-unicode".into()),
         ]
         .into();
 
         assert_eq!(
             reverse_diff_preserving_overrides(&diff, current),
-            [("CHANGED".into(), "before".into())].into()
+            [
+                ("CHANGED".into(), "before".into()),
+                ("mîse_foo".into(), "before-unicode".into()),
+            ]
+            .into()
         );
     }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -5,7 +5,7 @@ use crate::file::replace_path;
 use crate::shell::ShellType;
 use crate::{cli::args::ToolArg, file::display_path};
 use eyre::Context;
-use indexmap::IndexSet;
+use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
 use log::LevelFilter;
 pub(crate) use std::env::*;
@@ -910,11 +910,14 @@ fn get_pristine_env(mise_diff: &EnvDiff, orig_env: EnvMap) -> EnvMap {
 /// values changed or removed by the caller after mise applied the environment.
 fn reverse_diff_preserving_overrides(mise_diff: &EnvDiff, mut env: EnvMap) -> EnvMap {
     for (key, old_value) in &mise_diff.old {
-        match mise_diff.new.get(key) {
-            Some(new_value) if env.get(key) == Some(new_value) => {
-                env.insert(key.clone(), old_value.clone());
+        match env_diff_get(&mise_diff.new, key) {
+            Some(new_value) if env_map_get(&env, key) == Some(new_value) => {
+                let key = env_map_key(&env, key)
+                    .cloned()
+                    .unwrap_or_else(|| key.clone());
+                env.insert(key, old_value.clone());
             }
-            None if !env.contains_key(key) => {
+            None if env_map_get(&env, key).is_none() => {
                 env.insert(key.clone(), old_value.clone());
             }
             _ => {}
@@ -922,12 +925,42 @@ fn reverse_diff_preserving_overrides(mise_diff: &EnvDiff, mut env: EnvMap) -> En
     }
 
     for (key, new_value) in &mise_diff.new {
-        if !mise_diff.old.contains_key(key) && env.get(key) == Some(new_value) {
-            env.remove(key);
+        if env_diff_get(&mise_diff.old, key).is_none()
+            && env_map_get(&env, key) == Some(new_value)
+            && let Some(key) = env_map_key(&env, key).cloned()
+        {
+            env.remove(&key);
         }
     }
 
     env
+}
+
+#[cfg(not(windows))]
+fn env_map_key<'a>(env: &'a EnvMap, key: &str) -> Option<&'a String> {
+    env.get_key_value(key).map(|(key, _)| key)
+}
+
+#[cfg(windows)]
+fn env_map_key<'a>(env: &'a EnvMap, key: &str) -> Option<&'a String> {
+    env.keys()
+        .find(|candidate| candidate.eq_ignore_ascii_case(key))
+}
+
+fn env_map_get<'a>(env: &'a EnvMap, key: &str) -> Option<&'a String> {
+    env_map_key(env, key).and_then(|key| env.get(key))
+}
+
+#[cfg(not(windows))]
+fn env_diff_get<'a>(env: &'a IndexMap<String, String>, key: &str) -> Option<&'a String> {
+    env.get(key)
+}
+
+#[cfg(windows)]
+fn env_diff_get<'a>(env: &'a IndexMap<String, String>, key: &str) -> Option<&'a String> {
+    env.iter()
+        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(key))
+        .map(|(_, value)| value)
 }
 
 fn offline(args: &[String]) -> bool {
@@ -1279,6 +1312,30 @@ mod tests {
         assert_eq!(
             reverse_diff_preserving_overrides(&diff, EnvMap::new()),
             EnvMap::new()
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_reverse_diff_matches_environment_keys_case_insensitively_on_windows() {
+        let diff = EnvDiff {
+            old: [("Changed".into(), "before".into())].into(),
+            new: [
+                ("Added".into(), "managed".into()),
+                ("Changed".into(), "managed".into()),
+            ]
+            .into(),
+            ..Default::default()
+        };
+        let current = [
+            ("ADDED".into(), "managed".into()),
+            ("CHANGED".into(), "managed".into()),
+        ]
+        .into();
+
+        assert_eq!(
+            reverse_diff_preserving_overrides(&diff, current),
+            [("CHANGED".into(), "before".into())].into()
         );
     }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,6 +1,6 @@
 use crate::Result;
 use crate::config::miserc;
-use crate::env_diff::{EnvDiff, EnvDiffOperation, EnvDiffPatches, EnvMap};
+use crate::env_diff::{EnvDiff, EnvMap};
 use crate::file::replace_path;
 use crate::shell::ShellType;
 use crate::{cli::args::ToolArg, file::display_path};
@@ -882,8 +882,7 @@ pub(crate) fn var_path(key: &str) -> Option<PathBuf> {
 /// this returns the environment as if __MISE_DIFF was reversed.
 /// putting the shell back into a state before hook-env was run
 fn get_pristine_env(mise_diff: &EnvDiff, orig_env: EnvMap) -> EnvMap {
-    let patches = mise_diff.reverse().to_patches();
-    let mut env = apply_patches(&orig_env, &patches);
+    let mut env = reverse_diff_preserving_overrides(mise_diff, orig_env);
 
     // get the current path as a vector
     let path = match env.get(&*PATH_KEY) {
@@ -907,20 +906,28 @@ fn get_pristine_env(mise_diff: &EnvDiff, orig_env: EnvMap) -> EnvMap {
     env
 }
 
-fn apply_patches(env: &EnvMap, patches: &EnvDiffPatches) -> EnvMap {
-    let mut new_env = env.clone();
-    for patch in patches {
-        match patch {
-            EnvDiffOperation::Add(k, v) | EnvDiffOperation::Change(k, v) => {
-                new_env.insert(k.into(), v.into());
+/// Reverse values that are still in the state mise recorded, while preserving
+/// values changed or removed by the caller after mise applied the environment.
+fn reverse_diff_preserving_overrides(mise_diff: &EnvDiff, mut env: EnvMap) -> EnvMap {
+    for (key, old_value) in &mise_diff.old {
+        match mise_diff.new.get(key) {
+            Some(new_value) if env.get(key) == Some(new_value) => {
+                env.insert(key.clone(), old_value.clone());
             }
-            EnvDiffOperation::Remove(k) => {
-                new_env.remove(k);
+            None if !env.contains_key(key) => {
+                env.insert(key.clone(), old_value.clone());
             }
+            _ => {}
         }
     }
 
-    new_env
+    for (key, new_value) in &mise_diff.new {
+        if !mise_diff.old.contains_key(key) && env.get(key) == Some(new_value) {
+            env.remove(key);
+        }
+    }
+
+    env
 }
 
 fn offline(args: &[String]) -> bool {
@@ -1193,21 +1200,86 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test]
-    async fn test_apply_patches() {
-        let _config = Config::get().await.unwrap();
-        let mut env = EnvMap::new();
-        env.insert("foo".into(), "bar".into());
-        env.insert("baz".into(), "qux".into());
-        let patches = vec![
-            EnvDiffOperation::Add("foo".into(), "bar".into()),
-            EnvDiffOperation::Change("baz".into(), "qux".into()),
-            EnvDiffOperation::Remove("quux".into()),
-        ];
-        let new_env = apply_patches(&env, &patches);
-        assert_eq!(new_env.len(), 2);
-        assert_eq!(new_env.get("foo").unwrap(), "bar");
-        assert_eq!(new_env.get("baz").unwrap(), "qux");
+    #[test]
+    fn test_reverse_diff_preserves_runtime_overrides() {
+        let diff = EnvDiff {
+            old: [
+                ("CHANGED".into(), "before".into()),
+                ("REMOVED".into(), "before".into()),
+            ]
+            .into(),
+            new: [
+                ("ADDED".into(), "managed".into()),
+                ("CHANGED".into(), "managed".into()),
+            ]
+            .into(),
+            ..Default::default()
+        };
+        let current = [
+            ("ADDED".into(), "override".into()),
+            ("CHANGED".into(), "override".into()),
+            ("REMOVED".into(), "override".into()),
+        ]
+        .into();
+
+        assert_eq!(
+            reverse_diff_preserving_overrides(&diff, current),
+            [
+                ("ADDED".into(), "override".into()),
+                ("CHANGED".into(), "override".into()),
+                ("REMOVED".into(), "override".into()),
+            ]
+            .into()
+        );
+    }
+
+    #[test]
+    fn test_reverse_diff_restores_unchanged_managed_values() {
+        let diff = EnvDiff {
+            old: [
+                ("CHANGED".into(), "before".into()),
+                ("REMOVED".into(), "before".into()),
+            ]
+            .into(),
+            new: [
+                ("ADDED".into(), "managed".into()),
+                ("CHANGED".into(), "managed".into()),
+            ]
+            .into(),
+            ..Default::default()
+        };
+        let current = [
+            ("ADDED".into(), "managed".into()),
+            ("CHANGED".into(), "managed".into()),
+        ]
+        .into();
+
+        assert_eq!(
+            reverse_diff_preserving_overrides(&diff, current),
+            [
+                ("CHANGED".into(), "before".into()),
+                ("REMOVED".into(), "before".into()),
+            ]
+            .into()
+        );
+    }
+
+    #[test]
+    fn test_reverse_diff_preserves_runtime_removals() {
+        let diff = EnvDiff {
+            old: [("CHANGED".into(), "before".into())].into(),
+            new: [
+                ("ADDED".into(), "managed".into()),
+                ("CHANGED".into(), "managed".into()),
+            ]
+            .into(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            reverse_diff_preserving_overrides(&diff, EnvMap::new()),
+            EnvMap::new()
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- preserve command-line and runtime overrides while reconstructing the pre-mise environment
- reverse scalar entries from __MISE_DIFF only when the live value still matches the value mise recorded
- retain the existing PATH reconstruction behavior for nested mise invocations
- add regression coverage for templates, default entries, plain assignments, and mise run

## Root cause

An activated shell passes __MISE_DIFF to every mise invocation. PRISTINE_ENV previously reversed every scalar entry unconditionally, so a command prefix such as GRID_USER=bar was removed before templates or default directives evaluated the caller environment.

The new behavior treats a changed or explicitly removed live value as authoritative. Values that still match the recorded mise-managed state are reversed as before.

Closes https://github.com/jdx/mise/discussions/12389

## Verification

- cargo test --bin mise reverse_diff -- --nocapture
- mise run test:e2e e2e/env/test_command_env_overrides
- mise run test:e2e e2e/cli/test_run_nested_exec_path
- mise run lint-fix
- changed-file hk run check --safe --format json

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core env restoration used by templates, `mise env`, and nested invocations; behavior change is intentional but affects every activated-shell command.
> 
> **Overview**
> Fixes a bug where **command-prefix and runtime env overrides were lost** in activated shells because `PRISTINE_ENV` fully reversed every scalar entry from `__MISE_DIFF`, wiping values like `VAR=override` before `mise env` or `mise run` evaluated templates and defaults.
> 
> **`get_pristine_env`** now calls **`reverse_diff_preserving_overrides`** instead of blindly applying reverse patches: mise-managed values are rolled back only when the live env still matches what mise recorded; caller-changed or removed values stay as-is. Existing **PATH** stripping logic is unchanged.
> 
> On **Windows**, env key lookups during reversal use **ordinal case-insensitive** matching so reversal works across key spellings.
> 
> Adds **unit tests** for override preservation, unchanged managed rollback, runtime removals, and Windows key casing, plus an **e2e** script asserting overrides flow through `mise env -J` and `mise run`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfba15261f88c47d16177db3fef1133e0ba3ccf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment restoration when runtime variables are changed or removed.
  * Preserved environment variable names and values correctly on Windows, regardless of capitalization.
  * Correctly handled explicit overrides across environment inspection and command execution.

* **Tests**
  * Added end-to-end coverage for overrides, omitted defaults, preserved values, and runtime removals.
  * Added Windows regression coverage for case-insensitive environment variable handling and Unicode names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->