### PR TITLE
feat(exec): add temporary tool overlay syntax

### DIFF
--- a/docs/cli/exec.md
+++ b/docs/cli/exec.md
@@ -14,6 +14,8 @@ Note that only the plugin specified will be overridden, so if a `mise.toml` file
 includes "node 20" but you run `mise exec python@3.11`; it will still load node@20.
 
 The "--" separates runtimes from the commands to pass along to the subprocess.
+Prefix tools with "+" to make the command boundary implicit, e.g.
+`mise x +node@22 node -v`.
 
 ## Arguments
 - **`[TOOL@VERSION]…`** — Tool(s) to start e.g.: node@20 python@3.10
@@ -47,6 +49,7 @@ Examples:
 ```
 $ mise exec node@20 -- node ./app.js  # launch app.js using node-20.x
 $ mise x node@20 -- node ./app.js     # shorter alias
+$ mise x +node@22 node -v             # +tool makes -- optional
 
 # Specify command as a string:
 $ mise exec node@20 python@3.11 --command "node -v && python -V"

--- a/docs/dev-tools/index.md
+++ b/docs/dev-tools/index.md
@@ -399,6 +399,17 @@ $ mise x -- node -v
 20.x.x
 ```
 
+Prefix an explicitly selected tool with `+` to make the command boundary implicit:
+
+```sh
+mise x +python@3.12 ./myscript.py
+mise x +node@22 +python@3.12 node ./build.js
+```
+
+Leading `+TOOL@VERSION` arguments are temporary tool overlays. The first ordinary positional
+argument is the command, so the equivalent long form remains
+`mise x python@3.12 -- ./myscript.py`.
+
 ::: tip
 If you use this a lot, an alias can be helpful:
 

--- a/e2e/cli/test_exec_tool_overlay
+++ b/e2e/cli/test_exec_tool_overlay
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+assert_contains "mise x +dummy@1.0.0 dummy" "Dummy 1.0.0"
+assert_contains "mise x +dummy@2.0.0 -c dummy" "Dummy 2.0.0"
+assert_contains "mise x +dummy@1.0.0 +tiny@1.0.1 sh -c 'dummy; rtx-tiny'" "rtx-tiny: v1.0.1"
+
+# Without a sigil, exec keeps its existing explicit `--` boundary.
+assert_fail "mise x dummy@1.0.0 dummy"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2529,6 +2529,8 @@ Note that only the plugin specified will be overridden, so if a `mise.toml` file
 includes "node 20" but you run `mise exec python@3.11`; it will still load node@20.
 
 The "\-\-" separates runtimes from the commands to pass along to the subprocess.
+Prefix tools with "+" to make the command boundary implicit, e.g.
+`mise x +node@22 node \-v`.
 .PP
 \fBUsage:\fR mise exec [OPTIONS] [<TOOL@VERSION>] ... [<COMMAND>] ...
 .PP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1538,8 +1538,10 @@ Note that only the plugin specified will be overridden, so if a `mise.toml` file
 includes "node 20" but you run `mise exec python@3.11`; it will still load node@20.
 
 The "--" separates runtimes from the commands to pass along to the subprocess.
