### PR TITLE
chore(ci): use server cache for dispatched benchmarks

### DIFF
--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -17,7 +17,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write
+  id-token: write # Authenticate trusted manual dispatches to the cache server.
 
 concurrency:
   group: cache-benchmark-${{ github.ref }}

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: cache-benchmark-${{ github.ref }}

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -17,7 +17,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write # Authenticate trusted manual dispatches to the cache server.
 
 concurrency:
   group: cache-benchmark-${{ github.ref }}
@@ -31,6 +30,9 @@ env:
 jobs:
   mbx_linux:
     name: mbx (Linux)
+    permissions:
+      contents: read
+      id-token: write # Authenticate trusted manual dispatches to the cache server.
     runs-on: ubuntu-latest
     timeout-minutes: 90
     outputs:
@@ -107,6 +109,9 @@ jobs:
 
   mbx:
     name: mbx (macOS)
+    permissions:
+      contents: read
+      id-token: write # Authenticate trusted manual dispatches to the cache server.
     runs-on: macos-14
     timeout-minutes: 90
     outputs:
@@ -183,6 +188,9 @@ jobs:
 
   mbx_windows:
     name: mbx (Windows)
+    permissions:
+      contents: read
+      id-token: write # Authenticate trusted manual dispatches to the cache server.
     runs-on: windows-latest
     timeout-minutes: 90
     env:

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -40,7 +40,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
-          backend: github
+          backend: ${{ github.event_name == 'workflow_dispatch' && 'server' || 'github' }}
       - name: Build
         id: build
         shell: bash
@@ -116,7 +116,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
-          backend: github
+          backend: ${{ github.event_name == 'workflow_dispatch' && 'server' || 'github' }}
       - name: Build
         id: build
         shell: bash
