### PR TITLE
chore(ci): bump mr-boxington action

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563 # v1.0.1
+    - uses: jdx/mr-boxington-action@ccdc5852f8bd93375379830a75f24794407443df # main
       with:
         version: 0.5.4
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -5,13 +5,17 @@ inputs:
   backend:
     description: Explicit backend for structurally trusted or untrusted callers
     default: auto
+  cache-links:
+    description: Cache native links; "auto" enables this on Linux
+    default: auto
 
 runs:
   using: composite
   steps:
-    - uses: jdx/mr-boxington-action@ccdc5852f8bd93375379830a75f24794407443df # main
+    - uses: jdx/mr-boxington-action@ccdc5852f8bd93375379830a75f24794407443df
       with:
         version: 0.5.4
+        cache-links: ${{ inputs.cache-links }}
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/mise

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -12,7 +12,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: jdx/mr-boxington-action@ccdc5852f8bd93375379830a75f24794407443df
+    - uses: jdx/mr-boxington-action@0bb0a01e0b2b3f34db827eddc8307bd4b1fb48ec
       with:
         version: 0.5.4
         cache-links: ${{ inputs.cache-links }}


### PR DESCRIPTION
## Summary

Pin the merged mr-boxington action update from [jdx/mr-boxington-action#15](https://github.com/jdx/mr-boxington-action/pull/15). The action now enables eligible native-link caching automatically on Linux, with an explicit opt-out.

A controlled mise warm build improved from 124.7s to 84.9s (about 32%).

## Validation

- immutable action SHA
- YAML diff checked
- upstream action unit and platform matrix checks passed

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only composite action pin and a new input with a safe default; no application runtime or security-sensitive logic changes.
> 
> **Overview**
> Updates the composite **Set up mbx** action to pin a newer **mr-boxington-action** commit and forward a new **`cache-links`** input (default **`auto`**, which turns on native-link caching on Linux in the upstream action).
> 
> Existing workflows that call `./.github/actions/mbx` unchanged inherit **`auto`** behavior and should see faster warm builds on Linux without caller YAML changes. Callers can still override **`cache-links`** explicitly if they need to opt out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b54da060f7f9d917cb51309d4b7e2f4ef187e2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an internal automation component to a newer revision.
  * Retained caching configuration for automated workflows.
  * No user-facing functionality or behavior has changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->