### PR TITLE
chore(deps): update jdx-tar to 1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5656,9 +5656,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jdx-tar"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea172082e0f86db95eb1eb387cf802b02749322e79219378e59ca390dd0cd284"
+checksum = "d559dfeea3f218edf75e79299bd5d3e7f1269fbbba07974a23a3b28e6d95beed"
 dependencies = [
  "filetime",
 ]

--- a/src/file.rs
+++ b/src/file.rs
@@ -4352,8 +4352,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let archive_path = dir.path().join("pax-xattr.tar");
         let dest_dir = dir.path().join("out");
-        let mut archive = Vec::new();
-        let mut builder = jdx_tar::Builder::new(&mut archive);
+        let mut builder = jdx_tar::Builder::new(Vec::new());
 
         let key = "LIBARCHIVE.xattr.com.apple.cs.CodeSignature";
         let value = b"signature\nmetadata";
@@ -4383,8 +4382,7 @@ mod tests {
         builder
             .append_data(&mut header, "tool", contents.as_slice())
             .unwrap();
-        builder.finish().unwrap();
-        drop(builder);
+        let mut archive = builder.into_inner().unwrap();
 
         archive[156] = b'x';
         archive[257..265].copy_from_slice(b"ustar\x0000");

--- a/src/file.rs
+++ b/src/file.rs
@@ -4352,8 +4352,8 @@ mod tests {
         let dir = tempdir().unwrap();
         let archive_path = dir.path().join("pax-xattr.tar");
         let dest_dir = dir.path().join("out");
-        let archive = File::create(&archive_path).unwrap();
-        let mut builder = jdx_tar::Builder::new(archive);
+        let mut archive = Vec::new();
+        let mut builder = jdx_tar::Builder::new(&mut archive);
 
         let key = "LIBARCHIVE.xattr.com.apple.cs.CodeSignature";
         let value = b"signature\nmetadata";
@@ -4366,7 +4366,11 @@ mod tests {
         let mut pax = format!("{record_len} {key}=").into_bytes();
         pax.extend_from_slice(value);
         pax.push(b'\n');
-        let mut pax_header = jdx_tar::Header::new_gnu(EntryType::Other(b'x'));
+        // Build the raw PAX record under a neutral extension flag, then rewrite
+        // the type byte and checksum. jdx-tar's logical writer deliberately
+        // rejects raw extension headers, while this test specifically needs a
+        // malformed raw PAX fixture to exercise the reader.
+        let mut pax_header = jdx_tar::Header::new_gnu(EntryType::Other(b'X'));
         pax_header.set_size(pax.len() as u64);
         builder
             .append_data(&mut pax_header, "pax-xattr", pax.as_slice())
@@ -4380,6 +4384,17 @@ mod tests {
             .append_data(&mut header, "tool", contents.as_slice())
             .unwrap();
         builder.finish().unwrap();
+        drop(builder);
+
+        archive[156] = b'x';
+        archive[257..265].copy_from_slice(b"ustar\x0000");
+        archive[148..156].fill(b' ');
+        let checksum = archive[..512]
+            .iter()
+            .map(|byte| u64::from(*byte))
+            .sum::<u64>();
+        archive[148..156].copy_from_slice(format!("{checksum:06o}\0 ").as_bytes());
+        std::fs::write(&archive_path, archive).unwrap();
 
         extract_archive(
             &archive_path,


### PR DESCRIPTION
## Summary

- update `jdx-tar` from 1.1.0 to 1.1.1 in `Cargo.lock`
- retain the existing `jdx-tar = "1"` manifest requirement
- construct the intentionally malformed PAX test fixture as a raw USTAR header, since the logical writer now rejects raw extension records

## Testing

- `mbx check --locked`
- `cargo test --locked --bin mise file::tests::test_extract_archive_ignores_malformed_non_sparse_pax_metadata`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated archive extraction coverage for malformed, non-sparse PAX metadata.
  * Improved test setup to construct and validate malformed archive data more accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch dependency bump with no production Rust changes; install-time tar behavior may shift slightly via jdx-tar 1.1.1, but the PR only adjusts a test fixture to match the new writer rules.
> 
> **Overview**
> Bumps the locked **`jdx-tar`** dependency from **1.1.0** to **1.1.1**; the manifest still requires `jdx-tar = "1"`.
> 
> The only code change is in **`test_extract_archive_ignores_malformed_non_sparse_pax_metadata`**: because **1.1.1’s tar builder rejects raw PAX extension headers**, the test no longer writes a malformed `x` header through the high-level API. It builds the archive in memory, then **patches the first header’s type byte, USTAR magic, and checksum** before writing the fixture—so extraction still gets a deliberately bad PAX record and the assertion that **`tool` extracts correctly** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b16b12a7119c9767e37b84f18b4525c458f779d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->