### PR TITLE
registry: include llama.cpp prereleases

### DIFF
--- a/registry/llama.cpp.toml
+++ b/registry/llama.cpp.toml
@@ -30,4 +30,5 @@ bins = [
 full = "github:ggml-org/llama.cpp"
 
 [backends.options]
+prerelease = true
 version_prefix = "b"


### PR DESCRIPTION
## Summary
- include llama.cpp prereleases when resolving b-prefixed builds
- preserve the existing 24-hour minimum release age behavior

Upstream began marking its rolling bNNNN builds as prereleases. Once every b-prefixed release on the first GitHub API page had that flag, mise filtered them all and reported no versions matching the date filter. The stable v0.3.0 release is intentionally excluded by the existing b version prefix.

## Testing
- mise run build
- fresh GitHub-backed mise latest llama.cpp resolved 10688 with 17 newer releases held back by minimum_release_age
- target/debug/mise test-tool --jobs=1 llama.cpp installed and executed build 10688
- mise run lint-fix

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single registry option for one tool; only affects which GitHub releases are considered when resolving llama.cpp versions.
> 
> **Overview**
> **llama.cpp** registry backend now sets `prerelease = true` under `[backends.options]` for `github:ggml-org/llama.cpp`.
> 
> Upstream started flagging rolling **bNNNN** builds as GitHub prereleases. With the default exclusion, every **b**-prefixed release on the first API page could be filtered out, so version resolution failed even though those builds are what the existing `version_prefix = "b"` is meant to track. This change includes prereleases in resolution; **minimum release age** and the **b** prefix filter are unchanged (stable tags like **v0.3.0** stay out of scope).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3441680cc498f266cae295c20d8f3b262622ecf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled access to prerelease versions of the llama.cpp backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->