+Prefix tools with "+" to make the command boundary implicit, e.g.
+`mise x +node@22 node -v`.
 """#
-    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise exec node@20 -- node ./app.js\u{1b}[22m  # launch app.js using node-20.x\n    $ \u{1b}[1mmise x node@20 -- node ./app.js\u{1b}[22m     # shorter alias\n\n    # Specify command as a string:\n    $ \u{1b}[1mmise exec node@20 python@3.11 --command \"node -v && python -V\"\u{1b}[22m\n\n    # Run a command in a different directory:\n    $ \u{1b}[1mmise x -C /path/to/project node@20 -- node ./app.js\u{1b}[22m\n"
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise exec node@20 -- node ./app.js\u{1b}[22m  # launch app.js using node-20.x\n    $ \u{1b}[1mmise x node@20 -- node ./app.js\u{1b}[22m     # shorter alias\n    $ \u{1b}[1mmise x +node@22 node -v\u{1b}[22m             # +tool makes -- optional\n\n    # Specify command as a string:\n    $ \u{1b}[1mmise exec node@20 python@3.11 --command \"node -v && python -V\"\u{1b}[22m\n\n    # Run a command in a different directory:\n    $ \u{1b}[1mmise x -C /path/to/project node@20 -- node ./app.js\u{1b}[22m\n"
     flag "-c --command" help="Command string to execute" conflicts=COMMAND {
         arg <COMMAND>
     }

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -28,6 +28,8 @@ use crate::toolset::{InstallOptions, ResolveOptions, Toolset, ToolsetBuilder};
 /// includes "node 20" but you run `mise exec python@3.11`; it will still load node@20.
 ///
 /// The "--" separates runtimes from the commands to pass along to the subprocess.
+/// Prefix tools with "+" to make the command boundary implicit, e.g.
+/// `mise x +node@22 node -v`.
 #[derive(Debug, usage_rs::Args)]
 #[usage(visible_alias = "x", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(crate) struct Exec {
@@ -631,6 +633,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
     $ <bold>mise exec node@20 -- node ./app.js</bold>  # launch app.js using node-20.x
     $ <bold>mise x node@20 -- node ./app.js</bold>     # shorter alias
+    $ <bold>mise x +node@22 node -v</bold>             # +tool makes -- optional
 
     # Specify command as a string:
     $ <bold>mise exec node@20 python@3.11 --command "node -v && python -V"</bold>

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -431,9 +431,7 @@ fn find_subcommand<'a>(
 ) -> Option<&'a usage_rs::Command<'a>> {
     cmd.subcommands
         .iter()
-        .find(|subcommand| {
-            subcommand.name == name || subcommand.aliases.iter().any(|alias| *alias == name)
-        })
+        .find(|subcommand| subcommand.name == name || subcommand.aliases.contains(&name))
         .copied()
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -425,19 +425,35 @@ fn get_global_flags(cmd: &usage_rs::Command<'_>) -> (Vec<String>, Vec<String>) {
     (flags_with_values, boolean_flags)
 }
 
-/// Get all flags (with values and boolean) from both global Cli and Run subcommand
-fn get_all_run_flags(cmd: &usage_rs::Command<'_>) -> (Vec<String>, Vec<String>) {
+fn find_subcommand<'a>(
+    cmd: &'a usage_rs::Command<'a>,
+    name: &str,
+) -> Option<&'a usage_rs::Command<'a>> {
+    cmd.subcommands
+        .iter()
+        .find(|subcommand| {
+            subcommand.name == name || subcommand.aliases.iter().any(|alias| *alias == name)
+        })
+        .copied()
+}
+
+/// Get all flags (with values and boolean) from both the root CLI and a subcommand.
+fn get_all_subcommand_flags(cmd: &usage_rs::Command<'_>, name: &str) -> (Vec<String>, Vec<String>) {
     // Get global flags from Cli
     let (mut flags_with_values, mut boolean_flags) = get_global_flags(cmd);
 
-    // Get run-specific flags from Run subcommand
-    if let Some(run_cmd) = cmd.subcommands.iter().find(|s| s.name == "run") {
-        let (run_vals, run_bools) = get_global_flags(run_cmd);
-        flags_with_values.extend(run_vals);
-        boolean_flags.extend(run_bools);
+    if let Some(subcommand) = find_subcommand(cmd, name) {
+        let (values, booleans) = get_global_flags(subcommand);
+        flags_with_values.extend(values);
+        boolean_flags.extend(booleans);
     }
 
     (flags_with_values, boolean_flags)
+}
+
+/// Get all flags (with values and boolean) from both global Cli and Run subcommand
+fn get_all_run_flags(cmd: &usage_rs::Command<'_>) -> (Vec<String>, Vec<String>) {
+    get_all_subcommand_flags(cmd, "run")
 }
 
 fn get_value_taking_short_flags(cmd: &usage_rs::Command<'_>) -> Vec<(String, String)> {
@@ -449,16 +465,19 @@ fn get_value_taking_short_flags(cmd: &usage_rs::Command<'_>) -> Vec<(String, Str
         .collect()
 }
 
-fn get_all_run_value_taking_short_flags(cmd: &usage_rs::Command<'_>) -> Vec<(String, String)> {
+fn get_all_subcommand_value_taking_short_flags(
+    cmd: &usage_rs::Command<'_>,
+    name: &str,
+) -> Vec<(String, String)> {
     let mut flags = get_value_taking_short_flags(cmd);
-    if let Some(run_cmd) = cmd
-        .subcommands
-        .iter()
-        .find(|subcommand| subcommand.name == "run")
-    {
-        flags.extend(get_value_taking_short_flags(run_cmd));
+    if let Some(subcommand) = find_subcommand(cmd, name) {
+        flags.extend(get_value_taking_short_flags(subcommand));
     }
     flags
+}
+
+fn get_all_run_value_taking_short_flags(cmd: &usage_rs::Command<'_>) -> Vec<(String, String)> {
+    get_all_subcommand_value_taking_short_flags(cmd, "run")
 }
 
 /// Prefix used to escape flags that should be passed to tasks, not mise
@@ -726,6 +745,84 @@ pub(crate) fn unescape_task_args(args: &[String]) -> Vec<String> {
         .collect()
 }
 
+#[derive(Debug, Eq, PartialEq)]
+enum ToolOverlayRewrite {
+    Unchanged,
+    Rewritten(Vec<String>),
+}
+
+/// Rewrite leading `+TOOL@VERSION` arguments for commands that support temporary tool overlays.
+///
+/// `mise x +node@27 node -v` becomes `mise x node@27 -- node -v`. The explicit sigil makes the
+/// otherwise ambiguous boundary between exec's variadic tool list and its command visible without
+/// requiring the user to type `--`.
+fn rewrite_tool_overlay_args(cmd: &usage_rs::Command<'_>, args: &[String]) -> ToolOverlayRewrite {
+    let Some(subcommand_idx) = first_non_global_arg_idx(cmd, args) else {
+        return ToolOverlayRewrite::Unchanged;
+    };
+    let subcommand_name = args[subcommand_idx].as_str();
+    let Some(subcommand) = find_subcommand(cmd, subcommand_name) else {
+        return ToolOverlayRewrite::Unchanged;
+    };
+    if subcommand.name != "exec" {
+        return ToolOverlayRewrite::Unchanged;
+    }
+
+    let (flags_with_values, _) = get_all_subcommand_flags(cmd, subcommand_name);
+    let short_flags_with_values = get_all_subcommand_value_taking_short_flags(cmd, subcommand_name);
+    let mut overlay_indices = Vec::new();
+    let mut boundary_idx = None;
+    let mut i = subcommand_idx + 1;
+
+    while i < args.len() {
+        let arg = &args[i];
+        if arg == "--" {
+            boundary_idx = Some(i);
+            break;
+        }
+        if arg.strip_prefix('+').is_some_and(|tool| !tool.is_empty()) {
+            overlay_indices.push(i);
+            i += 1;
+            continue;
+        }
+        if arg.starts_with('-') && arg != "-" {
+            let takes_separate_value = if arg.starts_with("--") {
+                !arg.contains('=') && flags_with_values.iter().any(|flag| flag == arg)
+            } else {
+                short_flags_with_values
+                    .iter()
+                    .any(|(short, _)| arg == short)
+            };
+            i += usize::from(takes_separate_value && i + 1 < args.len()) + 1;
+            continue;
+        }
+        boundary_idx = Some(i);
+        break;
+    }
+
+    if overlay_indices.is_empty() {
+        return ToolOverlayRewrite::Unchanged;
+    }
+
+    let mut rewritten = args.to_vec();
+    for idx in overlay_indices {
+        rewritten[idx].remove(0);
+    }
+    if let Some(boundary_idx) = boundary_idx
+        && rewritten[boundary_idx] != "--"
+    {
+        rewritten.insert(boundary_idx, "--".to_string());
+    }
+    ToolOverlayRewrite::Rewritten(rewritten)
+}
+
+fn preprocess_tool_overlay_args(cmd: &usage_rs::Command<'_>, args: &[String]) -> Vec<String> {
+    match rewrite_tool_overlay_args(cmd, args) {
+        ToolOverlayRewrite::Unchanged => args.to_vec(),
+        ToolOverlayRewrite::Rewritten(args) => args,
+    }
+}
+
 fn preprocess_args_for_naked_run(cmd: &usage_rs::Command<'_>, args: &[String]) -> Vec<String> {
     // Check if this might be a naked run (no subcommand)
     if args.len() < 2 {
@@ -807,6 +904,7 @@ impl Cli {
         // Pre-process args to handle naked runs before parsing
         let cmd = measure!("build_cli_command", { Cli::command() });
         let processed_args = preprocess_args_for_naked_run(cmd, args);
+        let processed_args = preprocess_tool_overlay_args(cmd, &processed_args);
         // Escape flags after task names so they go to tasks, not mise
         let processed_args = escape_task_args(cmd, &processed_args);
         let deprecated_backends_alias = uses_deprecated_backends_alias(cmd, args);
@@ -1092,6 +1190,104 @@ mod tests {
     fn parse_cli<'a>(args: &'a [&'a str]) -> std::result::Result<Cli, usage_rs::Error<'a, 'a>> {
         let argv: Vec<&std::ffi::OsStr> = args.iter().map(std::ffi::OsStr::new).collect();
         Cli::parse_from_argv(&argv)
+    }
+
+    fn strings(args: &[&str]) -> Vec<String> {
+        args.iter().map(|arg| (*arg).to_string()).collect()
+    }
+
+    #[test]
+    fn test_rewrite_exec_tool_overlays() {
+        let cmd = Cli::command();
+        let cases = [
+            (
+                strings(&["mise", "x", "+node@27", "node", "-v"]),
+                strings(&["mise", "x", "node@27", "--", "node", "-v"]),
+            ),
+            (
+                strings(&[
+                    "mise",
+                    "exec",
+                    "+node@27",
+                    "+python@3.14",
+                    "--",
+                    "python",
+                    "app.py",
+                ]),
+                strings(&[
+                    "mise",
+                    "exec",
+                    "node@27",
+                    "python@3.14",
+                    "--",
+                    "python",
+                    "app.py",
+                ]),
+            ),
+            (
+                strings(&["mise", "x", "-j2", "+node@27", "node"]),
+                strings(&["mise", "x", "-j2", "node@27", "--", "node"]),
+            ),
+            (
+                strings(&["mise", "x", "+node@27", "-j", "2", "node"]),
+                strings(&["mise", "x", "node@27", "-j", "2", "--", "node"]),
+            ),
+            (
+                strings(&["mise", "x", "+node@27", "-c", "node -v"]),
+                strings(&["mise", "x", "node@27", "-c", "node -v"]),
+            ),
+            (
+                strings(&["mise", "--cd", "project", "x", "+node@27", "node"]),
+                strings(&["mise", "--cd", "project", "x", "node@27", "--", "node"]),
+            ),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(
+                rewrite_tool_overlay_args(cmd, &input),
+                ToolOverlayRewrite::Rewritten(expected),
+                "input: {input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_exec_tool_overlay_rewrite_leaves_existing_grammar_alone() {
+        let cmd = Cli::command();
+        for input in [
+            strings(&["mise", "x", "--", "+node@27"]),
+            strings(&["mise", "x", "node@27", "node", "-v"]),
+            strings(&["mise", "x", "node", "+node@27"]),
+            strings(&["mise", "run", "+node@27", "build"]),
+        ] {
+            assert_eq!(
+                rewrite_tool_overlay_args(cmd, &input),
+                ToolOverlayRewrite::Unchanged,
+                "input: {input:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_exec_tool_overlay_rewrite_round_trips_through_parser() {
+        crate::toolset::install_state::init().await.unwrap();
+        let cmd = Cli::command();
+        let input = strings(&["mise", "x", "-j2", "+node@27", "+python@3.14", "node", "-v"]);
+        let rewritten = preprocess_tool_overlay_args(cmd, &input);
+        let refs = rewritten.iter().map(String::as_str).collect::<Vec<_>>();
+        let cli = parse_cli(&refs).unwrap();
+        let Some(Commands::Exec(exec)) = cli.command else {
+            panic!("expected exec command");
+        };
+        assert_eq!(
+            exec.tool
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            ["node@27", "python@3.14"]
+        );
+        assert_eq!(exec.command, Some(strings(&["node", "-v"])));
+        assert_eq!(exec.jobs, Some(2));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- accept +TOOL@VERSION operands in mise exec and mise x
- resolve and install overlays through the normal tool request pipeline
- keep overlay tokens out of the executed command argv
- preserve explicit double dash behavior and existing command syntax
- document and test multiple overlays and backend-qualified requests

## Dependency
- Depends on jdx/usage#1322 and a published usage 6.5 release
- CI may fail until that dependency is available and mise is updated to it

## Test plan
- focused exec overlay unit and e2e tests
- mise run lint-fix
- mise run render

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shorthand syntax for `mise exec` and `mise x`: prefix tools with `+` to omit the explicit `--` command separator.
  * Supports multiple temporary tool overlays, such as `+node@22` and `+tiny@1.0.1`.

* **Documentation**
  * Updated command help, manuals, and developer documentation with the new syntax and examples.

* **Tests**
  * Added end-to-end coverage for single and multiple tool overlays, command handling, and invalid usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global argv preprocessing for every `mise` invocation when `exec` is used with `+` overlays; mistakes in boundary detection could mis-parse tools vs command, though tests cover flags and edge cases.
> 
> **Overview**
> **`mise exec` / `mise x`** now accept leading **`+TOOL@VERSION`** operands so you can skip the explicit `--` before the command (e.g. `mise x +node@22 node -v`). Multiple overlays are supported; the first non-overlay positional still starts the subprocess argv.
> 
> Before parsing, **`rewrite_tool_overlay_args`** in `src/cli/mod.rs` strips the `+` sigil, inserts `--` at the tool/command boundary when needed, and skips rewrite for other subcommands or when no `+` overlays appear—existing `node@20 -- …` and ambiguous forms without `+` stay unchanged.
> 
> CLI flag discovery was generalized (`find_subcommand`, `get_all_subcommand_flags`) so exec flags are respected during the rewrite. Docs, generated usage (`mise.usage.kdl`), man page, unit tests, and an e2e script cover the new syntax.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a926c1a9a5e7db28bf548d100ffdc194a9f2628. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->