### PR TITLE
fix(task): anchor injected tasks at their parent's keep-order slot

### DIFF
--- a/e2e/tasks/test_task_keep_order_task_reference
+++ b/e2e/tasks/test_task_keep_order_task_reference
@@ -7,8 +7,15 @@
 # task emitting a single line never reaches a second line to become active, so
 # it lost everything.
 #
-# --jobs 1 keeps this deterministic. Block order across tasks is a separate
-# defect and is deliberately not asserted here.
+# --jobs 1 keeps that part deterministic.
+#
+# Block order across tasks is asserted further down. Those cases need real
+# parallelism -- with --jobs 1 the semaphore serializes the tasks and the
+# ordering defect cannot reproduce.
+#
+# Not covered: a parent whose `run` interleaves scripts and task references.
+# keep-order is one contiguous block per task and cannot express "parent
+# output, children blocks, more parent output".
 
 cat >mise.toml <<'TOML'
 [tasks.launch]
@@ -44,3 +51,67 @@ out="$(mise run --quiet --jobs 1 --output keep-order launch 2>&1)"
 assert "printf '%s\n' \"$out\"" "[three] L1
 [three] L2
 [three] L3"
+
+# Blocks come out in the order the tasks were written, not the order they
+# happened to produce output. `fast` finishes first and used to print first.
+cat >mise.toml <<'TOML'
+[tasks.launch]
+run = { tasks = ["slow", "fast"] }
+
+[tasks.slow]
+run = 'sleep 1; echo SLOW'
+
+[tasks.fast]
+run = 'echo FAST'
+TOML
+
+out="$(MISE_JOBS=4 mise run --quiet --output keep-order launch 2>&1)"
+assert "printf '%s\n' \"$out\"" "[slow] SLOW
+[fast] FAST"
+
+# Injected tasks take the position of the task that injected them, so they come
+# before a task named after it on the command line -- even though that task
+# finishes first. `:::` separates the two tasks; without it `other` would be an
+# argument to `launch` rather than a second task.
+cat >mise.toml <<'TOML'
+[tasks.launch]
+run = { tasks = ["slow", "fast"] }
+
+[tasks.slow]
+run = 'sleep 1; echo SLOW'
+
+[tasks.fast]
+run = 'echo FAST'
+
+[tasks.other]
+run = 'echo OTHER'
+TOML
+
+out="$(MISE_JOBS=4 mise run --quiet --output keep-order launch ::: other 2>&1)"
+assert "printf '%s\n' \"$out\"" "[slow] SLOW
+[fast] FAST
+[other] OTHER"
+
+# Nesting: a task injected by a task reference keeps its own slot, so what it
+# injects in turn anchors there rather than at the end.
+cat >mise.toml <<'TOML'
+[tasks.outer]
+run = { tasks = ["inner", "last"] }
+
+[tasks.inner]
+run = { tasks = ["a", "b"] }
+
+[tasks.a]
+run = 'sleep 1; echo A'
+
+[tasks.b]
+run = 'echo B'
+
+[tasks.last]
+run = 'echo LAST'
+TOML
+
+out="$(MISE_JOBS=4 mise run --quiet --output keep-order outer 2>&1)"
+assert "printf '%s\n' \"$out\"" "[a] A
+[b] B
+[last] LAST"

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -18,6 +18,7 @@ use crate::task::task_helpers::task_needs_permit;
 use crate::task::task_list::{get_task_lists, resolve_depends};
 use crate::task::task_output::TaskOutput;
 use crate::task::task_output_handler::OutputHandler;
+use crate::task::task_scheduler::RunLoopHooks;
 use crate::task::{Deps, Task, TaskCacheMode, usage_command_for_args};
 use crate::toolset::{InstallOptions, ResolveOptions, ToolVersion, ToolsetBuilder};
 use crate::ui::{ctrlc, info, style};
