### PR TITLE
fix(bootstrap): preserve brew cask dependencies during prune

### DIFF
--- a/src/cli/system/prune.rs
+++ b/src/cli/system/prune.rs
@@ -119,12 +119,18 @@ impl SystemPrune {
             bail!("brew is not available: {}", manager.unavailable_reason());
         }
         let config = Config::get().await?;
-        let configured = system::packages_from_config_and_tracked_config_files(&config)
-            .await?
-            .into_iter()
+        let packages = system::packages_from_config_and_tracked_config_files(&config).await?;
+        let mut configured = packages
+            .iter()
             .find(|mp| mp.manager.name() == "brew")
-            .map(|mp| mp.requests)
+            .map(|mp| mp.requests.clone())
             .unwrap_or_default();
+        let configured_casks = packages
+            .iter()
+            .find(|mp| mp.manager.name() == "brew-cask")
+            .map(|mp| mp.requests.as_slice())
+            .unwrap_or_default();
+        configured.extend(brew::cask_formula_dependencies(configured_casks).await?);
         let plan = brew::prune_plan(&configured).await?;
         if plan.is_empty() {
             info!("brew: nothing to prune");

--- a/src/system/packages/brew/api.rs
+++ b/src/system/packages/brew/api.rs
@@ -186,6 +186,21 @@ pub(super) fn tap_name(name: &str) -> Option<String> {
     }
 }
 
