### PR TITLE
registry: drop os limits that no longer match what installs

### DIFF
--- a/e2e-win/exec_os_unsupported_tool.Tests.ps1
+++ b/e2e-win/exec_os_unsupported_tool.Tests.ps1
@@ -1,7 +1,7 @@
 Describe 'a tool the registry does not list for this platform' {
-    # `registry/grpc-health-probe.toml` carries `os = ["linux", "macos"]`, so on Windows the tool is
+    # `registry/docker-slim.toml` carries `os = ["linux", "macos"]`, so on Windows the tool is
     # dropped from the request set before any version resolves -- silently, because it is neither
-    # unknown nor user-disabled. Nothing is installed, `grpc_health_probe` is simply absent, and
+    # unknown nor user-disabled. Nothing is installed, `mint` is simply absent, and
     # `mise x` reported only `cannot find binary path` while `mise install` and `mise use` said
     # exactly what was wrong.
     #
@@ -21,11 +21,11 @@ Describe 'a tool the registry does not list for this platform' {
         # Whether the bin is absent from the runner decides whether this file tests anything at
         # all: if it resolves, `mise x` succeeds and never reaches the message. Recorded rather
         # than assumed -- an earlier revision used `aws-cli`, and the Windows image ships `aws`.
-        $script:SubjectOnPath = [bool](Get-Command grpc_health_probe -ErrorAction SilentlyContinue)
+        $script:SubjectOnPath = [bool](Get-Command mint -ErrorAction SilentlyContinue)
         $script:ControlOnPath = [bool](Get-Command not-a-tool-9f3a -ErrorAction SilentlyContinue)
 
         # No install is attempted for an excluded tool, so nothing here reaches the network.
-        $script:Out = mise x grpc-health-probe -- grpc_health_probe --version 2>&1 | Out-String
+        $script:Out = mise x docker-slim -- mint --version 2>&1 | Out-String
         $script:Exit = $LASTEXITCODE
         $script:Control = mise x -- not-a-tool-9f3a 2>&1 | Out-String
         # Captured before anything else can overwrite it. A control that only checks for absent
@@ -49,11 +49,11 @@ Describe 'a tool the registry does not list for this platform' {
     }
 
     It 'names the tool and this platform instead of only the missing binary' {
-        $script:Out | Should -Match 'grpc-health-probe'
+        $script:Out | Should -Match 'docker-slim'
         $script:Out | Should -Match 'not available on windows'
         # The bin is named differently from the tool, so the message has to carry both or the
         # user cannot connect the two.
-        $script:Out | Should -Match 'grpc_health_probe'
+        $script:Out | Should -Match 'mint'
     }
 
     It 'says where the tool does run' {

--- a/registry/entireio-cli.toml
+++ b/registry/entireio-cli.toml
@@ -6,6 +6,5 @@ backends = [
 ]
 bins = ["entire", "git-remote-entire"]
 description = "Entire is a new developer platform that hooks into your git workflow to capture AI agent sessions on every push, unifying your code with its context and reasoning."
-os = ["linux", "macos"]
 test = { cmd = "entire version", expected = "Entire CLI {{version}}" }
 version_order = "semver"

--- a/registry/gitsign.toml
+++ b/registry/gitsign.toml
@@ -1,6 +1,5 @@
 backends = ["aqua:sigstore/gitsign", "asdf:spencergilbert/asdf-gitsign"]
 bins = ["gitsign"]
 description = "Keyless Git signing using Sigstore"
-os = ["linux", "macos"]
 test = { cmd = "gitsign --version", expected = "gitsign version v{{version}}" }
 version_order = "semver"

--- a/registry/go-swagger.toml
+++ b/registry/go-swagger.toml
@@ -1,6 +1,5 @@
 backends = ["aqua:go-swagger/go-swagger", "asdf:jfreeland/asdf-go-swagger"]
 bins = ["swagger"]
 description = "Swagger 2.0 implementation for go"
-os = ["linux", "macos"]
 test = { cmd = "swagger version", expected = "version: v{{version}}" }
 version_order = "semver"

--- a/registry/grpc-health-probe.toml
+++ b/registry/grpc-health-probe.toml
@@ -4,6 +4,5 @@ backends = [
 ]
 bins = ["grpc_health_probe"]
 description = "A command-line tool to perform health-checks for gRPC applications in Kubernetes and elsewhere"
-os = ["linux", "macos"]
 test = { cmd = "grpc_health_probe --version", expected = "{{version}}" }
 version_order = "semver"

--- a/registry/httpie-go.toml
+++ b/registry/httpie-go.toml
@@ -1,6 +1,5 @@
 backends = ["aqua:nojima/httpie-go", "asdf:abatilo/asdf-httpie-go"]
 bins = ["ht"]
 description = "httpie-like HTTP client written in Go"
-os = ["linux", "macos"]
 test = { cmd = "ht --version", expected = "httpie-go {{version}}" }
 version_order = "semver"

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1058,6 +1058,60 @@ idiomatic_files = [{ path = ".example-version", parser = "shell" }]
         }
     }
 
+    // A tool's `os` list drops it from the tool request set before any backend is consulted, so a
+    // list that no longer matches what the backend can do makes mise refuse a tool that works.
+    //
+    // All 52 entries whose `os` line left out `windows` were put through `mise install` on Windows
+    // and then had whatever landed on disk executed. These five are the ones that produced a
+    // working Windows executable -- `entire.exe version` reports `OS/Arch: windows/amd64`,
+    // `gitsign.exe --version` reports `gitsign version v0.17.1` -- while their `os` line still said
+    // linux and macos only.
+    //
+    // Installing is not evidence on its own: eight more installed successfully and unpacked no
+    // Windows executable at all (`libsql-server` extracts a source tarball), so they keep their
+    // restriction. So do the few the sweep could not settle for reasons that have nothing to do
+    // with Windows -- `cocoapods` needs a ruby that is not there, `swift` overflowed the capture.
+    // Unsettled is not the same as wrong, and only measured entries were changed.
+    //
+    // Read from `BAKED_REGISTRY` rather than `REGISTRY`: the claim under test is about the
+    // `registry/*.toml` files in this commit, and `REGISTRY` hands back a cached floating registry
+    // instead whenever `registry_floating` is on and the cache exists. That would let the test pass
+    // against data this commit does not contain.
+    //
+    // Windows-only on purpose: off Windows every name here is allowed either way, so the assertion
+    // would hold without the change and prove nothing.
+    #[cfg(windows)]
+    #[test]
+    fn tools_that_run_on_windows_are_not_restricted_away_from_it() {
+        use super::*;
+
+        for short in [
+            "entireio-cli",
+            "gitsign",
+            "go-swagger",
+            "grpc-health-probe",
+            "httpie-go",
+        ] {
+            let rt = BAKED_REGISTRY.get(short).unwrap();
+            assert!(rt.is_supported_os(), "{short}: os = {:?}", rt.os);
+        }
+
+        // The controls, and they are the point: this is not "remove every os list". Each was
+        // checked the same way and each stays. `kpt` ships no Windows asset at all. `acli` looked
+        // like a candidate until `mise install` answered `unsupported env: windows/amd64
+        // (supported: ["linux/amd64", "linux/arm64", "darwin/amd64", "darwin/arm64"])` -- the aqua
+        // registry mise carries still restricts it, whatever the upstream one now says.
+        //
+        // `docker-slim` is a control twice over: it is also the fixture in
+        // `e2e-win/exec_os_unsupported_tool.Tests.ps1`, which asserts the exact message mise prints
+        // for a tool this platform is not listed for. Dropping its `os` line would leave that test
+        // with nothing to observe, so it fails here first, by name.
+        for short in ["acli", "docker-slim", "kpt"] {
+            let rt = BAKED_REGISTRY.get(short).unwrap();
+            assert!(!rt.is_supported_os(), "{short}: os = {:?}", rt.os);
+        }
+    }
+
     #[test]
     fn test_backend_platform_matching_preserves_os_only_and_order() {
         use super::*;

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -1197,6 +1197,31 @@ mod tests {
         assert_eq!(os_unsupported_tool_message("not-a-registry-bin-9f3a"), None);
     }
 
+    // `e2e-win/exec_os_unsupported_tool.Tests.ps1` observes this message by running
+    // `mise x docker-slim -- mint` on a Windows runner, and it can only observe it while
+    // `docker-slim` is still restricted away from Windows and still provides a bin under another
+    // name. A registry edit that takes either away leaves that file green with nothing to assert,
+    // and a full Windows e2e run to notice. The same strings are pinned here so `windows-unit`
+    // fails first, saying which one went.
+    //
+    // Windows-only because everywhere else `docker-slim` is supported and `None` is the right
+    // answer, so the assertions could not run at all.
+    #[cfg(windows)]
+    #[test]
+    fn os_unsupported_tool_message_still_backs_the_windows_e2e_fixture() {
+        let msg = os_unsupported_tool_message("mint")
+            .expect("docker-slim provides mint and its os list omits windows");
+        for expected in [
+            "docker-slim",
+            "not available on windows",
+            "mint",
+            "linux",
+            "macos",
+        ] {
+            assert!(msg.contains(expected), "{expected:?} missing from {msg:?}");
+        }
+    }
+
     #[test]
     fn windows_file_shim_body_recovers_the_arguments_cmd_destroys() {
         let body = windows_file_shim_body("gh");


### PR DESCRIPTION
## The problem

A tool's `os` list drops it from the tool request set before any backend is consulted
(`BackendArg::is_os_supported` → `ToolRequestSetBuilder::is_disabled`), so a list that has fallen
behind the backend makes mise refuse a tool that works.

This started as three entries found by reading aqua's registry. That method is unreliable — see
`acli` below — so it was replaced with a sweep: **every entry whose `os` line omitted `windows`, 52
of them, was put through `mise install` on Windows and then had whatever landed on disk executed.**
Reading a declaration is not measuring; only the second step decides anything here.

Measured on `2026.8.14 windows-x64`, with `MISE_DATA_DIR`, `MISE_CONFIG_DIR`, `MISE_CACHE_DIR` and
`MISE_TRUSTED_CONFIG_PATHS` all isolated.

## The five that work on Windows

```console
$ mise install entireio-cli@latest       # downloads entire_windows_amd64.zip
$ mise install go-swagger@latest         # downloads swagger_0.36.5_Windows_x86_64.zip
$ mise install httpie-go@latest          # downloads httpie-go_windows_amd64.exe
$ mise install gitsign@latest
$ mise install grpc-health-probe@latest
```

All five install. Each binary was then run **straight out of its install directory**, because the
`os` list is exactly what stops `mise x` from reaching it:

```console
$ entire.exe version
Entire CLI 0.10.2
Go version: go1.26.6
OS/Arch: windows/amd64

$ swagger.exe version
version: v0.36.5

$ ht.exe --version
httpie-go 0.7.0

$ gitsign.exe --version
gitsign version v0.17.1

$ grpc_health_probe.exe --version
0.4.56; commit b5fef775b4ec749eefb19fb00787089ec9a772d5
```

Each matches the `expected` string its own registry entry already declares.

## What the sweep did *not* change, and why

**Installing is not evidence by itself.** Ten entries exited 0; running the binaries showed only two
of them produced a Windows executable. The other eight unpacked none at all — most plainly
`libsql-server`, whose archive is a **source tarball** (`Dockerfile`, `Makefile`, `LICENSE`). Had the
sweep stopped at the exit code, this PR would have freed eight tools that cannot run. They keep their
restriction.

Eight more hit the unauthenticated GitHub rate limit mid-sweep and were resolved afterwards against
the releases API (`tmux`, `tridentctl`, `tuist`, `umoci`, `xchtmlreport`, `xcodegen`, `xcodes`,
`xcresultparser`): **none publishes a Windows asset of any kind.** Correct as they stand.

A few could not be settled for reasons that have nothing to do with Windows — `cocoapods` wants a
ruby that is not installed, `swift` overflowed the capture. Unsettled is not the same as wrong, so
they are untouched. Only measured entries were changed.

## `acli` — why the reading method was abandoned

`acli` looked like a sixth candidate: aqua's upstream registry file carries **no `supported_envs` at
all** plus a `goos: windows` override, and the upstream release publishes
`acli_1.3.30-stable_windows_amd64.zip` (HTTP 200). Then the install was actually run:

```console
$ mise install acli@latest
mise ERROR unsupported env: windows/amd64
      (supported: ["linux/amd64", "linux/arm64", "darwin/amd64", "darwin/arm64"])
```

**mise carries its own aqua-registry snapshot**, so what `raw.githubusercontent.com` serves today
does not predict mise's behaviour. `acli` stays restricted, and is a control in the test.

`kpt` is the other control: no Windows asset. Its file mentions `windows` six times, all in stale
blocks — grep cannot decide this either.

## Why the lines are removed, not rewritten

Not rewritten to `["linux", "macos", "windows"]`: 921 of 980 entries carry no `os` line, and for an
aqua-backed tool the list duplicates something **aqua holds per version while mise can only hold it
per tool**. That duplication is what went stale. Without it the backend answers, and it answers
accurately for old versions too — `unsupported env: ...` rather than a silent drop.

## The e2e fixture had to move in the same commit

`grpc-health-probe` is the fixture in `e2e-win/exec_os_unsupported_tool.Tests.ps1`, added by #12547,
which asserts the message mise prints for a tool this platform is not listed for. Freeing the tool
would have left that file **green with nothing to observe**. The fixture moves to `docker-slim`,
which is genuinely restricted and — like the old one — provides a bin under another name (`mint`),
which is the branch that has to name both.

A unit test in `src/shims.rs` now pins the same strings, so a registry edit that hollows the fixture
out fails in `windows-unit` **by name** instead of leaving a full Windows e2e run quietly passing.

## Tests

`src/registry.rs`, `#[cfg(windows)]`: the five are `is_supported_os()`, and `acli`, `kpt` and
`docker-slim` are **not**. Without the negative half, an implementation that deleted every `os` line
would pass. `docker-slim` is pinned there as well, so the fixture cannot be freed by accident.

Windows-only because off Windows every name is allowed either way and the assertions would hold
without the change.

## Impact

linux and macOS reach these tools exactly as before. The change is only that Windows stops being
told "no" for five tools that run there.

Depends on nothing; #12547 (already merged) is what makes the stale data user-visible — it turns the
silent drop into a confident sentence, which for these five would have been false.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded platform availability for Entire CLI, Go Swagger, HTTPie Go, GitSign, and gRPC Health Probe, including Windows and other supported platforms.
* **Bug Fixes**
  * Removed outdated operating-system restrictions that prevented these tools from being available across supported platforms.
* **Tests**
  * Added coverage confirming Windows support while preserving restrictions for platform-specific tools.
  * Updated Windows end-to-end coverage for Docker Slim.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->