### PR TITLE
perf(brew): download bootstrap bottles concurrently

### DIFF
--- a/src/system/packages/brew/fetch.rs
+++ b/src/system/packages/brew/fetch.rs
@@ -1,13 +1,31 @@
 //! Bottle downloads from ghcr.io with sha256 verification.
 
+use std::future::Future;
 use std::path::PathBuf;
 
+use futures_util::stream::{self, StreamExt, TryStreamExt};
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 
 use super::api::BottleFile;
 use crate::http::HTTP;
 use crate::result::Result;
 use crate::ui::progress_report::SingleReport;
+
+/// Drive independent downloads concurrently without requiring their futures
+/// to be `Send + 'static`. The brew install path may also contain source
+/// builds whose future is intentionally local to the package-manager driver.
+pub(super) async fn concurrently<T, E, F>(
+    futures: Vec<F>,
+    limit: usize,
+) -> std::result::Result<Vec<T>, E>
+where
+    F: Future<Output = std::result::Result<T, E>>,
+{
+    stream::iter(futures)
+        .buffer_unordered(limit.max(1))
+        .try_collect()
+        .await
+}
 
 /// Download a bottle to the mise cache (or reuse a verified cached copy).
 pub(super) async fn fetch_bottle(
@@ -36,4 +54,40 @@ pub(super) async fn fetch_bottle(
     }
     crate::hash::ensure_checksum(&path, &bottle.sha256, pr, "sha256")?;
     Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use tokio::sync::Barrier;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn concurrent_downloads_respect_the_limit() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let max_active = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(Barrier::new(2));
+        let futures = (0..4)
+            .map(|i| {
+                let active = active.clone();
+                let max_active = max_active.clone();
+                let barrier = barrier.clone();
+                async move {
+                    let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    max_active.fetch_max(current, Ordering::SeqCst);
+                    barrier.wait().await;
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    Ok::<_, ()>(i)
+                }
+            })
+            .collect();
+
+        let mut completed = concurrently(futures, 2).await.unwrap();
+        completed.sort_unstable();
+        assert_eq!(completed, vec![0, 1, 2, 3]);
+        assert_eq!(max_active.load(Ordering::SeqCst), 2);
+    }
 }

