### PR TITLE
feat(outdated): report the release page URL in --json

### DIFF
--- a/e2e/cli/test_outdated
+++ b/e2e/cli/test_outdated
@@ -54,3 +54,8 @@ mise install dummy@1.0.0
 
 assert "mise outdated dummy --json | jq -r '.dummy.latest'" "1.1.0"
 assert "mise outdated dummy -b --json | jq -r '.dummy.latest'" "2.0.0"
+
+# Most backends publish no release page, and those entries must not grow a
+# `"release_url": null`. `has` rather than a `//` default, which cannot tell an
+# absent key from a null one -- absent is the thing being asserted.
+assert "mise outdated dummy --json | jq -r '.dummy | has(\"release_url\")'" "false"

--- a/e2e/cli/test_outdated_slow
+++ b/e2e/cli/test_outdated_slow
@@ -4,3 +4,22 @@
 mise uninstall java --all
 mise install java@temurin-21.0.0
 assert_contains "mise outdated java --inactive --json | jq -r '.java.latest'" "temurin-21.0"
+
+# The github backend builds the release URL itself rather than reading it from a
+# remote listing, so this is where the whole path can be checked end to end: a
+# real version listing, the resolved latest, and the URL that comes back with it.
+# Worth pinning because the lookup matches on the version string -- if `latest`
+# and the listing ever disagreed on its form, `release_url` would quietly be
+# absent everywhere and nothing else would notice.
+cat <<EOF >mise.toml
+[tools]
+"github:cli/cli" = "2"
+EOF
+mise install "github:cli/cli@2.75.0"
+# Tied to `.latest`, not just to the prefix: a URL pointing at some other
+# release is the failure worth catching, and "is a cli/cli release page" would
+# pass straight through it. The tag is compared whole rather than by suffix --
+# suffix matching accepts `v12.75.0` for a reported `2.75.0` -- while still
+# allowing the leading `v` the backend strips from the version but keeps in the
+# URL. A missing `release_url` renders as `false` rather than a jq error.
+assert_contains "mise outdated --json | jq -r '.\"github:cli/cli\" | (.release_url // \"\") as \$u | .latest as \$l | (\$u | ltrimstr(\"https://github.com/cli/cli/releases/tag/\")) as \$tag | (\$u | startswith(\"https://github.com/cli/cli/releases/tag/\")) and (\$tag == \$l or \$tag == \"v\" + \$l)'" "true"

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -453,30 +453,7 @@ impl Backend for UnifiedGitBackend {
         let api_url = opts.api_url();
         let version_prefix = opts.version_prefix();
 
-        // Derive web URL base from API URL for enterprise support
-        let web_url_base = if self.is_gitlab() {
-            if api_url == DEFAULT_GITLAB_API_BASE_URL {
-                format!("https://gitlab.com/{}", repo)
-            } else {
-                // Enterprise GitLab - derive web URL from API URL
-                let web_url = api_url.replace("/api/v4", "");
-                format!("{}/{}", web_url, repo)
-            }
-        } else if self.is_forgejo() {
-            if api_url == DEFAULT_FORGEJO_API_BASE_URL {
-                format!("https://codeberg.org/{}", repo)
-            } else {
-                // Enterprise Forgejo - derive web URL from API URL
-                let web_url = api_url.replace("/api/v1", "");
-                format!("{}/{}", web_url, repo)
-            }
-        } else if api_url == DEFAULT_GITHUB_API_BASE_URL {
-            format!("https://github.com/{}", repo)
-        } else {
-            // Enterprise GitHub - derive web URL from API URL
-            let web_url = api_url.replace("/api/v3", "").replace("api.", "");
-            format!("{}/{}", web_url, repo)
-        };
+        let web_url_base = self.web_url_base(&api_url, &repo);
 
         // Get releases with full metadata from GitHub, GitLab, or Forgejo
         let raw_versions: Vec<VersionInfo> = if self.is_gitlab() {
@@ -594,12 +571,20 @@ impl Backend for UnifiedGitBackend {
             }
         };
 
+        let web_url_base = self.web_url_base(&api_url, &repo);
         Ok(latest_release
             .filter(|(tag, _, _)| version_prefix.is_none_or(|p| tag.starts_with(p)))
             .map(|(tag, created_at, prerelease)| VersionInfo {
                 version: self.strip_version_prefix(&tag, &opts),
                 created_at: Some(created_at),
                 prerelease: Some(prerelease),
+                // Same URL the listing would give for this release. Without it
+                // the shortcut answers about the newest release while knowing
+                // less about it than the slower path does, and a caller reading
+                // `release_url` gets nothing for exactly the release it is most
+                // likely to be asked about. GitLab has already returned above,
+                // so this is the GitHub/Forgejo tag form.
+                release_url: Some(format!("{web_url_base}/releases/tag/{tag}")),
                 ..Default::default()
             }))
     }
