### PR TITLE
feat(config): expose the config file's own path to templates

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -185,6 +185,19 @@ These variables offer key information about the current environment:
 - `vars: HashMap<String, String>` – Accesses user-defined [configuration variables](/configuration/vars).
 - `cwd: PathBuf` – Points to the current working directory.
 - `config_root: PathBuf` – Locates the directory containing your `mise.toml` file, or in the case of something like `~/src/myproj/.config/mise.toml`, it will point to `~/src/myproj`.
+- `config_source: String` – The config file the template itself is written in, as an absolute path. Unlike `config_root` this is the file, not the project it belongs to, and it is **not** resolved through symlinks — pipe it through `canonicalize` when you want where the real file lives. Available in `mise.toml`, `.tool-versions`, `[env]` directives and `[settings.age]`; task file templates and `.miserc.toml` only carry `config_root`.
+
+  A shared config symlinked into `conf.d` can add its own `bin` directory to the
+  path with it:
+
+  ```toml
+  [env]
+  _.path = "{{ config_source | canonicalize | dirname }}/bin"
+  ```
+
+  Leave `canonicalize` out to get the directory the file was reached through
+  rather than the one it lives in.
+
 - `mise_bin: String` - Points to the path to the current mise executable
 - `mise_pid: String` - Points to the pid of the current mise process
 - `mise_env: Vec<String>` - The configuration environment as specified by `MISE_ENV`, `-E`, or `--env`. Will be undefined if the configuration environment is not set.

--- a/e2e/config/test_config_source_template
+++ b/e2e/config/test_config_source_template
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# `{{config_source}}` is the config file the template is written in.
+#
+# The shape here is the one from discussions#9100: a shared config living in
+# some checkout, symlinked into `conf.d`, that wants to put its own `bin` on the
+# path. `config_root` cannot express that — for a global config it is
+# `MISE_GLOBAL_CONFIG_ROOT` by design, so it points at $HOME rather than at the
+# checkout — and before this change no variable did.
+
+SHARED="$MISE_TMP_DIR/shared-config"
+mkdir -p "$SHARED/bin" "$HOME/.config/mise/conf.d"
+
+cat >"$SHARED/bin/shared-tool" <<'EOF'
+#!/usr/bin/env bash
+echo shared-tool-ok
+EOF
+chmod +x "$SHARED/bin/shared-tool"
+
+# `canonicalize` resolves the symlink, `dirname` takes the directory it lives
+# in. Neither filter is new; the variable to feed them is.
+cat >"$SHARED/mise.team.toml" <<'EOF'
+[env]
+_.path = "{{ config_source | canonicalize | dirname }}/bin"
+REACHED_BY = "{{ config_source | dirname }}"
+LIVES_IN = "{{ config_source | canonicalize | dirname }}"
+EOF
+
+ln -sf "$SHARED/mise.team.toml" "$HOME/.config/mise/conf.d/mise.team.toml"
+
+# The point of the report: the checkout's bin ends up on PATH, so its tools run.
+assert_contains "mise x -- shared-tool" "shared-tool-ok"
+
+# Resolving is the template's choice, not mise's. Without `canonicalize` the
+# variable still names the path the file was reached through, which is why the
+# variable itself is left unresolved.
+assert_contains "mise env" "REACHED_BY=$HOME/.config/mise/conf.d"
+assert_contains "mise env" "LIVES_IN=$SHARED"
+
+# And it is the file, not the project: `config_root` still answers the question
+# it always answered.
+cat >mise.toml <<'EOF'
+[env]
+LOCAL_SOURCE = "{{ config_source }}"
+LOCAL_ROOT = "{{ config_root }}"
+EOF
+
+assert_contains "mise env" "LOCAL_SOURCE=$PWD/mise.toml"
+assert_contains "mise env" "LOCAL_ROOT=$PWD"

--- a/src/config/config_file/config_root.rs
+++ b/src/config/config_file/config_root.rs
@@ -15,6 +15,43 @@ pub(crate) fn reset() {
     CONFIG_ROOT_CACHE.lock().unwrap().clear();
 }
 
