### PR TITLE
ci(docs): skip the docs gate on forks, as its own jobs already are

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,7 @@ jobs:
 
   docs:
     name: docs
-    if: ${{ always() && !cancelled() && needs.trusted.result != 'cancelled' && needs.untrusted.result != 'cancelled' }}
+    if: ${{ always() && !cancelled() && github.repository == 'jdx/mise' && needs.trusted.result != 'cancelled' && needs.untrusted.result != 'cancelled' }}
     permissions: {}
     needs: [trusted, untrusted]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## The problem

`docs-impl.yml`'s job carries `if: github.repository == 'jdx/mise'`, so on a fork it is skipped — and both the `trusted` and `untrusted` callers in `docs.yml` therefore come back `skipped`. The gate job then checks for *exactly one* of them having succeeded and the other skipped, sees neither, and exits 1:

```
trusted=skipped untrusted=skipped
##[error]Process completed with exit code 1.
```

So every fork that syncs `main` gets a red `docs` run for work the workflow had already decided not to do. On my fork that is five consecutive `push` / `main` runs, all failing this way — the guard is there, the gate just does not know about it.

## The change

One condition, the same one its own jobs use, so the workflow skips as a whole.

**Verified on a fork rather than reasoned about**, by dispatching `docs.yml` on a branch with and without the change:

| | run | `trusted` | `untrusted / docs` | `docs` (gate) |
| --- | --- | --- | --- | --- |
| fork `main`, today | **failure** | skipped | skipped | **failure** |
| this branch | **skipped** | skipped | skipped | skipped |

## Pull requests are unaffected

`github.repository` is the **base** repo for a `pull_request` event, so a PR opened from a fork still runs docs. Confirmed on recent PRs from this account, where the `docs` and `untrusted / docs` checks both passed on `jdx/mise`.

## Only this workflow has the mismatch

`test`, `registry` and `test-vfox` have no repository guard in their impl workflows, so their jobs do run on forks and their gates see a success. `docs` is the one that is guarded, and the only one whose gate was not told.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation workflow reliability by limiting documentation jobs to the primary repository.
  * Prevented unnecessary documentation workflow runs in forked repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->