### PR TITLE
chore(ci): adopt mbx for Rust builds

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -35,7 +35,7 @@ self-hosted-runner:
 config-variables: null
 
 paths:
-  .github/workflows/test.yml:
+  .github/workflows/test-impl.yml:
     # actionlint 1.7.12 predates GitHub's native parallel step groups.
     # Remove this once actionlint recognizes the `parallel` keyword.
     ignore:

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,13 +1,18 @@
 name: Set up mbx
 description: Select the trusted jdx server or fork-safe GitHub cache backend
 
+inputs:
+  backend:
+    description: Explicit backend for structurally trusted or untrusted callers
+    default: auto
+
 runs:
   using: composite
   steps:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
         version: 0.4.0
-        backend: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'github' || 'server' }}
+        backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/mise
         oidc-audience: https://cache.mise.jdx.dev

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -7,7 +7,7 @@ runs:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
         version: 0.4.0
-        backend: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'github' || 'server' }}
+        backend: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'github' || 'server' }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/mise
         oidc-audience: https://cache.mise.jdx.dev

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
-        version: 0.3.0
+        version: 0.4.0
         backend: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'github' || 'server' }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/mise

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,0 +1,13 @@
+name: Set up mbx
+description: Select the trusted jdx server or fork-safe GitHub cache backend
+
+runs:
+  using: composite
+  steps:
+    - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
+      with:
+        version: 0.3.0
+        backend: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'github' || 'server' }}
+        server-url: https://cache.mise.jdx.dev
+        namespace: jdx/mise
+        oidc-audience: https://cache.mise.jdx.dev

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -7,7 +7,7 @@ runs:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
         version: 0.4.0
-        backend: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'github' || 'server' }}
+        backend: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'github' || 'server' }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/mise
         oidc-audience: https://cache.mise.jdx.dev

--- a/.github/actions/mise-tools/action.yml
+++ b/.github/actions/mise-tools/action.yml
@@ -1,10 +1,17 @@
 name: "Setup mise tools"
 description: "Cache and install mise tools with rate limit handling"
 
+inputs:
+  cache:
+    description: "Restore and save the mise tool cache"
+    required: false
+    default: "true"
+
 runs:
   using: "composite"
   steps:
     - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      if: inputs.cache == 'true'
       with:
         key: ${{ runner.os }}-${{ runner.arch }}-mise-tools-${{ hashFiles('mise.lock') }}
         restore-keys: ${{ runner.os }}-${{ runner.arch }}-mise-tools-

--- a/.github/workflows/docs-impl.yml
+++ b/.github/workflows/docs-impl.yml
@@ -72,4 +72,4 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
-          DRY_RUN: ${{ github.event_name != 'push' || github.ref != 'refs/heads/main' }}
+          DRY_RUN: ${{ !inputs.trusted || github.event_name != 'push' || github.ref != 'refs/heads/main' }}

