### PR TITLE
fix(npm): repair dangling aube tool installs

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2600,6 +2600,12 @@ pub(crate) trait Backend: Debug + Send + Sync {
     fn unresolved_latest_version(&self) -> Option<String> {
         None
     }
+    /// Backend-specific validation for an install prefix that exists and is
+    /// otherwise complete. Keep this check cheap: it runs anywhere mise asks
+    /// whether a version is installed, including activation and doctor.
+    fn is_install_path_healthy(&self, _install_path: &Path) -> bool {
+        true
+    }
     fn list_installed_versions(&self) -> Vec<String> {
         install_state::list_versions(&self.ba().short)
     }
@@ -2613,8 +2619,9 @@ pub(crate) trait Backend: Debug + Send + Sync {
             let is_installed = install_path.exists();
             let is_not_incomplete = !self.incomplete_file_path(tv).exists();
             let is_valid_symlink = !check_symlink || !is_runtime_symlink(install_path);
+            let is_healthy = is_installed && self.is_install_path_healthy(install_path);
 
-            let installed = is_installed && is_not_incomplete && is_valid_symlink;
+            let installed = is_healthy && is_not_incomplete && is_valid_symlink;
             if log::log_enabled!(log::Level::Trace) && !installed {
                 let mut msg = format!(
                     "{} is not installed, path: {}",
@@ -2629,6 +2636,9 @@ pub(crate) trait Backend: Debug + Send + Sync {
                 }
                 if !is_valid_symlink {
                     msg += " (runtime symlink)";
+                }
+                if is_installed && !is_healthy {
+                    msg += " (unhealthy)";
                 }
                 trace!("{}", msg);
             }

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -259,6 +259,29 @@ impl<'a> NpmOptions<'a> {
     }
 }
 
+/// Legacy embedded-aube installs linked each virtual-store entry into a shared
+/// cache. The install prefix can outlive that cache, leaving the directory in
+/// place while every package link is dangling. Check only the immediate
+/// virtual-store entries: each represents a whole package tree, so this stays
+/// cheap enough for mise's installed-version fast path.
+fn aube_install_tree_is_healthy(install_path: &Path) -> bool {
+    [".mise", ".aube"].iter().all(|name| {
+        let virtual_store = install_path.join("node_modules").join(name);
+        match virtual_store.symlink_metadata() {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return true,
+            Err(_) => return false,
+            Ok(_) => {}
+        }
+        let entries = match std::fs::read_dir(&virtual_store) {
+            Ok(entries) => entries,
+            Err(_) => return false,
+        };
+        entries
+            .map(|entry| entry.map(|entry| entry.path()))
+            .all(|path| path.is_ok_and(|path| path.try_exists().unwrap_or(false)))
+    })
+}
+
 #[async_trait]
 impl Backend for NPMBackend {
     fn get_type(&self) -> BackendType {
@@ -267,6 +290,10 @@ impl Backend for NPMBackend {
 
     fn ba(&self) -> &Arc<BackendArg> {
         &self.ba
+    }
+
+    fn is_install_path_healthy(&self, install_path: &Path) -> bool {
+        aube_install_tree_is_healthy(install_path)
     }
 
     fn get_dependencies(&self) -> eyre::Result<Vec<&str>> {
@@ -1755,7 +1782,7 @@ mod tests {
             self.0.lock().unwrap().push(message);
         }
     }
-    use crate::toolset::{ToolRequest, ToolSource, ToolVersionOptions};
+    use crate::toolset::{ToolRequest, ToolSource, ToolVersion, ToolVersionOptions};
     use pretty_assertions::assert_eq;
 
     fn create_npm_backend(tool: &str) -> NPMBackend {
@@ -2685,6 +2712,57 @@ pkg@1.2.0 '1.2.0'
             manifest["aube"]["allowBuilds"],
             serde_json::json!({ "esbuild": true })
         );
+    }
+
+    #[test]
+    fn aube_install_tree_without_virtual_store_is_healthy() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(aube_install_tree_is_healthy(tmp.path()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn aube_install_tree_rejects_dangling_legacy_entries() {
+        for name in [".mise", ".aube"] {
+            let tmp = tempfile::tempdir().unwrap();
+            let virtual_store = tmp.path().join("node_modules").join(name);
+            let target = tmp.path().join("shared-store/pkg@1.0.0");
+            std::fs::create_dir_all(&virtual_store).unwrap();
+            std::fs::create_dir_all(&target).unwrap();
+            std::os::unix::fs::symlink(&target, virtual_store.join("pkg@1.0.0")).unwrap();
+
+            assert!(aube_install_tree_is_healthy(tmp.path()));
+            std::fs::remove_dir_all(target).unwrap();
+            assert!(!aube_install_tree_is_healthy(tmp.path()));
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn dangling_aube_tree_is_not_an_installed_npm_version() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut ba = BackendArg::new_raw(
+            "npm".to_string(),
+            Some("pkg".to_string()),
+            "pkg".to_string(),
+            None,
+            BackendResolution::new(true),
+        );
+        ba.installs_path = tmp.path().join("installs/npm-pkg");
+        let backend = NPMBackend::from_arg(ba);
+        let request =
+            ToolRequest::new(backend.ba().clone(), "1.0.0", ToolSource::Argument).unwrap();
+        let tv = ToolVersion::new(request, "1.0.0".to_string());
+        let virtual_store = tv.install_path().join("node_modules/.mise");
+        std::fs::create_dir_all(&virtual_store).unwrap();
+        std::os::unix::fs::symlink(
+            tmp.path().join("missing-shared-store/pkg@1.0.0"),
+            virtual_store.join("pkg@1.0.0"),
+        )
+        .unwrap();
+
+        let config = crate::config::Config::get().await.unwrap();
+        assert!(!backend.is_version_installed(&config, &tv, true));
     }
 
     #[test]

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -1782,7 +1782,9 @@ mod tests {
             self.0.lock().unwrap().push(message);
         }
     }
-    use crate::toolset::{ToolRequest, ToolSource, ToolVersion, ToolVersionOptions};
+    #[cfg(unix)]
+    use crate::toolset::ToolVersion;
+    use crate::toolset::{ToolRequest, ToolSource, ToolVersionOptions};
     use pretty_assertions::assert_eq;
 
     fn create_npm_backend(tool: &str) -> NPMBackend {


### PR DESCRIPTION
## Summary

- add a backend health hook to installed-version checks
- detect dangling legacy `.mise`/`.aube` virtual-store entries for npm tools
- treat broken prefixes as missing so install/use can invoke aube to repair them and doctor reports them

Completes the mise-owned legacy tool-tree portion of https://github.com/jdx/aube/discussions/1405. The private node-gyp cache is handled by jdx/aube#1407.

## Validation

- `mbx test --all-features aube_install_tree`
- `mbx test --all-features aube_tree`
- `mise run lint`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the global installed-version fast path (activation, doctor) for all backends via the new hook, though only npm overrides it; misclassification could skip tools or trigger unnecessary reinstalls.
> 
> **Overview**
> Adds a **`is_install_path_healthy`** hook on backends and wires it into **`is_version_installed`**, so a prefix that exists can still count as missing when it is broken. Trace logging now includes an **(unhealthy)** reason when that happens.
> 
> For **npm**, health checks legacy embedded-aube layouts under `node_modules/.mise` and `node_modules/.aube`: if a virtual store exists, every immediate entry must resolve (no dangling symlinks after a removed shared cache). Missing virtual stores stay healthy. Broken trees are treated as not installed so **`mise install` / `use`** can reinstall via aube and **doctor** can surface the problem.
> 
> Unix tests cover the health helper and **`NPMBackend::is_version_installed`** with dangling `.mise` links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5edcb574c7ef749037aeba67614c831227276b82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of installed npm versions by validating installation health.
  * Installations with incomplete or unreadable virtual stores, or dangling links, are no longer reported as successfully installed.
  * Missing virtual stores continue to be treated as healthy installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->