### PR TITLE
fix(http): explain a download that fails because the path is too long

### DIFF
--- a/e2e-win/download_long_path.Tests.ps1
+++ b/e2e-win/download_long_path.Tests.ps1
@@ -1,0 +1,103 @@
+Describe 'a download whose destination is past MAX_PATH' {
+    # Every downloaded file lands through `tempfile`, whose persist does not get the
+    # extended-length path handling `std::fs` applies -- `file::PreparedAtomicWrite::commit`
+    # records the measurement: it breaks at a 253-character target while `fs::rename` on the same
+    # tree succeeds at 415. So a long `MISE_DATA_DIR` fails the download, and it used to fail as a
+    # bare `os error 3`: "the specified path cannot be found", for a directory the user had just
+    # configured and which was right there.
+    #
+    # This does not make long paths work. It makes the failure say what it is.
+
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        # All three, every time. A probe that isolated only some of these once wrote junctions into
+        # the real installs directory.
+        $script:Saved = @{}
+        foreach ($v in 'MISE_DATA_DIR', 'MISE_CONFIG_DIR', 'MISE_CACHE_DIR', 'MISE_TRUSTED_CONFIG_PATHS') {
+            $script:Saved[$v] = [Environment]::GetEnvironmentVariable($v, 'Process')
+        }
+
+        $script:Root = Join-Path $TestDrive 'longpath'
+        New-Item -ItemType Directory -Path $script:Root -Force | Out-Null
+
+        # Past MAX_PATH, so it has to be created with the extended-length prefix.
+        $script:LongData = Join-Path $script:Root ('d' * 40)
+        while ($script:LongData.Length -lt 300) { $script:LongData = Join-Path $script:LongData ('d' * 40) }
+        [System.IO.Directory]::CreateDirectory("\\?\$($script:LongData)") | Out-Null
+        $script:ShortData = Join-Path $script:Root 'short'
+        New-Item -ItemType Directory -Path $script:ShortData -Force | Out-Null
+
+        function script:InstallWith([string]$dataDir, [string]$tag) {
+            $cfg = Join-Path $script:Root "cfg-$tag"
+            $cache = Join-Path $script:Root "cache-$tag"
+            $proj = Join-Path $script:Root "proj-$tag"
+            New-Item -ItemType Directory -Path $cfg, $cache, $proj -Force | Out-Null
+            $env:MISE_DATA_DIR = $dataDir
+            $env:MISE_CONFIG_DIR = $cfg
+            $env:MISE_CACHE_DIR = $cache
+            $env:MISE_TRUSTED_CONFIG_PATHS = $script:Root
+            Set-Location $proj
+            '' | Out-File -FilePath 'mise.toml' -Encoding utf8NoBOM
+            $out = mise install jq@1.8.2 2>&1 | Out-String
+            return [pscustomobject]@{ Out = $out; Exit = $LASTEXITCODE }
+        }
+
+        $script:Long = script:InstallWith $script:LongData 'long'
+        $script:Short = script:InstallWith $script:ShortData 'short'
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        foreach ($v in $script:Saved.Keys) {
+            if ($null -ne $script:Saved[$v]) { Set-Item "Env:\$v" $script:Saved[$v] }
+            else { Remove-Item "Env:\$v" -ErrorAction SilentlyContinue }
+        }
+        # A tree past MAX_PATH cannot be removed through the ordinary API, and Pester hands the
+        # drive back by walking it -- so a tree left here does not stay a local problem: the run
+        # fails inside the framework afterwards, with every test in this file green. Swallowing
+        # the failure would remove the one line that explains that, so it is reported. Not
+        # rethrown: the tests themselves passed, and a throw here would attribute the framework's
+        # later failure to this container instead of leaving the warning next to it.
+        if (Test-Path -LiteralPath $script:LongData) {
+            try {
+                [System.IO.Directory]::Delete("\\?\$($script:Root)", $true)
+            } catch {
+                $why = $_.Exception.Message
+                Write-Warning "could not remove the long-path fixture at $($script:Root): $why"
+                Write-Warning ('Pester walks TestDrive to hand it back, so the run may fail ' +
+                    'after this file with every test in it green.')
+            }
+        }
+    }
+
+    It 'is actually testing the two lengths it claims to' {
+        # Checked on its own so a fixture that stopped being long fails here, saying so, rather
+        # than making the assertions below pass or fail for a reason nobody can see.
+        $downloadDest = Join-Path $script:LongData 'downloads\jq\1.8.2\jq-windows-amd64.exe'
+        $downloadDest.Length | Should -BeGreaterThan 260
+        (Join-Path $script:ShortData 'downloads\jq\1.8.2\jq-windows-amd64.exe').Length |
+            Should -BeLessThan 260
+    }
+
+    It 'still installs when the path is short' {
+        # The control. Without it "the long one failed" says nothing about the length.
+        $script:Short.Exit | Should -Be 0
+    }
+
+    It 'fails on the long one, because tempfile cannot write there' {
+        $script:Long.Exit | Should -Not -Be 0
+    }
+
+    It 'says the path length is what went wrong' {
+        # The old failure was `os error 3` and nothing else -- "the specified path cannot be
+        # found", about a directory that was right there.
+        $script:Long.Out | Should -Match '260'
+        $script:Long.Out | Should -Match 'characters'
+        $script:Long.Out | Should -Match 'shorter'
+    }
+
+    It 'names the operation that failed' {
+        # Without this the message could be attached to any step and still match above.
+        $script:Long.Out | Should -Match 'download'
+    }
+}