@@ -1345,6 +1330,38 @@ impl UnifiedGitBackend {
 
     fn is_forgejo(&self) -> bool {
         self.ba.backend_type() == BackendType::Forgejo
+    }
+
+    /// Web URL for the repository, derived from the API URL so an enterprise
+    /// host resolves to its own front end rather than the public one.
+    ///
+    /// Shared by the version listing and the stable-latest shortcut, which have
+    /// to agree: a release reached through one and then described by the other
+    /// would otherwise be handed two different URLs.
+    fn web_url_base(&self, api_url: &str, repo: &str) -> String {
+        if self.is_gitlab() {
+            if api_url == DEFAULT_GITLAB_API_BASE_URL {
+                format!("https://gitlab.com/{repo}")
+            } else {
+                // Enterprise GitLab - derive web URL from API URL
+                let web_url = api_url.replace("/api/v4", "");
+                format!("{web_url}/{repo}")
+            }
+        } else if self.is_forgejo() {
+            if api_url == DEFAULT_FORGEJO_API_BASE_URL {
+                format!("https://codeberg.org/{repo}")
+            } else {
+                // Enterprise Forgejo - derive web URL from API URL
+                let web_url = api_url.replace("/api/v1", "");
+                format!("{web_url}/{repo}")
+            }
+        } else if api_url == DEFAULT_GITHUB_API_BASE_URL {
+            format!("https://github.com/{repo}")
+        } else {
+            // Enterprise GitHub - derive web URL from API URL
+            let web_url = api_url.replace("/api/v3", "").replace("api.", "");
+            format!("{web_url}/{repo}")
+        }
     }
 
     fn repo(&self) -> String {

--- a/src/toolset/outdated_info.rs
+++ b/src/toolset/outdated_info.rs
@@ -27,6 +27,15 @@ pub(crate) struct OutdatedInfo {
     #[tabled(display("Self::display_bump"))]
     pub bump: Option<String>,
     pub latest: String,
+    /// Where to read about `latest`, when the backend knows.
+    ///
+    /// JSON only: a release URL is long enough to wreck the table, and the
+    /// table is the thing people read at a glance. Omitted rather than null
+    /// when the backend does not publish one, so a consumer can ask whether the
+    /// key is there instead of whether its value happens to be null.
+    #[tabled(skip)]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub release_url: Option<String>,
     pub source: ToolSource,
 }
 
@@ -43,6 +52,10 @@ impl OutdatedInfo {
             tool_version: tv,
             bump: None,
             latest,
+            // Filled in by `resolve`, which is the only path that knows the
+            // version was actually reported as outdated. Every other caller
+            // builds an `OutdatedInfo` for a version it already has in hand.
+            release_url: None,
         };
         Ok(oi)
     }
@@ -152,6 +165,31 @@ impl OutdatedInfo {
                 oi.tool_version.request.version()
             );
         }
