### PR TITLE
test(config): assert the tracking entry itself is removed

### DIFF
--- a/src/config/tracking.rs
+++ b/src/config/tracking.rs
@@ -137,11 +137,17 @@ mod tests {
         assert!(Tracker::list_all_in(&dir).unwrap().is_empty());
 
         Tracker::clean_in(&dir).unwrap();
-        assert!(!entry.exists());
+        assert!(
+            fs::symlink_metadata(&entry).is_err(),
+            "the tracking entry must be removed"
+        );
     }
 
     #[test]
     fn removes_an_entry_whose_target_is_gone() {
+        // The entry is checked with `symlink_metadata` rather than `exists`,
+        // which follows the link: a dangling symlink reports `false` whether or
+        // not the clean removed it, so `exists` would pass on unix regardless.
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path().join("tracked");
         let config = tmp.path().join("mise.toml");
@@ -151,6 +157,9 @@ mod tests {
         fs::remove_file(&config).unwrap();
 
         Tracker::clean_in(&dir).unwrap();
-        assert!(!entry.exists());
+        assert!(
+            fs::symlink_metadata(&entry).is_err(),
+            "the tracking entry must be removed"
+        );
     }
 }


### PR DESCRIPTION
Follow-up to #12380, which merged with one unaddressed review comment. The behaviour it shipped is correct — this is only about a test that could not have caught a regression in it.

## The problem

`Path::exists` follows symlinks. In `removes_an_entry_whose_target_is_gone` the target is deleted before the clean, so the entry is a dangling symlink on unix, and `!entry.exists()` is `true` whether or not `clean_in` removed anything:

```
dangling symlink, entry still present:
  exists()          -> false     # assertion passes anyway
  symlink_metadata() -> Ok
after removal:
  symlink_metadata() -> Err
```

So on linux and macOS that test asserted nothing. What made that worth a separate PR rather than leaving it: unix is the platform the original report came from, and the only job where the assertion had teeth was `windows-unit`, where `make_symlink_or_file` writes a plain file — and that job is gated on `full-ci`.

## The fix

Both cleanup tests use `fs::symlink_metadata`, which stats the entry instead of its target. The sibling test (`removes_an_entry_pointing_at_something_that_is_not_a_file`) was already meaningful, since a symlink to a live directory does resolve — it changes for consistency, so the rule in this module reads as one thing: these tests check the entry, not what it points at.

`keeps_an_entry_pointing_at_a_file` is left alone; its target exists, and the `list_all_in` assertion beside it already pins entry survival.

## Tests

Test-only change, no production code touched.

**I could not run `cargo test` for this.** There is no Rust toolchain on the machine I have, and a full mise build is not feasible on it, so I verified the filesystem semantics the change turns on (the transcript above) rather than the compiled assertion. `fs` is already imported in the module and `symlink_metadata` is std, so I expect CI to be the real check here — please treat it as such.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.241.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracking cleanup verification to correctly confirm that tracking entries are removed, including dangling symbolic links.
  * Added documentation explaining symbolic link cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->