### PR TITLE
registry: add spotify-player (github:aome510/spotify-player)

### DIFF
--- a/registry/spotify-player.toml
+++ b/registry/spotify-player.toml
@@ -1,0 +1,5 @@
+backends = ["github:aome510/spotify-player"]
+bins = ["spotify_player"]
+description = "A Spotify player in the terminal with full feature parity"
+test = { cmd = "spotify_player --version", expected = "spotify_player {{version}}" }
+version_order = "semver"


### PR DESCRIPTION
- https://github.com/aome510/spotify-player

Not in the aqua standard registry, so `github` is the tier 1 backend. Upstream ships per-platform archives for linux/macos/windows on amd64 and arm64, so no `asset_pattern`, `bin_path`, or `os` restriction is needed. The executable is `spotify_player` rather than the repository name, hence `bins`.

Every version `mise ls-remote` resolves for this tool is a strict `MAJOR.MINOR.PATCH`, hence `version_order = "semver"`.

## Popularity

- GitHub: 7,139 stars, 379 forks; latest release v0.24.1 published 2026-07-20
- Active maintenance: latest repository push 2026-07-20
- Also packaged in Homebrew as `spotify_player`

## Validation

- `mise test-tool spotify-player` -> `spotify-player: OK`
- `mise x github:aome510/spotify-player@0.24.1 -- spotify_player --version` -> `spotify_player 0.24.1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Spotify Player to the available application registry.
  * Included its executable, description, and version detection details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->