### PR TITLE
fix(ls-remote): fail on recorded listing errors

### DIFF
--- a/src/cli/ls_remote.rs
+++ b/src/cli/ls_remote.rs
@@ -5,7 +5,7 @@ use jiff::Timestamp;
 use serde::Serialize;
 
 use crate::backend::{Backend, VersionInfo};
-use crate::cli::args::ToolArg;
+use crate::cli::args::{BackendArg, ToolArg};
 use crate::config::Settings;
 use crate::install_before::{resolve_before_date_for_backend, resolve_cli_minimum_release_age};
 use crate::toolset::{ToolRequest, resolve_sub_base};
@@ -128,6 +128,7 @@ impl LsRemote {
             .into_iter()
             .filter(|v| matches_prefix(&v.version))
             .collect::<Vec<_>>();
+        ensure_version_listing_succeeded(plugin.ba(), plugin.id())?;
         let hidden_versions = before_date
             .map(|before| VersionInfo::count_hidden_by_date(&versions_matching_prefix, before))
             .unwrap_or_default();
@@ -193,6 +194,13 @@ impl LsRemote {
     }
 }
 
+fn ensure_version_listing_succeeded(ba: &BackendArg, id: &str) -> Result<()> {
+    if let Some(cause) = backend::version_listing_failure(ba) {
+        return Err(eyre::eyre!("unable to fetch versions for {id}: {cause}"));
+    }
+    Ok(())
+}
+
 fn warn_if_versions_hidden_by_minimum_release_age(tool: &str, hidden_versions: usize) {
     // usage sets __USAGE when running complete scripts; skip so Tab does not spam stderr
     if hidden_versions == 0 || crate::env::__USAGE.is_some() {
@@ -238,6 +246,19 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn test_single_tool_listing_surfaces_recorded_backend_failure() {
+        let _config = Config::get().await.unwrap();
+        let ba: BackendArg = "test-ls-remote-recorded-failure".into();
+        backend::record_version_listing_failure(&ba, &eyre::eyre!("second page request failed"));
+
+        let err = ensure_version_listing_succeeded(&ba, &ba.short).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "unable to fetch versions for test-ls-remote-recorded-failure: second page request failed"
+        );
+    }
 
     #[test]
     fn test_all_json_output_always_carries_prerelease() {


### PR DESCRIPTION
## Summary
- make single-tool `mise ls-remote` return an error when the backend recorded a version-listing failure
- preserve the underlying failure cause in the CLI error
- add regression coverage for the recorded-failure path

## Context

Some backends, including Aqua, record upstream listing failures and return an empty list so higher-level callers can retain their existing fallback behavior. Version resolution already converts that recorded state into an error, but single-tool `ls-remote` previously printed no versions and exited successfully. Automation could therefore treat a failed upstream request as a valid empty catalog.

This addresses the confirmed silent-success behavior observed while investigating [mise-versions commit 3278198d](https://github.com/jdx/mise-versions/commit/3278198d653fe4f38434b87e9828688358014db6); it does not claim that an HTTP failure caused that specific Mailpit truncation.

`ls-remote --all` remains best-effort, and a genuinely empty catalog without a recorded backend failure retains its existing behavior.

## Testing
- `cargo test --bin mise cli::ls_remote::tests`
- `mise run lint-fix`
- `mise run lint`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI behavior change for single-tool ls-remote only; aligns with existing backend failure recording and reduces silent false-empty results for automation.
> 
> **Overview**
> Single-tool **`mise ls-remote`** now **errors** when a backend has recorded an upstream version-listing failure, instead of printing an empty list and exiting 0. After filtering by prefix, **`run_single`** calls **`ensure_version_listing_succeeded`**, which reads **`backend::version_listing_failure`** and returns **`unable to fetch versions for {id}: {cause}`**.
> 
> **`ls-remote --all`** is unchanged (still best-effort). A real empty catalog with no recorded failure behaves as before. A regression test covers the recorded-failure message path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc6b0a121146255fcdb3c1c860db26bd738ecac1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for remote version listings.
  * The command now clearly reports when version information cannot be retrieved instead of proceeding with incomplete results.
  * Added coverage to verify the updated error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->