--- a/src/system/packages/brew/fetch.rs
+++ b/src/system/packages/brew/fetch.rs
@@ -58,36 +58,42 @@ pub(super) async fn fetch_bottle(
 
 #[cfg(test)]
 mod tests {
+    use std::future::pending;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
 
-    use tokio::sync::Barrier;
+    use tokio::time::timeout;
 
     use super::*;
 
     #[tokio::test]
     async fn concurrent_downloads_respect_the_limit() {
-        let active = Arc::new(AtomicUsize::new(0));
-        let max_active = Arc::new(AtomicUsize::new(0));
-        let barrier = Arc::new(Barrier::new(2));
+        let started = Arc::new(AtomicUsize::new(0));
         let futures = (0..4)
-            .map(|i| {
-                let active = active.clone();
-                let max_active = max_active.clone();
-                let barrier = barrier.clone();
+            .map(|_| {
+                let started = started.clone();
                 async move {
-                    let current = active.fetch_add(1, Ordering::SeqCst) + 1;
-                    max_active.fetch_max(current, Ordering::SeqCst);
-                    barrier.wait().await;
-                    active.fetch_sub(1, Ordering::SeqCst);
-                    Ok::<_, ()>(i)
+                    started.fetch_add(1, Ordering::SeqCst);
+                    pending::<std::result::Result<(), ()>>().await
                 }
             })
             .collect();
 
+        assert!(
+            timeout(Duration::from_millis(10), concurrently(futures, 2))
+                .await
+                .is_err()
+        );
+        assert_eq!(started.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn concurrent_downloads_collect_results() {
+        let futures = (0..4).map(|i| async move { Ok::<_, ()>(i) }).collect();
+
         let mut completed = concurrently(futures, 2).await.unwrap();
         completed.sort_unstable();
         assert_eq!(completed, vec![0, 1, 2, 3]);
-        assert_eq!(max_active.load(Ordering::SeqCst), 2);
     }
 }

--- a/src/system/packages/brew/mod.rs
+++ b/src/system/packages/brew/mod.rs
@@ -19,8 +19,11 @@
 
 use async_trait::async_trait;
 use eyre::bail;
+use std::collections::HashMap;
+use std::sync::Arc;
 
 use super::{InstallOpts, PackageRequest, PackageState, PackageStatus, SystemPackageManager};
+use crate::config::Settings;
 use crate::result::Result;
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::progress_report::{ProgressIcon, SingleReport};
@@ -169,27 +172,75 @@ impl BrewManager {
         // overall [cur/total] header above the per-formula clx jobs, same as
         // tool installs (no-op when only one formula is being installed)
         mpr.init_footer(false, "install", to_pour.len());
-        for rf in &to_pour {
-            let name = &rf.formula.name;
-            let pkg_version = rf.formula.pkg_version()?;
-            let pr: Box<dyn SingleReport> = mpr.add(&format!("brew:{name}"));
-            // branch on the same predicate the upfront classification used
-            let bottle = if source::has_bottle(&rf.formula) {
-                rf.formula.bottle_files().and_then(tag::select)
-            } else {
-                None
-            };
+        let pkg_versions = to_pour
+            .iter()
+            .map(|rf| rf.formula.pkg_version())
+            .collect::<Result<Vec<_>>>()?;
+        // Keep one report for both phases so every concurrent transfer has
+        // independent progress, then the same row advances through pouring.
+        let reports = to_pour
+            .iter()
+            .map(|rf| Arc::<dyn SingleReport>::from(mpr.add(&format!("brew:{}", rf.formula.name))))
+            .collect::<Vec<_>>();
+        let bottles = to_pour
+            .iter()
+            .map(|rf| {
+                source::has_bottle(&rf.formula)
+                    .then(|| rf.formula.bottle_files().and_then(tag::select))
+                    .flatten()
+            })
+            .collect::<Vec<_>>();
+        let downloads = bottles
+            .iter()
+            .enumerate()
+            .filter_map(|(index, bottle)| {
+                let (_, bottle) = bottle.as_ref()?;
+                let name = &to_pour[index].formula.name;
+                let pkg_version = &pkg_versions[index];
+                let pr = &reports[index];
+                Some(async move {
+                    fetch::fetch_bottle(name, pkg_version, bottle, Some(&**pr))
+                        .await
+                        .map(|path| (index, path))
+                        .map_err(|err| (index, err))
+                })
+            })
+            .collect::<Vec<_>>();
+        let mut tarballs: HashMap<usize, _> = match fetch::concurrently(
+            downloads,
+            crate::jobs::normalize(Settings::get().jobs),
+        )
+        .await
+        {
+            Ok(downloads) => downloads.into_iter().collect(),
+            Err((failed, err)) => {
+                for (index, pr) in reports.iter().enumerate() {
+                    if index == failed {
+                        pr.finish_with_icon("failed".to_string(), ProgressIcon::Error);
+                    } else {
+                        pr.abandon();
+                    }
+                }
+                mpr.footer_finish();
+                return Err(err);
+            }
+        };
+        // Pour and build in dependency order. Only network transfers above
+        // are concurrent; extraction and prefix linking mutate shared state.
+        for (index, rf) in to_pour.iter().enumerate() {
+            let pkg_version = &pkg_versions[index];
+            let pr = &reports[index];
+            let bottle = &bottles[index];
             let installed = match bottle {
                 Some((tag, bottle)) => {
-                    async {
-                        let tarball =
-                            fetch::fetch_bottle(name, &pkg_version, bottle, Some(&*pr)).await?;
-                        pour::pour(rf, &tag, bottle, &tarball, &closure, &*pr).await?;
-                        Ok(pkg_version.clone())
-                    }
-                    .await
+                    let tarball = tarballs
+                        .remove(&index)
+                        .expect("every selected bottle was prefetched");
+                    pour::pour(rf, tag, bottle, &tarball, &closure, &**pr)
+                        .await
+                        .map(|()| pkg_version.clone())
                 }
-                None => source::build(rf, &closure, &*pr)
+                None => source::build(rf, &closure, &**pr)
                     .await
                     .map(|()| pkg_version.clone()),
             };
@@ -197,6 +248,9 @@ impl BrewManager {
                 Ok(version) => version,
                 Err(err) => {
                     pr.finish_with_icon("failed".to_string(), ProgressIcon::Error);
+                    for pending in reports.iter().skip(index + 1) {
+                        pending.abandon();
+                    }
                     // render the final progress state so the error that
                     // propagates from here isn't masked by live jobs
                     mpr.footer_finish();

--- a/src/system/packages/brew/mod.rs
+++ b/src/system/packages/brew/mod.rs
@@ -78,6 +78,7 @@ impl BrewManager {
         Ok(repaired)
     }
 
+    /// Prefetch bottles concurrently, then install the closure in dependency order.
     async fn install_via_pour(&self, pkgs: &[PackageRequest], opts: &InstallOpts) -> Result<()> {
         // bottles only exist for a formula's current version — versioning is
         // expressed in the formula name itself (postgresql@17); the CLI


### PR DESCRIPTION
## Summary
- prefetch Homebrew bottles concurrently, bounded by `MISE_JOBS`
- keep extraction, source builds, and prefix linking in dependency order
- preserve per-formula progress and clean up pending progress rows on failure

## Tests
- `mise run lint-fix`
- `mbx test --locked --bin mise concurrent_downloads_respect_the_limit`

Discussion: #12598

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the brew install pipeline timing and progress lifecycle; pour/linking remain serial, but concurrent downloads and new error cleanup paths could affect edge-case install failures.
> 
> **Overview**
> Homebrew bottle installs now **prefetch all bottle downloads in parallel** (capped by `MISE_JOBS` via `jobs::normalize`), then **pour or source-build each formula in the existing closure order**. Network I/O is no longer tied one-formula-at-a-time to extraction and prefix linking.
> 
> A new `fetch::concurrently` helper runs a bounded set of futures with `buffer_unordered` without requiring `Send + 'static`, so it fits the brew driver alongside local source-build futures. **Per-formula progress rows** are created once (`Arc<dyn SingleReport>`) and reused from download through pour.
> 
> **Failure handling** marks the failing row, abandons other in-flight or not-yet-started rows, and finishes the multi-progress footer so errors stay visible. Unit tests cover concurrency limits and result collection for `concurrently`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51c7e8fd4e53402e382afad23ff3fcbef8f7fc15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Bottle downloads now run concurrently, reducing installation wait times while respecting the configured job limit.
  * Packages continue to be poured and built in dependency order after downloads complete.

* **Progress & Error Handling**
  * Installation progress is displayed consistently across download and build stages.
  * Failed operations are clearly marked, and remaining pending operations are canceled appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->