### PR TITLE
fix(file): silence chunks_exact_to_as_chunks in decode_text

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -635,8 +635,10 @@ pub(crate) fn decode_text(bytes: &[u8]) -> Result<String> {
             );
         }
         let units = bytes
-            .chunks_exact(2)
-            .map(|c| to_u16([c[0], c[1]]))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|c| to_u16(*c))
             .collect_vec();
         String::from_utf16(&units).wrap_err_with(|| format!("invalid {label} text"))
     }


### PR DESCRIPTION
Clippy 1.98 added `chunks_exact_to_as_chunks`. The workspace runs with `-D warnings`, so on a runner
that already has 1.98 the lint job dies on code that has been on `main` since #12013:

```
error: using `chunks_exact` with a constant chunk size
   --> src/file.rs:638:14
    |
638 |             .chunks_exact(2)
    |              ^^^^^^^^^^^^^^^ help: consider using `as_chunks` instead: `as_chunks::<2>().0.iter()`
    |
    = note: `-D clippy::chunks-exact-to-as-chunks` implied by `-D warnings`
    = help: for further information visit
      https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#chunks_exact_to_as_chunks
error: could not compile `mise` (bin "mise") due to 1 previous error
```

## Why it looks intermittent

Nothing in the repository decides which compiler `lint` uses. There is no `rust-toolchain.toml`, no
`rust` under `[tools]` in `mise.toml`, and the job installs no toolchain — `Cargo.toml`'s
`rust-version = "1.95"` is an MSRV floor, not a pin. So `mbx clippy` runs whatever rustup default
came preinstalled on the GitHub-hosted image.

That image is mid-rollout, and the two versions in circulation ship different compilers:

| image | Rust | `lint` |
| --- | --- | --- |
| `20260823.283.1` | 1.98.0 | **fails** |
| `20260816.277.1` | 1.97.1 | passes |

(diffing `actions/runner-images` `Ubuntu2404-Readme.md` at both tags, Rust/Cargo/Rustdoc are the
only entries that move.)

So the result tracks the machine, not the diff. Every run I checked:

| run | image | result |
| --- | --- | --- |
| #12444 (registry-only change) | `20260823.283.1` | fail |
| #12428 | `20260823.283.1` | fail |
| #12446 | `20260816.277.1` | pass |
| #12448 | `20260816.277.1` | pass |

#12444 touches nothing but `registry/` and still fails at this line, so the red PRs are not red for
anything they did; the green ones are green because they drew 1.97.1. As the rollout finishes,
failing becomes the only outcome. `trusted` PRs run on Namespace runners and move on their own
schedule.

`test-ci` follows either way, since it only reports `lint failed or was skipped`.

## The change

```rust
let units = bytes
    .as_chunks::<2>()
    .0
    .iter()
    .map(|c| to_u16(*c))
    .collect_vec();
```

`as_chunks::<2>()` yields `&[[u8; 2]]`, which is already what `to_u16: fn([u8; 2]) -> u16` takes, so
the pair no longer has to be rebuilt by index.

Discarding the remainder half is sound here rather than merely convenient: the guard immediately
above bails unless `bytes.len()` is a multiple of two, so `.1` is always empty at this point. The old
`chunks_exact` dropped the same remainder for the same reason.

`slice::as_chunks` is stable since 1.88, well under the 1.95 MSRV, so it does not move that floor.
Same code units, same order, same error paths.

This clears the current breakage. It does not address the recurrence — an unpinned toolchain means
the next release that adds a lint reddens unrelated PRs the same way — but pinning is a policy call
that belongs in its own change, not here.

## Verification

Kept as its own commit rather than folded into a PR that happens to be blocked by it, per AGENTS.md.

**What is not yet verified:** this PR's own `lint` run drew `20260816.277.1` — Rust 1.97.1, which
does not have the lint — so it shows the rewrite compiles and stays clean, but not that it clears the
1.98 error. I could not close that gap locally either; the toolchain on hand is 1.84, below both the
1.95 MSRV and the compiler that added the lint. The rewrite is verbatim the one Clippy's own `help`
line suggests, and a re-run that lands on `20260823.283.1` would confirm it directly.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*
