### PR TITLE
registry: use aqua for claude-code on windows

### DIFF
--- a/registry/claude.toml
+++ b/registry/claude.toml
@@ -7,7 +7,6 @@ version_order = "semver"
 bins = ["claude"]
 [[backends]]
 full = "aqua:anthropics/claude-code"
-platforms = ["linux", "macos"]
 
 [[backends]]
 full = "http:claude"


### PR DESCRIPTION
`registry/claude.toml` restricts the aqua backend to linux/macos, so Windows falls through to the `http:` backend. That restriction is now stale.

## Why it was there

#7842 added the aqua backend and its description records the reasoning: *"Add `aqua:anthropics/claude-code` as the primary backend for claude-code (linux/macos only) … Keeps http and npm backends as fallbacks (http supports windows)"*. Correct at the time — the aqua package defined `supported_envs: [darwin, linux]`.

## Why it no longer holds

The aqua registry's definition for current versions (`version_constraint: "true"`) is a `github_release` package that handles Windows explicitly:

```yaml
- version_constraint: "true"
  type: github_release
  asset: claude-{{.OS}}-{{.Arch}}.{{.Format}}
  overrides:
    - goos: windows
      format: zip
  replacements:
    windows: win32
```

The upstream releases ship the matching assets. For v2.1.243:

- `claude-win32-x64.zip` and `claude-win32-arm64.zip` are both published
- both are listed in `SHASUMS256.txt`, so aqua's `checksum: {type: github_release, asset: SHASUMS256.txt}` covers them (I downloaded `claude-win32-x64.zip` and confirmed its sha256 matches the published `a8e96d73…`)
- the zip contains `claude.exe` at the root, which is what the package's `files: [{name: claude}]` resolves to on Windows

## What Windows gains

- **A real version list.** The `http:` backend's `version_list_url` points at the `/latest` endpoint, whose body is a single version string — so today Windows can only ever see one version and cannot install an older one. aqua enumerates the GitHub releases.
- **`minimum_release_age` starts working.** The `http:` backend reports no release timestamps (`_list_remote_versions` leaves `created_at` at its `Default`, `src/backend/http.rs:1137`), and versions without timestamps are included by default — so the 24h supply-chain delay silently does not apply on Windows today, while linux/macos get it. aqua provides timestamps.
- **Checksum verification**, via `SHASUMS256.txt` as above.
- **windows-arm64.** The `http:` backend only defines `[backends.options.platforms.windows-x64]`, so arm64 has no URL at all today.

## Why drop the line instead of listing all three platforms

`backend_matches_platform` treats an empty list as "every platform" (`src/registry.rs:704`), so the two are equivalent. Removing it is the idiomatic form: no registry entry lists all three platforms, and each of the handful of backend-level `platforms` uses (`azure`, `glab`, `neo4j`, `android-cli`) is there to *restrict* a backend. The `http:` backend keeps its place as the fallback by being second in the list — something the aqua entry's `platforms` never governed.

## Verification

Verified on Windows through the explicit backend syntax, which bypasses the registry restriction: `mise ls-remote aqua:anthropics/claude-code` lists versions, `mise install aqua:anthropics/claude-code@2.1.243` installs, and the resulting binary runs.

The asset, checksum and zip-layout facts above were checked directly against the published release. No generated file embeds registry backend selectors, so `mise run render` is unaffected.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.241.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded Claude Code installation support beyond Linux and macOS by allowing the default platform selection to apply.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->