### PR TITLE
registry: add cursor-agent (http:cursor-agent)

### DIFF
--- a/registry/cursor-agent.toml
+++ b/registry/cursor-agent.toml
@@ -7,6 +7,7 @@ version_order = "source"
 bins = ["cursor-agent"]
 [[backends]]
 full = "http:cursor-agent"
+platforms = ["linux-x64", "linux-arm64", "macos-x64", "macos-arm64"]
 
 [backends.options]
 bin_path = "dist-package"

--- a/registry/cursor-agent.toml
+++ b/registry/cursor-agent.toml
@@ -1,0 +1,19 @@
+aliases = ["cursor-cli"]
+description = "Cursor Agent is Cursor's terminal coding agent that can write, review, and modify code from the command line"
+os = ["linux", "macos"]
+test = { cmd = "cursor-agent --version", expected = "{{version}}" }
+version_order = "source"
+
+bins = ["cursor-agent"]
+[[backends]]
+full = "http:cursor-agent"
+
+[backends.options]
+bin_path = "dist-package"
+strip_components = 0
+# Upstream does not publish a version index; the install script is rendered
+# with the current version, so extract it from there (same idea as claude's
+# `latest` file and grok's `stable` file).
+url = 'https://downloads.cursor.com/lab/{{ version }}/{{ os(macos="darwin") }}/{{ arch(x64="x64", arm64="arm64") }}/agent-cli-package.tar.gz'
+version_list_url = "https://cursor.com/install"
+version_regex = 'downloads\.cursor\.com/lab/([0-9]{4}\.[0-9]{2}\.[0-9]{2}-[0-9a-f]+)/'


### PR DESCRIPTION
Adds a registry entry for [Cursor Agent](https://cursor.com/cli) (`cursor-agent`), Cursor's terminal coding agent.

## Backend choice

`http:` rather than a tier-1 backend, because none of them can serve this tool:

- Not in the aqua registry, and upstream ships **no GitHub releases** — distribution is versioned tarballs from `downloads.cursor.com/lab/<version>/<os>/<arch>/agent-cli-package.tar.gz` (stable URL scheme, all four linux/darwin × x64/arm64 combinations verified, older versions remain available).
- The `cursor-agent` package on npm is an unrelated third-party tool, not Cursor's CLI.

Upstream publishes no version index, but https://cursor.com/install is server-rendered with the current version, so it serves as `version_list_url` with a `version_regex` — the same approach as `claude`'s `latest` file and `grok`'s `stable` file. Versions are date+hash (`2026.08.25-3e8eec8`), hence `version_order = "source"`.

`bins` is restricted to `cursor-agent` since the tarball also carries private helpers (`rg`, `cursorsandbox`, `cursor-askpass`). The `cursor-cli` alias matches the name the tool is packaged under elsewhere (e.g. the AUR).

## Popularity

- Cursor is one of the most widely used AI coding tools; the CLI is its official terminal agent.
- GitHub (cursor/cursor): 33.2k stars, 2.3k forks
- Very active release cadence: latest CLI version shipped 2026-08-25
- Packaged independently downstream, e.g. AUR `cursor-cli`

## Testing

Verified the exact backend options on linux-x64 (options inlined into a `mise.toml`, released mise 2026.8.14):

```
$ mise ls-remote "http:cursor-agent"
2026.08.25-3e8eec8
$ mise install "http:cursor-agent"
mise http:cursor-agent@2026.08.25-3e8eec8 ✓ installed
$ mise x "http:cursor-agent" -- cursor-agent --version
2026.08.25-3e8eec8
```

The `test` field (`cursor-agent --version` → `{{version}}`) matches that output exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for installing and managing the Cursor Agent on Linux and macOS.
  * Added version detection and platform-specific download configuration.
  * Added support for the `cursor-cli` command alias.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->