+/// The config file a template is being rendered for, made absolute but not
+/// resolved. Absolute in every case a working directory can be established —
+/// see the fallback chain below for the one that cannot.
+///
+/// Deliberately not desymlinked. Which of the two a caller wants depends on why
+/// the file is a symlink: a shared config linked into `conf.d` wants where the
+/// real file lives, and a config that merely sits behind a symlinked home wants
+/// the path it was reached by. Templates choose with the filters mise already
+/// has — `{{ config_source | canonicalize | dirname }}` for the first,
+/// `{{ config_source | dirname }}` for the second — rather than mise choosing
+/// for them here.
+///
+/// Returns a `String` rather than a `PathBuf` so a path that is not valid UTF-8
+/// still renders: serde's `PathBuf` serializer fails such a path outright, which
+/// would turn one odd byte in a directory name into a template error. Lossy is
+/// the better failure here — the value is being handed to a text template.
+pub(crate) fn config_source(path: &Path) -> String {
+    // `absolutize` asks the OS for the working directory, so it fails when that
+    // directory has gone away underneath the process. `dirs::CWD` was captured
+    // at startup and still holds a usable base in that case; joining a relative
+    // path onto it is absolute, and joining an absolute one returns it
+    // unchanged, so the same step is right either way.
+    //
+    // If both are unavailable the path is returned as given. That is the only
+    // case where the value can be relative, and it means the working directory
+    // was already gone before mise started — returning something a template can
+    // render still beats failing the render, which is why this degrades rather
+    // than propagating an error.
+    path.absolutize()
+        .map(|p| p.to_path_buf())
+        .ok()
+        .or_else(|| crate::dirs::CWD.as_ref().map(|cwd| cwd.join(path)))
+        .unwrap_or_else(|| path.to_path_buf())
+        .to_string_lossy()
+        .to_string()
+}
+
 pub(crate) fn config_root(path: &Path) -> PathBuf {
     let path = path
         .absolutize()
@@ -83,6 +120,40 @@ pub(crate) fn config_root(path: &Path) -> PathBuf {
 #[cfg(unix)]
 mod tests {
     use super::*;
+
+    /// A template variable that is sometimes relative is a trap, so the path is
+    /// absolutized even though it is not resolved.
+    #[test]
+    fn config_source_is_absolute() {
+        let cwd = std::env::current_dir().unwrap();
+        assert_eq!(
+            config_source(Path::new("mise.toml")),
+            cwd.join("mise.toml").to_string_lossy()
+        );
+    }
+
+    /// Not desymlinked, on purpose: `{{ config_source | canonicalize }}` asks
+    /// for where the real file lives and plain `config_source` asks for the path
+    /// it was reached by. Resolving here would take the second away.
+    #[test]
+    fn config_source_keeps_the_path_it_was_reached_by() {
+        let temp = tempfile::tempdir().unwrap();
+        let real = temp.path().join("shared").join("mise.team.toml");
+        std::fs::create_dir_all(real.parent().unwrap()).unwrap();
+        std::fs::write(&real, "").unwrap();
+        let conf_d = temp.path().join("conf.d");
+        std::fs::create_dir_all(&conf_d).unwrap();
+        let link = conf_d.join("mise.team.toml");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        assert_eq!(config_source(&link), link.to_string_lossy());
+        assert_ne!(config_source(&link), real.to_string_lossy());
+        // ...and the resolution the reporter wants is still one filter away.
+        assert_eq!(
+            std::fs::canonicalize(&link).unwrap(),
+            std::fs::canonicalize(&real).unwrap()
+        );
+    }
 
     #[test]
     fn test_config_root() {

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -530,6 +530,7 @@ impl MiseToml {
             "config_root",
             config_root::config_root(path).to_str().unwrap(),
         );
+        context.insert("config_source", &config_root::config_source(path));
         let mut rf = Self {
             path: path.to_path_buf(),
             context,
@@ -575,6 +576,8 @@ impl MiseToml {
             "config_root",
             config_root::config_root(path).to_str().unwrap(),
         );
+        rf.context
+            .insert("config_source", &config_root::config_source(path));
         rf.update_context_env(env::PRISTINE_ENV.clone());
         rf.path = path.to_path_buf();
         let project_root = rf.project_root().map(|p| p.to_path_buf());

--- a/src/config/config_file/tool_versions.rs
+++ b/src/config/config_file/tool_versions.rs
@@ -42,6 +42,10 @@ impl ToolVersions {
     pub(crate) fn init(filename: &Path) -> ToolVersions {
         let mut context = BASE_CONTEXT.clone();
         context.insert("config_root", filename.parent().unwrap().to_str().unwrap());
+        context.insert(
+            "config_source",
+            &crate::config::config_file::config_root::config_source(filename),
+        );
         ToolVersions {
             context,
             tools: Mutex::new(ToolRequestSet::new()),

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -522,6 +522,10 @@ impl EnvResults {
             let config_root = crate::config::config_file::config_root::config_root(&source);
             ctx.insert("cwd", &*dirs::CWD);
             ctx.insert("config_root", &config_root);
+            ctx.insert(
+                "config_source",
+                &crate::config::config_file::config_root::config_source(&source),
+            );
             let env_vars = env
                 .iter()
                 .map(|(k, (v, _))| (k.clone(), v.clone()))

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -798,6 +798,10 @@ fn resolve_age_paths(settings: &mut toml::Table, path: &Path) -> Result<()> {
     let mut context = tera::Context::new();
     context.insert("env", &*env::PRISTINE_ENV);
     context.insert("config_root", &config_root);
+    context.insert(
+        "config_source",
+        &crate::config::config_file::config_root::config_source(path),
+    );
     if let Ok(cwd) = std::env::current_dir() {
         context.insert("cwd", &cwd);
     }


### PR DESCRIPTION
Closes [#9100](https://github.com/jdx/mise/discussions/9100).

## Problem

A shared config lives in a checkout and is symlinked into `conf.d`:

```
~/.config/mise/conf.d/mise.team.toml -> ~/Documents/shared-config/mise.team.toml
```

It wants to put its own `bin` on the path, and cannot:

```toml
[env]
_.path = "{{config_root}}/bin"   # → $HOME/bin
```

The reporter's conclusion was that "there doesn't seem to be **any** variable expansion which points to `~/Documents/shared-config`". That is accurate, and both halves matter:

- `config_root` returning `MISE_GLOBAL_CONFIG_ROOT` for a global config is **deliberate** (`config_root.rs`), not a bug to fix.
- `config_root` is the only path variable put into a config file's template context (`mise_toml.rs`, `env_directive/mod.rs`). Nothing names the file itself.

The report is from April. It is worth doing now because the premise changed: `conf.d` became a supported feature in #12395 this month, so symlinking a shared config into it is a first-class arrangement rather than a trick.

## What this adds

`config_source` — the config file the template is written in, as an absolute path.

```toml
[env]
_.path = "{{ config_source | canonicalize | dirname }}/bin"
```

**It is not resolved through symlinks.** Which of the two a caller wants depends on *why* the file is a symlink: a shared config linked into `conf.d` wants where the real file lives, while a config sitting behind a symlinked home wants the path it was reached by. `dirname` and `canonicalize` are both already registered on both template engines, so exposing the path lets a template pick, where a pre-resolved directory variable would decide for it. It also makes things like `{{ config_source | basename }}` fall out for free.

**Not named `config_dir`**, which would collide with `MISE_CONFIG_DIR` (`~/.config/mise`). `config_source` matches the vocabulary already in the codebase — `task.config_source` is the file a task came from.

**Documented as a `String`, not a `PathBuf`, and that is the implementation too.** serde's `PathBuf` serializer *fails* on a path that is not valid UTF-8, so inserting one would turn an odd byte in a directory name into a template render error; `to_string_lossy` renders it instead. The neighbouring `config_root` is inserted as `.to_str().unwrap()` in `mise_toml.rs`, which would panic on the same input, so matching its declared type would have been the wrong kind of consistency.

**Absolute wherever a working directory can be established.** `absolutize` asks the OS for the working directory and fails when that directory has gone away underneath the process, so the fallback is `dirs::CWD`, captured at startup — joining a relative path onto it is absolute, and joining an absolute one returns it unchanged. If both are unavailable the path is returned as given, which is the one case it can be relative; that means the working directory was already gone before mise started, and rendering something still beats failing the render.

## Where it is available

Everywhere the config file is known: `mise.toml`, `.tool-versions`, `[env]` directives, and `[settings.age]`.

Not in task file templates, `render_task_input_entries`, bootstrap maps, or `.miserc.toml` — those are handed a `config_root` and never the originating path, so adding it there means threading a path through and is its own change. The docs say so explicitly; the `tools` variable already scopes itself the same way.

## Tests

`e2e/config/test_config_source_template` builds the reporter's arrangement — checkout, symlink into `conf.d` — and asserts the checkout's `bin` really does end up on `PATH` by running a tool from it. Without the change the template fails on an undefined variable.

It also pins the design rather than just the outcome: `{{ config_source | dirname }}` gives the `conf.d` path and `{{ config_source | canonicalize | dirname }}` gives the checkout, so "resolving is the template's choice" is a tested property. And a plain local `mise.toml` asserts `config_source` is the file while `config_root` still answers what it always answered.

Two unit tests in `config_root.rs` cover the path being absolutized, and a symlinked config keeping the path it was reached by.

Draft while CI runs — I cannot build locally.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `config_source` template variable, providing the absolute, non-canonical path of the configuration file in use.
  * Preserves symlink-based paths while supporting filters to resolve the canonical path or containing directory.
  * Available in configuration templates, tool version files, environment directives, and settings.
  * Configuration templates can use the shared configuration directory in `PATH` while retaining project-root behavior for `config_root`.
* **Documentation**
  * Added guidance and examples covering `config_source`, symlink behavior, and path filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
