### PR TITLE
registry: add ols (github:DanielGavin/ols)

### DIFF
--- a/registry/ols.toml
+++ b/registry/ols.toml
@@ -1,0 +1,10 @@
+bins = ["odinfmt", "ols"]
+description = "Language server for Odin"
+test = { cmd = "odinfmt -help", expected = "odinfmt [path]" } # ols itself has no CLI mode: any invocation starts the language server and blocks
+version_order = "source"
+
+[[backends]]
+full = "github:DanielGavin/ols"
+
+[backends.options]
+rename_exe = { "ols-*" = "ols", "odinfmt-*" = "odinfmt" }


### PR DESCRIPTION
Not in the aqua standard registry, so `github` is the tier 1 backend.

Releases are dated `dev-YYYY-MM` tags rather than `MAJOR.MINOR.PATCH`, so `version_order = "source"`. The rolling `nightly` tag is a prerelease and is already filtered out of `mise ls-remote`.

The archive ships two platform-suffixed binaries (`ols-arm64-darwin`, `odinfmt-arm64-darwin`, etc.), so the table form of `rename_exe` maps both onto clean names. This repository is the example already used for that option in docs/dev-tools/backends/github.md.

`ols` itself has no CLI mode -- every invocation, with or without flags, starts the language server and blocks -- so the test drives `odinfmt -help`, which exits 0 and prints a stable usage banner. `odinfmt` with no arguments exits 1, and neither binary reports a version string, so `expected` cannot use `{{version}}`.

This complements the existing `odin` entry (`github:odin-lang/Odin`): the compiler is already installable through mise, and ols is the language server for it, published by the same project used across editor integrations.

## Popularity

- GitHub: 1,162 stars, 183 forks; latest release dev-2026-06 published 2026-07-23
- Active maintenance: latest repository push 2026-08-23; first released 2020
- Packaged in nixpkgs as `ols`
- The de facto language server for Odin, used by the official Odin extensions for VS Code, Neovim, Sublime Text, and Zed
- https://github.com/DanielGavin/ols

## Validation

- `mise test-tool ols` -> `ols: OK`
- `mise ls-remote github:DanielGavin/ols` -> `dev-2025-09 ... dev-2026-06`
- installed tree contains `ols` and `odinfmt` after `rename_exe`
- `odinfmt -help` -> `odinfmt [path] [-config] [-stdin] [-w]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Odin language server and formatter.
  * Added installation and version tracking through the GitHub backend.
  * Added validation to confirm the formatter runs and displays usage information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->