### PR TITLE
chore: adopt mr-boxington 1.1 cargo shim

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -12,9 +12,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
+    - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
       with:
         version: 1.1.0
         backend: github
+        cache-generation: v2
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
       with:
-        version: 0.7.0
+        version: 1.1.0
         backend: github
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -5,13 +5,6 @@ inputs:
   backend:
     description: Explicit backend for structurally trusted or untrusted callers
     default: auto
-  cache-links:
-    description: Cache native links; "auto" enables this on Linux
-    default: auto
-  toolchain:
-    description: Rust toolchain named explicitly by the build
-    required: false
-
 runs:
   using: composite
   steps:
@@ -19,8 +12,6 @@ runs:
       with:
         version: 1.1.0
         cache-generation: v2
-        cache-links: ${{ inputs.cache-links }}
-        toolchain: ${{ inputs.toolchain }}
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/mise

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -74,7 +74,14 @@ jobs:
 
       # Keep development-only Cargo activation out of the measured process.
       - name: Remove mbx benchmark activation
-        run: mbx setup --uninstall --global
+        run: |
+          mbx setup --uninstall --global
+          cargo_path=$(command -v cargo)
+          case "$cargo_path" in
+            */mbx/bin/cargo) rm -f "$cargo_path" ;;
+          esac
+          hash -r
+          command -v cargo
 
       - name: Install valgrind
         run: |

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -82,6 +82,8 @@ jobs:
           esac
           hash -r
           command -v cargo
+          clean_path=$(printf '%s\n' "$PATH" | tr ':' '\n' | grep -v '/mbx/bin$' | paste -sd:)
+          echo "PATH=$clean_path" >> "$GITHUB_ENV"
 
       - name: Install valgrind
         run: |

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -72,6 +72,10 @@ jobs:
         env:
           MISE_LOCKED: "1"
 
+      # Keep development-only Cargo activation out of the measured process.
+      - name: Remove mbx benchmark activation
+        run: mbx setup --uninstall --global
+
       - name: Install valgrind
         run: |
           command -v valgrind || {

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -56,7 +56,14 @@ jobs:
 
       # Keep development-only Cargo activation out of the measured process.
       - name: Remove mbx benchmark activation
-        run: mbx setup --uninstall --global
+        run: |
+          mbx setup --uninstall --global
+          cargo_path=$(command -v cargo)
+          case "$cargo_path" in
+            */mbx/bin/cargo) rm -f "$cargo_path" ;;
+          esac
+          hash -r
+          command -v cargo
 
       # cachegrind is the whole point: it counts instructions, which reproduce
       # to ~0.02% run-to-run where wall clock on this same hardware moves by

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -54,6 +54,10 @@ jobs:
         env:
           MISE_LOCKED: "1"
 
+      # Keep development-only Cargo activation out of the measured process.
+      - name: Remove mbx benchmark activation
+        run: mbx setup --uninstall --global
+
       # cachegrind is the whole point: it counts instructions, which reproduce
       # to ~0.02% run-to-run where wall clock on this same hardware moves by
       # 4-20%. Without it tak still records timing, but the series stops being

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -64,6 +64,8 @@ jobs:
           esac
           hash -r
           command -v cargo
+          clean_path=$(printf '%s\n' "$PATH" | tr ':' '\n' | grep -v '/mbx/bin$' | paste -sd:)
+          echo "PATH=$clean_path" >> "$GITHUB_ENV"
 
       # cachegrind is the whole point: it counts instructions, which reproduce
       # to ~0.02% run-to-run where wall clock on this same hardware moves by

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -54,7 +54,7 @@ jobs:
           # build to use dependencies whose rust-version metadata exceeds our MSRV.
           # Keep using the same compiler path as the bootstrap build above: changing
           # to mbx in an existing CMake tree makes AWS-LC reject the reconfigure.
-          MISE_CARGO_BUILD_COMMAND: cargo build
+          MISE_CARGO_BUILD_COMMAND: MBX_DISABLE=1 cargo build
           MISE_CARGO_BUILD_EXTRA_ARGS: --ignore-rust-version
           # The full-feature build above already covers compilation. Avoid HK's
           # redundant cargo-check, which enforces dependency rust-version metadata.

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -400,7 +400,7 @@ jobs:
 
   windows-unit:
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     needs: [classify-changes]
     if: needs.classify-changes.outputs.full-ci == 'true'
     env:

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -140,6 +140,10 @@ jobs:
     needs: [classify-changes]
     if: needs.classify-changes.outputs.full-ci == 'true'
     env:
