### PR TITLE
fix(config): merge minimum release age exclusions

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -871,6 +871,47 @@ pub(crate) struct {name} {{"#,
 
     lines.push(
         r#"
+/// Apply the merge strategies declared in settings.toml to config-file layers.
+pub(crate) fn merge_settings_file_layers(layers: &mut [SettingsPartial]) {"#
+            .to_string(),
+    );
+    for (key, props) in &settings {
+        let props = props.as_table().unwrap();
+        let Some(strategy) = props.get("merge") else {
+            continue;
+        };
+        let strategy = strategy
+            .as_str()
+            .expect("setting merge strategy must be a string");
+        match (strategy, props.get("type").and_then(toml::Value::as_str)) {
+            ("append_unique", Some("ListString")) => lines.push(format!(
+                r#"    {{
+        let mut found = false;
+        let values = layers
+            .iter_mut()
+            .rev()
+            .filter_map(|layer| {{
+                let values = layer.{key}.take();
+                found |= values.is_some();
+                values
+            }})
+            .flatten()
+            .unique()
+            .collect();
+        if found {{
+            layers[0].{key} = Some(values);
+        }}
+    }}"#
+            )),
+            _ => panic!(
+                "unsupported merge strategy {strategy:?} for setting {key:?}; append_unique requires ListString"
+            ),
+        }
+    }
+    lines.push("}".to_string());
+
+    lines.push(
+        r#"
 pub(crate) static SETTINGS_META: Lazy<IndexMap<&'static str, SettingsMeta>> = Lazy::new(|| {
     indexmap!{"#
             .to_string(),

--- a/build.rs
+++ b/build.rs
@@ -751,6 +751,7 @@ pub(crate) struct Settings {"#
     let settings_toml = fs::read_to_string("settings.toml").expect("Failed to read settings.toml");
     let settings: toml::Table =
         toml::de::from_str(&settings_toml).expect("Failed to parse settings.toml");
+    /// Build a collision-resistant generated Rust type name for a settings path.
     fn settings_struct_name(path: &[&str]) -> String {
         if let [part] = path {
             return format!("Settings{}", part.to_upper_camel_case());
@@ -919,6 +920,7 @@ pub(crate) static SETTINGS_META: Lazy<IndexMap<&'static str, SettingsMeta>> = La
     indexmap!{"#
             .to_string(),
     );
+    /// Emit deprecation metadata shared by each generated settings metadata entry.
     fn push_deprecated_fields(lines: &mut Vec<String>, props: &toml::Table) {
         let deprecated = props
             .get("deprecated")
@@ -955,6 +957,7 @@ pub(crate) static SETTINGS_META: Lazy<IndexMap<&'static str, SettingsMeta>> = La
             props.get("env_only").is_some_and(|v| v.as_bool().unwrap())
         ));
     }
+    /// Emit flattened runtime metadata for settings and nested settings tables.
     fn emit_settings_meta(lines: &mut Vec<String>, table: &toml::Table, prefix: &str) {
         for (key, value) in table {
             let name = if prefix.is_empty() {

--- a/build.rs
+++ b/build.rs
@@ -736,6 +736,7 @@ fn yaml_string_field(value: &Value, key: &str) -> Option<String> {
     value.get(key)?.as_str().map(str::to_string)
 }
 
+/// Generate Rust setting types, metadata, and file-layer merge behavior from settings.toml.
 fn codegen_settings() {
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("settings.rs");
@@ -769,6 +770,7 @@ pub(crate) struct Settings {"#
         name
     }
 
+    /// Render one settings.toml entry as a field in a generated settings struct.
     fn props_to_code(key: &str, props: &toml::Value, parent_path: &[&str]) -> String {
         let mut lines = vec![];
         let props = props.as_table().unwrap();
@@ -844,6 +846,7 @@ pub(crate) struct Settings {"#
     }
     lines.push("}".to_string());
 
+    /// Emit generated settings structs for every nested settings.toml table.
     fn emit_nested_settings(lines: &mut Vec<String>, table: &toml::Table, parent_path: &[&str]) {
         for (child, props) in table
             .iter()

--- a/docs/security.md
+++ b/docs/security.md
@@ -148,7 +148,8 @@ minimum_release_age_excludes = ["trivy", "npm:*"]
 Exclusions can match backend wildcards like `npm:*`, tool shorthands like `trivy`, or full backend
 IDs like `npm:prettier`. Matching tools skip the global setting and built-in default. Per-tool
 `minimum_release_age` options and the CLI flag still apply even when a tool matches the exclusion
-list.
+list. Exclusions from multiple configuration files are merged and deduplicated, allowing project
+configuration to add exclusions without repeating exclusions from the global configuration.
 
 See [`minimum_release_age`](/configuration/settings.html#minimum_release_age) for the setting
 reference.

--- a/e2e/config/test_global_config_precedence
+++ b/e2e/config/test_global_config_precedence
@@ -2,8 +2,9 @@
 set -euo pipefail
 
 # Inside ~/.config/mise, config.local.toml overrides config.toml, which overrides
-# conf.d fragments. The ceiling keeps the config dir out of the cwd walk, so it is
-# only found as the global config group, together with ~/.tool-versions.
+# conf.d fragments. List entries in minimum_release_age_excludes are merged instead.
+# The ceiling keeps the config dir out of the cwd walk, so it is only found as the
+# global config group, together with ~/.tool-versions.
 export MISE_CEILING_PATHS="$HOME"
 
 mkdir -p "$MISE_CONFIG_DIR/conf.d"
@@ -37,15 +38,22 @@ minimum_release_age_excludes = ["from-local"]
 GLOBAL_PRECEDENCE = "from-local"
 EOF
 
+cat >mise.toml <<EOF
+[settings]
+minimum_release_age_excludes = ["from-project", "from-config"]
+EOF
+
 echo "dummy 1.0.0" >"$HOME/.tool-versions"
 
 assert "mise env | grep GLOBAL_PRECEDENCE" "export GLOBAL_PRECEDENCE=from-local"
 assert "mise env --json | jq -r .DOTTED_SYMLINK" "loaded"
 MISE_ENV_CONF_D=true assert "mise env --json | jq -r .DOTTED_SYMLINK" "null"
-assert "mise settings get minimum_release_age_excludes" '["from-local"]'
+assert "mise settings get minimum_release_age_excludes" '["from-conf-d", "from-config", "from-local", "from-project"]'
+assert "MISE_MINIMUM_RELEASE_AGE_EXCLUDES=from-env mise settings get minimum_release_age_excludes" '["from-env"]'
 # ~/.tool-versions joins the global group only under MISE_USE_TOML=0, and outranks
 # the config dir. Only the active version carries a source.
 assert "MISE_USE_TOML=0 mise ls dummy --json | jq -r '.[] | select(.source) | .source.path'" "$HOME/.tool-versions"
 
 rm "$MISE_CONFIG_DIR/config.local.toml"
 assert "mise env | grep GLOBAL_PRECEDENCE" "export GLOBAL_PRECEDENCE=from-config"
+assert "mise settings get minimum_release_age_excludes" '["from-conf-d", "from-config", "from-project"]'

--- a/settings.toml
+++ b/settings.toml
@@ -1682,6 +1682,7 @@ Values from multiple configuration files are merged and deduplicated, so a proje
 repeating exclusions from the global configuration. The environment variable replaces the merged file value.
 """
 env = "MISE_MINIMUM_RELEASE_AGE_EXCLUDES"
+merge = "append_unique"
 parse_env = "list_by_comma"
 type = "ListString"
 

--- a/settings.toml
+++ b/settings.toml
@@ -1677,6 +1677,9 @@ minimum_release_age_excludes = ["trivy", "npm:*"]
 
 This excludes matching tools from the global setting and built-in default. A per-tool `minimum_release_age` option
 or the `--minimum-release-age` CLI flag still applies to matching tools.
+
+Values from multiple configuration files are merged and deduplicated, so a project can add exclusions without
+repeating exclusions from the global configuration. The environment variable replaces the merged file value.
 """
 env = "MISE_MINIMUM_RELEASE_AGE_EXCLUDES"
 parse_env = "list_by_comma"

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -985,7 +985,7 @@ impl Settings {
             Some(root) => load_config_paths_from(root, &TOML_CONFIG_FILENAMES, false),
             None => load_config_paths(&TOML_CONFIG_FILENAMES, false),
         };
-        paths
+        let mut layers = paths
             .into_iter()
             .filter(|path| !safe_mode || crate::config::is_global_config(path))
             .filter(|path| match trust_policy {
@@ -1008,7 +1008,9 @@ impl Settings {
                     None
                 }
             })
-            .collect()
+            .collect::<Vec<_>>();
+        merge_minimum_release_age_excludes(&mut layers);
+        layers
     }
 
     pub(crate) fn try_get() -> Result<Arc<Self>> {
@@ -1662,6 +1664,28 @@ impl Settings {
     }
 }
 
+/// Merge exclusions from config files while preserving the precedence of environment and CLI
+/// layers, which are added separately before these layers. Config paths are ordered from highest
+/// to lowest precedence, so collect in reverse to keep inherited exclusions before local ones.
+fn merge_minimum_release_age_excludes(layers: &mut [SettingsPartial]) {
+    let mut found = false;
+    let excludes = layers
+        .iter_mut()
+        .rev()
+        .filter_map(|layer| {
+            let excludes = layer.minimum_release_age_excludes.take();
+            found |= excludes.is_some();
+            excludes
+        })
+        .flatten()
+        .unique()
+        .collect();
+
+    if found {
+        layers[0].minimum_release_age_excludes = Some(excludes);
+    }
+}
+
 fn redacted_settings_for_debug(settings: &Settings) -> Settings {
     let mut debug_settings = settings.clone();
     if debug_settings.task.cache.remote_token.is_some() {
@@ -1895,6 +1919,25 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_merge_minimum_release_age_excludes() {
+        let mut local = SettingsPartial::empty();
+        local.minimum_release_age_excludes = Some(sv(&["local", "shared"]));
+        let mut global = SettingsPartial::empty();
+        global.minimum_release_age_excludes = Some(sv(&["global", "shared"]));
+        let unrelated = SettingsPartial::empty();
+        let mut layers = vec![local, unrelated, global];
+
+        merge_minimum_release_age_excludes(&mut layers);
+
+        assert_eq!(
+            layers[0].minimum_release_age_excludes,
+            Some(sv(&["global", "shared", "local"]))
+        );
+        assert!(layers[1].minimum_release_age_excludes.is_none());
+        assert!(layers[2].minimum_release_age_excludes.is_none());
+    }
 
     /// `normalize_verbosity` is the whole answer to "what level is this run at", and it is now
     /// reached from two places -- the settings load and `cli_log_level`. Pin the precedence so the

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1922,6 +1922,7 @@ where
 mod tests {
     use super::*;
 
+    /// File-backed exclusions are inherited in low-to-high precedence order and deduplicated.
     #[test]
     fn test_merge_minimum_release_age_excludes() {
         let mut local = SettingsPartial::empty();

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1011,7 +1011,7 @@ impl Settings {
                 }
             })
             .collect::<Vec<_>>();
-        merge_minimum_release_age_excludes(&mut layers);
+        merge_settings_file_layers(&mut layers);
         layers
     }
 
@@ -1666,28 +1666,6 @@ impl Settings {
     }
 }
 
-/// Merge exclusions from config files while preserving the precedence of environment and CLI
-/// layers, which are added separately before these layers. Config paths are ordered from highest
-/// to lowest precedence, so collect in reverse to keep inherited exclusions before local ones.
-fn merge_minimum_release_age_excludes(layers: &mut [SettingsPartial]) {
-    let mut found = false;
-    let excludes = layers
-        .iter_mut()
-        .rev()
-        .filter_map(|layer| {
-            let excludes = layer.minimum_release_age_excludes.take();
-            found |= excludes.is_some();
-            excludes
-        })
-        .flatten()
-        .unique()
-        .collect();
-
-    if found {
-        layers[0].minimum_release_age_excludes = Some(excludes);
-    }
-}
-
 fn redacted_settings_for_debug(settings: &Settings) -> Settings {
     let mut debug_settings = settings.clone();
     if debug_settings.task.cache.remote_token.is_some() {
@@ -1932,7 +1910,7 @@ mod tests {
         let unrelated = SettingsPartial::empty();
         let mut layers = vec![local, unrelated, global];
 
-        merge_minimum_release_age_excludes(&mut layers);
+        merge_settings_file_layers(&mut layers);
 
         assert_eq!(
             layers[0].minimum_release_age_excludes,

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -972,6 +972,8 @@ impl Settings {
         Ok(builder.load()?)
     }
 
+    /// Load eligible config-file settings layers in precedence order and combine settings whose
+    /// semantics are additive across files.
     fn settings_layers_from(
         root: Option<&Path>,
         trust_policy: SettingsTrustPolicy,


### PR DESCRIPTION
## Summary
- merge and deduplicate `minimum_release_age_excludes` across system, global, and project config files
- preserve environment and CLI replacement precedence
- document the merged behavior and cover ordering, deduplication, and environment overrides

Addresses the behavior reported in https://github.com/jdx/mise/discussions/12452.

## Tests
- `cargo test --all-features config::settings::tests::test_merge_minimum_release_age_excludes`
- `mise run test:e2e e2e/config/test_global_config_precedence`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes effective settings resolution for a security-related list setting across layered configs; scope is limited to one setting today but introduces a general merge path in settings loading.
> 
> **Overview**
> **`minimum_release_age_excludes` now accumulates across config file layers** instead of letting the highest-precedence file replace the whole list. Values from system, global, `conf.d`, and project files are combined and deduplicated while preserving order, so projects can add exclusions without copying global entries.
> 
> This behavior is driven by a new **`merge = "append_unique"`** declaration in `settings.toml`, with `build.rs` codegen emitting `merge_settings_file_layers` and `settings_layers_from` invoking it after parsing file layers. **Environment variables still replace** the merged file value (and CLI precedence is unchanged).
> 
> Documentation in `settings.toml` and `docs/security.md` describes the merge behavior. E2E and unit tests cover cross-file ordering, deduplication, and env override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a35f599fede9be1f686d6bd0d589ae2a2d90c710. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `minimum_release_age_excludes` entries now merge across configuration files.
  * Duplicate exclusions are removed automatically while preserving configuration order.
  * Project-level settings can add exclusions without repeating global entries.
  * Environment variables replace file-based values, while command-line settings retain the highest precedence.
  * Layered configuration settings now follow consistent merging behavior.

* **Documentation**
  * Updated configuration guidance to explain merging, deduplication, and precedence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->