### PR TITLE
fix(test-tool): fail when no versions resolve

### DIFF
--- a/src/cli/test_tool.rs
+++ b/src/cli/test_tool.rs
@@ -8,6 +8,7 @@ use crate::toolset::{InstallOptions, ToolRequest, ToolRequestSet, ToolsetBuilder
 use crate::ui::time;
 use crate::{dirs, env, file};
 use eyre::{Result, bail, eyre};
+use std::fmt::Display;
 use std::path::{Path, PathBuf};
 use std::{collections::BTreeSet, sync::Arc};
 use tokio::task::JoinSet;
@@ -399,16 +400,13 @@ impl TestTool {
         };
         let (_, missing) = ts.install_missing_versions(&mut config, &opts).await?;
         ts.notify_missing_versions(missing);
-        let tv = if let Some(tv) = ts
-            .versions
-            .get(tool.ba.as_ref())
-            .and_then(|tvl| tvl.versions.first())
-        {
-            tv.clone()
-        } else {
-            warn!("no versions found for {tool}");
-            return Ok(String::new());
-        };
+        let tv = require_resolved_version(
+            ts.versions
+                .get(tool.ba.as_ref())
+                .and_then(|tvl| tvl.versions.first())
+                .cloned(),
+            tool,
+        )?;
         let backend = tv.backend()?;
         let env = ts.env_with_path(&config).await?;
         let mut which_parts = cmd.split_whitespace().collect::<Vec<_>>();
@@ -478,6 +476,22 @@ impl TestTool {
             ));
         }
         Ok(stdout.trim_end().to_string())
+    }
+}
+
+fn require_resolved_version<T>(version: Option<T>, tool: impl Display) -> Result<T> {
+    version.ok_or_else(|| eyre!("no versions found for {tool}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unresolved_tool_version_is_an_error() {
+        let err = require_resolved_version::<()>(None, "example").unwrap_err();
+
+        assert_eq!(err.to_string(), "no versions found for example");
     }
 }
 

--- a/src/cli/test_tool.rs
+++ b/src/cli/test_tool.rs
@@ -490,25 +490,6 @@ fn should_test_registry_tool(tool: &RegistryTool) -> bool {
     tool.is_supported_os()
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn unresolved_tool_version_is_an_error() {
-        let err = require_resolved_version::<()>(None, "example").unwrap_err();
-
-        assert_eq!(err.to_string(), "no versions found for example");
-    }
-
-    #[test]
-    fn unsupported_os_registry_tool_is_skipped() {
-        let tool = REGISTRY.get("figma-export").unwrap();
-
-        assert_eq!(should_test_registry_tool(tool), cfg!(target_os = "macos"));
-    }
-}
-
 struct TestToolTarget {
     index: usize,
     tool: ToolArg,
@@ -532,3 +513,22 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     $ <bold>mise test-tool ripgrep</bold>
 "#
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unresolved_tool_version_is_an_error() {
+        let err = require_resolved_version::<()>(None, "example").unwrap_err();
+
+        assert_eq!(err.to_string(), "no versions found for example");
+    }
+
+    #[test]
+    fn unsupported_os_registry_tool_is_skipped() {
+        let tool = REGISTRY.get("figma-export").unwrap();
+
+        assert_eq!(should_test_registry_tool(tool), cfg!(target_os = "macos"));
+    }
+}

--- a/src/cli/test_tool.rs
+++ b/src/cli/test_tool.rs
@@ -58,6 +58,9 @@ impl TestTool {
         let target_tools = self.get_target_tools(&config).await?;
         let mut targets = vec![];
         for (i, (tool, rt)) in target_tools.into_iter().enumerate() {
+            if !should_test_registry_tool(rt) {
+                continue;
+            }
             if *env::TEST_TRANCHE_COUNT > 0 && (i % *env::TEST_TRANCHE_COUNT) != *env::TEST_TRANCHE
             {
                 continue;
@@ -483,6 +486,10 @@ fn require_resolved_version<T>(version: Option<T>, tool: impl Display) -> Result
     version.ok_or_else(|| eyre!("no versions found for {tool}"))
 }
 
+fn should_test_registry_tool(tool: &RegistryTool) -> bool {
+    tool.is_supported_os()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -492,6 +499,13 @@ mod tests {
         let err = require_resolved_version::<()>(None, "example").unwrap_err();
 
         assert_eq!(err.to_string(), "no versions found for example");
+    }
+
+    #[test]
+    fn unsupported_os_registry_tool_is_skipped() {
+        let tool = REGISTRY.get("figma-export").unwrap();
+
+        assert_eq!(should_test_registry_tool(tool), cfg!(target_os = "macos"));
     }
 }
 


### PR DESCRIPTION
## Summary

- fail `mise test-tool` when a supported requested tool resolves to zero versions
- skip registry tools that are unsupported on the current OS
- add regression coverage for zero-version failures and platform filtering
- prevent registry CI from reporting unresolved tools as passing

## Testing

- `mise run test:unit cli::test_tool::tests`
- `mise run lint-fix`

Discovered while investigating the registry check on #12480.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect the `test-tool` CLI and its CI checks, not normal install/runtime paths; behavior is stricter (fail/skip) rather than permissive.
> 
> **Overview**
> **`mise test-tool` no longer treats “zero resolved versions” as success.** Version lookup is centralized in `require_resolved_version`, which returns an error with `no versions found for {tool}` instead of logging a warning and finishing with empty output (which registry CI could mark as passing).
> 
> When building the test target list (e.g. `--all`), **registry entries that don’t support the current OS are skipped** via `should_test_registry_tool` / `RegistryTool::is_supported_os()`, so CI doesn’t run installs for macOS-only tools on Linux.
> 
> **Regression tests** cover the unresolved-version error message and that `figma-export` is only eligible on macOS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db188d48c2bc74e07a8607c685e2cbbe5603e217. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The testing tool now skips registry tools unsupported by the current operating system.
  * Testing continues to report an error when a tool version cannot be resolved.
* **Tests**
  * Added coverage for unsupported tools and unresolved tool versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->