### PR TITLE
chore(sponsors): replace 37signals with omacom foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 </p>
 
 <p align="center">
-  Sponsored by <a href="https://entire.io">entire.io</a> and <a href="https://37signals.com">37signals</a>.<br>
+  Sponsored by <a href="https://entire.io">entire.io</a> and <a href="https://omarchy.org/patrons/">Omacom Foundation</a>.<br>
   <a href="https://jdx.dev/sponsors.html">View all sponsors</a>.
 </p>
 

--- a/src/cli/sponsors.rs
+++ b/src/cli/sponsors.rs
@@ -7,7 +7,7 @@ pub(crate) struct Sponsors;
 impl Sponsors {
     pub(crate) fn run(&self) -> Result<()> {
         miseprintln!(
-            "mise and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
+            "mise and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  Omacom Foundation - https://omarchy.org/patrons/\n\nView all sponsors: https://jdx.dev/sponsors.html"
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary
- replace 37signals with the Omacom Foundation in the README
- update the `mise sponsors` output and foundation link

## Verification
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated sponsor attribution in the README to feature the Omacom Foundation while retaining entire.io.

* **Style**
  * Updated the CLI sponsor display with the Omacom Foundation name and patrons link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->