### PR TITLE
refactor: share os/arch selector normalization helpers

### DIFF
--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -61,6 +61,33 @@ pub(crate) static ARCH: Lazy<String> = Lazy::new(|| {
     .to_string()
 });
 
+/// Normalize OS name aliases to the canonical form used by `std::env::consts::OS`.
+pub(crate) fn normalize_os(os: &str) -> &str {
+    match os {
+        "darwin" | "macos" => "macos",
+        "windows" | "win" => "windows",
+        other => other,
+    }
+}
+
+/// Normalize architecture name aliases to the canonical form used by [`ARCH`].
+pub(crate) fn normalize_arch(arch: &str) -> &str {
+    match arch {
+        "x86_64" | "amd64" | "x64" => "x64",
+        "aarch64" | "arm64" => "arm64",
+        other => other,
+    }
+}
+
+/// Whether an `os` or `os/arch` selector matches the current platform.
+pub(crate) fn os_selector_matches(entry: &str) -> bool {
+    if let Some((os, arch)) = entry.split_once('/') {
+        normalize_os(os) == OS.as_str() && normalize_arch(arch) == ARCH.as_str()
+    } else {
+        normalize_os(entry) == OS.as_str()
+    }
+}
+
 pub(crate) static VERSION_PLAIN: Lazy<String> = Lazy::new(|| {
     let mut v = V.to_string();
     if cfg!(debug_assertions) {
@@ -310,6 +337,26 @@ mod tests {
         let p = dir.join("latest-version");
         std::fs::write(&p, body).unwrap();
         p
+    }
+
+    #[test]
+    fn test_normalize_os() {
+        assert_eq!(normalize_os("macos"), "macos");
+        assert_eq!(normalize_os("darwin"), "macos");
+        assert_eq!(normalize_os("linux"), "linux");
+        assert_eq!(normalize_os("windows"), "windows");
+        assert_eq!(normalize_os("win"), "windows");
+        assert_eq!(normalize_os("freebsd"), "freebsd");
+    }
+
+    #[test]
+    fn test_normalize_arch() {
+        assert_eq!(normalize_arch("arm64"), "arm64");
+        assert_eq!(normalize_arch("aarch64"), "arm64");
+        assert_eq!(normalize_arch("x64"), "x64");
+        assert_eq!(normalize_arch("x86_64"), "x64");
+        assert_eq!(normalize_arch("amd64"), "x64");
+        assert_eq!(normalize_arch("riscv64"), "riscv64");
     }
 
     #[test]

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -174,7 +174,11 @@ impl PackageTomlConfig {
         let Self::Options(options) = self else {
             return true;
         };
-        options.os.is_empty() || options.os.iter().any(|entry| package_os_matches(entry))
+        options.os.is_empty()
+            || options
+                .os
+                .iter()
+                .any(|entry| crate::cli::version::os_selector_matches(entry))
     }
 }
 
@@ -203,32 +207,6 @@ where
         ));
     }
     Ok(values)
