### PR TITLE
fix(npm): intercept aube node-gyp bootstrap trampoline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,7 +306,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -317,7 +317,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -563,9 +563,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa3e036ccdbb8e8c7afc235d46946c625ae9656bbb8443308478fd8a88c0626"
+checksum = "4027b79b6026a4bc610590f1614a39d67b939c34562455d0e72a5d90f0f74e66"
 dependencies = [
  "aube-codes",
  "aube-linker",
@@ -619,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016f86f01109ae2e73f7f6de708fc285da0d9c69e4bb325935c4120fb30cf9a3"
+checksum = "16b4e236b4b5d9a203d1033df09049a7bd709e5e654a98cad47727379c160570"
 dependencies = [
  "serde",
  "serde_json",
@@ -629,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd329b3c20f68174e3e42484b4bc3e6c1717ec76a9817831a408246f868904f2"
+checksum = "32fc7109e9da311c65ea31cbe6a736ae02ace3eb4fb3e588ebacd46e219b51ec"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -657,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1300c6db4fb31f45973a2000a893a1650326a4e6f790ba520621aa44905d3ab9"
+checksum = "d20d0489316a219c17e61ac121b16d12db6a0747a633f7c4a2907a2dd6c6a1f5"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -683,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c1d80de10b649dd5e9694eb39056aa1b6464d0a762655a4f7b0a3965b0fc3"
+checksum = "a923ad15644bab410b1412f72f95a08c456544208be0b4929a23c8cf2ebf38d2"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -699,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46b595a604816c0c78bac1f54d0377d97bd1c3d706103a18c6a8585d6d7be17c"
+checksum = "8aac542c7384eed571eef71aa603a1a0c7ade9a0895330a82d610d32a827604a"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -726,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df9ef5e6aceb8e1fbe0e0a2963e58a9c69dc38e53a4973ea904259c0e2c20af"
+checksum = "783b0d5a695935824572b31e03bb29c50f7d7b313fa524f08559699175eab3c5"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -756,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "aube-runtime"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91c03949d9635f3fe229ec938403c733702e451e75e6ba2c8b2612c220be618"
+checksum = "46c2ce97e81fbbdfccc22d0c8dc06d040dc2d395e00179e62f889440278636de"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -781,9 +781,9 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82144c18d71d37d1b595047826900d7d12388c27c841c47cbbd338b1ec71f7c5"
+checksum = "75a0b34fe4cb83130b993e1e9fb1ed924d13c0de9443ffb15d491ea1493c32d3"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -801,9 +801,9 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c2ac6b6691c9bf3f74fafc241d4cab58b6a264eace334e60d8d5110412ecef1"
+checksum = "321286c45af2d47332d6ea1f02b428c2d359bf100b1a8b42f076616e8335fea6"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -815,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15dacadd9a83d51d0f79d7b2c0cc4e5ea9d72f60a2d8e070ae8f18169132534"
+checksum = "d6bca276f6ae7ae7ce7a8d36d7a8beae0e2126e44f8af21c64c3e9d9dd6c48c2"
 dependencies = [
  "aube-util",
  "base64 0.23.1",
@@ -842,9 +842,9 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "734ed5b3d9ed943ce17e5cd715af993eb44c87d5bdfad91baaf561cac91c5791"
+checksum = "bdb68791585edb859b48afab1a93652850479dcd36a30cf1d92ffb4da4d72493"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -864,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a26e873e3b3bd44bc82668b568aa13d4f871397c07b9e47321bed9959ff7936"
+checksum = "6267dd85efb3cd40a73bf8d242439c41b7b9d3d729254fad3b6fbc0f31140aed"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -2142,7 +2142,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2983,7 +2983,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3272,7 +3272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5291,7 +5291,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5815,7 +5815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
 dependencies = [
  "scopeguard",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5857,7 +5857,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6700,7 +6700,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6900,7 +6900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7718,7 +7718,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8730,7 +8730,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8789,7 +8789,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9773,7 +9773,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10128,10 +10128,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10199,7 +10199,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11381,7 +11381,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/e2e/backend/test_npm_node_gyp_bootstrap
+++ b/e2e/backend/test_npm_node_gyp_bootstrap
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Native npm packages with `allow_builds` run install scripts that shell out to
+# node-gyp. Embedded aube trampolines that through `$AUBE_NODE_GYP_EXE
+# __node-gyp-bootstrap`, which is this mise binary — mise must intercept that
+# private command or the install fails with "no tasks defined".
+
+# Hidden trampoline: print the bootstrapped node-gyp path (stdout only).
+bootstrap_out="$(mise __node-gyp-bootstrap "$PWD")"
+assert_contains "$bootstrap_out" "node-gyp"
+assert_succeed "test -x \"$bootstrap_out\""
+
+# node-pty's install script is `node-gyp rebuild`. Before the intercept this
+# failed with mise's "no tasks defined" naked-run error.
+cat >mise.toml <<'EOF'
+[tools]
+node = "20"
+"npm:node-pty" = { version = "1.0.0", allow_builds = ["node-pty"] }
+EOF
+
+assert_succeed "mise install"
+
+# Confirm the package landed and node-gyp produced a native binding.
+pkg_dir="$(find "$MISE_DATA_DIR/installs/npm-node-pty/1.0.0" -type d -name node-pty | head -1)"
+assert_succeed "test -n \"$pkg_dir\""
+assert_succeed "test -d \"$pkg_dir\""
+binding="$(find "$pkg_dir" -path '*/build/Release/*.node' | head -1)"
+assert_succeed "test -n \"$binding\""
+assert_succeed "test -f \"$binding\""

--- a/e2e/backend/test_npm_node_gyp_bootstrap
+++ b/e2e/backend/test_npm_node_gyp_bootstrap
@@ -1,16 +1,22 @@
 #!/usr/bin/env bash
-# Native npm packages with `allow_builds` run install scripts that shell out to
-# node-gyp. Embedded aube trampolines that through `$AUBE_NODE_GYP_EXE
-# __node-gyp-bootstrap`, which is this mise binary — mise must intercept that
-# private command or the install fails with "no tasks defined".
+# Regression for embedded-aube native builds (gemini-cli → node-pty).
+#
+# aube sets AUBE_NODE_GYP_EXE=$current_exe and lazy shims call:
+#   $AUBE_NODE_GYP_EXE __node-gyp-bootstrap <project-dir>
+# mise must intercept that before naked-run rewriting, or installs fail with
+# "no tasks defined". Registry test-tool alone is not enough coverage.
 
-# Hidden trampoline: print the bootstrapped node-gyp path (stdout only).
-bootstrap_out="$(mise __node-gyp-bootstrap "$PWD")"
-assert_contains "$bootstrap_out" "node-gyp"
-assert_succeed "test -x \"$bootstrap_out\""
+# Trampoline must succeed and must not fall through to `mise run`.
+assert_contains "mise __node-gyp-bootstrap \"$PWD\"" "node-gyp"
+assert_not_contains "mise __node-gyp-bootstrap \"$PWD\"" "no tasks defined"
+assert_not_contains "mise __node-gyp-bootstrap \"$PWD\"" "Are you in a project directory"
+node_gyp_path="$(mise __node-gyp-bootstrap "$PWD")"
+assert_succeed "test -x \"$node_gyp_path\""
 
-# node-pty's install script is `node-gyp rebuild`. Before the intercept this
-# failed with mise's "no tasks defined" naked-run error.
+# Going through the task runner is the bug path (naked-run rewrite).
+assert_fail "mise run __node-gyp-bootstrap \"$PWD\""
+
+# Full allow_builds install: node-pty's install script is `node-gyp rebuild`.
 cat >mise.toml <<'EOF'
 [tools]
 node = "20"
@@ -19,7 +25,6 @@ EOF
 
 assert_succeed "mise install"
 
-# Confirm the package landed and node-gyp produced a native binding.
 pkg_dir="$(find "$MISE_DATA_DIR/installs/npm-node-pty/1.0.0" -type d -name node-pty | head -1)"
 assert_succeed "test -n \"$pkg_dir\""
 assert_succeed "test -d \"$pkg_dir\""

--- a/src/backend/aube_host.rs
+++ b/src/backend/aube_host.rs
@@ -67,6 +67,17 @@ static MISE_HOST: Host = Host {
 
 static INIT: Once = Once::new();
 
+/// Hidden aube CLI entry that lifecycle shims invoke on the host executable.
+///
+/// Embedded aube sets `AUBE_NODE_GYP_EXE` to `current_exe()` (mise) and writes
+/// lazy `node-gyp` shims that call `$AUBE_NODE_GYP_EXE __node-gyp-bootstrap
+/// <project-dir>`. Standalone aube handles that itself; as an embedder mise
+/// must intercept it before its own argv parser — otherwise naked-run
+/// preprocessing turns it into `mise run __node-gyp-bootstrap` and native
+/// `allow_builds` installs (e.g. `gemini-cli` → `node-pty`) fail with "no
+/// tasks defined".
+const NODE_GYP_BOOTSTRAP_CMD: &str = "__node-gyp-bootstrap";
+
 /// Register mise as aube's host. Idempotent and cheap; call it before any
 /// aube work rather than relying on a single startup hook, so the library
 /// entry points (`npm:` installs and registry metadata queries) are each
@@ -82,6 +93,24 @@ pub(crate) fn init() {
         // embedder defaults anyway.
         aube::embed::initialize(&MISE_HOST, vec![]);
     });
+}
+
+/// Run aube's host-facing CLI when argv is one of its private trampoline
+/// commands. Returns `Some(exit_code)` so `main` can exit before mise's own
+/// parser, tokio runtime, or naked-run rewrite touch the args.
+///
+/// Uses [`aube::cli_main`]: aube 2.1 still routes `__node-gyp-bootstrap`
+/// through the CLI surface (`aube::embed::bootstrap_node_gyp` lands in a
+/// later aube release).
+pub(crate) fn try_run_embedded_cli(args: &[String]) -> Option<i32> {
+    if !is_embedded_cli_command(args) {
+        return None;
+    }
+    Some(aube::cli_main(&MISE_HOST))
+}
+
+fn is_embedded_cli_command(args: &[String]) -> bool {
+    args.get(1).map(String::as_str) == Some(NODE_GYP_BOOTSTRAP_CMD)
 }
 
 #[cfg(test)]
@@ -109,5 +138,20 @@ mod tests {
         assert!(!MISE_HOST.runtime_switching);
         assert!(!MISE_HOST.self_engines_check);
         assert!(!MISE_HOST.self_update_enabled);
+    }
+
+    #[test]
+    fn detects_aube_node_gyp_bootstrap_trampoline() {
+        assert!(is_embedded_cli_command(&[
+            "mise".into(),
+            NODE_GYP_BOOTSTRAP_CMD.into(),
+            "/tmp/project".into(),
+        ]));
+        assert!(!is_embedded_cli_command(&[
+            "mise".into(),
+            "install".into(),
+            "node".into(),
+        ]));
+        assert!(!is_embedded_cli_command(&["mise".into()]));
     }
 }

--- a/src/backend/aube_host.rs
+++ b/src/backend/aube_host.rs
@@ -14,6 +14,7 @@
 //! embedded npm installs separately pass invocation-scoped mise-owned cache
 //! and store paths and disable aube's global virtual store.
 
+use std::path::PathBuf;
 use std::sync::Once;
 
 use aube::embed::{AUBE, Host};
@@ -95,18 +96,41 @@ pub(crate) fn init() {
     });
 }
 
