### PR TITLE
fix(lockfile): ignore links from other backends

### DIFF
--- a/e2e/lockfile/test_lockfile_locked_mode
+++ b/e2e/lockfile/test_lockfile_locked_mode
@@ -100,12 +100,17 @@ assert_contains "cat mise.lock" "1.7.1"
 MISE_LOCKED=1 mise lock --platform "$PLATFORM"
 assert_contains "cat mise.lock" "1.7.1"
 
-# --- Test 8: linked versions do not suppress lock data in strict mode ---
+# --- Test 8: links from another backend do not suppress lock data ---
 # An alias can share an install directory with another backend (for example, core rust).
 # External symlinks in that directory must not prevent the aliased HTTP tool from loading
 # its platform URL from the lockfile.
 mkdir -p "$PWD/linked-rust" "$MISE_DATA_DIR/installs/rust"
 ln -s "$PWD/linked-rust" "$MISE_DATA_DIR/installs/rust/external"
+cat <<'EOF' >"$MISE_DATA_DIR/installs/rust/.mise.backend.toml"
+short = "rust"
+full = "core:rust"
+explicit_backend = true
+EOF
 
 cat <<EOF >mise.toml
 [tools.rust]

--- a/e2e/lockfile/test_lockfile_locked_mode
+++ b/e2e/lockfile/test_lockfile_locked_mode
@@ -100,5 +100,32 @@ assert_contains "cat mise.lock" "1.7.1"
 MISE_LOCKED=1 mise lock --platform "$PLATFORM"
 assert_contains "cat mise.lock" "1.7.1"
 
+# --- Test 8: linked versions do not suppress lock data in strict mode ---
+# An alias can share an install directory with another backend (for example, core rust).
+# External symlinks in that directory must not prevent the aliased HTTP tool from loading
+# its platform URL from the lockfile.
+mkdir -p "$PWD/linked-rust" "$MISE_DATA_DIR/installs/rust"
+ln -s "$PWD/linked-rust" "$MISE_DATA_DIR/installs/rust/external"
+
+cat <<EOF >mise.toml
+[tools.rust]
+version = "1.90.0"
+
+[tools.rust.platforms.$PLATFORM]
+url = "https://example.com/rust-1.90.0.tar.gz"
+
+[tool_alias]
+rust = "http:rust"
+EOF
+
+cat <<EOF >mise.lock
+[[tools.rust]]
+version = "1.90.0"
+backend = "http:rust"
+"platforms.$PLATFORM" = { url = "https://example.com/rust-1.90.0.tar.gz" }
+EOF
+
+assert_contains "mise install --locked --dry-run rust 2>&1" "would install"
+
 # Restore for any subsequent tests
 export MISE_LOCKFILE=1

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -15,7 +15,7 @@ use crate::hash::hash_to_str;
 use crate::install_before::{BeforeDateSource, resolve_before_date_for_tool_with_source};
 use crate::lockfile::{CondaPackageInfo, LockfileTool, PkgxPackageInfo, PlatformInfo};
 use crate::runtime_symlinks::is_runtime_symlink;
-use crate::toolset::{ToolRequest, ToolSource, tool_request};
+use crate::toolset::{ToolRequest, ToolSource, install_state, tool_request};
 use crate::{dirs, env};
 use console::style;
 use dashmap::DashMap;
