### PR TITLE
fix(trust): read the ignore list by what its entries point at

### DIFF
--- a/e2e-win/trust_ignore.Tests.ps1
+++ b/e2e-win/trust_ignore.Tests.ps1
@@ -1,0 +1,79 @@
+Describe 'mise trust --ignore on Windows' {
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        # Saved and restored in AfterAll: Pester runs every suite in one process, so a state dir
+        # left pointing into $TestDrive would follow the suites that run after this one.
+        $script:OriginalState = [Environment]::GetEnvironmentVariable('MISE_STATE_DIR', 'Process')
+        $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+
+        $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:TestRoot | Out-Null
+        $script:StateDir = Join-Path $script:TestRoot 'state'
+        $script:Store = Join-Path $script:StateDir 'ignored-configs'
+        $script:Project = Join-Path $script:TestRoot 'project'
+        New-Item -ItemType Directory -Path $script:Project | Out-Null
+        @"
+[env]
+IGNORE_PROBE = "loaded"
+"@ | Out-File (Join-Path $script:Project 'mise.toml')
+
+        $env:MISE_STATE_DIR = $script:StateDir
+        # `trusted_config_paths` overrides the persisted ignore list by design, so the setting CI
+        # sets globally would mask exactly what this suite is testing.
+        Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
+
+        function script:StoreCount {
+            @(Get-ChildItem $script:Store -Force -ErrorAction SilentlyContinue).Count
+        }
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        if ($null -eq $script:OriginalState) {
+            Remove-Item Env:MISE_STATE_DIR -ErrorAction Ignore
+        } else {
+            [Environment]::SetEnvironmentVariable('MISE_STATE_DIR', $script:OriginalState, 'Process')
+        }
+        if ($null -ne $script:OriginalTrusted) {
+            [Environment]::SetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', $script:OriginalTrusted, 'Process')
+        }
+    }
+
+    It 'keeps a config out of later processes' {
+        Set-Location $script:TestRoot
+        # Trusted first, so the control below holds off CI too: `is_trusted` short-circuits to true
+        # under `ci_info::is_ci()`, but nothing grants trust on a developer's machine. The ignore
+        # list is consulted *before* the persisted trust store, so trusting here does not weaken
+        # what the last assertion tests.
+        mise trust $script:Project | Out-Null
+        $LASTEXITCODE | Should -Be 0
+
+        Set-Location $script:Project
+        # Control: the config loads before anything is ignored. Without it a fix that broke config
+        # loading outright would pass the assertion at the end.
+        $out = mise env | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match 'IGNORE_PROBE'
+
+        # Named explicitly rather than relying on the no-argument form, which searches for the
+        # first untrusted config from the cwd upward and finds different things in different
+        # environments.
+        Set-Location $script:TestRoot
+        $out = mise trust --ignore $script:Project 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match 'ignored'
+
+        # Control, asserted on its own so a setup failure cannot be read as the defect: the entry
+        # really is written. On Windows it is a plain file holding the path rather than a symlink,
+        # because symlinks need a privilege mise does not require -- and resolving it was the part
+        # that was wrong.
+        (script:StoreCount) | Should -Be 1
+
+        # The point of the fix: a *new process* has to honour it. The ignore list is loaded once
+        # per process, so this is the only place the loading path is exercised.
+        Set-Location $script:Project
+        $out = mise env | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Not -Match 'IGNORE_PROBE'
+    }
+}

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -746,6 +746,21 @@ pub(crate) fn is_ignored_via_setting(path: &Path) -> bool {
     IGNORED_CONFIG_PATH_MATCHER.is_match(path)
 }
 
