### PR TITLE
fix(pipx): reject unavailable configured executable

### DIFF
--- a/e2e/backend/test_pipx_missing_dependency
+++ b/e2e/backend/test_pipx_missing_dependency
@@ -33,3 +33,24 @@ out="$(quiet_assert_fail "$(install_cmd) pipx:cowsay@6.1")"
 assert_contains_text "$out" "mise use uv@latest"
 assert_contains_text "$out" "mise use pipx@latest"
 assert_not_contains_text "$out" "os error 2"
+
+# The executable can disappear or have an unavailable interpreter after validation. Preserve
+# Unix PATH-based selection, but still translate that spawn failure into the actionable error.
+BROKEN_BIN="$PWD/broken-bin"
+mkdir -p "$BROKEN_BIN"
+cat >"$BROKEN_BIN/pipx" <<'EOF'
+#!/definitely/missing/pipx-interpreter
+EOF
+chmod +x "$BROKEN_BIN/pipx"
+out="$(quiet_assert_fail "env PATH=$BROKEN_BIN MISE_PIPX_UVX=0 MISE_PIPX_VERSION=system $MISE_BIN install pipx:cowsay@6.1")"
+assert_contains_text "$out" "pipx was found during dependency validation but could not be launched"
+assert_contains_text "$out" "mise which pipx"
+assert_not_contains_text "$out" "os error 2"
+
+# A configured `pipx` request must not suppress the executable check. The install graph has
+# already processed configured dependencies before the pipx package starts, so `system` here
+# means no runnable pipx will appear later in this invocation.
+out="$(quiet_assert_fail "$(install_cmd MISE_PIPX_UVX=0 MISE_PIPX_VERSION=system) pipx:cowsay@6.1")"
+assert_contains_text "$out" "pipx is configured but its executable was not found or is not runnable"
+assert_contains_text "$out" "mise use pipx@latest"
+assert_not_contains_text "$out" "os error 2"

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -278,6 +278,13 @@ impl Backend for PIPXBackend {
         } else {
             None
         };
+        let pipx_available = if uv_program.is_none() {
+            self.spawnable_dependency(&ctx.config, Some(&ctx.ts), "pipx")
+                .await
+                .is_some()
+        } else {
+            false
+        };
 
         if uv_program.is_none() {
             // Only offer uv as an alternative when this package can actually use it.
@@ -304,27 +311,31 @@ impl Backend for PIPXBackend {
                 .await;
 
             // Fail with the instructions above rather than letting `pipx install` die with a
-            // bare "No such file or directory (os error 2)". Skipped when a configured tool
-            // provides pipx, since mise installs that first — same rule as the warning.
+            // bare "No such file or directory (os error 2)". The install graph has already
+            // processed configured dependencies before this backend starts, so a configured
+            // but still unspawnable pipx will not become available later in this invocation.
             //
             // The gate asks `spawnable_dependency`, the same question `spawn_program` asks
             // below, so it cannot pass on evidence the spawn will then reject. On Windows a
             // `pipx.ps1` or a shebang-only `pipx.pyz` satisfies the plain lookup but cannot
             // be launched, and it used to reach `pipx install` and die with
             // "program not found" instead of these instructions.
-            let pipx_configured = match self.dependency_toolset(&ctx.config).await {
-                Ok(ts) => ts.versions.keys().any(|ba| ba.short == "pipx"),
-                Err(_) => false,
-            };
-            if !pipx_configured
-                && self
-                    .spawnable_dependency(&ctx.config, Some(&ctx.ts), "pipx")
-                    .await
-                    .is_none()
-            {
+            if !pipx_available {
+                let pipx_configured = match self.dependency_toolset(&ctx.config).await {
+                    Ok(ts) => ts.versions.keys().any(|ba| ba.short == "pipx"),
+                    Err(_) => false,
+                };
+                let reason = if pipx_configured {
+                    "pipx is configured but its executable was not found or is not runnable"
+                        .to_string()
+                } else {
+                    format!(
+                        "pipx is required to install {} but was not found",
+                        self.ba()
+                    )
+                };
                 bail!(
-                    "pipx is required to install {} but was not found.\n\n{instructions}",
-                    self.ba()
+                    "{reason}.\n\n{instructions}\n\nIf pipx is already installed, verify it with `mise which pipx` and `pipx --version`."
                 );
             }
         }
@@ -394,7 +405,20 @@ impl Backend for PIPXBackend {
             if let Some(args) = options.pipx_args() {
                 cmd = cmd.args(shell_words::split(args)?);
             }
-            cmd.execute()?;
+            if let Err(err) = cmd.execute() {
+                let not_found = err.chain().any(|cause| {
+                    cause
+                        .downcast_ref::<std::io::Error>()
+                        .is_some_and(|io| io.kind() == std::io::ErrorKind::NotFound)
+                });
+                if not_found {
+                    bail!(
+                        "pipx was found during dependency validation but could not be launched while installing {}.\n\nVerify the configured executable with `mise which pipx` and `pipx --version`. If pipx is unavailable, reinstall it with `mise use pipx@latest`.",
+                        self.ba()
+                    );
+                }
+                return Err(err);
+            }
         }
 
         // Fix venv Python symlink to use minor version path


### PR DESCRIPTION
## Summary
- verify that a configured pipx dependency is actually runnable after dependency installation
- preserve the existing platform-specific subprocess resolution and PATH precedence
- translate an actual pipx spawn ENOENT into actionable diagnostics, including validation-to-launch failures
- add regression coverage for both a missing configured executable and a runnable file with a missing shebang interpreter

Fixes the failure reported in https://github.com/jdx/mise/discussions/12414.

## Testing
- `mise run test:e2e e2e/backend/test_pipx_missing_dependency`
- `mise run test:e2e e2e/backend/test_pipx_direct_dependencies`
- `shellcheck -x e2e/backend/test_pipx_missing_dependency`
- `mise run lint-fix` (formatting and focused linters completed; successful all-features builds were run by the focused e2e commands)

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages when `pipx` is missing or configured but cannot be run.
  - Added actionable guidance for verifying and fixing `pipx` installation issues.
  - Prevented confusing raw “os error 2” messages from appearing when pipx commands cannot be launched.

- **Tests**
  - Added end-to-end coverage for unavailable and unusable `pipx` executables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->