### PR TITLE
registry: add yt-dlp-nightly (github:yt-dlp/yt-dlp-nightly-builds)

### DIFF
--- a/registry/yt-dlp-nightly.toml
+++ b/registry/yt-dlp-nightly.toml
@@ -1,0 +1,22 @@
+# yt-dlp's stable channel ships irregularly -- recent gaps between releases have
+# reached 84 days -- while extractors break far more often than that: YouTube and
+# other sites roll out Cloudflare challenges, captchas and signature changes
+# continuously, and each one can break downloads until an extractor fix ships.
+# The nightly channel is built by the yt-dlp org from the same repository and is
+# documented upstream via `yt-dlp --update-to nightly`.
+#
+# Both entries install a binary named `yt-dlp`, so `overrides` places this one
+# earlier on PATH when the stable entry is also installed.
+description = "Nightly builds of yt-dlp, a feature-rich command-line audio/video downloader"
+overrides = ["yt-dlp"]
+test = { cmd = "yt-dlp --version", expected = "{{version}}" }
+version_order = "source"
+
+bins = ["yt-dlp"]
+[[backends]]
+full = "github:yt-dlp/yt-dlp-nightly-builds"
+
+# Releases ship bare per-platform binaries (yt-dlp_macos, yt-dlp_linux,
+# yt-dlp_linux_aarch64, ...), so normalise them onto one name.
+[backends.options]
+rename_exe = "yt-dlp"


### PR DESCRIPTION
Adds the official yt-dlp nightly release channel as a separate shorthand alongside the existing `yt-dlp` entry.

- https://github.com/yt-dlp/yt-dlp-nightly-builds
- https://github.com/yt-dlp/yt-dlp

## Why a separate entry

yt-dlp's stable channel ships on a slow and irregular cadence, while extractors break far more often than that. Sites yt-dlp depends on -- YouTube in particular -- roll out Cloudflare challenges, captchas and signature changes continuously, and each one can break downloads until an extractor fix ships.

Recent stable releases and the gaps between them:

    2026.08.19   46 days
    2026.07.04   25 days
    2026.06.09   84 days
    2026.03.17    4 days
    2026.03.13   10 days
    2026.03.03

An 84-day gap between 2026.03.17 and 2026.06.09 is a long time to be on a build whose extractors have stopped working. Over the same period the nightly channel published six releases in nine days:

    2026.08.27.231323
    2026.08.27.003630
    2026.08.25.233329
    2026.08.20.234504
    2026.08.19.233000
    2026.08.18.122307

Upstream treats nightly as a supported channel rather than an experimental one: it is built from the same repository by the yt-dlp org, signed with the same SHA2-256/512 sums, and `yt-dlp --update-to nightly` is documented in the project README. For many users it is the only consistently working option.

## Interaction with the existing `yt-dlp` entry

Both entries install a binary named `yt-dlp`, so `overrides = ["yt-dlp"]` is set. When both are installed, `sort_by_overrides` places the nightly binary earlier on PATH, matching the existing `npm` -> `node` and `bundler` -> `ruby` precedent. Verified with both entries active:

    $ mise which yt-dlp
    .../installs/yt-dlp-nightly/latest/yt-dlp
    $ yt-dlp --version
    2026.08.27.003630          # nightly, not stable's 2026.08.19

Installing only one behaves exactly as before; nothing about the `yt-dlp` entry changes.

The backend options mirror the existing `yt-dlp` entry: the release ships bare per-platform binaries, so `rename_exe = "yt-dlp"` normalises `yt-dlp_macos`, `yt-dlp_linux`, `yt-dlp_linux_aarch64` and friends onto one name.

Versions are date-and-time stamps (`2026.08.27.003630`), so `version_order = "source"`.

## Popularity

Star count on `yt-dlp-nightly-builds` (409) is not a meaningful signal -- the repository exists only to host release artifacts and carries no code, issues or documentation. The project it builds is `yt-dlp/yt-dlp`: 187,418 stars, 16,187 forks, already in this registry.

- yt-dlp: 187,418 stars, 16,187 forks
- Nightly channel published by the yt-dlp organisation, latest 2026.08.27
- Documented upstream via `yt-dlp --update-to nightly`

## Validation

- `mise test-tool yt-dlp-nightly` -> `yt-dlp-nightly: OK`
- `mise ls-remote github:yt-dlp/yt-dlp-nightly-builds` -> `2026.08.25.233329 ... 2026.08.27.003630`
- `mise x github:yt-dlp/yt-dlp-nightly-builds@2026.08.27.003630 -- yt-dlp --version` -> `2026.08.27.003630`
- both entries installed together: `mise which yt-dlp` resolves to the nightly binary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing nightly builds of yt-dlp.
  * Nightly and stable installations can coexist, with the nightly build taking priority when enabled.
  * Added version detection and consistent executable naming across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->