### PR TITLE
fix(schema): align task dependency shapes

### DIFF
--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -97,6 +97,9 @@
               "items": {
                 "$ref": "#/$defs/task_dependency_item"
               }
+            },
+            {
+              "$ref": "#/$defs/task_dependency_table"
             }
           ]
         },
@@ -112,6 +115,9 @@
               "items": {
                 "$ref": "#/$defs/task_dependency_item"
               }
+            },
+            {
+              "$ref": "#/$defs/task_dependency_table"
             }
           ]
         },
@@ -127,6 +133,9 @@
                 "$ref": "#/$defs/task_dependency_item"
               },
               "type": "array"
+            },
+            {
+              "$ref": "#/$defs/task_dependency_table"
             }
           ]
         },
@@ -939,6 +948,33 @@
         }
       ]
     },
+    "task_dependency_table": {
+      "description": "task dependency with args, env, and optional flag",
+      "type": "object",
+      "properties": {
+        "task": {
+          "type": "string"
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "env": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "optional": {
+          "description": "do not fail when the task name or pattern has no matches",
+          "type": "boolean"
+        }
+      },
+      "required": ["task"],
+      "unevaluatedProperties": false
+    },
     "task_run_entry": {
       "oneOf": [
         {
@@ -997,33 +1033,11 @@
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "minItems": 1
         },
         {
-          "type": "object",
-          "properties": {
-            "task": {
-              "type": "string"
-            },
-            "args": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "env": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            },
-            "optional": {
-              "description": "do not fail when the task name or pattern has no matches",
-              "type": "boolean"
-            }
-          },
-          "required": ["task"],
-          "unevaluatedProperties": false
+          "$ref": "#/$defs/task_dependency_table"
         }
       ]
     },

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -14,35 +14,40 @@
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "minItems": 1
         },
         {
-          "type": "object",
-          "properties": {
-            "task": {
-              "type": "string"
-            },
-            "args": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "env": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            },
-            "optional": {
-              "description": "do not fail when the task name or pattern has no matches",
-              "type": "boolean"
-            }
-          },
-          "required": ["task"],
-          "unevaluatedProperties": false
+          "$ref": "#/$defs/task_dependency_table"
         }
       ]
+    },
+    "task_dependency_table": {
+      "description": "task dependency with args, env, and optional flag",
+      "type": "object",
+      "properties": {
+        "task": {
+          "type": "string"
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "env": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "optional": {
+          "description": "do not fail when the task name or pattern has no matches",
+          "type": "boolean"
+        }
+      },
+      "required": ["task"],
+      "unevaluatedProperties": false
     },
     "os_filter_item": {
       "description": "operating system or os/arch pair to install on",
@@ -3197,6 +3202,9 @@
               "items": {
                 "$ref": "#/$defs/task_dependency_item"
               }
+            },
+            {
+              "$ref": "#/$defs/task_dependency_table"
             }
           ]
         },
@@ -3212,6 +3220,9 @@
               "items": {
                 "$ref": "#/$defs/task_dependency_item"
               }
+            },
+            {
+              "$ref": "#/$defs/task_dependency_table"
             }
           ]
         },
@@ -3227,6 +3238,9 @@
                 "$ref": "#/$defs/task_dependency_item"
               },
               "type": "array"
+            },
+            {
+              "$ref": "#/$defs/task_dependency_table"
             }
           ]
         },


### PR DESCRIPTION
Narrows the original task-schema alignment PR to task dependency shapes only. The other independent contracts were split into #12795, #12796, and #12797.

## Change

- Accept a bare dependency table for `depends`, `depends_post`, and `wait_for`, matching the parser's map visitor.
- Share the dependency-table schema instead of duplicating it.
- Reject empty nested dependency arrays, which `TaskDep::visit_seq` rejects at runtime.

## Scope

- Schema-only; no runtime behavior changes.
- Based directly on `main`.

## Related split PRs

- #12796 — structured task-array entries
- #12797 — disabled automatic outputs
- #12795 — ignored Rust-cache verification

No merge order is required.

## Validation

- `mise run render:schema`
- `mise run test:e2e e2e/config/test_schema_tombi`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Task dependencies now support a shared object format, including task arguments, environment variables, and optional execution.
  - Bootstrap packages can specify whether they should be present or absent.
  - Added support for Aube, Deno, and Git submodule dependency providers.
  - Dotfiles can now be defined directly with inline content.
  - Task arrays use the expanded task-entry format.

- **Deprecations**
  - Rust cache settings, including verification, are deprecated and ignored while remaining accepted for compatibility.

- **Validation**
  - Dependency arrays must contain at least one item, with stricter validation for inline dotfile content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->