### PR TITLE
fix(backend): resolve latest from system installs

### DIFF
--- a/e2e/cli/test_install_system
+++ b/e2e/cli/test_install_system
@@ -14,9 +14,21 @@ USER_INSTALLS="$MISE_DATA_DIR/installs"
 mise install tiny@1.0.0
 mise install --system tiny@2.1.0
 
+# A tool installed only in the system dir must satisfy an unqualified `latest`
+# request without a remote lookup. Lazy backend loading keeps its user-local
+# installs_path, so latest resolution must recover the system path from install
+# state.
+mise install --system dummy@2.1.0
+cat >mise.toml <<'EOF'
+[tools]
+dummy = "latest"
+EOF
+assert "MISE_OFFLINE=1 mise current dummy" "2.1.0"
+
 # Both directories should have their respective version installed
 assert_directory_exists "$USER_INSTALLS/tiny/1.0.0"
 assert_directory_exists "$SYSTEM_INSTALLS/tiny/2.1.0"
+assert_directory_exists "$SYSTEM_INSTALLS/dummy/2.1.0"
 
 # The system dir should have a "latest" symlink pointing to its own version
 assert "readlink $SYSTEM_INSTALLS/tiny/latest" "./2.1.0"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3054,7 +3054,14 @@ pub(crate) trait Backend: Debug + Send + Sync {
                 Ok(find_match_in_list(&matches, &query))
             }
             None => {
-                let installed_symlink = self.ba().installs_path.join("latest");
+                // Lazy backend loading keeps the request's primary (user) install
+                // path, even when the only installed versions live in a system or
+                // shared directory. Install state has already applied that fallback
+                // and records the directory that supplied the tool.
+                let installs_path = install_state::get_tool(&self.ba().short)
+                    .and_then(|tool| tool.installs_path)
+                    .unwrap_or_else(|| self.ba().installs_path.clone());
+                let installed_symlink = installs_path.join("latest");
                 if installed_symlink.exists()
                     && let Some(target) = file::resolve_symlink(&installed_symlink)?
                 {
@@ -3065,12 +3072,12 @@ pub(crate) trait Backend: Debug + Send + Sync {
                         .to_string();
                     return Ok(Some(version));
                 }
-                Ok(file::dir_subdirs(&self.ba().installs_path)
+                Ok(file::dir_subdirs(&installs_path)
                     .unwrap_or_default()
                     .into_iter()
                     .filter(|v| !v.starts_with('.'))
-                    .filter(|v| !is_runtime_symlink(&self.ba().installs_path.join(v)))
-                    .filter(|v| !self.ba().installs_path.join(v).join("incomplete").exists())
+                    .filter(|v| !is_runtime_symlink(&installs_path.join(v)))
+                    .filter(|v| !installs_path.join(v).join("incomplete").exists())
                     .filter(|v| v != "latest")
                     .sorted_by_cached_key(|v| (Versioning::new(v), v.to_string()))
                     .last())


### PR DESCRIPTION
## Summary
- recover the effective install directory from lazy install state when resolving an unqualified `latest` request
- allow system/shared-only installs to satisfy offline `latest` resolution
- add coverage for a tool installed only with `mise install --system`

Fixes the regression reported in discussion #12398 after #12236.

## Tests
- `e2e/cli/test_install_system` passed via `mise run test:e2e e2e/cli/test_install_system` (the prefix-matching runner subsequently started an unrelated slow variant, which was stopped)
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how unqualified `latest` is resolved from disk for tools whose effective install root differs from the backend’s default user path; behavior is narrowed to install-state fallback but affects resolution and offline paths.
> 
> **Overview**
> Fixes **offline `latest` resolution** when a tool exists only under a system (or shared) install directory. After lazy backend loading, the backend could still point at the user `installs_path` even though install state already knew the real location—so unqualified `latest` looked in the wrong tree and failed without a network fetch.
> 
> **`latest_installed_version`** now picks the install directory from **`install_state::get_tool`’s `installs_path`** when present, and uses that path for the `latest` symlink and on-disk version scan instead of always using `ba().installs_path`.
> 
> E2E coverage adds a **system-only `dummy@2.1.0`** with `dummy = "latest"` in `mise.toml`, asserting **`MISE_OFFLINE=1 mise current dummy`** reports `2.1.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c0544df6687abb38518e4d2e82627fa01e26108. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected offline version resolution to recognize tools installed in the configured system installation directory.
  * Ensured “latest” version detection uses the appropriate installation location and resolves the expected installed version. 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->