--- a/.github/workflows/docs-impl.yml
+++ b/.github/workflows/docs-impl.yml
@@ -1,0 +1,75 @@
+name: docs implementation
+
+on:
+  workflow_call:
+    inputs:
+      trusted:
+        required: true
+        type: boolean
+      mbx-backend:
+        required: true
+        type: string
+    secrets:
+      CLOUDFLARE_ACCESS_KEY_ID:
+        required: false
+      CLOUDFLARE_SECRET_ACCESS_KEY:
+        required: false
+      MISE_GH_TOKEN:
+        required: false
+
+concurrency:
+  group: docs-${{ github.head_ref }}
+  cancel-in-progress: true
+
+env:
+  GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+
+jobs:
+  docs:
+    if: github.repository == 'jdx/mise'
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    steps:
+      - name: Assert OIDC is unavailable to untrusted docs builds
+        if: ${{ !inputs.trusted }}
+        run: |
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0 # for lastUpdated
+      - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
+      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4
+        with:
+          install_args: bun
+      # Check the API directly instead of bootstrapping the rate-limit helper,
+      # since installing the helper itself requires GitHub API access.
+      - name: Wait for GitHub rate limit
+        run: |
+          token=${MISE_GITHUB_TOKEN:-${GITHUB_API_TOKEN:-${GITHUB_TOKEN:-}}}
+          curl_args=(-sf -H "User-Agent: mise-ci")
+          if [ -n "$token" ]; then
+            curl_args+=(-H "Authorization: Bearer ${token}")
+          fi
+          rate_limit=$(curl --connect-timeout 10 --max-time 30 \
+            --retry 3 --retry-all-errors --retry-delay 2 --retry-max-time 60 \
+            "${curl_args[@]}" "https://api.github.com/rate_limit" || true)
+          remaining=$(echo "$rate_limit" | jq -er '.resources.core.remaining' 2>/dev/null || true)
+          reset=$(echo "$rate_limit" | jq -er '.resources.core.reset' 2>/dev/null || true)
+          if ! [[ "$remaining" =~ ^[0-9]+$ && "$reset" =~ ^[0-9]+$ ]]; then
+            echo "::warning::Unable to check GitHub core rate limit; continuing without waiting"
+          elif [ "$remaining" -le 1 ]; then
+            now=$(date +%s)
+            wait_seconds=$((reset - now + 1))
+            if [ "$wait_seconds" -gt 0 ]; then
+              echo "GitHub core rate limit exhausted; waiting ${wait_seconds}s"
+              sleep "$wait_seconds"
+            fi
+          fi
+      - run: bun i
+      - run: mise run docs:release
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
+          DRY_RUN: ${{ github.event_name != 'push' || github.ref != 'refs/heads/main' }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     paths: &docs-paths
       - ".github/actions/**"
       - ".github/workflows/docs.yml"
+      - ".github/workflows/docs-impl.yml"
       - "bun.lock"
       - "docs/**"
       - "mise.toml"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ env:
 jobs:
   docs:
     if: github.repository == 'jdx/mise'
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,11 +45,15 @@ env:
 jobs:
   docs:
     if: github.repository == 'jdx/mise'
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0 # for lastUpdated
+      - uses: ./.github/actions/mbx
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4
         with:
           install_args: bun

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ env:
 jobs:
   docs:
     if: github.repository == 'jdx/mise'
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: docs
 
 on:
   push:
-    paths:
+    paths: &docs-paths
       - ".github/actions/**"
       - ".github/workflows/docs.yml"
       - "bun.lock"
@@ -15,75 +15,54 @@ on:
       - "tasks.toml"
       - "tasks/docs/**"
       - "xtasks/docs/**"
-    branches:
-      - main
+    branches: [main]
   pull_request:
-    paths:
-      - ".github/actions/**"
-      - ".github/workflows/docs.yml"
-      - "bun.lock"
-      - "docs/**"
-      - "mise.toml"
-      - "package.json"
-      - "registry/**"
-      - "schema/**"
-      - "settings.toml"
-      - "tasks.toml"
-      - "tasks/docs/**"
-      - "xtasks/docs/**"
-    branches:
-      - main
+    paths: *docs-paths
+    branches: [main]
   workflow_dispatch:
 
-concurrency:
-  group: docs-${{ github.head_ref }}
-  cancel-in-progress: true
-
-env:
-  GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+permissions: {}
 
 jobs:
-  docs:
-    if: github.repository == 'jdx/mise'
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+  trusted:
+    if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
     permissions:
       contents: read
       id-token: write
+    uses: ./.github/workflows/docs-impl.yml
+    with:
+      trusted: true
+      mbx-backend: server
+    secrets:
+      CLOUDFLARE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
+      CLOUDFLARE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
+      MISE_GH_TOKEN: ${{ secrets.MISE_GH_TOKEN }}
+
+  untrusted:
+    if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/docs-impl.yml
+    with:
+      trusted: false
+      mbx-backend: github
+
+  docs:
+    name: docs
+    if: ${{ always() && !cancelled() && needs.trusted.result != 'cancelled' && needs.untrusted.result != 'cancelled' }}
+    permissions: {}
+    needs: [trusted, untrusted]
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          fetch-depth: 0 # for lastUpdated
-      - uses: ./.github/actions/mbx
-      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4
-        with:
-          install_args: bun
-      # Check the API directly instead of bootstrapping the rate-limit helper,
-      # since installing the helper itself requires GitHub API access.
-      - name: Wait for GitHub rate limit
-        run: |
-          token=${MISE_GITHUB_TOKEN:-${GITHUB_API_TOKEN:-${GITHUB_TOKEN:-}}}
-          curl_args=(-sf -H "User-Agent: mise-ci")
-          if [ -n "$token" ]; then
-            curl_args+=(-H "Authorization: Bearer ${token}")
-          fi
-          rate_limit=$(curl --connect-timeout 10 --max-time 30 \
-            --retry 3 --retry-all-errors --retry-delay 2 --retry-max-time 60 \
-            "${curl_args[@]}" "https://api.github.com/rate_limit" || true)
-          remaining=$(echo "$rate_limit" | jq -er '.resources.core.remaining' 2>/dev/null || true)
-          reset=$(echo "$rate_limit" | jq -er '.resources.core.reset' 2>/dev/null || true)
-          if ! [[ "$remaining" =~ ^[0-9]+$ && "$reset" =~ ^[0-9]+$ ]]; then
-            echo "::warning::Unable to check GitHub core rate limit; continuing without waiting"
-          elif [ "$remaining" -le 1 ]; then
-            now=$(date +%s)
-            wait_seconds=$((reset - now + 1))
-            if [ "$wait_seconds" -gt 0 ]; then
-              echo "GitHub core rate limit exhausted; waiting ${wait_seconds}s"
-              sleep "$wait_seconds"
-            fi
-          fi
-      - run: bun i
-      - run: mise run docs:release
+      - name: Check selected workflow result
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
-          DRY_RUN: ${{ github.event_name != 'push' || github.ref != 'refs/heads/main' }}
+          TRUSTED_RESULT: ${{ needs.trusted.result }}
+          UNTRUSTED_RESULT: ${{ needs.untrusted.result }}
+        run: |
+          if [[ "$TRUSTED_RESULT" == success && "$UNTRUSTED_RESULT" == skipped ]] ||
+             [[ "$TRUSTED_RESULT" == skipped && "$UNTRUSTED_RESULT" == success ]]; then
+            exit 0
+          fi
+          echo "trusted=$TRUSTED_RESULT untrusted=$UNTRUSTED_RESULT"
+          exit 1

--- a/.github/workflows/github-runner-cache.yml
+++ b/.github/workflows/github-runner-cache.yml
@@ -45,7 +45,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-fork-pr-mbx-v0.2.0-
       - uses: ./.github/actions/setup-mbx
-      - run: mbx build build --all-features --ignore-rust-version
+      - run: mbx build --all-features --ignore-rust-version
       # Bound each immutable GHA cache entry so Linux and macOS can coexist
       # within the repository cache quota.
       - run: mbx gc --max-size 3GB

--- a/.github/workflows/registry-impl.yml
+++ b/.github/workflows/registry-impl.yml
@@ -52,7 +52,7 @@ jobs:
           diff_base_sha="$(git merge-base "$PR_BASE_SHA" "$PR_HEAD_SHA")"
           echo "diff-base-sha=$diff_base_sha" >> "$GITHUB_OUTPUT"
           # Check if relevant files changed
-          if git diff --name-only "$diff_base_sha" "$PR_HEAD_SHA" | grep -qE '^(registry/.*\.toml|\.github/workflows/registry\.yml|src/cli/test_tool\.rs)$'; then
+          if git diff --name-only "$diff_base_sha" "$PR_HEAD_SHA" | grep -qE '^(registry/.*\.toml|\.github/workflows/registry(-impl)?\.yml|src/cli/test_tool\.rs)$'; then
             echo "registry-changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "registry-changed=false" >> "$GITHUB_OUTPUT"
@@ -111,7 +111,7 @@ jobs:
           DIFF_BASE_SHA: ${{ needs.check-changes.outputs.diff-base-sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          if git diff --name-only "$DIFF_BASE_SHA" "$PR_HEAD_SHA" | grep -q ".github/workflows/registry.yml"; then
+          if git diff --name-only "$DIFF_BASE_SHA" "$PR_HEAD_SHA" | grep -qE '^\.github/workflows/registry(-impl)?\.yml$'; then
             echo "modified=true" >> "$GITHUB_OUTPUT"
           fi
       - uses: ./.github/actions/registry-diff

--- a/.github/workflows/registry-impl.yml
+++ b/.github/workflows/registry-impl.yml
@@ -1,0 +1,408 @@
+name: registry implementation
+on:
+  workflow_call:
+    inputs:
+      trusted:
+        required: true
+        type: boolean
+      mbx-backend:
+        required: true
+        type: string
+    secrets:
+      MISE_GH_TOKEN:
+        required: false
+      MISE_VERSIONS_API_SECRET:
+        required: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.pull_request.number || github.event.pull_request.number || 'push' }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  MISE_TRUSTED_CONFIG_PATHS: ${{ github.workspace }}
+  MISE_EXPERIMENTAL: 1
+  MISE_LOCKFILE: 1
+  MISE_USE_VERSIONS_HOST_TRACK: 0
+  RUST_BACKTRACE: 1
+  MISE_GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+
+jobs:
+  check-changes:
+    permissions:
+      contents: read
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    timeout-minutes: 5
+    outputs:
+      registry-changed: ${{ steps.check.outputs.registry-changed }}
+      diff-base-sha: ${{ steps.check.outputs.diff-base-sha }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+      - id: check
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ] || [ "${{ github.event_name }}" == "push" ]; then
+            echo "registry-changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          diff_base_sha="$(git merge-base "$PR_BASE_SHA" "$PR_HEAD_SHA")"
+          echo "diff-base-sha=$diff_base_sha" >> "$GITHUB_OUTPUT"
+          # Check if relevant files changed
+          if git diff --name-only "$diff_base_sha" "$PR_HEAD_SHA" | grep -qE '^(registry/.*\.toml|\.github/workflows/registry\.yml|src/cli/test_tool\.rs)$'; then
+            echo "registry-changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "registry-changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    timeout-minutes: 20
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    needs: check-changes
+    if: needs.check-changes.outputs.registry-changed == 'true'
+    env:
+      GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Assert OIDC is unavailable to untrusted CI
+        if: ${{ !inputs.trusted }}
+        run: |
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
+        if: inputs.trusted
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/.global-cache
+      - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
+      - run: mbx build --all-features --ignore-rust-version
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: mise
+          path: target/debug/mise
+      - run: mbx cache stats
+        if: always()
+
+  list-changed-tools:
+    permissions:
+      contents: read
+    timeout-minutes: 10
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    needs: check-changes
+    if: github.event_name == 'pull_request' && needs.check-changes.outputs.registry-changed == 'true'
+    outputs:
+      tools: ${{ steps.determine-tools.outputs.tools }}
+      tranches: ${{ steps.determine-tools.outputs.tranches }}
+      skip-test-tool: ${{ steps.determine-tools.outputs.skip-test-tool }}
+      new_tools: ${{ steps.registry-diff.outputs.new_tools }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+      - id: workflow-check
+        env:
+          DIFF_BASE_SHA: ${{ needs.check-changes.outputs.diff-base-sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if git diff --name-only "$DIFF_BASE_SHA" "$PR_HEAD_SHA" | grep -q ".github/workflows/registry.yml"; then
+            echo "modified=true" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: ./.github/actions/registry-diff
+        id: registry-diff
+        if: steps.workflow-check.outputs.modified != 'true'
+        with:
+          base_sha: ${{ needs.check-changes.outputs.diff-base-sha }}
+          head_sha: ${{ github.event.pull_request.head.sha }}
+      - id: determine-tools
+        run: |
+          if [ "${{ steps.workflow-check.outputs.modified }}" == "true" ]; then
+            echo "Workflow modified, running all tests"
+            echo "tools=" >> "$GITHUB_OUTPUT"
+            echo "tranches=8" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          tools="${{ steps.registry-diff.outputs.modified_tools }}"
+          count=$(echo "$tools" | wc -w)
+          echo "Modified tools count: $count"
+
+          if [ "$count" -eq 0 ]; then
+            echo "No tools added or modified (deletion-only PR), skipping test-tool"
+            echo "tools=" >> "$GITHUB_OUTPUT"
+            echo "tranches=0" >> "$GITHUB_OUTPUT"
+            echo "skip-test-tool=true" >> "$GITHUB_OUTPUT"
+          elif [ "$count" -ge 64 ]; then
+            echo "64 or more tools updated, splitting changed tools across 8 tranches"
+            echo "tools=$tools" >> "$GITHUB_OUTPUT"
+            echo "tranches=8" >> "$GITHUB_OUTPUT"
+          else
+            echo "tools=$tools" >> "$GITHUB_OUTPUT"
+            echo "tranches=1" >> "$GITHUB_OUTPUT"
+          fi
+
+  validate-new-tools:
+    permissions:
+      contents: read
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    timeout-minutes: 5
+    needs: list-changed-tools
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.user.login != 'jdx' &&
+      needs.list-changed-tools.outputs.new_tools != ''
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Check new tools have tests
+        run: |
+          missing_tests=""
+          for tool in ${{ needs.list-changed-tools.outputs.new_tools }}; do
+            if ! grep -q '^test = ' "registry/$tool.toml"; then
+              missing_tests="$missing_tests $tool"
+            fi
+          done
+          if [ -n "$missing_tests" ]; then
+            echo "::error::New tools missing required 'test' field:$missing_tests"
+            echo ""
+            echo "All new tools must include a test field, e.g.:"
+            echo '  test = ["mytool --version", "v{{version}}"]'
+            exit 1
+          fi
+          echo "All new tools have tests"
+
+  test-tool:
+    permissions:
+      contents: read
+    name: test-tool-${{ matrix.tranche }}
+    timeout-minutes: 90
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    needs:
+      - build
+      - list-changed-tools
+      - validate-new-tools
+    if: |
+      !cancelled() &&
+      needs.build.result == 'success' &&
+      (needs.list-changed-tools.result == 'success' || needs.list-changed-tools.result == 'skipped') &&
+      (needs.validate-new-tools.result == 'success' || needs.validate-new-tools.result == 'skipped') &&
+      needs.list-changed-tools.outputs.skip-test-tool != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        tranche: ${{ fromJson((needs.list-changed-tools.outputs.tools == '' || needs.list-changed-tools.outputs.tranches == '8') && '[0,1,2,3,4,5,6,7]' || '[0]') }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Fetch token from pool
+        id: token
+        uses: ./.github/actions/fetch-token
+        with:
+          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
+      - name: Set pooled token
+        if: steps.token.outputs.token
+        run: |
+          {
+            echo "POOL_TOKEN=${{ steps.token.outputs.token }}"
+            echo "MISE_GITHUB_TOKEN=${{ steps.token.outputs.token }}"
+            echo "GITHUB_TOKEN=${{ steps.token.outputs.token }}"
+          } >> "$GITHUB_ENV"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: mise
+          path: target/debug
+      - run: chmod +x target/debug/mise
+      - run: echo target/debug >> "$GITHUB_PATH"
+      - uses: ./.github/actions/mise-tools
+      - name: Pull e2e Docker image
+        run: docker pull ghcr.io/jdx/mise:e2e
+      - name: Set test-tool jobs
+        run: |
+          jobs="$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
+          if ! [[ $jobs =~ ^[0-9]+$ ]] || [ "$jobs" -lt 1 ]; then
+            jobs=4
+          fi
+          echo "TEST_TOOL_JOBS=$jobs" >> "$GITHUB_ENV"
+      - id: test-tools
+        env:
+          TEST_TRANCHE: ${{ matrix.tranche }}
+          TEST_TRANCHE_COUNT: ${{ (needs.list-changed-tools.outputs.tools == '' || needs.list-changed-tools.outputs.tranches == '8') && 8 || 1 }}
+        run: |
+          summary_dir="$RUNNER_TEMP/test-tool-${{ matrix.tranche }}"
+          rm -rf "$summary_dir"
+          mkdir -p "$summary_dir"
+          chmod 777 "$summary_dir"
+          summary_file="$summary_dir/summary.md"
+          container_tmp_dir="$RUNNER_TEMP/test-tool-tmp-${{ matrix.tranche }}"
+          container_var_tmp_dir="$RUNNER_TEMP/test-tool-var-tmp-${{ matrix.tranche }}"
+          container_home_dir="$RUNNER_TEMP/test-tool-home-${{ matrix.tranche }}"
+          rm -rf "$container_tmp_dir" "$container_var_tmp_dir" "$container_home_dir"
+          mkdir -p "$container_tmp_dir" "$container_var_tmp_dir" "$container_home_dir"
+          chmod 777 "$container_tmp_dir" "$container_var_tmp_dir" "$container_home_dir"
+
+          set +e
+          docker run --rm \
+            --read-only \
+            -w /tmp \
+            -v "$container_tmp_dir:/tmp" \
+            -v "$container_var_tmp_dir:/var/tmp" \
+            -v "$container_home_dir:/root" \
+            -v "$PWD:/mise-src:ro" \
+            -v "$PWD/target/debug/mise:/usr/local/bin/mise:ro" \
+            -v "$summary_dir:/tmp/github-summary" \
+            -e MISE_GITHUB_TOKEN="${POOL_TOKEN:-${MISE_GITHUB_TOKEN:-}}" \
+            -e GITHUB_TOKEN="${POOL_TOKEN:-${GITHUB_TOKEN:-}}" \
+            -e GITHUB_STEP_SUMMARY=/tmp/github-summary/summary.md \
+            -e TEST_TOOL_JOBS="$TEST_TOOL_JOBS" \
+            -e TEST_TRANCHE="$TEST_TRANCHE" \
+            -e TEST_TRANCHE_COUNT="$TEST_TRANCHE_COUNT" \
+            -e MISE_EXPERIMENTAL=1 \
+            -e MISE_LOCKFILE=1 \
+            -e MISE_USE_VERSIONS_HOST_TRACK=0 \
+            -e RUST_BACKTRACE=1 \
+            ghcr.io/jdx/mise:e2e \
+            sh -lc '
+              set -e
+              export HOME=/root
+              export MISE_CACHE_DIR=/tmp/mise-cache
+              export MISE_CONFIG_DIR=/tmp/mise-config
+              export MISE_DATA_DIR=/tmp/mise-data
+              export MISE_STATE_DIR=/tmp/mise-state
+              export MISE_TMP_DIR=/tmp/mise-tmp
+              mkdir -p "$HOME" "$MISE_CACHE_DIR" "$MISE_CONFIG_DIR" "$MISE_DATA_DIR" "$MISE_STATE_DIR" "$MISE_TMP_DIR"
+
+              mise test-tool --jobs "$TEST_TOOL_JOBS" ${{ needs.list-changed-tools.outputs.tools == '' && '--all' || needs.list-changed-tools.outputs.tools }}
+            '
+          test_tool_status=$?
+          set -e
+
+          if [ -f "$summary_file" ]; then
+            cat "$summary_file" >> "$GITHUB_STEP_SUMMARY"
+            failed_tools=$(grep "Failed Tools" "$summary_file" | sed 's/\*\*Failed Tools\*\*: //' | tr ',' ' ' || true)
+          else
+            failed_tools=""
+          fi
+          echo "failed_tools=$failed_tools" >> "$GITHUB_OUTPUT"
+          if [ "$test_tool_status" -ne 0 ] && [ -z "$failed_tools" ]; then
+            echo "::error::mise test-tool exited with status $test_tool_status without reporting failed tools"
+            exit "$test_tool_status"
+          fi
+      - name: Retry failed tools
+        id: retry
+        if: steps.test-tools.outputs.failed_tools != ''
+        run: |
+          summary_dir="$RUNNER_TEMP/test-tool-retry-${{ matrix.tranche }}"
+          rm -rf "$summary_dir"
+          mkdir -p "$summary_dir"
+          chmod 777 "$summary_dir"
+          summary_file="$summary_dir/summary.md"
+          container_tmp_dir="$RUNNER_TEMP/test-tool-retry-tmp-${{ matrix.tranche }}"
+          container_var_tmp_dir="$RUNNER_TEMP/test-tool-retry-var-tmp-${{ matrix.tranche }}"
+          container_home_dir="$RUNNER_TEMP/test-tool-retry-home-${{ matrix.tranche }}"
+          rm -rf "$container_tmp_dir" "$container_var_tmp_dir" "$container_home_dir"
+          mkdir -p "$container_tmp_dir" "$container_var_tmp_dir" "$container_home_dir"
+          chmod 777 "$container_tmp_dir" "$container_var_tmp_dir" "$container_home_dir"
+
+          set +e
+          docker run --rm \
+            --read-only \
+            -w /tmp \
+            -v "$container_tmp_dir:/tmp" \
+            -v "$container_var_tmp_dir:/var/tmp" \
+            -v "$container_home_dir:/root" \
+            -v "$PWD:/mise-src:ro" \
+            -v "$PWD/target/debug/mise:/usr/local/bin/mise:ro" \
+            -v "$summary_dir:/tmp/github-summary" \
+            -e MISE_GITHUB_TOKEN="${POOL_TOKEN:-${MISE_GITHUB_TOKEN:-}}" \
+            -e GITHUB_TOKEN="${POOL_TOKEN:-${GITHUB_TOKEN:-}}" \
+            -e GITHUB_STEP_SUMMARY=/tmp/github-summary/summary.md \
+            -e TEST_TOOL_JOBS="$TEST_TOOL_JOBS" \
+            -e MISE_EXPERIMENTAL=1 \
+            -e MISE_LOCKFILE=1 \
+            -e MISE_USE_VERSIONS_HOST_TRACK=0 \
+            -e RUST_BACKTRACE=1 \
+            ghcr.io/jdx/mise:e2e \
+            sh -lc '
+              set -e
+              export HOME=/root
+              export MISE_CACHE_DIR=/tmp/mise-cache
+              export MISE_CONFIG_DIR=/tmp/mise-config
+              export MISE_DATA_DIR=/tmp/mise-data
+              export MISE_STATE_DIR=/tmp/mise-state
+              export MISE_TMP_DIR=/tmp/mise-tmp
+              mkdir -p "$HOME" "$MISE_CACHE_DIR" "$MISE_CONFIG_DIR" "$MISE_DATA_DIR" "$MISE_STATE_DIR" "$MISE_TMP_DIR"
+
+              mise test-tool --jobs "$TEST_TOOL_JOBS" ${{ steps.test-tools.outputs.failed_tools }}
+            '
+          test_tool_status=$?
+          set -e
+
+          if [ -f "$summary_file" ]; then
+            cat "$summary_file" >> "$GITHUB_STEP_SUMMARY"
+            failed_tools=$(grep "Failed Tools" "$summary_file" | sed 's/\*\*Failed Tools\*\*: //' | tr ',' ' ' || true)
+          else
+            failed_tools=""
+          fi
+          echo "failed_tools=$failed_tools" >> "$GITHUB_OUTPUT"
+          if [ "$test_tool_status" -ne 0 ] && [ -z "$failed_tools" ]; then
+            echo "::error::mise test-tool retry exited with status $test_tool_status without reporting failed tools"
+            exit "$test_tool_status"
+          fi
+      - name: Handle retry failures
+        if: steps.retry.outputs.failed_tools != '' && github.head_ref != 'release' && github.ref != 'refs/heads/release'
+        run: |
+          echo "Tools still failing after retry: ${{ steps.retry.outputs.failed_tools }}"
+          exit 1
+      - name: Check grace period for release branch failures
+        if: steps.retry.outputs.failed_tools != '' && (github.head_ref == 'release' || github.ref == 'refs/heads/release')
+        env:
+          GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+        run: mise run test-tool-retry --check-only --grace-period ${{ steps.retry.outputs.failed_tools }}
+
+  registry-ci:
+    permissions: {}
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    timeout-minutes: 1
+    needs:
+      - check-changes
+      - build
+      - list-changed-tools
+      - validate-new-tools
+      - test-tool
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Check CI job results
+        run: |
+          if [ "${{ needs.check-changes.result }}" != "success" ]; then
+            echo "check-changes job failed"
+            exit 1
+          fi
+          if [ "${{ needs.check-changes.outputs.registry-changed }}" != "true" ]; then
+            echo "No registry changes detected, skipping registry CI checks"
+            exit 0
+          fi
+          if [ "${{ needs.build.result }}" != "success" ]; then
+            echo "build failed or was skipped"
+            exit 1
+          fi
+          if [ "${{ needs.list-changed-tools.result }}" != "success" ] && [ "${{ needs.list-changed-tools.result }}" != "skipped" ]; then
+            echo "list-changed-tools failed"
+            exit 1
+          fi
+          if [ "${{ needs.validate-new-tools.result }}" == "failure" ]; then
+            echo "validate-new-tools failed - new tools must include tests"
+            exit 1
+          fi
+          if [ "${{ needs.list-changed-tools.outputs.skip-test-tool }}" == "true" ]; then
+            echo "test-tool intentionally skipped (deletion-only PR)"
+          elif [ "${{ needs.test-tool.result }}" != "success" ]; then
+            echo "test-tool failed or was skipped"
+            exit 1
+          fi
+          echo "All CI jobs completed successfully"

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   check-changes:
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 5
     outputs:
       registry-changed: ${{ steps.check.outputs.registry-changed }}
@@ -51,7 +51,7 @@ jobs:
 
   build:
     timeout-minutes: 20
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     needs: check-changes
     if: needs.check-changes.outputs.registry-changed == 'true'
     env:
@@ -79,7 +79,7 @@ jobs:
 
   list-changed-tools:
     timeout-minutes: 10
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     needs: check-changes
     if: github.event_name == 'pull_request' && needs.check-changes.outputs.registry-changed == 'true'
     outputs:
@@ -133,7 +133,7 @@ jobs:
           fi
 
   validate-new-tools:
-    runs-on: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 5
     needs: list-changed-tools
     if: |
@@ -162,7 +162,7 @@ jobs:
   test-tool:
     name: test-tool-${{ matrix.tranche }}
     timeout-minutes: 90
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     needs:
       - build
       - list-changed-tools
@@ -347,7 +347,7 @@ jobs:
         run: mise run test-tool-retry --check-only --grace-period ${{ steps.retry.outputs.failed_tools }}
 
   registry-ci:
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 1
     needs:
       - check-changes

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   check-changes:
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 5
     outputs:
       registry-changed: ${{ steps.check.outputs.registry-changed }}
@@ -51,11 +51,14 @@ jobs:
 
   build:
     timeout-minutes: 20
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     needs: check-changes
     if: needs.check-changes.outputs.registry-changed == 'true'
     env:
       GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
@@ -65,10 +68,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             ~/.cargo/.global-cache
-            ~/.cache/mbx
-      - uses: ./.github/actions/setup-mbx
-        with:
-          restore-cache: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+      - uses: ./.github/actions/mbx
       - run: mbx build build --all-features --ignore-rust-version
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -79,7 +79,7 @@ jobs:
 
   list-changed-tools:
     timeout-minutes: 10
-    runs-on: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     needs: check-changes
     if: github.event_name == 'pull_request' && needs.check-changes.outputs.registry-changed == 'true'
     outputs:
@@ -133,7 +133,7 @@ jobs:
           fi
 
   validate-new-tools:
-    runs-on: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
+    runs-on: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 5
     needs: list-changed-tools
     if: |
@@ -162,7 +162,7 @@ jobs:
   test-tool:
     name: test-tool-${{ matrix.tranche }}
     timeout-minutes: 90
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     needs:
       - build
       - list-changed-tools
@@ -347,7 +347,7 @@ jobs:
         run: mise run test-tool-retry --check-only --grace-period ${{ steps.retry.outputs.failed_tools }}
 
   registry-ci:
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 1
     needs:
       - check-changes

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -69,7 +69,7 @@ jobs:
             ~/.cargo/git
             ~/.cargo/.global-cache
       - uses: ./.github/actions/mbx
-      - run: mbx build build --all-features --ignore-rust-version
+      - run: mbx build --all-features --ignore-rust-version
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mise

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   check-changes:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 5
     outputs:
       registry-changed: ${{ steps.check.outputs.registry-changed }}
@@ -51,7 +51,7 @@ jobs:
 
   build:
     timeout-minutes: 20
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     needs: check-changes
     if: needs.check-changes.outputs.registry-changed == 'true'
     env:
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
-        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
+        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')
         with:
           path: |
             ~/.cargo/registry
@@ -79,7 +79,7 @@ jobs:
 
   list-changed-tools:
     timeout-minutes: 10
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     needs: check-changes
     if: github.event_name == 'pull_request' && needs.check-changes.outputs.registry-changed == 'true'
     outputs:
@@ -133,7 +133,7 @@ jobs:
           fi
 
   validate-new-tools:
-    runs-on: ${{ (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 5
     needs: list-changed-tools
     if: |
@@ -162,7 +162,7 @@ jobs:
   test-tool:
     name: test-tool-${{ matrix.tranche }}
     timeout-minutes: 90
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     needs:
       - build
       - list-changed-tools
@@ -347,7 +347,7 @@ jobs:
         run: mise run test-tool-retry --check-only --grace-period ${{ steps.retry.outputs.failed_tools }}
 
   registry-ci:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 1
     needs:
       - check-changes

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -1,388 +1,53 @@
 name: registry
+
 on:
   workflow_dispatch:
   push:
-    branches:
-      - release
+    branches: [release]
   pull_request:
     branches: [main]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.pull_request.number || github.event.pull_request.number || 'push' }}
-  cancel-in-progress: true
-
-env:
-  CARGO_TERM_COLOR: always
-  MISE_TRUSTED_CONFIG_PATHS: ${{ github.workspace }}
-  MISE_EXPERIMENTAL: 1
-  MISE_LOCKFILE: 1
-  MISE_USE_VERSIONS_HOST_TRACK: 0
-  RUST_BACKTRACE: 1
-  MISE_GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+permissions: {}
 
 jobs:
-  check-changes:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
-    timeout-minutes: 5
-    outputs:
-      registry-changed: ${{ steps.check.outputs.registry-changed }}
-      diff-base-sha: ${{ steps.check.outputs.diff-base-sha }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          fetch-depth: 0
-      - id: check
-        env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ] || [ "${{ github.event_name }}" == "push" ]; then
-            echo "registry-changed=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          diff_base_sha="$(git merge-base "$PR_BASE_SHA" "$PR_HEAD_SHA")"
-          echo "diff-base-sha=$diff_base_sha" >> "$GITHUB_OUTPUT"
-          # Check if relevant files changed
-          if git diff --name-only "$diff_base_sha" "$PR_HEAD_SHA" | grep -qE '^(registry/.*\.toml|\.github/workflows/registry\.yml|src/cli/test_tool\.rs)$'; then
-            echo "registry-changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "registry-changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-  build:
-    timeout-minutes: 20
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
-    needs: check-changes
-    if: needs.check-changes.outputs.registry-changed == 'true'
-    env:
-      GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+  trusted:
+    if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
     permissions:
       contents: read
       id-token: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
-        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/.global-cache
-      - uses: ./.github/actions/mbx
-      - run: mbx build --all-features --ignore-rust-version
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: mise
-          path: target/debug/mise
-      - run: mbx cache stats
-        if: always()
+    uses: ./.github/workflows/registry-impl.yml
+    with:
+      trusted: true
+      mbx-backend: server
+    secrets:
+      MISE_GH_TOKEN: ${{ secrets.MISE_GH_TOKEN }}
+      MISE_VERSIONS_API_SECRET: ${{ secrets.MISE_VERSIONS_API_SECRET }}
 
-  list-changed-tools:
-    timeout-minutes: 10
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
-    needs: check-changes
-    if: github.event_name == 'pull_request' && needs.check-changes.outputs.registry-changed == 'true'
-    outputs:
-      tools: ${{ steps.determine-tools.outputs.tools }}
-      tranches: ${{ steps.determine-tools.outputs.tranches }}
-      skip-test-tool: ${{ steps.determine-tools.outputs.skip-test-tool }}
-      new_tools: ${{ steps.registry-diff.outputs.new_tools }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          fetch-depth: 0
-      - id: workflow-check
-        env:
-          DIFF_BASE_SHA: ${{ needs.check-changes.outputs.diff-base-sha }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          if git diff --name-only "$DIFF_BASE_SHA" "$PR_HEAD_SHA" | grep -q ".github/workflows/registry.yml"; then
-            echo "modified=true" >> "$GITHUB_OUTPUT"
-          fi
-      - uses: ./.github/actions/registry-diff
-        id: registry-diff
-        if: steps.workflow-check.outputs.modified != 'true'
-        with:
-          base_sha: ${{ needs.check-changes.outputs.diff-base-sha }}
-          head_sha: ${{ github.event.pull_request.head.sha }}
-      - id: determine-tools
-        run: |
-          if [ "${{ steps.workflow-check.outputs.modified }}" == "true" ]; then
-            echo "Workflow modified, running all tests"
-            echo "tools=" >> "$GITHUB_OUTPUT"
-            echo "tranches=8" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          tools="${{ steps.registry-diff.outputs.modified_tools }}"
-          count=$(echo "$tools" | wc -w)
-          echo "Modified tools count: $count"
-
-          if [ "$count" -eq 0 ]; then
-            echo "No tools added or modified (deletion-only PR), skipping test-tool"
-            echo "tools=" >> "$GITHUB_OUTPUT"
-            echo "tranches=0" >> "$GITHUB_OUTPUT"
-            echo "skip-test-tool=true" >> "$GITHUB_OUTPUT"
-          elif [ "$count" -ge 64 ]; then
-            echo "64 or more tools updated, splitting changed tools across 8 tranches"
-            echo "tools=$tools" >> "$GITHUB_OUTPUT"
-            echo "tranches=8" >> "$GITHUB_OUTPUT"
-          else
-            echo "tools=$tools" >> "$GITHUB_OUTPUT"
-            echo "tranches=1" >> "$GITHUB_OUTPUT"
-          fi
-
-  validate-new-tools:
-    runs-on: ${{ (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
-    timeout-minutes: 5
-    needs: list-changed-tools
-    if: |
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.user.login != 'jdx' &&
-      needs.list-changed-tools.outputs.new_tools != ''
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - name: Check new tools have tests
-        run: |
-          missing_tests=""
-          for tool in ${{ needs.list-changed-tools.outputs.new_tools }}; do
-            if ! grep -q '^test = ' "registry/$tool.toml"; then
-              missing_tests="$missing_tests $tool"
-            fi
-          done
-          if [ -n "$missing_tests" ]; then
-            echo "::error::New tools missing required 'test' field:$missing_tests"
-            echo ""
-            echo "All new tools must include a test field, e.g.:"
-            echo '  test = ["mytool --version", "v{{version}}"]'
-            exit 1
-          fi
-          echo "All new tools have tests"
-
-  test-tool:
-    name: test-tool-${{ matrix.tranche }}
-    timeout-minutes: 90
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
-    needs:
-      - build
-      - list-changed-tools
-      - validate-new-tools
-    if: |
-      !cancelled() &&
-      needs.build.result == 'success' &&
-      (needs.list-changed-tools.result == 'success' || needs.list-changed-tools.result == 'skipped') &&
-      (needs.validate-new-tools.result == 'success' || needs.validate-new-tools.result == 'skipped') &&
-      needs.list-changed-tools.outputs.skip-test-tool != 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        tranche: ${{ fromJson((needs.list-changed-tools.outputs.tools == '' || needs.list-changed-tools.outputs.tranches == '8') && '[0,1,2,3,4,5,6,7]' || '[0]') }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          persist-credentials: false
-      - name: Fetch token from pool
-        id: token
-        uses: ./.github/actions/fetch-token
-        with:
-          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
-      - name: Set pooled token
-        if: steps.token.outputs.token
-        run: |
-          {
-            echo "POOL_TOKEN=${{ steps.token.outputs.token }}"
-            echo "MISE_GITHUB_TOKEN=${{ steps.token.outputs.token }}"
-            echo "GITHUB_TOKEN=${{ steps.token.outputs.token }}"
-          } >> "$GITHUB_ENV"
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: mise
-          path: target/debug
-      - run: chmod +x target/debug/mise
-      - run: echo target/debug >> "$GITHUB_PATH"
-      - uses: ./.github/actions/mise-tools
-      - name: Pull e2e Docker image
-        run: docker pull ghcr.io/jdx/mise:e2e
-      - name: Set test-tool jobs
-        run: |
-          jobs="$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
-          if ! [[ $jobs =~ ^[0-9]+$ ]] || [ "$jobs" -lt 1 ]; then
-            jobs=4
-          fi
-          echo "TEST_TOOL_JOBS=$jobs" >> "$GITHUB_ENV"
-      - id: test-tools
-        env:
-          TEST_TRANCHE: ${{ matrix.tranche }}
-          TEST_TRANCHE_COUNT: ${{ (needs.list-changed-tools.outputs.tools == '' || needs.list-changed-tools.outputs.tranches == '8') && 8 || 1 }}
-        run: |
-          summary_dir="$RUNNER_TEMP/test-tool-${{ matrix.tranche }}"
-          rm -rf "$summary_dir"
-          mkdir -p "$summary_dir"
-          chmod 777 "$summary_dir"
-          summary_file="$summary_dir/summary.md"
-          container_tmp_dir="$RUNNER_TEMP/test-tool-tmp-${{ matrix.tranche }}"
-          container_var_tmp_dir="$RUNNER_TEMP/test-tool-var-tmp-${{ matrix.tranche }}"
-          container_home_dir="$RUNNER_TEMP/test-tool-home-${{ matrix.tranche }}"
-          rm -rf "$container_tmp_dir" "$container_var_tmp_dir" "$container_home_dir"
-          mkdir -p "$container_tmp_dir" "$container_var_tmp_dir" "$container_home_dir"
-          chmod 777 "$container_tmp_dir" "$container_var_tmp_dir" "$container_home_dir"
-
-          set +e
-          docker run --rm \
-            --read-only \
-            -w /tmp \
-            -v "$container_tmp_dir:/tmp" \
-            -v "$container_var_tmp_dir:/var/tmp" \
-            -v "$container_home_dir:/root" \
-            -v "$PWD:/mise-src:ro" \
-            -v "$PWD/target/debug/mise:/usr/local/bin/mise:ro" \
-            -v "$summary_dir:/tmp/github-summary" \
-            -e MISE_GITHUB_TOKEN="${POOL_TOKEN:-${MISE_GITHUB_TOKEN:-}}" \
-            -e GITHUB_TOKEN="${POOL_TOKEN:-${GITHUB_TOKEN:-}}" \
-            -e GITHUB_STEP_SUMMARY=/tmp/github-summary/summary.md \
-            -e TEST_TOOL_JOBS="$TEST_TOOL_JOBS" \
-            -e TEST_TRANCHE="$TEST_TRANCHE" \
-            -e TEST_TRANCHE_COUNT="$TEST_TRANCHE_COUNT" \
-            -e MISE_EXPERIMENTAL=1 \
-            -e MISE_LOCKFILE=1 \
-            -e MISE_USE_VERSIONS_HOST_TRACK=0 \
-            -e RUST_BACKTRACE=1 \
-            ghcr.io/jdx/mise:e2e \
-            sh -lc '
-              set -e
-              export HOME=/root
-              export MISE_CACHE_DIR=/tmp/mise-cache
-              export MISE_CONFIG_DIR=/tmp/mise-config
-              export MISE_DATA_DIR=/tmp/mise-data
-              export MISE_STATE_DIR=/tmp/mise-state
-              export MISE_TMP_DIR=/tmp/mise-tmp
-              mkdir -p "$HOME" "$MISE_CACHE_DIR" "$MISE_CONFIG_DIR" "$MISE_DATA_DIR" "$MISE_STATE_DIR" "$MISE_TMP_DIR"
-
-              mise test-tool --jobs "$TEST_TOOL_JOBS" ${{ needs.list-changed-tools.outputs.tools == '' && '--all' || needs.list-changed-tools.outputs.tools }}
-            '
-          test_tool_status=$?
-          set -e
-
-          if [ -f "$summary_file" ]; then
-            cat "$summary_file" >> "$GITHUB_STEP_SUMMARY"
-            failed_tools=$(grep "Failed Tools" "$summary_file" | sed 's/\*\*Failed Tools\*\*: //' | tr ',' ' ' || true)
-          else
-            failed_tools=""
-          fi
-          echo "failed_tools=$failed_tools" >> "$GITHUB_OUTPUT"
-          if [ "$test_tool_status" -ne 0 ] && [ -z "$failed_tools" ]; then
-            echo "::error::mise test-tool exited with status $test_tool_status without reporting failed tools"
-            exit "$test_tool_status"
-          fi
-      - name: Retry failed tools
-        id: retry
-        if: steps.test-tools.outputs.failed_tools != ''
-        run: |
-          summary_dir="$RUNNER_TEMP/test-tool-retry-${{ matrix.tranche }}"
-          rm -rf "$summary_dir"
-          mkdir -p "$summary_dir"
-          chmod 777 "$summary_dir"
-          summary_file="$summary_dir/summary.md"
-          container_tmp_dir="$RUNNER_TEMP/test-tool-retry-tmp-${{ matrix.tranche }}"
-          container_var_tmp_dir="$RUNNER_TEMP/test-tool-retry-var-tmp-${{ matrix.tranche }}"
-          container_home_dir="$RUNNER_TEMP/test-tool-retry-home-${{ matrix.tranche }}"
-          rm -rf "$container_tmp_dir" "$container_var_tmp_dir" "$container_home_dir"
-          mkdir -p "$container_tmp_dir" "$container_var_tmp_dir" "$container_home_dir"
-          chmod 777 "$container_tmp_dir" "$container_var_tmp_dir" "$container_home_dir"
-
-          set +e
-          docker run --rm \
-            --read-only \
-            -w /tmp \
-            -v "$container_tmp_dir:/tmp" \
-            -v "$container_var_tmp_dir:/var/tmp" \
-            -v "$container_home_dir:/root" \
-            -v "$PWD:/mise-src:ro" \
-            -v "$PWD/target/debug/mise:/usr/local/bin/mise:ro" \
-            -v "$summary_dir:/tmp/github-summary" \
-            -e MISE_GITHUB_TOKEN="${POOL_TOKEN:-${MISE_GITHUB_TOKEN:-}}" \
-            -e GITHUB_TOKEN="${POOL_TOKEN:-${GITHUB_TOKEN:-}}" \
-            -e GITHUB_STEP_SUMMARY=/tmp/github-summary/summary.md \
-            -e TEST_TOOL_JOBS="$TEST_TOOL_JOBS" \
-            -e MISE_EXPERIMENTAL=1 \
-            -e MISE_LOCKFILE=1 \
-            -e MISE_USE_VERSIONS_HOST_TRACK=0 \
-            -e RUST_BACKTRACE=1 \
-            ghcr.io/jdx/mise:e2e \
-            sh -lc '
-              set -e
-              export HOME=/root
-              export MISE_CACHE_DIR=/tmp/mise-cache
-              export MISE_CONFIG_DIR=/tmp/mise-config
-              export MISE_DATA_DIR=/tmp/mise-data
-              export MISE_STATE_DIR=/tmp/mise-state
-              export MISE_TMP_DIR=/tmp/mise-tmp
-              mkdir -p "$HOME" "$MISE_CACHE_DIR" "$MISE_CONFIG_DIR" "$MISE_DATA_DIR" "$MISE_STATE_DIR" "$MISE_TMP_DIR"
-
-              mise test-tool --jobs "$TEST_TOOL_JOBS" ${{ steps.test-tools.outputs.failed_tools }}
-            '
-          test_tool_status=$?
-          set -e
-
-          if [ -f "$summary_file" ]; then
-            cat "$summary_file" >> "$GITHUB_STEP_SUMMARY"
-            failed_tools=$(grep "Failed Tools" "$summary_file" | sed 's/\*\*Failed Tools\*\*: //' | tr ',' ' ' || true)
-          else
-            failed_tools=""
-          fi
-          echo "failed_tools=$failed_tools" >> "$GITHUB_OUTPUT"
-          if [ "$test_tool_status" -ne 0 ] && [ -z "$failed_tools" ]; then
-            echo "::error::mise test-tool retry exited with status $test_tool_status without reporting failed tools"
-            exit "$test_tool_status"
-          fi
-      - name: Handle retry failures
-        if: steps.retry.outputs.failed_tools != '' && github.head_ref != 'release' && github.ref != 'refs/heads/release'
-        run: |
-          echo "Tools still failing after retry: ${{ steps.retry.outputs.failed_tools }}"
-          exit 1
-      - name: Check grace period for release branch failures
-        if: steps.retry.outputs.failed_tools != '' && (github.head_ref == 'release' || github.ref == 'refs/heads/release')
-        env:
-          GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-        run: mise run test-tool-retry --check-only --grace-period ${{ steps.retry.outputs.failed_tools }}
+  untrusted:
+    if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/registry-impl.yml
+    with:
+      trusted: false
+      mbx-backend: github
 
   registry-ci:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    name: registry-ci
+    if: ${{ always() && !cancelled() && needs.trusted.result != 'cancelled' && needs.untrusted.result != 'cancelled' }}
+    permissions: {}
+    needs: [trusted, untrusted]
+    runs-on: ubuntu-latest
     timeout-minutes: 1
-    needs:
-      - check-changes
-      - build
-      - list-changed-tools
-      - validate-new-tools
-      - test-tool
-    if: ${{ !cancelled() }}
     steps:
-      - name: Check CI job results
+      - name: Check selected workflow result
+        env:
+          TRUSTED_RESULT: ${{ needs.trusted.result }}
+          UNTRUSTED_RESULT: ${{ needs.untrusted.result }}
         run: |
-          if [ "${{ needs.check-changes.result }}" != "success" ]; then
-            echo "check-changes job failed"
-            exit 1
-          fi
-          if [ "${{ needs.check-changes.outputs.registry-changed }}" != "true" ]; then
-            echo "No registry changes detected, skipping registry CI checks"
+          if [[ "$TRUSTED_RESULT" == success && "$UNTRUSTED_RESULT" == skipped ]] ||
+             [[ "$TRUSTED_RESULT" == skipped && "$UNTRUSTED_RESULT" == success ]]; then
             exit 0
           fi
-          if [ "${{ needs.build.result }}" != "success" ]; then
-            echo "build failed or was skipped"
-            exit 1
-          fi
-          if [ "${{ needs.list-changed-tools.result }}" != "success" ] && [ "${{ needs.list-changed-tools.result }}" != "skipped" ]; then
-            echo "list-changed-tools failed"
-            exit 1
-          fi
-          if [ "${{ needs.validate-new-tools.result }}" == "failure" ]; then
-            echo "validate-new-tools failed - new tools must include tests"
-            exit 1
-          fi
-          if [ "${{ needs.list-changed-tools.outputs.skip-test-tool }}" == "true" ]; then
-            echo "test-tool intentionally skipped (deletion-only PR)"
-          elif [ "${{ needs.test-tool.result }}" != "success" ]; then
-            echo "test-tool failed or was skipped"
-            exit 1
-          fi
-          echo "All CI jobs completed successfully"
+          echo "trusted=$TRUSTED_RESULT untrusted=$UNTRUSTED_RESULT"
+          exit 1

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -22,7 +22,8 @@ jobs:
   release-plz:
     if: github.repository == 'jdx/mise'
     timeout-minutes: 80
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-release-plz-rust-linux
+    # Release builds must never restore or save persistent caches.
+    runs-on: namespace-profile-endev-linux-amd64
     permissions:
       pull-requests: write
       contents: write
@@ -41,6 +42,8 @@ jobs:
       - run: mkdir -p "$HOME/bin" && echo "$HOME/bin" >> "$GITHUB_PATH"
       - run: cargo build --all-features --ignore-rust-version && cp target/debug/mise "$HOME"/bin
       - uses: ./.github/actions/mise-tools
+        with:
+          cache: false
       - run: mise x -- bun i
       - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: crates-io-auth

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
   build-tarball-linux:
     if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
     name: build-tarball-${{matrix.name}}
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64-xlarge' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64-xlarge' }}
     # PGO and cross-built release tarballs can exceed 90 minutes on
     # loaded runners, especially once archive generation is included.
     timeout-minutes: 150
@@ -94,7 +94,7 @@ jobs:
   build-tarball-macos:
     if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
     name: build-tarball-${{matrix.name}}
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'macos-14' || 'namespace-profile-endev-macos-arm64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'macos-14' || 'namespace-profile-endev-macos-arm64' }}
     timeout-minutes: 300
     env:
       MINIO_AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
   build-tarball-linux:
     if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
     name: build-tarball-${{matrix.name}}
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64-xlarge' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64-xlarge' }}
     # PGO and cross-built release tarballs can exceed 90 minutes on
     # loaded runners, especially once archive generation is included.
     timeout-minutes: 150
@@ -94,7 +94,7 @@ jobs:
   build-tarball-macos:
     if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
     name: build-tarball-${{matrix.name}}
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'macos-14' || 'namespace-profile-endev-macos-arm64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'macos-14' || 'namespace-profile-endev-macos-arm64' }}
     timeout-minutes: 300
     env:
       MINIO_AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -174,7 +174,7 @@ jobs:
         if: always()
 
   lint:
-    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64-xlarge' }}
     timeout-minutes: 80
     needs: [build-ubuntu]
     env:

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -174,7 +174,7 @@ jobs:
         if: always()
 
   lint:
-    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64-xlarge' }}
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64-large' }}
     timeout-minutes: 80
     needs: [build-ubuntu]
     env:

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -222,12 +222,10 @@ jobs:
       # compete with the MSRV build for memory. Clippy is stricter than HK's
       # cargo-check, so CI can skip that redundant compilation while retaining it
       # for local lint runs.
-      # test-standalone creates and removes tmp/install.sh, which hk may discover
-      # while collecting shellcheck inputs if both run concurrently.
-      - run: ./scripts/test-standalone.sh
       - parallel:
           - run: rm -rf ~/.cargo/advisory-dbs && cargo deny check
           - run: cargo machete --with-metadata
+          - run: ./scripts/test-standalone.sh
           - run: mise run lint
             env:
               HK_SKIP_STEPS: cargo-check

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -222,10 +222,12 @@ jobs:
       # compete with the MSRV build for memory. Clippy is stricter than HK's
       # cargo-check, so CI can skip that redundant compilation while retaining it
       # for local lint runs.
+      # test-standalone creates and removes tmp/install.sh, which hk may discover
+      # while collecting shellcheck inputs if both run concurrently.
+      - run: ./scripts/test-standalone.sh
       - parallel:
           - run: rm -rf ~/.cargo/advisory-dbs && cargo deny check
           - run: cargo machete --with-metadata
-          - run: ./scripts/test-standalone.sh
           - run: mise run lint
             env:
               HK_SKIP_STEPS: cargo-check

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -1,0 +1,523 @@
+name: test implementation
+on:
+  workflow_call:
+    inputs:
+      trusted:
+        required: true
+        type: boolean
+      mbx-backend:
+        required: true
+        type: string
+    secrets:
+      FORGEJO_TOKEN:
+        required: false
+      MISE_GH_TOKEN:
+        required: false
+      MISE_VERSIONS_API_SECRET:
+        required: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  MISE_TRUSTED_CONFIG_PATHS: ${{ github.workspace }}
+  MISE_EXPERIMENTAL: 1
+  MISE_LOCKFILE: 1
+  RUST_BACKTRACE: 1
+  MISE_GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+  FORGEJO_TOKEN: ${{ secrets.FORGEJO_TOKEN }}
+
+jobs:
+  classify-changes:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      full-ci: ${{ steps.classify.outputs.full-ci }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+      - name: Classify changes
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          echo "full-ci=true" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            exit 0
+          fi
+
+          changed=0
+          while IFS= read -r path; do
+            changed=1
+            case "$path" in
+              docs/* | *.md) ;;
+              *) exit 0 ;;
+            esac
+          done < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+
+          if [ "$changed" -eq 1 ]; then
+            echo "full-ci=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-ubuntu:
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    timeout-minutes: 60
+    steps:
+      - name: Assert OIDC is unavailable to untrusted CI
+        if: ${{ !inputs.trusted }}
+        run: |
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
+        if: inputs.trusted
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/.global-cache
+      - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
+      - run: |
+          mbx build --all-features --ignore-rust-version
+          echo "$PWD/target/debug" >> "$GITHUB_PATH"
+      - run: mise -v
+      # Downstream jobs only execute this binary, so keep full debug symbols in
+      # the build job while transferring a much smaller stripped copy.
+      - name: Prepare mise artifact
+        run: |
+          install -Dm755 target/debug/mise target/ci-artifacts/mise
+          strip --strip-debug target/ci-artifacts/mise
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: mise-ubuntu-latest
+          path: target/ci-artifacts/mise
+      - run: mbx cache stats
+        if: always()
+
+  build-windows:
+    runs-on: windows-latest
+    timeout-minutes: 60
+    needs: [classify-changes]
+    if: needs.classify-changes.outputs.full-ci == 'true'
+    env:
+      MISE_DATA_DIR: ~/.local/share/mise
+      MISE_CACHE_DIR: ~/.cache/mise
+      # Keep Windows paths short enough for MSBuild/FileTracker and place the
+      # binaries where downstream artifact steps already expect them.
+      MBX_TARGET_VIEWS: "0"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
+      - shell: pwsh
+        run: |
+          mbx build --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update
+          mbx build -p mise-shim
+          Add-Content $env:GITHUB_PATH "$env:GITHUB_WORKSPACE\target\debug"
+      - parallel:
+          - run: mise -v
+          - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+            with:
+              name: mise-windows-latest
+              path: |
+                target/debug/mise.exe
+                target/debug/mise-shim.exe
+
+  unit:
+    name: unit-macos
+    runs-on: ${{ !inputs.trusted && 'macos-14' || 'namespace-profile-endev-macos-arm64' }}
+    timeout-minutes: 90
+    needs: [classify-changes]
+    if: needs.classify-changes.outputs.full-ci == 'true'
+    env:
+      MISE_CARGO_BUILD_EXTRA_ARGS: --ignore-rust-version
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.head_ref }}
+      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
+        if: inputs.trusted
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/.global-cache
+      - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
+      - name: Install test tools
+        run: brew install fd tmux
+      - run: |
+          mbx build --all-features --ignore-rust-version
+          echo "$PWD/target/debug" >> "$GITHUB_PATH"
+      - uses: ./.github/actions/mise-tools
+      - run: mise x -- mbx test --all-features --ignore-rust-version
+      # `cargo test` above resolves to the root package, so the workspace members are built as
+      # dependencies but never tested. Run them separately rather than adding --workspace to the
+      # line above, which would extend --all-features to members whose features are exclusive.
+      - name: cargo test (workspace members)
+        run: mbx test --workspace --exclude mise --ignore-rust-version
+      - run: mise run test:e2e e2e/cli/test_system_install_brew_macos_slow
+      - run: mise run test:e2e e2e/tasks/test_task_zsh_process_substitution_tmux_macos
+      - run: mbx cache stats
+        if: always()
+
+  lint:
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    timeout-minutes: 80
+    needs: [build-ubuntu]
+    env:
+      # Clippy's all-features build can otherwise exhaust the runner's memory.
+      CARGO_BUILD_JOBS: "2"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
+      - parallel:
+          - name: Install mold
+            run: sudo apt-get update && sudo apt-get install -y mold
+          - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
+            with:
+              tool: cargo-deny,cargo-msrv,cargo-machete
+          - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
+            if: inputs.trusted
+            with:
+              path: |
+                ~/.cargo/registry
+                ~/.cargo/git
+                ~/.cargo/.global-cache
+          - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+            with:
+              name: mise-ubuntu-latest
+              path: target/debug
+      - run: echo "$PWD/target/debug" >> "$GITHUB_PATH" && chmod +x target/debug/mise
+      - uses: ./.github/actions/mise-tools
+      - run: mise x -- bun i
+      # build-ubuntu produced this commit's binary, downloaded above.
+      - run: mise run render
+        env:
+          MISE_TASK_SKIP: build
+      - name: assert render produces no diff
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::'mise run render' produced changes. Run it locally and commit."
+            git status
+            git diff HEAD
+            exit 1
+          fi
+      # Keep these independent checks on one Namespace runner while overlapping
+      # their work. Clippy runs afterward so its all-features test build does not
+      # compete with the MSRV build for memory. Clippy is stricter than HK's
+      # cargo-check, so CI can skip that redundant compilation while retaining it
+      # for local lint runs.
+      - parallel:
+          - run: rm -rf ~/.cargo/advisory-dbs && cargo deny check
+          - run: cargo machete --with-metadata
+          - run: ./scripts/test-standalone.sh
+          - run: mise run lint
+            env:
+              HK_SKIP_STEPS: cargo-check
+          # MSRV uses a separate target directory so its older compiler cannot
+          # invalidate stable's build artifacts. Some AWS crates declare a newer
+          # rust-version than their code requires; rustc still rejects genuinely
+          # incompatible syntax and APIs when the metadata check is ignored.
+          - name: Verify MSRV
+            run: mbx msrv verify -- cargo check --ignore-rust-version
+            env:
+              CARGO_TARGET_DIR: target/msrv
+      - name: Run Clippy
+        run: |
+          mbx clippy --ignore-rust-version -- -D warnings
+          mbx clippy --all-features --all-targets --ignore-rust-version -- -D warnings
+
+  e2e:
+    name: e2e
+    permissions:
+      contents: read
+    # The release PR runs the full suite against the packaged release tarball.
+    # Keep that stronger signal instead of also testing the debug artifact.
+    if: ${{ needs.classify-changes.outputs.full-ci == 'true' && (github.event_name != 'pull_request' || github.head_ref != 'release' || github.base_ref != 'main') }}
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    needs: [build-ubuntu, classify-changes]
+    timeout-minutes: 125
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+      # Fetch sequentially so the pool can rotate its cursor between requests.
+      # Each token is also rejected by the action when its core budget is empty.
+      - name: Fetch token 0
+        id: token_0
+        uses: ./.github/actions/fetch-token
+        with:
+          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
+      - name: Fetch token 1
+        id: token_1
+        uses: ./.github/actions/fetch-token
+        with:
+          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
+      - name: Fetch token 2
+        id: token_2
+        uses: ./.github/actions/fetch-token
+        with:
+          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
+      - name: Fetch token 3
+        id: token_3
+        uses: ./.github/actions/fetch-token
+        with:
+          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
+      - name: Fetch token 4
+        id: token_4
+        uses: ./.github/actions/fetch-token
+        with:
+          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
+      - name: Fetch token 5
+        id: token_5
+        uses: ./.github/actions/fetch-token
+        with:
+          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
+      - name: Fetch token 6
+        id: token_6
+        uses: ./.github/actions/fetch-token
+        with:
+          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
+      - name: Fetch token 7
+        id: token_7
+        uses: ./.github/actions/fetch-token
+        with:
+          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: mise-ubuntu-latest
+          path: target/debug
+      - run: echo "$PWD/target/debug" >> "$GITHUB_PATH" && chmod +x target/debug/mise
+      - parallel:
+          - uses: ./.github/actions/mise-tools
+          - name: Pull e2e Docker image
+            run: docker pull ghcr.io/jdx/mise:e2e
+      # Each test gets isolated host directories and an ephemeral container.
+      # Run four branches on a standard runner; each branch handles two
+      # token-isolated tranches sequentially, capped at eight containers total.
+      - parallel:
+          - name: Test tranches 0 and 4
+            uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+            env:
+              E2E_JOBS: 2
+              MISE_E2E_DOCKER: "1"
+              TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
+              TEST_TRANCHE_COUNT: 8
+              TRANCHE_A: 0
+              TRANCHE_B: 4
+              TOKEN_A: ${{ steps.token_0.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              TOKEN_B: ${{ steps.token_4.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+            with: &e2e-retry
+              timeout_minutes: 30
+              retry_wait_seconds: 30
+              max_attempts: 2
+              command: |
+                e2e_status=0
+                MISE_GITHUB_TOKEN="$TOKEN_A" GITHUB_TOKEN="$TOKEN_A" TEST_TRANCHE="$TRANCHE_A" ./e2e/run_all_tests || e2e_status=$?
+                MISE_GITHUB_TOKEN="$TOKEN_B" GITHUB_TOKEN="$TOKEN_B" TEST_TRANCHE="$TRANCHE_B" ./e2e/run_all_tests || e2e_status=$?
+                exit "$e2e_status"
+          - name: Test tranches 1 and 5
+            uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+            env:
+              E2E_JOBS: 2
+              MISE_E2E_DOCKER: "1"
+              TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
+              TEST_TRANCHE_COUNT: 8
+              TRANCHE_A: 1
+              TRANCHE_B: 5
+              TOKEN_A: ${{ steps.token_1.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              TOKEN_B: ${{ steps.token_5.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+            with: *e2e-retry
+          - name: Test tranches 2 and 6
+            uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+            env:
+              E2E_JOBS: 2
+              MISE_E2E_DOCKER: "1"
+              TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
+              TEST_TRANCHE_COUNT: 8
+              TRANCHE_A: 2
+              TRANCHE_B: 6
+              TOKEN_A: ${{ steps.token_2.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              TOKEN_B: ${{ steps.token_6.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+            with: *e2e-retry
+          - name: Test tranches 3 and 7
+            uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+            env:
+              E2E_JOBS: 2
+              MISE_E2E_DOCKER: "1"
+              TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
+              TEST_TRANCHE_COUNT: 8
+              TRANCHE_A: 3
+              TRANCHE_B: 7
+              TOKEN_A: ${{ steps.token_3.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              TOKEN_B: ${{ steps.token_7.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+            with: *e2e-retry
+
+  bootstrap-linux-host:
+    permissions:
+      contents: read
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    timeout-minutes: 20
+    needs: [build-ubuntu, classify-changes]
+    if: needs.classify-changes.outputs.full-ci == 'true'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: mise-ubuntu-latest
+          path: target/debug
+      - run: chmod +x target/debug/mise
+      - name: Converge a complete Linux host over SSH
+        run: scripts/test-bootstrap-linux-host.sh target/debug/mise
+
+  windows-unit:
+    runs-on: windows-latest
+    timeout-minutes: 30
+    needs: [classify-changes]
+    if: needs.classify-changes.outputs.full-ci == 'true'
+    env:
+      MISE_DATA_DIR: ~/.local/share/mise
+      MISE_CACHE_DIR: ~/.cache/mise
+      # The default content-addressed target path can exceed Windows tooling's
+      # path limits during workspace tests.
+      MBX_TARGET_VIEWS: "0"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
+      - name: check unused code
+        run: mbx check -p mise --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update --all-targets
+        env:
+          RUSTFLAGS: -D unused
+      - name: cargo test
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+        with:
+          timeout_minutes: 30
+          retry_wait_seconds: 30
+          max_attempts: 2
+          command: mbx test
+      # Windows is where the members rot fastest: their tests assume POSIX paths and shells
+      # unless something runs them here.
+      - name: cargo test (workspace members)
+        run: mbx test --workspace --exclude mise
+  windows-e2e:
+    permissions:
+      contents: read
+    runs-on: windows-latest
+    timeout-minutes: 100
+    needs: [build-windows, classify-changes]
+    if: needs.classify-changes.outputs.full-ci == 'true'
+    env:
+      MISE_DATA_DIR: ~/.local/share/mise
+      MISE_CACHE_DIR: ~/.cache/mise
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: mise-windows-latest
+          path: target/debug
+      - run: ls target\debug
+      - run: Add-Content $env:GITHUB_PATH "$env:GITHUB_WORKSPACE\target\debug"
+      - uses: ./.github/actions/mise-tools
+      - name: e2e
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+        with:
+          timeout_minutes: 30
+          retry_wait_seconds: 30
+          max_attempts: 2
+          command: pwsh e2e-win\run.ps1
+
+  test-ci:
+    permissions: {}
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    timeout-minutes: 1
+    needs:
+      - classify-changes
+      - build-ubuntu
+      - build-windows
+      - unit
+      - lint
+      - e2e
+      - bootstrap-linux-host
+      - windows-unit
+      - windows-e2e
+    # Evaluate skipped and failed dependencies, but do not waste a runner when
+    # the workflow is cancelled.
+    if: ${{ always() && !cancelled() }}
+    steps:
+      - name: Check CI job results
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          full_ci="${{ needs.classify-changes.outputs.full-ci }}"
+          if [ "${{ needs.build-ubuntu.result }}" != "success" ]; then
+            echo "build-ubuntu failed or was skipped"
+            exit 1
+          fi
+          if [ "${{ needs.lint.result }}" != "success" ]; then
+            echo "lint failed or was skipped"
+            exit 1
+          fi
+
+          if [ "$full_ci" == "true" ]; then
+            if [ "${{ needs.build-windows.result }}" != "success" ]; then
+              echo "build-windows failed or was skipped"
+              exit 1
+            fi
+            if [ "${{ needs.unit.result }}" != "success" ]; then
+              echo "unit failed or was skipped"
+              exit 1
+            fi
+            if [ "${{ github.event_name }}" == "pull_request" ] && [ "$HEAD_REF" == "release" ] && [ "$BASE_REF" == "main" ]; then
+              if [ "${{ needs.e2e.result }}" != "skipped" ]; then
+                echo "e2e should be handled by the release workflow"
+                exit 1
+              fi
+            elif [ "${{ needs.e2e.result }}" != "success" ]; then
+              echo "e2e failed or was skipped"
+              exit 1
+            fi
+            if [ "${{ needs.bootstrap-linux-host.result }}" != "success" ]; then
+              echo "bootstrap-linux-host failed or was skipped"
+              exit 1
+            fi
+            if [ "${{ needs.windows-unit.result }}" != "success" ]; then
+              echo "windows-unit failed or was skipped"
+              exit 1
+            fi
+            if [ "${{ needs.windows-e2e.result }}" != "success" ]; then
+              echo "windows-e2e failed or was skipped"
+              exit 1
+            fi
+          else
+            for result in \
+              "${{ needs.build-windows.result }}" \
+              "${{ needs.unit.result }}" \
+              "${{ needs.e2e.result }}" \
+              "${{ needs.bootstrap-linux-host.result }}" \
+              "${{ needs.windows-unit.result }}" \
+              "${{ needs.windows-e2e.result }}"; do
+              if [ "$result" != "skipped" ]; then
+                echo "docs-only jobs should be skipped"
+                exit 1
+              fi
+            done
+          fi
+          echo "All CI jobs completed successfully"

--- a/.github/workflows/test-vfox-impl.yml
+++ b/.github/workflows/test-vfox-impl.yml
@@ -1,0 +1,58 @@
+name: test-vfox implementation
+
+on:
+  workflow_call:
+    inputs:
+      trusted:
+        required: true
+        type: boolean
+      mbx-backend:
+        required: true
+        type: string
+    secrets:
+      MISE_GH_TOKEN:
+        required: false
+
+concurrency:
+  group: test-vfox-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  MISE_TRUSTED_CONFIG_PATHS: ${{ github.workspace }}
+  MISE_EXPERIMENTAL: 1
+  MISE_LOCKFILE: 1
+  RUST_BACKTRACE: 1
+  GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+
+jobs:
+  "test-vfox":
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    steps:
+      - name: Assert OIDC is unavailable to untrusted CI
+        if: ${{ !inputs.trusted }}
+        run: |
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
+        if: inputs.trusted
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/.global-cache
+      - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
+      - run: |
+          mbx build --all-features --ignore-rust-version
+          echo "$PWD/target/debug" >> "$GITHUB_PATH"
+      - run: mise -v
+      - run: mbx build
+        working-directory: crates/vfox
+      - run: mise --cd crates/vfox run lint
+      - run: mbx test
+        working-directory: crates/vfox
+      - run: mbx cache stats
+        if: always()

--- a/.github/workflows/test-vfox.yml
+++ b/.github/workflows/test-vfox.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/test-vfox.yml
+++ b/.github/workflows/test-vfox.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   "test-vfox":
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/test-vfox.yml
+++ b/.github/workflows/test-vfox.yml
@@ -21,14 +21,14 @@ env:
 
 jobs:
   "test-vfox":
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     permissions:
       contents: read
       id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
-        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
+        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/test-vfox.yml
+++ b/.github/workflows/test-vfox.yml
@@ -36,13 +36,13 @@ jobs:
             ~/.cargo/.global-cache
       - uses: ./.github/actions/mbx
       - run: |
-          mbx build build --all-features --ignore-rust-version
+          mbx build --all-features --ignore-rust-version
           echo "$PWD/target/debug" >> "$GITHUB_PATH"
       - run: mise -v
-      - run: mbx build build
+      - run: mbx build
         working-directory: crates/vfox
       - run: mise --cd crates/vfox run lint
-      - run: mbx build test
+      - run: mbx test
         working-directory: crates/vfox
       - run: mbx cache stats
         if: always()

--- a/.github/workflows/test-vfox.yml
+++ b/.github/workflows/test-vfox.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - "crates/vfox/**"
+      - ".github/workflows/test-vfox.yml"
+      - ".github/workflows/test-vfox-impl.yml"
   push:
     branches: [release]
 

--- a/.github/workflows/test-vfox.yml
+++ b/.github/workflows/test-vfox.yml
@@ -7,42 +7,46 @@ on:
   push:
     branches: [release]
 
-concurrency:
-  group: test-vfox-${{ github.ref }}
-  cancel-in-progress: true
-
-env:
-  CARGO_TERM_COLOR: always
-  MISE_TRUSTED_CONFIG_PATHS: ${{ github.workspace }}
-  MISE_EXPERIMENTAL: 1
-  MISE_LOCKFILE: 1
-  RUST_BACKTRACE: 1
-  GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+permissions: {}
 
 jobs:
-  "test-vfox":
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+  trusted:
+    if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
     permissions:
       contents: read
       id-token: write
+    uses: ./.github/workflows/test-vfox-impl.yml
+    with:
+      trusted: true
+      mbx-backend: server
+    secrets:
+      MISE_GH_TOKEN: ${{ secrets.MISE_GH_TOKEN }}
+
+  untrusted:
+    if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/test-vfox-impl.yml
+    with:
+      trusted: false
+      mbx-backend: github
+
+  test-vfox:
+    name: test-vfox
+    if: ${{ always() && !cancelled() && needs.trusted.result != 'cancelled' && needs.untrusted.result != 'cancelled' }}
+    permissions: {}
+    needs: [trusted, untrusted]
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
-        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/.global-cache
-      - uses: ./.github/actions/mbx
-      - run: |
-          mbx build --all-features --ignore-rust-version
-          echo "$PWD/target/debug" >> "$GITHUB_PATH"
-      - run: mise -v
-      - run: mbx build
-        working-directory: crates/vfox
-      - run: mise --cd crates/vfox run lint
-      - run: mbx test
-        working-directory: crates/vfox
-      - run: mbx cache stats
-        if: always()
+      - name: Check selected workflow result
+        env:
+          TRUSTED_RESULT: ${{ needs.trusted.result }}
+          UNTRUSTED_RESULT: ${{ needs.untrusted.result }}
+        run: |
+          if [[ "$TRUSTED_RESULT" == success && "$UNTRUSTED_RESULT" == skipped ]] ||
+             [[ "$TRUSTED_RESULT" == skipped && "$UNTRUSTED_RESULT" == success ]]; then
+            exit 0
+          fi
+          echo "trusted=$TRUSTED_RESULT untrusted=$UNTRUSTED_RESULT"
+          exit 1

--- a/.github/workflows/test-vfox.yml
+++ b/.github/workflows/test-vfox.yml
@@ -21,7 +21,10 @@ env:
 
 jobs:
   "test-vfox":
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
@@ -31,10 +34,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             ~/.cargo/.global-cache
-            ~/.cache/mbx
-      - uses: ./.github/actions/setup-mbx
-        with:
-          restore-cache: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+      - uses: ./.github/actions/mbx
       - run: |
           mbx build build --all-features --ignore-rust-version
           echo "$PWD/target/debug" >> "$GITHUB_PATH"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,9 @@ jobs:
   build-ubuntu:
     runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 60
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
         with:
           path: |
             ~/.cargo/registry
@@ -137,7 +137,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
         with:
           path: |
             ~/.cargo/registry
@@ -178,7 +178,7 @@ jobs:
             with:
               tool: cargo-deny,cargo-msrv,cargo-machete
           - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
-            if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+            if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
             with:
               path: |
                 ~/.cargo/registry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,5 @@
 name: test
+
 on:
   push:
     tags: ["v*"]
@@ -7,503 +8,56 @@ on:
     branches: ["main"]
   workflow_dispatch:
   workflow_call:
+    secrets:
+      FORGEJO_TOKEN:
+        required: false
+      MISE_GH_TOKEN:
+        required: false
+      MISE_VERSIONS_API_SECRET:
+        required: false
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'push' }}
-
-env:
-  CARGO_TERM_COLOR: always
-  MISE_TRUSTED_CONFIG_PATHS: ${{ github.workspace }}
-  MISE_EXPERIMENTAL: 1
-  MISE_LOCKFILE: 1
-  RUST_BACKTRACE: 1
-  MISE_GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-  GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-  FORGEJO_TOKEN: ${{ secrets.FORGEJO_TOKEN }}
-
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
-  classify-changes:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      full-ci: ${{ steps.classify.outputs.full-ci }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          fetch-depth: 0
-      - name: Classify changes
-        id: classify
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-        run: |
-          echo "full-ci=true" >> "$GITHUB_OUTPUT"
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            exit 0
-          fi
-
-          changed=0
-          while IFS= read -r path; do
-            changed=1
-            case "$path" in
-              docs/* | *.md) ;;
-              *) exit 0 ;;
-            esac
-          done < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
-
-          if [ "$changed" -eq 1 ]; then
-            echo "full-ci=false" >> "$GITHUB_OUTPUT"
-          fi
-
-  build-ubuntu:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
-    timeout-minutes: 60
+  trusted:
+    if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
     permissions:
       contents: read
       id-token: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
-        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/.global-cache
-      - uses: ./.github/actions/mbx
-      - run: |
-          mbx build --all-features --ignore-rust-version
-          echo "$PWD/target/debug" >> "$GITHUB_PATH"
-      - run: mise -v
-      # Downstream jobs only execute this binary, so keep full debug symbols in
-      # the build job while transferring a much smaller stripped copy.
-      - name: Prepare mise artifact
-        run: |
-          install -Dm755 target/debug/mise target/ci-artifacts/mise
-          strip --strip-debug target/ci-artifacts/mise
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: mise-ubuntu-latest
-          path: target/ci-artifacts/mise
-      - run: mbx cache stats
-        if: always()
+    uses: ./.github/workflows/test-impl.yml
+    with:
+      trusted: true
+      mbx-backend: server
+    secrets:
+      FORGEJO_TOKEN: ${{ secrets.FORGEJO_TOKEN }}
+      MISE_GH_TOKEN: ${{ secrets.MISE_GH_TOKEN }}
+      MISE_VERSIONS_API_SECRET: ${{ secrets.MISE_VERSIONS_API_SECRET }}
 
-  build-windows:
-    runs-on: windows-latest
-    timeout-minutes: 60
-    needs: [classify-changes]
-    if: needs.classify-changes.outputs.full-ci == 'true'
+  untrusted:
+    if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
     permissions:
       contents: read
-      id-token: write
-    env:
-      MISE_DATA_DIR: ~/.local/share/mise
-      MISE_CACHE_DIR: ~/.cache/mise
-      # Keep Windows paths short enough for MSBuild/FileTracker and place the
-      # binaries where downstream artifact steps already expect them.
-      MBX_TARGET_VIEWS: "0"
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: ./.github/actions/mbx
-      - shell: pwsh
-        run: |
-          mbx build --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update
-          mbx build -p mise-shim
-          Add-Content $env:GITHUB_PATH "$env:GITHUB_WORKSPACE\target\debug"
-      - parallel:
-          - run: mise -v
-          - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-            with:
-              name: mise-windows-latest
-              path: |
-                target/debug/mise.exe
-                target/debug/mise-shim.exe
-
-  unit:
-    name: unit-macos
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'macos-14' || 'namespace-profile-endev-macos-arm64' }}
-    timeout-minutes: 90
-    needs: [classify-changes]
-    if: needs.classify-changes.outputs.full-ci == 'true'
-    permissions:
-      contents: read
-      id-token: write
-    env:
-      MISE_CARGO_BUILD_EXTRA_ARGS: --ignore-rust-version
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.head_ref }}
-      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
-        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/.global-cache
-      - uses: ./.github/actions/mbx
-      - name: Install test tools
-        run: brew install fd tmux
-      - run: |
-          mbx build --all-features --ignore-rust-version
-          echo "$PWD/target/debug" >> "$GITHUB_PATH"
-      - uses: ./.github/actions/mise-tools
-      - run: mise x -- mbx test --all-features --ignore-rust-version
-      # `cargo test` above resolves to the root package, so the workspace members are built as
-      # dependencies but never tested. Run them separately rather than adding --workspace to the
-      # line above, which would extend --all-features to members whose features are exclusive.
-      - name: cargo test (workspace members)
-        run: mbx test --workspace --exclude mise --ignore-rust-version
-      - run: mise run test:e2e e2e/cli/test_system_install_brew_macos_slow
-      - run: mise run test:e2e e2e/tasks/test_task_zsh_process_substitution_tmux_macos
-      - run: mbx cache stats
-        if: always()
-
-  lint:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
-    timeout-minutes: 80
-    needs: [build-ubuntu]
-    permissions:
-      contents: read
-      id-token: write
-    env:
-      # Clippy's all-features build can otherwise exhaust the runner's memory.
-      CARGO_BUILD_JOBS: "2"
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: ./.github/actions/mbx
-      - parallel:
-          - name: Install mold
-            run: sudo apt-get update && sudo apt-get install -y mold
-          - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
-            with:
-              tool: cargo-deny,cargo-msrv,cargo-machete
-          - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
-            if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')
-            with:
-              path: |
-                ~/.cargo/registry
-                ~/.cargo/git
-                ~/.cargo/.global-cache
-          - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-            with:
-              name: mise-ubuntu-latest
-              path: target/debug
-      - run: echo "$PWD/target/debug" >> "$GITHUB_PATH" && chmod +x target/debug/mise
-      - uses: ./.github/actions/mise-tools
-      - run: mise x -- bun i
-      # build-ubuntu produced this commit's binary, downloaded above.
-      - run: mise run render
-        env:
-          MISE_TASK_SKIP: build
-      - name: assert render produces no diff
-        run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "::error::'mise run render' produced changes. Run it locally and commit."
-            git status
-            git diff HEAD
-            exit 1
-          fi
-      # Keep these independent checks on one Namespace runner while overlapping
-      # their work. Clippy runs afterward so its all-features test build does not
-      # compete with the MSRV build for memory. Clippy is stricter than HK's
-      # cargo-check, so CI can skip that redundant compilation while retaining it
-      # for local lint runs.
-      - parallel:
-          - run: rm -rf ~/.cargo/advisory-dbs && cargo deny check
-          - run: cargo machete --with-metadata
-          - run: ./scripts/test-standalone.sh
-          - run: mise run lint
-            env:
-              HK_SKIP_STEPS: cargo-check
-          # MSRV uses a separate target directory so its older compiler cannot
-          # invalidate stable's build artifacts. Some AWS crates declare a newer
-          # rust-version than their code requires; rustc still rejects genuinely
-          # incompatible syntax and APIs when the metadata check is ignored.
-          - name: Verify MSRV
-            run: mbx msrv verify -- cargo check --ignore-rust-version
-            env:
-              CARGO_TARGET_DIR: target/msrv
-      - name: Run Clippy
-        run: |
-          mbx clippy --ignore-rust-version -- -D warnings
-          mbx clippy --all-features --all-targets --ignore-rust-version -- -D warnings
-
-  e2e:
-    name: e2e
-    # The release PR runs the full suite against the packaged release tarball.
-    # Keep that stronger signal instead of also testing the debug artifact.
-    if: ${{ needs.classify-changes.outputs.full-ci == 'true' && (github.event_name != 'pull_request' || github.head_ref != 'release' || github.base_ref != 'main') }}
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
-    needs: [build-ubuntu, classify-changes]
-    timeout-minutes: 125
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          fetch-depth: 0
-      # Fetch sequentially so the pool can rotate its cursor between requests.
-      # Each token is also rejected by the action when its core budget is empty.
-      - name: Fetch token 0
-        id: token_0
-        uses: ./.github/actions/fetch-token
-        with:
-          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
-      - name: Fetch token 1
-        id: token_1
-        uses: ./.github/actions/fetch-token
-        with:
-          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
-      - name: Fetch token 2
-        id: token_2
-        uses: ./.github/actions/fetch-token
-        with:
-          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
-      - name: Fetch token 3
-        id: token_3
-        uses: ./.github/actions/fetch-token
-        with:
-          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
-      - name: Fetch token 4
-        id: token_4
-        uses: ./.github/actions/fetch-token
-        with:
-          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
-      - name: Fetch token 5
-        id: token_5
-        uses: ./.github/actions/fetch-token
-        with:
-          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
-      - name: Fetch token 6
-        id: token_6
-        uses: ./.github/actions/fetch-token
-        with:
-          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
-      - name: Fetch token 7
-        id: token_7
-        uses: ./.github/actions/fetch-token
-        with:
-          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: mise-ubuntu-latest
-          path: target/debug
-      - run: echo "$PWD/target/debug" >> "$GITHUB_PATH" && chmod +x target/debug/mise
-      - parallel:
-          - uses: ./.github/actions/mise-tools
-          - name: Pull e2e Docker image
-            run: docker pull ghcr.io/jdx/mise:e2e
-      # Each test gets isolated host directories and an ephemeral container.
-      # Run four branches on a standard runner; each branch handles two
-      # token-isolated tranches sequentially, capped at eight containers total.
-      - parallel:
-          - name: Test tranches 0 and 4
-            uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
-            env:
-              E2E_JOBS: 2
-              MISE_E2E_DOCKER: "1"
-              TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
-              TEST_TRANCHE_COUNT: 8
-              TRANCHE_A: 0
-              TRANCHE_B: 4
-              TOKEN_A: ${{ steps.token_0.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-              TOKEN_B: ${{ steps.token_4.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-            with: &e2e-retry
-              timeout_minutes: 30
-              retry_wait_seconds: 30
-              max_attempts: 2
-              command: |
-                e2e_status=0
-                MISE_GITHUB_TOKEN="$TOKEN_A" GITHUB_TOKEN="$TOKEN_A" TEST_TRANCHE="$TRANCHE_A" ./e2e/run_all_tests || e2e_status=$?
-                MISE_GITHUB_TOKEN="$TOKEN_B" GITHUB_TOKEN="$TOKEN_B" TEST_TRANCHE="$TRANCHE_B" ./e2e/run_all_tests || e2e_status=$?
-                exit "$e2e_status"
-          - name: Test tranches 1 and 5
-            uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
-            env:
-              E2E_JOBS: 2
-              MISE_E2E_DOCKER: "1"
-              TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
-              TEST_TRANCHE_COUNT: 8
-              TRANCHE_A: 1
-              TRANCHE_B: 5
-              TOKEN_A: ${{ steps.token_1.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-              TOKEN_B: ${{ steps.token_5.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-            with: *e2e-retry
-          - name: Test tranches 2 and 6
-            uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
-            env:
-              E2E_JOBS: 2
-              MISE_E2E_DOCKER: "1"
-              TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
-              TEST_TRANCHE_COUNT: 8
-              TRANCHE_A: 2
-              TRANCHE_B: 6
-              TOKEN_A: ${{ steps.token_2.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-              TOKEN_B: ${{ steps.token_6.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-            with: *e2e-retry
-          - name: Test tranches 3 and 7
-            uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
-            env:
-              E2E_JOBS: 2
-              MISE_E2E_DOCKER: "1"
-              TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
-              TEST_TRANCHE_COUNT: 8
-              TRANCHE_A: 3
-              TRANCHE_B: 7
-              TOKEN_A: ${{ steps.token_3.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-              TOKEN_B: ${{ steps.token_7.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-            with: *e2e-retry
-
-  bootstrap-linux-host:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
-    timeout-minutes: 20
-    needs: [build-ubuntu, classify-changes]
-    if: needs.classify-changes.outputs.full-ci == 'true'
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: mise-ubuntu-latest
-          path: target/debug
-      - run: chmod +x target/debug/mise
-      - name: Converge a complete Linux host over SSH
-        run: scripts/test-bootstrap-linux-host.sh target/debug/mise
-
-  windows-unit:
-    runs-on: windows-latest
-    timeout-minutes: 30
-    needs: [classify-changes]
-    if: needs.classify-changes.outputs.full-ci == 'true'
-    permissions:
-      contents: read
-      id-token: write
-    env:
-      MISE_DATA_DIR: ~/.local/share/mise
-      MISE_CACHE_DIR: ~/.cache/mise
-      # The default content-addressed target path can exceed Windows tooling's
-      # path limits during workspace tests.
-      MBX_TARGET_VIEWS: "0"
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: ./.github/actions/mbx
-      - name: check unused code
-        run: mbx check -p mise --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update --all-targets
-        env:
-          RUSTFLAGS: -D unused
-      - name: cargo test
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
-        with:
-          timeout_minutes: 30
-          retry_wait_seconds: 30
-          max_attempts: 2
-          command: mbx test
-      # Windows is where the members rot fastest: their tests assume POSIX paths and shells
-      # unless something runs them here.
-      - name: cargo test (workspace members)
-        run: mbx test --workspace --exclude mise
-  windows-e2e:
-    runs-on: windows-latest
-    timeout-minutes: 100
-    needs: [build-windows, classify-changes]
-    if: needs.classify-changes.outputs.full-ci == 'true'
-    env:
-      MISE_DATA_DIR: ~/.local/share/mise
-      MISE_CACHE_DIR: ~/.cache/mise
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: mise-windows-latest
-          path: target/debug
-      - run: ls target\debug
-      - run: Add-Content $env:GITHUB_PATH "$env:GITHUB_WORKSPACE\target\debug"
-      - uses: ./.github/actions/mise-tools
-      - name: e2e
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
-        with:
-          timeout_minutes: 30
-          retry_wait_seconds: 30
-          max_attempts: 2
-          command: pwsh e2e-win\run.ps1
+    uses: ./.github/workflows/test-impl.yml
+    with:
+      trusted: false
+      mbx-backend: github
 
   test-ci:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    name: test-ci
+    if: ${{ always() && !cancelled() && needs.trusted.result != 'cancelled' && needs.untrusted.result != 'cancelled' }}
+    permissions: {}
+    needs: [trusted, untrusted]
+    runs-on: ubuntu-latest
     timeout-minutes: 1
-    needs:
-      - classify-changes
-      - build-ubuntu
-      - build-windows
-      - unit
-      - lint
-      - e2e
-      - bootstrap-linux-host
-      - windows-unit
-      - windows-e2e
-    # Evaluate skipped and failed dependencies, but do not waste a runner when
-    # the workflow is cancelled.
-    if: ${{ always() && !cancelled() }}
     steps:
-      - name: Check CI job results
+      - name: Check selected workflow result
         env:
-          BASE_REF: ${{ github.base_ref }}
-          HEAD_REF: ${{ github.head_ref }}
+          TRUSTED_RESULT: ${{ needs.trusted.result }}
+          UNTRUSTED_RESULT: ${{ needs.untrusted.result }}
         run: |
-          full_ci="${{ needs.classify-changes.outputs.full-ci }}"
-          if [ "${{ needs.build-ubuntu.result }}" != "success" ]; then
-            echo "build-ubuntu failed or was skipped"
-            exit 1
+          if [[ "$TRUSTED_RESULT" == success && "$UNTRUSTED_RESULT" == skipped ]] ||
+             [[ "$TRUSTED_RESULT" == skipped && "$UNTRUSTED_RESULT" == success ]]; then
+            exit 0
           fi
-          if [ "${{ needs.lint.result }}" != "success" ]; then
-            echo "lint failed or was skipped"
-            exit 1
-          fi
-
-          if [ "$full_ci" == "true" ]; then
-            if [ "${{ needs.build-windows.result }}" != "success" ]; then
-              echo "build-windows failed or was skipped"
-              exit 1
-            fi
-            if [ "${{ needs.unit.result }}" != "success" ]; then
-              echo "unit failed or was skipped"
-              exit 1
-            fi
-            if [ "${{ github.event_name }}" == "pull_request" ] && [ "$HEAD_REF" == "release" ] && [ "$BASE_REF" == "main" ]; then
-              if [ "${{ needs.e2e.result }}" != "skipped" ]; then
-                echo "e2e should be handled by the release workflow"
-                exit 1
-              fi
-            elif [ "${{ needs.e2e.result }}" != "success" ]; then
-              echo "e2e failed or was skipped"
-              exit 1
-            fi
-            if [ "${{ needs.bootstrap-linux-host.result }}" != "success" ]; then
-              echo "bootstrap-linux-host failed or was skipped"
-              exit 1
-            fi
-            if [ "${{ needs.windows-unit.result }}" != "success" ]; then
-              echo "windows-unit failed or was skipped"
-              exit 1
-            fi
-            if [ "${{ needs.windows-e2e.result }}" != "success" ]; then
-              echo "windows-e2e failed or was skipped"
-              exit 1
-            fi
-          else
-            for result in \
-              "${{ needs.build-windows.result }}" \
-              "${{ needs.unit.result }}" \
-              "${{ needs.e2e.result }}" \
-              "${{ needs.bootstrap-linux-host.result }}" \
-              "${{ needs.windows-unit.result }}" \
-              "${{ needs.windows-e2e.result }}"; do
-              if [ "$result" != "skipped" ]; then
-                echo "docs-only jobs should be skipped"
-                exit 1
-              fi
-            done
-          fi
-          echo "All CI jobs completed successfully"
+          echo "trusted=$TRUSTED_RESULT untrusted=$UNTRUSTED_RESULT"
+          exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
           fi
 
   build-ubuntu:
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -71,10 +71,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             ~/.cargo/.global-cache
-            ~/.cache/mbx
-      - uses: ./.github/actions/setup-mbx
-        with:
-          restore-cache: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+      - uses: ./.github/actions/mbx
       - run: |
           mbx build build --all-features --ignore-rust-version
           echo "$PWD/target/debug" >> "$GITHUB_PATH"
@@ -97,19 +94,19 @@ jobs:
     timeout-minutes: 60
     needs: [classify-changes]
     if: needs.classify-changes.outputs.full-ci == 'true'
+    permissions:
+      contents: read
+      id-token: write
     env:
       MISE_DATA_DIR: ~/.local/share/mise
       MISE_CACHE_DIR: ~/.cache/mise
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2 # zizmor: ignore[cache-poisoning] save-if already gates writes to main/release
-        with:
-          shared-key: build
-          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release' }}
+      - uses: ./.github/actions/mbx
       - shell: pwsh
         run: |
-          cargo build --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update
-          cargo build -p mise-shim
+          mbx build build --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update
+          mbx build build -p mise-shim
           Add-Content $env:GITHUB_PATH "$env:GITHUB_WORKSPACE\target\debug"
       - parallel:
           - run: mise -v
@@ -122,10 +119,13 @@ jobs:
 
   unit:
     name: unit-macos
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'macos-14' || 'namespace-profile-endev-macos-arm64;overrides.cache-tag=mise-pr-rust-macos' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'macos-14' || 'namespace-profile-endev-macos-arm64' }}
     timeout-minutes: 90
     needs: [classify-changes]
     if: needs.classify-changes.outputs.full-ci == 'true'
+    permissions:
+      contents: read
+      id-token: write
     env:
       MISE_CARGO_BUILD_EXTRA_ARGS: --ignore-rust-version
     steps:
@@ -140,10 +140,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             ~/.cargo/.global-cache
-            ~/.cache/mbx
-      - uses: ./.github/actions/setup-mbx
-        with:
-          restore-cache: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+      - uses: ./.github/actions/mbx
       - name: Install test tools
         run: brew install fd tmux
       - run: |
@@ -162,17 +159,21 @@ jobs:
         if: always()
 
   lint:
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 80
     needs: [build-ubuntu]
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ./.github/actions/mbx
       - parallel:
           - name: Install mold
             run: sudo apt-get update && sudo apt-get install -y mold
           - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
             with:
-              tool: cargo-deny,cargo-msrv,cargo-machete,sccache
+              tool: cargo-deny,cargo-msrv,cargo-machete
           - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
             if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
             with:
@@ -180,35 +181,10 @@ jobs:
                 ~/.cargo/registry
                 ~/.cargo/git
                 ~/.cargo/.global-cache
-                ~/.cache/sccache
-          # Clippy is not cacheable by mbx yet, but it can still reuse the
-          # Cargo downloads bundled with the same read-only main cache.
-          - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-            if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-            with:
-              path: |
-                ~/.cargo/registry
-                ~/.cargo/git
-                ~/.cargo/.global-cache
-                ~/.cache/mbx
-              key: ${{ runner.os }}-${{ runner.arch }}-fork-pr-mbx-v0.2.0-${{ github.event.pull_request.base.sha }}
-              restore-keys: |
-                ${{ runner.os }}-${{ runner.arch }}-fork-pr-mbx-v0.2.0-
           - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
             with:
               name: mise-ubuntu-latest
               path: target/debug
-      - name: Configure sccache
-        run: |
-          export RUSTC_WRAPPER=sccache
-          export SCCACHE_DIR="$HOME/.cache/sccache"
-          export SCCACHE_CACHE_SIZE=20G
-          {
-            echo "RUSTC_WRAPPER=$RUSTC_WRAPPER"
-            echo "SCCACHE_DIR=$SCCACHE_DIR"
-            echo "SCCACHE_CACHE_SIZE=$SCCACHE_CACHE_SIZE"
-          } >> "$GITHUB_ENV"
-          sccache --zero-stats
       - run: echo "$PWD/target/debug" >> "$GITHUB_PATH" && chmod +x target/debug/mise
       - uses: ./.github/actions/mise-tools
       - run: mise x -- bun i
@@ -241,25 +217,20 @@ jobs:
           # rust-version than their code requires; rustc still rejects genuinely
           # incompatible syntax and APIs when the metadata check is ignored.
           - name: Verify MSRV
-            run: cargo msrv verify -- cargo check --ignore-rust-version
+            run: mbx build msrv verify -- cargo check --ignore-rust-version
             env:
               CARGO_TARGET_DIR: target/msrv
       - name: Run Clippy
         run: |
-          cargo clippy --ignore-rust-version -- -D warnings
-          cargo clippy --all-features --all-targets --ignore-rust-version -- -D warnings
-        env:
-          CARGO_BUILD_JOBS: "1"
-          CARGO_INCREMENTAL: "0"
-      - run: sccache --show-stats
-        if: always()
+          mbx build clippy --ignore-rust-version -- -D warnings
+          mbx build clippy --all-features --all-targets --ignore-rust-version -- -D warnings
 
   e2e:
     name: e2e
     # The release PR runs the full suite against the packaged release tarball.
     # Keep that stronger signal instead of also testing the debug artifact.
     if: ${{ needs.classify-changes.outputs.full-ci == 'true' && (github.event_name != 'pull_request' || github.head_ref != 'release' || github.base_ref != 'main') }}
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     needs: [build-ubuntu, classify-changes]
     timeout-minutes: 125
     steps:
@@ -379,7 +350,7 @@ jobs:
             with: *e2e-retry
 
   bootstrap-linux-host:
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 20
     needs: [build-ubuntu, classify-changes]
     if: needs.classify-changes.outputs.full-ci == 'true'
@@ -398,17 +369,17 @@ jobs:
     timeout-minutes: 30
     needs: [classify-changes]
     if: needs.classify-changes.outputs.full-ci == 'true'
+    permissions:
+      contents: read
+      id-token: write
     env:
       MISE_DATA_DIR: ~/.local/share/mise
       MISE_CACHE_DIR: ~/.cache/mise
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2 # zizmor: ignore[cache-poisoning] save-if already gates writes to main/release
-        with:
-          shared-key: build
-          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release' }}
+      - uses: ./.github/actions/mbx
       - name: check unused code
-        run: cargo check -p mise --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update --all-targets
+        run: mbx build check -p mise --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update --all-targets
         env:
           RUSTFLAGS: -D unused
       - name: cargo test
@@ -417,11 +388,11 @@ jobs:
           timeout_minutes: 30
           retry_wait_seconds: 30
           max_attempts: 2
-          command: cargo test
+          command: mbx build test
       # Windows is where the members rot fastest: their tests assume POSIX paths and shells
       # unless something runs them here.
       - name: cargo test (workspace members)
-        run: cargo test --workspace --exclude mise
+        run: mbx build test --workspace --exclude mise
   windows-e2e:
     runs-on: windows-latest
     timeout-minutes: 100
@@ -448,7 +419,7 @@ jobs:
           command: pwsh e2e-win\run.ps1
 
   test-ci:
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 1
     needs:
       - classify-changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
           fi
 
   build-ubuntu:
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 60
     permissions:
       contents: read
@@ -122,7 +122,7 @@ jobs:
 
   unit:
     name: unit-macos
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'macos-14' || 'namespace-profile-endev-macos-arm64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'macos-14' || 'namespace-profile-endev-macos-arm64' }}
     timeout-minutes: 90
     needs: [classify-changes]
     if: needs.classify-changes.outputs.full-ci == 'true'
@@ -162,7 +162,7 @@ jobs:
         if: always()
 
   lint:
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 80
     needs: [build-ubuntu]
     permissions:
@@ -233,7 +233,7 @@ jobs:
     # The release PR runs the full suite against the packaged release tarball.
     # Keep that stronger signal instead of also testing the debug artifact.
     if: ${{ needs.classify-changes.outputs.full-ci == 'true' && (github.event_name != 'pull_request' || github.head_ref != 'release' || github.base_ref != 'main') }}
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     needs: [build-ubuntu, classify-changes]
     timeout-minutes: 125
     steps:
@@ -353,7 +353,7 @@ jobs:
             with: *e2e-retry
 
   bootstrap-linux-host:
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 20
     needs: [build-ubuntu, classify-changes]
     if: needs.classify-changes.outputs.full-ci == 'true'
@@ -422,7 +422,7 @@ jobs:
           command: pwsh e2e-win\run.ps1
 
   test-ci:
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 1
     needs:
       - classify-changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
           fi
 
   build-ubuntu:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 60
     permissions:
       contents: read
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
-        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
+        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')
         with:
           path: |
             ~/.cargo/registry
@@ -125,7 +125,7 @@ jobs:
 
   unit:
     name: unit-macos
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'macos-14' || 'namespace-profile-endev-macos-arm64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'macos-14' || 'namespace-profile-endev-macos-arm64' }}
     timeout-minutes: 90
     needs: [classify-changes]
     if: needs.classify-changes.outputs.full-ci == 'true'
@@ -140,7 +140,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
-        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
+        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')
         with:
           path: |
             ~/.cargo/registry
@@ -165,7 +165,7 @@ jobs:
         if: always()
 
   lint:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 80
     needs: [build-ubuntu]
     permissions:
@@ -184,7 +184,7 @@ jobs:
             with:
               tool: cargo-deny,cargo-msrv,cargo-machete
           - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
-            if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
+            if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')
             with:
               path: |
                 ~/.cargo/registry
@@ -239,7 +239,7 @@ jobs:
     # The release PR runs the full suite against the packaged release tarball.
     # Keep that stronger signal instead of also testing the debug artifact.
     if: ${{ needs.classify-changes.outputs.full-ci == 'true' && (github.event_name != 'pull_request' || github.head_ref != 'release' || github.base_ref != 'main') }}
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     needs: [build-ubuntu, classify-changes]
     timeout-minutes: 125
     steps:
@@ -359,7 +359,7 @@ jobs:
             with: *e2e-retry
 
   bootstrap-linux-host:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 20
     needs: [build-ubuntu, classify-changes]
     if: needs.classify-changes.outputs.full-ci == 'true'
@@ -431,7 +431,7 @@ jobs:
           command: pwsh e2e-win\run.ps1
 
   test-ci:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 1
     needs:
       - classify-changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
             ~/.cargo/.global-cache
       - uses: ./.github/actions/mbx
       - run: |
-          mbx build build --all-features --ignore-rust-version
+          mbx build --all-features --ignore-rust-version
           echo "$PWD/target/debug" >> "$GITHUB_PATH"
       - run: mise -v
       # Downstream jobs only execute this binary, so keep full debug symbols in
@@ -108,8 +108,8 @@ jobs:
       - uses: ./.github/actions/mbx
       - shell: pwsh
         run: |
-          mbx build build --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update
-          mbx build build -p mise-shim
+          mbx build --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update
+          mbx build -p mise-shim
           Add-Content $env:GITHUB_PATH "$env:GITHUB_WORKSPACE\target\debug"
       - parallel:
           - run: mise -v
@@ -147,15 +147,15 @@ jobs:
       - name: Install test tools
         run: brew install fd tmux
       - run: |
-          mbx build build --all-features --ignore-rust-version
+          mbx build --all-features --ignore-rust-version
           echo "$PWD/target/debug" >> "$GITHUB_PATH"
       - uses: ./.github/actions/mise-tools
-      - run: mise x -- mbx build test --all-features --ignore-rust-version
+      - run: mise x -- mbx test --all-features --ignore-rust-version
       # `cargo test` above resolves to the root package, so the workspace members are built as
       # dependencies but never tested. Run them separately rather than adding --workspace to the
       # line above, which would extend --all-features to members whose features are exclusive.
       - name: cargo test (workspace members)
-        run: mbx build test --workspace --exclude mise --ignore-rust-version
+        run: mbx test --workspace --exclude mise --ignore-rust-version
       - run: mise run test:e2e e2e/cli/test_system_install_brew_macos_slow
       - run: mise run test:e2e e2e/tasks/test_task_zsh_process_substitution_tmux_macos
       - run: mbx cache stats
@@ -220,13 +220,13 @@ jobs:
           # rust-version than their code requires; rustc still rejects genuinely
           # incompatible syntax and APIs when the metadata check is ignored.
           - name: Verify MSRV
-            run: mbx build msrv verify -- cargo check --ignore-rust-version
+            run: mbx msrv verify -- cargo check --ignore-rust-version
             env:
               CARGO_TARGET_DIR: target/msrv
       - name: Run Clippy
         run: |
-          mbx build clippy --ignore-rust-version -- -D warnings
-          mbx build clippy --all-features --all-targets --ignore-rust-version -- -D warnings
+          mbx clippy --ignore-rust-version -- -D warnings
+          mbx clippy --all-features --all-targets --ignore-rust-version -- -D warnings
 
   e2e:
     name: e2e
@@ -382,7 +382,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/mbx
       - name: check unused code
-        run: mbx build check -p mise --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update --all-targets
+        run: mbx check -p mise --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update --all-targets
         env:
           RUSTFLAGS: -D unused
       - name: cargo test
@@ -391,11 +391,11 @@ jobs:
           timeout_minutes: 30
           retry_wait_seconds: 30
           max_attempts: 2
-          command: mbx build test
+          command: mbx test
       # Windows is where the members rot fastest: their tests assume POSIX paths and shells
       # unless something runs them here.
       - name: cargo test (workspace members)
-        run: mbx build test --workspace --exclude mise
+        run: mbx test --workspace --exclude mise
   windows-e2e:
     runs-on: windows-latest
     timeout-minutes: 100

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,9 @@ jobs:
     env:
       MISE_DATA_DIR: ~/.local/share/mise
       MISE_CACHE_DIR: ~/.cache/mise
+      # Keep Windows paths short enough for MSBuild/FileTracker and place the
+      # binaries where downstream artifact steps already expect them.
+      MBX_TARGET_VIEWS: "0"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/mbx
@@ -168,6 +171,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    env:
+      # Clippy's all-features build can otherwise exhaust the runner's memory.
+      CARGO_BUILD_JOBS: "2"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/mbx
@@ -378,6 +384,9 @@ jobs:
     env:
       MISE_DATA_DIR: ~/.local/share/mise
       MISE_CACHE_DIR: ~/.cache/mise
+      # The default content-addressed target path can exceed Windows tooling's
+      # path limits during workspace tests.
+      MBX_TARGET_VIEWS: "0"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/mbx

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,16 @@
 # Repository Agent Guide
 
+## mbx build cache
+
+Compilation-heavy mise tasks and hk checks use `mbx`. If an mbx command fails
+or creates a development papercut, rerun the exact equivalent `cargo` command
+from `CONTRIBUTING.md`; this unblocks work without weakening the check. If Cargo
+succeeds, surface the mismatch and recommend a
+[mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions) with
+the repository and commit, OS, `mbx --version`, both commands and outputs, the
+cache summary, and `MBX_BYPASS_LOG` details when relevant. Do not silently make
+Cargo the permanent path, and do not post externally without user authorization.
+
 This file is the canonical agent guide. `CLAUDE.md` is a symlink to `AGENTS.md` for compatibility with existing tooling.
 
 ## Registry Submissions: READ THIS FIRST

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,22 @@
 # Contributing
 
 See the [contributing guide](https://mise.jdx.dev/contributing).
+
+## mbx build cache
+
+The normal `mise run build`, `mise run test:unit`, and `mise run lint` workflows
+use [mbx](https://mr-boxington.jdx.dev) for compilation-heavy Cargo work. If mbx
+appears to be the problem, use the equivalent Cargo commands to unblock
+yourself without skipping or weakening the check:
+
+```sh
+cargo build --all-features
+cargo test --all-features
+cargo check --all-features
+```
+
+If Cargo succeeds where mbx fails, or mbx introduces a papercut, please start a
+[mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions).
+Include the repository and commit, operating system, `mbx --version`, both
+commands and their output, the mbx cache summary, and an `MBX_BYPASS_LOG` when
+relevant (for example, `MBX_BYPASS_LOG=mbx-bypasses.log mise run build`).

--- a/hk.pkl
+++ b/hk.pkl
@@ -2,7 +2,7 @@ amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.
 import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
 
 local bash_glob = List("*.sh", "xtasks/**", "scripts/**", "e2e/**")
-local bash_exclude = List("*.ps1", "**/*.fish", "*.ts", "*.js", "*.json", "*.bat", "**/.*", "src/assets/bash_zsh_support/**", "e2e/shell/xonsh_script", "**/*.py", "**/*.xsh")
+local bash_exclude = List("*.ps1", "**/*.fish", "*.ts", "*.js", "*.json", "*.bat", "**/.*", "src/assets/bash_zsh_support/**", "e2e/shell/xonsh_script", "tmp/install.sh", "**/*.py", "**/*.xsh")
 local linters = new Mapping<String, Step> {
     ["schema"] {
         glob = List("schema/**/*.json")

--- a/hk.pkl
+++ b/hk.pkl
@@ -50,7 +50,7 @@ local linters = new Mapping<String, Step> {
     }
     ["cargo-check"] = (Builtins.cargo_check) {
       check = new CommandSpec {
-        command = "cargo check --all-features"
+        command = "mbx build check --all-features"
         effect = "write"
       }
     }

--- a/hk.pkl
+++ b/hk.pkl
@@ -50,7 +50,7 @@ local linters = new Mapping<String, Step> {
     }
     ["cargo-check"] = (Builtins.cargo_check) {
       check = new CommandSpec {
-        command = "mbx build check --all-features"
+        command = "mbx check --all-features"
         effect = "write"
       }
     }

--- a/mise.lock
+++ b/mise.lock
@@ -483,53 +483,53 @@ url = "https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.
 url_api = "https://api.github.com/repos/orhun/git-cliff/releases/assets/405851866"
 
 [[tools."github:jdx/mr-boxington"]]
-version = "0.3.0"
+version = "0.4.0"
 backend = "github:jdx/mr-boxington"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-arm64"]
-checksum = "sha256:4be02935fb0c1892b659c8146e07fe092fb12f6c4e86c6ebbc3b63449d5dcb25"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704880"
+checksum = "sha256:ed81dab87775bcc8764c7257d8bea0dd8b7f811d6263b71bc7cd83a879661593"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719396"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-arm64-musl"]
-checksum = "sha256:4be02935fb0c1892b659c8146e07fe092fb12f6c4e86c6ebbc3b63449d5dcb25"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704880"
+checksum = "sha256:ed81dab87775bcc8764c7257d8bea0dd8b7f811d6263b71bc7cd83a879661593"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719396"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64"]
-checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+checksum = "sha256:b288265404b8fa4620ea1d082ba9b33a0a1695212d88a385e76aa07a743da250"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719409"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64-baseline"]
-checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+checksum = "sha256:b288265404b8fa4620ea1d082ba9b33a0a1695212d88a385e76aa07a743da250"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719409"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64-musl"]
-checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+checksum = "sha256:b288265404b8fa4620ea1d082ba9b33a0a1695212d88a385e76aa07a743da250"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719409"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+checksum = "sha256:b288265404b8fa4620ea1d082ba9b33a0a1695212d88a385e76aa07a743da250"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719409"
 
 [tools."github:jdx/mr-boxington"."platforms.macos-arm64"]
-checksum = "sha256:1803cec79be0b753fc3af23044edc46fd81ffdf9d66fcb7b6637cfb22cc6db4a"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704881"
+checksum = "sha256:416cab92e23c4652183e4a794af3fdcbc50b56296d8c09f8b6548e7577416307"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719398"
 
 [tools."github:jdx/mr-boxington"."platforms.windows-x64"]
-checksum = "sha256:9d99f1f57789e88f4870ac61fd6c4e2ceec5ed532f4c9c8e9be4f32663a1fd16"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704879"
+checksum = "sha256:f841b1907cf86c54db4d3d2d1e88f87303ccc8f720efff90b6331d7d5592bf4e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719397"
 
 [tools."github:jdx/mr-boxington"."platforms.windows-x64-baseline"]
-checksum = "sha256:9d99f1f57789e88f4870ac61fd6c4e2ceec5ed532f4c9c8e9be4f32663a1fd16"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704879"
+checksum = "sha256:f841b1907cf86c54db4d3d2d1e88f87303ccc8f720efff90b6331d7d5592bf4e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719397"
 
 [[tools."github:jdx/tak"]]
 version = "0.0.5"

--- a/mise.lock
+++ b/mise.lock
@@ -483,53 +483,53 @@ url = "https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.
 url_api = "https://api.github.com/repos/orhun/git-cliff/releases/assets/405851866"
 
 [[tools."github:jdx/mr-boxington"]]
-version = "0.2.0"
+version = "0.3.0"
 backend = "github:jdx/mr-boxington"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-arm64"]
-checksum = "sha256:8ed75a027ae0f8e28a76868ba1ad649bb55ece2ac731c06b25ef5750e9e844ca"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.2.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526595248"
+checksum = "sha256:4be02935fb0c1892b659c8146e07fe092fb12f6c4e86c6ebbc3b63449d5dcb25"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704880"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-arm64-musl"]
-checksum = "sha256:8ed75a027ae0f8e28a76868ba1ad649bb55ece2ac731c06b25ef5750e9e844ca"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.2.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526595248"
+checksum = "sha256:4be02935fb0c1892b659c8146e07fe092fb12f6c4e86c6ebbc3b63449d5dcb25"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704880"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64"]
-checksum = "sha256:5a83aa55e6f83eb6c77ac4e0397b345d3eb4cf5cb6f7430185469d02e4c0f409"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.2.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526595259"
+checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64-baseline"]
-checksum = "sha256:5a83aa55e6f83eb6c77ac4e0397b345d3eb4cf5cb6f7430185469d02e4c0f409"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.2.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526595259"
+checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64-musl"]
-checksum = "sha256:5a83aa55e6f83eb6c77ac4e0397b345d3eb4cf5cb6f7430185469d02e4c0f409"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.2.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526595259"
+checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:5a83aa55e6f83eb6c77ac4e0397b345d3eb4cf5cb6f7430185469d02e4c0f409"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.2.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526595259"
+checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
 
 [tools."github:jdx/mr-boxington"."platforms.macos-arm64"]
-checksum = "sha256:a8428b18eaf2240c47f36c628219d02a405cca4f65de5b3c649af481d6778b8f"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.2.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526595246"
+checksum = "sha256:1803cec79be0b753fc3af23044edc46fd81ffdf9d66fcb7b6637cfb22cc6db4a"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704881"
 
 [tools."github:jdx/mr-boxington"."platforms.windows-x64"]
-checksum = "sha256:24e44ab08896284b207fece614fe461db8c9399467cf934b115ef796ebf467e0"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.2.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526595245"
+checksum = "sha256:9d99f1f57789e88f4870ac61fd6c4e2ceec5ed532f4c9c8e9be4f32663a1fd16"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704879"
 
 [tools."github:jdx/mr-boxington"."platforms.windows-x64-baseline"]
-checksum = "sha256:24e44ab08896284b207fece614fe461db8c9399467cf934b115ef796ebf467e0"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.2.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526595245"
+checksum = "sha256:9d99f1f57789e88f4870ac61fd6c4e2ceec5ed532f4c9c8e9be4f32663a1fd16"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704879"
 
 [[tools."github:jdx/tak"]]
 version = "0.0.5"

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,7 @@ _.path = ["./target/debug", "./node_modules/.bin"]
 
 [tools]
 actionlint = "latest"
-"github:jdx/mr-boxington" = "0.2.0"
+"github:jdx/mr-boxington" = "latest"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
 # in mise's numbers, indistinguishable from a real regression. Bump

--- a/tasks.toml
+++ b/tasks.toml
@@ -14,8 +14,8 @@ depends = ['lint:*']
 
 [build]
 alias = "b"
-run = "cargo build --all-features {{ get_env(name='MISE_CARGO_BUILD_EXTRA_ARGS', default='') }}"
-run_windows = "cargo build {{ get_env(name='MISE_CARGO_BUILD_EXTRA_ARGS', default='') }}"
+run = "mbx build build --all-features {{ get_env(name='MISE_CARGO_BUILD_EXTRA_ARGS', default='') }}"
+run_windows = "mbx build build {{ get_env(name='MISE_CARGO_BUILD_EXTRA_ARGS', default='') }}"
 description = "Build the project"
 #sources = ["Cargo.*", "src/**/*.rs"]
 #outputs = ["target/debug/mise"]
@@ -139,7 +139,7 @@ run = ["mise tasks run test:unit", "mise tasks run test:e2e"]
 
 ["test:unit"]
 description = "run unit tests"
-run = "cargo test --all-features"
+run = "mbx build test --all-features"
 env = { CARGO_TERM_COLOR = "always", "RUST_TEST_THREADS" = "1" }
 
 ["test:e2e"]

--- a/tasks.toml
+++ b/tasks.toml
@@ -14,8 +14,8 @@ depends = ['lint:*']
 
 [build]
 alias = "b"
-run = "mbx build build --all-features {{ get_env(name='MISE_CARGO_BUILD_EXTRA_ARGS', default='') }}"
-run_windows = "mbx build build {{ get_env(name='MISE_CARGO_BUILD_EXTRA_ARGS', default='') }}"
+run = "mbx build --all-features {{ get_env(name='MISE_CARGO_BUILD_EXTRA_ARGS', default='') }}"
+run_windows = "mbx build {{ get_env(name='MISE_CARGO_BUILD_EXTRA_ARGS', default='') }}"
 description = "Build the project"
 #sources = ["Cargo.*", "src/**/*.rs"]
 #outputs = ["target/debug/mise"]
@@ -139,7 +139,7 @@ run = ["mise tasks run test:unit", "mise tasks run test:e2e"]
 
 ["test:unit"]
 description = "run unit tests"
-run = "mbx build test --all-features"
+run = "mbx test --all-features"
 env = { CARGO_TERM_COLOR = "always", "RUST_TEST_THREADS" = "1" }
 
 ["test:e2e"]


### PR DESCRIPTION
## Summary

- route compilation-heavy local mise tasks and hk checks through mbx
- configure trusted Namespace jobs for the jdx server cache and fork-safe GitHub-hosted cache restores
- document exact Cargo fallbacks and the mr-boxington Discussions escalation path
- use the direct Cargo-subcommand syntax released in mbx 0.4.0
- pin local and CI setup to mbx 0.4.0
- ensure release, publishing, and packaging builds never restore or save persistent caches

## Validation

- resolved the committed mise lock to mbx 0.4.0
- installed the locked tool and confirmed `mbx 0.4.0`
- evaluated the mise configuration and task list
- confirmed `mbx build` direct syntax
- ran actionlint over changed workflows
- audited release and publish entrypoints for Rust, Actions, Namespace, mise, Node, and mbx caches


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent, fork-safe build caching across documentation, testing, registry, and vfox workflows.
  - Standardized build, test, lint, and verification commands across supported platforms.

- **Documentation**
  - Added guidance for cached builds, Cargo fallback commands, and reporting build issues.

- **Chores**
  - Updated the build tool to the latest version.
  - Simplified task commands and corrected redundant command arguments.
  - Added configurable caching for tool setup and disabled it where inappropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large CI and cache-trust boundary changes (OIDC, workflow_call secrets, untrusted job gating) could mis-route PRs or break builds, but application runtime and auth logic are untouched.
> 
> **Overview**
> This PR routes **compilation-heavy** local work through **mbx** (`tasks.toml`, `hk.pkl`’s `cargo-check`) and bumps the locked **mr-boxington** tool to **0.4.0** with direct subcommands (`mbx build`, `mbx test`, etc.).
> 
> CI is restructured around a new **`.github/actions/mbx`** composite action that picks the **jdx OIDC server cache** for trusted runs vs a **fork-safe GitHub cache backend** for untrusted ones. **test**, **docs**, **registry**, and **test-vfox** workflows become thin entrypoints with **`permissions: {}`**, delegating to new **`*-impl.yml`** callable workflows via mutually exclusive **trusted** / **untrusted** jobs; a small aggregator job asserts exactly one path succeeded. Untrusted impl jobs **assert OIDC env vars are absent**, use **`ubuntu-latest`** (or public macOS) instead of Namespace profiles, and skip Namespace cargo restores; trusted jobs get **`id-token: write`** and **`mbx-backend: server`**.
> 
> Other notable CI changes: **lint** drops **sccache** / fork **mbx** cache restore; Windows builds use **mbx** with **`MBX_TARGET_VIEWS: "0"`**; **`mise-tools`** gains a **`cache: false`** option used on **release-plz**; **release-plz** drops the release-specific Namespace cache tag; **release** tarball jobs treat non-**jdx** PR authors like external forks for runner selection; **github-runner-cache** fixes **`mbx build`** invocation.
> 
> **AGENTS.md** and **CONTRIBUTING.md** document **Cargo fallbacks** and reporting mismatches to **mr-boxington** Discussions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 841f087c4b9fefce5987bf719aadbc473399a4f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->