+/// The config path an ignore-list entry records.
+///
+/// Resolve the entry; do not canonicalize it. mise writes these as symlinks on unix and, since
+/// Windows symlinks need a privilege mise does not require, as plain files holding the path there
+/// (`file::make_symlink_or_file`). `Path::canonicalize` follows a symlink, so unix happened to come
+/// out right — on Windows it returned the entry's own path inside `ignored-configs`, which is never
+/// a config path, so the loaded set matched nothing and `mise trust --ignore` had no effect beyond
+/// the process that ran it.
+///
+/// No second `canonicalize` on the result: [`add_ignored`] canonicalizes before writing, so the
+/// recorded form already matches what the caller below compares against.
+fn ignored_entry_path(entry: &Path) -> Option<PathBuf> {
+    file::resolve_symlink(entry).ok().flatten()
+}
+
 /// Whether `path` is in the persisted ignore list.
 ///
 /// Entries are recorded when the user answers "No" to a trust prompt or runs
@@ -760,8 +775,8 @@ pub(crate) fn is_persisted_ignored(path: &Path) -> bool {
         }
         let mut is_ignored = IS_IGNORED.lock().unwrap();
         for entry in file::ls(&dirs::IGNORED_CONFIGS).unwrap_or_default() {
-            if let Ok(canonicalized_path) = entry.canonicalize() {
-                is_ignored.insert(canonicalized_path);
+            if let Some(path) = ignored_entry_path(&entry) {
+                is_ignored.insert(path);
             }
         }
     });
@@ -1502,5 +1517,49 @@ mod tests {
             result2,
             Path::new("/tmp/trusted/infra-mise.toml-a1b2c3d4e5f67890.monorepo")
         );
+    }
+}
+
+/// Deliberately not `#[cfg(unix)]` like the module above: Windows is the platform these are about.
+/// The entry there is a plain file rather than a symlink, and reading it as one is the whole
+/// defect — gated out, these would have passed by never being compiled. Same reasoning as
+/// [`ignored_config_path_tests`].
+#[cfg(test)]
+mod ignore_entry_tests {
+    use super::*;
+
+    /// The entry goes in through `file::make_symlink_or_file`, the writer [`add_ignored`] uses, so
+    /// each platform is exercised in the form it actually writes: a symlink on unix, a plain file
+    /// holding the path on Windows.
+    #[test]
+    fn an_ignore_entry_resolves_to_the_config_it_records() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        let store = tmp.path().join("ignored-configs");
+        std::fs::create_dir_all(&store).unwrap();
+        let entry = store.join("project-abc123");
+        file::make_symlink_or_file(&project, &entry).unwrap();
+
+        let resolved = ignored_entry_path(&entry).expect("an entry mise wrote has to resolve");
+
+        assert_eq!(
+            resolved, project,
+            "it has to be the config that was ignored"
+        );
+        // And explicitly not the entry: `entry.canonicalize()` returned this on Windows, where the
+        // entry is a plain file, which is why nothing ever matched the ignore list there.
+        assert_ne!(resolved, entry, "never the entry's own path");
+    }
+
+    #[test]
+    fn an_entry_mise_did_not_write_resolves_to_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join("ignored-configs");
+        let stray = store.join("a-directory");
+        std::fs::create_dir_all(&stray).unwrap();
+
+        assert_eq!(ignored_entry_path(&stray), None);
+        assert_eq!(ignored_entry_path(&store.join("not-there")), None);
     }
 }


### PR DESCRIPTION
`mise trust --ignore` — and answering "No" to a trust prompt — has no effect on Windows past the
process that recorded it. The entry is written; it is the reading that is wrong.

`is_persisted_ignored` loads the store like this:

```rust
for entry in file::ls(&dirs::IGNORED_CONFIGS).unwrap_or_default() {
    if let Ok(canonicalized_path) = entry.canonicalize() {
        is_ignored.insert(canonicalized_path);
    }
}
```

**`Path::canonicalize` follows a symlink.** mise records these entries as symlinks on unix, so this
lands on the config the entry names and happens to be right. On Windows symlinks need a privilege
mise does not require, so `file::make_symlink_or_file` writes **a plain file holding the path** —
and canonicalizing *that* returns the entry's own path inside `ignored-configs`. The loaded set is
full of paths under mise's state directory, which no config will ever match.

## Measured

Isolated `MISE_*_DIR`, 2026.8.12 (the function is byte-identical on `main`):

