### PR TITLE
fix(link): show and allow removing a link whose target is gone

### DIFF
--- a/e2e-win/link_broken_target.Tests.ps1
+++ b/e2e-win/link_broken_target.Tests.ps1
@@ -1,0 +1,119 @@
+Describe 'a linked version whose target is gone' {
+    # `mise link` writes a junction on Windows, and a junction whose target is gone is removed by a
+    # different system call than a unix symlink (`remove_file` refuses it outright). Passing on
+    # Linux says nothing about here, so the same behaviour is checked on both.
+
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:TestRoot | Out-Null
+        Set-Location $script:TestRoot
+
+        # `mise link` does not need the tool installed -- it points a version name at a directory
+        # of the user's, which is exactly the arrangement that breaks when that directory moves.
+        $script:Target = Join-Path $script:TestRoot 'vanishing'
+        New-Item -ItemType Directory -Path $script:Target | Out-Null
+        mise link node@e2e-broken $script:Target | Out-Null
+        $script:LinkExit = $LASTEXITCODE
+        # Captured on a line of its own: a failed `mise where` would otherwise hand `Split-Path`
+        # an empty string, and every path assertion below would be about the wrong place while
+        # still looking like a result.
+        $where = mise where node@e2e-broken
+        $script:WhereExit = $LASTEXITCODE
+        $script:Entry = Join-Path (Split-Path $where) 'e2e-broken'
+
+        # Whether the entry is there, asked without resolving it -- the same question
+        # `file::entry_exists` asks on the Rust side, and the one this whole change is about.
+        #
+        # `Test-Path` measured True for a dangling junction here, so it would work; enumerating the
+        # parent does not depend on that at all. It matters because the assertion after the
+        # uninstall is only meaningful if the check is True while the entry dangles: a check that
+        # resolved the target would be False either way and would pass whether or not anything was
+        # removed.
+        function script:EntryPresent([string]$Path) {
+            $name = Split-Path $Path -Leaf
+            [bool](Get-ChildItem -LiteralPath (Split-Path $Path) -Force -ErrorAction SilentlyContinue |
+                    Where-Object { $_.Name -eq $name })
+        }
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        mise uninstall node@e2e-broken 2>&1 | Out-Null
+        mise uninstall node@e2e-kept 2>&1 | Out-Null
+    }
+
+    It 'is an ordinary linked version while its target is there' {
+        # The control. Everything below is about what changes when the target goes away, so the
+        # starting state has to be the working one.
+        $script:LinkExit | Should -Be 0
+        $script:WhereExit | Should -Be 0
+        script:EntryPresent $script:Entry | Should -BeTrue
+
+        $out = mise ls node | Out-String
+        $status = $LASTEXITCODE
+        $out | Should -BeLike '*e2e-broken (symlink)*'
+        $status | Should -Be 0
+    }
+
+    It 'is reported as broken once the target is gone' {
+        Remove-Item -LiteralPath $script:Target -Recurse -Force
+        # The entry is still there. This is the control for the assertion after the uninstall:
+        # a check that resolved the link would be False here too, and that later assertion would
+        # then pass whether or not anything had been removed.
+        script:EntryPresent $script:Entry | Should -BeTrue
+
+        $out = mise ls node | Out-String
+        $status = $LASTEXITCODE
+        $out | Should -BeLike '*e2e-broken (broken symlink)*'
+        # A listing that named it and still failed would not be the fix this claims to be.
+        $status | Should -Be 0
+    }
+
+    It 'is not counted as installed' {
+        # `mise link` already makes this call by keeping the incomplete marker for a dangling link.
+        # Listing it is about making it findable, not about claiming it works.
+        $json = mise ls --json node | Out-String
+        $jsonStatus = $LASTEXITCODE
+        ($json | jq -r '.[] | select(.version == "e2e-broken") | "\(.broken) \(.installed)"') |
+            Should -Be 'true false'
+        $jsonStatus | Should -Be 0
+
+        $out = mise ls -i node | Out-String
+        $status = $LASTEXITCODE
+        $out | Should -Not -BeLike '*e2e-broken*'
+        # Without this, a `mise ls -i` that failed outright would satisfy the line above.
+        $status | Should -Be 0
+    }
+
+    It 'can be uninstalled, which is what frees the name' {
+        mise uninstall node@e2e-broken 2>&1 | Out-Null
+        $LASTEXITCODE | Should -Be 0
+        script:EntryPresent $script:Entry | Should -BeFalse
+
+        $out = mise ls node | Out-String
+        $status = $LASTEXITCODE
+        $out | Should -Not -BeLike '*e2e-broken*'
+        $status | Should -Be 0
+    }
+
+    It 'still removes only the link when the target is alive' {
+        # The regression control: the directory a live link points at belongs to the user, and
+        # uninstalling the version must not take it.
+        $kept = Join-Path $script:TestRoot 'kept'
+        New-Item -ItemType Directory -Path $kept | Out-Null
+        Set-Content -LiteralPath (Join-Path $kept 'sentinel.txt') -Value 'important'
+        mise link node@e2e-kept $kept | Out-Null
+        $LASTEXITCODE | Should -Be 0
+        $where = mise where node@e2e-kept
+        $LASTEXITCODE | Should -Be 0
+        $entry = Join-Path (Split-Path $where) 'e2e-kept'
+        script:EntryPresent $entry | Should -BeTrue
+
+        mise uninstall node@e2e-kept 2>&1 | Out-Null
+        $LASTEXITCODE | Should -Be 0
+        script:EntryPresent $entry | Should -BeFalse
+        # A plain file, so `Test-Path` is exactly the right question for it.
+        Test-Path -LiteralPath (Join-Path $kept 'sentinel.txt') | Should -BeTrue
+    }
+}

