### PR TITLE
test(env): replace the argument-less format! calls clippy now rejects

### DIFF
--- a/src/path_env.rs
+++ b/src/path_env.rs
@@ -368,7 +368,7 @@ mod tests {
         path_env.add("/3".into());
         assert_eq!(
             path_env.to_string(),
-            format!("/1:/2:/3:/before-1:/before-2:/before-3:/after-1:/after-2:/after-3")
+            "/1:/2:/3:/before-1:/before-2:/before-3:/after-1:/after-2:/after-3"
         );
     }
     #[tokio::test]
@@ -376,6 +376,6 @@ mod tests {
         let _config = Config::get().await.unwrap();
         let mut path_env = PathEnv::from_iter(["/item1", "/item2"].map(PathBuf::from));
         path_env.add("/1:/2".into());
-        assert_eq!(path_env.to_string(), format!("/1:/2:/item1:/item2"));
+        assert_eq!(path_env.to_string(), "/1:/2:/item1:/item2");
     }
 }


### PR DESCRIPTION
`lint` is failing on `main`, and therefore on every open PR.

## What happened

A clippy update started firing `useless_format` on a `format!` whose only argument is a literal with nothing to interpolate. The job runs with `-D warnings`, so it is an error:

```
error: useless use of `format!`
   --> src/path_env.rs:371:13
    |
371 |             format!("/1:/2:/3:/before-1:/before-2:/before-3:/after-1:/after-2:/after-3")
    |
    = note: `-D clippy::useless-format` implied by `-D warnings`

error: useless use of `format!`
   --> src/path_env.rs:379:42

error: could not compile `mise` (bin "mise" test) due to 2 previous errors
```

Both are assertions in the `path_env` tests. The literals say exactly the same thing without the macro, so they are just written out.

No `#[allow(clippy::useless_format)]` — `AGENTS.md` rules those out, and there is nothing here worth suppressing.

## Scope

I scanned the whole tree (`src/`, `crates/`, `xtasks/`, `build.rs`) for `format!` with a literal containing no `{`, and these two are the only ones. A nearby call three lines up survives because it interpolates `{shims}`.

**Worth saying plainly:** clippy stops at the first failing target, so it has not yet reported anything that sits behind these. If the same update has surfaced other lints elsewhere in the workspace, they will only become visible once this lands — this unblocks the job, it does not promise the job then passes. (I do not build locally, so CI on this PR is the first full clippy run against the new version.)

This is the same shape as #12449, which silenced `chunks_exact_to_as_chunks` in `decode_text` after an earlier clippy bump.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified Unix path environment test expectations without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->