### PR TITLE
fix(activate): keep pwsh deactivation preamble out of $Error

### DIFF
--- a/e2e-win/activate_error_hygiene.Tests.ps1
+++ b/e2e-win/activate_error_hygiene.Tests.ps1
@@ -1,0 +1,40 @@
+Describe 'activate keeps $Error clean' {
+    # The deactivation preamble that `activate` prepends removes `function:mise` and
+    # $global:__mise_pwsh_chpwd_handled so that re-activating is idempotent. A session
+    # that has only inherited __MISE_DIFF has neither yet, and -ErrorAction
+    # SilentlyContinue keeps the two failures off the screen while still appending them
+    # to $Error - so the shell started with two entries the user had not caused.
+    #
+    # Two levels, because the preamble is only emitted when __MISE_DIFF is set: the
+    # outer shell activates to produce it, the inner one is the fresh session that used
+    # to start dirty. -NoProfile so a developer profile cannot pre-activate and define
+    # the very names under test.
+    It 'adds nothing to $Error when activating with __MISE_DIFF inherited' {
+        $probe = Join-Path $TestDrive 'error_hygiene_probe.ps1'
+        Set-Content -LiteralPath $probe -Value @'
+$Error.Clear()
+mise activate pwsh | Out-String | Invoke-Expression
+# without this the count below would pass even if Invoke-Expression never ran the script
+if (-not (Get-Command mise -CommandType Function -ErrorAction Ignore)) {
+    Write-Output 'ACTIVATION-ERROR: activation did not define the mise function'
+    exit 1
+}
+foreach ($e in $Error) { Write-Output "ERROR-RECORD: $($e.Exception.Message)" }
+Write-Output "ERROR-COUNT: $($Error.Count)"
+'@
+        $outer = @"
+mise activate pwsh | Out-String | Invoke-Expression
+if (-not (Test-Path Env:/__MISE_DIFF)) {
+    Write-Output 'SETUP-ERROR: activation left __MISE_DIFF unset, so the child gets no deactivation preamble'
+    exit 1
+}
+& pwsh -NoProfile -NonInteractive -File '$probe'
+"@
+        $out = pwsh -NoProfile -NonInteractive -Command $outer 2>&1 | Out-String
+
+        $out | Should -Not -Match 'SETUP-ERROR'
+        $out | Should -Not -Match 'ACTIVATION-ERROR'
+        $out | Should -Not -Match 'ERROR-RECORD'
+        $out | Should -Match 'ERROR-COUNT: 0'
+    }
+}

--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -270,13 +270,21 @@ impl Shell for Pwsh {
         out
     }
 
+    /// `Ignore` rather than `SilentlyContinue`: both keep the error record off the screen, but
+    /// only `Ignore` keeps it out of `$Error`. This block is prepended to every activation, and a
+    /// session that has merely inherited `__MISE_DIFF` has neither `function:mise` nor
+    /// `$global:__mise_pwsh_chpwd_handled` yet -- so those two removals used to leave a shell
+    /// with two entries in `$Error` before the user had run anything. The `Env:/` removals do not
+    /// error today, the Environment provider being quiet about a missing key, but the intent is
+    /// the same "remove if present, never report" and resting it on a per-provider quirk is
+    /// fragile.
     fn deactivate(&self) -> String {
         formatdoc! {r#"
-        Remove-Item -ErrorAction SilentlyContinue function:mise
-        Remove-Item -ErrorAction SilentlyContinue -Path Env:/MISE_SHELL
-        Remove-Item -ErrorAction SilentlyContinue -Path Env:/__MISE_DIFF
-        Remove-Item -ErrorAction SilentlyContinue -Path Env:/__MISE_SESSION
-        Remove-Variable -Name __mise_pwsh_chpwd_handled -Scope Global -ErrorAction SilentlyContinue
+        Remove-Item -ErrorAction Ignore function:mise
+        Remove-Item -ErrorAction Ignore -Path Env:/MISE_SHELL
+        Remove-Item -ErrorAction Ignore -Path Env:/__MISE_DIFF
+        Remove-Item -ErrorAction Ignore -Path Env:/__MISE_SESSION
+        Remove-Variable -Name __mise_pwsh_chpwd_handled -Scope Global -ErrorAction Ignore
         "#}
     }
 
@@ -558,9 +566,31 @@ mod tests {
         assert_snapshot!(Pwsh::default().unset_env("FOO"));
     }
 
+    /// Pins the exact text of the block `activate` prepends to every session, `-ErrorAction`
+    /// values included -- see the test below for what rides on that argument.
     #[test]
     fn test_deactivate() {
         let deactivate = Pwsh::default().deactivate();
         assert_snapshot!(replace_path(&deactivate));
+    }
+
+    /// `SilentlyContinue` hides an error record but still appends it to `$Error`; only `Ignore`
+    /// keeps it out. This block runs at the top of every activation, and the function and the
+    /// global it removes do not exist in a session that has only inherited `__MISE_DIFF` -- so
+    /// `SilentlyContinue` here left two entries in `$Error` before the user had run anything.
+    #[test]
+    fn test_deactivate_does_not_write_to_the_error_collection() {
+        let out = Pwsh::default().deactivate();
+        assert!(!out.contains("SilentlyContinue"), "{out}");
+        assert!(
+            out.contains("Remove-Item -ErrorAction Ignore function:mise"),
+            "{out}"
+        );
+        assert!(
+            out.contains(
+                "Remove-Variable -Name __mise_pwsh_chpwd_handled -Scope Global -ErrorAction Ignore"
+            ),
+            "{out}"
+        );
     }
 }