--- a/e2e/cli/test_link
+++ b/e2e/cli/test_link
@@ -104,3 +104,36 @@ mkdir -p tmp/tiny3
 mkdir -p "$MISE_CACHE_DIR/tiny/9.9.7/incomplete"
 assert_fail "mise link tiny@9.9.7 tmp/tiny3"
 assert "test -d \"$MISE_CACHE_DIR/tiny/9.9.7/incomplete\""
+
+# A link whose target went away is still an entry occupying its version's name. It used to be
+# invisible to `mise ls` -- no config names it, and every check resolved the link before answering
+# -- while `mise uninstall` refused it as "not installed", so nothing could free the name again.
+mkdir -p tmp/tiny-vanishing
+mise link tiny@9.9.4 tmp/tiny-vanishing
+# Control: while the target is there it is an ordinary linked version.
+assert_contains "mise ls tiny" "tiny  9.9.4 (symlink)"
+rmdir tmp/tiny-vanishing
+
+# It is reported, and reported as broken rather than as an ordinary symlink.
+assert_contains "mise ls tiny" "tiny  9.9.4 (broken symlink)"
+# ...but not as installed. `mise link` already makes that call by keeping the incomplete marker
+# for a dangling link, and `-i` lists only what is installed.
+assert "mise ls -i tiny | grep -c 9.9.4 || true" "0"
+assert "mise ls --json tiny | jq -r '.[] | select(.version == \"9.9.4\") | \"\\(.broken) \\(.installed)\"'" "true false"
+
+# The point of showing it: `uninstall` can now free the name.
+assert "mise uninstall tiny@9.9.4"
+# `test ! -e` alone proves nothing here -- it follows the link, so it was already true while the
+# entry existed. `-L` is what distinguishes removed from dangling.
+assert "test ! -L \"$MISE_DATA_DIR/installs/tiny/9.9.4\" && test ! -e \"$MISE_DATA_DIR/installs/tiny/9.9.4\""
+assert "mise ls tiny | grep -c 9.9.4 || true" "0"
+
+# The regression control: a live link still uninstalls to the link only, leaving the directory it
+# points at -- which belongs to the user, not to mise.
+mkdir -p tmp/tiny-kept
+touch tmp/tiny-kept/sentinel
+mise link tiny@9.9.3 tmp/tiny-kept
+assert_contains "mise ls tiny" "tiny  9.9.3 (symlink)"
+assert "mise uninstall tiny@9.9.3"
+assert "test ! -L \"$MISE_DATA_DIR/installs/tiny/9.9.3\""
+assert "test -f tmp/tiny-kept/sentinel"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -19,7 +19,8 @@ use crate::config::config_file::config_root;
 use crate::config::{Config, Settings};
 use crate::duration::parse_into_timestamp;
 use crate::file::{
-    canonicalize_cached, display_path, remove_all_with_progress, remove_all_with_warning,
+    canonicalize_cached, display_path, entry_exists, remove_all_with_progress,
+    remove_all_with_warning,
 };
 use crate::install_before::resolve_before_date_for_tool;
 use crate::install_context::InstallContext;
