### PR TITLE
fix(file): stop create_dir_all reporting success when it created nothing

### DIFF
--- a/e2e-win/install_reserved_device_name.Tests.ps1
+++ b/e2e-win/install_reserved_device_name.Tests.ps1
@@ -1,0 +1,79 @@
+Describe 'an install directory Windows will not create' {
+    # `std::fs::create_dir_all` answers Ok for a path ending in `nul` and creates nothing --
+    # measured with a standalone rustc probe:
+    #
+    #     installs/jq/zzz   create_dir_all=Ok   after: is_dir()=true
+    #     installs/jq/aux   create_dir_all=Ok   after: is_dir()=true
+    #     installs/jq/nul   create_dir_all=Ok   after: is_dir()=false
+    #
+    # `create_install_dirs` made three such calls and then wrote a marker file underneath, so the
+    # failure surfaced from `File::create` -- three calls away from the cause, with no path and no
+    # operation, as a bare `(os error 3)`.
+    #
+    # This does not make `nul` a usable version. It makes the refusal say which path and why.
+
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        # All four, every time. A probe that isolated only some of these once wrote junctions into
+        # the real installs directory.
+        $script:Saved = @{}
+        foreach ($v in 'MISE_DATA_DIR', 'MISE_CONFIG_DIR', 'MISE_CACHE_DIR', 'MISE_TRUSTED_CONFIG_PATHS') {
+            $script:Saved[$v] = [Environment]::GetEnvironmentVariable($v, 'Process')
+        }
+
+        # Not named for a device itself: an earlier attempt at this used `nul` for the probe root
+        # and Windows refused to create it, which broke the isolation rather than the subject.
+        $script:Root = Join-Path $TestDrive 'devname'
+        $cfg = Join-Path $script:Root 'cfg'
+        $cache = Join-Path $script:Root 'cache'
+        $data = Join-Path $script:Root 'data'
+        $proj = Join-Path $script:Root 'proj'
+        New-Item -ItemType Directory -Path $cfg, $cache, $data, $proj -Force | Out-Null
+
+        $env:MISE_DATA_DIR = $data
+        $env:MISE_CONFIG_DIR = $cfg
+        $env:MISE_CACHE_DIR = $cache
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:Root
+        Set-Location $proj
+        '' | Out-File -FilePath 'mise.toml' -Encoding utf8NoBOM
+
+        # Neither version exists, so both must fail. The question is what they say.
+        $script:Device = mise install jq@nul 2>&1 | Out-String
+        $script:DeviceExit = $LASTEXITCODE
+        $script:Control = mise install jq@zzz 2>&1 | Out-String
+        $script:ControlExit = $LASTEXITCODE
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        foreach ($v in $script:Saved.Keys) {
+            if ($null -ne $script:Saved[$v]) { Set-Item "Env:\$v" $script:Saved[$v] }
+            else { Remove-Item "Env:\$v" -ErrorAction SilentlyContinue }
+        }
+    }
+
+    It 'still fails, because the directory genuinely cannot be created' {
+        $script:DeviceExit | Should -Not -Be 0
+    }
+
+    It 'names the path it could not create instead of only an OS error number' {
+        $script:Device | Should -Match 'created nothing'
+        $script:Device | Should -Match 'installs'
+    }
+
+    It 'names the component Windows objects to' {
+        # Without this the message says a directory is missing and leaves the reader to work out
+        # which part of the path Windows refuses.
+        $script:Device | Should -Match 'reserves for a device'
+        $script:Device | Should -Match 'nul'
+    }
+
+    It 'leaves an ordinary missing version reporting what it always did' {
+        # The control. A change that rewrote every install failure would pass the assertions above
+        # and fail here: `zzz` creates its directories fine and is refused by the aqua registry,
+        # which is a different answer arrived at by a different route.
+        $script:ControlExit | Should -Not -Be 0
+        $script:Control | Should -Match 'no asset released'
+        $script:Control | Should -Not -Match 'created nothing'
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,7 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 use std::ffi::OsString;
 use std::fmt::{Debug, Display, Formatter};
-use std::fs::File;
 use std::hash::Hash;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
@@ -3726,7 +3725,10 @@ pub(crate) trait Backend: Debug + Send + Sync {
         file::create_dir_all(tv.install_path())?;
         file::create_dir_all(tv.download_path())?;
         file::create_dir_all(tv.cache_path())?;
-        File::create(self.incomplete_file_path(tv))?;
+        // `file::create` rather than `File::create`: it creates the parent and wraps the failure
+        // with the path. The bare call reported `mise install jq@nul` as an unexplained
+        // `(os error 3)` -- true, and useless, because it named neither the file nor the operation.
+        file::create(&self.incomplete_file_path(tv))?;
         Ok(())
     }
     fn cleanup_install_dirs_on_error(&self, tv: &ToolVersion) {

--- a/src/file.rs
+++ b/src/file.rs
@@ -748,6 +748,14 @@ pub(crate) fn create_dir_all<P: AsRef<Path>>(path: P) -> Result<()> {
     let _lock = LOCK.lock().unwrap();
 
     let path = path.as_ref();
+    // `Path::new("plainstub").parent()` is `Some("")`, so every caller that ensures a parent
+    // directory for a bare filename lands here with nothing. std answers Ok and creates nothing —
+    // correctly, since the directory in question is the one already in use — and the check below
+    // would otherwise read that as the failure it is looking for. Measured: `exists()` false,
+    // `create_dir_all` Ok, `is_dir()` false.
+    if path.as_os_str().is_empty() {
+        return Ok(());
+    }
     if !path.exists() {
         trace!("mkdir -p {}", display_path(path));
         if let Err(err) = fs::create_dir_all(path) {
@@ -757,8 +765,65 @@ pub(crate) fn create_dir_all<P: AsRef<Path>>(path: P) -> Result<()> {
                     .wrap_err_with(|| format!("failed create_dir_all: {}", display_path(path)));
             }
         }
+        // `std::fs::create_dir_all` can answer Ok and leave nothing behind. Measured on Windows
+        // for a path ending in `nul`: Ok, and `is_dir()` false afterwards. Everything downstream
+        // then works from a directory that is not there, and the first operation to touch it
+        // fails somewhere else entirely — `mise install jq@nul` surfaced as a bare
+        // `(os error 3)` from a marker file three calls later.
+        //
+        // Only after an attempt: a path that already existed as a file keeps returning Ok, as it
+        // always has. This narrows the change to the case that was measured.
+        if !path.is_dir() {
+            // Two different states, and saying the wrong one sends the reader somewhere useless.
+            // `symlink_metadata` rather than `exists`: the guard above already answered false for
+            // a link whose target is gone, and such a link is very much in the way even though
+            // nothing resolves through it.
+            if path.symlink_metadata().is_ok() {
+                bail!(
+                    "failed create_dir_all: {} exists and is not a directory",
+                    display_path(path)
+                );
+            }
+            bail!(
+                "failed create_dir_all: {} reported success but created nothing{}",
+                display_path(path),
+                device_name_note(path)
+            );
+        }
     }
     Ok(())
+}
+
+/// Name the cause when the final component is one Windows reserves for a device.
+///
+/// A check, not a guess: the component either is one of those names or it is not. It is also not a
+/// prediction — `aux` was measured creating a directory perfectly well on the machine this was
+/// written on, so the note is only ever added to a failure that already happened, never used to
+/// refuse a name in advance.
+#[cfg(windows)]
+fn device_name_note(path: &Path) -> String {
+    const RESERVED: &[&str] = &[
+        "con", "prn", "aux", "nul", "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8",
+        "com9", "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9",
+    ];
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return String::new();
+    };
+    // `nul.txt` addresses the same device as `nul`, so the extension is not part of the name.
+    let stem = name.split_once('.').map_or(name, |(stem, _)| stem);
+    if RESERVED.contains(&stem.to_ascii_lowercase().as_str()) {
+        format!(
+            ".\n`{stem}` is a name Windows reserves for a device, so a directory cannot take it. \
+             Renaming that path component is the only fix."
+        )
+    } else {
+        String::new()
+    }
+}
+
+#[cfg(not(windows))]
+fn device_name_note(_path: &Path) -> String {
+    String::new()
 }
 
 /// A path formatted for a person to read: `$HOME` becomes `~`, a Windows extended-length prefix
@@ -2760,6 +2825,77 @@ mod tests {
     use crate::config::Config;
 
     use super::*;
+
+    // `std::fs::create_dir_all` answers Ok for a path ending in `nul` and creates nothing --
+    // measured with a standalone rustc probe before any of this was written:
+    //
+    //     installs/jq/zzz   create_dir_all=Ok   after: is_dir()=true
+    //     installs/jq/aux   create_dir_all=Ok   after: is_dir()=true
+    //     installs/jq/nul   create_dir_all=Ok   after: is_dir()=false
+    //
+    // Everything downstream then works from a directory that is not there. `mise install jq@nul`
+    // failed three calls later, in an unrelated place, with a bare `(os error 3)`.
+    #[test]
+    #[cfg(windows)]
+    fn create_dir_all_refuses_to_report_success_for_a_directory_it_did_not_make() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("nul");
+
+        let err = create_dir_all(&path).unwrap_err().to_string();
+
+        assert!(err.contains("created nothing"), "{err}");
+        // The name Windows objects to, so the reader knows which component to change.
+        assert!(err.contains("nul"), "{err}");
+        assert!(!path.is_dir(), "nothing should have appeared");
+    }
+
+    // The property being fixed, stated as an invariant rather than a verdict per name: whatever
+    // this function answers has to match what is on disk afterwards.
+    //
+    // Deliberately not "reserved names fail". `aux` was measured creating a directory perfectly
+    // well on the machine this was written on, and asserting otherwise would pin a claim about
+    // Windows that this repository has not established.
+    #[test]
+    #[cfg(windows)]
+    fn create_dir_all_answers_agree_with_the_filesystem_for_device_names() {
+        for name in ["zzz", "aux", "con", "prn", "lpt1"] {
+            let tmp = tempfile::tempdir().unwrap();
+            let path = tmp.path().join(name);
+
+            let created = create_dir_all(&path).is_ok();
+
+            assert_eq!(
+                created,
+                path.is_dir(),
+                "{name}: create_dir_all said {created} and is_dir() says {}",
+                path.is_dir()
+            );
+        }
+    }
+
+    // An empty path is what `parent()` gives for a bare filename, and `file::create` passes it
+    // straight through. std answers Ok for it and creates nothing, which is the exact shape the
+    // check above looks for -- so without the guard every tool stub written to the working
+    // directory failed. It did: six Windows and eight Linux e2e cases, all reporting
+    // `failed create_dir_all: ` with no path at all.
+    #[test]
+    fn create_dir_all_treats_an_empty_path_as_the_no_op_it_has_always_been() {
+        create_dir_all("").unwrap();
+        create_dir_all(Path::new("").join("")).unwrap();
+    }
+
+    // The unix side of the same invariant. The new check runs on every platform, so this is what
+    // says it has not started refusing ordinary directories.
+    #[test]
+    #[cfg(unix)]
+    fn create_dir_all_still_makes_ordinary_directories() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("nul").join("deep");
+
+        create_dir_all(&path).unwrap();
+
+        assert!(path.is_dir());
+    }
 
     /// Whether a directory entry is there at all, without resolving it.
     ///


