### PR TITLE
fix(task): accept a single string for sources

### DIFF
--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -4112,24 +4112,6 @@ run = "cargo build"
     }
 
     #[test]
-    fn test_task_sources_array() {
-        let body = r#"
-[tasks.build]
-sources = ["Cargo.toml", "src/**/*.rs"]
-run = "cargo build"
-"#;
-
-        let path = std::path::Path::new("/tmp/mise.toml");
-        let rf = MiseToml::from_str(body, path).unwrap();
-        let task = rf.tasks.0.get("build").expect("build task should exist");
-
-        assert_eq!(
-            task.sources,
-            vec!["Cargo.toml".to_string(), "src/**/*.rs".to_string()]
-        );
-    }
-
-    #[test]
     fn test_task_template_sources_single_string() {
         let body = r#"
 [task_templates.build]

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -4091,6 +4091,67 @@ run = 'echo "template"'
         ));
     }
 
+    #[test]
+    fn test_task_sources_single_string() {
+        let body = r#"
+[tasks.build]
+sources = "src/**/*.rs"
+outputs = ["target/debug/mycli"]
+run = "cargo build"
+"#;
+
+        let path = std::path::Path::new("/tmp/mise.toml");
+        let rf = MiseToml::from_str(body, path).unwrap();
+        let task = rf.tasks.0.get("build").expect("build task should exist");
+
+        assert_eq!(
+            task.sources,
+            vec!["src/**/*.rs".to_string()],
+            "single string sources should be wrapped in a vec"
+        );
+    }
+
+    #[test]
+    fn test_task_sources_array() {
+        let body = r#"
+[tasks.build]
+sources = ["Cargo.toml", "src/**/*.rs"]
+run = "cargo build"
+"#;
+
+        let path = std::path::Path::new("/tmp/mise.toml");
+        let rf = MiseToml::from_str(body, path).unwrap();
+        let task = rf.tasks.0.get("build").expect("build task should exist");
+
+        assert_eq!(
+            task.sources,
+            vec!["Cargo.toml".to_string(), "src/**/*.rs".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_task_template_sources_single_string() {
+        let body = r#"
+[task_templates.build]
+sources = "src/**/*.rs"
+run = "cargo build"
+"#;
+
+        let path = std::path::Path::new("/tmp/mise.toml");
+        let rf = MiseToml::from_str(body, path).unwrap();
+        let template = rf
+            .task_templates
+            .0
+            .get("build")
+            .expect("build template should exist");
+
+        assert_eq!(
+            template.sources,
+            vec!["src/**/*.rs".to_string()],
+            "single string sources should be wrapped in a vec"
+        );
+    }
+
     #[tokio::test]
     async fn test_remove_alias() {
         let _config = Config::get().await.unwrap();

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -711,7 +711,7 @@ pub(crate) struct Task {
     pub raw_args: bool,
     #[serde(default)]
     pub interactive: bool,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_arr")]
     pub sources: Vec<String>,
     #[serde(default)]
     pub watch: Option<TaskWatchOptions>,

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1434,7 +1434,14 @@ impl Task {
         task.raw = p.parse_bool("raw").unwrap_or_default();
         task.raw_args = p.parse_bool("raw_args").unwrap_or_default();
         task.interactive = p.parse_bool("interactive").unwrap_or_default();
-        task.sources = p.parse_array("sources").unwrap_or_default();
+        task.sources = p
+            .get_raw("sources")
+            .map(|v| {
+                deserialize_arr::<_, Vec<String>, String>(v.clone())
+                    .map_err(|e| eyre!("failed to parse sources field in task header: {e}"))
+            })
+            .transpose()?
+            .unwrap_or_default();
         task.watch = p
             .get_raw("watch")
             .map(|v| {
@@ -4541,6 +4548,28 @@ echo "hello world"
         expected.aliases = vec!["b".to_string()];
         expected.sources = vec!["Cargo.toml".to_string(), "src/**/*.rs".to_string()];
         assert_eq!(result.unwrap(), expected);
+    }
+
+    #[tokio::test]
+    async fn test_from_path_sources_single_string() {
+        use std::fs;
+        use tempfile::tempdir;
+
+        let config = Config::get().await.unwrap();
+        let temp_dir = tempdir().unwrap();
+        let task_path = temp_dir.path().join("test_task");
+
+        fs::write(
+            &task_path,
+            r#"#!/bin/bash
+#MISE sources="src/**/*.rs"
+echo "hello world"
+"#,
+        )
+        .unwrap();
+
+        let result = Task::from_path(&config, &task_path, temp_dir.path(), temp_dir.path()).await;
+        assert_eq!(result.unwrap().sources, vec!["src/**/*.rs".to_string()]);
     }
 
     #[tokio::test]

--- a/src/task/task_template.rs
+++ b/src/task/task_template.rs
@@ -30,7 +30,7 @@ pub(crate) struct TaskTemplate {
     pub vars: EnvList,
     #[serde(default)]
     pub dir: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_arr")]
     pub sources: Vec<String>,
     #[serde(default)]
     pub watch: Option<TaskWatchOptions>,


### PR DESCRIPTION
Task `sources` is documented and schematized as `string | string[]`, but runtime deserialization only accepted an array. This updates tasks and task templates to use the existing `deserialize_arr` helper, and updates tracked file-task headers to accept the same scalar form.

Coverage includes scalar TOML tasks, scalar task templates, and scalar `#MISE sources=...` file-task headers.

Validation after rebasing onto current main:

- `mbx test --bin mise sources_single_string` (3 passed)
- scoped `hk fix` (cargo fmt and all-features cargo check)
- `git diff --check upstream/main...HEAD`


## Gap provenance

- [#8285](https://github.com/jdx/mise/pull/8285) (merged 2026-02-21) added a scalar-string branch for task `sources` to both JSON schemas, while the TOML task parser continued to require an array. This PR removes that schema-only form.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Task and task template source settings now accept either a single file path or a list of file paths.
  - Existing configurations using a single `sources` value are now parsed correctly.

- **Tests**
  - Added coverage for single-value source configurations in tasks and task templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*
