### PR TITLE
chore(ci): adopt mbx 0.5.4

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -9,9 +9,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
+    - uses: jdx/mr-boxington-action@d311086f3b4337b7ad305330ff77ea716d372fc1 # v1
       with:
-        version: 0.5.1
+        version: 0.5.3
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/mise

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -11,7 +11,7 @@ runs:
   steps:
     - uses: jdx/mr-boxington-action@d311086f3b4337b7ad305330ff77ea716d372fc1 # v1
       with:
-        version: 0.5.3
+        version: 0.5.4
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/mise

--- a/mise.lock
+++ b/mise.lock
@@ -483,53 +483,63 @@ url = "https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.
 url_api = "https://api.github.com/repos/orhun/git-cliff/releases/assets/405851866"
 
 [[tools."github:jdx/mr-boxington"]]
-version = "0.5.1"
+version = "0.5.3"
 backend = "github:jdx/mr-boxington"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-arm64"]
-checksum = "sha256:34f3b95832e4a422a9bdb7a30fedcbcef801448d0e5692753b4ba78da4d95e6b"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.1/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/531288157"
+checksum = "sha256:05b465304902e9a37d3345623b89673e34a76ec960ddd2a623b3b4adc57ebdee"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.3/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533059747"
+provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-arm64-musl"]
-checksum = "sha256:34f3b95832e4a422a9bdb7a30fedcbcef801448d0e5692753b4ba78da4d95e6b"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.1/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/531288157"
+checksum = "sha256:05b465304902e9a37d3345623b89673e34a76ec960ddd2a623b3b4adc57ebdee"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.3/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533059747"
+provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64"]
-checksum = "sha256:405b82a99b0175532adbcfcb3b3d6dfc6c57981140b97b255c7fab2de0e262e9"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.1/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/531288155"
+checksum = "sha256:ba20120238687571e1cd8649c336ae278dbbf3b4acf560b75d43351b7de06635"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.3/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533059753"
+provenance = "github-attestations"
+provenance_verified = true
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64-baseline"]
-checksum = "sha256:405b82a99b0175532adbcfcb3b3d6dfc6c57981140b97b255c7fab2de0e262e9"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.1/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/531288155"
+checksum = "sha256:ba20120238687571e1cd8649c336ae278dbbf3b4acf560b75d43351b7de06635"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.3/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533059753"
+provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64-musl"]
-checksum = "sha256:405b82a99b0175532adbcfcb3b3d6dfc6c57981140b97b255c7fab2de0e262e9"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.1/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/531288155"
+checksum = "sha256:ba20120238687571e1cd8649c336ae278dbbf3b4acf560b75d43351b7de06635"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.3/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533059753"
+provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:405b82a99b0175532adbcfcb3b3d6dfc6c57981140b97b255c7fab2de0e262e9"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.1/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/531288155"
+checksum = "sha256:ba20120238687571e1cd8649c336ae278dbbf3b4acf560b75d43351b7de06635"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.3/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533059753"
+provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.macos-arm64"]
-checksum = "sha256:02b014fa97bacec5333c3aac49af38f3787d960a0c67c657efa9d73c349164c1"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.1/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/531288158"
+checksum = "sha256:f29a17bd8242f140d2ffdff26116b0433d70073e89b8b602da47931ee7184ab6"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.3/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533059748"
+provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.windows-x64"]
-checksum = "sha256:df3adb7deb325ef283d0b5d441f3ce5bf0f4cedc72effa379688d786110fb929"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.1/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/531288152"
+checksum = "sha256:5baf59eed06b711f2e363e52009953d03bb00bc03b25cdd73c318c061d518a1d"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.3/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533059746"
+provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.windows-x64-baseline"]
-checksum = "sha256:df3adb7deb325ef283d0b5d441f3ce5bf0f4cedc72effa379688d786110fb929"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.1/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/531288152"
+checksum = "sha256:5baf59eed06b711f2e363e52009953d03bb00bc03b25cdd73c318c061d518a1d"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.3/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533059746"
+provenance = "github-attestations"
 
 [[tools."github:jdx/tak"]]
 version = "0.0.8"

