### PR TITLE
fix(http): list the platform keys a tool actually declares

### DIFF
--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -469,6 +469,15 @@ pub(crate) fn lookup_platform_value<'a>(
     )
 }
 
+/// Whether the lookup this list describes would get a value out of `value`.
+///
+/// Existence is not enough. `ToolVersionOptions`'s nested lookup converts scalars and returns
+/// nothing for a table or an array, so a `url` written as either resolves to no URL — and listing
+/// its platform as available would send the reader looking for a key that is already there.
+fn resolves_to_a_value(value: &toml::Value) -> bool {
+    crate::toolset::scalar_value_to_string(value).is_some()
+}
+
 /// Lists platform keys (e.g. "macos-x64") for which a given key_type exists (e.g. "url").
 pub(crate) fn list_available_platforms_with_key(
     opts: &ToolVersionOptions,
@@ -477,11 +486,12 @@ pub(crate) fn list_available_platforms_with_key(
     let mut set = IndexSet::new();
 
     // Gather from flat keys
-    for (k, _) in opts.iter() {
+    for (k, v) in opts.iter() {
         if let Some(rest) = k
             .strip_prefix("platforms_")
             .or_else(|| k.strip_prefix("platform_"))
             && let Some(platform_part) = rest.strip_suffix(&format!("_{}", key_type))
+            && resolves_to_a_value(v)
         {
             // Only convert the OS/arch separator underscore to a dash, preserving
             // underscores inside architecture names like x86_64
@@ -494,14 +504,37 @@ pub(crate) fn list_available_platforms_with_key(
         }
     }
 
-    // Probe nested keys using shared patterns
-    for os in BINARY_OS_TOKENS {
-        for arch in BINARY_ARCH_TOKENS {
-            for prefix in ["platforms", "platform"] {
-                let nested_key = format!("{prefix}.{os}-{arch}.{key_type}");
-                if opts.contains_key(&nested_key) {
-                    set.insert(format!("{os}-{arch}"));
+    // Read the keys that are actually there rather than probing a grid of known OS and arch
+    // tokens. The grid could only see platforms it already knew the name of, so a key mise does
+    // not recognise -- a typo like `lnux-x64`, an underscore where a dash belongs -- came back as
+    // nothing at all, and the caller reported "requires 'url' option" to someone who had written
+    // one. Naming what is declared is the whole point of this list.
+    //
+    // Two shapes, because `ToolVersionOptions::contains_key` resolves both: a nested table, and a
+    // literal dotted key at the top level. Together they are a superset of what the grid saw.
+    for (k, v) in opts.iter() {
+        // `platforms = { "lnux-x64" = { url = "..." } }`
+        if k == "platforms" || k == "platform" {
+            if let Some(table) = v.as_table() {
+                for (platform_key, entry) in table {
+                    if entry
+                        .as_table()
+                        .and_then(|entry| entry.get(key_type))
+                        .is_some_and(resolves_to_a_value)
+                    {
+                        set.insert(platform_key.clone());
+                    }
                 }
+            }
+            continue;
+        }
+        // `"platforms.lnux-x64.url" = "..."` written as one key
+        for prefix in ["platforms.", "platform."] {
+            if let Some(rest) = k.strip_prefix(prefix)
+                && let Some(platform_key) = rest.strip_suffix(&format!(".{key_type}"))
+                && resolves_to_a_value(v)
+            {
+                set.insert(platform_key.to_string());
             }
         }
     }
@@ -1863,6 +1896,161 @@ Path      : C:\\a\\deno\\deno\\target\\release\\deno-x86_64-pc-windows-msvc.zip
                 initial_target
             );
         }
+    }
+
+    /// `platforms = { "<name>" = { <key> = ... } }`, the shape a nested table takes.
+    fn nested_platforms(entries: &[(&str, &str)], key_type: &str) -> ToolVersionOptions {
+        let mut platforms = toml::value::Table::new();
+        for (platform_key, value) in entries {
+            let mut entry = toml::value::Table::new();
+            entry.insert(key_type.to_string(), toml::Value::String(value.to_string()));
+            platforms.insert(platform_key.to_string(), toml::Value::Table(entry));
+        }
+        let mut opts = IndexMap::new();
+        opts.insert("platforms".to_string(), toml::Value::Table(platforms));
+        ToolVersionOptions {
+            opts: opts.into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn list_available_platforms_names_keys_mise_does_not_recognise() {
+        // What the list is for: telling someone which platform keys their tool declares. Probing a
+        // grid of known OS and arch tokens could only ever name the ones mise already knew, so a
+        // typo came back as an empty list and the http backend told the author to provide a `url`
+        // they had written. Measured before the change, host windows-x64:
+        //
+        //     platforms = { lnux-x64  = { url = ... } }  ->  Http backend requires 'url' option
+        //     platforms = { linux-x64 = { url = ... } }  ->  ... Available: linux-x64.
+        let opts = nested_platforms(
+            &[
+                ("lnux-x64", "https://example.invalid/a.tar.gz"),
+                ("linux_x64", "https://example.invalid/b.tar.gz"),
+                ("plan9-mips", "https://example.invalid/c.tar.gz"),
+            ],
+            "url",
+        );
+
+        let platforms = list_available_platforms_with_key(&opts, "url");
+
+        assert!(platforms.contains(&"lnux-x64".to_string()), "{platforms:?}");
+        assert!(
+            platforms.contains(&"linux_x64".to_string()),
+            "{platforms:?}"
+        );
+        assert!(
+            platforms.contains(&"plan9-mips".to_string()),
+            "{platforms:?}"
+        );
+    }
+
+    #[test]
+    fn list_available_platforms_still_names_the_keys_the_grid_used_to_find() {
+        // The control for removing the token grid: everything it could see is still seen.
+        let opts = nested_platforms(
+            &[
+                ("linux-x64", "https://example.invalid/linux.tar.gz"),
+                ("macos-arm64", "https://example.invalid/macos.tar.gz"),
+                ("windows-x64", "https://example.invalid/windows.zip"),
+            ],
+            "url",
+        );
+
+        let platforms = list_available_platforms_with_key(&opts, "url");
+
+        for expected in ["linux-x64", "macos-arm64", "windows-x64"] {
+            assert!(platforms.contains(&expected.to_string()), "{platforms:?}");
+        }
+    }
+
+    #[test]
+    fn list_available_platforms_is_about_one_key_not_every_platform() {
+        // The second control, and the one that stops this from becoming "list every platform
+        // mentioned anywhere": a platform that declares a checksum but no url must not be offered
+        // as somewhere a url could be found.
+        let opts = nested_platforms(&[("linux-x64", "sha256:abc")], "checksum");
+
+        assert!(list_available_platforms_with_key(&opts, "url").is_empty());
+        assert_eq!(
+            list_available_platforms_with_key(&opts, "checksum"),
+            vec!["linux-x64".to_string()]
+        );
+    }
+
+    #[test]
+    fn list_available_platforms_skips_a_value_the_lookup_would_reject() {
+        // Existence is not enough. The nested lookup converts scalars and returns nothing for a
+        // table or an array, so a `url` written as either resolves to no URL -- and offering its
+        // platform as available sends the reader looking for a key that is already there. The
+        // token grid this replaced had the same hole, since `contains_key` only asks whether
+        // something is at the path.
+        let mut platforms = toml::value::Table::new();
+
+        let mut as_table = toml::value::Table::new();
+        as_table.insert(
+            "url".to_string(),
+            toml::Value::Table({
+                let mut inner = toml::value::Table::new();
+                inner.insert("href".to_string(), toml::Value::String("x".to_string()));
+                inner
+            }),
+        );
+        platforms.insert("linux-x64".to_string(), toml::Value::Table(as_table));
+
+        let mut as_array = toml::value::Table::new();
+        as_array.insert(
+            "url".to_string(),
+            toml::Value::Array(vec![toml::Value::String("x".to_string())]),
+        );
+        platforms.insert("macos-arm64".to_string(), toml::Value::Table(as_array));
+
+        let mut as_string = toml::value::Table::new();
+        as_string.insert(
+            "url".to_string(),
+            toml::Value::String("https://example.invalid/w.zip".to_string()),
+        );
+        platforms.insert("windows-x64".to_string(), toml::Value::Table(as_string));
+
+        let mut opts = IndexMap::new();
+        opts.insert("platforms".to_string(), toml::Value::Table(platforms));
+        let tool_opts = ToolVersionOptions {
+            opts: opts.into(),
+            ..Default::default()
+        };
+
+        let platforms = list_available_platforms_with_key(&tool_opts, "url");
+
+        // The control is the third entry: a well-formed neighbour still shows up, so this is a
+        // value check rather than the list quietly emptying itself.
+        assert_eq!(platforms, vec!["windows-x64".to_string()]);
+    }
+
+    #[test]
+    fn list_available_platforms_reads_a_literal_dotted_key() {
+        // The other shape `ToolVersionOptions::contains_key` resolves, and the other half of what
+        // the grid was covering: the whole path written as one top-level key.
+        let mut opts = IndexMap::new();
+        opts.insert(
+            "platforms.lnux-x64.url".to_string(),
+            toml::Value::String("https://example.invalid/a.tar.gz".to_string()),
+        );
+        opts.insert(
+            "platform.macos-arm64.url".to_string(),
+            toml::Value::String("https://example.invalid/b.tar.gz".to_string()),
+        );
+        let tool_opts = ToolVersionOptions {
+            opts: opts.into(),
+            ..Default::default()
+        };
+
+        let platforms = list_available_platforms_with_key(&tool_opts, "url");
+
+        assert!(platforms.contains(&"lnux-x64".to_string()), "{platforms:?}");
+        assert!(
+            platforms.contains(&"macos-arm64".to_string()),
+            "{platforms:?}"
+        );
     }
 
     #[test]

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -44,7 +44,8 @@ pub(crate) use tool_version::{ResolveOptions, ToolVersion};
 pub(crate) use tool_version_list::ToolVersionList;
 pub(crate) use tool_version_options::{
     CoreToolOptions, EPHEMERAL_OPT_KEYS, RawBackendOptions, ResolvedToolOptions, ToolOptionSource,
-    ToolOptions, ToolVersionOptions, parse_tool_options, try_parse_tool_options,
+    ToolOptions, ToolVersionOptions, parse_tool_options, scalar_value_to_string,
+    try_parse_tool_options,
 };
 
 mod builder;

--- a/src/toolset/tool_version_options.rs
+++ b/src/toolset/tool_version_options.rs
@@ -576,7 +576,10 @@ fn preserves_backend_option_type(key: &str) -> bool {
     matches!(key, "allow_builds")
 }
 
-fn scalar_value_to_string(value: &toml::Value) -> Option<String> {
+/// `pub(crate)` so callers that only want to know whether a value would resolve can ask the same
+/// question the lookup answers, instead of keeping a second copy of the rule that can drift from
+/// this one.
+pub(crate) fn scalar_value_to_string(value: &toml::Value) -> Option<String> {
     match value {
         toml::Value::String(s) => Some(s.clone()),
         toml::Value::Integer(i) => Some(i.to_string()),


### PR DESCRIPTION
## Measured

Each fixture declares only a platform that is **not** the host, so all six must fail. The difference
is what they say. Host `windows-x64`:

| declared platform | message |
| --- | --- |
| `linux-x64` | `No URL for platform windows-x64. Available: linux-x64.` |
| `linux-amd64` | `No URL for platform windows-x64. Available: linux-amd64.` |
| `darwin-arm64` | `No URL for platform windows-x64. Available: darwin-arm64.` |
| **`lnux-x64`** | **`Http backend requires 'url' option`** |
| **`linux_x64`** | **`Http backend requires 'url' option`** |
| **`plan9-mips`** | **`Http backend requires 'url' option`** |

The bottom three are the realistic ones: a typo, and a separator written the wrong way. Both tell an
author **who wrote a `url`** that they need to provide one — with nothing to say which part was not
understood, because `Available:` came back empty.

## Why

`Available:` exists to name the platforms a tool declares. It only ever named the ones mise already
recognised, because it was built by probing a grid of known OS and arch tokens instead of reading
the keys that are there:

```rust
for os in BINARY_OS_TOKENS {
    for arch in BINARY_ARCH_TOKENS {
        for prefix in ["platforms", "platform"] {
            let nested_key = format!("{prefix}.{os}-{arch}.{key_type}");
            if opts.contains_key(&nested_key) { ... }
```

A key outside the grid is invisible, the list is empty, and `missing_url_error`'s other branch fires.

## The change

The list now reads the keys. `ToolVersionOptions::contains_key` resolves two shapes — a nested
table, and the whole path written as one top-level key — and both are now walked **without knowing
any platform name in advance**, which is a superset of everything the grid could see.

The flat `platforms_linux_x64_url` branch is left alone. It is a third shape, and its underscore
handling (`macos_x86_64` must stay `macos-x86_64`, not `macos-x86-64`) is pinned by an existing test.

**Reading the keys is not enough on its own: the value has to be one the lookup would accept.** The
grid used `contains_key`, which only ever saw keys whose value resolves; walking the table directly
would otherwise start offering `platforms.linux-x64.url = { href = "…" }` as an available platform
while the lookup still rejects it. So all three branches are gated on
`toolset::scalar_value_to_string` returning `Some` — the same function the lookup itself uses, made
`pub(crate)` and re-exported for this. Tables and arrays are excluded; strings, integers, booleans,
floats and datetimes are not. That is the only reason `src/toolset/mod.rs` and
`src/toolset/tool_version_options.rs` appear in this diff.

## Scope

**Diagnostic only.** `list_available_platforms_with_key` has exactly one production caller —
`HttpOptions::url_platforms`, used to build this message. Nothing about which asset is chosen, or
which install runs, changes here.

## What it does not do

It improves the diagnosis; it does not add validation. An unrecognised `platforms.<key>` is still
ignored silently while resolving — whether mise should reject one is a separate question about
validation rather than about what an error says.

For registry entries the JSON schema already rejects a malformed selector in CI
(`^(linux|macos|windows)-(x64|arm64|x86|loongarch64|riscv64)$`). This is about a user's own
`mise.toml`, where nothing checks at runtime.

## Tests

Unit tests only — the function is pure, and the message as a whole is already asserted end to end by
the e2e in #12568.

- the three unrecognised keys above are listed (today they are not)
- **control**: `linux-x64`, `macos-arm64`, `windows-x64` are still listed — nothing the grid saw is lost
- **control**: a platform declaring `checksum` but no `url` is *not* offered when asking for `url`,
  so this stays "platforms that have this key" rather than becoming "every platform mentioned"
- **control**: the literal dotted top-level key shape still works — the other half of what the grid covered
- **control**: a `url` written as a table or an array is *not* listed, while a plain string beside
  them is — the list may not offer a platform the lookup would refuse
- the existing flat-underscore test is unchanged and still passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Platform listings now include all platform keys declared in configuration, including custom or previously unrecognized names.
  * Fixed an issue where platform entries could be silently omitted when their names did not match expected conventions.
  * Invalid platform values, such as tables or arrays, are now excluded from listings to match lookup behavior.
  * Added coverage for nested platform configurations, dotted keys, custom names, and unsupported values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
