### PR TITLE
registry: add zwasm (aqua:zwasm/zwasm)

### DIFF
--- a/registry/zwasm.toml
+++ b/registry/zwasm.toml
@@ -1,0 +1,5 @@
+backends = ["aqua:zwasm/zwasm"]
+bins = ["zwasm"]
+description = "A fast, spec-compliant WebAssembly runtime written in Zig"
+test = { cmd = "zwasm --version", expected = "zwasm v{{version}}" }
+version_order = "semver"


### PR DESCRIPTION
## Summary

- add a `zwasm` shorthand backed by the preferred `aqua:zwasm/zwasm` backend
- declare the `zwasm` binary and a version-command check
- `version_order = "semver"`: every tag `mise ls-remote` resolves is a strict `MAJOR.MINOR.PATCH`

zwasm is a from-scratch WebAssembly runtime written in Zig, with an interpreter and a JIT behind one CLI. It was added to the aqua standard registry in aquaproj/aqua-registry#59300, so `aqua` is available as the preferred backend; the releases carry a `SHA256SUMS` asset, which the aqua entry uses for checksum verification.

## Popularity

- GitHub: 169 stars, 11 forks; latest release v2.5.0 published 2026-08-12
- Active maintenance: latest repository push 2026-08-26
- Listed on the WebAssembly project's runtime feature table: https://webassembly.org/features/?categories=standalones
- https://github.com/zwasm/zwasm

## Validation

- `mise ls-remote aqua:zwasm/zwasm` -> `2.2.0 2.2.1 2.3.0 2.4.0 2.4.1 2.5.0`
- `mise x aqua:zwasm/zwasm@2.5.0 -- zwasm --version` -> `zwasm v2.5.0 (wasm: v3_0, wasi: p2, engine: both)`
- `mise test-tool zwasm` -> `zwasm: OK` (built from this branch; the released binary compiles the registry in, so a source build is needed to exercise a new entry)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added registry support for the `zwasm` package.
  * Declared its executable, description, version check, and semantic version ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->