### PR TITLE
fix(task): give injected dependencies keep-order slots

### DIFF
--- a/e2e/tasks/test_task_keep_order_task_reference
+++ b/e2e/tasks/test_task_keep_order_task_reference
@@ -9,8 +9,9 @@
 #
 # --jobs 1 keeps that part deterministic.
 #
-# Block order across tasks is asserted further down. Those cases need real
-# parallelism -- with --jobs 1 the semaphore serializes the tasks and the
+# Block order across tasks is asserted further down, for the tasks named in the
+# run entry and for the ones their own `depends` bring along. Those cases need
+# real parallelism -- with --jobs 1 the semaphore serializes the tasks and the
 # ordering defect cannot reproduce.
 #
 # Not covered: a parent whose `run` interleaves scripts and task references.
@@ -115,3 +116,131 @@ out="$(MISE_JOBS=4 mise run --quiet --output keep-order outer 2>&1)"
 assert "printf '%s\n' \"$out\"" "[a] A
 [b] B
 [last] LAST"
+
+# A task named in a run entry brings its own `depends` along, and those got no
+# slot: their blocks landed in whatever order they finished in. `dep3` takes the
+# longest and so printed last, but it belongs first -- `mise run r1 ::: r2 :::
+# r3` puts it there, and reaching the same tasks through `launch` must not
+# differ. The sleeps are inverted deliberately, so the old behaviour is wrong
+# every time rather than most of the time.
+cat >mise.toml <<'TOML'
+[tasks.launch]
+run = { tasks = ["r1", "r2", "r3"] }
+
+[tasks.r1]
+depends = ["dep1"]
+run = 'echo R1'
+
+[tasks.r2]
+depends = ["dep2"]
+run = 'echo R2'
+
+[tasks.r3]
+depends = ["dep3"]
+run = 'echo R3'
+
+[tasks.dep1]
+run = 'echo DEP1'
+
+[tasks.dep2]
+run = 'sleep 0.5; echo DEP2'
+
+[tasks.dep3]
+run = 'sleep 1; echo DEP3'
+TOML
+
+out="$(MISE_JOBS=4 mise run --quiet --output keep-order launch 2>&1)"
+assert "printf '%s\n' \"$out\"" "[r1] R1
+[r2] R2
+[r3] R3
+[dep3] DEP3
+[dep2] DEP2
+[dep1] DEP1"
+
+# The invariant behind that literal: the two forms run the same task set, so
+# they must produce the same blocks. `launch` prints nothing of its own, so the
+# outputs are comparable as-is. Asserted separately from the order above, which
+# is only today's answer to this.
+injected="$(MISE_JOBS=4 mise run --quiet --output keep-order launch 2>&1)"
+toplevel="$(MISE_JOBS=4 mise run --quiet --output keep-order r1 ::: r2 ::: r3 2>&1)"
+[[ $injected == "$toplevel" ]] || fail "injected through a run entry:
+$injected
+
+named directly:
+$toplevel"
+
+# And it has to hold every time. Without the sleeps the dependencies finish in
+# whatever order the scheduler happened to start them in, which is the shape
+# that made this report intermittent -- 20 runs of it produced four different
+# orders.
+cat >mise.toml <<'TOML'
+[tasks.launch]
+run = { tasks = ["r1", "r2", "r3"] }
+
+[tasks.r1]
+depends = ["dep1"]
+run = 'echo R1'
+
+[tasks.r2]
+depends = ["dep2"]
+run = 'echo R2'
+
+[tasks.r3]
+depends = ["dep3"]
+run = 'echo R3'
+
+[tasks.dep1]
+run = 'echo DEP1'
+
+[tasks.dep2]
+run = 'echo DEP2'
+
+[tasks.dep3]
+run = 'echo DEP3'
+TOML
+
+first=""
+for run_n in 1 2 3 4 5; do
+  out="$(MISE_JOBS=4 mise run --quiet --output keep-order launch 2>&1)"
+  if [[ -z $first ]]; then
+    first="$out"
+  elif [[ $out != "$first" ]]; then
+    fail "run $run_n reordered the blocks:
+$out
+
+the first run was:
+$first"
+  fi
+done
+
+# `depends_post` arrives through the same path and was equally unslotted.
+# Compared against the top-level form rather than a literal: where a post task's
+# block belongs relative to the tasks that triggered it is a question this change
+# deliberately leaves alone, and equality is the property that does not depend on
+# the answer.
+cat >mise.toml <<'TOML'
+[tasks.launch]
+run = { tasks = ["p1", "p2"] }
+
+[tasks.p1]
+depends_post = ["post1"]
+run = 'echo P1'
+
+[tasks.p2]
+depends_post = ["post2"]
+run = 'echo P2'
+
+[tasks.post1]
+run = 'echo POST1'
+
+[tasks.post2]
+run = 'sleep 0.5; echo POST2'
+TOML
+
+injected="$(MISE_JOBS=4 mise run --quiet --output keep-order launch 2>&1)"
+toplevel="$(MISE_JOBS=4 mise run --quiet --output keep-order p1 ::: p2 2>&1)"
+[[ $injected == "$toplevel" ]] || fail "depends_post, injected through a run entry:
+$injected
+
+named directly:
+$toplevel"

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1245,8 +1245,10 @@ impl Run {
             });
         }
 
