### PR TITLE
fix(watch): restore the terminal when the process is signalled

### DIFF
--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -170,6 +170,10 @@ jobs:
         run: mbx test --workspace --exclude mise --ignore-rust-version
       - run: mise run test:e2e e2e/cli/test_system_install_brew_macos_slow
       - run: mise run test:e2e e2e/tasks/test_task_zsh_process_substitution_tmux_macos
+      # The e2e suite is Linux-only, and this one turns on `TIOCSCTTY` and
+      # signal-driven termios restore — both places where the two platforms have
+      # differed before. Run it here so the claim covers macOS as well.
+      - run: mise run test:e2e e2e/cli/test_watch_terminal_restore_on_signal
       - run: mbx cache stats
         if: always()
 

--- a/e2e/cli/test_watch_terminal_restore_on_signal
+++ b/e2e/cli/test_watch_terminal_restore_on_signal
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression test: killing `mise watch` with a signal must still put the
+# terminal back.
+#
+# `TerminalState` restores termios from `Drop`, which covers every exit that
+# unwinds — but not being killed. A `mise watch` nested under a `mise run` is
+# killed by that run's `exit::kill_all()`, which sends SIGTERM, and mise handles
+# only SIGINT. So the process died where it stood and the terminal kept whatever
+# watchexec had left in it: no echo (#8269).
+#
+# Two things this test needs that a plain e2e run does not give it:
+#
+#   * a controlling terminal. `TerminalState::capture()` prefers `/dev/tty` and
+#     saves nothing at all when no descriptor is a terminal, so without a pty
+#     there is no defect to observe.
+#   * a watchexec that reliably clears ECHO. The real one does it through
+#     `--clear=reset`, but a stub makes the test deterministic and independent of
+#     what version of watchexec is installed. `e2e/cli/test_watch_default_task`
+#     already stubs watchexec this way.
+
+mkdir -p "$HOME/bin"
+cat >"$HOME/bin/watchexec" <<'EOF'
+#!/usr/bin/env bash
+# Stand in for `--clear=reset`: drop ECHO on the controlling terminal, say so,
+# then stay alive until something kills us.
+stty -echo </dev/tty
+: >"$HOME/watchexec-ready"
+while :; do sleep 1; done
+EOF
+chmod +x "$HOME/bin/watchexec"
+export PATH="$HOME/bin:$PATH"
+
+cat >mise.toml <<'EOF'
+[tasks.watched]
+run = "echo watched"
+sources = ["src/**/*.rs"]
+EOF
+
+rm -f "$HOME/watchexec-ready"
+
+python3 - "$HOME" <<'PY'
+import fcntl
+import os
+import pty
+import signal
+import sys
+import termios
+import time
+
+home = sys.argv[1]
+ready = os.path.join(home, "watchexec-ready")
+
+master, slave = pty.openpty()
+
+pid = os.fork()
+if pid == 0:
+    # The child has to become a session leader and claim the pty before exec,
+    # or `/dev/tty` resolves to whatever terminal the test runner is attached to
+    # (usually none) and mise captures nothing.
+    os.setsid()
+    fcntl.ioctl(slave, termios.TIOCSCTTY, 0)
+    for fd in (0, 1, 2):
+        os.dup2(slave, fd)
+    os.close(master)
+    os.close(slave)
+    os.execvp("mise", ["mise", "watch", "watched"])
+    os._exit(127)
+
+os.close(slave)
+
+
+def echo_on():
+    return bool(termios.tcgetattr(master)[3] & termios.ECHO)
+
+
+def wait_for(predicate, what, timeout=30.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.05)
+    raise SystemExit(f"timed out waiting for {what}")
+
+
+def wait_for_exit(timeout=30.0):
+    # Bounded on purpose. This change replaces SIGTERM's default action, so a
+    # regression in handing the signal back leaves the process alive — and a
+    # test for "it still dies" must fail saying so rather than hang until the
+    # CI timeout kills it with no explanation.
+    deadline = time.monotonic() + timeout
+    while True:
+        waited, status = os.waitpid(pid, os.WNOHANG)
+        if waited == pid:
+            return status
+        if time.monotonic() >= deadline:
+            raise SystemExit("timed out waiting for mise to exit after SIGTERM")
+        time.sleep(0.05)
+
+
+# Everything from here is inside the `finally`: a timeout waiting for the stub
+# is as capable of stranding these processes as a failed assertion is.
+try:
+    # The stub reports that it has taken ECHO away. Assert it really is gone, so
+    # a pass cannot come from the premise never holding.
+    wait_for(lambda: os.path.exists(ready), "the watchexec stub to start")
+    wait_for(lambda: not echo_on(), "the watchexec stub to clear ECHO")
+
+    # This is the kill that `exit::kill_all()` performs on a nested watch: a
+    # plain `kill` on the pid, since a watch that has its own session is not
+    # killed by process group (`should_use_pgroup` returns false for a session
+    # leader).
+    os.kill(pid, signal.SIGTERM)
+    status = wait_for_exit()
+
+    if not echo_on():
+        raise SystemExit("terminal still has ECHO off after SIGTERM")
+
+    # The restore must not swallow the cause of death: callers read it from the
+    # exit status, which is why the signal is re-raised rather than exiting a
+    # code of our own choosing.
+    if not os.WIFSIGNALED(status):
+        raise SystemExit(f"expected death by signal, got status {status}")
+    if os.WTERMSIG(status) != signal.SIGTERM:
+        raise SystemExit(f"expected SIGTERM, got signal {os.WTERMSIG(status)}")
+finally:
+    # The stub sits in the watch's session but is not killed with it, so it has
+    # to be reaped here or it outlives the test holding the pty. Killing the
+    # group also takes the watch itself if we never got as far as signalling it.
+    try:
+        os.killpg(pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass
+
+print("terminal restored after SIGTERM")
+PY

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -352,6 +352,11 @@ impl Watch {
         // dropped by the ctrl-c branch of `run_with_exit_signal` (#8269).
         #[cfg(unix)]
         let _terminal = TerminalState::capture();
+        // ...and however the *process* ends, including the exits that never
+        // reach a `Drop`: a `mise watch` nested under a `mise run` is killed by
+        // that run's `exit::kill_all()`, which sends SIGTERM.
+        #[cfg(unix)]
+        let _signal_restore = _terminal.arm();
 
         cmd.run()?;
         Ok(())
@@ -1436,14 +1441,22 @@ pub(crate) enum ColourMode {
 //endregion
 
 /// Terminal attributes captured before watchexec runs, put back when this is
-/// dropped.
+/// dropped — or when a signal kills the process before anything can be dropped.
 ///
 /// `--clear=reset` leaves the terminal without echo when watchexec is
 /// interrupted, and restoring on the straight-line path after the child exits
 /// is not enough: mise exited the process from the signal path until 2026.7.16,
 /// so the restore never ran, and `run_with_exit_signal` still drops the command
-/// future when ctrl-c wins the race. Restoring from `Drop` covers every one of
-/// those exits.
+/// future when ctrl-c wins the race.
+///
+/// `Drop` covers the exits that unwind, which is every one of those. It does
+/// not cover being killed. An earlier version of this comment claimed it
+/// covered "every one of those exits" and that was wrong: a `mise watch` nested
+/// under a `mise run` is killed by that run's `exit::kill_all()`, which sends
+/// SIGTERM, and mise handles only SIGINT — so the process dies where it stands
+/// and the terminal keeps whatever watchexec left in it. [`Self::arm`] closes
+/// that by restoring from a signal thread before letting the signal finish the
+/// job.
 #[cfg(unix)]
 struct TerminalState {
     saved: Vec<(std::os::fd::OwnedFd, nix::sys::termios::Termios)>,
@@ -1500,6 +1513,75 @@ impl TerminalState {
 }
 
 #[cfg(unix)]
+impl TerminalState {
+    /// Also restore if a signal kills the process, where `Drop` never runs.
+    ///
+    /// Only the signals whose default action is to terminate are taken. SIGINT
+    /// is deliberately left alone: `tokio::signal::ctrl_c` already owns it and
+    /// that path unwinds, so `Drop` restores and a second registration would
+    /// only make the ordering harder to reason about.
+    ///
+    /// This uses `signal_hook`'s thread rather than a raw handler, matching
+    /// `CmdLineRunner`. Registering replaces the default action, so the process
+    /// no longer dies where it stands and the thread has time to put the
+    /// terminal back. It then hands the signal its original meaning with
+    /// `emulate_default_handler`, so the exit status still says the process was
+    /// killed by that signal rather than reporting some invented code.
+    #[must_use = "the guard disarms the signal thread when dropped"]
+    fn arm(&self) -> SignalRestore {
+        use signal_hook::consts::{SIGHUP, SIGQUIT, SIGTERM};
+
+        let saved = self
+            .saved
+            .iter()
+            .filter_map(|(fd, attrs)| Some((fd.try_clone().ok()?, attrs.clone())))
+            .collect::<Vec<_>>();
+        if saved.is_empty() {
+            return SignalRestore { handle: None };
+        }
+        let mut signals = match signal_hook::iterator::Signals::new([SIGTERM, SIGHUP, SIGQUIT]) {
+            Ok(signals) => signals,
+            Err(err) => {
+                // Worth saying out loud: the terminal is now only as safe as the
+                // unwinding paths, which is the state this exists to improve on.
+                debug!("could not watch for signals to restore the terminal: {err}");
+                return SignalRestore { handle: None };
+            }
+        };
+        let handle = signals.handle();
+        std::thread::spawn(move || {
+            let Some(signal) = signals.forever().next() else {
+                // `handle.close()` ended the iterator: the command finished and
+                // `Drop` is doing the restore instead.
+                return;
+            };
+            for (fd, attrs) in &saved {
+                let _ = nix::sys::termios::tcsetattr(fd, nix::sys::termios::SetArg::TCSANOW, attrs);
+            }
+            let _ = signal_hook::low_level::emulate_default_handler(signal);
+        });
+        SignalRestore {
+            handle: Some(handle),
+        }
+    }
+}
+
+/// Stops the signal thread armed by [`TerminalState::arm`].
+#[cfg(unix)]
+struct SignalRestore {
+    handle: Option<signal_hook::iterator::Handle>,
+}
+
+#[cfg(unix)]
+impl Drop for SignalRestore {
+    fn drop(&mut self) {
+        if let Some(handle) = &self.handle {
+            handle.close();
+        }
+    }
+}
+
+#[cfg(unix)]
 impl Drop for TerminalState {
     fn drop(&mut self) {
         for (fd, attrs) in &self.saved {
@@ -1535,6 +1617,32 @@ mod terminal_state_tests {
                 .saved
                 .is_empty()
         );
+    }
+
+    /// With nothing captured there is nothing to put back, so the signals are
+    /// left with their default meaning rather than being taken over for a
+    /// restore that would do nothing.
+    #[test]
+    fn arming_an_empty_capture_registers_nothing() {
+        let (r, w) = nix::unistd::pipe().unwrap();
+        let state = TerminalState::capture_from([r.as_fd(), w.as_fd()]);
+        assert!(state.arm().handle.is_none());
+    }
+
+    /// Arming duplicates the descriptors rather than borrowing them, so the
+    /// guard is still able to restore after the signal thread has its own copy.
+    #[test]
+    fn arming_leaves_the_guard_able_to_restore() {
+        let pty = nix::pty::openpty(None, None).unwrap();
+        let state = TerminalState::capture_from([pty.master.as_fd()]);
+        assert_eq!(state.saved.len(), 1);
+        let armed = state.arm();
+        assert!(armed.handle.is_some());
+        set_echo(pty.master.as_fd(), false);
+        assert!(!echo_is_on(pty.master.as_fd()));
+        drop(armed);
+        drop(state);
+        assert!(echo_is_on(pty.master.as_fd()));
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #12328, which fixed [#8269](https://github.com/jdx/mise/discussions/8269). That PR left a hole, and its own doc comment asserted the opposite:

> Restoring from `Drop` covers **every one of those exits**.

`Drop` covers every exit that *unwinds*. It does not run when the process is killed.

## The path that reaches it

1. mise installs a handler for **SIGINT only** — `tokio::signal::ctrl_c` in `src/ui/ctrlc.rs`. SIGTERM, SIGHUP and SIGQUIT keep their default action.
2. A `mise run` that requests an exit code calls `exit::kill_all()` (`src/main.rs`), which is `CmdLineRunner::kill_all(SIGTERM)`.
3. A `mise watch` nested under that run gets the SIGTERM and dies where it stands. `TerminalState::drop` never runs.
4. watchexec is a separate process (`cmd::cmd("watchexec", …)`) killed alongside it, and it does not put the terminal back either.

The terminal keeps what `--clear=reset` did to it: no echo. Exactly the symptom #8269 reported, through the one exit #12328 did not cover.

## Fix

`TerminalState::arm()` starts a `signal_hook` thread for SIGTERM, SIGHUP and SIGQUIT, matching the `Signals`-plus-thread shape `CmdLineRunner` already uses rather than doing work in a raw handler. Registering replaces the default action, so the process no longer dies immediately and the thread has time to write the saved attributes back.

It then calls `signal_hook::low_level::emulate_default_handler`, so the process still dies *of that signal*. Exiting with a code of our own would erase the cause of death from the exit status, which is what callers read.

**SIGINT is deliberately not included.** `tokio::signal::ctrl_c` already owns it, so SIGINT does not kill the process outright — which is the situation this guard exists for. A second registration alongside tokio's would only make the ordering harder to reason about.

That is a statement about scope, not a claim that the SIGINT path is airtight: it has gaps of its own that this does not touch, and closing them is a different change from making a killing signal restore first.

With nothing captured — no descriptor is a terminal — nothing is registered, so the signals keep their default meaning rather than being taken over for a restore that would do nothing.

## Test

`e2e/cli/test_watch_terminal_restore_on_signal` needs two things a plain e2e run does not provide:

- **A controlling terminal.** `TerminalState::capture()` prefers `/dev/tty` and saves nothing when no descriptor is a terminal, so without a pty there is no defect to observe. A python driver opens a pty, forks, and the child does `setsid` + `TIOCSCTTY` before exec — otherwise `/dev/tty` resolves to the runner's terminal, if it has one.
- **A watchexec that reliably clears ECHO.** A stub does it directly, the way `e2e/cli/test_watch_default_task` already stubs watchexec, so the test does not depend on which watchexec is installed.

It then asserts, in order: the stub really did clear ECHO (so a pass cannot come from the premise never holding), ECHO is back after SIGTERM (this is what fails without the fix), and the child was killed by SIGTERM rather than exiting a code.

Two unit tests cover arming an empty capture registering nothing, and arming leaving the guard still able to restore.

## Deliberately not in scope

- **Terminal restore on signal generally.** The hidden cursor has the same gap — `show_cursor_after_ctrl_c` is SIGINT-only — but that is a separate surface and mixing it in would make both harder to review and to bisect.
- **Orphaned watchexec.** Under `killpg` it dies with mise, but a plain `kill` on mise's pid leaves it running. watchexec is spawned through duct, so it is not in `RUNNING_PIDS` and tracking it is its own change.

Draft while CI runs — I cannot build locally, and the pty test is the kind that wants to be seen passing on both Linux and macOS before this is called ready.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `mise watch` on Unix systems so terminal settings, including echo, are restored when terminated by a signal.
  * Preserved normal signal-based termination while keeping terminal descriptors intact.

* **Tests**
  * Added end-to-end coverage for terminal restoration during `SIGTERM`.
  * Added coverage for empty terminal-state captures and descriptor preservation.
  * Extended macOS test coverage for signal-driven terminal handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
