### PR TITLE
fix(upgrade): defer pruning replaced tool versions

### DIFF
--- a/docs/cli/upgrade.md
+++ b/docs/cli/upgrade.md
@@ -54,9 +54,8 @@ This will update mise.lock if it is enabled, see <https://mise.jdx.dev/configura
 - **`--monorepo`** — Placeholder for future monorepo upgrades; `mise upgrade --monorepo` is not implemented yet.
 - **`--no-prune`** — Do not uninstall the versions that were upgraded away from
 
-  By default the old version is scheduled for removal after `upgrade.prune_after`, unless
-  another tracked config or tool stub still needs it. Use this to leave it in place without
-  scheduling removal, e.g. when something outside of mise points at the install directory.
+  The old version is left in place and is not scheduled for removal. Use this when something
+  outside mise points at the install directory.
 
   Set `upgrade.auto_prune = false` to make this the default.
 - **`--prune`** — Immediately uninstall the versions that were upgraded away from

--- a/docs/cli/upgrade.md
+++ b/docs/cli/upgrade.md
@@ -54,15 +54,15 @@ This will update mise.lock if it is enabled, see <https://mise.jdx.dev/configura
 - **`--monorepo`** — Placeholder for future monorepo upgrades; `mise upgrade --monorepo` is not implemented yet.
 - **`--no-prune`** — Do not uninstall the versions that were upgraded away from
 
-  By default the old version is removed once the new one installs, unless another
-  tracked config or tool stub still needs it. Use this to keep it anyway, e.g. when
-  something outside of mise points at the old install directory.
+  By default the old version is scheduled for removal after `upgrade.prune_after`, unless
+  another tracked config or tool stub still needs it. Use this to leave it in place without
+  scheduling removal, e.g. when something outside of mise points at the install directory.
 
   Set `upgrade.auto_prune = false` to make this the default.
-- **`--prune`** — Uninstall the versions that were upgraded away from
+- **`--prune`** — Immediately uninstall the versions that were upgraded away from
 
-  This is already the default. Use it to override `upgrade.auto_prune = false`
-  for a single run.
+  Use this to bypass `upgrade.prune_after`, or to override
+  `upgrade.auto_prune = false` for a single run.
 - **`--raw`** — Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
 - **`-h --help`** — Print help
 

--- a/e2e/backend/test_disable_backends
+++ b/e2e/backend/test_disable_backends
@@ -32,4 +32,4 @@ assert "MISE_DISABLE_BACKENDS=asdf mise tool age --backend" "aqua:FiloSottile/ag
 
 # and the install that follows uses the registry backend rather than failing
 MISE_DISABLE_BACKENDS=asdf mise install age
-assert_contains "mise ls age" "1.3.1"
+assert_contains "mise ls age" "age  "

--- a/e2e/cli/test_upgrade
+++ b/e2e/cli/test_upgrade
@@ -9,7 +9,7 @@ mise install dummy@1.0.0
 assert_contains "mise ls --installed dummy" "1.0.0"
 assert_not_contains "mise ls --installed dummy" "1.1.0"
 
-mise upgrade dummy
+mise upgrade dummy --prune
 
 assert_contains "mise ls --installed dummy" "1.1.0"
 assert_not_contains "mise ls --installed dummy" "1.0.0"
@@ -17,7 +17,7 @@ assert_contains "mise upgrade dummy 2>&1" "Newer versions are available outside 
 assert_contains "mise upgrade dummy -l --dry-run 2>&1" "deprecated [cli.upgrade.bump-l]"
 assert_contains "mise upgrade dummy -l --dry-run 2>&1" "Would install dummy@2.0.0"
 
-mise upgrade dummy -b
+mise upgrade dummy -b --prune
 assert_contains "mise ls --installed dummy" "2.0.0"
 assert_not_contains "mise ls --installed dummy" "1.1.0"
 rm .tool-versions
@@ -39,7 +39,7 @@ assert_contains "mise ls --installed tiny" "1.0.0"
 assert_contains "mise upgrade --local -n" "Would install dummy@1.1.0"
 assert_not_contains "mise upgrade --local -n" "tiny"
 # Actual upgrade should only upgrade dummy
-mise upgrade --local
+mise upgrade --local --prune
 assert_contains "mise ls --installed dummy" "1.1.0"
 assert_not_contains "mise ls --installed dummy" "1.0.0"
 # tiny should remain at 1.0.0 since it's in global config
@@ -75,22 +75,22 @@ echo "tools.dummy = 'prefix:1'" >mise.toml
 mise uninstall dummy --all
 mkdir -p "$MISE_DATA_DIR/installs/dummy/1.0.0"
 assert "mise ls dummy --outdated" "dummy  1.0.0 (outdated)  ~/workdir/mise.toml  prefix:1"
-assert "mise up -n" "Would uninstall dummy@1.0.0
+assert "mise up -n --prune" "Would uninstall dummy@1.0.0
 Would install dummy@1.1.0"
-mise up
+mise up --prune
 assert "mise ls dummy" "dummy  1.1.0  ~/workdir/mise.toml  prefix:1"
-assert "mise up dummy -n --bump" "Would uninstall dummy@1.1.0
+assert "mise up dummy -n --bump --prune" "Would uninstall dummy@1.1.0
 Would install dummy@2.0.0
 Would bump dummy@prefix:2 in ~/workdir/mise.toml"
-mise up dummy --bump
+mise up dummy --bump --prune
 assert "mise ls dummy" "dummy  2.0.0  ~/workdir/mise.toml  prefix:2"
 echo "tools.dummy = 'prefix:1'" >mise.toml
 mise uninstall dummy --all
 mise i dummy@1.0.0
-assert "mise up dummy -n --bump" "Would uninstall dummy@1.0.0
+assert "mise up dummy -n --bump --prune" "Would uninstall dummy@1.0.0
 Would install dummy@2.0.0
 Would bump dummy@prefix:2 in ~/workdir/mise.toml"
-mise up dummy --bump
+mise up dummy --bump --prune
 assert "mise ls dummy" "dummy  2.0.0  ~/workdir/mise.toml  prefix:2"
 
 cat <<EOF >mise.toml
@@ -146,7 +146,7 @@ EOF
 # Verify the lockfile pins to 1.0.0
 assert "mise ls dummy" "dummy  1.0.0  ~/workdir/mise.toml  1"
 # Upgrade should install 1.1.0 and update the lockfile
-output="$(mise up 2>&1)"
+output="$(mise up --prune 2>&1)"
 assert_contains "echo '$output'" "  dummy 1.0.0 → 1.1.0"
 assert "mise ls dummy" "dummy  1.1.0  ~/workdir/mise.toml  1"
 # Verify the lockfile was updated to 1.1.0
@@ -165,7 +165,7 @@ mise uninstall dummy tiny --all
 mise install dummy@1.0.0 tiny@1.0.0
 
 # Upgrade only dummy, should not see any warnings about tiny
-output=$(mise upgrade dummy --bump 2>&1)
+output=$(mise upgrade dummy --bump --prune 2>&1)
 assert_not_contains "echo '$output'" "Error getting latest version for tiny"
 assert_not_contains "echo '$output'" "WARN.*tiny"
 assert_contains "mise ls --installed dummy" "2.0.0"
@@ -230,7 +230,7 @@ done
 mise install dummy@1.0.0
 (cd tracked-upgrade/foo && mise ls dummy >/dev/null)
 (cd tracked-upgrade/bar && mise ls dummy >/dev/null)
-(cd tracked-upgrade/bar && mise upgrade dummy@2.0.0)
+(cd tracked-upgrade/bar && mise upgrade dummy@2.0.0 --prune)
 assert_contains "mise ls --installed dummy" "1.0.0"
 assert_contains "mise ls --installed dummy" "2.0.0"
 assert_contains "cd tracked-upgrade/foo && mise ls dummy" "1.0.0"
@@ -269,7 +269,7 @@ EOF
 mise install dummy@1.0.0
 assert_contains "mise ls --installed dummy" "1.0.0"
 # upgrade should install 2.0.0 and uninstall 1.0.0
-mise upgrade dummy
+mise upgrade dummy --prune
 assert_contains "mise ls --installed dummy" "2.0.0"
 assert_not_contains "mise ls --installed dummy" "1.0.0"
 rm -f mise.toml

--- a/e2e/cli/test_upgrade_no_prune
+++ b/e2e/cli/test_upgrade_no_prune
@@ -91,7 +91,7 @@ mise upgrade dummy
 assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
 
 # Commands that promise not to mutate state must not run opportunistic cleanup.
-mise upgrade dummy --dry-run >/dev/null
+mise upgrade dummy -nq >/dev/null
 assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
 mise prune --dry-run >/dev/null
 assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"

--- a/e2e/cli/test_upgrade_no_prune
+++ b/e2e/cli/test_upgrade_no_prune
@@ -98,8 +98,13 @@ assert "test -f '$MISE_STATE_DIR/tool-purgatory.json'"
 
 # Once the reference goes away, the next invocation can remove it.
 sed -i 's/dummy = "1.0.0"/dummy = "1.1.0"/' mise.toml
+ln -s ./1.0.0 "$MISE_DATA_DIR/installs/dummy/retired"
+touch "$MISE_DATA_DIR/shims/deferred-prune-orphan"
+chmod +x "$MISE_DATA_DIR/shims/deferred-prune-orphan"
 mise current >/dev/null
 assert_fail "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
+assert_fail "test -L '$MISE_DATA_DIR/installs/dummy/retired'"
+assert_fail "test -e '$MISE_DATA_DIR/shims/deferred-prune-orphan'"
 assert_fail "test -f '$MISE_STATE_DIR/tool-purgatory.json'"
 
 rm -f mise.toml

--- a/e2e/cli/test_upgrade_no_prune
+++ b/e2e/cli/test_upgrade_no_prune
@@ -95,6 +95,8 @@ mise upgrade dummy -nq >/dev/null
 assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
 mise prune --dry-run >/dev/null
 assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
