### PR TITLE
fix(install): stop --dry-run claiming it would install what it cannot

### DIFF
--- a/e2e/cli/test_install_dry_run_feasibility
+++ b/e2e/cli/test_install_dry_run_feasibility
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# `--dry-run` used to resolve a version and stop there, so it answered "would install" for tools
+# that cannot install here at all -- measured as `mise install --dry-run acli@latest` succeeding on
+# Windows while the same command without `--dry-run` failed with `unsupported env: windows/amd64`.
+# The check the install does was on the far side of an early return.
+
+# The http backend can tell from its options alone. This suite runs on Linux (Windows has its own,
+# `e2e-win/`), so a tool that declares only `windows-x64` has no URL here and needs no platform
+# staging to stay reproducible.
+#
+# The platform has to be one mise recognises. `list_available_platforms_with_key` enumerates nested
+# keys by probing known OS tokens, so an invented platform like `plan9-mips` leaves the list empty
+# and the message becomes "Http backend requires 'url' option" -- true of a tool that declares no
+# URL at all, and misleading for one that declares a URL for somewhere else.
+cat <<EOF >mise.toml
+[tools."http:dry-run-no-url-here"]
+version = "1.0.0"
+platforms = { windows-x64 = { url = "https://example.invalid/tool-{{version}}.tar.gz" } }
+EOF
+assert_fail "mise install --dry-run" "No URL for platform"
+# and it names what the tool does declare, since adding that key is usually the fix
+assert_fail "mise install --dry-run" "Available: windows-x64"
+
+# aqua can tell from the registry entry. Specific versions are marked `no_asset` there regardless
+# of platform, which is what makes this runnable on any runner: `unsupported env` depends on the
+# host, and aqua reads the host from `env::consts::OS` rather than from settings, so `MISE_OS`
+# cannot stage it.
+assert_fail "mise install --dry-run age@1.0.0-beta1" "no asset released"
+
+# The controls. Both pass before this change as well as after, and a fix that simply made
+# `--dry-run` pessimistic would break them.
+cat <<EOF >mise.toml
+[tools."http:dry-run-installable"]
+version = "1.0.0"
+url = "https://mise.jdx.dev/test-fixtures/hello-world-{{version}}.tar.gz"
+bin_path = "hello-world-1.0.0/bin"
+EOF
+
+# A tool that can install still reports that it would.
+assert_contains "mise install --dry-run 2>&1" "would install"
+
+# And once it is installed, feasibility is not re-examined: the check only runs where an install
+# would actually be attempted, so a machine whose tools predate a registry restriction keeps
+# working rather than failing a dry run for an install nobody asked for.
+mise install
+assert_contains "mise install http:dry-run-installable@1.0.0 --dry-run 2>&1" "already installed"

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -158,6 +158,17 @@ enum GithubAttestationStatus {
     Unavailable,
 }
 
