### PR TITLE
feat(task): let task_source_files return only what changed

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -312,6 +312,18 @@ For example, `task_source_files()` returns a different set of filepaths dependin
   files, it will be omitted from the result. Returns an empty array if no sources are configured or if
   no files match the patterns.
 
+  Pass `only_changed=true` to narrow the result to the sources written since mise last considered
+  this task up to date. This is useful for linters and formatters that are much faster when given a
+  small set of files. A task mise has never seen up to date has no baseline to compare against, so
+  every source is returned. A run that _fails_ does not advance the baseline, so the same files stay
+  in the list until the task passes. Like mise's own source freshness checking, this compares
+  modification times, so it inherits the same caveats around `touch` and restored caches.
+
+  Filtering never narrows the result all the way to nothing: if no source changed and yet the task
+  is running — `--force`, a dependency that did work, an output deleted while the sources stood
+  still — every source is returned instead, because a task handed no files does none of the work it
+  was run to do.
+
 #### Examples
 
 ```toml
@@ -331,6 +343,13 @@ run = '''
   echo "Processing: {{ file }}"
 {% endfor %}
 '''
+
+# Only lint what changed since this task last succeeded. Each path goes through
+# `quote`, so a filename containing a space or a shell metacharacter stays one
+# argument (POSIX shells — see the quote filter's note).
+[tasks.lint]
+sources = ["src/**/*.ts"]
+run = "eslint{% for file in task_source_files(only_changed=true) %} {{ file | quote }}{% endfor %}"
 ```
 
 ### Exec Options

--- a/e2e/tasks/test_task_source_files_only_changed
+++ b/e2e/tasks/test_task_source_files_only_changed
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+# `task_source_files(only_changed=true)` narrows the list to the sources
+# written since the task last succeeded, so a slow linter can be handed just
+# the new work instead of the whole project.
+# See: https://github.com/jdx/mise/discussions/9715
+
+mkdir -p src
+
+# The task definition must stay byte-identical for the whole test: the state
+# key that locates the baseline hashes `run` and `sources`, so editing either
+# would point at a fresh marker and make every file look changed. `fail` is a
+# sentinel file instead, so a run can be made to fail without touching this.
+cat <<'EOF' >mise.toml
+[tasks.lint]
+run = "echo 'checked:{{ task_source_files(only_changed=true) | join(sep=\" \") }}' >>log.txt && test ! -f fail"
+sources = ["src/*.txt"]
+EOF
+
+echo a >src/a.txt
+echo b >src/b.txt
+
+# No marker exists before the first success, so every source is outstanding.
+assert_succeed "mise run lint"
+assert_contains "cat log.txt" "checked:src/a.txt src/b.txt"
+rm -f log.txt
+
+# Timestamps have to land strictly after the marker the run above wrote.
+sleep 1
+echo changed >src/b.txt
+
+# Only the file written since that success is reported.
+assert_succeed "mise run lint"
+assert_contains "cat log.txt" "checked:src/b.txt"
+assert_not_contains "cat log.txt" "src/a.txt"
+rm -f log.txt
+
+# A failed run must not advance the baseline. `save_checksum` only writes the
+# marker after the task succeeds, so the same file stays outstanding.
+sleep 1
+echo changed-again >src/b.txt
+touch fail
+assert_fail "mise run lint"
+rm -f log.txt fail
+
+assert_succeed "mise run lint"
+assert_contains "cat log.txt" "checked:src/b.txt"
+assert_not_contains "cat log.txt" "src/a.txt"
+rm -f log.txt
+
+# Once it succeeds with nothing newly written, there is no outstanding work.
+sleep 1
+touch src/a.txt
+assert_succeed "mise run lint"
+assert_contains "cat log.txt" "checked:src/a.txt"
+assert_not_contains "cat log.txt" "src/b.txt"
+rm -f log.txt
+
+# --force runs the task without consulting the sources at all. Nothing has been
+# written since the success above, so the baseline accounts for none of this
+# run — and a task handed no files does none of the work it was run to do.
+sleep 1
+assert_succeed "mise run --force lint"
+assert_contains "cat log.txt" "checked:src/a.txt src/b.txt"
+rm -f log.txt
+
+# The freshness check runs immediately before the render, so it must not
+# advance the baseline on its way into the run it just decided was needed. In
+# content-hash mode it can reach that point with the sources matching and the
+# *outputs* stale, which is where it used to write the marker anyway.
+#
+# This needs its own task: `lint` has no declared outputs, so mise touches an
+# automatic one and the check comes out fresh. Appending a task and a setting
+# leaves `lint`'s own definition, and so its state key, alone.
+cat <<'EOF' >>mise.toml
+
+[tasks.hashed]
+run = "echo 'hashed:{{ task_source_files(only_changed=true) | join(sep=\" \") }}' >>hashed-log.txt && cp gen/x.txt out.txt"
+sources = ["gen/*.txt"]
+outputs = ["out.txt"]
+
+[settings]
+task.source_freshness_hash_contents = true
+EOF
+
+mkdir -p gen
+echo x >gen/x.txt
+echo y >gen/y.txt
+
+assert_succeed "mise run hashed"
+assert_contains "cat hashed-log.txt" "hashed:gen/x.txt gen/y.txt"
+rm -f hashed-log.txt
+
+# `touch` leaves the content alone, so the source hash still matches and the
+# check reaches the branch above. Deleting the output is what makes it report
+# stale, so the task runs — with one source written since the last success.
+sleep 1
+touch gen/y.txt
+rm -f out.txt
+
+assert_succeed "mise run hashed"
+assert_contains "cat hashed-log.txt" "hashed:gen/y.txt"
+assert_not_contains "cat hashed-log.txt" "gen/x.txt"

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -2020,7 +2020,9 @@ impl Task {
                 Some(cwd) => Some(cwd),
                 None => self.dir(config).await?,
             };