### PR DESCRIPTION
## The measurement

`std::fs::create_dir_all` can answer `Ok` and leave nothing behind. From a standalone rustc probe,
run on the exact path shape mise builds:

```
installs/jq/zzz   exists()=false  create_dir_all=Ok  after: is_dir()=true
installs/jq/aux   exists()=false  create_dir_all=Ok  after: is_dir()=true
installs/jq/nul   exists()=false  create_dir_all=Ok  after: is_dir()=false     ← nothing there
```

Everything downstream then works from a directory that is not there, and the failure surfaces
somewhere else entirely.

## How it reached the user

`create_install_dirs` makes three of those calls and then writes a marker file underneath —
`install_state::incomplete_file_path` is `<CACHE>/<short>/<version>/incomplete`, whose parent is the
`cache_path` from the call just above:

```rust
file::create_dir_all(tv.install_path())?;   // installs/jq/nul  -> Ok, nothing created
file::create_dir_all(tv.download_path())?;  // ditto
file::create_dir_all(tv.cache_path())?;     // <CACHE>/jq/nul   -> Ok, nothing created
File::create(self.incomplete_file_path(tv))?;   // parent missing -> os error 3, unwrapped
```

```console
$ mise install jq@nul
mise ERROR Failed to install aqua:jqlang/jq@nul: The system cannot find the path specified. (os error 3)
```

