### PR TITLE
registry: add 7zip (github:ip7z/7zip)

### DIFF
--- a/e2e/cli/test_search
+++ b/e2e/cli/test_search
@@ -12,10 +12,16 @@ jqp   A TUI playground to experiment with jq. https://github.com/noahgorstein/jq
 
 assert "mise search --match-type equal jq" "jq  Command-line JSON processor. https://github.com/jqlang/jq"
 
-assert_contains "mise search 7zip" "aqua:ip7z/7zip"
-assert_contains "mise search --match-type contains 7zip" "aqua:ip7z/7zip"
-assert_contains "mise search --match-type equal 7zip" "aqua:ip7z/7zip"
+# An aqua package with no registry shorthand is still surfaced by name
+assert_contains "mise search buildkit" "aqua:moby/buildkit"
+assert_contains "mise search --match-type contains buildkit" "aqua:moby/buildkit"
+assert_contains "mise search --match-type equal buildkit" "aqua:moby/buildkit"
+
+# Querying an explicit backend returns the backend form even when a shorthand exists
 assert_contains "mise search aqua:ip7z/7zip" "aqua:ip7z/7zip"
+
+# The 7zip shorthand collapses its aqua and github packages into a single result
+assert "mise search --match-type equal 7zip" "7zip  7-Zip is a file archiver with a high compression ratio. https://github.com/ip7z/7zip"
 
 # Backend prefixes matching a shorthand do not dump translated aqua packages
 assert_not_contains "mise search cargo" "cargo:broot"

--- a/registry/7zip.toml
+++ b/registry/7zip.toml
@@ -1,0 +1,6 @@
+aliases = ["7z"]
+backends = ["aqua:ip7z/7zip", "github:ip7z/7zip"]
+bins = ["7zz", "7zzs", "7za"]
+description = "7-Zip is a file archiver with a high compression ratio"
+test = { cmd = "7zz", expected = "7-Zip (z) {{version}}" }
+version_order = "source"


### PR DESCRIPTION
In the aqua standard registry, so `aqua` is the preferred backend, with `github` as a tier 1 fallback. Releases use two-component versions (`24.09`, `26.02`) rather than `MAJOR.MINOR.PATCH`, so `version_order = "source"`.

## Binaries

Upstream ships different standalone console builds per platform. Per 7-Zip's own DOC/readme.txt, `7zz` is the standalone console that supports all formats, while `7za` is the standalone that supports only 7z/xz/cab/zip/gzip/bzip2/tar. `7zzs` is the statically linked build of `7zz` (verified: no ELF interpreter, whereas `7zz` links libc/libstdc++).

    7zz    all-format standalone console         linux, macos
    7zzs   same, statically linked               linux only
    7za    reduced-format standalone             windows only

The windows package is sourced from `7z<version>-extra.7z`, which contains only `7za.exe` and its DLLs -- there is no `7zz.exe` in it -- so `7za` is the only standalone available on that platform. All three names are listed in `bins` so the command resolves to this tool wherever it exists; trimming the list would leave windows unmapped.

## Test

7-Zip has no `--version` flag and exits non-zero on an unknown switch. The bare command prints the banner and exits 0, so the test matches against that.

## Popularity

- GitHub: 3,786 stars, 396 forks; latest release 26.02 published 2026-06-26
- Active maintenance: latest repository push 2026-06-26
- Also packaged in Homebrew as `sevenzip`
- 7-Zip is one of the most widely used archivers in existence; this repository is Igor Pavlov's official source mirror

## Validation

- `mise test-tool 7zip` -> `7zip: OK`
- `mise x aqua:ip7z/7zip@26.02 -- 7zz` -> `7-Zip (z) 26.02 (arm64) : Copyright (c) 1999-2026 Igor Pavlov`
- `mise x github:ip7z/7zip@26.02 -- 7zz` -> `7-Zip (z) 26.02 (arm64) : Copyright (c) 1999-2026 Igor Pavlov`
- archive contents confirmed directly: linux-x64 tarball ships `7zz` + `7zzs`, mac tarball ships `7zz`, `7z2602-extra.7z` ships `7za.exe` only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added 7-Zip to the available software registry.
  * Supports multiple 7-Zip command-line binaries, installation sources, and version detection.

* **Bug Fixes**
  * Improved search results for 7-Zip shorthand queries, presenting a single consolidated result.
  * Updated search coverage for BuildKit across default, contains, and exact-match modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->