### PR TITLE
fix(lockfile): break version ties when a legacy lockfile answers latest

### DIFF
--- a/e2e/lockfile/test_lockfile_version
+++ b/e2e/lockfile/test_lockfile_version
@@ -186,6 +186,28 @@ EOF
 
 assert "cd unbound-versioned && mise ls dummy --json --current | jq -r '.[0].version'" "2.0.0"
 
+echo "=== legacy latest picks the newer of two versions that compare equal ==="
+# `versions` compares an alphanumeric chunk by its leading digits and stops, so
+# 3.7b and 3.7c both reduce to 7 and tie. Entries are written in lexicographic
+# order of the version string, and the sort is stable, so without a tie-break
+# the older entry always won. Listed here in the order mise itself writes.
+mkdir legacy-tie
+cat >legacy-tie/mise.toml <<'EOF'
+[tools]
+dummy = "latest"
+EOF
+cat >legacy-tie/mise.lock <<'EOF'
+[[tools.dummy]]
+version = "3.7b"
+backend = "asdf:dummy"
+
+[[tools.dummy]]
+version = "3.7c"
+backend = "asdf:dummy"
+EOF
+
+assert "cd legacy-tie && mise ls dummy --json --current | jq -r '.[0].version'" "3.7c"
+
 echo "=== failed upgrades preserve legacy monorepo lockfiles ==="
 mkdir -p failed-monorepo-upgrade/packages/b
 cat >failed-monorepo-upgrade/mise.toml <<'EOF'

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -3550,9 +3550,7 @@ pub(crate) fn get_locked_version(
         // Only sort when prefix is "latest" and we have multiple matches
         // This is expensive, so avoid it for specific version prefixes
         if prefix == "latest" && matching.len() > 1 {
-            matching.sort_by(|a, b| {
-                versions::Versioning::new(&b.version).cmp(&versions::Versioning::new(&a.version))
-            });
+            matching.sort_by(|a, b| cmp_lockfile_versions_newest_first(&a.version, &b.version));
         }
 
         if let Some(found) = matching.first() {
@@ -3566,10 +3564,7 @@ pub(crate) fn get_locked_version(
                 .filter(|v| version_matches(v) && v.options.is_empty())
                 .collect();
             if prefix == "latest" && legacy.len() > 1 {
-                legacy.sort_by(|a, b| {
-                    versions::Versioning::new(&b.version)
-                        .cmp(&versions::Versioning::new(&a.version))
-                });
+                legacy.sort_by(|a, b| cmp_lockfile_versions_newest_first(&a.version, &b.version));
             }
             if let Some(found) = legacy.first() {
                 trace!(
@@ -3585,6 +3580,36 @@ pub(crate) fn get_locked_version(
     }
 
     Ok(None)
+}
+
+/// Newest-first ordering for the lockfile entries that all satisfy one
+/// `latest` request.
+///
+/// The version string is a tie-break, not decoration. `versions` compares an
+/// alphanumeric chunk by its leading digits and stops there, so `3.7b` and
+/// `3.7c` both reduce to `7` and come back `Equal` (fosskers/rs-versions#39).
+/// Entries are written in lexicographic order of the version string
+/// (`merge_tool_entries`) and `sort_by` is stable, so with nothing to break the
+/// tie that file order survives and the *older* entry always wins.
+/// `install_state` breaks the same tie the same way.
+///
+/// Two identical strings still compare `Equal`, which leaves the stable sort to
+/// keep duplicate entries in the order they were read.
+///
+/// Deliberately not `Backend::version_order`, which is what the versioned
+/// branch delegates to. That enum has two variants and neither answers this
+/// better:
+///
+/// - `Source` means "the order the source listed them". The source here is
+///   `merge_tool_entries`, which writes entries sorted by the version *string*,
+///   so taking the end of that list answers `1.9.0` for a pair of `1.9.0` and
+///   `1.10.0`.
+/// - `Semver` parks everything `semver::Version` cannot parse ahead of
+///   everything it can, in that same lexicographic order, so it answers `1.9b`
+///   for a pair of `1.9b` and `1.10b`. Where it does order, `Versioning` agrees
+///   with it: `Versioning::new` reaches for `SemVer` first.
+fn cmp_lockfile_versions_newest_first(a: &str, b: &str) -> std::cmp::Ordering {
+    (versions::Versioning::new(b), b).cmp(&(versions::Versioning::new(a), a))
 }
 
 fn select_unbound_lockfile_tool<'a>(
@@ -4557,6 +4582,73 @@ options = { exe = "rg" }
         // an empty prefix must not match everything
         assert!(!lockfile_version_matches_prefix_boundary("", "1.0.0"));
         assert!(!lockfile_version_matches_prefix_boundary("2", "1.0.0"));
+    }
+
+    #[test]
+    fn test_cmp_lockfile_versions_newest_first() {
+        use std::cmp::Ordering;
+
+        // The tie `versions` cannot break on its own: both chunks reduce to `7`.
+        // Without the version-string tie-break these compare Equal and the
+        // caller's stable sort keeps whichever the file listed first.
+        assert_eq!(
+            cmp_lockfile_versions_newest_first("3.7b", "3.7c"),
+            Ordering::Greater
+        );
+        assert_eq!(
+            cmp_lockfile_versions_newest_first("3.7c", "3.7b"),
+            Ordering::Less
+        );
+
+        // The tie-break must stay a tie-break: where the versions really do
+        // order, the string must not get a say. Lexicographically "1.10.0" is
+        // the smaller of these two.
+        assert_eq!(
+            cmp_lockfile_versions_newest_first("1.9.0", "1.10.0"),
+            Ordering::Greater
+        );
+        assert_eq!(
+            cmp_lockfile_versions_newest_first("1.10.0", "1.9.0"),
+            Ordering::Less
+        );
+
+        // Non-semver, and the pair that separates this from every ordering
+        // that falls back to file order: `semver::Version` parses neither, and
+        // lexicographically "1.10b" comes first, so reading off the end of the
+        // stored order answers "1.9b".
+        assert_eq!(
+            cmp_lockfile_versions_newest_first("1.9b", "1.10b"),
+            Ordering::Greater
+        );
+        assert_eq!(
+            cmp_lockfile_versions_newest_first("1.10b", "1.9b"),
+            Ordering::Less
+        );
+
+        // A prerelease is older than its release. `Versioning::new` tries
+        // `SemVer` before anything else, so this follows semver precedence
+        // rather than the "package release revision" reading of `-rc1`.
+        assert_eq!(
+            cmp_lockfile_versions_newest_first("1.0.0-rc1", "1.0.0"),
+            Ordering::Greater
+        );
+
+        // Identical strings still tie, so a stable sort leaves duplicate
+        // entries in the order they were read.
+        assert_eq!(
+            cmp_lockfile_versions_newest_first("1.0.0", "1.0.0"),
+            Ordering::Equal
+        );
+    }
+
+    #[test]
+    fn test_latest_selection_picks_the_newer_of_a_tied_pair() {
+        // The order `merge_tool_entries` writes: lexicographic by version
+        // string. `get_locked_version` sorts this newest-first and takes the
+        // head, so the head has to be `3.7c`.
+        let mut entries = ["3.7b", "3.7c"];
+        entries.sort_by(|a, b| cmp_lockfile_versions_newest_first(a, b));
+        assert_eq!(entries.first(), Some(&"3.7c"));
     }
 
     #[test]


### PR DESCRIPTION
## The defect

A legacy lockfile — one with no `lockfile_version` key, so `uses_request_bindings()` is false — that holds several entries for the same tool answers a `latest` request by sorting them and taking the head:

```rust
if prefix == "latest" && matching.len() > 1 {
    matching.sort_by(|a, b| {
        versions::Versioning::new(&b.version).cmp(&versions::Versioning::new(&a.version))
    });
}
if let Some(found) = matching.first() {
```

That comparator returns `Equal` for two versions that are not the same version. `Chunk::cmp_lenient` reduces an alphanumeric chunk to its leading digits and stops there, so `Alphanum("7b")` and `Alphanum("7c")` both become `7` and compare equal — `Version::new("3.7b") == Version::new("3.7c")`. Upstream is [fosskers/rs-versions#39](https://github.com/fosskers/rs-versions/issues/39), open with no comments since 2026-08-27, so mise has to settle it locally.

**The outcome is not arbitrary — it is always the older entry.** Two things combine:

- entries are written sorted by `a.version.cmp(&b.version)`, i.e. **lexicographic order of the version string** (`merge_tool_entries` and `preserve_absent_tool_entries`), so `3.7b` is on disk before `3.7c`;
- `sort_by` is stable, so a tie leaves that order untouched and `.first()` returns `3.7b`.

Real shape: `tmux` ships `3.7b` / `3.7c`. Any tool with a letter-suffixed release series hits it.

## The fix

Add the version string as a secondary key. This is the tie-break every sibling site already carries — `install_state.rs` (`list_installed_versions` and the two normalizing sort keys) and `runtime_symlinks.rs` both sort by `(Versioning::new(v), v.to_string())`. `lockfile.rs` was the only place comparing bare `Versioning` values.

The comparator is lifted into a named function so it can be unit-tested; the two call sites are otherwise unchanged, including the `prefix == "latest"` condition, the `len() > 1` guard, and `.first()`.

**Where the versions really do order, the string gets no say.** `1.9.0` vs `1.10.0` still resolves to `1.10.0`, even though `1.10.0` is the lexicographically smaller string — there is a unit test pinning exactly that, since it is the way this change could plausibly regress. Two identical strings still compare `Equal`, so duplicate entries keep the order they were read in.

## Scope

Only the legacy path. A versioned lockfile with an ambiguous match `bail!`s instead of choosing, and `select_unbound_lockfile_tool` is untouched — that one delegates to `backend.version_order()`.

## Tests

- `test_cmp_lockfile_versions_newest_first` — the tie in both directions, the no-regression case in both directions, and the identical-string case.
- `test_latest_selection_picks_the_newer_of_a_tied_pair` — sorts `["3.7b", "3.7c"]` in the on-disk order and asserts the head. Fails before this change.
- `e2e/lockfile/test_lockfile_version` — a new block next to the existing legacy-lockfile cases, with a hand-written v0 lockfile holding both entries. Uses `mise ls --current` rather than an install, because the `dummy` plugin's `list-all` has no letter-suffixed versions and that fixture is load-bearing for other tests.

## Two things found next door, deliberately not changed

Raising them here rather than acting on them, since both are your call:

1. **`AGENTS.md` says lockfile versions must not be ordered at all** — *"Lockfile version strings must be treated as opaque — compare with `==`, never with a version ordering."* This PR keeps the ordering and only makes it decide correctly. Removing the ordering entirely would need an answer for what `latest` should pick among several legacy pins, which is a different change.

2. **`select_unbound_lockfile_tool` picks from opposite ends depending on whether it has a backend.** With `None` it returns `matching.first()`; with `Some` it returns `version_order().order_by(..).last()`. And the default `VersionOrder::Source` returns its input unchanged (`src/backend/options.rs`), so on that path `.last()` means "the lexicographically largest version string" — which picks `1.9.0` over `1.10.0`. I did not touch it because it is reached from the versioned-lockfile path and fixing it properly is a separate question about what source order means for a lockfile.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.236.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed selection of the latest version when lockfile entries have equivalent version comparisons.
  * Ensured the newer matching entry is selected consistently, regardless of entry read order.

* **Tests**
  * Added coverage for tied version entries and legacy lockfiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->