### PR TITLE
chore(release): support BSD tar ownership flags

### DIFF
--- a/scripts/build-tarball.sh
+++ b/scripts/build-tarball.sh
@@ -160,8 +160,13 @@ if [[ $os == "windows" ]]; then
 	zip -r "$basename.zip" mise
 	ls -oh "$basename.zip"
 else
-	XZ_OPT=-9 tar --owner=0 --group=0 -acf "$basename.tar.xz" mise
-	tar --owner=0 --group=0 -cf - mise | gzip -9 >"$basename.tar.gz"
-	ZSTD_NBTHREADS=0 ZSTD_CLEVEL=19 tar --owner=0 --group=0 -acf "$basename.tar.zst" mise
+	tar_owner_args=(--owner=0 --group=0)
+	if tar --version 2>&1 | grep -q '^bsdtar'; then
+		# macOS ships BSD tar, whose ownership flags differ from GNU tar's.
+		tar_owner_args=(--uid 0 --gid 0 --uname root --gname root)
+	fi
+	XZ_OPT=-9 tar "${tar_owner_args[@]}" -acf "$basename.tar.xz" mise
+	tar "${tar_owner_args[@]}" -cf - mise | gzip -9 >"$basename.tar.gz"
+	ZSTD_NBTHREADS=0 ZSTD_CLEVEL=19 tar "${tar_owner_args[@]}" -acf "$basename.tar.zst" mise
 	ls -oh "$basename.tar."*
 fi


### PR DESCRIPTION
## Summary
- detect BSD tar when packaging release archives
- use BSD-compatible ownership flags while preserving root/root archive entries
- keep the existing GNU tar behavior on Linux

Fixes the macOS packaging failure in https://github.com/jdx/mise/actions/runs/33237264236/job/99079364424.

## Testing
- `mise run lint-fix`
- `shellcheck scripts/build-tarball.sh`
- created and inspected an archive with libarchive bsdtar, confirming root/root entries

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only packaging script change with no runtime or auth impact; wrong flags would fail the build rather than ship bad archives silently.
> 
> **Overview**
> Fixes **macOS release packaging** when the system `tar` is BSD/libarchive (`bsdtar`), which rejects GNU-style `--owner=0` / `--group=0`.
> 
> The tarball step now **detects bsdtar** via `tar --version` and switches to **`--uid` / `--gid` / `--uname` / `--gname`** so entries still record as root/root. **Linux GNU tar** keeps the original ownership flags. The same argument list is applied to **`.tar.xz`, `.tar.gz`, and `.tar.zst`** builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8819fe715690bbd9c008411c2b12762fed0e7ac8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive creation compatibility across GNU tar and BSD tar.
  * Ensured `.tar.xz`, `.tar.gz`, and `.tar.zst` packages preserve the intended ownership settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->