### PR TITLE
fix(monorepo): resolve idiomatic version files from the task's own config root

### DIFF
--- a/e2e/tasks/test_task_monorepo_idiomatic_tools_config_root_settings
+++ b/e2e/tasks/test_task_monorepo_idiomatic_tools_config_root_settings
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Regression test: a monorepo config root's own idiomatic_version_file_enable_tools
+# setting must be honored when a task is dispatched cross-directory (e.g. from the
+# monorepo root via `mise run //path/to/root:task`), not just when invoked with cwd
+# already inside that config root.
+#
+# The monorepo root here does NOT enable idiomatic version files for "tiny" - only
+# packages/app1's own [settings] does. Explicit [tools] entries (packages/app2)
+# already resolve correctly across directories; idiomatic version files did not.
+export MISE_EXPERIMENTAL=1
+
+# Install the tiny plugin which supports idiomatic .tiny-version files
+mise plugin install tiny
+
+# Root config intentionally leaves idiomatic_version_file_enable_tools unset/empty -
+# it must not need "tiny" enabled globally for this to work.
+cat <<EOF >mise.toml
+monorepo_root = true
+
+[monorepo]
+config_roots = ["packages/*"]
+EOF
+
+# Subproject enables idiomatic version files for "tiny" only in its OWN config,
+# diverging from the root's settings.
+mkdir -p packages/app1
+echo "1.0.1" >packages/app1/.tiny-version
+cat <<EOF >packages/app1/mise.toml
+[settings]
+idiomatic_version_file_enable_tools = ["tiny"]
+
+[tasks.check]
+run = 'rtx-tiny'
+EOF
+
+# Comparison subproject using an explicit [tools] entry instead of an idiomatic file.
+mkdir -p packages/app2
+cat <<EOF >packages/app2/mise.toml
+[tools]
+tiny = "2.0.1"
+
+[tasks.check]
+run = 'rtx-tiny'
+EOF
+
+# Install tools from within each subdirectory, where the config root's own settings
+# are naturally in effect.
+mise -C packages/app1 install
+mise -C packages/app2 install
+
+# Test 1: Explicit [tools] entry resolves cross-directory from the monorepo root.
+echo "=== Test 1: Cross-directory task with explicit [tools] ==="
+assert_contains "mise run //packages/app2:check" "v2.0.1"
+
+# Test 2: Idiomatic version file, enabled only via the config root's own [settings],
+# must also resolve cross-directory from the monorepo root - not just when cwd is
+# already inside packages/app1.
+echo "=== Test 2: Cross-directory task with config-root-local idiomatic version file ==="
+assert_contains "mise run //packages/app1:check" "v1.0.1"
+
+echo "=== All config-root-local idiomatic tool monorepo tests passed! ==="

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2447,6 +2447,15 @@ fn detect_auto_env_candidate_files() -> Vec<PathBuf> {
 /// including MISE_ENV-specific configs and idiomatic version files.
 /// Returns (paths, idiomatic_filenames) so callers can pass the map to
 /// load_config_files_from_paths without a redundant second computation.
+///
+/// `start_dir` is typically a monorepo config root (or a directory under one)
+/// that differs from the process's invocation directory. Idiomatic version
+/// file discovery is therefore resolved from `start_dir`'s own config
+/// hierarchy via `idiomatic_filenames_for_root`, the same helper
+/// `monorepo_union_with_root_toolset` uses for lockfile maintenance, rather
+/// than from the invocation-rooted `Settings::get()` snapshot: a config root
+/// can enable `idiomatic_version_file_enable_tools` for a tool that the
+/// invocation directory's settings never mention.
 pub(crate) async fn load_config_hierarchy_from_dir(
     start_dir: &Path,
 ) -> Result<(Vec<PathBuf>, BTreeMap<String, Vec<String>>)> {
@@ -2454,7 +2463,8 @@ pub(crate) async fn load_config_hierarchy_from_dir(
         return Ok((vec![], BTreeMap::new()));
     }
 
-    let idiomatic_files = load_idiomatic_filenames().await;
+    let default_idiomatic_files = load_idiomatic_filenames().await;
+    let idiomatic_files = idiomatic_filenames_for_root(start_dir, &default_idiomatic_files).await?;
     let config_filenames: Vec<String> = idiomatic_files
         .keys()
         .cloned()


### PR DESCRIPTION
## Root cause
`load_config_hierarchy_from_dir` builds the config hierarchy for a monorepo
task's own directory, but computed which idiomatic version filenames to even
look for via `load_idiomatic_filenames()` — a process-wide `Settings::get()`
snapshot rooted at the invocation directory, not at `start_dir`. A config
root's `[settings].idiomatic_version_file_enable_tools` was therefore ignored
whenever a task defined in that root was dispatched cross-directory (`mise run
//path/to/root:task`) from elsewhere in the monorepo: the idiomatic file was
never even recognized as a config source, so the tool it named never made it
onto the task's toolset or PATH. Explicit `[tools]` entries were unaffected,
since TOML-based tool resolution walks the whole config hierarchy regardless
of idiomatic settings.

This is the original bug reported in discussion #8629: running
`mise //packages/app1:format` from the monorepo root failed with "pnpm:
command not found" (idiomatic version file case), while an equivalent
explicit `[tools]` entry worked, and running the task from inside
`packages/app1` also worked. #11463 (bf727b2d4) previously fixed
`idiomatic_filenames_for_root`'s other caller
(`monorepo_union_with_root_toolset`, used by `mise ls --monorepo` and
lockfile union resolution) but did not cover this task-dispatch call site,
leaving #8629's own repro unresolved.

## Fix
Reuse `idiomatic_filenames_for_root` — the same helper
`monorepo_union_with_root_toolset` already uses — to resolve
`idiomatic_version_file_enable_tools`/`disable_files` from `start_dir`'s own
config hierarchy instead of the invocation-rooted snapshot. No new precedence
logic; this is the existing settings-resolution machinery applied where task
dispatch was missing it.

`load_config_hierarchy_from_dir` is shared by every monorepo cross-directory
task path (`TaskContextBuilder::build_toolset_for_task`,
`resolve_task_env_with_config`, `TaskToolInstaller::collect_tools_from_dir`),
so this one change fixes toolset building, env resolution, and tool
installation together.

## Before / After
- Before: a config root's own `idiomatic_version_file_enable_tools` was
  silently ignored for cross-directory task dispatch; the idiomatic-versioned
  tool was never installed or put on PATH, only working when cwd was already
  inside that config root.
- After: cross-directory task dispatch resolves idiomatic version files from
  the task's own config root, matching non-cross-directory behavior and the
  behavior `mise ls --monorepo` already had after #11463.

## Test
Added `e2e/tasks/test_task_monorepo_idiomatic_tools_config_root_settings`
(prior commit), which fails against the current `main` and passes with this
fix: a config root enables an idiomatic version file for a tool only in its
own `[settings]` (not at the monorepo root), and a task in that root is run
cross-directory via `mise run //packages/app1:check` from the monorepo root.
A sibling subproject using an explicit `[tools]` entry is included as a
passing comparison case.

## Compliance checklist
- `mise run render` — clean, no diff
- `mise run lint-fix` / `mise run lint` — clean
- `cargo clippy --all-features --all-targets -- -D warnings` — clean
- `cargo test --all-features` and `cargo test --workspace --exclude mise` — all pass
- `cargo deny check`, `cargo machete --with-metadata` — both pass

## Related
- Originally reported in #8629 (still open, zero replies) — this closes it.
- #11463 / bf727b2d4 fixed the same underlying gap for a different caller
  (`mise ls --monorepo`/lockfile union) but not task dispatch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cross-directory tasks now honor idiomatic version-file settings defined in the target project’s configuration root.
  * Tasks invoked from a monorepo root correctly resolve tools using configuration-local version files, such as `.tiny-version`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->