### PR TITLE
feat(dotfiles): support git-tracked directory manifests

### DIFF
--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -23,6 +23,7 @@ dotfiles.default_mode = "symlink"
 "~/.ssh/config" = { source = "dotfiles/ssh_config.tmpl", mode = "template" }
 "~/.config/nvim" = "dotfiles/nvim"                                   # symlink the directory itself
 "~/.local/bin" = { source = "dotfiles/bin", mode = "symlink-each" }  # symlink each file within
+"~/managed-home" = { source = "home", mode = "symlink-each", manifest = "git" }
 "~/hosts/dev" = { line = "127.0.0.1 dev.local" }                     # edit one line in ~/hosts
 ```
 
@@ -109,14 +110,31 @@ everything under it.
 Excluding a file mise already applied removes what it left behind on the next
 apply, the same as deleting the source would.
 
+## Git-tracked directories
+
+Set `manifest = "git"` on a directory-walking entry to manage only files in
+Git's index. This supports repositories that use `gitignore *` and opt files
+in with `git add -f`, without listing every path again in mise:
+
+```toml
+[dotfiles]
+"~" = { source = ".", mode = "symlink-each", manifest = "git" }
+```
+
+mise runs `git ls-files` from the source directory. Ignored and untracked
+files are left alone, while removing a file from the index removes a
+mise-owned `symlink-each` link on the next apply. `exclude` can be combined
+with the Git manifest for an additional filter. Git manifests require a
+directory source and either `symlink-each` or `copy` mode.
+
 ## Modes
 
-| Mode           | Behavior                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `symlink`      | Symlink the target to the source. Works for files and directories — a directory source gets one link for the whole directory. This is the default.                                                                                                                                                                                                                                                                                                                      |
-| `symlink-each` | Source must be a directory: recreate its directory structure under the target and symlink each file individually, so the target directory (say, `~/.config`) can also hold files mise doesn't manage. Deleting a source file removes the link it left behind on the next apply; files and links mise didn't create are never touched. Managed links are recorded under `$MISE_STATE_DIR/dotfiles`, so shared targets are not recursively scanned after the first apply. |
-| `copy`         | Copy the source file (or directory, recursively). Use when the target must be a real file — e.g. tools that rewrite their config in place. Directory copies are additive: matching files are overwritten, files mise doesn't manage are left in place. Copies are never pruned, so removing a source file leaves the copy behind.                                                                                                                                       |
-| `template`     | Render the source through the [mise template engine](/templates.html) and write the result. Permissions are taken from the source file (and repaired if they drift).                                                                                                                                                                                                                                                                                                    |
+| Mode           | Behavior                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `symlink`      | Symlink the target to the source. Works for files and directories — a directory source gets one link for the whole directory. This is the default.                                                                                                                                                                                                                                                                                                                                                                |
+| `symlink-each` | Source must be a directory: recreate its directory structure under the target and symlink each file individually, so the target directory (say, `~/.config`) can also hold files mise doesn't manage. Deleting a source file or removing it from the selected manifest removes the link it left behind on the next apply; files and links mise didn't create are never touched. Managed links are recorded under `$MISE_STATE_DIR/dotfiles`, so shared targets are not recursively scanned after the first apply. |
+| `copy`         | Copy the source file (or directory, recursively). Use when the target must be a real file — e.g. tools that rewrite their config in place. Directory copies are additive: matching files are overwritten, files mise doesn't manage are left in place. Copies are never pruned, so removing a source file leaves the copy behind.                                                                                                                                                                                 |
+| `template`     | Render the source through the [mise template engine](/templates.html) and write the result. Permissions are taken from the source file (and repaired if they drift).                                                                                                                                                                                                                                                                                                                                              |
 
 Templates get the same context as other mise templates (`env`, `vars`,
 `exec()`, etc.), which is the main reason to use them: one source file,

--- a/e2e/cli/test_dotfiles_files
+++ b/e2e/cli/test_dotfiles_files
@@ -6,7 +6,7 @@ assert_contains "mise bootstrap dotfiles --help" "add"
 assert_contains "mise bootstrap dotfiles --help" "edit"
 
 mkdir -p dotfiles/nvim dotfiles/bin
-echo "gitconfig content" >dotfiles/gitconfig
+printf '[user]\n\tname = Test User\n' >dotfiles/gitconfig
 echo "starship config" >dotfiles/starship.toml
 echo "init.lua" >dotfiles/nvim/init.lua
 echo "one" >dotfiles/bin/one
@@ -141,6 +141,74 @@ mkdir ~/.local/mybin/private
 chmod 000 ~/.local/mybin/private
 assert_not_contains "MISE_DEBUG=1 mise dotfiles status 2>&1" "$HOME/.local/mybin/private"
 chmod 700 ~/.local/mybin/private
+
+# A Git manifest manages the index instead of requiring every file in the
+# directory to be listed in mise config. Ignored/untracked files stay alone.
+mkdir -p tracked-home/.config
+git -C tracked-home init -q
+printf '*\n' >tracked-home/.gitignore
+echo "tracked" >tracked-home/.config/tracked.conf
+ln -s tracked.conf tracked-home/.config/tracked-link.conf
+echo "excluded source" >tracked-home/.config/excluded.conf
+echo "untracked" >tracked-home/.config/untracked.conf
+mkdir -p tracked-home/vendor/submodule
+echo "gitlink source" >tracked-home/vendor/submodule/untracked-inside
+git -C tracked-home add -f .gitignore .config/tracked.conf .config/tracked-link.conf .config/excluded.conf
+git -C tracked-home config user.email test@example.com
+git -C tracked-home config user.name "mise test"
+git -C tracked-home commit -qm initial
+gitlink_commit=$(git -C tracked-home rev-parse HEAD)
+git -C tracked-home update-index --add --cacheinfo "160000,$gitlink_commit,vendor/submodule"
+
+# Conflicted index stages must not duplicate a manifest path or its operations.
+mkdir conflicted-home
+git -C conflicted-home init -q
+git -C conflicted-home config user.email test@example.com
+git -C conflicted-home config user.name "mise test"
+echo "base" >conflicted-home/file
+git -C conflicted-home add file
+git -C conflicted-home commit -qm base
+base_branch=$(git -C conflicted-home branch --show-current)
+git -C conflicted-home checkout -qb side
+echo "side" >conflicted-home/file
+git -C conflicted-home commit -am side -q
+git -C conflicted-home checkout -q "$base_branch"
+echo "main" >conflicted-home/file
+git -C conflicted-home commit -am main -q
+git -C conflicted-home merge side >/dev/null 2>&1 || true
+cat >conflicted-manifest.toml <<EOF
+[dotfiles]
+"~/.local/conflicted-home" = { source = "conflicted-home", mode = "symlink-each", manifest = "git" }
+EOF
+assert_fail "MISE_CONFIG_FILE=$PWD/conflicted-manifest.toml mise dotfiles apply --yes" "unresolved Git index entry"
+
+cat <<EOF >>mise.toml
+"~/.local/tracked-home" = { source = "tracked-home", mode = "symlink-each", manifest = "git", exclude = [".config/excluded.conf"] }
+"~/.local/tracked-copy" = { source = "tracked-home", mode = "copy", manifest = "git", exclude = [".config/excluded.conf"] }
+"~/.local/tracked-subdir" = { source = "tracked-home/.config", mode = "symlink-each", manifest = "git", exclude = ["excluded.conf"] }
+EOF
+assert_succeed "GIT_DIR=/nonexistent GIT_INDEX_FILE=/nonexistent mise dotfiles apply ~/.local/tracked-home --yes"
+assert "readlink ~/.local/tracked-home/.config/tracked.conf" "$PWD/tracked-home/.config/tracked.conf"
+assert_fail "test -e ~/.local/tracked-home/.config/untracked.conf"
+assert_succeed "mise dotfiles apply ~/.local/tracked-subdir --yes"
+assert "readlink ~/.local/tracked-subdir/tracked.conf" "$PWD/tracked-home/.config/tracked.conf"
+
+# Refreshing an existing Git-manifest copy validates against its repository and
+# captures tracked files without replacing the repository or its index.
+assert_succeed "mise dotfiles apply ~/.local/tracked-copy --yes"
+echo "captured" >~/.local/tracked-copy/.config/tracked.conf
+assert_succeed "mise dotfiles add ~/.local/tracked-copy --yes"
+assert "cat tracked-home/.config/tracked.conf" "captured"
+assert "readlink tracked-home/.config/tracked-link.conf" "tracked.conf"
+assert "cat tracked-home/.config/excluded.conf" "excluded source"
+assert "cat tracked-home/vendor/submodule/untracked-inside" "gitlink source"
+assert_succeed "git -C tracked-home status --short"
+
+# Dropping a still-present ignored file from the index also prunes its old link.
+git -C tracked-home rm -fq --cached .config/tracked.conf
+assert_contains "mise dotfiles status ~/.local/tracked-home" "stale link"
+assert_succeed "mise dotfiles apply ~/.local/tracked-home --yes"
+assert_fail "test -e ~/.local/tracked-home/.config/tracked.conf"
 
 # symlink-each cleans up after itself: deleting a source file removes the
 # link it left behind (and any directory that emptied out), while files and

--- a/src/cli/dotfiles/add.rs
+++ b/src/cli/dotfiles/add.rs
@@ -10,7 +10,7 @@ use crate::dirs;
 use crate::file;
 use crate::path::PathExt;
 use crate::system;
-use crate::system::files::{FileMode, FileRequest};
+use crate::system::files::{FileManifest, FileMode, FileRequest};
 use crate::ui::prompt;
 
 /// Add or update dotfiles in `[dotfiles]`
@@ -290,7 +290,15 @@ impl DotfilesAdd {
                                 &backup_dir.path().join("targets").join(index.to_string()),
                             )?,
                         ));
-                        system::files::copy_path(&item.target, &item.source)?;
+                        if let Some(request) = item
+                            .already_managed
+                            .as_ref()
+                            .filter(|request| request.manifest == Some(FileManifest::Git))
+                        {
+                            system::files::capture_git_manifest(request)?;
+                        } else {
+                            system::files::copy_path(&item.target, &item.source)?;
+                        }
                         info!(
                             "dotfiles: copied {} to {}",
                             item.target.display_user(),
@@ -411,7 +419,10 @@ impl PlannedAdd {
     /// as the future source footprint when add is about to copy or move it.
     fn validation_request(&self, config_path: &std::path::Path) -> FileRequest {
         let mut request = self.managed_request(config_path);
-        if self.target.exists() && !same_file(&self.target, &self.source) {
+        if request.manifest.is_none()
+            && self.target.exists()
+            && !same_file(&self.target, &self.source)
+        {
             request.source = self.target.clone();
         } else if !self.source.exists() && self.mode != FileMode::SymlinkEach {
             // Add creates an empty source file in this case. Content mode gives
@@ -439,6 +450,7 @@ impl PlannedAdd {
             content: None,
             mode: self.mode,
             exclude: vec![],
+            manifest: None,
             base: config_path
                 .parent()
                 .unwrap_or(std::path::Path::new("."))

--- a/src/git.rs
+++ b/src/git.rs
@@ -514,6 +514,12 @@ fn sanitize_git_cmd_runner<'a>(cmd: CmdLineRunner<'a>) -> CmdLineRunner<'a> {
         .fold(cmd, |cmd, env| cmd.env_remove(env))
 }
 
+pub(crate) fn sanitize_git_command(cmd: &mut std::process::Command) {
+    for env in GIT_CONTEXT_ENV {
+        cmd.env_remove(env);
+    }
+}
+
 const GIT_CONTEXT_ENV: &[&str] = &[
     "GIT_DIR",
     "GIT_WORK_TREE",

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -19,9 +19,11 @@
 //! (global -> local, local overrides by target key) and are only ever
 //! applied by an explicit command, never implicitly.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
-use eyre::{Result, bail};
+use eyre::{Result, WrapErr, bail};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use regex::Regex;
@@ -50,6 +52,20 @@ pub(crate) enum FileMode {
     Template,
     /// write literal content declared directly in mise.toml
     Content,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FileManifest {
+    Git,
+}
+
+impl FileManifest {
+    fn parse(s: &str) -> Option<Self> {
+        match s {
+            "git" => Some(Self::Git),
+            _ => None,
+        }
+    }
 }
 
 impl FileMode {
@@ -93,6 +109,8 @@ pub(crate) enum FileTomlEntry {
         mode: Option<String>,
         #[serde(default)]
         exclude: Option<Vec<String>>,
+        #[serde(default)]
+        manifest: Option<String>,
     },
 }
 
@@ -112,6 +130,8 @@ pub(crate) struct FileRequest {
     /// glob patterns, matched against source-relative paths, for files a
     /// directory-walking mode should skip (see [`is_excluded`])
     pub exclude: Vec<glob::Pattern>,
+    /// optional source manifest limiting which directory entries are managed
+    pub manifest: Option<FileManifest>,
     /// directory of the declaring config file — base dir for template
     /// functions like `exec` and `read_file`
     pub base: PathBuf,
@@ -187,8 +207,28 @@ pub(crate) fn files_from_config(config: &Config) -> Result<Vec<FileRequest>> {
 pub(crate) fn validate_composed_file_footprints(requests: &[FileRequest]) -> Result<()> {
     let mut leaves: IndexMap<PathBuf, &FileRequest> = IndexMap::new();
     let mut directories: IndexMap<PathBuf, &FileRequest> = IndexMap::new();
+    let mut symlink_each_identities: HashMap<(&Path, &Path), &FileRequest> = HashMap::new();
 
     for request in requests {
+        if request.manifest.is_some() && request.source.exists() && !request.source.is_dir() {
+            bail!(
+                "[dotfiles].\"{}\": manifest requires the source to be a directory: {}",
+                request.target_raw,
+                request.source.display_user()
+            );
+        }
+        if request.mode == FileMode::SymlinkEach
+            && let Some(existing) = symlink_each_identities.insert(
+                (request.source.as_path(), request.target.as_path()),
+                request,
+            )
+        {
+            return Err(composed_file_footprint_conflict(
+                &request.target,
+                existing,
+                request,
+            ));
+        }
         // A missing source has an unknown eventual shape, but it still claims
         // its target. Whole-resource modes reserve a leaf; symlink-each has a
         // known directory-shaped target even before its children are known.
@@ -266,6 +306,7 @@ fn file_requests_match(config: &Config, first: &FileRequest, second: &FileReques
         && first.source == second.source
         && first.content == second.content
         && first.mode == second.mode
+        && first.manifest == second.manifest
         && first
             .exclude
             .iter()
@@ -313,6 +354,7 @@ fn file_entry_from_toml(target_raw: &str, value: toml::Value) -> Option<FileToml
             if table.is_empty()
                 || table.contains_key("mode")
                 || table.contains_key("exclude")
+                || table.contains_key("manifest")
                 || ((table.contains_key("source") || table.contains_key("content"))
                     && !table.contains_key("block")
                     && !table.contains_key("line")
@@ -340,14 +382,15 @@ fn merge_file_entry(
     origin: &ResourceOrigin,
     merged: &mut IndexMap<PathBuf, FileRequest>,
 ) {
-    let (source, content, mode, exclude) = match entry {
-        FileTomlEntry::Source(source) => (Some(source), None, None, None),
+    let (source, content, mode, exclude, manifest) = match entry {
+        FileTomlEntry::Source(source) => (Some(source), None, None, None, None),
         FileTomlEntry::Table {
             source,
             content,
             mode,
             exclude,
-        } => (source, content, mode, exclude),
+            manifest,
+        } => (source, content, mode, exclude, manifest),
     };
     if source.is_some() && content.is_some() {
         warn!(
@@ -355,9 +398,9 @@ fn merge_file_entry(
         );
         return;
     }
-    if content.is_some() && (mode.is_some() || exclude.is_some()) {
+    if content.is_some() && (mode.is_some() || exclude.is_some() || manifest.is_some()) {
         warn!(
-            "[dotfiles].\"{target_raw}\": inline content does not support mode or exclude, ignoring entry"
+            "[dotfiles].\"{target_raw}\": inline content does not support mode, exclude, or manifest, ignoring entry"
         );
         return;
     }
@@ -384,6 +427,22 @@ fn merge_file_entry(
             }
         },
     };
+    let manifest = match manifest.as_deref() {
+        None => None,
+        Some(value) => match FileManifest::parse(value) {
+            Some(manifest) => Some(manifest),
+            None => {
+                warn!("[dotfiles].\"{target_raw}\": unknown manifest '{value}', ignoring entry");
+                return;
+            }
+        },
+    };
+    if manifest.is_some() && !matches!(mode, FileMode::Copy | FileMode::SymlinkEach) {
+        warn!(
+            "[dotfiles].\"{target_raw}\": manifest requires mode copy or symlink-each, ignoring entry"
+        );
+        return;
+    }
     let target = resolve_target_arg(&target_raw);
     if target.is_relative() {
         warn!(
@@ -401,6 +460,7 @@ fn merge_file_entry(
                 content: Some(content),
                 mode: FileMode::Content,
                 exclude: vec![],
+                manifest: None,
                 base: base.to_path_buf(),
                 origin: origin.clone(),
             },
@@ -426,15 +486,17 @@ fn merge_file_entry(
     };
     let mut origin = origin.clone();
     origin.source = Some(source.clone());
-    for req in expand_request(
+    for req in expand_request(FileRequest {
         target_raw,
         target,
         source,
+        content: None,
         mode,
         exclude,
-        base.to_path_buf(),
+        manifest,
+        base: base.to_path_buf(),
         origin,
-    ) {
+    }) {
         merged.insert(req.target.clone(), req);
     }
 }
@@ -526,15 +588,18 @@ pub(crate) fn copy_path(source: &Path, target: &Path) -> Result<()> {
     Ok(())
 }
 
-fn expand_request(
-    target_raw: String,
-    target: PathBuf,
-    source: PathBuf,
-    mode: FileMode,
-    exclude: Vec<glob::Pattern>,
-    base: PathBuf,
-    origin: ResourceOrigin,
-) -> Vec<FileRequest> {
+fn expand_request(req: FileRequest) -> Vec<FileRequest> {
+    let FileRequest {
+        target_raw,
+        target,
+        source,
+        mode,
+        exclude,
+        manifest,
+        base,
+        origin,
+        ..
+    } = req;
     if !is_glob_pattern(&source) {
         return vec![FileRequest {
             target_raw,
@@ -543,6 +608,7 @@ fn expand_request(
             content: None,
             mode,
             exclude,
+            manifest,
             base,
             origin,
         }];
@@ -587,6 +653,7 @@ fn expand_request(
             content: None,
             mode,
             exclude,
+            manifest,
             base,
             origin: ResourceOrigin {
                 source: Some(matches[0].clone()),
@@ -619,6 +686,7 @@ fn expand_request(
                 content: None,
                 mode,
                 exclude: exclude.clone(),
+                manifest,
                 base: base.clone(),
                 origin: ResourceOrigin {
                     source: Some(matched_source.clone()),
@@ -1168,6 +1236,26 @@ fn is_excluded(rel: &Path, patterns: &[glob::Pattern]) -> bool {
 /// every (source file, target path) pair of a directory-walking entry —
 /// `symlink-each`, and `copy` with a directory source
 fn walk_source_files(req: &FileRequest) -> Result<Vec<(PathBuf, PathBuf)>> {
+    if req.manifest == Some(FileManifest::Git) {
+        return git_tracked_paths(&req.source)?.into_iter().try_fold(
+            vec![],
+            |mut out, entry| -> Result<_> {
+                if entry.is_gitlink || is_excluded(&entry.path, &req.exclude) {
+                    return Ok(out);
+                }
+                let source = req.source.join(&entry.path);
+                match std::fs::symlink_metadata(&source) {
+                    Ok(metadata) if !metadata.file_type().is_dir() => {
+                        out.push((source, req.target.join(entry.path)));
+                    }
+                    Ok(_) => {}
+                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(err) => return Err(err.into()),
+                }
+                Ok(out)
+            },
+        );
+    }
     let mut out = vec![];
     let mut walk = walkdir::WalkDir::new(&req.source)
         .sort_by_file_name()
@@ -1189,6 +1277,140 @@ fn walk_source_files(req: &FileRequest) -> Result<Vec<(PathBuf, PathBuf)>> {
         out.push((entry.path().to_path_buf(), req.target.join(rel)));
     }
     Ok(out)
+}
+
+struct GitTrackedPath {
+    path: PathBuf,
+    is_gitlink: bool,
+    is_symlink: bool,
+}
+
+fn git_tracked_paths(source: &Path) -> Result<Vec<GitTrackedPath>> {
+    let mut root_command = Command::new("git");
+    root_command
+        .arg("-C")
+        .arg(source)
+        .args(["-c", "safe.directory=*", "rev-parse", "--show-toplevel"])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    crate::git::sanitize_git_command(&mut root_command);
+    let root_output = root_command.output().wrap_err_with(|| {
+        format!(
+            "failed to locate Git repository for {}",
+            source.display_user()
+        )
+    })?;
+    if !root_output.status.success() {
+        let stderr = String::from_utf8_lossy(&root_output.stderr)
+            .trim()
+            .to_string();
+        bail!(
+            "failed to locate Git repository for {}: {}",
+            source.display_user(),
+            if stderr.is_empty() {
+                root_output.status.to_string()
+            } else {
+                stderr
+            }
+        );
+    }
+    let root = root_output
+        .stdout
+        .strip_suffix(b"\n")
+        .unwrap_or(&root_output.stdout);
+    let root = root.strip_suffix(b"\r").unwrap_or(root);
+    let safe = format!("safe.directory={}", path_buf_from_git_bytes(root).display());
+    let mut command = Command::new("git");
+    command
+        .arg("-C")
+        .arg(source)
+        .arg("-c")
+        .arg(safe)
+        .arg("-c")
+        .arg("core.autocrlf=false")
+        .args(["ls-files", "-z", "--cached", "--stage", "--", "."])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    crate::git::sanitize_git_command(&mut command);
+    let output = command.output().wrap_err_with(|| {
+        format!(
+            "failed to list Git-tracked files in {}",
+            source.display_user()
+        )
+    })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        bail!(
+            "failed to list Git-tracked files in {}: {}",
+            source.display_user(),
+            if stderr.is_empty() {
+                output.status.to_string()
+            } else {
+                stderr
+            }
+        );
+    }
+    output
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|record| !record.is_empty())
+        .map(|record| {
+            let tab = record
+                .iter()
+                .position(|byte| *byte == b'\t')
+                .ok_or_else(|| {
+                    eyre::eyre!(
+                        "unexpected git ls-files output for {}",
+                        source.display_user()
+                    )
+                })?;
+            let metadata = &record[..tab];
+            let path = path_buf_from_git_bytes(&record[tab + 1..]);
+            if !metadata.ends_with(b" 0") {
+                bail!(
+                    "unresolved Git index entry {} in {}",
+                    path.display(),
+                    source.display_user()
+                );
+            }
+            Ok(GitTrackedPath {
+                is_gitlink: metadata.starts_with(b"160000 "),
+                is_symlink: metadata.starts_with(b"120000 "),
+                path,
+            })
+        })
+        .collect()
+}
+
+/// Capture only the files selected by a Git manifest, preserving the source
+/// repository and any untracked files around them.
+pub(crate) fn capture_git_manifest(req: &FileRequest) -> Result<()> {
+    for entry in git_tracked_paths(&req.source)? {
+        if entry.is_gitlink || entry.is_symlink || is_excluded(&entry.path, &req.exclude) {
+            continue;
+        }
+        let from = req.target.join(&entry.path);
+        let to = req.source.join(entry.path);
+        if from.exists() || from.is_symlink() {
+            if !file::same_file(&from, &to) {
+                copy_path(&from, &to)?;
+            }
+        } else if to.exists() || to.is_symlink() {
+            remove_existing(&to)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn path_buf_from_git_bytes(path: &[u8]) -> PathBuf {
+    use std::os::unix::ffi::OsStringExt;
+    std::ffi::OsString::from_vec(path.to_vec()).into()
+}
+
+#[cfg(not(unix))]
+fn path_buf_from_git_bytes(path: &[u8]) -> PathBuf {
+    String::from_utf8_lossy(path).into_owned().into()
 }
 
 pub(crate) struct ApplyOpts {
@@ -2286,6 +2508,7 @@ mod tests {
             content: None,
             mode,
             exclude: vec![],
+            manifest: None,
             base: source.parent().expect("source parent").to_path_buf(),
             origin: ResourceOrigin {
                 config: PathBuf::from("/mise.toml"),
@@ -2315,6 +2538,21 @@ mod tests {
             link_req(&source_a, &target, FileMode::SymlinkEach),
             link_req(&source_b, &target, FileMode::SymlinkEach),
         ])?;
+        Ok(())
+    }
+
+    #[test]
+    fn composed_symlink_each_rejects_duplicate_state_identity() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let source = dir.path().join("source");
+        let target = dir.path().join("target");
+        file::create_dir_all(&source)?;
+        let ordinary = link_req(&source, &target, FileMode::SymlinkEach);
+        let mut git_manifest = ordinary.clone();
+        git_manifest.manifest = Some(FileManifest::Git);
+
+        let err = validate_composed_file_footprints(&[ordinary, git_manifest]).unwrap_err();
+        assert!(err.to_string().contains("conflicting symlink-each"));
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- add `manifest = "git"` for directory `copy` and `symlink-each` entries
- enumerate only paths returned by `git ls-files`, avoiding traversal of ignored home-directory content
- preserve excludes and stale managed-path cleanup

## Testing
- `cargo check --locked`
- `mise run test:e2e e2e/cli/test_dotfiles_files`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for limiting directory-based dotfile management to files tracked by Git.
  - Untracked and ignored files remain untouched.
  - Links are removed when files are removed from the Git index.
  - Supports exclusions with copy or per-file symlink modes.
  - Refreshing managed copies can capture Git-tracked files back into the source directory.
  - Added validation for compatible directory and mode configurations.

- **Documentation**
  - Added configuration guidance, requirements, behavior details, and examples for Git-tracked directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in dotfiles behavior now shells out to Git and can link or copy home paths based on the index; misconfiguration or a dirty index could surprise users, though conflicted entries fail closed.
> 
> **Overview**
> Adds **`manifest = "git"`** for directory **`copy`** and **`symlink-each`** `[dotfiles]` entries so mise manages only paths from **`git ls-files`** (index stage 0), not every file on disk. That supports dotfile repos that **`gitignore *`** and force-add selected paths, with **`exclude`** still applied on top.
> 
> Apply/status/walk logic now branches on the Git manifest: untracked/ignored files are skipped, gitlinks and conflicted index entries are rejected or ignored, and **`symlink-each`** stale-link cleanup also runs when a path drops out of the index. Git invocations strip inherited **`GIT_DIR`** / **`GIT_WORK_TREE`** / **`GIT_INDEX_FILE`** so parent-repo env does not break listing.
> 
> **`mise bootstrap dotfiles add`** on an already-managed Git-manifest entry uses **`capture_git_manifest`** to sync only tracked files back into the source repo without wiping the tree. Validation blocks manifest on non-directories, incompatible modes, and duplicate **`symlink-each`** state for the same source/target pair.
> 
> Docs add a **Git-tracked directories** section; e2e coverage exercises apply, add, excludes, env sanitization, merge conflicts, and index removal pruning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 066fabd5f7139b7800ce65801cbc5c63292f662d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->