### PR TITLE
chore(ci): pin mr-boxington-action v1.0.1

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: jdx/mr-boxington-action@d311086f3b4337b7ad305330ff77ea716d372fc1 # v1
+    - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563 # v1.0.1
       with:
         version: 0.5.4
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}


### PR DESCRIPTION
Pin the mbx setup composite to the tagged v1.0.1 action commit. This release authenticates release-metadata lookups with the workflow token, preventing the intermittent GitHub API 403s seen when many CLI jobs start together. The matching tag annotation also satisfies Zizmor’s ref-version check.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pin update with no application or auth logic changes in this repo.
> 
> **Overview**
> Updates the **mbx** composite action to use **`jdx/mr-boxington-action` v1.0.1** (new commit SHA) instead of the previous **v1** pin.
> 
> The bump is meant to fix **intermittent GitHub API 403s** when many workflows start at once, by having release-metadata lookups use the **workflow token**. The **v1.0.1** tag annotation also aligns with **Zizmor** ref-version checks. No changes to mbx inputs, backend selection logic, or cache settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14c065735c3a017eaa7c95ca53081c23f18c3f5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the automated workflow component to its latest `v1.0.1` revision.
  - No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->