### PR TITLE
fix(azure): include pip for CLI extension support

### DIFF
--- a/registry/azure.toml
+++ b/registry/azure.toml
@@ -33,4 +33,4 @@ asset_pattern = "azure-cli-{{ version }}-x64.zip"
 full = "pipx:azure-cli"
 
 [backends.options]
-uvx_args = "--prerelease=allow"
+uvx_args = "--prerelease=allow --with pip"


### PR DESCRIPTION
This PR installs `pip` when installing the `azure-cli` tool. The `az` can install extensions, however without `pip`, a command like the following will fail:

```sh
$ az extension add --name containerapp --upgrade --allow-preview true

...

DEBUG: cli.azure.cli.core.extension.operations: Executing pip with args: ['install', '--target', '/var/home/esteve/.azure/cliextensions/contai
nerapp', '/tmp/tmpt6qvzsvl/containerapp-1.3.0b4-py2.py3-none-any.whl']                                                                        
DEBUG: cli.azure.cli.core.extension.operations: Running: ['/var/home/esteve/.local/share/mise/installs/azure-cli/2.89.1/azure-cli/bin/python',
 '-m', 'pip', 'install', '--target', '/var/home/esteve/.azure/cliextensions/containerapp', '/tmp/tmpt6qvzsvl/containerapp-1.3.0b4-py2.py3-none
-any.whl', '--disable-pip-version-check', '--no-cache-dir']                                                                                   
DEBUG: cli.azure.cli.core.extension.operations: /var/home/esteve/.local/share/mise/installs/azure-cli/2.89.1/azure-cli/bin/python: No module n
amed pip

DEBUG: cli.azure.cli.core.extension.operations: Command '['/var/home/esteve/.local/share/mise/installs/azure-cli/2.89.1/azure-cli/bin/python',
 '-m', 'pip', 'install', '--target', '/var/home/esteve/.azure/cliextensions/containerapp', '/tmp/tmpt6qvzsvl/containerapp-1.3.0b4-py2.py3-none
-any.whl', '--disable-pip-version-check', '--no-cache-dir']' returned non-zero exit status 1.
DEBUG: cli.azure.cli.core.extension.operations: Pip failed so deleting anything we might have installed at /var/home/esteve/.azure/cliextensio
ns/containerapp
DEBUG: cli.azure.cli.core.azclierror: Traceback (most recent call last):
  File "/var/home/esteve/.local/share/mise/installs/azure-cli/2.89.1/azure-cli/lib/python3.11/site-packages/knack/cli.py", line 233, in invoke
    cmd_result = self.invocation.execute(args)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/home/esteve/.local/share/mise/installs/azure-cli/2.89.1/azure-cli/lib/python3.11/site-packages/azure/cli/core/commands/__init__.p
y", line 677, in execute
    raise ex
  File "/var/home/esteve/.local/share/mise/installs/azure-cli/2.89.1/azure-cli/lib/python3.11/site-packages/azure/cli/core/commands/__init__.p
y", line 820, in _run_jobs_serially
    results.append(self._run_job(expanded_arg, cmd_copy))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/home/esteve/.local/share/mise/installs/azure-cli/2.89.1/azure-cli/lib/python3.11/site-packages/azure/cli/core/commands/__init__.p
y", line 789, in _run_job
    result = cmd_copy(params)
             ^^^^^^^^^^^^^^^^
  File "/var/home/esteve/.local/share/mise/installs/azure-cli/2.89.1/azure-cli/lib/python3.11/site-packages/azure/cli/core/commands/__init__.p
y", line 335, in __call__
    return self.handler(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/home/esteve/.local/share/mise/installs/azure-cli/2.89.1/azure-cli/lib/python3.11/site-packages/azure/cli/core/commands/command_op
eration.py", line 120, in handler
    return op(**command_args)
           ^^^^^^^^^^^^^^^^^^
  File "/var/home/esteve/.local/share/mise/installs/azure-cli/2.89.1/azure-cli/lib/python3.11/site-packages/azure/cli/command_modules/extensio
n/custom.py", line 16, in add_extension_cmd
    return add_extension(cli_ctx=cmd.cli_ctx, source=source, extension_name=extension_name, index_url=index_url,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/home/esteve/.local/share/mise/installs/azure-cli/2.89.1/azure-cli/lib/python3.11/site-packages/azure/cli/core/extension/operation
s.py", line 344, in add_extension
    extension_name = _add_whl_ext(cli_ctx=cmd_cli_ctx, source=source, ext_sha256=ext_sha256,
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/home/esteve/.local/share/mise/installs/azure-cli/2.89.1/azure-cli/lib/python3.11/site-packages/azure/cli/core/extension/operation
s.py", line 173, in _add_whl_ext
    raise CLIError('An error occurred. Pip failed with status code {}. '
knack.util.CLIError: An error occurred. Pip failed with status code 1. Use --debug for more information.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure CLI setup by ensuring `pip` is available in its temporary execution environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->