### PR TITLE
fix(task): cascade task inputs from defining roots

### DIFF
--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -1380,7 +1380,8 @@ were defined.
 
 A descendant's non-empty `global_inputs` replaces the inherited value. Descendant `input_groups`
 merge with inherited groups by name; the nearest definition wins when the same name appears more
-than once. Each group remains relative to the config root where it was defined.
+than once. This also applies to group references in inherited `global_inputs`. Each group remains
+relative to the config root where it was defined.
 
 ### `task_config.dir`
 

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -1378,8 +1378,9 @@ This applies to `dir`, `shell`, `cache`, `rust_cache`, `global_inputs`, `input_g
 `includes`. Inherited include paths and task inputs remain relative to the config root where they
 were defined.
 
-When a descendant defines non-empty `global_inputs` or `input_groups`, it replaces that inherited
-field. mise replaces the whole input group map instead of merging group names.
+A descendant's non-empty `global_inputs` replaces the inherited value. Descendant `input_groups`
+merge with inherited groups by name; the nearest definition wins when the same name appears more
+than once. Each group remains relative to the config root where it was defined.
 
 ### `task_config.dir`
 

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -1374,9 +1374,12 @@ cascade = true
 shell = "bash -c"
 ```
 
-This applies to `dir`, `shell`, `cache`, `rust_cache`, and `includes`. Inherited include paths
-remain relative to the config root where they were defined, allowing a monorepo root to provide one
-shared task set.
+This applies to `dir`, `shell`, `cache`, `rust_cache`, `global_inputs`, `input_groups`, and
+`includes`. Inherited include paths and task inputs remain relative to the config root where they
+were defined.
+
+When a descendant defines non-empty `global_inputs` or `input_groups`, it replaces that inherited
+field. mise replaces the whole input group map instead of merging group names.
 
 ### `task_config.dir`
 

--- a/e2e/tasks/test_task_artifact_cache_input_groups
+++ b/e2e/tasks/test_task_artifact_cache_input_groups
@@ -188,6 +188,7 @@ cat <<'EOF' >cascade-local/mise.toml
 [task_config.input_groups]
 workspace-lock = ["Cargo.lock"]
 child-only = ["child-group.txt"]
+global-toolchain = ["child-global-toolchain.txt"]
 
 [tasks.child]
 run = "true"
@@ -196,9 +197,11 @@ outputs = []
 EOF
 printf 'child-lock\n' >cascade-local/Cargo.lock
 printf 'child-group\n' >cascade-local/child-group.txt
+printf 'child-global-toolchain\n' >cascade-local/child-global-toolchain.txt
 assert "mise -C cascade-local task info child --json | jq -r '.sources[] | select(endswith(\"/Cargo.lock\"))'" "$PWD/cascade-local/Cargo.lock"
 assert "mise -C cascade-local task info child --json | jq -r '.sources[] | select(endswith(\"/toolchain.txt\"))'" "$PWD/toolchain.txt"
 assert "mise -C cascade-local task info child --json | jq -r '.sources[] | select(endswith(\"/child-group.txt\"))'" "$PWD/cascade-local/child-group.txt"
+assert "mise -C cascade-local task info child --json | jq -r '.sources[] | select(endswith(\"/child-global-toolchain.txt\"))'" "$PWD/cascade-local/child-global-toolchain.txt"
 assert "mise -C cascade-local task info child --json | jq -r '.sources[] | select(endswith(\"/workspace.txt\"))'" "$PWD/workspace.txt"
 
 # cascade = false stops both inherited input fields.

--- a/e2e/tasks/test_task_artifact_cache_input_groups
+++ b/e2e/tasks/test_task_artifact_cache_input_groups
@@ -7,6 +7,7 @@ cat <<'EOF' >mise.toml
 experimental = true
 
 [task_config]
