### PR TITLE
fix(schema): add deprecated monorepo root alias

### DIFF
--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -17,6 +17,8 @@ REGISTRY_TOOL_SCHEMA_PATH="$ROOT/schema/mise-registry-tool.json"
 TOMBI="mise x tombi@$TOMBI_VERSION -- tombi"
 TOMBI_LINT="$TOMBI lint --offline --no-cache --error-on-warnings --quiet"
 assert_contains "$TOMBI --version" "tombi $TOMBI_VERSION"
+assert "jq -r '.properties.experimental_monorepo_root.deprecated' '$SCHEMA_PATH'" "true"
+assert "jq -r '.properties.experimental_monorepo_root[\"\$ref\"] == \"#/\$defs/monorepo_root\"' '$SCHEMA_PATH'" "true"
 
 # Set up tombi config pointing to local schema
 cat >"$HOME/tombi.toml" <<EOF

--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -17,8 +17,6 @@ REGISTRY_TOOL_SCHEMA_PATH="$ROOT/schema/mise-registry-tool.json"
 TOMBI="mise x tombi@$TOMBI_VERSION -- tombi"
 TOMBI_LINT="$TOMBI lint --offline --no-cache --error-on-warnings --quiet"
 assert_contains "$TOMBI --version" "tombi $TOMBI_VERSION"
-assert "jq -r '.properties.experimental_monorepo_root.deprecated' '$SCHEMA_PATH'" "true"
-assert "jq -r '.properties.experimental_monorepo_root[\"\$ref\"] == \"#/\$defs/monorepo_root\"' '$SCHEMA_PATH'" "true"
 
 # Set up tombi config pointing to local schema
 cat >"$HOME/tombi.toml" <<EOF

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -3770,6 +3770,11 @@
       "description": "marks this config as a monorepo root for task path syntax",
       "$ref": "#/$defs/monorepo_root"
     },
+    "experimental_monorepo_root": {
+      "deprecated": true,
+      "description": "deprecated alias for monorepo_root",
+      "$ref": "#/$defs/monorepo_root"
+    },
     "monorepo": {
       "description": "configuration for monorepo task discovery",
       "$ref": "#/$defs/monorepo"


### PR DESCRIPTION
Adds the deprecated `experimental_monorepo_root` alias to the configuration schema so editors recognize the same key accepted by the runtime parser.

The alias points to the existing `monorepo_root` definition and is marked deprecated. The runtime warning schedules its removal for mise 2027.12.0.

This is schema validation/completion only; runtime behavior is unchanged.

## Validation

- `mise run render:schema`
- `mise run test:e2e e2e/config/test_schema_tombi`
- `mise run lint-fix`

## Gap provenance

- [#11052](https://github.com/jdx/mise/pull/11052) (merged 2026-07-16) retained `experimental_monorepo_root` as a deprecated parser alias without modeling it in the schema.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Added the deprecated `experimental_monorepo_root` configuration alias. Use `monorepo_root` instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*
