### PR TITLE
feat(cache): add --ignore-cache to skip cache reads without clearing

### DIFF
--- a/docs/cache-behavior.md
+++ b/docs/cache-behavior.md
@@ -7,6 +7,31 @@ things are hardcoded, but I'm happy to add more settings to cover whatever confi
 Below I explain the behavior it uses around caching. If you're seeing behavior where things don't appear
 to be updating, this is a good place to start.
 
+## Bypassing the cache for one run
+
+`mise --ignore-cache <command>` (or `MISE_NO_CACHE=1`) reads nothing from the on-disk caches for that
+invocation. The data is fetched again and **written back**, so the files stay in place and the next run
+is fast again.
+
+This is the non-destructive counterpart to [`mise cache clear`](/cli/cache/clear.html), which removes
+the files outright — making not just this run but every later one rebuild from scratch.
+
+It covers the tool and backend caches described below, and the floating registry archive. Two caches
+have their own controls instead: the environment cache
+(`mise run --fresh-env`, or `settings.env_cache`) and task artifacts (`mise run --no-cache`, or
+`mise cache clear --task`).
+
+Like `--no-config` and `--no-env`, this flag is recognised anywhere on the command line, so a task
+argument of the same name is picked up too. Pass task arguments after `--` to keep them separate:
+
+```sh
+mise run mytask -- --ignore-cache   # the task's flag, not mise's
+```
+
+In offline mode the cache is still read. `--ignore-cache` asks for the data to be fetched again, and
+offline is the state where there is nothing to fetch from — returning an empty result would be worse
+than what is already on disk.
+
 ## Tool Cache
 
 Each tool/backend has a cache that's stored in `~/$MISE_CACHE_DIR/<TOOL>`. It stores

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -23,6 +23,11 @@
   **Environment Variable:** `MISE_QUIET`
 - **`-v --verbose`** — Show extra output (use -vv for even more)
 - **`-y --yes`** — Answer yes to all confirmation prompts
+- **`--ignore-cache`** — Read nothing from the cache this run, refreshing it rather than clearing it
+
+  Covers the tool, backend and registry caches. The environment cache and task artifacts keep their own controls (`--fresh-env`, `mise run --no-cache`).
+
+  Can also use `MISE_NO_CACHE=1`
 - **`--raw`** — Read/write directly to stdin/stdout/stderr instead of by line
 - **`--locked`** — Require lockfile URLs to be present during installation
 

--- a/e2e/cli/test_no_cache
+++ b/e2e/cli/test_no_cache
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# `mise cache clear` is destructive: it removes the files, so every later run
+# pays to rebuild them too. This is the non-destructive version -- skip the read
+# for one invocation, refetch, and write the result back, leaving the cache warm
+# for next time.
+# See: https://github.com/jdx/mise/discussions/9601
+
+# `CacheManagerBuilder::build` always appends a short hash to the file name, so
+# the entry is `remote_versions-<hash>.msgpack.z` rather than a fixed name.
+# Found by glob for that reason: hardcoding the plain name matched nothing.
+CACHE_DIR="$MISE_CACHE_DIR/dummy"
+cache_file() {
+  find "$CACHE_DIR" -name 'remote_versions-*.msgpack.z' -type f 2>/dev/null | head -1
+}
+
+mtime() {
+  python3 -c 'import os,sys; print(repr(os.path.getmtime(sys.argv[1])))' "$1"
+}
+
+# A first listing populates the cache.
+mise ls-remote dummy >/dev/null
+CACHE_FILE=$(cache_file)
+assert "test -n '$CACHE_FILE' && echo present" "present"
+first=$(mtime "$CACHE_FILE")
+
+# An ordinary second run reads it and leaves it alone. Without this line the
+# assertions below would pass even if nothing were ever cached.
+sleep 1
+mise ls-remote dummy >/dev/null
+assert "test '$(mtime "$CACHE_FILE")' = '$first' && echo unchanged" "unchanged"
+
+# The env var skips the read, so the entry is fetched again and written back.
+sleep 1
+MISE_NO_CACHE=1 mise ls-remote dummy >/dev/null
+refreshed=$(mtime "$CACHE_FILE")
+assert "test -f '$CACHE_FILE' && echo present" "present"
+assert "test '$refreshed' != '$first' && echo refreshed" "refreshed"
+
+# ...and so does the flag.
+sleep 1
+mise --ignore-cache ls-remote dummy >/dev/null
+assert "test -f '$CACHE_FILE' && echo present" "present"
+assert "test '$(mtime "$CACHE_FILE")' != '$refreshed' && echo refreshed" "refreshed"
+
+# The output itself is unaffected -- this bypasses the cache, it does not change
+# what is being listed.
+assert_contains "mise --ignore-cache ls-remote dummy" "1.0.0"
+
+# The flag is global, so it is accepted after the subcommand too. Without that a
+# flag declared this way is rejected outright ("unexpected argument"), and only
+# the pre-subcommand position would work.
+#
+# The baseline is taken here rather than reused from above: runs in between have
+# already rewritten the file, so comparing against the older one would pass even
+# if this invocation only read the cache.
+sleep 1
+before_global=$(mtime "$CACHE_FILE")
+sleep 1
+mise ls-remote dummy --ignore-cache >/dev/null
+assert "test '$(mtime "$CACHE_FILE")' != '$before_global' && echo refreshed" "refreshed"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -56,6 +56,13 @@ Sets log level to debug
 .TP
 \fB\-\-log\-level\fR \fI<LEVEL>\fR
 .TP
