### PR TITLE
fix(generate): say when a --mise-bin path has no Windows launcher

### DIFF
--- a/docs/cli/generate/task-stubs.md
+++ b/docs/cli/generate/task-stubs.md
@@ -19,6 +19,10 @@ When a parent and nested task both exist, the parent stub is written to `<parent
 
   Use `--mise-bin=./bin/mise` to use a mise bin generated from `mise generate install-script`
 
+  On Windows a path is run as written, so that script needs its own launcher beside it:
+  generate it with `mise generate install-script --write ./bin/mise --windows`. The default
+  `mise` is a bare name and resolves off PATH, which needs nothing extra.
+
   **Default:** `mise`
 - **`--windows-launcher <WINDOWS_LAUNCHER>`** — What to write beside each stub for Windows to launch
 

--- a/e2e/generate/test_generate_task_stubs
+++ b/e2e/generate/test_generate_task_stubs
@@ -258,3 +258,37 @@ assert "mise generate task-stubs --dir default-bin --windows-launcher cmd"
 assert_succeed "test -f default-bin/deploy"
 assert_succeed "test -f default-bin/deploy.cmd"
 assert_fail "test -e default-bin/deploy.exe"
+
+# `--mise-bin` pointing at a path only works on Windows if something Windows can execute is beside
+# it. `mise generate install-script --write bin/mise` writes a `#!/usr/bin/env bash` script, and its
+# own `.cmd` is opt-in (`--windows`, deliberately: it is a second committed file). Pairing the two
+# as documented therefore leaves a `bin/<task>.cmd` that fails with `'"./bin/mise"' is not
+# recognized` — so say so here, where it can still be fixed.
+#
+# Asserted on this host, not only on Windows, for the same reason the launcher is written on every
+# host: whoever generates `bin/` on Linux is exactly the person who will not see the failure.
+mkdir -p warn-bin
+printf '#!/usr/bin/env bash\necho fake mise\n' >warn-bin/mise
+chmod +x warn-bin/mise
+assert_contains \
+  "mise generate task-stubs --dir warn-stubs --mise-bin ./warn-bin/mise 2>&1" \
+  "no Windows launcher beside it"
+# The advice has to name the command that fixes it, not just the symptom.
+assert_contains \
+  "mise generate task-stubs --dir warn-stubs --mise-bin ./warn-bin/mise 2>&1" \
+  "--windows"
+# It is a warning, not a failure: the stubs are still what the user asked for, and on a POSIX host
+# they work as they always did.
+assert "mise generate task-stubs --dir warn-stubs --mise-bin ./warn-bin/mise"
+# `deploy`, not `xxx`: `mise.toml` was overwritten above, so the task added at the top of this file
+# no longer exists here and an assertion naming it would hold whatever the command did.
+assert_succeed "test -f warn-stubs/deploy"
+
+# With the launcher beside it there is nothing to say. This is the control: without it the
+# assertions above would hold for a warning that fires unconditionally.
+printf '@echo off\r\n' >warn-bin/mise.cmd
+assert_fail "mise generate task-stubs --dir warn-stubs2 --mise-bin ./warn-bin/mise 2>&1 | grep -q 'no Windows launcher beside it'"
+
+# The default resolves off PATH, where PATHEXT finds an executable for a bare name, so it must stay
+# silent too -- otherwise the warning would fire on nearly every run of this command.
+assert_fail "mise generate task-stubs --dir warn-stubs3 2>&1 | grep -q 'no Windows launcher beside it'"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2839,6 +2839,10 @@ Directory to create task stubs inside of
 Path to a mise bin to use when running the task stub.
 
 Use `\-\-mise\-bin=./bin/mise` to use a mise bin generated from `mise generate install\-script`
