### PR TITLE
fix(docs): serialize usage and help rendering

### DIFF
--- a/tasks.toml
+++ b/tasks.toml
@@ -98,6 +98,9 @@ run = "usage generate manpage --file mise.usage.kdl > man/man1/mise.1"
 ["render:help"]
 description = 'Render help documentation'
 depends = ["build"]
+# markdown-magic scans docs/cli while render:usage replaces that directory.
+# When both tasks are part of `mise run render`, wait for the replacement to finish.
+wait_for = ["render:usage"]
 env = { NO_COLOR = "1" }
 sources = ["mise"]
 outputs = ["README.md"]


### PR DESCRIPTION
## Summary

- make `render:help` wait for `render:usage` when both tasks are scheduled
- prevent markdown-magic from scanning `docs/cli` while that directory is being replaced
- preserve standalone `render:help` behavior without forcing a Usage docs regeneration

## Testing

- `mise tasks deps render`
- `mise run render`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-task ordering and comments only; no runtime product or security impact.
> 
> **Overview**
> Fixes a race when running **`mise run render`**: **`render:help`** now **`wait_for = ["render:usage"]`** so markdown-magic does not scan **`docs/cli`** while **`render:usage`** is deleting and regenerating that tree.
> 
> Unlike adding a hard **`depends`**, **`wait_for`** only blocks when both tasks are scheduled together, so a standalone **`mise run render:help`** still does not force a usage docs rebuild.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c49f93164b3f18525a47811cc7c2c4d1e767446e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the render workflow by ensuring help content waits for usage content to finish generating when both are requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->