### PR TITLE
fix(file): remove a link whose target is gone

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -143,8 +143,20 @@ fn with_io_hint(msg: String, path: &Path, err: &std::io::Error) -> String {
 
 pub(crate) fn remove_all<P: AsRef<Path>>(path: P) -> Result<()> {
     let path = path.as_ref();
-    match path.metadata().map(|m| m.file_type()) {
-        Ok(x) if x.is_symlink() || x.is_file() => {
+    // `symlink_metadata`, not `metadata`: the latter resolves the entry before deciding what to do
+    // with it, so a link that no longer points anywhere reports `NotFound` and falls through to
+    // the no-op arm below — the entry stays on disk and the caller is told nothing. `mise link`
+    // creates exactly such an entry whenever its target is moved or deleted. Resolving also made
+    // the `is_symlink` test unreachable, since a followed link never reports as one.
+    match fs::symlink_metadata(path).map(|m| m.file_type()) {
+        // Removing the link, never what it points at. On Windows `make_symlink` writes a junction,
+        // which is a directory carrying a reparse point: `remove_file` refuses it outright
+        // (measured: `PermissionDenied`, live or dangling), so this goes through the helper that
+        // deletes by handle after checking the reparse tag.
+        Ok(x) if x.is_symlink() => {
+            remove_symlink_or_junction(path)?;
+        }
+        Ok(x) if x.is_file() => {
             remove_file(path)?;
         }
         Ok(x) if x.is_dir() => {
@@ -2669,6 +2681,71 @@ mod tests {
     use crate::config::Config;
 
     use super::*;
+
+    /// Whether a directory entry is there at all, without resolving it.
+    ///
+    /// `Path::exists` answers about the *target*, so it is false for a link whose target is gone —
+    /// which is the entry these tests are about. An assertion written with it would hold before
+    /// the removal as well as after, and prove nothing.
+    fn entry_present(path: &Path) -> bool {
+        fs::symlink_metadata(path).is_ok()
+    }
+
+    /// Deliberately not `#[cfg(unix)]`: `make_symlink` writes a real symlink on unix and a
+    /// junction on Windows, and the two are removed by different system calls. The behaviour under
+    /// test is what happens to a link mise itself wrote, so it has to be checked on both.
+    #[test]
+    fn remove_all_removes_a_link_whose_target_is_gone() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        create_dir_all(&target).unwrap();
+        write(target.join("keep.txt"), "important").unwrap();
+        make_symlink(&target, &link).unwrap();
+
+        remove_all(&target).unwrap();
+        // Control: the entry really is a link that no longer resolves. Without this the assertion
+        // below could be passing because there was nothing there to begin with.
+        assert!(entry_present(&link));
+        assert!(!link.exists());
+
+        remove_all(&link).unwrap();
+        assert!(!entry_present(&link));
+    }
+
+    #[test]
+    fn remove_all_removes_a_live_link_without_touching_its_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        create_dir_all(&target).unwrap();
+        write(target.join("keep.txt"), "important").unwrap();
+        make_symlink(&target, &link).unwrap();
+
+        remove_all(&link).unwrap();
+        assert!(!entry_present(&link));
+        // The other half, and the reason the link arm cannot simply recurse: `mise link` points at
+        // a directory the user owns, and removing the link must not take its contents with it.
+        assert!(target.join("keep.txt").exists());
+    }
+
+    #[test]
+    fn remove_all_still_removes_ordinary_files_and_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("file.txt");
+        let subdir = dir.path().join("subdir");
+        write(&file, "x").unwrap();
+        create_dir_all(subdir.join("nested")).unwrap();
+        write(subdir.join("nested/x.txt"), "x").unwrap();
+
+        remove_all(&file).unwrap();
+        assert!(!entry_present(&file));
+        remove_all(&subdir).unwrap();
+        assert!(!entry_present(&subdir));
+
+        // A path that was never there is not an error: most callers remove opportunistically.
+        remove_all(dir.path().join("never-existed")).unwrap();
+    }
 
     #[cfg(unix)]
     #[test]


### PR DESCRIPTION
## The problem

`file::remove_all` decided what to do by resolving the entry first:

```rust
match path.metadata().map(|m| m.file_type()) {
    Ok(x) if x.is_symlink() || x.is_file() => { remove_file(path)?; }
    Ok(x) if x.is_dir() => { /* remove_dir_all */ }
    _ => {}
}
```

`Path::metadata` follows links, so a link whose target is gone reports `NotFound` and falls through to `_ => {}`. **The entry stays on disk and the caller is told nothing.** The same resolution also made `is_symlink()` unreachable — a followed link never reports as one — so that half of the first arm was dead.

`mise link` creates exactly such an entry the moment its target is moved or deleted, and `mise uninstall` then cannot remove it.

Measured on both platforms, running the current `remove_all` body against real fixtures:

| entry | `metadata()` | `symlink_metadata()` | current `remove_all` |
| --- | --- | --- | --- |
| live link → dir | `dir=true, symlink=false` | `symlink=true` | `remove_dir_all` — removes the link, target kept |
| live link → file | `file=true, symlink=false` | `symlink=true` | `remove_file` — removes the link, target kept |
| **link with no target** | `Err NotFound` | `symlink=true` | **`_ =>` — does nothing, no error** |

## The fix

Match on `symlink_metadata` and give links their own arm.

The arm calls the existing `remove_symlink_or_junction` rather than `remove_file`, because `remove_file` is not enough on Windows. `make_symlink` writes a **junction** there, which is a directory carrying a reparse point:

| Windows entry | `remove_file` | `remove_dir` | `remove_dir_all` |
| --- | --- | --- | --- |
| live junction | **Err PermissionDenied** | Ok | Ok |
| dangling junction | **Err PermissionDenied** | Ok | Ok |

`remove_symlink_or_junction` already handles this: on Windows it opens with `FILE_FLAG_OPEN_REPARSE_POINT`, checks the reparse tag is `IO_REPARSE_TAG_MOUNT_POINT` or `IO_REPARSE_TAG_SYMLINK`, and deletes by handle; on unix it confirms the entry is a link and unlinks it. Measured against the cases this now routes to it:

| | live link | link with no target | plain file | real directory |
| --- | --- | --- | --- | --- |
| Windows (junction) | Ok | **Ok** | Err — refused, tag `0x0` | Err — refused |
| Linux (symlink) | Ok | **Ok** | Err — `refusing to remove non-link` | Err — refused |

Target contents survive in every case, and the "refuse anything that is not a link" property is kept.

## What changes for callers

`remove_all` has ~150 call sites, so the important part is what does *not* change:

| entry | before | after |
| --- | --- | --- |
| real file | `remove_file` | `remove_file` |
| real directory | `remove_dir_all` | `remove_dir_all` |
| live link → dir | link removed, target kept | link removed, target kept |
| live link → file | link removed, target kept | link removed, target kept |
| path that was never there | no-op | no-op |
| **link with no target** | **no-op, entry survives** | **entry removed** |

A Windows app-execution alias — a 0-byte reparse point, e.g. `WindowsApps\notepad.exe` — reports `is_symlink=false, is_file=true`, so it keeps taking the file arm and is not routed through the link path.

## Tests

Three, and deliberately **not** `#[cfg(unix)]`: `make_symlink` writes a real symlink on unix and a junction on Windows, and the two are removed by different system calls, so the behaviour has to be checked on both.

- a link whose target is gone is removed. The control before it asserts the entry really is a link that no longer resolves — written with `symlink_metadata`, not `Path::exists`, which answers about the *target* and so is false both before and after the removal, proving nothing.
- a live link is removed **without touching its target's contents** — the failure that would matter most, since `mise link` points at a directory the user owns.
- ordinary files, directories, and a path that was never there still behave as before.

Verified on CI rather than by conclusion: all three run and pass on Windows (`file::tests::remove_all_*`), which is the junction path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved removal of symbolic links and Windows junctions without following them.
  - Prevented linked target files or directories from being deleted accidentally.
  - Added reliable handling for dangling links, regular files, directories, and missing paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->