### PR TITLE
refactor(config): track config provenance

### DIFF
--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -13,6 +13,7 @@ use crate::cli::args::{BackendArg, ToolArg};
 use crate::config::config_file::min_version::MinVersionSpec;
 use crate::config::config_file::mise_toml::{MiseToml, MonorepoConfig};
 use crate::config::env_directive::EnvDirective;
+use crate::config::provenance::ConfigProvenance;
 use crate::config::settings::IdiomaticVersionFileSettings;
 use crate::config::{AliasMap, Settings, settings};
 use crate::deps::DepsConfig;
@@ -86,6 +87,9 @@ fn detection_error(path: &Path, detection: ConfigFileDetection) -> eyre::Report 
 
 pub(crate) trait ConfigFile: Debug + Send + Sync {
     fn get_path(&self) -> &Path;
+    fn provenance(&self) -> ConfigProvenance {
+        ConfigProvenance::from_path(self.get_path())
+    }
     fn min_version(&self) -> Option<&MinVersionSpec> {
         None
     }
@@ -94,10 +98,11 @@ pub(crate) trait ConfigFile: Debug + Send + Sync {
     /// files like ~/src/foo/.mise/config.toml will return ~/src/foo
     /// and ~/src/foo/.mise.config.toml will return None
     fn project_root(&self) -> Option<PathBuf> {
-        let p = self.get_path();
-        if config::is_global_config(p) {
+        let provenance = self.provenance();
+        if !provenance.scope().is_project() {
             return None;
         }
+        let p = provenance.path();
         match p.parent() {
             Some(dir) => match dir {
                 dir if dir.starts_with(*dirs::CONFIG) => None,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -50,6 +50,7 @@ use crate::{backend, dirs, env, file, lockfile, registry, runtime_symlinks, shim
 pub(crate) mod config_file;
 pub(crate) mod env_directive;
 pub(crate) mod miserc;
+pub(crate) mod provenance;
 pub(crate) mod settings;
 pub(crate) mod tracking;
 

--- a/src/config/provenance.rs
+++ b/src/config/provenance.rs
@@ -1,0 +1,74 @@
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use crate::config::{is_global_config, is_system_config};
+
+/// The ownership layer of a loaded configuration file.
+///
+/// This remains attached to values that need to retain their source after
+/// configuration layers are composed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum ConfigFileScope {
+    System,
+    User,
+    Project,
+}
+
+impl ConfigFileScope {
+    pub(crate) fn is_project(self) -> bool {
+        self == Self::Project
+    }
+}
+
+/// Identifies both the file and ownership layer from which configuration came.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct ConfigProvenance {
+    path: PathBuf,
+    scope: ConfigFileScope,
+}
+
+impl ConfigProvenance {
+    pub(crate) fn from_path(path: &Path) -> Self {
+        let scope = if is_system_config(path) {
+            ConfigFileScope::System
+        } else if is_global_config(path) {
+            ConfigFileScope::User
+        } else {
+            ConfigFileScope::Project
+        };
+        Self {
+            path: path.to_path_buf(),
+            scope,
+        }
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub(crate) fn scope(&self) -> ConfigFileScope {
+        self.scope
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::env;
+
+    #[test]
+    fn classifies_standard_config_layers() {
+        let system_path = env::MISE_SYSTEM_CONFIG_FILE.as_ref().unwrap();
+        let user_path = env::MISE_GLOBAL_CONFIG_FILE.as_ref().unwrap();
+        let system = ConfigProvenance::from_path(system_path);
+        let user = ConfigProvenance::from_path(user_path);
+        let project = ConfigProvenance::from_path(Path::new("/workspace/mise.toml"));
+
+        assert_eq!(system.scope(), ConfigFileScope::System);
+        assert_eq!(user.scope(), ConfigFileScope::User);
+        assert_eq!(project.scope(), ConfigFileScope::Project);
+        assert_eq!(system.path(), system_path);
+    }
+}


### PR DESCRIPTION
## Summary

- add a first-class `ConfigProvenance` value containing a config's source path and ownership scope
- classify loaded configuration as system, user, or project using the existing config discovery rules
- expose provenance from every `ConfigFile`
- use provenance for existing project-root detection

This is a prerequisite for routing source-owned configuration artifacts, including system and user tool-stub bins, without inferring ownership after layers have been composed.

Stacked on #12593.

## Validation

- `cargo test --locked --bin mise config::provenance`
- `cargo check --locked --all-features`
- `mise run lint-fix` (all checks passed; mbx's initial native rebuild encountered the environment's unresolved `go` shim, and its configured Cargo fallback passed)

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor with unit tests; project-root logic is equivalent but routed through provenance, with no auth or data-path changes.
> 
> **Overview**
> Introduces **`ConfigProvenance`** (path + **system / user / project** scope) so config can keep source ownership after layers are merged. Scope is derived from the same rules as today via `is_system_config` / `is_global_config`.
> 
> Every **`ConfigFile`** now exposes a default **`provenance()`** built from its path. **`project_root()`** no longer calls **`is_global_config`** directly—it returns **`None`** when scope is not project, then resolves the root from the provenance path (behavior unchanged for typical project vs global/system files).
> 
> This is groundwork for routing source-owned artifacts (e.g. system/user tool-stub bins) without re-inferring ownership after composition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dae88dab4cf6d28001b33fd7f61ab2e713fb2855. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved configuration-source tracking by distinguishing system, user, and project configuration files.
  * Project configuration paths are now resolved using their recorded configuration scope, improving consistency when determining project roots.
  * Existing configuration behavior remains unchanged while providing more reliable handling across configuration locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->