### PR TITLE
chore(ci): compare mbx with rust-cache

### DIFF
--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -24,13 +24,14 @@ concurrency:
 
 env:
   CARGO_INCREMENTAL: 0
+  CARGO_PROFILE_DEV_DEBUG: 0
   CARGO_TERM_COLOR: always
 
 jobs:
   mbx:
     name: mbx (macOS)
     runs-on: macos-14
-    timeout-minutes: 30
+    timeout-minutes: 90
     outputs:
       seconds: ${{ steps.build.outputs.seconds }}
     steps:
@@ -44,16 +45,17 @@ jobs:
         id: build
         shell: bash
         run: |
-          SECONDS=0
+          started=$(python3 -c 'import time; print(time.monotonic_ns())')
           mbx build --all-features --ignore-rust-version
-          elapsed=$SECONDS
+          ended=$(python3 -c 'import time; print(time.monotonic_ns())')
+          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
           echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
           mbx cache stats
 
   rust-cache:
     name: Swatinem rust-cache (macOS)
     runs-on: macos-14
-    timeout-minutes: 30
+    timeout-minutes: 90
     outputs:
       seconds: ${{ steps.build.outputs.seconds }}
     steps:
@@ -63,15 +65,16 @@ jobs:
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2 # zizmor: ignore[cache-poisoning] save-if restricts writes to main pushes
         with:
-          shared-key: cache-benchmark-macos-v1
+          shared-key: cache-benchmark-macos-v2
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Build
         id: build
         shell: bash
         run: |
-          SECONDS=0
+          started=$(python3 -c 'import time; print(time.monotonic_ns())')
           cargo build --all-features --ignore-rust-version
-          elapsed=$SECONDS
+          ended=$(python3 -c 'import time; print(time.monotonic_ns())')
+          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
           echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
 
   comparison_macos:
@@ -104,7 +107,9 @@ jobs:
   mbx_windows:
     name: mbx (Windows)
     runs-on: windows-latest
-    timeout-minutes: 40
+    timeout-minutes: 90
+    env:
+      MBX_TARGET_VIEWS: 0
     outputs:
       seconds: ${{ steps.build.outputs.seconds }}
     steps:
@@ -116,18 +121,20 @@ jobs:
           backend: github
       - name: Build
         id: build
-        shell: bash
+        shell: pwsh
         run: |
-          SECONDS=0
+          $timer = [System.Diagnostics.Stopwatch]::StartNew()
           mbx build --all-features --ignore-rust-version
-          elapsed=$SECONDS
-          echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $timer.Stop()
+          $elapsed = $timer.Elapsed.TotalSeconds.ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          "seconds=$elapsed" >> $env:GITHUB_OUTPUT
           mbx cache stats
 
   rust_cache_windows:
     name: Swatinem rust-cache (Windows)
     runs-on: windows-latest
-    timeout-minutes: 40
+    timeout-minutes: 90
     outputs:
       seconds: ${{ steps.build.outputs.seconds }}
     steps:
@@ -137,16 +144,18 @@ jobs:
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2 # zizmor: ignore[cache-poisoning] save-if restricts writes to main pushes
         with:
-          shared-key: cache-benchmark-windows-v1
+          shared-key: cache-benchmark-windows-v2
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Build
         id: build
-        shell: bash
+        shell: pwsh
         run: |
-          SECONDS=0
+          $timer = [System.Diagnostics.Stopwatch]::StartNew()
           cargo build --all-features --ignore-rust-version