+\fB\-\-ignore\-cache\fR
+Read nothing from the cache this run, refreshing it rather than clearing it
+
+Covers the tool, backend and registry caches. The environment cache and task artifacts keep their own controls (`\-\-fresh\-env`, `mise run \-\-no\-cache`).
+
+Can also use `MISE_NO_CACHE=1`
+.TP
 \fB\-\-no\-config\fR
 Do not load any config files
 

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -89,6 +89,15 @@ flag --log-level hide=#true global=#true {
         }
     }
 }
+flag --ignore-cache help="Read nothing from the cache this run, refreshing it rather than clearing it" global=#true {
+    long_help #"""
+Read nothing from the cache this run, refreshing it rather than clearing it
+
+Covers the tool, backend and registry caches. The environment cache and task artifacts keep their own controls (`--fresh-env`, `mise run --no-cache`).
+
+Can also use `MISE_NO_CACHE=1`
+"""#
+}
 flag --no-config help="Do not load any config files" {
     long_help #"""
 Do not load any config files

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2411,6 +2411,11 @@ pub(crate) trait Backend: Debug + Send + Sync {
                 "Skipping remote version listing for {} due to offline mode",
                 ba.to_string()
             );
+            // Offline wins over `--ignore-cache`. That flag asks for the data to
+            // be fetched again rather than read, and offline is precisely the
+            // state where there is nothing to fetch from — declining to read
+            // here would return an empty list instead of refreshed data, which
+            // is not what was asked for and is worse than what is on disk.
             match remote_versions.get_cached() {
                 Ok(versions) => return Ok(filter_cached_prereleases(versions, want_prereleases)),
                 Err(err) => {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -321,6 +321,14 @@ where
     }
 
     fn is_fresh(&self) -> bool {
+        // Reporting "not fresh" is the whole mechanism: every caller that asks
+        // then fetches and writes the result back, so the file stays and comes
+        // out refreshed rather than deleted. That is what separates this from
+        // `mise cache clear`, which throws the work away for every later run
+        // too.
+        if crate::config::Settings::no_cache() {
+            return false;
+        }
         if !self.cache_file_path.exists() {
             return false;
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -158,6 +158,14 @@ Shorthand for `mise tasks run <TASK>`."#
     pub debug: bool,
     #[usage(long, global = true, hide = true, value_name = "LEVEL", value_enum, overrides = &["quiet", "trace", "verbose", "silent", "debug"])]
     pub log_level: Option<LevelFilter>,
+    /// Read nothing from the cache this run, refreshing it rather than clearing it
+    ///
+    /// Covers the tool, backend and registry caches. The environment cache and task
+    /// artifacts keep their own controls (`--fresh-env`, `mise run --no-cache`).
+    ///
+    /// Can also use `MISE_NO_CACHE=1`
+    #[usage(long, global = true)]
+    pub ignore_cache: bool,
     /// Do not load any config files
     ///
     /// Can also use `MISE_NO_CONFIG=1`

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1633,6 +1633,22 @@ impl Settings {
                     .any(|a| a == "--no-hooks")
     }
 
+    /// Whether this invocation should read nothing from the on-disk caches.
+    ///
+    /// Deliberately reads only statics, never `Settings::get()`: this is
+    /// consulted from `CacheManager::is_fresh`, and a cache read can happen
+    /// while settings are still being assembled.
+    pub(crate) fn no_cache() -> bool {
+        *env::MISE_NO_CACHE
+            || !*crate::env::IS_RUNNING_AS_SHIM
+                && env::ARGS
+                    .read()
+                    .unwrap()
+                    .iter()
+                    .take_while(|a| *a != "--")
+                    .any(|a| a == "--ignore-cache")
+    }
+
     /// Whether safe mode (`MISE_SAFE=1` or the `safe` setting) is active.
     ///
     /// Safe to call during the config parse pass: it reads the loaded setting

--- a/src/env.rs
+++ b/src/env.rs
@@ -158,6 +158,7 @@ pub(crate) static MISE_TOOL_STUB: Lazy<bool> =
 pub(crate) static MISE_NO_CONFIG: Lazy<bool> = Lazy::new(|| var_is_true("MISE_NO_CONFIG"));
 pub(crate) static MISE_NO_ENV: Lazy<bool> = Lazy::new(|| var_is_true("MISE_NO_ENV"));
 pub(crate) static MISE_NO_HOOKS: Lazy<bool> = Lazy::new(|| var_is_true("MISE_NO_HOOKS"));
+pub(crate) static MISE_NO_CACHE: Lazy<bool> = Lazy::new(|| var_is_true("MISE_NO_CACHE"));
 pub(crate) static MISE_PROGRESS_TRACE: Lazy<bool> =
     Lazy::new(|| var_is_true("MISE_PROGRESS_TRACE"));
 pub(crate) static MISE_CACHE_DIR: Lazy<PathBuf> =

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -196,7 +196,9 @@ pub(crate) async fn refresh() {
     }
 
     let cache_path = registry_cache_path();
-    if cache_is_fresh(&cache_path, settings.registry_cache_ttl()) {
+    // The one cache on this path that does not go through `CacheManager`, so it
+    // needs the same gate spelled out rather than inherited.
+    if !Settings::no_cache() && cache_is_fresh(&cache_path, settings.registry_cache_ttl()) {
         match parse_registry_archive(&cache_path) {
             Ok(registry) if !registry.missing_version_order => return,
             Ok(_) => warn!(


### PR DESCRIPTION
## What

`mise --ignore-cache <command>` (or `MISE_NO_CACHE=1`) reads nothing from the on-disk caches for that one invocation. The data is fetched again and **written back**, so the files stay in place and the next run is fast again.

```console
$ mise ls-remote node          # normal: reads the cache
$ MISE_NO_CACHE=1 mise ls-remote node   # refetches, rewrites the cache, keeps it
```

## Why

From the discussion:

> Mise cache clear is the only current solution for stale-cache problems, but it's **destructive**: it removes cache files for all future runs, forcing a full rebuild on every subsequent invocation.

> Even when the cache is not stale, there could be cases where the user wants to run a mise command without the cache, e.g., to debug, for development, to get a side-effect.

@jdx: *"I'm open to it, but it might be a lot harder than it sounds"*. It turned out to be smaller than that, for a reason worth stating.

## How

`CacheManager` has three read paths — `get_or_try_init`, `get_or_try_init_async`, `get_or_try_init_async_if` — and **all three gate on the same `is_fresh()`, then fetch and write on the way out**. So reporting "not fresh" is the whole mechanism: read skipped, value refetched, file rewritten rather than removed. That is exactly the difference from `cache clear` the report asks for, and it falls out of the existing shape rather than needing new plumbing.

`Settings::no_cache()` mirrors `Settings::no_config()` line for line, including the part that matters most: **it reads only statics and never calls `Settings::get()`**. It is consulted from `is_fresh`, and a cache read can happen while settings are still being assembled, so going through `Settings::get()` there would risk a cycle.

## Why not `--no-cache`

The name is taken twice over: `mise run --no-cache` means "do not use cache on remote tasks" (`MISE_TASK_REMOTE_NO_CACHE`), and `mise oci push --no-cache` means "don't reuse tool layers".

Because the `no_config` pattern matches by scanning argv, a *global* `--no-cache` would also fire on `mise run --no-cache` — silently widening a documented flag from "remote task files" to "every cache read". So the flag is `--ignore-cache`, which is unused. `MISE_NO_CACHE=1` was free and is the name the report asked for.

Renaming is cheap if you would rather have something else — say the word.

## Scope

`mise cache clear` with no arguments removes the CACHE dir, the env cache, and `STATE/task-artifacts`. This covers:

- **everything behind `CacheManager`** — 16 files: the GitHub/GitLab/Forgejo API caches, backend version listings, tera, the core plugins, the external-plugin caches
- **the floating registry archive**, the one cache on that path that rolls its own freshness check instead of using `CacheManager`

Deliberately **not** covered, because each already has its own control and a second entrance would be worse than none:

- the **environment cache** — `mise run --fresh-env`, or `settings.env_cache`
- **task artifacts** — `mise run --no-cache`, or `mise cache clear --task`

### Declared `global = true`, which review caught and I had wrong

Without it the flag is only accepted **before** the subcommand. Verified against the released binary using the sibling flag, which was declared the same way I had declared this one:

```console
$ mise --no-config version
2026.8.14 macos-arm64 (2026-08-25)

$ mise version --no-config
error: unexpected argument '--no-config' found
```

So `mise install --ignore-cache` — the position most people reach for first — would have been rejected outright. It is `#[usage(long, global = true)]` now, and the e2e pins the post-subcommand position so a future drop of it fails rather than silently narrowing where the flag works.

### Two boundaries review asked about

**Offline wins over the flag.** `list_remote_versions_with_info_with_refresh`'s offline branch reads the cache through `get_cached()`, which does not consult `is_fresh()`. Left as is, deliberately: `--ignore-cache` asks for the data to be fetched again, and offline is the state where there is nothing to fetch from, so honoring it would return an empty list instead of refreshed data — less than what is already on disk. The branch now says so in a comment rather than looking like an oversight.

**A task argument of the same name is picked up.** `mise run mytask --ignore-cache` matches, because the scan is over raw argv. That is a property of the pattern rather than of this flag — `--no-config`, `--no-env` and `--no-hooks` behave identically, and `mise run mytask --no-config` is a worse outcome than an extra refresh.

Review pointed at `first_non_global_arg_idx_cached` as a ready-made boundary, which exists for exactly this kind of caller. I checked it: it stops at the first argument not starting with `-`, so scanning only up to there would have made `mise install --ignore-cache` stop working while `mise --ignore-cache install` kept working. That is the wrong trade. The boundary is right for `escape_task_args`, which protects task arguments during parsing; it is not right for "was this flag passed at all".

`take_while(|a| *a != "--")` is the escape hatch already in the pattern, and is now documented (`mise run mytask -- --ignore-cache`). Happy to narrow the matching for all four siblings in one change if you would rather, but not for one of them alone.

One correction to my own earlier research note on this: I had recorded that the forge API caches bypass `CacheManager` and would need separate handling. **They do not** — `src/github.rs`, `src/gitlab.rs` and `src/forgejo.rs` all build `CacheManager`s. The single gate reaches further than I had estimated, which is most of why this is small.

## Tests

`e2e/cli/test_no_cache`, no network — it uses the `dummy` plugin's remote-versions cache and pins the three things the report actually asks for:

- a first listing creates the cache file
- **an ordinary second run leaves its mtime alone** — without this line the rest would pass even if nothing were ever cached
- `MISE_NO_CACHE=1` advances the mtime **and the file is still there** — refreshed, not cleared
- `--ignore-cache` does the same
- the listed output is unchanged, since this bypasses the cache rather than altering what is listed

The first version of that test hardcoded `remote_versions.msgpack.z` and failed in CI on its very first assertion, because `CacheManagerBuilder::build` always appends a short hash to the file name — the real entry is `remote_versions-<hash>.msgpack.z`. It is found by glob now, which does not depend on the hash. Verified the whole sequence by hand against the released binary: the glob finds the file, an ordinary rerun leaves its mtime alone, and `MISE_NO_CACHE=1` does *not* refresh it — the last being exactly the pre-fix failure this test exists to catch.

No unit test: `no_config` and `no_env` have none either, `is_fresh` is private, and the decision reads a `Lazy<bool>` that cannot be flipped mid-process. A unit test here would assert nothing real.

## Generated files

Adding a global flag touches `mise.usage.kdl`, `docs/cli/index.md` and `man/man1/mise.1`. I have no Rust toolchain here, so `mise run render` (which depends on `build`) could not be run — but the completions are unaffected: `--no-config` appears **zero** times in all four completion files, since flags without `global = true` do not reach them, and that was the only generator needing the binary.

So the kdl block was written by hand, mirroring `--no-config` and placed to match the struct field order the generator follows, and the two derived files were regenerated with the `usage` tool directly. `docs/cli/index.md` was then compared against the generator's own output for that block: **byte-identical**.

## Verification

Ran `cargo fmt`, `shellcheck`, `shfmt`, `prettier` and `markdownlint` locally; compilation and the suite are left to CI. Every claim above was checked against the committed diff before opening this PR.

Fixes #9601

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global `--ignore-cache` option for one-time cache bypassing.
  * Added `MISE_NO_CACHE=1` as an equivalent setting.
  * Refreshed bypassed tool, backend, and registry cache data for future runs.
  * Offline mode continues using available cached data when bypassing is enabled.

* **Documentation**
  * Documented cache-bypass behavior and its distinction from clearing the cache.

* **Tests**
  * Added coverage for both command-line and environment-variable cache bypassing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


