### PR TITLE
fix(config): resolve a bare tool_alias value through the registry

### DIFF
--- a/e2e/config/test_tool_alias_registry_short
+++ b/e2e/config/test_tool_alias_registry_short
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# A `[tool_alias]` value with no backend prefix names a *tool*, so it should
+# resolve through the registry. Left alone it reaches the plugin path instead,
+# which builds an asdf repo URL out of the name -- so the alias either silently
+# installs a different tool through a backend this repo no longer accepts new
+# plugins for (`myjq = "jq"` fetched mise-plugins/asdf-jq), or fails outright
+# when no such plugin exists (`llama = "llama.cpp"`).
+# See: https://github.com/jdx/mise/discussions/9316
+
+cat >mise.toml <<'EOF'
+[tool_alias]
+myjq = "jq"
+llama = "llama.cpp"
+notatool = "definitely-not-in-the-registry"
+mynode = "nodejs"
+mytool = "aqua:jqlang/jq"
+EOF
+
+# `mise tool` resolves the backend without listing versions, so this needs no
+# network and cannot be satisfied by a cached listing. The backend it prints is
+# the whole point: before the fix `myjq` reported a bare `jq`, which is a tool
+# name rather than a backend, and `llama` failed to resolve at all.
+assert_contains "mise tool myjq" "aqua:jqlang/jq"
+assert_contains "mise tool llama" "github:ggml-org/llama.cpp"
+
+# Resolving the backend is only half of it. Options, version order and OS
+# support all key on a registry short, and `llama` is not one -- so without
+# carrying the resolved key into those lookups the alias would install the right
+# tool and then misread every version of it. `llama.cpp` exists in the registry
+# precisely because of its non-standard versioning, which is what this pins.
+assert_contains "mise tool llama" 'version_prefix=String("b")'
+
+# A legacy spelling still finds its canonical entry.
+assert_contains "mise tool mynode" "core:node"
+
+# A value the registry does not know keeps its current meaning, so anyone whose
+# alias names a plugin rather than a tool is unaffected. Matching the message
+# rather than just a nonzero exit: a bare `assert_fail` would stay green if this
+# started failing through some unrelated path.
+assert_fail_contains "mise tool notatool" "not found in mise tool registry"
+
+# An explicit backend is passed through untouched.
+assert_contains "mise tool mytool" "aqua:jqlang/jq"

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -341,7 +341,7 @@ impl BackendArg {
             }
         } else {
             // Check if the tool is in the registry but has no available backends
-            if let Some(rt) = REGISTRY.get(self.short.as_str())
+            if let Some(rt) = REGISTRY.get(self.registry_short().as_str())
                 && rt.backends().is_empty()
                 && !rt.backends.is_empty()
             {
@@ -423,6 +423,47 @@ impl BackendArg {
         BackendType::Unknown
     }
 
+    /// The registry short a bare `[tool_alias]` value points at, if there is one.
+    ///
+    /// A value with no backend prefix names a *tool*, not a backend:
+    /// `llama = "llama.cpp"` means "whatever the registry installs for
+    /// llama.cpp". Left unresolved it reaches the plugin path, which builds an
+    /// asdf repo URL out of the name — so the alias either resolves to a
+    /// different tool through a backend this repo no longer accepts new plugins
+    /// for, or fails outright when no such plugin exists.
+    ///
+    /// Everything the registry knows about that tool has to be read from the
+    /// same entry, not from the alias key: options, version order and OS
+    /// support all key on a registry short, and `llama` is not one. Resolving
+    /// the backend while losing `llama.cpp`'s `version_prefix` would install
+    /// the right tool and then misread every version of it.
+    ///
+    /// Options are stripped for the lookup only — they are read from the alias
+    /// entry separately by `get_backend_alias_opts`, so they survive either way.
+    /// Legacy spellings are normalised, so `mytool = "nodejs"` finds `node`.
+    fn aliased_registry_short(&self) -> Option<String> {
+        if self.resolution.explicit || self.has_env_backend_override() || !config::is_loaded() {
+            return None;
+        }
+        let full = Config::get_()
+            .all_aliases
+            .get(unalias_backend(&self.short))
+            .and_then(|a| a.backend.clone())?;
+        let name = split_bracketed_opts(&full).map_or(full.as_str(), |(name, _)| name);
+        if name.contains(':') {
+            return None;
+        }
+        let name = unalias_backend(name);
+        REGISTRY.contains_key(name).then(|| name.to_string())
+    }
+
+    /// The registry key this arg's metadata should be read from: the tool a
+    /// bare alias points at, or the short itself.
+    fn registry_short(&self) -> String {
+        self.aliased_registry_short()
+            .unwrap_or_else(|| self.short.to_string())
+    }
+
     pub(crate) fn full(&self) -> String {
         let short = unalias_backend(&self.short);
 
@@ -447,6 +488,13 @@ impl BackendArg {
                 .get(short)
                 .and_then(|a| a.backend.clone())
             {
+                if let Some(registry_full) = self
+                    .aliased_registry_short()
+                    .and_then(|name| REGISTRY.get(name.as_str()))
+                    .and_then(|rt| rt.backends().first().cloned())
+                {
+                    return registry_full.to_string();
+                }
                 return full;
             }
             if let Some(url) = Config::get_().repo_urls.get(short) {
@@ -544,7 +592,7 @@ impl BackendArg {
     pub(crate) fn registry_opts(&self) -> ToolVersionOptions {
         let full = self.full_without_opts();
         REGISTRY
-            .get(self.short.as_str())
+            .get(self.registry_short().as_str())
             .map(|rt| rt.backend_options(&full))
             .unwrap_or_default()
     }
@@ -552,7 +600,7 @@ impl BackendArg {
     pub(crate) fn registry_version_order(&self) -> Option<VersionOrder> {
         let full = self.full_without_opts();
         REGISTRY
-            .get(self.short.as_str())
+            .get(self.registry_short().as_str())
             .and_then(|tool| tool.version_order(&full))
     }
 
@@ -724,7 +772,7 @@ impl BackendArg {
         if self.uses_plugin() {
             return true;
         }
-        if let Some(rt) = REGISTRY.get(self.short.as_str()) {
+        if let Some(rt) = REGISTRY.get(self.registry_short().as_str()) {
             return rt.is_supported_os();
         }
         true


### PR DESCRIPTION
## What

A `[tool_alias]` value with no backend prefix now resolves through the registry.

```toml
[tool_alias]
llama = "llama.cpp"
```

## Why

From the discussion:

> I expected to add a tool alias like this ... with the intent of a simple name alias that resolves the backend through the registry. But it seems that this is unsupported.

The reporter had just added `llama.cpp` to the registry themselves and wanted a shorter name for it. No reply in four months.

## Measured

Released 2026.8.14, isolated `MISE_DATA_DIR` / `MISE_CACHE_DIR`:

| input | result |
| --- | --- |
| `mise ls-remote llama.cpp` (no alias) | **works** — the registry short resolves on its own |
| `llama = "llama.cpp"` → `mise ls-remote llama` | `llama not found in mise tool registry` |
| `myjq = "jq"` → `mise ls-remote myjq` | **clones `mise-plugins/asdf-jq`** into `plugins/myjq` and lists from it |

The second row is what was reported. **The third is worse, and I found it while checking the second**: the alias silently resolves to a different tool through a backend this repo no longer accepts new plugins for, and the cloned plugin then wins over the registry through `plugin_overrides_registry`.

## Cause

`BackendArg::full()` returned the alias value verbatim:

```rust
if let Some(full) = Config::get_().all_aliases.get(short).and_then(|a| a.backend.clone()) {
    return full;
}
```

A bare name is not a backend, so it fell through to the plugin path below, where `Config::get_repo_url` turns it into `mise-plugins/asdf-<name>`. With a matching asdf plugin that clones; without one, resolution fails on the alias *key*, which is where the "not found in mise tool registry" comes from.

`BackendType::guess` returns `Unknown` for a bare name, so nothing earlier catches it either.

## Fix

Look a bare value up in the registry first, and fall through unchanged when it is not there.

```rust
let name = split_bracketed_opts(&full).map_or(full.as_str(), |(name, _)| name);
if !name.contains(':')
    && let Some(registry_full) = REGISTRY.get(name).and_then(|rt| rt.backends().first().cloned())
{
    return registry_full.to_string();
}
return full;
```

**Resolving the backend is only half of it**, which review caught. `registry_opts`, `registry_version_order` and `is_os_supported` all key on `self.short` — still `llama`, which is not a registry short. So the alias would have installed the right tool and then read no registry metadata at all. That is not a corner case: `llama.cpp` is in the registry *because of* its versioning, and `registry/llama.cpp.toml` carries `version_prefix = "b"`. Losing it means misreading every version of the tool — arguably worse than the original failure, which at least failed loudly.

The resolution is now one helper, `aliased_registry_short()`, used by `full()` and by a `registry_short()` that those lookups key on. Legacy spellings are normalised through `unalias_backend`, so `mytool = "nodejs"` finds `node`.

- **`myjq = "jq"` changes behaviour, deliberately.** It now resolves to `aqua:jqlang/jq` and clones nothing.
- **An alias that really does name a plugin keeps working.** A registry miss falls through to exactly what happens today, so nobody relying on the plugin meaning is broken.
- **Options are stripped for the lookup only.** They are read from the alias entry separately by `get_backend_alias_opts`, so they survive either branch.

## Tests

`e2e/config/test_tool_alias_registry_short`, **no network**: `mise tool` resolves the backend without listing versions, so the assertion cannot be satisfied by a cached listing.

- `myjq` reports `aqua:jqlang/jq` — before the fix it reported a bare `jq`, which is a tool name rather than a backend
- `llama` reports `github:ggml-org/llama.cpp` — before the fix it failed to resolve at all
- `llama` reports `version_prefix=String("b")` — the registry metadata follows the resolved key
- `mynode = "nodejs"` reports `core:node` — legacy spellings normalise
- an unknown value still fails **with the same message** (regression guard for the plugin meaning; a bare `assert_fail` would stay green if it started failing through an unrelated path)
- an explicit `aqua:jqlang/jq` value is passed through untouched

Each assertion was run against the released binary first to confirm it fails, or holds, for the right reason. That check removed two mistakes from the first draft: I had asserted that an unknown value *prints* its value when it actually errors, and I had an assertion on `plugins/` being empty that **passed before the fix too**, because `mise tool` does not reach the clone. A test that passes either way proves nothing, so it is gone — the backend string is the precise evidence, and the clone is its downstream consequence.

## Verification

Ran `cargo fmt`, `shellcheck` and `shfmt` locally; compilation and the suite are left to CI per this repo's local constraints. Every claim above was checked against the committed diff before opening this PR.

Fixes #9316

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tool aliases using short, backend-free names now resolve through the tool registry to the correct full tool identifier.
  * Preserved explicit backend-prefixed aliases without modification.
  * Unknown tool aliases continue to report an error instead of being incorrectly resolved.

* **Tests**
  * Added end-to-end coverage for registry resolution, unknown aliases, and explicitly prefixed aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