True, and useless: it named neither the path nor the operation, and the cause was three calls
earlier. The controls — `aux`, `prn`, `nulx`, `auxx`, `zzz` — all gave the ordinary
`no asset released`, so the shape of the error offered no hint either. A trace confirms `nul` and
`zzz` are identical up through aqua's package resolution and diverge only after it.

## The fix

`create_dir_all` now checks, after an attempt, that a directory is actually there — and
distinguishes two states, because saying the wrong one sends the reader somewhere useless:

- **something is in the way** — `symlink_metadata` succeeds: a file, or a link whose target is gone,
  which the `exists()` guard above answers `false` for
- **nothing was created** — the case above

Measured, so the branch is not a guess: for the `nul` path both `metadata` and `symlink_metadata`
fail with error 1, so it takes the second branch; a plain file takes the first.

**The check runs only when creation was attempted.** A path that already existed as a file still
returns `Ok`, exactly as before. This narrows the change to the case that was measured rather than
tightening a helper the whole codebase leans on.

When the final component is one Windows reserves for a device, the message says so. That is a check
rather than a guess — the component either is one of those names or it is not — but deliberately
**not** a prediction: **`aux` created a directory perfectly well** on the machine this was written
on, so the note is only ever added to a failure that already happened, and is never used to refuse a
name in advance.

