### PR TITLE
fix(pipx): track latest git revisions

### DIFF
--- a/docs/dev-tools/backends/pipx.md
+++ b/docs/dev-tools/backends/pipx.md
@@ -89,9 +89,9 @@ mise _should_ do this automatically when using `mise up python`.
 | Git syntax for a branch               | `pipx:git+https://github.com/psf/black.git@main`       |
 | Https with zipfile                    | `pipx:https://github.com/psf/black/archive/18.9b0.zip` |
 
-For Git URLs, `latest` resolves to the newest version-sorted tag. GitHub URLs prefer
-published GitHub Releases and fall back to tags if there are no releases. If no tags
-or releases exist, `latest` installs the repository's default-branch HEAD.
+For Git URLs, `latest` resolves from the tags returned by the remote. GitHub URLs
+prefer published GitHub Releases and fall back to tags if there are no releases. If
+no tags or releases exist, `latest` installs the repository's default-branch HEAD.
 
 Other syntax may work but is unsupported and untested.
 

--- a/docs/dev-tools/backends/pipx.md
+++ b/docs/dev-tools/backends/pipx.md
@@ -89,9 +89,10 @@ mise _should_ do this automatically when using `mise up python`.
 | Git syntax for a branch               | `pipx:git+https://github.com/psf/black.git@main`       |
 | Https with zipfile                    | `pipx:https://github.com/psf/black/archive/18.9b0.zip` |
 
-For Git URLs, `latest` resolves from the tags returned by the remote. GitHub URLs
-prefer published GitHub Releases and fall back to tags if there are no releases. If
-no tags or releases exist, `latest` installs the repository's default-branch HEAD.
+For GitHub URLs, `latest` resolves to the latest published GitHub Release and falls
+back to default-branch HEAD when there are no releases. For other Git URLs, `latest`
+tracks default-branch HEAD and resolves it to a concrete commit before installation.
+Remote tags are available for explicit version requests.
 
 Other syntax may work but is unsupported and untested.
 

--- a/docs/dev-tools/backends/pipx.md
+++ b/docs/dev-tools/backends/pipx.md
@@ -89,6 +89,10 @@ mise _should_ do this automatically when using `mise up python`.
 | Git syntax for a branch               | `pipx:git+https://github.com/psf/black.git@main`       |
 | Https with zipfile                    | `pipx:https://github.com/psf/black/archive/18.9b0.zip` |
 
+For Git URLs, `latest` resolves to the newest version-sorted tag. GitHub URLs prefer
+published GitHub Releases and fall back to tags if there are no releases. If no tags
+or releases exist, `latest` installs the repository's default-branch HEAD.
+
 Other syntax may work but is unsupported and untested.
 
 ## Settings

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -178,12 +178,7 @@ impl Backend for PIPXBackend {
             PipxRequest::Git(url) if url.starts_with("https://github.com/") => {
                 let repo = url.strip_prefix("https://github.com/").unwrap();
                 let data = github::list_releases(repo).await?;
-                let versions = Self::versions_from_github_releases(data);
-                if versions.is_empty() {
-                    Self::versions_from_git_tags(&url).await?
-                } else {
-                    versions
-                }
+                Self::versions_from_github_releases(data)
             }
             PipxRequest::Git(url) => Self::versions_from_git_tags(&url).await?,
         };