+
+On Windows a path is run as written, so that script needs its own launcher beside it:
+generate it with `mise generate install\-script \-\-write ./bin/mise \-\-windows`. The default
+`mise` is a bare name and resolves off PATH, which needs nothing extra.
 .RS
 \fIDefault: \fRmise
 .RE

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1796,6 +1796,10 @@ When a parent and nested task both exist, the parent stub is written to `<parent
 Path to a mise bin to use when running the task stub.
 
 Use `--mise-bin=./bin/mise` to use a mise bin generated from `mise generate install-script`
+
+On Windows a path is run as written, so that script needs its own launcher beside it:
+generate it with `mise generate install-script --write ./bin/mise --windows`. The default
+`mise` is a bare name and resolves off PATH, which needs nothing extra.
 """#
             arg <MISE_BIN>
         }

--- a/src/cli/generate/task_stubs.rs
+++ b/src/cli/generate/task_stubs.rs
@@ -26,6 +26,10 @@ pub(super) struct TaskStubs {
     /// Path to a mise bin to use when running the task stub.
     ///
     /// Use `--mise-bin=./bin/mise` to use a mise bin generated from `mise generate install-script`
+    ///
+    /// On Windows a path is run as written, so that script needs its own launcher beside it:
+    /// generate it with `mise generate install-script --write ./bin/mise --windows`. The default
+    /// `mise` is a bare name and resolves off PATH, which needs nothing extra.
     #[usage(long, short, verbatim_doc_comment, default = "mise")]
     mise_bin: PathBuf,
 
@@ -92,6 +96,13 @@ impl TaskStubs {
                 StubMigration::Directory(path) => file::remove_all(path)?,
             }
         }
+        // Only when this run actually writes one. A task set that is empty, or whose names all
+        // already end in an executable extension, gets no launcher at all — and a warning about
+        // launchers that were not written would describe something that did not happen.
+        if stubs.iter().any(|s| launchers.path(&s.path).is_some()) {
+            warn_if_windows_cannot_run(&self.mise_bin);
+        }
+
         for stub in &stubs {
             if let Some(parent) = stub.path.parent() {
                 file::create_dir_all(parent)?;
@@ -124,9 +135,11 @@ impl TaskStubs {
 
     /// The Windows launcher body for `task`, mirroring what the stub itself runs.
     ///
-    /// `mise_bin` is embedded as given: with the default `mise` it resolves off PATH, and a
-    /// `--mise-bin` pointing at a `mise generate install-script` script will start working here as soon
-    /// as that script gains a Windows form of its own.
+    /// `mise_bin` is embedded as given. With the default `mise` it resolves off PATH, where
+    /// PATHEXT finds a `.cmd`, `.bat` or `.exe` for a bare name. A path is run as written, so a
+    /// `--mise-bin` pointing at a `mise generate install-script` script needs that script's own
+    /// Windows launcher beside it — `--windows`, which is opt-in because it is a second committed
+    /// file. [`warn_if_windows_cannot_run`] says so when it is missing.
     fn generate_launcher(&self, task: &Task) -> String {
         let mise_bin = super::cmd_quote(&self.mise_bin.to_string_lossy());
         // The task name goes through the same quoting: it is interpolated into the same cmd line,
@@ -161,6 +174,72 @@ exec {mise_bin} run {display_name} "$@"
         );
         Ok(script.trim().to_string())
     }
+}
+
+/// Say so when the launchers this run writes cannot run the mise they were told to use.
+///
+/// The launcher runs `--mise-bin` as written, so a path has to name something Windows can execute.
+/// `mise generate install-script --write ./bin/mise` writes a `#!/usr/bin/env bash` script, which
+/// Windows cannot execute at all; its own launcher is opt-in (`--windows`), deliberately, because
+/// it is a second committed file. Pairing the two commands the way the help suggests therefore
+/// produces a `bin/<task>.cmd` that fails with `'"./bin/mise"' is not recognized` — and nothing
+/// said so at the point where it could still be fixed.
+///
+/// Warned on every host, like the `.cmd` itself is written on every host: whoever generated `bin/`
+/// on Linux is exactly the person who will not see the failure.
+fn warn_if_windows_cannot_run(mise_bin: &Path) {
+    if windows_can_run(mise_bin) {
+        return;
+    }
+    warn!(
+        "{} is a path with no Windows launcher beside it, so the generated launchers cannot run it. \
+         Write one with `mise generate install-script --write {} --windows`, or drop --mise-bin to \
+         resolve mise off PATH.",
+        display_path(mise_bin),
+        mise_bin.display()
+    );
+}
+
+/// Whether Windows can execute `mise_bin` as the generated launcher spells it.
+///
+/// Answered by Windows' rules, not the generating host's: the value is interpreted by cmd, and the
+/// launcher is written on every platform for a contributor on another one.
+fn windows_can_run(mise_bin: &Path) -> bool {
+    // `\` as well as `/`, because cmd takes both as separators. `Path::components` on unix reads
+    // `.\bin\mise` as a single component and would call it a bare name — the exact case where the
+    // warning is needed, since cmd will run it as a path.
+    if !mise_bin.to_string_lossy().contains(['/', '\\']) {
+        return true;
+    }
+    if windows_runnable_extension(mise_bin) {
+        return true;
+    }
+    let (Some(parent), Some(name)) = (mise_bin.parent(), mise_bin.file_name()) else {
+        return true;
+    };
+    // Matched case-insensitively, as Windows matches: on a case-sensitive generating host a
+    // `mise.CMD` beside the script is a launcher Windows would find and a lowercase-only probe
+    // would not, which would warn about a gap that is not there.
+    let Ok(entries) = fs::read_dir(parent) else {
+        return false;
+    };
+    entries.filter_map(|e| e.ok()).any(|entry| {
+        let file_name = entry.file_name();
+        let sibling = Path::new(&file_name);
+        sibling
+            .file_stem()
+            .is_some_and(|stem| stem.eq_ignore_ascii_case(name))
+            && windows_runnable_extension(sibling)
+    })
+}
+
+/// Whether the name ends in an extension Windows runs from a path alone.
+fn windows_runnable_extension(path: &Path) -> bool {
+    path.extension().is_some_and(|ext| {
+        ["cmd", "bat", "exe"]
+            .iter()
+            .any(|known| ext.eq_ignore_ascii_case(known))
+    })
 }
 
 /// Which launcher form this run writes beside each stub, and what it can recognise as its own.
