### PR TITLE
registry: install magika from its github releases

### DIFF
--- a/registry/magika.toml
+++ b/registry/magika.toml
@@ -1,4 +1,27 @@
-backends = ["cargo:magika-cli"]
 description = "Fast and accurate AI powered file content types detection"
 test = { cmd = "magika --version", expected = "magika {{version | trim_start(pat='v')}}" }
 version_order = "semver"
+
+# Google publishes prebuilt CLI binaries under `cli/v*` tags, so the tool
+# installs without a toolchain. `cargo:magika-cli` cannot: on a machine with no
+# cargo it fails outright with "you need to install Rust first".
+#
+# The platforms are listed arch-qualified rather than as a bare `linux`, which
+# would match every Linux architecture including the riscv64 and loongarch64
+# ones Google publishes nothing for. What is left out -- Intel macOS, whose
+# `x86_64-apple-darwin` asset was dropped at 1.0.2, and windows-arm64, which
+# never had a build -- falls through to cargo on its own, since registry
+# backends are filtered by platform before the first one is picked.
+#
+# Cost of listing github first: 0.0.0 through 0.1.2 are unreachable on the
+# platforms it covers, since a backend list is a preference filter and not a
+# per-version fallback. Those predate the CLI's first GitHub release.
+[[backends]]
+full = "github:google/magika"
+platforms = ["macos-arm64", "linux-x64", "linux-arm64", "windows-x64"]
+
+[backends.options]
+version_prefix = "cli/v"
+
+[[backends]]
+full = "cargo:magika-cli"


### PR DESCRIPTION
`magika` is listed as `cargo:magika-cli` and nothing else. `AGENTS.md` puts `cargo:` in tier 3 because it "relies on a separately-installed runtime/toolchain being present on PATH", and that is not abstract here — in a Debian 13 container with no Rust:

```
$ mise install cargo:magika-cli@1.1.0
mise ERROR To use cargo packages with mise, you need to install Rust first:
             mise use rust@latest

$ mise install 'github:google/magika[version_prefix=cli/v]@1.1.0'
mise github:google/magika@1.1.0 ✓ installed
$ magika --version
magika 1.1.0 standard_v3_3
```

So `mise use magika` fails today on any machine without a Rust toolchain. Google publishes prebuilt CLI binaries under `cli/v*` tags, and `version_prefix` makes them listable.

This is not about build time — the cargo build took 27s on my machine, `ort-sys` and 100+ crates included. The toolchain requirement is the whole argument.

## Versions

```
$ mise ls-remote 'github:google/magika[version_prefix=cli/v]'
0.1.3 0.1.4 1.0.0 1.0.1 1.0.2 1.1.0          # latest 1.1.0

$ mise ls-remote magika                       # cargo, today
0.0.0 0.1.0 0.1.1 0.1.2 0.1.3 0.1.4 1.0.0 1.0.1 1.0.2 1.1.0    # latest 1.1.0
```

Latest matches. Every listed version installs and runs — I checked 0.1.3, 1.0.0, 1.0.2 and 1.1.0, which spans the asset rename at 1.1.0 (`magika-<triple>` → `magika-cli-<triple>`); mise's autodetection handles both shapes without an `asset_pattern`.

`magika --version` prints `magika <version> standard_v3_3` on stdout from either backend, so the existing `test` line is unaffected.

**Cost: 0.0.0 through 0.1.2 become unreachable on the platforms `github:` covers.** A backend list is a preference filter, not a per-version fallback, so `cargo:` behind it does not fill that gap. Those four predate the CLI's first GitHub release.

## Platforms

| platform | asset | backend | verified |
| --- | --- | --- | --- |
| macos-arm64 | `aarch64-apple-darwin` | github | installed and ran |
| macos-x64 | **dropped at 1.0.2** | cargo | — |
| linux-x64 / linux-arm64 | `*-unknown-linux-gnu` | github | Debian 13 arm64: installed, ran, classified a file |
| windows-x64 | `x86_64-pc-windows-msvc` | github | **not verified** — no Windows host; asset presence only |
| windows-arm64 | none | cargo | — |

Backends are filtered by platform before the first is picked, so Intel macOS and windows-arm64 fall through to `cargo:` on their own. Bare `linux` is used because both Linux arches are covered.

## musl

Worth stating plainly. On Alpine (musl, aarch64) **neither backend produces a working magika**:

```
cargo:   error: ort-sys@2.0.0-rc.12: ort does not provide prebuilt binaries
         for the target `aarch64-alpine-linux-musl`
github:  installs, then
         "…/magika" couldn't exec process: No such file or directory
```

So this is not a regression — magika is not usable on musl either way. But **the failure moves from a clear build error to an install that appears to succeed and then cannot exec**, which is worse to diagnose. `platforms` cannot express libc (the schema pattern is `^(linux|macos|windows)-(x64|arm64|…)$`), and a libc mismatch is a −10 score in `asset_matcher`, not an exclusion, so the gnu asset is still selected. I could not find a way to scope musl out; happy to drop `linux` from the list if you would rather keep the cleaner failure.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for installing Magika from prebuilt GitHub releases on macOS ARM64, Linux x64, Linux ARM64, and Windows x64.
  * GitHub releases are selected using the `cli/v` version format.

* **Bug Fixes**
  * Preserved Cargo-based installation as a fallback for Intel macOS, Windows ARM64, and Magika versions released before the available GitHub builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->