### PR TITLE
fix(elvish): write elvish's quoting rules, not bash's

### DIFF
--- a/src/shell/elvish.rs
+++ b/src/shell/elvish.rs
@@ -1,9 +1,9 @@
 #![allow(unknown_lints)]
+use std::borrow::Cow;
 use std::fmt::Display;
 
 use crate::shell::{self, ActivateOptions, Shell};
 use indoc::formatdoc;
-use shell_escape::unix::escape;
 
 #[derive(Default)]
 pub(super) struct Elvish {}
@@ -74,24 +74,36 @@ impl Shell for Elvish {
     }
 
     fn set_env(&self, k: &str, v: &str) -> String {
-        let k = shell_escape::unix::escape(k.into());
-        let v = shell_escape::unix::escape(v.into());
-        let v = v.replace("\\n", "\n");
+        let k = escape(k.into());
+        // No `\n` rewriting. This used to replace the two characters `\` and `n` with a newline,
+        // which no other shell here does, and which cost `C:\nodejs` its `n`: the value reached
+        // elvish as `C:` + newline + `odejs`, since a newline inside `'...'` is just a newline.
+        // A value that holds a real newline still carries one through, unchanged -- so the only
+        // thing this drops is the rewriting of values that never had one.
+        let v = escape(v.into());
         format!("set-env {k} {v}\n")
     }
 
     fn prepend_env(&self, k: &str, v: &str) -> String {
-        let k = shell_escape::unix::escape(k.into());
-        let v = shell_escape::unix::escape(v.into());
-        // The list separator is required: without it the new entry is glued
-        // onto the first existing one, so prepending /new/dir to
-        // /usr/bin:/bin produced /new/dir/usr/bin:/bin. bash and zsh hardcode
-        // ":" here for the same reason.
-        format!("set-env {k} {v}':'(get-env {k})\n")
+        let k = escape(k.into());
+        // The list separator is required: without it the new entry is glued onto the first
+        // existing one, so prepending /new/dir to /usr/bin:/bin produced /new/dir/usr/bin:/bin.
+        //
+        // It goes inside the quoted value rather than beside it, because two quoted words may
+        // not be written adjacent: elvish reads `''` as one literal quote, so `{v}':'` was a
+        // single string ending in `':` whenever `v` itself came out quoted. On Windows that is
+        // every time -- a drive letter and backslashes both trip `needs_quoting`.
+        //
+        // The separator is the host's, since the shell reading this script runs on the platform
+        // mise was built for. bash and zsh hardcode ":" here too, but under Git Bash their own
+        // $PATH is unix-form and colon-separated, so that is a different question.
+        let sep = if cfg!(windows) { ';' } else { ':' };
+        let v = escape(format!("{v}{sep}").into());
+        format!("set-env {k} {v}(get-env {k})\n")
     }
 
     fn unset_env(&self, k: &str) -> String {
-        format!("unset-env {k}\n", k = shell_escape::unix::escape(k.into()))
+        format!("unset-env {k}\n", k = escape(k.into()))
     }
 }
 
@@ -99,6 +111,33 @@ impl Display for Elvish {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "elvish")
     }