@@ -104,7 +104,7 @@ impl ToolVersion {
 
         trace!("resolving {} {}", &request, opts);
         if opts.use_locked_version
-            && !linked_version_overrides_lockfile(config, &request)
+            && !has_linked_version(request.ba())
             && let Some(lt) = request.lockfile_resolve(config)?
         {
             return Ok(Self::from_lockfile(request.clone(), lt).with_before_date(opts.before_date));
@@ -369,7 +369,7 @@ impl ToolVersion {
             None => (v.as_str(), false),
         };
         if opts.use_locked_version
-            && !linked_version_overrides_lockfile(config, &request)
+            && !has_linked_version(request.ba())
             && let Some(lt) =
                 request.lockfile_resolve_with_prefix(config, lock_query, lock_prefix_boundary)?
         {
@@ -380,7 +380,7 @@ impl ToolVersion {
         if (settings.locked || tool_config_locked)
             && opts.use_locked_version
             && settings.lockfile_enabled()
-            && !linked_version_overrides_lockfile(config, &request)
+            && !has_linked_version(request.ba())
             && request.source().path().is_some()
         {
             let hint = if tool_config_locked && !settings.locked {
@@ -892,19 +892,15 @@ impl ResolveOptions {
     }
 }
 
-/// Linked versions normally take precedence over lockfile entries, but strict locked mode must
-/// keep the lockfile authoritative. In particular, an alias can share an install directory with a
-/// different backend whose external symlinks must not suppress the aliased backend's lock data.
-fn linked_version_overrides_lockfile(config: &Config, request: &ToolRequest) -> bool {
-    !Settings::get().locked
-        && !config.tool_config_locked(request.source())
-        && has_linked_version(request.ba())
-}
-
 /// Check if a tool has any user-linked versions (created by `mise link`).
 /// A linked version is an installed version whose path is a symlink to an external
 /// absolute path, as opposed to runtime symlinks or mise-managed install/cache links.
 fn has_linked_version(ba: &BackendArg) -> bool {
+    if install_state::get_tool_full(&ba.short)
+        .is_some_and(|installed| installed != ba.full_without_opts())
+    {
+        return false;
+    }
     let installs_dir = &ba.installs_path;
     let Ok(entries) = std::fs::read_dir(installs_dir) else {
         return false;

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -104,7 +104,7 @@ impl ToolVersion {
 
         trace!("resolving {} {}", &request, opts);
         if opts.use_locked_version
-            && !has_linked_version(request.ba())
+            && !linked_version_overrides_lockfile(config, &request)
             && let Some(lt) = request.lockfile_resolve(config)?
         {
             return Ok(Self::from_lockfile(request.clone(), lt).with_before_date(opts.before_date));
@@ -369,7 +369,7 @@ impl ToolVersion {
             None => (v.as_str(), false),
         };
         if opts.use_locked_version
-            && !has_linked_version(request.ba())
+            && !linked_version_overrides_lockfile(config, &request)
             && let Some(lt) =
                 request.lockfile_resolve_with_prefix(config, lock_query, lock_prefix_boundary)?
         {
@@ -380,7 +380,7 @@ impl ToolVersion {
         if (settings.locked || tool_config_locked)
             && opts.use_locked_version
             && settings.lockfile_enabled()
-            && !has_linked_version(request.ba())
+            && !linked_version_overrides_lockfile(config, &request)
             && request.source().path().is_some()
         {
             let hint = if tool_config_locked && !settings.locked {
@@ -890,6 +890,15 @@ impl ResolveOptions {
         }
         Ok(())
     }
+}
+
+/// Linked versions normally take precedence over lockfile entries, but strict locked mode must
+/// keep the lockfile authoritative. In particular, an alias can share an install directory with a
+/// different backend whose external symlinks must not suppress the aliased backend's lock data.
+fn linked_version_overrides_lockfile(config: &Config, request: &ToolRequest) -> bool {
+    !Settings::get().locked
+        && !config.tool_config_locked(request.source())
+        && has_linked_version(request.ba())
 }
 
 /// Check if a tool has any user-linked versions (created by `mise link`).


### PR DESCRIPTION
## Summary
- only let linked versions override lockfile resolution when the installed and requested backend identities match
- ignore core-tool links when a short name is explicitly aliased to another backend
- add regression coverage for `rust = "http:rust"` alongside a recorded `core:rust` external symlink

## Root cause
Linked versions normally override lockfile entries for the same tool. The detection scanned the install directory by short name without checking which backend owned it. As a result, `rust = "http:rust"` inspected `installs/rust`, treated core Rust/rustup symlinks as HTTP linked versions, and skipped hydration of the HTTP platform URL.

This keeps the existing linked-version precedence from #8050, but scopes it to the backend that owns those links. Locked and non-locked resolution follow the same backend-identity rule.

Discussion: https://github.com/jdx/mise/discussions/12602

## Tests
- `mise run test:e2e e2e/lockfile/test_lockfile_locked_mode e2e/cli/test_link_lockfile`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches version resolution and lockfile vs linked-version precedence; scope is narrow but affects install/locked dry-run paths for shared short names.
> 
> **Overview**
> **Locked mode** again uses lockfile URLs when an aliased tool shares an install directory with another backend (e.g. `rust = "http:rust"` alongside `core:rust`).
> 
> `has_linked_version` used to scan `installs/<short>` and treat *any* external symlink as a user `mise link`, which skipped lockfile resolution. It now **ignores** that directory when install state records a **different** backend full name than the request, so unrelated symlinks no longer block lockfile hydration.
> 
> Adds **e2e test 8** in `test_lockfile_locked_mode` for HTTP rust with a fake core rust layout and external link under the same folder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8600e33ec5f1cd8007a70dcce84e3b66293e9385. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Locked-mode installations now consistently honor versions and platform URLs recorded in the lockfile.
  * Linked tool versions no longer incorrectly override lockfile data when strict locked mode is enabled.
  * Aliases sharing installation directories with other backends are handled correctly during locked, dry-run installations.
  * Added end-to-end coverage to verify these scenarios report the expected installation actions without modifying the environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->