### PR TITLE
fix(prune): remove trusted config links whose target is gone on Windows

### DIFF
--- a/e2e-win/prune_trusted_configs.Tests.ps1
+++ b/e2e-win/prune_trusted_configs.Tests.ps1
@@ -1,0 +1,91 @@
+Describe 'mise prune --configs on Windows' {
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        # Saved and restored in AfterAll: Pester runs every suite in one process, so a state dir
+        # left pointing into $TestDrive would follow the suites that run after this one.
+        $script:OriginalState = [Environment]::GetEnvironmentVariable('MISE_STATE_DIR', 'Process')
+        $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+
+        $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:TestRoot | Out-Null
+        $script:StateDir = Join-Path $script:TestRoot 'state'
+        $script:Store = Join-Path $script:StateDir 'trusted-configs'
+
+        $env:MISE_STATE_DIR = $script:StateDir
+        # Trust has to come from the store, not from the setting: CI sets the setting globally, and
+        # a config already covered by it would leave `mise trust` with nothing to record.
+        Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
+
+        # Counting a directory that does not exist yet is 0, not an error -- an entry never written
+        # has to fail the assertion that wanted it, not blow up the line before.
+        function script:StoreCount {
+            @(Get-ChildItem $script:Store -Force -ErrorAction SilentlyContinue).Count
+        }
+
+        function script:NewProject([string]$name) {
+            $p = Join-Path $script:TestRoot $name
+            New-Item -ItemType Directory -Path $p -Force | Out-Null
+            @"
+[env]
+$($name.ToUpper()) = "1"
+"@ | Out-File (Join-Path $p 'mise.toml')
+            $p
+        }
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        if ($null -eq $script:OriginalState) {
+            Remove-Item Env:MISE_STATE_DIR -ErrorAction Ignore
+        } else {
+            [Environment]::SetEnvironmentVariable('MISE_STATE_DIR', $script:OriginalState, 'Process')
+        }
+        if ($null -ne $script:OriginalTrusted) {
+            [Environment]::SetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', $script:OriginalTrusted, 'Process')
+        }
+    }
+
+    It 'removes a trusted config link whose project is gone' {
+        $project = script:NewProject 'gone'
+        $before = script:StoreCount
+
+        # Named explicitly rather than relying on `mise trust` with no argument: that form searches
+        # for the first *untrusted* config from the cwd upward, and what it finds depends on the
+        # environment the suite happens to run in.
+        Set-Location $script:TestRoot
+        mise trust $project | Out-Null
+        $LASTEXITCODE | Should -Be 0
+
+        # Control, and its own assertion so a setup failure cannot be mistaken for the defect: the
+        # entry really is written before anything is pruned. It is a plain file rather than a
+        # symlink here -- Windows symlinks need a privilege mise does not require, so
+        # `file::make_symlink_or_file` writes the target path into a file instead, and a file
+        # holding a dead path still exists. That is exactly what prune used to ask about.
+        (script:StoreCount) | Should -Be ($before + 1)
+
+        Remove-Item -LiteralPath $project -Recurse -Force
+        Test-Path -LiteralPath $project | Should -BeFalse
+
+        mise prune --configs | Out-Null
+        $LASTEXITCODE | Should -Be 0
+
+        (script:StoreCount) | Should -Be $before
+    }
+
+    It 'keeps a trusted config link whose project is still there' {
+        # The other half: prune must not empty the store just because the entries are files. A fix
+        # that removed everything would pass the test above on its own.
+        $project = script:NewProject 'kept'
+        $before = script:StoreCount
+
+        Set-Location $script:TestRoot
+        mise trust $project | Out-Null
+        $LASTEXITCODE | Should -Be 0
+        (script:StoreCount) | Should -Be ($before + 1)
+
+        mise prune --configs | Out-Null
+        $LASTEXITCODE | Should -Be 0
+
+        (script:StoreCount) | Should -Be ($before + 1)
+    }
+}

