### PR TITLE
registry(pre-commit): use the pipx backend on Windows, as aws-sam does

### DIFF
--- a/registry/pre-commit.toml
+++ b/registry/pre-commit.toml
@@ -1,5 +1,11 @@
 backends = [
-  "aqua:pre-commit/pre-commit",
+  # Upstream ships a `.pyz` zipapp, not a native binary, so aqua marks the package
+  # `supported_envs: [darwin, linux]` -- Windows has no shebang to run one with. Same reason
+  # aws-sam sends Windows to pipx.
+  { full = "aqua:pre-commit/pre-commit", platforms = [
+    "linux",
+    "macos",
+  ] },
   "asdf:jonathanmorley/asdf-pre-commit",
   "pipx:pre-commit",
 ]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1197,6 +1197,52 @@ idiomatic_files = [{ path = ".example-version", parser = "shell" }]
         }
     }
 
+    // `pre-commit` ships a `.pyz` zipapp rather than a native binary, so aqua marks the package
+    // `supported_envs: [darwin, linux]` and always will -- Windows has nothing to run a shebang
+    // with. A short name resolves to `backends().first()` and there is no install-time fallback,
+    // so without the `platforms` annotation Windows lands on that backend and stops, with the
+    // registered `pipx:` one never reached. Split by platform rather than written as one test
+    // because the pair is its own control: the same expression has to answer differently by
+    // platform, which is the whole claim.
+    //
+    // Both first assert that `MISE_BACKENDS_PRE_COMMIT` is unset: `backends()` returns that
+    // override ahead of every filter, so a process carrying one would make these pass or fail
+    // without touching the registry at all. Asserted rather than cleared, because removing it
+    // would mutate process-wide state other tests share.
+    //
+    // Read from `BAKED_REGISTRY` for the same reason the `os` test above does: the claim is about
+    // `registry/pre-commit.toml` in this commit, and `REGISTRY` substitutes a cached floating
+    // registry whenever `registry_floating` is on and the cache exists.
+    #[cfg(windows)]
+    #[test]
+    fn pre_commit_falls_through_to_pipx_on_windows() {
+        use super::*;
+
+        assert!(env::var("MISE_BACKENDS_PRE_COMMIT").is_err());
+        let backends = BAKED_REGISTRY.get("pre-commit").unwrap().backends();
+        assert_eq!(
+            backends.first().copied(),
+            Some("pipx:pre-commit"),
+            "{backends:?}"
+        );
+    }
+
+    // Not `not(windows)`: mise runs on Android too, where `backend_matches_platform` sees `android`
+    // and drops the aqua backend along with Windows, so this expectation would be wrong there.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn pre_commit_keeps_the_aqua_backend_off_windows() {
+        use super::*;
+
+        assert!(env::var("MISE_BACKENDS_PRE_COMMIT").is_err());
+        let backends = BAKED_REGISTRY.get("pre-commit").unwrap().backends();
+        assert_eq!(
+            backends.first().copied(),
+            Some("aqua:pre-commit/pre-commit"),
+            "{backends:?}"
+        );
+    }
+
     #[test]
     fn test_backend_platform_matching_preserves_os_only_and_order() {
         use super::*;


### PR DESCRIPTION
## The problem

A short name resolves to `backends().first()` — the first backend surviving the `platforms`, type
and experimental filters — and there is **no install-time fallback**. So a first backend that cannot
serve this platform is where resolution ends, even when a backend that can is registered right after
it.

`pre-commit` is that shape on Windows. Measured on `2026.8.14 windows-x64`, `MISE_DATA_DIR` isolated:

```console
$ mise install pre-commit@latest
mise ERROR Failed to install aqua:pre-commit/pre-commit@latest:
           unsupported env: windows/amd64 (supported: ["darwin", "linux"])

$ mise tool pre-commit
Backend:            aqua:pre-commit/pre-commit
```

while `pipx:pre-commit`, already listed two lines down in the same entry, works here:

```console
$ mise install pipx:pre-commit@latest
mise pipx:pre-commit@4.6.2 ✓ installed

$ mise x pipx:pre-commit@4.6.2 -- pre-commit --version
pre-commit 4.6.2
```

## Why this is not an aqua-registry issue

Upstream ships **`pre-commit-4.6.2.pyz`** — a Python zipapp, not a native binary. The aqua package
takes it as-is:

```yaml
asset: pre-commit-{{trimV .Version}}.pyz
format: raw
complete_windows_ext: false
supported_envs: [darwin, linux]
```

On unix the execute bit plus the shebang inside the zipapp make that runnable. Windows has no such
mechanism, which is why aqua excludes it and will keep excluding it. Same structural shape as
`aws-cli`, where the only Windows artifact is an MSI.

## The precedent

`aws-sam` is the identical situation — a Python tool aqua can only serve on unix — and it was
already solved this way. Its aqua backend carries `platforms = ["linux", "macos"]`, and on Windows:

```console
$ mise tool aws-sam
Backend:            pipx:aws-sam-cli

$ mise install aws-sam@latest      # verified, exit 0
```

This change puts `pre-commit` in the same shape.

## What this does not change

`linux` and `macos` are both in the annotation, so aqua stays first there — the path every existing
user is on is untouched. The registry CI runs on Linux, so a green run is the non-regression check.

The pipx backend needs `uv` or `pipx` present. When neither is, the failure names what to install
(`mise use uv@latest`) instead of being the dead end `unsupported env` is.

## Deliberately not included

The same shape appears in 11 other registry entries that list a second backend with no `platforms`
annotation. I checked each upstream before proposing anything, and **none of them belongs in this
PR**:

| tools | why not |
| --- | --- |
| `mark`, `sheldon`, `turso`, `xcodegen`, `zprint` | the `github:` alternative has **no Windows asset either** — routing Windows there would trade one failure for another |
| `herdr`, `rustic` | upstream **does** ship Windows binaries, so the gap is in `aqua-registry`'s `supported_envs`. Annotating here would permanently divert Windows even after aqua is fixed |
| `jless`, `ripgrep-all`, `sheldon` | `cargo:` alternative, but their CI does not build on Windows at all — no basis to claim it works |
| `action-validator` | `cargo:`, one incidental Windows mention in CI; too weak |
| `semver` | the `vfox:` alternative wraps a bash script |

## Tests

`src/registry.rs`, split by platform so the pair is its own control — the same expression has to
answer differently on Windows than off it, which is the entire claim:

- Windows: `BAKED_REGISTRY["pre-commit"].backends().first()` is `pipx:pre-commit`
- Linux and macOS: it is `aqua:pre-commit/pre-commit`

Three details that are deliberate rather than incidental:

- **`BAKED_REGISTRY`, not `REGISTRY`.** The claim is about `registry/pre-commit.toml` in this commit,
  and `REGISTRY` substitutes a cached floating registry whenever `registry_floating` is on and the
  cache exists.
- **The off-Windows test is `cfg(any(target_os = "linux", target_os = "macos"))`, not
  `cfg(not(windows))`.** mise runs on Android too, where `backend_matches_platform` sees `android`
  and drops the aqua backend along with Windows, so `not(windows)` would assert something false
  there.
- **Both assert `MISE_BACKENDS_PRE_COMMIT` is unset first.** `backends()` returns that override
  ahead of every filter, so a process carrying one would make these pass or fail without touching
  the registry at all. Asserted rather than cleared, since removing it would mutate process-wide
  state other tests share.

`backends()` applies every filter (platform, backend type, experimental), so these exercise the real
resolution rather than just reading the TOML back. The existing
`test_backend_platform_matching_normalizes_settings` already covers the matcher itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved platform-specific installation behavior for `pre-commit`.
  - Linux and macOS use the Aqua backend, while Windows uses compatible alternatives such as `pipx` or `asdf`.
  - Improved Windows ARM64 compatibility by supporting x64 downloads where appropriate, including Android CLI tools.

- **Tests**
  - Added coverage to verify backend selection and platform compatibility across Windows, Linux, macOS, and ARM64 environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
