### PR TITLE
fix(registry): let windows/arm64 use x64 backends, as aqua already does

### DIFF
--- a/e2e/cli/test_registry_platform_emulation
+++ b/e2e/cli/test_registry_platform_emulation
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# `backend_matches_platform` decides which registry backends survive for a platform, and it runs
+# before any backend is asked whether it supports that platform. Windows on arm64 was matching
+# neither `windows-x64` nor `x64`, so backends aqua itself would have accepted were dropped first.
+#
+# `MISE_OS`/`MISE_ARCH` move only that decision, so the whole rule is observable from this runner --
+# no Windows arm64 machine involved, and mise CI has none. What is *not* covered here is whether an
+# amd64 binary really runs on Windows arm64; that assumption is mise's own, already written into
+# `is_platform_supported` in the aqua backend.
+#
+# imagemagick is asserted by containment rather than equality on purpose: the asdf backend is
+# dropped by `cfg!(windows)`, a compile-time check that `MISE_OS` cannot move, so the full list
+# differs between this runner and a Windows one.
+
+# imagemagick's aqua backend is declared `platforms = ["windows-x64"]`, and aqua's own
+# `supported_envs` for it is `[windows/amd64, linux/amd64]` -- which `is_platform_supported` extends
+# with `windows/amd64` for windows/arm64. Only the registry filter stood between them.
+assert_contains "MISE_OS=windows MISE_ARCH=arm64 mise registry imagemagick" "aqua:ImageMagick/ImageMagick"
+
+# android-cli has exactly one backend, so on windows/arm64 it had none at all.
+assert "MISE_OS=windows MISE_ARCH=arm64 mise registry android-cli" "http:android-cli"
+
+# The controls. Without them a rule that matched x64 selectors everywhere would pass both
+# assertions above.
+
+# Linux on arm64 cannot execute an x86_64 build. android-cli publishes only linux-x64, so having no
+# backend there is the correct answer and has to stay that way.
+assert_empty "MISE_OS=linux MISE_ARCH=arm64 mise registry android-cli"
+
+# macOS has Rosetta, but aqua declares no rule for it and this change invents none: imagemagick's
+# aqua backend stays out of reach on macos/arm64, exactly as before.
+assert_not_contains "MISE_OS=macos MISE_ARCH=arm64 mise registry imagemagick" "aqua:ImageMagick/ImageMagick"
+
+# And the platform that already worked is untouched.
+assert_contains "MISE_OS=windows MISE_ARCH=x64 mise registry imagemagick" "aqua:ImageMagick/ImageMagick"

--- a/registry/android-cli.toml
+++ b/registry/android-cli.toml
@@ -21,6 +21,13 @@ version_regex = '(?m)^Version: (\S+)$'
 # Google ships only these four targets -- there is no linux-arm64 or
 # windows-arm64 build -- so each URL is declared per platform rather than
 # templated, to keep `mise lock` from recording targets that 404.
+#
+# windows-arm64 is served the windows-x64 binary on purpose: Windows arm64 runs
+# amd64 executables under emulation, which is the same assumption the aqua
+# backend makes in `is_platform_supported`. Without this block the platform
+# resolves a backend and then fails looking for a URL. linux-arm64 gets no such
+# block: Linux on arm64 cannot run the x86_64 build, so having no backend there
+# is the correct answer.
 [backends.options.platforms.linux-x64]
 checksum_url = "https://dl.google.com/android/cli/{{ version }}/linux_x86_64/android.sha256"
 url = "https://dl.google.com/android/cli/{{ version }}/linux_x86_64/android"
@@ -32,6 +39,11 @@ url = "https://dl.google.com/android/cli/{{ version }}/darwin_arm64/android"
 [backends.options.platforms.macos-x64]
 checksum_url = "https://dl.google.com/android/cli/{{ version }}/darwin_x86_64/android.sha256"
 url = "https://dl.google.com/android/cli/{{ version }}/darwin_x86_64/android"
