### PR TITLE
fix(ci): use large release runners for mise-en-dev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
   build-tarball-linux:
     if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
     name: build-tarball-${{matrix.name}}
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64-xlarge' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || (github.event.pull_request.user.login != 'jdx' && github.event.pull_request.user.login != 'mise-en-dev')) && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64-xlarge' }}
     # PGO and cross-built release tarballs can exceed 90 minutes on
     # loaded runners, especially once archive generation is included.
     timeout-minutes: 150
@@ -94,7 +94,7 @@ jobs:
   build-tarball-macos:
     if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
     name: build-tarball-${{matrix.name}}
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'macos-14' || 'namespace-profile-endev-macos-arm64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || (github.event.pull_request.user.login != 'jdx' && github.event.pull_request.user.login != 'mise-en-dev')) && 'macos-14' || 'namespace-profile-endev-macos-arm64' }}
     timeout-minutes: 300
     env:
       MINIO_AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Summary
- trust the `mise-en-dev` release automation account for Namespace runner selection
- keep fork PRs and other authors on standard GitHub-hosted runners
- apply the allowlist consistently to Linux and macOS release builds

## Validation
- `mise run lint-fix`
- `actionlint .github/workflows/release.yml`
- `git diff --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only runner selection change with no application or release artifact logic touched.
> 
> **Overview**
> Expands the **release workflow** runner allowlist so PRs opened by **`mise-en-dev`** (in addition to **`jdx`**) on the main repo can use Namespace **endev** runners instead of default GitHub-hosted machines.
> 
> The `runs-on` expressions on **`build-tarball-linux`** and **`build-tarball-macos`** now treat both logins as trusted: fork PRs and other authors still get `ubuntu-latest` / `macos-14`, while tag pushes and allowlisted in-repo release PRs keep the large `namespace-profile-endev-*` profiles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 285398ae43d61ad889dd9a3190f4905b89152480. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request automation to use hosted runners for eligible external-repository builds.
  * Preserved dedicated runner profiles for supported internal build sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->