@@ -193,6 +188,9 @@ impl Backend for PIPXBackend {
     async fn latest_stable_version(&self, config: &Arc<Config>) -> eyre::Result<Option<String>> {
         let package = match self.tool_name().parse()? {
             PipxRequest::Pypi(package) => package,
+            PipxRequest::Git(url) if !url.starts_with("https://github.com/") => {
+                return Self::git_head(&url).await.map(Some);
+            }
             PipxRequest::Git(_) => return Ok(None),
         };
         let registry_url = self.get_registry_url(config).await?;
@@ -233,9 +231,44 @@ impl Backend for PIPXBackend {
         .cloned()
     }
 
+    fn is_rolling_channel(&self, version: &str) -> bool {
+        version == "latest"
+            && matches!(
+                self.tool_name().parse::<PipxRequest>(),
+                Ok(PipxRequest::Git(url)) if !url.starts_with("https://github.com/")
+            )
+    }
+
+    fn latest_installed_channel_version(&self, channel: &str) -> Option<String> {
+        if !self.is_rolling_channel(channel) {
+            return None;
+        }
+        self.latest_installed_version(None).ok().flatten()
+    }
+
+    async fn resolve_channel_version(
+        &self,
+        _config: &Arc<Config>,
+        version: &str,
+    ) -> Result<Option<String>> {
+        if !self.is_rolling_channel(version) {
+            return Ok(None);
+        }
+        match self.tool_name().parse()? {
+            PipxRequest::Git(url) => Self::git_head(&url).await.map(Some),
+            PipxRequest::Pypi(_) => Ok(None),
+        }
+    }
+
+    fn requires_concrete_channel_version(&self, version: &str) -> bool {
+        self.is_rolling_channel(version)
+    }
+
     fn unresolved_latest_version(&self) -> Option<String> {
         match self.tool_name().parse() {
-            Ok(PipxRequest::Git(_)) => Some("latest".to_string()),
+            Ok(PipxRequest::Git(url)) if url.starts_with("https://github.com/") => {
+                Some("latest".to_string())
+            }
             _ => None,
         }
     }
@@ -432,6 +465,33 @@ pub(crate) fn install_time_option_keys() -> Vec<String> {
 }
 
 impl PIPXBackend {
+    /// Resolves a Git remote's default-branch HEAD to a concrete commit SHA.
+    async fn git_head(url: &str) -> Result<String> {
+        let remote = format!("{url}.git");
+        timeout::run_with_timeout_async(
+            async || {
+                let output = crate::cmd::cmd_read_async_inherited_env(
+                    "git",
+                    &["ls-remote", &remote, "HEAD"],
+                    std::iter::empty::<(&str, &std::ffi::OsStr)>(),
+                )
+                .await?;
+                Self::git_head_from_ls_remote(&output)
+                    .ok_or_else(|| eyre!("no HEAD found for {remote}"))
+            },
+            Settings::get().fetch_remote_versions_timeout(),
+        )
+        .await
+    }
+
+    /// Parses the concrete HEAD commit from `git ls-remote <url> HEAD` output.
+    fn git_head_from_ls_remote(output: &str) -> Option<String> {
+        output.lines().find_map(|line| {
+            let (sha, git_ref) = line.split_once('\t')?;
+            (git_ref == "HEAD").then(|| sha.to_string())
+        })
+    }
+
     /// Lists tags from a Git remote while preserving Git's source ordering.
     async fn versions_from_git_tags(url: &str) -> Result<Vec<VersionInfo>> {
         let remote = format!("{url}.git");
@@ -1105,6 +1165,16 @@ cccccccccccccccccccccccccccccccccccccccc\trefs/heads/main\n";
         );
     }
 
+    #[test]
+    fn parses_git_head_from_ls_remote() {
+        let output = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\tHEAD\n";
+
+        assert_eq!(
+            PIPXBackend::git_head_from_ls_remote(output).as_deref(),
+            Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        );
+    }
+
     #[tokio::test]
     async fn simple_index_resolves_wheel_only_packages() {
         use crate::backend::Backend;
@@ -1316,6 +1386,20 @@ cccccccccccccccccccccccccccccccccccccccc\trefs/heads/main\n";
                 "{tool} should use remote discovery"
             );
         }
+    }
+
+    #[test]
+    fn non_github_latest_is_a_rolling_channel() {
+        use crate::backend::Backend;
+
+        let gitlab =
+            PIPXBackend::from_arg("pipx:git+https://gitlab.example.com/sre/mytool.git".into());
+        let github = PIPXBackend::from_arg("pipx:git+https://github.com/psf/black.git".into());
+
+        assert!(gitlab.is_rolling_channel("latest"));
+        assert!(gitlab.requires_concrete_channel_version("latest"));
+        assert!(!gitlab.is_rolling_channel("v0.8.1"));
+        assert!(!github.is_rolling_channel("latest"));
     }
 
     #[test]

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -432,19 +432,14 @@ pub(crate) fn install_time_option_keys() -> Vec<String> {
 }
 
 impl PIPXBackend {
+    /// Lists tags from a Git remote while preserving Git's source ordering.
     async fn versions_from_git_tags(url: &str) -> Result<Vec<VersionInfo>> {
         let remote = format!("{url}.git");
         timeout::run_with_timeout_async(
             async || {
                 let output = crate::cmd::cmd_read_async_inherited_env(
                     "git",
-                    &[
-                        "ls-remote",
-                        "--tags",
-                        "--refs",
-                        "--sort=version:refname",
-                        &remote,
-                    ],
+                    &["ls-remote", "--tags", "--refs", &remote],
                     std::iter::empty::<(&str, &std::ffi::OsStr)>(),
                 )
                 .await?;
@@ -455,6 +450,7 @@ impl PIPXBackend {
         .await
     }
 
+    /// Parses `git ls-remote --tags --refs` output into opaque version candidates.
     fn versions_from_git_ls_remote(output: &str) -> Vec<VersionInfo> {
         output
             .lines()

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -178,9 +178,14 @@ impl Backend for PIPXBackend {
             PipxRequest::Git(url) if url.starts_with("https://github.com/") => {
                 let repo = url.strip_prefix("https://github.com/").unwrap();
                 let data = github::list_releases(repo).await?;
-                Self::versions_from_github_releases(data)
+                let versions = Self::versions_from_github_releases(data);
+                if versions.is_empty() {
+                    Self::versions_from_git_tags(&url).await?
+                } else {
+                    versions
+                }
             }
-            PipxRequest::Git { .. } => vec![],
+            PipxRequest::Git(url) => Self::versions_from_git_tags(&url).await?,
         };
         Ok(versions.into_iter().map(stamp_pep440_prerelease).collect())
     }
@@ -427,6 +432,43 @@ pub(crate) fn install_time_option_keys() -> Vec<String> {
 }
 
 impl PIPXBackend {
+    async fn versions_from_git_tags(url: &str) -> Result<Vec<VersionInfo>> {
+        let remote = format!("{url}.git");
+        timeout::run_with_timeout_async(
+            async || {
+                let output = crate::cmd::cmd_read_async_inherited_env(
+                    "git",
+                    &[
+                        "ls-remote",
+                        "--tags",
+                        "--refs",
+                        "--sort=version:refname",
+                        &remote,
+                    ],
+                    std::iter::empty::<(&str, &std::ffi::OsStr)>(),
+                )
+                .await?;
+                Ok(Self::versions_from_git_ls_remote(&output))
+            },
+            Settings::get().fetch_remote_versions_timeout(),
+        )
+        .await
+    }
+
+    fn versions_from_git_ls_remote(output: &str) -> Vec<VersionInfo> {
+        output
+            .lines()
+            .filter_map(|line| line.split_once('\t'))
+            .filter_map(|(_, git_ref)| git_ref.strip_prefix("refs/tags/"))
+            .filter(|tag| !tag.is_empty())
+            .unique()
+            .map(|version| VersionInfo {
+                version: version.to_string(),
+                ..Default::default()
+            })
+            .collect()
+    }
+
     fn versions_from_simple_index(package: &str, html: &str) -> Vec<String> {
         let href_re = regex!(r#"(?i)href\s*=\s*["']([^"']+)["']"#);
 
@@ -1048,6 +1090,22 @@ mod tests {
         assert_eq!(
             PIPXBackend::versions_from_simple_index("Demo_Pkg", html),
             vec!["1.0+cpu", "2.0+cpu"]
+        );
+    }
+
+    #[test]
+    fn parses_versions_from_git_ls_remote() {
+        let output = "\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\trefs/tags/v0.8.0\n\
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\trefs/tags/v0.8.1\n\
+cccccccccccccccccccccccccccccccccccccccc\trefs/heads/main\n";
+
+        assert_eq!(
+            PIPXBackend::versions_from_git_ls_remote(output)
+                .into_iter()
+                .map(|version| version.version)
+                .collect::<Vec<_>>(),
+            vec!["v0.8.0", "v0.8.1"]
         );
     }
 

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -175,12 +175,13 @@ impl Backend for PIPXBackend {
                         .collect()
                 }
             }
-            PipxRequest::Git(url) if url.starts_with("https://github.com/") => {
-                let repo = url.strip_prefix("https://github.com/").unwrap();
-                let data = github::list_releases(repo).await?;
-                Self::versions_from_github_releases(data)
-            }
-            PipxRequest::Git(url) => Self::versions_from_git_tags(&url).await?,
+            PipxRequest::Git(url) => match PipxRequest::github_repo(&url) {
+                Some(repo) => {
+                    let data = github::list_releases(&repo).await?;
+                    Self::versions_from_github_releases(data)
+                }
+                None => Self::versions_from_git_tags(&url).await?,
+            },
         };
         Ok(versions.into_iter().map(stamp_pep440_prerelease).collect())
     }
@@ -188,10 +189,13 @@ impl Backend for PIPXBackend {
     async fn latest_stable_version(&self, config: &Arc<Config>) -> eyre::Result<Option<String>> {
         let package = match self.tool_name().parse()? {
             PipxRequest::Pypi(package) => package,
-            PipxRequest::Git(url) if !url.starts_with("https://github.com/") => {
-                return Self::git_head(&url).await.map(Some);
+            PipxRequest::Git(url) => {
+                return if PipxRequest::github_repo(&url).is_some() {
+                    Ok(None)
+                } else {
+                    Self::git_head(&url).await.map(Some)
+                };
             }
-            PipxRequest::Git(_) => return Ok(None),
         };
         let registry_url = self.get_registry_url(config).await?;
         let latest_version_cache = self.latest_version_cache(&registry_url);
@@ -235,15 +239,14 @@ impl Backend for PIPXBackend {
         version == "latest"
             && matches!(
                 self.tool_name().parse::<PipxRequest>(),
-                Ok(PipxRequest::Git(url)) if !url.starts_with("https://github.com/")
+                Ok(PipxRequest::Git(url)) if PipxRequest::github_repo(&url).is_none()
             )
     }
 
-    fn latest_installed_channel_version(&self, channel: &str) -> Option<String> {
-        if !self.is_rolling_channel(channel) {
-            return None;
-        }
-        self.latest_installed_version(None).ok().flatten()
+    fn latest_installed_channel_version(&self, _channel: &str) -> Option<String> {
+        // Installed versions do not retain enough provenance to distinguish a
+        // rolling HEAD resolution from an explicitly installed tag or ref.
+        None
     }
 
     async fn resolve_channel_version(
@@ -266,7 +269,7 @@ impl Backend for PIPXBackend {
 
     fn unresolved_latest_version(&self) -> Option<String> {
         match self.tool_name().parse() {
-            Ok(PipxRequest::Git(url)) if url.starts_with("https://github.com/") => {
+            Ok(PipxRequest::Git(url)) if PipxRequest::github_repo(&url).is_some() => {
                 Some("latest".to_string())
             }
             _ => None,
@@ -850,6 +853,17 @@ enum PipxRequest {
 }
 
 impl PipxRequest {
+    /// Returns the `owner/repo` path for GitHub remotes, regardless of the Git
+    /// transport used to reach GitHub.
+    fn github_repo(url: &str) -> Option<String> {
+        let url = url::Url::parse(url).ok()?;
+        if url.host_str() != Some("github.com") {
+            return None;
+        }
+        let repo = url.path().trim_matches('/').trim_end_matches(".git");
+        (!repo.is_empty()).then(|| repo.to_string())
+    }
+
     fn extras_from_opts(&self, opts: &PipxOptions<'_>) -> String {
         match opts.extras() {
             Some(extras) => format!("[{extras}]"),
@@ -1395,11 +1409,18 @@ cccccccccccccccccccccccccccccccccccccccc\trefs/heads/main\n";
         let gitlab =
             PIPXBackend::from_arg("pipx:git+https://gitlab.example.com/sre/mytool.git".into());
         let github = PIPXBackend::from_arg("pipx:git+https://github.com/psf/black.git".into());
+        let github_ssh =
+            PIPXBackend::from_arg("pipx:git+ssh://git@github.com/psf/black.git".into());
 
         assert!(gitlab.is_rolling_channel("latest"));
         assert!(gitlab.requires_concrete_channel_version("latest"));
         assert!(!gitlab.is_rolling_channel("v0.8.1"));
         assert!(!github.is_rolling_channel("latest"));
+        assert!(!github_ssh.is_rolling_channel("latest"));
+        assert_eq!(
+            PipxRequest::github_repo("ssh://git@github.com/psf/black"),
+            Some("psf/black".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- resolve non-GitHub pipx Git `latest` requests to the remote default-branch HEAD commit
- treat non-GitHub Git `latest` as a rolling channel so `outdated` and `upgrade` detect branch movement
- discover remote tags for explicit version requests without imposing version ordering
- preserve existing GitHub Release behavior and document the distinction

Addresses https://github.com/jdx/mise/discussions/12404

## Validation
- `mise run lint-fix` (initial implementation)
- `cargo test --bin mise backend::pipx::tests` (initial implementation)
- `cargo fmt --check`
- local bare-repository smoke test
- GitHub Actions for the final rolling-channel implementation

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved Git-based package version resolution.
  - GitHub sources now use the latest published release, with fallback to the default branch when no releases are available.
  - Other Git sources now track the default branch for `latest` and resolve it to a specific commit.
  - HTTPS and SSH GitHub sources are supported consistently.
  - Explicit version requests can continue to use remote tags or references.

- **Documentation**
  - Updated developer documentation to explain Git source version-resolution behavior and fallback rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pipx version discovery and install resolution for Git-sourced tools (network/git dependency), though GitHub release behavior is largely preserved.
> 
> **Overview**
> **Non-GitHub pipx Git sources** now resolve `latest` to the remote default-branch HEAD (via `git ls-remote`) and expose that as a **rolling channel**, so `outdated` / `upgrade` can see when the branch moves. Explicit versions can be chosen from **remote tags** listed with `git ls-remote --tags`.
> 
> **GitHub Git sources** keep using GitHub Releases for version lists; `latest` still follows the existing release-based path. GitHub detection is centralized in `PipxRequest::github_repo`, including non-HTTPS transports (e.g. SSH).
> 
> The pipx backend docs now spell out how `latest` behaves for GitHub vs other Git URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f9ca2b625f87776afd613a72790e6659f060abc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->