-/// Run aube's host-facing CLI when argv is one of its private trampoline
-/// commands. Returns `Some(exit_code)` so `main` can exit before mise's own
-/// parser, tokio runtime, or naked-run rewrite touch the args.
+/// Handle aube's private trampoline argv before mise's own parser, tokio
+/// runtime, or naked-run rewrite touch the args. Returns `Some(exit_code)`.
 ///
-/// Uses [`aube::cli_main`]: aube 2.1 still routes `__node-gyp-bootstrap`
-/// through the CLI surface (`aube::embed::bootstrap_node_gyp` lands in a
-/// later aube release).
+/// Uses [`aube::embed::bootstrap_node_gyp`] (aube ≥ 2.2) rather than routing
+/// through [`aube::cli_main`], matching standalone aube's `__node-gyp-bootstrap`
+/// behavior: bootstrap into the cache and print the executable path.
 pub(crate) fn try_run_embedded_cli(args: &[String]) -> Option<i32> {
     if !is_embedded_cli_command(args) {
         return None;
     }
-    Some(aube::cli_main(&MISE_HOST))
+    let project_dir = args
+        .get(2)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."));
+    init();
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(err) => {
+            eprintln!("mise: failed to start runtime for node-gyp bootstrap: {err}");
+            return Some(1);
+        }
+    };
+    match runtime.block_on(aube::embed::bootstrap_node_gyp(&project_dir)) {
+        Ok(path) => {
+            println!("{}", path.display());
+            Some(0)
+        }
+        Err(err) => {
+            eprintln!("{err:?}");
+            Some(1)
+        }
+    }
 }
 
 fn is_embedded_cli_command(args: &[String]) -> bool {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1514,6 +1514,31 @@ mod tests {
     }
 
     #[test]
+    fn test_aube_node_gyp_bootstrap_would_become_naked_run_without_early_intercept() {
+        // Embedded aube re-execs the host as `__node-gyp-bootstrap`. That name is
+        // not a mise subcommand, so the naked-run rewrite injects `run` — which is
+        // exactly the gemini-cli / node-pty failure mode. `main` must intercept
+        // this argv *before* preprocess_args_for_naked_run runs.
+        let cmd = Cli::command();
+        let args = [
+            "mise".to_string(),
+            "__node-gyp-bootstrap".to_string(),
+            "/tmp/project".to_string(),
+        ];
+        let processed = preprocess_args_for_naked_run(cmd, &args);
+        assert_eq!(
+            processed,
+            [
+                "mise".to_string(),
+                "run".to_string(),
+                "__node-gyp-bootstrap".to_string(),
+                "/tmp/project".to_string(),
+            ],
+            "if this no longer rewrites to `run`, update main's early aube dispatch"
+        );
+    }
+
+    #[test]
     fn test_escape_task_args_preserves_naked_task_separator_tail() {
         let cmd = Cli::command();
         let args = vec![

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,13 @@ fn main() -> ExitCode {
     if env::invoked_as_self_replace_helper() {
         return ExitCode::SUCCESS;
     }
+    // Embedded aube lifecycle shims re-exec this binary with private commands
+    // (notably `__node-gyp-bootstrap`). Hand those to aube before mise's
+    // naked-run rewrite / clap parser can claim them.
+    let early_args = env::args_safe();
+    if let Some(code) = backend::aube_host::try_run_embedded_cli(&early_args) {
+        return exit::status(code);
+    }
     let nprocs = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or_default();

--- a/tests/aube_node_gyp_bootstrap.rs
+++ b/tests/aube_node_gyp_bootstrap.rs
@@ -1,0 +1,57 @@
+//! Regression: embedded aube re-execs the host as `__node-gyp-bootstrap`.
+//!
+//! Without an early `main` intercept, mise's naked-run rewrite turns that into
+//! `mise run __node-gyp-bootstrap`, which fails with "no tasks defined" and
+//! breaks `allow_builds` installs that need node-gyp (gemini-cli → node-pty).
+//! Registry `test-tool` can miss this; this binary-level check must keep passing.
+
+use std::fs;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn mise_binary_services_aube_node_gyp_bootstrap_trampoline() {
+    let mise = env!("CARGO_BIN_EXE_mise");
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    let project = std::env::temp_dir().join(format!("mise-aube-ngyp-{stamp}"));
+    fs::create_dir_all(&project).expect("create temp project dir");
+    let project = project.to_str().expect("utf-8 path");
+
+    let output = Command::new(mise)
+        .args(["__node-gyp-bootstrap", project])
+        .output()
+        .expect("spawn mise");
+
+    let _ = fs::remove_dir_all(project);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+
+    assert!(
+        output.status.success(),
+        "mise __node-gyp-bootstrap should exit 0; status={:?}\nstdout={stdout}\nstderr={stderr}",
+        output.status
+    );
+    assert!(
+        stdout.contains("node-gyp"),
+        "expected bootstrapped node-gyp path on stdout, got: {stdout:?}"
+    );
+    assert!(
+        !combined.contains("no tasks defined"),
+        "trampoline must not fall through to naked `mise run`; output was: {combined}"
+    );
+    assert!(
+        !combined.contains("Are you in a project directory"),
+        "trampoline must not fall through to naked `mise run`; output was: {combined}"
+    );
+
+    let path = stdout.lines().next().unwrap_or_default().trim();
+    assert!(
+        std::path::Path::new(path).is_file(),
+        "bootstrapped path should exist and be a file: {path:?}"
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Registry `test-tool` was failing on **gemini-cli** because embedded aube’s lazy `node-gyp` shim re-execs the host binary as:

```sh
"$AUBE_NODE_GYP_EXE" __node-gyp-bootstrap "$AUBE_NODE_GYP_PROJECT_DIR"
```

With aube embedded in mise, `AUBE_NODE_GYP_EXE` is the mise binary. mise did not handle that private command, so naked-run rewriting turned it into `mise run __node-gyp-bootstrap …` and failed with:

> no tasks defined in …/node-pty. Are you in a project directory?

That broke `allow_builds` installs whose lifecycle scripts call `node-gyp` (gemini-cli → node-pty).

## Fix

- Intercept `__node-gyp-bootstrap` in `main` before tokio/clap/naked-run setup
- Dispatch via `aube::embed::bootstrap_node_gyp` (aube **2.2.0**)
- Bump embedded aube workspace crates to 2.2.0
- Add regression coverage that does **not** rely on registry `test-tool`:
  - binary integration test: `tests/aube_node_gyp_bootstrap.rs`
  - unit test that documents naked-run rewrite of the trampoline argv
  - e2e: trampoline success, asserts against the “no tasks defined” failure mode, asserts `mise run __node-gyp-bootstrap` fails, plus `npm:node-pty` `allow_builds` install

## Test plan

- [x] `cargo test --locked --bin mise --test aube_node_gyp_bootstrap aube_node_gyp_bootstrap`
- [x] `mise run test:e2e e2e/backend/test_npm_node_gyp_bootstrap`
- [x] `mise run test:e2e e2e/backend/test_npm_aube`
- [x] `mise install gemini-cli@0.56.0` succeeds (node-gyp rebuild completes)
- [x] `mise run lint-fix`

*AI-assisted — Tool: Cursor; model: Composer; version: unavailable.*

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03a40-eee7-7c00-917a-ab9f59c3323b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03a40-eee7-7c00-917a-ab9f59c3323b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with embedded Node.js tooling that relies on the private node-gyp bootstrap command.
  * Prevented the bootstrap command from being misinterpreted as a regular task invocation.
  * Native modules, such as `node-pty`, can now install successfully when builds are allowed.

* **Tests**
  * Added end-to-end and regression coverage for node-gyp bootstrapping, executable path output, error handling, and native binding generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->