### PR TITLE
chore(ci): restore mbx remote cache

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -19,7 +19,7 @@ runs:
       with:
         version: 1.0.0
         cache-generation: v2
-        save-on-workflow-dispatch: ${{ github.actor == 'jdx' && github.triggering_actor == 'jdx' && github.ref == 'refs/heads/main' }}
+        save-on-workflow-dispatch: ${{ github.actor == 'jdx' && github.triggering_actor == 'jdx' }}
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -15,9 +15,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
+    - uses: jdx/mr-boxington-action@cff2f8f0606288b60e7ff0570a06faf5c3ebd3ac
       with:
         version: 1.0.0
+        cache-generation: v2
+        save-on-workflow-dispatch: ${{ github.actor == 'jdx' && github.triggering_actor == 'jdx' && github.ref == 'refs/heads/main' }}
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -17,7 +17,7 @@ runs:
   steps:
     - uses: jdx/mr-boxington-action@9a406893b83a977c45324a34aed553e3c43f414d
       with:
-        version: 1.0.0
+        version: 1.0.1
         cache-generation: v2
         save-on-workflow-dispatch: ${{ github.actor == 'jdx' && github.triggering_actor == 'jdx' }}
         cache-links: ${{ inputs.cache-links }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -17,7 +17,7 @@ runs:
   steps:
     - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
       with:
-        version: 0.7.0
+        version: 1.0.0
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -15,7 +15,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: jdx/mr-boxington-action@cff2f8f0606288b60e7ff0570a06faf5c3ebd3ac
+    - uses: jdx/mr-boxington-action@9a406893b83a977c45324a34aed553e3c43f414d
       with:
         version: 1.0.0
         cache-generation: v2

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -19,7 +19,6 @@ runs:
       with:
         version: 1.0.1
         cache-generation: v2
-        save-on-workflow-dispatch: ${{ github.actor == 'jdx' && github.triggering_actor == 'jdx' }}
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -17,7 +17,7 @@ runs:
   steps:
     - uses: jdx/mr-boxington-action@9a406893b83a977c45324a34aed553e3c43f414d
       with:
-        version: 1.0.1
+        version: 1.1.0
         cache-generation: v2
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,7 +1,10 @@
 name: Set up mbx
-description: Set up mbx with the GitHub Actions cache backend
+description: Select the trusted jdx server or fork-safe GitHub cache backend
 
 inputs:
+  backend:
+    description: Explicit backend for structurally trusted or untrusted callers
+    default: auto
   cache-links:
     description: Cache native links; "auto" enables this on Linux
     default: auto
@@ -15,6 +18,9 @@ runs:
     - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
       with:
         version: 0.7.0
-        backend: github
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
+        backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
+        server-url: https://cache.mise.jdx.dev
+        namespace: jdx/mise
+        oidc-audience: https://cache.mise.jdx.dev

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -39,6 +39,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/mbx
+        with:
+          backend: github
       - name: Build
         id: build
         shell: bash
@@ -113,6 +115,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/mbx
+        with:
+          backend: github
       - name: Build
         id: build
         shell: bash
@@ -189,6 +193,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/mbx
+        with:
+          backend: github
       - name: Build
         id: build
         shell: pwsh

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -32,6 +32,9 @@ jobs:
     name: mbx (Linux)
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    permissions:
+      contents: read
+      id-token: write # Main pushes authenticate to the cache server; its policy keeps other events read-only.
     outputs:
       seconds: ${{ steps.build.outputs.seconds }}
     steps:
@@ -40,7 +43,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
-          backend: github
+          backend: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
       - name: Build
         id: build
         shell: bash
@@ -101,13 +104,16 @@ jobs:
             echo
             echo "mbx delta: **${delta}** (positive means mbx was faster)."
             echo
-            echo "> Treat the first main-branch run as cache seeding. Compare workflow_dispatch runs after it. Build time excludes checkout and cache setup; compare those step durations separately."
+            echo "> The main-branch push seeds both backends. Compare them with the warm cache benchmark dispatched on main. Build time excludes checkout and cache setup; compare those step durations separately."
           } >> "$GITHUB_STEP_SUMMARY"
 
   mbx:
     name: mbx (macOS)
     runs-on: macos-14
     timeout-minutes: 90
