### PR TITLE
fix(shim): skip non-executable system fallbacks

### DIFF
--- a/e2e/cli/test_shims_system_fallback
+++ b/e2e/cli/test_shims_system_fallback
@@ -10,15 +10,20 @@ mkdir -p "$fake_bin"
 printf '#!/bin/sh\necho fake-system-dummy\n' >"$fake_bin/dummy"
 chmod +x "$fake_bin/dummy"
 
+non_executable_bin="$PWD/non-executable-bin"
+mkdir -p "$non_executable_bin"
+printf '#!/bin/sh\necho non-executable-dummy\n' >"$non_executable_bin/dummy"
+chmod 644 "$non_executable_bin/dummy"
+
 cat >mise.toml <<'EOF'
 [tools]
 dummy = "2.0.0"
 EOF
 
 export MISE_NOT_FOUND_AUTO_INSTALL=0
-export PATH="$shim_dir:$fake_bin:$PATH"
+export PATH="$shim_dir:$non_executable_bin:$fake_bin:$PATH"
 
-# default behavior is preserved: system fallback still wins
+# default behavior skips a non-executable PATH entry and uses the executable fallback
 assert_contains "dummy" "fake-system-dummy"
 
 # with the fallback disabled via env var the shim must fail loudly instead of substituting

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -183,7 +183,7 @@ async fn which_shim(
                 continue;
             }
             let bin = path.join(bin_name);
-            if bin.exists() {
+            if bin.is_file() && file::is_executable(&bin) {
                 if file::is_active_mise_shim(&bin) {
                     continue;
                 }


### PR DESCRIPTION
## Summary
- require system fallback candidates to be executable files
- skip non-executable PATH entries and continue to later candidates
- add regression coverage for a non-executable file shadowing an executable fallback

Addresses https://github.com/jdx/mise/discussions/12541

## Testing
- `mise run test:e2e e2e/cli/test_shims_system_fallback`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows shim system-fallback selection in `which_shim`; behavior change is intentional and covered by e2e, with limited blast radius outside PATH resolution when tools are missing.
> 
> **Overview**
> When a shim cannot resolve a mise-managed tool and **system fallback** is enabled, mise no longer treats any existing PATH file as a candidate. It now requires the match to be a **regular file** that passes **`file::is_executable`**, then continues scanning PATH if an earlier entry is only present but not executable.
> 
> The e2e **`test_shims_system_fallback`** scenario adds a non-executable `dummy` earlier on PATH than an executable fake system binary and asserts the shim still runs the executable fallback (and that disabling fallback still errors without substituting the system binary).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbde58814ec3088532f80c1a2350eb30b17392a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system fallback detection by ignoring non-executable files and directories in the system path.
  * Ensured executable fallback binaries are selected correctly when earlier path entries are invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->