### PR TITLE
fix(fish): split PATH on the host's separator, not always ':'

### DIFF
--- a/e2e-win/env_fish_path.Tests.ps1
+++ b/e2e-win/env_fish_path.Tests.ps1
@@ -1,0 +1,66 @@
+Describe 'fish PATH on Windows' {
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        # Saved here, restored in AfterAll: Pester runs every suite in one process, so removing an
+        # inherited value would leave the next suite without it.
+        $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+        $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:TestRoot | Out-Null
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:TestRoot
+
+        # `_.path` is what puts a drive-lettered directory in front of PATH. `FOO` is the control:
+        # it holds a `;` too, but it is not PATH, so nothing may split it.
+        @(
+            '[env]'
+            '_.path = ["C:/aaa/bin"]'
+            'FOO = "a;b"'
+        ) | Out-File -Encoding ascii (Join-Path $script:TestRoot "mise.toml")
+
+        Set-Location $script:TestRoot
+
+        function Get-FishLine {
+            param([string]$Pattern)
+            (mise env -s fish | Select-String -Pattern $Pattern | Select-Object -First 1).Line
+        }
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        if ($null -eq $script:OriginalTrusted) {
+            Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
+        } else {
+            [Environment]::SetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', $script:OriginalTrusted, 'Process')
+        }
+    }
+
+    It 'gives fish one list element per directory' {
+        # The reproduction. This printed `set -gx PATH C '/aaa/bin;C' '\Users\...;C' ...`: fish
+        # keeps PATH as a list, and the value was split on `:`, so every drive letter became an
+        # element of its own and the rest of that path was glued to the next one. A `;` surviving
+        # anywhere on this line means the split did not happen on the host's separator.
+        $line = Get-FishLine '^set -gx PATH '
+        $line | Should -Not -BeNullOrEmpty
+        $line | Should -Not -Match ';'
+    }
+
+    It 'keeps a declared directory whole' {
+        # Asserted separately from the line above: an empty PATH would also contain no `;`.
+        $line = Get-FishLine '^set -gx PATH '
+        $line | Should -Match "'C:[\\/]aaa[\\/]bin'"
+    }
+
+    It 'leaves a semicolon in any other variable alone' {
+        # Control: only PATH is a list. Without this, splitting too much would look like a fix.
+        $line = Get-FishLine '^set -gx FOO '
+        $line | Should -Match "set -gx FOO 'a;b'"
+    }
+
+    It 'still joins PATH into one value for pwsh' {
+        # Control: pwsh takes PATH as a single separated string, which was already right and has
+        # to stay that way. It is also what shows this suite is reading real output -- the two
+        # PATH assertions above would pass just as well against nothing at all.
+        $line = (mise env -s pwsh | Select-String -Pattern 'Env:PATH' | Select-Object -First 1).Line
+        $line | Should -Not -BeNullOrEmpty
+        $line | Should -Match ';'
+    }
+}

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -148,9 +148,25 @@ impl Shell for Fish {
 
     fn set_env(&self, key: &str, v: &str) -> String {
         let k = escape(key.into());
-        // Fish uses space-separated list for PATH, not colon-separated string
-        if key == "PATH" {
-            let paths = v.split(':').map(|p| escape(p.into())).join(" ");
+        // Fish keeps PATH as a list, so the value is split on the host's separator -- `;` on
+        // Windows, `:` on unix -- the way `prepend_env` below already does it. Splitting on `:`
+        // unconditionally severed every Windows drive letter from its path, and matching on the
+        // literal name missed `Path`, which is how Windows itself spells it.
+        //
+        // Empty entries are dropped, as they are in `prepend_env` and in `env::split_colon_list`:
+        // an empty element of a fish list is the current directory, and a Windows PATH ending in
+        // `;` -- the usual shape -- yields one from `split_paths`.
+        if env::is_path_key(key) {
+            let paths = env::split_paths(v)
+                .filter_map(|p| {
+                    let p = p.to_string_lossy().into_owned();
+                    if p.is_empty() {
+                        None
+                    } else {
+                        Some(escape(p.into()))
+                    }
+                })
+                .join(" ");
             format!("set -gx PATH {paths}\n")
         } else {
             let v = escape(v.into());
@@ -261,6 +277,40 @@ mod tests {
         assert_snapshot!(Fish::default().set_env("FOO", "1"));
     }
 
+    /// The regression guard for the Windows fix. On unix `env::split_paths` splits on `:` and
+    /// `env::is_path_key` is `key == "PATH"`, so both are the identity on what this did before --
+    /// the only unix output that moves is a value with an empty segment, pinned below. Written
+    /// out rather than snapshotted so the expected string is next to the claim.
+    #[test]
+    fn a_colon_list_still_becomes_one_fish_element_per_directory() {
+        assert_eq!(
+            Fish::default().set_env("PATH", "/some/dir:/2/dir"),
+            "set -gx PATH /some/dir /2/dir\n"
+        );
+    }
+
+    /// `Path` is PATH on Windows and a variable of its own on unix -- which is the distinction
+    /// `env::is_path_key` exists to make. Without this, folding every spelling everywhere would
+    /// look like a fix.
+    #[test]
+    fn another_spelling_of_path_is_not_path_here() {
+        assert_eq!(
+            Fish::default().set_env("Path", "/a:/b"),
+            "set -gx Path '/a:/b'\n"
+        );
+    }
+
+    /// The one place unix output does move. An empty element of a fish list is the current
+    /// directory, so `PATH=/a::/b` used to put the cwd on PATH; `prepend_env` below and
+    /// `env::split_colon_list` already drop these.
+    #[test]
+    fn an_empty_segment_does_not_become_the_current_directory() {
+        assert_eq!(
+            Fish::default().set_env("PATH", "/a::/b"),
+            "set -gx PATH /a /b\n"
+        );
+    }
+
     #[test]
     fn test_prepend_env() {
         let sh = Fish::default();
@@ -284,5 +334,53 @@ mod tests {
     fn test_deactivate() {
         let deactivate = Fish::default().deactivate();
         assert_snapshot!(replace_path(&deactivate));
+    }
+}
+
+/// A sibling of the module above rather than tests inside it: that one is `not(windows)` whole,
+/// and Windows is the platform these are about.
+#[cfg(all(test, windows))]
+mod windows_tests {
+    use test_log::test;
+
+    use super::*;
+
+    /// The reproduction. `mise env -s fish` on Windows printed
+    /// `set -gx PATH C '\a\bin;C' '\b\bin'` -- every drive letter severed from its path, because
+    /// the split was on `:` while a Windows PATH is separated by `;`.
+    #[test]
+    fn a_windows_path_becomes_one_fish_element_per_directory() {
+        assert_eq!(
+            Fish::default().set_env("PATH", r"C:\a\bin;C:\b\bin"),
+            concat!(r"set -gx PATH 'C:\a\bin' 'C:\b\bin'", "\n")
+        );
+    }
+
+    /// The other half, and the reason for `env::is_path_key` rather than `key == "PATH"`:
+    /// `Path` is how Windows itself writes it, and it names the same variable. Matching on the
+    /// literal name left it in the scalar branch as `set -gx Path 'C:\a\bin;C:\b\bin'`.
+    #[test]
+    fn the_windows_spelling_of_path_takes_the_list_branch_too() {
+        assert_eq!(
+            Fish::default().set_env("Path", r"C:\a\bin;C:\b\bin"),
+            concat!(r"set -gx PATH 'C:\a\bin' 'C:\b\bin'", "\n")
+        );
+    }
+
+    /// A Windows PATH usually ends in `;`, and `split_paths` yields an empty entry for it --
+    /// measured, not assumed. An empty element of a fish list is the current directory.
+    #[test]
+    fn a_trailing_separator_does_not_add_the_current_directory() {
+        assert_eq!(
+            Fish::default().set_env("PATH", r"C:\a\bin;"),
+            concat!(r"set -gx PATH 'C:\a\bin'", "\n")
+        );
+    }
+
+    /// The control. Only PATH is a list; any other variable holding a `;` has to survive whole,
+    /// or this would read as "mise now splits everything on the path separator".
+    #[test]
+    fn a_semicolon_in_any_other_variable_is_left_alone() {
+        assert_eq!(Fish::default().set_env("FOO", "a;b"), "set -gx FOO 'a;b'\n");
     }
 }


### PR DESCRIPTION
## What happens

Measured on **mise 2026.8.14 windows-x64**. The only config is `_.path = ["C:/aaa/bin", "C:/bbb/bin"]`.

```
$ mise env -s fish
set -gx PATH C '/aaa/bin;C' '/bbb/bin;C' '\Users\Jam\bin;C' '\Program Files\Git\mingw64\bin;C' ...
```

Every drive letter is severed from its path, and the rest of each path is glued to the next one. `mise hook-env -s fish` — what actually runs after `mise activate fish`, via `build_env_commands` — prints the same thing.

The other six shells are fine on the same config:

| shell | `mise env -s <shell>` |
|---|---|
| bash / zsh | `export PATH='C:/aaa/bin;C:/bbb/bin;C:\Users\...'` ✅ |
| pwsh | `${Env:PATH}='C:/aaa/bin;C:/bbb/bin;...'` ✅ |
| nu / xonsh / elvish | `;`-separated value intact ✅ |
| **fish** | as above ❌ |

## Why

`Shell::set_env` for fish:

```rust
// Fish uses space-separated list for PATH, not colon-separated string
if key == "PATH" {
    let paths = v.split(':').map(|p| escape(p.into())).join(" ");
```

Two things are wrong on Windows, where the separator is `;` and PATH is spelled however the environment spells it:

1. `v.split(':')` — the measurement above.
2. `key == "PATH"` — `env::PATH_KEY` is the spelling the process actually has, and on Windows that is often `Path`. Then the branch is skipped and PATH comes out as a scalar, which is not what fish keeps it as.

`prepend_env` and `move_prepend_env`, eight lines below in the same file, already do this correctly with `env::PATH_KEY` and `env::split_paths`. Only `set_env` was left behind.

## The change

`set_env` now uses `env::is_path_key` and `env::split_paths`, the two helpers that already exist for exactly this. **On unix both are the identity on what the code did before** — `split_paths` splits on `:`, and `is_path_key` reduces to `key == "PATH"` — so unix output does not move, with one deliberate exception below.

Empty entries are now dropped. That is a behaviour change on unix for a value like `/a::/b`. It is intentional and pinned by a test:

- an empty element of a fish list is the current directory, so this was putting the cwd on PATH;
- `prepend_env` right below already drops them, as does `env::split_colon_list`;
- a Windows PATH usually ends in `;`, and `std::env::split_paths` yields an empty entry for it. I measured that rather than assuming it:

```
"C:\\a\\bin;C:\\b\\bin"  -> ["C:\\a\\bin", "C:\\b\\bin"]  (n=2)
"C:\\a\\bin;"            -> ["C:\\a\\bin", ""]            (n=2)
"C:\\a\\bin;;C:\\b\\bin" -> ["C:\\a\\bin", "", "C:\\b\\bin"] (n=3)
```

`prepend_env` and `move_prepend_env` are untouched — they were already right.

## Tests

There were none for this branch: `test_set_env` covered `set_env("FOO", "1")` and nothing else, and fish's whole `mod tests` is `#[cfg(all(test, not(windows)))]`, so a Windows test could not go in it. Hence a sibling `mod windows_tests`.

- **windows** — a `;` list becomes one fish element per directory; the `Path` spelling takes the same branch; a trailing `;` does not add an empty element; and, as the control, a `;` in any other variable survives whole.
- **unix** — the colon list still produces the same output as before, `Path` is still *not* PATH there, and the empty-segment case is pinned.
- **`e2e-win/env_fish_path.Tests.ps1`** — the unit tests are on a pure function, so this runs the path the measurement above came from. It needs no fish installed. Controls: pwsh still joins PATH into one `;`-separated value, and a non-PATH variable holding a `;` is left alone.

## Limits

- **The `Path` spelling is not measured.** `PATH_KEY` resolved to `PATH` on the machine I tested, so I only saw the separator half break. The unit test pins the `is_path_key` branch; it is not a reproduction.
- fish does not run natively on Windows. This affects MSYS2/Cygwin fish being handed a `;`-separated Windows PATH by a native `mise.exe`, and anyone reading `mise env -s fish`. The internal inconsistency — one of three functions in the file using a different separator — stands on its own regardless.
- bash and zsh hardcode `":"` in their `prepend_env` too, which is visible in `mise activate --shims` on Windows. Different function, different controls; not in this PR. elvish had the same problem and is fixed separately in #12584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `mise env` PATH handling for Fish on Windows, including correctly recognizing `Path` and semicolon-separated values.
  * Prevented empty PATH segments from unintentionally adding the current directory.
  * Preserved non-PATH variables containing semicolons.
  * Maintained expected colon-separated PATH behavior on Unix systems.

* **Tests**
  * Added coverage for Fish and PowerShell PATH output across Windows and Unix scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