+    permissions:
+      contents: read
+      id-token: write # Main pushes authenticate to the cache server; its policy keeps other events read-only.
     outputs:
       seconds: ${{ steps.build.outputs.seconds }}
     steps:
@@ -116,7 +122,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
-          backend: github
+          backend: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
       - name: Build
         id: build
         shell: bash
@@ -177,13 +183,16 @@ jobs:
             echo
             echo "mbx delta: **${delta}** (positive means mbx was faster)."
             echo
-            echo "> Treat the first main-branch run as cache seeding. Compare workflow_dispatch runs after it. Build time excludes checkout and cache setup; compare those step durations separately."
+            echo "> The main-branch push seeds both backends. Compare them with the warm cache benchmark dispatched on main. Build time excludes checkout and cache setup; compare those step durations separately."
           } >> "$GITHUB_STEP_SUMMARY"
 
   mbx_windows:
     name: mbx (Windows)
     runs-on: windows-latest
     timeout-minutes: 90
+    permissions:
+      contents: read
+      id-token: write # Main pushes authenticate to the cache server; its policy keeps other events read-only.
     env:
       MBX_TARGET_VIEWS: 0
     outputs:
@@ -194,7 +203,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
-          backend: github
+          backend: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
       - name: Build
         id: build
         shell: pwsh
@@ -257,5 +266,5 @@ jobs:
             echo
             echo "mbx delta: **${delta}** (positive means mbx was faster)."
             echo
-            echo "> Treat the first main-branch run as cache seeding. Compare workflow_dispatch runs after it. Build time excludes checkout and cache setup; compare those step durations separately."
+            echo "> The main-branch push seeds both backends. Compare them with the warm cache benchmark dispatched on main. Build time excludes checkout and cache setup; compare those step durations separately."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docs-impl.yml
+++ b/.github/workflows/docs-impl.yml
@@ -6,6 +6,9 @@ on:
       trusted:
         required: true
         type: boolean
+      mbx-backend:
+        required: true
+        type: string
     secrets:
       CLOUDFLARE_ACCESS_KEY_ID:
         required: false
@@ -35,6 +38,8 @@ jobs:
         with:
           fetch-depth: 0 # for lastUpdated
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4
         with:
           install_args: bun

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,6 +33,7 @@ jobs:
     uses: ./.github/workflows/docs-impl.yml
     with:
       trusted: true
+      mbx-backend: server
     secrets:
       CLOUDFLARE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
       CLOUDFLARE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
@@ -45,6 +46,7 @@ jobs:
     uses: ./.github/workflows/docs-impl.yml
     with:
       trusted: false
+      mbx-backend: github
 
   docs:
     name: docs

--- a/.github/workflows/github-runner-cache.yml
+++ b/.github/workflows/github-runner-cache.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/mbx
+        with:
+          backend: github
       - name: Warm the Unix cache
         if: runner.os != 'Windows'
         run: mbx build --all-features --ignore-rust-version

--- a/.github/workflows/registry-impl.yml
+++ b/.github/workflows/registry-impl.yml
@@ -5,6 +5,9 @@ on:
       trusted:
         required: true
         type: boolean
+      mbx-backend:
+        required: true
+        type: string
     secrets:
       MISE_GH_TOKEN:
         required: false
@@ -77,6 +80,8 @@ jobs:
             ~/.cargo/git
             ~/.cargo/.global-cache
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
       - run: mbx build --all-features --ignore-rust-version
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -18,6 +18,7 @@ jobs:
     uses: ./.github/workflows/registry-impl.yml
     with:
       trusted: true
+      mbx-backend: server
     secrets:
       MISE_GH_TOKEN: ${{ secrets.MISE_GH_TOKEN }}
       MISE_VERSIONS_API_SECRET: ${{ secrets.MISE_VERSIONS_API_SECRET }}
@@ -29,6 +30,7 @@ jobs:
     uses: ./.github/workflows/registry-impl.yml
     with:
       trusted: false
