### PR TITLE
fix(upgrade): show versions outside configured ranges

### DIFF
--- a/e2e/cli/test_upgrade
+++ b/e2e/cli/test_upgrade
@@ -13,7 +13,10 @@ mise upgrade dummy --prune
 
 assert_contains "mise ls --installed dummy" "1.1.0"
 assert_not_contains "mise ls --installed dummy" "1.0.0"
-assert_contains "mise upgrade dummy 2>&1" "Newer versions are available outside the configured version ranges"
+assert_contains "mise upgrade dummy 2>&1" 'Newer versions are available but do not match the configured version ranges'
+assert_contains "mise upgrade dummy 2>&1" 'dummy 1.1.0 → 2.0.0'
+assert_contains "mise upgrade dummy 2>&1" "to update the configuration and upgrade"
+assert_not_contains "mise upgrade dummy 2>&1" "All tools are up to date"
 assert_contains "mise upgrade dummy -l --dry-run 2>&1" "deprecated [cli.upgrade.bump-l]"
 assert_contains "mise upgrade dummy -l --dry-run 2>&1" "Would install dummy@2.0.0"
 
@@ -111,9 +114,9 @@ assert_fail_contains "mise up --dry-run-code 2>&1" "Would install"
 # Verify nothing was actually upgraded
 assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
 
-# Test: --dry-run-code should exit 0 when everything is up to date
+# Test: --dry-run-code should exit 0 when the configured range is up to date
 mise up
-assert_contains "mise up --dry-run-code 2>&1" "All tools are up to date"
+assert_contains "mise up --dry-run-code 2>&1" "do not match the configured version ranges"
 
 # Test: upgrade should not re-download a version that is already installed
 # This verifies the fix for https://github.com/jdx/mise/discussions/8260
@@ -127,8 +130,8 @@ mise install dummy@1.0.0
 mise install dummy@1.1.0
 assert_contains "mise ls --installed dummy" "1.0.0"
 assert_contains "mise ls --installed dummy" "1.1.0"
-# upgrade should report "All tools are up to date" since 1.1.0 is already installed
-assert_contains "mise up 2>&1" "All tools are up to date"
+# upgrade should report the newer release outside the configured range
+assert_contains "mise up 2>&1" "dummy 1.1.0 → 2.0.0"
 
 # Test: upgrade with lockfile should update the lockfile to the new version
 cat <<EOF >mise.toml

--- a/e2e/cli/test_upgrade
+++ b/e2e/cli/test_upgrade
@@ -15,6 +15,7 @@ assert_contains "mise ls --installed dummy" "1.1.0"
 assert_not_contains "mise ls --installed dummy" "1.0.0"
 assert_contains "mise upgrade dummy 2>&1" 'Newer versions are available but do not match the configured version ranges'
 assert_contains "mise upgrade dummy 2>&1" 'dummy 1.1.0 → 2.0.0'
