### PR TITLE
registry: add onefetch (github:o2sh/onefetch)

### DIFF
--- a/registry/onefetch.toml
+++ b/registry/onefetch.toml
@@ -1,0 +1,5 @@
+backends = ["aqua:o2sh/onefetch", "github:o2sh/onefetch"]
+bins = ["onefetch"]
+description = "Command-line Git information tool"
+test = { cmd = "onefetch --version", expected = "onefetch {{version}}" }
+version_order = "semver"


### PR DESCRIPTION
In the aqua standard registry, so `aqua` is the preferred backend, with `github` as a tier 1 fallback.

Every version `mise ls-remote` resolves for this tool is a strict `MAJOR.MINOR.PATCH`, hence `version_order = "semver"`.

## Popularity

- GitHub: 12,027 stars, 326 forks; latest release 2.27.1 published 2026-03-19
- Active maintenance: latest repository push 2026-08-17
- Also packaged in Homebrew
- https://github.com/o2sh/onefetch

## Validation

- `mise test-tool onefetch` -> `onefetch: OK`
- `mise x aqua:o2sh/onefetch@2.27.1 -- onefetch --version` -> `onefetch 2.27.1`
- `mise x github:o2sh/onefetch@2.27.1 -- onefetch --version` -> `onefetch 2.27.1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Onefetch to the registry with Aqua and GitHub installation support.
  * Included version detection and semantic version ordering for Onefetch releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->