+      mbx-backend: github
 
   registry-ci:
     name: registry-ci

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -396,7 +396,7 @@ jobs:
 
   windows-unit:
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     needs: [classify-changes]
     if: needs.classify-changes.outputs.full-ci == 'true'
     env:

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -5,6 +5,9 @@ on:
       trusted:
         required: true
         type: boolean
+      mbx-backend:
+        required: true
+        type: string
     secrets:
       FORGEJO_TOKEN:
         required: false
@@ -81,6 +84,8 @@ jobs:
             ~/.cargo/git
             ~/.cargo/.global-cache
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
       - run: |
           mbx build --all-features --ignore-rust-version
           echo "$PWD/target/debug" >> "$GITHUB_PATH"
@@ -112,6 +117,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
       - shell: pwsh
         run: |
           mbx build --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update
@@ -147,6 +154,8 @@ jobs:
             ~/.cargo/git
             ~/.cargo/.global-cache
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
       - name: Install test tools
         run: brew install fd tmux
       - run: |
@@ -175,6 +184,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
       - parallel:
           - name: Install mold
             run: sudo apt-get update && sudo apt-get install -y mold
@@ -397,6 +408,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
       - name: check unused code
         run: mbx check -p mise --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update --all-targets
         env:

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -396,7 +396,7 @@ jobs:
 
   windows-unit:
     runs-on: windows-latest
-    timeout-minutes: 45
+    timeout-minutes: 30
     needs: [classify-changes]
     if: needs.classify-changes.outputs.full-ci == 'true'
     env:

--- a/.github/workflows/test-vfox-impl.yml
+++ b/.github/workflows/test-vfox-impl.yml
@@ -6,6 +6,9 @@ on:
       trusted:
         required: true
         type: boolean
+      mbx-backend:
+        required: true
+        type: string
     secrets:
       MISE_GH_TOKEN:
         required: false
@@ -40,6 +43,8 @@ jobs:
             ~/.cargo/git
             ~/.cargo/.global-cache
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
       - run: |
           mbx build --all-features --ignore-rust-version
           echo "$PWD/target/debug" >> "$GITHUB_PATH"

--- a/.github/workflows/test-vfox.yml
+++ b/.github/workflows/test-vfox.yml
@@ -20,6 +20,7 @@ jobs:
     uses: ./.github/workflows/test-vfox-impl.yml
     with:
       trusted: true
+      mbx-backend: server
     secrets:
       MISE_GH_TOKEN: ${{ secrets.MISE_GH_TOKEN }}
 
@@ -30,6 +31,7 @@ jobs:
     uses: ./.github/workflows/test-vfox-impl.yml
     with:
       trusted: false
+      mbx-backend: github
 
   test-vfox:
     name: test-vfox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
     uses: ./.github/workflows/test-impl.yml
     with:
       trusted: true
+      mbx-backend: server
     secrets:
       FORGEJO_TOKEN: ${{ secrets.FORGEJO_TOKEN }}
       MISE_GH_TOKEN: ${{ secrets.MISE_GH_TOKEN }}
@@ -39,6 +40,7 @@ jobs:
     uses: ./.github/workflows/test-impl.yml
     with:
       trusted: false