--- a/mise.lock
+++ b/mise.lock
@@ -483,62 +483,62 @@ url = "https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.
 url_api = "https://api.github.com/repos/orhun/git-cliff/releases/assets/405851866"
 
 [[tools."github:jdx/mr-boxington"]]
-version = "0.5.3"
+version = "0.5.4"
 backend = "github:jdx/mr-boxington"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-arm64"]
-checksum = "sha256:05b465304902e9a37d3345623b89673e34a76ec960ddd2a623b3b4adc57ebdee"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.3/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533059747"
+checksum = "sha256:e34adc416bb508f2ce9893b1bfc37baf648cf37633f22ec2056313b134a8b8bf"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.4/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533135048"
 provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-arm64-musl"]
-checksum = "sha256:05b465304902e9a37d3345623b89673e34a76ec960ddd2a623b3b4adc57ebdee"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.3/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533059747"
+checksum = "sha256:e34adc416bb508f2ce9893b1bfc37baf648cf37633f22ec2056313b134a8b8bf"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.4/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533135048"
 provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64"]
-checksum = "sha256:ba20120238687571e1cd8649c336ae278dbbf3b4acf560b75d43351b7de06635"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.3/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533059753"
+checksum = "sha256:e63b7b1c1a628da767a7f6acd8c8a359c4a3266bc8dbad633983b6320861a8b8"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.4/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533135059"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64-baseline"]
-checksum = "sha256:ba20120238687571e1cd8649c336ae278dbbf3b4acf560b75d43351b7de06635"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.3/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533059753"
+checksum = "sha256:e63b7b1c1a628da767a7f6acd8c8a359c4a3266bc8dbad633983b6320861a8b8"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.4/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533135059"
 provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64-musl"]
-checksum = "sha256:ba20120238687571e1cd8649c336ae278dbbf3b4acf560b75d43351b7de06635"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.3/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533059753"
+checksum = "sha256:e63b7b1c1a628da767a7f6acd8c8a359c4a3266bc8dbad633983b6320861a8b8"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.4/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533135059"
 provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:ba20120238687571e1cd8649c336ae278dbbf3b4acf560b75d43351b7de06635"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.3/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533059753"
+checksum = "sha256:e63b7b1c1a628da767a7f6acd8c8a359c4a3266bc8dbad633983b6320861a8b8"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.4/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533135059"
 provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.macos-arm64"]
-checksum = "sha256:f29a17bd8242f140d2ffdff26116b0433d70073e89b8b602da47931ee7184ab6"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.3/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533059748"
+checksum = "sha256:290e5400fb0626331e5216a51384a6dfe11c0e05817e3bc9f54aa471c38ddf14"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.4/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533135050"
 provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.windows-x64"]
-checksum = "sha256:5baf59eed06b711f2e363e52009953d03bb00bc03b25cdd73c318c061d518a1d"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.3/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533059746"
+checksum = "sha256:54f05f2b7da4b6b3570c1867d2ba5c4ce9c17732bd9199adab138a6914c8ff2e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.4/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533135049"
 provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.windows-x64-baseline"]
-checksum = "sha256:5baf59eed06b711f2e363e52009953d03bb00bc03b25cdd73c318c061d518a1d"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.3/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533059746"
+checksum = "sha256:54f05f2b7da4b6b3570c1867d2ba5c4ce9c17732bd9199adab138a6914c8ff2e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.4/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533135049"
 provenance = "github-attestations"
 
 [[tools."github:jdx/tak"]]


### PR DESCRIPTION
## Summary

- update the composite CI wrapper to install mbx 0.5.4
- pin the action revision that supports immutable release digests and Windows ARM64
- refresh `mise.lock` URLs, checksums, asset IDs, and GitHub attestation provenance
- preserve the existing trusted-server and fork-safe GitHub cache routing

mbx 0.5.4 includes the persistent compiler-shim fix needed by builds that retain `HOST_CC` paths across sessions.

## Testing

- `mise lock --bump --minimum-release-age 0 github:jdx/mr-boxington`
- locked Linux install reports `mbx 0.5.4`
- `git diff --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*