### PR TITLE
registry: add pastel (github:sharkdp/pastel)

### DIFF
--- a/registry/pastel.toml
+++ b/registry/pastel.toml
@@ -1,0 +1,5 @@
+backends = ["aqua:sharkdp/pastel", "github:sharkdp/pastel"]
+bins = ["pastel"]
+description = "A command-line tool to generate, analyze, convert and manipulate colors"
+test = { cmd = "pastel --version", expected = "pastel {{version}}" }
+version_order = "semver"


### PR DESCRIPTION
In the aqua standard registry, so `aqua` is the preferred backend, with `github` as a tier 1 fallback.

Every version `mise ls-remote` resolves for this tool is a strict `MAJOR.MINOR.PATCH`, hence `version_order = "semver"`.

## Popularity

- GitHub: 6,471 stars, 130 forks; latest release v0.12.0 published 2026-02-14
- Active maintenance: latest repository push 2026-05-01
- Also packaged in Homebrew
- https://github.com/sharkdp/pastel

## Validation

- `mise test-tool pastel` -> `pastel: OK`
- `mise x aqua:sharkdp/pastel@0.12.0 -- pastel --version` -> `pastel 0.12.0`
- `mise x github:sharkdp/pastel@0.12.0 -- pastel --version` -> `pastel 0.12.0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing and managing the `pastel` tool.
  * Added version detection and semantic version ordering for `pastel`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->