### PR TITLE
fix(http): copy raw binaries on Windows, where a junction cannot name a file

### DIFF
--- a/e2e-win/backend/http_raw_bin_path.Tests.ps1
+++ b/e2e-win/backend/http_raw_bin_path.Tests.ps1
@@ -1,0 +1,64 @@
+Describe 'backend_http_raw_bin_path' {
+    # A raw binary declared with `bin_path` is the one shape of `http:` install
+    # that `create_install_symlink` links file-to-file. On Windows that used to
+    # go through `junction::create`, which builds a *directory* reparse point:
+    # it succeeds, and leaves a link that cannot be resolved.
+    #
+    # `http_binary_clean.Tests.ps1` covers the same binary without `bin_path`,
+    # which takes the other branch and links the install directory instead - so
+    # the broken combination was the one thing untested here.
+    #
+    # `bin` is set so the installed filename is decided outright rather than by
+    # the name-cleaning heuristics, which keeps a failure here pointing at the
+    # link rather than at what the file ended up called.
+    BeforeAll {
+        # `run.ps1` does not change directory, so a config written to the working
+        # directory would land on the repository's own tracked `mise.toml`.
+        $script:OriginalDir = Get-Location
+        $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:TestRoot | Out-Null
+        Set-Location $script:TestRoot
+
+        # Saved here, restored in AfterAll: Pester runs every suite in one
+        # process, so removing an inherited value would leave the next without it.
+        $script:OriginalExperimental = [Environment]::GetEnvironmentVariable('MISE_EXPERIMENTAL', 'Process')
+        $env:MISE_EXPERIMENTAL = "1"
+
+        @"
+[tools]
+"http:docker-compose-binpath" = { version = "2.29.1", url = "https://github.com/docker/compose/releases/download/v{version}/docker-compose-windows-x86_64.exe", bin = "docker-compose.exe", bin_path = "bin" }
+"@ | Set-Content -Path (Join-Path $script:TestRoot "mise.toml")
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        if ($null -eq $script:OriginalExperimental) {
+            Remove-Item -Path Env:\MISE_EXPERIMENTAL -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:MISE_EXPERIMENTAL = $script:OriginalExperimental
+        }
+    }
+
+    It 'reports the install as successful' {
+        # Asserted on purpose: the defect said nothing at install time. Without
+        # this line a reader could assume the install used to fail loudly.
+        mise install -f http:docker-compose-binpath
+        $LASTEXITCODE | Should -Be 0
+    }
+
+    It 'resolves the binary from the tool it installed' {
+        # Checking the version alone is not enough. Docker ships on the GitHub
+        # Windows images, so an unrelated `docker-compose.exe` further along PATH
+        # could satisfy a version check while the installed link stayed broken -
+        # the test would pass on unfixed code. Assert where the command actually
+        # resolves from first.
+        $resolved = (mise exec http:docker-compose-binpath -- where.exe docker-compose | Select-Object -First 1)
+        $resolved | Should -BeLike "*http-docker-compose-binpath*"
+        $resolved | Should -BeLike "*bin*docker-compose.exe"
+    }
+
+    It 'installs a binary that actually runs' {
+        mise exec http:docker-compose-binpath -- docker-compose version | Should -BeLike "Docker Compose version *"
+    }
+}

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -825,7 +825,16 @@ impl HttpBackend {
 
             let cached_file = cache_path.join(filename);
             let install_file = dest_dir.join(filename);
-            file::make_symlink(&cached_file, &install_file)?;
+            // Not `make_symlink`: the target here is a *file*, and on Windows
+            // that goes through `junction::create`, which builds a directory
+            // reparse point. It succeeds and leaves a link that cannot be
+            // resolved — the install looks fine and the binary will not run.
+            // `make_symlink_or_copy` is what the rest of the codebase uses for a
+            // file that has to be executable at the link path (swift, github,
+            // conda and aqua all do). The cost is that Windows keeps a copy
+            // rather than sharing the cached one, which is the right way round:
+            // a duplicate that works beats a link that does not.
+            file::make_symlink_or_copy(&cached_file, &install_file)?;
             return Ok(());
         }
 


