### PR TITLE
registry: add mosh (conda:mosh)

### DIFF
--- a/registry/mosh.toml
+++ b/registry/mosh.toml
@@ -1,0 +1,6 @@
+backends = ["conda:mosh"]
+bins = ["mosh", "mosh-client", "mosh-server"]
+description = "Mobile Shell"
+os = ["linux", "macos"]
+test = { cmd = "mosh --version", expected = "mosh {{version}}" }
+version_order = "semver"


### PR DESCRIPTION
## Why conda rather than aqua or github

mosh publishes no prebuilt cross-platform binaries. The only assets on its GitHub releases are:

    mosh-1.4.0.tar.gz                 source tarball (needs ./configure && make)
    mosh-1.4.0.pkg                    macos-only Apple installer package
    mosh-1.4.0-osx-build-report.tbz   build diagnostics (plists, no binaries)

A `github:` backend selects the build report and reports success while installing nothing runnable -- verified: `mise x github:mobile-shell/mosh@mosh-1.4.0 -- mosh --version` fails with "couldn't exec process: No such file or directory". mosh is also not in the aqua standard registry, and aqua only packages prebuilt binaries, so neither tier 1 backend can work here.

conda-forge builds mosh from source and publishes binaries for linux-64, linux-aarch64, linux-ppc64le, osx-64, and osx-arm64. Per the backend tiers in contributing.md, conda is the tier 2 option "for tools that can't reasonably be supported via aqua/github", and mise's conda backend needs no separately installed package manager. This entry follows the existing `ffmpeg`, `ghc`, `clang`, and `clang-format` entries, which use `conda:` as their primary backend.

conda-forge has no windows build and mosh has no native windows port, hence `os = ["linux", "macos"]`.

The package installs `mosh`, `mosh-client`, and `mosh-server`, so all three are listed in `bins`.

## Popularity

- GitHub: 14,402 stars, 855 forks; created 2011, latest repository push 2026-03-22
- conda-forge: 299,784 downloads
- Also packaged in Homebrew and nixpkgs
- Note: the last tagged release is mosh-1.4.0 (2022-10-27); development continues on the default branch
- https://mosh.org/
- https://github.com/mobile-shell/mosh

## Validation

- `mise test-tool mosh` -> `mosh: OK`
- `mise ls-remote conda:mosh` -> `1.3.2`, `1.4.0`
- `mise x conda:mosh@1.4.0 -- mosh --version` -> `mosh 1.4.0 [build mosh 1.4.0]`
- `mise x conda:mosh@1.4.0 -- mosh-client --version` -> `mosh-client (mosh 1.4.0) [build mosh 1.4.0]`
- `mise x conda:mosh@1.4.0 -- mosh-server --version` -> `mosh-server (mosh 1.4.0) [build mosh 1.4.0]`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Mosh to the registry with Conda installation support.
  * Included platform compatibility details, descriptive metadata, version detection, and semantic version ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->