### PR TITLE
feat(task): add gated temporary tool overlays

### DIFF
--- a/docs/cli/env.md
+++ b/docs/cli/env.md
@@ -10,6 +10,8 @@ Exports env vars to activate mise a single time
 
 Use this if you don't want to permanently install mise. It's not necessary to
 use this if you have `mise activate` in your shell rc file.
+Tools may be prefixed with `+` to make their temporary overlay role explicit, e.g.
+`mise env +node@22`.
 
 ## Arguments
 - **`[TOOL@VERSION]…`** — Tool(s) to use

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -13,6 +13,9 @@ If source is configured on a task, it will only run if the source
 files have changed.
 
 Tasks can be defined in mise.toml or as standalone scripts.
+When `task.run_tool_overlay` is enabled, leading `+TOOL@VERSION` arguments temporarily add or
+override tools for the invocation. For example, `mise run +node@22 build` is equivalent to
+`mise run --tool node@22 build`.
 In mise.toml, tasks take this form:
 
 ```
@@ -140,6 +143,9 @@ $ mise run --raw test
 
 # Runs the "lint", "test", and "check" tasks in parallel.
 $ mise run lint ::: test ::: check
+
+# Run "build" with a temporary Node.js version (requires task.run_tool_overlay).
+$ mise run +node@22 build
 
 # Execute multiple tasks each with their own arguments.
 $ mise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2

--- a/docs/cli/shell.md
+++ b/docs/cli/shell.md
@@ -12,6 +12,7 @@ Only works in a session where mise is already activated.
 
 This works by setting environment variables for the current shell session
 such as `MISE_NODE_VERSION=20` which is "eval"ed as a shell function created by `mise activate`.
+Tools may be prefixed with `+`, e.g. `mise shell +node@22`.
 
 ## Arguments
 - **`<TOOL@VERSION>…`** — Tool(s) to use

--- a/docs/cli/tasks/run.md
+++ b/docs/cli/tasks/run.md
@@ -13,6 +13,9 @@ If source is configured on a task, it will only run if the source
 files have changed.
 
 Tasks can be defined in mise.toml or as standalone scripts.
+When `task.run_tool_overlay` is enabled, leading `+TOOL@VERSION` arguments temporarily add or
+override tools for the invocation. For example, `mise run +node@22 build` is equivalent to
+`mise run --tool node@22 build`.
 In mise.toml, tasks take this form:
 
 ```
@@ -140,6 +143,9 @@ $ mise run --raw test
 
 # Runs the "lint", "test", and "check" tasks in parallel.
 $ mise run lint ::: test ::: check
+
+# Run "build" with a temporary Node.js version (requires task.run_tool_overlay).
+$ mise run +node@22 build
 
 # Execute multiple tasks each with their own arguments.
 $ mise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2

--- a/docs/cli/watch.md
+++ b/docs/cli/watch.md
@@ -9,6 +9,8 @@ Run task(s) and watch for changes to rerun it
 
 This command uses the `watchexec` tool to watch for changes to files and rerun the specified task(s).
 It must be installed for this command to work, but you can install it with `mise use -g watchexec@latest`.
+When `task.run_tool_overlay` is enabled, use `mise watch +node@22 build` to rerun a task with a
+temporary tool version.
 
 For more advanced process management (daemon management, auto-restart, readiness checks,
 cron scheduling), see mise's sister project: https://pitchfork.jdx.dev
@@ -22,6 +24,7 @@ cron scheduling), see mise's sister project: https://pitchfork.jdx.dev
 
 ## Flags
 - **`--skip-deps`** — Run only the specified tasks skipping all dependencies
+- **`-T --tool <TOOL@VERSION>`** — Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10
 - **`-o --on-busy-update <MODE>`** — What to do when receiving events while the command is running
 
   Default is to 'do-nothing', which ignores events while the command is running, so that changes that occur due to the command are ignored, like compilation outputs. You can also use 'queue' which will run the command once again when the current run has finished if any events occur while it's running, or 'restart', which terminates the running command and starts a new one. Finally, there's 'signal', which only sends a signal; this can be useful with programs that can reload their configuration without a full restart.

--- a/docs/cli/which.md
+++ b/docs/cli/which.md
@@ -8,6 +8,7 @@
 Shows the path that a tool's bin points to.
 
 Use this to figure out what version of a tool is currently active.
+A leading tool overlay can replace `--tool`, e.g. `mise which +node@22 npm`.
 
 ## Arguments
 - **`[BIN_NAME]`** — The bin to look up