+cascade = true
 global_inputs = [
   "workspace.txt",
   "{{ config_root }}/templated.txt",
@@ -44,6 +45,7 @@ cat <<'EOF' >mise.local.toml
 [task_config.input_groups]
 global-toolchain = ["global-toolchain.txt"]
 toolchain = ["toolchain.txt"]
+workspace-lock = ["Cargo.lock"]
 app = [
   "packages/app/src/**/*",
   "packages/app/src/**/*.rs",
@@ -62,6 +64,7 @@ printf 'templated-one\n' >templated.txt
 printf 'escaped-one\n' >'!important.txt'
 printf 'global-toolchain-one\n' >global-toolchain.txt
 printf 'toolchain-one\n' >toolchain.txt
+printf 'parent-lock-one\n' >Cargo.lock
 
 # Named groups and global inputs resolve independently across layered configs,
 # and their paths are rooted at the config rather than each task's working directory.
@@ -139,6 +142,76 @@ rm -rf packages/app/dist
 mise run build ::: check
 assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "8"
 assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "8"
+
+# https://github.com/jdx/mise/discussions/12481
+# Cascaded task inputs keep the root that defined each field.
+mkdir -p cascade-child
+cat <<'EOF' >cascade-child/mise.toml
+[tasks.child]
+run = "printf 'ran\\n' >> child-runs.txt"
+sources = ["@group:workspace-lock"]
+outputs = []
+EOF
+printf 'child-lock-one\n' >cascade-child/Cargo.lock
+assert "mise -C cascade-child task info child --json | jq -r '.sources[] | select(endswith(\"/Cargo.lock\"))'" "$PWD/Cargo.lock"
+assert "mise -C cascade-child task info child --json | jq -r '.sources[] | select(endswith(\"/workspace.txt\"))'" "$PWD/workspace.txt"
+
+mise -C cascade-child run child
+mise -C cascade-child run child
+assert "wc -l < cascade-child/child-runs.txt | tr -d ' '" "1"
+printf 'parent-lock-two\n' >Cargo.lock
+mise -C cascade-child run child
+assert "wc -l < cascade-child/child-runs.txt | tr -d ' '" "2"
+printf 'child-lock-two\n' >cascade-child/Cargo.lock
+mise -C cascade-child run child
+assert "wc -l < cascade-child/child-runs.txt | tr -d ' '" "2"
+
+# A local global_inputs value overrides that field without losing the inherited groups.
+mkdir -p cascade-global-override
+cat <<'EOF' >cascade-global-override/mise.toml
+[task_config]
+global_inputs = ["child-global.txt"]
+
+[tasks.child]
+run = "true"
+sources = ["@group:workspace-lock"]
+outputs = []
+EOF
+printf 'child-global\n' >cascade-global-override/child-global.txt
+assert "mise -C cascade-global-override task info child --json | jq -r '.sources[] | select(endswith(\"/Cargo.lock\"))'" "$PWD/Cargo.lock"
+assert "mise -C cascade-global-override task info child --json | jq -r '.sources[] | select(endswith(\"/child-global.txt\"))'" "$PWD/cascade-global-override/child-global.txt"
+
+# Local values replace both inherited fields and resolve from the child root.
+mkdir -p cascade-local
+cat <<'EOF' >cascade-local/mise.toml
+[task_config]
+global_inputs = ["child-global.txt"]
+
+[task_config.input_groups]
+workspace-lock = ["Cargo.lock"]
+
+[tasks.child]
+run = "true"
+sources = ["@group:workspace-lock"]
+outputs = []
+EOF
+printf 'child-global\n' >cascade-local/child-global.txt
+printf 'child-lock\n' >cascade-local/Cargo.lock
+assert "mise -C cascade-local task info child --json | jq -r '.sources[] | select(endswith(\"/Cargo.lock\"))'" "$PWD/cascade-local/Cargo.lock"
+assert "mise -C cascade-local task info child --json | jq -r '.sources[] | select(endswith(\"/child-global.txt\"))'" "$PWD/cascade-local/child-global.txt"
+
+# cascade = false stops both inherited input fields.
+mkdir -p cascade-stopped
+cat <<'EOF' >cascade-stopped/mise.toml
+[task_config]
+cascade = false
+
+[tasks.child]
+run = "true"
+sources = ["@group:workspace-lock"]
+outputs = []
+EOF
+assert_fail_contains "mise -C cascade-stopped task info child" 'undefined input group "workspace-lock"'
 
 # Group references are validated even when no input groups or global inputs
 # are configured, rather than being retained as literal source paths.

--- a/e2e/tasks/test_task_artifact_cache_input_groups
+++ b/e2e/tasks/test_task_artifact_cache_input_groups
@@ -181,24 +181,25 @@ printf 'child-global\n' >cascade-global-override/child-global.txt
 assert "mise -C cascade-global-override task info child --json | jq -r '.sources[] | select(endswith(\"/Cargo.lock\"))'" "$PWD/Cargo.lock"
 assert "mise -C cascade-global-override task info child --json | jq -r '.sources[] | select(endswith(\"/child-global.txt\"))'" "$PWD/cascade-global-override/child-global.txt"
 
-# Local values replace both inherited fields and resolve from the child root.
+# Local groups merge by name, override matching groups from the child root,
+# and leave inherited global inputs unchanged.
 mkdir -p cascade-local
 cat <<'EOF' >cascade-local/mise.toml
-[task_config]
-global_inputs = ["child-global.txt"]
-
 [task_config.input_groups]
 workspace-lock = ["Cargo.lock"]
+child-only = ["child-group.txt"]
 
 [tasks.child]
 run = "true"
-sources = ["@group:workspace-lock"]
+sources = ["@group:workspace-lock", "@group:toolchain", "@group:child-only"]
 outputs = []
 EOF
-printf 'child-global\n' >cascade-local/child-global.txt
 printf 'child-lock\n' >cascade-local/Cargo.lock
+printf 'child-group\n' >cascade-local/child-group.txt
 assert "mise -C cascade-local task info child --json | jq -r '.sources[] | select(endswith(\"/Cargo.lock\"))'" "$PWD/cascade-local/Cargo.lock"
-assert "mise -C cascade-local task info child --json | jq -r '.sources[] | select(endswith(\"/child-global.txt\"))'" "$PWD/cascade-local/child-global.txt"
+assert "mise -C cascade-local task info child --json | jq -r '.sources[] | select(endswith(\"/toolchain.txt\"))'" "$PWD/toolchain.txt"
+assert "mise -C cascade-local task info child --json | jq -r '.sources[] | select(endswith(\"/child-group.txt\"))'" "$PWD/cascade-local/child-group.txt"
+assert "mise -C cascade-local task info child --json | jq -r '.sources[] | select(endswith(\"/workspace.txt\"))'" "$PWD/workspace.txt"
 
 # cascade = false stops both inherited input fields.
 mkdir -p cascade-stopped

--- a/e2e/tasks/test_task_artifact_cache_input_groups
+++ b/e2e/tasks/test_task_artifact_cache_input_groups
@@ -202,6 +202,7 @@ assert "mise -C cascade-local task info child --json | jq -r '.sources[] | selec
 assert "mise -C cascade-local task info child --json | jq -r '.sources[] | select(endswith(\"/toolchain.txt\"))'" "$PWD/toolchain.txt"
 assert "mise -C cascade-local task info child --json | jq -r '.sources[] | select(endswith(\"/child-group.txt\"))'" "$PWD/cascade-local/child-group.txt"
 assert "mise -C cascade-local task info child --json | jq -r '.sources[] | select(endswith(\"/child-global-toolchain.txt\"))'" "$PWD/cascade-local/child-global-toolchain.txt"
+assert "mise -C cascade-local task info child --json | jq -r '.sources[] | select(endswith(\"/global-toolchain.txt\"))'" ""
 assert "mise -C cascade-local task info child --json | jq -r '.sources[] | select(endswith(\"/workspace.txt\"))'" "$PWD/workspace.txt"
 
 # cascade = false stops both inherited input fields.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3293,6 +3293,15 @@ impl ResolvedTaskInputs {
     fn is_empty(&self) -> bool {
         self.global_inputs.is_none() && self.input_groups.is_none()
     }
+
+    fn overlay(&mut self, overlay: Self) {
+        if overlay.global_inputs.is_some() {
+            self.global_inputs = overlay.global_inputs;
+        }
+        if overlay.input_groups.is_some() {
+            self.input_groups = overlay.input_groups;
+        }
+    }
 }
 
 fn anchor_task_input(root: &Path, input: &str) -> String {
@@ -4867,6 +4876,7 @@ struct TaskSources {
 #[derive(Clone)]
 struct CascadedTaskConfig {
     task_config: TaskConfig,
+    inputs: ResolvedTaskInputs,
     includes_root: PathBuf,
     excludes_root: PathBuf,
 }
@@ -4875,6 +4885,9 @@ fn merge_cascaded_task_config(
     cascaded: &mut CascadedTaskConfig,
     configs: &[&Arc<dyn ConfigFile>],
 ) -> Result<()> {
+    cascaded
+        .inputs
+        .overlay(ResolvedTaskInputs::from_configs(configs));
     if let Some(dir) = configs.iter().find_map(|cf| cf.task_config().dir.clone()) {
         cascaded.task_config.dir = Some(dir);
     }
@@ -4953,6 +4966,7 @@ fn cascaded_task_config_for_dir(
             Some(true) if cascaded.is_none() => {
                 cascaded = Some(CascadedTaskConfig {
                     task_config: TaskConfig::default(),
+                    inputs: ResolvedTaskInputs::default(),
                     includes_root: root.clone(),
                     excludes_root: root,
                 });
@@ -5096,10 +5110,15 @@ async fn load_task_sources_from_configs(
         .unwrap_or_default();
     let excludes = resolve_task_excludes(&excludes_root, &excludes);
 
+    let mut inputs = cascaded_task_config
+        .map(|tc| tc.inputs.clone())
+        .unwrap_or_default();
+    inputs.overlay(ResolvedTaskInputs::from_configs(&configs));
+
     // Resolve task defaults once for the config root so inline tasks from
     // lower-precedence overlay files use the same defaults as file tasks.
     let task_config = ResolvedTaskConfig {
-        inputs: ResolvedTaskInputs::from_configs(&configs),
+        inputs,
         environment: ResolvedTaskEnvironment::from_configs(
             &configs,
             cascaded_task_config.map(|tc| &tc.task_config),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3263,7 +3263,7 @@ const TASK_INPUT_GROUP_PREFIX: &str = "@group:";
 #[derive(Clone, Debug, Default)]
 struct ResolvedTaskInputs {
     global_inputs: Option<(Vec<String>, PathBuf)>,
-    input_groups: Option<(IndexMap<String, Vec<String>>, PathBuf)>,
+    input_groups: IndexMap<String, (Vec<String>, PathBuf)>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -3283,24 +3283,31 @@ impl ResolvedTaskInputs {
                 let inputs = &cf.task_config().global_inputs;
                 (!inputs.is_empty()).then(|| (inputs.clone(), cf.config_root()))
             }),
-            input_groups: configs.iter().find_map(|cf| {
-                let groups = &cf.task_config().input_groups;
-                (!groups.is_empty()).then(|| (groups.clone(), cf.config_root()))
-            }),
+            input_groups: configs
+                .iter()
+                .find_map(|cf| {
+                    let groups = &cf.task_config().input_groups;
+                    (!groups.is_empty()).then(|| {
+                        let root = cf.config_root();
+                        groups
+                            .iter()
+                            .map(|(name, entries)| (name.clone(), (entries.clone(), root.clone())))
+                            .collect()
+                    })
+                })
+                .unwrap_or_default(),
         }
     }
 
     fn is_empty(&self) -> bool {
-        self.global_inputs.is_none() && self.input_groups.is_none()
+        self.global_inputs.is_none() && self.input_groups.is_empty()
     }
 
     fn overlay(&mut self, overlay: Self) {
         if overlay.global_inputs.is_some() {
             self.global_inputs = overlay.global_inputs;
         }
-        if overlay.input_groups.is_some() {
-            self.input_groups = overlay.input_groups;
-        }
+        self.input_groups.extend(overlay.input_groups);
     }
 }
 
@@ -3344,10 +3351,7 @@ fn expand_task_inputs(
             });
             continue;
         };
-        let (groups, groups_root) = task_inputs.input_groups.as_ref().ok_or_else(|| {
-            eyre!("task {task_name} references undefined input group {group:?} with {entry:?}")
-        })?;
-        let inputs = groups.get(group).ok_or_else(|| {
+        let (inputs, group_root) = task_inputs.input_groups.get(group).ok_or_else(|| {
             eyre!("task {task_name} references undefined input group {group:?} with {entry:?}")
         })?;
         if let Some(cycle_start) = stack.iter().position(|name| name == group) {
@@ -3362,7 +3366,7 @@ fn expand_task_inputs(
         expanded.extend(expand_task_inputs(
             inputs,
             task_inputs,
-            groups_root,
+            group_root,
             task_name,
             stack,
             true,
@@ -3414,21 +3418,19 @@ async fn apply_task_config_inputs(
         )),
         None => None,
     };
-    let input_groups = match &task_inputs.input_groups {
-        Some((groups, root)) => Some((
-            groups
-                .iter()
-                .map(|(name, entries)| {
-                    Ok((
-                        name.clone(),
-                        render_task_input_entries(entries, root, &tera_ctx)?,
-                    ))
-                })
-                .collect::<Result<_>>()?,
-            root.clone(),
-        )),
-        None => None,
-    };
+    let input_groups = task_inputs
+        .input_groups
+        .iter()
+        .map(|(name, (entries, root))| {
+            Ok((
+                name.clone(),
+                (
+                    render_task_input_entries(entries, root, &tera_ctx)?,
+                    root.clone(),
+                ),
+            ))
+        })
+        .collect::<Result<_>>()?;
     let task_inputs = ResolvedTaskInputs {
         global_inputs,
         input_groups,
@@ -5470,27 +5472,30 @@ mod tests {
     #[test]
     fn test_expand_task_inputs_supports_nested_groups() -> Result<()> {
         let task_inputs = ResolvedTaskInputs {
-            input_groups: Some((
-                IndexMap::from([
+            input_groups: IndexMap::from([
+                (
+                    "shared".to_string(),
                     (
-                        "shared".to_string(),
                         vec![
                             "Cargo.toml".to_string(),
                             "src/**/*.rs".to_string(),
                             "\\!important.txt".to_string(),
                         ],
+                        PathBuf::from("/workspace"),
                     ),
+                ),
+                (
+                    "production".to_string(),
                     (
-                        "production".to_string(),
                         vec![
                             "@group:shared".to_string(),
                             "!src/**/*_test.rs".to_string(),
                             "src/**/*.rs".to_string(),
                         ],
+                        PathBuf::from("/project"),
                     ),
-                ]),
-                PathBuf::from("/workspace"),
-            )),
+                ),
+            ]),
             ..Default::default()
         };
         let root = Path::new("/workspace");
@@ -5509,8 +5514,8 @@ mod tests {
                 "/workspace/Cargo.toml",
                 "/workspace/src/**/*.rs",
                 "/workspace/!important.txt",
-                "!/workspace/src/**/*_test.rs",
-                "/workspace/src/**/*.rs",
+                "!/project/src/**/*_test.rs",
+                "/project/src/**/*.rs",
             ]
         );
         Ok(())
@@ -5519,13 +5524,16 @@ mod tests {
     #[test]
     fn test_expand_task_inputs_rejects_unknown_and_cyclic_groups() {
         let task_inputs = ResolvedTaskInputs {
-            input_groups: Some((
-                IndexMap::from([
-                    ("a".to_string(), vec!["@group:b".to_string()]),
-                    ("b".to_string(), vec!["@group:a".to_string()]),
-                ]),
-                PathBuf::from("/workspace"),
-            )),
+            input_groups: IndexMap::from([
+                (
+                    "a".to_string(),
+                    (vec!["@group:b".to_string()], PathBuf::from("/workspace")),
+                ),
+                (
+                    "b".to_string(),
+                    (vec!["@group:a".to_string()], PathBuf::from("/workspace")),
+                ),
+            ]),
             ..Default::default()
         };
 


### PR DESCRIPTION
Discussion: https://github.com/jdx/mise/discussions/12481

## Summary

- carry `global_inputs` and `input_groups` through `task_config.cascade`
- merge inherited input groups by name, with the nearest definition winning
- preserve the config root that defined each group and the active `global_inputs`
- document the behavior and cover parent/child roots, overrides, opt-out, and cache invalidation

## Testing

- `mbx test --all-features test_expand_task_inputs_supports_nested_groups`
- `mise run test:e2e e2e/tasks/test_task_artifact_cache_input_groups`
- `mise run lint-fix`
- `mise run lint`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task configuration cascading now merges `input_groups` by name, with closer definitions taking precedence.
  * Input groups and inherited group references resolve paths relative to their defining configuration.
  * Descendant `global_inputs` continue to replace inherited values.

* **Bug Fixes**
  * Improved task invalidation when inherited input files change.
  * Disabling cascading now prevents inherited inputs and reports undefined groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->