### PR TITLE
registry: add broot (github:canop/broot)

### DIFF
--- a/e2e/cli/test_did_you_mean
+++ b/e2e/cli/test_did_you_mean
@@ -13,8 +13,8 @@ assert_fail "mise use nod" "node"
 assert_fail "mise use pythn" "python"
 
 # Test: Aqua Cargo and GoInstall packages should use runnable backend suggestions
-assert_not_contains "mise use broot 2>&1 || true" "aqua:crates.io/broot"
-assert_fail "mise use broot" "cargo:broot"
+assert_not_contains "mise use wasmi_cli 2>&1 || true" "aqua:crates.io/wasmi_cli"
+assert_fail "mise use wasmi_cli" "cargo:wasmi_cli"
 assert_not_contains "mise use benchstat 2>&1 || true" "aqua:golang.org/x/perf/cmd/benchstat"
 assert_fail "mise use benchstat" "go:golang.org/x/perf/cmd/benchstat"
 assert_fail "mise use mapotf" "go:github.com/Azure/mapotf"

--- a/e2e/cli/test_search
+++ b/e2e/cli/test_search
@@ -24,13 +24,16 @@ assert_contains "mise search aqua:ip7z/7zip" "aqua:ip7z/7zip"
 assert "mise search --match-type equal 7zip" "7zip  7-Zip is a file archiver with a high compression ratio. https://github.com/ip7z/7zip"
 
 # Backend prefixes matching a shorthand do not dump translated aqua packages
-assert_not_contains "mise search cargo" "cargo:broot"
+assert_not_contains "mise search cargo" "cargo:wasmi_cli"
 assert_not_contains "mise search aqua" "aqua:"
 
 # Aqua Cargo and GoInstall packages use runnable backends in search results
-assert_contains "mise search --match-type equal broot" "cargo:broot"
-assert_not_contains "mise search --match-type equal broot" "aqua:crates.io/broot"
-assert_contains "mise search cargo:broot" "cargo:broot"
+assert_contains "mise search --match-type equal wasmi_cli" "cargo:wasmi_cli"
+assert_not_contains "mise search --match-type equal wasmi_cli" "aqua:crates.io/wasmi_cli"
+assert_contains "mise search cargo:wasmi_cli" "cargo:wasmi_cli"
+
+# The broot shorthand collapses its translated Cargo package into a single result
+assert "mise search --match-type equal broot" "broot  A new way to see and navigate directory trees. https://github.com/canop/broot"
 assert_contains "mise search --match-type equal benchstat" "go:golang.org/x/perf/cmd/benchstat"
 assert_not_contains "mise search --match-type equal benchstat" "aqua:golang.org/x/perf/cmd/benchstat"
 assert_contains "mise search go:golang.org/x/perf/cmd/benchstat" "go:golang.org/x/perf/cmd/benchstat"

--- a/registry/broot.toml
+++ b/registry/broot.toml
@@ -1,0 +1,10 @@
+description = "A new way to see and navigate directory trees"
+test = { cmd = "broot --version", expected = "broot {{version}}" }
+version_order = "semver"
+
+bins = ["broot"]
+[[backends]]
+full = "github:canop/broot"
+
+[backends.options]
+bin_path = '{{ arch(x64="x86_64", arm64="aarch64") }}-{{ os(macos="apple-darwin", linux="unknown-linux-gnu", windows="pc-windows-gnu") }}'


### PR DESCRIPTION
- https://github.com/Canop/broot

Not in the aqua standard registry as a GitHub release package, so `github` is the tier 1 backend.

Every version `mise ls-remote` resolves for this tool is a strict `MAJOR.MINOR.PATCH` -- a single legacy `0.13.5b` tag is filtered out -- hence `version_order = "semver"`.

## bin_path

broot publishes one universal `broot_<version>.zip` rather than per-platform assets, with each build under a Rust target-triple directory (`aarch64-apple-darwin/broot`, `x86_64-unknown-linux-gnu/broot`, `x86_64-pc-windows-gnu/broot.exe`, ...) alongside non-binary directories such as `completion/` and `default-conf/`. Without `bin_path`, autodetection picks an arbitrary target directory and the selected binary fails to execute. Since the directory names are exactly Rust target triples, one templated `bin_path` covers every platform rather than a per-platform table:

    macos-arm64  -> aarch64-apple-darwin
    linux-x64    -> x86_64-unknown-linux-gnu
    linux-arm64  -> aarch64-unknown-linux-gnu
    windows-x64  -> x86_64-pc-windows-gnu

Upstream ships no `x86_64-apple-darwin` build, so intel macos is not covered by the release archive; `cargo:broot` remains available for that case.

## e2e/cli/test_search

`test_search` used broot as its example of an aqua Cargo package translated into a runnable `cargo:` backend (added in #12225, "suggest compatible package backends"). Adding this shorthand makes `mise search broot` return the registry entry instead, so the test needed updating.

Rather than rewrite those assertions to expect the shorthand -- which would remove the coverage #12225 added -- the aqua Cargo subject is moved to `wasmi_cli`, which is in the aqua registry under `crates.io/` with no mise shorthand and behaves identically. An exact-match assertion for the broot shorthand is added alongside, matching the style used for `jq` and `7zip`.

If you would rather keep broot as that example, this entry can be dropped instead -- happy either way.

## Popularity

- GitHub: 12,918 stars, 309 forks; latest release v1.59.0 published 2026-08-22
- Active maintenance: latest repository push 2026-08-25
- crates.io `broot`: 440,553 downloads
- Also packaged in Homebrew

## Validation

- `mise test-tool broot` -> `broot: OK` (against v1.59.0)
- `mise run test:e2e e2e/cli/test_search` -> passes
- resolved bin path `.../installs/broot/latest/aarch64-apple-darwin/broot`
- `broot --version` -> `broot 1.59.0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `broot` to the tool registry with version detection, platform-specific installation support, and source repository information.

* **Tests**
  * Updated CLI search coverage for `wasmi_cli`.
  * Verified that the `broot` shorthand consolidates its translated Cargo package into one result.
  * Updated “Did you mean?” coverage for accurate `wasmi_cli` suggestions and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->