+      # The bootstrap build below uses explicit mbx before mise installs the
+      # project tools. Keep nested task builds on the same entrypoint so AWS-LC
+      # does not reconfigure an existing CMake tree with a different compiler.
+      MISE_CARGO_BUILD_COMMAND: mbx build
       MISE_CARGO_BUILD_EXTRA_ARGS: --ignore-rust-version
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,14 +2,15 @@
 
 ## mbx build cache
 
-Compilation-heavy mise tasks and hk checks use `mbx`. If an mbx command fails
-or creates a development papercut, rerun the exact equivalent `cargo` command
-from `CONTRIBUTING.md`; this unblocks work without weakening the check. If Cargo
-succeeds, surface the mismatch and recommend a
+Mise installs mbx 1.1 and activates its transparent Cargo shim, so
+compilation-heavy mise tasks and hk checks use ordinary `cargo` commands. If
+the shim fails or creates a development papercut, rerun the exact equivalent
+command from `CONTRIBUTING.md` with `MBX_DISABLE=1`; this unblocks work without
+weakening the check. If bypassed Cargo succeeds, surface the mismatch and recommend a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions) with
-the repository and commit, OS, `mbx --version`, both commands and outputs, the
-cache summary, and `MBX_BYPASS_LOG` details when relevant. Do not silently make
-Cargo the permanent path, and do not post externally without user authorization.
+the repository and commit, OS, `mbx --version`, `mbx doctor`, and both commands
+and outputs. Do not permanently disable the shim, and do not post externally
+without user authorization.
 
 This file is the canonical agent guide. `CLAUDE.md` is a symlink to `AGENTS.md` for compatibility with existing tooling.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,9 @@ command from `CONTRIBUTING.md` with `MBX_DISABLE=1`; this unblocks work without
 weakening the check. If bypassed Cargo succeeds, surface the mismatch and recommend a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions) with
 the repository and commit, OS, `mbx --version`, `mbx doctor`, and both commands
