### PR TITLE
fix(http): remove the extraction temp dir when extraction fails

### DIFF
--- a/e2e/backend/test_http_failed_extraction_cleanup
+++ b/e2e/backend/test_http_failed_extraction_cleanup
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression test: a failed extraction must not leave its temp directory behind.
+#
+# `extract_to_cache` extracts into `<key>.tmp-<pid>-<ms>` beside the real entries
+# and renames it into place. The name is unique to the process and millisecond,
+# so the "clean up any stale temp directory" check before it can never match what
+# an earlier run left, and before the fix nothing removed one on the way out of a
+# failure. Every failed extraction leaked a hash-named directory into
+# `http-tarballs` permanently. `mise prune` cannot reclaim them either — it skips
+# `.tmp-` names so it cannot destroy an extraction in flight.
+
+FIXTURES="$TMPDIR/http-failed-extraction-fixtures"
+PORT_FILE="$TMPDIR/http-failed-extraction-port"
+TARBALLS="$MISE_DATA_DIR/http-tarballs"
+
+mkdir -p "$FIXTURES"
+
+# Named like a tarball, but the bytes are not gzip. With no checksum configured
+# `verify_artifact` has nothing to reject, so this fails during extraction —
+# which is the path under test.
+printf 'this is not a gzip stream\n' >"$FIXTURES/broken.tar.gz"
+
+mkdir -p "$FIXTURES/good/bin"
+cat >"$FIXTURES/good/bin/good-tool" <<'EOF'
+#!/usr/bin/env bash
+echo good-tool-ok
+EOF
+chmod +x "$FIXTURES/good/bin/good-tool"
+tar czf "$FIXTURES/good.tar.gz" -C "$FIXTURES" good
+
+python3 -u - "$FIXTURES" "$PORT_FILE" <<'PY' >/dev/null 2>&1 &
+import functools
+import http.server
+import socketserver
+import sys
+from pathlib import Path
+
+root = sys.argv[1]
+port_file = Path(sys.argv[2])
+handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=root)
+with socketserver.TCPServer(("127.0.0.1", 0), handler) as httpd:
+    port_file.write_text(str(httpd.server_address[1]))
+    httpd.serve_forever()
+PY
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
+wait_for_file "$PORT_FILE" "http failed extraction test server port file" 30 "$SERVER_PID"
+PORT=$(cat "$PORT_FILE")
+
+# Recursive so the shared-install case does not depend on the tool directory's
+# name, and harmless for the cache dir where the entries are one level down.
+leftover_temps() {
+  find "$1" -name "$2" 2>/dev/null | wc -l | tr -d ' '
+}
+
+cat >mise.toml <<EOF
+[tools."http:broken"]
+version = "1.0.0"
+url = "http://127.0.0.1:$PORT/broken.tar.gz"
+bin_path = "bin"
+EOF
+
+assert_fail "mise install"
+
+# Before the fix this found one directory per failed attempt, forever.
+assert "test '$(leftover_temps "$TARBALLS" '*.tmp-*')' = 0"
+
+# Failing twice must not accumulate either.
+assert_fail "mise install"
+assert "test '$(leftover_temps "$TARBALLS" '*.tmp-*')' = 0"
+
+# The same artifact through the shared-install branch, which extracts straight
+# to the install path rather than the cache. That one already cleaned up after
+# itself — pinned here so it stays that way.
+SHARED_INSTALLS="$TMPDIR/http-failed-extraction-shared"
+mkdir -p "$SHARED_INSTALLS"
+assert_fail "mise install --shared '$SHARED_INSTALLS'"
+assert "test '$(leftover_temps "$SHARED_INSTALLS" '.mise-tmp-*')' = 0"
+
+# And a working install still works afterwards.
+cat >mise.toml <<EOF
+[tools."http:good"]
+version = "1.0.0"
+url = "http://127.0.0.1:$PORT/good.tar.gz"
+bin_path = "good/bin"
+EOF
+
+mise install
+assert_contains "mise x -- good-tool" "good-tool-ok"
+assert "test '$(leftover_temps "$TARBALLS" '*.tmp-*')' = 0"

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -503,15 +503,34 @@ impl HttpBackend {
             let _ = file::remove_all(&tmp_path);
         }
 
-        // Perform extraction
+        // Every path out of here from now on removes the temp directory it
+        // created. The name carries this process's pid and the millisecond it
+        // started, so nothing else will ever match it and the cleanup above can
+        // never reclaim what an earlier run left behind — a failure that walks
+        // away leaves a hash-named directory beside the real entries for good.
+        // `extract_to_install_path` already does this; this is the same shape.
+        // Cleanup errors are dropped rather than returned so they cannot hide
+        // the failure that caused them.
         let extraction_type =