@@ -763,6 +842,75 @@ mod tests {
         let missing = dir.path().join("missing.cmd");
         remove_owned_launcher(&Some(missing), &launchers).unwrap();
         remove_owned_launcher(&None, &launchers).unwrap();
+    }
+
+    #[test]
+    fn a_bare_mise_bin_needs_nothing_beside_it() {
+        // The default. cmd resolves a bare name through PATH, where PATHEXT finds `mise.exe`, so
+        // warning about it would fire on nearly every run of this command and mean nothing.
+        for bin in ["mise", "mise.exe"] {
+            assert!(windows_can_run(Path::new(bin)), "{bin}");
+        }
+    }
+
+    #[test]
+    fn a_windows_spelled_path_is_a_path_on_every_host() {
+        // `Path::components` on unix reads this as one component, which would classify it as a
+        // bare name. cmd does not: it runs `.\bin\mise` as a path, and that is the case the
+        // warning exists for. Judged by Windows' rules because the launcher is written on every
+        // platform for someone on another one.
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!windows_can_run(&dir.path().join(".\\bin\\mise")));
+    }
+
+    #[test]
+    fn a_path_mise_bin_needs_something_windows_can_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("bin");
+        fs::create_dir_all(&bin).unwrap();
+
+        // What `mise generate install-script --write bin/mise` leaves without `--windows`: a
+        // shebang script, which cmd cannot execute at all.
+        let script = bin.join("mise");
+        fs::write(&script, "#!/usr/bin/env bash\n").unwrap();
+        assert!(!windows_can_run(&script));
+
+        // What `--windows` adds. Checked by name, not by content: that is the file cmd would find.
+        fs::write(bin.join("mise.cmd"), "@echo off\r\n").unwrap();
+        assert!(windows_can_run(&script));
+
+        // A path that already names something Windows runs needs no sibling at all.
+        for name in ["other.exe", "other.CMD", "other.bat"] {
+            assert!(windows_can_run(&bin.join(name)), "{name}");
+        }
+    }
+
+    #[test]
+    fn a_sibling_is_matched_the_way_windows_matches_it() {
+        // On a case-sensitive host `mise.CMD` is a different filename from `mise.cmd`; on Windows,
+        // where the launcher runs, it is the same one and cmd would find it. Warning here would be
+        // about a gap that is not there.
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("mise");
+        fs::write(&script, "#!/usr/bin/env bash\n").unwrap();
+        fs::write(dir.path().join("mise.CMD"), "@echo off\r\n").unwrap();
+        assert!(windows_can_run(&script));
+    }
+
+    #[test]
+    fn a_sibling_that_is_not_there_does_not_count() {
+        // The control for the two tests above: the sibling check has to be able to answer "no", or
+        // it would be satisfied by any path at all.
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("bin");
+        fs::create_dir_all(&bin).unwrap();
+        // A sibling that is not runnable is not a launcher either -- `mise.txt` beside `mise`
+        // must not count.
+        fs::write(bin.join("mise"), "#!/usr/bin/env bash\n").unwrap();
+        fs::write(bin.join("mise.txt"), "notes\n").unwrap();
+        assert!(!windows_can_run(&bin.join("mise")));
+        // And a directory that does not exist cannot hold one.
+        assert!(!windows_can_run(&dir.path().join("nested").join("mise")));
     }
 
     #[test]