-            let (scripts, spec) = Self::make_script_parser(parser_dir, extra_vars)
+            let (scripts, spec) = self
+                .make_script_parser(config, parser_dir, extra_vars)
+                .await
                 .parse_run_scripts(config, self, &scripts_only, &env)
                 .await?;
             (spec, scripts)
@@ -2030,11 +2032,39 @@ impl Task {
         Ok((spec, scripts))
     }
 
-    fn make_script_parser(
+    /// Build the script parser for this task.
+    ///
+    /// The source baseline is resolved here rather than inside the parser
+    /// because `task_source_files(only_changed=true)` needs the marker written
+    /// under the task's *real* working directory, and only this layer has the
+    /// config needed to determine it.
+    async fn make_script_parser(
+        &self,
+        config: &Arc<Config>,
         cwd: Option<PathBuf>,
         extra_vars: Option<IndexMap<String, String>>,
     ) -> TaskScriptParser {
         let parser = TaskScriptParser::new(cwd);
+        // Skipped for a task with no sources: `task_source_files()` returns an
+        // empty array there regardless, and resolving the baseline would mean
+        // a `task_cwd` call — and with it a possible `dir` template render —
+        // that the task would not otherwise pay for.
+        let parser = if self.sources.is_empty() {
+            parser
+        } else {
+            match task_source_checker::source_baseline_path(self, config).await {
+                Ok(baseline) => parser.with_baseline(baseline),
+                Err(err) => {
+                    // Without a baseline `only_changed` falls back to reporting
+                    // every source, which is the safe direction.
+                    trace!(
+                        "could not resolve source baseline for task {}: {err:?}",
+                        self.name
+                    );
+                    parser
+                }
+            }
+        };
         match extra_vars {
             Some(vars) => parser.with_extra_vars(vars),
             None => parser,
@@ -2124,7 +2154,9 @@ impl Task {
                 None => self.dir(config).await?,
             };
             let scripts_only = self.run_script_strings();
-            let scripts = Self::make_script_parser(parser_dir, extra_vars)
+            let scripts = self
+                .make_script_parser(config, parser_dir, extra_vars)
+                .await
                 .parse_run_scripts_with_args(config, self, &scripts_only, &env, &args, &spec)
                 .await?;
             Ok(scripts.into_iter().map(|s| (s, vec![])).collect())

--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -14,6 +14,7 @@ use std::collections::{HashMap, HashSet};
 use std::iter::once;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
 
 type TeraSpecParsingResult = (
     TeraEngine,
@@ -24,10 +25,36 @@ type TeraSpecParsingResult = (
 
 type TaskTemplateResult = std::result::Result<JsonValue, String>;
 
+/// mtime of the marker recording that the task's work is done, if there is one.
+///
+/// Absent means mise has never seen this task up to date here, so there is no
+/// baseline to compare against and every source is outstanding work.
+fn last_success_time(marker: &Path) -> Option<SystemTime> {
+    std::fs::metadata(marker).and_then(|m| m.modified()).ok()
+}
+
+/// Whether `path` was written at or after the baseline.
+///
+/// A file we cannot stat counts as changed. This is the deliberate direction to
+/// err in: re-checking a file that did not change costs a little time, while
+/// skipping one that did means the task silently does less than it should. The
+/// reinstatement in `task_source_files` errs the same way when the baseline
+/// accounts for nothing at all.
+fn is_changed_since(path: &Path, baseline: SystemTime) -> bool {
+    match std::fs::metadata(path).and_then(|m| m.modified()) {
+        Ok(modified) => modified >= baseline,
+        Err(_) => true,
+    }
+}
+
 pub(super) struct TaskScriptParser {
     dir: Option<PathBuf>,
     /// Extra vars to inject into the tera context (for monorepo task vars resolution)
     extra_vars: Option<IndexMap<String, String>>,
+    /// Marker left by the task's last successful run, used by
+    /// `task_source_files(only_changed=true)`. Stored as a path rather than a
+    /// timestamp so a template that never asks for filtering costs no syscall.
+    baseline: Option<PathBuf>,
 }
 
 impl TaskScriptParser {
@@ -35,11 +62,17 @@ impl TaskScriptParser {
         TaskScriptParser {
             dir,
             extra_vars: None,
+            baseline: None,
         }
     }
 
     pub(super) fn with_extra_vars(mut self, vars: IndexMap<String, String>) -> Self {
         self.extra_vars = Some(vars);
+        self
+    }
+
+    pub(super) fn with_baseline(mut self, baseline: PathBuf) -> Self {
+        self.baseline = Some(baseline);
         self
     }
 
@@ -175,8 +208,21 @@ impl TaskScriptParser {
                 &root,
                 &task.sources,
             ));
+            let baseline = self.baseline.clone();
 
-            move |_| -> TaskTemplateResult {
+            move |args: &HashMap<String, JsonValue>| -> TaskTemplateResult {
+                let only_changed = args
+                    .get("only_changed")
+                    .and_then(JsonValue::as_bool)
+                    .unwrap_or(false);
+                // Resolved once per call, and only when asked for. `None` means
+                // every source counts as changed: either no filtering was
+                // requested, or the task has never succeeded, in which case all
+                // of its sources really are outstanding work.
+                let changed_since = only_changed
+                    .then(|| baseline.as_deref().and_then(last_success_time))
+                    .flatten();
+
                 if glob_patterns.is_empty() {
                     trace!(
                         "tera::render::resolve_task_sources `task_source_files` called in task with empty sources array"
@@ -185,10 +231,22 @@ impl TaskScriptParser {
                 };
 
                 let mut resolved = Vec::with_capacity(glob_patterns.len());
+                // A source held back by the baseline keeps its slot in
+                // `resolved` while the loop runs, so declaration order survives
+                // whichever way this ends; the slots are dropped afterwards only
+                // if something else got through. See below the loop.
+                let mut held_back: Vec<usize> = Vec::new();
+                let mut any_changed = false;
                 let escaped_root = glob::Pattern::escape(root.to_string_lossy().as_ref());
 
                 for pattern in glob_patterns.iter() {
                     if contains_template_syntax(pattern) {
+                        // Passed through verbatim rather than resolved, so the
+                        // baseline never sees it. It is deliberately not counted
+                        // as changed: it is no evidence that anything is
+                        // outstanding, and counting it would suppress the
+                        // reinstatement below and drop every real source from a
+                        // run that could not account for a single one of them.
                         trace!(
                             "tera::render::resolve_task_sources including tera template string in resolved task sources: {pattern}"
                         );
@@ -258,11 +316,22 @@ impl TaskScriptParser {
                                             } else {
                                                 &path
                                             };
-                                            let source = source.display();
+                                            let source = source.display().to_string();
+                                            if let Some(since) = changed_since
+                                                && !is_changed_since(&path, since)
+                                            {
+                                                trace!(
+                                                    "tera::render::resolve_task_sources holding back '{source}': unchanged since the last successful run"
+                                                );
+                                                held_back.push(resolved.len());
+                                                resolved.push(source);
+                                                continue;
+                                            }
                                             trace!(
                                                 "tera::render::resolve_task_sources resolved source from pattern '{pattern}': {source}"
                                             );
-                                            resolved.push(source.to_string());
+                                            any_changed = true;
+                                            resolved.push(source);
                                         }
                                         Err(error) => {
                                             let source = error.path().display();
@@ -282,6 +351,27 @@ impl TaskScriptParser {
                             }
                         }
                     }
+                }
+
+                // The held-back slots go only if something got through the
+                // filter. If nothing did, the task is being rendered for a
+                // reason the baseline cannot account for — forced, a dependency
+                // did work, an output went missing while the sources stood still
+                // — and a baseline that explains none of this run is not one to
+                // filter by. Handing the task an empty list would have it
+                // silently do nothing, so the held-back sources stay, in the
+                // slots they were declared in.
+                if any_changed {
+                    // Back to front, so each removal leaves the earlier indices
+                    // alone.
+                    for idx in held_back.iter().rev() {
+                        resolved.remove(*idx);
+                    }
+                } else if !held_back.is_empty() {
+                    trace!(
+                        "tera::render::resolve_task_sources nothing changed since the last successful run, reporting all {} source(s)",
+                        held_back.len()
+                    );
                 }
 
                 Ok(json!(resolved))
@@ -1455,6 +1545,167 @@ mod tests {
             .unwrap();
 
         assert_eq!(parsed, vec!["echo input.txt"]);
+    }
+
+    /// `only_changed=true` compares each source against the marker mise writes
+    /// when a task's work is done. These tests place that marker by hand and
+    /// drive the parser directly, so the comparison is exercised without
+    /// running a task.
+    struct ChangedSinceFixture {
+        _temp: tempfile::TempDir,
+        root: PathBuf,
+        marker: PathBuf,
+        task: Task,
+    }
+
+    /// Two sources, one written before the last successful run and one after.
+    fn changed_since_fixture() -> ChangedSinceFixture {
+        // Fixed timestamps rather than `now`, so the test does not depend on
+        // filesystem timestamp granularity or on how long it takes to run.
+        const BASELINE: i64 = 1_700_000_000;
+
+        fn set_mtime(path: &Path, secs: i64) {
+            filetime::set_file_mtime(path, filetime::FileTime::from_unix_time(secs, 0)).unwrap();
+        }
+
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().to_path_buf();
+        let marker = root.join("last-success");
+
+        for (name, mtime) in [("stale.txt", BASELINE - 60), ("fresh.txt", BASELINE + 60)] {
+            let path = root.join(name);
+            std::fs::write(&path, "x").unwrap();
+            set_mtime(&path, mtime);
+        }
+        std::fs::write(&marker, "source-hash").unwrap();
+        set_mtime(&marker, BASELINE);
+
+        ChangedSinceFixture {
+            _temp: temp,
+            root,
+            marker,
+            // Listed as literal patterns so the resolved order follows the
+            // declaration order and does not depend on directory iteration.
+            task: Task {
+                sources: vec!["stale.txt".to_string(), "fresh.txt".to_string()],
+                ..Default::default()
+            },
+        }
+    }
+
+    async fn render_sources(parser: TaskScriptParser, task: &Task, template: &str) -> String {
+        let config = Config::get().await.unwrap();
+        let scripts = vec![template.to_string()];
+        let (parsed, _) = parser
+            .parse_run_scripts(&config, task, &scripts, &Default::default())
+            .await
+            .unwrap();
+        parsed.into_iter().next().unwrap()
+    }
+
+    const ONLY_CHANGED: &str = "echo {{ task_source_files(only_changed=true) | join(sep=' ') }}";
+    const ALL_SOURCES: &str = "echo {{ task_source_files() | join(sep=' ') }}";
+
+    #[tokio::test]
+    async fn only_changed_returns_the_sources_touched_since_the_last_success() {
+        let f = changed_since_fixture();
+        let parser = TaskScriptParser::new(Some(f.root.clone())).with_baseline(f.marker.clone());
+
+        let rendered = render_sources(parser, &f.task, ONLY_CHANGED).await;
+
+        assert_eq!(rendered, "echo fresh.txt");
+    }
+
+    #[tokio::test]
+    async fn only_changed_reports_every_source_when_the_task_has_never_succeeded() {
+        let f = changed_since_fixture();
+        // A task that has not completed successfully has no marker, and every
+        // one of its sources is still outstanding work.
+        let parser = TaskScriptParser::new(Some(f.root.clone()))
+            .with_baseline(f.root.join("no-such-marker"));
+
+        let rendered = render_sources(parser, &f.task, ONLY_CHANGED).await;
+
+        assert_eq!(rendered, "echo stale.txt fresh.txt");
+    }
+
+    /// A task can run for a reason the baseline knows nothing about — `--force`,
+    /// a dependency that did work, an output deleted while the sources stood
+    /// still. Filtering then leaves nothing, and a task handed no files does
+    /// none of the work it was run to do, so the whole set goes back in.
+    #[tokio::test]
+    async fn only_changed_reports_every_source_when_the_baseline_explains_none_of_them() {
+        let f = changed_since_fixture();
+        // Written after both sources, so neither counts as outstanding.
+        let after_both = filetime::FileTime::from_unix_time(1_700_000_000 + 120, 0);
+        filetime::set_file_mtime(&f.marker, after_both).unwrap();
+        let parser = TaskScriptParser::new(Some(f.root.clone())).with_baseline(f.marker.clone());
+
+        let rendered = render_sources(parser, &f.task, ONLY_CHANGED).await;
+
+        assert_eq!(rendered, "echo stale.txt fresh.txt");
+    }
+
+    /// A source still holding template syntax is passed through verbatim rather
+    /// than resolved, so the baseline never measures it. It is not a changed
+    /// source — counting it as one would suppress the reinstatement and hand a
+    /// `--force` run a single unrendered string in place of every file it asked
+    /// for.
+    ///
+    /// It is also the only thing that can sit between two held-back sources, so
+    /// this is where declaration order is at stake: reinstating by appending put
+    /// the pass-through in front of files declared before it.
+    #[tokio::test]
+    async fn a_pass_through_source_does_not_stand_in_for_a_changed_one() {
+        let f = changed_since_fixture();
+        let after_both = filetime::FileTime::from_unix_time(1_700_000_000 + 120, 0);
+        filetime::set_file_mtime(&f.marker, after_both).unwrap();
+        let task = Task {
+            sources: vec![
+                "stale.txt".to_string(),
+                "{{ config_root }}/generated.txt".to_string(),
+                "fresh.txt".to_string(),
+            ],
+            ..Default::default()
+        };
+        let parser = TaskScriptParser::new(Some(f.root.clone())).with_baseline(f.marker.clone());
+
+        let rendered = render_sources(parser, &task, ONLY_CHANGED).await;
+
+        assert_eq!(
+            rendered,
+            "echo stale.txt {{ config_root }}/generated.txt fresh.txt"
+        );
+    }
+
+    /// And the other way round: when something does get through, the held-back
+    /// slots come out without disturbing what is left.
+    #[tokio::test]
+    async fn dropping_held_back_sources_leaves_the_rest_in_order() {
+        let f = changed_since_fixture();
+        let task = Task {
+            sources: vec![
+                "stale.txt".to_string(),
+                "{{ config_root }}/generated.txt".to_string(),
+                "fresh.txt".to_string(),
+            ],
+            ..Default::default()
+        };
+        let parser = TaskScriptParser::new(Some(f.root.clone())).with_baseline(f.marker.clone());
+
+        let rendered = render_sources(parser, &task, ONLY_CHANGED).await;
+
+        assert_eq!(rendered, "echo {{ config_root }}/generated.txt fresh.txt");
+    }
+
+    #[tokio::test]
+    async fn a_call_without_only_changed_is_unaffected_by_the_baseline() {
+        let f = changed_since_fixture();
+        let parser = TaskScriptParser::new(Some(f.root.clone())).with_baseline(f.marker.clone());
+
+        let rendered = render_sources(parser, &f.task, ALL_SOURCES).await;
+
+        assert_eq!(rendered, "echo stale.txt fresh.txt");
     }
 
     #[tokio::test]

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -769,7 +769,18 @@ pub(crate) async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Resu
             let stored_output_hash = output_existing_hash(task, &root);
             let fresh = current_output_hash.is_some()
                 && current_output_hash.as_deref() == stored_output_hash.as_deref();
-            file::write(&source_hash_path, &source_hash)?;
+            // Only when there is nothing to do. The hash mismatch above has
+            // already returned, so `source_hash` equals what is stored and the
+            // write moves nothing but the file's mtime — which is the baseline
+            // `task_source_files(only_changed=true)` measures against. Advancing
+            // it on the way into a run that has to repair a missing or modified
+            // output told that run nothing was outstanding, and it rendered an
+            // empty file list. Same reason the mismatch branch does not write:
+            // the task is about to run, and `save_checksum` records the baseline
+            // once it succeeds.
+            if fresh {
+                file::write(&source_hash_path, &source_hash)?;
+            }
             return Ok(fresh);
         }
         let sources = get_last_modified_from_metadatas(&source_metadatas);
@@ -902,6 +913,24 @@ fn sources_hash_path(task: &Task, root: &Path, content_hash: bool) -> PathBuf {
     dirs::STATE
         .join("task-sources")
         .join(format!("{}{suffix}", task_state_key(task, root)))
+}
+
+/// Path of the marker recording that this task's work is done. Its mtime is
+/// the baseline for "changed since mise last considered this task up to date":
+/// `save_checksum` writes it after a successful run, and `sources_are_fresh`
+/// writes it when a freshness check finds there is nothing to do. A *failed*
+/// run advances neither, so its sources stay outstanding until it passes.
+///
+/// Callers outside this module cannot build the path themselves, because
+/// `task_state_key` hashes the working directory — it is only correct when
+/// the root comes from `task_cwd`.
+pub(crate) async fn source_baseline_path(task: &Task, config: &Arc<Config>) -> Result<PathBuf> {
+    let root = task_cwd(task, config).await?;
+    Ok(sources_hash_path(
+        task,
+        &root,
+        Settings::get().task.source_freshness_hash_contents,
+    ))
 }
 
 /// Get the existing source hash for a task, if it exists


### PR DESCRIPTION
## What

Adds an `only_changed` argument to the `task_source_files()` template function. When true, it returns only the sources written since mise last considered the task up to date, instead of every file matching `sources`.

```toml
[tasks.lint]
sources = ["src/**/*.ts"]
run = "eslint{% for file in task_source_files(only_changed=true) %} {{ file | quote }}{% endfor %}"
```

Calls without the argument behave exactly as before.

## Why

From the discussion:

> some linters/formatters take a long time to process the entire project and are more efficient with a small set of files

Today the function returns the whole matched set, so a task built around it re-checks everything on every run even when one file moved.

## What "changed" means

The definition is one mise already maintains, so no new state is introduced. The marker under `STATE/task-sources/` is written in two places:

- `save_checksum` writes it after a task **succeeds**
- `sources_are_fresh` writes it when a freshness check finds there is **nothing to do**

A run that **fails** advances neither. So its sources stay in the list until the task actually passes — a linter that failed sees the same files on the next invocation rather than silently forgetting them. The e2e test pins this.

Both freshness modes write the marker: in `compute_source_hash`, `source_freshness_hash_contents` selects how the hash is computed, not whether the file is written.

### Two things keep that baseline honest

**A stale check must not advance it.** In content-hash mode `sources_are_fresh` rewrote the marker before returning false — including when the sources matched but an output was missing or modified, so a run that existed to *repair* that output was told nothing was outstanding. The value written there is the one already stored (a mismatch returns earlier), so the write moved nothing but the mtime the baseline is read from. It now happens only when the check finds nothing to do, which is the rule the mtime branch already stated in a comment.

(An earlier revision of this description claimed a task with **no declared outputs** hits this on every run. It does not: mise gives such a task an `Auto` output and touches it on success, so the check comes out fresh and the task is skipped. The e2e proved it, and the case now uses a task with a declared output that is deleted between runs.)

**Filtering never narrows the list to nothing.** A task can be running for a reason the baseline knows nothing about: `--force` and `dependency_state.any_did_work` both bypass the freshness check outright, and an output can go missing while the sources stand still. A baseline that accounts for none of the run is not one to filter by, so if no source changed and the task is being rendered anyway, the whole set goes back in. Same direction the unstat-able-file rule errs in, below: re-checking a file that did not change costs a little time; handing a linter zero files costs the entire run, silently.

## Why the plumbing looks the way it does

The marker path cannot be built inside the template function. `task_state_key` hashes the working directory, and the root has to be the one from `task_cwd` — the template function's own root falls back to `dirs::CWD` while `task_cwd` falls back to `config.project_root`, so they can disagree when running from a subdirectory. `TaskScriptParser` has no access to `config`.

So `source_baseline_path` is resolved in `make_script_parser`, which has both the task and the config, and handed to the parser as a **path** rather than a timestamp. Two consequences:

- a template that never asks for filtering performs no extra syscall
- a task with no `sources` skips the lookup entirely, so it does not pay for a `task_cwd` call (and a possible `dir` template render) it would not otherwise make

Only the two run paths get a baseline. The spec-extraction and syntax-validation parsers do not, where the file list is not used anyway.

## Judgement calls

A file that cannot be stat'd is treated as **changed**. Re-checking a file that did not change costs a little time; skipping one that did means the task silently does less than it asked for.

This compares modification times, so it inherits the same caveats as mise's default freshness checking — `touch` and restored caches can move a timestamp without the content changing. That tradeoff is already the one mise makes for `sources`, so `only_changed` agrees with the rest of the system rather than inventing a second notion of staleness.

## Tests

Unit (`src/task/task_script_parser.rs`), driving the parser with a hand-placed marker and fixed mtimes via `filetime`, so nothing depends on timestamp granularity or wall-clock:

- `only_changed_returns_the_sources_touched_since_the_last_success`
- `only_changed_reports_every_source_when_the_task_has_never_succeeded`
- `only_changed_reports_every_source_when_the_baseline_explains_none_of_them`
- `a_call_without_only_changed_is_unaffected_by_the_baseline`

e2e (`e2e/tasks/test_task_source_files_only_changed`): first run lists everything, one touched file is reported alone on the next, a failed run leaves that file outstanding, and it drops out only once the task passes. Then `mise run --force` gets the whole set back, and a second task under `task.source_freshness_hash_contents` — sources `touch`ed so their content still matches, output deleted so the check reports stale — pins the marker rule: the touched source must still read as written since the last success. The task definition is held byte-identical throughout, since editing `run` or `sources` would change the state key and point at a different marker; the setting is appended instead, which the state key does not hash.

The first unit test and the e2e both fail on `main` by returning the full list.

## Verification

Per the repo's local constraints I ran `cargo fmt`, `shellcheck`, `shfmt`, and `prettier` locally and left compilation and the test suite to CI. Every claim above was checked against the committed diff before opening this PR.

Fixes #9715

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for listing only source files changed since a task’s last successful run.
  * Failed runs do not update the change-detection baseline.
  * Initial runs and cases where no changes are identifiable report all source files.
  * Forced runs continue to include every source file.
  * Content-hash freshness tracking maintains its own source baseline.

* **Documentation**
  * Documented the optional `only_changed=true` argument with usage examples.

* **Tests**
  * Added coverage for initial, successful, failed, forced, modified, and content-hash-based runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

