### PR TITLE
fix(copr): restore parallel Rust codegen

### DIFF
--- a/packaging/copr/build-copr.sh
+++ b/packaging/copr/build-copr.sh
@@ -186,6 +186,11 @@ echo "=== Creating RPM Spec File ==="
 cat >"SPECS/${PACKAGE_NAME}.spec" <<'EOF'
 %global debug_package %{nil}
 %global _missing_build_ids_terminate_build 0
+# Fedora's Rust RPM macros default to one codegen unit and full debuginfo.
+# Keep release optimizations while restoring Cargo's parallel release defaults;
+# debuginfo is unused because this package does not produce a debug package.
+%global rustflags_codegen_units 16
+%global rustflags_debuginfo 0
 
 Name:           __PACKAGE_NAME__
 Version:        __VERSION__

--- a/packaging/copr/build-copr.sh
+++ b/packaging/copr/build-copr.sh
@@ -186,8 +186,9 @@ echo "=== Creating RPM Spec File ==="
 cat >"SPECS/${PACKAGE_NAME}.spec" <<'EOF'
 %global debug_package %{nil}
 %global _missing_build_ids_terminate_build 0
-# Fedora's Rust RPM macros default to one codegen unit and full debuginfo.
-# Keep release optimizations while restoring Cargo's parallel release defaults;
+# Fedora's automatic %%set_build_flags expands these Rust RPM macros into
+# RUSTFLAGS before %%build, even though the spec invokes Cargo directly. Keep
+# release optimizations while restoring Cargo's parallel release defaults;
 # debuginfo is unused because this package does not produce a debug package.
 %global rustflags_codegen_units 16
 %global rustflags_debuginfo 0


### PR DESCRIPTION
## Summary
- keep Fedora's release optimization level and hardening flags
- restore Cargo's 16 parallel codegen units for COPR builds
- disable full Rust debuginfo because the RPM intentionally produces no debug package

## Rationale
Fedora's RPM macros override Cargo's release defaults with one codegen unit and full debuginfo. Recent Fedora COPR builds take up to 44 hours, while equivalent EPEL builds without those overrides finish in roughly 25 minutes.

This uses Fedora's supported RPM macro knobs instead of unsetting RUSTFLAGS, so opt-level 3, frame pointers, package notes, and warning flags remain enabled.

## Testing
- bash syntax check
- scoped hk shellcheck and shfmt checks
- COPR dry-run generated the expected spec; the local run then stopped at rpmbuild because that executable is unavailable in this environment

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change to generated RPM spec macros; no runtime or application logic is affected.
> 
> **Overview**
> Fedora COPR RPM specs generated by `build-copr.sh` now set **`rustflags_codegen_units` to 16** and **`rustflags_debuginfo` to 0** in the embedded spec template, with comments explaining that Fedora’s `%%set_build_flags` still injects these into `RUSTFLAGS` even when the spec calls Cargo directly.
> 
> That restores Cargo’s parallel release codegen defaults and skips full debuginfo work, while leaving Fedora’s other release/hardening `RUSTFLAGS` in place—addressing very long COPR compile times caused by single codegen unit plus full debuginfo overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f4a70a173298c13221935a56b0e78c4fac6872b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build Improvements**
  * Clarified packaging build documentation for Fedora RPM builds.
  * Existing parallel compilation and reduced debuginfo settings remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->