### PR TITLE
fix(doctor): gate self-update leftover check

### DIFF
--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -165,7 +165,7 @@ impl Doctor {
         self.analyze_backend_mismatches();
         self.analyze_system_deps(ts).await;
         self.analyze_new_version().await;
-        #[cfg(windows)]
+        #[cfg(all(windows, feature = "self_update"))]
         self.analyze_self_update_leftovers();
         self.check_path_ordering(ts, &config).await;
         self.check_shim_shadowing(&desired_shims).await;
@@ -320,7 +320,7 @@ impl Doctor {
         self.analyze_settings()?;
 
         self.analyze_new_version().await;
-        #[cfg(windows)]
+        #[cfg(all(windows, feature = "self_update"))]
         self.analyze_self_update_leftovers();
 
         miseprintln!();
@@ -421,7 +421,7 @@ impl Doctor {
     /// Only another `self-update` collects them, so without this nothing says they are there: they
     /// sit outside the cache, and their generated names mean nothing to anyone reading a directory
     /// listing. Reported rather than deleted — `doctor` is not a command that should remove files.
-    #[cfg(windows)]
+    #[cfg(all(windows, feature = "self_update"))]
     fn analyze_self_update_leftovers(&mut self) {
         let orphans = crate::cli::self_update::helper_orphans();
         if orphans.is_empty() {


### PR DESCRIPTION
Starting with mise v2026.08.10, Windows builds fail when the `self_update` feature is disabled. This change fixes the regression.

### Details

`doctor::analyze_self_update_leftovers()` and its two call sites in `src/cli/doctor/mod.rs` were gated with `#[cfg(windows)]` only, but they call `crate::cli::self_update::helper_orphans()`, which only exists in the real `self_update` module — not in `self_update_stub.rs`, which is swapped in when the `self_update` feature is disabled (`src/cli/mod.rs:62`). Building for Windows without the `self_update` feature therefore failed to resolve the symbol. Changed the three `cfg` attributes to `cfg(all(windows, feature = "self_update"))`. Verified `cargo check` succeeds both with default features and with `--no-default-features --features=native-tls,rustls-native-roots,vfox/vendored-lua`.

Assisted-by: Copilot:claude-sonnet-5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows diagnostics by showing self-update checks only when self-update support is enabled.
  * Prevented stale self-update helper information from appearing in unsupported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->