### PR TITLE
registry: add syncthing (github:syncthing/syncthing)

### DIFF
--- a/registry/syncthing.toml
+++ b/registry/syncthing.toml
@@ -1,0 +1,5 @@
+backends = ["aqua:syncthing/syncthing", "github:syncthing/syncthing"]
+bins = ["syncthing"]
+description = "Open Source Continuous File Synchronization"
+test = { cmd = "syncthing --version", expected = "syncthing v{{version}}" }
+version_order = "semver"


### PR DESCRIPTION
In the aqua standard registry, so `aqua` is the preferred backend, with `github` as a tier 1 fallback. The version banner prefixes the number with `v`, so the test expects `syncthing v{{version}}`.

Every version `mise ls-remote` resolves for this tool is a strict `MAJOR.MINOR.PATCH` -- upstream release candidates such as `v2.0.0-rc.1` are filtered out -- hence `version_order = "semver"`.

## Popularity

- GitHub: 87,991 stars, 5,432 forks; latest release v2.1.3 published 2026-08-05
- Active maintenance: latest repository push 2026-08-25
- Also packaged in Homebrew
- https://github.com/syncthing/syncthing

## Validation

- `mise test-tool syncthing` -> `syncthing: OK`
- `mise x aqua:syncthing/syncthing@2.1.3 -- syncthing --version` -> `syncthing v2.1.3 "Hafnium Hornet" ...`
- `mise x github:syncthing/syncthing@2.1.3 -- syncthing --version` -> `syncthing v2.1.3 "Hafnium Hornet" ...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Syncthing to the registry with Aqua and GitHub sources.
  * Included version detection and semantic version ordering for Syncthing releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->