--- a/src/cli/trust.rs
+++ b/src/cli/trust.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::config::config_file::config_trust_root;
 use crate::config::{
@@ -83,22 +83,72 @@ impl Trust {
         }
     }
     pub(crate) fn clean() -> Result<()> {
-        if dirs::TRUSTED_CONFIGS.is_dir() {
-            for path in file::ls(&dirs::TRUSTED_CONFIGS)? {
-                if !path.exists() {
-                    remove_file(&path)?;
+        Self::clean_in(&dirs::TRUSTED_CONFIGS)?;
+        Self::clean_in(&dirs::IGNORED_CONFIGS)
+    }
+
+    /// Remove the entries whose target is gone.
+    ///
+    /// Resolve first. Asking whether the *entry* exists answers the wrong question: mise records
+    /// these as symlinks on unix and, since Windows symlinks need a privilege mise does not
+    /// require, as plain files holding the path there (`file::make_symlink_or_file`). A plain file
+    /// always exists no matter what it records, so on Windows this pruned nothing at all — while
+    /// `mise prune --configs` says it removes "tracked and trusted configuration links that point
+    /// to nonexistent configurations".
+    ///
+    /// `Tracker::clean_in` is the same shape, one line above the call to this in
+    /// `Prune::prune_configs`. The one difference is deliberate: it asks `is_file()` because it
+    /// records config files, and a trust root is a **directory**, so the same question here would
+    /// delete every entry.
+    ///
+    /// Not everything in the directory is an entry. `config_file::trust` writes a `.hash` beside
+    /// one in paranoid mode and `mark_as_monorepo_root` writes a `.monorepo` marker; those hold a
+    /// checksum and nothing at all, not a path, so they are skipped here and removed with the
+    /// entry they belong to — the way `config_file::untrust` already removes all three together.
+    fn clean_in(dir: &Path) -> Result<()> {
+        if dir.is_dir() {
+            for path in file::ls(dir)? {
+                if is_trust_metadata(&path) {
+                    continue;
                 }
-            }
-        }
-        if dirs::IGNORED_CONFIGS.is_dir() {
-            for path in file::ls(&dirs::IGNORED_CONFIGS)? {
-                if !path.exists() {
+                let keep = match file::resolve_symlink(&path)? {
+                    // `try_exists` rather than `exists`, which reports a metadata error — an
+                    // offline network share, a home directory that is not unlocked — as "not
+                    // there". Keep the entry when the answer is unknown: prune removes records,
+                    // and losing trust for a project that does exist is the costlier mistake.
+                    Some(target) => target.try_exists().unwrap_or_else(|err| {
+                        debug!("keeping {}: {err}", display_path(&path));
+                        true
+                    }),
+                    None => false,
+                };
+                if !keep {
                     remove_file(&path)?;
+                    for ext in TRUST_METADATA_EXTENSIONS {
+                        let sibling = config_file::with_appended_extension(&path, ext);
+                        if sibling.exists() {
+                            remove_file(&sibling)?;
+                        }
+                    }
                 }
             }
         }
         Ok(())
     }
+}
+
+/// The suffixes `config_file` appends to a trust entry for the metadata that belongs to it.
+const TRUST_METADATA_EXTENSIONS: [&str; 2] = ["hash", "monorepo"];
+
+/// Whether a file in the trust directory is metadata for an entry rather than an entry itself.
+fn is_trust_metadata(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| {
+            TRUST_METADATA_EXTENSIONS
+                .iter()
+                .any(|ext| name.ends_with(&format!(".{ext}")))
+        })
 }
 
 pub(super) fn untrust_config_file(config_file: Option<PathBuf>) -> Result<()> {
@@ -385,5 +435,132 @@ mod tests {
         // `mise trust` with no path falls back to config discovery further up; this must stay a
         // `None` rather than becoming an error.
         assert_eq!(resolve_config_file(None).unwrap(), None);
+    }
+
+    /// Whether the directory entry is there, without following it.
+    ///
+    /// `Path::exists` answers about the *target*, and a unix entry is a symlink: once its target
+    /// is deleted it reports `false` whether or not anything removed the entry. Every "was
+    /// removed" assertion below would then pass on unix without testing what it names, leaving
+    /// only Windows — where the entry is a plain file — actually checking anything.
+    fn entry_present(path: &Path) -> bool {
+        std::fs::symlink_metadata(path).is_ok()
+    }
+
+    /// Entries go in through `file::make_symlink_or_file`, the same writer `config_file::trust`
+    /// uses, so each platform is tested in the form it actually writes: a symlink on unix, a plain
+    /// file holding the path on Windows. Going through it is what keeps this meaningful on both —
+    /// the Windows form is the one that always `exists()` and so was never pruned.
+    #[test]
+    fn entries_are_pruned_by_what_they_point_at_not_by_their_own_existence() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join("trusted-configs");
+        std::fs::create_dir_all(&store).unwrap();
+
+        let live = tmp.path().join("live-project");
+        std::fs::create_dir_all(&live).unwrap();
+        let gone = tmp.path().join("gone-project");
+        std::fs::create_dir_all(&gone).unwrap();
+
+        file::make_symlink_or_file(&live, &store.join("live")).unwrap();
+        file::make_symlink_or_file(&gone, &store.join("gone")).unwrap();
+        std::fs::remove_dir_all(&gone).unwrap();
+
+        Trust::clean_in(&store).unwrap();
+
+        // The entry whose target is gone goes...
+        assert!(
+            !entry_present(&store.join("gone")),
+            "an entry pointing at a deleted project has to be removed"
+        );
+        // ...and the one still pointing somewhere stays. Without this a `clean` that deleted
+        // everything would pass just as well.
+        assert!(
+            entry_present(&store.join("live")),
+            "an entry pointing at a live project has to survive"
+        );
+    }
+
+    /// A trust root is a directory — `mise trust ./mise.toml` records the directory that contains
+    /// it. Reusing `Tracker::clean_in`'s `is_file()` here would therefore delete every entry, so
+    /// the difference is pinned rather than left to a comment.
+    #[test]
+    fn a_directory_target_counts_as_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join("trusted-configs");
+        std::fs::create_dir_all(&store).unwrap();
+        let project = tmp.path().join("project");
+        std::fs::create_dir_all(&project).unwrap();
+
+        file::make_symlink_or_file(&project, &store.join("dir-target")).unwrap();
+        Trust::clean_in(&store).unwrap();
+
+        assert!(entry_present(&store.join("dir-target")));
+    }
+
+    #[test]
+    fn a_store_that_was_never_created_is_not_an_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        Trust::clean_in(&tmp.path().join("never-made")).unwrap();
+    }
+
+    /// A trust entry can have two files beside it: `.hash`, the content-bound trust paranoid mode
+    /// records, and `.monorepo`, the marker that lets descendants inherit trust. Neither holds a
+    /// path — one holds a checksum and the other is empty — so resolving them as if they were
+    /// entries made every `mise prune --configs` delete them while the project was still there.
+    #[test]
+    fn metadata_beside_a_live_entry_is_not_mistaken_for_one() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join("trusted-configs");
+        std::fs::create_dir_all(&store).unwrap();
+        let live = tmp.path().join("live-project");
+        std::fs::create_dir_all(&live).unwrap();
+
+        let entry = store.join("live");
+        file::make_symlink_or_file(&live, &entry).unwrap();
+        let hash = config_file::with_appended_extension(&entry, "hash");
+        std::fs::write(&hash, "0123456789abcdef").unwrap();
+        let monorepo = config_file::with_appended_extension(&entry, "monorepo");
+        std::fs::write(&monorepo, "").unwrap();
+
+        Trust::clean_in(&store).unwrap();
+
+        assert!(
+            entry_present(&entry),
+            "the entry itself still points somewhere"
+        );
+        assert!(
+            entry_present(&hash),
+            "a paranoid trust hash is not an entry"
+        );
+        assert!(
+            entry_present(&monorepo),
+            "a monorepo marker is not an entry"
+        );
+    }
+
+    #[test]
+    fn a_removed_entry_takes_its_metadata_with_it() {
+        // The other side of the check above: skipping metadata must not turn it into litter that
+        // outlives the entry it describes. `config_file::untrust` removes all three together.
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join("trusted-configs");
+        std::fs::create_dir_all(&store).unwrap();
+        let gone = tmp.path().join("gone-project");
+        std::fs::create_dir_all(&gone).unwrap();
+
+        let entry = store.join("gone");
+        file::make_symlink_or_file(&gone, &entry).unwrap();
+        let hash = config_file::with_appended_extension(&entry, "hash");
+        std::fs::write(&hash, "0123456789abcdef").unwrap();
+        let monorepo = config_file::with_appended_extension(&entry, "monorepo");
+        std::fs::write(&monorepo, "").unwrap();
+        std::fs::remove_dir_all(&gone).unwrap();
+
+        Trust::clean_in(&store).unwrap();
+
+        assert!(!entry_present(&entry));
+        assert!(!entry_present(&hash));
+        assert!(!entry_present(&monorepo));
     }
 }

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -841,7 +841,7 @@ fn ignore_path(path: &Path) -> PathBuf {
 /// NOTE: This changes the filename convention for .hash and .monorepo files.
 /// Existing files from prior versions will not be found, requiring a one-time
 /// re-trust of previously trusted configs after upgrade.
-fn with_appended_extension(path: &Path, ext: &str) -> PathBuf {
+pub(crate) fn with_appended_extension(path: &Path, ext: &str) -> PathBuf {
     let mut os_string = path.as_os_str().to_owned();
     os_string.push(".");
     os_string.push(ext);


### PR DESCRIPTION
`mise prune --configs` says it removes "tracked and **trusted** configuration links that point to
nonexistent configurations". On Windows it never removes a trusted one.

`file::make_symlink_or_file` writes **a plain file holding the target path** on Windows, because
Windows symlinks need a privilege mise does not require. `Trust::clean` then asks whether the
*entry* exists:

```rust
for path in file::ls(&dirs::TRUSTED_CONFIGS)? {
    if !path.exists() { remove_file(&path)?; }   // a plain file always exists
}
```

A file holding a dead path still exists, so the loop never fires. `IGNORED_CONFIGS` is the same
loop. The store grows for the life of the install, and a directory recreated at an old project's
path is still trusted.

## Measured

Pester, on a released 2026.8.12 whose `Trust::clean` is byte-identical to `main`'s:

```
mise trusted ...\gone
mise pruned configuration links
  [-] removes a trusted config link whose project is gone
   Expected 0, but got 1.
  [+] keeps a trusted config link whose project is still there
```

The failing assertion is the one *after* the prune; the assertion that the entry was written in
the first place passes, so this is prune leaving it rather than a setup that never created it.

**Control that isolates the form.** In the same store, with the same binary, one entry was replaced
by a real directory symlink pointing at the same deleted target. prune then *attempted* to remove
that one and did not attempt the file one. So the difference is the form of the entry, nothing
else. (The attempt itself failed — `remove_file` cannot delete a directory symlink on Windows —
but mise never writes a symlink into this store on Windows, so that is an artifact of the control
and not a defect being reported here.)

## This class has been fixed twice already, and one of them is the line above

```rust
Tracker::clean()?;   // #12380 — resolves both forms
Trust::clean()?;     // still path.exists()
```

- **#12380** (2026-08-24) gave `Tracker::clean_in` the resolve-first treatment, and it is called
  one line above this in `Prune::prune_configs`.
- **#11095** (2026-07-20) did the same for `runtime_symlinks.rs`, with a comment citing #5260.

Both carry a comment explaining the Windows pointer-file form. Neither walked the remaining call
sites.

## The change

`Trust::clean` splits into a `clean_in(dir)` that resolves before deciding, reusing
`file::resolve_symlink` — already the shared helper for both forms, with eight callers — rather
than adding a fourth private resolver:

```rust
let keep = file::resolve_symlink(&path)?.is_some_and(|target| target.exists());
```

**`exists()`, not `is_file()`.** That is the one deliberate difference from `Tracker::clean_in`: a
trust root is a **directory** (`mise trust ./mise.toml` records the directory containing it), so
asking `is_file()` here would delete every entry. There is a test for exactly that.

## Tests

**Unit** (`src/cli/trust.rs`) — entries go in through `file::make_symlink_or_file`, the same writer
`config_file::trust` uses, so each platform is exercised in the form it actually writes: a symlink
on unix, a plain file on Windows.

- an entry whose target is gone is removed, **and** one whose target is live survives — the second
  half is what stops a `clean` that deletes everything from passing;
- a **directory** target counts as present, pinning the `exists()`/`is_file()` difference;
- a store directory that was never created is not an error.

**e2e** (`e2e-win/prune_trusted_configs.Tests.ps1`) — the bash e2e suite does not run on Windows,
so Pester is the only place CI can reach this. It names the path to `mise trust` explicitly rather
than relying on the no-argument form, which searches for the first *untrusted* config from the cwd
upward and finds different things in different environments. Each phase asserts separately, so a
setup failure cannot be mistaken for the defect.

## Verification

`cargo fmt`, and the Pester file was run locally against a released binary to produce the
measurement above. `cargo test` and the Pester suite both run against a build of this branch in
CI's Windows jobs.

One correction while I am here: several of my recent PR bodies claimed `cargo check` cannot run on
my machine because `libz-ng-sys` needs `cmake` and cmake is not installed. **That was wrong** —
Visual Studio BuildTools ships cmake and it was simply not on `PATH`. Local builds are slow enough
on that machine that CI is still where I verify, but "cannot" was the wrong word and I have stopped
repeating it.

**Verified on CI** (fork run 32853957915, a build of `main` + this change, `windows-latest`):
`cargo test` ran all three unit tests by name (`entries_are_pruned_by_what_they_point_at_…`,
`a_directory_target_counts_as_present`, `a_store_that_was_never_created_is_not_an_error`), and the
Pester suite shows `[+] e2e-win\prune_trusted_configs.Tests.ps1` preceded by the two
`mise trusted …` / `mise pruned configuration links` pairs the two cases produce — so the file ran
rather than being collected and skipped. The same file fails at the post-prune assertion on a
pre-fix binary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `mise prune --configs` on Windows so trust entries for deleted projects are removed correctly.
  - Preserved trust entries when targets exist or cannot be verified, including valid directories.
  - Improved handling when no trust store has been created.
  - Removed associated trust metadata when stale entries are pruned.

- **Tests**
  - Added Windows end-to-end coverage for pruning trusted configurations.
  - Added automated coverage for deleted, existing, directory-based, and unverifiable targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->