--- a/src/shell/snapshots/mise__shell__pwsh__tests__deactivate.snap
+++ b/src/shell/snapshots/mise__shell__pwsh__tests__deactivate.snap
@@ -2,8 +2,8 @@
 source: src/shell/pwsh.rs
 expression: replace_path(&deactivate)
 ---
-Remove-Item -ErrorAction SilentlyContinue function:mise
-Remove-Item -ErrorAction SilentlyContinue -Path Env:/MISE_SHELL
-Remove-Item -ErrorAction SilentlyContinue -Path Env:/__MISE_DIFF
-Remove-Item -ErrorAction SilentlyContinue -Path Env:/__MISE_SESSION
-Remove-Variable -Name __mise_pwsh_chpwd_handled -Scope Global -ErrorAction SilentlyContinue
+Remove-Item -ErrorAction Ignore function:mise
+Remove-Item -ErrorAction Ignore -Path Env:/MISE_SHELL
+Remove-Item -ErrorAction Ignore -Path Env:/__MISE_DIFF
+Remove-Item -ErrorAction Ignore -Path Env:/__MISE_SESSION
+Remove-Variable -Name __mise_pwsh_chpwd_handled -Scope Global -ErrorAction Ignore


### PR DESCRIPTION
## Problem

`mise activate pwsh` prepends the deactivation block so that re-activating an already active
shell is idempotent (`src/shell/pwsh.rs`, `Shell::activate` → `shell::build_deactivation_script`).
Two of the statements in that block remove things a session has not created yet:

```powershell
Remove-Item -ErrorAction SilentlyContinue function:mise
Remove-Variable -Name __mise_pwsh_chpwd_handled -Scope Global -ErrorAction SilentlyContinue
```

`SilentlyContinue` keeps the error record off the screen but **still appends it to the automatic
`$Error` collection** — only `Ignore` skips `$Error`. So a shell that activates mise starts with
two records nobody caused:

```
Cannot find a variable with the name '__mise_pwsh_chpwd_handled'.
Cannot find path 'Function:\mise' because it does not exist.
```

Nothing is printed and nothing is broken. The cost is `$Error` hygiene: `$Error[0]` is not what the
user's last command produced, and anything branching on `$Error.Count` — profile logic, prompt
hooks, test harnesses, CI scripts asserting a clean startup — sees two spurious entries.

The preamble is emitted when `__MISE_DIFF` is present (`env::is_activated()`), i.e. in any session
that inherited it — a pwsh started from an activated pwsh, an editor's integrated terminal, a
nested shell. There, neither the `mise` function nor the global exists yet, so both statements fail.

The three `Env:/…` removals do not error today, because the Environment provider is quiet about a
missing key. Only the `Function:` and `Variable:` providers raise.

## Fix

All five statements in `fn deactivate` use `-ErrorAction Ignore`. `Ignore` is valid as an
`-ErrorAction` argument (it is rejected only as an `$ErrorActionPreference` value) and removes
exactly the same way, so idempotency is unchanged. The `Env:/` lines are aligned as well: their
intent is the same "remove if present, never report", and resting their silence on a per-provider
quirk is fragile.

Deliberately unchanged elsewhere in `pwsh.rs`:

- `Invoke-Expression -ErrorAction SilentlyContinue` in the `mise` wrapper — it evaluates user
  command output; `Ignore` there would hide real failures from `$Error`.
- `Remove-Item … Function:/__enable_mise_*` — those functions exist at the point of removal.
- `Get-Command $Name -ErrorAction SilentlyContinue` — a lookup inside the command-not-found
  handler, not a startup path.
- `unset_env`'s `Remove-Item -LiteralPath 'Env:/…'` — Environment provider, out of scope here.

## Verification

Measured with PowerShell 7.6.5, replaying the exact script `activate` emits (deactivation preamble
+ activation body, taken from the insta snapshots):

```
before:  ERROR-COUNT: 2
           ! Cannot find a variable with the name '__mise_pwsh_chpwd_handled'.
           ! Cannot find path 'Function:/mise' because it does not exist.
after:   ERROR-COUNT: 0
```

Idempotency re-checked with the names present: all five removals still remove, `$Error.Count` 0.

Tests:

- `src/shell/pwsh.rs` — new `test_deactivate_does_not_write_to_the_error_collection` guards the
  `-ErrorAction` value, plus the updated `deactivate` snapshot.
  (`mise__shell__pwsh__tests__activate.snap` needs no change: the unit test environment has no
  `__MISE_DIFF`, so the preamble is not part of that snapshot.)
- `e2e-win/activate_error_hygiene.Tests.ps1` — new Pester test. Two levels, because the preamble is
  only emitted once `__MISE_DIFF` is set: the outer shell activates to produce it, the inner
  `pwsh -NoProfile` is the fresh session that used to start dirty, and asserts `$Error.Count` is 0
  after activation.

Fixes the `$Error` pollution described above; CI covers build, clippy, unit snapshots and the
Windows e2e suite.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.246.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PowerShell activation and deactivation to prevent suppressed errors from accumulating in the session’s error history.
  * Ensured reactivation works cleanly when a session inherits activation state.

* **Tests**
  * Added coverage confirming PowerShell activation completes without emitting errors and defines the expected command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->