-          elapsed=$SECONDS
-          echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $timer.Stop()
+          $elapsed = $timer.Elapsed.TotalSeconds.ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          "seconds=$elapsed" >> $env:GITHUB_OUTPUT
 
   comparison_windows:
     name: comparison (Windows)

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -1,0 +1,102 @@
+name: cache benchmark
+
+on:
+  pull_request:
+    paths:
+      - .github/actions/mbx/action.yml
+      - .github/workflows/cache-benchmark.yml
+  push:
+    branches: [main]
+    paths:
+      - .github/actions/mbx/action.yml
+      - .github/workflows/cache-benchmark.yml
+      - Cargo.lock
+      - Cargo.toml
+      - "**/*.rs"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cache-benchmark-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_TERM_COLOR: always
+
+jobs:
+  mbx:
+    name: mbx (macOS)
+    runs-on: macos-14
+    timeout-minutes: 30
+    outputs:
+      seconds: ${{ steps.build.outputs.seconds }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/mbx
+        with:
+          backend: github
+      - name: Build
+        id: build
+        shell: bash
+        run: |
+          SECONDS=0
+          mbx build --all-features --ignore-rust-version
+          elapsed=$SECONDS
+          echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
+          mbx cache stats
+
+  rust-cache:
+    name: Swatinem rust-cache (macOS)
+    runs-on: macos-14
+    timeout-minutes: 30
+    outputs:
+      seconds: ${{ steps.build.outputs.seconds }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Restore Cargo cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2 # zizmor: ignore[cache-poisoning] save-if restricts writes to main pushes
+        with:
+          shared-key: cache-benchmark-macos-v1
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      - name: Build
+        id: build
+        shell: bash
+        run: |
+          SECONDS=0
+          cargo build --all-features --ignore-rust-version
+          elapsed=$SECONDS
+          echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
+
+  comparison:
+    name: comparison
+    needs: [mbx, rust-cache]
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    env:
+      MBX_SECONDS: ${{ needs.mbx.outputs.seconds }}
+      RUST_CACHE_SECONDS: ${{ needs.rust-cache.outputs.seconds }}
+    steps:
+      - name: Summarize results
+        shell: bash
+        run: |
+          delta=$(awk -v mbx="$MBX_SECONDS" -v rust="$RUST_CACHE_SECONDS" \
+            'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
+          {
+            echo "## Cache build comparison"
+            echo
+            echo "| Backend | Build time |"
+            echo "| --- | ---: |"
+            echo "| mbx | ${MBX_SECONDS}s |"
+            echo "| Swatinem/rust-cache | ${RUST_CACHE_SECONDS}s |"
+            echo
+            echo "mbx delta: **${delta}** (positive means mbx was faster)."
+            echo
+            echo "> Treat the first main-branch run as cache seeding. Compare workflow_dispatch runs after it. Build time excludes checkout and cache setup; compare those step durations separately."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -74,8 +74,8 @@ jobs:
           elapsed=$SECONDS
           echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
 
-  comparison:
-    name: comparison
+  comparison_macos:
+    name: comparison (macOS)
     needs: [mbx, rust-cache]
     runs-on: ubuntu-latest
     timeout-minutes: 1
@@ -89,7 +89,81 @@ jobs:
           delta=$(awk -v mbx="$MBX_SECONDS" -v rust="$RUST_CACHE_SECONDS" \
             'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
           {
-            echo "## Cache build comparison"
+            echo "## macOS cache build comparison"
+            echo
+            echo "| Backend | Build time |"
+            echo "| --- | ---: |"
+            echo "| mbx | ${MBX_SECONDS}s |"
+            echo "| Swatinem/rust-cache | ${RUST_CACHE_SECONDS}s |"
+            echo
+            echo "mbx delta: **${delta}** (positive means mbx was faster)."
+            echo
+            echo "> Treat the first main-branch run as cache seeding. Compare workflow_dispatch runs after it. Build time excludes checkout and cache setup; compare those step durations separately."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  mbx_windows:
+    name: mbx (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 40
+    outputs:
+      seconds: ${{ steps.build.outputs.seconds }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/mbx
+        with:
+          backend: github
+      - name: Build
+        id: build
+        shell: bash
+        run: |
+          SECONDS=0
+          mbx build --all-features --ignore-rust-version
+          elapsed=$SECONDS
+          echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
+          mbx cache stats
+
+  rust_cache_windows:
+    name: Swatinem rust-cache (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 40
+    outputs:
+      seconds: ${{ steps.build.outputs.seconds }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Restore Cargo cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2 # zizmor: ignore[cache-poisoning] save-if restricts writes to main pushes
+        with:
+          shared-key: cache-benchmark-windows-v1
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      - name: Build
+        id: build
+        shell: bash
+        run: |
+          SECONDS=0
+          cargo build --all-features --ignore-rust-version
+          elapsed=$SECONDS
+          echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
+
+  comparison_windows:
+    name: comparison (Windows)
+    needs: [mbx_windows, rust_cache_windows]
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    env:
+      MBX_SECONDS: ${{ needs.mbx_windows.outputs.seconds }}
+      RUST_CACHE_SECONDS: ${{ needs.rust_cache_windows.outputs.seconds }}
+    steps:
+      - name: Summarize results
+        shell: bash
+        run: |
+          delta=$(awk -v mbx="$MBX_SECONDS" -v rust="$RUST_CACHE_SECONDS" \
+            'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
+          {
+            echo "## Windows cache build comparison"
             echo
             echo "| Backend | Build time |"
             echo "| --- | ---: |"

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -124,7 +124,7 @@ jobs:
         shell: pwsh
         run: |
           $timer = [System.Diagnostics.Stopwatch]::StartNew()
-          mbx build --all-features --ignore-rust-version
+          mbx build --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update --ignore-rust-version
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           $timer.Stop()
           $elapsed = $timer.Elapsed.TotalSeconds.ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
@@ -151,7 +151,7 @@ jobs:
         shell: pwsh
         run: |
           $timer = [System.Diagnostics.Stopwatch]::StartNew()
-          cargo build --all-features --ignore-rust-version
+          cargo build --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update --ignore-rust-version
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           $timer.Stop()
           $elapsed = $timer.Elapsed.TotalSeconds.ToString("F3", [Globalization.CultureInfo]::InvariantCulture)


### PR DESCRIPTION
## Summary
- add macOS and Windows A/B workflows for mbx and Swatinem/rust-cache
- run equivalent non-incremental builds and publish per-platform build timings
- keep the benchmark off release and tag workflows

## Method
The first main-branch run seeds the dedicated rust-cache keys. Warm comparisons should use later workflow_dispatch runs. Build timing excludes checkout and cache setup; those remain visible as separate step durations.

The Windows mbx path exercises the native-search-directory fix in jdx/mr-boxington#120 once that fix is released and the pinned mbx version is updated.

## Validation
- actionlint .github/workflows/cache-benchmark.yml
- mise x zizmor@1.29.0 -- zizmor .github/workflows/cache-benchmark.yml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only benchmarking with read-only `contents` permission and restricted rust-cache writes on main; no application or release workflow behavior changes.
> 
> **Overview**
> Adds a new **cache benchmark** GitHub Actions workflow that A/B tests **mbx** (via `.github/actions/mbx`) against **Swatinem/rust-cache** on **macOS** and **Windows**.
> 
> Each platform runs parallel jobs that time only the compile step (`mbx build` vs `cargo build` with matching feature flags), then a lightweight comparison job writes a markdown table and **mbx delta %** to the workflow step summary. Builds disable incremental compilation and debug info for consistency; rust-cache uses dedicated `shared-key` values and **save-if** limited to main pushes so PRs can compare warm restores without poisoning cache writes.
> 
> Triggers are scoped: PRs only when the mbx action or this workflow changes; pushes to **main** also when Rust sources or lockfiles change; **workflow_dispatch** is supported for manual warm runs after seeding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18929a8b30d292c88fe0434c2b16db066889d5fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated cross-platform build benchmarking for Windows and macOS.
  * Reports build durations, cache effectiveness, and cache statistics for easier performance comparison.
  * Improved platform-specific reporting and benchmark consistency.
  * Supports pull requests, updates to the main branch, and manual benchmark runs.
  * Added safeguards to improve reliability and ensure failed builds are reported accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->