### PR DESCRIPTION
## The gap

`mise generate task-stubs --mise-bin ./bin/mise` writes `bin/<task>.cmd` on every host — stubs are committed and the contributor who runs one on Windows is not the person who generated it. The launcher runs `--mise-bin` **as written**, so a path has to name something Windows can execute.

`mise generate install-script --write ./bin/mise` writes a `#!/usr/bin/env bash` script, which Windows cannot execute at all. Its own launcher is opt-in behind `--windows` (#11919), and **that decision is deliberate and unchanged here**: the flag's own comment says why — *"most projects never need it, and it is a second committed file."*

The consequence is that pairing the two commands the way the CLI help suggests leaves a launcher that cannot work, with nothing said at the point where it could still be fixed:

```console
$ mise generate install-script --write bin/mise
Wrote to bin\mise
$ mise generate task-stubs --mise-bin=./bin/mise
Wrote to bin\hello
Wrote to bin\hello.cmd

PS> .\bin\hello.cmd
'"./bin/mise"' is not recognized as an internal or external command,
operable program or batch file.
```

**The control is one flag.** Same steps, `--windows` added to the first command:

```console
$ mise generate install-script --write bin/mise --windows
Wrote to bin\mise
Wrote to bin\mise.cmd

PS> .\bin\hello.cmd
[hello] $ echo hi-from-task
hi-from-task     (exit 0)
```

So nothing about the stub, the launcher body or the quoting is wrong — only the file `--mise-bin` points at.

## What this changes

mise knows both halves at generation time: that it is writing a Windows launcher, and what `--mise-bin` points at. It now says so, once per run, and names the command that fixes it:

```
mise WARN  ./bin/mise is a path with no Windows launcher beside it, so the generated .cmd
files cannot run it. Write one with `mise generate install-script --write ./bin/mise --windows`,
or drop --mise-bin to resolve mise off PATH.
```

Silent for the default `mise`, which is a bare name and resolves off `PATH`, where PATHEXT finds an executable — otherwise this would fire on nearly every run of the command. Silent when the path already names a `.cmd`, `.bat` or `.exe`, and when one of those sits beside it.

Warned on every host, like the launcher itself is written on every host: whoever generates `bin/` on Linux is exactly the person who will not see the failure.

Two smaller things fall out:

- **`--mise-bin`'s help** now mentions what Windows needs. `docs/tips-and-tricks.md` already told Windows users to add `--windows`; the CLI help did not, and neither did the run that created the gap.
- **A stale doc comment.** `generate_launcher` said a `--mise-bin` pointing at an install-script "will start working here as soon as that script gains a Windows form of its own". It gained one in #11919; the comment predicted a future that has arrived.

## What this deliberately does not change

Making `install-script` write the `.cmd` unconditionally would close the same gap and is **not** proposed. That default was decided in #11919 with a recorded reason, and nothing measured here contradicts it — a project that never sees a Windows contributor still should not carry a second committed file it does not use. This adds a sentence, not a file.

## Tests

**Unit** — the predicate, on every platform, since the launcher is written on every platform:

- a bare `mise` and a bare `mise.exe` need nothing beside them
- a path at a shebang script is not runnable; adding `mise.cmd` beside it makes it so; a path that already ends in `.exe` / `.CMD` / `.bat` needs no sibling (case-insensitive, as Windows is)
- **the control**: a path whose sibling is not there answers *no*, so the sibling check cannot be satisfied by any path at all

**e2e (bash)** — added to `e2e/generate/test_generate_task_stubs`, and deliberately not Windows-only:

- the warning fires for a path with no launcher beside it, and **names `--windows`** rather than only describing the symptom
- generation still **succeeds** — this is a warning, not a failure, and the stubs are what the user asked for
- **two controls**: with `mise.cmd` beside it the warning does not fire, and the default `--mise-bin` does not fire either. Without those, an unconditionally-firing warning would pass the assertions above

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a warning when `mise generate task-stubs --mise-bin` points to a path without a Windows launcher.
  - The warning recommends generating a launcher with `--windows`; generation still completes successfully.
  - Default `cmd` launcher generation succeeds without creating an unnecessary `.exe`.
  - Requests for unavailable launcher types now fail without creating stubs.
  - Warnings are suppressed when a valid launcher exists or `mise` is resolved through PATH.

- **Documentation**
  - Clarified Windows launcher requirements for custom `--mise-bin` paths and how to generate them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->