### PR DESCRIPTION
Found while investigating a Windows test failure on #12419.

## The bug

`create_install_symlink` has one branch that links **file to file** — a raw binary declared with `bin_path`:

```rust
if let ExtractionType::RawFile { filename } = extraction_type
    && let Some(bin_path_template) = opts.bin_path()
{
    let cached_file = cache_path.join(filename);
    let install_file = dest_dir.join(filename);
    file::make_symlink(&cached_file, &install_file)?;   // target is a file
```

On Windows `file::make_symlink` goes through `create_windows_dir_link` → `junction::create`, and a junction is a **directory** reparse point. It cannot name a file.

**It does not fail.** `junction::create` succeeds and leaves a link that cannot be resolved. Evidence from #12419's CI, where a unit test happened to build the same shape — `make_symlink` returned `Ok`, and the failure surfaced later at the first attempt to resolve the path:

```
failed to resolve C:\...\installs\http-tool\1.0.0\bin\tool: The directory name is invalid
```

So on Windows this install reports success and leaves a broken junction where the binary should be.

## Why it went unnoticed

The one Windows `http:` test, `e2e-win/backend/http_binary_clean.Tests.ps1`, installs a raw `.exe` — but sets no `bin_path`. Without it the guard above is false and the install takes the other branch, linking the whole install directory to the cache: a **directory** target, which a junction handles correctly.

On Linux the raw-plus-`bin_path` combination appears in `e2e/backend/test_http_system_install`, but that goes through `--system`, so `install_path_is_explicit` is set and extraction lands in the install path directly without ever calling `create_install_symlink`.

The broken combination was the one thing neither side covered.

## Fix

`file::make_symlink_or_copy` — symlink on unix, copy on Windows.

Not a new mechanism: it is what the rest of the codebase already reaches for when a file has to be executable at the link path, in `swift.rs`, `github.rs`, `conda.rs` and `aqua.rs`.

Not `make_symlink_or_file` either — that writes the target path into a text file, which is the convention mise resolves itself for tracking and runtime symlinks. The OS cannot execute it.

**Trade-off, stated plainly:** the branch's comment says it exists "for deduplication", and on Windows a copy gives that up. A duplicate that runs beats a link that does not. unix behaviour is untouched. A hard link would keep dedup and stay executable, but that introduces a mechanism for one call site and a same-volume constraint, so it is noted rather than done.

## Relationship to #12419

No conflict — different lines of the same file — and no contradiction. #12419's sweep counts an entry as referenced when an install link resolves into it. With a copy, a Windows install genuinely does not reference the cache entry, so reclaiming that entry is correct rather than harmful: the copy stands alone.

## Test

`e2e-win/backend/http_raw_bin_path.Tests.ps1`, shaped like its neighbour with the one thing that was missing — `bin_path`. `bin` is set explicitly so the installed filename is decided outright rather than by the name-cleaning heuristics, keeping a failure pointed at the link.

It asserts the install **succeeds** before asserting the binary runs. That is deliberate: the defect said nothing at install time, and the test should say so too.

Between those two it asserts **where the command resolves from**, which review caught as the difference between a test and a passing test: Docker ships on the GitHub Windows images, so an unrelated `docker-compose.exe` further along PATH could satisfy a version check while the installed link stayed broken. `mise exec ... -- where.exe docker-compose` is checked to be under this tool's install *and* under `bin_path`.

The suite runs from the checkout root and `run.ps1` does not change directory, so the config is written into a `TestDrive` directory rather than over the repository's own tracked `mise.toml`, and `MISE_EXPERIMENTAL` is restored rather than removed — Pester runs every suite in one process.

**I have no Windows machine — CI is the first execution of this.** unix is unaffected by construction, since `make_symlink_or_copy` is `make_symlink` there.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows installations of raw HTTP binaries configured with a binary path.
  * Installed executables now run successfully instead of creating unusable directory links.
  * Added end-to-end coverage to verify successful installation and execution of these binaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
