### PR TITLE
fix(task): reject negative template argument bounds

### DIFF
--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -302,9 +302,8 @@ impl TaskScriptParser {
             let input_args = input_args.clone();
             let arg_order = arg_order.clone();
             move |args| {
-                let i = Self::template_arg::<i64>(args, "i")?
-                    .unwrap_or(input_args.lock().map_err(Self::lock_error)?.len() as i64)
-                    as usize;
+                let i = Self::template_arg::<usize>(args, "i")?
+                    .unwrap_or(input_args.lock().map_err(Self::lock_error)?.len());
 
                 let required = Self::template_arg::<bool>(args, "required")?.unwrap_or(true);
                 let var = Self::template_arg::<bool>(args, "var")?.unwrap_or(false);
@@ -323,8 +322,8 @@ impl TaskScriptParser {
                 let help_long = Self::template_arg::<String>(args, "help_long")?;
                 let help_md = Self::template_arg::<String>(args, "help_md")?;
 
-                let var_min = Self::template_arg::<i64>(args, "var_min")?.map(|v| v as usize);
-                let var_max = Self::template_arg::<i64>(args, "var_max")?.map(|v| v as usize);
+                let var_min = Self::template_arg::<usize>(args, "var_min")?;
+                let var_max = Self::template_arg::<usize>(args, "var_max")?;
 
                 let hide = Self::template_arg::<bool>(args, "hide")?.unwrap_or(false);
 
@@ -789,8 +788,7 @@ impl TaskScriptParser {
                         let seen_args = Arc::new(Mutex::new(HashSet::new()));
                         {
                             let mut seen_args = seen_args.lock().unwrap();
-                            let i = Self::template_arg::<i64>(args, "i")?
-                                .map(|i| i as usize)
+                            let i = Self::template_arg::<usize>(args, "i")?
                                 .unwrap_or_else(|| seen_args.len());
                             let name = Self::template_arg::<String>(args, "name")?
                                 .unwrap_or(i.to_string());
@@ -1035,6 +1033,27 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(parsed_scripts, vec!["echo abc"]);
+    }
+
+    #[tokio::test]
+    async fn test_task_parse_arg_rejects_negative_numeric_arguments() {
+        let config = Config::get().await.unwrap();
+        let task = Task::default();
+        let parser = TaskScriptParser::new(None);
+
+        for argument in ["i", "var_min", "var_max"] {
+            let scripts = vec![format!("echo {{{{ arg(name='foo', {argument}=-1) }}}}")];
+            let error = parser
+                .parse_run_scripts(&config, &task, &scripts, &Default::default())
+                .await
+                .unwrap_err();
+
+            let message = format!("{error:#}");
+            assert!(
+                message.contains(&format!("invalid `{argument}` argument")),
+                "unexpected error for {argument}: {message}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -1054,6 +1054,24 @@ mod tests {
                 "unexpected error for {argument}: {message}"
             );
         }
+
+        let scripts = vec!["echo {{ arg(i=-1) }}".to_string()];
+        let error = parser
+            .parse_run_scripts_with_args(
+                &config,
+                &task,
+                &scripts,
+                &Default::default(),
+                &[],
+                &usage::Spec::default(),
+            )
+            .await
+            .unwrap_err();
+        let message = format!("{error:#}");
+        assert!(
+            message.contains("invalid `i` argument"),
+            "unexpected rendering error: {message}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- deserialize task template indices and variadic bounds directly as unsigned values
- reject negative i, var_min, and var_max arguments instead of wrapping them to huge values
- add a regression test for all three arguments

## Tests
- cargo test --bin mise task::task_script_parser::tests::test_task_parse_arg_rejects_negative_numeric_arguments
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- mise run lint-fix

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized validation change in deprecated Tera task-arg parsing; behavior improves by rejecting invalid input instead of silent wraparound.
> 
> **Overview**
> Fixes a bug where negative values passed to deprecated Tera `arg()` helpers for **`i`**, **`var_min`**, and **`var_max`** were accepted as `i64` and cast to **`usize`**, producing huge bounds instead of failing.
> 
> Those parameters are now deserialized directly as **`usize`**, so negatives fail during spec collection and script rendering with an **`invalid \`…\` argument`** error from `template_arg`. The same typing applies in both spec-parsing and **`parse_run_scripts_with_args`** `arg()` handlers.
> 
> A regression test covers **`i`**, **`var_min`**, and **`var_max`** on **`parse_run_scripts`** and **`i=-1`** on **`parse_run_scripts_with_args`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aebb8839c486a318167438c29a70843b838a0690. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for numeric script arguments.
  * Negative values are now rejected with a clear error instead of being converted into unexpected large values.

* **Tests**
  * Added coverage to verify that negative arguments are properly rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->