### PR TITLE
fix(schema): accept all backend and platform values in registry schema

### DIFF
--- a/schema/mise-registry-tool.json
+++ b/schema/mise-registry-tool.json
@@ -7,7 +7,7 @@
   "$defs": {
     "backendFull": {
       "type": "string",
-      "pattern": "^(aqua|asdf|cargo|conda|core|dotnet|gem|github|gitlab|go|http|npm|pipx|spm|ubi|vfox):([^\\[\\]]|\\[[^\\]=]*\\])+$"
+      "pattern": "^(aqua|asdf|cargo|conda|core|dotnet|forgejo|gem|github|gitlab|go|http|npm|pipx|pkgx|s3|spm|ubi|vfox):([^\\[\\]]|\\[[^\\]=]*\\])+$"
     },
     "optionValue": {
       "description": "Backend option value.",
@@ -41,11 +41,11 @@
     },
     "platform": {
       "type": "string",
-      "pattern": "^(linux|macos|windows)-(x64|arm64|x86|loongarch64|riscv64)$"
+      "pattern": "^(freebsd|linux|macos|openbsd|windows)-(x64|arm64|x86|loongarch64|riscv64)$"
     },
     "optionPlatform": {
       "type": "string",
-      "pattern": "^(linux|macos|darwin|windows)-(x64|amd64|x86_64|arm64|aarch64|x86|loongarch64|riscv64)$"
+      "pattern": "^(freebsd|linux|macos|darwin|openbsd|windows)-(x64|amd64|x86_64|arm64|aarch64|x86|loongarch64|riscv64)$"
     },
     "platformSelector": {
       "description": "OS, architecture, or platform this backend supports.",


### PR DESCRIPTION
## Summary

`schema/mise-registry-tool.json` rejected backend and platform values that are part of the registry runtime contract. This PR aligns the hand-maintained schema with the implemented backend variants and canonical registry platform formats.

## Changes

- **`$defs/backendFull`**: add `forgejo`, `pkgx`, and `s3`. These are concrete `BackendType` variants dispatched by `src/backend/mod.rs` and accepted by registry resolution.
- **`$defs/platform`**: add `freebsd` and `openbsd`, matching the existing canonical `$defs/os` contract used by registry backend selectors.
- **`$defs/optionPlatform`**: add the same BSD OS names. Platform-option lookup passes unrecognized host OS names through, so these canonical keys are reachable on BSD hosts.

The registry selector contract remains deliberately narrower than every value `Settings::os()` or `Settings::arch()` can carry. Android and other Rust target OS names, architecture aliases, and qualified selectors are not added here: the earlier platform-schema change explicitly established five canonical OS names and five canonical architecture names, current registry data uses those forms, and option lookup does not read qualified keys such as `linux-x64-musl`.

Schema-only change; no runtime code is touched.


## Gap provenance

- [#7820](https://github.com/jdx/mise/pull/7820) (merged 2026-01-25) introduced the split registry schema while omitting already-supported Forgejo ([#7469](https://github.com/jdx/mise/pull/7469), merged 2026-01-05), S3 ([#7668](https://github.com/jdx/mise/pull/7668), merged 2026-01-14), and BSD platform values.
- [#10408](https://github.com/jdx/mise/pull/10408) (merged 2026-06-13) added the `pkgx` backend without extending the registry schema enum.

## Validation

- All 982 `registry/*.toml` files validate against the edited schema with Taplo.
- A focused fixture using `forgejo:`/`pkgx:`/`s3:` backends, BSD platform selectors, and a BSD option-platform key passes.
- Focused negative cases remain rejected: an unknown backend prefix, alias-form `windows-amd64` as a registry selector, qualified `linux-x64-musl` as an option key, and out-of-contract `android-arm64`.
- Scoped `hk run fix --safe` passes the JSON Schema and Prettier checks.

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Forgejo, pkgx, and S3 backend options.
  * Added FreeBSD and OpenBSD platform selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->