### PR TITLE
fix(backend): detect rolling updates behind versions host

### DIFF
--- a/crates/vfox/embedded-plugins/vfox-neovim/hooks/available.lua
+++ b/crates/vfox/embedded-plugins/vfox-neovim/hooks/available.lua
@@ -33,13 +33,15 @@ local function get_release_checksum(release, http)
         return nil
     end
 
-    local checksum_name = "nvim-" .. platform .. ext .. ".sha256sum"
+    local asset_name = "nvim-" .. platform .. ext
+    local checksum_name = asset_name .. ".sha256sum"
     local checksum_url = nil
 
     for _, asset in ipairs(release.assets or {}) do
-        if asset.name == checksum_name then
+        if asset.name == asset_name and asset.digest ~= nil then
+            return asset.digest:gsub("^sha256:", "")
+        elseif asset.name == checksum_name then
             checksum_url = asset.browser_download_url
-            break
         end
     end
 

--- a/crates/vfox/embedded-plugins/vfox-neovim/hooks/pre_install.lua
+++ b/crates/vfox/embedded-plugins/vfox-neovim/hooks/pre_install.lua
@@ -65,10 +65,14 @@ function PLUGIN:PreInstall(ctx)
     local checksum_name = asset_name .. ".sha256sum"
     local download_url = nil
     local checksum_url = nil
+    local sha256 = nil
 
     for _, asset in ipairs(release.assets) do
         if asset.name == asset_name then
             download_url = asset.browser_download_url
+            if asset.digest ~= nil then
+                sha256 = asset.digest:gsub("^sha256:", "")
+            end
         elseif asset.name == checksum_name then
             checksum_url = asset.browser_download_url
         end
@@ -79,8 +83,7 @@ function PLUGIN:PreInstall(ctx)
     end
 
     -- Fetch the sha256 checksum if available