+
+[backends.options.platforms.windows-arm64]
+bin = "android.exe"
+checksum_url = "https://dl.google.com/android/cli/{{ version }}/windows_x86_64/android.exe.sha256"
+url = "https://dl.google.com/android/cli/{{ version }}/windows_x86_64/android.exe"
 
 [backends.options.platforms.windows-x64]
 bin = "android.exe"

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -696,6 +696,13 @@ impl RegistryTool {
 /// Unlike `backends.options.platforms.*` lookup, this is deliberately not
 /// alias-tolerant: registry selectors use canonical names such as `macos-x64`,
 /// while option lookup accepts release asset aliases such as `darwin-amd64`.
+///
+/// Windows on arm64 additionally matches the x64 selectors. That is not alias
+/// tolerance creeping in — `windows-x64` still names a different platform than
+/// `windows-arm64` — it is the same capability rule the aqua backend already
+/// applies in `is_platform_supported`: Windows arm64 runs amd64 binaries under
+/// emulation. Without it the registry drops a backend here, before aqua is ever
+/// asked whether it supports the platform, and aqua would have said yes.
 fn backend_matches_platform(platforms: &[&str], settings: &Settings) -> bool {
     let os = settings.os();
     let arch = settings.arch();
@@ -705,6 +712,9 @@ fn backend_matches_platform(platforms: &[&str], settings: &Settings) -> bool {
         || platforms.contains(&os)
         || platforms.contains(&arch)
         || platforms.contains(&platform.as_str())
+        || (os == "windows"
+            && arch == "arm64"
+            && (platforms.contains(&"x64") || platforms.contains(&"windows-x64")))
 }
 
 pub(crate) fn shorts_for_full(full: &str) -> &'static Vec<&'static str> {
@@ -1109,6 +1119,81 @@ idiomatic_files = [{ path = ".example-version", parser = "shell" }]
         for short in ["acli", "docker-slim", "kpt"] {
             let rt = BAKED_REGISTRY.get(short).unwrap();
             assert!(!rt.is_supported_os(), "{short}: os = {:?}", rt.os);
+        }
+    }
+
+    // `mod tests` imports nothing at this level -- each test brings its own `use super::*` -- so
+    // this one names the path.
+    fn settings_for(os: &str, arch: &str) -> crate::config::Settings {
+        crate::config::Settings {
+            os: Some(os.to_string()),
+            arch: Some(arch.to_string()),
+            ..Default::default()
+        }
+    }
+
+    // Windows arm64 runs amd64 binaries under emulation. The aqua backend already assumes this in
+    // `is_platform_supported`, so a registry selector of `windows-x64` was dropping backends that
+    // aqua itself would have accepted -- measured with `MISE_OS`/`MISE_ARCH`, where
+    // `mise registry imagemagick` returned only `conda:imagemagick` on windows/arm64 while
+    // windows/x64 got `aqua:ImageMagick/ImageMagick` first.
+    #[test]
+    fn windows_arm64_matches_x64_selectors_the_way_aqua_does() {
+        use super::*;
+
+        let settings = settings_for("windows", "arm64");
+        for selector in ["windows-x64", "x64"] {
+            assert!(
+                backend_matches_platform(&[selector], &settings),
+                "windows-arm64 should reach the {selector} backend under emulation"
+            );
+        }
+    }
+
+    // The controls. Each one fails if the rule above was written more broadly than intended, and
+    // together they are what distinguishes "Windows emulates amd64" from "any arm64 takes x64".
+    #[test]
+    fn the_x64_fallback_is_confined_to_windows_arm64() {
+        use super::*;
+
+        for (os, arch, selector) in [
+            // Linux on arm64 cannot execute an x86_64 build, so no backend is the right answer.
+            ("linux", "arm64", "linux-x64"),
+            // macOS has Rosetta, but aqua declares no rule for it and this change invents none.
+            ("macos", "arm64", "macos-x64"),
+            // Right platform, wrong OS in the selector.
+            ("windows", "arm64", "linux-x64"),
+            // Still not alias-tolerant, which the doc comment on the function promises: these name
+            // the same machine as `windows-x64` but are not the canonical spelling.
+            ("windows", "arm64", "windows-amd64"),
+            ("windows", "arm64", "amd64"),
+            // And the emulation direction is one-way -- x64 does not get to run arm64 builds.
+            ("windows", "x64", "windows-arm64"),
+        ] {
+            let settings = settings_for(os, arch);
+            assert!(
+                !backend_matches_platform(&[selector], &settings),
+                "{os}-{arch} should not match {selector}"
+            );
+        }
+    }
+
+    // Passing the backend filter is only half of it: the http backend then looks up
+    // `platforms.<key>.url`, and `platform_aliases()` has no emulation rule of its own, so
+    // windows/arm64 would resolve a backend and fail to find a URL. `android-cli` declares the
+    // block explicitly rather than relying on a lookup fallback, and it has to stay pointed at the
+    // x64 download -- Google publishes no arm64 build at all.
+    #[test]
+    fn android_cli_serves_windows_arm64_the_x64_download() {
+        use super::*;
+
+        let rt = BAKED_REGISTRY.get("android-cli").unwrap();
+        let opts = rt.backend_options("http:android-cli");
+        for key in ["url", "checksum_url", "bin"] {
+            let arm64 = opts.get_nested_string(&format!("platforms.windows-arm64.{key}"));
+            let x64 = opts.get_nested_string(&format!("platforms.windows-x64.{key}"));
+            assert!(arm64.is_some(), "platforms.windows-arm64.{key} is missing");
+            assert_eq!(arm64, x64, "windows-arm64 {key} should be the x64 one");
         }
     }
 


### PR DESCRIPTION
## The problem

mise already states that Windows arm64 runs amd64 binaries. It is written into the aqua backend,
[`is_platform_supported`](https://github.com/jdx/mise/blob/main/src/backend/aqua.rs#L4919):

```rust
// Windows ARM64 can typically run AMD64 binaries via emulation
if os == "windows" && arch == "arm64" {
    myself.insert("windows/amd64");
    myself.insert("amd64");
}
```

`backend_matches_platform` in `src/registry.rs` does not, **and it runs first**. A backend declared
`platforms = ["windows-x64"]` is filtered out before aqua is ever asked whether it supports the
platform — and aqua would have said yes.

## Measured

`MISE_OS`/`MISE_ARCH` move only this decision, so the whole thing is observable without arm64
hardware. On `2026.8.14 windows-x64`:

| platform | `mise registry imagemagick` | `mise registry android-cli` |
| --- | --- | --- |
| windows/x64 | `aqua:ImageMagick/ImageMagick conda:imagemagick` | `http:android-cli` |
| **windows/arm64** | **`conda:imagemagick`** — aqua dropped | **(empty — no backend at all)** |
| macos/arm64 | `conda:imagemagick` | `http:android-cli` |
| linux/arm64 | `conda:imagemagick` | (empty) |

imagemagick reaches aqua on **windows/x64 only**. That row is the control for everything below.

And the vendored aqua registry says the backend wants the platform:

```yaml
# vendor/aqua-registry/registry.yml — ImageMagick, current block
supported_envs:
  - windows/amd64
  - linux/amd64
overrides:
  - goos: windows
    asset: ImageMagick-{{.Version}}-portable-Q16-HDRI-x64.{{.Format}}
```

## Three layers decide this, not one

| layer | windows/arm64 accepts x64? |
| --- | --- |
| aqua `is_platform_supported` | **yes** |
| registry `backend_matches_platform` | no |
| options `platform_aliases()` (`src/backend/static_helpers.rs`) | no |

**The third layer is why this is not a one-line change.** Fixing only the filter lets `android-cli`
through and then fails in `src/backend/http.rs` with `No URL for platform windows-arm64` — one
failure traded for another.

`platform_aliases()` is used by every backend and by `mise lock`, so it is **left alone**. Instead
`registry/android-cli.toml` declares its windows-arm64 URLs explicitly, pointing at the x64
download, with the reason in the file. Google publishes no arm64 build at all, so emulation is the
only way that tool runs there. `imagemagick` needs no data change — aqua selects its own asset.

## What this deliberately does not do

**No Rosetta rule.** aqua declares none for macOS, and adding one here would be inventing an
assumption rather than applying an existing one consistently. macos/arm64 keeps resolving
imagemagick to conda, and a control pins that.

**No alias tolerance.** The function's doc comment already promises it is *"deliberately not
alias-tolerant"*, and that still holds: `windows-amd64` and `amd64` remain non-matching. This adds a
different axis — a capability rule about what the machine can execute — and the comment now says so.

## Tests

Unit tests build `Settings { os, arch }` the way `test_backend_platform_matching_normalizes_settings`
already does, so they run on every platform in CI. The e2e drives the same decision through
`MISE_OS`/`MISE_ARCH` and runs on the ordinary Linux runner.

The controls are the substance of it:

- linux/arm64 must **still** get no backend for `android-cli` — it cannot execute an x86_64 build
- macos/arm64 must **not** gain aqua for imagemagick
- `windows-amd64` and `amd64` must **still** not match
- the emulation direction is one-way: windows/x64 does not match `windows-arm64`
- android-cli's windows-arm64 URL must equal its windows-x64 URL, so the emulation intent cannot
  silently drift

Without the negative half, a rule that matched x64 selectors everywhere would pass.

imagemagick is asserted by containment rather than equality in the e2e, because the asdf backend is
removed by `cfg!(windows)` — a compile-time check `MISE_OS` cannot move — so the full list differs
between a Linux runner and a Windows one.

## Not verified

**Whether an amd64 binary actually runs on Windows arm64 is not tested here.** Neither this machine
nor mise CI has an arm64 Windows runner. That assumption is mise's own, quoted at the top; this
change only makes a second layer agree with it. Everything asserted is the routing decision, which
is fully observable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Windows ARM64 support for the Android CLI backend using compatible Windows x64 binaries.
  - Improved registry platform matching so Windows ARM64 can use compatible x64 backends, including supported tools such as ImageMagick.

- **Bug Fixes**
  - Prevented incompatible backends from appearing on Linux and macOS ARM64.
  - Preserved existing Windows x64 behavior while expanding Windows ARM64 compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->