+assert_contains "mise upgrade dummy 2>&1" 'mise outdated --bump'
 assert_contains "mise upgrade dummy 2>&1" "to update the configuration and upgrade"
 assert_not_contains "mise upgrade dummy 2>&1" "All tools are up to date"
 assert_contains "mise upgrade dummy -l --dry-run 2>&1" "deprecated [cli.upgrade.bump-l]"

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -227,22 +227,35 @@ impl Upgrade {
             outdated = self.get_interactive_tool_set(&outdated)?;
         }
         if outdated.is_empty() {
-            info!("All tools are up to date");
-            if !self.bump {
-                let bump_outdated = ts
-                    .list_outdated_versions_filtered(
-                        &config,
-                        true,
-                        &opts,
-                        filter_tools,
-                        exclude_tools,
-                    )
-                    .await;
-                if bump_outdated.iter().any(|o| o.bump.is_some()) {
-                    info!(
-                        "Newer versions are available outside the configured version ranges. Use `mise upgrade --bump` to upgrade them."
-                    );
-                }
+            let bump_outdated = if self.bump {
+                Vec::new()
+            } else {
+                ts.list_outdated_versions_filtered(
+                    &config,
+                    true,
+                    &opts,
+                    filter_tools,
+                    exclude_tools,
+                )
+                .await
+                .into_iter()
+                .filter(|o| o.bump.is_some())
+                .collect::<Vec<_>>()
+            };
+            if bump_outdated.is_empty() {
+                info!("All tools are up to date");
+            } else {
+                let updates = bump_outdated
+                    .iter()
+                    .map(|o| {
+                        let current = o.current.as_deref().unwrap_or("MISSING");
+                        format!("  {} {} → {} ({})", o.name, current, o.latest, o.source)
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                info!(
+                    "Newer versions are available but do not match the configured version ranges:\n{updates}\nRun `mise upgrade --bump` to update the configuration and upgrade."
+                );
             }
         } else {
             self.upgrade(&mut config, outdated, before_date).await?;

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -29,6 +29,8 @@ use eyre::{Context, Result, eyre};
 use indexmap::IndexMap;
 use jiff::{Span, Timestamp, civil::date};
 
+const MAX_OUT_OF_RANGE_UPDATES: usize = 5;
+
 /// Upgrades outdated tools
 ///
 /// By default, this keeps the range specified in mise.toml. So if you have node@20 set, it will
@@ -225,6 +227,9 @@ impl Upgrade {
         .await;
         if self.interactive && !outdated.is_empty() {
             outdated = self.get_interactive_tool_set(&outdated)?;
+            if outdated.is_empty() {
+                return Ok(());
+            }
         }
         if outdated.is_empty() {
             let bump_outdated = if self.bump {
@@ -245,16 +250,21 @@ impl Upgrade {
             if bump_outdated.is_empty() {
                 info!("All tools are up to date");
             } else {
-                let updates = bump_outdated
+                let hidden = bump_outdated.len().saturating_sub(MAX_OUT_OF_RANGE_UPDATES);
+                let mut updates = bump_outdated
                     .iter()
+                    .take(MAX_OUT_OF_RANGE_UPDATES)
                     .map(|o| {
                         let current = o.current.as_deref().unwrap_or("MISSING");
                         format!("  {} {} → {} ({})", o.name, current, o.latest, o.source)
                     })
                     .collect::<Vec<_>>()
                     .join("\n");
+                if hidden > 0 {
+                    updates.push_str(&format!("\n  … and {hidden} more"));
+                }
                 info!(
-                    "Newer versions are available but do not match the configured version ranges:\n{updates}\nRun `mise upgrade --bump` to update the configuration and upgrade."
+                    "Newer versions are available but do not match the configured version ranges:\n{updates}\nRun `mise outdated --bump` to view all, or `mise upgrade --bump` to update the configuration and upgrade."
                 );
             }
         } else {


### PR DESCRIPTION
## Summary

- list each tool with its current and available version when newer releases fall outside configured ranges
- include the configuration source responsible for each constrained tool
- avoid the contradictory “All tools are up to date” message in this case
- clarify that `mise upgrade --bump` updates configuration before upgrading

## Example

```text
mise Newer versions are available but do not match the configured version ranges:
  node 26.7.0 → 26.8.1 (~/.config/mise/config.toml)
Run `mise upgrade --bump` to update the configuration and upgrade.
```

## Validation

- `cargo build --all-features`
- `mise run test:e2e e2e/cli/test_upgrade`
- `cargo fmt --all -- --check`
- `shellcheck -x e2e/cli/test_upgrade`

The repository lint-fix command was also run; its mbx cargo-check step is unavailable in this sandbox, so the equivalent Cargo build was used. A full direct Clippy run reaches two pre-existing warnings in `src/backend/cargo.rs` and `src/task/task_source_checker.rs`; neither file is changed here.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing CLI messaging and status reporting only; upgrade/install logic is unchanged aside from clearer guidance when ranges block newer versions.
> 
> **Overview**
> When tools are current for their **configured version ranges** but newer releases exist beyond those ranges, `mise upgrade` no longer prints **“All tools are up to date”** alone. It now reports that newer versions **do not match** the configured ranges, lists up to five tools as `name current → latest (config source)`, and notes any additional tools with an ellipsis line.
> 
> The message also directs users to **`mise outdated --bump`** for the full list and **`mise upgrade --bump`** to change config and upgrade. That out-of-range listing is skipped when **`--bump`** is already set, and interactive mode exits quietly if nothing is selected.
> 
> E2E coverage in `test_upgrade` was updated for the new copy and for cases where the install is satisfied in-range but **2.x** is still available (e.g. `dummy 1.1.0 → 2.0.0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 925fca30e886d1d202d668e3852ed1f01794ebfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `mise upgrade` now reports newer tool versions outside configured version ranges.
  * Shows current and available versions, update sources, and guidance to use `mise outdated --bump`.
  * Limits out-of-range results to five entries and indicates when additional updates are hidden.

* **Bug Fixes**
  * Prevents incorrect “all tools up to date” messaging for out-of-range updates.
  * Improved handling when no tools are selected during interactive upgrades.
  * Updated dry-run output to reflect these changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->