-}
-
-fn package_os_matches(entry: &str) -> bool {
-    let current_os = crate::cli::version::OS.as_str();
-    let current_arch = crate::cli::version::ARCH.as_str();
-    if let Some((os, arch)) = entry.split_once('/') {
-        normalize_package_os(os) == current_os && normalize_package_arch(arch) == current_arch
-    } else {
-        normalize_package_os(entry) == current_os
-    }
-}
-
-fn normalize_package_os(os: &str) -> &str {
-    match os {
-        "darwin" | "macos" => "macos",
-        "windows" | "win" => "windows",
-        other => other,
-    }
-}
-
-fn normalize_package_arch(arch: &str) -> &str {
-    match arch {
-        "x86_64" | "amd64" | "x64" => "x64",
-        "aarch64" | "arm64" => "arm64",
-        other => other,
-    }
 }
 
 pub(crate) fn plugins_from_config(config: &Config) -> IndexMap<String, String> {

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -472,16 +472,9 @@ impl ToolRequest {
 
     pub(crate) fn is_os_supported(&self) -> bool {
         if let Some(os_list) = self.os() {
-            let current_os = &crate::cli::version::OS;
-            let current_arch = &crate::cli::version::ARCH;
-            let matched = os_list.iter().any(|entry| {
-                if let Some((os, arch)) = entry.split_once('/') {
-                    normalize_os(os) == current_os.as_str()
-                        && normalize_arch(arch) == current_arch.as_str()
-                } else {
-                    normalize_os(entry) == current_os.as_str()
-                }
-            });
+            let matched = os_list
+                .iter()
+                .any(|entry| crate::cli::version::os_selector_matches(entry));
             if !matched {
                 return false;
             }
@@ -664,24 +657,6 @@ fn resolve_path(p: &str, source: &ToolSource) -> PathBuf {
             .unwrap_or_else(|| PathBuf::from(".")),
     };
     base.join(p)
-}
-
-/// Normalize OS name aliases to the canonical form used by `std::env::consts::OS`.
-fn normalize_os(os: &str) -> &str {
-    match os {
-        "darwin" | "macos" => "macos",
-        "windows" | "win" => "windows",
-        other => other,
-    }
-}
-
-/// Normalize architecture name aliases to the canonical form used by `cli::version::ARCH`.
-fn normalize_arch(arch: &str) -> &str {
-    match arch {
-        "x86_64" | "amd64" | "x64" => "x64",
-        "aarch64" | "arm64" => "arm64",
-        other => other,
-    }
 }
 
 /// subtracts sub from orig and removes suffix
@@ -1050,27 +1025,5 @@ mod tests {
         assert!(version_sub("latest", "1").is_err());
         assert!(version_sub("1.2.3", "x").is_err());
         assert!(version_sub("", "1").is_err());
-    }
-
-    #[test]
-    fn test_normalize_os() {
-        use super::normalize_os;
-        assert_eq!(normalize_os("macos"), "macos");
-        assert_eq!(normalize_os("darwin"), "macos");
-        assert_eq!(normalize_os("linux"), "linux");
-        assert_eq!(normalize_os("windows"), "windows");
-        assert_eq!(normalize_os("win"), "windows");
-        assert_eq!(normalize_os("freebsd"), "freebsd");
-    }
-
-    #[test]
-    fn test_normalize_arch() {
-        use super::normalize_arch;
-        assert_eq!(normalize_arch("arm64"), "arm64");
-        assert_eq!(normalize_arch("aarch64"), "arm64");
-        assert_eq!(normalize_arch("x64"), "x64");
-        assert_eq!(normalize_arch("x86_64"), "x64");
-        assert_eq!(normalize_arch("amd64"), "x64");
-        assert_eq!(normalize_arch("riscv64"), "riscv64");
     }
 }


### PR DESCRIPTION
#11809 introduced `normalize_package_os` / `normalize_package_arch` and `package_os_matches` in `src/system/mod.rs` as byte-for-byte copies of `normalize_os` / `normalize_arch` and the `os` / `os/arch` selector matching in `src/toolset/tool_request.rs`. Two copies of the alias tables (`darwin`→`macos`, `win`→`windows`, `x86_64`/`amd64`→`x64`, `aarch64`→`arm64`) are a drift risk: a new alias added to one silently diverges the `[tools]` os filter from the `[bootstrap.packages]` os filter.

This moves the helpers to `src/cli/version.rs` next to the `OS` / `ARCH` statics they compare against, adds a shared `os_selector_matches`, and points both call sites at it. The `test_normalize_os` / `test_normalize_arch` unit tests move along with the helpers; behavior is unchanged.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform matching for package and tool selections.
  * Added support for common operating system and architecture aliases, including macOS, Windows, x64, and ARM64.
  * Ensured platform filters behave consistently across supported features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Project review — 2026-09-05

Done: [#12493](https://github.com/jdx/mise/pull/12493) merged 2026-08-27T12:37:38Z. Current main contains the shared platform-selector helpers used by both bootstrap packages and tool requests. The original description above records the implementation; there is no remaining normalization refactor for this card. Future alias additions should update the shared helper and its regression cases, rather than recreating separate tables. Merge state and source were checked; no test suite was rerun in this planning audit.

## Independent completion evidence

The original PR scope is consolidating the tool/bootstrap alias tables and selector matcher, not every platform normalizer in mise. Current `src/cli/version.rs` owns `normalize_os`, `normalize_arch`, and `os_selector_matches`; `src/system/mod.rs` and `src/toolset/tool_request.rs` delegate to them. The former `normalize_package_*` copies are gone, and normalization tests moved with the shared helper. This fulfills the original refactor without inventing a broader behavior change from the automated release-note wording. Source/tests inspected on main b8e4ec001; no fresh test run claimed.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*