### PR TITLE
registry: install sbt from its github releases

### DIFF
--- a/registry/sbt.toml
+++ b/registry/sbt.toml
@@ -1,4 +1,7 @@
-backends = ["conda:sbt", "asdf:mise-plugins/mise-sbt"]
+backends = ["github:sbt/sbt", "conda:sbt", "asdf:mise-plugins/mise-sbt"]
 description = "sbt, the interactive build tool"
-test = { cmd = "sbt --version", expected = "sbt" }
+# The upstream `sbt` script looks for a JVM before it will answer `--version`,
+# where the conda wrapper reports its runner version without one. `tools` is how
+# `gradle` covers the same requirement.
+test = { cmd = "sbt --version", expected = "sbt", tools = ["java"] }
 version_order = "semver"


### PR DESCRIPTION
`sbt` is listed as `conda:sbt` first, but sbt publishes a universal `sbt-<version>.tgz` on its own GitHub releases, which `AGENTS.md` places a tier above conda ("potentially acceptable when the tool can't be supported via aqua/github" — it can be).

**This is alignment, not a fix.** `conda:sbt` works today, and the conda backend needs no separately-installed package manager, so there is no broken-without-a-toolchain story here of the kind that motivates moving `pipx:`/`cargo:` entries. If that is not worth the churn, closing this is a reasonable answer.

No `platforms` scoping and no `version_prefix` — the tarball is universal and mise's autodetection resolves it as-is.

## Versions

```
mise ls-remote github:sbt/sbt   ->  63 versions, 1.6.2 … 2.0.7
mise ls-remote conda:sbt        ->  51 versions
```

**The default listing is clean.** Of the 200 upstream releases, the only stable ones without a `.tgz` are the ten sbt 0.13.x releases from 2014–2017, and neither those nor the 69 prereleases appear in the default listing. Asset naming is `sbt-<version>.tgz` unbroken back to 1.3.13.

Six versions are in conda's listing and not in github's default one — 1.5.2 through 1.6.1. They are simply past the 100-release page boundary, and they install when pinned:

```
mise install github:sbt/sbt@1.5.5   -> ok, sbt 1.5.5
mise install github:sbt/sbt@1.6.1   -> ok, sbt 1.6.1
mise install github:sbt/sbt@1.5.2   -> ok
```

Two things worth stating rather than leaving to be discovered:

- Under `MISE_LIST_ALL_VERSIONS=1` the listing grows to 130 and **does** include the 0.13.x releases, which cannot install because upstream published no tarball for them. That is an opt-in flag and does not affect the default experience.
- While testing I saw `mise latest github:sbt/sbt` return 2.0.7 while conda returned 2.0.8, and 2.0.8 stayed missing through a cleared cache, `MISE_USE_VERSIONS_HOST=0` and `MISE_LIST_ALL_VERSIONS=1`. That is **not a defect** — it is `minimum_release_age`'s 24h default, and 2.0.8 was published that morning. With `MISE_MINIMUM_RELEASE_AGE=0s` it appears and `latest` is 2.0.8. Noting it so nobody re-investigates it.

## `tools = ["java"]`, and the one regression

Neither backend bundles a JDK, but they differ on `--version`:

```
mise x conda:sbt@2.0.7      -- sbt --version   ->  sbt runner version: 2.0.7
mise x github:sbt/sbt@2.0.8 -- sbt --version   ->  Unable to locate a Java Runtime
```

The conda wrapper answers without starting a JVM; the upstream `sbt` script looks for Java first. So:

1. The registry test needs a JDK, which is what `gradle` already does — `test = { cmd = "gradle -V", expected = "Gradle", tools = ["java"] }`. Same shape here.
2. **For a user with no JDK, `sbt --version` stops working.** sbt cannot do anything useful without a JVM either way, so `--version` is the whole of it — but it is a regression and should not be buried.

With a JDK present both backends behave identically and the entry's `expected = "sbt"` matches.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing `sbt` through the GitHub backend.

* **Bug Fixes**
  * Updated `sbt --version` validation to ensure Java is available, matching the tool’s runtime requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->