--- a/src/file.rs
+++ b/src/file.rs
@@ -134,7 +134,12 @@ fn windows_io_hint(_path: &Path, _err: &std::io::Error) -> Option<String> {
 }
 
 /// Attach [`windows_io_hint`] to `err`, if it has anything to say about this path.
-fn with_io_hint(msg: String, path: &Path, err: &std::io::Error) -> String {
+/// `msg`, plus whatever [`windows_io_hint`] can say about `err` at `path`.
+///
+/// `pub(crate)` because the operations that need it are not all in this module: `tempfile`'s
+/// persist is used directly by the downloader too, and that is the call that fails first as a
+/// path approaches `MAX_PATH`.
+pub(crate) fn with_io_hint(msg: String, path: &Path, err: &std::io::Error) -> String {
     match windows_io_hint(path, err) {
         Some(hint) => format!("{msg}\n{hint}"),
         None => msg,
@@ -4633,6 +4638,59 @@ mod tests {
         // and it must offer what that branch actually accepts
         assert!(hint.contains("exe"), "{hint}");
         assert!(hint.contains("build"), "{hint}");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_io_hint_explains_a_path_at_the_limit() {
+        use std::io::{Error, ErrorKind};
+
+        let long = PathBuf::from(format!(r"C:\{}", "d".repeat(MAX_PATH)));
+        let hint = windows_io_hint(&long, &Error::from_raw_os_error(3))
+            .expect("a path past MAX_PATH failing with ERROR_PATH_NOT_FOUND should be explained");
+        assert!(hint.contains(&MAX_PATH.to_string()), "{hint}");
+        assert!(hint.contains(&(MAX_PATH + 3).to_string()), "{hint}");
+
+        // The control, and the reason the length test is there at all: the same error on a path
+        // nowhere near the limit is a genuinely missing directory, and answering it with advice
+        // about path length would send the user after the wrong thing.
+        assert_eq!(
+            windows_io_hint(Path::new(r"C:\short"), &Error::from_raw_os_error(3)),
+            None
+        );
+
+        // The other two codes Windows uses for the same cause.
+        for code in [123, 206] {
+            assert!(
+                windows_io_hint(&long, &Error::from_raw_os_error(code)).is_some(),
+                "os error {code}"
+            );
+        }
+
+        // A different branch entirely, so a hint that only ever talked about length would fail.
+        let in_use = windows_io_hint(Path::new(r"C:\short"), &Error::from_raw_os_error(32))
+            .expect("a sharing violation should be explained");
+        assert!(in_use.contains("in use"), "{in_use}");
+        assert_eq!(
+            windows_io_hint(Path::new(r"C:\short"), &Error::from(ErrorKind::NotFound)),
+            None
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_io_hint_measures_the_units_windows_counts() {
+        use std::io::Error;
+
+        // `OsStr::len()` is WTF-8 bytes on Windows and the limit counts UTF-16 code units, so a
+        // path of non-ASCII characters measures ~3x too long by bytes. Each of these is one unit
+        // and three bytes: by bytes this is well past the limit, by units it is nowhere near.
+        let short_but_fat = PathBuf::from(format!(r"C:\{}", "あ".repeat(100)));
+        assert!(short_but_fat.as_os_str().len() > MAX_PATH, "fixture");
+        assert_eq!(
+            windows_io_hint(&short_but_fat, &Error::from_raw_os_error(3)),
+            None
+        );
     }
 
     #[test]

--- a/src/http.rs
+++ b/src/http.rs
@@ -216,6 +216,24 @@ struct PartialDownload {
     request_hash: String,
 }
 
+/// The prefix `tempfile` builds the download-state name from. Named so the length the hint
+/// measures and the length that is actually created cannot drift apart.
+const DOWNLOAD_STATE_PREFIX: &str = ".mise-download-state.";
+
+/// Name the operation and the path, and add the platform hint the bare error does not carry.
+///
+/// Every downloaded file lands through `tempfile`, whose persist does **not** get the
+/// extended-length path handling `std::fs` applies — `file::PreparedAtomicWrite::commit` records
+/// the measurement: it breaks at a 253-character target while `fs::rename` on the same tree
+/// succeeds at 415. So on Windows this is the first thing to fail as a directory approaches
+/// `MAX_PATH`, and until now it failed as a bare `os error 3` with nothing naming the cause.
+fn io_error(err: std::io::Error, doing: &str, path: &Path) -> eyre::Report {
+    // The hint is resolved while `err` is still borrowable, then the error becomes the source and
+    // the message the context -- the same order `PreparedAtomicWrite::commit` uses.
+    let msg = file::with_io_hint(format!("{doing}: {}", display_path(path)), path, &err);
+    eyre::Report::new(err).wrap_err(msg)
+}
+
 impl PartialDownload {
     fn new(destination: &Path, request_hash: String) -> Result<Self> {
         let parent = destination.parent().ok_or_else(|| {
@@ -279,10 +297,24 @@ impl PartialDownload {
 
     fn write_state(&self, state: &PartialDownloadState) -> Result<()> {
         let parent = self.state_path.parent().unwrap();
-        let mut temp = tempfile::NamedTempFile::with_prefix_in(".mise-download-state.", parent)?;
+        // The name `tempfile` is about to generate, not the directory holding it: the hint decides
+        // from the length of what it is given, and the generated name is 27 units longer than the
+        // directory. Measuring the directory would leave a window where the temp path is over the
+        // limit while the directory is under the hint's threshold, and the failure would go back
+        // to being unexplained. `XXXXXX` stands in for the six random characters and is the same
+        // length, so what is measured is what Windows sees.
+        let temp_name = parent.join(format!("{DOWNLOAD_STATE_PREFIX}XXXXXX"));
+        let mut temp = tempfile::NamedTempFile::with_prefix_in(DOWNLOAD_STATE_PREFIX, parent)
+            .map_err(|err| io_error(err, "failed to create the download state file", &temp_name))?;
         serde_json::to_writer(&mut temp, state)?;
         temp.as_file_mut().sync_all()?;
-        temp.persist(&self.state_path).map_err(|err| err.error)?;
+        temp.persist(&self.state_path).map_err(|err| {
+            io_error(
+                err.error,
+                "failed to write the download state file",
+                &self.state_path,
+            )
+        })?;
         Ok(())
     }
 
@@ -305,7 +337,11 @@ impl PartialDownload {
         if let Err(err) = temp_path.persist(destination) {
             let error = err.error;
             let _ = err.path.keep();
-            return Err(error.into());
+            return Err(io_error(
+                error,
+                "failed to move the downloaded file into place",
+                destination,
+            ));
         }
         self.remove_state_if_exists()?;
         Ok(())
@@ -1967,6 +2003,42 @@ mod tests {
     use reqwest::dns::{Name, Resolve, Resolving};
     use std::path::PathBuf;
     use url::Url;
+
+    #[test]
+    fn download_state_placeholder_is_the_length_tempfile_will_produce() {
+        // What the hint measures has to be what Windows will see. Compared against a name
+        // `tempfile` actually produces rather than against the placeholder's own definition:
+        // asserting `PREFIX.len() + 6` would be true whatever `tempfile` does, and the number
+        // that matters is its suffix width, which is its choice and not ours.
+        let placeholder = format!("{DOWNLOAD_STATE_PREFIX}XXXXXX");
+        let dir = tempfile::tempdir().unwrap();
+        let real = tempfile::NamedTempFile::with_prefix_in(DOWNLOAD_STATE_PREFIX, dir.path())
+            .unwrap()
+            .path()
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .chars()
+            .count();
+        assert_eq!(
+            real,
+            placeholder.chars().count(),
+            "tempfile's generated name is {real} characters; the stand-in the hint measures is \
+             {}. A stand-in shorter than the real name lets a path over the limit measure under \
+             the hint's threshold, which is the case this whole change exists for.",
+            placeholder.chars().count()
+        );
+
+        // And it has to be worth measuring separately from the directory: the reason the parent
+        // is not used is that this is meaningfully longer than it.
+        let parent = PathBuf::from(r"C:\some\dir");
+        let temp = parent.join(&placeholder);
+        assert!(
+            temp.as_os_str().len() > parent.as_os_str().len() + 16,
+            "the stand-in adds {} units, which the hint's own margin would absorb",
+            temp.as_os_str().len() - parent.as_os_str().len()
+        );
+    }
 
     // Mutex to ensure tests don't interfere with each other when modifying global settings
     static TEST_SETTINGS_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());


### PR DESCRIPTION
## The problem

A `MISE_DATA_DIR` past Windows' 260-character limit fails every install with nothing to go on:

```console
$ mise install jq@1.8.2
mise jq@1.8.2        [1/2] download jq-windows-amd64.exe
mise ERROR Failed to install aqua:jqlang/jq@1.8.2: the specified path cannot be found (os error 3)
```

— about a directory the user had just configured and which was right there.

Bisected on `2026.8.14 windows-x64`, with `MISE_DATA_DIR`, `MISE_CONFIG_DIR` and `MISE_CACHE_DIR`
all isolated:

| data dir | download destination | result |
| --- | --- | --- |
| 182 | 222 | **ok** |
| 232 | 272 | `os error 3` |
| 252 | 292 | `os error 3` |
| 342 | 382 | `os error 3` |

The threshold sits between 222 and 272 — `MAX_PATH`. **Creating the directory with the
extended-length prefix is not the variable**: a 161-character directory created the same way
installs fine.

`LongPathsEnabled` is `0` here, which is the Windows default, so CI reproduces it.

## Why it fails, and why mise already knows

`std::fs` is not the limit. A standalone probe created a 372-character directory tree and a
404-character file without complaint. The limit is `tempfile`, whose persist does not get the
extended-length path handling `std::fs` applies.

**mise has this written down already.** `file::PreparedAtomicWrite::commit` carries the explanation
*and* the measurement — "breaks at a 253-character target while `fs::rename` on the same tree
succeeded at 415" — and routes its error through `with_io_hint`, which produces:

> The path is N characters, at or near Windows' 260-character limit, which may be the real cause
> rather than a missing directory. mise writes through a temporary file whose name is longer than
> the final one, so it crosses the limit first. Try a shorter directory.

The downloader uses `tempfile` directly and reached none of it: all three of its temp-file
operations dropped the error to a bare `io::Error` with no context. Same shape as #12547 — the
right answer existed one branch over.

## The fix

`with_io_hint` becomes `pub(crate)`, and the three temp-file operations in `PartialDownload` name
what they were doing and carry the hint.

**Which of the three fires first was not pinned down.** They are consecutive steps on the same
directory, and the failure surfaces identically from any of them, so all three are covered rather
than guessed between. Saying so rather than implying a precision the diagnosis did not reach.

**This does not make long paths work.** It makes the failure say what it is — the same choice
`PreparedAtomicWrite::commit` already made.

## Tests

**Unit** — `windows_io_hint` had **no tests at all** before this. Now: a path past the limit failing
with `ERROR_PATH_NOT_FOUND` is explained and the message names both the measured length and 260;
the other two codes Windows uses for the same cause (123, 206) are covered; the sharing-violation
branch still produces its own message. **With two controls**: the same error on a short path returns
`None` — without it, an implementation that always blamed length would pass — and a `NotFound` with
no OS code returns `None`.

A second test pins the unit the limit counts. `OsStr::len()` is WTF-8 bytes on Windows while the
limit counts UTF-16 code units, so a path of 100 non-ASCII characters measures 3× too long by bytes;
it must still return `None`. The existing code comments call this trap out, and nothing was holding
it.

**e2e-win** — a long `MISE_DATA_DIR` install, modelled on `self_update_long_temp.Tests.ps1`
including its environment hygiene. It asserts the fixture first (that the long destination really
exceeds 260 and the short one really does not), so a fixture that stopped being long fails saying
so instead of looking like a regression. **With the control**: the same install at a short data dir
must succeed, or "the long one failed" says nothing about length.

Draft until the fork CI run on this branch reports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download error messages for Windows paths exceeding the supported length.
  * Download failures now identify the affected operation and path more clearly.
  * Added clearer handling for errors when saving download state or completing downloads.

* **Tests**
  * Added Windows coverage for long-path download scenarios and related error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->