### PR TITLE
fix(npm): keep aube settings out of npmrc

### DIFF
--- a/docs/dev-tools/backends/npm.md
+++ b/docs/dev-tools/backends/npm.md
@@ -306,8 +306,8 @@ To exempt only selected versions, use aube's package-version pattern syntax:
 "npm:some-tool" = { version = "latest", trust_policy_excludes = ["undici@^5 || >=6 <7"] }
 ```
 
-`trust_policy_excludes` is written to the aube install `.npmrc` as `trustPolicyExclude`. It does
-not affect `npm`, `pnpm`, or `bun` installs.
+`trust_policy_excludes` is written to the aube install's `.config/aube/config.toml` as
+`trustPolicyExclude`. It does not affect `npm`, `pnpm`, or `bun` installs.
 
 ### `allow_low_downloads`
 
@@ -323,9 +323,10 @@ refusing to add some-tool: only 930 weekly downloads (threshold: 1000).
 "npm:some-tool" = { version = "latest", allow_low_downloads = true }
 ```
 
-The exemption is scoped to the package you asked for, written to the aube install `.npmrc` as
-`allowedUnpopularPackages=<package>`. Transitive dependencies stay gated, and the threshold itself
-is left alone — so this cannot silently admit an unpopular dependency you did not choose.
+The exemption is scoped to the package you asked for, written to the aube install's
+`.config/aube/config.toml` under `allowedUnpopularPackages`. Transitive dependencies stay gated,
+and the threshold itself is left alone — so this cannot silently admit an unpopular dependency
+you did not choose.
 
 An npm tool resolved from `mise.lock` is trusted automatically for this download-count check, so
 reproducing an existing lockfile does not require `allow_low_downloads`. The explicit option is

--- a/e2e/backend/test_npm_aube
+++ b/e2e/backend/test_npm_aube
@@ -12,6 +12,8 @@ assert_succeed "test -d '$install_dir/node_modules'"
 assert_succeed "test -x '$install_dir/node_modules/.bin/cowsay'"
 assert_succeed "test -f '$install_dir/aube-lock.yaml'"
 assert_contains "cat '$install_dir/aube-lock.yaml'" "cowsay@1.6.0"
+assert_succeed "test -f '$install_dir/.config/aube/config.toml'"
+assert_succeed "test ! -e '$install_dir/.npmrc'"
 
 # Regenerable aube state stays under mise's npm cache root, where
 # `mise cache prune npm` owns its lifecycle.

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -1231,6 +1231,7 @@ impl NPMBackend {
         Ok(())
     }
 