```
1. after trust      : LOADED
2. after --ignore   : LOADED
3. new process again: LOADED
ignored-configs : 1 entry -> \\?\C:\...\proj   (Mode=-a---)
```

`is_trusted` checks in this order: setting-ignore → in-memory `IS_TRUSTED` → `trusted_config_paths`
→ **persisted ignore** → … → persisted trust store. The fourth would keep the config out of a fresh
process if it fired. It never does.

**The trust side is not affected.** The persisted trust store is read through
`trust_path(path).exists()`, a hash-derived filename lookup with no directory walk. Only the ignore
list resolves entries.

**Linux already has the control.** `e2e/cli/test_trusted_config_paths_override_ignore` asserts the
config is *not* loaded while ignored, and it passes — confirmed in the `e2e` job of a green `main`
run: `PASS: cli/test_trusted_config_paths_override_ignore`. So the logic is right and only the
Windows record form is being read wrong.

## The change

```rust
fn ignored_entry_path(entry: &Path) -> Option<PathBuf> {
    file::resolve_symlink(entry).ok().flatten()
}
```

`file::resolve_symlink` is the existing shared helper for both forms — eight callers already — so
this adds no new resolver. Same shape as `Tracker::tracked_path`, which resolves the tracked-config
store for exactly this reason.

No second `canonicalize` on the result: `add_ignored` canonicalizes before writing, so the recorded
form already matches what `is_persisted_ignored` compares its argument against.

**Unix behaviour is unchanged.** The symlink target is already canonical, so `read_link` returns
what `entry.canonicalize()` used to. The only difference is a *dangling* entry, which the old code
skipped and this one inserts — harmless, since the queried path must canonicalize to match, and
nothing existing can equal a dead path.

## Tests

**Unit** — `ignored_entry_path` resolves to the config an entry records and explicitly **not** to
the entry's own path, which is the value Windows was producing. Entries go in through
`file::make_symlink_or_file`, the writer `add_ignored` uses, so each platform is exercised in the
form it actually writes.

They live in a new `mod ignore_entry_tests` rather than the `mod tests` further down that file,
because that one is `#[cfg(unix)]` — Windows is the platform this is about, and gated out the tests
would have "passed" by never being compiled. The file already has one ungated module for the same
reason (`ignored_config_path_tests`), with a comment saying so.

**e2e** (`e2e-win/trust_ignore.Tests.ps1`) — the bash e2e suite does not run on Windows, so Pester
is the only place CI reaches this. Each phase asserts separately, so a setup failure cannot be read
as the defect: the config loads before the ignore, `mise trust --ignore` exits 0 and says `ignored`,
the store has an entry, and then a **new process** must not load the config. The path is named
explicitly rather than relying on the no-argument form, which searches from the cwd upward and finds
different things in different environments.

## Verification

`cargo fmt`. The Pester file was run locally against a released binary first, where it fails at the
last assertion — the new process still loading the config — rather than anywhere earlier. `cargo
test` and the Pester suite both run against a build of this branch in CI's Windows jobs.

**Verified on CI** (fork run 32863481333, a build of `main` + this change, `windows-latest`):

```
test config::config_file::ignore_entry_tests::an_entry_mise_did_not_write_resolves_to_nothing ... ok
test config::config_file::ignore_entry_tests::an_ignore_entry_resolves_to_the_config_it_records ... ok
[+] D:\a\mise\mise\e2e-win\trust_ignore.Tests.ps1 338ms
```

Both unit tests are listed by name, so they were compiled and run rather than gated out — an
earlier revision of this branch put them in the `#[cfg(unix)]` module in the same file, where
`windows-unit` went green without ever building them. `config::config_file::tests::` is still
absent from that log, which is how the gating shows up when it applies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `mise trust --ignore` on Windows so ignored configuration files are correctly recognized across subsequent processes.
  * Improved handling of persisted ignore entries across Windows and Unix environments.

* **Tests**
  * Added end-to-end coverage for Windows ignore behavior and persistence.
  * Added platform-specific tests for ignored configuration entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->