### PR TITLE
fix(task): skip a task path that links back into itself

### DIFF
--- a/e2e-win/task_symlink_loop.Tests.ps1
+++ b/e2e-win/task_symlink_loop.Tests.ps1
@@ -1,0 +1,104 @@
+Describe 'a task directory that links back into itself' {
+    # Task discovery follows links, which is what lets a shared task directory be linked in, and
+    # also what makes a loop reachable. On Windows the link is a junction, made by `mklink /J`
+    # without any privilege -- the "current" junction beside a versioned directory is a common
+    # shape -- so this is easier to arrive at here than a symlink loop is on unix. One of them
+    # used to fail every task command, including a task defined in `mise.toml` with no task file
+    # behind it at all.
+
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+
+        function script:NewProject([string]$path) {
+            New-Item -ItemType Directory -Path (Join-Path $path 'mise-tasks') -Force | Out-Null
+            @'
+[tasks.from_config]
+run = "echo CONFIG_RAN"
+'@ | Out-File -FilePath (Join-Path $path 'mise.toml') -Encoding utf8NoBOM
+            "#!/usr/bin/env bash`necho FILE_RAN" |
+                Out-File -FilePath (Join-Path $path 'mise-tasks\healthy') -Encoding utf8NoBOM
+        }
+
+        $script:TestRoot = Join-Path $TestDrive 'symlink-loop'
+        New-Item -ItemType Directory -Path $script:TestRoot -Force | Out-Null
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:TestRoot
+
+        # The subject and its control differ in exactly one thing: the junction.
+        $script:Looped = Join-Path $script:TestRoot 'looped'
+        $script:Plain = Join-Path $script:TestRoot 'plain'
+        script:NewProject $script:Looped
+        script:NewProject $script:Plain
+        cmd /c mklink /J "$script:Looped\mise-tasks\current" "$script:Looped\mise-tasks" | Out-Null
+        $script:LinkExit = $LASTEXITCODE
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        # Pester hands the drive back by enumerating it with
+        # Directory.GetFileSystemEntries(AllDirectories), which follows this junction and does not
+        # come back out. Left in place it fails the run in the framework, with every test in it
+        # green. Delete the link, not what it points at.
+        $junction = Join-Path $script:Looped 'mise-tasks\current'
+        if (Test-Path -LiteralPath $junction) {
+            [System.IO.Directory]::Delete($junction, $false)
+        }
+        if ($null -ne $script:OriginalTrusted) {
+            $env:MISE_TRUSTED_CONFIG_PATHS = $script:OriginalTrusted
+        } else {
+            Remove-Item Env:\MISE_TRUSTED_CONFIG_PATHS -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'made the junction it is about' {
+        # Checked on its own: if the fixture has no junction, everything below passes for the
+        # wrong reason while still looking like a result.
+        $script:LinkExit | Should -Be 0
+        $entry = Get-Item -LiteralPath (Join-Path $script:Looped 'mise-tasks\current') -Force
+        $entry.Attributes.ToString() | Should -Match 'ReparsePoint'
+    }
+
+    It 'lists the tasks it can reach' {
+        Set-Location $script:Looped
+        $out = mise tasks ls --name-only 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        # The failure had one exact signature, and it is the thing this test is here to keep out.
+        $out | Should -Not -Match 'File system loop found'
+        $names = @($out -split "`r?`n" | Where-Object { $_ -ne '' } | ForEach-Object { $_.Trim() })
+        $names | Should -Contain 'healthy'
+        $names | Should -Contain 'from_config'
+        # The junction is a directory and is skipped, so it does not become a task of its own.
+        $names | Should -Not -Contain 'current'
+    }
+
+    It 'runs a task defined in the config, which the walk has nothing to do with' {
+        Set-Location $script:Looped
+        $out = mise run from_config 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match 'CONFIG_RAN'
+    }
+
+    It 'runs a file task from the directory the junction points at' {
+        Set-Location $script:Looped
+        $out = mise run healthy 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match 'FILE_RAN'
+    }
+
+    It 'gives the same answer as the identical tree without the junction' {
+        # The control. Stated as equality so the claim is "the loop changes nothing", not
+        # "each of these happens to work".
+        Set-Location $script:Looped
+        $looped = (mise tasks ls --name-only 2>&1 | Out-String).Trim()
+        $loopedExit = $LASTEXITCODE
+        Set-Location $script:Plain
+        $plain = (mise tasks ls --name-only 2>&1 | Out-String).Trim()
+        $plainExit = $LASTEXITCODE
+        # Each captured before the next command can overwrite it. Equality on its own would also
+        # hold if both sides failed the same way, which would read as the loop changing nothing
+        # while nothing had been listed at all.
+        $loopedExit | Should -Be 0
+        $plainExit | Should -Be 0
+        $looped | Should -Be $plain
+    }
+}

--- a/e2e/tasks/test_task_broken_symlinks
+++ b/e2e/tasks/test_task_broken_symlinks
@@ -2,6 +2,13 @@
 
 mkdir -p .mise/tasks "$HOME/.config/mise/tasks"
 
+# Defined in the config, not as a file. It shares nothing with the walk below except that both
+# happen while tasks load, which is what made it collateral damage of a bad entry in that walk.
+cat <<'EOF' >mise.toml
+[tasks.from_config]
+run = "echo 'config ran'"
+EOF
+
 cat <<'EOF' >.mise/tasks/healthy
 #!/usr/bin/env bash
 echo "healthy ran"
@@ -22,9 +29,18 @@ ln -s missing-target .mise/tasks/.#healthy
 # the task group dangling while other local and global tasks remain usable.
 ln -s "$MISE_TMP_DIR/missing-global-task-dir" "$HOME/.config/mise/tasks/global"
 
-assert "mise tasks ls --name-only" "global-ok
+# A "current"-style link pointing at the directory being walked. Discovery follows links so a
+# shared task directory can be linked in, which is also what makes a loop reachable. Skipping the
+# looping entry loses nothing -- it is the same directory, already visited -- and one of these
+# used to fail every task command, including tasks defined in a config file with no task file at
+# all.
+ln -s "$PWD/.mise/tasks" .mise/tasks/current
+
+assert "mise tasks ls --name-only" "from_config
+global-ok
 healthy"
 assert_contains "mise run healthy" "healthy ran"
 assert_contains "mise run global-ok" "global ran"
+assert_contains "mise run from_config" "config ran"
 assert_contains "mise tasks --usage" 'cmd healthy help="" {'
 assert_contains "mise tasks --usage" 'cmd global-ok help="" {'

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4452,6 +4452,16 @@ fn collect_task_files(root: &Path, excludes: &[PathBuf]) -> Result<Vec<PathBuf>>
                 debug!("skipping missing task entry: {err}");
                 None
             }
