### PR TITLE
registry: add cliamp (github:bjarneo/cliamp)

### DIFF
--- a/registry/cliamp.toml
+++ b/registry/cliamp.toml
@@ -1,0 +1,11 @@
+# Upstream ships bare per-platform binaries (cliamp-linux-amd64,
+# cliamp-darwin-arm64, ...), which mise normalises onto `cliamp`.
+#
+# The macOS binaries link dynamically against Homebrew's FLAC, Vorbis, Ogg and
+# mpg123; upstream documents `brew install flac libvorbis libogg mpg123` for the
+# release artifacts. The Linux binaries link those codecs statically.
+backends = ["github:bjarneo/cliamp"]
+bins = ["cliamp"]
+description = "Retro terminal music player inspired by Winamp"
+test = { cmd = "cliamp --version", expected = "cliamp version v{{version}}" }
+version_order = "semver"


### PR DESCRIPTION
- https://github.com/bjarneo/cliamp
Not in the aqua standard registry, so `github` is the tier 1 backend. Upstream ships bare per-platform binaries (`cliamp-linux-amd64`, `cliamp-darwin-arm64`, ...) for linux/macos on amd64 and arm64 plus windows amd64, which mise normalises onto `cliamp`, so no `asset_pattern`, `bin_path`, `rename_exe` or `os` restriction is needed.

Every version `mise ls-remote` resolves for this tool is a strict `MAJOR.MINOR.PATCH`, hence `version_order = "semver"`. The `2.0.0-rc.*` prereleases are filtered out by the backend and do not appear.

## Codec libraries

The macOS release binaries link dynamically against Homebrew's FLAC, Vorbis, Ogg and mpg123; upstream documents `brew install flac libvorbis libogg mpg123` as a prerequisite for the release artifacts, and its own Homebrew formula pulls them in. The Linux binaries link those codecs statically and need nothing extra. This is recorded as a comment in the registry entry so the requirement is not rediscovered from a dyld error.

## Popularity

- GitHub: 3,827 stars, 228 forks; latest release v1.63.2 published 2026-08-13
- Active maintenance: latest repository push 2026-08-26
- Also packaged in Homebrew (`bjarneo/cliamp/cliamp`), the AUR, and Nix

## Validation

- `mise test-tool cliamp` -> `cliamp: OK`
- `mise x github:bjarneo/cliamp@1.63.2 -- cliamp --version` -> `cliamp version v1.63.2`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `cliamp` to the application registry.
  * Included version detection and semantic version ordering.
  * Documented platform-specific binary naming and macOS codec requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->