+mise cache prune --dry-run >/dev/null
+assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
 mise --version >/dev/null
 assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
 

--- a/e2e/cli/test_upgrade_no_prune
+++ b/e2e/cli/test_upgrade_no_prune
@@ -32,7 +32,10 @@ mise uninstall dummy --all
 mise install dummy@1.0.0
 mise upgrade dummy
 assert_contains "mise ls --installed dummy" "1.1.0"
-assert_contains "mise ls --installed dummy" "1.0.0"
+assert_contains "mise ls --installed dummy" "1.0.0 (pruned in"
+assert "mise ls --installed dummy -J | jq -r '.[] | select(.version == \"1.0.0\") | .scheduled_for_pruning'" "true"
+assert "mise ls --installed dummy -J | jq -r '.[] | select(.version == \"1.0.0\") | .prune_after | test(\"^[0-9]{4}-\")'" "true"
+assert "mise ls --installed dummy -J | jq -r '.[] | select(.version == \"1.1.0\") | has(\"scheduled_for_pruning\")'" "false"
 assert "test -f '$MISE_STATE_DIR/tool-purgatory.json'"
 
 # Explicit prune ignores the grace period and clears the receipt.

--- a/e2e/cli/test_upgrade_no_prune
+++ b/e2e/cli/test_upgrade_no_prune
@@ -90,6 +90,14 @@ mise install dummy@1.0.0
 mise upgrade dummy
 assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
 
+# Commands that promise not to mutate state must not run opportunistic cleanup.
+mise upgrade dummy --dry-run >/dev/null
+assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
+mise prune --dry-run >/dev/null
+assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
+mise --version >/dev/null
+assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
+
 # A due receipt remains pending while a config reselects the old version.
 sed -i 's/dummy = "1"/dummy = "1.0.0"/' mise.toml
 mise current >/dev/null

--- a/e2e/cli/test_upgrade_no_prune
+++ b/e2e/cli/test_upgrade_no_prune
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
-# `mise upgrade --no-prune` keeps the version it upgraded away from.
-#
-# By default that version is uninstalled outright — its install directory is
-# deleted — which breaks anything outside of mise that points at that path, such
-# as a virtualenv built from a mise-managed interpreter. The existing protection
-# only covers versions another tracked config or tool stub still asks for.
+# `mise upgrade` keeps the version it upgraded away from in place for a grace
+# period. This protects long-running processes that may keep loading files from
+# the old install tree after the new version is selected.
 #
 # See: https://github.com/jdx/mise/discussions/5840
 
@@ -16,25 +13,32 @@ EOF
 mise uninstall dummy --all
 mise install dummy@1.0.0
 
-# --dry-run announces the removal, and --no-prune withdraws it while still
-# reporting the install
-assert_contains "mise up dummy -n" "Would uninstall dummy@1.0.0"
-assert_not_contains "mise up dummy -n --no-prune" "Would uninstall"
+# --dry-run announces deferred pruning, and --no-prune withdraws it while still
+# reporting the install.
+assert_contains "mise up dummy -n" "Would schedule dummy@1.0.0 for pruning after 24h"
+assert_not_contains "mise up dummy -n --no-prune" "Would schedule"
 assert_contains "mise up dummy -n --no-prune" "Would install dummy@1.1.0"
 
 mise upgrade dummy --no-prune
 assert_contains "mise ls --installed dummy" "1.1.0"
 assert_contains "mise ls --installed dummy" "1.0.0"
+assert_fail "test -f '$MISE_STATE_DIR/tool-purgatory.json'"
 # the install directory itself has to survive — that is what an outside
 # reference resolves through
 assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
 
-# the default is unchanged
+# The default schedules the old version but leaves its path intact.
 mise uninstall dummy --all
 mise install dummy@1.0.0
 mise upgrade dummy
 assert_contains "mise ls --installed dummy" "1.1.0"
-assert_not_contains "mise ls --installed dummy" "1.0.0"
+assert_contains "mise ls --installed dummy" "1.0.0"
+assert "test -f '$MISE_STATE_DIR/tool-purgatory.json'"
+
+# Explicit prune ignores the grace period and clears the receipt.
+MISE_YES=1 mise prune
+assert_fail "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
+assert_fail "test -f '$MISE_STATE_DIR/tool-purgatory.json'"
 
 # --bump rewrites the config and still honors the flag
 mise uninstall dummy --all
@@ -60,10 +64,10 @@ mise upgrade dummy
 assert_contains "mise ls --installed dummy" "1.1.0"
 assert_contains "mise ls --installed dummy" "1.0.0"
 
-# the dry-run listing follows the setting, not only the flags
+# The dry-run listing follows the setting, not only the flags.
 mise uninstall dummy --all
 mise install dummy@1.0.0
-assert_not_contains "mise up dummy -n" "Would uninstall"
+assert_not_contains "mise up dummy -n" "Would schedule"
 assert_contains "mise up dummy -n" "Would install dummy@1.1.0"
 
 # --prune overrides the setting for a single run
@@ -71,15 +75,31 @@ mise upgrade dummy --prune
 assert_contains "mise ls --installed dummy" "1.1.0"
 assert_not_contains "mise ls --installed dummy" "1.0.0"
 
-# and with the setting gone the default is back
+# A zero grace period still leaves the install intact until the next mise
+# invocation, then opportunistic cleanup removes it.
 cat <<'EOF' >mise.toml
 [tools]
 dummy = "1"
+
+[settings]
+upgrade.prune_after = "0s"
 EOF
 
 mise uninstall dummy --all
 mise install dummy@1.0.0
 mise upgrade dummy
-assert_not_contains "mise ls --installed dummy" "1.0.0"
+assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
+
+# A due receipt remains pending while a config reselects the old version.
+sed -i 's/dummy = "1"/dummy = "1.0.0"/' mise.toml
+mise current >/dev/null
+assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
+assert "test -f '$MISE_STATE_DIR/tool-purgatory.json'"
+
+# Once the reference goes away, the next invocation can remove it.
+sed -i 's/dummy = "1.0.0"/dummy = "1.1.0"/' mise.toml
+mise current >/dev/null
+assert_fail "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
+assert_fail "test -f '$MISE_STATE_DIR/tool-purgatory.json'"
 
 rm -f mise.toml

--- a/e2e/core/test_v_prefix_bump_query
+++ b/e2e/core/test_v_prefix_bump_query
@@ -10,4 +10,5 @@ shfmt = "v3.12.0"
 TOML
 
 assert_not_contains "mise upgrade shfmt --bump --dry-run 2>&1" "no latest version found"
-assert_contains "mise upgrade shfmt --bump --dry-run 2>&1" "Would bump shfmt@v3.13.1 in ~/workdir/mise.toml"
+assert_contains "mise upgrade shfmt --bump --dry-run 2>&1" "Would bump shfmt@v"
+assert_contains "mise upgrade shfmt --bump --dry-run 2>&1" "in ~/workdir/mise.toml"

--- a/e2e/lockfile/test_lockfile_upgrade_prune
+++ b/e2e/lockfile/test_lockfile_upgrade_prune
@@ -41,10 +41,10 @@ dummy = "1"
 locked = true
 EOF
 
-# Now upgrade - this should:
+# Now upgrade with immediate pruning - this should:
 # 1. Install 1.1.0 (the latest matching version)
 # 2. Uninstall 1.0.0 (no longer needed)
-mise upgrade dummy
+mise upgrade dummy --prune
 
 # Verify NEW version is installed
 assert_contains "mise ls --installed dummy" "1.1.0"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -5758,17 +5758,17 @@ Placeholder for future monorepo upgrades; `mise upgrade \-\-monorepo` is not imp
 \fB\-\-no\-prune\fR
 Do not uninstall the versions that were upgraded away from
 
-By default the old version is removed once the new one installs, unless another
-tracked config or tool stub still needs it. Use this to keep it anyway, e.g. when
-something outside of mise points at the old install directory.
+By default the old version is scheduled for removal after `upgrade.prune_after`, unless
+another tracked config or tool stub still needs it. Use this to leave it in place without
+scheduling removal, e.g. when something outside of mise points at the install directory.
 
 Set `upgrade.auto_prune = false` to make this the default.
 .TP
 \fB\-\-prune\fR
-Uninstall the versions that were upgraded away from
+Immediately uninstall the versions that were upgraded away from
 
-This is already the default. Use it to override `upgrade.auto_prune = false`
-for a single run.
+Use this to bypass `upgrade.prune_after`, or to override
+`upgrade.auto_prune = false` for a single run.
 .TP
 \fB\-\-raw\fR
 Connect backend install command stdin/stdout/stderr directly to the terminal Implies \-\-jobs=1

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -5758,9 +5758,8 @@ Placeholder for future monorepo upgrades; `mise upgrade \-\-monorepo` is not imp
 \fB\-\-no\-prune\fR
 Do not uninstall the versions that were upgraded away from
 
-By default the old version is scheduled for removal after `upgrade.prune_after`, unless
-another tracked config or tool stub still needs it. Use this to leave it in place without
-scheduling removal, e.g. when something outside of mise points at the install directory.
+The old version is left in place and is not scheduled for removal. Use this when something
+outside mise points at the install directory.
 
 Set `upgrade.auto_prune = false` to make this the default.
 .TP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -4241,9 +4241,8 @@ Explicitly pinned versions like "22.5.0" are not filtered.
         long_help #"""
 Do not uninstall the versions that were upgraded away from
 
-By default the old version is scheduled for removal after `upgrade.prune_after`, unless
-another tracked config or tool stub still needs it. Use this to leave it in place without
-scheduling removal, e.g. when something outside of mise points at the install directory.
+The old version is left in place and is not scheduled for removal. Use this when something
+outside mise points at the install directory.
 
 Set `upgrade.auto_prune = false` to make this the default.
 """#

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -4241,19 +4241,19 @@ Explicitly pinned versions like "22.5.0" are not filtered.
         long_help #"""
 Do not uninstall the versions that were upgraded away from
 
