### PR TITLE
fix(schema): enforce env required value combinations

### DIFF
--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -143,8 +143,9 @@ TOML
 # placeholder values while running tombi through `mise x`.
 cat >"$HOME/workdir/mise-age.toml" <<'TOML'
 [env]
-VALUE_OBJECT = { value = 123, tools = true, redact = true, required = "set VALUE_OBJECT" }
+VALUE_OBJECT = { value = 123, tools = true, redact = true, required = false }
 VALUE_DEFAULT = { default = 123, tools = true, redact = true }
+REQUIRED_HELP = { required = "set REQUIRED_HELP", tools = true }
 SECRET_SIMPLE = { age = "AGE-SECRET", tools = true }
 SECRET_COMPLEX = { age = { value = "AGE-SECRET", format = "raw", tools = true, redact = true } }
 TOML
@@ -229,7 +230,7 @@ strict = true
 
 [[schemas]]
 path = "file://$SCHEMA_PATH"
-include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-dotfiles.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-env-float.toml", "mise-bad-install-env-float.toml", "mise-bad-minimum-release-age-array.toml", "mise-bad-minimum-release-age-table.toml", "mise-bad-package-state.toml", "mise-bad-postinstall.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-launchd-queue.toml", "mise-bad-launchd-throttle.toml", "mise-bad-systemd.toml", "mise-bad-oci-copy.toml", "mise-bad-shell-activate.toml"]
+include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-dotfiles.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-env-required.toml", "mise-bad-env-float.toml", "mise-bad-install-env-float.toml", "mise-bad-minimum-release-age-array.toml", "mise-bad-minimum-release-age-table.toml", "mise-bad-package-state.toml", "mise-bad-postinstall.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-launchd-queue.toml", "mise-bad-launchd-throttle.toml", "mise-bad-systemd.toml", "mise-bad-oci-copy.toml", "mise-bad-shell-activate.toml"]
 
 [[schemas]]
 path = "file://$TASK_SCHEMA_PATH"
@@ -362,6 +363,15 @@ TOOLS_FILTERED = { value = "not actually resolved as a var", tools = true }
 TOML
 
 assert_fail "$TOMBI_LINT mise-bad-vars.toml"
+
+# A concrete value may opt out of required validation, but it cannot also be
+# marked as required.
+cat >"$HOME/workdir/mise-bad-env-required.toml" <<'TOML'
+[env]
+VALUE_AND_REQUIRED = { value = "x", required = true }
+TOML
+
+assert_fail "$TOMBI_LINT mise-bad-env-required.toml"
 
 # Verify that extends is rejected on task_templates (not supported at runtime)
 cat >"$HOME/workdir/mise-bad-tmpl.toml" <<'TOML'

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -421,7 +421,8 @@
                 "$ref": "#/$defs/env_redact"
               },
               "required": {
-                "$ref": "#/$defs/env_required"
+                "const": false,
+                "description": "cannot be required when a value is provided; only `required = false` is accepted"
               }
             },
             "required": ["value"],
@@ -453,7 +454,15 @@
                 "$ref": "#/$defs/env_redact"
               },
               "required": {
-                "$ref": "#/$defs/env_required"
+                "oneOf": [
+                  {
+                    "const": true
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "description": "a variable without a value must be required: `true` or a help string on how to set it"
               }
             },
             "required": ["required"],
@@ -1049,19 +1058,6 @@
       "type": "boolean",
       "description": "redact the value from logs"
     },
-    "env_required": {
-      "oneOf": [
-        {
-          "type": "boolean",
-          "description": "require this environment variable to be defined before mise runs or in a later config file"
-        },
-        {
-          "type": "string",
-          "description": "require this environment variable with user help text on how to set it"
-        }
-      ],
-      "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
-    },
     "env_default": {
       "oneOf": [
         {
@@ -1078,6 +1074,19 @@
     "env_age": {
       "type": "string",
       "description": "[experimental] age-encrypted value (simplified format)"
+    },
+    "env_required": {
+      "oneOf": [
+        {
+          "type": "boolean",
+          "description": "require this environment variable to be defined before mise runs or in a later config file"
+        },
+        {
+          "type": "string",
+          "description": "require this environment variable with user help text on how to set it"
+        }
+      ],
+      "description": "require this environment variable to be defined before mise runs or in a later config file. Can be a boolean or a help string. A variable that carries its own `value` cannot also be `required = true`."
     },
     "tool_options": {
       "properties": {

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -155,7 +155,7 @@
           "description": "require this environment variable with user help text on how to set it"
         }
       ],
-      "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
+      "description": "require this environment variable to be defined before mise runs or in a later config file. Can be a boolean or a help string. A variable that carries its own `value` cannot also be `required = true`."
     },
     "env_default": {
       "oneOf": [
@@ -242,7 +242,8 @@
                 "$ref": "#/$defs/env_redact"
               },
               "required": {
-                "$ref": "#/$defs/env_required"
+                "const": false,
+                "description": "cannot be required when a value is provided; only `required = false` is accepted"
               }
             },
             "required": ["value"],
@@ -274,7 +275,15 @@
                 "$ref": "#/$defs/env_redact"
               },
               "required": {
-                "$ref": "#/$defs/env_required"
+                "oneOf": [
+                  {
+                    "const": true
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "description": "a variable without a value must be required: `true` or a help string on how to set it"
               }
             },
             "required": ["required"],


### PR DESCRIPTION
## Summary

- allow `required = false` alongside a concrete environment `value`
- reject `required = true` or help text alongside a concrete value
- require standalone `required` entries to be `true` or a help string
- correct the shared option description to match those combinations

This PR is now the focused required-value portion of the former combined env/vars schema change.

## Split work

The scopes are independent and can merge in any order:

- this PR: environment required/value combinations
- #12793: environment directive aliases and options
- #12794: vars values, directives, and ignored-tools restrictions

## Validation

- `mise run render:schema`
- `mise run test:e2e e2e/config/test_schema_tombi`
- `mise run lint-fix`

Schema-only change; runtime behavior is unchanged.

## Gap provenance

- #10697 added required/redacted variable option behavior without fully equivalent schema coverage.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Tightened environment variable validation to prevent entries with a concrete value from also being marked as required.
  - Preserved support for required-only variables using `true` or a help message.
  - Added validation coverage for invalid combinations and updated schema fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->