+}
+
+/// Quote `input` for elvish, leaving it bare when it needs no quoting.
+///
+/// Inside `'...'` elvish escapes nothing: "All enclosed characters represent themselves, except
+/// the single quote. Two consecutive single quotes are handled as a special case: they represent
+/// one single quote." `shell_escape::unix::escape` was writing bash's rules instead — `'` as
+/// `'\''` and `!` as `'\!'` — and a backslash is an ordinary bareword character in elvish, not an
+/// escape. So neither produced a parse error; both simply arrived with a backslash stuck to them,
+/// and `a'b` reached the environment as `a\'b`. Same reasoning as `escape_sq` in the pwsh shell
+/// and `xonsh_escape_sq` in the xonsh one, both of which already spell their own shell's rules.
+///
+/// The signature is `shell_escape`'s so the call sites are unchanged.
+fn escape(input: Cow<'_, str>) -> Cow<'_, str> {
+    if !input.is_empty() && !input.contains(needs_quoting) {
+        return input;
+    }
+    Cow::Owned(format!("'{}'", input.replace('\'', "''")))
+}
+
+/// Whether `ch` forces its string to be quoted.
+///
+/// Deliberately the set `shell_escape` used, not elvish's own bareword set, which is wider
+/// (`!%+,-./:@\_` and more). Quoting something elvish would have accepted bare is harmless, and
+/// keeping the decision fixed means this change is only about how a quoted value is written.
+fn needs_quoting(ch: char) -> bool {
+    !matches!(ch, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '=' | '/' | ',' | '.' | '+')
 }
 
 #[cfg(test)]
@@ -129,10 +168,114 @@ mod tests {
         assert_snapshot!(Elvish::default().set_env("FOO", "1"));
     }
 
+    /// The separator differs by host, so this one is unix-only; the Windows form is asserted
+    /// below. The snapshot moved because the value here needs quoting: it used to end
+    /// `'/some/dir:/2/dir'':'`, which elvish reads as the single string `/some/dir:/2/dir':`.
+    #[cfg(not(windows))]
     #[test]
     fn test_prepend_env() {
         let sh = Elvish::default();
         assert_snapshot!(replace_path(&sh.prepend_env("PATH", "/some/dir:/2/dir")));
+    }
+
+    /// The control for the change on unix: a path the escaper leaves bare is what production
+    /// actually passes, and there the emitted text moved from `/some/dir':'(get-env PATH)` to
+    /// this while the value elvish builds -- `/some/dir:` then PATH -- did not.
+    #[cfg(not(windows))]
+    #[test]
+    fn a_bare_path_still_prepends_the_same_value() {
+        assert_eq!(
+            Elvish::default().prepend_env("PATH", "/some/dir"),
+            "set-env PATH '/some/dir:'(get-env PATH)\n"
+        );
+    }
+
+    /// The rule this is all about, stated directly. Elvish reads `''` as one literal quote
+    /// rather than as the end of one string and the start of the next, so two quoted words may
+    /// never be written adjacent. A value with a space is quoted on either host, so this test
+    /// means the same thing on both.
+    #[test]
+    fn two_quotes_are_never_written_together() {
+        // No apostrophe in the value on purpose: `''` is elvish's way of writing one, so a value
+        // that holds an apostrophe is allowed -- and required -- to contain it.
+        let out = Elvish::default().prepend_env("PATH", "/some dir");
+        assert!(!out.contains("''"), "{out:?}");
+        assert!(out.contains("/some dir"), "{out:?}");
+        assert!(out.ends_with("(get-env PATH)\n"), "{out:?}");
+    }
+
+    /// Elvish writes an apostrophe by doubling it. `shell_escape::unix::escape` wrote bash's
+    /// `'\''`, and since a backslash is an ordinary bareword character in elvish rather than an
+    /// escape, that was not a parse error -- it reached the environment as `a\'b`.
+    #[test]
+    fn an_apostrophe_is_doubled_rather_than_backslashed() {
+        assert_eq!(
+            Elvish::default().set_env("FOO", "a'b"),
+            "set-env FOO 'a''b'\n"
+        );
+    }
+
+    /// The other character bash escaping treats specially. Elvish has no history expansion, so
+    /// `!` inside quotes is already literal; it was arriving as `a\!b`.
+    #[test]
+    fn a_bang_carries_no_backslash() {
+        assert_eq!(
+            Elvish::default().set_env("FOO", "a!b"),
+            "set-env FOO 'a!b'\n"
+        );
+    }
+
+    /// The empty value takes the quoting branch on its own, and `''` is an empty string in
+    /// elvish rather than the start of an escaped quote -- the lookahead only pairs them when a
+    /// third character follows.
+    #[test]
+    fn an_empty_value_is_an_empty_quoted_string() {
+        assert_eq!(Elvish::default().set_env("FOO", ""), "set-env FOO ''\n");
+    }
+
+    /// `set_env` used to replace the two characters `\` and `n` with a newline, which no other
+    /// shell in this directory does. Measured on 2026.8.14: `mise env -s elvish` printed
+    /// `set-env NODEDIR 'C:` / `odejs'` across two lines for a value of `C:\nodejs`, and a newline
+    /// inside `'...'` is just a newline, so that is what the variable ended up holding.
+    #[test]
+    fn a_literal_backslash_n_stays_two_characters() {
+        assert_eq!(
+            Elvish::default().set_env("NODEDIR", r"C:\nodejs"),
+            concat!(r"set-env NODEDIR 'C:\nodejs'", "\n")
+        );
+    }
+
+    /// The control, and the reason removing that replacement loses nothing: a value that really
+    /// does hold a newline still carries one through. Before this, the two were indistinguishable
+    /// -- `C:\nodejs` and a genuine newline produced the same text -- which is the defect.
+    #[test]
+    fn a_real_newline_is_still_carried_through() {
+        assert_eq!(
+            Elvish::default().set_env("MULTI", "a\nb"),
+            "set-env MULTI 'a\nb'\n"
+        );
+    }
+
+    /// The control for the quoting decision, which this change deliberately leaves alone: a value
+    /// that needed no quotes still gets none.
+    #[test]
+    fn a_plain_value_is_still_left_bare() {
+        assert_eq!(
+            Elvish::default().set_env("FOO", "a=b/c.d"),
+            "set-env FOO a=b/c.d\n"
+        );
+    }
+
+    /// The reproduction. A Windows path is always quoted -- the drive letter's `:` and the
+    /// backslashes are both outside the escaper's whitelist -- so it always hit the doubled
+    /// quote, and it was joined to the rest of PATH by `:` rather than `;`.
+    #[cfg(windows)]
+    #[test]
+    fn a_windows_path_is_quoted_once_and_joined_with_a_semicolon() {
+        assert_eq!(
+            Elvish::default().prepend_env("PATH", r"C:\a\shims"),
+            concat!(r"set-env PATH 'C:\a\shims;'(get-env PATH)", "\n")
+        );
     }
 
     #[test]

--- a/src/shell/snapshots/mise__shell__elvish__tests__prepend_env.snap
+++ b/src/shell/snapshots/mise__shell__elvish__tests__prepend_env.snap
@@ -3,4 +3,4 @@ source: src/shell/elvish.rs
 expression: "replace_path(&sh.prepend_env(\"PATH\", \"/some/dir:/2/dir\"))"
 snapshot_kind: text
 ---
-set-env PATH '/some/dir:/2/dir'':'(get-env PATH)
+set-env PATH '/some/dir:/2/dir:'(get-env PATH)


### PR DESCRIPTION
Four defects in one place, all from `src/shell/elvish.rs` reaching for `shell_escape::unix::escape` and for bash's idea of how quoted words compose. Three are about how a value is written; one is about the PATH separator.

## 1 and 2 — `mise activate --shims elvish` on Windows

Measured on **mise 2026.8.14 windows-x64**:

```
$ mise activate --shims elvish
set-env PATH 'C:\...\shims'':'(get-env PATH)
```

That is not the shims directory followed by a separator. [Elvish's language reference](https://elv.sh/ref/language.html) says of single-quoted strings:

> "Two consecutive single quotes are handled as a special case: they represent one single quote, instead of terminating a single-quoted string and starting another."

So `'C:\...\shims'':'` is **one** string — `C:\...\shims':` — which then compounds with `(get-env PATH)`. PATH ends up starting with a directory that has a stray quote on it, joined to everything else by `:` where a Windows PATH is separated by `;`.

The other shells are fine on the same command:

| shell | `mise activate --shims <shell>` |
|---|---|
| pwsh | `${Env:PATH}='C:\...\shims'+[IO.Path]::PathSeparator+${env:PATH}` ✅ |
| fish | `fish_add_path --global --move --path 'C:\...\shims'` ✅ |
| nu / xonsh | `prepend` / `.add(front=True)` — list APIs ✅ |
| **elvish** | as above ❌ |

The separator was written as a word of its own next to `{v}`, which is fine while `v` comes out **bare** — and on unix it usually does, so `/home/…/shims':'(get-env PATH)` works. A Windows path never comes out bare: the drive letter's `:` and the backslashes both force quoting, so the two quotes always meet. On unix the same thing happens for any path that needs quoting — one containing a space, for instance.

The existing snapshot was pinning that: its input needs quoting, so the recorded output evaluates to `/some/dir:/2/dir':` + PATH rather than the intended value.

**Fixed** by moving the separator inside the quoted value, and by choosing it from the host. The emitted form is now always a single `'…'` followed by `(get-env K)`, so two quotes can no longer meet — by construction rather than by luck.

## 3 — apostrophes and `!` arrive with a backslash

Inside `'...'` elvish escapes nothing:

> "All enclosed characters represent themselves, except the single quote."

`shell_escape::unix::escape` writes bash's rules instead. Measured, same mise build, from a config declaring `QUOTE = "a'b"` and `BANG = "a!b"`:

```
$ mise env -s elvish
set-env QUOTE 'a'\''b'
set-env BANG  'a'\!'b'
--- controls: shells that already spell their own rules
$ mise env -s pwsh
${Env:QUOTE}='a''b'          # PowerShell doubling      ✅
$ mise env -s xonsh
XSH.env['QUOTE'] = 'a\'b'    # Python escaping          ✅
```

Neither is a parse error, which is what makes it easy to miss. The reference notes that "since the backslash (`\`) is a valid bareword character in Elvish, it cannot be used to escape metacharacter" — so `'a'\''b'` reads as the string `a`, then a bare `\`, then the string `'b`, compounding to **`a\'b`**. `BANG` likewise becomes `a\!b`. The value silently changes instead of failing.

**Fixed** with a local `escape` that doubles the apostrophe and leaves `!` alone, following `escape_sq` in the pwsh shell and `xonsh_escape_sq` in the xonsh one. It keeps `shell_escape`'s signature, so no call site moves, and it keeps `shell_escape`'s bare-or-quoted decision, so no snapshot moves for that reason — quoting something elvish would have taken bare is harmless, and leaving that decision alone keeps this change about how a quoted value is written.

## 4 — `C:\nodejs` lost its `n`

Found by CodeRabbit on this PR, and it is right. `set_env` ended with

```rust
let v = v.replace("\\n", "\n");
```

— replacing the two characters `\` and `n` with a newline. No other shell in `src/shell/` does that; `xonsh_escape_sq` goes the other way, turning a real newline into `\n` because Python wants it. A newline inside `'...'` is just a newline to elvish, so the value was corrupted. Measured, same mise build, from `NODEDIR = 'C:\nodejs'`:

```
$ mise env -s elvish
set-env NODEDIR 'C:
odejs'
--- controls: the same three values, other shells
$ mise env -s pwsh
${Env:NODEDIR}='C:\nodejs'      ✅
$ mise env -s bash
export NODEDIR='C:\nodejs'      ✅
--- control: only `\n` is hit
set-env OK 'C:\Users\Jam'       (untouched)
set-env TABDIR 'C:\tools'       (untouched — the replacement is `\n` only)
```

**Removed.** Nothing is lost by it: a value that really holds a newline already reached elvish as a literal newline inside the quotes, without going through that replacement, and still does. Before this the two were indistinguishable — `C:\nodejs` and a genuine newline produced the same text — which is exactly the defect.

## What does not change

On unix, for the input shape production actually passes — one bare directory, from `ActivatePrelude::Prepend` in `cli/activate.rs` — the value elvish builds is unchanged. Only the emitted text moves, from `/some/dir':'(get-env PATH)` to `'/some/dir:'(get-env PATH)`. It changes for values that needed quoting, which is the bug.

## Tests

`elvish`'s `mod tests` is plain `#[cfg(test)]`, so it runs on Windows too, and the separator now differs by host.

- `test_prepend_env` is unix-only, and its snapshot moves. The diff is the unix half of defect 1: `'/some/dir:/2/dir'':'` → `'/some/dir:/2/dir:'`.
- A bare path still prepends the same value — the control for "unix behaviour is unchanged where it mattered".
- Two quotes are never written together: asserted directly, on a value that is quoted on either host, so it means the same thing on both.
- Windows: `C:\a\shims` is quoted once and joined with `;`.
- An apostrophe is doubled rather than backslashed; a `!` carries no backslash; the empty value is `''`; and a value needing no quotes is still left bare — the control for the quoting decision this change deliberately leaves alone.
- `C:\nodejs` stays two characters at the `\n`, with a value holding a real newline as the control — the two must now produce different text, since producing the same text is what defect 4 was.

## Limits

- **I did not run elvish.** It is not in mise's registry (`mise registry elvish` → `tool not found in registry`) and `e2e/shell/` has never had an elvish test, so there is nothing to hang an e2e off. Every claim about mise's own output above is measured; every claim about how elvish reads it comes from the reference wording quoted here.
- **bash and zsh hardcode `":"` in their `prepend_env` too**, and `mise activate --shims bash` shows it on Windows. But under Git Bash their own `$PATH` is unix-form and colon-separated, so which separator is right there is entangled with #3961. Left alone deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed environment path handling in Elvish shells.
  * Ensured path entries use the correct separator on Windows and Unix systems.
  * Improved handling of bare and quoted paths to prevent malformed values.
  * Preserved literal exclamation marks and backslashes when setting values.
  * Improved apostrophe escaping and handling of empty environment values.
  * Ensured environment values remain valid across supported platforms and shell formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
