### PR TITLE
test(http): make DNS failure test deterministic

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -1964,11 +1964,26 @@ mod tests {
     use super::*;
     use confique::Layer;
     use indexmap::IndexMap;
+    use reqwest::dns::{Name, Resolve, Resolving};
     use std::path::PathBuf;
     use url::Url;
 
     // Mutex to ensure tests don't interfere with each other when modifying global settings
     static TEST_SETTINGS_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct FailingDnsResolver;
+
+    impl Resolve for FailingDnsResolver {
+        fn resolve(&self, _name: Name) -> Resolving {
+            Box::pin(async {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "test DNS resolution failure",
+                )
+                .into())
+            })
+        }
+    }
 
     // Helper to create test settings with specific URL replacements
     fn with_test_settings<F, R>(replacements: IndexMap<String, String>, test_fn: F) -> R
@@ -3000,6 +3015,7 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         let client = Client {
             reqwest: Ok(Client::_new()
                 .no_proxy()
+                .dns_resolver(FailingDnsResolver)
                 .read_timeout(timeout)
                 .connect_timeout(timeout)
                 .build()


### PR DESCRIPTION
## Summary
- inject a deterministic failing reqwest DNS resolver in the HTTP circuit-breaker test
- preserve coverage for DNS classification, circuit opening, and credential redaction
- avoid relying on the CI runner DNS response time for the reserved `.invalid` domain

This addresses the macOS unit-test failure observed in #12378.

## Testing
- `cargo test --all-features --bin mise http::tests::test_reqwest_dns_error_is_not_transient_and_opens_circuit`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code paths modified.
> 
> **Overview**
> Makes **`test_reqwest_dns_error_is_not_transient_and_opens_circuit`** reliable on CI (including macOS) by no longer depending on how quickly the runner resolves **`*.invalid`**.
> 
> The test adds a **`FailingDnsResolver`** (reqwest **`Resolve`**) that always returns a **`NotFound`** DNS error, and wires it into the test **`Client`** via **`.dns_resolver(FailingDnsResolver)`**. The same assertions still apply: DNS errors are classified as non-transient, **`prefer_offline`** records the host in **`UNAVAILABLE_HTTP_HOSTS`**, and stored causes must not leak URL query secrets like **`token=secret`**.
> 
> Production HTTP behavior is unchanged; this is test-only plumbing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c398fb6df621491e0ec72bab1c7008590fbc6d81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regression coverage for DNS resolution failures in circuit-breaker scenarios.
  * Ensured DNS errors are handled consistently by the test client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->