+            // Losing nothing by skipping: walkdir reports this only when a link resolves to a
+            // directory already on the walk stack, so everything under it has been visited
+            // through the real path. A permission or I/O error is not like that -- a whole
+            // subtree goes unseen -- so those stay fatal. One `mise-tasks/current -> mise-tasks`
+            // used to fail every task command, including tasks defined in `mise.toml` that
+            // involve no file at all.
+            Err(err) if err.loop_ancestor().is_some() => {
+                debug!("skipping task path that links back into itself: {err}");
+                None
+            }
             Err(err) => Some(Err(err)),
         })
         .try_collect::<_, Vec<PathBuf>, _>()
@@ -5423,7 +5433,33 @@ mod tests {
     }
 
     #[test]
-    fn test_collect_task_files_preserves_symlink_loop_errors() -> Result<()> {
+    fn test_collect_task_files_skips_links_back_into_the_walk() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let root = tmp.path().join("tasks");
+        fs::create_dir(&root)?;
+        let task = root.join("healthy");
+        fs::write(&task, "echo ok")?;
+
+        // The control: the same tree one link earlier. Without it, "the loop changed nothing"
+        // is not something this test can claim.
+        let before = collect_task_files(&root, &[])?;
+        assert_eq!(before, vec![task]);
+
+        // A `current`-style link pointing at the directory being walked. Nothing under it is
+        // lost -- it is the same directory, already visited -- so it must not fail the walk.
+        std::os::unix::fs::symlink(&root, root.join("current"))?;
+
+        assert_eq!(collect_task_files(&root, &[])?, before);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_collect_task_files_preserves_unresolvable_symlink_errors() -> Result<()> {
+        // Renamed from `..._preserves_symlink_loop_errors`: what it pins is a link that cannot be
+        // resolved at all. `fs::metadata` fails with ELOOP before walkdir gets as far as its own
+        // ancestor check, so this arrives as an io error rather than a `loop_ancestor` one and is
+        // deliberately still fatal -- unlike the case above, nothing was reached through it.
         let tmp = TempDir::new()?;
         std::os::unix::fs::symlink("loop", tmp.path().join("loop"))?;
 


### PR DESCRIPTION
## The problem

File-task discovery walks with `follow_links(true)`. That is deliberate — it is what lets a shared
task directory be linked into a project, and that works: a junction at `mise-tasks/lib` pointing
elsewhere is walked and `mise run lib:shared` runs. It is also what makes a loop reachable, and when
one was reached, walkdir's loop error was collected as fatal.

Measured on the same tree, one junction apart, nothing else changed:

| command | before | after `mise-tasks/current -> mise-tasks` |
| --- | --- | --- |
| `mise tasks ls` | exit 0 — `ok` | **exit 1** |
| `mise run ok` (a task file) | exit 0 | **exit 1** |
| `mise run from_config` (**defined in `mise.toml`**) | exit 0 — `FROM_TOML` | **exit 1** |

```
mise ERROR File system loop found: ...\mise-tasks\current points to an ancestor ...\mise-tasks
```

**The third row is the point.** A task defined in a config file has no task file behind it and
shares nothing with the walk, yet it goes down with it. Mutual links (`a -> b`, `b -> a`, no
self-reference) do the same. `mise env` and `mise ls --current` are unaffected, so the blast radius
is task loading.

The same walk already gave three different answers for a bad entry:

| entry under a task directory | before this change |
| --- | --- |
| a plain link to another directory | followed, its tasks work |
| a **dangling** link | skipped, everything else works |
| a link forming a **loop** | **every task command exits 1** |

Easier to arrive at on Windows than the symlink equivalent is on unix: `mklink /J` needs no
privilege, and a `current` junction beside a versioned directory is a common shape. The defect
itself is not Windows-specific.

## The fix

One arm beside the one that already skips a missing entry:

```rust
Err(err) if err.loop_ancestor().is_some() => {
    debug!("skipping task path that links back into itself: {err}");
    None
}
```

**Skipping loses nothing.** walkdir's `check_loop` compares the resolved link against the
directories already on the walk stack and only errors when it is one of them — so everything under
it has been visited through the real path. A permission or I/O error is not like that: a whole
subtree goes unseen, and those stay fatal. `debug!` rather than `warn!` for the same reason, and to
match the arm above it: there is nothing for the user to do.

## This narrows a decision I made in #11574

Worth stating plainly rather than leaving to be discovered. #11574 is mine, it added the
skip-dangling-entries arm, and its body says *"Other traversal errors remain fatal"* and names
*"permission, loop, and other filesystem errors"*. The test pinning it is mine too.

What changed my mind is that **#11574's own problem statement applies unchanged here** — it
"aborted all task commands, including completion, even when other tasks were healthy" — and that
loops are separable from the rest on a principle the others fail: nothing is lost. The sibling walk
in `vfox.rs::lua_sources_fingerprint` had already reached the same conclusion, in a comment:
*"Symlink cycles surface as errors here and are skipped below."*

### The boundary, and the inconsistency it leaves

Only `loop_ancestor()`. A link that cannot be resolved **at all** — `ln -s loop loop` — fails in
`fs::metadata` with ELOOP before walkdir reaches its ancestor check, so it arrives as an io error
and stays fatal. Nothing was reached through that one either, so the argument above does not cover
it; widening to it would be a broader reversal than this change is making. The existing test passes
unchanged and is **renamed** to `test_collect_task_files_preserves_unresolvable_symlink_errors`,
because after this change its old name describes the case that is now skipped.

`file::recursive_ls` has the same `follow_links(true)` + `try_collect()?` shape. Its one caller is
copying an extracted tool, not a path this measurement went through, so it is deliberately left
alone.

## Tests

**Unit** — a `current`-style link pointing at the directory being walked, asserted to give the
**same result as the same tree one link earlier**. Stated as equality rather than "it still returns
something", so the claim is that the loop changes nothing. The renamed ELOOP test staying green is
what shows the change is the narrow one it says it is.

Note the module is `#[cfg(test)] #[cfg(unix)]`, so these run on unix only. Windows is covered by
the Pester file below rather than left to inference from the unix result — junctions are a different
mechanism.

**e2e** (`e2e/tasks/test_task_broken_symlinks`) — the loop goes beside the dangling link that
#11574 put there. A config-file task is added to the fixture and asserted to run, since that is the
collateral damage the walk should not be able to cause.

**e2e-win** (`e2e-win/task_symlink_loop.Tests.ps1`) — the junction path. One test asserts the
fixture really is a reparse point **before** anything is concluded from it; the listing test asserts
the output does not contain `File system loop found`, which is the exact signature of the old
failure; and a control compares the looped tree against an identical one without the junction and
requires the two listings to be equal.

Draft until the fork CI run on this branch reports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved task discovery when task directories contain circular symbolic links or Windows junctions.
  - Task listing and execution now continue without filesystem loop errors.
  - Circular links are excluded from task listings.
  - Config-defined tasks are correctly discovered and executable without a matching task file.
  - Genuine permission, I/O, and unresolved-link errors continue to be reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->