@@ -3631,7 +3632,9 @@ pub(crate) trait Backend: Debug + Send + Sync {
         }
         let rmdir = |dir: &Path| {
             if dryrun {
-                if dir.exists() {
+                // Not `exists()`, which resolves a link: a dry run has to name the entry the real
+                // run would remove, and a link whose target is gone is one of them.
+                if entry_exists(dir) {
                     pr.set_message(format!("remove {}", display_path(dir)));
                 }
                 return Ok(());

--- a/src/cli/ls.rs
+++ b/src/cli/ls.rs
@@ -14,6 +14,7 @@ use crate::cli::prune;
 use crate::config;
 use crate::config::Config;
 use crate::env;
+use crate::file;
 use crate::runtime_symlinks::is_runtime_symlink;
 use crate::toolset::{ToolRequestSet, ToolSource, ToolVersion, Toolset};
 use crate::ui::table::MiseTable;
@@ -336,9 +337,14 @@ impl Ls {
                 )
             })
             .map(|(k, tv)| (self, k.0, tv.clone(), tv.request.source().clone()))
-            // if it isn't installed and it's not specified, don't show it
+            // if it isn't installed and it's not specified, don't show it -- unless there is
+            // something at its install path that simply does not resolve. A `mise link` whose
+            // target went away is that case, and hiding it is how it became impossible to find:
+            // no config names it, and `is_version_installed` resolves the link before answering.
             .filter(|(_ls, p, tv, source)| {
-                !source.is_unknown() || p.is_version_installed(config, tv, true)
+                !source.is_unknown()
+                    || p.is_version_installed(config, tv, true)
+                    || file::entry_exists(tv.install_path())
             })
             .filter(|(_ls, p, _, _)| match &self.installed_tool {
                 Some(backend) => matches_requested_tool(backend, p.ba()),
@@ -384,9 +390,14 @@ impl Ls {
             })
             .unique_by(|(_, tv)| tv.tv_pathname())
             .map(|(k, tv)| (self, k.0, tv.clone(), tv.request.source().clone()))
-            // if it isn't installed and it's not specified, don't show it
+            // if it isn't installed and it's not specified, don't show it -- unless there is
+            // something at its install path that simply does not resolve. A `mise link` whose
+            // target went away is that case, and hiding it is how it became impossible to find:
+            // no config names it, and `is_version_installed` resolves the link before answering.
             .filter(|(_ls, p, tv, source)| {
-                !source.is_unknown() || p.is_version_installed(config, tv, true)
+                !source.is_unknown()
+                    || p.is_version_installed(config, tv, true)
+                    || file::entry_exists(tv.install_path())
             })
             .filter(|(_ls, p, _, _)| match &self.installed_tool {
                 Some(backend) => matches_requested_tool(backend, p.ba()),
@@ -441,8 +452,19 @@ struct JSONToolVersion {
     sources: Option<Vec<JSONToolSource>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     symlinked_to: Option<PathBuf>,
+    /// The link at `install_path` no longer resolves.
+    ///
+    /// Omitted when false, so output for everything else is unchanged. `installed` is false for
+    /// these too — this says *why*, and distinguishes an entry that is still on disk and needs
+    /// removing from a version that was simply never installed.
+    #[serde(skip_serializing_if = "is_false")]
+    broken: bool,
     installed: bool,
     active: bool,
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
 }
 
 type RuntimeRow<'a> = (&'a Ls, Arc<dyn Backend>, ToolVersion, ToolSource);
@@ -480,6 +502,11 @@ impl Row {
                     cell = cell.add_attribute(Attribute::Dim);
                 }
                 cell
+            }
+            // Red like `Missing`, but not crossed out: the entry is still there, and the point of
+            // showing it is that the user has something to act on.
+            VersionStatus::BrokenSymlink(version) => {
+                Cell::new(format!("{version} (broken symlink)")).fg(Color::Red)
             }
             VersionStatus::Shared(version, active, label) => {
                 let mut cell = Cell::new(format!("{version} ({label})"));
@@ -579,7 +606,13 @@ async fn json_tool_version_from(
             Some(source.as_json())
         },
         sources: if all_sources { sources } else { None },
-        installed: !matches!(vs, VersionStatus::Missing(_)),
+        broken: matches!(vs, VersionStatus::BrokenSymlink(_)),
+        // A link that leads nowhere is not an install, the same call `mise link` already makes by
+        // keeping the `incomplete` marker for one.
+        installed: !matches!(
+            vs,
+            VersionStatus::Missing(_) | VersionStatus::BrokenSymlink(_)
+        ),
         active: match &vs {
             VersionStatus::Active(_, _) => true,
             VersionStatus::Symlink(_, active) => *active,
@@ -595,6 +628,10 @@ enum VersionStatus {
     Inactive(String),
     Missing(String),
     Symlink(String, bool),
+    /// A link that is still on disk but no longer resolves — a `mise link` whose target moved or
+    /// was deleted. Distinct from `Missing`, which is a version that was never there: this one
+    /// occupies its name and has to be removed before that name is free again.
+    BrokenSymlink(String),
     /// Version from a shared or system install directory
     Shared(String, bool, &'static str),
 }
@@ -622,7 +659,12 @@ async fn resolve_version_status(
 ) -> VersionStatus {
     let install_path = tv.install_path();
     if install_path.is_symlink() && !is_runtime_symlink(&install_path) {
-        VersionStatus::Symlink(tv.version.clone(), active)
+        // `exists()` resolves the link, so this is asking whether it still leads anywhere.
+        if install_path.exists() {
+            VersionStatus::Symlink(tv.version.clone(), active)
+        } else {
+            VersionStatus::BrokenSymlink(tv.version.clone())
+        }
     } else if !p.is_version_installed(config, tv, true) {
         VersionStatus::Missing(tv.version.clone())
     } else {

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -59,7 +59,14 @@ impl Uninstall {
         let mpr = MultiProgressReport::get();
         let mut has_work = false;
         for (plugin, tv) in tool_versions {
-            if !plugin.is_version_installed(&config, &tv, true) {
+            // `is_version_installed` resolves the install path, so it says no for a link whose
+            // target is gone -- and that entry is precisely what someone running `uninstall` is
+            // trying to get rid of. Refusing it left the name occupied with no command able to
+            // free it. It is still not *installed*: this only decides whether there is something
+            // here to remove.
+            if !plugin.is_version_installed(&config, &tv, true)
+                && !file::entry_exists(tv.install_path())
+            {
                 warn!("{} is not installed", tv.style());
                 continue;
             }

--- a/src/file.rs
+++ b/src/file.rs
@@ -271,12 +271,23 @@ pub(crate) fn remove_all_with_warning<P: AsRef<Path>>(path: P) -> Result<()> {
     })
 }
 
+/// Whether a directory entry is there at all, without resolving it.
+///
+/// [`Path::exists`] answers about a link's *target*, so it is false for one whose target is gone —
+/// and that entry is exactly the thing a caller asking "is there something here to remove, or to
+/// tell the user about?" needs to find.
+pub(crate) fn entry_exists<P: AsRef<Path>>(path: P) -> bool {
+    fs::symlink_metadata(path.as_ref()).is_ok()
+}
+
 pub(crate) fn remove_all_with_progress<P: AsRef<Path>>(
     path: P,
     pr: &dyn SingleReport,
 ) -> Result<()> {
     let path = path.as_ref();
-    if !path.exists() {
+    // Not `exists()`: a link whose target is gone is still an entry to remove, and reporting
+    // nothing to do would leave it behind exactly where a user went looking for it.
+    if !entry_exists(path) {
         return Ok(());
     }
     pr.set_message(format!("remove {}", display_path(path)));
@@ -885,6 +896,20 @@ pub(crate) fn find_up<FN: AsRef<str>>(from: &Path, filenames: &[FN]) -> Option<P
 }
 
 pub(crate) fn dir_subdirs(dir: &Path) -> Result<BTreeSet<String>> {
+    subdirs(dir, false)
+}
+
+/// [`dir_subdirs`], but keeping a link whose target is gone.
+///
+/// Most callers want the plain version: a link that resolves to nothing is not a directory they
+/// can read a plugin, a cached download or another version manager's install out of. Version
+/// listing is the exception — the entry is still there, still occupying the name, and still the
+/// thing a user has to be told about before they can remove it.
+pub(crate) fn dir_subdirs_keeping_broken_links(dir: &Path) -> Result<BTreeSet<String>> {
+    subdirs(dir, true)
+}
+
+fn subdirs(dir: &Path, keep_broken_links: bool) -> Result<BTreeSet<String>> {
     let mut output = Default::default();
 
     if !dir.exists() {
@@ -893,8 +918,14 @@ pub(crate) fn dir_subdirs(dir: &Path) -> Result<BTreeSet<String>> {
 
     for entry in dir.read_dir()? {
         let entry = entry?;
+        // `entry.file_type()` describes the entry itself; `entry.path().is_dir()` resolves it.
+        // A link is kept when it leads to a directory, or — for the callers that asked — when it
+        // leads nowhere at all.
         let ft = entry.file_type()?;
-        if ft.is_dir() || (ft.is_symlink() && entry.path().is_dir()) {
+        let keep = ft.is_dir()
+            || (ft.is_symlink()
+                && (entry.path().is_dir() || keep_broken_links && !entry.path().exists()));
+        if keep {
             output.insert(entry.file_name().into_string().unwrap());
         }
     }
@@ -2694,6 +2725,61 @@ mod tests {
     /// Deliberately not `#[cfg(unix)]`: `make_symlink` writes a real symlink on unix and a
     /// junction on Windows, and the two are removed by different system calls. The behaviour under
     /// test is what happens to a link mise itself wrote, so it has to be checked on both.
+    /// Deliberately not `#[cfg(unix)]`, like the removal tests below: `make_symlink` writes a real
+    /// symlink on unix and a junction on Windows, and only `symlink_metadata` describes both
+    /// without resolving them.
+    #[test]
+    fn entry_exists_sees_what_path_exists_hides() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let live = dir.path().join("live");
+        let broken = dir.path().join("broken");
+        let plain = dir.path().join("plain.txt");
+        create_dir_all(&target).unwrap();
+        write(&plain, "x").unwrap();
+        make_symlink(&target, &live).unwrap();
+        make_symlink(&dir.path().join("nowhere"), &broken).unwrap();
+
+        for p in [&target, &plain, &live, &broken] {
+            assert!(entry_exists(p), "{}", p.display());
+        }
+        assert!(!entry_exists(dir.path().join("never-existed")));
+
+        // The control, and the whole reason this function exists: `Path::exists` answers about the
+        // link's target, so it disagrees for exactly the entry that needs finding.
+        assert!(!broken.exists());
+    }
+
+    /// Also pins that `DirEntry::file_type()` reports a Windows junction as a symlink, which is
+    /// what the predicate keys on. `make_symlink` writes a junction here, so if that were not so,
+    /// `broken` would be dropped below — and the *live* junction would never have been listed
+    /// either, which is how `mise ls` has been showing linked versions on Windows all along.
+    #[test]
+    fn only_the_version_scan_keeps_a_link_that_leads_nowhere() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        create_dir_all(&target).unwrap();
+        make_symlink(&target, &dir.path().join("live")).unwrap();
+        make_symlink(&dir.path().join("nowhere"), &dir.path().join("broken")).unwrap();
+        write(dir.path().join("plain.txt"), "x").unwrap();
+
+        // The control: the plain listing still drops it, because a link that resolves to nothing
+        // is not a directory its callers can read a plugin or a cached download out of.
+        let plain = dir_subdirs(dir.path()).unwrap();
+        assert!(
+            plain.contains("target") && plain.contains("live"),
+            "{plain:?}"
+        );
+        assert!(!plain.contains("broken"), "{plain:?}");
+
+        let kept = dir_subdirs_keeping_broken_links(dir.path()).unwrap();
+        assert!(kept.contains("broken"), "{kept:?}");
+        // Everything else it reports is unchanged -- including that a regular file is still not a
+        // subdirectory.
+        assert!(kept.contains("target") && kept.contains("live"), "{kept:?}");
+        assert!(!kept.contains("plain.txt"), "{kept:?}");
+    }
+
     #[test]
     fn remove_all_removes_a_link_whose_target_is_gone() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -234,7 +234,11 @@ fn load_plugins() -> MutexResult<InstallStatePlugins> {
 /// deletes every shim it cannot account for. Callers that are explicitly
 /// best-effort (read-only shared dirs) downgrade this to a warning.
 fn scan_versions(dir: &Path) -> Result<Vec<String>> {
-    Ok(file::dir_subdirs(dir)?
+    // Keeping the links that lead nowhere. `mise link` leaves one behind as soon as its target is
+    // moved or deleted, and dropping it here is what made the version invisible to `mise ls` and
+    // unreachable to `mise uninstall` — occupying a name nothing would admit to. It is listed, not
+    // treated as installed: `is_version_installed` still resolves the path and still says no.
+    Ok(file::dir_subdirs_keeping_broken_links(dir)?
         .into_iter()
         .filter(|v| !v.starts_with('.'))
         .filter(|v| !runtime_symlinks::is_runtime_symlink(&dir.join(v)))


### PR DESCRIPTION
## The problem

`mise link node@dev <dir>` leaves a link at `installs/<tool>/<version>`. Move or delete that
directory — or link a path that was never there, which `e2e/cli/test_link` already does — and the
entry stays behind while every check that decides about it resolves it first:

| command | before |
| --- | --- |
| `mise ls node` | nothing at all |
| `mise ls --json node` | `[]` |
| `mise uninstall node@dev` | `WARN ... is not installed`, exit 0, entry survives |
| `mise uninstall --all node` | `WARN no versions found`, entry survives |
| `mise prune` | does not consider it |
| `mise where node@dev` | `ERROR ... not installed` |

The name stays occupied by something no command will admit to, and nothing frees it. Re-linking
recovers it, but nothing tells you that.

Four gates, all the same shape — deciding about an entry after resolving it:

| where | test |
| --- | --- |
| [`file::dir_subdirs`](src/file.rs) via [`install_state::scan_versions`](src/toolset/install_state.rs) | `ft.is_symlink() && entry.path().is_dir()` |
| [`cli/ls.rs`](src/cli/ls.rs) | `!source.is_unknown() \|\| is_version_installed(..)` |
| [`cli/uninstall.rs`](src/cli/uninstall.rs) | `is_version_installed(..)` |
| [`file::remove_all_with_progress`](src/file.rs) and the dry-run branch of `uninstall_version` | `!path.exists()` |

## The fix

**Version scanning keeps such a link.** Through a sibling of `dir_subdirs` rather than by changing
it: the other ~15 callers — plugin listing, cached downloads, other version managers' installs —
are right to drop it, since a link resolving to nothing is not a directory any of them can read.

**`mise ls` shows it as `<version> (broken symlink)`**, in red, alongside the existing `(symlink)`
and `(missing)`. `--json` gains `broken: true`, omitted when false so existing output is byte-identical.

**`mise uninstall` accepts it**: the gate becomes "installed, *or* there is an entry here".

**`entry_exists`** names the question these callers were getting wrong — whether there is an entry
at all, asked without resolving it — and replaces the `exists()` guards in the removal path.

## It is listed, not called installed

`e2e/cli/test_link` already decides that "a dangling external link is not a complete install and
must keep the marker". Nothing here changes that:

- `is_version_installed` is untouched and still says no
- `installed` is false in `--json`
- `mise ls -i` still omits it

Listing it is about making it findable. `uninstall` is what acts on it.

## Junctions

`mise link` writes a junction on Windows for a non-UNC target, and both the `dir_subdirs` predicate
and `resolve_version_status` key on `is_symlink()`. That does recognise a junction — measured on
fixtures built with `junction::create`, live and dangling, through both `DirEntry::file_type()` and
`Path::is_symlink()`. It is load-bearing already: `ft.is_symlink() && entry.path().is_dir()` is
pre-existing, and a **live** `mise link` on Windows renders as `<version> (symlink)` through exactly
these branches today.

Both are covered on Windows CI rather than argued. `only_the_version_scan_keeps_a_link_that_leads_nowhere`
builds junctions and asserts the broken one is kept; the e2e-win suite asserts `mise ls` prints
`(broken symlink)` with the target deleted.

## Knock-on effects, checked rather than assumed

- **Shims.** `get_desired_shims` now sees one more version. `list_tool_bins` filters bin paths by
  `path.exists()`, so a broken install contributes nothing and produces no warning.
- **Runtime symlinks.** `installed_versions_in_dir` uses the plain `dir_subdirs`, so a broken
  version can never become the target of `latest`.
- **`prune`.** It shares the listing, so a broken link is now prunable. That matches what already
  happens to a *live* link, and `mise link` writes nothing to config that would protect either.
  Worth a maintainer's opinion: a link into a temporarily-unmounted volume would be offered for
  pruning. It is opt-in and confirmed unless `--yes`.

## Tests

**Unit, on every platform** — `make_symlink` writes a symlink on unix and a junction on Windows, so
both are exercised:

- `entry_exists` is true for a file, a directory, a live link and a broken one; false for a path
  that was never there. The control asserts `Path::exists` disagrees for the broken one — that
  disagreement is the whole reason the function exists.
- the version-scanning listing keeps a broken link while the plain `dir_subdirs` still drops it,
  and neither starts reporting a regular file.

**e2e (bash)** — added to `e2e/cli/test_link`, which already has the fixtures: link, confirm it
reads as `(symlink)` while the target is there, remove the target, confirm `(broken symlink)`,
confirm `broken/installed` in `--json`, then uninstall and confirm the entry is gone. The removal
assertion uses `test ! -L` and not just `test ! -e`: `-e` follows the link, so it was already true
while the entry existed and would have proved nothing.

**e2e-win** — the same, for the junction path. A junction whose target is gone is removed by a
different system call than a unix symlink (`remove_file` refuses it with `PermissionDenied`), so
passing on Linux says nothing about Windows. Whether the entry is there is asked by enumerating
the parent directory, which does not depend on how any one cmdlet treats a link — the same
question `entry_exists` asks in Rust. That matters because the assertion after the uninstall is
only meaningful if the check reads true *while the entry dangles*: one that resolved the target
would be false either way, and would pass whether or not anything had been removed.

Both e2e suites end with the regression control: a **live** link still uninstalls to the link only,
leaving the directory it points at — which belongs to the user, not to mise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `mise ls` now shows broken linked versions and clearly labels them as broken.
  - JSON listings identify broken links with `broken: true` and `installed: false`.
  - Broken links can be removed with `mise uninstall`.

- **Bug Fixes**
  - Removing linked versions now deletes only the managed link, preserving the target directory and its contents.
  - Broken links remain manageable even when their original targets are missing.

- **Tests**
  - Added coverage for broken-link detection, listing, JSON output, and safe removal on supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->