+/// What `install_version_` needs before it fetches anything, and the point at which aqua can
+/// already tell that a version is not installable on this machine.
+struct ResolvedPackage {
+    platform_key: String,
+    existing_platform: Option<String>,
+    existing_url_api: Option<String>,
+    pkg: AquaPackage,
+    v: String,
+    v_prefixed: Option<String>,
+}
+
 #[async_trait]
 impl Backend for AquaBackend {
     fn version_order(&self, opts: &ToolVersionOptions) -> Result<VersionOrder> {
@@ -419,76 +430,27 @@ impl Backend for AquaBackend {
         self.latest_marked_release_version().await
     }
 
+    /// aqua knows, from the registry entry alone, when a version cannot be installed here:
+    /// `no_asset`, an `error_message`, a platform outside `supported_envs`, or a package type
+    /// this backend does not implement. `validate` has always said so during the install; this
+    /// makes `--dry-run` ask the same question before answering "would install".
+    async fn verify_install_feasible(&self, _ctx: &InstallContext, tv: &ToolVersion) -> Result<()> {
+        self.resolve_validated_package(tv).await.map(|_| ())
+    }
+
     async fn install_version_(
         &self,
         ctx: &InstallContext,
         mut tv: ToolVersion,
     ) -> Result<ToolVersion> {
-        // Check if URL already exists in lockfile platforms first
-        // This allows us to skip API calls when lockfile has the URL
-        let platform_key = self.get_platform_key();
-        let existing_platform = tv
-            .lock_platforms
-            .get(&platform_key)
-            .and_then(|asset| asset.url.clone());
-        // Private repos download via the API asset endpoint; carry it from the lockfile so
-        // `--locked` installs of private tools can still fall back to it.
-        let existing_url_api = tv
-            .lock_platforms
-            .get(&platform_key)
-            .and_then(|asset| asset.url_api.clone());
-
-        // Skip get_version_tags() API call if the lockfile URL contains the release tag.
-        // Keep the tag for selecting Aqua version overrides, which may be scoped by prefix.
-        let locked_tag = existing_platform
-            .as_deref()
-            .and_then(github_release_tag_from_url);
-        let tag = if let Some(tag) = locked_tag {
-            Some(tag)
-        } else if existing_platform.is_some() {
-            None
-        } else {
-            match self.get_version_tags().await {
-                Ok(tags) => tags
-                    .iter()
-                    .find(|(version, _)| version == &tv.version)
-                    .map(|(_, tag)| tag.clone()),
-                Err(e) => {
-                    warn!(
-                        "[{}] failed to fetch version tags, URL may be incorrect: {e}",
-                        self.id
-                    );
-                    None
-                }
-            }
-        };
-        if tag.is_none() && existing_platform.is_none() && !tv.version.starts_with('v') {
-            debug!(
-                "[{}] no tag found for version {}, will try with 'v' prefix",
-                self.id, tv.version
-            );
-        }
-        let mut v = tag.clone().unwrap_or_else(|| tv.version.clone());
-        let mut v_prefixed =
-            (tag.is_none() && !tv.version.starts_with('v')).then(|| format!("v{v}"));
-        let pkg = AQUA_REGISTRY.package(&self.id).await?;
-        let versions = install_package_version_candidates(&tv.version, tag.as_deref(), &pkg);
-        let versions = versions.iter().map(|v| v.as_ref()).collect_vec();
-        let mut pkg = Self::package_with_options_for_pkg(&tv, pkg, &versions)?;
-        if let Some(prefix) = &pkg.version_prefix
-            && !v.starts_with(prefix)
-        {
-            v = format!("{prefix}{v}");
-            // Don't add prefix to v_prefixed if it already starts with the prefix
-            v_prefixed = v_prefixed.map(|vp| {
-                if vp.starts_with(prefix) {
-                    vp
-                } else {
-                    format!("{prefix}{vp}")
-                }
-            });
-        }
-        validate(&pkg, &v)?;
+        let ResolvedPackage {
+            platform_key,
+            existing_platform,
+            existing_url_api,
+            mut pkg,
+            v,
+            v_prefixed,
+        } = self.resolve_validated_package(&tv).await?;
 
         // Validate lockfile URL matches expected asset pattern from registry
         // This handles cases where the registry format changed (e.g., raw binary -> tar.gz)
@@ -1035,6 +997,90 @@ impl Backend for AquaBackend {
 }
 
 impl AquaBackend {
+    /// Resolve the registry entry for `tv` and decide whether it can be installed here at all.
+    ///
+    /// Split out of `install_version_` so `verify_install_feasible` can reach `validate` without
+    /// downloading anything. Extracted rather than reimplemented on purpose: skipping the tag
+    /// lookup would select a different `version_overrides` block, and a feasibility check reading
+    /// the wrong block would call a tool impossible when it installs fine -- a worse answer than
+    /// the optimism it replaces.
+    async fn resolve_validated_package(&self, tv: &ToolVersion) -> Result<ResolvedPackage> {
+        // Check if URL already exists in lockfile platforms first
+        // This allows us to skip API calls when lockfile has the URL
+        let platform_key = self.get_platform_key();
+        let existing_platform = tv
+            .lock_platforms
+            .get(&platform_key)
+            .and_then(|asset| asset.url.clone());
+        // Private repos download via the API asset endpoint; carry it from the lockfile so
+        // `--locked` installs of private tools can still fall back to it.
+        let existing_url_api = tv
+            .lock_platforms
+            .get(&platform_key)
+            .and_then(|asset| asset.url_api.clone());
+
+        // Skip get_version_tags() API call if the lockfile URL contains the release tag.
+        // Keep the tag for selecting Aqua version overrides, which may be scoped by prefix.
+        let locked_tag = existing_platform
+            .as_deref()
+            .and_then(github_release_tag_from_url);
+        let tag = if let Some(tag) = locked_tag {
+            Some(tag)
+        } else if existing_platform.is_some() {
+            None
+        } else {
+            match self.get_version_tags().await {
+                Ok(tags) => tags
+                    .iter()
+                    .find(|(version, _)| version == &tv.version)
+                    .map(|(_, tag)| tag.clone()),
+                Err(e) => {
+                    warn!(
+                        "[{}] failed to fetch version tags, URL may be incorrect: {e}",
+                        self.id
+                    );
+                    None
+                }
+            }
+        };
+        if tag.is_none() && existing_platform.is_none() && !tv.version.starts_with('v') {
+            debug!(
+                "[{}] no tag found for version {}, will try with 'v' prefix",
+                self.id, tv.version
+            );
+        }
+        let mut v = tag.clone().unwrap_or_else(|| tv.version.clone());
+        let mut v_prefixed =
+            (tag.is_none() && !tv.version.starts_with('v')).then(|| format!("v{v}"));
+        let pkg = AQUA_REGISTRY.package(&self.id).await?;
+        let versions = install_package_version_candidates(&tv.version, tag.as_deref(), &pkg);
+        let versions = versions.iter().map(|v| v.as_ref()).collect_vec();
+        let pkg = Self::package_with_options_for_pkg(tv, pkg, &versions)?;
+        if let Some(prefix) = &pkg.version_prefix
+            && !v.starts_with(prefix)
+        {
+            v = format!("{prefix}{v}");
+            // Don't add prefix to v_prefixed if it already starts with the prefix
+            v_prefixed = v_prefixed.map(|vp| {
+                if vp.starts_with(prefix) {
+                    vp
+                } else {
+                    format!("{prefix}{vp}")
+                }
+            });
+        }
+        validate(&pkg, &v)?;
+
+        Ok(ResolvedPackage {
+            platform_key,
+            existing_platform,
+            existing_url_api,
+            pkg,
+            v,
+            v_prefixed,
+        })
+    }
+
     fn package_with_options_for_pkg(
         tv: &ToolVersion,
         pkg: AquaPackage,
@@ -3558,6 +3604,43 @@ pub(crate) fn is_install_time_option_key(key: &str) -> bool {
 mod tests {
     use super::*;
     use aqua_registry::{AquaFile, AquaVar, ParsedRegistry};
+
+    // `--dry-run` reaches `validate` through `resolve_validated_package`, and this is the sentence
+    // it has to be able to produce before the install starts. Pinned here because
+    // `e2e/cli/test_install_dry_run_feasibility` greps for it: aqua marks specific versions
+    // `no_asset` regardless of platform, which is what makes that e2e runnable on any runner.
+    #[test]
+    fn validate_refuses_a_package_the_registry_marks_as_having_no_asset() {
+        // `validate` reads the package it is handed; selecting the right `version_overrides` block
+        // happens upstream in `package_with_options_for_pkg`. So the two cases are two packages
+        // here, not two versions of one -- writing `no_asset` under `version_overrides` would
+        // leave the base package unmarked and assert nothing.
+        let registry = ParsedRegistry::parse_yaml(
+            r#"
+packages:
+  - type: github_release
+    repo_owner: example
+    repo_name: unreleased
+    no_asset: true
+  - type: github_release
+    repo_owner: example
+    repo_name: released
+    asset: tool.tar.gz
+"#,
+        )
+        .unwrap();
+
+        let unreleased = registry.package("example/unreleased").unwrap();
+        assert_eq!(
+            validate(&unreleased, "v1.0.0").unwrap_err().to_string(),
+            "no asset released"
+        );
+
+        // The control: an otherwise identical package that does ship an asset passes. Without it
+        // this test would be satisfied by a `validate` that rejected everything.
+        let released = registry.package("example/released").unwrap();
+        assert!(validate(&released, "v1.0.0").is_ok());
+    }
 
     #[test]
     fn cargo_warning_uses_crate_name() {

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -254,6 +254,23 @@ impl HttpBackend {
         Self { ba: Arc::new(ba) }
     }
 
+    /// Built in one place so the dry-run check and the install itself cannot drift apart.
+    /// Names the platform it looked for and the ones the tool does declare, because the fix is
+    /// usually to add that key rather than to pick a different tool.
+    fn missing_url_error(&self, opts: &HttpOptions<'_>) -> eyre::Report {
+        let platform_key = self.get_platform_key();
+        let available = opts.url_platforms();
+        if available.is_empty() {
+            eyre::eyre!("Http backend requires 'url' option")
+        } else {
+            eyre::eyre!(
+                "No URL for platform {platform_key}. Available: {}. \
+                 Provide 'url' or add 'platforms.{platform_key}.url'",
+                available.join(", ")
+            )
+        }
+    }
+
     // -------------------------------------------------------------------------
     // Cache path helpers
     // -------------------------------------------------------------------------
@@ -1176,6 +1193,18 @@ impl Backend for HttpBackend {
             .collect())
     }
 
+    /// An http tool with no URL for this platform cannot be installed, and the options say so
+    /// without a single request. `--dry-run` used to answer "would install" for exactly the case
+    /// the real install rejects on its first line.
+    async fn verify_install_feasible(&self, _ctx: &InstallContext, tv: &ToolVersion) -> Result<()> {
+        let raw_opts = tv.request.options();
+        let opts = HttpOptions::new(&raw_opts);
+        match opts.url() {
+            Some(_) => Ok(()),
+            None => Err(self.missing_url_error(&opts)),
+        }
+    }
+
     async fn install_version_(
         &self,
         ctx: &InstallContext,
@@ -1185,19 +1214,7 @@ impl Backend for HttpBackend {
         let opts = HttpOptions::new(&raw_opts);
 
         // Get URL template
-        let url_template = opts.url().ok_or_else(|| {
-            let platform_key = self.get_platform_key();
-            let available = opts.url_platforms();
-            if !available.is_empty() {
-                eyre::eyre!(
-                    "No URL for platform {platform_key}. Available: {}. \
-                     Provide 'url' or add 'platforms.{platform_key}.url'",
-                    available.join(", ")
-                )
-            } else {
-                eyre::eyre!("Http backend requires 'url' option")
-            }
-        })?;
+        let url_template = opts.url().ok_or_else(|| self.missing_url_error(&opts))?;
 
         let url = template_string(&url_template, &tv);
 
@@ -1589,6 +1606,38 @@ mod tests {
         assert_eq!(
             HttpBackend::install_path_for(&tv, "abcdef123456"),
             destination
+        );
+    }
+
+    // The message `--dry-run` now produces before claiming it would install. Built by
+    // `missing_url_error` so the dry-run check and the install itself cannot drift apart; this
+    // asserts both of its branches, which are two different mistakes with two different fixes.
+    #[test]
+    fn missing_url_error_names_this_platform_and_the_ones_declared() {
+        let backend = HttpBackend {
+            ba: Arc::new(BackendArg::new_raw(
+                "http-mytool".to_string(),
+                Some("http:mytool".to_string()),
+                "mytool".to_string(),
+                None,
+                BackendResolution::new(true),
+            )),
+        };
+
+        let declared =
+            crate::toolset::parse_tool_options("platforms_linux_x64_url=https://example.invalid/t");
+        let declared = HttpOptions::new(&declared);
+        let err = backend.missing_url_error(&declared).to_string();
+        assert!(err.contains(&backend.get_platform_key()), "{err}");
+        assert!(err.contains("linux-x64"), "{err}");
+
+        // A tool that declares no URL anywhere is a different mistake: there is no list to print
+        // and nothing platform-specific to say.
+        let none = ToolVersionOptions::default();
+        let none = HttpOptions::new(&none);
+        assert_eq!(
+            backend.missing_url_error(&none).to_string(),
+            "Http backend requires 'url' option"
         );
     }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3333,6 +3333,11 @@ pub(crate) trait Backend: Debug + Send + Sync {
                 ctx.pr
                     .finish_with_icon("already installed".into(), ProgressIcon::Skipped);
             } else {
+                // Only when an install would actually happen. Asking whether an already-installed
+                // tool *could* be installed is a different question, and answering it here would
+                // start failing `--dry-run` on machines whose tools predate a registry
+                // restriction -- for an install that is not going to be attempted.
+                self.verify_install_feasible(&ctx, &tv).await?;
                 ctx.pr
                     .finish_with_icon("would install".into(), ProgressIcon::Skipped);
             }
@@ -3576,6 +3581,24 @@ pub(crate) trait Backend: Debug + Send + Sync {
     /// Default is 3: download, checksum, extract
     async fn install_operation_count(&self, _tv: &ToolVersion, _ctx: &InstallContext) -> usize {
         3
+    }
+
+    /// Whether this version could install here at all, judged without downloading anything.
+    ///
+    /// `--dry-run` answers before `install_version_` runs, so a backend that would have refused
+    /// the platform, the version or the package type never got asked, and the answer came back
+    /// "would install" for something that cannot. Backends that can tell cheaply -- from data
+    /// already on disk or already fetched -- override this.
+    ///
+    /// **The default is silence, not a claim of feasibility.** A backend that has not implemented
+    /// this says nothing about whether the install would work, and `--dry-run` stays as optimistic
+    /// for it as it was before.
+    async fn verify_install_feasible(
+        &self,
+        _ctx: &InstallContext,
+        _tv: &ToolVersion,
+    ) -> Result<()> {
+        Ok(())
     }
 
     async fn install_version_(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion>;


### PR DESCRIPTION
## The problem

`--dry-run` resolves a version and stops. It never asks whether that version can be installed on
this machine, so it answers **the same way** for a tool that works and one that cannot exist here.

Measured in one isolated environment (`MISE_DATA_DIR`, `MISE_CONFIG_DIR`, `MISE_CACHE_DIR`,
`MISE_TRUSTED_CONFIG_PATHS` all pointed at a scratch tree):

```console
$ mise install --dry-run acli@latest
mise acli@1.3.30-stable ⇢ would install                              # exit 0

$ mise install acli@latest                                           # same environment
mise ERROR Failed to install aqua:atlassian.com/acli@latest: unsupported env: windows/amd64
           (supported: ["linux/amd64", "linux/arm64", "darwin/amd64", "darwin/arm64"])
                                                                     # exit 1
```

The control is a tool that genuinely installs:

```console
$ mise install --dry-run jq@latest
mise jq@1.8.2      ⇢ would install                                   # exit 0
```

Same shape, same exit code. A CI job using `--dry-run` as a pre-check passes and then fails for
real.

## It is placement, not a missing check

`Backend::install_version` returns from its dry-run branch **before** calling `install_version_`,
and the answer lives past that return. aqua's `validate()` rejects `no_asset`, an `error_message`, a
platform outside `supported_envs`, and package types the backend does not implement — all from data
already on disk.

So the dry-run branch now asks. `verify_install_feasible` is a new `Backend` method whose default is
`Ok(())`, called **only when an install would actually be attempted**. An already-installed tool is
not re-examined: answering that question would start failing dry runs on machines whose tools
predate a registry restriction, for an install nobody is going to attempt.

### aqua reuses the install path rather than restating it

The resolve-and-validate prefix of `install_version_` moved into `resolve_validated_package`, which
both callers use. **Skipping the tag lookup would have been cheaper and wrong**: it selects a
different `version_overrides` block, and a feasibility check reading the wrong block would call a
working tool impossible — a worse answer than the optimism it replaces. Extraction keeps the
judgement identical to the real install.

### http knows it from its options

Its first act is to look up `platforms.<key>.url`, which touches no network, so
`No URL for platform …` was already knowable before "would install" was printed. That message moved
into `missing_url_error` so the two callers cannot drift apart.

## This changes what `--dry-run` exits with

It used to always succeed. It now **fails where the install would fail, with the same message**.
That is the point of the change, but scripts that relied on `--dry-run` never failing will notice,
so it belongs in the release notes rather than buried here.

## What it deliberately does not do

The default of `Ok(())` stays. **cargo, go, npm and the rest are as optimistic as they were** — a
backend that has not implemented this says nothing, rather than claiming feasibility. This makes
`--dry-run` report what is cheaply knowable; it is not a guarantee that the install will succeed.

## Tests

Neither new e2e case needs the network for its subject, and neither needs a staged platform:

- **http**: a fixture whose only declared platform is `windows-x64`. This suite runs on Linux —
  Windows has its own, in `e2e-win/` — so that URL is missing on every runner here.

  The platform has to be one mise recognises. An invented one like `plan9-mips` leaves
  `list_available_platforms_with_key` empty, because it enumerates nested keys by probing known OS
  tokens, and the message then becomes `Http backend requires 'url' option` — the branch for a tool
  that declares no URL at all, which is not what this fixture is. (That enumeration is what #12580
  fixes; this fixture does not depend on it.)
- **aqua**: a version aqua marks `no_asset`, which does not depend on the host. `unsupported env`
  does, and aqua reads the host from `env::consts::OS` rather than from settings, so `MISE_OS`
  cannot stage it — that is why the reproduction above is Windows-only but the test is not.

The controls are the other half, and a fix that simply made `--dry-run` pessimistic would fail them:
a tool that can install still reports `would install`, and once installed it still reports
`already installed` — the second one is the evidence for the "only when an install would happen"
guard.

Unit tests pin the two messages the e2e greps for, including `missing_url_error`'s two branches,
which are different mistakes with different fixes.

## Checked for regressions

Existing `--dry-run` e2e coverage was reviewed first: `test_http_flutter_url` and `test_http_upgrade`
are the http ones, and both declare a URL that resolves on the runner, so neither is affected. The
cargo, go and npm dry-run tests take the default `Ok(())` path unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `mise install --dry-run` accuracy by validating platform availability, versions, package types, configured errors, and downloadable assets before reporting an installation.
  * Clearer errors now identify unavailable platforms, missing URLs, and unreleased assets.
  * Unhealthy installation paths are no longer reported as successfully installed.

* **Tests**
  * Added end-to-end coverage for unavailable and available tools, unsupported assets, and already-installed tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
