### PR TITLE
fix(env,tasks): stop discarding files Windows' own shell wrote as UTF-16

### DIFF
--- a/e2e-win/task_utf16.Tests.ps1
+++ b/e2e-win/task_utf16.Tests.ps1
@@ -1,0 +1,73 @@
+Describe 'a task file the Windows shell saved as UTF-16' {
+    # Windows PowerShell 5.1 -- the one that ships with Windows -- writes UTF-16LE from a bare `>`
+    # and from `Out-File`. `has_shebang` reads the first bytes, so the `#!` in such a file is
+    # invisible to it and the file is not a task. That much is deliberate: no interpreter mise
+    # dispatches to can run a UTF-16 script, so accepting one would trade silence for a confusing
+    # failure at exec time. What was wrong was the advice, which told the user to add the shebang
+    # that was already the first line of the file.
+
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+
+        $script:TestRoot = Join-Path $TestDrive 'utf16-task'
+        New-Item -ItemType Directory -Path (Join-Path $script:TestRoot 'mise-tasks') -Force | Out-Null
+        Set-Location $script:TestRoot
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:TestRoot
+        '' | Out-File -FilePath 'mise.toml' -Encoding utf8NoBOM
+
+        # Written by Windows PowerShell 5.1 itself rather than by placing the bytes here: the claim
+        # is that the shell shipped with the OS produces this, and a hand-built BOM would not test
+        # that claim. `powershell.exe` is the 5.1 host; the `pwsh` running Pester is 7.x, which
+        # defaults to UTF-8 and would not reproduce it.
+        $script:Utf16Task = Join-Path $script:TestRoot 'mise-tasks\utf16'
+        powershell.exe -NoProfile -Command "'#!/usr/bin/env bash' > '$script:Utf16Task'; 'echo UTF16_RAN' >> '$script:Utf16Task'"
+        $script:Utf16Wrote = $LASTEXITCODE
+
+        # Control 1: the same script, UTF-8. Only the encoding differs.
+        Set-Content -Path 'mise-tasks\utf8' -Value "#!/usr/bin/env bash`necho UTF8_RAN" -Encoding utf8NoBOM
+
+        # Control 2: UTF-8 with no shebang at all -- the case the old advice was written for.
+        Set-Content -Path 'mise-tasks\noshebang' -Value "echo NOPE" -Encoding utf8NoBOM
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        if ($null -ne $script:OriginalTrusted) {
+            $env:MISE_TRUSTED_CONFIG_PATHS = $script:OriginalTrusted
+        } else {
+            Remove-Item Env:\MISE_TRUSTED_CONFIG_PATHS -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'is really UTF-16LE, as Windows PowerShell 5.1 wrote it' {
+        # Checked on its own: if the fixture is not what it claims to be, every assertion below is
+        # about something else while still looking like a result.
+        $script:Utf16Wrote | Should -Be 0
+        $bytes = [System.IO.File]::ReadAllBytes($script:Utf16Task)
+        $bytes[0..1] | Should -Be @(0xFF, 0xFE)
+        # and the shebang really is the first thing in it
+        [System.IO.File]::ReadAllText($script:Utf16Task, [Text.Encoding]::Unicode) |
+            Should -BeLike '#!/usr/bin/env bash*'
+    }
+
+    It 'names the encoding instead of asking for a shebang that is already there' {
+        $out = mise run utf16 2>&1 | Out-String
+        $out | Should -Match 'UTF-16'
+        $out | Should -Not -Match 'Add a shebang line'
+    }
+
+    It 'runs the same script saved as UTF-8' {
+        # Control 1. Without it, "mise refuses this file" could be about anything in it.
+        $out = mise run utf8 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match 'UTF8_RAN'
+    }
+
+    It 'still asks for a shebang when there is genuinely no shebang' {
+        # Control 2. Without it an implementation that always blamed the encoding would pass.
+        $out = mise run noshebang 2>&1 | Out-String
+        $out | Should -Match 'Add a shebang line'
+        $out | Should -Not -Match 'UTF-16'
+    }
+}

--- a/e2e/env/test_env_file
+++ b/e2e/env/test_env_file
@@ -127,3 +127,19 @@ _.file = 'bom.json'
 TOML
 printf '\xef\xbb\xbf{"BOM_BAZ": "qux"}\n' >bom.json
 assert "mise env | grep '^export BOM_BAZ='" "export BOM_BAZ=qux"
+
+# The same shell one step further: Windows PowerShell 5.1's bare `>` and `Out-File` write UTF-16LE,
+# not UTF-8 with a mark. `read_to_string` is UTF-8 only, so this file used to be opened, decoded
+# unsuccessfully and dropped without a word -- the variable was simply absent. Not a Windows-only
+# path: a `.env` written there and committed was skipped by every platform reading it.
+cat <<TOML >mise.toml
+[env]
+_.file = 'utf16-env'
+TOML
+printf '\xff\xfeU\x00T\x00F\x001\x006\x00_\x00F\x00O\x00O\x00=\x00b\x00a\x00r\x00\n\x00' >utf16-env
+assert "mise env | grep '^export UTF16_FOO='" "export UTF16_FOO=bar"
+
+# The control: byte-for-byte the same text as UTF-8, same expectation. The claim is that the
+# encoding makes no difference, not that this one file happens to work.
+printf 'UTF16_FOO=bar\n' >utf16-env
+assert "mise env | grep '^export UTF16_FOO='" "export UTF16_FOO=bar"

--- a/src/config/env_directive/file.rs
+++ b/src/config/env_directive/file.rs
@@ -9,6 +9,7 @@ use eyre::{WrapErr, bail, eyre};
 use indexmap::IndexMap;
 use rops::file::format::{JsonFileFormat, TomlFileFormat, YamlFileFormat};
 use std::{
+    fs,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -221,13 +222,26 @@ impl EnvResults {
         // Read here rather than letting dotenvy open the file, so a byte-order mark can be taken
         // off before the parser sees it. A mark belongs to the first key's name as far as dotenvy
         // is concerned, and one bad line fails the whole file — so a `.env` saved by an editor
-        // that writes one is rejected entirely, naming a character nobody can see. An unreadable
-        // file still yields nothing rather than an error, which is what the previous
-        // `if let Ok(..)` did.
-        let Ok(content) = file::read_to_string(p) else {
+        // that writes one is rejected entirely, naming a character nobody can see.
+        //
+        // `decode_text` rather than `read_to_string`: the latter is UTF-8 only, and Windows
+        // PowerShell 5.1's `>` and `Out-File` write UTF-16LE by default, so a `.env` saved with
+        // the shell that ships with the OS used to be thrown away here without a word.
+        let Ok(bytes) = fs::read(p) else {
+            // Unchanged: a file that cannot be opened yields nothing rather than an error, which
+            // is what the original `if let Ok(..)` did. A glob can match a file that has since
+            // gone, and that is not worth a diagnostic.
             return Ok(EnvMap::new());
         };
-        let content = file::strip_utf8_bom(&content);
+        let content = match file::decode_text(&bytes) {
+            Ok(content) => content,
+            Err(err) => {
+                // Read and then discarded is a different thing from never opened, and it is the
+                // silence this exists to end: the user wrote a file mise looked at and dropped.
+                warn!("ignoring {}: {err:#}", display_path(p));
+                return Ok(EnvMap::new());
+            }
+        };
         if !expand {
             // Preserve dotenvy's normal behavior unless cross-file expansion was
             // explicitly requested.
@@ -528,5 +542,33 @@ mod tests {
         assert!(!is_env_key("1FOO"));
         assert!(!is_env_key("FOO-BAR"));
         assert!(!is_env_key(""));
+    }
+
+    #[tokio::test]
+    async fn dotenv_reads_a_file_whatever_it_is_encoded_in() {
+        // Windows PowerShell 5.1's `>` and `Out-File` write UTF-16LE by default, so the shell
+        // that ships with the OS produces the second of these. It used to yield nothing at all,
+        // with no diagnostic -- the variable was simply absent.
+        async fn read(dir: &Path, name: &str, bytes: &[u8]) -> EnvMap {
+            let path = dir.join(name);
+            std::fs::write(&path, bytes).unwrap();
+            EnvResults::dotenv(&path, &TeraEnvMap::new(), false)
+                .await
+                .unwrap()
+        }
+        let tmp = tempfile::tempdir().unwrap();
+
+        let utf8 = read(tmp.path(), "utf8.env", b"FROM_ENV=hello\n").await;
+        let utf16 = read(
+            tmp.path(),
+            "utf16.env",
+            b"\xff\xfeF\0R\0O\0M\0_\0E\0N\0V\0=\0h\0e\0l\0l\0o\0\n\0",
+        )
+        .await;
+
+        assert_eq!(utf8.get("FROM_ENV").map(String::as_str), Some("hello"));
+        // Stated as equality rather than two separate assertions: the claim is that the encoding
+        // makes no difference, not merely that each one happens to work.
+        assert_eq!(utf16, utf8);
     }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -677,6 +677,37 @@ pub(crate) fn decode_text(bytes: &[u8]) -> Result<String> {
     }
 }
 
+/// The UTF-16 encoding `path` announces with a byte-order mark, if it announces one.
+///
+/// The marks are the ones [`decode_text`] matches, kept here rather than spelled out again at the
+/// call site so there is one description of what a mark looks like.
+///
+/// A UTF-8 mark is deliberately not reported. `has_shebang` already looks past that one, so a
+/// file carrying it is executable and never reaches a caller that needs to explain why it is not.
+/// (Named without a link: that function is `#[cfg(windows)]` and this doc is built on unix too.)
+///
+/// Compiled for tests on every platform so the byte matching is checked everywhere, but only used
+/// on Windows: on unix the execute bit decides what is executable, and a UTF-16 script with that
+/// bit set fails at exec rather than being skipped.
+#[cfg(any(windows, test))]
+pub(crate) fn utf16_bom(path: &Path) -> Option<&'static str> {
+    // `read_to_end` on a `take`, not `read_exact`: a one-byte file is a legitimate answer of
+    // "no mark", and `read_exact` would fail on it. Same shape as `has_shebang` below.
+    let bytes = std::fs::File::open(path)
+        .and_then(|f| {
+            use std::io::Read;
+            let mut buf = Vec::with_capacity(2);
+            f.take(2).read_to_end(&mut buf)?;
+            Ok(buf)
+        })
+        .ok()?;
+    match bytes[..] {
+        [0xff, 0xfe] => Some("UTF-16LE"),
+        [0xfe, 0xff] => Some("UTF-16BE"),
+        _ => None,
+    }
+}
+
 /// [`read_to_string`], but tolerant of a byte-order mark. See [`decode_text`].
 ///
 /// Only reads *from disk* need this. Bodies fetched over HTTP already arrive decoded: reqwest's
@@ -1395,6 +1426,18 @@ pub(crate) fn make_executable_hint(path: &Path) -> String {
 
 #[cfg(windows)]
 pub(crate) fn make_executable_hint(path: &Path) -> String {
+    // A shebang the file already carries, in an encoding `has_shebang` reads as bytes and so
+    // cannot see. Windows PowerShell 5.1's `>` and `Out-File` write UTF-16LE by default, which
+    // makes this the shell that ships with the OS producing a file mise then tells the user to
+    // add a shebang to. Naming the encoding is the fix; telling them to add what is already
+    // there is not. Said whether or not a shebang is in there, because either way the encoding
+    // is what has to change first.
+    if let Some(encoding) = utf16_bom(path) {
+        return format!(
+            "{} is {encoding}. mise reads a shebang as bytes, so save it as UTF-8.",
+            display_path(path),
+        );
+    }
     format!(
         "Add a shebang line to {}, or give it one of these extensions: {}",
         display_path(path),
@@ -4577,6 +4620,63 @@ mod tests {
         // and it must offer what that branch actually accepts
         assert!(hint.contains("exe"), "{hint}");
         assert!(hint.contains("build"), "{hint}");
+    }
+
+    #[test]
+    fn utf16_bom_reports_only_the_marks_that_hide_a_shebang() {
+        let tmp = tempfile::tempdir().unwrap();
+        let write = |name: &str, bytes: &[u8]| {
+            let path = tmp.path().join(name);
+            fs::write(&path, bytes).unwrap();
+            path
+        };
+        const SCRIPT: &[u8] = b"#!/usr/bin/env bash\necho hi\n";
+
+        // What Windows PowerShell 5.1's `>` and `Out-File` write by default.
+        let mut le = vec![0xff, 0xfe];
+        le.extend(SCRIPT.iter().flat_map(|b| [*b, 0]));
+        assert_eq!(utf16_bom(&write("le", &le)), Some("UTF-16LE"));
+        let mut be = vec![0xfe, 0xff];
+        be.extend(SCRIPT.iter().flat_map(|b| [0, *b]));
+        assert_eq!(utf16_bom(&write("be", &be)), Some("UTF-16BE"));
+
+        // A UTF-8 mark is not reported: `has_shebang` reads past it, so such a file is executable
+        // and never reaches a caller that has to explain why it is not.
+        let mut utf8_bom = vec![0xef, 0xbb, 0xbf];
+        utf8_bom.extend_from_slice(SCRIPT);
+        assert_eq!(utf16_bom(&write("utf8_bom", &utf8_bom)), None);
+        assert_eq!(utf16_bom(&write("plain", SCRIPT)), None);
+
+        // Shorter than a mark, and absent entirely: answers, not panics.
+        assert_eq!(utf16_bom(&write("empty", b"")), None);
+        assert_eq!(utf16_bom(&write("one", b"#")), None);
+        assert_eq!(utf16_bom(&tmp.path().join("does-not-exist")), None);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn make_executable_hint_names_the_encoding_when_a_shebang_is_hidden_by_one() {
+        let tmp = tempfile::tempdir().unwrap();
+        let script = b"#!/usr/bin/env bash\necho hi\n";
+
+        let utf16 = tmp.path().join("build");
+        let mut bytes = vec![0xff, 0xfe];
+        bytes.extend(script.iter().flat_map(|b| [*b, 0]));
+        fs::write(&utf16, &bytes).unwrap();
+        let hint = make_executable_hint(&utf16);
+        // The shebang is the first thing in the file. Telling the user to add one sends them
+        // after something that is already there, so the encoding has to be what is named.
+        assert!(hint.contains("UTF-16LE"), "{hint}");
+        assert!(hint.contains("UTF-8"), "{hint}");
+        assert!(!hint.contains("Add a shebang line"), "{hint}");
+
+        // The control: without a mark the advice is unchanged. Without this, an implementation
+        // that always blamed the encoding would pass too.
+        let utf8 = tmp.path().join("plain");
+        fs::write(&utf8, b"echo hi\n").unwrap();
+        let hint = make_executable_hint(&utf8);
+        assert!(hint.contains("Add a shebang line"), "{hint}");
+        assert!(!hint.contains("UTF-16"), "{hint}");
     }
 
     #[test]

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -228,7 +228,9 @@ async fn make_task_executable(
     // the file at all -- so on Windows it carries the remedy instead of handing off to a prompt.
     let windows_has_no_prompt = cfg!(windows);
     let remedy = if windows_has_no_prompt {
-        format!(" {}", file::make_executable_hint(&path))
+        // The stop matters: without it the path and the remedy run together into one unreadable
+        // line -- `...\mise-tasks\build Add a shebang line to ...`.
+        format!(". {}", file::make_executable_hint(&path))
     } else {
         String::new()
     };


### PR DESCRIPTION
## The problem

Windows PowerShell 5.1 — the host that ships with Windows — writes UTF-16LE from a bare `>` and
from `Out-File`. Measured:

```
'#!/usr/bin/env bash' > redir      first8 = FF FE 23 00 21 00 2F 00
'#!/usr/bin/env bash' | Out-File   first8 = FF FE 23 00 21 00 2F 00
```

Two places then behave as if the user had written nothing. Both measured against a UTF-8 twin of
the same content, on `2026.8.14 windows-x64`:

**A `.env` reached through `_.file` is dropped in silence.**

```
mise env   (.env as UTF-16LE)  →  the variable is absent. No warning. exit 0.
mise env   (.env as UTF-8)     →  ${Env:FROM_ENV}='utf8'
```

**A task file is told to add the shebang it already has.**

```
mise WARN  no task build found, but a non-executable file exists at ...\mise-tasks\build
           Add a shebang line to ...\mise-tasks\build, or give it one of these extensions: ...
mise ERROR no task build found
```

The first line of that file is `#!/usr/bin/env bash`. The UTF-8 twin was a task.

**`mise.toml` already reports this properly**, which is what makes the other two look like
oversights rather than policy:

```
mise ERROR failed read_to_string: ...\mise.toml
mise ERROR stream did not contain valid UTF-8
```

## The fix — and why the two halves end differently

**The `.env` can simply be read.** `file::decode_text` already handles a UTF-8 BOM, UTF-16LE and
UTF-16BE, and its own documentation names this exact cause (#5399, the same `Out-File` default).
It was used only for aqua checksums. The dotenv path now reads bytes and decodes them.

That also separates two things the old code folded together:

```rust
// before
let Ok(content) = file::read_to_string(p) else { return Ok(EnvMap::new()); };
```

*Could not be opened* keeps yielding nothing, exactly as before — a glob can match a file that has
since gone. *Was opened, decoded unsuccessfully and thrown away* now warns. That is the silence
this is about: a file the user wrote and mise looked at.

**A task file cannot be read**, and should not be. `has_shebang` refusing a UTF-16 mark is a
deliberate decision already written down in its documentation — no interpreter mise dispatches to
can run a UTF-16 script, so accepting one would trade silence for a confusing failure at exec time.
That stands. Only the advice changes:

```
<path> is UTF-16LE. mise reads a shebang as bytes, so save it as UTF-8.
```

The detection is a small `file::utf16_bom`, kept beside `decode_text` so there is one description
of what a byte-order mark looks like rather than the bytes spelled out again at the call site. It
deliberately does **not** report a UTF-8 mark: `has_shebang` already reads past that one, so such a
file is executable and never reaches the hint.

**Also**: that warning ran its two sentences together with nothing between the path and the remedy
— `...\mise-tasks\build Add a shebang line to ...`. The other three callers of the hint already had
a stop or a newline; this one now does too.

## Behaviour changes

- A `.env` in UTF-16 is now **loaded** instead of ignored. This is not Windows-only: one written
  there and committed was skipped by every platform reading it.
- A `.env` whose bytes cannot be decoded at all now emits a warning where it used to emit nothing.
  A file that cannot be opened is unchanged.
- The Windows "not executable" hint says something different for a UTF-16 file. Every other file
  gets the same text as before.

## Tests

**Unit, all platforms** — `file::utf16_bom` reports UTF-16LE and UTF-16BE, and reports `None` for a
UTF-8 mark, for no mark, for an empty file, for a one-byte file and for a path that does not exist
(answers, not panics).

**Unit, Windows** — `make_executable_hint` on a UTF-16LE file names the encoding and does not say
"Add a shebang line". **With the control**: a file with no mark and no shebang still gets the old
text, so an implementation that always blamed the encoding would fail.

**Unit, all platforms** — `EnvResults::dotenv` on a UTF-16LE `.env` equals the result for the same
content as UTF-8. Stated as equality rather than two assertions: the claim is that the encoding
makes no difference.

**e2e** (`e2e/env/test_env_file`) — the dotenv half is platform-independent, so it is checked on the
bash side, beside the existing UTF-8-BOM case it is the sequel to. The bytes are written with
`printf` rather than through `iconv`, so the test brings no dependency.

**e2e-win** (`e2e-win/task_utf16.Tests.ps1`) — the fixture is written **by `powershell.exe` itself**
rather than by placing BOM bytes: the claim is that the shell shipped with the OS produces this, and
a hand-built mark would not test that claim. The `pwsh` running Pester is 7.x and defaults to UTF-8,
so it cannot reproduce it. One test checks the fixture really is UTF-16LE with the shebang first,
before anything is concluded from it, and two controls follow — the same script as UTF-8 runs, and a
UTF-8 file with genuinely no shebang still gets the old advice.

Draft until the fork CI run on this branch reports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for reading UTF-16LE `.env` files on Windows.
  - Improved guidance for UTF-16 task files by recommending conversion to UTF-8 when appropriate.
- **Bug Fixes**
  - Corrected Windows task error hints so shell commands are displayed clearly.
  - Preserved helpful shebang guidance for scripts that genuinely lack one.
- **Tests**
  - Added coverage for UTF-16 task files, environment files, byte-order detection, and equivalent UTF-8 behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->