### PR TITLE
docs(security): update paranoid mode behavior

### DIFF
--- a/docs/paranoid.md
+++ b/docs/paranoid.md
@@ -46,7 +46,8 @@ Note that global and system config files (e.g., `~/.config/mise/config.toml`) ar
 
 [Safe mode](/security.html#safe-mode) takes precedence when both modes are enabled.
 Because safe mode makes project config inert, it loads untrusted config without a
-trust prompt or error.
+trust prompt or untrusted-config error. Other configuration errors are still
+reported.
 
 ## Community plugins
 

--- a/docs/paranoid.md
+++ b/docs/paranoid.md
@@ -51,13 +51,15 @@ reported.
 
 ## Community plugins
 
-Unless automatic confirmation is enabled with `--yes`, paranoid mode refuses to
-install an untrusted community plugin by short name. It allows plugin URLs
-registered with mise and plugins maintained under the `mise-plugins` GitHub
-organization.
+Paranoid mode refuses to install an untrusted community plugin by short name
+unless automatic confirmation is enabled with `--yes` or `MISE_YES=1`, mise is
+running in CI, or the installation uses `--force`. A short-name plugin is trusted
+when its resolved URL matches an asdf or vfox remote in mise's built-in registry,
+or when it is maintained under the `mise-plugins` GitHub organization.
 
-To install any other community plugin, specify its full Git repository URL. By
-providing the URL explicitly, you are choosing and trusting that source:
+To install any other community plugin, specify its full Git repository URL on the
+command line or in `[plugins]` configuration. Explicitly providing the URL bypasses
+the registry trust check because you are choosing and trusting that source:
 
 ```sh
 mise plugin install example https://github.com/example/asdf-example

--- a/docs/paranoid.md
+++ b/docs/paranoid.md
@@ -45,8 +45,10 @@ If you change your config file, you'll need to trust it again.
 Note that global and system config files (e.g., `~/.config/mise/config.toml`) are implicitly trusted and exempt from this check. This allows paranoid mode to be enabled in a global config without requiring a trust prompt for that file itself.
 
 [Safe mode](/security.html#safe-mode) takes precedence when both modes are enabled.
-Because safe mode makes project config inert, it loads untrusted config without a
-trust prompt or untrusted-config error. Other configuration errors are still
+Safe mode disables project-defined code execution and environment injection while
+retaining non-executable configuration such as tool definitions, task metadata,
+plugin declarations, and tool aliases. It therefore loads untrusted config without
+a trust prompt or untrusted-config error. Other configuration errors are still
 reported.
 
 ## Community plugins

--- a/docs/paranoid.md
+++ b/docs/paranoid.md
@@ -50,9 +50,10 @@ trust prompt or error.
 
 ## Community plugins
 
-Paranoid mode refuses to install an untrusted community plugin by short name. It
-allows plugin URLs registered with mise and plugins maintained under the
-`mise-plugins` GitHub organization.
+Unless automatic confirmation is enabled with `--yes`, paranoid mode refuses to
+install an untrusted community plugin by short name. It allows plugin URLs
+registered with mise and plugins maintained under the `mise-plugins` GitHub
+organization.
 
 To install any other community plugin, specify its full Git repository URL. By
 providing the URL explicitly, you are choosing and trusting that source:

--- a/docs/paranoid.md
+++ b/docs/paranoid.md
@@ -5,11 +5,14 @@ for a bad actor to compromise your system. These are settings that I
 personally do not use on my own system because I find the behavior too
 restrictive for the benefits.
 
-Paranoid mode can be enabled with either `MISE_PARANOID=1` or a setting:
+Paranoid mode can be enabled with either `MISE_PARANOID=1` or a global setting:
 
 ```sh
 mise settings paranoid=1
 ```
+
+The setting is global-only, so a project config cannot enable or disable paranoid
+mode for itself.
 
 ## Config files
 
@@ -41,30 +44,25 @@ If you change your config file, you'll need to trust it again.
 
 Note that global and system config files (e.g., `~/.config/mise/config.toml`) are implicitly trusted and exempt from this check. This allows paranoid mode to be enabled in a global config without requiring a trust prompt for that file itself.
 
+[Safe mode](/security.html#safe-mode) takes precedence when both modes are enabled.
+Because safe mode makes project config inert, it loads untrusted config without a
+trust prompt or error.
+
 ## Community plugins
 
-Community plugins cannot be directly installed via short-name under paranoid.
-You can install plugins that are either core, maintained by the mise team,
-or plugins that mise has marked as "first-party"—meaning plugins developed by
-the same team that builds the tool the plugin installs.
+Paranoid mode refuses to install an untrusted community plugin by short name. It
+allows plugin URLs registered with mise and plugins maintained under the
+`mise-plugins` GitHub organization.
 
-Other than that, say for "shfmt", you'll need to specify the full git repo
-to install:
+To install any other community plugin, specify its full Git repository URL. By
+providing the URL explicitly, you are choosing and trusting that source:
 
 ```sh
-mise plugin install shfmt https://github.com/luizm/asdf-shfmt
+mise plugin install example https://github.com/example/asdf-example
 ```
 
-Unlike in normal mode where `mise plugin install shfmt` would be sufficient.
-
-## Always uses HTTPS
-
-Some endpoints in mise are fetched over HTTP such as checking for the latest mise
-version and pulling version lists of tools. These are not security risks and a
-malicious actor injecting false data would not introduce a security risk.
-Normally mise uses HTTP because loading the TLS module takes about 10ms and this
-affects commonly used commands so it is a noticeably delay.
-In paranoid mode, all endpoints will be fetched over HTTPS.
+In normal mode, mise may instead warn and ask for confirmation before installing
+an untrusted community plugin by short name.
 
 ## Provenance re-verification
 
@@ -83,9 +81,10 @@ This behavior can also be enabled independently via the
 
 ## See also
 
-[Safe mode](/security.html#safe-mode) (`MISE_SAFE=1`) is a related but distinct control: where
-paranoid tightens _trust_ (which configs are loaded and re-verified), safe mode is a hard boundary
-on _code execution_ for running mise against configuration you do not control.
+[Safe mode](/security.html#safe-mode) (`MISE_SAFE=1`) is a related but distinct
+control: paranoid tightens _trust_ (which configs are loaded and re-verified),
+while safe mode is a hard boundary on _code execution_ for running mise against
+configuration you do not control.
 
 ## More?
 


### PR DESCRIPTION
## Summary
- remove the obsolete HTTPS behavior, since built-in version endpoints always use HTTPS
- document current paranoid-mode rules for registered and explicitly sourced community plugins
- clarify that paranoid is global-only and that safe mode takes precedence over trust checks

## Testing
- `mise run docs:build`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to paranoid mode; no runtime or security behavior is modified.
> 
> **Overview**
> **Updates `docs/paranoid.md`** to match current paranoid behavior and remove outdated guidance.
> 
> Paranoid is described as **global-only** (`mise settings paranoid=1` / `MISE_PARANOID=1`), with a note that project configs cannot toggle it. A new **safe mode** subsection under config files explains that when both are on, safe mode wins: untrusted project config can load for non-executable settings without trust prompts, while other config errors still surface.
> 
> The **community plugins** section is rewritten: paranoid blocks untrusted short-name installs unless `--yes`/`MISE_YES=1`, CI, or `--force`; trusted short names are tied to the built-in registry or `mise-plugins` on GitHub; other plugins need an explicit Git URL. Normal mode’s confirm-on-install behavior is called out separately.
> 
> The obsolete **“Always uses HTTPS”** section is removed (version endpoints now use HTTPS by default). The **See also** safe-mode blurb is tightened for readability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db4b48d11d22ae0f8ae09d026d55874eddcf7299. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that paranoid mode is controlled globally and cannot be overridden by project configuration.
  - Explained that safe mode disables project-defined code execution and environment injection while retaining non-executable configuration.
  - Documented safe mode’s handling of untrusted configurations and other configuration errors.
  - Expanded community plugin guidance for CI, `--force`, `MISE_YES=1`, registry URLs, GitHub ownership, full URLs, and normal-mode confirmations.
  - Updated related guidance and formatting for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->