### PR TITLE
fix(github): omit releases with no assets from the version list

### DIFF
--- a/docs/dev-tools/backends/github.md
+++ b/docs/dev-tools/backends/github.md
@@ -22,6 +22,37 @@ The version will be set in `~/.config/mise/config.toml` with the following forma
 "github:BurntSushi/ripgrep" = "latest"
 ```
 
+## Version Listing
+
+`mise ls-remote` lists a repository's releases. **Releases with no assets attached
+are left out**: mise installs from a release's uploaded assets and never falls
+back to the auto-generated source archive, so such a release has nothing to
+install from and listing it would advertise a version that only fails.
+
+This is emptiness, not platform fit — a release whose assets do not cover your
+platform is still listed, because the version list has to mean the same thing on
+every host for cross-platform lockfiles to work.
+
+Tools that set a **platform-scoped** `url` — `platforms.<os>-<arch>.url`, or the
+flat `platform_<os>_<arch>_url` — are exempt: they fetch from that URL instead of
+selecting a release asset, so their releases are listed whether or not anything
+is attached to them. A bare top-level `url` is not an exemption, because this
+backend only reads the option per platform and would still fall through to asset
+selection.
+
+The exemption is all-or-nothing, for the same reason the filter is: one version
+list serves every platform. A `url` set for only some platforms therefore keeps
+asset-less releases listed everywhere, and installing one on a platform the
+`url` does not cover still fails — exactly as it did before this filtering
+existed. Cover every platform you support, or leave `url` unset and let asset
+selection do the work.
+
+mise fetches one page of releases and reads further only until it finds a stable
+release it can offer. Because an asset-less release is not one, a repository
+whose newest stable releases have nothing attached is now read past rather than
+stopped at, up to a small page limit. Set `MISE_LIST_ALL_VERSIONS=1` to read
+every page.
+
 ## Tool Options
 
 The following [tool-options](/dev-tools/#tool-options) are available for the `github` backend—these

--- a/e2e/backend/test_github_ls_remote_skips_assetless
+++ b/e2e/backend/test_github_ls_remote_skips_assetless
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# A GitHub release with no assets has nothing to install from -- mise never
+# falls back to the auto-generated source archive -- so listing it advertises a
+# version that only fails. Real cases: pypa/hatch hatch-v1.7.0 and every
+# kitlangton/ghui release below v0.4.0.
+#
+# The `/releases/latest` shortcut has to agree with the listing, or `latest`
+# resolves to a version the listing does not offer.
+#
+# Served from a local stand-in for the GitHub API so the fixture is stable and
+# the test needs no network.
+
+PORT_FILE="$PWD/server-port"
+
+python3 - "$PORT_FILE" <<'PY' &
+import http.server
+import json
+import socketserver
+import sys
+
+port_file = sys.argv[1]
+
+WITH_ASSET = {
+    "tag_name": "v2.0.0",
+    "draft": False,
+    "prerelease": False,
+    "created_at": "2026-02-01T00:00:00Z",
+    "published_at": "2026-02-01T00:00:00Z",
+    "assets": [
+        {
+            "name": "tool-x86_64-unknown-linux-gnu.tar.gz",
+            "browser_download_url": "https://example.invalid/tool.tar.gz",
+            "url": "https://example.invalid/api/tool.tar.gz",
+        }
+    ],
+}
+
+# Published, not a draft, but nothing attached -- and marked as the repo's
+# "Latest", which is what makes the shortcut interesting.
+WITHOUT_ASSET = {
+    "tag_name": "v3.0.0",
+    "draft": False,
+    "prerelease": False,
+    "created_at": "2026-03-01T00:00:00Z",
+    "published_at": "2026-03-01T00:00:00Z",
+    "assets": [],
+}
+
+
+class ReleasesHandler(http.server.BaseHTTPRequestHandler):
+    def reply(self, payload):
+        body = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        path = self.path.split("?")[0]
+        if path.endswith("/releases/latest"):
+            self.reply(WITHOUT_ASSET)
+        elif path.endswith("/releases"):
+            self.reply([WITHOUT_ASSET, WITH_ASSET])
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, *args):
+        pass
+
+
+socketserver.TCPServer.allow_reuse_address = True
+with socketserver.TCPServer(("127.0.0.1", 0), ReleasesHandler) as httpd:
+    with open(port_file, "w") as file:
+        file.write(str(httpd.server_address[1]))
+    httpd.serve_forever()
+PY
+SERVER_PID=$!
+cleanup() { kill "$SERVER_PID" 2>/dev/null || true; }
+trap cleanup EXIT
+
+wait_for_file "$PORT_FILE" "github api stand-in port" 30 "$SERVER_PID"
+SERVER_PORT=$(cat "$PORT_FILE")
+
+TOOL="github:acme/tool[api_url=http://127.0.0.1:$SERVER_PORT]"
+
+# The release that carries an asset is listed. Asserting this first is what
+# keeps the next line from passing vacuously -- if the listing were empty for
+# some unrelated reason, this would fail before it.
+assert_contains "mise ls-remote --no-versions-host '$TOOL'" "2.0.0"
+
+# The one with none is not.
+assert_not_contains "mise ls-remote --no-versions-host '$TOOL'" "3.0.0"
+
+# `latest` must not take the `/releases/latest` shortcut to a release the
+# listing just excluded: it falls through and resolves against the list.
+export MISE_USE_VERSIONS_HOST=0
+assert "mise latest '$TOOL'" "2.0.0"
+
+# A platform-specific direct URL makes asset-less releases installable. It must
+# not reuse the filtered cache populated above, even though the repository and
+# API URL are otherwise identical. `prerelease = true` makes `latest` use the
+# cached listing path instead of the `/releases/latest` shortcut.
+cat >mise.toml <<EOF
+[tools."github:acme/tool"]
+version = "latest"
+api_url = "http://127.0.0.1:$SERVER_PORT"
+prerelease = true
+
+[tools."github:acme/tool".platforms]
+linux-x64 = { url = "https://example.invalid/tool-linux-x64.tar.gz" }
+linux-arm64 = { url = "https://example.invalid/tool-linux-arm64.tar.gz" }
+macos-x64 = { url = "https://example.invalid/tool-macos-x64.tar.gz" }
+macos-arm64 = { url = "https://example.invalid/tool-macos-arm64.tar.gz" }
+EOF
+
+CONFIGURED_TOOL="github:acme/tool"
+assert_contains "mise ls-remote --no-versions-host '$CONFIGURED_TOOL'" "3.0.0"
+assert "mise latest '$CONFIGURED_TOOL'" "3.0.0"

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -152,6 +152,64 @@ impl<'a> GitBackendOptions<'a> {
             .collect()
     }
 
+    /// Whether a platform-scoped direct download URL is configured for *any*
+    /// platform.
+    ///
+    /// `url` short-circuits asset selection entirely in
+    /// `resolve_asset_for_target`, so a release with no uploaded assets still
+    /// installs. Version listing has to keep those releases, and the question
+    /// has to be answered without a target because the listing is shared
+    /// across platforms.
+    ///
+    /// Only the platform-scoped spellings count, because only those are read at
+    /// install time: [`Self::direct_url_for_target`] goes through
+    /// `platform_string_for_target_without_base`, which resolves
+    /// `platforms.<os>-<arch>.url` and `platform_<os>_<arch>_url` and never
+    /// falls back to a bare top-level `url`. Treating a base-level `url` as an
+    /// exemption would keep asset-less releases listed for a tool that still
+    /// runs asset selection and still fails.
+    ///
+    /// The `<os>-<arch>` half of that is load-bearing, which is why this checks
+    /// the shape rather than just the prefix and suffix.
+    /// `lookup_platform_value_for_aliases` builds every key it reads as
+    /// `{platform|platforms}.{os}-{arch}.url` or
+    /// `{platform|platforms}_{os}_{arch}_url`, so an option named
+    /// `platforms.url` or `platform_linux_url` is never read at all. Counting
+    /// one of those as an exemption is the same failure as counting a base-level
+    /// `url`: the release stays listed and the install still ends in "No
+    /// matching asset found".
+    ///
+    /// A `url` covering only some platforms exempts the tool everywhere, so an
+    /// asset-less release stays listed on a platform the `url` misses and fails
+    /// to install there. Narrowing that would mean deciding the version list
+    /// per target, which is the thing this filter is written to avoid; the
+    /// uncovered platform is no worse off than it was before any filtering
+    /// existed.
+    ///
+    /// Whether a *value* counts is not decided here: the two lookups the install
+    /// path uses answer that, so a value they reject cannot be read as an
+    /// exemption and one they accept cannot be missed. They take any TOML scalar
+    /// — `url = false` resolves to the string `"false"` and short-circuits asset
+    /// selection just as a real URL would, badly but definitely — and reject
+    /// tables and arrays.
+    fn has_direct_url(&self) -> bool {
+        let raw = self.values.raw();
+        let opts = raw.opts.as_map();
+        opts.iter().any(|(key, value)| {
+            (key == "platforms" || key == "platform")
+                && value.as_table().is_some_and(|table| {
+                    table.keys().any(|platform| {
+                        platform.contains('-')
+                            && raw
+                                .get_nested_string(&format!("{key}.{platform}.url"))
+                                .is_some()
+                    })
+                })
+        }) || opts
+            .keys()
+            .any(|key| is_flat_platform_url_key(key) && raw.get_string(key).is_some())
+    }
+
     fn direct_url_for_target(&self, target: &PlatformTarget) -> Option<String> {
         self.values
             .platform_string_for_target_without_base("url", target)
@@ -322,6 +380,71 @@ pub(crate) fn install_time_option_keys() -> Vec<String> {
     ]
 }
 
+/// Whether a flat option name is one the install path reads as a
+/// platform-scoped `url`: `platform_<os>_<arch>_url` or the `platforms_` spelling.
+///
+/// The arch half is required. `platform_linux_url` looks like one of these and
+/// is never read, so treating it as an exemption would list releases that
+/// cannot be installed. Split on the *first* underscore only, so an arch that
+/// contains one — `platform_linux_x86_64_url` — still resolves.
+fn is_flat_platform_url_key(key: &str) -> bool {
+    key.strip_prefix("platforms_")
+        .or_else(|| key.strip_prefix("platform_"))
+        .and_then(|rest| rest.strip_suffix("_url"))
+        .and_then(|platform| platform.split_once('_'))
+        .is_some_and(|(os, arch)| !os.is_empty() && !arch.is_empty())
+}
+
+/// Partition the remote-version cache only when this tool's direct-URL
+/// exemption is not the one the registry hands everybody.
+///
+/// The exemption changes the shape of the version list, so a tool that has it
+/// cannot share a cache entry with one that does not. But a registry entry that
+/// declares platform URLs gives *every* client the same exemption, and
+/// mise-versions is built from that same canonical configuration — so isolating
+/// there would only cost the shared listing for no difference in content. The
+/// context therefore appears when a local config, alias, or inline option moves
+/// the exemption away from the registry default, in either direction.
+///
+/// This mirrors what `has_local_version_listing_option_override` already does
+/// for `api_url` and `version_prefix` in `backend/mod.rs`: a registry-supplied
+/// value is identical for everyone, so it keeps the versions host available.
+///
+/// Only the effective boolean is hashed. The URL itself is install-only and may
+/// carry a token.
+fn direct_url_cache_context(effective: bool, registry_default: bool) -> Option<String> {
+    (effective != registry_default).then(|| crate::hash::hash_to_str(&effective))
+}
+
+/// Whether a release has anything mise could install from.
+///
+/// A release with nothing attached has no source at all: mise never falls back
+/// to the forge's auto-generated source archives, so every asset-selection path
+/// ends in "No matching asset found". Listing such a release advertises a
+/// version that cannot be installed -- `mise install <tool>@<version>` fails
+/// with that error rather than doing anything useful.
+///
+/// Deliberately *not* "has an asset for the current platform". That would make
+/// the version list platform-dependent, which cross-platform lockfiles rely on
+/// it not being. Emptiness gives the same answer on every host.
+fn github_release_has_assets(release: &github::GithubRelease) -> bool {
+    !release.assets.is_empty()
+}
+
+/// GitLab counterpart of [`github_release_has_assets`], keyed on `links`.
+///
+/// `assets.sources` is GitLab's auto-generated zip/tar.gz of the tag and is
+/// always populated, so testing the whole `assets` struct would never exclude
+/// anything. The install path reads `assets.links` exclusively.
+fn gitlab_release_has_assets(release: &gitlab::GitlabRelease) -> bool {
+    !release.assets.links.is_empty()
+}
+
+/// Forgejo counterpart of [`github_release_has_assets`].
+fn forgejo_release_has_assets(release: &forgejo::ForgejoRelease) -> bool {
+    !release.assets.is_empty()
+}
+
 #[async_trait]
 impl Backend for UnifiedGitBackend {
     fn version_order(&self, opts: &ToolVersionOptions) -> Result<VersionOrder> {
@@ -391,11 +514,23 @@ impl Backend for UnifiedGitBackend {
         let opts = self.options(&raw_opts);
         let api_url = opts.api_url();
 
-        let releases = github::list_releases_from_url(api_url.as_str(), &repo)
-            .await
-            .unwrap_or_default();
+        // Same `require_assets` this backend's own listing asks for, so the two
+        // share a cache entry instead of fetching the repository's releases
+        // twice under different keys. `list_releases_from_url` would hardcode
+        // `false` and split them. The flag comes from the backend arg rather
+        // than the config, which is all this trait method is handed; a `url`
+        // set only in config would still split, as it did before.
+        let releases = github::list_releases_including_prereleases_from_url(
+            api_url.as_str(),
+            &repo,
+            !opts.has_direct_url(),
+        )
+        .await
+        .unwrap_or_default();
 
-        let latest_release = releases.first();
+        // What `list_releases_from_url` used to answer: the newest release that
+        // is not a prerelease.
+        let latest_release = releases.iter().find(|r| !r.prerelease);
 
         // Check for checksum files in assets
         if let Some(release) = latest_release {
@@ -446,6 +581,33 @@ impl Backend for UnifiedGitBackend {
         &["api_url", "version_prefix"]
     }
 
+    /// The registry baseline is read straight off the registry entry, not
+    /// reconstructed from the effective options' provenance.
+    ///
+    /// `options_from_sources` attributes whole *top-level* keys, so a local
+    /// `[platforms]` table replaces the registry's table and takes the
+    /// attribution with it: the registry's `platforms.<os>-<arch>.url` becomes
+    /// unrecoverable. Paired with a local `platforms` table carrying no `url`,
+    /// both sides would read `false`, no context would be produced, and a
+    /// configuration that *must* filter asset-less releases would read the
+    /// canonical unfiltered listing -- advertising versions whose install then
+    /// fails, which is the failure this whole change exists to remove.
+    ///
+    /// [`BackendArg::registry_opts`] is the very layer `resolve_opts_with_layers`
+    /// applies as [`crate::toolset::ToolOptionSource::Registry`], so it cannot
+    /// lose the key. It also settles the mirror case: a local
+    /// `platforms.<b>.url` replacing the registry's `platforms.<a>.url` matches
+    /// the baseline and keeps the shared partition instead of being isolated
+    /// for nothing.
+    async fn remote_version_cache_context(&self, config: &Arc<Config>) -> Result<Option<String>> {
+        let effective = config.get_tool_opts_with_overrides(&self.ba).await?;
+        let registry_default = self.ba.registry_opts();
+        Ok(direct_url_cache_context(
+            self.options(&effective).has_direct_url(),
+            self.options(&registry_default).has_direct_url(),
+        ))
+    }
+
     async fn _list_remote_versions(&self, config: &Arc<Config>) -> Result<Vec<VersionInfo>> {
         let repo = self.ba.tool_name();
         let id = self.ba.to_string();
@@ -453,6 +615,10 @@ impl Backend for UnifiedGitBackend {
         let opts = self.options(&raw_opts);
         let api_url = opts.api_url();
         let version_prefix = opts.version_prefix();
+
+        // A tool with a `url` option never selects an asset, so its releases
+        // must not be judged on having one.
+        let skip_asset_check = opts.has_direct_url();
 
         let web_url_base = self.web_url_base(&api_url, &repo);
 
@@ -462,6 +628,7 @@ impl Backend for UnifiedGitBackend {
                 .await?
                 .into_iter()
                 .filter(|r| version_prefix.is_none_or(|p| r.tag_name.starts_with(p)))
+                .filter(|r| skip_asset_check || gitlab_release_has_assets(r))
                 .map(|r| VersionInfo {
                     version: self.strip_version_prefix(&r.tag_name, &opts),
                     created_at: r.released_at,
@@ -470,39 +637,49 @@ impl Backend for UnifiedGitBackend {
                 })
                 .collect()
         } else if self.is_forgejo() {
-            forgejo::list_releases_including_prereleases_from_url(api_url.as_str(), &repo)
-                .await?
-                .into_iter()
-                .filter(|r| version_prefix.is_none_or(|p| r.tag_name.starts_with(p)))
-                .map(|r| VersionInfo {
-                    version: self.strip_version_prefix(&r.tag_name, &opts),
-                    created_at: Some(r.created_at),
-                    release_url: Some(format!("{}/releases/tag/{}", web_url_base, r.tag_name)),
-                    prerelease: Some(r.prerelease),
-                    ..Default::default()
-                })
-                .collect()
+            forgejo::list_releases_including_prereleases_from_url(
+                api_url.as_str(),
+                &repo,
+                !skip_asset_check,
+            )
+            .await?
+            .into_iter()
+            .filter(|r| version_prefix.is_none_or(|p| r.tag_name.starts_with(p)))
+            .filter(|r| skip_asset_check || forgejo_release_has_assets(r))
+            .map(|r| VersionInfo {
+                version: self.strip_version_prefix(&r.tag_name, &opts),
+                created_at: Some(r.created_at),
+                release_url: Some(format!("{}/releases/tag/{}", web_url_base, r.tag_name)),
+                prerelease: Some(r.prerelease),
+                ..Default::default()
+            })
+            .collect()
         } else {
             // Always fetch the pre-release superset and stamp `prerelease` on
             // each entry. The shared remote-versions cache stores the superset
             // so flipping the `prerelease` tool option (e.g. via a project
             // override) is correct without invalidating the cache; the read
             // path filters on `prerelease` according to the current opts.
-            github::list_releases_including_prereleases_from_url(api_url.as_str(), &repo)
-                .await?
-                .into_iter()
-                .filter(|r| version_prefix.is_none_or(|p| r.tag_name.starts_with(p)))
-                .map(|r| {
-                    let created_at = Some(r.released_at().to_string());
-                    VersionInfo {
-                        version: self.strip_version_prefix(&r.tag_name, &opts),
-                        created_at,
-                        release_url: Some(format!("{}/releases/tag/{}", web_url_base, r.tag_name)),
-                        prerelease: Some(r.prerelease),
-                        ..Default::default()
-                    }
-                })
-                .collect()
+            github::list_releases_including_prereleases_from_url(
+                api_url.as_str(),
+                &repo,
+                !skip_asset_check,
+            )
+            .await?
+            .into_iter()
+            .filter(|r| version_prefix.is_none_or(|p| r.tag_name.starts_with(p)))
+            .filter(|r| skip_asset_check || github_release_has_assets(r))
+            .map(|r| {
+                let created_at = Some(r.released_at().to_string());
+                VersionInfo {
+                    version: self.strip_version_prefix(&r.tag_name, &opts),
+                    created_at,
+                    release_url: Some(format!("{}/releases/tag/{}", web_url_base, r.tag_name)),
+                    prerelease: Some(r.prerelease),
+                    ..Default::default()
+                }
+            })
+            .collect()
         };
 
         // Apply common validation and reverse order
@@ -545,11 +722,22 @@ impl Backend for UnifiedGitBackend {
             return Ok(None);
         }
 
+        // The `/releases/latest` shortcut has to reject an asset-less release for
+        // the same reason the full listing does, or `latest` would resolve to a
+        // version the listing no longer offers and the install would fail with
+        // "No matching asset found". Returning `None` falls through to
+        // `latest_version_for_query`, which picks the newest listed version.
+        let skip_asset_check = opts.has_direct_url();
+
         let latest_release = if self.is_gitlab() {
             // GitLab doesn't have a "latest" endpoint
             return Ok(None);
         } else if self.is_forgejo() {
             match forgejo::get_release_for_url(&api_url, &repo, "latest").await {
+                Ok(r) if !skip_asset_check && !forgejo_release_has_assets(&r) => {
+                    debug!("Latest Forgejo release for {repo} has no assets; using the listing");
+                    return Ok(None);
+                }
                 Ok(r) => Some((r.tag_name, r.created_at, r.prerelease)),
                 Err(e) => {
                     debug!("Failed to fetch latest Forgejo release for {repo}: {e}");
@@ -561,6 +749,10 @@ impl Backend for UnifiedGitBackend {
                 .get_github_release_for_url(&api_url, &repo, "latest")
                 .await
             {
+                Ok(r) if !skip_asset_check && !github_release_has_assets(&r) => {
+                    debug!("Latest GitHub release for {repo} has no assets; using the listing");
+                    return Ok(None);
+                }
                 Ok(r) => {
                     let released_at = r.released_at().to_string();
                     Some((r.tag_name, released_at, r.prerelease))
@@ -3207,6 +3399,332 @@ mod tests {
             pick_slsa_provenance(&picker, &assets, "tool-linux-amd64").as_deref(),
             Some("tool-linux-amd64.provenance.json")
         );
+    }
+
+    fn github_release(assets: Vec<&str>) -> github::GithubRelease {
+        github::GithubRelease {
+            tag_name: "v1.0.0".into(),
+            draft: false,
+            prerelease: false,
+            created_at: "2026-01-01T00:00:00Z".into(),
+            published_at: None,
+            assets: assets
+                .into_iter()
+                .map(|name| github::GithubAsset {
+                    name: name.into(),
+                    browser_download_url: format!("https://example.com/{name}"),
+                    url: format!("https://api.example.com/{name}"),
+                    digest: None,
+                })
+                .collect(),
+        }
+    }
+
+    fn gitlab_release(sources: Vec<&str>, links: Vec<&str>) -> gitlab::GitlabRelease {
+        gitlab::GitlabRelease {
+            tag_name: "v1.0.0".into(),
+            description: None,
+            released_at: None,
+            assets: gitlab::GitlabAssets {
+                sources: sources
+                    .into_iter()
+                    .map(|format| gitlab::GitlabAssetSource {
+                        format: format.into(),
+                        url: "https://example.com/source".into(),
+                    })
+                    .collect(),
+                links: links
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, name)| gitlab::GitlabAssetLink {
+                        id: i as i64,
+                        name: name.into(),
+                        url: format!("https://example.com/{name}"),
+                        direct_asset_url: format!("https://example.com/d/{name}"),
+                        link_type: "other".into(),
+                    })
+                    .collect(),
+            },
+        }
+    }
+
+    fn forgejo_release(assets: Vec<&str>) -> forgejo::ForgejoRelease {
+        forgejo::ForgejoRelease {
+            id: 1,
+            tag_name: "v1.0.0".into(),
+            draft: false,
+            prerelease: false,
+            created_at: "2026-01-01T00:00:00Z".into(),
+            assets: assets
+                .into_iter()
+                .enumerate()
+                .map(|(i, name)| forgejo::ForgejoAsset {
+                    id: i as u64,
+                    name: name.into(),
+                    uuid: format!("uuid-{i}"),
+                    browser_download_url: format!("https://example.com/{name}"),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn test_a_release_with_no_assets_is_not_listable() {
+        // Nothing is attached, so every asset-selection path would end in
+        // "No matching asset found" -- there is no source archive fallback.
+        // Measured cases: pypa/hatch hatch-v1.7.0 and kitlangton/ghui v0.3.3.
+        assert!(!github_release_has_assets(&github_release(vec![])));
+        assert!(github_release_has_assets(&github_release(vec![
+            "tool-x86_64-unknown-linux-gnu.tar.gz"
+        ])));
+
+        assert!(!forgejo_release_has_assets(&forgejo_release(vec![])));
+        assert!(forgejo_release_has_assets(&forgejo_release(vec![
+            "tool-linux.tar.gz"
+        ])));
+    }
+
+    #[test]
+    fn test_a_configured_url_exempts_a_tool_from_the_asset_check() {
+        // `url` short-circuits asset selection during install
+        // (`resolve_asset_for_target` returns before any picker runs), so those
+        // releases install without carrying an asset and must stay listed.
+        let backend = create_test_backend();
+        let has_url = |opts: &ToolVersionOptions| backend.options(opts).has_direct_url();
+
+        assert!(!has_url(&ToolVersionOptions::default()));
+
+        // A bare top-level `url` is *not* an exemption: install reads the
+        // option through `platform_string_for_target_without_base`, which
+        // resolves only the platform-scoped spellings and never falls back to
+        // this one. Exempting it would keep asset-less releases listed for a
+        // tool that still runs asset selection and still fails.
+        let mut base = ToolVersionOptions::default();
+        base.opts.insert(
+            "url".into(),
+            toml::Value::String("https://example.com/tool.tar.gz".into()),
+        );
+        assert!(!has_url(&base));
+
+        // Platform-scoped, which is how the option has to be written to take
+        // effect. The check has to see it without a target, because one version
+        // list is shared across platforms.
+        let mut scoped = ToolVersionOptions::default();
+        let mut linux = toml::Table::new();
+        linux.insert(
+            "url".into(),
+            toml::Value::String("https://example.com/tool-linux.tar.gz".into()),
+        );
+        let mut platforms = toml::Table::new();
+        platforms.insert("linux-x64".into(), toml::Value::Table(linux));
+        scoped
+            .opts
+            .insert("platforms".into(), toml::Value::Table(platforms));
+        assert!(has_url(&scoped));
+
+        // The flat spelling of the same thing.
+        let mut flat = ToolVersionOptions::default();
+        flat.opts.insert(
+            "platform_linux_x64_url".into(),
+            toml::Value::String("https://example.com/tool-linux.tar.gz".into()),
+        );
+        assert!(has_url(&flat));
+
+        // An arch that contains an underscore still resolves: the split takes
+        // the first underscore only.
+        let mut underscored_arch = ToolVersionOptions::default();
+        underscored_arch.opts.insert(
+            "platform_linux_x86_64_url".into(),
+            toml::Value::String("https://example.com/tool-linux.tar.gz".into()),
+        );
+        assert!(has_url(&underscored_arch));
+
+        // Shapes that *look* platform-scoped but name no platform the install
+        // path ever asks for. `lookup_platform_value_for_aliases` only builds
+        // `{os}-{arch}` keys, so neither of these is ever read, and counting
+        // them would list releases that cannot be installed.
+        let mut nested_without_platform = ToolVersionOptions::default();
+        let mut bare = toml::Table::new();
+        bare.insert(
+            "url".into(),
+            toml::Value::String("https://example.com/tool.tar.gz".into()),
+        );
+        nested_without_platform
+            .opts
+            .insert("platforms".into(), toml::Value::Table(bare));
+        assert!(!has_url(&nested_without_platform));
+
+        let mut os_only_nested = ToolVersionOptions::default();
+        let mut linux_only = toml::Table::new();
+        linux_only.insert(
+            "url".into(),
+            toml::Value::String("https://example.com/tool.tar.gz".into()),
+        );
+        let mut os_only_platforms = toml::Table::new();
+        os_only_platforms.insert("linux".into(), toml::Value::Table(linux_only));
+        os_only_nested
+            .opts
+            .insert("platforms".into(), toml::Value::Table(os_only_platforms));
+        assert!(!has_url(&os_only_nested));
+
+        let mut os_only_flat = ToolVersionOptions::default();
+        os_only_flat.opts.insert(
+            "platform_linux_url".into(),
+            toml::Value::String("https://example.com/tool.tar.gz".into()),
+        );
+        assert!(!has_url(&os_only_flat));
+
+        // Values are judged by the two lookups the install path uses, not by a
+        // separate rule here. A table has no scalar reading, so
+        // `get_nested_string` returns `None` and asset selection still runs.
+        let mut table_valued = ToolVersionOptions::default();
+        let mut inner = toml::Table::new();
+        inner.insert("href".into(), toml::Value::String("https://x".into()));
+        let mut linux_table = toml::Table::new();
+        linux_table.insert("url".into(), toml::Value::Table(inner));
+        let mut table_platforms = toml::Table::new();
+        table_platforms.insert("linux-x64".into(), toml::Value::Table(linux_table));
+        table_valued
+            .opts
+            .insert("platforms".into(), toml::Value::Table(table_platforms));
+        assert!(!has_url(&table_valued));
+
+        // A non-string scalar *is* read: `get_nested_string` renders it, so
+        // install short-circuits asset selection with the string "false" and
+        // fails on the download rather than on asset matching. Rejecting it
+        // here would filter releases out of a listing for a tool whose install
+        // path never runs asset selection -- the direction that hides
+        // installable versions.
+        let mut boolean_valued = ToolVersionOptions::default();
+        let mut linux_bool = toml::Table::new();
+        linux_bool.insert("url".into(), toml::Value::Boolean(false));
+        let mut bool_platforms = toml::Table::new();
+        bool_platforms.insert("linux-x64".into(), toml::Value::Table(linux_bool));
+        boolean_valued
+            .opts
+            .insert("platforms".into(), toml::Value::Table(bool_platforms));
+        assert!(has_url(&boolean_valued));
+
+        // A neighbouring option that merely ends in `url` is not one.
+        let mut unrelated = ToolVersionOptions::default();
+        unrelated.opts.insert(
+            "api_url".into(),
+            toml::Value::String("https://api.github.example".into()),
+        );
+        assert!(!has_url(&unrelated));
+
+        // The two platform-scoped spellings of the same thing must agree, so
+        // they cannot land in different cache partitions.
+        assert_eq!(
+            backend.options(&scoped).has_direct_url(),
+            backend.options(&flat).has_direct_url()
+        );
+    }
+
+    #[test]
+    fn test_direct_url_cache_context_isolates_only_departures_from_the_registry() {
+        // Both cases where the tool agrees with the registry share the default
+        // partition — which is what keeps mise-versions usable. That matters
+        // most for the second one: a registry entry that ships platform URLs
+        // gives every client the same exemption, and mise-versions is built
+        // from that same configuration.
+        assert_eq!(direct_url_cache_context(false, false), None);
+        assert_eq!(direct_url_cache_context(true, true), None);
+
+        // A local config that adds an exemption the registry does not have, and
+        // one that takes away an exemption the registry does have, are both
+        // departures and both need their own entry.
+        let added = direct_url_cache_context(true, false);
+        let removed = direct_url_cache_context(false, true);
+        assert!(added.is_some());
+        assert!(removed.is_some());
+
+        // ...and they are not the same entry: the two produce different lists.
+        assert_ne!(added, removed);
+    }
+
+    #[test]
+    fn test_a_local_platforms_table_cannot_erase_the_registry_url_baseline() {
+        use crate::toolset::{ResolvedToolOptions, ToolOptionSource};
+
+        let backend = create_test_backend();
+        let has_url = |opts: &ToolVersionOptions| backend.options(opts).has_direct_url();
+
+        // `platforms.<os>-<arch>.url`, the shape the install path reads.
+        let platforms_url = |platform: &str| {
+            let mut entry = toml::Table::new();
+            entry.insert(
+                "url".into(),
+                toml::Value::String("https://example.com/tool.tar.gz".into()),
+            );
+            let mut platforms = toml::Table::new();
+            platforms.insert(platform.into(), toml::Value::Table(entry));
+            let mut opts = ToolVersionOptions::default();
+            opts.opts
+                .insert("platforms".into(), toml::Value::Table(platforms));
+            opts
+        };
+
+        // The registry entry declares a platform URL, so every client gets the
+        // exemption and the canonical listing is the unfiltered one.
+        let registry = platforms_url("linux-x64");
+        let baseline = has_url(&registry);
+        assert!(baseline);
+
+        // A local `[platforms]` table carrying no `url` replaces it wholesale.
+        // This tool therefore *does* filter asset-less releases and must not
+        // read the canonical listing.
+        let mut local = ToolVersionOptions::default();
+        let mut entry = toml::Table::new();
+        entry.insert("checksum".into(), toml::Value::String("sha256:abc".into()));
+        let mut platforms = toml::Table::new();
+        platforms.insert("linux-x64".into(), toml::Value::Table(entry));
+        local
+            .opts
+            .insert("platforms".into(), toml::Value::Table(platforms));
+
+        let mut resolved = ResolvedToolOptions::default();
+        resolved.apply_overrides(&registry, ToolOptionSource::Registry);
+        resolved.apply_overrides(&local, ToolOptionSource::Config);
+        let effective = has_url(resolved.effective());
+        assert!(!effective);
+
+        // Reading the registry entry itself keeps the baseline, so the
+        // departure is seen and the listing gets its own partition.
+        assert!(direct_url_cache_context(effective, baseline).is_some());
+
+        // The provenance reconstruction this replaces loses it: `platforms` is
+        // one top-level key, so the local table takes the attribution with it
+        // and the registry-filtered view is empty. Both sides then read
+        // `false`, no context is produced, and the filtered configuration lands
+        // on the shared unfiltered partition.
+        let reconstructed = resolved.options_from_sources(&[ToolOptionSource::Registry]);
+        let lost_baseline = has_url(&reconstructed);
+        assert!(!lost_baseline);
+        assert_eq!(direct_url_cache_context(effective, lost_baseline), None);
+
+        // The mirror case: a local table that moves the `url` to another
+        // platform still matches the registry baseline, so it stays on the
+        // shared partition rather than being isolated for nothing.
+        let mut mirrored = ResolvedToolOptions::default();
+        mirrored.apply_overrides(&registry, ToolOptionSource::Registry);
+        mirrored.apply_overrides(&platforms_url("macos-arm64"), ToolOptionSource::Config);
+        let moved_url = has_url(mirrored.effective());
+        assert!(moved_url);
+        assert_eq!(direct_url_cache_context(moved_url, baseline), None);
+    }
+
+    #[test]
+    fn test_gitlab_auto_generated_sources_do_not_count_as_assets() {
+        // The case that makes GitLab need its own predicate: `assets.sources`
+        // is the auto-generated zip/tar.gz of the tag and is always populated,
+        // so testing the whole `assets` struct would never exclude anything.
+        // Only `links` is read by the install path.
+        let sources_only = gitlab_release(vec!["zip", "tar.gz"], vec![]);
+        assert!(!gitlab_release_has_assets(&sources_only));
+
+        let with_link = gitlab_release(vec!["zip", "tar.gz"], vec!["tool-linux.tar.gz"]);
+        assert!(gitlab_release_has_assets(&with_link));
     }
 
     #[test]

--- a/src/forgejo.rs
+++ b/src/forgejo.rs
@@ -70,15 +70,20 @@ async fn get_release_cache<'a>(key: &str) -> RwLockReadGuard<'a, CacheGroup<Forg
 /// always filtered out. The cache stores this non-draft superset so callers can
 /// apply the current `prerelease` option at read time without invalidating
 /// cached release metadata.
+///
+/// `require_assets` mirrors the argument of the same name in
+/// `github::list_releases_including_prereleases_from_url`, for the same reason
+/// and with the same effect on the cache key.
 pub(crate) async fn list_releases_including_prereleases_from_url(
     api_url: &str,
     repo: &str,
+    require_assets: bool,
 ) -> Result<Vec<ForgejoRelease>> {
-    let key = format!("{api_url}-{repo}").to_kebab_case();
+    let key = releases_cache_key(api_url, repo, require_assets);
     let cache = get_releases_cache(&key).await;
     let cache = cache.get(&key).unwrap();
     Ok(cache
-        .get_or_try_init_async(async || list_releases_(api_url, repo).await)
+        .get_or_try_init_async(async || list_releases_(api_url, repo, require_assets).await)
         .await?
         .to_vec())
 }
@@ -88,7 +93,30 @@ pub(crate) async fn list_releases_including_prereleases_from_url(
 /// release without unbounded API calls. (#10343)
 const MAX_RELEASE_FALLBACK_PAGES: usize = 3;
 
-async fn list_releases_(api_url: &str, repo: &str) -> Result<Vec<ForgejoRelease>> {
+/// Forgejo counterpart of `github::releases_cache_key`, and unambiguous for the
+/// same reason: `require_assets` as a `-with-assets` suffix would let
+/// `("owner/foo", true)` and `("owner/foo-with-assets", false)` share a
+/// persisted cache entry.
+fn releases_cache_key(api_url: &str, repo: &str, require_assets: bool) -> String {
+    format!(
+        "{}-{}",
+        format!("{api_url}-{repo}").to_kebab_case(),
+        crate::hash::hash_to_str(&(api_url, repo, require_assets))
+    )
+}
+
+/// Forgejo counterpart of `github::has_stopping_stable_release`.
+fn has_stopping_stable_release(releases: &[ForgejoRelease], require_assets: bool) -> bool {
+    releases
+        .iter()
+        .any(|r| !r.prerelease && !r.draft && (!require_assets || !r.assets.is_empty()))
+}
+
+async fn list_releases_(
+    api_url: &str,
+    repo: &str,
+    require_assets: bool,
+) -> Result<Vec<ForgejoRelease>> {
     let url = format!("{api_url}/repos/{repo}/releases?limit=100");
     let headers = get_headers(&url, api_url);
     let (mut releases, mut headers) = crate::http::HTTP_FETCH
@@ -102,7 +130,7 @@ async fn list_releases_(api_url: &str, repo: &str) -> Result<Vec<ForgejoRelease>
     let mut pages_fetched = 1;
     while let Some(next) = next_page(&headers) {
         if !*env::MISE_LIST_ALL_VERSIONS
-            && (releases.iter().any(|r| !r.prerelease && !r.draft)
+            && (has_stopping_stable_release(&releases, require_assets)
                 || pages_fetched >= MAX_RELEASE_FALLBACK_PAGES)
         {
             break;
@@ -393,6 +421,26 @@ mod tests {
     }
 
     #[test]
+    fn releases_cache_key_separates_the_suffix_collision() {
+        let api = "https://codeberg.org/api/v1";
+
+        // The pair a `-with-assets` suffix would collapse onto one persisted
+        // entry, serving one repository the other's releases.
+        assert_ne!(
+            releases_cache_key(api, "owner/foo", true),
+            releases_cache_key(api, "owner/foo-with-assets", false)
+        );
+        assert_ne!(
+            releases_cache_key(api, "owner/foo", true),
+            releases_cache_key(api, "owner/foo", false)
+        );
+        assert_eq!(
+            releases_cache_key(api, "owner/foo", true),
+            releases_cache_key(api, "owner/foo", true)
+        );
+    }
+
+    #[test]
     fn test_is_published_release_keeps_prereleases() {
         assert!(is_published_release(&release("1.0.0", false, false)));
         assert!(is_published_release(&release("1.1.0-rc1", false, true)));
@@ -487,7 +535,7 @@ something_else = "value"
             .create_async()
             .await;
 
-        let releases = list_releases_(&base, repo).await.unwrap();
+        let releases = list_releases_(&base, repo, false).await.unwrap();
         page1_mock.assert_async().await;
         page2_mock.assert_async().await;
         assert!(
@@ -529,7 +577,7 @@ something_else = "value"
             .create_async()
             .await;
 
-        let releases = list_releases_(&base, repo).await.unwrap();
+        let releases = list_releases_(&base, repo, false).await.unwrap();
         page1_mock.assert_async().await;
         page2_mock.assert_async().await;
         assert!(releases.iter().any(|r| r.tag_name == "v1.0.0"));
@@ -583,7 +631,7 @@ something_else = "value"
             .create_async()
             .await;
 
-        let releases = list_releases_(&base, repo).await.unwrap();
+        let releases = list_releases_(&base, repo, false).await.unwrap();
         p1.assert_async().await;
         p2.assert_async().await;
         p3.assert_async().await;
@@ -672,7 +720,7 @@ something_else = "value"
             .create_async()
             .await;
 
-        let releases = list_releases_(&base, repo).await.unwrap();
+        let releases = list_releases_(&base, repo, false).await.unwrap();
         page1.assert_async().await;
         page2.assert_async().await;
         assert_eq!(releases.len(), 2);

--- a/src/github.rs
+++ b/src/github.rs
@@ -160,11 +160,16 @@ pub(crate) async fn list_releases_from_url(
     api_url: &str,
     repo: &str,
 ) -> Result<Vec<GithubRelease>> {
-    Ok(list_releases_including_prereleases_from_url(api_url, repo)
-        .await?
-        .into_iter()
-        .filter(|r| !r.prerelease)
-        .collect())
+    // `false`: this variant's callers (ubi, spm, and the github backend's
+    // security-feature probe) keep asset-less releases, so their pagination
+    // must stop where it always did.
+    Ok(
+        list_releases_including_prereleases_from_url(api_url, repo, false)
+            .await?
+            .into_iter()
+            .filter(|r| !r.prerelease)
+            .collect(),
+    )
 }
 
 /// Like [`list_releases`] but includes releases flagged `prerelease: true`.
@@ -176,25 +181,67 @@ pub(crate) async fn list_releases_including_prereleases(repo: &str) -> Result<Ve
     let cache = get_releases_cache(&key).await;
     let cache = cache.get(&key).unwrap();
     Ok(cache
-        .get_or_try_init_async(async || list_releases_(API_URL, repo).await)
+        .get_or_try_init_async(async || list_releases_(API_URL, repo, false).await)
         .await?
         .to_vec())
 }
 
+/// `require_assets` reaches the fetch loop from the caller's own filter: the
+/// `github:` backend drops releases with nothing uploaded, so for it a stable
+/// release with no assets is not a place to stop paginating. See
+/// `has_stopping_stable_release`. It is part of the cache key because the two
+/// answers are different lists — the `true` list is a superset, and handing the
+/// shorter one to a caller that filters is the bug this argument exists to fix.
 pub(crate) async fn list_releases_including_prereleases_from_url(
     api_url: &str,
     repo: &str,
+    require_assets: bool,
 ) -> Result<Vec<GithubRelease>> {
-    let key = format!("{api_url}-{repo}").to_kebab_case();
+    let key = releases_cache_key(api_url, repo, require_assets);
     let cache = get_releases_cache(&key).await;
     let cache = cache.get(&key).unwrap();
     Ok(cache
-        .get_or_try_init_async(async || list_releases_(api_url, repo).await)
+        .get_or_try_init_async(async || list_releases_(api_url, repo, require_assets).await)
         .await?
         .to_vec())
 }
 
-async fn list_releases_(api_url: &str, repo: &str) -> Result<Vec<GithubRelease>> {
+/// Cache key for one release listing.
+///
+/// `require_assets` cannot be a suffix on the readable part. Appending
+/// `-with-assets` makes `("owner/foo", true)` and `("owner/foo-with-assets",
+/// false)` the same string, and this cache is global and persisted, so one
+/// repository would be served the other's releases. The hash of the tuple is
+/// what separates them; the kebab-cased prefix is kept only so the file on disk
+/// is still recognisable.
+fn releases_cache_key(api_url: &str, repo: &str, require_assets: bool) -> String {
+    format!(
+        "{}-{}",
+        format!("{api_url}-{repo}").to_kebab_case(),
+        crate::hash::hash_to_str(&(api_url, repo, require_assets))
+    )
+}
+
+/// Whether the bounded prerelease fallback has found what it went looking for:
+/// a stable release the caller will actually keep.
+///
+/// Without `require_assets` this is the original test — any published,
+/// non-prerelease release. With it, a stable release that carries no assets no
+/// longer counts, because the `github:` backend removes those from the version
+/// list; stopping on one would leave an installable stable release sitting on a
+/// page that is never fetched. Callers that keep every release pass `false` and
+/// stop exactly where they always have.
+fn has_stopping_stable_release(releases: &[GithubRelease], require_assets: bool) -> bool {
+    releases
+        .iter()
+        .any(|r| !r.prerelease && !r.draft && (!require_assets || !r.assets.is_empty()))
+}
+
+async fn list_releases_(
+    api_url: &str,
+    repo: &str,
+    require_assets: bool,
+) -> Result<Vec<GithubRelease>> {
     let mut url = format!("{api_url}/repos/{repo}/releases?per_page=100");
     let headers = get_headers(&url)?;
     let (mut releases, mut headers) = crate::http::HTTP_FETCH
@@ -209,7 +256,7 @@ async fn list_releases_(api_url: &str, repo: &str) -> Result<Vec<GithubRelease>>
     let mut pages_fetched = 1;
     while let Some(next) = next_page(&headers) {
         if !*env::MISE_LIST_ALL_VERSIONS
-            && (releases.iter().any(|r| !r.prerelease && !r.draft)
+            && (has_stopping_stable_release(&releases, require_assets)
                 || pages_fetched >= MAX_RELEASE_FALLBACK_PAGES)
         {
             break;
@@ -1320,6 +1367,79 @@ something_else = "value"
         mock.assert_async().await;
     }
 
+    fn asset(name: &str) -> GithubAsset {
+        GithubAsset {
+            name: name.to_string(),
+            browser_download_url: format!("https://example.invalid/{name}"),
+            url: format!("https://example.invalid/api/{name}"),
+            digest: None,
+        }
+    }
+
+    #[test]
+    fn releases_cache_key_separates_the_suffix_collision() {
+        let api = "https://api.github.com";
+
+        // The pair a `-with-assets` suffix would collapse. This cache is global
+        // and persisted, so a collision serves one repository the other's
+        // releases.
+        assert_ne!(
+            releases_cache_key(api, "owner/foo", true),
+            releases_cache_key(api, "owner/foo-with-assets", false)
+        );
+
+        // The flag still separates one repository from itself...
+        assert_ne!(
+            releases_cache_key(api, "owner/foo", true),
+            releases_cache_key(api, "owner/foo", false)
+        );
+        // ...the api_url still separates two hosts...
+        assert_ne!(
+            releases_cache_key(api, "owner/foo", false),
+            releases_cache_key("https://github.example.com/api/v3", "owner/foo", false)
+        );
+        // ...and the same inputs still land on the same entry.
+        assert_eq!(
+            releases_cache_key(api, "owner/foo", true),
+            releases_cache_key(api, "owner/foo", true)
+        );
+    }
+
+    #[test]
+    fn stopping_stable_release_ignores_assets_unless_asked() {
+        let mut assetless = make_release("v1.0.0");
+        let mut nightly = make_release("v2.0.0-nightly");
+        nightly.prerelease = true;
+        let releases = vec![nightly, assetless.clone()];
+
+        // A caller that keeps every release stops here, exactly as before.
+        assert!(has_stopping_stable_release(&releases, false));
+
+        // The `github:` backend does not: it will drop `v1.0.0` from the
+        // listing, so stopping on it would hide an installable stable release
+        // sitting on the next page.
+        assert!(!has_stopping_stable_release(&releases, true));
+
+        assetless.assets = vec![asset("tool-x86_64-unknown-linux-gnu.tar.gz")];
+        assert!(has_stopping_stable_release(&[assetless], true));
+    }
+
+    #[test]
+    fn stopping_stable_release_still_rejects_drafts_and_prereleases() {
+        // Assets do not promote a draft or a prerelease into a stopping point.
+        let mut draft = make_release("v1.0.0");
+        draft.draft = true;
+        draft.assets = vec![asset("tool.tar.gz")];
+
+        let mut prerelease = make_release("v2.0.0");
+        prerelease.prerelease = true;
+        prerelease.assets = vec![asset("tool.tar.gz")];
+
+        let releases = vec![draft, prerelease];
+        assert!(!has_stopping_stable_release(&releases, true));
+        assert!(!has_stopping_stable_release(&releases, false));
+    }
+
     #[test]
     fn release_date_prefers_published_at() {
         let mut release = make_release("v1.0.0");
@@ -1570,7 +1690,7 @@ something_else = "value"
             .create_async()
             .await;
 
-        let releases = list_releases_(&base, repo).await.unwrap();
+        let releases = list_releases_(&base, repo, false).await.unwrap();
         page1_mock.assert_async().await;
         page2_mock.assert_async().await;
         assert!(
@@ -1578,6 +1698,93 @@ something_else = "value"
                 .iter()
                 .any(|r| r.tag_name == "v1.0.0" && !r.prerelease),
             "stable release from page 2 should be discovered, got {:?}",
+            releases.iter().map(|r| &r.tag_name).collect::<Vec<_>>()
+        );
+    }
+
+    // The listing filter reaching back into the fetch loop: a stable release
+    // with no assets is dropped from the version list, so for a caller that
+    // drops it there is nothing on this page worth stopping for.
+    #[tokio::test]
+    async fn test_list_releases_paginates_past_an_assetless_stable_release() {
+        let _config = crate::config::Config::get().await.unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+
+        // Published, not a draft, not a prerelease -- and nothing attached.
+        let assetless_page = vec![make_release("v2.0.0")];
+        let asset_page = vec![GithubRelease {
+            assets: vec![asset("tool-x86_64-unknown-linux-gnu.tar.gz")],
+            ..make_release("v1.0.0")
+        }];
+
+        let repo = "owner/assetless-stable-first-page";
+        let page1_mock = server
+            .mock("GET", format!("/repos/{repo}/releases").as_str())
+            .match_query(mockito::Matcher::UrlEncoded(
+                "per_page".into(),
+                "100".into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("link", format!("<{base}/page2>; rel=\"next\"").as_str())
+            .with_body(serde_json::to_string(&assetless_page).unwrap())
+            .expect(1)
+            .create_async()
+            .await;
+        let page2_mock = server
+            .mock("GET", "/page2")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::to_string(&asset_page).unwrap())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let releases = list_releases_(&base, repo, true).await.unwrap();
+        page1_mock.assert_async().await;
+        page2_mock.assert_async().await;
+        assert!(
+            releases.iter().any(|r| r.tag_name == "v1.0.0"),
+            "installable stable release from page 2 should be discovered, got {:?}",
+            releases.iter().map(|r| &r.tag_name).collect::<Vec<_>>()
+        );
+
+        // The same first page still stops the loop for a caller that keeps
+        // asset-less releases. Without this the test above would also pass if
+        // the bound had simply been removed for everyone.
+        let kept_repo = "owner/assetless-stable-kept";
+        let kept_page1_mock = server
+            .mock("GET", format!("/repos/{kept_repo}/releases").as_str())
+            .match_query(mockito::Matcher::UrlEncoded(
+                "per_page".into(),
+                "100".into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header(
+                "link",
+                format!("<{base}/page2-kept>; rel=\"next\"").as_str(),
+            )
+            .with_body(serde_json::to_string(&assetless_page).unwrap())
+            .expect(1)
+            .create_async()
+            .await;
+        let kept_page2_mock = server
+            .mock("GET", "/page2-kept")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::to_string(&asset_page).unwrap())
+            .expect(0)
+            .create_async()
+            .await;
+
+        let releases = list_releases_(&base, kept_repo, false).await.unwrap();
+        kept_page1_mock.assert_async().await;
+        kept_page2_mock.assert_async().await;
+        assert!(
+            releases.iter().all(|r| r.tag_name != "v1.0.0"),
+            "page 2 should not have been fetched, got {:?}",
             releases.iter().map(|r| &r.tag_name).collect::<Vec<_>>()
         );
     }
@@ -1614,7 +1821,7 @@ something_else = "value"
             .create_async()
             .await;
 
-        let releases = list_releases_(&base, repo).await.unwrap();
+        let releases = list_releases_(&base, repo, false).await.unwrap();
         page1_mock.assert_async().await;
         page2_mock.assert_async().await;
         assert!(releases.iter().any(|r| r.tag_name == "v1.0.0"));
@@ -1671,7 +1878,7 @@ something_else = "value"
             .create_async()
             .await;
 
-        let releases = list_releases_(&base, repo).await.unwrap();
+        let releases = list_releases_(&base, repo, false).await.unwrap();
         p1.assert_async().await;
         p2.assert_async().await;
         p3.assert_async().await;
@@ -1736,7 +1943,7 @@ something_else = "value"
             .create_async()
             .await;
 
-        let releases = list_releases_(&api, repo).await.unwrap();
+        let releases = list_releases_(&api, repo, false).await.unwrap();
         page1.assert_async().await;
         page2.assert_async().await;
         assert_eq!(releases.len(), 2);


### PR DESCRIPTION
`mise ls-remote` on a `github:` tool lists releases that cannot be installed.

```
$ mise ls-remote 'github:pypa/hatch[version_prefix=hatch-v]' | grep -x 1.7.0
1.7.0

$ mise install 'github:pypa/hatch[version_prefix=hatch-v]@1.7.0'
mise ERROR No matching asset found for platform macos-arm64
```

`pypa/hatch`'s `hatch-v1.7.0` has **no assets at all** — not "none for this platform". mise installs from a release's uploaded assets and never falls back to the auto-generated source archive (`tarball_url` / `zipball_url` appear nowhere in the codebase), so there is genuinely nothing to download.

## Why it happens

`_list_remote_versions` maps each release through `tag_name`, `released_at` and `prerelease`, and filters on `version_prefix` plus "does this parse as a version". It never looks at `assets` — even though `GithubRelease` already carries them in the same response that supplies `release_url`. No extra API call is needed to fix this.

## How common

Measured on released 2026.8.14:

| repo | listed versions with no assets |
| --- | --- |
| `pypa/hatch` | **16 of 43** (1.1.0 – 1.7.0; binaries begin at 1.8.0) |
| `kitlangton/ghui` | **26 of 40** (v0.2.0 – v0.3.3) |
| `pdm-project/pdm` | **68 of the newest 95 releases** |

This is not academic for me: it is why I dropped three registry entries (`hatch`, `ghui`, `qwen`) that would otherwise have moved from tier-3 backends to `github:`. Promoting them would have made `mise ls-remote` advertise versions that only fail.

## Emptiness, not platform fit

The filter asks "does this release have *any* asset", not "does it have one for my platform".

The stricter test would make the version list differ per host — and cross-platform lockfiles depend on it not doing that. `asset_matcher.rs` already notes the same concern for libc ("avoid polluting cross-platform lockfile entries with the current system's libc"). Emptiness gives the same answer on every host, so lockfiles are unaffected.

A release whose assets simply do not cover your platform is still listed, exactly as before.

## GitLab needs a different predicate

GitLab is keyed on `assets.links`, not on the whole `assets` struct. `assets.sources` is GitLab's auto-generated zip/tar.gz of the tag; it is always populated, so testing the struct would exclude nothing — and the install path reads `links` exclusively. That distinction has its own unit test.

Forgejo matches GitHub.

## Two exemptions the review process turned up

Both were found by AI review on this PR and both were real. They are the reason the diff is larger than "add a filter".

**A platform-scoped `url` disables the filter.** `resolve_asset_for_target` returns the configured URL before any picker runs, so a tool with `url` set installs from a release that has nothing attached. Filtering those out hid versions that install fine. `has_direct_url` answers this without a target, because one version list serves every platform.

Only the platform-scoped spellings count — `platforms.<os>-<arch>.url` and the flat `platform_<os>_<arch>_url`. A bare top-level `url` is **not** an exemption: `direct_url_for_target` goes through `platform_string_for_target_without_base`, which has no base fallback, so that key is inert for this backend and exempting it would keep asset-less releases listed for a tool that still fails. Which *values* count is not restated here either — `has_direct_url` performs the same two lookups the install path does (`get_nested_string` / `get_string`), so a value they reject cannot be read as an exemption and one they accept cannot be missed. That is why a table-valued `url` is not an exemption while `url = false` is: the latter resolves to the string `"false"` and short-circuits asset selection, badly but definitely.

The exemption is therefore all-or-nothing across platforms. A `url` covering only some of them keeps asset-less releases listed everywhere, and installing one on an uncovered platform still fails — exactly as it did before this filtering existed. Narrowing that would mean deciding the version list per target, which is the property the whole change is built on. Documented rather than silently accepted.

**`latest` had to learn the same rule.** `latest_stable_version_info` takes the `/releases/latest` shortcut and previously applied only `version_prefix`. With the listing filtered and this path not, `latest` could resolve to a version `ls-remote` no longer offered and then fail on install — worse than before the PR. Both forge branches now check the predicate on the release they already hold and return `None` when it has no assets, falling through to `latest_version_for_query` and the filtered list.

## Pagination

The bounded prerelease fallback stopped as soon as a page held any published, non-draft release. Once asset-less releases are dropped from the listing, such a release is no longer a reason to stop: an installable stable release could be sitting on a page that is never fetched — the change would then *lose* a version in the case it was written to protect.

The stopping predicate now takes the caller's filter as an argument:

```rust
fn has_stopping_stable_release(releases: &[GithubRelease], require_assets: bool) -> bool {
    releases
        .iter()
        .any(|r| !r.prerelease && !r.draft && (!require_assets || !r.assets.is_empty()))
}
```

`list_releases_including_prereleases_from_url` takes `require_assets` and passes it down; the `github:` backend passes `!skip_asset_check`, so a tool exempted by direct URLs keeps today's stopping point exactly. Existing callers — `list_releases`, `list_releases_including_prereleases`, `list_releases_from_url` — pass `false`, so ubi, spm, the core plugins and the security-feature probe stop where they always did. `true` is a superset and was deliberately *not* made universal: it would change what the core plugins list.

`src/forgejo.rs` carries a copy of the same predicate from #10343 and got the same treatment. GitLab does not need it — `src/gitlab.rs` only paginates under `MISE_LIST_ALL_VERSIONS` and has no stable-release stop.

## Caches

Two caches sit on this path and both had to be told apart.

**The release listing** (`src/github.rs`, `src/forgejo.rs`) is global and persisted, and `require_assets` selects between two genuinely different lists. It is therefore part of the key — hashed with the rest rather than appended as a suffix, because `-with-assets` on the readable part makes `("owner/foo", true)` and `("owner/foo-with-assets", false)` the same string, and `to_kebab_case` flattens any separator chosen to prevent that:

```rust
fn releases_cache_key(api_url: &str, repo: &str, require_assets: bool) -> String {
    format!(
        "{}-{}",
        format!("{api_url}-{repo}").to_kebab_case(),
        crate::hash::hash_to_str(&(api_url, repo, require_assets))
    )
}
```

The kebab-cased prefix is kept only so the file on disk stays recognisable when debugging. This re-keys existing entries, so the first listing after upgrade refetches.

**The remote-version cache** is partitioned by the direct-URL exemption, because the exemption changes the shape of the version list. But it is partitioned only when the tool *departs* from the exemption the registry hands everybody: a registry entry that declares platform URLs gives every client the same exemption and mise-versions is built from that same canonical configuration, so isolating there would cost the shared listing for no difference in content. This mirrors `has_local_version_listing_option_override`, which already makes that distinction for `api_url` and `version_prefix`.

The baseline is read straight off the registry entry:

```rust
async fn remote_version_cache_context(&self, config: &Arc<Config>) -> Result<Option<String>> {
    let effective = config.get_tool_opts_with_overrides(&self.ba).await?;
    let registry_default = self.ba.registry_opts();
    Ok(direct_url_cache_context(
        self.options(&effective).has_direct_url(),
        self.options(&registry_default).has_direct_url(),
    ))
}
```

An earlier revision reconstructed that baseline from the effective options' provenance, via `options_from_sources(&[ToolOptionSource::Registry])`. That cannot answer the question. Provenance is recorded per *top-level* key, so a local `[platforms]` table replaces the registry's whole table and takes the attribution with it — the registry's `platforms.<os>-<arch>.url` becomes unrecoverable. Paired with a local `platforms` table carrying no `url`, both sides read `false`, no context is produced, and a configuration that must filter asset-less releases reads the canonical *unfiltered* listing. Reading `registry_opts()` cannot lose the key, and it settles the mirror case too: a local `platforms.<b>.url` replacing the registry's `platforms.<a>.url` now matches the baseline instead of being isolated for nothing.

Only the effective boolean is hashed. The URL itself is install-only and may contain secrets.

Filtering before the cache is otherwise safe: the cache stores the pre-release superset and the read path filters on `prerelease`, and asset presence does not depend on settings.

## Notes

- **Nothing that works today stops working.** The versions this removes could not be installed before either — `mise install github:pdm-project/pdm@2.22.4` already fails.
- **The versions host is not a bypass.** mise-versions is built from `ls-remote --json` output, so the corrected listing propagates there on its next refresh.
- Only `glab` uses `gitlab:` in the registry today, and nothing uses `forgejo:`.
- Rebased on `main` (`40ec77c`).

## Tests

Unit — listing predicates:

- `test_a_release_with_no_assets_is_not_listable` — GitHub and Forgejo predicates.
- `test_gitlab_auto_generated_sources_do_not_count_as_assets` — `sources` populated, `links` empty. The case that makes GitLab need its own predicate.
- `test_a_configured_url_exempts_a_tool_from_the_asset_check` — nested and flat platform spellings exempt; a bare top-level `url`, a neighbouring `api_url`, a `platforms.url` with no `<os>-<arch>`, and a table-valued `url` do not; a boolean-valued one does, with the reasoning recorded so it does not read as an oversight.

Unit — pagination (`src/github.rs`, mirrored in `src/forgejo.rs`):

- A mockito test serving an asset-less stable release on page 1 and an installable one on page 2. It asserts both directions: with `require_assets` the fallback follows the `Link` header, and without it page 2 is never requested (`.expect(0)`), so it cannot pass by the bound simply having been removed for everyone.
- Table tests for the predicate, including that assets do not promote a draft or a prerelease into a stopping point.

Unit — caches:

- `releases_cache_key_separates_the_suffix_collision` (both files) — the `("owner/foo", true)` / `("owner/foo-with-assets", false)` pair, the flag separating a repository from itself, the `api_url` separating two hosts, and identical inputs still landing on the same entry.
- `test_direct_url_cache_context_isolates_only_departures_from_the_registry` — all four effective/registry-default combinations, including that `(true, true)` stays on the shared partition.
- `test_a_local_platforms_table_cannot_erase_the_registry_url_baseline` — a registry `platforms.<a>.url` replaced locally by a `platforms` table with no `url`: a context *is* produced, while the provenance reconstruction this replaces yields `None`. It also pins the mirror case (`platforms.<b>.url` replacing `platforms.<a>.url`) as sharing the default partition.

e2e (`test_github_ls_remote_skips_assetless`) — a local stand-in for the GitHub API serves `/releases` and `/releases/latest`, with `v2.0.0` carrying an asset and `v3.0.0` (the repo's "Latest") carrying none:

```sh
assert_contains     "mise ls-remote …" "2.0.0"   # listed
assert_not_contains "mise ls-remote …" "3.0.0"   # not listed
assert              "mise latest …"    "2.0.0"   # shortcut falls through to the list
# and with platform-scoped urls configured, on a separate cache partition:
assert_contains     "mise ls-remote …" "3.0.0"   # exempt, so listed again
assert              "mise latest …"    "3.0.0"
```

The positive assertions come first so the negative one cannot pass vacuously, and `assert` is exact-match so `latest` returning the wrong version fails.

One limit worth stating plainly: the registry-baseline test builds the registry layer by hand rather than resolving a real registry entry, because no `github:`/`gitlab:`/`forgejo:` entry in `registry/` declares a platform-scoped `url` today (the eight that do are all `http:`). Pinning the test to one would couple it to volatile registry data. It exercises `has_direct_url` and `direct_url_cache_context` against options assembled exactly as `resolve_opts_with_layers` assembles them; the remaining uncovered step is the single `self.ba.registry_opts()` read.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.251.*