-    local sha256 = nil
-    if checksum_url ~= nil then
+    if sha256 == nil and checksum_url ~= nil then
         local checksum_resp, checksum_err = http.get({
             url = checksum_url,
         })

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3112,6 +3112,13 @@ pub(crate) trait Backend: Debug + Send + Sync {
         // Fetch direct backend metadata only for rolling entries that need it.
         let latest_checksum = match version_info.checksum {
             Some(checksum) => checksum,
+            None if Settings::get().offline() => {
+                trace!(
+                    "No cached checksum available for rolling version {} while offline",
+                    version
+                );
+                return false;
+            }
             None => match self._list_remote_versions(config).await {
                 Ok(versions) => match versions
                     .into_iter()
@@ -4377,6 +4384,7 @@ mod latest_version_tests {
     use super::*;
     use crate::cli::args::BackendResolution;
     use crate::config::settings::SettingsPartial;
+    use crate::toolset::ToolSource;
     use confique::Layer;
     use pretty_assertions::assert_eq;
     use std::fs;
@@ -4886,6 +4894,38 @@ mod latest_version_tests {
         Settings::reset(None);
 
         assert_eq!(versions, vec!["1.0.0".to_string(), "2.0.0".to_string()]);
+        assert_eq!(backend.list_calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_offline_rolling_check_does_not_fetch_missing_checksum() {
+        let config = Config::get().await.unwrap();
+        let backend = LatestBackend::new("test-offline-rolling-check");
+        backend
+            .get_remote_version_cache()
+            .lock()
+            .await
+            .write(&vec![VersionInfo {
+                version: "nightly".to_string(),
+                rolling: true,
+                ..Default::default()
+            }])
+            .unwrap();
+        let request = ToolRequest::Version {
+            backend: backend.ba.clone(),
+            version: "nightly".to_string(),
+            options: ToolVersionOptions::default(),
+            source: ToolSource::Argument,
+        };
+        let tv = ToolVersion::new(request, "nightly".to_string());
+
+        let mut partial = SettingsPartial::empty();
+        partial.offline = Some(true);
+        Settings::reset(Some(partial));
+        let outdated = backend.is_rolling_version_outdated(&config, &tv).await;
+        Settings::reset(None);
+
+        assert!(!outdated);
         assert_eq!(backend.list_calls(), 0);
     }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3107,13 +3107,34 @@ pub(crate) trait Backend: Debug + Send + Sync {
             _ => return false, // Not rolling or not found
         };
 
-        // If no checksum available, we can't detect changes - don't assume outdated
-        let Some(latest_checksum) = version_info.checksum else {
-            trace!(
-                "No checksum available for rolling version {}, cannot detect updates",
-                version
-            );
-            return false;
+        // The versions host carries the platform-independent rolling bit, but
+        // not the checksum because release assets vary by OS and architecture.
+        // Fetch direct backend metadata only for rolling entries that need it.
+        let latest_checksum = match version_info.checksum {
+            Some(checksum) => checksum,
+            None => match self._list_remote_versions(config).await {
+                Ok(versions) => match versions
+                    .into_iter()
+                    .find(|info| info.version == version && info.rolling)
+                    .and_then(|info| info.checksum)
+                {
+                    Some(checksum) => checksum,
+                    None => {
+                        trace!(
+                            "No checksum available for rolling version {}, cannot detect updates",
+                            version
+                        );
+                        return false;
+                    }
+                },
+                Err(err) => {
+                    debug!(
+                        "Failed to fetch direct metadata for rolling version {}: {err:#}",
+                        version
+                    );
+                    return false;
+                }
+            },
         };
 
         // Compare with stored checksum

--- a/src/versions_host.rs
+++ b/src/versions_host.rs
@@ -59,6 +59,11 @@ struct VersionEntry {
     created_at: toml::value::Datetime,
     #[serde(default)]
     release_url: Option<String>,
+    /// Whether this name is a moving release channel. The versions host keeps
+    /// this platform-independent signal, while platform-specific checksums are
+    /// fetched directly from the backend when needed.
+    #[serde(default)]
+    rolling: bool,
     /// Pre-release flag, when the producing source can distinguish it. Absent
     /// in old host data — and for entries from sources that don't track
     /// prereleases — which maps to `None` ("unknown") without any schema
@@ -246,6 +251,7 @@ pub(crate) async fn list_versions(tool: &str) -> eyre::Result<Option<Vec<Version
                     version,
                     created_at: Some(entry.created_at.to_string()),
                     release_url: entry.release_url,
+                    rolling: entry.rolling,
                     prerelease: entry.prerelease,
                     ..Default::default()
                 })
@@ -652,6 +658,21 @@ mod tests {
             version_list_url("node"),
             "https://mise-versions.jdx.dev/data/node.toml"
         );
+    }
+
+    #[test]
+    fn test_version_entry_deserializes_rolling_metadata() {
+        let response: VersionsResponse = toml::from_str(
+            r#"
+[versions]
+"1.0.0" = { created_at = 2026-01-01T00:00:00Z }
+"nightly" = { created_at = 2026-01-02T00:00:00Z, rolling = true }
+"#,
+        )
+        .unwrap();
+
+        assert!(!response.versions["1.0.0"].rolling);
+        assert!(response.versions["nightly"].rolling);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- deserialize the platform-independent `rolling` flag from mise-versions
- fetch direct backend metadata only when a rolling host entry needs a platform-specific checksum
- update the embedded vfox-neovim plugin to use GitHub asset digests, matching mise-plugins/vfox-neovim#5

The versions host currently shadows backend `rolling` and `checksum` metadata. Publishing checksums from the host would be incorrect across platforms because the collector runs on Ubuntu x86_64. This keeps the cheap shared listing while limiting the direct backend request to rolling entries.

Fixes #10017.

Companion PRs:
- mise-plugins/vfox-neovim#5
- jdx/mise-versions#288

Merge/deployment order: the plugin and mise-versions changes can land independently; this client change becomes effective once the host starts emitting `rolling = true`.

## Testing
- `cargo test --locked --bin mise test_version_entry_deserializes_rolling_metadata`
- `mise run test:e2e e2e/backend/test_vfox_rolling_install`
- `mise run lint-fix`
- live vfox-neovim nightly install verified the GitHub digest and persisted it in `.mise.checksum`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Rolling upgrade detection now triggers extra backend fetches when the versions host omits checksums; offline behavior changes to avoid false positives. Neovim install checksum sourcing changes but retains fallback.
> 
> **Overview**
> Fixes rolling-channel update detection when version lists come from **mise-versions** instead of the plugin directly. The host now exposes a platform-independent **`rolling`** flag (not checksums, which differ by OS/arch); mise reads that flag and, only for rolling entries missing a checksum, calls the backend’s direct metadata to obtain a platform-specific checksum for comparison with `.mise.checksum`.
> 
> **Offline:** if no checksum is cached, rolling “outdated” checks skip network fetch and treat the install as current.
> 
> The embedded **vfox-neovim** plugin prefers GitHub release asset **`digest`** for SHA-256 when present, with the same fallback to `.sha256sum` files as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9883760c6176d3a38ad6a555b4f30b23da04b8eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Neovim installation verification using embedded release checksums when available, with reliable fallback to checksum files.
  - Improved rolling-version update detection when cached checksum information is unavailable.
  - Prevented updates when required release metadata cannot be retrieved, avoiding unreliable results.

- **Improvements**
  - Rolling and fixed release channels are now identified more accurately during version processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->