### PR TITLE
fix(config): truncate picker descriptions safely

### DIFF
--- a/crates/mise-interactive-config/src/render.rs
+++ b/crates/mise-interactive-config/src/render.rs
@@ -2,11 +2,39 @@
 
 use console::{Style, Term};
 use std::io::{self, Write};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::cursor::{AddButtonKind, Cursor, CursorTarget};
 use crate::document::{EntryValue, TomlDocument};
 use crate::inline_edit::InlineEdit;
 use crate::picker::PickerState;
+
+fn truncate_picker_description(name: &str, description: &str, terminal_width: u16) -> String {
+    const PADDING_WIDTH: usize = 10;
+    const ELLIPSIS: &str = "...";
+
+    let available_width =
+        usize::from(terminal_width).saturating_sub(name.width().saturating_add(PADDING_WIDTH));
+    if description.width() <= available_width {
+        return description.to_owned();
+    }
+    if available_width <= ELLIPSIS.len() {
+        return ".".repeat(available_width);
+    }
+
+    let content_width = available_width - ELLIPSIS.len();
+    let mut used_width: usize = 0;
+    let mut end = 0;
+    for (index, character) in description.char_indices() {
+        let character_width = character.width().unwrap_or(0);
+        if used_width.saturating_add(character_width) > content_width {
+            break;
+        }
+        used_width += character_width;
+        end = index + character.len_utf8();
+    }
+    format!("{}{ELLIPSIS}", &description[..end])
+}
 
 /// What kind of picker is currently active
 #[derive(Debug, Clone)]
@@ -962,12 +990,7 @@ impl Renderer {
 
             // Truncate description if too long
             let (_, width) = self.term.size();
-            let max_desc_len = width.saturating_sub(name.len() as u16 + 10) as usize;
-            let truncated_desc = if desc.len() > max_desc_len && max_desc_len > 3 {
-                format!("{}...", &desc[..max_desc_len.saturating_sub(3)])
-            } else {
-                desc.to_string()
-            };
+            let truncated_desc = truncate_picker_description(name, desc, width);
 
             let line = if visible.is_selected {
                 format!(
@@ -1010,5 +1033,42 @@ impl Renderer {
 impl Default for Renderer {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate_picker_description;
+
+    #[test]
+    fn truncates_picker_descriptions_at_character_boundaries() {
+        assert_eq!(
+            truncate_picker_description("tool", "café au lait", 21),
+            "café..."
+        );
+        assert_eq!(
+            truncate_picker_description("tool", "日本語 description", 23),
+            "日本語..."
+        );
+    }
+
+    #[test]
+    fn picker_description_truncation_handles_narrow_terminals() {
+        assert_eq!(
+            truncate_picker_description("a very long name", "description", 10),
+            ""
+        );
+        assert_eq!(
+            truncate_picker_description("tool", "description", 17),
+            "..."
+        );
+    }
+
+    #[test]
+    fn picker_description_truncation_preserves_text_that_fits() {
+        assert_eq!(
+            truncate_picker_description("tool", "short description", 40),
+            "short description"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- measure picker names and descriptions by terminal display width
- truncate descriptions only at UTF-8 character boundaries
- handle wide characters and narrow terminals without width wraparound or panics
- add focused tests for accented text, CJK text, narrow terminals, and unchanged text

## Tests
- cargo test -p mise-interactive-config render::tests
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- mise run lint-fix

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terminal UI-only change in the interactive config picker with no security or persistence impact.
> 
> **Overview**
> **Picker descriptions** in the interactive config editor now truncate using **terminal display width** (via `unicode_width`) instead of raw byte length, so wide characters (CJK, accented text) no longer break layout or risk invalid UTF-8 slices.
> 
> The inline truncation logic is replaced by a dedicated `truncate_picker_description` helper that reserves space for the tool name and padding, walks characters to cut at safe boundaries, and degrades gracefully on very narrow terminals (empty string, dots-only, or `...`). **Unit tests** cover accented/CJK text, narrow widths, and unchanged text when it fits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b35cd8843901aeee4ca90e47026bab424aa3487d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved picker description rendering for accented, wide, and other Unicode characters.
  - Descriptions now fit available terminal space without cutting characters incorrectly.
  - Added graceful handling for very narrow terminals, including ellipsis when text is truncated.
  - Descriptions that fit within the available width are displayed unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->