--- a/docs/tasks/running-tasks.md
+++ b/docs/tasks/running-tasks.md
@@ -37,6 +37,25 @@ Extra arguments will be passed to the task, for example, if we want to run in re
 mise run build --release
 ```
 
+## Temporary tool overlays
+
+Enable [`task.run_tool_overlay`](/configuration/settings.html#task-run-tool-overlay) to select tool
+versions for one task invocation with leading `+TOOL@VERSION` arguments:
+
+```bash
+mise run +node@22 +pnpm@10 build
+mise +node@22 build
+mise watch +node@22 build
+```
+
+This is shorthand for `mise run --tool node@22 --tool pnpm@10 build`. Overlays are recognized only
+before the first task name and never after the `:::` separator, so `+argument` remains an ordinary
+task argument in `mise run build +argument`.
+
+Task names beginning with `+` are deprecated because this syntax will become enabled by default in
+mise 2027.3.0. Until then, the setting defaults to false so existing `+`-prefixed tasks continue to
+run. Rename those tasks before the default changes.
+
 For a precise, validated task interface, define arguments and flags with the
 [`usage` field](/tasks/task-arguments#usage-field). Without a `usage` specification, extra arguments
 are forwarded according to how the task is executed:

--- a/e2e/tasks/test_task_plus_name_deprecation
+++ b/e2e/tasks/test_task_plus_name_deprecation
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[tasks."+weird"]
+run = "echo weird"
+EOF
+
+# The compatibility default still treats a leading `+` as a task name.
+assert "mise run +weird" "weird"
+
+# With overlays enabled, the old task spelling is interpreted as a tool and the
+# error explains the migration.
+assert_fail_contains \
+  "MISE_TASK_RUN_TOOL_OVERLAY=1 mise run +weird" \
+  "was interpreted as a temporary tool overlay"

--- a/e2e/tasks/test_task_tool_overlay
+++ b/e2e/tasks/test_task_tool_overlay
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[tasks.show]
+run = "dummy"
+EOF
+
+assert_contains "MISE_TASK_RUN_TOOL_OVERLAY=1 mise run +dummy@2.0.0 show" "Dummy 2.0.0"
+assert_contains "MISE_TASK_RUN_TOOL_OVERLAY=1 mise tasks run +dummy@2.0.0 show" "Dummy 2.0.0"
+assert_contains "MISE_TASK_RUN_TOOL_OVERLAY=1 mise +dummy@1.0.0 show" "Dummy 1.0.0"
+assert_contains "mise run --tool dummy@2.0.0 show" "Dummy 2.0.0"
+
+# Once the task name is seen, `+` arguments belong to the task.
+assert_contains "MISE_TASK_RUN_TOOL_OVERLAY=1 mise run +dummy@1.0.0 show +literal" "+literal"
+
+# The same overlay notation is available to environment-oriented commands.
+assert_contains "mise which +dummy@1.0.0 dummy" "/dummy/1.0.0/"
+assert_contains "mise env +dummy@1.0.0 --json" "/dummy/1.0.0/bin"

--- a/e2e/tasks/test_task_tool_overlay
+++ b/e2e/tasks/test_task_tool_overlay
@@ -10,6 +10,19 @@ assert_contains "MISE_TASK_RUN_TOOL_OVERLAY=1 mise tasks run +dummy@2.0.0 show" 
 assert_contains "MISE_TASK_RUN_TOOL_OVERLAY=1 mise +dummy@1.0.0 show" "Dummy 1.0.0"
 assert_contains "mise run --tool dummy@2.0.0 show" "Dummy 2.0.0"
 
+mkdir project
+cat <<'EOF' >project/mise.toml
+[settings]
+task.run_tool_overlay = true
+
+[tasks.show]
+run = "dummy"
+EOF
+
+# The gate is loaded from the project selected by a global or run-local --cd.
+assert_contains "mise --cd project run +dummy@2.0.0 show" "Dummy 2.0.0"
+assert_contains "mise run --cd project +dummy@1.0.0 show" "Dummy 1.0.0"
+
 # Once the task name is seen, `+` arguments belong to the task.
 assert_contains "MISE_TASK_RUN_TOOL_OVERLAY=1 mise run +dummy@1.0.0 show +literal" "+literal"
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2488,6 +2488,8 @@ Exports env vars to activate mise a single time
 
 Use this if you don't want to permanently install mise. It's not necessary to
 use this if you have `mise activate` in your shell rc file.
+Tools may be prefixed with `+` to make their temporary overlay role explicit, e.g.
+`mise env +node@22`.
 .PP
 \fBUsage:\fR mise env [OPTIONS] [<TOOL@VERSION>] ...
 .PP
@@ -4103,6 +4105,9 @@ If source is configured on a task, it will only run if the source
 files have changed.
 
 Tasks can be defined in mise.toml or as standalone scripts.
+When `task.run_tool_overlay` is enabled, leading `+TOOL@VERSION` arguments temporarily add or
+override tools for the invocation. For example, `mise run +node@22 build` is equivalent to
+`mise run \-\-tool node@22 build`.
 In mise.toml, tasks take this form:
 
     [tasks.build]
@@ -4607,6 +4612,7 @@ Only works in a session where mise is already activated.
 
 This works by setting environment variables for the current shell session
 such as `MISE_NODE_VERSION=20` which is "eval"ed as a shell function created by `mise activate`.
+Tools may be prefixed with `+`, e.g. `mise shell +node@22`.
 .PP
 \fBUsage:\fR mise shell [OPTIONS] <TOOL@VERSION> ...
 .PP
@@ -5055,6 +5061,9 @@ If source is configured on a task, it will only run if the source
 files have changed.
 
 Tasks can be defined in mise.toml or as standalone scripts.
+When `task.run_tool_overlay` is enabled, leading `+TOOL@VERSION` arguments temporarily add or
+override tools for the invocation. For example, `mise run +node@22 build` is equivalent to
+`mise run \-\-tool node@22 build`.
 In mise.toml, tasks take this form:
 
     [tasks.build]
@@ -5858,6 +5867,8 @@ Run task(s) and watch for changes to rerun it
 
 This command uses the `watchexec` tool to watch for changes to files and rerun the specified task(s).
 It must be installed for this command to work, but you can install it with `mise use \-g watchexec@latest`.
+When `task.run_tool_overlay` is enabled, use `mise watch +node@22 build` to rerun a task with a
+temporary tool version.
 
 For more advanced process management (daemon management, auto\-restart, readiness checks,
 cron scheduling), see mise's sister project: https://pitchfork.jdx.dev
@@ -5876,6 +5887,9 @@ Defaults to sources from the task(s)
 .TP
 \fB\-\-skip\-deps\fR
 Run only the specified tasks skipping all dependencies
+.TP
+\fB\-T, \-\-tool\fR \fI<TOOL@VERSION>\fR
+Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10
 .TP
 \fB\-w, \-\-watch\fR \fI<PATH>\fR
 Watch a specific file or directory
@@ -6441,6 +6455,7 @@ used for asdf compatibility
 Shows the path that a tool's bin points to.
 
 Use this to figure out what version of a tool is currently active.
+A leading tool overlay can replace `\-\-tool`, e.g. `mise which +node@22 npm`.
 .PP
 \fBUsage:\fR mise which [OPTIONS] [<BIN_NAME>]
 .PP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1501,6 +1501,8 @@ Exports env vars to activate mise a single time
 
 Use this if you don't want to permanently install mise. It's not necessary to
 use this if you have `mise activate` in your shell rc file.
+Tools may be prefixed with `+` to make their temporary overlay role explicit, e.g.
+`mise env +node@22`.
 """#
     after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1meval \"$(mise env -s bash)\"\u{1b}[22m\n    $ \u{1b}[1meval \"$(mise env -s zsh)\"\u{1b}[22m\n    $ \u{1b}[1mmise env -s fish | source\u{1b}[22m\n    $ \u{1b}[1mexecx($(mise env -s xonsh))\u{1b}[22m\n"
     flag "-D --dotenv" help="Output in dotenv format" overrides=--shell
@@ -3024,6 +3026,9 @@ If source is configured on a task, it will only run if the source
 files have changed.
 
 Tasks can be defined in mise.toml or as standalone scripts.
+When `task.run_tool_overlay` is enabled, leading `+TOOL@VERSION` arguments temporarily add or
+override tools for the invocation. For example, `mise run +node@22 build` is equivalent to
+`mise run --tool node@22 build`.
 In mise.toml, tasks take this form:
 
     [tasks.build]
@@ -3042,7 +3047,7 @@ The name of the script will be the name of the tasks.
     EOF
     $ mise run build
 """#
-    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Runs the \"lint\" tasks. This needs to either be defined in mise.toml\n    # or as a standalone script. See the project README for more information.\n    $ \u{1b}[1mmise run lint\u{1b}[22m\n\n    # Forces the \"build\" tasks to run even if its sources are up-to-date.\n    $ \u{1b}[1mmise run --force build\u{1b}[22m\n\n    # Run \"test\" with stdin/stdout/stderr all connected to the current terminal.\n    # This forces `--jobs=1` to prevent interleaving of output.\n    $ \u{1b}[1mmise run --raw test\u{1b}[22m\n\n    # Runs the \"lint\", \"test\", and \"check\" tasks in parallel.\n    $ \u{1b}[1mmise run lint ::: test ::: check\u{1b}[22m\n\n    # Execute multiple tasks each with their own arguments.\n    $ \u{1b}[1mmise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2\u{1b}[22m\n"
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Runs the \"lint\" tasks. This needs to either be defined in mise.toml\n    # or as a standalone script. See the project README for more information.\n    $ \u{1b}[1mmise run lint\u{1b}[22m\n\n    # Forces the \"build\" tasks to run even if its sources are up-to-date.\n    $ \u{1b}[1mmise run --force build\u{1b}[22m\n\n    # Run \"test\" with stdin/stdout/stderr all connected to the current terminal.\n    # This forces `--jobs=1` to prevent interleaving of output.\n    $ \u{1b}[1mmise run --raw test\u{1b}[22m\n\n    # Runs the \"lint\", \"test\", and \"check\" tasks in parallel.\n    $ \u{1b}[1mmise run lint ::: test ::: check\u{1b}[22m\n\n    # Run \"build\" with a temporary Node.js version (requires task.run_tool_overlay).\n    $ \u{1b}[1mmise run +node@22 build\u{1b}[22m\n\n    # Execute multiple tasks each with their own arguments.\n    $ \u{1b}[1mmise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2\u{1b}[22m\n"
     flag --affected help="Run matching tasks only for projects affected by Git changes"
     flag --affected-base help=#"""
 Git base revision for --affected
@@ -3411,6 +3416,7 @@ Only works in a session where mise is already activated.
 
 This works by setting environment variables for the current shell session
 such as `MISE_NODE_VERSION=20` which is "eval"ed as a shell function created by `mise activate`.
+Tools may be prefixed with `+`, e.g. `mise shell +node@22`.
 """#
     after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise shell node@20\u{1b}[22m\n    $ \u{1b}[1mnode -v\u{1b}[22m\n    v20.0.0\n"
     flag "-j --jobs" help=#"""
@@ -3704,6 +3710,9 @@ If source is configured on a task, it will only run if the source
 files have changed.
 
 Tasks can be defined in mise.toml or as standalone scripts.
+When `task.run_tool_overlay` is enabled, leading `+TOOL@VERSION` arguments temporarily add or
+override tools for the invocation. For example, `mise run +node@22 build` is equivalent to
+`mise run --tool node@22 build`.
 In mise.toml, tasks take this form:
 
     [tasks.build]
@@ -3722,7 +3731,7 @@ The name of the script will be the name of the tasks.
     EOF
     $ mise run build
 """#
-        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Runs the \"lint\" tasks. This needs to either be defined in mise.toml\n    # or as a standalone script. See the project README for more information.\n    $ \u{1b}[1mmise run lint\u{1b}[22m\n\n    # Forces the \"build\" tasks to run even if its sources are up-to-date.\n    $ \u{1b}[1mmise run --force build\u{1b}[22m\n\n    # Run \"test\" with stdin/stdout/stderr all connected to the current terminal.\n    # This forces `--jobs=1` to prevent interleaving of output.\n    $ \u{1b}[1mmise run --raw test\u{1b}[22m\n\n    # Runs the \"lint\", \"test\", and \"check\" tasks in parallel.\n    $ \u{1b}[1mmise run lint ::: test ::: check\u{1b}[22m\n\n    # Execute multiple tasks each with their own arguments.\n    $ \u{1b}[1mmise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2\u{1b}[22m\n"
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Runs the \"lint\" tasks. This needs to either be defined in mise.toml\n    # or as a standalone script. See the project README for more information.\n    $ \u{1b}[1mmise run lint\u{1b}[22m\n\n    # Forces the \"build\" tasks to run even if its sources are up-to-date.\n    $ \u{1b}[1mmise run --force build\u{1b}[22m\n\n    # Run \"test\" with stdin/stdout/stderr all connected to the current terminal.\n    # This forces `--jobs=1` to prevent interleaving of output.\n    $ \u{1b}[1mmise run --raw test\u{1b}[22m\n\n    # Runs the \"lint\", \"test\", and \"check\" tasks in parallel.\n    $ \u{1b}[1mmise run lint ::: test ::: check\u{1b}[22m\n\n    # Run \"build\" with a temporary Node.js version (requires task.run_tool_overlay).\n    $ \u{1b}[1mmise run +node@22 build\u{1b}[22m\n\n    # Execute multiple tasks each with their own arguments.\n    $ \u{1b}[1mmise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2\u{1b}[22m\n"
         flag --affected help="Run matching tasks only for projects affected by Git changes"
         flag --affected-base help=#"""
 Git base revision for --affected
@@ -4356,6 +4365,8 @@ Run task(s) and watch for changes to rerun it
 
 This command uses the `watchexec` tool to watch for changes to files and rerun the specified task(s).
 It must be installed for this command to work, but you can install it with `mise use -g watchexec@latest`.
+When `task.run_tool_overlay` is enabled, use `mise watch +node@22 build` to rerun a task with a
+temporary tool version.
 
 For more advanced process management (daemon management, auto-restart, readiness checks,
 cron scheduling), see mise's sister project: https://pitchfork.jdx.dev
@@ -4371,6 +4382,9 @@ Defaults to sources from the task(s)
         arg <GLOB>
     }
     flag --skip-deps help="Run only the specified tasks skipping all dependencies"
+    flag "-T --tool" help="Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10" var=#true {
+        arg <TOOL@VERSION>
+    }
     flag "-w --watch" help="Watch a specific file or directory" var=#true help_heading=Filtering {
         long_help #"""
 Watch a specific file or directory
@@ -5056,6 +5070,7 @@ cmd which help="Shows the path that a tool's bin points to." effect=read {
 Shows the path that a tool's bin points to.
 
 Use this to figure out what version of a tool is currently active.
+A leading tool overlay can replace `--tool`, e.g. `mise which +node@22 npm`.
 """#
     after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise which node\u{1b}[22m\n    /home/username/.local/share/mise/installs/node/20.0.0/bin/node\n\n    $ \u{1b}[1mmise which node --plugin\u{1b}[22m\n    node\n\n    $ \u{1b}[1mmise which node --version\u{1b}[22m\n    20.0.0\n"
     flag "-t --tool" help=#"""

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1957,6 +1957,11 @@
               "description": "Automatically install missing tools when executing tasks.",
               "type": "boolean"
             },
+            "run_tool_overlay": {
+              "default": false,
+              "description": "Treat leading `+TOOL@VERSION` arguments to `mise run`, naked tasks, and `mise watch` as temporary tool overlays. This will default to true in mise 2027.3.0. `mise exec` tool overlays are always enabled.",
+              "type": "boolean"
+            },
             "show_full_cmd": {
               "description": "Disable truncation of command lines in task execution output. When true, the full command line will be shown.",
               "type": "boolean"

--- a/settings.toml
+++ b/settings.toml
@@ -3122,6 +3122,12 @@ description = "Automatically install missing tools when executing tasks."
 env = "MISE_TASK_RUN_AUTO_INSTALL"
 type = "Bool"
 
+[task.run_tool_overlay]
+default = false
+description = "Treat leading `+TOOL@VERSION` arguments to `mise run`, naked tasks, and `mise watch` as temporary tool overlays. This will default to true in mise 2027.3.0. `mise exec` tool overlays are always enabled."
+env = "MISE_TASK_RUN_TOOL_OVERLAY"
+type = "Bool"
+
 [task.show_full_cmd]
 description = "Disable truncation of command lines in task execution output. When true, the full command line will be shown."
 env = "MISE_TASK_SHOW_FULL_CMD"

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -13,6 +13,8 @@ use indexmap::IndexSet;
 ///
 /// Use this if you don't want to permanently install mise. It's not necessary to
 /// use this if you have `mise activate` in your shell rc file.
+/// Tools may be prefixed with `+` to make their temporary overlay role explicit, e.g.
+/// `mise env +node@22`.
 #[derive(Debug, usage_rs::Args)]
 #[usage(visible_alias = "e", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(crate) struct Env {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -750,6 +750,91 @@ enum ToolOverlayRewrite {
     GatedTask,
 }
 
+fn tool_overlay_subcommand<'a>(
+    cmd: &'a usage_rs::Command<'a>,
+    args: &[String],
+) -> Option<(usize, &'a usage_rs::Command<'a>)> {
+    let mut subcommand_idx = first_non_global_arg_idx(cmd, args)?;
+    let mut subcommand = find_subcommand(cmd, args[subcommand_idx].as_str())?;
+    if subcommand.name == "tasks"
+        && let Some(nested_name) = args.get(subcommand_idx + 1)
+        && let Some(nested) = find_subcommand(subcommand, nested_name)
+        && nested.name == "run"
+    {
+        subcommand_idx += 1;
+        subcommand = nested;
+    }
+    Some((subcommand_idx, subcommand))
+}
+
+/// Find a `--cd` that affects overlay preprocessing. Task arguments after the task name are
+/// deliberately out of scope: `mise run task --cd elsewhere` passes `--cd` to the task.
+fn tool_overlay_settings_root(cmd: &usage_rs::Command<'_>, args: &[String]) -> Option<PathBuf> {
+    let (subcommand_idx, subcommand) = tool_overlay_subcommand(cmd, args)?;
+    if !matches!(subcommand.name, "run" | "watch") {
+        return None;
+    }
+    let (flags_with_values, _) = get_all_subcommand_flags(cmd, subcommand.name);
+    let short_flags_with_values = get_all_subcommand_value_taking_short_flags(cmd, subcommand.name);
+    let mut root = None;
+    let mut i = 1;
+    while i < args.len() {
+        if i == subcommand_idx {
+            i += 1;
+            continue;
+        }
+        let arg = &args[i];
+        if i > subcommand_idx
+            && (arg == "--" || arg == ":::" || (!arg.starts_with('-') && !arg.starts_with('+')))
+        {
+            break;
+        }
+        if let Some(value) = arg.strip_prefix("--cd=") {
+            root = Some(PathBuf::from(value));
+            i += 1;
+            continue;
+        }
+        if let Some(value) = arg.strip_prefix("-C=") {
+            root = Some(PathBuf::from(value));
+            i += 1;
+            continue;
+        }
+        if let Some(value) = arg.strip_prefix("-C").filter(|value| !value.is_empty()) {
+            root = Some(PathBuf::from(value));
+            i += 1;
+            continue;
+        }
+        if matches!(arg.as_str(), "--cd" | "-C") {
+            if let Some(value) = args.get(i + 1) {
+                root = Some(PathBuf::from(value));
+            }
+            i += 2;
+            continue;
+        }
+        if arg.starts_with('-') && arg != "-" {
+            let takes_separate_value = if arg.starts_with("--") {
+                !arg.contains('=') && flags_with_values.iter().any(|flag| flag == arg)
+            } else {
+                short_flags_with_values
+                    .iter()
+                    .any(|(short, _)| arg == short)
+            };
+            i += usize::from(takes_separate_value && i + 1 < args.len()) + 1;
+            continue;
+        }
+        i += 1;
+    }
+    root.map(|root| {
+        if root.is_absolute() {
+            root
+        } else {
+            std::env::current_dir()
+                .map(|cwd| cwd.join(&root))
+                .unwrap_or(root)
+        }
+    })
+}
+
 /// Rewrite leading `+TOOL@VERSION` arguments for commands that support temporary tool overlays.
 ///
 /// `mise x +node@27 node -v` becomes `mise x node@27 -- node -v`. The explicit sigil makes the
@@ -760,20 +845,9 @@ fn rewrite_tool_overlay_args(
     args: &[String],
     task_overlay_enabled: bool,
 ) -> ToolOverlayRewrite {
-    let Some(mut subcommand_idx) = first_non_global_arg_idx(cmd, args) else {
+    let Some((subcommand_idx, subcommand)) = tool_overlay_subcommand(cmd, args) else {
         return ToolOverlayRewrite::Unchanged;
     };
-    let Some(mut subcommand) = find_subcommand(cmd, args[subcommand_idx].as_str()) else {
-        return ToolOverlayRewrite::Unchanged;
-    };
-    if subcommand.name == "tasks"
-        && let Some(nested_name) = args.get(subcommand_idx + 1)
-        && let Some(nested) = find_subcommand(subcommand, nested_name)
-        && nested.name == "run"
-    {
-        subcommand_idx += 1;
-        subcommand = nested;
-    }
     let subcommand_name = args[subcommand_idx].as_str();
     let is_exec = subcommand.name == "exec";
     let is_task_runner = matches!(subcommand.name, "run" | "watch");
@@ -848,8 +922,9 @@ fn rewrite_tool_overlay_args(
 }
 
 fn preprocess_tool_overlay_args(cmd: &usage_rs::Command<'_>, args: &[String]) -> Vec<String> {
-    let task_overlay_enabled = Settings::try_get()
-        .map(|settings| settings.task.run_tool_overlay)
+    let task_overlay_enabled = tool_overlay_settings_root(cmd, args)
+        .map(|root| Settings::task_run_tool_overlay_from(&root))
+        .unwrap_or_else(|| Settings::try_get().map(|settings| settings.task.run_tool_overlay))
         .unwrap_or(false);
     match rewrite_tool_overlay_args(cmd, args, task_overlay_enabled) {
         ToolOverlayRewrite::Unchanged => args.to_vec(),
@@ -1375,6 +1450,26 @@ mod tests {
                 "input: {input:?}"
             );
         }
+    }
+
+    #[test]
+    fn test_tool_overlay_settings_root_honors_cd_before_task_name() {
+        let cmd = Cli::command();
+        for input in [
+            strings(&["mise", "--cd", "project", "run", "+node@27", "build"]),
+            strings(&["mise", "run", "--cd=project", "+node@27", "build"]),
+            strings(&["mise", "tasks", "run", "-Cproject", "+node@27", "build"]),
+        ] {
+            assert!(
+                tool_overlay_settings_root(cmd, &input)
+                    .is_some_and(|root| root.ends_with("project")),
+                "input: {input:?}"
+            );
+        }
+        assert_eq!(
+            tool_overlay_settings_root(cmd, &strings(&["mise", "run", "build", "--cd", "project"])),
+            None
+        );
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -921,6 +921,19 @@ fn rewrite_tool_overlay_args(
     ToolOverlayRewrite::Rewritten(rewritten)
 }
 
+pub(crate) fn has_leading_task_tool_overlay(args: &[String]) -> bool {
+    let cmd = Cli::command();
+    let args = preprocess_args_for_naked_run(cmd, args);
+    let Some((_, subcommand)) = tool_overlay_subcommand(cmd, &args) else {
+        return false;
+    };
+    matches!(subcommand.name, "run" | "watch")
+        && matches!(
+            rewrite_tool_overlay_args(cmd, &args, true),
+            ToolOverlayRewrite::Rewritten(_)
+        )
+}
+
 fn preprocess_tool_overlay_args(cmd: &usage_rs::Command<'_>, args: &[String]) -> Vec<String> {
     let task_overlay_enabled = tool_overlay_settings_root(cmd, args)
         .map(|root| Settings::task_run_tool_overlay_from(&root))
@@ -1497,6 +1510,13 @@ mod tests {
                 "input: {input:?}"
             );
         }
+
+        assert!(has_leading_task_tool_overlay(&strings(&[
+            "mise", "run", "+node@27"
+        ])));
+        assert!(!has_leading_task_tool_overlay(&strings(&[
+            "mise", "run", "default", "+literal"
+        ])));
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -747,6 +747,7 @@ pub(crate) fn unescape_task_args(args: &[String]) -> Vec<String> {
 enum ToolOverlayRewrite {
     Unchanged,
     Rewritten(Vec<String>),
+    GatedTask,
 }
 
 /// Rewrite leading `+TOOL@VERSION` arguments for commands that support temporary tool overlays.
@@ -754,15 +755,31 @@ enum ToolOverlayRewrite {
 /// `mise x +node@27 node -v` becomes `mise x node@27 -- node -v`. The explicit sigil makes the
 /// otherwise ambiguous boundary between exec's variadic tool list and its command visible without
 /// requiring the user to type `--`.
-fn rewrite_tool_overlay_args(cmd: &usage_rs::Command<'_>, args: &[String]) -> ToolOverlayRewrite {
-    let Some(subcommand_idx) = first_non_global_arg_idx(cmd, args) else {
+fn rewrite_tool_overlay_args(
+    cmd: &usage_rs::Command<'_>,
+    args: &[String],
+    task_overlay_enabled: bool,
+) -> ToolOverlayRewrite {
+    let Some(mut subcommand_idx) = first_non_global_arg_idx(cmd, args) else {
         return ToolOverlayRewrite::Unchanged;
     };
+    let Some(mut subcommand) = find_subcommand(cmd, args[subcommand_idx].as_str()) else {
+        return ToolOverlayRewrite::Unchanged;
+    };
+    if subcommand.name == "tasks"
+        && let Some(nested_name) = args.get(subcommand_idx + 1)
+        && let Some(nested) = find_subcommand(subcommand, nested_name)
+        && nested.name == "run"
+    {
+        subcommand_idx += 1;
+        subcommand = nested;
+    }
     let subcommand_name = args[subcommand_idx].as_str();
-    let Some(subcommand) = find_subcommand(cmd, subcommand_name) else {
-        return ToolOverlayRewrite::Unchanged;
-    };
-    if subcommand.name != "exec" {
+    let is_exec = subcommand.name == "exec";
+    let is_task_runner = matches!(subcommand.name, "run" | "watch");
+    let strips_sigil = matches!(subcommand.name, "env" | "shell");
+    let uses_tool_flag = is_task_runner || subcommand.name == "which";
+    if !is_exec && !strips_sigil && !uses_tool_flag {
         return ToolOverlayRewrite::Unchanged;
     }
 
@@ -775,6 +792,10 @@ fn rewrite_tool_overlay_args(cmd: &usage_rs::Command<'_>, args: &[String]) -> To
     while i < args.len() {
         let arg = &args[i];
         if arg == "--" {
+            boundary_idx = Some(i);
+            break;
+        }
+        if is_task_runner && arg == ":::" {
             boundary_idx = Some(i);
             break;
         }
@@ -802,12 +823,24 @@ fn rewrite_tool_overlay_args(cmd: &usage_rs::Command<'_>, args: &[String]) -> To
         return ToolOverlayRewrite::Unchanged;
     }
 
-    let mut rewritten = args.to_vec();
-    for idx in overlay_indices {
-        rewritten[idx].remove(0);
+    if is_task_runner && !task_overlay_enabled {
+        return ToolOverlayRewrite::GatedTask;
     }
-    if let Some(boundary_idx) = boundary_idx
-        && rewritten[boundary_idx] != "--"
+
+    let mut rewritten = Vec::with_capacity(args.len() + overlay_indices.len());
+    for (idx, arg) in args.iter().enumerate() {
+        if overlay_indices.contains(&idx) {
+            if uses_tool_flag {
+                rewritten.push("--tool".to_string());
+            }
+            rewritten.push(arg[1..].to_string());
+        } else {
+            rewritten.push(arg.clone());
+        }
+    }
+    if is_exec
+        && let Some(boundary_idx) = boundary_idx
+        && args[boundary_idx] != "--"
     {
         rewritten.insert(boundary_idx, "--".to_string());
     }
@@ -815,9 +848,24 @@ fn rewrite_tool_overlay_args(cmd: &usage_rs::Command<'_>, args: &[String]) -> To
 }
 
 fn preprocess_tool_overlay_args(cmd: &usage_rs::Command<'_>, args: &[String]) -> Vec<String> {
-    match rewrite_tool_overlay_args(cmd, args) {
+    let task_overlay_enabled = Settings::try_get()
+        .map(|settings| settings.task.run_tool_overlay)
+        .unwrap_or(false);
+    match rewrite_tool_overlay_args(cmd, args, task_overlay_enabled) {
         ToolOverlayRewrite::Unchanged => args.to_vec(),
         ToolOverlayRewrite::Rewritten(args) => args,
+        ToolOverlayRewrite::GatedTask => {
+            deprecated_at!(
+                "2026.9.0",
+                "2027.9.0",
+                "run.plus_tool_overlay",
+                "`+TOOL@VERSION` arguments to `mise run` and `mise watch` will become temporary \
+                 tool overlays (like `mise run --tool`) by default in mise 2027.3.0. Set \
+                 `task.run_tool_overlay = true` to enable now, or rename tasks whose names start \
+                 with `+`."
+            );
+            args.to_vec()
+        }
     }
 }
 
@@ -1242,7 +1290,7 @@ mod tests {
 
         for (input, expected) in cases {
             assert_eq!(
-                rewrite_tool_overlay_args(cmd, &input),
+                rewrite_tool_overlay_args(cmd, &input, false),
                 ToolOverlayRewrite::Rewritten(expected),
                 "input: {input:?}"
             );
@@ -1256,14 +1304,153 @@ mod tests {
             strings(&["mise", "x", "--", "+node@27"]),
             strings(&["mise", "x", "node@27", "node", "-v"]),
             strings(&["mise", "x", "node", "+node@27"]),
-            strings(&["mise", "run", "+node@27", "build"]),
         ] {
             assert_eq!(
-                rewrite_tool_overlay_args(cmd, &input),
+                rewrite_tool_overlay_args(cmd, &input, false),
                 ToolOverlayRewrite::Unchanged,
                 "input: {input:?}"
             );
         }
+    }
+
+    #[test]
+    fn test_rewrite_task_tool_overlays() {
+        let cmd = Cli::command();
+        let cases = [
+            (
+                strings(&["mise", "run", "+node@27", "build"]),
+                strings(&["mise", "run", "--tool", "node@27", "build"]),
+            ),
+            (
+                strings(&["mise", "r", "-j2", "+node@27", "build"]),
+                strings(&["mise", "r", "-j2", "--tool", "node@27", "build"]),
+            ),
+            (
+                strings(&["mise", "tasks", "run", "+node@27", "build"]),
+                strings(&["mise", "tasks", "run", "--tool", "node@27", "build"]),
+            ),
+            (
+                strings(&["mise", "run", "+node@27", "+python@3.14", "build"]),
+                strings(&[
+                    "mise",
+                    "run",
+                    "--tool",
+                    "node@27",
+                    "--tool",
+                    "python@3.14",
+                    "build",
+                ]),
+            ),
+            (
+                strings(&[
+                    "mise",
+                    "run",
+                    "+node@27",
+                    "build",
+                    ":::",
+                    "+python@3.14",
+                    "test",
+                ]),
+                strings(&[
+                    "mise",
+                    "run",
+                    "--tool",
+                    "node@27",
+                    "build",
+                    ":::",
+                    "+python@3.14",
+                    "test",
+                ]),
+            ),
+            (
+                strings(&["mise", "watch", "+node@27", "build"]),
+                strings(&["mise", "watch", "--tool", "node@27", "build"]),
+            ),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(
+                rewrite_tool_overlay_args(cmd, &input, true),
+                ToolOverlayRewrite::Rewritten(expected),
+                "input: {input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_task_tool_overlays_are_gated_and_respect_boundaries() {
+        let cmd = Cli::command();
+        for input in [
+            strings(&["mise", "run", "+node@27", "build"]),
+            strings(&["mise", "watch", "+node@27", "build"]),
+        ] {
+            assert_eq!(
+                rewrite_tool_overlay_args(cmd, &input, false),
+                ToolOverlayRewrite::GatedTask,
+                "input: {input:?}"
+            );
+        }
+
+        for input in [
+            strings(&["mise", "run", "--", "+legacy-task"]),
+            strings(&["mise", "run", "build", "+argument"]),
+            strings(&["mise", "run", "build", ":::", "+legacy-task"]),
+        ] {
+            assert_eq!(
+                rewrite_tool_overlay_args(cmd, &input, true),
+                ToolOverlayRewrite::Unchanged,
+                "input: {input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_rewrite_tool_overlays_for_environment_commands() {
+        let cmd = Cli::command();
+        for (input, expected) in [
+            (
+                strings(&["mise", "env", "+node@27"]),
+                strings(&["mise", "env", "node@27"]),
+            ),
+            (
+                strings(&["mise", "shell", "+node@27"]),
+                strings(&["mise", "shell", "node@27"]),
+            ),
+            (
+                strings(&["mise", "which", "+node@27", "npm"]),
+                strings(&["mise", "which", "--tool", "node@27", "npm"]),
+            ),
+        ] {
+            assert_eq!(
+                rewrite_tool_overlay_args(cmd, &input, false),
+                ToolOverlayRewrite::Rewritten(expected),
+                "input: {input:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_naked_task_tool_overlay_rewrite_round_trips_through_parser() {
+        crate::toolset::install_state::init().await.unwrap();
+        let cmd = Cli::command();
+        let input = strings(&["mise", "+node@27", "build", "+argument"]);
+        let naked = preprocess_args_for_naked_run(cmd, &input);
+        let ToolOverlayRewrite::Rewritten(rewritten) = rewrite_tool_overlay_args(cmd, &naked, true)
+        else {
+            panic!("expected tool overlay rewrite");
+        };
+        let escaped = escape_task_args(cmd, &rewritten);
+        let refs = escaped.iter().map(String::as_str).collect::<Vec<_>>();
+        let cli = parse_cli(&refs).unwrap();
+        let Some(Commands::Run(run)) = cli.command else {
+            panic!("expected run command");
+        };
+        assert_eq!(
+            run.tool.iter().map(ToString::to_string).collect::<Vec<_>>(),
+            ["node@27"]
+        );
+        assert_eq!(run.task.as_deref(), Some("build"));
+        assert_eq!(unescape_task_args(&run.args), ["+argument"]);
     }
 
     #[tokio::test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -750,6 +750,13 @@ enum ToolOverlayRewrite {
     GatedTask,
 }
 
+struct ToolOverlayScan<'a> {
+    subcommand: &'a usage_rs::Command<'a>,
+    overlay_indices: Vec<usize>,
+    boundary_idx: Option<usize>,
+    settings_root: Option<PathBuf>,
+}
+
 fn tool_overlay_subcommand<'a>(
     cmd: &'a usage_rs::Command<'a>,
     args: &[String],
@@ -767,16 +774,21 @@ fn tool_overlay_subcommand<'a>(
     Some((subcommand_idx, subcommand))
 }
 
-/// Find a `--cd` that affects overlay preprocessing. Task arguments after the task name are
-/// deliberately out of scope: `mise run task --cd elsewhere` passes `--cd` to the task.
-fn tool_overlay_settings_root(cmd: &usage_rs::Command<'_>, args: &[String]) -> Option<PathBuf> {
+/// Classify the leading overlay grammar once so settings lookup and rewriting agree on exactly
+/// where command options end. Task arguments after the task name are deliberately out of scope:
+/// `mise run task --cd elsewhere` passes `--cd` to the task.
+fn scan_tool_overlay_args<'a>(
+    cmd: &'a usage_rs::Command<'a>,
+    args: &[String],
+) -> Option<ToolOverlayScan<'a>> {
     let (subcommand_idx, subcommand) = tool_overlay_subcommand(cmd, args)?;
-    if !matches!(subcommand.name, "run" | "watch") {
-        return None;
-    }
-    let (flags_with_values, _) = get_all_subcommand_flags(cmd, subcommand.name);
-    let short_flags_with_values = get_all_subcommand_value_taking_short_flags(cmd, subcommand.name);
-    let mut root = None;
+    let subcommand_name = args[subcommand_idx].as_str();
+    let is_task_runner = matches!(subcommand.name, "run" | "watch");
+    let (flags_with_values, _) = get_all_subcommand_flags(cmd, subcommand_name);
+    let short_flags_with_values = get_all_subcommand_value_taking_short_flags(cmd, subcommand_name);
+    let mut overlay_indices = Vec::new();
+    let mut boundary_idx = None;
+    let mut settings_root = None;
     let mut i = 1;
     while i < args.len() {
         if i == subcommand_idx {
@@ -784,29 +796,41 @@ fn tool_overlay_settings_root(cmd: &usage_rs::Command<'_>, args: &[String]) -> O
             continue;
         }
         let arg = &args[i];
-        if i > subcommand_idx
-            && (arg == "--" || arg == ":::" || (!arg.starts_with('-') && !arg.starts_with('+')))
+        if i > subcommand_idx {
+            if arg == "--" || (is_task_runner && arg == ":::") {
+                boundary_idx = Some(i);
+                break;
+            }
+            if arg.strip_prefix('+').is_some_and(|tool| !tool.is_empty()) {
+                overlay_indices.push(i);
+                i += 1;
+                continue;
+            }
+            if arg == "-" || !arg.starts_with('-') {
+                boundary_idx = Some(i);
+                break;
+            }
+        }
+        if is_task_runner && let Some(value) = arg.strip_prefix("--cd=") {
+            settings_root = Some(PathBuf::from(value));
+            i += 1;
+            continue;
+        }
+        if is_task_runner && let Some(value) = arg.strip_prefix("-C=") {
+            settings_root = Some(PathBuf::from(value));
+            i += 1;
+            continue;
+        }
+        if is_task_runner
+            && let Some(value) = arg.strip_prefix("-C").filter(|value| !value.is_empty())
         {
-            break;
-        }
-        if let Some(value) = arg.strip_prefix("--cd=") {
-            root = Some(PathBuf::from(value));
+            settings_root = Some(PathBuf::from(value));
             i += 1;
             continue;
         }
-        if let Some(value) = arg.strip_prefix("-C=") {
-            root = Some(PathBuf::from(value));
-            i += 1;
-            continue;
-        }
-        if let Some(value) = arg.strip_prefix("-C").filter(|value| !value.is_empty()) {
-            root = Some(PathBuf::from(value));
-            i += 1;
-            continue;
-        }
-        if matches!(arg.as_str(), "--cd" | "-C") {
+        if is_task_runner && matches!(arg.as_str(), "--cd" | "-C") {
             if let Some(value) = args.get(i + 1) {
-                root = Some(PathBuf::from(value));
+                settings_root = Some(PathBuf::from(value));
             }
             i += 2;
             continue;
@@ -824,7 +848,7 @@ fn tool_overlay_settings_root(cmd: &usage_rs::Command<'_>, args: &[String]) -> O
         }
         i += 1;
     }
-    root.map(|root| {
+    let settings_root = settings_root.map(|root| {
         if root.is_absolute() {
             root
         } else {
@@ -832,6 +856,12 @@ fn tool_overlay_settings_root(cmd: &usage_rs::Command<'_>, args: &[String]) -> O
                 .map(|cwd| cwd.join(&root))
                 .unwrap_or(root)
         }
+    });
+    Some(ToolOverlayScan {
+        subcommand,
+        overlay_indices,
+        boundary_idx,
+        settings_root,
     })
 }
 
@@ -840,15 +870,24 @@ fn tool_overlay_settings_root(cmd: &usage_rs::Command<'_>, args: &[String]) -> O
 /// `mise x +node@27 node -v` becomes `mise x node@27 -- node -v`. The explicit sigil makes the
 /// otherwise ambiguous boundary between exec's variadic tool list and its command visible without
 /// requiring the user to type `--`.
+#[cfg(test)]
 fn rewrite_tool_overlay_args(
     cmd: &usage_rs::Command<'_>,
     args: &[String],
     task_overlay_enabled: bool,
 ) -> ToolOverlayRewrite {
-    let Some((subcommand_idx, subcommand)) = tool_overlay_subcommand(cmd, args) else {
+    let Some(scan) = scan_tool_overlay_args(cmd, args) else {
         return ToolOverlayRewrite::Unchanged;
     };
-    let subcommand_name = args[subcommand_idx].as_str();
+    rewrite_scanned_tool_overlay_args(args, &scan, task_overlay_enabled)
+}
+
+fn rewrite_scanned_tool_overlay_args(
+    args: &[String],
+    scan: &ToolOverlayScan<'_>,
+    task_overlay_enabled: bool,
+) -> ToolOverlayRewrite {
+    let subcommand = scan.subcommand;
     let is_exec = subcommand.name == "exec";
     let is_task_runner = matches!(subcommand.name, "run" | "watch");
     let strips_sigil = matches!(subcommand.name, "env" | "shell");
@@ -856,44 +895,7 @@ fn rewrite_tool_overlay_args(
     if !is_exec && !strips_sigil && !uses_tool_flag {
         return ToolOverlayRewrite::Unchanged;
     }
-
-    let (flags_with_values, _) = get_all_subcommand_flags(cmd, subcommand_name);
-    let short_flags_with_values = get_all_subcommand_value_taking_short_flags(cmd, subcommand_name);
-    let mut overlay_indices = Vec::new();
-    let mut boundary_idx = None;
-    let mut i = subcommand_idx + 1;
-
-    while i < args.len() {
-        let arg = &args[i];
-        if arg == "--" {
-            boundary_idx = Some(i);
-            break;
-        }
-        if is_task_runner && arg == ":::" {
-            boundary_idx = Some(i);
-            break;
-        }
-        if arg.strip_prefix('+').is_some_and(|tool| !tool.is_empty()) {
-            overlay_indices.push(i);
-            i += 1;
-            continue;
-        }
-        if arg.starts_with('-') && arg != "-" {
-            let takes_separate_value = if arg.starts_with("--") {
-                !arg.contains('=') && flags_with_values.iter().any(|flag| flag == arg)
-            } else {
-                short_flags_with_values
-                    .iter()
-                    .any(|(short, _)| arg == short)
-            };
-            i += usize::from(takes_separate_value && i + 1 < args.len()) + 1;
-            continue;
-        }
-        boundary_idx = Some(i);
-        break;
-    }
-
-    if overlay_indices.is_empty() {
+    if scan.overlay_indices.is_empty() {
         return ToolOverlayRewrite::Unchanged;
     }
 
@@ -901,9 +903,9 @@ fn rewrite_tool_overlay_args(
         return ToolOverlayRewrite::GatedTask;
     }
 
-    let mut rewritten = Vec::with_capacity(args.len() + overlay_indices.len());
+    let mut rewritten = Vec::with_capacity(args.len() + scan.overlay_indices.len());
     for (idx, arg) in args.iter().enumerate() {
-        if overlay_indices.contains(&idx) {
+        if scan.overlay_indices.contains(&idx) {
             if uses_tool_flag {
                 rewritten.push("--tool".to_string());
             }
@@ -913,7 +915,7 @@ fn rewrite_tool_overlay_args(
         }
     }
     if is_exec
-        && let Some(boundary_idx) = boundary_idx
+        && let Some(boundary_idx) = scan.boundary_idx
         && args[boundary_idx] != "--"
     {
         rewritten.insert(boundary_idx, "--".to_string());
@@ -924,22 +926,27 @@ fn rewrite_tool_overlay_args(
 pub(crate) fn has_leading_task_tool_overlay(args: &[String]) -> bool {
     let cmd = Cli::command();
     let args = preprocess_args_for_naked_run(cmd, args);
-    let Some((_, subcommand)) = tool_overlay_subcommand(cmd, &args) else {
+    let Some(scan) = scan_tool_overlay_args(cmd, &args) else {
         return false;
     };
-    matches!(subcommand.name, "run" | "watch")
+    matches!(scan.subcommand.name, "run" | "watch")
         && matches!(
-            rewrite_tool_overlay_args(cmd, &args, true),
+            rewrite_scanned_tool_overlay_args(&args, &scan, true),
             ToolOverlayRewrite::Rewritten(_)
         )
 }
 
 fn preprocess_tool_overlay_args(cmd: &usage_rs::Command<'_>, args: &[String]) -> Vec<String> {
-    let task_overlay_enabled = tool_overlay_settings_root(cmd, args)
-        .map(|root| Settings::task_run_tool_overlay_from(&root))
+    let Some(scan) = scan_tool_overlay_args(cmd, args) else {
+        return args.to_vec();
+    };
+    let task_overlay_enabled = scan
+        .settings_root
+        .as_ref()
+        .map(|root| Settings::task_run_tool_overlay_from(root))
         .unwrap_or_else(|| Settings::try_get().map(|settings| settings.task.run_tool_overlay))
         .unwrap_or(false);
-    match rewrite_tool_overlay_args(cmd, args, task_overlay_enabled) {
+    match rewrite_scanned_tool_overlay_args(args, &scan, task_overlay_enabled) {
         ToolOverlayRewrite::Unchanged => args.to_vec(),
         ToolOverlayRewrite::Rewritten(args) => args,
         ToolOverlayRewrite::GatedTask => {
@@ -1474,13 +1481,15 @@ mod tests {
             strings(&["mise", "tasks", "run", "-Cproject", "+node@27", "build"]),
         ] {
             assert!(
-                tool_overlay_settings_root(cmd, &input)
+                scan_tool_overlay_args(cmd, &input)
+                    .and_then(|scan| scan.settings_root)
                     .is_some_and(|root| root.ends_with("project")),
                 "input: {input:?}"
             );
         }
         assert_eq!(
-            tool_overlay_settings_root(cmd, &strings(&["mise", "run", "build", "--cd", "project"])),
+            scan_tool_overlay_args(cmd, &strings(&["mise", "run", "build", "--cd", "project"]),)
+                .and_then(|scan| scan.settings_root),
             None
         );
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -764,11 +764,13 @@ fn tool_overlay_subcommand<'a>(
     let mut subcommand_idx = first_non_global_arg_idx(cmd, args)?;
     let mut subcommand = find_subcommand(cmd, args[subcommand_idx].as_str())?;
     if subcommand.name == "tasks"
-        && let Some(nested_name) = args.get(subcommand_idx + 1)
+        && let Some(nested_idx) = first_non_global_arg_idx(cmd, &args[subcommand_idx..])
+            .map(|nested_idx| subcommand_idx + nested_idx)
+        && let Some(nested_name) = args.get(nested_idx)
         && let Some(nested) = find_subcommand(subcommand, nested_name)
         && nested.name == "run"
     {
-        subcommand_idx += 1;
+        subcommand_idx = nested_idx;
         subcommand = nested;
     }
     Some((subcommand_idx, subcommand))
@@ -1425,6 +1427,14 @@ mod tests {
                 strings(&["mise", "tasks", "run", "--tool", "node@27", "build"]),
             ),
             (
+                strings(&[
+                    "mise", "tasks", "--cd", "project", "run", "+node@27", "build",
+                ]),
+                strings(&[
+                    "mise", "tasks", "--cd", "project", "run", "--tool", "node@27", "build",
+                ]),
+            ),
+            (
                 strings(&["mise", "run", "+node@27", "+python@3.14", "build"]),
                 strings(&[
                     "mise",
@@ -1479,6 +1489,9 @@ mod tests {
             strings(&["mise", "--cd", "project", "run", "+node@27", "build"]),
             strings(&["mise", "run", "--cd=project", "+node@27", "build"]),
             strings(&["mise", "tasks", "run", "-Cproject", "+node@27", "build"]),
+            strings(&[
+                "mise", "tasks", "--cd", "project", "run", "+node@27", "build",
+            ]),
         ] {
             assert!(
                 scan_tool_overlay_args(cmd, &input)

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -38,6 +38,9 @@ use tokio::sync::Mutex;
 /// files have changed.
 ///
 /// Tasks can be defined in mise.toml or as standalone scripts.
+/// When `task.run_tool_overlay` is enabled, leading `+TOOL@VERSION` arguments temporarily add or
+/// override tools for the invocation. For example, `mise run +node@22 build` is equivalent to
+/// `mise run --tool node@22 build`.
 /// In mise.toml, tasks take this form:
 ///
 ///     [tasks.build]
@@ -1535,6 +1538,9 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
     # Runs the "lint", "test", and "check" tasks in parallel.
     $ <bold>mise run lint ::: test ::: check</bold>
+
+    # Run "build" with a temporary Node.js version (requires task.run_tool_overlay).
+    $ <bold>mise run +node@22 build</bold>
 
     # Execute multiple tasks each with their own arguments.
     $ <bold>mise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2</bold>

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -14,6 +14,7 @@ use crate::toolset::{InstallOptions, ToolSource, ToolsetBuilder, tool_env_var_na
 ///
 /// This works by setting environment variables for the current shell session
 /// such as `MISE_NODE_VERSION=20` which is "eval"ed as a shell function created by `mise activate`.
+/// Tools may be prefixed with `+`, e.g. `mise shell +node@22`.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, visible_alias = "sh", after_long_help = AFTER_LONG_HELP)]
 pub(crate) struct Shell {

--- a/src/cli/tasks/add.rs
+++ b/src/cli/tasks/add.rs
@@ -72,6 +72,12 @@ pub(super) struct TasksAdd {
 
 impl TasksAdd {
     pub(super) async fn run(self) -> Result<()> {
+        if self.task.starts_with('+') {
+            warn!(
+                "task names starting with `+` are reserved for temporary tool overlays and will \
+                 stop being runnable by name when task.run_tool_overlay is enabled"
+            );
+        }
         if self.file {
             let mut path = Task::task_dir()
                 .await?

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -90,14 +90,18 @@ impl Watch {
         };
         let (_, missing) = ts.install_missing_versions(&mut config, &opts).await?;
         ts.notify_missing_versions(missing);
-        if let Err(err) = which::which("watchexec")
-            && ts.which(&config, "watchexec").await.is_none()
-        {
-            eprintln!("{}: {}", style("Error").red().bold(), err);
-            eprintln!("{}: Install watchexec with:", style("Hint").bold());
-            eprintln!("  mise use -g watchexec@latest");
-            return Err(request_exit(1));
-        }
+        let watchexec = match ts.which_bin_spawnable(&config, "watchexec").await {
+            Some(path) => path,
+            None => match which::which("watchexec") {
+                Ok(path) => path,
+                Err(err) => {
+                    eprintln!("{}: {}", style("Error").red().bold(), err);
+                    eprintln!("{}: Install watchexec with:", style("Hint").bold());
+                    eprintln!("  mise use -g watchexec@latest");
+                    return Err(request_exit(1));
+                }
+            },
+        };
         let mut args = once(self.task)
             .flatten()
             .chain(self.task_flag.iter().cloned())
@@ -357,7 +361,7 @@ impl Watch {
             args.push(arg);
         }
         debug!("$ watchexec {}", args.join(" "));
-        let mut cmd = cmd::cmd("watchexec", &args);
+        let mut cmd = cmd::cmd(&watchexec, &args);
         for (k, v) in ts.env_with_path(&config).await? {
             cmd = cmd.env(k, v);
         }

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -1,5 +1,5 @@
 use crate::Result;
-use crate::cli::args::BackendArg;
+use crate::cli::args::{BackendArg, ToolArg};
 use crate::cli::render_subcommand_help;
 use crate::cmd;
 use crate::config::Config;
@@ -19,6 +19,8 @@ use std::path::{Path, PathBuf};
 ///
 /// This command uses the `watchexec` tool to watch for changes to files and rerun the specified task(s).
 /// It must be installed for this command to work, but you can install it with `mise use -g watchexec@latest`.
+/// When `task.run_tool_overlay` is enabled, use `mise watch +node@22 build` to rerun a task with a
+/// temporary tool version.
 ///
 /// For more advanced process management (daemon management, auto-restart, readiness checks,
 /// cron scheduling), see mise's sister project: https://pitchfork.jdx.dev
@@ -54,6 +56,11 @@ pub(crate) struct Watch {
     #[usage(long, verbatim_doc_comment)]
     pub skip_deps: bool,
 
+    /// Tool(s) to run in addition to what is in mise.toml files
+    /// e.g.: node@20 python@3.10
+    #[usage(short = 'T', long, value_name = "TOOL@VERSION")]
+    tool: Vec<ToolArg>,
+
     #[usage(flatten)]
     watchexec: WatchexecArgs,
 }
@@ -71,7 +78,10 @@ impl Watch {
             }
         }
         let config = Config::get().await?;
-        let ts = ToolsetBuilder::new().build(&config).await?;
+        let ts = ToolsetBuilder::new()
+            .with_args(&self.tool)
+            .build(&config)
+            .await?;
         if let Err(err) = which::which("watchexec") {
             let watchexec: BackendArg = "watchexec".into();
             if !ts.versions.contains_key(&watchexec) {
@@ -319,6 +329,10 @@ impl Watch {
             env::MISE_BIN.to_string_lossy().to_string(),
             "run".to_string(),
         ]);
+        for tool in &self.tool {
+            args.push("--tool".to_string());
+            args.push(tool.to_string());
+        }
         if self.skip_deps {
             args.push("--skip-deps".to_string());
         }

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -1,14 +1,14 @@
 use crate::Result;
-use crate::cli::args::{BackendArg, ToolArg};
+use crate::cli::args::ToolArg;
 use crate::cli::render_subcommand_help;
 use crate::cmd;
-use crate::config::Config;
+use crate::config::{Config, Settings};
 use crate::dirs;
 use crate::env;
 use crate::request_exit;
 use crate::task::task_source_checker::task_cwd;
 use crate::task::{Deps, Task};
-use crate::toolset::ToolsetBuilder;
+use crate::toolset::{InstallOptions, ToolsetBuilder};
 use console::style;
 use itertools::Itertools;
 use std::cmp::PartialEq;
@@ -77,19 +77,26 @@ impl Watch {
                 return Ok(());
             }
         }
-        let config = Config::get().await?;
-        let ts = ToolsetBuilder::new()
+        let mut config = Config::get().await?;
+        let mut ts = ToolsetBuilder::new()
             .with_args(&self.tool)
             .build(&config)
             .await?;
-        if let Err(err) = which::which("watchexec") {
-            let watchexec: BackendArg = "watchexec".into();
-            if !ts.versions.contains_key(&watchexec) {
-                eprintln!("{}: {}", style("Error").red().bold(), err);
-                eprintln!("{}: Install watchexec with:", style("Hint").bold());
-                eprintln!("  mise use -g watchexec@latest");
-                return Err(request_exit(1));
-            }
+        let opts = InstallOptions {
+            missing_args_only: true,
+            skip_auto_install: !Settings::get().task.run_auto_install
+                || !Settings::get().auto_install,
+            ..Default::default()
+        };
+        let (_, missing) = ts.install_missing_versions(&mut config, &opts).await?;
+        ts.notify_missing_versions(missing);
+        if let Err(err) = which::which("watchexec")
+            && ts.which(&config, "watchexec").await.is_none()
+        {
+            eprintln!("{}: {}", style("Error").red().bold(), err);
+            eprintln!("{}: Install watchexec with:", style("Hint").bold());
+            eprintln!("  mise use -g watchexec@latest");
+            return Err(request_exit(1));
         }
         let mut args = once(self.task)
             .flatten()

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -90,17 +90,19 @@ impl Watch {
         };
         let (_, missing) = ts.install_missing_versions(&mut config, &opts).await?;
         ts.notify_missing_versions(missing);
-        let watchexec = match ts.which_bin_spawnable(&config, "watchexec").await {
-            Some(path) => path,
-            None => match which::which("watchexec") {
-                Ok(path) => path,
-                Err(err) => {
-                    eprintln!("{}: {}", style("Error").red().bold(), err);
-                    eprintln!("{}: Install watchexec with:", style("Hint").bold());
-                    eprintln!("  mise use -g watchexec@latest");
-                    return Err(request_exit(1));
-                }
-            },
+        let watch_env = ts.env_with_path(&config).await?;
+        let watchexec = match which::which_in(
+            "watchexec",
+            watch_env.get(env::PATH_KEY.as_str()).map(String::as_str),
+            std::env::current_dir()?,
+        ) {
+            Ok(path) => path,
+            Err(err) => {
+                eprintln!("{}: {}", style("Error").red().bold(), err);
+                eprintln!("{}: Install watchexec with:", style("Hint").bold());
+                eprintln!("  mise use -g watchexec@latest");
+                return Err(request_exit(1));
+            }
         };
         let mut args = once(self.task)
             .flatten()
@@ -362,7 +364,7 @@ impl Watch {
         }
         debug!("$ watchexec {}", args.join(" "));
         let mut cmd = cmd::cmd(&watchexec, &args);
-        for (k, v) in ts.env_with_path(&config).await? {
+        for (k, v) in watch_env {
             cmd = cmd.env(k, v);
         }
         // Propagate profiles selected with -E/--env to the nested `mise run` command.

--- a/src/cli/which.rs
+++ b/src/cli/which.rs
@@ -11,6 +11,7 @@ use itertools::Itertools;
 /// Shows the path that a tool's bin points to.
 ///
 /// Use this to figure out what version of a tool is currently active.
+/// A leading tool overlay can replace `--tool`, e.g. `mise which +node@22 npm`.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(crate) struct Which {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1129,6 +1129,16 @@ impl Config {
         for task in tasks.values_mut() {
             task.display_name = task.display_name(&all_tasks);
         }
+        if let Some(task_name) = tasks.keys().find(|name| name.starts_with('+')) {
+            deprecated_at!(
+                "2026.9.0",
+                "2027.9.0",
+                "tasks.plus_prefix_name",
+                "task name `{task_name}` starts with `+`, which is reserved for temporary tool \
+                 overlays. Rename the task before `task.run_tool_overlay` defaults to true in mise \
+                 2027.3.0."
+            );
+        }
         time!("load_all_tasks {count}", count = tasks.len(),);
         Ok(tasks)
     }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -856,6 +856,13 @@ impl Settings {
     const WINDOWS_DEFAULT_FILE_SHELL_ARGS: &'static str = "cmd /c";
     const WINDOWS_DEFAULT_INLINE_SHELL_ARGS: &'static str = "cmd /c";
 
+    /// Resolve the task overlay gate for an explicit project root without changing the
+    /// process working directory or populating the global settings cache.
+    pub(crate) fn task_run_tool_overlay_from(root: &Path) -> Result<bool> {
+        Self::load_sources_from(Some(root), SettingsLoadPolicy::HIERARCHY)
+            .map(|settings| settings.task.run_tool_overlay)
+    }
+
     pub(crate) fn parse_default_package_line(package: &str) -> Option<String> {
         let package = package.split('#').next().unwrap_or_default().trim();
         (!package.is_empty()).then(|| package.to_string())

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -1,4 +1,4 @@
-use crate::config::{self, Config, Settings};
+use crate::config::{self, Config};
 use crate::file::display_path;
 use crate::task::{
     GetMatchingExt, Task, TaskLoadContext, extract_monorepo_path, is_workspace_project_task,
@@ -371,12 +371,7 @@ async fn err_no_task(
     }
 
     if name == "default"
-        && Settings::get().task.run_tool_overlay
-        && crate::env::ARGS
-            .read()
-            .unwrap()
-            .iter()
-            .any(|arg| arg.strip_prefix('+').is_some_and(|tool| !tool.is_empty()))
+        && crate::cli::has_leading_task_tool_overlay(&crate::env::ARGS.read().unwrap())
     {
         err_msg.push_str(
             "\n\nA leading `+TOOL@VERSION` argument was interpreted as a temporary tool overlay. \

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -1,4 +1,4 @@
-use crate::config::{self, Config};
+use crate::config::{self, Config, Settings};
 use crate::file::display_path;
 use crate::task::{
     GetMatchingExt, Task, TaskLoadContext, extract_monorepo_path, is_workspace_project_task,
@@ -361,6 +361,29 @@ async fn err_no_task(
 
     // Suggest similar tasks using fuzzy matching for monorepo tasks
     let mut err_msg = format!("no task {} found", style::ered(name));
+
+    if name.starts_with('+') {
+        err_msg.push_str(
+            "\n\nLeading `+TOOL@VERSION` arguments are temporary tool overlays when \
+             `task.run_tool_overlay` is enabled. Disable that setting to run a legacy task whose \
+             name starts with `+`, and rename the task before the syntax becomes the default.",
+        );
+    }
+
+    if name == "default"
+        && Settings::get().task.run_tool_overlay
+        && crate::env::ARGS
+            .read()
+            .unwrap()
+            .iter()
+            .any(|arg| arg.strip_prefix('+').is_some_and(|tool| !tool.is_empty()))
+    {
+        err_msg.push_str(
+            "\n\nA leading `+TOOL@VERSION` argument was interpreted as a temporary tool overlay. \
+             Add a task name after the overlay, or disable `task.run_tool_overlay` to run a legacy \
+             `+`-prefixed task.",
+        );
+    }
 
     let similar = similar_tasks(name, &tasks_for_error);
     if !similar.is_empty() {


### PR DESCRIPTION
## Summary
- extend +TOOL@VERSION overlays to run, r, tasks run, naked tasks, and watch
- gate task overlays behind task.run_tool_overlay for backward compatibility
- support always-unambiguous overlay forms in env, shell, and which flows
- add migration diagnostics, settings documentation, completions, and e2e coverage

## Dependency
- Depends on #12426
- Also depends on jdx/usage#1322 and a published usage 6.5 release
- Temporary CI failures are expected until those dependencies land

## Test plan
- focused task, watch, env, shell, and which e2e tests
- mise run lint-fix
- mise run render

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global argv preprocessing and task-name parsing for run/watch, which can break projects with legacy `+`-prefixed tasks when the setting is enabled; watch also changes tool resolution and nested run invocation.
> 
> **Overview**
> Adds **`task.run_tool_overlay`** (default **off**, planned default **on** in 2027.3.0) so leading **`+TOOL@VERSION`** tokens before the first task name on **`mise run`**, **`tasks run`**, naked **`mise +tool task`**, and **`mise watch`** are rewritten to **`--tool`** for that invocation only. Overlays stop at the first task name, **`:::`**, or **`--`**; **`--cd`** before the task selects which project’s setting applies.
> 
> **`env`**, **`shell`**, and **`which`** always accept **`+`** overlays (strip or map to **`--tool`**). **`mise watch`** gains **`-T/--tool`**, forwards tools into the nested **`mise run`**, and resolves **`watchexec`** on the overlay PATH.
> 
> Backward compatibility: with the gate off, **`+`-prefixed task names** still run; enabling overlays or hitting migration paths emits deprecations and clearer “interpreted as overlay” errors. Docs, schema, usage spec, man pages, unit tests, and e2e coverage accompany the arg-scan/rewrite logic in **`src/cli/mod.rs`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62a1007d60b172dd53f1bf716f294cee1e7f4961. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->