+        // Asked for after the up-to-date checks above, so a tool that is not
+        // going to be reported does not pay for the lookup. It reads the remote
+        // listing, which is cached and which resolution has usually just read,
+        // so this normally costs no extra request.
+        //
+        // `oi.latest` rather than the requested version: what is wanted is where
+        // to read about the version being offered, not the one already pinned.
+        oi.release_url = match t.get_version_info(config, &oi.latest).await {
+            Some(info) => info.release_url,
+            // A plain `latest` without prereleases does not come from that
+            // listing at all — `latest_version` takes the backend's
+            // stable-latest shortcut, which can name a release the cached
+            // listing has not caught up with. Looking that version up here then
+            // finds nothing, and the URL would go missing precisely for the
+            // freshest release. The shortcut carries the URL itself, so ask it
+            // rather than report nothing.
+            None => t
+                .latest_stable_version_info(config)
+                .await
+                .ok()
+                .flatten()
+                // Only if it is describing the version actually being reported.
+                .filter(|info| info.version == oi.latest)
+                .and_then(|info| info.release_url),
+        };
         if bump {
             let old = oi.tool_version.request.version();
             let old = old.strip_prefix(&prefix).unwrap_or(old.as_str());
@@ -666,5 +704,71 @@ mod tests {
         let info = OutdatedInfo::new(&config, tv, "1.25.10".into()).unwrap();
 
         assert_eq!(info.current.as_deref(), Some("1.25.10"));
+    }
+
+    /// Build an `OutdatedInfo` the way the tests above do, for the cases that
+    /// only care about how it is rendered.
+    async fn outdated_info_for(short: &str) -> OutdatedInfo {
+        let config = Config::get().await.unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut backend = BackendArg::new_raw(
+            short.into(),
+            Some(format!("asdf:{short}")),
+            short.into(),
+            Some(ToolVersionOptions::default()),
+            BackendResolution::new(true),
+        );
+        backend.installs_path = temp_dir.path().join("installs").join(short);
+        let request = ToolRequest::new(Arc::new(backend), "1.25", ToolSource::Argument).unwrap();
+        let tv = ToolVersion::new(request, "1.25.10".into());
+        OutdatedInfo::new(&config, tv, "1.25.10".into()).unwrap()
+    }
+
+    /// Most backends publish no release URL, and those entries must not gain a
+    /// `"release_url": null`. A consumer should be able to ask whether the key
+    /// is there rather than whether its value happens to be null.
+    #[tokio::test]
+    async fn a_missing_release_url_leaves_the_key_out_of_the_json() {
+        let info = outdated_info_for("release-url-absent-test").await;
+
+        let json = serde_json::to_string(&info).unwrap();
+
+        assert!(
+            !json.contains("release_url"),
+            "a tool with no release URL still carried the key: {json}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_release_url_is_reported_in_the_json() {
+        let mut info = outdated_info_for("release-url-present-test").await;
+        info.release_url = Some("https://example.invalid/releases/tag/v1.25.10".to_string());
+
+        let json = serde_json::to_string(&info).unwrap();
+
+        assert!(
+            json.contains(r#""release_url":"https://example.invalid/releases/tag/v1.25.10""#),
+            "the release URL did not reach the json: {json}"
+        );
+    }
+
+    /// The table is the thing people read at a glance, and a release URL is long
+    /// enough to wreck it. `#[tabled(skip)]` keeps it out; this is what notices
+    /// if that attribute is dropped.
+    #[tokio::test]
+    async fn a_release_url_stays_out_of_the_table() {
+        let mut info = outdated_info_for("release-url-table-test").await;
+        info.release_url = Some("https://example.invalid/releases/tag/v1.25.10".to_string());
+
+        let rendered = tabled::Table::new(vec![info]).to_string();
+
+        assert!(
+            !rendered.contains("example.invalid"),
+            "the release URL leaked into the table: {rendered}"
+        );
+        assert!(
+            !rendered.contains("release_url"),
+            "the table grew a release_url column: {rendered}"
+        );
     }
 }


### PR DESCRIPTION
## What

Adds `release_url` to `mise outdated --json`: where to read about the version being offered.

```json
{
  "gh": {
    "requested": "2",
    "current": "2.75.0",
    "latest": "2.83.0",
    "release_url": "https://github.com/cli/cli/releases/tag/v2.83.0",
    "source": { "type": "mise.toml", "path": "~/src/app/mise.toml" }
  }
}
```

## Why

From the discussion:

> it would be nice to have the release url too, so I can build my own commit message

`outdated` reports that a newer version exists but gives no way to reach what changed in it, so the URL has to be reconstructed by hand — differently per forge.

## The reporter's guess was right

They suspected the data was already there, and it is. `VersionInfo::release_url` is populated by four sources today — the versions host, aqua, github/gitlab, and the rust core plugin — and `outdated` simply never looked at it.

One correction to my own earlier note on this: I had written that the URL is discarded at the `OutdatedInfo` boundary because `OutdatedInfo::new` takes `latest` as a `String`. That is true but not the whole story — `Backend::latest_version` returns a `String` too, so it is already gone before `new` is reached. It does not change the size of the fix, because `get_version_info` can look the version back up, but the claim as I first made it was wrong.

## How

`resolve` asks `get_version_info` for the version it is about to report:

```rust
oi.release_url = t
    .get_version_info(config, &oi.latest)
    .await
    .and_then(|info| info.release_url);
```

Three things about where that sits:

- **After the up-to-date checks.** A tool that will not be reported does not pay for the lookup.
- **Normally no extra request.** `get_version_info` reads `list_remote_versions_with_info`, which is behind `VersionCacheManager` and is the listing resolution has usually just read.

But that listing is not the only source, which review caught. A plain `latest` without prereleases takes the backend's stable-latest shortcut (`should_use_latest_stable_fast_path`) instead, so `latest` can name a release the cached listing has not caught up with — the lookup then finds nothing and the URL goes missing precisely for the freshest release.

That needed a fix in two places. **The shortcut was not filling the field at all**: GitHub's `latest_stable_version_info` built its `VersionInfo` from `version` / `created_at` / `prerelease` and `..Default::default()`, so `release_url` was always `None` there. It has the tag in hand, so it now derives the URL the same way the listing does. The derivation — including the enterprise-host handling — was a ~20-line inline block in `_list_remote_versions`; duplicating it would have let the two paths drift, so it is extracted to `web_url_base(&self, api_url, repo)` and both call it. GitLab returns `None` from the shortcut before that point, so the tag form there is the GitHub/Forgejo one.

**And `resolve` now falls back to it** when the listing comes up empty, trusting it only when it describes the version actually being reported:

```rust
oi.release_url = match t.get_version_info(config, &oi.latest).await {
    Some(info) => info.release_url,
    None => t
        .latest_stable_version_info(config)
        .await
        .ok()
        .flatten()
        .filter(|info| info.version == oi.latest)
        .and_then(|info| info.release_url),
};
```
- **`oi.latest`, not the requested version.** What is wanted is where to read about the version being offered, not the one already pinned.

`OutdatedInfo::new` keeps its signature. Its nine other callers — four in the rust core plugin, one in `upgrade.rs`, and the existing unit tests — build an info for a version they already hold; only `resolve` knows a version was actually reported as outdated.

## Judgement calls

**JSON only** (`#[tabled(skip)]`). A release URL is long enough to wreck the table, and the table is the thing people read at a glance.

**Omitted, not null** (`skip_serializing_if = "Option::is_none"`). Most backends publish no release page — asdf and vfox plugins, cargo, npm, and so on — and every one of those entries growing a `"release_url": null` would be noise. A consumer can ask whether the key is there instead of whether its value happens to be null.

## Tests

Unit, in `src/toolset/outdated_info.rs`:

- `a_missing_release_url_leaves_the_key_out_of_the_json` — the key is absent, not null
- `a_release_url_is_reported_in_the_json`
- `a_release_url_stays_out_of_the_table` — notices if `#[tabled(skip)]` is ever dropped

e2e:

- `e2e/cli/test_outdated` — `dummy` has no release URL, so `has("release_url")` is `false`. `has` rather than a `//` default, which cannot tell an absent key from a null one, and absent is the thing being asserted. No network.
- `e2e/cli/test_outdated_slow` — `github:cli/cli` pinned to `2.75.0`, asserting the URL comes back **and points at `.latest`**, not merely at some cli/cli release page. The github backend builds the URL itself rather than reading it from a remote listing, so this checks the whole path: a real listing, the resolved latest, and the URL that comes with it. Worth pinning because the lookup matches on the version string — if `latest` and the listing disagree on its form, `release_url` would quietly be absent and nothing else would notice. The tag is compared whole rather than by suffix — suffix matching accepts `v12.75.0` for a reported `2.75.0`, which is exactly the wrong-release case the assertion exists to catch — while still tolerating the leading `v` the backend strips from `version` but keeps in the URL. Checked against five inputs before committing, including a matching `v` tag, a bare tag, a wrong release, the `v12.75.0` near-miss, and an absent URL.

## Also changed

`src/backend/github.rs` gains `web_url_base` and fills `release_url` in `latest_stable_version_info`. That is strictly a fix to the backend — the shortcut previously answered about the newest release while knowing less about it than the slower path did — and every consumer of `VersionInfo` gets it, not just `outdated`.

## Verification

Per the repo's local constraints I ran `cargo fmt`, `shellcheck` and `shfmt` locally and left compilation and the suite to CI. The CLI help text is untouched, so no `mise run render` output changes. Every claim above was checked against the committed diff before opening this PR.

Fixes #9708

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `outdated --json` output by omitting `release_url` when no release page is available, instead of returning a null value.
  - Added release links for supported GitHub tools, including direct URLs to relevant version tags.
  - Kept release URLs limited to JSON output without affecting the standard table display.
  - Added fallback handling to provide release links when version details are available through alternate release information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