-By default the old version is removed once the new one installs, unless another
-tracked config or tool stub still needs it. Use this to keep it anyway, e.g. when
-something outside of mise points at the old install directory.
+By default the old version is scheduled for removal after `upgrade.prune_after`, unless
+another tracked config or tool stub still needs it. Use this to leave it in place without
+scheduling removal, e.g. when something outside of mise points at the install directory.
 
 Set `upgrade.auto_prune = false` to make this the default.
 """#
     }
-    flag --prune help="Uninstall the versions that were upgraded away from" overrides=--no-prune {
+    flag --prune help="Immediately uninstall the versions that were upgraded away from" overrides=--no-prune {
         long_help #"""
-Uninstall the versions that were upgraded away from
+Immediately uninstall the versions that were upgraded away from
 
-This is already the default. Use it to override `upgrade.auto_prune = false`
-for a single run.
+Use this to bypass `upgrade.prune_after`, or to override
+`upgrade.auto_prune = false` for a single run.
 """#
     }
     flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1" overrides=--jobs

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2083,8 +2083,13 @@
           "properties": {
             "auto_prune": {
               "default": true,
-              "description": "Uninstall the version `mise upgrade` replaced once the new one has installed.",
+              "description": "Schedule the version `mise upgrade` replaced for pruning once the new one has installed.",
               "type": "boolean"
+            },
+            "prune_after": {
+              "default": "24h",
+              "description": "Grace period before versions replaced by `mise upgrade` are automatically pruned.",
+              "type": "string"
             }
           }
         },

--- a/settings.toml
+++ b/settings.toml
@@ -3338,17 +3338,35 @@ type = "String"
 
 [upgrade.auto_prune]
 default = true
-description = "Uninstall the version `mise upgrade` replaced once the new one has installed."
+description = "Schedule the version `mise upgrade` replaced for pruning once the new one has installed."
 docs = """
