### PR TITLE
chore: release 2026.8.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [2026.8.14](https://github.com/jdx/mise/compare/v2026.8.13..v2026.8.14) - 2026-08-25
+
+### 🐛 Bug Fixes
+
+- **(http)** remove the extraction temp dir when extraction fails by @Marukome0743 in [#12420](https://github.com/jdx/mise/pull/12420)
+- **(npm)** keep aube settings out of npmrc by @jdx in [#12425](https://github.com/jdx/mise/pull/12425)
+- **(npm)** intercept aube node-gyp bootstrap trampoline by @jdx in [#12429](https://github.com/jdx/mise/pull/12429)
+- **(prune)** remove trusted config links whose target is gone on Windows by @JamBalaya56562 in [#12418](https://github.com/jdx/mise/pull/12418)
+
+### 📚 Documentation
+
+- add sponsor logos to readme by @jdx in [#12436](https://github.com/jdx/mise/pull/12436)
+
+### 📦️ Dependency Updates
+
+- update ghcr.io/jdx/mise:rpm docker digest to a7ada36 by @renovate[bot] in [#12432](https://github.com/jdx/mise/pull/12432)
+- update ghcr.io/jdx/mise:alpine docker digest to b6314a4 by @renovate[bot] in [#12430](https://github.com/jdx/mise/pull/12430)
+- update rust crate aube-registry to v2.2.0 by @renovate[bot] in [#12433](https://github.com/jdx/mise/pull/12433)
+- update ghcr.io/jdx/mise:deb docker digest to baffc30 by @renovate[bot] in [#12431](https://github.com/jdx/mise/pull/12431)
+
+### Chore
+
+- **(sponsors)** replace 37signals with omacom foundation by @jdx in [#12435](https://github.com/jdx/mise/pull/12435)
+
 ## [2026.8.13](https://github.com/jdx/mise/compare/v2026.8.12..v2026.8.13) - 2026-08-25
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6261,7 +6261,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.8.13"
+version = "2026.8.14"
 dependencies = [
  "age 0.12.1",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.8.13"
+version = "2026.8.14"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.8.13 macos-arm64 (2026-08-25)
+2026.8.14 macos-arm64 (2026-08-25)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.8.13";
+  version = "2026.8.14";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.8.13
+Version: 2026.8.14
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.8.13"
+version: "2026.8.14"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "b59b11f29f14a9eb93bef65a55084280acd8f0eb"
+  "tag": "6d546dfab62d3ff4ee47312222c9559b82f6b3f4"
 }


### PR DESCRIPTION
### 🐛 Bug Fixes

- **(http)** remove the extraction temp dir when extraction fails by @Marukome0743 in [#12420](https://github.com/jdx/mise/pull/12420)
- **(npm)** keep aube settings out of npmrc by @jdx in [#12425](https://github.com/jdx/mise/pull/12425)
- **(npm)** intercept aube node-gyp bootstrap trampoline by @jdx in [#12429](https://github.com/jdx/mise/pull/12429)
- **(prune)** remove trusted config links whose target is gone on Windows by @JamBalaya56562 in [#12418](https://github.com/jdx/mise/pull/12418)

### 📚 Documentation

- add sponsor logos to readme by @jdx in [#12436](https://github.com/jdx/mise/pull/12436)

### 📦️ Dependency Updates

- update ghcr.io/jdx/mise:rpm docker digest to a7ada36 by @renovate[bot] in [#12432](https://github.com/jdx/mise/pull/12432)
- update ghcr.io/jdx/mise:alpine docker digest to b6314a4 by @renovate[bot] in [#12430](https://github.com/jdx/mise/pull/12430)
- update rust crate aube-registry to v2.2.0 by @renovate[bot] in [#12433](https://github.com/jdx/mise/pull/12433)
- update ghcr.io/jdx/mise:deb docker digest to baffc30 by @renovate[bot] in [#12431](https://github.com/jdx/mise/pull/12431)

### Chore

- **(sponsors)** replace 37signals with omacom foundation by @jdx in [#12435](https://github.com/jdx/mise/pull/12435)