-        // Validate and initialize task output
-        for task in tasks.all() {
+        // Validate and initialize task output. In creation order: keep-order
+        // hands out its output slots here, and the same order is used for the
+        // tasks a run entry injects later, so the two agree by construction.
+        for task in tasks.all_in_creation_order() {
             self.validate_task(task)?;
             self.output_handler.as_mut().unwrap().init_task(task);
         }

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -106,6 +106,7 @@ pub(crate) struct Deps {
     cache_keys: HashMap<TaskKey, String>, // stable artifact identities published by completed tasks
     dep_edges: HashMap<TaskKey, HashSet<TaskKey>>, // maps each task to its direct dependency task keys
     post_dep_parents: HashMap<TaskKey, HashSet<TaskKey>>, // maps each post-subtree task to its triggering parents
+    creation_order: Vec<TaskKey>, // every node in the order the graph created it, see `all_in_creation_order`
     tx: mpsc::UnboundedSender<Option<Task>>,
     // not clone, notify waiters via tx None
 }
@@ -306,6 +307,14 @@ impl Deps {
         let executed = HashSet::new();
         let did_work = HashSet::new();
         let cache_keys = HashMap::new();
+        // Node indices are handed out by `add_idx` alone -- roots in the order
+        // they were named, then dependencies as the worklist reaches them -- and
+        // nothing has removed a node yet, so index order is creation order here
+        // and nowhere later.
+        let creation_order = graph
+            .node_indices()
+            .map(|idx| task_key(&graph[idx]))
+            .collect();
         Ok(Self {
             graph,
             tx,
@@ -316,6 +325,7 @@ impl Deps {
             cache_keys,
             dep_edges,
             post_dep_parents,
+            creation_order,
         })
     }
 
@@ -497,8 +507,40 @@ impl Deps {
             .find(|&idx| &self.graph[idx] == task)
     }
 
+    /// Every task still in the graph, in no particular order.
+    ///
+    /// Node index order is creation order only until the first removal, so
+    /// anything that cares about the order wants
+    /// [`all_in_creation_order`](Self::all_in_creation_order) instead.
     pub(crate) fn all(&self) -> impl Iterator<Item = &Task> {
         self.graph.node_indices().map(|idx| &self.graph[idx])
+    }
+
+    /// Every task still in the graph, in the order the graph created its nodes:
+    /// the roots in the order they were named, then each task's `depends` and
+    /// `depends_post` in the order the worklist reached them.
+    ///
+    /// This is the order keep-order hands out its output slots in, so it has to
+    /// survive removals — and [`all`](Self::all) does not. petgraph's
+    /// `remove_node` swap-removes, moving the last node into the hole, so a
+    /// single pruned or finished task is enough to scramble index order.
+    ///
+    /// Tasks the graph no longer holds are dropped rather than reported: a task
+    /// pruned as already complete never runs, so nothing would ever retire the
+    /// slot it was given, and an empty slot at the front of the buffer map stops
+    /// everything behind it from streaming.
+    pub(crate) fn all_in_creation_order(&self) -> Vec<&Task> {
+        let mut present: HashMap<TaskKey, &Task> = self
+            .graph
+            .node_indices()
+            .map(|idx| (task_key(&self.graph[idx]), &self.graph[idx]))
+            .collect();
+        // `add_idx` deduplicates by key, so key to node is one-to-one and
+        // removing as we go is just that stated out loud.
+        self.creation_order
+            .iter()
+            .filter_map(|key| present.remove(key))
+            .collect()
     }
 
     /// Mark tasks that share a display_name so their prefix includes args
@@ -678,6 +720,7 @@ mod tests {
             cache_keys: HashMap::new(),
             dep_edges,
             post_dep_parents,
+            creation_order: Vec::new(),
             tx,
         }
     }
@@ -806,6 +849,86 @@ mod tests {
         assert_eq!(
             deps.dependency_state(&waiter),
             TaskDependencyState::default()
+        );
+    }
+
+    /// Roots keep the order they were named; a dependency is discovered by the
+    /// worklist and lands after every root. Both halves matter: keep-order hands
+    /// out its output slots in this order.
+    #[tokio::test]
+    async fn creation_order_is_roots_then_discovered_dependencies() {
+        let config = Config::get().await.unwrap();
+        let tasks = config.tasks().await.unwrap();
+        let mut root = tasks["configtask"].clone();
+        root.depends = vec!["lint".parse().unwrap()];
+        let other = tasks["test"].clone();
+
+        let deps = Deps::new(&config, vec![root, other]).await.unwrap();
+
+        assert_eq!(
+            deps.all_in_creation_order()
+                .iter()
+                .map(|t| t.name.as_str())
+                .collect_vec(),
+            ["configtask", "test", "lint"],
+            "roots as named, then what the worklist reached"
+        );
+    }
+
+    /// petgraph's `remove_node` swap-removes, so one departure is enough to
+    /// scramble node index order. That is the whole reason this accessor exists
+    /// rather than callers using `all`.
+    #[tokio::test]
+    async fn creation_order_survives_a_removal() {
+        let config = Config::get().await.unwrap();
+        let tasks = config.tasks().await.unwrap();
+        let mut root = tasks["configtask"].clone();
+        root.depends = vec!["lint".parse().unwrap()];
+        let other = tasks["test"].clone();
+        let mut deps = Deps::new(&config, vec![root.clone(), other]).await.unwrap();
+
+        deps.remove(&root);
+
+        assert_eq!(
+            deps.all_in_creation_order()
+                .iter()
+                .map(|t| t.name.as_str())
+                .collect_vec(),
+            ["test", "lint"],
+            "the survivors, still in the order they were created"
+        );
+        assert_eq!(
+            deps.all().map(|t| t.name.as_str()).collect_vec(),
+            ["lint", "test"],
+            "while index order has the last node moved into the hole"
+        );
+    }
+
+    /// A task pruned as already complete never runs, so nothing would retire the
+    /// slot it was given and everything behind it would stay buffered.
+    #[tokio::test]
+    async fn a_pruned_task_is_absent_from_creation_order() {
+        let config = Config::get().await.unwrap();
+        let tasks = config.tasks().await.unwrap();
+        let mut root = tasks["configtask"].clone();
+        root.depends = vec!["lint".parse().unwrap()];
+        let other = tasks["test"].clone();
+        let completion_state = TaskCompletionState {
+            completed: HashSet::from([task_key(&other)]),
+            ..Default::default()
+        };
+
+        let deps = Deps::new_pruned(&config, vec![root, other], &completion_state)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            deps.all_in_creation_order()
+                .iter()
+                .map(|t| t.name.as_str())
+                .collect_vec(),
+            ["configtask", "lint"],
+            "the completed task is gone, the rest keep their order"
         );
     }
 

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -12,6 +12,7 @@ use crate::task::task_cache::{
     CommandInput, TaskCacheContext, TaskCacheMissReason, TaskCacheRestore,
 };
 use crate::task::task_context_builder::TaskContextBuilder;
