### PR TITLE
fix(schema): align settings meta-schema with build consumers

### DIFF
--- a/schema/mise-settings.json
+++ b/schema/mise-settings.json
@@ -176,6 +176,16 @@
         }
       },
       "required": ["description", "type"],
+      "if": {
+        "required": ["merge"]
+      },
+      "then": {
+        "properties": {
+          "type": {
+            "const": "ListString"
+          }
+        }
+      },
       "unevaluatedProperties": false
     }
   }

--- a/schema/mise-settings.json
+++ b/schema/mise-settings.json
@@ -176,16 +176,51 @@
         }
       },
       "required": ["description", "type"],
-      "if": {
-        "required": ["merge"]
-      },
-      "then": {
-        "properties": {
-          "type": {
-            "const": "ListString"
+      "allOf": [
+        {
+          "if": {
+            "required": ["merge"]
+          },
+          "then": {
+            "properties": {
+              "type": {
+                "const": "ListString"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "BoolOrString"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["rust_type"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "enum": [
+                  "ListString",
+                  "ListPath",
+                  "SetString",
+                  "IndexMap<String, String>"
+                ]
+              }
+            },
+            "required": ["env", "type"]
+          },
+          "then": {
+            "required": ["parse_env"]
           }
         }
-      },
+      ],
       "unevaluatedProperties": false
     }
   }

--- a/schema/mise-settings.json
+++ b/schema/mise-settings.json
@@ -121,9 +121,18 @@
           "type": "boolean",
           "description": "Setting is read before config files load, so it only works as an environment variable; a value in a config file is dropped with a warning"
         },
+        "global_only": {
+          "type": "boolean",
+          "description": "Setting is only honored in the global config file"
+        },
         "hide": {
           "type": "boolean",
           "description": "Whether to hide this setting from documentation"
+        },
+        "merge": {
+          "type": "string",
+          "enum": ["append_unique"],
+          "description": "Merge strategy applied across config-file layers; only \"append_unique\" on ListString settings is supported"
         },
         "optional": {
           "type": "boolean",
@@ -132,7 +141,6 @@
         "parse_env": {
           "type": "string",
           "enum": [
-            "bool_string",
             "list_by_comma",
             "list_by_colon",
             "list_by_os_path_separator",
@@ -167,7 +175,7 @@
           "description": "Type of this setting"
         }
       },
-      "required": ["description"],
+      "required": ["description", "type"],
       "unevaluatedProperties": false
     }
   }


### PR DESCRIPTION
## Summary

`schema/mise-settings.json` is the hand-maintained meta-schema that validates `settings.toml` in editors (wired up via `.taplo.toml`). It had drifted from what `build.rs`, the generated settings code, and runtime validation actually require. This PR realigns it.

## Changes

- **Add `global_only`** (boolean). It is used throughout `settings.toml` and emitted into `SETTINGS_META` by `build.rs`.
- **Add `merge`** with the only supported value, `append_unique`, and require merged settings to use `type = "ListString"`, matching `merge_settings_file_layers`.
- **Require `type` on leaf settings.** `build.rs` uses its presence as the leaf-vs-group discriminator.
- **Require `rust_type` for `BoolOrString`.** Both settings code-generation paths explicitly panic when that type has no Rust representation override.
- **Require `parse_env` when a collection setting declares `env`.** Without it, confique hands a raw string to a collection deserializer and mise aborts; `src/config/settings.rs` carries a guard for this invariant across `ListString`, `ListPath`, `SetString`, and `IndexMap<String, String>`.
- **Remove `bool_string` from `parse_env`.** It is a `deserialize_with` function, not an environment parser. The remaining values match the implemented parsers used by `settings.toml`.

This only affects validation of the repository's `settings.toml`; it does not change runtime behavior.


## Gap provenance

- [#6361](https://github.com/jdx/mise/pull/6361) (merged 2025-09-21) introduced `schema/mise-settings.json` without modeling `global_only` or the leaf-type/codegen invariants enforced by the build.
- [#7905](https://github.com/jdx/mise/pull/7905) (merged 2026-02-02) added the `BoolOrString` setting form without encoding its required Rust type in the meta-schema.
- [#11835](https://github.com/jdx/mise/pull/11835) (merged 2026-08-11) added list-setting environment parsing requirements that the meta-schema did not enforce.
- [#12460](https://github.com/jdx/mise/pull/12460) (merged 2026-08-26) introduced the `append_unique` merge strategy without adding it to the meta-schema enum.

## Validation

- `taplo check settings.toml` passes against the edited schema.
- Focused positive cases for `BoolOrString` with `rust_type` and an environment-readable collection with `parse_env` pass.
- Focused negative cases are rejected as intended: a leaf without `type`, `BoolOrString` without `rust_type`, a collection with `env` but no `parse_env`, and `merge = "append_unique"` on a non-`ListString` setting.
- Scoped `hk run fix --safe` passes the JSON Schema and Prettier checks.

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for settings that apply only globally.
  - Added an `append_unique` merge option for list-based settings.

- **Validation**
  - Settings definitions must now include a type alongside their description.
  - The `append_unique` option is limited to `ListString` settings.
  - `BoolOrString` settings must specify their Rust type.
  - List-based settings using environment variables must define how values are parsed.
  - Removed the deprecated `bool_string` parsing option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->