### PR TITLE
fix(shims): deliver "file"-mode shim arguments intact

### DIFF
--- a/e2e-win/shim_args.Tests.ps1
+++ b/e2e-win/shim_args.Tests.ps1
@@ -1,0 +1,224 @@
+Describe 'file-mode shim argument delivery' {
+    # `windows_shim_mode = "file"` writes a `<tool>.cmd`, and cmd.exe parses the whole command line
+    # before a batch file's `%*` expands. Every shape that reaches a native shim intact used to
+    # arrive different through this one: `c&d` ran `d` as a second command, `a>b` redirected the
+    # shim's own output into a file called `b`, `e%OS%f` became `eWindows_NTf`. The `.cmd` now
+    # recovers the original text out of cmd's `CMDCMDLINE`, the same way a task-stub launcher does.
+    #
+    # Shims are invoked by bare name off PATH, so that is how they are invoked here: the recovery
+    # matches the shim's own full path against the raw line, and only a run that resolved the name
+    # to that path can be recovered.
+
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        $script:OriginalPath = $env:PATH
+        $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+        # The mode is switched through the environment, not `mise settings`: that writes to the
+        # global config, and unsetting it afterwards would clear a preference the developer set.
+        $script:OriginalShimMode = [Environment]::GetEnvironmentVariable('MISE_WINDOWS_SHIM_MODE', 'Process')
+
+        $script:TestRoot = Join-Path $TestDrive 'shim-args'
+        New-Item -ItemType Directory -Path $script:TestRoot -Force | Out-Null
+        Set-Location $script:TestRoot
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:TestRoot
+
+        $script:ShimDir = Join-Path $env:MISE_DATA_DIR 'shims'
+
+        # The fake tool. It prints one line per argument, and it has to survive its own arguments:
+        # `%~1` is substituted before cmd parses redirection, so `echo ARG:%~1` would redirect on
+        # `a>b`. Going through a variable and reading it back with delayed expansion puts the value
+        # past that parse.
+        $script:ToolRoot = Join-Path $script:TestRoot 'faketool'
+        New-Item -ItemType Directory -Path $script:ToolRoot -Force | Out-Null
+        $echoer = @'
+@echo off
+setlocal EnableDelayedExpansion
+:loop
+if "%~1"=="" goto :eof
+set "arg=%~1"
+echo ARG:!arg!
+shift
+goto loop
+'@
+        # `mise link` points a version name at a directory of the user's, so nothing is downloaded.
+        # Core node's Windows bin path is the install root; the `bin` copy is there in case that
+        # ever changes, and costs nothing.
+        $echoer | Out-File -FilePath (Join-Path $script:ToolRoot 'argecho.cmd') -Encoding ascii
+        New-Item -ItemType Directory -Path (Join-Path $script:ToolRoot 'bin') -Force | Out-Null
+        $echoer | Out-File -FilePath (Join-Path $script:ToolRoot 'bin\argecho.cmd') -Encoding ascii
+
+        # `--force` because `$TestDrive` is a new directory every run: a run that died before
+        # `AfterAll` leaves `e2e-shimargs` pointing somewhere else, and an unforced link would then
+        # fail for every later run rather than just this one.
+        mise link --force node@e2e-shimargs $script:ToolRoot | Out-Null
+        $script:LinkExit = $LASTEXITCODE
+        @'
+[tools]
+node = "e2e-shimargs"
+'@ | Out-File -FilePath (Join-Path $script:TestRoot 'mise.toml') -Encoding utf8NoBOM
+
+        # The shapes cmd destroys on the way into a batch file. `k|l` and a bare `"` are deliberately
+        # absent: cmd builds a pipe for the first and swallows the second before the shim runs, so
+        # its own command line no longer holds them and no `.cmd` can recover them. They are checked
+        # separately below.
+        $script:Shapes = @('plain', 'c&d', 'i^j', 'e%OS%f', 'a>b', 'a<b', '^caret')
+
+        # Compared as one string: an argument that vanished shifts everything after it, and reading
+        # that off a joined line is far easier than off two collections.
+        function script:ArgText($output) {
+            (@($output | ForEach-Object { "$_" } | Where-Object { $_ -like 'ARG:*' } |
+                        ForEach-Object { $_.Substring(4) }) -join ' :: ')
+        }
+
+        function script:SetMode([string]$mode) {
+            $env:MISE_WINDOWS_SHIM_MODE = $mode
+            mise reshim --force | Out-Null
+        }
+
+        function script:UseShims([string]$dir) {
+            $env:PATH = "$dir;$($script:OriginalPath)"
+        }
+
+        # What the tool receives when nothing between the caller and mise is a batch file:
+        # PowerShell hands `mise.exe` its argv directly. Every assertion below is against this.
+        $script:Reference = script:ArgText (mise x -- argecho @script:Shapes)
+        $script:Expected = ($script:Shapes -join ' :: ')
+    }
+
+    AfterAll {
+        if ($null -ne $script:OriginalShimMode) {
+            $env:MISE_WINDOWS_SHIM_MODE = $script:OriginalShimMode
+        } else {
+            # `Remove-Item`, not `SetEnvironmentVariable(.., $null, ..)`: PowerShell binds `$null`
+            # to that `[string]` parameter as an empty string, so the variable stays present and
+            # mise reads an empty mode for the rest of the run.
+            Remove-Item Env:\MISE_WINDOWS_SHIM_MODE -ErrorAction SilentlyContinue
+        }
+        mise uninstall node@e2e-shimargs | Out-Null
+        # Back to whatever mode this machine is configured for, so the shims left behind are the
+        # ones that were there before.
+        mise reshim --force | Out-Null
+        Set-Location $script:OriginalDir
+        $env:PATH = $script:OriginalPath
+        if ($null -ne $script:OriginalTrusted) {
+            $env:MISE_TRUSTED_CONFIG_PATHS = $script:OriginalTrusted
+        } else {
+            Remove-Item Env:\MISE_TRUSTED_CONFIG_PATHS -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'links the fake tool and reaches it without a shim' {
+        # If this fails every comparison below is against nothing, so it is checked on its own.
+        $script:LinkExit | Should -Be 0
+        $script:Reference | Should -Be $script:Expected
+    }
+
+    Context 'file mode' {
+        BeforeAll {
+            script:SetMode 'file'
+            $script:FileShim = Join-Path $script:ShimDir 'argecho.cmd'
+
+            # The old body, kept to show the shapes really did not arrive before this change. It is
+            # reached the same way -- bare name, first on PATH -- so the body is the only difference.
+            $script:OldDir = Join-Path $script:TestRoot 'oldshims'
+            New-Item -ItemType Directory -Path $script:OldDir -Force | Out-Null
+            @'
+@echo off
+setlocal
+set "shim_path=%~f0"
+if /I "%__MISE_SHIM_PATH%"=="%shim_path%" (
+  echo mise: recursive shim invocation detected for argecho: %shim_path% 1>&2
+  exit /b 1
+)
+set "__MISE_SHIM_PATH=%shim_path%"
+mise x -- argecho %*
+'@ | Out-File -FilePath (Join-Path $script:OldDir 'argecho.cmd') -Encoding ascii
+        }
+
+        It 'writes a .cmd shim, not a native one' {
+            Test-Path $script:FileShim | Should -BeTrue
+            Test-Path (Join-Path $script:ShimDir 'argecho.exe') | Should -BeFalse
+            # file mode also emits the extension-less shim for Git Bash/Cygwin.
+            Test-Path (Join-Path $script:ShimDir 'argecho') -PathType Leaf | Should -BeTrue
+        }
+
+        It 'recovers the caller arguments out of the raw command line' {
+            (Get-Content $script:FileShim -Raw) | Should -BeLike '*!CMDCMDLINE!*'
+        }
+
+        It 'delivers every argument through a PATH-resolved shim' {
+            script:UseShims $script:ShimDir
+            script:ArgText (& argecho @script:Shapes) | Should -Be $script:Reference
+        }
+
+        It 'the old body did not' {
+            # The control. Without it this file would pass just as well against the old shim.
+            script:UseShims $script:OldDir
+            script:ArgText (& argecho @script:Shapes 2>&1) | Should -Not -Be $script:Reference
+        }
+
+        It 'the old body expanded %VAR% out of an argument and the new one does not' {
+            # One shape on its own, because the aggregate above can only say "different". `e%OS%f`
+            # involves no redirection and no queued command, so what it shows is unambiguous.
+            script:UseShims $script:OldDir
+            script:ArgText (& argecho 'e%OS%f' 2>&1) | Should -Be 'eWindows_NTf'
+            script:UseShims $script:ShimDir
+            script:ArgText (& argecho 'e%OS%f') | Should -Be 'e%OS%f'
+        }
+
+        It 'reports the tool exit code rather than a command cmd queued' {
+            # `&` in an argument makes cmd queue a second command from the same line -- given `c&d`
+            # it intends to run `d` next, and that failure would be reported as the tool's status.
+            script:UseShims $script:ShimDir
+            $out = & argecho 'c&d' 2>&1 | Out-String
+            $LASTEXITCODE | Should -Be 0
+            $out | Should -Not -Match 'not recognized as an internal or external command'
+        }
+
+        It 'still refuses to invoke itself' {
+            script:UseShims $script:ShimDir
+            $previousShimPath = [Environment]::GetEnvironmentVariable('__MISE_SHIM_PATH', 'Process')
+            $env:__MISE_SHIM_PATH = (Resolve-Path $script:FileShim).Path
+            try {
+                $out = & argecho plain 2>&1 | Out-String
+                $LASTEXITCODE | Should -Be 1
+                $out | Should -Match 'recursive shim invocation detected for argecho'
+            } finally {
+                if ($null -ne $previousShimPath) {
+                    $env:__MISE_SHIM_PATH = $previousShimPath
+                } else {
+                    Remove-Item Env:\__MISE_SHIM_PATH -ErrorAction SilentlyContinue
+                }
+            }
+        }
+
+        It 'cannot carry a pipe, and neither could the old body' {
+            # Stated rather than hidden: cmd builds the pipe before the shim runs, so the shim's own
+            # command line no longer holds it. A native shim is handed argv and has no such problem.
+            script:UseShims $script:ShimDir
+            $new = script:ArgText (& argecho 'k|l' 2>&1)
+            script:UseShims $script:OldDir
+            $old = script:ArgText (& argecho 'k|l' 2>&1)
+            $new | Should -Not -Be 'k|l'
+            $old | Should -Not -Be 'k|l'
+        }
+    }
+
+    Context 'exe mode' {
+        BeforeAll {
+            script:SetMode 'exe'
+        }
+
+        It 'writes a native shim' {
+            Test-Path (Join-Path $script:ShimDir 'argecho.exe') | Should -BeTrue
+            Test-Path (Join-Path $script:ShimDir 'argecho.cmd') | Should -BeFalse
+        }
+
+        It 'delivers every argument, including the one no .cmd can carry' {
+            script:UseShims $script:ShimDir
+            script:ArgText (& argecho @script:Shapes) | Should -Be $script:Reference
+            # A native shim receives argv, so the shape the batch recovery gives up on arrives too.
+            script:ArgText (& argecho 'k|l') | Should -Be 'k|l'
+        }
+    }
+}

--- a/src/cli/generate/mod.rs
+++ b/src/cli/generate/mod.rs
@@ -269,6 +269,32 @@ mod windows_launcher_tests {
     }
 
     #[test]
+    fn the_shim_body_carries_the_same_recovery() {
+        // `shims::windows_file_shim_body` writes the same protocol for a "file"-mode shim, with a
+        // recursion guard of its own in front. The two are separate because that guard has to run
+        // first and because `is_generated_launcher` pins this body's line layout -- but a fix
+        // applied to one and not the other would be silent, so compare the part they share.
+        fn recovery(body: &str, label: &str, command: &str) -> Vec<String> {
+            body.lines()
+                .skip_while(|l| !l.contains("CMDCMDLINE"))
+                .map(|l| l.replace(label, "LABEL").replace(command, "COMMAND"))
+                .collect()
+        }
+        assert_eq!(
+            recovery(
+                &crate::shims::windows_file_shim_body("hello"),
+                "mise_shim_fallback",
+                "mise x -- hello",
+            ),
+            recovery(
+                &windows_launcher_body("mise run hello"),
+                "mise_launcher_fallback",
+                "mise run hello",
+            ),
+        );
+    }
+
+    #[test]
     fn the_command_line_index_matches_the_body() {
         // `is_generated_launcher` reads the command back out of the file by this index, so a line
         // added to the body above without moving it would silently stop recognising our own

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -453,7 +453,8 @@ pub(crate) fn find_mise_shim_bin(mise_bin: &Path) -> Option<PathBuf> {
 fn effective_shim_mode(mise_bin: &Path) -> String {
     let mode = Settings::get().windows_shim_mode.clone();
     if mode == "exe" && find_mise_shim_bin(mise_bin).is_none() {
-        warn!(
+        // Once, not once per shim: this runs for every desired shim and for every shim written.
+        warn_once!(
             "mise-shim.exe not found next to {} or on PATH, falling back to \"file\" shim mode",
             display_path(mise_bin)
         );
@@ -506,6 +507,68 @@ fn bash_shim_script(tool: &str) -> String {
         "#}
 }
 
+/// The `.cmd` body for a `"file"`-mode shim: run `mise x -- <tool>` with the caller's arguments.
+///
+/// `%*` alone does not carry them. cmd.exe parses the whole command line before a batch file runs,
+/// so calling one from PowerShell loses `& ^ | " < >` and expands `%VAR%` before `%*` ever expands.
+/// Measured through a shim, every shape that arrives intact in `"exe"` mode arrives different here:
+/// `c&d` runs `d` as a second command, `i^j` becomes `ij`, `a>b` writes a file called `b`, `e%OS%f`
+/// becomes `eWindows_NTf`. The other three modes are native executables and are handed argv
+/// directly, so this is the only mode that needs it.
+///
+/// The recovery is the one [`crate::cli::generate::windows_launcher_body`] documents in full: what
+/// cmd destroys on the way in it also keeps, in its `CMDCMDLINE` pseudo-variable, so the body
+/// copies that out — `!CMDCMDLINE!` rather than `%CMDCMDLINE%`, which is substituted before special
+/// characters are parsed and truncates at the first `&` — and passes it through the environment,
+/// where cmd gets no second chance to parse it. mise re-splits it with the rules a native program's
+/// runtime uses and substitutes the result for everything after [`env::LAUNCHER_ARGS_SENTINEL`].
+///
+/// The guard decides whether cmd was spawned *for* this shim. When it was not — an interactive
+/// prompt, a `call` from another batch file — the shell already split the arguments as it would for
+/// a native program, so `%*` is correct and the script must not `exit`, which would close the
+/// caller's shell. When it was, `exit` (rather than `exit /b`) also stops cmd running whatever it
+/// queued from the same line, which would otherwise be reported as the tool's exit code.
+///
+/// Kept separate from the launcher body rather than shared: this one runs its recursion guard
+/// first, and the launcher's line layout is pinned by `is_generated_launcher`, which has no
+/// business tracking shim changes. The names come from the same constants, and
+/// `the_shim_body_carries_the_same_recovery` fails if the shapes drift.
+///
+/// Compiled for tests on every platform, unlike the shim code around it, so the body itself is
+/// unit-tested everywhere; `pub(crate)` so that comparison can live beside the launcher.
+#[cfg(any(windows, test))]
+pub(crate) fn windows_file_shim_body(shim: &str) -> String {
+    let raw = env::LAUNCHER_RAW_CMDLINE_ENV;
+    let path = env::LAUNCHER_PATH_ENV;
+    let sentinel = env::LAUNCHER_ARGS_SENTINEL;
+    let shim_env = env::MISE_SHIM_PATH_ENV;
+    let run = format!("mise x -- {shim} {sentinel} %*");
+    [
+        "@echo off",
+        // `%~f0` is captured before delayed expansion is on, so a `!` in the path survives.
+        "setlocal DisableDelayedExpansion",
+        "set \"shim_path=%~f0\"",
+        &format!("if /I \"%{shim_env}%\"==\"%shim_path%\" ("),
+        &format!("  echo mise: recursive shim invocation detected for {shim}: %shim_path% 1>&2"),
+        "  exit /b 1",
+        ")",
+        &format!("set \"{shim_env}=%shim_path%\""),
+        "setlocal EnableDelayedExpansion",
+        &format!("set \"{path}=!shim_path!\""),
+        &format!("set \"{raw}=!CMDCMDLINE!\""),
+        &format!("if \"!{raw}!\"==\"!{raw}:%{path}%=!\" goto mise_shim_fallback"),
+        &run,
+        "exit !ERRORLEVEL!",
+        ":mise_shim_fallback",
+        // Cleared, or a value inherited from an outer launcher would be recovered as this one's.
+        &format!("set \"{raw}=\""),
+        &format!("set \"{path}=\""),
+        &run,
+    ]
+    .join("\r\n")
+        + "\r\n"
+}
+
 #[cfg(windows)]
 fn add_shim(mise_bin: &Path, symlink_path: &Path, shim: &str) -> Result<()> {
     match effective_shim_mode(mise_bin).as_ref() {
@@ -541,17 +604,7 @@ fn add_shim(mise_bin: &Path, symlink_path: &Path, shim: &str) -> Result<()> {
             )?;
             file::write(
                 symlink_path.with_extension("cmd"),
-                formatdoc! {r#"
-        @echo off
-        setlocal
-        set "shim_path=%~f0"
-        if /I "%__MISE_SHIM_PATH%"=="%shim_path%" (
-          echo mise: recursive shim invocation detected for {shim}: %shim_path% 1>&2
-          exit /b 1
-        )
-        set "__MISE_SHIM_PATH=%shim_path%"
-        mise x -- {shim} %*
-        "#},
+                windows_file_shim_body(shim),
             )
             .wrap_err_with(|| {
                 eyre!(
@@ -1074,6 +1127,71 @@ mod tests {
         // Matching is by tool name, so a bin like npm (provided by node) is not
         // recognized and the caller keeps its existing message.
         assert!(inactive_installed_tool_message(&ts, &["node".to_string()], "npm").is_none());
+    }
+
+    #[test]
+    fn windows_file_shim_body_recovers_the_arguments_cmd_destroys() {
+        let body = windows_file_shim_body("gh");
+        let lines: Vec<&str> = body.lines().collect();
+        let enable = lines
+            .iter()
+            .position(|l| l.contains("EnableDelayedExpansion"))
+            .unwrap();
+
+        // `%~f0` is captured before delayed expansion is on, or a `!` in the path would be eaten.
+        let capture = lines.iter().position(|l| l.contains("%~f0")).unwrap();
+        assert!(capture < enable, "{body}");
+
+        // `!CMDCMDLINE!`, not `%CMDCMDLINE%`: the percent form is substituted before special
+        // characters are parsed and truncates the line at the first `&`.
+        assert!(
+            body.contains(r#"set "__MISE_RAW_CMDLINE=!CMDCMDLINE!""#),
+            "{body}"
+        );
+        assert!(!body.contains("%CMDCMDLINE%"), "{body}");
+
+        // The recursion guard is unchanged, and still decides before anything else runs.
+        let guard = lines
+            .iter()
+            .position(|l| l.contains("%__MISE_SHIM_PATH%"))
+            .unwrap();
+        assert!(guard < enable, "{body}");
+        assert!(
+            body.contains("recursive shim invocation detected for gh"),
+            "{body}"
+        );
+        assert!(body.contains("exit /b 1"), "{body}");
+
+        // Both arms hand mise the same command; the sentinel marks where `%*` begins, so a run
+        // that cannot recover the raw line still gets what cmd managed to deliver.
+        let run = format!("mise x -- gh {} %*", env::LAUNCHER_ARGS_SENTINEL);
+        assert_eq!(lines.iter().filter(|l| **l == run).count(), 2, "{body}");
+
+        // The recovering arm exits rather than `exit /b`, so cmd does not go on to run whatever it
+        // queued from the same line -- given `gh c&d`, that is `d`.
+        assert!(body.contains("goto mise_shim_fallback"), "{body}");
+        assert!(body.contains("exit !ERRORLEVEL!"), "{body}");
+    }
+
+    #[test]
+    fn windows_file_shim_body_clears_the_launcher_variables_when_it_declines() {
+        let body = windows_file_shim_body("gh");
+        let after: Vec<&str> = body
+            .lines()
+            .skip_while(|l| *l != ":mise_shim_fallback")
+            .collect();
+        assert!(!after.is_empty(), "{body}");
+        // Or a value inherited from an outer launcher would be recovered as this shim's arguments.
+        assert!(after.contains(&r#"set "__MISE_RAW_CMDLINE=""#), "{body}");
+        assert!(after.contains(&r#"set "__MISE_LAUNCHER=""#), "{body}");
+    }
+
+    #[test]
+    fn windows_file_shim_body_is_crlf_terminated() {
+        // A label reached by `goto` is the classic thing a lone `\n` breaks in a batch file.
+        let body = windows_file_shim_body("gh");
+        assert!(body.ends_with("\r\n"));
+        assert_eq!(body.matches('\n').count(), body.matches("\r\n").count());
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
## The problem

`windows_shim_mode = "file"` writes a `<tool>.cmd`, and cmd.exe parses the whole command line
before a batch file's `%*` expands. Calling one from PowerShell — which hands the argument to
`cmd /c` unquoted, having no reason to know the target is a batch file — loses `& ^ | " < >` and
expands `%VAR%` before `%*` ever runs.

The other three modes write native executables and are handed argv directly, so this is the only
mode affected. Measured with the same arguments through each mode:

| mode | writes | of 6 shapes, wrong |
| --- | --- | --- |
| `exe` (default) / `hardlink` / `symlink` | `<tool>.exe` | **0** |
| `file` | `<tool>` and `<tool>.cmd` | **6** |

Per shape, in `file` mode:

| argument | what the tool received |
| --- | --- |
| `c&d` | `c`, then cmd ran `d` — `'d' is not recognized`, exit 255 |
| `i^j` | `ij` |
| `e%OS%f` | `eWindows_NTf` |
| `a>b` | nothing; the shim's own output went into a file called `b` |
| `a<b` | `a` |
| `^caret` | `caret` |

**The mode is reachable without asking for it.** `effective_shim_mode` falls back to `"file"` when
`mise-shim.exe` is not next to the binary or on PATH, so a default-settings install that lost its
`mise-shim.exe` lands here silently.

## The fix

The recovery #12463 built for task-stub launchers, applied to the shim body and reusing its
constants: copy cmd's own `CMDCMDLINE` — with `!` expansion, because `%CMDCMDLINE%` is substituted
before special characters are parsed and truncates at the first `&` — pass it through the
environment rather than back onto a command line, and let mise re-split it with the rules a native
program's runtime uses.

- The existing recursion guard is **unchanged and still runs first**, before delayed expansion is
  enabled and before anything else.
- A run whose raw line cannot be shown to be this shim's — an interactive `cmd` prompt, a `call`
  from another batch file — clears both variables and falls back to `%*`, exactly as before. No
  behaviour changes there.
- The recovering arm `exit`s rather than `exit /b`, so cmd does not go on to run what it queued from
  the same line and report that failure as the tool's exit code.
- The extension-less bash shim for Git Bash/Cygwin passes `"$@"` and was never affected; it is
  unchanged.
- Existing shims are rewritten on the next mise upgrade: `shim_version_stale` already covers
  `"file"` through the `.version` marker.

### What it still cannot do

`k|l` and a bare `"` cannot be recovered — cmd builds the pipe and consumes the quote before the
shim runs, so the shim's own command line no longer holds them. A native shim has neither problem,
which is why `exe` is the default. The e2e states this rather than leaving it implied.

### Also in here

`warn!` → `warn_once!` on the fallback warning in the same function. `effective_shim_mode` runs for
every desired shim and again for every shim written, so three tools produced eight copies of that
one warning.

## Tests

**Unit** (`src/shims.rs`, compiled for tests on every platform): the body captures `%~f0` before
delayed expansion is enabled, uses `!CMDCMDLINE!` and never `%CMDCMDLINE%`, keeps the recursion
guard ahead of the recovery, hands mise the same command on both arms, and clears both variables on
the fallback path. Plus a CRLF check — a `goto` label is the classic thing a lone `\n` breaks.

**Drift** (`src/cli/generate/mod.rs`): the shim body and the launcher body carry the same protocol,
compared line for line with only the label and the command normalised away. They are kept separate
because the shim needs its guard first and because `is_generated_launcher` pins the launcher's line
layout — but a fix applied to one and not the other would otherwise be silent.

**e2e-win** (`e2e-win/shim_args.Tests.ps1`), argument delivery per shim mode, which nothing checked
before:

- the tool is a `mise link`ed directory holding a batch file that prints one line per argument, so
  nothing is downloaded
- the shim is invoked **by bare name off PATH**, the way shims are actually used, not by path
- every assertion is against a reference taken from `mise x -- argecho <shapes>`, where PowerShell
  hands `mise.exe` its argv directly
- **a control**: the old body, reached the same way from its own directory, so the body is the only
  difference. It must *not* match the reference, and one shape (`e%OS%f`) is checked on its own so
  the difference is unambiguous rather than merely "different"
- `exe` mode is checked in the same file, including the shapes no `.cmd` can carry

Draft until the fork CI run on this branch reports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows file-based shims to preserve special characters and environment-variable text in command-line arguments.
  * Ensured shims report the correct tool exit code.
  * Reduced repeated fallback warnings.
  * Maintained protections against recursive shim invocation.
  * Preserved native executable shim support for complex arguments.
  * Improved reliability when generating and running Windows command shims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->