### PR TITLE
registry: add stagelint (aqua:abemedia/stagelint)

### DIFF
--- a/registry/stagelint.toml
+++ b/registry/stagelint.toml
@@ -1,0 +1,12 @@
+backends = ["aqua:abemedia/stagelint", "cargo:stagelint"]
+bins = ["stagelint"]
+description = "Run commands like linters and formatters on staged git files"
+detect = [
+  ".stagelint.yml",
+  ".stagelint.yaml",
+  ".stagelint.json",
+  ".stagelint.jsonc",
+  ".stagelint.json5",
+]
+test = { cmd = "stagelint --version", expected = "stagelint {{version}}" }
+version_order = "semver"


### PR DESCRIPTION
Adds `stagelint`, a CLI that runs linters and formatters against staged git files. I am the author.

The aqua entry (aquaproj/aqua-registry#59532) merged earlier today; `cargo:stagelint` is a fallback for platforms without prebuilt binaries.

Verified `aqua:abemedia/stagelint@0.1.3` installs and runs on linux-x64 and macos-x64, with cosign and checksum verification passing on both.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `stagelint` to the tool registry.
  - Documented supported installation methods, configuration detection, version checking, and version ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->