### PR TITLE
fix(task): suppress `taskkill` output on Windows

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -597,6 +597,8 @@ impl<'a> CmdLineRunner<'a> {
                 .arg("/T")
                 .arg("/PID")
                 .arg(pid.to_string())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
                 .spawn()
             {
                 warn!("Failed to kill cmd {pid}: {e}");


### PR DESCRIPTION
## Summary

Suppress `taskkill` output when stopping sibling tasks after a task failure on Windows.

## Problem

On Windows, when a task fails and mise stops its sibling tasks, `taskkill` prints message for each terminated process. For example:

```
SUCCESS: The process with PID 18296 (child process of PID 15936) has been terminated.
SUCCESS: The process with PID 15936 (child process of PID 23892) has been terminated.
```

When multiple processes are terminated, this can result in a large amount of unnecessary output.

## Fix

Other `taskkill` invocations used for timeout and panic cleanup already suppress both stdout and stderr with:

```rust
.stdout(Stdio::null())
.stderr(Stdio::null())
```

Apply the same behavior to `CmdLineRunner::kill_all()` when terminating sibling tasks after a task failure.

## Testing

- `mise run lint-fix`
- `cargo test windows_tests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Windows process termination no longer displays unwanted system command output to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->