### PR TITLE
test(e2e): avoid pinning live shfmt release

### DIFF
--- a/e2e/core/test_v_prefix_bump_query
+++ b/e2e/core/test_v_prefix_bump_query
@@ -10,4 +10,4 @@ shfmt = "v3.12.0"
 TOML
 
 assert_not_contains "mise upgrade shfmt --bump --dry-run 2>&1" "no latest version found"
-assert_contains "mise upgrade shfmt --bump --dry-run 2>&1" "Would bump shfmt@v3.13.1 in ~/workdir/mise.toml"
+assert_matches "mise upgrade shfmt --bump --dry-run 2>&1" 'Would bump shfmt@v3\.[0-9]+\.[0-9]+ in ~/workdir/mise\.toml'


### PR DESCRIPTION
## Summary
- match any concrete `v3.x.y` shfmt bump instead of pinning the live latest release
- preserve the regression checks that version discovery succeeds and the configured leading `v` remains in the proposed bump

The test fixture deliberately exercises the live aqua registry. Its exact expected release became stale when shfmt advanced from 3.13.1 to 3.14.0, causing otherwise-correct mainline and PR CI runs to fail.

## Test
- `mise run test:e2e e2e/core/test_v_prefix_bump_query`
- `hk fix e2e/core/test_v_prefix_bump_query`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated regression coverage to accept any compatible `v3.x.y` shfmt bump version instead of requiring one exact version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->