### PR TITLE
registry: add exiftool (conda:exiftool)

### DIFF
--- a/registry/exiftool.toml
+++ b/registry/exiftool.toml
@@ -1,0 +1,5 @@
+backends = ["conda:exiftool"]
+bins = ["exiftool"]
+description = "ExifTool meta information reader/writer"
+test = { cmd = "exiftool -ver", expected = "{{version}}" }
+version_order = "source"


### PR DESCRIPTION
ExifTool is Phil Harvey's metadata reader/writer for images, audio and video.

- https://exiftool.org/
- https://github.com/exiftool/exiftool

## Why conda rather than aqua or github

`github:exiftool/exiftool` cannot list versions. The repository publishes no GitHub releases at all -- only git tags -- so the github backend finds nothing:

    $ mise ls-remote github:exiftool/exiftool
    mise WARN  No versions found for github:exiftool/exiftool

Upstream distributes from exiftool.org instead: a Perl source tarball, a Windows `.zip`, and a macOS `.pkg`. There is no cross-platform prebuilt binary to point a tier 1 backend at. exiftool is also absent from the aqua standard registry -- the only aqua match is `yashikota/exiftool-go`, an unrelated third-party Go wrapper, not this project.

conda-forge builds exiftool with its Perl runtime bundled and publishes for linux-64, linux-aarch64, linux-ppc64le, osx-64, osx-arm64 and win-64, so no `os` restriction is needed. Per the backend tiers in contributing.md, conda is the tier 2 option "for tools that can't reasonably be supported via aqua/github", and mise's conda backend needs no separately installed package manager. This follows the existing `ffmpeg`, `ghc`, `clang`, `clang-format`, and `mosh` entries, which use `conda:` as their primary backend.

Although the package bundles a Perl distribution, mise exposes only `exiftool` in `.mise-bins` -- the bundled `perl`, `cpan`, and `h2ph` are not surfaced, so there is no collision with the existing `perl` entry.

Releases are two-component versions (`12.30`, `13.59`) rather than `MAJOR.MINOR.PATCH`, so `version_order = "source"`.

## Popularity

- conda-forge: 131,409 downloads; latest 13.59
- GitHub mirror: 4,988 stars, 478 forks; latest push 2026-05-27
- Also packaged in Homebrew, Debian, Fedora, and Arch
- The de facto standard tool for reading and writing media metadata, in continuous release since 2003

## Validation

- `mise test-tool exiftool` -> `exiftool: OK`
- `mise ls-remote conda:exiftool` -> `12.30 ... 13.59` (17 versions)
- `mise x conda:exiftool@13.59 -- exiftool -ver` -> `13.59`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ExifTool to the available software registry.
  * ExifTool can be installed through the Conda backend and includes version verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->