### PR TITLE
fix(schema): mark ignored install hook shell as deprecated

### DIFF
--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2820,7 +2820,8 @@
           "$ref": "#/$defs/hook_script_value"
         },
         "shell": {
-          "description": "ignored for this deprecated form; use a run hook to select an inline shell",
+          "deprecated": true,
+          "description": "ignored for preinstall/postinstall hooks that use script; use a run hook to select an inline shell",
           "type": "string"
         }
       },
@@ -2837,7 +2838,8 @@
           "$ref": "#/$defs/hook_scripts_value"
         },
         "shell": {
-          "description": "ignored for this deprecated form; use a run hook to select an inline shell",
+          "deprecated": true,
+          "description": "ignored for preinstall/postinstall hooks that use scripts; use a run hook to select an inline shell",
           "type": "string"
         }
       },


### PR DESCRIPTION
The `shell` key in the deprecated `script`/`scripts` hook tables is accepted but ignored for preinstall/postinstall hooks — mise warns that `shell` is ignored for install hooks that use `script` or `scripts` (`src/hooks.rs`). The sibling properties and their tables already carry `"deprecated": true` in `schema/mise.json`, but `shell` did not, so editors gave no deprecation hint.

This schema-annotation-only change adds `"deprecated": true` to `shell` in `hook_install_script_table` and `hook_install_scripts_table`, and clarifies that a run hook should be used to select an inline shell.


## Gap provenance

- [#11041](https://github.com/jdx/mise/pull/11041) (merged 2026-07-16) introduced the corrected root hook schema tables.
- [#11043](https://github.com/jdx/mise/pull/11043) (merged 2026-07-16) deprecated spawned install-hook scripts but left the accepted, ignored nested `shell` property without a schema deprecation marker.

## Validation

- `mise run render:schema` — generated schema is current.
- `mise run test:e2e e2e/config/test_schema_root_hook_keys` — passed.
- Scoped `hk run check --safe --format json` — AJV schema compilation and formatting checks passed after the final rebase.

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*