### PR TITLE
fix(exec): say when a tool is not available on this platform

### DIFF
--- a/e2e-win/exec_os_unsupported_tool.Tests.ps1
+++ b/e2e-win/exec_os_unsupported_tool.Tests.ps1
@@ -1,0 +1,73 @@
+Describe 'a tool the registry does not list for this platform' {
+    # `registry/grpc-health-probe.toml` carries `os = ["linux", "macos"]`, so on Windows the tool is
+    # dropped from the request set before any version resolves -- silently, because it is neither
+    # unknown nor user-disabled. Nothing is installed, `grpc_health_probe` is simply absent, and
+    # `mise x` reported only `cannot find binary path` while `mise install` and `mise use` said
+    # exactly what was wrong.
+    #
+    # The tool also provides a bin under a different name than its own, which is the branch that
+    # has to name both.
+    #
+    # Checked here as well as on the bash side because Windows has its own `exec_program`
+    # (`#[cfg(all(windows, not(test)))]`) with its own call to `err_cannot_find_binary_path`;
+    # the unix path passing says nothing about this one.
+
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        $script:TestRoot = Join-Path $TestDrive 'os-unsupported'
+        New-Item -ItemType Directory -Path $script:TestRoot -Force | Out-Null
+        Set-Location $script:TestRoot
+
+        # Whether the bin is absent from the runner decides whether this file tests anything at
+        # all: if it resolves, `mise x` succeeds and never reaches the message. Recorded rather
+        # than assumed -- an earlier revision used `aws-cli`, and the Windows image ships `aws`.
+        $script:SubjectOnPath = [bool](Get-Command grpc_health_probe -ErrorAction SilentlyContinue)
+        $script:ControlOnPath = [bool](Get-Command not-a-tool-9f3a -ErrorAction SilentlyContinue)
+
+        # No install is attempted for an excluded tool, so nothing here reaches the network.
+        $script:Out = mise x grpc-health-probe -- grpc_health_probe --version 2>&1 | Out-String
+        $script:Exit = $LASTEXITCODE
+        $script:Control = mise x -- not-a-tool-9f3a 2>&1 | Out-String
+        # Captured before anything else can overwrite it. A control that only checks for absent
+        # text would be satisfied by a command that unexpectedly succeeded and printed nothing.
+        $script:ControlExit = $LASTEXITCODE
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+    }
+
+    It 'is asking about a binary this machine does not have' {
+        # Checked on its own so a runner that starts shipping these fails here, saying why,
+        # instead of failing the assertions below as though the message had regressed.
+        $script:SubjectOnPath | Should -BeFalse
+        $script:ControlOnPath | Should -BeFalse
+    }
+
+    It 'still fails, because the tool genuinely cannot run here' {
+        $script:Exit | Should -Not -Be 0
+    }
+
+    It 'names the tool and this platform instead of only the missing binary' {
+        $script:Out | Should -Match 'grpc-health-probe'
+        $script:Out | Should -Match 'not available on windows'
+        # The bin is named differently from the tool, so the message has to carry both or the
+        # user cannot connect the two.
+        $script:Out | Should -Match 'grpc_health_probe'
+    }
+
+    It 'says where the tool does run' {
+        # Without this the message tells the user something is impossible and nothing else.
+        $script:Out | Should -Match 'linux'
+        $script:Out | Should -Match 'macos'
+    }
+
+    It 'leaves an unrelated missing binary alone' {
+        # The control: a hint appended to every resolution failure would pass the assertions above.
+        # It has to have failed for the same reason as the subject, or "the text is absent" says
+        # nothing about the hint.
+        $script:ControlExit | Should -Not -Be 0
+        $script:Control | Should -Not -Match 'registry lists it for'
+        $script:Control | Should -Not -Match 'not available on'
+    }
+}

--- a/e2e/cli/test_exec_os_unsupported_tool
+++ b/e2e/cli/test_exec_os_unsupported_tool
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# A tool the registry marks for other platforms is dropped from the tool request set before any
+# version resolves. The drop is silent by design -- such a tool is neither unknown nor disabled by
+# the user -- so nothing is installed, the bin is simply absent, and `mise exec` used to report
+# only that it could not find it. `mise install` and `mise use` reach the backend and say why, so
+# the reason was known and only this command withheld it.
+#
+# `gsudo` carries `os = ["windows"]` in the registry, which excludes it from every platform this
+# suite runs on.
+
+assert_fail_contains "mise exec gsudo -- gsudo" "not available on"
+assert_fail_contains "mise exec gsudo -- gsudo" "gsudo"
+# The remedy is knowing where it does run, so the platforms have to be named.
+assert_fail_contains "mise exec gsudo -- gsudo" "windows"
+
+# The control: a bin no excluded tool provides keeps its original error untouched. Without this a
+# hint appended to every failure would satisfy the assertions above. It has to have failed for the
+# same reason as the subject, or "the text is absent" says nothing about the hint -- so the failure
+# is asserted before the absences are read from the output the `|| true` above lets through.
+assert_fail "mise exec -- not-a-tool-9f3a"
+unknown_out="$(mise exec -- not-a-tool-9f3a 2>&1 || true)"
+assert_not_contains_text "$unknown_out" "registry lists it for"
+assert_not_contains_text "$unknown_out" "not available on"

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -974,6 +974,43 @@ pub(crate) fn inactive_installed_tool_message(
     Some(msg.trim().to_string())
 }
 