+      mbx-backend: github
 
   test-ci:
     name: test-ci

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -1,0 +1,116 @@
+name: warm cache benchmark
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: warm-cache-benchmark-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_PROFILE_DEV_DEBUG: 0
+  CARGO_TERM_COLOR: always
+
+jobs:
+  mbx:
+    name: mbx (${{ matrix.label }})
+    if: github.actor == 'jdx' && github.triggering_actor == 'jdx' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      id-token: write # Authenticate the main-branch dispatch to the cache server.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: Linux
+            target-views: "1"
+          - os: macos-14
+            label: macOS
+            target-views: "1"
+          - os: windows-latest
+            label: Windows
+            target-views: "0"
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    env:
+      MBX_TARGET_VIEWS: ${{ matrix.target-views }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/mbx
+        with:
+          backend: server
+      - name: Build
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          mbx build --all-features --ignore-rust-version
+          ended=$(python3 -c 'import time; print(time.monotonic_ns())')
+          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
+          echo "## mbx ${{ matrix.label }}: ${elapsed}s" >> "$GITHUB_STEP_SUMMARY"
+          mbx cache stats
+      - name: Build
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $timer = [System.Diagnostics.Stopwatch]::StartNew()
+          mbx build --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update --ignore-rust-version
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $timer.Stop()
+          $elapsed = $timer.Elapsed.TotalSeconds.ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          "## mbx ${{ matrix.label }}: ${elapsed}s" >> $env:GITHUB_STEP_SUMMARY
+          mbx cache stats
+
+  rust_cache:
+    name: Swatinem rust-cache (${{ matrix.label }})
+    if: github.actor == 'jdx' && github.triggering_actor == 'jdx' && github.ref == 'refs/heads/main'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: Linux
+            shared-key: cache-benchmark-linux-v2
+          - os: macos-14
+            label: macOS
+            shared-key: cache-benchmark-macos-v2
+          - os: windows-latest
+            label: Windows
+            shared-key: cache-benchmark-windows-v2
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Restore Cargo cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          shared-key: ${{ matrix.shared-key }}
+          save-if: false
+      - name: Build
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          cargo build --all-features --ignore-rust-version
+          ended=$(python3 -c 'import time; print(time.monotonic_ns())')
+          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
+          echo "## Swatinem/rust-cache ${{ matrix.label }}: ${elapsed}s" >> "$GITHUB_STEP_SUMMARY"
+      - name: Build
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $timer = [System.Diagnostics.Stopwatch]::StartNew()
+          cargo build --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update --ignore-rust-version
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $timer.Stop()
+          $elapsed = $timer.Elapsed.TotalSeconds.ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          "## Swatinem/rust-cache ${{ matrix.label }}: ${elapsed}s" >> $env:GITHUB_STEP_SUMMARY

--- a/registry/llama.cpp.toml
+++ b/registry/llama.cpp.toml
@@ -30,4 +30,5 @@ bins = [
 full = "github:ggml-org/llama.cpp"
 
 [backends.options]
+prerelease = true
 version_prefix = "b"


### PR DESCRIPTION
## Summary
- restore trusted mise CI to the mbx server backend
- keep fork PRs on the GitHub Actions backend
- keep cache benchmark jobs pinned to the GitHub backend for a fair rust-cache comparison
- restore the GitHub-cache mirror and dispatched warm-cache benchmark

## Validation
- `actionlint -shellcheck=` on every changed workflow
- restored files match the tree immediately before the server-cache removal

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable build-cache backend selection, supporting automatic detection or explicit trusted-server and GitHub-backed modes.
  - Trusted and untrusted build, test, documentation, and registry workflows now use the appropriate cache backend.
  - Added a manually triggered cross-platform workflow to benchmark build performance across cache backends.

- **Improvements**
  - Benchmark builds now report elapsed times in workflow summaries across Linux, macOS, and Windows.
  - Updated the cache action to improve backend configuration and workflow integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Trusted jobs authenticate via OIDC to an external cache host; misconfigured trust rules could expose cache writes, though fork/untrusted paths are explicitly forced to GitHub.
> 
> **Overview**
> Restores **mbx** remote caching for trusted maintainer CI while keeping fork and untrusted runs on the **GitHub Actions** cache backend.
> 
> The composite **`.github/actions/mbx`** action upgrades **mr-boxington** to **1.1.0** with **cache-generation v2**, adds an optional **`backend`** input (default **`auto`**), and wires **`server-url`**, **`namespace`**, and **OIDC** for **`https://cache.mise.jdx.dev`**. Reusable workflows (**test**, **docs**, **registry**, **test-vfox**) take a required **`mbx-backend`** input; caller workflows pass **`server`** for trusted jobs (with **`id-token: write`**) and **`github`** for untrusted paths.
> 
> **Cache benchmark** jobs gain OIDC where needed, use the server backend on **main** pushes to seed cache, and stay on GitHub elsewhere for apples-to-apples **rust-cache** comparison. A new **`warm-cache-benchmark`** **workflow_dispatch** runs warm **mbx** vs **Swatinem/rust-cache** builds on **main** only.
> 
> **`github-runner-cache`** pins **`backend: github`**. **`registry/llama.cpp.toml`** sets **`prerelease = true`** for version resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13893889fb661143980610912250ec5e0873bfd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->