### PR TITLE
fix(schema): allow data and cache-key on all plugin script tables

### DIFF
--- a/schema/mise.plugin.json
+++ b/schema/mise.plugin.json
@@ -11,14 +11,14 @@
       "unevaluatedProperties": false,
       "properties": {
         "cache-key": {
-          "description": "cache the script results separately based on these values",
+          "description": "cache the script results separately based on these values; only consumed for list-bin-paths and exec-env, accepted elsewhere",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "data": {
-          "description": "static data to use instead of executing the script",
+          "description": "static data to use instead of executing the script; only consumed for list-aliases, list-idiomatic-filenames, and list-legacy-filenames, accepted elsewhere",
           "type": "string"
         }
       }

--- a/schema/mise.plugin.json
+++ b/schema/mise.plugin.json
@@ -16,6 +16,10 @@
           "items": {
             "type": "string"
           }
+        },
+        "data": {
+          "description": "static data to use instead of executing the script",
+          "type": "string"
         }
       }
     }
@@ -23,36 +27,15 @@
   "properties": {
     "list-aliases": {
       "description": "configuration for bin/list-aliases script",
-      "type": "object",
-      "unevaluatedProperties": false,
-      "properties": {
-        "data": {
-          "description": "list of aliases to add",
-          "type": "string"
-        }
-      }
+      "$ref": "#/$defs/plugin-script-config"
     },
     "list-legacy-filenames": {
       "description": "configuration for bin/list-legacy-filenames script",
-      "type": "object",
-      "unevaluatedProperties": false,
-      "properties": {
-        "data": {
-          "description": "list of idiomatic filenames to check for",
-          "type": "string"
-        }
-      }
+      "$ref": "#/$defs/plugin-script-config"
     },
     "list-idiomatic-filenames": {
       "description": "configuration for idiomatic filename discovery",
-      "type": "object",
-      "unevaluatedProperties": false,
-      "properties": {
-        "data": {
-          "description": "list of idiomatic filenames to check for",
-          "type": "string"
-        }
-      }
+      "$ref": "#/$defs/plugin-script-config"
     },
     "list-bin-paths": {
       "description": "configuration for bin/list-bin-paths script",
@@ -61,6 +44,14 @@
     "exec-env": {
       "description": "configuration for bin/exec-env script",
       "$ref": "#/$defs/plugin-script-config"
+    },
+    "idiomatic-filenames": {
+      "description": "legacy key from old plugins (e.g. rtx-python) that is ignored; when present, mise stops parsing the file entirely",
+      "deprecated": true
+    },
+    "legacy-filenames": {
+      "description": "legacy key from old plugins (e.g. rtx-python) that is ignored; when present, mise stops parsing the file entirely",
+      "deprecated": true
     },
     "package-manager": {
       "description": "configuration for a package-manager plugin",


### PR DESCRIPTION
## Summary

`schema/mise.plugin.json` (the hand-maintained schema for `mise.plugin.toml`) was out of sync with the parser in `src/plugins/mise_plugin_toml.rs`: it rejected valid keys the parser accepts and rejected legacy keys the parser explicitly tolerates. This PR aligns the schema with the parser.

## Changes (with implementation evidence)

- **All five script tables accept both `cache-key` and `data`.** `exec-env`, `list-aliases`, `list-bin-paths`, `list-idiomatic-filenames`, and `list-legacy-filenames` all route through the same `parse_script_config` (`src/plugins/mise_plugin_toml.rs:54-59`), which accepts `cache-key` (string array) and `data` (string) for every table (`src/plugins/mise_plugin_toml.rs:100-105`). Previously the schema only allowed `cache-key` in `$defs/plugin-script-config` (used by `exec-env`/`list-bin-paths`) and only `data` in the inline tables for `list-aliases`/`list-legacy-filenames`/`list-idiomatic-filenames`, so e.g. `data` under `[exec-env]` or `cache-key` under `[list-aliases]` failed validation despite being valid. Now `data` is added to `$defs/plugin-script-config` and all five properties `$ref` it.
- **Tolerate legacy top-level `idiomatic-filenames` / `legacy-filenames`.** The parser explicitly recognizes these old keys (from rtx-era plugins such as rtx-python) and stops parsing rather than erroring (`src/plugins/mise_plugin_toml.rs:61-63`), but the schema's root `unevaluatedProperties: false` rejected them. They are now declared as `"deprecated": true` properties with no value-shape constraint, since the parser tolerates any value.

Schema-only change; no Rust code is touched.


## Gap provenance

- [#385](https://github.com/jdx/mise/pull/385) (merged 2023-03-23) introduced the plugin TOML parser and schema with a shared script-table parser that accepted both `cache-key` and `data`, while the schema modeled only a subset of those combinations.
- [#389](https://github.com/jdx/mise/pull/389) (merged 2023-03-24) extended that parser to alias and legacy-filename tables without fully extending the schema.
- [#9647](https://github.com/jdx/mise/pull/9647) (merged 2026-05-07) consolidated the schema's script-table definition around `cache-key` only, preserving the parser/schema gap this PR closes.

## Validation

- `test/fixtures/mise.plugin.toml` (which has a `#:schema` header pointing at this schema) lints cleanly with `tombi lint`.
- A scratch `mise.plugin.toml` exercising `data`+`cache-key` on all five script tables plus both legacy top-level keys lints cleanly (the legacy keys emit deprecation warnings, as intended).
- JSON validated with `python3 -m json.tool`; formatted with `prettier` (no changes needed).

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared configuration support for plugin scripts, including cache keys and custom data.
  * Added indicators for deprecated filename configuration keys that are ignored.

* **Documentation**
  * Clarified configuration behavior for aliases and legacy or idiomatic filename settings.
  * Documented which plugin scripts consume cache-key and custom data values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->