### PR TITLE
fix(install): say when an install produced none of the binaries it declares

### DIFF
--- a/e2e/cli/test_install_missing_bins
+++ b/e2e/cli/test_install_missing_bins
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# mise judges an install by whether the archive was fetched and unpacked; nothing looked at what
+# came out. `mise install libsql-server` on Windows unpacked a source tarball -- Dockerfile,
+# Makefile, LICENSE -- and reported success, and the user found out at `mise x`.
+#
+# The check reads the registry's `bins`, so a tool written as `http:whatever` in mise.toml has
+# nothing declared and is skipped. `MISE_BACKENDS_<SHORT>` is returned by `RegistryTool::backends()`
+# ahead of every other filter, so the short stays a registry short -- `jq` still declares `bins =
+# ["jq"]` -- while the backend behind it becomes one this test controls.
+
+SERVE_DIR="$TMPDIR/archives"
+mkdir -p "$SERVE_DIR/nobin" "$SERVE_DIR/withbin"
+
+# The two archives differ in exactly one way: whether anything in them can be run. That is what
+# makes the pair a control rather than two separate tests.
+printf 'FROM scratch\n' >"$SERVE_DIR/nobin/Dockerfile"
+printf 'all:\n\techo build me first\n' >"$SERVE_DIR/nobin/Makefile"
+tar -czf "$SERVE_DIR/nobin.tar.gz" -C "$SERVE_DIR/nobin" .
+
+printf 'FROM scratch\n' >"$SERVE_DIR/withbin/Dockerfile"
+printf '#!/usr/bin/env bash\necho jq-1.0.0\n' >"$SERVE_DIR/withbin/jq"
+chmod +x "$SERVE_DIR/withbin/jq"
+tar -czf "$SERVE_DIR/withbin.tar.gz" -C "$SERVE_DIR/withbin" .
+
+HTTP_PORT_FILE="$TMPDIR/missing_bins_port"
+python3 -c "
+import http.server, socketserver
+s = socketserver.TCPServer(('', 0), lambda *a: http.server.SimpleHTTPRequestHandler(*a, directory='$SERVE_DIR'))
+with open('$HTTP_PORT_FILE', 'w') as f:
+    f.write(str(s.server_address[1]))
+s.serve_forever()
+" &
+HTTP_SERVER_PID=$!
+
+cleanup() {
+  kill $HTTP_SERVER_PID 2>/dev/null || true
+}
+trap cleanup EXIT
+
+for _i in {1..20}; do
+  if [[ -f $HTTP_PORT_FILE ]]; then break; fi
+  sleep 0.1
+done
+HTTP_PORT=$(cat "$HTTP_PORT_FILE")
+
+if ! curl -sfI "http://localhost:$HTTP_PORT/nobin.tar.gz" >/dev/null; then
+  fail "HTTP server failed to start"
+fi
+
+export MISE_BACKENDS_JQ="http:jq"
+
+cat <<EOF >mise.toml
+[tools.jq]
+version = "1.0.0"
+url = "http://localhost:$HTTP_PORT/nobin.tar.gz"
+EOF
+
+# It still installs -- the archive downloaded and unpacked, which is all mise ever checked, and
+# turning that into a failure would break every tool whose declared bins are inaccurate.
+assert_succeed "mise install"
+assert_contains "mise install --force 2>&1" "none of the binaries it declares"
+assert_contains "mise install --force 2>&1" "jq"
+
+# The control: same short, same backend, same code path, an archive that does contain a program.
+cat <<EOF >mise.toml
+[tools.jq]
+version = "1.0.0"
+url = "http://localhost:$HTTP_PORT/withbin.tar.gz"
+EOF
+
+assert_succeed "mise install --force"
+assert_not_contains "mise install --force 2>&1" "none of the binaries it declares"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -825,6 +825,36 @@ where
     })
 }
 