@@ -194,7 +194,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
-          backend: github
+          backend: ${{ github.event_name == 'workflow_dispatch' && 'server' || 'github' }}
       - name: Build
         id: build
         shell: pwsh

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -43,7 +43,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ github.event_name == 'workflow_dispatch' && 'server' || 'github' }}
+          backend: ${{ github.event_name == 'workflow_dispatch' && github.actor == 'jdx' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
       - name: Build
         id: build
         shell: bash
@@ -122,7 +122,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ github.event_name == 'workflow_dispatch' && 'server' || 'github' }}
+          backend: ${{ github.event_name == 'workflow_dispatch' && github.actor == 'jdx' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
       - name: Build
         id: build
         shell: bash
@@ -203,7 +203,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ github.event_name == 'workflow_dispatch' && 'server' || 'github' }}
+          backend: ${{ github.event_name == 'workflow_dispatch' && github.actor == 'jdx' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
       - name: Build
         id: build
         shell: pwsh

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -30,9 +30,6 @@ env:
 jobs:
   mbx_linux:
     name: mbx (Linux)
-    permissions:
-      contents: read
-      id-token: write # Authenticate trusted manual dispatches to the cache server.
     runs-on: ubuntu-latest
     timeout-minutes: 90
     outputs:
@@ -43,7 +40,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ github.event_name == 'workflow_dispatch' && github.actor == 'jdx' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
+          backend: github
       - name: Build
         id: build
         shell: bash
@@ -109,9 +106,6 @@ jobs:
 
   mbx:
     name: mbx (macOS)
-    permissions:
-      contents: read
-      id-token: write # Authenticate trusted manual dispatches to the cache server.
     runs-on: macos-14
     timeout-minutes: 90
     outputs:
@@ -122,7 +116,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ github.event_name == 'workflow_dispatch' && github.actor == 'jdx' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
+          backend: github
       - name: Build
         id: build
         shell: bash
@@ -188,9 +182,6 @@ jobs:
 
   mbx_windows:
     name: mbx (Windows)
-    permissions:
-      contents: read
-      id-token: write # Authenticate trusted manual dispatches to the cache server.
     runs-on: windows-latest
     timeout-minutes: 90
     env:
@@ -203,7 +194,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ github.event_name == 'workflow_dispatch' && github.actor == 'jdx' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
+          backend: github
       - name: Build
         id: build
         shell: pwsh

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   mbx:
     name: mbx (${{ matrix.label }})
-    if: github.actor == 'jdx' && github.ref == 'refs/heads/main'
+    if: github.actor == 'jdx' && github.triggering_actor == 'jdx' && github.ref == 'refs/heads/main'
     permissions:
       contents: read
       id-token: write # Authenticate the main-branch dispatch to the cache server.
@@ -70,7 +70,7 @@ jobs:
 
   rust_cache:
     name: Swatinem rust-cache (${{ matrix.label }})
-    if: github.actor == 'jdx' && github.ref == 'refs/heads/main'
+    if: github.actor == 'jdx' && github.triggering_actor == 'jdx' && github.ref == 'refs/heads/main'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -1,0 +1,109 @@
+name: warm cache benchmark
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: warm-cache-benchmark-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_PROFILE_DEV_DEBUG: 0
+  CARGO_TERM_COLOR: always
+
+jobs:
+  mbx:
+    name: mbx (${{ matrix.label }})
+    permissions:
+      contents: read
+      id-token: write # Authenticate the main-branch dispatch to the cache server.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: Linux
+          - os: macos-14
+            label: macOS
+          - os: windows-latest
+            label: Windows
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/mbx
+        with:
+          backend: server
+      - name: Build
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          mbx build --all-features --ignore-rust-version
+          ended=$(python3 -c 'import time; print(time.monotonic_ns())')
+          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
+          echo "## mbx ${{ matrix.label }}: ${elapsed}s" >> "$GITHUB_STEP_SUMMARY"
+          mbx cache stats
+      - name: Build
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $timer = [System.Diagnostics.Stopwatch]::StartNew()
+          mbx build --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update --ignore-rust-version
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $timer.Stop()
+          $elapsed = $timer.Elapsed.TotalSeconds.ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          "## mbx ${{ matrix.label }}: ${elapsed}s" >> $env:GITHUB_STEP_SUMMARY
+          mbx cache stats
+
+  rust_cache:
+    name: Swatinem rust-cache (${{ matrix.label }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: Linux
+            shared-key: cache-benchmark-linux-v2
+          - os: macos-14
+            label: macOS
+            shared-key: cache-benchmark-macos-v2
+          - os: windows-latest
+            label: Windows
+            shared-key: cache-benchmark-windows-v2
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Restore Cargo cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          shared-key: ${{ matrix.shared-key }}
+          save-if: false
+      - name: Build
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          cargo build --all-features --ignore-rust-version
+          ended=$(python3 -c 'import time; print(time.monotonic_ns())')
+          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
+          echo "## Swatinem/rust-cache ${{ matrix.label }}: ${elapsed}s" >> "$GITHUB_STEP_SUMMARY"
+      - name: Build
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $timer = [System.Diagnostics.Stopwatch]::StartNew()
+          cargo build --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update --ignore-rust-version
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $timer.Stop()
+          $elapsed = $timer.Elapsed.TotalSeconds.ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          "## Swatinem/rust-cache ${{ matrix.label }}: ${elapsed}s" >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -28,12 +28,17 @@ jobs:
         include:
           - os: ubuntu-latest
             label: Linux
+            target-views: "1"
           - os: macos-14
             label: macOS
+            target-views: "1"
           - os: windows-latest
             label: Windows
+            target-views: "0"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
+    env:
+      MBX_TARGET_VIEWS: ${{ matrix.target-views }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -65,6 +70,7 @@ jobs:
 
   rust_cache:
     name: Swatinem rust-cache (${{ matrix.label }})
+    if: github.actor == 'jdx' && github.ref == 'refs/heads/main'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -18,6 +18,7 @@ env:
 jobs:
   mbx:
     name: mbx (${{ matrix.label }})
+    if: github.actor == 'jdx' && github.ref == 'refs/heads/main'
     permissions:
       contents: read
       id-token: write # Authenticate the main-branch dispatch to the cache server.


### PR DESCRIPTION
## Summary

- keep pull request and main-push cache benchmarks on the GitHub backend
- use the trusted mbx server backend for manual dispatches
- allow a seed dispatch followed by a real warm-cache comparison without immutable GitHub cache collisions

## Validation

- `git diff --check`
- `actionlint -shellcheck='' .github/workflows/cache-benchmark.yml`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only, manually gated workflow with no application or production runtime impact.
> 
> **Overview**
> Adds a new **`workflow_dispatch`** workflow **`.github/workflows/warm-cache-benchmark.yml`** so warm-cache build timing can be run on demand without colliding with the existing PR/push **`cache-benchmark`** flow.
> 
> On **`main`**, only when **`jdx`** triggers it, the workflow runs a **Linux / macOS / Windows** matrix with two parallel comparisons: **`mbx build`** via the **server** cache backend (including **`id-token`** for auth and **`mbx cache stats`** in the summary) versus **`cargo build`** after **`Swatinem/rust-cache`** restore with **`save-if: false`** and the same **`cache-benchmark-*-v2`** shared keys. Each job records elapsed seconds in **`GITHUB_STEP_SUMMARY`**; Windows uses a reduced feature set matching the other benchmark workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6299c8d93e201e4ce0a224b1bd949b0cf7d44507. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an on-demand workflow to benchmark warm-cache build times across Linux, macOS, and Windows.
  * Reports build duration results in the workflow summary.
  * Includes cache statistics for additional performance insights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->