+/// Name the registry tool that provides `bin_name` on other platforms but not this one.
+///
+/// `registry/<tool>.toml` carries an `os` list, and a tool whose list omits the running OS is
+/// dropped by `ToolRequestSetBuilder::is_disabled` before any version is resolved. That drop is
+/// silent by design — the tool is not unknown, and the user has not disabled it — so nothing is
+/// installed and the bin is simply absent. `mise install` and `mise use` reach the backend and
+/// report the reason; `mise exec` only ever saw the missing bin. mise has the answer in its own
+/// registry, so say it rather than leaving the user with `cannot find binary path`.
+///
+/// Matched on `bins` and on the tool's own name, so `mise x aws-cli -- aws` is recognised through
+/// either. Returns `None` when the OS list is empty or includes this one, which is the normal case.
+pub(crate) fn os_unsupported_tool_message(bin_name: &str) -> Option<String> {
+    let shorts = crate::registry::REGISTRY
+        .values()
+        .unique_by(|rt| rt.short)
+        .filter(|rt| !rt.is_supported_os())
+        .filter(|rt| rt.short == bin_name || rt.bins.contains(&bin_name))
+        .map(|rt| (rt.short, rt.os.join(", ")))
+        .collect_vec();
+    if shorts.is_empty() {
+        return None;
+    }
+    let mut msg = String::new();
+    for (short, oses) in &shorts {
+        let provides = if *short == bin_name {
+            String::new()
+        } else {
+            format!(", which provides {bin_name},")
+        };
+        msg.push_str(&format!(
+            "{short}{provides} is not available on {}: mise's registry lists it for {oses} only.\n",
+            std::env::consts::OS,
+        ));
+    }
+    Some(msg.trim().to_string())
+}
+
 /// Gather what [`inactive_installed_tool_message`] needs. Only called once a
 /// binary has definitively failed to resolve, so the config/toolset load lands
 /// on a path that is about to abort anyway.
@@ -999,6 +1036,9 @@ pub(crate) async fn exec_resolution_hint(bin_name: &str) -> Option<String> {
         .filter(|short| crate::registry::tool_enabled(enable_tools.as_ref(), &disable_tools, short))
         .collect_vec();
     inactive_installed_tool_message(&ts, &installed_shorts, bin_stem)
+        // Checked second because the two cannot both apply: a tool this OS is excluded from is
+        // never installed here, so there is nothing to be "installed but not activated".
+        .or_else(|| os_unsupported_tool_message(bin_stem))
 }
 
 #[cfg(test)]
@@ -1127,6 +1167,34 @@ mod tests {
         // Matching is by tool name, so a bin like npm (provided by node) is not
         // recognized and the caller keeps its existing message.
         assert!(inactive_installed_tool_message(&ts, &["node".to_string()], "npm").is_none());
+    }
+
+    #[test]
+    fn os_unsupported_tool_message_names_the_tool_and_this_platform() {
+        // Taken from the registry rather than hardcoded: which tools are excluded depends on the
+        // platform the test runs on, and a hardcoded name would pass for the wrong reason
+        // wherever it happens to be supported. Every platform has some — the registry carries
+        // `["macos"]`, `["linux"]` and `["windows"]` entries.
+        let rt = crate::registry::REGISTRY
+            .values()
+            .unique_by(|rt| rt.short)
+            .find(|rt| !rt.is_supported_os() && !rt.bins.is_empty())
+            .expect("the registry lists no tool this platform is excluded from");
+
+        let msg = os_unsupported_tool_message(rt.bins[0])
+            .expect("a bin only an excluded tool provides should be explained");
+        assert!(msg.contains(rt.short), "{msg}");
+        assert!(msg.contains(std::env::consts::OS), "{msg}");
+        // and it must say where the tool *is* available, or the user learns nothing actionable
+        assert!(msg.contains(rt.os[0]), "{msg}");
+    }
+
+    #[test]
+    fn os_unsupported_tool_message_is_silent_when_nothing_is_excluded() {
+        // The control. Without it a message that fired for every name would satisfy the test
+        // above. `node` carries no `os` list, so it is supported everywhere.
+        assert_eq!(os_unsupported_tool_message("node"), None);
+        assert_eq!(os_unsupported_tool_message("not-a-registry-bin-9f3a"), None);
     }
 
     #[test]