+pub(super) fn tap_name_from_url(url: &str) -> Option<String> {
+    let url = url.trim_end_matches(".git").trim_end_matches('/');
+    let rest = url.strip_prefix("https://github.com/")?;
+    let mut parts = rest.split('/');
+    let owner = parts.next()?;
+    let repo = parts.next()?;
+    if parts.next().is_some() || owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "{owner}/{}",
+        repo.strip_prefix("homebrew-").unwrap_or(repo)
+    ))
+}
+
 fn split_tap(name: &str) -> Option<(&str, &str)> {
     let mut parts = name.split('/');
     let owner = parts.next()?;

--- a/src/system/packages/brew/api.rs
+++ b/src/system/packages/brew/api.rs
@@ -187,7 +187,7 @@ pub(super) fn tap_name(name: &str) -> Option<String> {
 }
 
 pub(super) fn tap_name_from_url(url: &str) -> Option<String> {
-    let url = url.trim_end_matches(".git").trim_end_matches('/');
+    let url = url.trim_end_matches('/').trim_end_matches(".git");
     let rest = url.strip_prefix("https://github.com/")?;
     let mut parts = rest.split('/');
     let owner = parts.next()?;
@@ -244,7 +244,7 @@ pub(super) fn tap_raw_base(owner: &str, tap: &str, tap_url: Option<&str>) -> Opt
 }
 
 pub(super) fn github_raw_base(url: &str) -> Option<String> {
-    let url = url.trim_end_matches(".git").trim_end_matches('/');
+    let url = url.trim_end_matches('/').trim_end_matches(".git");
     let rest = url.strip_prefix("https://github.com/")?;
     let mut parts = rest.split('/');
     let owner = parts.next()?;
@@ -255,5 +255,20 @@ pub(super) fn github_raw_base(url: &str) -> Option<String> {
         Some(format!(
             "https://raw.githubusercontent.com/{owner}/{repo}/HEAD"
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn github_tap_urls_allow_trailing_slashes() {
+        let url = "https://github.com/acme/homebrew-tools.git/";
+        assert_eq!(tap_name_from_url(url).as_deref(), Some("acme/tools"));
+        assert_eq!(
+            github_raw_base(url).as_deref(),
+            Some("https://raw.githubusercontent.com/acme/homebrew-tools/HEAD")
+        );
     }
 }

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -357,6 +357,12 @@ pub(crate) struct CaskPrunePlan {
     pub skipped: Vec<CaskPruneSkip>,
 }
 
+#[derive(Debug, Default)]
+struct CaskDependencyClosure {
+    casks: BTreeSet<String>,
+    formulae: BTreeMap<String, PackageRequest>,
+}
+
 impl CaskPrunePlan {
     pub(crate) fn is_empty(&self) -> bool {
         self.remove.is_empty()
@@ -7100,11 +7106,55 @@ fn read_receipt(caskroom: &Path) -> Result<Option<CaskReceipt>> {
 }
 
 pub(crate) async fn cask_prune_plan(configured: &[PackageRequest]) -> Result<CaskPrunePlan> {
-    let mut keep = BTreeSet::new();
-    for request in configured {
-        keep.insert(fetch_cask(request).await?.token);
+    let closure = resolve_cask_dependency_closure(configured).await?;
+    cask_prune_plan_from_tokens(&closure.casks, &crate::dirs::STATE)
+}
+
+pub(crate) async fn cask_formula_dependencies(
+    configured: &[PackageRequest],
+) -> Result<Vec<PackageRequest>> {
+    Ok(resolve_cask_dependency_closure(configured)
+        .await?
+        .formulae
+        .into_values()
+        .collect())
+}
+
+async fn resolve_cask_dependency_closure(
+    configured: &[PackageRequest],
+) -> Result<CaskDependencyClosure> {
+    let mut closure = CaskDependencyClosure::default();
+    let mut pending = configured.to_vec();
+    while let Some(request) = pending.pop() {
+        let cask = fetch_cask(&request).await?;
+        extend_cask_dependency_closure(&mut closure, &mut pending, cask);
     }
-    cask_prune_plan_from_tokens(&keep, &crate::dirs::STATE)
+    Ok(closure)
+}
+
+fn extend_cask_dependency_closure(
+    closure: &mut CaskDependencyClosure,
+    pending: &mut Vec<PackageRequest>,
+    cask: Cask,
+) {
+    if !closure.casks.insert(cask.token) {
+        return;
+    }
+    for name in cask.depends_on.formula {
+        closure
+            .formulae
+            .entry(name.clone())
+            .or_insert(PackageRequest {
+                name,
+                version: None,
+                tap_url: None,
+            });
+    }
+    pending.extend(cask.depends_on.cask.into_iter().map(|name| PackageRequest {
+        name,
+        version: None,
+        tap_url: None,
+    }));
 }
 
 fn cask_prune_plan_from_tokens(keep: &BTreeSet<String>, state_dir: &Path) -> Result<CaskPrunePlan> {
@@ -7898,6 +7948,32 @@ mod tests {
             tap_git_head: None,
             raw_base: None,
         }
+    }
+
+    #[test]
+    fn cask_dependency_closure_collects_formulae_and_transitive_casks() {
+        let mut root = test_cask("root", "1.0.0");
+        root.depends_on.formula = vec!["python@3.14".to_string()];
+        root.depends_on.cask = vec!["child".to_string()];
+        let mut child = test_cask("child", "1.0.0");
+        child.depends_on.formula = vec!["openssl@3".to_string(), "python@3.14".to_string()];
+        child.depends_on.cask = vec!["root".to_string()];
+
+        let mut closure = CaskDependencyClosure::default();
+        let mut pending = Vec::new();
+        extend_cask_dependency_closure(&mut closure, &mut pending, root.clone());
+        assert_eq!(pending.len(), 1);
+        extend_cask_dependency_closure(&mut closure, &mut pending, child);
+        extend_cask_dependency_closure(&mut closure, &mut pending, root);
+
+        assert_eq!(
+            closure.casks,
+            BTreeSet::from(["child".to_string(), "root".to_string()])
+        );
+        assert_eq!(
+            closure.formulae.into_keys().collect::<Vec<_>>(),
+            vec!["openssl@3".to_string(), "python@3.14".to_string()]
+        );
     }
 
     fn write_test_app_receipt(cask: &Cask, app_name: &str) -> Result<PathBuf> {

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -359,8 +359,8 @@ pub(crate) struct CaskPrunePlan {
 
 #[derive(Debug, Default)]
 struct CaskDependencyClosure {
-    casks: BTreeSet<String>,
-    formulae: BTreeMap<String, PackageRequest>,
+    casks: BTreeMap<(String, Option<String>), String>,
+    formulae: BTreeMap<(String, Option<String>), PackageRequest>,
 }
 
 impl CaskPrunePlan {
@@ -971,6 +971,7 @@ fn validate_cask_path_component(kind: &str, value: &str) -> Result<()> {
     let mut components = Path::new(value).components();
     let valid = !value.is_empty()
         && !value.contains('\0')
+        && !value.contains('\\')
         && matches!(components.next(), Some(Component::Normal(_)))
         && components.next().is_none()
         && value != ".metadata"
@@ -7135,7 +7136,8 @@ fn read_receipt(caskroom: &Path) -> Result<Option<CaskReceipt>> {
 
 pub(crate) async fn cask_prune_plan(configured: &[PackageRequest]) -> Result<CaskPrunePlan> {
     let closure = resolve_cask_dependency_closure(configured).await?;
-    cask_prune_plan_from_tokens(&closure.casks, &crate::dirs::STATE)
+    let keep = closure.casks.into_values().collect();
+    cask_prune_plan_from_tokens(&keep, &crate::dirs::STATE)
 }
 
 pub(crate) async fn cask_formula_dependencies(
@@ -7154,7 +7156,7 @@ async fn resolve_cask_dependency_closure(
     let mut closure = CaskDependencyClosure::default();
     let mut pending = configured.to_vec();
     while let Some(request) = pending.pop() {
-        if closure.casks.contains(cask_request_token(&request.name)) {
+        if closure.casks.contains_key(&cask_dependency_key(&request)) {
             continue;
         }
         let cask = fetch_cask(&request).await?;
@@ -7169,24 +7171,45 @@ fn cask_request_token(name: &str) -> &str {
         .unwrap_or(name)
 }
 
+fn cask_dependency_key(request: &PackageRequest) -> (String, Option<String>) {
+    (
+        cask_request_token(&request.name).to_string(),
+        request_tap_url(request),
+    )
+}
+
+fn request_tap_url(request: &PackageRequest) -> Option<String> {
+    request.tap_url.clone().or_else(|| {
+        split_tap_name(&request.name).and_then(|(owner, tap, _)| {
+            (owner != "homebrew" || tap != "cask")
+                .then(|| format!("https://github.com/{owner}/homebrew-{tap}.git"))
+        })
+    })
+}
+
 fn extend_cask_dependency_closure(
     closure: &mut CaskDependencyClosure,
     pending: &mut Vec<PackageRequest>,
     request: &PackageRequest,
     cask: Cask,
 ) {
-    if !closure.casks.insert(cask.token) {
+    if closure
+        .casks
+        .insert(cask_dependency_key(request), cask.token)
+        .is_some()
+    {
         return;
     }
     for name in cask.depends_on.formula {
+        let request = PackageRequest {
+            tap_url: dependency_tap_url(request, &name),
+            name,
+            version: None,
+        };
         closure
             .formulae
-            .entry(name.clone())
-            .or_insert(PackageRequest {
-                tap_url: dependency_tap_url(request, &name),
-                name,
-                version: None,
-            });
+            .entry((request.name.clone(), request_tap_url(&request)))
+            .or_insert(request);
     }
     pending.extend(cask.depends_on.cask.into_iter().map(|name| PackageRequest {
         tap_url: dependency_tap_url(request, &name),
@@ -8025,7 +8048,7 @@ mod tests {
         extend_cask_dependency_closure(&mut closure, &mut pending, &root_request, root);
 
         assert_eq!(
-            closure.casks,
+            closure.casks.values().cloned().collect::<BTreeSet<_>>(),
             BTreeSet::from(["child".to_string(), "root".to_string()])
         );
         assert!(
@@ -8035,13 +8058,12 @@ mod tests {
                 .all(|request| request.tap_url == root_request.tap_url)
         );
         assert_eq!(
-            closure.formulae.into_keys().collect::<Vec<_>>(),
-            vec!["openssl@3".to_string(), "python@3.14".to_string()]
-        );
-        assert!(
             closure
-                .casks
-                .contains(cask_request_token("acme/tools/root"))
+                .formulae
+                .values()
+                .map(|request| request.name.clone())
+                .collect::<Vec<_>>(),
+            vec!["openssl@3".to_string(), "python@3.14".to_string()]
         );
         let standard_tap_request = PackageRequest {
             tap_url: None,
@@ -8060,6 +8082,50 @@ mod tests {
         assert_eq!(
             normalize_cask_raw_base("https://example.com/custom".to_string()),
             "https://example.com/custom"
+        );
+    }
+
+    #[test]
+    fn cask_dependency_closure_keeps_duplicate_names_from_each_tap() {
+        let tap_urls = [
+            "https://github.com/acme/homebrew-tools.git",
+            "https://github.com/other/homebrew-tools.git",
+        ];
+        let mut closure = CaskDependencyClosure::default();
+        let mut pending = Vec::new();
+        for (owner, tap_url) in ["acme", "other"].into_iter().zip(tap_urls) {
+            let mut root = test_cask("shared", "1.0.0");
+            root.depends_on.formula = vec!["shared-formula".to_string()];
+            root.depends_on.cask = vec!["shared-child".to_string()];
+            let request = PackageRequest {
+                name: format!("{owner}/tools/shared"),
+                version: None,
+                tap_url: Some(tap_url.to_string()),
+            };
+            extend_cask_dependency_closure(&mut closure, &mut pending, &request, root);
+        }
+        for request in std::mem::take(&mut pending) {
+            extend_cask_dependency_closure(
+                &mut closure,
+                &mut pending,
+                &request,
+                test_cask("shared-child", "1.0.0"),
+            );
+        }
+
+        assert_eq!(closure.casks.len(), 4);
+        assert_eq!(closure.formulae.len(), 2);
+        assert_eq!(
+            closure.casks.into_values().collect::<BTreeSet<_>>(),
+            BTreeSet::from(["shared".to_string(), "shared-child".to_string()])
+        );
+        assert_eq!(
+            closure
+                .formulae
+                .into_values()
+                .filter_map(|request| request.tap_url)
+                .collect::<BTreeSet<_>>(),
+            tap_urls.into_iter().map(str::to_string).collect()
         );
     }
 
@@ -8104,7 +8170,17 @@ mod tests {
 
     #[test]
     fn rejects_unsafe_cask_identity_components() {
-        for value in ["", ".", "..", ".metadata", ".mise-tmp-x", "a/b", "a\0b"] {
+        for value in [
+            "",
+            ".",
+            "..",
+            ".metadata",
+            ".mise-tmp-x",
+            "a/b",
+            "a\\b",
+            "a\\..\\b",
+            "a\0b",
+        ] {
             assert!(validate_cask_path_component("token", value).is_err());
         }
         assert!(validate_cask_path_component("token", "zed@preview").is_ok());

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -880,6 +880,17 @@ impl SystemPackageManager for BrewCaskManager {
 
 async fn fetch_cask(req: &PackageRequest) -> Result<Cask> {
     let name = &req.name;
+    if split_tap_name(name).is_none()
+        && let Some(raw_base) = req.tap_url.as_deref().and_then(super::api::github_raw_base)
+    {
+        let url = format!("{raw_base}/api/cask/{name}.json");
+        match fetch_cask_url(name, &url, Some(raw_base), false).await {
+            Ok(cask) => return Ok(cask),
+            Err(err) => debug!(
+                "brew-cask: {name} unavailable in parent tap metadata ({err}); falling back to official metadata"
+            ),
+        }
+    }
     let (requested_token, official_api) = match split_tap_name(name) {
         Some(("homebrew", "cask", token)) => (token, true),
         Some((_, _, token)) => (token, false),
@@ -907,12 +918,21 @@ async fn fetch_cask(req: &PackageRequest) -> Result<Cask> {
             Some(HOMEBREW_CASK_RAW.to_string()),
         ),
     };
+    fetch_cask_url(requested_token, &url, raw_base, official_api).await
+}
+
+async fn fetch_cask_url(
+    requested_token: &str,
+    url: &str,
+    raw_base: Option<String>,
+    official_api: bool,
+) -> Result<Cask> {
     let mut cask = HTTP_FETCH
         .json_cached::<Cask, _>(url)
         .await
         .wrap_err_with(|| {
             format!(
-                "failed to fetch Homebrew cask '{name}' directly. \
+                "failed to fetch Homebrew cask '{requested_token}' directly. \
                  Tapped casks must publish API metadata at api/cask/<token>.json"
             )
         })?;
@@ -7130,7 +7150,7 @@ async fn resolve_cask_dependency_closure(
             continue;
         }
         let cask = fetch_cask(&request).await?;
-        extend_cask_dependency_closure(&mut closure, &mut pending, cask);
+        extend_cask_dependency_closure(&mut closure, &mut pending, &request, cask);
     }
     Ok(closure)
 }
@@ -7144,6 +7164,7 @@ fn cask_request_token(name: &str) -> &str {
 fn extend_cask_dependency_closure(
     closure: &mut CaskDependencyClosure,
     pending: &mut Vec<PackageRequest>,
+    request: &PackageRequest,
     cask: Cask,
 ) {
     if !closure.casks.insert(cask.token) {
@@ -7154,16 +7175,29 @@ fn extend_cask_dependency_closure(
             .formulae
             .entry(name.clone())
             .or_insert(PackageRequest {
+                tap_url: dependency_tap_url(request, &name),
                 name,
                 version: None,
-                tap_url: None,
             });
     }
     pending.extend(cask.depends_on.cask.into_iter().map(|name| PackageRequest {
+        tap_url: dependency_tap_url(request, &name),
         name,
         version: None,
-        tap_url: None,
     }));
+}
+
+fn dependency_tap_url(parent: &PackageRequest, dependency: &str) -> Option<String> {
+    let parent_tap = split_tap_name(&parent.name)
+        .and_then(|(owner, tap, _)| (owner != "homebrew" || tap != "cask").then_some((owner, tap)));
+    if let Some((owner, tap, _)) = split_tap_name(dependency)
+        && parent_tap != Some((owner, tap))
+    {
+        return None;
+    }
+    parent.tap_url.clone().or_else(|| {
+        parent_tap.map(|(owner, tap)| format!("https://github.com/{owner}/homebrew-{tap}.git"))
+    })
 }
 
 fn cask_prune_plan_from_tokens(keep: &BTreeSet<String>, state_dir: &Path) -> Result<CaskPrunePlan> {
@@ -7970,14 +8004,27 @@ mod tests {
 
         let mut closure = CaskDependencyClosure::default();
         let mut pending = Vec::new();
-        extend_cask_dependency_closure(&mut closure, &mut pending, root.clone());
+        let root_request = PackageRequest {
+            name: "acme/tools/root".to_string(),
+            version: None,
+            tap_url: Some("https://github.com/acme/custom-tools.git".to_string()),
+        };
+        extend_cask_dependency_closure(&mut closure, &mut pending, &root_request, root.clone());
         assert_eq!(pending.len(), 1);
-        extend_cask_dependency_closure(&mut closure, &mut pending, child);
-        extend_cask_dependency_closure(&mut closure, &mut pending, root);
+        assert_eq!(pending[0].tap_url, root_request.tap_url);
+        let child_request = pending.pop().unwrap();
+        extend_cask_dependency_closure(&mut closure, &mut pending, &child_request, child);
+        extend_cask_dependency_closure(&mut closure, &mut pending, &root_request, root);
 
         assert_eq!(
             closure.casks,
             BTreeSet::from(["child".to_string(), "root".to_string()])
+        );
+        assert!(
+            closure
+                .formulae
+                .values()
+                .all(|request| request.tap_url == root_request.tap_url)
         );
         assert_eq!(
             closure.formulae.into_keys().collect::<Vec<_>>(),
@@ -7987,6 +8034,14 @@ mod tests {
             closure
                 .casks
                 .contains(cask_request_token("acme/tools/root"))
+        );
+        let standard_tap_request = PackageRequest {
+            tap_url: None,
+            ..root_request
+        };
+        assert_eq!(
+            dependency_tap_url(&standard_tap_request, "child"),
+            Some("https://github.com/acme/homebrew-tools.git".to_string())
         );
     }
 

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -880,7 +880,14 @@ impl SystemPackageManager for BrewCaskManager {
 
 async fn fetch_cask(req: &PackageRequest) -> Result<Cask> {
     let name = &req.name;
-    if split_tap_name(name).is_none()
+    let tap_name = split_tap_name(name);
+    let (requested_token, official_api) = match tap_name {
+        Some(("homebrew", "cask", token)) => (token, true),
+        Some((_, _, token)) => (token, false),
+        None => (name.as_str(), true),
+    };
+    validate_cask_path_component("requested token", requested_token)?;
+    if tap_name.is_none()
         && let Some(raw_base) = req.tap_url.as_deref().and_then(super::api::github_raw_base)
     {
         let url = format!("{raw_base}/api/cask/{name}.json");
@@ -891,13 +898,7 @@ async fn fetch_cask(req: &PackageRequest) -> Result<Cask> {
             ),
         }
     }
-    let (requested_token, official_api) = match split_tap_name(name) {
-        Some(("homebrew", "cask", token)) => (token, true),
-        Some((_, _, token)) => (token, false),
-        None => (name.as_str(), true),
-    };
-    validate_cask_path_component("requested token", requested_token)?;
-    let (url, raw_base) = match split_tap_name(name) {
+    let (url, raw_base) = match tap_name {
         Some(("homebrew", "cask", token)) => (
             format!("{API_BASE}/cask/{token}.json"),
             Some(HOMEBREW_CASK_RAW.to_string()),

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -884,7 +884,7 @@ async fn fetch_cask(req: &PackageRequest) -> Result<Cask> {
         && let Some(raw_base) = req.tap_url.as_deref().and_then(super::api::github_raw_base)
     {
         let url = format!("{raw_base}/api/cask/{name}.json");
-        match fetch_cask_url(name, &url, Some(raw_base), false).await {
+        match fetch_cask_url(name, &url, Some(normalize_cask_raw_base(raw_base)), false).await {
             Ok(cask) => return Ok(cask),
             Err(err) => debug!(
                 "brew-cask: {name} unavailable in parent tap metadata ({err}); falling back to official metadata"
@@ -910,7 +910,7 @@ async fn fetch_cask(req: &PackageRequest) -> Result<Cask> {
             };
             (
                 format!("{base}/api/cask/{token}.json"),
-                Some(base.trim_end_matches("/HEAD").to_string()),
+                Some(normalize_cask_raw_base(base)),
             )
         }
         None => (
@@ -919,6 +919,13 @@ async fn fetch_cask(req: &PackageRequest) -> Result<Cask> {
         ),
     };
     fetch_cask_url(requested_token, &url, raw_base, official_api).await
+}
+
+fn normalize_cask_raw_base(mut raw_base: String) -> String {
+    if raw_base.ends_with("/HEAD") {
+        raw_base.truncate(raw_base.len() - "/HEAD".len());
+    }
+    raw_base
 }
 
 async fn fetch_cask_url(
@@ -8042,6 +8049,16 @@ mod tests {
         assert_eq!(
             dependency_tap_url(&standard_tap_request, "child"),
             Some("https://github.com/acme/homebrew-tools.git".to_string())
+        );
+        assert_eq!(
+            normalize_cask_raw_base(
+                "https://raw.githubusercontent.com/acme/homebrew-tools/HEAD".to_string()
+            ),
+            "https://raw.githubusercontent.com/acme/homebrew-tools"
+        );
+        assert_eq!(
+            normalize_cask_raw_base("https://example.com/custom".to_string()),
+            "https://example.com/custom"
         );
     }
 

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -7126,10 +7126,19 @@ async fn resolve_cask_dependency_closure(
     let mut closure = CaskDependencyClosure::default();
     let mut pending = configured.to_vec();
     while let Some(request) = pending.pop() {
+        if closure.casks.contains(cask_request_token(&request.name)) {
+            continue;
+        }
         let cask = fetch_cask(&request).await?;
         extend_cask_dependency_closure(&mut closure, &mut pending, cask);
     }
     Ok(closure)
+}
+
+fn cask_request_token(name: &str) -> &str {
+    split_tap_name(name)
+        .map(|(_, _, token)| token)
+        .unwrap_or(name)
 }
 
 fn extend_cask_dependency_closure(
@@ -7973,6 +7982,11 @@ mod tests {
         assert_eq!(
             closure.formulae.into_keys().collect::<Vec<_>>(),
             vec!["openssl@3".to_string(), "python@3.14".to_string()]
+        );
+        assert!(
+            closure
+                .casks
+                .contains(cask_request_token("acme/tools/root"))
         );
     }
 

--- a/src/system/packages/brew/mod.rs
+++ b/src/system/packages/brew/mod.rs
@@ -39,7 +39,9 @@ mod source;
 mod tag;
 
 pub(crate) struct BrewManager {}
-pub(crate) use cask::{BrewCaskManager, apply_cask_prune_plan, cask_prune_plan};
+pub(crate) use cask::{
+    BrewCaskManager, apply_cask_prune_plan, cask_formula_dependencies, cask_prune_plan,
+};
 pub(crate) use maintenance::{apply_prune_plan, default_tap_url, linked_formulae, prune_plan};
 
 impl BrewManager {

--- a/src/system/packages/brew/resolve.rs
+++ b/src/system/packages/brew/resolve.rs
@@ -66,7 +66,8 @@ pub(super) async fn resolve_closure_with_taps(
         .map(|req| {
             (
                 req.name.clone(),
-                api::tap_name(&req.name),
+                api::tap_name(&req.name)
+                    .or_else(|| req.tap_url.as_deref().and_then(api::tap_name_from_url)),
                 req.tap_url.clone(),
             )
         })


### PR DESCRIPTION
## Summary
- include formula dependencies from configured casks in the brew prune keep closure
- retain transitive cask dependencies during brew-cask pruning
- deduplicate dependency formulae and terminate safely on cask cycles

Fixes the behavior reported in discussion #12457.

## Tests
- `mise run test:unit -- cask_dependency_closure_collects_formulae_and_transitive_casks`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what Homebrew formulae and casks are removed during prune; incorrect closure or tap inference could retain extra packages or still drop needed deps, but the intent is to fix overly aggressive pruning.
> 
> **Overview**
> **Brew and brew-cask pruning** now treat configured casks as a dependency closure instead of only the explicitly listed cask tokens.
> 
> For **formula pruning** (`mise system prune` with brew), configured `brew-cask` packages are resolved and their `depends_on.formula` entries are merged into the brew keep set via `cask_formula_dependencies`, so formulae installed only as cask deps are not removed.
> 
> For **cask pruning**, `cask_prune_plan` uses the same closure logic to keep transitive `depends_on.cask` entries, with deduplication keyed by token plus tap URL so the same name from different taps stays distinct. Tap context for dependencies is inherited from the parent request when appropriate.
> 
> **Metadata fetching** improves custom taps: GitHub tap URLs tolerate trailing slashes and `.git`, `tap_name_from_url` infers taps for formula resolution, and cask fetch can try parent `tap_url` metadata before the official API. Cask identity validation rejects backslashes in path components.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9296668fab0e5dfff202cd407139e07a91a66139. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Homebrew pruning now preserves configured casks and their transitive dependencies.
  - Formula dependencies required by configured casks are retained during pruning.
  - Duplicate dependencies are removed for more accurate prune plans.
  - Dependency handling safely supports circular references and tapped cask names.
  - Cask dependencies resolve correctly across custom taps and transitive dependencies.
  - Tap information is correctly inferred from package names or repository URLs.
  - Repository URLs ending in `.git` or trailing slashes are handled consistently.
  - Cask metadata resolution falls back appropriately when tap-specific information is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->