### PR TITLE
registry: Add spin-framework

### DIFF
--- a/registry/spin-framework.toml
+++ b/registry/spin-framework.toml
@@ -1,0 +1,5 @@
+backends = ["github:spinframework/spin"]
+bins = ["spin"]
+description = "Spin is the open source developer tool for building and running serverless applications powered by WebAssembly."
+test = { cmd = "spin --version", expected = "spin {{version}}" }
+version_order = "semver"


### PR DESCRIPTION
## Summary
- Add `spin-framework` shorthand backed by `github:spinframework/spin`
- Declare the `spin` binary including version check

## Popularity
- GitHub: 6505 stars, 311 forks
- Latest release `4.0.2` published on 2026-06-23
- Spin is a [CNCF](https://cncf.io) project, currently on the sandbox tier
- Spin Documentation: [spinframework.dev](https://spinframework.dev)

## Testing

- `mise ls-remote github:spinframework/spin` -> `0.1.0`...`4.0.2`
- `mise run lint-fix` -> all green

### On-The-Fly Tool Execution

```bash
MISE_MINIMUM_RELEASE_AGE=0 mise x github:spinframework/spin@4.0.2 -- spin --version 
spin 4.0.2 (bfc7543 2026-06-23)
```

### Local Tool Testing

```bash
mise run build
./target/debug/mise test-tool spin-framework
# ...
cleaning spin-framework                                             ✔
spin-framework@4.0.2      extract spin-v4.0.2-macos-aarch64.tar.gz  ✔
mise $ /Users/<USER>/.local/share/mise/installs/spin-framework/latest/spin --version
spin 4.0.2 (bfc7543 2026-06-23)
mise spin-framework: OK
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added registry support for the Spin framework.
  * Enables version detection for the `spin` command using semantic versioning.
  * Includes framework metadata and links to its official source repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->