### PR DESCRIPTION
## The problem

A tool whose registry entry carries an `os` list that omits the running OS is dropped by
`ToolRequestSetBuilder::is_disabled` before any version resolves. The drop is silent on purpose —
such a tool is neither unknown nor disabled by the user, and `should_report_unknown_tool`
deliberately excludes it — so nothing is installed and the bin is simply absent.

Measured on Windows, where `registry/aws-cli.toml` is `os = ["linux", "macos"]`:

| command | result |
| --- | --- |
| `mise install aws-cli@latest` | `ERROR unsupported env: windows/amd64 (supported: ["linux", "darwin"])` |
| `mise use aws-cli@latest` | the same |
| **`mise x aws-cli@latest -- aws --version`** | **`ERROR cannot find binary path`** |

Two commands reach the backend and say exactly what is wrong. The third was asked about the same
tool, and reported only that a binary was missing — while the reason sat in mise's own registry the
whole time.

This is the shape discussion #11183 was about on the shim side: an opaque error where a specific one
was already available a layer down.

### mise already says this well one branch over

A tool can leave the request set two ways, and only one of them was silent. When *every* backend is
filtered out — rather than the tool being dropped by its registry `os` list — the message is exactly
what it should be. Measured with `MISE_ARCH=arm64`, which makes `android-cli` unbuildable because
its only backend is pinned to `["macos", "linux-x64", "windows-x64"]`:

```console
$ mise tool android-cli
mise ERROR android-cli is in the mise tool registry but none of its backends
           (http:android-cli) are supported in the current configuration
```

Named tool, named backend, and it says the exclusion is configuration rather than a missing file.
The `os`-list path had no equivalent, so the same underlying situation reached the user as
`cannot find binary path`. This change gives that path a message of its own.

## The fix

`exec_resolution_hint` already appends "installed but not activated" to this same failure (#4407),
so the new explanation goes beside it. The two cannot both apply — a tool this platform is excluded
from is never installed here — so it is an `or_else`, not a second paragraph.

```
aws-cli, which provides aws, is not available on windows:
mise's registry lists it for linux, macos only.
```

Matched on the registry's `bins` and on the tool's own short name, so both `mise x aws-cli -- aws`
and `mise x gsudo -- gsudo` are recognised. `None` when the `os` list is empty or includes this
platform, which is the overwhelmingly normal case.

**Not Windows-specific.** A macOS-only tool asked for on Linux — `xcodes`, `mas` — went the same
way. So does `gsudo`, which the registry lists for Windows only, on both unix platforms.

## Scope

This does not change what is installable, and it does not touch `is_disabled`. Folding the four
reasons that function currently lumps together (unknown backend, asdf-on-Windows, OS unsupported,
user-disabled) into distinguishable outcomes would be a larger change; this reports the one that
measurably reaches users through `mise exec` with no explanation at all.

`--dry-run` is a separate matter and is deliberately not touched here. It answers `⇢ would install`
for `aws-cli` on Windows, but it also answers that for `aws-cli@99.99.99`, a version that does not
exist — so it is not checking feasibility at all rather than missing this one check, and changing
that is a design question rather than a fix.

## Tests

**Unit** — the message names the tool, this platform, and the platforms the tool does run on. The
tool is **taken from the registry at test time rather than hardcoded**, because which tools are
excluded depends on where the test runs and a hardcoded name would pass for the wrong reason
wherever it happens to be supported. **With the control**: `node`, which carries no `os` list, and a
name in no registry entry both produce `None` — without that, a message that fired for every name
would satisfy the first test.

**e2e** (`e2e/cli/test_exec_os_unsupported_tool`) — sibling to `test_exec_inactive_installed_tool`,
which covers the other half of the same hint. Uses `gsudo` (`os = ["windows"]`), excluded on every
platform this suite runs on, and asserts an unrelated missing bin keeps its original error.

**e2e-win** (`e2e-win/exec_os_unsupported_tool.Tests.ps1`) — Windows has its own `exec_program`
(`#[cfg(all(windows, not(test)))]`) with its own call to `err_cannot_find_binary_path`, so the unix
result says nothing about it. Same assertions and the same control, through `aws-cli`. No install is
attempted for an excluded tool, so nothing in either e2e reaches the network.

Draft until the fork CI run on this branch reports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer error messages when a requested tool is unavailable on the current operating system.
  * Errors identify the affected tool and list supported platforms.

* **Bug Fixes**
  * Prevented platform-specific guidance from appearing for unrelated missing-tool errors.
  * Improved command resolution to require an executable file.
  * Added coverage for unsupported tools across Windows and other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