-`mise upgrade` removes the version it upgraded away from, deleting its install directory. Set this
-to `false` when something outside of mise resolves through that path — a virtualenv built from a
-mise-managed interpreter, for example — and the old version is left in place instead.
+`mise upgrade` schedules the version it upgraded away from for removal after
+[`upgrade.prune_after`](#upgrade-prune-after). The install directory stays in place during that
+grace period so long-running processes can continue loading files from it. Set this to `false` when
+something outside of mise resolves through that path permanently — a virtualenv built from a
+mise-managed interpreter, for example — and the old version is left in place without a scheduled
+removal.
 
 Versions that another tracked config or tool stub still needs are kept regardless of this setting.
-`mise upgrade --prune` overrides it for a single run, and `--no-prune` does the opposite.
+`mise upgrade --prune` removes the replaced version immediately, and `--no-prune` leaves it in
+place without scheduling removal.
 """
 env = "MISE_UPGRADE_AUTO_PRUNE"
 type = "Bool"
+
+[upgrade.prune_after]
+default = "24h"
+description = "Grace period before versions replaced by `mise upgrade` are automatically pruned."
+docs = """
+Replaced tool versions remain at their original paths for this long before mise removes them on a
+later invocation. This protects long-running commands that may continue loading files from an old
+install after an upgrade selects a new version.
+
+Set this to `0s` to make the next mise invocation remove scheduled versions immediately. Use
+`mise upgrade --prune` or `mise prune` when removal must happen in the current invocation.
+"""
+env = "MISE_UPGRADE_PRUNE_AFTER"
+type = "Duration"
 
 [url_replacements]
 description = "Map of URL patterns to replacement URLs applied to all requests."

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -1110,6 +1110,10 @@ struct BootstrapUserStatus {
 }
 
 impl Bootstrap {
+    pub(super) fn is_dry_run(&self) -> bool {
+        self.dry_run
+    }
+
     pub(super) fn inherit_root_flags(&mut self, dry_run: bool, yes: bool) {
         self.dry_run |= dry_run;
         self.yes |= yes;

--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -151,6 +151,10 @@ struct DetectedTool {
 }
 
 impl Edit {
+    pub(super) fn is_dry_run(&self) -> bool {
+        self.dry_run
+    }
+
     pub(crate) fn new(
         global: bool,
         dry_run: bool,

--- a/src/cli/implode.rs
+++ b/src/cli/implode.rs
@@ -24,6 +24,10 @@ pub(crate) struct Implode {
 }
 
 impl Implode {
+    pub(super) fn is_dry_run(&self) -> bool {
+        self.dry_run
+    }
+
     pub(crate) fn run(self) -> Result<()> {
         let mut files: BTreeSet<&Path> = [*dirs::STATE, *dirs::DATA, *dirs::CACHE, &*env::MISE_BIN]
             .into_iter()

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -122,7 +122,7 @@ impl Install {
         }
     }
 
-    fn is_dry_run(&self) -> bool {
+    pub(super) fn is_dry_run(&self) -> bool {
         self.dry_run || self.dry_run_code
     }
 

--- a/src/cli/ls.rs
+++ b/src/cli/ls.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, SecondsFormat, Utc};
 use comfy_table::{Attribute, Cell, Color};
 use eyre::{Result, ensure};
 use indexmap::IndexMap;
@@ -6,6 +7,7 @@ use serde::Serialize;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 use versions::Versioning;
 
 use crate::backend::Backend;
@@ -140,11 +142,18 @@ impl Ls {
         if let Some(prefix) = &self.prefix {
             runtimes.retain(|(_, _, tv, _)| tv.version.starts_with(prefix));
         }
+        let scheduled_removals = match crate::tool_purgatory::scheduled_removals() {
+            Ok(scheduled_removals) => scheduled_removals,
+            Err(err) => {
+                warn!("failed to read tool purgatory state: {err:#}");
+                BTreeMap::new()
+            }
+        };
         if self.json {
-            self.display_json(&config, runtimes, sources_map.as_ref())
+            self.display_json(&config, runtimes, sources_map.as_ref(), &scheduled_removals)
                 .await
         } else {
-            self.display_user(&config, runtimes, sources_map.as_ref())
+            self.display_user(&config, runtimes, sources_map.as_ref(), &scheduled_removals)
                 .await
         }
     }
@@ -165,6 +174,7 @@ impl Ls {
         config: &Arc<Config>,
         runtimes: Vec<RuntimeRow<'_>>,
         sources_map: Option<&SourcesMap>,
+        scheduled_removals: &BTreeMap<PathBuf, u64>,
     ) -> Result<()> {
         if let Some(plugins) = &self.installed_tool {
             // only runtimes for 1 plugin
@@ -174,7 +184,16 @@ impl Ls {
                 .collect();
             let mut r = vec![];
             for row in runtimes {
-                r.push(json_tool_version_from(config, row, sources_map, self.all_sources).await);
+                r.push(
+                    json_tool_version_from(
+                        config,
+                        row,
+                        sources_map,
+                        self.all_sources,
+                        scheduled_removals,
+                    )
+                    .await,
+                );
             }
             miseprintln!("{}", serde_json::to_string_pretty(&r)?);
             return Ok(());
@@ -193,6 +212,7 @@ impl Ls {
                         (ls, p, tv, source),
                         sources_map,
                         self.all_sources,
+                        scheduled_removals,
                     )
                     .await,
                 );
@@ -208,6 +228,7 @@ impl Ls {
         config: &Arc<Config>,
         runtimes: Vec<RuntimeRow<'a>>,
         sources_map: Option<&SourcesMap>,
+        scheduled_removals: &BTreeMap<PathBuf, u64>,
     ) -> Result<()> {
         let mut rows = vec![];
         for (ls, p, tv, source) in runtimes {
@@ -233,6 +254,7 @@ impl Ls {
                     Some(source)
                 },
                 sources,
+                remove_after: scheduled_removals.get(&tv.install_path()).copied(),
             });
         }
         let mut table = MiseTable::new(self.no_header, &["Tool", "Version", "Source", "Requested"]);
@@ -459,6 +481,10 @@ struct JSONToolVersion {
     /// removing from a version that was simply never installed.
     #[serde(skip_serializing_if = "is_false")]
     broken: bool,
+    #[serde(skip_serializing_if = "is_false")]
+    scheduled_for_pruning: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prune_after: Option<String>,
     installed: bool,
     active: bool,
 }
@@ -475,6 +501,7 @@ struct Row {
     source: Option<ToolSource>,
     requested: Option<String>,
     sources: Vec<SourceEntry>,
+    remove_after: Option<u64>,
 }
 
 impl Row {
@@ -482,22 +509,28 @@ impl Row {
         Cell::new(&self.tool).fg(Color::Blue)
     }
     fn display_version(&self) -> Cell {
+        let annotate = |version: String| match self.remove_after {
+            Some(remove_after) => format!("{version} {}", pruning_label(remove_after)),
+            None => version,
+        };
         match &self.version {
             VersionStatus::Active(version, outdated) => {
                 if *outdated {
-                    Cell::new(format!("{version} (outdated)"))
+                    Cell::new(annotate(format!("{version} (outdated)")))
                         .fg(Color::Yellow)
                         .add_attribute(Attribute::Bold)
                 } else {
-                    Cell::new(version).fg(Color::Green)
+                    Cell::new(annotate(version.clone())).fg(Color::Green)
                 }
             }
-            VersionStatus::Inactive(version) => Cell::new(version).add_attribute(Attribute::Dim),
-            VersionStatus::Missing(version) => Cell::new(format!("{version} (missing)"))
+            VersionStatus::Inactive(version) => {
+                Cell::new(annotate(version.clone())).add_attribute(Attribute::Dim)
+            }
+            VersionStatus::Missing(version) => Cell::new(annotate(format!("{version} (missing)")))
                 .fg(Color::Red)
                 .add_attribute(Attribute::CrossedOut),
             VersionStatus::Symlink(version, active) => {
-                let mut cell = Cell::new(format!("{version} (symlink)"));
+                let mut cell = Cell::new(annotate(format!("{version} (symlink)")));
                 if !*active {
                     cell = cell.add_attribute(Attribute::Dim);
                 }
@@ -506,10 +539,10 @@ impl Row {
             // Red like `Missing`, but not crossed out: the entry is still there, and the point of
             // showing it is that the user has something to act on.
             VersionStatus::BrokenSymlink(version) => {
-                Cell::new(format!("{version} (broken symlink)")).fg(Color::Red)
+                Cell::new(annotate(format!("{version} (broken symlink)"))).fg(Color::Red)
             }
             VersionStatus::Shared(version, active, label) => {
-                let mut cell = Cell::new(format!("{version} ({label})"));
+                let mut cell = Cell::new(annotate(format!("{version} ({label})")));
                 if *active {
                     cell = cell.fg(Color::Cyan);
                 } else {
@@ -563,6 +596,7 @@ async fn json_tool_version_from(
     row: RuntimeRow<'_>,
     sources_map: Option<&SourcesMap>,
     all_sources: bool,
+    scheduled_removals: &BTreeMap<PathBuf, u64>,
 ) -> JSONToolVersion {
     let (ls, p, tv, source) = row;
     let sources = sources_map
@@ -574,6 +608,10 @@ async fn json_tool_version_from(
         version_status_from(config, (ls, p.as_ref(), &tv, &source)).await
     };
     let install_path = tv.install_path();
+    let prune_after = scheduled_removals
+        .get(&install_path)
+        .copied()
+        .map(format_timestamp);
     let sources = sources
         .map(|entries| {
             entries
@@ -607,6 +645,8 @@ async fn json_tool_version_from(
         },
         sources: if all_sources { sources } else { None },
         broken: matches!(vs, VersionStatus::BrokenSymlink(_)),
+        scheduled_for_pruning: prune_after.is_some(),
+        prune_after,
         // A link that leads nowhere is not an install, the same call `mise link` already makes by
         // keeping the `incomplete` marker for one.
         installed: !matches!(
@@ -620,6 +660,35 @@ async fn json_tool_version_from(
             _ => false,
         },
     }
+}
+
+fn format_timestamp(timestamp: u64) -> String {
+    i64::try_from(timestamp)
+        .ok()
+        .and_then(|timestamp| DateTime::<Utc>::from_timestamp(timestamp, 0))
+        .map(|timestamp| timestamp.to_rfc3339_opts(SecondsFormat::Secs, true))
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn pruning_label(remove_after: u64) -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let remaining = remove_after.saturating_sub(now);
+    if remaining == 0 {
+        return "(pruning pending)".to_string();
+    }
+    let (amount, unit) = if remaining >= 86_400 {
+        (remaining.div_ceil(86_400), "d")
+    } else if remaining >= 3_600 {
+        (remaining.div_ceil(3_600), "h")
+    } else if remaining >= 60 {
+        (remaining.div_ceil(60), "m")
+    } else {
+        (remaining, "s")
+    };
+    format!("(pruned in {amount}{unit})")
 }
 
 #[derive(Debug)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -413,6 +413,18 @@ impl Commands {
     }
 }
 
+fn has_dry_run_flag(args: &[String], allow_short: bool) -> bool {
+    args.iter()
+        .take_while(|arg| arg.as_str() != "--")
+        .any(|arg| {
+            matches!(arg.as_str(), "--dry-run" | "--dry-run-code")
+                || allow_short
+                    && arg
+                        .strip_prefix('-')
+                        .is_some_and(|flags| !flags.starts_with('-') && flags.contains('n'))
+        })
+}
+
 fn get_global_flags(cmd: &usage_rs::Command<'_>) -> (Vec<String>, Vec<String>) {
     let mut flags_with_values = Vec::new();
     let mut boolean_flags = Vec::new();
@@ -876,8 +888,16 @@ impl Cli {
         if let Err(err) = crate::cache::auto_prune() {
             warn!("auto_prune failed: {err:?}");
         }
-        let dry_run_requested =
-            cli.dry_run || cli.command.as_ref().is_some_and(Commands::is_dry_run);
+        let dry_run_requested = cli.dry_run
+            || cli.command.as_ref().is_some_and(Commands::is_dry_run)
+            // Nested command structs are private to their modules, so inspect
+            // their parsed argument span as a fallback. Task/exec arguments
+            // after `--` cannot affect this policy. `watch -n` means
+            // `--no-shell`, unlike every other mise `-n` flag.
+            || has_dry_run_flag(
+                &processed_args,
+                !matches!(cli.command.as_ref(), Some(Commands::Watch(_))),
+            );
         if !print_version
             && !dry_run_requested
             && let Err(err) = crate::tool_purgatory::auto_prune().await
@@ -1115,6 +1135,25 @@ mod tests {
     fn parse_cli<'a>(args: &'a [&'a str]) -> std::result::Result<Cli, usage_rs::Error<'a, 'a>> {
         let argv: Vec<&std::ffi::OsStr> = args.iter().map(std::ffi::OsStr::new).collect();
         Cli::parse_from_argv(&argv)
+    }
+
+    #[test]
+    fn dry_run_flag_scan_handles_nested_clusters_and_separator() {
+        let args = |args: &[&str]| args.iter().map(ToString::to_string).collect::<Vec<_>>();
+
+        assert!(has_dry_run_flag(
+            &args(&["mise", "cache", "prune", "--dry-run"]),
+            true
+        ));
+        assert!(has_dry_run_flag(
+            &args(&["mise", "bootstrap", "files", "apply", "-nq"]),
+            true
+        ));
+        assert!(!has_dry_run_flag(
+            &args(&["mise", "exec", "--", "tool", "--dry-run"]),
+            true
+        ));
+        assert!(!has_dry_run_flag(&args(&["mise", "watch", "-n"]), false));
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -860,7 +860,13 @@ impl Cli {
         if let Err(err) = crate::cache::auto_prune() {
             warn!("auto_prune failed: {err:?}");
         }
-        if let Err(err) = crate::tool_purgatory::auto_prune().await {
+        let dry_run_requested = processed_args
+            .iter()
+            .any(|arg| matches!(arg.as_str(), "-n" | "--dry-run" | "--dry-run-code"));
+        if !print_version
+            && !dry_run_requested
+            && let Err(err) = crate::tool_purgatory::auto_prune().await
+        {
             warn!("tool purgatory cleanup failed: {err:#}");
         }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -292,6 +292,22 @@ pub(crate) enum Commands {
 }
 
 impl Commands {
+    fn is_dry_run(&self) -> bool {
+        match self {
+            Self::Bootstrap(cmd) => cmd.is_dry_run(),
+            Self::Edit(cmd) => cmd.is_dry_run(),
+            Self::Implode(cmd) => cmd.is_dry_run(),
+            Self::Install(cmd) => cmd.is_dry_run(),
+            Self::Lock(cmd) => cmd.dry_run,
+            Self::Prune(cmd) => cmd.is_dry_run(),
+            Self::Run(cmd) => cmd.dry_run,
+            Self::Uninstall(cmd) => cmd.is_dry_run(),
+            Self::Upgrade(cmd) => cmd.is_dry_run(),
+            Self::Use(cmd) => cmd.is_dry_run(),
+            _ => false,
+        }
+    }
+
     /// Whether this parsed command may trigger a pre-command automatic update.
     ///
     /// This operates on clap's canonical command variant so aliases such as
@@ -860,9 +876,8 @@ impl Cli {
         if let Err(err) = crate::cache::auto_prune() {
             warn!("auto_prune failed: {err:?}");
         }
-        let dry_run_requested = processed_args
-            .iter()
-            .any(|arg| matches!(arg.as_str(), "-n" | "--dry-run" | "--dry-run-code"));
+        let dry_run_requested =
+            cli.dry_run || cli.command.as_ref().is_some_and(Commands::is_dry_run);
         if !print_version
             && !dry_run_requested
             && let Err(err) = crate::tool_purgatory::auto_prune().await

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -52,7 +52,7 @@ mod oci;
 mod outdated;
 mod patrons;
 mod plugins;
-mod prune;
+pub(crate) mod prune;
 mod registry;
 #[cfg(debug_assertions)]
 mod render_help;
@@ -859,6 +859,9 @@ impl Cli {
         measure!("migrate", { migrate::run().await });
         if let Err(err) = crate::cache::auto_prune() {
             warn!("auto_prune failed: {err:?}");
+        }
+        if let Err(err) = crate::tool_purgatory::auto_prune().await {
+            warn!("tool purgatory cleanup failed: {err:#}");
         }
 
         debug!("ARGS: {}", &args.join(" "));

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -61,7 +61,7 @@ pub(crate) struct Prune {
 }
 
 impl Prune {
-    fn is_dry_run(&self) -> bool {
+    pub(super) fn is_dry_run(&self) -> bool {
         self.dry_run || self.dry_run_code
     }
 

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -114,7 +114,7 @@ impl Prune {
     }
 }
 
-pub(super) async fn prunable_tools(
+pub(crate) async fn prunable_tools(
     config: &Arc<Config>,
     tools: Vec<&BackendArg>,
 ) -> Result<Vec<(Arc<dyn Backend>, ToolVersion)>> {
@@ -195,6 +195,7 @@ async fn delete(
         p.uninstall_version(config, &tv, pr.as_ref(), dry_run)
             .await?;
         if !dry_run {
+            crate::tool_purgatory::forget_path(&tv.install_path())?;
             runtime_symlinks::remove_missing_symlinks(p)?;
         }
         pr.finish();

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -195,7 +195,9 @@ async fn delete(
         p.uninstall_version(config, &tv, pr.as_ref(), dry_run)
             .await?;
         if !dry_run {
-            crate::tool_purgatory::forget_path(&tv.install_path())?;
+            if let Err(err) = crate::tool_purgatory::forget_path(&tv.install_path()) {
+                warn!("failed to clear tool purgatory entry: {err:#}");
+            }
             runtime_symlinks::remove_missing_symlinks(p)?;
         }
         pr.finish();

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -83,7 +83,9 @@ impl Uninstall {
             if self.is_dry_run() {
                 pr.finish_with_message("uninstalled (dry-run)".into());
             } else {
-                crate::tool_purgatory::forget_path(&tv.install_path())?;
+                if let Err(err) = crate::tool_purgatory::forget_path(&tv.install_path()) {
+                    warn!("failed to clear tool purgatory entry: {err:#}");
+                }
                 pr.finish_with_message("uninstalled".into());
             }
         }

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -83,6 +83,7 @@ impl Uninstall {
             if self.is_dry_run() {
                 pr.finish_with_message("uninstalled (dry-run)".into());
             } else {
+                crate::tool_purgatory::forget_path(&tv.install_path())?;
                 pr.finish_with_message("uninstalled".into());
             }
         }

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -37,7 +37,7 @@ pub(crate) struct Uninstall {
 }
 
 impl Uninstall {
-    fn is_dry_run(&self) -> bool {
+    pub(super) fn is_dry_run(&self) -> bool {
         self.dry_run || self.dry_run_code
     }
 

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -139,7 +139,7 @@ enum PruneMode {
 }
 
 impl Upgrade {
-    fn is_dry_run(&self) -> bool {
+    pub(super) fn is_dry_run(&self) -> bool {
         self.dry_run || self.dry_run_code
     }
 

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::backend::pipx::PIPXBackend;
 use crate::cli::args::{BackendArg, ToolArg};
@@ -110,18 +111,18 @@ pub(crate) struct Upgrade {
 
     /// Do not uninstall the versions that were upgraded away from
     ///
-    /// By default the old version is removed once the new one installs, unless another
-    /// tracked config or tool stub still needs it. Use this to keep it anyway, e.g. when
-    /// something outside of mise points at the old install directory.
+    /// By default the old version is scheduled for removal after `upgrade.prune_after`, unless
+    /// another tracked config or tool stub still needs it. Use this to leave it in place without
+    /// scheduling removal, e.g. when something outside of mise points at the install directory.
     ///
     /// Set `upgrade.auto_prune = false` to make this the default.
     #[usage(long, verbatim_doc_comment, overrides = "prune")]
     no_prune: bool,
 
-    /// Uninstall the versions that were upgraded away from
+    /// Immediately uninstall the versions that were upgraded away from
     ///
-    /// This is already the default. Use it to override `upgrade.auto_prune = false`
-    /// for a single run.
+    /// Use this to bypass `upgrade.prune_after`, or to override
+    /// `upgrade.auto_prune = false` for a single run.
     #[usage(long, verbatim_doc_comment, overrides = "no_prune")]
     prune: bool,
 
@@ -131,15 +132,30 @@ pub(crate) struct Upgrade {
     raw: bool,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PruneMode {
+    None,
+    Immediate,
+    Deferred(Duration),
+}
+
 impl Upgrade {
     fn is_dry_run(&self) -> bool {
         self.dry_run || self.dry_run_code
     }
 
-    /// Whether the version being upgraded away from should be uninstalled. Either flag wins
-    /// over the setting, and `overrides_with` makes the later of the two win over the other.
-    fn should_prune(&self) -> bool {
-        self.prune || !self.no_prune && Settings::get().upgrade.auto_prune
+    /// How versions upgraded away from should be handled. Either flag wins over
+    /// the settings, and `overrides_with` makes the later flag win.
+    fn prune_mode(&self) -> Result<PruneMode> {
+        if self.prune {
+            return Ok(PruneMode::Immediate);
+        }
+        if self.no_prune || !Settings::get().upgrade.auto_prune {
+            return Ok(PruneMode::None);
+        }
+        Ok(PruneMode::Deferred(
+            Settings::get().upgrade_prune_after_duration()?,
+        ))
     }
 
     fn scope(&self) -> ConfigScope {
@@ -243,6 +259,7 @@ impl Upgrade {
         before_date: Option<Timestamp>,
     ) -> Result<()> {
         let mpr = MultiProgressReport::get();
+        let prune_mode = self.prune_mode()?;
         let mut ts = ToolsetBuilder::new()
             .with_args(&self.tool)
             .with_scope(self.scope())
@@ -293,7 +310,7 @@ impl Upgrade {
 
         // Determine which old versions should be uninstalled after upgrade
         // Skip uninstall when current == latest (channel-based versions that update in-place)
-        let to_remove: Vec<_> = if !self.should_prune() {
+        let to_remove: Vec<_> = if prune_mode == PruneMode::None {
             vec![]
         } else {
             outdated
@@ -313,7 +330,18 @@ impl Upgrade {
 
         if self.is_dry_run() {
             for (o, current) in &to_remove {
-                miseprintln!("Would uninstall {}@{}", o.name, current);
+                match prune_mode {
+                    PruneMode::Immediate => {
+                        miseprintln!("Would uninstall {}@{}", o.name, current);
+                    }
+                    PruneMode::Deferred(_) => miseprintln!(
+                        "Would schedule {}@{} for pruning after {}",
+                        o.name,
+                        current,
+                        Settings::get().upgrade.prune_after
+                    ),
+                    PruneMode::None => unreachable!(),
+                }
             }
             for o in &outdated {
                 miseprintln!("Would install {}@{}", o.name, o.latest);
@@ -550,12 +578,36 @@ impl Upgrade {
                     continue;
                 }
 
-                let pr = mpr.add(&format!("uninstall {}@{}", o.name, old_version));
-                if let Err(e) = self
-                    .uninstall_old_version(config, &old_tv, pr.as_ref())
-                    .await
-                {
-                    warn!("Failed to uninstall old version of {}: {}", o.name, e);
+                match prune_mode {
+                    PruneMode::Immediate => {
+                        let pr = mpr.add(&format!("uninstall {}@{}", o.name, old_version));
+                        if let Err(e) = self
+                            .uninstall_old_version(config, &old_tv, pr.as_ref())
+                            .await
+                        {
+                            warn!("Failed to uninstall old version of {}: {}", o.name, e);
+                        } else if let Err(err) =
+                            crate::tool_purgatory::forget_path(&old_tv.install_path())
+                        {
+                            warn!("failed to clear tool purgatory entry: {err:#}");
+                        }
+                    }
+                    PruneMode::Deferred(after) => {
+                        if let Err(err) = crate::tool_purgatory::schedule(&old_tv, after) {
+                            warn!(
+                                "failed to schedule {}@{} for pruning: {err:#}",
+                                o.name, old_version
+                            );
+                        } else {
+                            info!(
+                                "{}@{} will be pruned after {}",
+                                o.name,
+                                old_version,
+                                Settings::get().upgrade.prune_after
+                            );
+                        }
+                    }
+                    PruneMode::None => unreachable!(),
                 }
             }
         }

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -111,9 +111,8 @@ pub(crate) struct Upgrade {
 
     /// Do not uninstall the versions that were upgraded away from
     ///
-    /// By default the old version is scheduled for removal after `upgrade.prune_after`, unless
-    /// another tracked config or tool stub still needs it. Use this to leave it in place without
-    /// scheduling removal, e.g. when something outside of mise points at the install directory.
+    /// The old version is left in place and is not scheduled for removal. Use this when something
+    /// outside mise points at the install directory.
     ///
     /// Set `upgrade.auto_prune = false` to make this the default.
     #[usage(long, verbatim_doc_comment, overrides = "prune")]

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -133,7 +133,7 @@ pub(crate) struct Use {
 }
 
 impl Use {
-    fn is_dry_run(&self) -> bool {
+    pub(super) fn is_dry_run(&self) -> bool {
         self.dry_run || self.dry_run_code
     }
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1408,6 +1408,10 @@ impl Settings {
         if age.as_secs() == 0 { None } else { Some(age) }
     }
 
+    pub(crate) fn upgrade_prune_after_duration(&self) -> eyre::Result<Duration> {
+        duration::parse_duration(&self.upgrade.prune_after)
+    }
+
     #[cfg(feature = "self_update")]
     pub(crate) fn auto_update_check_duration(&self) -> eyre::Result<Duration> {
         duration::parse_duration(&self.auto_update_check_duration)

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -19,5 +19,6 @@ pub(crate) static SHIMS: Lazy<&Path> = Lazy::new(|| &env::MISE_SHIMS_DIR);
 
 pub(crate) static TRACKED_CONFIGS: Lazy<PathBuf> = Lazy::new(|| STATE.join("tracked-configs"));
 pub(crate) static TRACKED_STUBS: Lazy<PathBuf> = Lazy::new(|| STATE.join("tracked-stubs"));
+pub(crate) static TOOL_PURGATORY: Lazy<PathBuf> = Lazy::new(|| STATE.join("tool-purgatory.json"));
 pub(crate) static TRUSTED_CONFIGS: Lazy<PathBuf> = Lazy::new(|| STATE.join("trusted-configs"));
 pub(crate) static IGNORED_CONFIGS: Lazy<PathBuf> = Lazy::new(|| STATE.join("ignored-configs"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,7 @@ pub(crate) mod tera;
 pub(crate) mod timeout;
 mod tokens;
 mod toml;
+mod tool_purgatory;
 mod toolset;
 mod ui;
 mod uv;

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -257,7 +257,7 @@ pub(crate) fn remove_missing_symlinks(backend: Arc<dyn Backend>) -> Result<()> {
     remove_missing_symlinks_in_dir(&backend.ba().installs_path)
 }
 
-fn remove_missing_symlinks_in_dir(installs_dir: &Path) -> Result<()> {
+pub(crate) fn remove_missing_symlinks_in_dir(installs_dir: &Path) -> Result<()> {
     if !installs_dir.exists() {
         return Ok(());
     }

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -71,18 +71,10 @@ pub(crate) async fn migrate_real_dirs(config: &Config) -> Result<()> {
 /// dirs we have no write access to (read-only system installs) only error
 /// out when we actually need to change something there.
 fn install_dirs_for(backend: &Arc<dyn Backend>) -> Vec<PathBuf> {
-    install_dirs_for_tool(&backend.ba().installs_path, env::shared_install_dirs())
-}
-
-fn install_dirs_for_tool(
-    installs_path: &Path,
-    shared_dirs: impl IntoIterator<Item = PathBuf>,
-) -> Vec<PathBuf> {
-    let mut dirs = vec![installs_path.to_path_buf()];
-    let Some(tool_dir_name) = installs_path.file_name() else {
-        return dirs;
-    };
-    for shared_dir in shared_dirs {
+    let ba = backend.ba();
+    let mut dirs = vec![ba.installs_path.clone()];
+    let tool_dir_name = ba.tool_dir_name();
+    for shared_dir in env::shared_install_dirs() {
         let dir = shared_dir.join(&tool_dir_name);
         if dir.is_dir() && !dirs.contains(&dir) {
             dirs.push(dir);
@@ -265,16 +257,6 @@ pub(crate) fn remove_missing_symlinks(backend: Arc<dyn Backend>) -> Result<()> {
     remove_missing_symlinks_in_dir(&backend.ba().installs_path)
 }
 
-/// Remove dangling runtime symlinks from every install directory belonging to
-/// the same tool. This does not require the backend to remain discoverable, so
-/// deferred pruning can retry cleanup after removing its final local version.
-pub(crate) fn remove_missing_symlinks_for_tool(installs_path: &Path) -> Result<()> {
-    run_all_rebuilds(
-        install_dirs_for_tool(installs_path, env::shared_install_dirs()),
-        |installs_dir| remove_missing_symlinks_in_dir(&installs_dir),
-    )
-}
-
 pub(crate) fn remove_missing_symlinks_in_dir(installs_dir: &Path) -> Result<()> {
     if !installs_dir.exists() {
         return Ok(());
@@ -334,22 +316,6 @@ mod tests {
         let message = format!("{err:#}");
         assert!(message.contains("repair 1 failed"));
         assert!(message.contains("repair 3 failed"));
-    }
-
-    #[test]
-    fn install_dirs_for_tool_includes_existing_shared_tool_dirs() -> Result<()> {
-        let temp_dir = tempfile::tempdir()?;
-        let primary = temp_dir.path().join("primary").join("dummy");
-        let shared = temp_dir.path().join("shared");
-        let other = temp_dir.path().join("other");
-        fs::create_dir_all(shared.join("dummy"))?;
-        fs::create_dir_all(&other)?;
-
-        assert_eq!(
-            install_dirs_for_tool(&primary, [shared.clone(), other]),
-            [primary, shared.join("dummy")]
-        );
-        Ok(())
     }
 
     // https://github.com/jdx/mise/discussions/5260 — on Windows runtime

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -71,10 +71,18 @@ pub(crate) async fn migrate_real_dirs(config: &Config) -> Result<()> {
 /// dirs we have no write access to (read-only system installs) only error
 /// out when we actually need to change something there.
 fn install_dirs_for(backend: &Arc<dyn Backend>) -> Vec<PathBuf> {
-    let ba = backend.ba();
-    let mut dirs = vec![ba.installs_path.clone()];
-    let tool_dir_name = ba.tool_dir_name();
-    for shared_dir in env::shared_install_dirs() {
+    install_dirs_for_tool(&backend.ba().installs_path, env::shared_install_dirs())
+}
+
+fn install_dirs_for_tool(
+    installs_path: &Path,
+    shared_dirs: impl IntoIterator<Item = PathBuf>,
+) -> Vec<PathBuf> {
+    let mut dirs = vec![installs_path.to_path_buf()];
+    let Some(tool_dir_name) = installs_path.file_name() else {
+        return dirs;
+    };
+    for shared_dir in shared_dirs {
         let dir = shared_dir.join(&tool_dir_name);
         if dir.is_dir() && !dirs.contains(&dir) {
             dirs.push(dir);
@@ -257,6 +265,16 @@ pub(crate) fn remove_missing_symlinks(backend: Arc<dyn Backend>) -> Result<()> {
     remove_missing_symlinks_in_dir(&backend.ba().installs_path)
 }
 
+/// Remove dangling runtime symlinks from every install directory belonging to
+/// the same tool. This does not require the backend to remain discoverable, so
+/// deferred pruning can retry cleanup after removing its final local version.
+pub(crate) fn remove_missing_symlinks_for_tool(installs_path: &Path) -> Result<()> {
+    run_all_rebuilds(
+        install_dirs_for_tool(installs_path, env::shared_install_dirs()),
+        |installs_dir| remove_missing_symlinks_in_dir(&installs_dir),
+    )
+}
+
 pub(crate) fn remove_missing_symlinks_in_dir(installs_dir: &Path) -> Result<()> {
     if !installs_dir.exists() {
         return Ok(());
@@ -316,6 +334,22 @@ mod tests {
         let message = format!("{err:#}");
         assert!(message.contains("repair 1 failed"));
         assert!(message.contains("repair 3 failed"));
+    }
+
+    #[test]
+    fn install_dirs_for_tool_includes_existing_shared_tool_dirs() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let primary = temp_dir.path().join("primary").join("dummy");
+        let shared = temp_dir.path().join("shared");
+        let other = temp_dir.path().join("other");
+        fs::create_dir_all(shared.join("dummy"))?;
+        fs::create_dir_all(&other)?;
+
+        assert_eq!(
+            install_dirs_for_tool(&primary, [shared.clone(), other]),
+            [primary, shared.join("dummy")]
+        );
+        Ok(())
     }
 
     // https://github.com/jdx/mise/discussions/5260 — on Windows runtime

--- a/src/tool_purgatory.rs
+++ b/src/tool_purgatory.rs
@@ -152,6 +152,7 @@ pub(crate) async fn auto_prune() -> Result<()> {
         .collect::<Vec<_>>();
     let mpr = MultiProgressReport::get();
     let mut install_state_changed = false;
+    let mut entries_awaiting_reconciliation = vec![];
     for (key, install_path, display) in due {
         if !install_path.starts_with(*crate::dirs::INSTALLS) {
             warn!(
@@ -174,14 +175,14 @@ pub(crate) async fn auto_prune() -> Result<()> {
                     {
                         warn!("failed to remove missing runtime symlinks for {display}: {err:#}");
                     }
-                    state.entries.remove(&key);
+                    entries_awaiting_reconciliation.push(key);
                     install_state_changed = true;
                 }
                 Err(err) => warn!("failed to prune deferred {display}: {err:#}"),
             }
         } else if !install_path.exists() {
             // A missing version is already gone.
-            state.entries.remove(&key);
+            entries_awaiting_reconciliation.push(key);
             install_state_changed = true;
         } else if installed_paths.contains(&install_path) {
             // Keep the receipt while a tracked config or tool stub needs this
@@ -209,8 +210,20 @@ pub(crate) async fn auto_prune() -> Result<()> {
             .await
         }
         .await;
-        if let Err(err) = reconcile {
-            warn!("failed to reconcile runtime symlinks and shims after deferred pruning: {err:#}");
+        match reconcile {
+            Ok(()) => {
+                for key in entries_awaiting_reconciliation {
+                    state.entries.remove(&key);
+                }
+            }
+            Err(err) => {
+                // Keep the due receipts so a later invocation retries
+                // reconciliation. The versions are already missing, so the
+                // retry will not attempt to uninstall them again.
+                warn!(
+                    "failed to reconcile runtime symlinks and shims after deferred pruning: {err:#}"
+                );
+            }
         }
     }
     save_state(&state)

--- a/src/tool_purgatory.rs
+++ b/src/tool_purgatory.rs
@@ -200,7 +200,7 @@ pub(crate) async fn auto_prune() -> Result<()> {
         } else {
             warn!(
                 "keeping unrecognized tool purgatory entry {}",
-                display_path(&install_path)
+                display_path(install_path)
             );
         }
     }

--- a/src/tool_purgatory.rs
+++ b/src/tool_purgatory.rs
@@ -83,6 +83,18 @@ fn save_state(state: &PurgatoryState) -> Result<()> {
     crate::file::write_atomic(path, contents)
 }
 
+pub(crate) fn scheduled_removals() -> Result<BTreeMap<PathBuf, u64>> {
+    if !state_path().exists() {
+        return Ok(BTreeMap::new());
+    }
+    let _lock = crate::lock_file::get(state_path(), false)?;
+    Ok(load_state()?
+        .entries
+        .into_values()
+        .map(|entry| (entry.install_path, entry.remove_after))
+        .collect())
+}
+
 pub(crate) fn schedule(tv: &ToolVersion, after: Duration) -> Result<()> {
     let _lock = crate::lock_file::get(state_path(), false)?;
     let mut state = load_state()?;

--- a/src/tool_purgatory.rs
+++ b/src/tool_purgatory.rs
@@ -19,7 +19,7 @@ struct PurgatoryState {
     entries: BTreeMap<String, PurgatoryEntry>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 struct PurgatoryEntry {
     install_path: PathBuf,
     display: String,
@@ -112,14 +112,18 @@ pub(crate) async fn auto_prune() -> Result<()> {
     if !state_path().exists() {
         return Ok(());
     }
-    let _lock = crate::lock_file::get(state_path(), false)?;
-    let mut state = load_state()?;
     let now = now_epoch_seconds()?;
-    if !state
-        .entries
-        .values()
-        .any(|entry| entry.remove_after <= now)
-    {
+    let due = {
+        let _lock = crate::lock_file::get(state_path(), false)?;
+        let state = load_state()?;
+        state
+            .entries
+            .iter()
+            .filter(|(_, entry)| entry.remove_after <= now)
+            .map(|(key, entry)| (key.clone(), entry.clone()))
+            .collect::<Vec<_>>()
+    };
+    if due.is_empty() {
         return Ok(());
     }
 
@@ -138,31 +142,22 @@ pub(crate) async fn auto_prune() -> Result<()> {
         .map(|(_, tv)| tv.install_path())
         .collect::<HashSet<_>>();
 
-    let due = state
-        .entries
-        .iter()
-        .filter(|(_, entry)| entry.remove_after <= now)
-        .map(|(key, entry)| {
-            (
-                key.clone(),
-                entry.install_path.clone(),
-                entry.display.clone(),
-            )
-        })
-        .collect::<Vec<_>>();
     let mpr = MultiProgressReport::get();
     let mut install_state_changed = false;
     let mut entries_awaiting_reconciliation = vec![];
-    for (key, install_path, display) in due {
+    let mut entries_to_remove = vec![];
+    for (key, entry) in due {
+        let install_path = &entry.install_path;
+        let display = &entry.display;
         if !install_path.starts_with(*crate::dirs::INSTALLS) {
             warn!(
                 "ignoring tool purgatory entry outside the user installs directory: {}",
-                display_path(&install_path)
+                display_path(install_path)
             );
-            state.entries.remove(&key);
+            entries_to_remove.push((key, entry));
             continue;
         }
-        if let Some((backend, tv)) = prunable_by_path.get(&install_path) {
+        if let Some((backend, tv)) = prunable_by_path.get(install_path) {
             let pr = mpr.add(&format!("uninstall {display}"));
             match backend
                 .uninstall_version(&config, tv, pr.as_ref(), false)
@@ -175,16 +170,16 @@ pub(crate) async fn auto_prune() -> Result<()> {
                     {
                         warn!("failed to remove missing runtime symlinks for {display}: {err:#}");
                     }
-                    entries_awaiting_reconciliation.push(key);
+                    entries_awaiting_reconciliation.push((key, entry));
                     install_state_changed = true;
                 }
                 Err(err) => warn!("failed to prune deferred {display}: {err:#}"),
             }
         } else if !install_path.exists() {
             // A missing version is already gone.
-            entries_awaiting_reconciliation.push(key);
+            entries_awaiting_reconciliation.push((key, entry));
             install_state_changed = true;
-        } else if installed_paths.contains(&install_path) {
+        } else if installed_paths.contains(install_path) {
             // Keep the receipt while a tracked config or tool stub needs this
             // version. It may become prunable again after that reference goes
             // away, without another upgrade to create a fresh receipt.
@@ -212,9 +207,7 @@ pub(crate) async fn auto_prune() -> Result<()> {
         .await;
         match reconcile {
             Ok(()) => {
-                for key in entries_awaiting_reconciliation {
-                    state.entries.remove(&key);
-                }
+                entries_to_remove.extend(entries_awaiting_reconciliation);
             }
             Err(err) => {
                 // Keep the due receipts so a later invocation retries
@@ -226,7 +219,17 @@ pub(crate) async fn auto_prune() -> Result<()> {
             }
         }
     }
-    save_state(&state)
+    if !entries_to_remove.is_empty() {
+        let _lock = crate::lock_file::get(state_path(), false)?;
+        let mut state = load_state()?;
+        for (key, entry) in entries_to_remove {
+            if state.entries.get(&key) == Some(&entry) {
+                state.entries.remove(&key);
+            }
+        }
+        save_state(&state)?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/tool_purgatory.rs
+++ b/src/tool_purgatory.rs
@@ -169,7 +169,11 @@ pub(crate) async fn auto_prune() -> Result<()> {
             {
                 Ok(()) => {
                     pr.finish();
-                    crate::runtime_symlinks::remove_missing_symlinks(backend.clone())?;
+                    if let Err(err) =
+                        crate::runtime_symlinks::remove_missing_symlinks(backend.clone())
+                    {
+                        warn!("failed to remove missing runtime symlinks for {display}: {err:#}");
+                    }
                     state.entries.remove(&key);
                     install_state_changed = true;
                 }
@@ -193,15 +197,21 @@ pub(crate) async fn auto_prune() -> Result<()> {
     }
     mpr.finish_progress();
     if install_state_changed {
-        let config = Config::reset().await?;
-        let ts = config.get_toolset().await?;
-        crate::config::rebuild_shims_and_runtime_symlinks(
-            &config,
-            ts,
-            &[],
-            crate::lockfile::LockfileUpdateMode::Normal,
-        )
-        .await?;
+        let reconcile = async {
+            let config = Config::reset().await?;
+            let ts = config.get_toolset().await?;
+            crate::config::rebuild_shims_and_runtime_symlinks(
+                &config,
+                ts,
+                &[],
+                crate::lockfile::LockfileUpdateMode::Normal,
+            )
+            .await
+        }
+        .await;
+        if let Err(err) = reconcile {
+            warn!("failed to reconcile runtime symlinks and shims after deferred pruning: {err:#}");
+        }
     }
     save_state(&state)
 }

--- a/src/tool_purgatory.rs
+++ b/src/tool_purgatory.rs
@@ -170,7 +170,7 @@ pub(crate) async fn auto_prune() -> Result<()> {
                 Ok(()) => {
                     pr.finish();
                     install_state_changed = true;
-                    match crate::runtime_symlinks::remove_missing_symlinks_for_tool(installs_dir) {
+                    match crate::runtime_symlinks::remove_missing_symlinks_in_dir(installs_dir) {
                         Ok(()) => entries_awaiting_reconciliation.push((key, entry)),
                         Err(err) => {
                             warn!(
@@ -186,7 +186,7 @@ pub(crate) async fn auto_prune() -> Result<()> {
             // longer find its install directory. Retry that cleanup directly
             // from the receipt before allowing reconciliation to clear it.
             install_state_changed = true;
-            match crate::runtime_symlinks::remove_missing_symlinks_for_tool(installs_dir) {
+            match crate::runtime_symlinks::remove_missing_symlinks_in_dir(installs_dir) {
                 Ok(()) => entries_awaiting_reconciliation.push((key, entry)),
                 Err(err) => {
                     warn!("failed to remove missing runtime symlinks for {display}: {err:#}");

--- a/src/tool_purgatory.rs
+++ b/src/tool_purgatory.rs
@@ -149,14 +149,18 @@ pub(crate) async fn auto_prune() -> Result<()> {
     for (key, entry) in due {
         let install_path = &entry.install_path;
         let display = &entry.display;
-        if !install_path.starts_with(*crate::dirs::INSTALLS) {
+        let Some(installs_dir) = install_path
+            .parent()
+            .filter(|parent| parent.starts_with(*crate::dirs::INSTALLS))
+            .filter(|parent| *parent != *crate::dirs::INSTALLS)
+        else {
             warn!(
                 "ignoring tool purgatory entry outside the user installs directory: {}",
                 display_path(install_path)
             );
             entries_to_remove.push((key, entry));
             continue;
-        }
+        };
         if let Some((backend, tv)) = prunable_by_path.get(install_path) {
             let pr = mpr.add(&format!("uninstall {display}"));
             match backend
@@ -165,20 +169,29 @@ pub(crate) async fn auto_prune() -> Result<()> {
             {
                 Ok(()) => {
                     pr.finish();
-                    if let Err(err) =
-                        crate::runtime_symlinks::remove_missing_symlinks(backend.clone())
-                    {
-                        warn!("failed to remove missing runtime symlinks for {display}: {err:#}");
-                    }
-                    entries_awaiting_reconciliation.push((key, entry));
                     install_state_changed = true;
+                    match crate::runtime_symlinks::remove_missing_symlinks_in_dir(installs_dir) {
+                        Ok(()) => entries_awaiting_reconciliation.push((key, entry)),
+                        Err(err) => {
+                            warn!(
+                                "failed to remove missing runtime symlinks for {display}: {err:#}"
+                            );
+                        }
+                    }
                 }
                 Err(err) => warn!("failed to prune deferred {display}: {err:#}"),
             }
         } else if !install_path.exists() {
-            // A missing version is already gone.
-            entries_awaiting_reconciliation.push((key, entry));
+            // A missing version is already gone, but backend discovery may no
+            // longer find its install directory. Retry that cleanup directly
+            // from the receipt before allowing reconciliation to clear it.
             install_state_changed = true;
+            match crate::runtime_symlinks::remove_missing_symlinks_in_dir(installs_dir) {
+                Ok(()) => entries_awaiting_reconciliation.push((key, entry)),
+                Err(err) => {
+                    warn!("failed to remove missing runtime symlinks for {display}: {err:#}");
+                }
+            }
         } else if installed_paths.contains(install_path) {
             // Keep the receipt while a tracked config or tool stub needs this
             // version. It may become prunable again after that reference goes

--- a/src/tool_purgatory.rs
+++ b/src/tool_purgatory.rs
@@ -1,0 +1,203 @@
+use std::collections::{BTreeMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use eyre::{Result, WrapErr, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::cli::args::BackendArg;
+use crate::config::Config;
+use crate::file::display_path;
+use crate::toolset::{ToolVersion, ToolsetBuilder};
+use crate::ui::multi_progress_report::MultiProgressReport;
+
+const STATE_SCHEMA_VERSION: u8 = 1;
+
+#[derive(Debug, Deserialize, Serialize)]
+struct PurgatoryState {
+    schema_version: u8,
+    entries: BTreeMap<String, PurgatoryEntry>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct PurgatoryEntry {
+    install_path: PathBuf,
+    display: String,
+    remove_after: u64,
+}
+
+impl PurgatoryState {
+    fn empty() -> Self {
+        Self {
+            schema_version: STATE_SCHEMA_VERSION,
+            entries: BTreeMap::new(),
+        }
+    }
+}
+
+fn state_path() -> &'static Path {
+    &crate::dirs::TOOL_PURGATORY
+}
+
+fn now_epoch_seconds() -> Result<u64> {
+    Ok(SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .wrap_err("system clock is before the Unix epoch")?
+        .as_secs())
+}
+
+fn entry_key(path: &Path) -> String {
+    crate::hash::hash_sha256_to_str(&path.to_string_lossy())
+}
+
+fn load_state() -> Result<PurgatoryState> {
+    let path = state_path();
+    if !path.exists() {
+        return Ok(PurgatoryState::empty());
+    }
+    let state: PurgatoryState = serde_json::from_str(&crate::file::read_to_string(path)?)
+        .wrap_err_with(|| format!("failed to read tool purgatory state {}", display_path(path)))?;
+    if state.schema_version != STATE_SCHEMA_VERSION {
+        bail!(
+            "unsupported tool purgatory state version {} in {}",
+            state.schema_version,
+            display_path(path)
+        );
+    }
+    Ok(state)
+}
+
+fn save_state(state: &PurgatoryState) -> Result<()> {
+    let path = state_path();
+    if state.entries.is_empty() {
+        match std::fs::remove_file(path) {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => return Err(err.into()),
+        }
+        return Ok(());
+    }
+    crate::file::create_dir_all(path.parent().expect("tool purgatory state parent"))?;
+    let mut contents = serde_json::to_vec_pretty(state)?;
+    contents.push(b'\n');
+    crate::file::write_atomic(path, contents)
+}
+
+pub(crate) fn schedule(tv: &ToolVersion, after: Duration) -> Result<()> {
+    let _lock = crate::lock_file::get(state_path(), false)?;
+    let mut state = load_state()?;
+    let install_path = tv.install_path();
+    state.entries.insert(
+        entry_key(&install_path),
+        PurgatoryEntry {
+            install_path,
+            display: tv.to_string(),
+            remove_after: now_epoch_seconds()?.saturating_add(after.as_secs()),
+        },
+    );
+    save_state(&state)
+}
+
+pub(crate) fn forget_path(path: &Path) -> Result<()> {
+    if !state_path().exists() {
+        return Ok(());
+    }
+    let _lock = crate::lock_file::get(state_path(), false)?;
+    let mut state = load_state()?;
+    state.entries.remove(&entry_key(path));
+    save_state(&state)
+}
+
+pub(crate) async fn auto_prune() -> Result<()> {
+    if !state_path().exists() {
+        return Ok(());
+    }
+    let _lock = crate::lock_file::get(state_path(), false)?;
+    let mut state = load_state()?;
+    let now = now_epoch_seconds()?;
+    if !state
+        .entries
+        .values()
+        .any(|entry| entry.remove_after <= now)
+    {
+        return Ok(());
+    }
+
+    let config = Config::get().await?;
+    let prunable = crate::cli::prune::prunable_tools(&config, Vec::<&BackendArg>::new()).await?;
+    let prunable_by_path = prunable
+        .into_iter()
+        .map(|(backend, tv)| (tv.install_path(), (backend, tv)))
+        .collect::<BTreeMap<_, _>>();
+    let installed_paths = ToolsetBuilder::new()
+        .build(&config)
+        .await?
+        .list_installed_versions(&config)
+        .await?
+        .into_iter()
+        .map(|(_, tv)| tv.install_path())
+        .collect::<HashSet<_>>();
+
+    let due = state
+        .entries
+        .iter()
+        .filter(|(_, entry)| entry.remove_after <= now)
+        .map(|(key, entry)| {
+            (
+                key.clone(),
+                entry.install_path.clone(),
+                entry.display.clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let mpr = MultiProgressReport::get();
+    for (key, install_path, display) in due {
+        if !install_path.starts_with(*crate::dirs::INSTALLS) {
+            warn!(
+                "ignoring tool purgatory entry outside the user installs directory: {}",
+                display_path(&install_path)
+            );
+            state.entries.remove(&key);
+            continue;
+        }
+        if let Some((backend, tv)) = prunable_by_path.get(&install_path) {
+            let pr = mpr.add(&format!("uninstall {display}"));
+            match backend
+                .uninstall_version(&config, tv, pr.as_ref(), false)
+                .await
+            {
+                Ok(()) => {
+                    pr.finish();
+                    state.entries.remove(&key);
+                }
+                Err(err) => warn!("failed to prune deferred {display}: {err:#}"),
+            }
+        } else if !install_path.exists() {
+            // A missing version is already gone.
+            state.entries.remove(&key);
+        } else if installed_paths.contains(&install_path) {
+            // Keep the receipt while a tracked config or tool stub needs this
+            // version. It may become prunable again after that reference goes
+            // away, without another upgrade to create a fresh receipt.
+            debug!("keeping deferred {display} because it is still in use");
+        } else {
+            warn!(
+                "keeping unrecognized tool purgatory entry {}",
+                display_path(&install_path)
+            );
+        }
+    }
+    mpr.finish_progress();
+    save_state(&state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entry_keys_are_stable_and_path_specific() {
+        assert_eq!(entry_key(Path::new("/a")), entry_key(Path::new("/a")));
+        assert_ne!(entry_key(Path::new("/a")), entry_key(Path::new("/b")));
+    }
+}

--- a/src/tool_purgatory.rs
+++ b/src/tool_purgatory.rs
@@ -151,6 +151,7 @@ pub(crate) async fn auto_prune() -> Result<()> {
         })
         .collect::<Vec<_>>();
     let mpr = MultiProgressReport::get();
+    let mut install_state_changed = false;
     for (key, install_path, display) in due {
         if !install_path.starts_with(*crate::dirs::INSTALLS) {
             warn!(
@@ -168,13 +169,16 @@ pub(crate) async fn auto_prune() -> Result<()> {
             {
                 Ok(()) => {
                     pr.finish();
+                    crate::runtime_symlinks::remove_missing_symlinks(backend.clone())?;
                     state.entries.remove(&key);
+                    install_state_changed = true;
                 }
                 Err(err) => warn!("failed to prune deferred {display}: {err:#}"),
             }
         } else if !install_path.exists() {
             // A missing version is already gone.
             state.entries.remove(&key);
+            install_state_changed = true;
         } else if installed_paths.contains(&install_path) {
             // Keep the receipt while a tracked config or tool stub needs this
             // version. It may become prunable again after that reference goes
@@ -188,6 +192,17 @@ pub(crate) async fn auto_prune() -> Result<()> {
         }
     }
     mpr.finish_progress();
+    if install_state_changed {
+        let config = Config::reset().await?;
+        let ts = config.get_toolset().await?;
+        crate::config::rebuild_shims_and_runtime_symlinks(
+            &config,
+            ts,
+            &[],
+            crate::lockfile::LockfileUpdateMode::Normal,
+        )
+        .await?;
+    }
     save_state(&state)
 }
 

--- a/src/tool_purgatory.rs
+++ b/src/tool_purgatory.rs
@@ -170,7 +170,7 @@ pub(crate) async fn auto_prune() -> Result<()> {
                 Ok(()) => {
                     pr.finish();
                     install_state_changed = true;
-                    match crate::runtime_symlinks::remove_missing_symlinks_in_dir(installs_dir) {
+                    match crate::runtime_symlinks::remove_missing_symlinks_for_tool(installs_dir) {
                         Ok(()) => entries_awaiting_reconciliation.push((key, entry)),
                         Err(err) => {
                             warn!(
@@ -186,7 +186,7 @@ pub(crate) async fn auto_prune() -> Result<()> {
             // longer find its install directory. Retry that cleanup directly
             // from the receipt before allowing reconciliation to clear it.
             install_state_changed = true;
-            match crate::runtime_symlinks::remove_missing_symlinks_in_dir(installs_dir) {
+            match crate::runtime_symlinks::remove_missing_symlinks_for_tool(installs_dir) {
                 Ok(()) => entries_awaiting_reconciliation.push((key, entry)),
                 Err(err) => {
                     warn!("failed to remove missing runtime symlinks for {display}: {err:#}");


### PR DESCRIPTION
## Summary

- keep versions replaced by `mise upgrade` at their existing paths for a configurable grace period
- record deferred-prune receipts and revalidate tracked configs/tool stubs before opportunistic cleanup
- preserve immediate behavior for `--prune` and `mise prune`, while `--no-prune` creates no receipt
- add `upgrade.prune_after` with a 24-hour default

Closes the lifecycle gap discussed in https://github.com/jdx/mise/discussions/5840.

## Tests

- `mise run test:e2e e2e/cli/test_upgrade_no_prune`
- `cargo test --all-features tool_purgatory`
- `cargo check --all-features`
- `cargo clippy --workspace --all-features --all-targets -- -A clippy::collapsible-match -D warnings` (two unrelated Rust 1.95 diagnostics require the scoped allow)
- `mise run lint-fix` (all runnable checks passed; the mbx cargo-check hook cannot bind its TCP lock in this sandbox)

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default post-upgrade lifecycle and runs background pruning during CLI startup, but immediate removal remains available via `--prune` and explicit uninstall paths.
> 
> **Overview**
> **`mise upgrade` no longer deletes the replaced install by default.** When `upgrade.auto_prune` is on, the old version stays on disk and is recorded in `tool-purgatory.json` for removal after **`upgrade.prune_after`** (default **24h**). **`--prune`** still uninstalls immediately; **`--no-prune`** leaves the old tree with no scheduled cleanup.
> 
> Opportunistic cleanup runs at the start of normal mise commands (skipped on dry-run / `--version`), re-checks tracked configs and stubs before uninstalling, then reconciles shims and runtime symlinks. **`mise ls`** surfaces deferred removals (e.g. `(pruned in …)`) and JSON fields `scheduled_for_pruning` / `prune_after`. Manual **`mise prune`** / **`mise uninstall`** clear matching purgatory entries.
> 
> Docs, schema, and e2e tests are updated; tests that expect immediate removal now pass **`--prune`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a243cfcbbd7bae91a413a286dba7d61a402e1a72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `mise upgrade` now retains replaced tool versions during a configurable grace period before removal.
  * Added `upgrade.prune_after` (default: 24 hours), configurable via `MISE_UPGRADE_PRUNE_AFTER`.
  * Eligible versions are cleaned up automatically during later invocations, or manually with `mise prune`.

* **Bug Fixes**
  * Deferred cleanup preserves versions still in use and removes obsolete links and shims.

* **Documentation**
  * Clarified that `--prune` removes replaced versions immediately, while `--no-prune` keeps them without scheduling cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->