+/// Whether none of `bins` is present in `dirs` as a runnable file.
+///
+/// Uses [`file::is_spawnable`], whose `false` means "the OS will not launch this", rather than the
+/// permissive predicate that answers with shebang scripts. Any one of `bins` is enough — a tool
+/// that ships some of what it declares has installed something usable, and saying otherwise would
+/// be noise.
+///
+/// Deliberately not [`which_in_dirs`], though it walks the same candidates. Two differences, both
+/// needed here and neither wanted there:
+///
+/// * **A directory does not count.** On unix `file::is_executable` answers true for a mode-0755
+///   directory and [`file::is_spawnable`] matches it byte for byte — a pinned decision, see
+///   `is_spawnable_matches_is_executable_on_unix`. `execv` on a directory is `EACCES`, so an
+///   archive that unpacks `sqld/` has not produced `sqld`, and treating it as one would suppress
+///   exactly the warning this exists for.
+/// * **It does not stop at the first directory that matches.** `which_in_dirs` returns the first
+///   hit and stops; a `sqld/` directory in an earlier bin path would then hide a real `sqld` in a
+///   later one, which would be a warning about a tool that installed fine.
+fn no_declared_bin_present(bins: &[&str], dirs: &[PathBuf]) -> bool {
+    !bins.iter().any(|bin| {
+        let names = file::executable_names(bin);
+        dirs.iter().any(|dir| {
+            names
+                .iter()
+                .map(|name| dir.join(name))
+                .any(|candidate| candidate.is_file() && file::is_spawnable(&candidate))
+        })
+    })
+}
+
 /// PATH-side counterpart of [`which_non_pristine_executable`], narrowed to what the OS can
 /// actually spawn.
 ///
@@ -946,6 +976,76 @@ mod tests {
             normalize_idiomatic_contents("20.0.0\n\u{feff}18.0.0"),
             "20.0.0\n\u{feff}18.0.0"
         );