+use crate::task::task_helpers::task_gets_keep_order_slot;
 use crate::task::task_list::split_task_spec;
 use crate::task::task_output::{TaskOutput, trunc};
 use crate::task::task_output_handler::OutputHandler;
@@ -1071,7 +1072,6 @@ impl TaskExecutor {
                 to_run.push(t);
             }
         }
-        let injected = to_run.clone();
         let sub_deps = Deps::new_pruned(config, to_run, completion_state).await?;
         // Give these tasks their keep-order slots now, while the order they were
         // written in is still known and before any of them can produce a line.
@@ -1079,16 +1079,31 @@ impl TaskExecutor {
         // `Arc<Mutex<..>>`, and the guard is a temporary in a statement with no
         // await in it, so it never crosses a suspension point.
         {
-            let children: Vec<Task> = injected
+            // The whole sub-graph, not just the names in the run entry. A
+            // `depends` of one of those names is scheduled here too, and without
+            // a slot its block landed wherever its first line happened to arrive
+            // — so the same tasks came out in a different order from one run to
+            // the next. Creation order is what the identical `mise run a ::: b`
+            // would have given them, since that builds its graph the same way
+            // from the same list.
+            //
+            // A task the sub-graph pruned as already complete is absent from
+            // that order by construction: it never runs, so nothing would ever
+            // call `on_task_finished` and its empty slot would sit at the front
+            // for the rest of the run.
+            let children: Vec<Task> = sub_deps
+                .all_in_creation_order()
                 .into_iter()
-                // A task the sub-graph pruned as already complete never runs, so
-                // it would never call `on_task_finished` — its empty slot would
-                // sit at the front for the rest of the run.
-                .filter(|t| sub_deps.all().any(|scheduled| scheduled == t))
-                // Same reason, for a task whose own `output` opts out of
-                // keep-order: `on_task_finished` is only called for keep-order
-                // tasks (see cli/run.rs).
-                .filter(|t| self.output(Some(t)) == TaskOutput::KeepOrder)
+                .filter(|t| {
+                    // Same reason as the pruned tasks, for one whose own
+                    // `output` opts out of keep-order: `on_task_finished` is
+                    // called for keep-order tasks only (see cli/run.rs), so its
+                    // slot would never be retired. And the rule the up-front
+                    // registration applies, so a task that only aggregates
+                    // `depends` does not take a slot ahead of what it waits on.
+                    self.output(Some(*t)) == TaskOutput::KeepOrder && task_gets_keep_order_slot(t)
+                })
+                .cloned()
                 .collect();
             if !children.is_empty() {
                 self.output_handler

--- a/src/task/task_helpers.rs
+++ b/src/task/task_helpers.rs
@@ -19,6 +19,18 @@ pub(crate) fn task_runs_task_references(task: &Task) -> bool {
     task.run().iter().any(|e| !matches!(e, RunEntry::Script(_)))
 }
 
+/// Whether keep-order should reserve an output slot for this task.
+///
+/// Tasks that produce output, plus the ones that inject other tasks: those
+/// produce nothing themselves but anchor their children's blocks at their own
+/// declared position. A task that only aggregates `depends` gets neither and
+/// stays out — it finishes after everything it waits on, and only the front
+/// entry of the buffer map may stream, so its empty slot would hold the live
+/// stream for the whole run.
+pub(crate) fn task_gets_keep_order_slot(task: &Task) -> bool {
+    task_needs_permit(task) || task_runs_task_references(task)
+}
+
 /// Canonicalize a path for use as cache key
 /// Falls back to original path if canonicalization fails
 pub(crate) fn canonicalize_path(path: &Path) -> PathBuf {

--- a/src/task/task_output_handler.rs
+++ b/src/task/task_output_handler.rs
@@ -1,5 +1,5 @@
 use crate::config::Settings;
-use crate::task::task_helpers::{task_needs_permit, task_runs_task_references};
+use crate::task::task_helpers::{task_gets_keep_order_slot, task_needs_permit};
 use crate::task::task_output::TaskOutput;
 use crate::task::{Task, TaskCacheOutput};
 use crate::ui::multi_progress_report::MultiProgressReport;
@@ -357,12 +357,10 @@ impl OutputHandler {
     /// Initialize output handling for a task
     pub(crate) fn init_task(&mut self, task: &Task) {
         match self.output(Some(task)) {
-            TaskOutput::KeepOrder if task_needs_permit(task) || task_runs_task_references(task) => {
-                // Tasks that produce output, plus the ones that inject other
-                // tasks: those produce nothing themselves but anchor their
-                // children's blocks at their own declared position. A task that
-                // only aggregates `depends` gets neither and stays out, so it
-                // cannot sit at the front holding the live stream all run.
+            // See `task_gets_keep_order_slot` for which tasks get a slot and why.
+            // The executor applies the same rule to the tasks a run entry
+            // injects, so both paths agree on who is in the buffer map.
+            TaskOutput::KeepOrder if task_gets_keep_order_slot(task) => {
                 self.keep_order_state.lock().unwrap().init_task(task);
             }
             TaskOutput::Replacing => {
@@ -744,6 +742,54 @@ mod tests {
         state.insert_tasks_before(&mixed, &[task_named("one"), task_named("two")]);
 
         assert_eq!(keys(&state), ["mixed", "one", "two"]);
+    }
+
+    #[test]
+    fn only_tasks_that_produce_or_inject_get_a_keep_order_slot() {
+        // The gate both registration paths apply. A task that only aggregates
+        // `depends` prints nothing and finishes after everything it waits on, so
+        // a slot for it would sit at the front of the map -- where only the
+        // front entry may stream -- for the whole run.
+        assert!(
+            !task_gets_keep_order_slot(&task_named("aggregator")),
+            "nothing to print and nothing to anchor"
+        );
+        assert!(
+            task_gets_keep_order_slot(&Task {
+                name: "script".to_string(),
+                run: vec![RunEntry::Script("echo A".to_string())],
+                ..Default::default()
+            }),
+            "produces output of its own"
+        );
+        assert!(
+            task_gets_keep_order_slot(&Task {
+                name: "launch".to_string(),
+                run: vec![RunEntry::TaskGroup {
+                    tasks: vec!["one".to_string()],
+                }],
+                ..Default::default()
+            }),
+            "anchors what it injects"
+        );
+    }
+
+    #[test]
+    fn injected_tasks_keep_their_order_however_many_there_are() {
+        // The executor now hands over a whole sub-graph -- the tasks named in the
+        // run entry *and* their dependencies -- rather than two or three names,
+        // and their relative order is the thing being carried across.
+        let mut state = KeepOrderState::new();
+        let launch = task_named("launch");
+        state.init_task(&launch);
+
+        let children = ["r1", "r2", "r3", "dep3", "dep2", "dep1"].map(task_named);
+        state.insert_tasks_before(&launch, &children);
+
+        assert_eq!(
+            keys(&state),
+            ["r1", "r2", "r3", "dep3", "dep2", "dep1", "launch"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #12370 and #12397, closing the last ordering hole from [#12238](https://github.com/jdx/mise/discussions/12238).

## The bug

`keep-order` groups each task's output into one contiguous block and emits those blocks in a declaration-derived order, so the output does not depend on which task printed first. #12397 gave tasks started from a task reference a slot anchored at their parent's position — but only the tasks **named in the run entry** were handed to `insert_tasks_before`. The `depends` / `depends_post` those tasks bring with them are scheduled in the same sub-graph and got no slot, so their entry in the buffer map was created by their first output line and appended at the tail.

Three roots, each with one `depends`, `MISE_JOBS=4`, twenty runs of each form on 2026.8.14:

```
mise run launch            (run = { tasks = ["r1","r2","r3"] })
      9 r1 r2 r3 dep3 dep2 dep1
      5 r1 r2 r3 dep2 dep3 dep1
      3 r1 r2 r3 dep3 dep1 dep2
      3 r1 r2 r3 dep1 dep3 dep2

mise run r1 ::: r2 ::: r3  (the same tasks, named directly)
     20 r1 r2 r3 dep3 dep2 dep1
```

Same config, same machine. `depends_post` behaves the same way. `wait_for` does not — it never creates a task occurrence, only edges, so there is no block for it to misplace.

The point worth separating out: **which** order is right is a design question, but *varying between runs* is not. `keep-order` exists to take the scheduler out of the answer, and on this path the scheduler was the answer.

## The fix

The whole scheduled sub-graph takes slots, not just the run entry's names.

The order comes from `Deps`, and that is what makes this a bug fix rather than a redesign: the sub-graph is built by the same `Deps::new` from the same ordered list that `mise run r1 ::: r2 ::: r3` uses. Reusing its construction order makes the two forms agree **by construction** rather than by luck. Nothing decides what the order should be — `dep3 dep2 dep1` is an artifact of the LIFO worklist in `new_with_cycle_limit`, not a design, and it is left exactly as it was. If that is worth revisiting, both forms move together now.

`Deps::all` could not supply that order. petgraph's `remove_node` swap-removes, moving the last node into the hole, so one pruned or finished task scrambles node index order. Nothing said `all`'s order was meaningful, which is how `setup_output_and_validate` came to depend on running before the first removal without a comment saying so. `all_in_creation_order` records the order at construction and filters to the nodes still in the graph — which also subsumes the filter the old code did by hand, since a task pruned as already complete never runs and nothing would ever retire the slot it was given.

`src/cli/run.rs` now uses the same accessor. That is a no-op today, and deliberately so: it puts the ordering contract in one place instead of leaving the injected path to match the up-front path by coincidence.

## The one behaviour change beyond the ordering

`task_gets_keep_order_slot` is the rule the up-front registration already applied (`task_needs_permit || task_runs_task_references`), extracted so the injection path applies it too.

This is load-bearing now that dependencies are included. A task that only aggregates `depends` produces nothing and finishes after everything it waits on; only the front entry of the buffer map may stream, so a slot for it would hold the live stream for the whole run. The only slot this newly withholds is for an aggregator named in a run entry — safe, because it prints nothing and, having no non-script run entries, can never be a nesting anchor either.

## Worth a reviewer's eye

The change enlarges the set of tasks holding empty slots, and an empty slot at the front blocks live streaming until it is retired. I audited three retirement paths and found no fourth exit — `run.rs` on normal completion, `retire_keep_order_slot` while stopping, and `never_started` on the abort path (which iterates `deps.all()` and so already covers the new slots). Please check that rather than take my word for it.

Deliberately not done: switching `graph` to `StableDiGraph`, which would retire this whole class of problem by making `all` itself stable. It reaches `leaves`, `find_cycles`, `is_linear`, `node_idx`, `mark_ambiguous_prefixes` and the `pub graph` field's users, and changes index-reuse semantics — the wrong risk to take inside a nondeterminism fix. Happy to open an issue.

## Tests

Unit, `src/task/deps.rs`:
- `creation_order_is_roots_then_discovered_dependencies` — roots as named, then what the worklist reached.
- `creation_order_survives_a_removal` — asserts the accessor is in creation order **and** that `all()` is not, so the divergence is documented as behaviour rather than as a comment.
- `a_pruned_task_is_absent_from_creation_order`.

Unit, `src/task/task_output_handler.rs`:
- `only_tasks_that_produce_or_inject_get_a_keep_order_slot` — pins the extracted gate, the one change here that could silently withhold a needed slot.
- `injected_tasks_keep_their_order_however_many_there_are` — six tasks; the existing cases only covered two.

e2e, `e2e/tasks/test_task_keep_order_task_reference`:
- The literal order, with the sleeps inverted so the old behaviour is wrong **every** time rather than most of the time — measured 3/3 before the fix.
- `mise run launch` and `mise run r1 ::: r2 ::: r3` must be byte-identical. No hard-coded order, so it survives the order being redesigned later.
- Five runs of a *sleepless* config compared against the first — the shape that produced the 9/5/3/3 split above.
- `depends_post`, asserted by equality with the top-level form only. Where a post task's block belongs relative to its trigger is a question this change leaves alone, and equality does not depend on the answer.

## On verification

I have no Rust toolchain on this machine, so **I have not compiled or run any of this** — CI is the first execution. What I did verify locally: `rustfmt --check` is clean, and every ordering the new e2e cases assert was measured against released 2026.8.14 first, including the `depends_post` top-level order, so the expected values are recorded behaviour rather than predictions.

The `lint` job will fail on `src/file.rs:638` (`clippy::chunks_exact_to_as_chunks`). That is pre-existing on `main` — #12444, which touches no Rust at all, fails identically — and is untouched by this branch.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.241.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keep-order output for tasks that reference other tasks, including nested dependencies and post-dependency tasks.
  * Ensured task results maintain consistent relative ordering during parallel execution.
  * Aligned output ordering between injected tasks and tasks executed directly by name.
  * Preserved creation order for eligible tasks while excluding removed, pruned, or non-output tasks from ordering slots.
  * Improved deterministic results across repeated parallel runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->