`create_install_dirs` also switches its marker file from `File::create` to `file::create`, which
already creates the parent and wraps the failure with the path. That is the half that turned a
specific problem into an anonymous one.

### The empty path has to stay a no-op

`Path::new("plainstub").parent()` is `Some("")`, and `file::create` passes that straight through. std
answers `Ok` for an empty path and creates nothing — the exact shape the new check looks for. So the
guard is not decoration: without it every tool stub written to the working directory failed, which
is what the first CI run reported — **six Windows and eight Linux e2e cases**, all with
`failed create_dir_all: ` and no path at all. An explicit early return keeps it the no-op it has
always been, pinned by its own test.

## `nul` is the reproduction, not the subject

Nobody needs `nul` as a version. What this fixes is a helper that reported success for work it had
not done — reachable by any path component the filesystem will not take, with the failure landing
wherever the first user of that directory happens to be.

## Tests

The unit tests state the fix as **an invariant rather than a verdict per name**: whatever
`create_dir_all` answers has to match what is on disk afterwards. "Reserved names fail" would be a
claim about Windows that the `aux` measurement contradicts, so it is not asserted.

- Windows: `create_dir_all(<tmp>/nul)` must now be `Err`, and name both the path and the component
- Windows: `zzz`, `aux`, `con`, `prn`, `lpt1` — `is_ok()` must equal `is_dir()`, whichever way each
  one goes on the runner
- unix: an ordinary nested directory still gets created, since the new check runs everywhere
- both: the empty path is still a no-op — `create_dir_all("")` and the `Path::new("").join("")` that
  `parent()` produces

The Windows e2e drives `mise install jq@nul` and asserts the message names the path and the
component, with `jq@zzz` as the control — it creates its directories fine and is refused by the aqua
registry instead, so a change that rewrote every install failure would fail there.

## Not verified locally

The message assertions were matched against a string built from the format string, not against
output from a build containing this change; mise here is `2026.8.14`, which predates it. The real
output is what CI checks.

`create_dir_all` is used throughout, so the broadest regression surface is CI itself rather than any
one test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation errors when paths contain Windows-reserved names, such as `nul`.
  * Error messages now identify the affected path and clarify whether it conflicts with a file or reserved device name.
  * Preserved standard “no asset released” errors for ordinary missing versions.
  * Improved directory creation reliability across Windows and Unix systems, including clearer handling of invalid paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
