### PR TITLE
fix(ci): keep release builds on one compiler path

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -52,6 +52,9 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
           # render tasks rebuild mise after bumping its version. Allow that nested
           # build to use dependencies whose rust-version metadata exceeds our MSRV.
+          # Keep using the same compiler path as the bootstrap build above: changing
+          # to mbx in an existing CMake tree makes AWS-LC reject the reconfigure.
+          MISE_CARGO_BUILD_COMMAND: cargo build
           MISE_CARGO_BUILD_EXTRA_ARGS: --ignore-rust-version
           # The full-feature build above already covers compilation. Avoid HK's
           # redundant cargo-check, which enforces dependency rust-version metadata.

--- a/tasks.toml
+++ b/tasks.toml
@@ -14,8 +14,8 @@ depends = ['lint:*']
 
 [build]
 alias = "b"
-run = "mbx build --all-features {{ get_env(name='MISE_CARGO_BUILD_EXTRA_ARGS', default='') }}"
-run_windows = "mbx build {{ get_env(name='MISE_CARGO_BUILD_EXTRA_ARGS', default='') }}"
+run = "{{ get_env(name='MISE_CARGO_BUILD_COMMAND', default='mbx build') }} --all-features {{ get_env(name='MISE_CARGO_BUILD_EXTRA_ARGS', default='') }}"
+run_windows = "{{ get_env(name='MISE_CARGO_BUILD_COMMAND', default='mbx build') }} {{ get_env(name='MISE_CARGO_BUILD_EXTRA_ARGS', default='') }}"
 description = "Build the project"
 #sources = ["Cargo.*", "src/**/*.rs"]
 #outputs = ["target/debug/mise"]


### PR DESCRIPTION
Allow the shared build task to select plain Cargo, then use that path in `release-plz`. The release job bootstraps `target/debug` with Cargo and deliberately disables persistent caches; switching that existing CMake tree to mbx during the render rebuild makes AWS-LC reject the compiler change.

Normal development and CI builds still default to `mbx build`.

Validation:
- `mise run --dry-run build`
- `MISE_CARGO_BUILD_COMMAND="cargo build" mise run --dry-run build`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the release-plz workflow and the mise build task wrapper; default builds are unchanged.
> 
> **Overview**
> Release `release-plz` was bootstrapping with plain **`cargo build`**, then nested render rebuilds went through the shared **`build`** task using **`mbx`**, which reconfigured an existing CMake/AWS-LC tree and failed.
> 
> The **`build`** task now honors **`MISE_CARGO_BUILD_COMMAND`** (still defaults to **`mbx build`** for normal dev/CI). The release workflow sets **`MISE_CARGO_BUILD_COMMAND=cargo build`** so post-bump rebuilds stay on the same compiler path as the bootstrap step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d53311f017232e0b582a83caf6c6e5fb73d72981. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release builds by ensuring nested builds use the same compiler path as the initial build.
  * Prevented build failures caused by reconfiguring existing build directories with an incompatible build command.
  * Added support for configuring the Cargo build command through an environment variable, while retaining the existing default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->