@@ -911,13 +912,16 @@ impl Run {
             .run_loop(
                 &mut main_done_rx,
                 main_deps.clone(),
-                || this.is_stopping(),
-                // What overrides `continue_on_error` is the *user* interrupting
-                // mise, not any task being interrupted. A child that took SIGINT
-                // on its own stops that task; it is not a reason to drop work the
-                // user asked to keep going.
-                ctrlc::is_cancelled,
-                this.continue_on_error,
+                RunLoopHooks {
+                    should_stop: || this.is_stopping(),
+                    // What overrides `continue_on_error` is the *user* interrupting
+                    // mise, not any task being interrupted. A child that took SIGINT
+                    // on its own stops that task; it is not a reason to drop work the
+                    // user asked to keep going.
+                    was_interrupted: ctrlc::is_cancelled,
+                    on_task_dropped: |task: &Task| this.retire_keep_order_slot(task),
+                    continue_on_error: this.continue_on_error,
+                },
                 |task, deps_for_remove, allow_during_interruption| {
                     let this = this.clone();
                     let spawn_context = spawn_context.clone();
@@ -1145,6 +1149,21 @@ impl Run {
         Ok(())
     }
 
+    /// Retire a task's keep-order slot because it will never run.
+    ///
+    /// The completion path that normally does this lives inside the task's
+    /// execution closure, so a task abandoned before that point would leave its
+    /// slot in the buffer map. An abandoned parent's slot is an anchor, and
+    /// since only the front entry may stream, everything behind it would stay
+    /// buffered until the final flush.
+    fn retire_keep_order_slot(&self, task: &Task) {
+        if let Some(oh) = &self.output_handler
+            && oh.output(Some(task)) == TaskOutput::KeepOrder
+        {
+            oh.keep_order_state.lock().unwrap().on_task_finished(task);
+        }
+    }
+
     async fn should_abort_while_stopping(
         this: &Self,
         task: &Task,
@@ -1162,6 +1181,8 @@ impl Run {
             return false;
         }
         deps.remove(task);
+        drop(deps);
+        this.retire_keep_order_slot(task);
         true
     }
 

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -410,6 +410,13 @@ impl Deps {
         }
     }
 
+    /// Whether this task ever started executing. `mark_executed` runs
+    /// synchronously before the task is spawned, so a task missing here has no
+    /// execution in flight and will never reach the completion callbacks.
+    pub(crate) fn has_executed(&self, task: &Task) -> bool {
+        self.executed.contains(&task_key(task))
+    }
+
     /// Mark a task as having actually started execution.
     /// This is distinct from being scheduled (sent) — a task may be scheduled as a
     /// graph leaf but then skipped because an earlier task failed.

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -54,6 +54,7 @@ use xx::file;
 /// Interactive tasks acquire a write lock (exclusive), non-interactive tasks acquire a read lock (shared).
 static TASK_RUNTIME_LOCK: LazyLock<RwLock<()>> = LazyLock::new(|| RwLock::new(()));
 type TaskOutputCapture = Arc<StdMutex<Vec<TaskCacheOutput>>>;
+
 const COMMAND_INPUT_TIMEOUT: Duration = Duration::from_secs(30);
 const COMMAND_INPUT_MAX_OUTPUT_BYTES: usize = 16 * 1024 * 1024;
 
@@ -119,6 +120,9 @@ fn task_env_path(path: &Path) -> String {
 #[derive(Clone, Copy)]
 struct TaskInjectionContext<'a> {
     config: &'a Arc<Config>,
+    /// The task whose run entry is injecting these tasks. keep-order anchors the
+    /// injected blocks at this task's position.
+    parent: &'a Task,
     task_env: &'a [(String, String)],
     sched_tx: &'a Arc<mpsc::UnboundedSender<SchedMsg>>,
     completion_state: &'a TaskCompletionState,
@@ -946,6 +950,7 @@ impl TaskExecutor {
                             override_env_ref,
                             TaskInjectionContext {
                                 config,
+                                parent: task,
                                 task_env,
                                 sched_tx: &sched_tx,
                                 completion_state: &completion_state,
@@ -973,6 +978,7 @@ impl TaskExecutor {
                             None,
                             TaskInjectionContext {
                                 config,
+                                parent: task,
                                 task_env,
                                 sched_tx: &sched_tx,
                                 completion_state: &completion_state,
@@ -999,6 +1005,7 @@ impl TaskExecutor {
     ) -> Result<TaskCompletionState> {
         let TaskInjectionContext {
             config,
+            parent,
             task_env,
             sched_tx,
             completion_state,
@@ -1064,7 +1071,33 @@ impl TaskExecutor {
                 to_run.push(t);
             }
         }
+        let injected = to_run.clone();
         let sub_deps = Deps::new_pruned(config, to_run, completion_state).await?;
+        // Give these tasks their keep-order slots now, while the order they were
+        // written in is still known and before any of them can produce a line.
+        // Reaching this from `&self` is fine: the state is behind the shared
+        // `Arc<Mutex<..>>`, and the guard is a temporary in a statement with no
+        // await in it, so it never crosses a suspension point.
+        {
+            let children: Vec<Task> = injected
+                .into_iter()
+                // A task the sub-graph pruned as already complete never runs, so
+                // it would never call `on_task_finished` — its empty slot would
+                // sit at the front for the rest of the run.
+                .filter(|t| sub_deps.all().any(|scheduled| scheduled == t))
+                // Same reason, for a task whose own `output` opts out of
+                // keep-order: `on_task_finished` is only called for keep-order
+                // tasks (see cli/run.rs).
+                .filter(|t| self.output(Some(t)) == TaskOutput::KeepOrder)
+                .collect();
+            if !children.is_empty() {
+                self.output_handler
+                    .keep_order_state
+                    .lock()
+                    .unwrap()
+                    .insert_tasks_before(parent, &children);
+            }
+        }
         let sub_deps = Arc::new(Mutex::new(sub_deps));
 
         // Pump subgraph into scheduler and signal completion via oneshot when done
@@ -1142,10 +1175,33 @@ impl TaskExecutor {
                 // Clean up the dependency graph to ensure completion
                 let mut deps = sub_deps.lock().await;
                 let tasks_to_remove: Vec<Task> = deps.all().cloned().collect();
+                // These tasks are abandoned here, without ever reaching the
+                // scheduler, so nothing else retires the keep-order slots they
+                // were given -- and a slot left behind is an anchor holding the
+                // front of the buffer map.
+                //
+                // Only the ones that never started. A task that did start either
+                // retires its own slot when it ends or is still producing
+                // output, and this path returns after waiting just 100ms for the
+                // subgraph to drain, so one may well still be alive. Retiring a
+                // live task's slot would strand every line it prints afterwards
+                // at the tail of the map.
+                let never_started: Vec<Task> = tasks_to_remove
+                    .iter()
+                    .filter(|t| !deps.has_executed(t))
+                    .cloned()
+                    .collect();
                 for task in tasks_to_remove {
                     deps.remove(&task);
                 }
                 drop(deps);
+                for task in &never_started {
+                    self.output_handler
+                        .keep_order_state
+                        .lock()
+                        .unwrap()
+                        .retire_unused_slot(task);
+                }
                 // Give a short time for the spawned task to finish cleanly
                 let _ = tokio::time::timeout(Duration::from_millis(100), done_rx).await;
                 return Err(eyre!("task sequence aborted due to failure"));

--- a/src/task/task_helpers.rs
+++ b/src/task/task_helpers.rs
@@ -1,5 +1,5 @@
 use crate::file::canonicalize_or_self;
-use crate::task::Task;
+use crate::task::{RunEntry, Task};
 use std::path::{Path, PathBuf};
 
 /// Check if a task needs a permit from the semaphore
@@ -7,6 +7,16 @@ use std::path::{Path, PathBuf};
 /// Orchestrator-only tasks (pure groups of sub-tasks) do not.
 pub(crate) fn task_needs_permit(task: &Task) -> bool {
     task.file.is_some() || !task.run_script_strings().is_empty()
+}
+
+/// Whether this task starts other tasks from its `run` entries.
+///
+/// Such a task produces no output of its own — `task_needs_permit` is false, and
+/// the `Finished in` line is gated on the same condition — but keep-order still
+/// needs a slot for it, to anchor the blocks of the tasks it injects at the
+/// position the task itself was declared in.
+pub(crate) fn task_runs_task_references(task: &Task) -> bool {
+    task.run().iter().any(|e| !matches!(e, RunEntry::Script(_)))
 }
 
 /// Canonicalize a path for use as cache key

--- a/src/task/task_output_handler.rs
+++ b/src/task/task_output_handler.rs
@@ -1,5 +1,5 @@
 use crate::config::Settings;
-use crate::task::task_helpers::task_needs_permit;
+use crate::task::task_helpers::{task_needs_permit, task_runs_task_references};
 use crate::task::task_output::TaskOutput;
 use crate::task::{Task, TaskCacheOutput};
 use crate::ui::multi_progress_report::MultiProgressReport;
@@ -49,6 +49,44 @@ impl KeepOrderState {
         self.buffers.entry(task.clone()).or_default();
     }
 
+    /// Give `tasks` slots immediately before `parent`'s, keeping their relative
+    /// order, so tasks a parent injects at runtime occupy the position the
+    /// parent itself was declared in rather than landing wherever their first
+    /// line happened to arrive.
+    ///
+    /// `parent` keeps its own (empty) slot afterwards: a later run entry, or a
+    /// nested injection by one of these tasks, has to find the same anchor.
+    /// `on_task_finished` reaps it.
+    ///
+    /// A parent that produces output of its own is left alone. keep-order is one
+    /// contiguous block per task and cannot express "parent output, children
+    /// blocks, more parent output", and moving such a parent behind its children
+    /// would reorder lines it had already buffered. Those tasks keep what this
+    /// did before -- appended -- only now in the order they were written rather
+    /// than the order they happened to print.
+    pub(crate) fn insert_tasks_before(&mut self, parent: &Task, tasks: &[Task]) {
+        let anchor = if task_needs_permit(parent) {
+            None
+        } else {
+            self.buffers.get_index_of(parent)
+        };
+        let Some(mut idx) = anchor else {
+            for task in tasks {
+                self.init_task(task);
+            }
+            return;
+        };
+        for task in tasks {
+            // `shift_insert` *moves* a key it already holds, which would drag a
+            // task out of the position it was given earlier.
+            if self.buffers.contains_key(task) {
+                continue;
+            }
+            self.buffers.shift_insert(idx, task.clone(), Vec::new());
+            idx += 1;
+        }
+    }
+
     /// Whether this task should stream live (is active, or is first in
     /// definition order when no task is active yet).
     fn is_active(&self, task: &Task) -> bool {
@@ -84,6 +122,25 @@ impl KeepOrderState {
                 .entry(task.clone())
                 .or_default()
                 .push(KeepOrderLine::Stderr(prefix, line));
+        }
+    }
+
+    /// Retire the slot of a task the run abandoned before it produced anything.
+    ///
+    /// Only an empty slot is touched. A slot holding lines belongs to a task
+    /// that did produce output, and the normal completion path flushes it in
+    /// turn -- removing it here could print it out of order, and if the task is
+    /// somehow still running its later lines would be stranded at the tail.
+    pub(crate) fn retire_unused_slot(&mut self, task: &Task) {
+        // The live task's buffer is empty too -- `activate` drained it on the
+        // way in -- so "empty" alone does not mean "produced nothing". Retiring
+        // it would hand the stream to another task and strand the rest of its
+        // output at the tail of the map.
+        if self.active.as_ref() == Some(task) {
+            return;
+        }
+        if self.buffers.get(task).is_some_and(|lines| lines.is_empty()) {
+            self.on_task_finished(task);
         }
     }
 
@@ -130,8 +187,19 @@ impl KeepOrderState {
     /// Promote the next buffered (still-running) task to active so it can
     /// stream live going forward.
     fn promote_next(&mut self) {
-        if let Some((task, _)) = self.buffers.first() {
-            let task = task.clone();
+        // Skip an entry holding no lines. That is an anchor: it never produces
+        // output of its own, so activating it would pin the live stream to a
+        // task that cannot release it until it finishes -- which is after
+        // everything it injected -- and the tasks behind it would buffer to the
+        // end of the run. Leaving `active` as None costs nothing, since
+        // `is_active` already lets the front entry claim the stream on its next
+        // line.
+        let next = self
+            .buffers
+            .first()
+            .filter(|(_, lines)| !lines.is_empty())
+            .map(|(task, _)| task.clone());
+        if let Some(task) = next {
             self.activate(&task);
         }
     }
@@ -289,8 +357,12 @@ impl OutputHandler {
     /// Initialize output handling for a task
     pub(crate) fn init_task(&mut self, task: &Task) {
         match self.output(Some(task)) {
-            TaskOutput::KeepOrder if task_needs_permit(task) => {
-                // Only add tasks that produce output (not orchestrator-only tasks)
+            TaskOutput::KeepOrder if task_needs_permit(task) || task_runs_task_references(task) => {
+                // Tasks that produce output, plus the ones that inject other
+                // tasks: those produce nothing themselves but anchor their
+                // children's blocks at their own declared position. A task that
+                // only aggregates `depends` gets neither and stays out, so it
+                // cannot sit at the front holding the live stream all run.
                 self.keep_order_state.lock().unwrap().init_task(task);
             }
             TaskOutput::Replacing => {
@@ -495,6 +567,7 @@ impl OutputHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::task::RunEntry;
 
     #[test]
     fn colored_prefix_modes_require_a_rendered_style() {
@@ -524,6 +597,10 @@ mod tests {
 
     fn buffered(state: &KeepOrderState, task: &Task) -> usize {
         state.buffers.get(task).map(Vec::len).unwrap_or(0)
+    }
+
+    fn keys(state: &KeepOrderState) -> Vec<String> {
+        state.buffers.keys().map(|t| t.name.clone()).collect()
     }
 
     #[test]
@@ -583,5 +660,202 @@ mod tests {
 
         let outputs = handler.timed_outputs.lock().unwrap();
         assert_eq!(outputs.get("build").unwrap().1, ["first", "second"]);
+    }
+
+    #[test]
+    fn injected_tasks_take_the_parents_slot() {
+        // A task started from a run entry is not in the up-front task graph, so
+        // without an anchor its block lands wherever its first line happened to
+        // arrive rather than where the parent was declared (#12238).
+        let mut state = KeepOrderState::new();
+        let launch = task_named("launch");
+        let other = task_named("other");
+        state.init_task(&launch);
+        state.init_task(&other);
+
+        state.insert_tasks_before(&launch, &[task_named("one"), task_named("two")]);
+
+        assert_eq!(keys(&state), ["one", "two", "launch", "other"]);
+    }
+
+    #[test]
+    fn a_task_declared_after_the_parent_cannot_stream_ahead_of_the_children() {
+        let mut state = KeepOrderState::new();
+        let launch = task_named("launch");
+        let other = task_named("other");
+        state.init_task(&launch);
+        state.init_task(&other);
+        state.insert_tasks_before(&launch, &[task_named("one"), task_named("two")]);
+
+        state.on_stdout(&other, "other".into(), "first".into());
+        state.on_stdout(&other, "other".into(), "second".into());
+
+        assert_eq!(
+            buffered(&state, &other),
+            2,
+            "a task behind the injected ones must still be held"
+        );
+        assert_eq!(keys(&state)[0], "one");
+    }
+
+    #[test]
+    fn a_second_injection_reuses_the_parent_anchor() {
+        // Consuming the anchor on the first injection would leave the second run
+        // entry with nothing to anchor to, and it would append behind whatever
+        // was declared after the parent.
+        let mut state = KeepOrderState::new();
+        let launch = task_named("launch");
+        state.init_task(&launch);
+
+        state.insert_tasks_before(&launch, &[task_named("a")]);
+        state.insert_tasks_before(&launch, &[task_named("b")]);
+
+        assert_eq!(keys(&state), ["a", "b", "launch"]);
+    }
+
+    #[test]
+    fn a_task_that_already_has_a_slot_is_not_moved() {
+        // `shift_insert` moves a key it already holds, which would drag a task
+        // out of the position it was given earlier.
+        let mut state = KeepOrderState::new();
+        let launch = task_named("launch");
+        let a = task_named("a");
+        state.init_task(&launch);
+        state.init_task(&a);
+
+        state.insert_tasks_before(&launch, &[a.clone(), task_named("b")]);
+
+        assert_eq!(keys(&state), ["b", "launch", "a"]);
+    }
+
+    #[test]
+    fn a_parent_with_output_of_its_own_is_not_used_as_an_anchor() {
+        // The mixed case: keep-order cannot express "parent output, children,
+        // more parent output", and anchoring here would move lines the parent
+        // had already buffered behind its children's blocks.
+        let mut state = KeepOrderState::new();
+        let mixed = Task {
+            name: "mixed".to_string(),
+            run: vec![RunEntry::Script("echo A".to_string())],
+            ..Default::default()
+        };
+        state.init_task(&mixed);
+
+        state.insert_tasks_before(&mixed, &[task_named("one"), task_named("two")]);
+
+        assert_eq!(keys(&state), ["mixed", "one", "two"]);
+    }
+
+    #[test]
+    fn retiring_a_task_that_never_ran_releases_the_ones_behind_it() {
+        // The scheduler drops tasks on teardown without ever spawning them, so
+        // nothing else reports them as finished. An anchor left behind that way
+        // would hold the front of the map and keep everything after it buffered
+        // until the final flush.
+        let mut state = KeepOrderState::new();
+        let launch = task_named("launch");
+        let other = task_named("other");
+        state.init_task(&launch);
+        state.init_task(&other);
+
+        state.on_stdout(&other, "other".into(), "held".into());
+        assert_eq!(
+            buffered(&state, &other),
+            1,
+            "held while the anchor is ahead"
+        );
+
+        state.on_task_finished(&launch);
+
+        assert_eq!(keys(&state), ["other"]);
+        assert!(
+            state.is_active(&other),
+            "and streams once the anchor is gone"
+        );
+    }
+
+    #[test]
+    fn a_task_held_behind_an_anchor_flushes_when_the_anchor_finishes() {
+        // `promote_next` leaves `active` unset when the front slot is an empty
+        // anchor, so nothing streams while the anchor is there. The anchor's own
+        // completion has to release what queued up behind it rather than leaving
+        // it for `flush_all`: with `active` unset, `is_active` is true for the
+        // front entry, so the anchor takes the active path and flushes.
+        let mut state = KeepOrderState::new();
+        let launch = task_named("launch");
+        let other = task_named("other");
+        state.init_task(&launch);
+        state.init_task(&other);
+
+        state.on_stdout(&other, "other".into(), "held".into());
+        assert_eq!(buffered(&state, &other), 1);
+        assert!(
+            state.active.is_none(),
+            "an empty anchor must not be promoted"
+        );
+
+        state.on_task_finished(&launch);
+
+        assert_eq!(keys(&state), ["other"], "the anchor is gone");
+        assert_eq!(
+            buffered(&state, &other),
+            0,
+            "and what queued behind it has been printed"
+        );
+    }
+
+    #[test]
+    fn retiring_a_slot_never_touches_the_live_task() {
+        // An active task holds an empty buffer, so a retirement that keyed only
+        // off emptiness would take the stream away from a task that is still
+        // writing to it.
+        let mut state = KeepOrderState::new();
+        let a = task_named("a");
+        let other = task_named("other");
+        state.init_task(&a);
+        state.init_task(&other);
+
+        state.on_stdout(&a, "a".into(), "line".into());
+        assert_eq!(buffered(&state, &a), 0, "the live task buffers nothing");
+
+        state.retire_unused_slot(&a);
+
+        assert_eq!(keys(&state), ["a", "other"], "its slot must survive");
+        assert!(state.is_active(&a), "and it keeps the stream");
+    }
+
+    #[test]
+    fn an_unanchored_parent_falls_back_to_appending() {
+        let mut state = KeepOrderState::new();
+        let other = task_named("other");
+        state.init_task(&other);
+
+        state.insert_tasks_before(&task_named("unregistered"), &[task_named("one")]);
+
+        assert_eq!(keys(&state), ["other", "one"]);
+    }
+
+    #[test]
+    fn an_empty_anchor_does_not_pin_the_live_stream() {
+        // An anchor holds no lines and never produces any. Promoting it would
+        // pin the live slot until the parent finishes — which is after every
+        // task it injects — so the next child would buffer to the end of the run
+        // instead of streaming.
+        let mut state = KeepOrderState::new();
+        let launch = task_named("launch");
+        let a = task_named("a");
+        state.init_task(&a);
+        state.init_task(&launch);
+
+        state.on_stdout(&a, "a".into(), "line".into());
+        state.on_task_finished(&a);
+        assert!(
+            state.active.is_none(),
+            "the anchor must not have claimed the stream"
+        );
+
+        let b = task_named("b");
+        state.insert_tasks_before(&launch, std::slice::from_ref(&b));
+        assert!(state.is_active(&b), "the next child must stream live");
     }
 }

--- a/src/task/task_scheduler.rs
+++ b/src/task/task_scheduler.rs
@@ -35,6 +35,47 @@ pub(crate) struct Scheduler {
     pub in_flight: Arc<AtomicUsize>,
 }
 
+/// What the scheduler needs from its caller to decide when to stop and what to
+/// do with the work it drops.
+///
+/// These travel together rather than as loose parameters so that adding one
+/// does not push `run_loop` over clippy's argument limit.
+pub(crate) struct RunLoopHooks<S, I, D> {
+    /// Whether the run is stopping, because a task failed or the user interrupted.
+    pub should_stop: S,
+    /// Whether the *user* interrupted, which is what overrides `continue_on_error`.
+    pub was_interrupted: I,
+    /// Called for every task the loop removes without ever spawning it. Nothing
+    /// else reports those, since the completion path runs inside the job.
+    pub on_task_dropped: D,
+    pub continue_on_error: bool,
+}
+
+/// Remove a task the loop must not start now that the run is stopping.
+///
+/// Returns true when the task was dropped, so the caller must not spawn it.
+/// Both receive paths go through this: they carried the same logic inline, and
+/// the copy in the `select!` arm was missed when the drop callback was added.
+async fn drop_while_stopping(
+    task: &Task,
+    deps_for_remove: &Arc<Mutex<Deps>>,
+    allow_during_interruption: bool,
+    on_task_dropped: &mut impl FnMut(&Task),
+) -> bool {
+    let mut deps = deps_for_remove.lock().await;
+    // Post-dep (cleanup) tasks still run on failure, but only if their parent
+    // actually started.
+    if allow_during_interruption || deps.is_runnable_post_dep(task) {
+        return false;
+    }
+    deps.remove(task);
+    drop(deps);
+    // Nothing else reports this task: the completion path runs inside the job,
+    // which it never reaches.
+    on_task_dropped(task);
+    true
+}
+
 impl Scheduler {
     pub(crate) fn new(jobs: usize) -> Self {
         let (sched_tx, sched_rx) = mpsc::unbounded_channel::<SchedMsg>();
@@ -170,19 +211,26 @@ impl Scheduler {
     ///
     /// Or if should_stop returns true (for early exit due to failures or interruption).
     /// An interruption always stops new work, even in continue-on-error mode.
-    pub(crate) async fn run_loop<F, Fut>(
+    pub(crate) async fn run_loop<F, Fut, S, I, D>(
         &mut self,
         main_done_rx: &mut tokio::sync::watch::Receiver<bool>,
         main_deps: Arc<Mutex<Deps>>,
-        should_stop: impl Fn() -> bool,
-        was_interrupted: impl Fn() -> bool,
-        continue_on_error: bool,
+        hooks: RunLoopHooks<S, I, D>,
         mut spawn_job: F,
     ) -> Result<()>
     where
         F: FnMut(Task, Arc<Mutex<Deps>>, bool) -> Fut,
         Fut: std::future::Future<Output = Result<()>>,
+        S: Fn() -> bool,
+        I: Fn() -> bool,
+        D: FnMut(&Task),
     {
+        let RunLoopHooks {
+            should_stop,
+            was_interrupted,
+            mut on_task_dropped,
+            continue_on_error,
+        } = hooks;
         let mut sched_rx = self.take_receiver().expect("receiver already taken");
         let mut stop_cleanup_done = false;
 
@@ -199,14 +247,16 @@ impl Scheduler {
                         drained_any = true;
                         trace!("scheduler received: {} {}", task.name, task.args.join(" "));
                         if should_stop() && (!continue_on_error || was_interrupted()) {
-                            // Still allow post-dep (cleanup) tasks to run on failure,
-                            // but only if their parent was actually started
-                            let mut deps = deps_for_remove.lock().await;
-                            if !allow_during_interruption && !deps.is_runnable_post_dep(&task) {
-                                deps.remove(&task);
+                            let dropped = drop_while_stopping(
+                                &task,
+                                &deps_for_remove,
+                                allow_during_interruption,
+                                &mut on_task_dropped,
+                            )
+                            .await;
+                            if dropped {
                                 continue;
                             }
-                            drop(deps);
                         }
                         spawn_job(task, deps_for_remove, allow_during_interruption).await?;
                     }
@@ -229,6 +279,12 @@ impl Scheduler {
                     .filter(|t| !deps.is_runnable_post_dep(t))
                     .cloned()
                     .collect();
+                // Only the ones that never started: a task already executing
+                // reports itself when it ends, and telling the caller twice
+                // would retire it while it is still producing output.
+                for task in tasks_to_remove.iter().filter(|t| !deps.has_executed(t)) {
+                    on_task_dropped(task);
+                }
                 deps.remove_batch(&tasks_to_remove);
                 if deps.is_empty() {
                     drop(deps);
@@ -254,14 +310,16 @@ impl Scheduler {
                     }) = m {
                         trace!("scheduler received: {} {}", task.name, task.args.join(" "));
                         if should_stop() && (!continue_on_error || was_interrupted()) {
-                            let mut deps = deps_for_remove.lock().await;
-                            if !allow_during_interruption
-                                && !deps.is_runnable_post_dep(&task)
-                            {
-                                deps.remove(&task);
+                            let dropped = drop_while_stopping(
+                                &task,
+                                &deps_for_remove,
+                                allow_during_interruption,
+                                &mut on_task_dropped,
+                            )
+                            .await;
+                            if dropped {
                                 continue;
                             }
-                            drop(deps);
                         }
                         spawn_job(task, deps_for_remove, allow_during_interruption).await?;
                     } else {


### PR DESCRIPTION
Follow-up to #12370, which fixed the more serious half of discussion #12238 (output being dropped outright) and deliberately left this part alone.

## Problem

`--output keep-order` emits one contiguous block per task in declaration order, even under parallelism. That holds for tasks named on the CLI and for `depends`, but not for tasks started from a task-reference run entry:

```toml
[tasks.launch]
run = { tasks = ["slow", "fast"] }

[tasks.slow]
run = 'sleep 1; echo SLOW'

[tasks.fast]
run = 'echo FAST'
```

```console
$ MISE_JOBS=4 mise run --quiet --output keep-order launch
[fast] FAST
[slow] SLOW      # declared first, printed second
```

`tasks.all()` follows only `depends`/`depends_post` — `all_depends` never inspects `self.run`, and `deps.rs` has no `RunEntry` handling — so `KeepOrderState::init_task` never sees an injected task. It is absent from the buffer map until its first line lands, and that line appends it at the tail. Block order becomes "whoever printed first".

**Correcting the record from #12370:** that PR's description claimed the array form `run = [{task="a"},{task="b"}]` "registers the children". It does not. `exec_task_run_entries` awaits each `SingleTask` entry before advancing, so the array form runs sequentially and `a`'s block simply finishes before `b` starts. `test_task_sequence_keep_order` passes for that reason, not registration. So this is not mapping-form-specific: it is any run entry injecting tasks in parallel, plus every injected task's position relative to other up-front tasks.

## Fix

`inject_and_wait` already resolves the ordered task list before anything is scheduled or can print, so the slots are handed out there. A parent that injects tasks gets a slot of its own as an **anchor**, and its children are inserted immediately before it in written order. The parent keeps the anchor for its whole lifetime, so a second run entry or a nested injection finds it again; `on_task_finished` reaps the empty entry.

Registering the `to_run` elements themselves is what makes this take effect: `Task` identity is `(name, args, own env, run_phase)`, `derive_env` only extends `inherited_env` and so preserves it, and `with_dependency_env` — which does change it — is applied before `to_run.push`. The key inserted is the key `on_stdout` will use.

Two things the change must not do, both of which shaped it:

- **Do not anchor a task that only aggregates `depends`.** Such a task emits nothing (`Finished in` is gated on the same condition as `task_needs_permit`), so it would sit at the front of the map with `is_active` letting nobody stream until the run ended. Output would still be correct, so no test would catch it — but a long parallel build would print nothing until it finished. Hence the narrower `task_runs_task_references` predicate, which leaves the `depends`-aggregator case byte-identical.
- **Do not move a parent that produces output of its own.** keep-order is one block per task and cannot express "parent output, children blocks, more parent output"; anchoring there would reorder lines the parent had already buffered. Those parents keep the previous behavior — appended — only now in written order rather than print order.

`promote_next` also has to skip an entry holding no lines, or it pins the live stream to an anchor that cannot release it until the parent finishes, and the next child buffers to the end of the run. This is what would otherwise regress the sequential array form.

## Deliberately not fixed

- A parent whose `run` interleaves scripts and task references, per the second point above.
- An injected task's own `depends`: those come from `Deps::new_pruned`, not `to_run`, and still append at the tail. Not a regression — they are exactly as unordered as before. Ordering them means reproducing `Deps`' LIFO discovery order at the output layer, which is a redesign rather than a targeted fix.
- Ordering follows **run-entry declaration order** (`tasks = ["slow","fast"]`), consistent with how keep-order already treats CLI argument order and `depends` order.

## Behavior change to be aware of

A task with both `depends` and a task-reference `run` now prints its injected children before its `depends` blocks, since the anchor precedes the dependency's slot.

## Tests

Six unit tests on `KeepOrderState` covering: children take the parent's slot; a task declared after the parent cannot stream ahead of them; a second injection reuses the anchor (this is what fails if the anchor is consumed rather than kept); an existing slot is never moved; a parent with its own output is not used as an anchor; and an empty anchor does not pin the live stream.

`e2e/tasks/test_task_keep_order_task_reference` keeps both existing cases and gains three: parallel ordering, injected children versus a later CLI-named task, and nesting. Its header comment said block order was "deliberately not asserted here" and has been rewritten. These need `MISE_JOBS=4` and a sleep skew — with `--jobs 1` the semaphore serializes the tasks and the defect cannot reproduce, which is why the existing cases in that file did not catch it.

`test_task_sequence_keep_order` and `test_task_keep_order` are left untouched as the regression guards for the array form and the `depends` form.

## What I could not verify

**I could not compile or run anything.** The machine I worked on has no Rust toolchain and cannot build mise, so there are no local test results — CI is the real check here, and I would ask that it be treated as such rather than assumed green. What I did verify locally: `shellcheck -x` and `shfmt -l -s` are clean on the e2e file, and the reasoning above is traced against the code rather than remembered.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.241.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `keep-order` output so task blocks consistently follow declaration order, regardless of completion timing.
  * Preserved correct placement of dynamically injected and nested tasks alongside their parent tasks.
  * Improved ordering for task groups and repeated injections.
  * Added fallback handling for injected tasks without an identifiable parent.
  * Prevented dropped or skipped tasks from leaving empty output positions.

* **Tests**
  * Expanded regression coverage for parallel execution, nested references, repeated injections, and mixed task output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->