-            self.extract_artifact(tv, &tmp_path, file_path, cache.plan, opts, pr)?;
+            match self.extract_artifact(tv, &tmp_path, file_path, cache.plan, opts, pr) {
+                std::result::Result::Ok(extraction_type) => extraction_type,
+                Err(err) => {
+                    let _ = file::remove_all(&tmp_path);
+                    return Err(err);
+                }
+            };
 
         // Atomic replace
-        if cache_path.exists() {
-            file::remove_all(&cache_path)?;
+        if cache_path.exists()
+            && let Err(err) = file::remove_all(&cache_path)
+        {
+            let _ = file::remove_all(&tmp_path);
+            return Err(err);
         }
-        std::fs::rename(&tmp_path, &cache_path)?;
+        if let Err(err) = std::fs::rename(&tmp_path, &cache_path) {
+            let _ = file::remove_all(&tmp_path);
+            return Err(err.into());
+        }
 
         // Write metadata
         self.write_metadata(cache.dir, &cache.plan.key, url, file_path, opts)?;
@@ -559,7 +578,10 @@ impl HttpBackend {
             return Err(err);
         }
 
-        Self::remove_install_path(&install_path)?;
+        if let Err(err) = Self::remove_install_path(&install_path) {
+            let _ = file::remove_all(&tmp_path);
+            return Err(err);
+        }
         if let Err(err) = std::fs::rename(&tmp_path, &install_path) {
             let _ = file::remove_all(&tmp_path);
             return Err(err.into());


### PR DESCRIPTION
Found while implementing #12419.

## Problem

`extract_to_cache` extracts a cache entry into `<key>.tmp-<pid>-<ms>` **beside** the real entries in `http-tarballs` and renames it into place. Two things combine badly:

```rust
let tmp_path = cache.dir.join(format!("{}.tmp-{}-{}", key, process::id(), now_millis));

// Clean up any stale temp directory
if tmp_path.exists() { let _ = file::remove_all(&tmp_path); }

let extraction_type = self.extract_artifact(...)?;          // (1)
if cache_path.exists() { file::remove_all(&cache_path)?; }  // (2)
std::fs::rename(&tmp_path, &cache_path)?;                   // (3)
```

**The stale-temp cleanup can never fire.** The name carries this process's pid and the millisecond it started, so `tmp_path.exists()` is true only if the same process collides with itself inside one millisecond. It cannot see what a previous run left.

**No path out of a failure removes it.** All three `?` above walk away and leave the directory. There is no `Drop` guard and no scopeguard.

So every failed extraction — a truncated download, an unreadable archive, a full disk, a Ctrl-C during extraction — leaves a hash-named directory in `http-tarballs` **permanently**. That is a slow leak into the same directory discussions#9477 is about.

It also cannot be reclaimed later: #12419's sweep deliberately skips `.tmp-` names, because the installer's lock is on the key rather than on the temp path and deleting one would destroy an extraction in flight.

## Fix

`extract_to_install_path` — the sibling branch used for `--system` / `--shared`, forty lines up — already does the right thing:

```rust
if let Err(err) = self.extract_artifact(tv, &extract_path, file_path, cache_plan, opts, pr) {
    let _ = file::remove_all(&tmp_path);
    return Err(err);
}
```

This gives `extract_to_cache` the same shape on all three paths, and closes the one place the sibling still missed (`remove_install_path` failing before the rename). Cleanup errors are dropped rather than returned so they cannot hide the failure that caused them — again matching the sibling.

## Deliberately not fixed

**Directories already leaked, and extractions killed with `SIGKILL`, are not reclaimed.** Doing that safely needs the invariant that nothing holding the cache-entry lock is mid-extraction — which is what #12419 establishes by having forced installs take the lock too. Tying the two together would couple the PRs, and this one stands on its own: it stops the leak, it just does not undo it. #12419 does not touch `extract_to_cache`, so the two do not conflict.

## Test

`e2e/backend/test_http_failed_extraction_cleanup`, modelled on `e2e/backend/test_aqua_failed_install_cleanup` ("a failed install should not leave X behind") with the local HTTP server from `e2e/backend/test_http_system_install`.

It serves a file named `broken.tar.gz` whose bytes are not gzip — with no checksum configured, `verify_artifact` has nothing to reject, so the failure lands in extraction, which is the path under test. Then:

- one failed install leaves no `*.tmp-*` in `http-tarballs` (this is what fails without the fix)
- failing twice does not accumulate
- the same artifact through `--shared` leaves no `.mise-tmp-*` either, pinning the sibling's existing behaviour
- a working install still works afterwards

`e2e/backend/test_http_caching` counts cache entries, so it also notices if a stray directory appears.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed failed HTTP artifact installations leaving temporary directories behind.
  * Improved cleanup for both cached and shared installations after extraction or rename errors.
  * Confirmed subsequent installation attempts can succeed after a failed attempt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->