### PR TITLE
docs: add sponsor logos to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,22 @@
 </p>
 
 <p align="center">
-  Sponsored by <a href="https://entire.io">entire.io</a> and <a href="https://omarchy.org/patrons/">Omacom Foundation</a>.<br>
-  <a href="https://jdx.dev/sponsors.html">View all sponsors</a>.
+  Sponsored by<br><br>
+  <a href="https://entire.io">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://jdx.dev/sponsors/entire-lockup.svg">
+      <img src="https://jdx.dev/sponsors/entire-lockup-on-light.svg" alt="Entire" height="36">
+    </picture>
+  </a>
+  &nbsp;&nbsp;&nbsp;
+  <a href="https://omarchy.org/patrons/">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://jdx.dev/sponsors/omacom-foundation.svg">
+      <img src="https://jdx.dev/sponsors/omacom-foundation-on-light.svg" alt="Omacom Foundation" height="36">
+    </picture>
+  </a>
+  <br><br>
+  <a href="https://jdx.dev/sponsors.html">View all sponsors</a>
 </p>
 
 <hr />


### PR DESCRIPTION
## Summary
- replace the text-only sponsor line with linked Entire and Omarchy wordmarks
- select dark- or light-background assets based on the reader theme
- retain the link to the complete sponsor list

## Verification
- `markdownlint README.md`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README markup with external image URLs; no runtime or security impact.
> 
> **Overview**
> Updates the **README** sponsor block from a single text line to **linked Entire and Omacom Foundation wordmarks**, using `<picture>` so GitHub picks dark- or light-background SVGs via `prefers-color-scheme`.
> 
> Layout adds spacing around the logos and keeps the **View all sponsors** link unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2383b1725c057525eb6c41b9e9dce23292af3e4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README sponsor section with linked logos for Entire and the Omacom Foundation.
  * Added dark and light display variants for sponsor logos.
  * Retained the link to view all sponsors and removed the previous inline sponsorship text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->