-and outputs. Do not permanently disable the shim, and do not post externally
-without user authorization.
+and outputs. Redact secrets, absolute cache paths, remote URLs, namespaces, and
+other sensitive or identifying details. Do not permanently disable the shim,
+and do not post externally without user authorization.
 
 This file is the canonical agent guide. `CLAUDE.md` is a symlink to `AGENTS.md` for compatibility with existing tooling.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,19 +4,19 @@ See the [contributing guide](https://mise.jdx.dev/contributing).
 
 ## mbx build cache
 
-The normal `mise run build`, `mise run test:unit`, and `mise run lint` workflows
-use [mbx](https://mr-boxington.jdx.dev) for compilation-heavy Cargo work. If mbx
-appears to be the problem, use the equivalent Cargo commands to unblock
-yourself without skipping or weakening the check:
+`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.1 and activates
+its transparent Cargo shim. The normal `mise run build`, `mise run test:unit`,
+and `mise run lint` workflows therefore use the cache while invoking Cargo
+normally. To bypass mbx without skipping or weakening a check, prefix the
+equivalent Cargo command with `MBX_DISABLE=1`:
 
 ```sh
-cargo build --all-features
-cargo test --all-features
-cargo check --all-features
+MBX_DISABLE=1 cargo build --all-features
+MBX_DISABLE=1 cargo test --all-features
+MBX_DISABLE=1 cargo check --all-features
 ```
 
-If Cargo succeeds where mbx fails, or mbx introduces a papercut, please start a
+If bypassed Cargo succeeds where the shim fails, or mbx introduces a papercut, please start a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions).
-Include the repository and commit, operating system, `mbx --version`, both
-commands and their output, the mbx cache summary, and an `MBX_BYPASS_LOG` when
-relevant (for example, `MBX_BYPASS_LOG=mbx-bypasses.log mise run build`).
+Include the repository and commit, operating system, `mbx --version`,
+`mbx doctor`, and both commands and their output.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,4 +19,6 @@ MBX_DISABLE=1 cargo check --all-features
 If bypassed Cargo succeeds where the shim fails, or mbx introduces a papercut, please start a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions).
 Include the repository and commit, operating system, `mbx --version`,
-`mbx doctor`, and both commands and their output.
+`mbx doctor`, and both commands and their output. Before posting, redact
+secrets, absolute cache paths, remote URLs, namespaces, and other sensitive or
+identifying details.

--- a/hk.pkl
+++ b/hk.pkl
@@ -50,7 +50,7 @@ local linters = new Mapping<String, Step> {
     }
     ["cargo-check"] = (Builtins.cargo_check) {
       check = new CommandSpec {
-        command = "mbx check --all-features"
+        command = "cargo check --all-features"
         effect = "write"
       }
     }

--- a/mise.lock
+++ b/mise.lock
@@ -482,66 +482,6 @@ checksum = "sha256:3ae3a5549e85c7ad5b20192ebcfee4371269deca51255f6f2f2e051c6541f
 url = "https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.13.1-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/orhun/git-cliff/releases/assets/405851866"
 
-[[tools."github:jdx/mr-boxington"]]
-version = "0.7.0"
-backend = "github:jdx/mr-boxington"
-
-[tools."github:jdx/mr-boxington"."platforms.linux-arm64"]
-checksum = "sha256:5dfd6554293c0adc3d7178952bc2a26d01c4e3c970d43c7a630ea3fd0a9b97c3"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/534515056"
-provenance = "github-attestations"
-
-[tools."github:jdx/mr-boxington"."platforms.linux-arm64-musl"]
-checksum = "sha256:5dfd6554293c0adc3d7178952bc2a26d01c4e3c970d43c7a630ea3fd0a9b97c3"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/534515056"
-provenance = "github-attestations"
-
-[tools."github:jdx/mr-boxington"."platforms.linux-x64"]
-checksum = "sha256:059936e1c794b129b92e6a712eb684218927a28cdac7474b12cc1e6e957cd702"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/534515070"
-provenance = "github-attestations"
-provenance_verified = true
-
-[tools."github:jdx/mr-boxington"."platforms.linux-x64-baseline"]
-checksum = "sha256:059936e1c794b129b92e6a712eb684218927a28cdac7474b12cc1e6e957cd702"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/534515070"
-provenance = "github-attestations"
-
-[tools."github:jdx/mr-boxington"."platforms.linux-x64-musl"]
-checksum = "sha256:059936e1c794b129b92e6a712eb684218927a28cdac7474b12cc1e6e957cd702"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/534515070"
-provenance = "github-attestations"
-
-[tools."github:jdx/mr-boxington"."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:059936e1c794b129b92e6a712eb684218927a28cdac7474b12cc1e6e957cd702"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/534515070"
-provenance = "github-attestations"
-
-[tools."github:jdx/mr-boxington"."platforms.macos-arm64"]
-checksum = "sha256:7842ae216a0dc5abc3121aafd22025285112bc36d5d906266d5139cb24c148fe"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/534515059"
-provenance = "github-attestations"
-provenance_verified = true
-
-[tools."github:jdx/mr-boxington"."platforms.windows-x64"]
-checksum = "sha256:4a0e0c86adc339b625b42fb8a1c3710a7255726af18eb9767dcc93d24fe03aaf"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/534515061"
-provenance = "github-attestations"
-
-[tools."github:jdx/mr-boxington"."platforms.windows-x64-baseline"]
-checksum = "sha256:4a0e0c86adc339b625b42fb8a1c3710a7255726af18eb9767dcc93d24fe03aaf"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/534515061"
-provenance = "github-attestations"
-
 [[tools."github:jdx/tak"]]
 version = "0.0.8"
 backend = "github:jdx/tak"
@@ -756,6 +696,65 @@ url_api = "https://api.github.com/repos/LuaLS/lua-language-server/releases/asset
 checksum = "sha256:fdb9a59108cf62517813c97fa5549b0e16d1ef0688306bac728b08434db7e4cd"
 url = "https://github.com/LuaLS/lua-language-server/releases/download/3.19.1/lua-language-server-3.19.1-win32-x64.zip"
 url_api = "https://api.github.com/repos/LuaLS/lua-language-server/releases/assets/513572668"
+
+[[tools.mr-boxington]]
+version = "1.1.0"
+backend = "github:jdx/mr-boxington"
+
+[tools.mr-boxington."platforms.linux-arm64"]
+checksum = "sha256:ded60221f2217a6e0abfe0ba3583674bae63e5a7b696c4fa145827a3a0e352af"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232514"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.linux-arm64-musl"]
+checksum = "sha256:70a882277389bd6e6b606fc291083a857a7ef0c742b60ba5a7822cc49fe7c4ac"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232511"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.linux-x64"]
+checksum = "sha256:8e718ff25e71057f758d02f3039481258cd531be914afd3f77198811d0113a74"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232519"
+provenance = "github-attestations"
+provenance_verified = true
+
+[tools.mr-boxington."platforms.linux-x64-baseline"]
+checksum = "sha256:8e718ff25e71057f758d02f3039481258cd531be914afd3f77198811d0113a74"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232519"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.linux-x64-musl"]
+checksum = "sha256:9f590a0fd0fc0a5896791257863980fe9c6035458414575749cc43e68e7ff0cf"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232518"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.linux-x64-musl-baseline"]
+checksum = "sha256:9f590a0fd0fc0a5896791257863980fe9c6035458414575749cc43e68e7ff0cf"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232518"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.macos-arm64"]
+checksum = "sha256:da96661534480fff35ec78e598124d208ac1f2624c6d3c287c9ae2a5852b0b29"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232513"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.windows-x64"]
+checksum = "sha256:4adbb02bf97f00644d2e1e3930e154df39a07df1e574e0829b5d6e34474a3c95"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232517"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.windows-x64-baseline"]
+checksum = "sha256:4adbb02bf97f00644d2e1e3930e154df39a07df1e574e0829b5d6e34474a3c95"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232517"
+provenance = "github-attestations"
 
 [[tools.node]]
 version = "24.19.0"

--- a/mise.toml
+++ b/mise.toml
@@ -53,17 +53,17 @@ dir = "{{config_root}}"
 # log HTTP warnings and their instruction counts move with whatever the registry
 # happened to answer. Ignoring the repository config keeps its development tools
 # out of the fixture so editing this file does not change a benchmark's input.
-# Bypass mbx so restored compiler artifacts cannot perturb the measured binary.
-env = { MISE_OFFLINE = "1", MISE_IGNORED_CONFIG_PATHS = "{{config_root}}/mise.toml", MBX_DISABLE = "1" }
-run = ["cargo build --release", "tak run"]
+# Bypass mbx only for the build so its environment does not perturb the benchmark.
+env = { MISE_OFFLINE = "1", MISE_IGNORED_CONFIG_PATHS = "{{config_root}}/mise.toml" }
+run = ["MBX_DISABLE=1 cargo build --release", "tak run"]
 
 # Same measurement, appended to refs/notes/tak for this commit. Run by the
 # `perf` workflow on every push to main; the notes are the history. Safe to run
 # locally — nothing leaves the machine until `tak push`.
 [tasks."perf:record"]
 dir = "{{config_root}}"
-env = { MISE_OFFLINE = "1", MISE_IGNORED_CONFIG_PATHS = "{{config_root}}/mise.toml", MBX_DISABLE = "1" }
-run = ["cargo build --release", "tak run --record"]
+env = { MISE_OFFLINE = "1", MISE_IGNORED_CONFIG_PATHS = "{{config_root}}/mise.toml" }
+run = ["MBX_DISABLE=1 cargo build --release", "tak run --record"]
 
 # End-to-end task artifact cache phases. The harness generates an isolated
 # large fixture so benchmark inputs never need to be checked into the repo.

--- a/mise.toml
+++ b/mise.toml
@@ -53,7 +53,8 @@ dir = "{{config_root}}"
 # log HTTP warnings and their instruction counts move with whatever the registry
 # happened to answer. Ignoring the repository config keeps its development tools
 # out of the fixture so editing this file does not change a benchmark's input.
-env = { MISE_OFFLINE = "1", MISE_IGNORED_CONFIG_PATHS = "{{config_root}}/mise.toml" }
+# Bypass mbx so restored compiler artifacts cannot perturb the measured binary.
+env = { MISE_OFFLINE = "1", MISE_IGNORED_CONFIG_PATHS = "{{config_root}}/mise.toml", MBX_DISABLE = "1" }
 run = ["cargo build --release", "tak run"]
 
 # Same measurement, appended to refs/notes/tak for this commit. Run by the
@@ -61,7 +62,7 @@ run = ["cargo build --release", "tak run"]
 # locally — nothing leaves the machine until `tak push`.
 [tasks."perf:record"]
 dir = "{{config_root}}"
-env = { MISE_OFFLINE = "1", MISE_IGNORED_CONFIG_PATHS = "{{config_root}}/mise.toml" }
+env = { MISE_OFFLINE = "1", MISE_IGNORED_CONFIG_PATHS = "{{config_root}}/mise.toml", MBX_DISABLE = "1" }
 run = ["cargo build --release", "tak run --record"]
 
 # End-to-end task artifact cache phases. The harness generates an isolated

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,7 @@ _.path = ["./target/debug", "./node_modules/.bin"]
 
 [tools]
 actionlint = "latest"
-"github:jdx/mr-boxington" = "latest"
+mr-boxington = { version = "1.1.0", postinstall = "mbx setup --yes" }
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
 # in mise's numbers, indistinguishable from a real regression. Bump

--- a/mise.toml
+++ b/mise.toml
@@ -47,6 +47,10 @@ includes = ["tasks.toml", "xtasks"]
 # number whose absolute value does not matter. What matters is that every
 # measurement in a series is built the same way, and the series is partitioned
 # on runner class so a change of build profile would start a fresh one anyway.
+[tasks."perf:build"]
+env = { MISE_OFFLINE = "1", MISE_IGNORED_CONFIG_PATHS = "{{config_root}}/mise.toml", MBX_DISABLE = "1" }
+run = "cargo build --release"
+
 [tasks.perf]
 dir = "{{config_root}}"
 # MISE_OFFLINE keeps `ls`, `env` and `hook-env` off the network. Without it they
@@ -55,7 +59,8 @@ dir = "{{config_root}}"
 # out of the fixture so editing this file does not change a benchmark's input.
 # Bypass mbx only for the build so its environment does not perturb the benchmark.
 env = { MISE_OFFLINE = "1", MISE_IGNORED_CONFIG_PATHS = "{{config_root}}/mise.toml" }
-run = ["MBX_DISABLE=1 cargo build --release", "tak run"]
+depends = ["perf:build"]
+run = "tak run"
 
 # Same measurement, appended to refs/notes/tak for this commit. Run by the
 # `perf` workflow on every push to main; the notes are the history. Safe to run
@@ -63,7 +68,8 @@ run = ["MBX_DISABLE=1 cargo build --release", "tak run"]
 [tasks."perf:record"]
 dir = "{{config_root}}"
 env = { MISE_OFFLINE = "1", MISE_IGNORED_CONFIG_PATHS = "{{config_root}}/mise.toml" }
-run = ["MBX_DISABLE=1 cargo build --release", "tak run --record"]
+depends = ["perf:build"]
+run = "tak run --record"
 
 # End-to-end task artifact cache phases. The harness generates an isolated
 # large fixture so benchmark inputs never need to be checked into the repo.

--- a/mise.toml
+++ b/mise.toml
@@ -47,19 +47,14 @@ includes = ["tasks.toml", "xtasks"]
 # number whose absolute value does not matter. What matters is that every
 # measurement in a series is built the same way, and the series is partitioned
 # on runner class so a change of build profile would start a fresh one anyway.
-[tasks."perf:build"]
-env = { MISE_OFFLINE = "1", MISE_IGNORED_CONFIG_PATHS = "{{config_root}}/mise.toml" }
-run = "cargo build --release"
-
 [tasks.perf]
 dir = "{{config_root}}"
 # MISE_OFFLINE keeps `ls`, `env` and `hook-env` off the network. Without it they
 # log HTTP warnings and their instruction counts move with whatever the registry
 # happened to answer. Ignoring the repository config keeps its development tools
 # out of the fixture so editing this file does not change a benchmark's input.
-# Bypass mbx only for the build so its environment does not perturb the benchmark.
 env = { MISE_OFFLINE = "1", MISE_IGNORED_CONFIG_PATHS = "{{config_root}}/mise.toml" }
-run = [{ task = "perf:build", env = { MBX_DISABLE = "1" } }, "tak run"]
+run = ["cargo build --release", "tak run"]
 
 # Same measurement, appended to refs/notes/tak for this commit. Run by the
 # `perf` workflow on every push to main; the notes are the history. Safe to run
@@ -67,7 +62,7 @@ run = [{ task = "perf:build", env = { MBX_DISABLE = "1" } }, "tak run"]
 [tasks."perf:record"]
 dir = "{{config_root}}"
 env = { MISE_OFFLINE = "1", MISE_IGNORED_CONFIG_PATHS = "{{config_root}}/mise.toml" }
-run = [{ task = "perf:build", env = { MBX_DISABLE = "1" } }, "tak run --record"]
+run = ["cargo build --release", "tak run --record"]
 
 # End-to-end task artifact cache phases. The harness generates an isolated
 # large fixture so benchmark inputs never need to be checked into the repo.

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,7 @@ _.path = ["./target/debug", "./node_modules/.bin"]
 
 [tools]
 actionlint = "latest"
-mr-boxington = { version = "1.1.0", postinstall = "mbx setup --yes" }
+mr-boxington = { version = "1.1.0", postinstall = "mbx setup --global" }
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
 # in mise's numbers, indistinguishable from a real regression. Bump

--- a/mise.toml
+++ b/mise.toml
@@ -48,7 +48,7 @@ includes = ["tasks.toml", "xtasks"]
 # measurement in a series is built the same way, and the series is partitioned
 # on runner class so a change of build profile would start a fresh one anyway.
 [tasks."perf:build"]
-env = { MISE_OFFLINE = "1", MISE_IGNORED_CONFIG_PATHS = "{{config_root}}/mise.toml", MBX_DISABLE = "1" }
+env = { MISE_OFFLINE = "1", MISE_IGNORED_CONFIG_PATHS = "{{config_root}}/mise.toml" }
 run = "cargo build --release"
 
 [tasks.perf]
@@ -59,8 +59,7 @@ dir = "{{config_root}}"
 # out of the fixture so editing this file does not change a benchmark's input.
 # Bypass mbx only for the build so its environment does not perturb the benchmark.
 env = { MISE_OFFLINE = "1", MISE_IGNORED_CONFIG_PATHS = "{{config_root}}/mise.toml" }
-depends = ["perf:build"]
-run = "tak run"
+run = [{ task = "perf:build", env = { MBX_DISABLE = "1" } }, "tak run"]
 
 # Same measurement, appended to refs/notes/tak for this commit. Run by the
 # `perf` workflow on every push to main; the notes are the history. Safe to run
@@ -68,8 +67,7 @@ run = "tak run"
 [tasks."perf:record"]
 dir = "{{config_root}}"
 env = { MISE_OFFLINE = "1", MISE_IGNORED_CONFIG_PATHS = "{{config_root}}/mise.toml" }
-depends = ["perf:build"]
-run = "tak run --record"
+run = [{ task = "perf:build", env = { MBX_DISABLE = "1" } }, "tak run --record"]
 
 # End-to-end task artifact cache phases. The harness generates an isolated
 # large fixture so benchmark inputs never need to be checked into the repo.

--- a/tasks.md
+++ b/tasks.md
@@ -104,8 +104,6 @@ Lint HK files
 
 ## `perf`
 
-- Depends: perf:build
-
 - **Usage:** `perf`
 
 ## `perf:build`
@@ -113,8 +111,6 @@ Lint HK files
 - **Usage:** `perf:build`
 
 ## `perf:record`
-
-- Depends: perf:build
 
 - **Usage:** `perf:record`
 

--- a/tasks.md
+++ b/tasks.md
@@ -104,9 +104,17 @@ Lint HK files
 
 ## `perf`
 
+- Depends: perf:build
+
 - **Usage:** `perf`
 
+## `perf:build`
+
+- **Usage:** `perf:build`
+
 ## `perf:record`
+
+- Depends: perf:build
 
 - **Usage:** `perf:record`
 

--- a/tasks.md
+++ b/tasks.md
@@ -106,10 +106,6 @@ Lint HK files
 
 - **Usage:** `perf`
 
-## `perf:build`
-
-- **Usage:** `perf:build`
-
 ## `perf:record`
 
 - **Usage:** `perf:record`

--- a/tasks.toml
+++ b/tasks.toml
@@ -14,8 +14,8 @@ depends = ['lint:*']
 
 [build]
 alias = "b"
-run = "{{ get_env(name='MISE_CARGO_BUILD_COMMAND', default='mbx build') }} --all-features {{ get_env(name='MISE_CARGO_BUILD_EXTRA_ARGS', default='') }}"
-run_windows = "{{ get_env(name='MISE_CARGO_BUILD_COMMAND', default='mbx build') }} {{ get_env(name='MISE_CARGO_BUILD_EXTRA_ARGS', default='') }}"
+run = "{{ get_env(name='MISE_CARGO_BUILD_COMMAND', default='cargo build') }} --all-features {{ get_env(name='MISE_CARGO_BUILD_EXTRA_ARGS', default='') }}"
+run_windows = "{{ get_env(name='MISE_CARGO_BUILD_COMMAND', default='cargo build') }} {{ get_env(name='MISE_CARGO_BUILD_EXTRA_ARGS', default='') }}"
 description = "Build the project"
 #sources = ["Cargo.*", "src/**/*.rs"]
 #outputs = ["target/debug/mise"]
@@ -142,7 +142,7 @@ run = ["mise tasks run test:unit", "mise tasks run test:e2e"]
 
 ["test:unit"]
 description = "run unit tests"
-run = "mbx test --all-features"
+run = "cargo test --all-features"
 env = { CARGO_TERM_COLOR = "always", "RUST_TEST_THREADS" = "1" }
 
 ["test:e2e"]


### PR DESCRIPTION
## Summary

- adopt the `mr-boxington` mise shorthand at 1.1.0 with the setup post-install hook
- run compilation-heavy tasks through ordinary `cargo` commands and the transparent shim
- refresh the locked release and contributor/agent guidance

## Validation

- `MISE_LOCKED=1 mise install mr-boxington`
- `mise exec -- mbx --version` (`mbx 1.1.0`)
- `mise tasks ls`
- `git diff --check`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches default build/test paths and several CI workflows (release, perf, macOS bootstrap); misconfiguration could affect compile consistency or benchmark validity, but changes are narrowly scoped with explicit bypass flags.
> 
> **Overview**
> Upgrades **mbx / mr-boxington to 1.1.0** and switches day-to-day builds to plain `cargo` while the global post-install shim provides caching. `mise.toml` pins `mr-boxington` with `mbx setup --global`; `tasks.toml` and `hk.pkl` default `build`, `test:unit`, and `cargo-check` to `cargo` instead of `mbx` subcommands. Lock and the composite **Set up mbx** action move to 1.1.0 and drop unused `cache-links` / `toolchain` inputs.
> 
> **Contributor docs** (`AGENTS.md`, `CONTRIBUTING.md`) now describe shim-first workflows and **`MBX_DISABLE=1`** as the bypass, with updated mr-boxington reporting guidance.
> 
> **CI adjustments** keep measurements and nested compiles honest: `perf.yml` and `perf-pr.yml` uninstall mbx activation and strip `/mbx/bin` from `PATH` before tak runs; `release-plz` sets `MISE_CARGO_BUILD_COMMAND` to `MBX_DISABLE=1 cargo build` to avoid CMake/AWS-LC reconfigure; macOS unit tests set `MISE_CARGO_BUILD_COMMAND: mbx build` for bootstrap consistency. Windows unit job timeout increases from 30 to 40 minutes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97b7e08e5431f5375dafb5b9c6b7ea4f5ab67baa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated build-cache tooling to version 1.1 with transparent Cargo integration.
  - Build and unit-test tasks now use standard Cargo commands by default while preserving customization options.
  - Improved release and test workflows for consistent cache-aware builds.
  - Benchmarks can bypass the cache during compilation without affecting other steps.

- **Documentation**
  - Updated setup, troubleshooting, and diagnostic guidance for the new build-cache workflow.
  - Added recommendations for redacting sensitive information in diagnostic reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->