+    }
+
+    /// A spawnable file under `name`, whatever that means on this platform.
+    fn write_spawnable(dir: &Path, name: &str) -> PathBuf {
+        let path = dir.join(if cfg!(windows) {
+            format!("{name}.exe")
+        } else {
+            name.to_string()
+        });
+        fs::write(&path, "MZ").unwrap();
+        file::make_executable(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn no_declared_bin_present_is_true_when_the_archive_held_no_program() {
+        // The shape that started this: `mise install libsql-server` succeeded on Windows and
+        // unpacked a source tarball. The install directory is real and non-empty; none of it can
+        // be run.
+        let dir = tempfile::tempdir().unwrap();
+        for name in ["Dockerfile", "Makefile", "LICENSE"] {
+            fs::write(dir.path().join(name), "not a program\n").unwrap();
+        }
+        let dirs = vec![dir.path().to_path_buf()];
+
+        assert!(no_declared_bin_present(&["sqld"], &dirs));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_directory_named_like_the_bin_does_not_count_as_the_bin() {
+        // `is_executable` answers true for a mode-0755 directory and `is_spawnable` matches it, by
+        // a decision this must not disturb (`is_spawnable_matches_is_executable_on_unix`). Measured
+        // on Linux: a directory's mode & 0o111 is non-zero, and `execv` on it fails EACCES. So an
+        // archive that unpacks `sqld/` has produced no `sqld`, and the warning has to still fire.
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join("sqld")).unwrap();
+        assert!(no_declared_bin_present(
+            &["sqld"],
+            &[dir.path().to_path_buf()]
+        ));
+
+        // And the directory must not hide a real one further along the bin paths. `which_in_dirs`
+        // would stop at the first match and answer with the directory; this walks past it.
+        let real = tempfile::tempdir().unwrap();
+        write_spawnable(real.path(), "sqld");
+        assert!(!no_declared_bin_present(
+            &["sqld"],
+            &[dir.path().to_path_buf(), real.path().to_path_buf()]
+        ));
+    }
+
+    #[test]
+    fn no_declared_bin_present_is_false_once_any_declared_bin_is_there() {
+        // The control, and it is what stops "warn on every install" from passing the test above.
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("Makefile"), "not a program\n").unwrap();
+        let dirs = vec![dir.path().to_path_buf()];
+
+        write_spawnable(dir.path(), "sqld");
+        assert!(!no_declared_bin_present(&["sqld"], &dirs));
+
+        // And any one of them is enough. A tool that ships some of what it declares has installed
+        // something usable, so warning about the rest would be noise.
+        assert!(!no_declared_bin_present(
+            &["missing-one", "sqld", "missing-two"],
+            &dirs
+        ));
+        // ...while a name it does not ship at all is still absent.
+        assert!(no_declared_bin_present(&["missing-one"], &dirs));
     }
 
     #[test]
@@ -3429,8 +3529,67 @@ pub(crate) trait Backend: Debug + Send + Sync {
                 .finish_with_message("running custom postinstall hook".to_string());
             self.run_postinstall_hook(&ctx, &tv, script).await?;
         }
+        // After the postinstall hook, which is allowed to be what puts the binary there.
+        self.warn_if_no_declared_bin_landed(&ctx, &tv).await;
         ctx.pr.finish_with_message("installed".to_string());
         Ok(tv)
+    }
+
+    /// Say so when an install finished and produced none of the binaries its registry entry
+    /// declares.
+    ///
+    /// mise judges an install by whether the archive was fetched and unpacked; nothing looks at
+    /// what came out. `registry/<tool>.toml`'s `bins` is only ever read to resolve shims
+    /// (`RegistryTool::provides_bin`), and its `test` field belongs to `mise test-tool`, which is
+    /// a separate command. So a download that contains no build for this platform — a source
+    /// tarball, say — installs and reports success, and the user finds out at `mise x`.
+    ///
+    /// Warns rather than fails. Every installed tool on the machine this was written on resolved
+    /// at least one declared bin, but that is 31 tools against the 937 registry entries that
+    /// declare `bins`, and a single inaccurate entry would turn a working install into a failure.
+    /// A warning cannot do that, and can be promoted later.
+    async fn warn_if_no_declared_bin_landed(&self, ctx: &InstallContext, tv: &ToolVersion) {
+        // Nothing was installed, and `list_bin_paths` returns nothing for it, so every bin would
+        // look missing.
+        if matches!(tv.request, ToolRequest::System { .. }) {
+            return;
+        }
+        // A full backend spec (`aqua:owner/repo`) has no registry entry, so nothing was declared
+        // and there is nothing to check against.
+        let Some(rt) = REGISTRY.get(tv.short()) else {
+            return;
+        };
+        if rt.bins.is_empty() {
+            return;
+        }
+        // Ask about the version just installed, not the request's runtime symlink. For a fuzzy
+        // request (`version = "3"`) `installs/python/3` still points at the previous version until
+        // symlinks are rebuilt, and `list_bin_paths` follows it -- the same trap `run_postinstall_hook`
+        // documents (#10347). Reading the old install would hide a warning that belongs, or invent
+        // one when there is no old install to read.
+        let tv = tv.clone().with_locked();
+        // An error here means the backend could not say where its binaries are -- vfox runs a
+        // plugin hook and asdf runs `bin/list-bin-paths` to answer -- which is not evidence that
+        // there are none. Staying quiet is the only honest option.
+        let Ok(dirs) = self.list_bin_paths(&ctx.config, &tv).await else {
+            return;
+        };
+        let dirs: Vec<PathBuf> = dirs.into_iter().filter(|p| p.parent().is_some()).collect();
+        if !no_declared_bin_present(rt.bins, &dirs) {
+            return;
+        }
+        // Deliberately no guess at why. mise knows the binaries are absent and nothing more; the
+        // cause could be a source-only release, a platform the archive does not cover, or a layout
+        // mise did not expect, and naming the wrong one sends the reader somewhere useless.
+        warn!(
+            "{} installed, but none of the binaries it declares ({}) are there.\nLooked in: {}\n`mise x {} -- {}` will not find one.",
+            tv.style(),
+            rt.bins.join(", "),
+            dirs.iter().map(display_path).join(", "),
+            tv.short(),
+            // Non-empty: the early return above is what guarantees it.
+            rt.bins[0],
+        );
     }
 
     async fn run_postinstall_hook(


### PR DESCRIPTION
## The problem

mise judges an install by whether the archive was fetched and unpacked. **Nothing looks at what came
out**, so a download containing no build for this platform installs, reports success, and the user
finds out at `mise x`.

Found while sweeping the registry on Windows. Ten tools installed with exit 0; running what landed
on disk showed **only two of them produced a Windows executable**. The clearest case:

```console
$ mise install libsql-server@latest     # exit 0
$ ls ~/.local/share/mise/installs/libsql-server/*/
Dockerfile  Makefile  LICENSE           # a source tarball. no sqld, no binary of any kind
```

## Nothing was checking, and nothing was meant to

- `registry/<tool>.toml`'s **`bins`** is read in exactly one place — `RegistryTool::provides_bin`,
  to resolve shims.
- Its **`test = { cmd, expected }`** belongs to `mise test-tool`, a separate command for registry
  CI. It is not a post-install step.

So `install_version` now looks — **after the postinstall hook**, which is allowed to be the thing
that puts the binary there — and warns when none of the declared bins is present as something the
OS could spawn.

The spawnable predicate rather than the permissive one: its `None` means *"provides nothing runnable
under that name"*, while the permissive one answers with shebang scripts. Any single declared bin is
enough — a tool that ships some of what it declares has installed something usable, and warning
about the rest would be noise.

## Why a warning and not a failure

Measured: on the machine this was written on, **every installed tool with a registry entry resolved
at least one declared bin — 31 of 31, no false positives.**

That is not enough to fail an install on. **31 tools against the 937 registry entries that declare
`bins`**, and the sample is all tools that work — they are installed because they were useful. One
inaccurate entry would turn a working install into a failure. A warning cannot do that, and it can
be promoted later if the data proves out.

(The first attempt at that measurement was wrong and is worth naming: it used `mise which <bin>`,
which resolves against whatever is **active in the current directory**, so nine installed-but-inactive
tools looked like failures. `mise which <bin> --tool <short>@<version>` is the question that was
actually meant.)

## Four cases stay silent

Each because a warning there would be *wrong*, not merely noisy:

| case | why |
| --- | --- |
| `ToolRequest::System` | nothing was installed and `list_bin_paths` is empty, so every bin would look missing |
| no registry entry | `aqua:owner/repo` declares nothing to check against |
| `bins` empty | 43 entries declare none; none declares an empty list |
| `list_bin_paths` errored | vfox answers by running a plugin hook, asdf by running `bin/list-bin-paths`. A backend that could not say where its binaries are has not said there are none |

## The message does not guess why

```
libsql-server@0.24.32 installed, but none of the binaries it declares (sqld) are there.
Looked in: ~/.local/share/mise/installs/libsql-server/0.24.32
`mise x libsql-server -- sqld` will not find one.
```

mise knows the binaries are absent and nothing more. A source-only release, an archive that skips
this platform, and a layout mise did not expect all look identical from here — naming the wrong one
sends the reader somewhere useless.

## Tests

Unit tests cover the predicate directly, including the `libsql-server` shape (a directory of
`Dockerfile` / `Makefile` / `LICENSE`) and the "any one is enough" rule.

The e2e serves **two archives that differ only in whether anything in them can be run**, both
through `MISE_BACKENDS_JQ` — which `backends()` returns ahead of every other filter, so the short
stays a registry short (`jq` still declares its bins) while the backend behind it becomes one the
test controls. Same short, same backend, same code path; only the archive differs. That is what
makes the pair a control rather than two separate tests, and a warning that fired for every install
would fail the second one.

## Not verified

What current `main` prints for `mise x libsql-server -- sqld` is **not** measured here. The mise on
this machine is `2026.8.14` (built 08-25), which predates #12547, so it still answers `cannot find
binary path`. This PR is about the install saying something untrue; it makes no claim about what the
exec path says today.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a warning when an installed tool archive contains none of the executable binaries declared for that tool.
  * The warning identifies the missing binaries and directories checked.
  * Installation still succeeds when files are fetched and unpacked, while forced reinstalls surface the warning.
  * Tools with valid declared executables install without warnings.
  * Warnings are not shown for system tools or tools without declared binaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->