### PR TITLE
fix(github): retry stale cached attestations

### DIFF
--- a/src/github/sigstore.rs
+++ b/src/github/sigstore.rs
@@ -36,6 +36,22 @@ pub(crate) use mise_sigstore::{AttestationError, SlsaArtifact};
 /// Result alias that matches `mise_sigstore`'s internal convention.
 type AttestationResult<T> = std::result::Result<T, AttestationError>;
 
+#[derive(Debug)]
+enum CachedAttestationVerification {
+    Verified,
+    Retry(Option<AttestationError>),
+}
+
+fn classify_cached_attestation_verification(
+    result: AttestationResult<bool>,
+) -> CachedAttestationVerification {
+    match result {
+        Ok(true) => CachedAttestationVerification::Verified,
+        Ok(false) => CachedAttestationVerification::Retry(None),
+        Err(err) => CachedAttestationVerification::Retry(Some(err)),
+    }
+}
+
 /// Resolve a GitHub token for an optional API base URL, defaulting to [`crate::github::API_URL`].
 fn resolve_token_for_wrapper(api_url: Option<&str>) -> Option<String> {
     let url = api_url.unwrap_or(crate::github::API_URL);
@@ -136,18 +152,19 @@ pub(crate) async fn verify_attestation(
                     // GitHub may append attestations for a digest after mise-versions first
                     // caches it. Treat only a successful verification as authoritative so an
                     // incomplete cached set can still be refreshed from GitHub directly.
-                    match mise_sigstore::verify_github_attestation_with_attestations(
-                        artifact_path,
-                        &attestations,
-                        expected_workflow,
-                    )
-                    .await
-                    {
-                        Ok(true) => return Ok(true),
-                        Ok(false) => debug!(
+                    match classify_cached_attestation_verification(
+                        mise_sigstore::verify_github_attestation_with_attestations(
+                            artifact_path,
+                            &attestations,
+                            expected_workflow,
+                        )
+                        .await,
+                    ) {
+                        CachedAttestationVerification::Verified => return Ok(true),
+                        CachedAttestationVerification::Retry(None) => debug!(
                             "mise-versions GitHub attestations did not verify for {owner}/{repo}; falling back to GitHub API"
                         ),
-                        Err(err) => debug!(
+                        CachedAttestationVerification::Retry(Some(err)) => debug!(
                             "mise-versions GitHub attestations did not verify for {owner}/{repo}; falling back to GitHub API: {err}"
                         ),
                     }
@@ -577,6 +594,26 @@ mod tests {
         assert!(!is_api_failure(&AttestationError::Json(
             serde_json::from_str::<serde_json::Value>("{").unwrap_err()
         )));
+    }
+
+    #[test]
+    fn test_cached_attestation_verification_accepts_only_success() {
+        assert!(matches!(
+            classify_cached_attestation_verification(Ok(true)),
+            CachedAttestationVerification::Verified
+        ));
+        assert!(matches!(
+            classify_cached_attestation_verification(Ok(false)),
+            CachedAttestationVerification::Retry(None)
+        ));
+
+        let outcome = classify_cached_attestation_verification(Err(
+            AttestationError::WorkflowMismatch("stale cached signer".to_string()),
+        ));
+        assert!(matches!(
+            outcome,
+            CachedAttestationVerification::Retry(Some(AttestationError::WorkflowMismatch(_)))
+        ));
     }
 
     #[test]

--- a/src/github/sigstore.rs
+++ b/src/github/sigstore.rs
@@ -133,12 +133,24 @@ pub(crate) async fn verify_attestation(
                         "mise-versions returned GitHub attestations without inline bundles; falling back to GitHub API"
                     );
                 } else {
-                    return mise_sigstore::verify_github_attestation_with_attestations(
+                    // GitHub may append attestations for a digest after mise-versions first
+                    // caches it. Treat only a successful verification as authoritative so an
+                    // incomplete cached set can still be refreshed from GitHub directly.
+                    match mise_sigstore::verify_github_attestation_with_attestations(
                         artifact_path,
                         &attestations,
                         expected_workflow,
                     )
-                    .await;
+                    .await
+                    {
+                        Ok(true) => return Ok(true),
+                        Ok(false) => debug!(
+                            "mise-versions GitHub attestations did not verify for {owner}/{repo}; falling back to GitHub API"
+                        ),
+                        Err(err) => debug!(
+                            "mise-versions GitHub attestations did not verify for {owner}/{repo}; falling back to GitHub API: {err}"
+                        ),
+                    }
                 }
             }
             Ok(None) => {}


### PR DESCRIPTION
## Summary

- accept a mise-versions attestation response only when it verifies successfully
- retry the GitHub attestations API when the cached set is incomplete or does not satisfy the configured workflow identity
- preserve the existing fast path for valid cached attestations

Closes the failure reported in https://github.com/jdx/mise/discussions/12492. GitHub returned a later GoReleaser workflow attestation for the same digest, but mise-versions had already cached only the immutable-release attestation.

## Verification

- `mbx test --all-features github::sigstore::tests`
- `cargo test --all-features github::sigstore::tests`
- `mise run build`
- `cargo build --all-features`
- `mise run lint-fix`
- reproduced the original GoReleaser 2.18.0 failure, then verified the patched debug binary installs it successfully with `MISE_USE_VERSIONS_HOST=1`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub attestation verification behavior for the mise-versions fast path; incorrect fallback logic could affect install security, but the change narrows the success case and preserves direct GitHub verification on failure.
> 
> **Overview**
> Fixes installs failing when **mise-versions** serves an older attestation set for a digest while GitHub has since added another bundle (e.g. GoReleaser vs immutable-release).
> 
> When inline bundles come from the versions host, verification no longer treats any cached verify outcome as final. Only **`Ok(true)`** short-circuits success; **`Ok(false)`** or verification errors trigger a **fallback to the GitHub attestations API** (with debug logging), reusing the existing digest-aware path.
> 
> Adds **`classify_cached_attestation_verification`** and a unit test so only successful cached verification is accepted as authoritative.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac0dea86ae41a0f38fd9f5641de4aca3f6eb41e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attestation verification when cached inline bundles are incomplete or invalid.
  * Automatically falls back to fetching verification data from GitHub when cached verification fails or cannot be completed.
  * Prevents unsuccessful cached checks from being treated as final verification results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->