+    /// Build the project-scoped Aube settings shared by embedded and CLI installs.
     fn aube_project_config(
         &self,
         before_date: Option<Timestamp>,

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -229,11 +229,6 @@ impl<'a> NpmOptions<'a> {
         Ok((!excludes.is_empty()).then(|| format!("{excludes:?}")))
     }
 
-    fn aube_trust_policy_excludes_npmrc_value(&self) -> eyre::Result<Option<String>> {
-        let excludes = self.trust_policy_excludes()?;
-        Ok((!excludes.is_empty()).then(|| excludes.join(",")))
-    }
-
     fn canonical_allow_builds_lockfile_value(&self) -> eyre::Result<Option<String>> {
         Ok(match self.allow_builds()? {
             AllowBuilds::None => None,
@@ -993,9 +988,9 @@ impl NPMBackend {
     /// (`aube::embed::add`) instead of shelling out to the `aube` binary.
     ///
     /// The install directory doubles as a throwaway project: a seed
-    /// `package.json` + `.npmrc` carry the install-scoped config (release age,
-    /// build-script allowlist) that aube reads during resolution, exactly as
-    /// the `aube add --global` path did via its written `.npmrc`. aube installs
+    /// `package.json` + `.config/aube/config.toml` carry the install-scoped
+    /// config (release age, build-script allowlist) that aube reads during
+    /// resolution. Aube installs
     /// into `<install>/node_modules`; the resulting `node_modules/.bin` shims
     /// are linked into `<install>/bin` so mise's default `list_bin_paths`
     /// (which points at `<install>/bin`) keeps working unchanged.
@@ -1129,9 +1124,9 @@ impl NPMBackend {
     /// the actual reason — a supply-chain trust-policy block on a transitive
     /// dependency surfaces as an opaque resolution failure otherwise. Walk the
     /// cause chain so the real diagnostic is visible, and for the trust
-    /// downgrade code translate aube's own `.npmrc` / `pnpm-workspace.yaml`
-    /// help into the mise-native `trust_policy_excludes` / `npm.shell_out`
-    /// remedies, since mise owns the synthetic `.npmrc` aube's help tells the
+    /// downgrade code translate aube's own config-file help into the
+    /// mise-native `trust_policy_excludes` / `npm.shell_out`
+    /// remedies, since mise owns the synthetic config aube's help tells the
     /// user to edit.
     fn format_aube_install_error(&self, err: miette::Report) -> eyre::Report {
         eyre::eyre!(build_aube_install_error_message(&err, &self.ba().full()))
@@ -1163,10 +1158,11 @@ impl NPMBackend {
         }
     }
 
-    /// Write the throwaway project's `package.json` + `.npmrc` for an embedded
-    /// aube install. `allowBuilds` package lists go in `package.json` (aube's
-    /// manifest namespace); release age and trust-policy excludes go in
-    /// `.npmrc`, which aube's resolver reads from the project dir.
+    /// Write the throwaway project's `package.json` + aube config for an
+    /// embedded aube install. `allowBuilds` package lists go in `package.json`
+    /// (aube's manifest namespace); release age and trust-policy excludes go
+    /// in `.config/aube/config.toml`, which keeps aube-only keys out of npm's
+    /// config.
     fn write_aube_embed_project(
         &self,
         install_path: &Path,
@@ -1177,8 +1173,7 @@ impl NPMBackend {
     ) -> Result<()> {
         // Validate the fallible options before writing anything, so a malformed
         // value fails without leaving a half-written project dir behind.
-        let trust_policy_excludes = options.aube_trust_policy_excludes_npmrc_value()?;
-        let allow_low_downloads = options.allow_low_downloads()?;
+        let aube_config = self.aube_project_config(before_date, options, resolved_from_lockfile)?;
 
         let mut manifest = serde_json::json!({
             "name": "mise-npm-install",
@@ -1196,27 +1191,12 @@ impl NPMBackend {
             format!("{}\n", serde_json::to_string_pretty(&manifest)?),
         )?;
 
-        let mut npmrc = String::new();
-        if let Some(before_date) = before_date {
-            let minutes = Self::build_aube_minimum_release_age(elapsed_seconds_ceil(
-                before_date,
-                process_now(),
-            ));
-            // aube documents minimumReleaseAge in minutes, matching pnpm's setting.
-            npmrc.push_str(&format!("minimumReleaseAge={minutes}\n"));
-        }
-        if let Some(excludes) = trust_policy_excludes {
-            npmrc.push_str(&format!("trustPolicyExclude={excludes}\n"));
-        }
-        if allow_low_downloads || resolved_from_lockfile {
-            // Exempt only this tool's own package, not the whole install, so a
-            // transitive dependency below the threshold still fails the gate.
-            // aube gates the directly-requested packages, which for mise is
-            // always exactly this one. A matching mise.lock pin is itself
-            // approval for the download-count check.
-            npmrc.push_str(&format!("allowedUnpopularPackages={}\n", self.tool_name()));
-        }
-        crate::file::write(install_path.join(".npmrc"), npmrc)?;
+        let config_dir = install_path.join(".config/aube");
+        crate::file::create_dir_all(&config_dir)?;
+        crate::file::write(
+            config_dir.join("config.toml"),
+            format!("{}\n", toml::to_string_pretty(&aube_config)?),
+        )?;
         Ok(())
     }
 
@@ -1229,35 +1209,68 @@ impl NPMBackend {
         options: &NpmOptions<'_>,
         resolved_from_lockfile: bool,
     ) -> Result<()> {
-        let trust_policy_excludes = options.aube_trust_policy_excludes_npmrc_value()?;
-        let allow_low_downloads = options.allow_low_downloads()?;
         let bin_dir = install_path.join("bin");
         crate::file::create_dir_all(install_path)?;
         crate::file::create_dir_all(&bin_dir)?;
-        let mut npmrc = format!(
-            "globalDir={}\nglobalBinDir={}\n",
-            Self::npmrc_path_value(install_path),
-            Self::npmrc_path_value(&bin_dir)
+        let mut aube_config =
+            self.aube_project_config(before_date, options, resolved_from_lockfile)?;
+        aube_config.insert(
+            "globalDir".to_string(),
+            toml::Value::String(install_path.to_string_lossy().into_owned()),
         );
+        aube_config.insert(
+            "globalBinDir".to_string(),
+            toml::Value::String(bin_dir.to_string_lossy().into_owned()),
+        );
+        let config_dir = install_path.join(".config/aube");
+        crate::file::create_dir_all(&config_dir)?;
+        crate::file::write(
+            config_dir.join("config.toml"),
+            format!("{}\n", toml::to_string_pretty(&aube_config)?),
+        )?;
+        Ok(())
+    }
+
+    fn aube_project_config(
+        &self,
+        before_date: Option<Timestamp>,
+        options: &NpmOptions<'_>,
+        resolved_from_lockfile: bool,
+    ) -> Result<toml::Table> {
+        let trust_policy_excludes = options.trust_policy_excludes()?;
+        let allow_low_downloads = options.allow_low_downloads()?;
+        let mut config = toml::Table::new();
         if let Some(before_date) = before_date {
             let minutes = Self::build_aube_minimum_release_age(elapsed_seconds_ceil(
                 before_date,
                 process_now(),
             ));
-            npmrc.push_str(&format!("minimumReleaseAge={minutes}\n"));
+            config.insert(
+                "minimumReleaseAge".to_string(),
+                toml::Value::Integer(minutes.try_into()?),
+            );
         }
-        if let Some(excludes) = trust_policy_excludes {
-            npmrc.push_str(&format!("trustPolicyExclude={excludes}\n"));
+        if !trust_policy_excludes.is_empty() {
+            config.insert(
+                "trustPolicyExclude".to_string(),
+                toml::Value::Array(
+                    trust_policy_excludes
+                        .into_iter()
+                        .map(toml::Value::String)
+                        .collect(),
+                ),
+            );
         }
         if allow_low_downloads || resolved_from_lockfile {
-            npmrc.push_str(&format!("allowedUnpopularPackages={}\n", self.tool_name()));
+            // Exempt only this tool's own package, not the whole install, so a
+            // transitive dependency below the threshold still fails the gate.
+            // A matching mise.lock pin is itself approval for this check.
+            config.insert(
+                "allowedUnpopularPackages".to_string(),
+                toml::Value::Array(vec![toml::Value::String(self.tool_name())]),
+            );
         }
-        crate::file::write(install_path.join(".npmrc"), npmrc)?;
-        Ok(())
-    }
-
-    fn npmrc_path_value(path: &Path) -> String {
-        path.to_string_lossy().replace('\\', "/")
+        Ok(config)
     }
 
     fn build_aube_minimum_release_age(seconds: u64) -> u64 {
@@ -2623,7 +2636,7 @@ pkg@1.2.0 '1.2.0'
     }
 
     #[test]
-    fn test_write_aube_embed_project_emits_npmrc_and_manifest() {
+    fn test_write_aube_embed_project_emits_aube_config_and_manifest() {
         let backend = create_npm_backend("vercel");
         let tmp = tempfile::tempdir().unwrap();
         let install_path = tmp.path().join("npm-vercel").join("54.20.1");
@@ -2647,9 +2660,18 @@ pkg@1.2.0 '1.2.0'
             .write_aube_embed_project(&install_path, None, &options, &allow_builds, false)
             .unwrap();
 
-        // Trust-policy excludes go in .npmrc for the resolver to read.
-        let npmrc = std::fs::read_to_string(install_path.join(".npmrc")).unwrap();
-        assert!(npmrc.contains("trustPolicyExclude=undici,undici@^5\n"));
+        let config: toml::Table = toml::from_str(
+            &std::fs::read_to_string(install_path.join(".config/aube/config.toml")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            config["trustPolicyExclude"],
+            toml::Value::Array(vec![
+                toml::Value::String("undici".to_string()),
+                toml::Value::String("undici@^5".to_string()),
+            ])
+        );
+        assert!(!install_path.join(".npmrc").exists());
         // The build-script allowlist goes in package.json's aube namespace.
         let manifest: serde_json::Value =
             serde_json::from_slice(&std::fs::read(install_path.join("package.json")).unwrap())
@@ -2676,17 +2698,24 @@ pkg@1.2.0 '1.2.0'
             .write_aube_cli_project(&install_path, None, &options, true)
             .unwrap();
 
-        let npmrc = std::fs::read_to_string(install_path.join(".npmrc")).unwrap();
-        assert!(npmrc.contains(&format!(
-            "globalDir={}\n",
-            NPMBackend::npmrc_path_value(&install_path)
-        )));
-        assert!(npmrc.contains(&format!(
-            "globalBinDir={}\n",
-            NPMBackend::npmrc_path_value(&install_path.join("bin"))
-        )));
-        assert!(npmrc.contains("trustPolicyExclude=undici\n"));
-        assert!(npmrc.contains("allowedUnpopularPackages=vercel\n"));
+        let config: toml::Table = toml::from_str(
+            &std::fs::read_to_string(install_path.join(".config/aube/config.toml")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            config["globalDir"].as_str(),
+            Some(install_path.to_string_lossy().as_ref())
+        );
+        assert_eq!(
+            config["globalBinDir"].as_str(),
+            Some(install_path.join("bin").to_string_lossy().as_ref())
+        );
+        assert_eq!(config["trustPolicyExclude"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            config["allowedUnpopularPackages"].as_array().unwrap().len(),
+            1
+        );
+        assert!(!install_path.join(".npmrc").exists());
         assert!(install_path.join("bin").is_dir());
         assert!(!install_path.join("package.json").exists());
     }
@@ -2711,10 +2740,16 @@ pkg@1.2.0 '1.2.0'
 
         // Only the requested package is exempt — not a wildcard, so a
         // transitive dependency below the threshold still fails aube's gate.
-        let npmrc = std::fs::read_to_string(install_path.join(".npmrc")).unwrap();
-        assert!(npmrc.contains("allowedUnpopularPackages=bibtex-tidy\n"));
-        assert!(!npmrc.contains('*'));
-        assert!(!npmrc.contains("lowDownloadThreshold"));
+        let config: toml::Table = toml::from_str(
+            &std::fs::read_to_string(install_path.join(".config/aube/config.toml")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            config["allowedUnpopularPackages"],
+            toml::Value::Array(vec![toml::Value::String("bibtex-tidy".to_string())])
+        );
+        assert!(!config.contains_key("lowDownloadThreshold"));
+        assert!(!install_path.join(".npmrc").exists());
     }
 
     #[test]
@@ -2739,7 +2774,7 @@ pkg@1.2.0 '1.2.0'
         // Options are validated up front, so the aborted call leaves no
         // half-written project behind for a later step to trip over.
         assert!(!install_path.join("package.json").exists());
-        assert!(!install_path.join(".npmrc").exists());
+        assert!(!install_path.join(".config/aube/config.toml").exists());
     }
 
     #[test]
@@ -2776,8 +2811,12 @@ pkg@1.2.0 '1.2.0'
             .write_aube_embed_project(&install_path, None, &options, &allow_builds, false)
             .unwrap();
 
-        let npmrc = std::fs::read_to_string(install_path.join(".npmrc")).unwrap();
-        assert!(!npmrc.contains("allowedUnpopularPackages"));
+        let config: toml::Table = toml::from_str(
+            &std::fs::read_to_string(install_path.join(".config/aube/config.toml")).unwrap(),
+        )
+        .unwrap();
+        assert!(!config.contains_key("allowedUnpopularPackages"));
+        assert!(!install_path.join(".npmrc").exists());
     }
 
     #[test]
@@ -2794,8 +2833,14 @@ pkg@1.2.0 '1.2.0'
             .write_aube_embed_project(&install_path, None, &options, &allow_builds, true)
             .unwrap();
 
-        let npmrc = std::fs::read_to_string(install_path.join(".npmrc")).unwrap();
-        assert!(npmrc.contains("allowedUnpopularPackages=bibtex-tidy\n"));
+        let config: toml::Table = toml::from_str(
+            &std::fs::read_to_string(install_path.join(".config/aube/config.toml")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            config["allowedUnpopularPackages"],
+            toml::Value::Array(vec![toml::Value::String("bibtex-tidy".to_string())])
+        );
     }
 
     #[test]

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -4774,6 +4774,38 @@ run = 'echo "template"'
     }
 
     #[tokio::test]
+    async fn test_npm_table_syntax_preserves_aube_install_options() {
+        let _config = Config::get().await.unwrap();
+        let cf = parse(formatdoc! {r#"
+            [tools]
+            "npm:gws-axi" = {{
+                version = "0.17.0",
+                allow_low_downloads = true,
+                trust_policy_excludes = ["undici"]
+            }}
+        "#});
+        let trs = cf.to_tool_request_set().unwrap();
+        let request = trs
+            .tools
+            .iter()
+            .find(|(ba, _)| ba.short == "npm:gws-axi")
+            .map(|(_, requests)| &requests[0])
+            .expect("npm request should be in tool request set");
+        let options = request.options();
+
+        assert_eq!(
+            options.opts.get("allow_low_downloads"),
+            Some(&toml::Value::String("true".to_string()))
+        );
+        assert_eq!(
+            options.opts.get("trust_policy_excludes"),
+            Some(&toml::Value::Array(vec![toml::Value::String(
+                "undici".to_string()
+            )]))
+        );
+    }
+
+    #[tokio::test]
     async fn test_depends_field_parsing() {
         let _config = Config::get().await.unwrap();
         let cf = parse(formatdoc! {r#"

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -4793,6 +4793,7 @@ run = 'echo "template"'
             .expect("npm request should be in tool request set");
         let options = request.options();
 
+        // Backend scalar options are normalized to strings by ToolOptions.
         assert_eq!(
             options.opts.get("allow_low_downloads"),
             Some(&toml::Value::String("true".to_string()))


### PR DESCRIPTION
## Summary

- write embedded and standalone Aube settings to `.config/aube/config.toml`
- preserve per-tool trust and download exceptions as typed TOML arrays
- cover the reported inline-table configuration and assert installs do not create a synthetic `.npmrc`

Related to https://github.com/jdx/mise/discussions/12424.

## Testing

- `cargo test --locked --bin mise write_aube_ -- --nocapture`
- `cargo test --locked --bin mise test_npm_table_syntax_preserves_aube_install_options -- --nocapture`
- `mise run lint-fix`
- `mise run test:e2e e2e/backend/test_npm_aube`
- exact `npm:gws-axi@0.17.0` reproduction from the discussion

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where embedded and CLI aube installs read trust and download gates, but behavior is intended to be equivalent and is covered by unit and e2e tests.
> 
> **Overview**
> **Aube-backed npm installs** no longer drop a synthetic **`.npmrc`** in the per-tool install directory. Install-scoped settings (**`minimumReleaseAge`**, **`trustPolicyExclude`**, **`allowedUnpopularPackages`**, and for CLI installs **`globalDir` / `globalBinDir`**) now go in **`.config/aube/config.toml`** as typed TOML (arrays where appropriate), via a shared **`aube_project_config`** helper used by both embedded and standalone aube paths.
> 
> **`allowBuilds`** stays in **`package.json`** under the aube namespace; only the aube-only resolver keys moved off npm’s config surface.
> 
> Docs under the npm backend now describe the new file paths. E2E **`test_npm_aube`** asserts the config file exists and **`.npmrc`** does not; unit tests and a new **`mise.toml`** parse test confirm inline-table **`trust_policy_excludes`** / **`allow_low_downloads`** still round-trip into install options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28ca6fe742728275b747cfd92b0dc11b26d35faa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated npm backend documentation to clarify that install-scoped settings are stored in aube’s configuration file.

* **Bug Fixes**
  * npm installations now use aube configuration instead of generating an `.npmrc` file.
  * Preserved trust-policy exclusions and low-download package settings.
  * Added support for CLI-specific npm directories in the generated configuration.

* **Tests**
  * Added coverage confirming configuration creation, `.npmrc` absence, and preservation of npm settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->