### PR TITLE
feat(shims): add command wrappers

### DIFF
--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -396,7 +396,7 @@ jobs:
 
   windows-unit:
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     needs: [classify-changes]
     if: needs.classify-changes.outputs.full-ci == 'true'
     env:

--- a/docs/dev-tools/shims.md
+++ b/docs/dev-tools/shims.md
@@ -140,6 +140,42 @@ Note that `mise` already runs a reshim anytime a tool is installed/updated/remov
 
 Do not add additional executable in the `mise` directory, `mise` will delete them with the next reshim.
 
+## Command wrappers
+
+Use `[wrappers]` when a command should always pass through another program while
+keeping its ordinary name. For example, this routes every `cargo` invocation
+through [Mr Boxington](https://github.com/jdx/mr-boxington):
+
+```toml
+[tools]
+mr-boxington = "1.1.0"
+
+[wrappers.cargo]
+command = "mbx"
+env = { MBX_CARGO_SHIM_MODE = "1" }
+```
+
+Run `mise reshim` after adding or removing a wrapper. The wrapper is available
+with both `mise activate` and `mise activate --shims`, and takes precedence over
+an executable with the same name. When it delegates, mise removes its dispatch
+directories from `PATH`, so `mbx` resolves Cargo from mise-managed Rust when
+configured and otherwise falls through to rustup or the system installation.
+
+A short form is available when no arguments or environment variables are needed:
+
+```toml
+[wrappers]
+terraform = "tofu"
+```
+
+The detailed form can insert arguments before those supplied by the user:
+
+```toml
+[wrappers.python]
+command = "uv"
+args = ["run", "python"]
+```
+
 ## Shims vs PATH {#shims-vs-path}
 
 The following features are affected when shims are used **instead** of [PATH activation](#path-activation):

--- a/docs/directories.md
+++ b/docs/directories.md
@@ -91,3 +91,8 @@ Setting it there can make an install use one directory while later commands and 
 
 This is where mise places shims. Generally these are used for IDE integration or if `mise activate`
 does not work for some reason.
+
+### `~/.local/share/mise/command-wrappers/bin`
+
+This is where mise places dispatch shims configured by `[wrappers]`. Mise manages
+this directory; use `mise reshim` after adding or removing a command wrapper.

--- a/e2e/cli/test_command_wrappers
+++ b/e2e/cli/test_command_wrappers
@@ -12,7 +12,7 @@ cat >"$fake_bin/cargo" <<'EOF'
 echo system-cargo
 EOF
 chmod +x "$fake_bin/mbx" "$fake_bin/cargo"
-export PATH="$MISE_DATA_DIR/command-wrappers/bin:$MISE_DATA_DIR/shims:$fake_bin:$PATH"
+export PATH="$fake_bin:$PATH"
 
 cat >mise.toml <<'EOF'
 [wrappers.cargo]
@@ -23,6 +23,10 @@ EOF
 mise reshim
 assert_contains "mise hook-env -s bash --force" "$MISE_DATA_DIR/command-wrappers/bin"
 assert_contains "mise activate bash --shims" "$MISE_DATA_DIR/command-wrappers/bin"
+eval "$(mise activate bash --shims)"
+eval "$(mise activate bash --shims)"
+assert "printf '%s\n' \"\$PATH\" | tr ':' '\n' | grep -cx '$MISE_DATA_DIR/command-wrappers/bin'" "1"
+assert "printf '%s\n' \"\$PATH\" | tr ':' '\n' | grep -cx '$MISE_DATA_DIR/shims'" "1"
 assert "mise x -- cargo check" "mbx:1
 system-cargo"
 assert "cargo check" "mbx:1
@@ -74,3 +78,16 @@ other = "mbx"
 EOF
 mise reshim
 assert_fail "test -e '$MISE_DATA_DIR/command-wrappers/bin/cargo'"
+
+cat >mise.toml <<'EOF'
+[wrappers]
+cargo = " "
+EOF
+assert_fail "mise reshim" "must have a non-blank command"
+
+cat >mise.toml <<'EOF'
+[tools]
+dummy = "1.0.0"
+EOF
+mise reshim
+assert_fail "test -e '$MISE_DATA_DIR/command-wrappers/bin'"

--- a/e2e/cli/test_command_wrappers
+++ b/e2e/cli/test_command_wrappers
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+fake_bin="$HOME/wrapper-bin"
+mkdir -p "$fake_bin"
+cat >"$fake_bin/mbx" <<'EOF'
+#!/usr/bin/env bash
+printf 'mbx:%s\n' "$MBX_CARGO_SHIM_MODE"
+exec cargo "$@"
+EOF
+cat >"$fake_bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+echo system-cargo
+EOF
+chmod +x "$fake_bin/mbx" "$fake_bin/cargo"
+export PATH="$MISE_DATA_DIR/command-wrappers/bin:$MISE_DATA_DIR/shims:$fake_bin:$PATH"
+
+cat >mise.toml <<'EOF'
+[wrappers.cargo]
+command = "mbx"
+env = { MBX_CARGO_SHIM_MODE = "1" }
+EOF
+
+mise reshim
+assert_contains "mise hook-env -s bash --force" "$MISE_DATA_DIR/command-wrappers/bin"
+assert_contains "mise activate bash --shims" "$MISE_DATA_DIR/command-wrappers/bin"
+assert "mise x -- cargo check" "mbx:1
+system-cargo"
+assert "cargo check" "mbx:1
+system-cargo"
+
+mise install dummy@1.0.0
+managed_bin="$MISE_DATA_DIR/installs/dummy/1.0.0/bin"
+cat >"$managed_bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+echo managed-cargo
+EOF
+chmod +x "$managed_bin/cargo"
+cat >>mise.toml <<'EOF'
+
+[tools]
+dummy = "1.0.0"
+EOF
+
+mise reshim
+assert "mise x -- cargo check" "mbx:1
+managed-cargo"
+assert "cargo check" "mbx:1
+managed-cargo"
+
+cat >mise.toml <<'EOF'
+[wrappers]
+cargo = "mbx"
+EOF
+mise reshim
+assert "cargo check" "mbx:
+system-cargo"
+
+cat >mise.toml <<'EOF'
+[wrappers.cargo]
+command = "mbx"
+args = ["--fixed"]
+EOF
+cat >"$fake_bin/mbx" <<'EOF'
+#!/usr/bin/env bash
+echo "$*"
+EOF
+chmod +x "$fake_bin/mbx"
+mise reshim
+assert "cargo check" "--fixed check"
+
+cat >mise.toml <<'EOF'
+[wrappers]
+other = "mbx"
+EOF
+mise reshim
+assert_fail "test -e '$MISE_DATA_DIR/command-wrappers/bin/cargo'"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -3612,14 +3612,18 @@
         "oneOf": [
           {
             "description": "command to run",
-            "type": "string"
+            "type": "string",
+            "minLength": 1,
+            "pattern": ".*\\S.*"
           },
           {
             "type": "object",
             "properties": {
               "command": {
                 "description": "command to run",
-                "type": "string"
+                "type": "string",
+                "minLength": 1,
+                "pattern": ".*\\S.*"
               },
               "args": {
                 "description": "arguments inserted before the intercepted command's arguments",

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -3605,6 +3605,43 @@
         "type": "string"
       }
     },
+    "wrappers": {
+      "description": "commands that intercept a binary name before delegating to the active toolset",
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "description": "command to run",
+            "type": "string"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "command": {
+                "description": "command to run",
+                "type": "string"
+              },
+              "args": {
+                "description": "arguments inserted before the intercepted command's arguments",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "env": {
+                "description": "environment variables set for the wrapper",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": ["command"],
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
     "env": {
       "description": "environment variables to set",
       "oneOf": [

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -851,7 +851,7 @@ fn which_non_pristine_spawnable(bin: &str) -> Option<PathBuf> {
     let skip_shims = cfg!(windows);
     let dirs = env::PATH_NON_PRISTINE
         .iter()
-        .filter(|p| !skip_shims || !file::is_mise_shims_dir(p))
+        .filter(|p| !skip_shims || !file::is_mise_dispatch_dir(p))
         .cloned();
     which_in_dirs(dirs, bin, true)
 }
@@ -859,7 +859,7 @@ fn which_non_pristine_spawnable(bin: &str) -> Option<PathBuf> {
 pub(crate) fn which_no_shims_spawnable(bin: &str) -> Option<PathBuf> {
     let dirs = env::PATH_NON_PRISTINE
         .iter()
-        .filter(|p| !file::is_mise_shims_dir(p))
+        .filter(|p| !file::is_mise_dispatch_dir(p))
         .cloned();
     which_in_dirs(dirs, bin, true)
 }
@@ -4037,7 +4037,7 @@ pub(crate) trait Backend: Debug + Send + Sync {
             let original_len = paths.len();
             let filtered: Vec<_> = paths
                 .into_iter()
-                .filter(|p| !file::is_mise_shims_dir(p))
+                .filter(|p| !file::is_mise_dispatch_dir(p))
                 .collect();
             if filtered.len() != original_len {
                 let joined = env::join_paths(&filtered)?;

--- a/src/cli/activate.rs
+++ b/src/cli/activate.rs
@@ -122,6 +122,11 @@ impl Activate {
         if let Some(p) = self.shims_prepend_path(shell, &dirs::SHIMS, prepended_exe_dir) {
             prelude.push(p);
         }
+        if dirs::COMMAND_WRAPPERS.is_dir()
+            && let Some(p) = self.shims_prepend_path(shell, &dirs::COMMAND_WRAPPERS, true)
+        {
+            prelude.push(p);
+        }
         miseprint!("{}", shell.format_activate_prelude(&prelude))?;
         Ok(())
     }

--- a/src/cli/activate.rs
+++ b/src/cli/activate.rs
@@ -119,13 +119,18 @@ impl Activate {
         } else {
             false
         };
-        if let Some(p) = self.shims_prepend_path(shell, &dirs::SHIMS, prepended_exe_dir) {
-            prelude.push(p);
-        }
-        if dirs::COMMAND_WRAPPERS.is_dir()
-            && let Some(p) = self.shims_prepend_path(shell, &dirs::COMMAND_WRAPPERS, true)
-        {
-            prelude.push(p);
+        let has_command_wrappers = dirs::COMMAND_WRAPPERS.is_dir();
+        let dispatch_dirs_already_first = has_command_wrappers
+            && are_dirs_first_in_paths(&env::PATH, &[&dirs::COMMAND_WRAPPERS, &dirs::SHIMS]);
+        if shell.supports_move_path() || prepended_exe_dir || !dispatch_dirs_already_first {
+            if let Some(p) = self.shims_prepend_path(shell, &dirs::SHIMS, prepended_exe_dir) {
+                prelude.push(p);
+            }
+            if has_command_wrappers
+                && let Some(p) = self.shims_prepend_path(shell, &dirs::COMMAND_WRAPPERS, true)
+            {
+                prelude.push(p);
+            }
         }
         miseprint!("{}", shell.format_activate_prelude(&prelude))?;
         Ok(())
@@ -286,6 +291,14 @@ fn is_dir_first_in_paths(paths: &[PathBuf], dir: &Path) -> bool {
         .is_some_and(|p| canonicalize_or_self(p) == dir)
 }
 
+fn are_dirs_first_in_paths(paths: &[PathBuf], dirs: &[&Path]) -> bool {
+    paths.len() >= dirs.len()
+        && paths
+            .iter()
+            .zip(dirs)
+            .all(|(path, dir)| canonicalize_or_self(path) == canonicalize_or_self(dir))
+}
+
 fn is_dir_not_in_nix(dir: &Path) -> bool {
     !canonicalize_or_self(dir).starts_with("/nix/")
 }
@@ -303,7 +316,10 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
-    use super::{forwarded_logging_flags, is_dir_first_in_paths, should_prepend_shims};
+    use super::{
+        are_dirs_first_in_paths, forwarded_logging_flags, is_dir_first_in_paths,
+        should_prepend_shims,
+    };
     use std::path::PathBuf;
 
     fn args(values: &[&str]) -> Vec<String> {
@@ -394,6 +410,27 @@ mod tests {
             std::slice::from_ref(&target),
             &target,
             true
+        ));
+    }
+
+    #[test]
+    fn detects_an_existing_dispatch_prefix() {
+        let root = tempfile::tempdir().unwrap();
+        let wrappers = root.path().join("wrappers");
+        let shims = root.path().join("shims");
+        let other = root.path().join("other");
+
+        assert!(are_dirs_first_in_paths(
+            &[wrappers.clone(), shims.clone(), other.clone()],
+            &[&wrappers, &shims]
+        ));
+        assert!(!are_dirs_first_in_paths(
+            &[shims.clone(), wrappers.clone(), other],
+            &[&wrappers, &shims]
+        ));
+        assert!(!are_dirs_first_in_paths(
+            std::slice::from_ref(&wrappers),
+            &[&wrappers, &shims]
         ));
     }
 }

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -138,8 +138,15 @@ impl Exec {
                 .await?
         });
 
-        self.run_with_context(config, ts, resolve_options, has_explicit_latest)
-            .await
+        self.run_with_context(
+            config,
+            ts,
+            resolve_options,
+            has_explicit_latest,
+            BTreeMap::new(),
+            false,
+        )
+        .await
     }
 
     /// Execute with a toolset that the shim path has already resolved while
@@ -149,8 +156,32 @@ impl Exec {
         config: Arc<Config>,
         ts: Toolset,
     ) -> eyre::Result<()> {
-        self.run_with_context(config, ts, ResolveOptions::default(), false)
-            .await
+        self.run_with_context(
+            config,
+            ts,
+            ResolveOptions::default(),
+            false,
+            BTreeMap::new(),
+            false,
+        )
+        .await
+    }
+
+    pub(crate) async fn run_with_command_wrapper(
+        self,
+        config: Arc<Config>,
+        ts: Toolset,
+        wrapper_env: BTreeMap<String, String>,
+    ) -> eyre::Result<()> {
+        self.run_with_context(
+            config,
+            ts,
+            ResolveOptions::default(),
+            false,
+            wrapper_env,
+            true,
+        )
+        .await
     }
 
     async fn run_with_context(
@@ -159,6 +190,8 @@ impl Exec {
         mut ts: Toolset,
         resolve_options: ResolveOptions,
         has_explicit_latest: bool,
+        wrapper_env: BTreeMap<String, String>,
+        strip_dispatch_dirs: bool,
     ) -> eyre::Result<()> {
         let opts = InstallOptions {
             force: false,
@@ -190,6 +223,10 @@ impl Exec {
         let (program, mut args) = parse_command(&env::SHELL, &self.command, &self.c);
 
         let mut env = measure!("env_with_path", { ts.env_with_path(&config).await? });
+        env.extend(wrapper_env);
+        if strip_dispatch_dirs && let Some(path) = env.get_mut(&*env::PATH_KEY) {
+            *path = crate::file::strip_dispatch_dirs_from_path(path);
+        }
 
         // Run auto-enabled deps steps (unless --no-deps)
         if !self.no_deps {
@@ -347,19 +384,38 @@ where
             // The child process still inherits the full unmodified PATH.
             let pristine: std::collections::HashSet<_> = crate::env::PATH.iter().collect();
             let all_paths: Vec<_> = std::env::split_paths(&OsString::from(path_val)).collect();
+            let wrappers: Vec<_> = all_paths
+                .iter()
+                .filter(|p| crate::file::is_command_wrapper_dir(p))
+                .cloned()
+                .collect();
             // Mise-added paths first (preserving relative order)
             let mise_added: Vec<_> = all_paths
                 .iter()
-                .filter(|p| !pristine.contains(p) && !crate::file::is_mise_shims_dir(p))
+                .filter(|p| {
+                    !pristine.contains(p)
+                        && !crate::file::is_mise_shims_dir(p)
+                        && !crate::file::is_command_wrapper_dir(p)
+                })
                 .cloned()
                 .collect();
             // Then original system paths (minus shims)
             let original: Vec<_> = all_paths
                 .iter()
-                .filter(|p| pristine.contains(p) && !crate::file::is_mise_shims_dir(p))
+                .filter(|p| {
+                    pristine.contains(p)
+                        && !crate::file::is_mise_shims_dir(p)
+                        && !crate::file::is_command_wrapper_dir(p)
+                })
                 .cloned()
                 .collect();
-            std::env::join_paths(mise_added.iter().chain(original.iter())).unwrap()
+            std::env::join_paths(
+                wrappers
+                    .iter()
+                    .chain(mise_added.iter())
+                    .chain(original.iter()),
+            )
+            .unwrap()
         });
         let is_shim_dispatch = env::MISE_SHIM_PATH.read().unwrap().is_some();
         match which::which_in_all(&program, lookup_path, cwd) {
@@ -470,6 +526,11 @@ where
             })
             .collect();
         let all_paths: Vec<_> = std::env::split_paths(&OsString::from(path_val)).collect();
+        let wrappers: Vec<_> = all_paths
+            .iter()
+            .filter(|p| crate::file::is_command_wrapper_dir(p))
+            .cloned()
+            .collect();
         let mise_added: Vec<_> = all_paths
             .iter()
             .filter(|p| {
@@ -477,7 +538,9 @@ where
                     .to_string_lossy()
                     .to_lowercase()
                     .replace('/', "\\");
-                !pristine.contains(&normalized) && !crate::file::is_mise_shims_dir(p)
+                !pristine.contains(&normalized)
+                    && !crate::file::is_mise_shims_dir(p)
+                    && !crate::file::is_command_wrapper_dir(p)
             })
             .cloned()
             .collect();
@@ -488,11 +551,19 @@ where
                     .to_string_lossy()
                     .to_lowercase()
                     .replace('/', "\\");
-                pristine.contains(&normalized) && !crate::file::is_mise_shims_dir(p)
+                pristine.contains(&normalized)
+                    && !crate::file::is_mise_shims_dir(p)
+                    && !crate::file::is_command_wrapper_dir(p)
             })
             .cloned()
             .collect();
-        std::env::join_paths(mise_added.iter().chain(original.iter())).unwrap()
+        std::env::join_paths(
+            wrappers
+                .iter()
+                .chain(mise_added.iter())
+                .chain(original.iter()),
+        )
+        .unwrap()
     });
     // Capture the requested program name before `which_in_all` consumes it, so
     // a resolution failure while dispatching a shim can name the tool.

--- a/src/config/command_wrapper.rs
+++ b/src/config/command_wrapper.rs
@@ -1,0 +1,44 @@
+use indexmap::IndexMap;
+use serde::Deserialize;
+
+/// A command that intercepts a binary name before delegating to the toolset.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum CommandWrapper {
+    Command(String),
+    Detailed(CommandWrapperOptions),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct CommandWrapperOptions {
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub env: IndexMap<String, String>,
+}
+
+impl CommandWrapper {
+    pub(crate) fn command(&self) -> &str {
+        match self {
+            Self::Command(command) => command,
+            Self::Detailed(options) => &options.command,
+        }
+    }
+
+    pub(crate) fn args(&self) -> &[String] {
+        match self {
+            Self::Command(_) => &[],
+            Self::Detailed(options) => &options.args,
+        }
+    }
+
+    pub(crate) fn env(&self) -> &IndexMap<String, String> {
+        static EMPTY: std::sync::LazyLock<IndexMap<String, String>> =
+            std::sync::LazyLock::new(IndexMap::new);
+        match self {
+            Self::Command(_) => &EMPTY,
+            Self::Detailed(options) => &options.env,
+        }
+    }
+}

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -27,7 +27,7 @@ use crate::config::env_directive::{
     AgeFormat, EnvDirective, EnvDirectiveOptions, EnvValue, RequiredValue,
 };
 use crate::config::settings::SettingsPartial;
-use crate::config::{Alias, AliasMap, Config, Settings};
+use crate::config::{Alias, AliasMap, CommandWrapper, Config, Settings};
 use crate::deps::{DepsConfig, DepsTemplateContext};
 use crate::env_diff::EnvMap;
 use crate::file::{create_dir_all, display_path};
@@ -383,6 +383,8 @@ pub(crate) struct MiseToml {
     tool_alias: AliasMap,
     #[serde(default)]
     shell_alias: IndexMap<String, String>,
+    #[serde(default)]
+    wrappers: IndexMap<String, CommandWrapper>,
     #[serde(skip)]
     doc: Mutex<OnceCell<DocumentMut>>,
     #[serde(default)]
@@ -1598,6 +1600,10 @@ impl ConfigFile for MiseToml {
             .collect()
     }
 
+    fn command_wrappers(&self) -> eyre::Result<IndexMap<String, CommandWrapper>> {
+        Ok(self.wrappers.clone())
+    }
+
     fn task_config(&self) -> &TaskConfig {
         &self.task_config
     }
@@ -1874,6 +1880,7 @@ impl Clone for MiseToml {
             alias: self.alias.clone(),
             tool_alias: self.tool_alias.clone(),
             shell_alias: self.shell_alias.clone(),
+            wrappers: self.wrappers.clone(),
             doc: Mutex::new(self.doc.lock().unwrap().clone()),
             hooks: self.hooks.clone(),
             tools: Mutex::new(self.tools.lock().unwrap().clone()),

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -15,7 +15,7 @@ use crate::config::config_file::mise_toml::{MiseToml, MonorepoConfig};
 use crate::config::env_directive::EnvDirective;
 use crate::config::provenance::ConfigProvenance;
 use crate::config::settings::IdiomaticVersionFileSettings;
-use crate::config::{AliasMap, Settings, settings};
+use crate::config::{AliasMap, CommandWrapper, Settings, settings};
 use crate::deps::DepsConfig;
 use crate::errors::Error::UntrustedConfig;
 use crate::file::display_path;
@@ -146,6 +146,10 @@ pub(crate) trait ConfigFile: Debug + Send + Sync {
     }
 
     fn shell_aliases(&self) -> eyre::Result<IndexMap<String, String>> {
+        Ok(Default::default())
+    }
+
+    fn command_wrappers(&self) -> eyre::Result<IndexMap<String, CommandWrapper>> {
         Ok(Default::default())
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -47,6 +47,7 @@ use crate::toolset::{
 use crate::ui::style;
 use crate::{backend, dirs, env, file, lockfile, registry, runtime_symlinks, shims, timeout};
 
+pub(crate) mod command_wrapper;
 pub(crate) mod config_file;
 pub(crate) mod env_directive;
 pub(crate) mod miserc;
@@ -62,6 +63,7 @@ use crate::redactions::Redactor;
 use crate::tera::BASE_CONTEXT;
 use crate::watch_files::WatchFile;
 use crate::wildcard::Wildcard;
+pub(crate) use command_wrapper::CommandWrapper;
 
 type AliasMap = IndexMap<String, Alias>;
 pub(crate) type ConfigMap = IndexMap<PathBuf, Arc<dyn ConfigFile>>;
@@ -1263,7 +1265,7 @@ impl Config {
         if let Some(cache_key) = cache_key.as_ref()
             && let Some(cached) = CachedNonToolEnv::load(cache_key)?
         {
-            let env_results = EnvResults {
+            let mut env_results = EnvResults {
                 env: cached.env.clone(),
                 vars: Default::default(),
                 env_remove: cached.env_remove.clone(),
@@ -1277,6 +1279,13 @@ impl Config {
                 watch_files: cached.watch_files.clone(),
                 has_uncacheable: false,
             };
+            if !load_command_wrappers(&self.config_files)?.is_empty()
+                && !env_results.env_paths.contains(&*dirs::COMMAND_WRAPPERS)
+            {
+                env_results
+                    .env_paths
+                    .insert(0, dirs::COMMAND_WRAPPERS.clone());
+            }
             let redact_keys = self
                 .redaction_keys()
                 .into_iter()
@@ -1320,6 +1329,11 @@ impl Config {
             },
         )
         .await?;
+        if !load_command_wrappers(&self.config_files)?.is_empty() {
+            env_results
+                .env_paths
+                .insert(0, dirs::COMMAND_WRAPPERS.clone());
+        }
         for env_file in Settings::get().env_files() {
             if env_results.env_files.contains(&env_file) {
                 continue;
@@ -2964,6 +2978,21 @@ fn load_shell_aliases(config_files: &ConfigMap) -> Result<EnvWithSources> {
     trace!("load_shell_aliases: {}", shell_aliases.len());
 
     Ok(shell_aliases)
+}
+
+/// Load command wrappers from global through project scope.
+pub(crate) fn load_command_wrappers(
+    config_files: &ConfigMap,
+) -> Result<IndexMap<String, CommandWrapper>> {
+    let mut wrappers = IndexMap::new();
+    let safe_mode = Settings::safe_mode();
+    for config_file in config_files.values().rev() {
+        if safe_mode && !is_global_config(config_file.get_path()) {
+            continue;
+        }
+        wrappers.extend(config_file.command_wrappers()?);
+    }
+    Ok(wrappers)
 }
 
 fn load_plugins(config_files: &ConfigMap) -> Result<HashMap<String, String>> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2990,7 +2990,12 @@ pub(crate) fn load_command_wrappers(
         if safe_mode && !is_global_config(config_file.get_path()) {
             continue;
         }
-        wrappers.extend(config_file.command_wrappers()?);
+        for (name, wrapper) in config_file.command_wrappers()? {
+            if wrapper.command().trim().is_empty() {
+                bail!("command wrapper for {name:?} must have a non-blank command");
+            }
+            wrappers.insert(name, wrapper);
+        }
     }
     Ok(wrappers)
 }

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -16,6 +16,8 @@ pub(crate) static PLUGINS: Lazy<&Path> = Lazy::new(|| &env::MISE_PLUGINS_DIR);
 pub(crate) static DOWNLOADS: Lazy<&Path> = Lazy::new(|| &env::MISE_DOWNLOADS_DIR);
 pub(crate) static INSTALLS: Lazy<&Path> = Lazy::new(|| &env::MISE_INSTALLS_DIR);
 pub(crate) static SHIMS: Lazy<&Path> = Lazy::new(|| &env::MISE_SHIMS_DIR);
+pub(crate) static COMMAND_WRAPPERS: Lazy<PathBuf> =
+    Lazy::new(|| DATA.join("command-wrappers").join("bin"));
 
 pub(crate) static TRACKED_CONFIGS: Lazy<PathBuf> = Lazy::new(|| STATE.join("tracked-configs"));
 pub(crate) static TRACKED_STUBS: Lazy<PathBuf> = Lazy::new(|| STATE.join("tracked-stubs"));

--- a/src/file.rs
+++ b/src/file.rs
@@ -1804,7 +1804,7 @@ pub(crate) fn is_active_mise_shim(path: &Path) -> bool {
 pub(crate) fn path_env_without_shims() -> std::ffi::OsString {
     let filtered: Vec<_> = env::PATH_NON_PRISTINE
         .iter()
-        .filter(|p| !is_mise_shims_dir(p))
+        .filter(|p| !is_mise_dispatch_dir(p))
         .cloned()
         .collect();
     std::env::join_paths(filtered)
@@ -1815,7 +1815,7 @@ pub(crate) fn path_env_without_shims() -> std::ffi::OsString {
 /// subprocess receives a custom env map (e.g. `PRISTINE_ENV`) rather
 /// than inheriting the current process's PATH.
 pub(crate) fn strip_shims_from_path(path_val: &str) -> String {
-    let filtered = env::split_paths(path_val).filter(|p| !is_mise_shims_dir(p));
+    let filtered = env::split_paths(path_val).filter(|p| !is_mise_dispatch_dir(p));
     std::env::join_paths(filtered)
         .unwrap_or_else(|_| std::ffi::OsString::from(path_val))
         .to_string_lossy()
@@ -1826,8 +1826,7 @@ pub(crate) fn strip_shims_from_path(path_val: &str) -> String {
 /// delegates. This lets the wrapped command resolve a tool managed by mise or
 /// fall through to rustup/the system without invoking the wrapper again.
 pub(crate) fn strip_dispatch_dirs_from_path(path_val: &str) -> String {
-    let filtered =
-        env::split_paths(path_val).filter(|p| !is_mise_shims_dir(p) && !is_command_wrapper_dir(p));
+    let filtered = env::split_paths(path_val).filter(|p| !is_mise_dispatch_dir(p));
     std::env::join_paths(filtered)
         .unwrap_or_else(|_| std::ffi::OsString::from(path_val))
         .to_string_lossy()
@@ -1835,7 +1834,16 @@ pub(crate) fn strip_dispatch_dirs_from_path(path_val: &str) -> String {
 }
 
 pub(crate) fn is_command_wrapper_dir(path: &Path) -> bool {
-    paths_eq(&replace_path(path), &dirs::COMMAND_WRAPPERS)
+    let resolved = replace_path(path);
+    paths_eq(&resolved, &dirs::COMMAND_WRAPPERS)
+        || paths_eq(
+            &canonicalize_or_self(&resolved),
+            &canonicalize_or_self(&dirs::COMMAND_WRAPPERS),
+        )
+}
+
+pub(crate) fn is_mise_dispatch_dir(path: &Path) -> bool {
+    is_mise_shims_dir(path) || is_command_wrapper_dir(path)
 }
 
 /// returns the first executable in PATH, excluding the mise shim directories
@@ -1844,7 +1852,7 @@ pub(crate) fn is_command_wrapper_dir(path: &Path) -> bool {
 pub(crate) fn which_no_shims<P: AsRef<Path>>(name: P) -> Option<PathBuf> {
     let paths: Vec<PathBuf> = env::PATH_NON_PRISTINE
         .iter()
-        .filter(|p| !is_mise_shims_dir(p))
+        .filter(|p| !is_mise_dispatch_dir(p))
         .cloned()
         .collect();
     _which(name, &paths)

--- a/src/file.rs
+++ b/src/file.rs
@@ -1822,6 +1822,22 @@ pub(crate) fn strip_shims_from_path(path_val: &str) -> String {
         .into_owned()
 }
 
+/// Strip every mise dispatch directory from PATH before a command wrapper
+/// delegates. This lets the wrapped command resolve a tool managed by mise or
+/// fall through to rustup/the system without invoking the wrapper again.
+pub(crate) fn strip_dispatch_dirs_from_path(path_val: &str) -> String {
+    let filtered =
+        env::split_paths(path_val).filter(|p| !is_mise_shims_dir(p) && !is_command_wrapper_dir(p));
+    std::env::join_paths(filtered)
+        .unwrap_or_else(|_| std::ffi::OsString::from(path_val))
+        .to_string_lossy()
+        .into_owned()
+}
+
+pub(crate) fn is_command_wrapper_dir(path: &Path) -> bool {
+    paths_eq(&replace_path(path), &dirs::COMMAND_WRAPPERS)
+}
+
 /// returns the first executable in PATH, excluding the mise shim directories
 /// use this for internal tool lookups to avoid recursive shim invocations
 /// (shims call `mise exec`, which would re-enter the same code path)

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -938,7 +938,7 @@ fn external_rustup_bin_dir(
 ) -> Option<PathBuf> {
     paths
         .iter()
-        .filter(|path| !file::is_mise_shims_dir(path))
+        .filter(|path| !file::is_mise_dispatch_dir(path))
         .find(|path| {
             [RUSTUP_BIN, CARGO_BIN, RUSTC_BIN]
                 .iter()

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -496,7 +496,7 @@ fn remove_shims_individually(shims_dir: &Path) -> Result<()> {
 /// reshim or when the lock is released.
 fn remove_shim_with_rename_fallback(path: &Path) -> Result<()> {
     // First, try to clean up any leftover .old files from a previous run.
-    let old_path = path.with_extension("old");
+    let old_path = old_shim_path(path);
     if old_path.exists() {
         let _ = fs::remove_file(&old_path); // best-effort
     }
@@ -522,6 +522,12 @@ fn remove_shim_with_rename_fallback(path: &Path) -> Result<()> {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(e) => Err(e).wrap_err_with(|| format!("failed to remove shim: {}", display_path(path))),
     }
+}
+
+fn old_shim_path(path: &Path) -> PathBuf {
+    let mut name = path.file_name().unwrap_or_default().to_os_string();
+    name.push(".old");
+    path.with_file_name(name)
 }
 
 /// Find the `mise-shim.exe` that ships beside `mise_bin`, if there is one.
@@ -1137,6 +1143,15 @@ mod tests {
     use super::*;
     use crate::cli::args::BackendArg;
     use crate::toolset::{ToolRequest, ToolSource, ToolVersionList};
+
+    #[test]
+    fn locked_windows_shims_get_distinct_old_paths() {
+        assert_eq!(old_shim_path(Path::new("foo")), PathBuf::from("foo.old"));
+        assert_eq!(
+            old_shim_path(Path::new("foo.cmd")),
+            PathBuf::from("foo.cmd.old")
+        );
+    }
 
     #[test]
     fn snap_mise_bin_uses_refresh_stable_current_path() {

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -10,7 +10,7 @@ use std::{
 use crate::backend::Backend;
 use crate::cli::args::BackendArg;
 use crate::cli::exec::Exec;
-use crate::config::{Config, Settings};
+use crate::config::{CommandWrapper, Config, Settings, load_command_wrappers};
 use crate::file::display_path;
 use crate::lock_file::LockFile;
 use crate::toolset::{ResolveOptions, ToolVersion, Toolset, ToolsetBuilder};
@@ -53,8 +53,11 @@ pub(crate) async fn handle_shim() -> Result<()> {
     let mut args = env::ARGS.read().unwrap().clone();
     env::PREFER_OFFLINE.store(true, Ordering::Relaxed);
     trace!("shim[{bin_name}] args: {}", args.join(" "));
-    let (bin, ts) = which_shim(&mut config, &env::MISE_BIN_NAME, &args).await?;
+    let (bin, ts, wrapper) = which_shim(&mut config, &env::MISE_BIN_NAME, &args).await?;
     args[0] = bin.to_string_lossy().to_string();
+    if let Some(wrapper) = &wrapper {
+        args.splice(1..1, wrapper.args().iter().cloned());
+    }
     env::set_var("__MISE_SHIM", "1");
     let exec = Exec {
         tool: vec![],
@@ -75,7 +78,20 @@ pub(crate) async fn handle_shim() -> Result<()> {
         allow_env: vec![],
     };
     time!("shim exec");
-    exec.run_with_toolset(config, ts).await?;
+    if let Some(wrapper) = wrapper {
+        exec.run_with_command_wrapper(
+            config,
+            ts,
+            wrapper
+                .env()
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect(),
+        )
+        .await?;
+    } else {
+        exec.run_with_toolset(config, ts).await?;
+    }
     Err(request_exit(0))
 }
 
@@ -101,7 +117,7 @@ async fn which_shim(
     config: &mut Arc<Config>,
     bin_name: &str,
     args: &[String],
-) -> Result<(PathBuf, Toolset)> {
+) -> Result<(PathBuf, Toolset, Option<CommandWrapper>)> {
     // Shell completion invokes `usage complete-word` through the `usage` shim.
     // It should use the installed CLI or fail locally, never resolve a floating
     // tool version or auto-install over the network while the user is pressing
@@ -124,6 +140,13 @@ async fn which_shim(
         .with_resolve_options(resolve_options)
         .build(config)
         .await?;
+    if let Some(wrapper) = load_command_wrappers(&config.config_files)?.get(bin_stem) {
+        if wrapper.command() == bin_stem {
+            bail!("command wrapper for {bin_stem} cannot delegate to itself");
+        }
+        trace!("shim[{bin_name}] WRAPPER command: {}", wrapper.command());
+        return Ok((PathBuf::from(wrapper.command()), ts, Some(wrapper.clone())));
+    }
     // A configured tool may intentionally override an executable bundled by another installed
     // tool (for example, a pinned npm overrides Node's npm). Install a missing provider declared
     // by the registry before resolving an incidental installed provider.
@@ -144,7 +167,7 @@ async fn which_shim(
                     "shim[{bin_name}] REGISTRY ToolVersion: {tv} bin: {bin}",
                     bin = display_path(&bin)
                 );
-                return Ok((bin, ts));
+                return Ok((bin, ts, None));
             }
         }
     }
@@ -155,7 +178,7 @@ async fn which_shim(
             "shim[{bin_name}] ToolVersion: {tv} bin: {bin}",
             bin = display_path(&bin)
         );
-        return Ok((bin, ts));
+        return Ok((bin, ts, None));
     }
     // Auto-installing here would download a tool over the network; skip it for
     // offline completion so `usage complete-word` fails locally instead.
@@ -171,7 +194,7 @@ async fn which_shim(
                     "shim[{bin_name}] NOT_FOUND ToolVersion: {tv} bin: {bin}",
                     bin = display_path(&bin)
                 );
-                return Ok((bin, ts));
+                return Ok((bin, ts, None));
             }
         }
     }
@@ -179,7 +202,7 @@ async fn which_shim(
     if Settings::get().not_found_system_fallback {
         let mise_bin = file::canonicalize_or_self(&env::MISE_BIN);
         for path in &*env::PATH {
-            if file::is_mise_shims_dir(path) {
+            if file::is_mise_shims_dir(path) || file::is_command_wrapper_dir(path) {
                 continue;
             }
             let bin = path.join(bin_name);
@@ -192,7 +215,7 @@ async fn which_shim(
                     continue;
                 }
                 trace!("shim[{bin_name}] SYSTEM {bin}", bin = display_path(&bin));
-                return Ok((bin, ts));
+                return Ok((bin, ts, None));
             }
         }
     }
@@ -333,6 +356,54 @@ pub(crate) async fn reshim(config: &Arc<Config>, ts: &Toolset, force: bool) -> R
         .into_iter()
         .collect::<Result<Vec<_>>>()?;
 
+    sync_command_wrapper_shims(
+        config,
+        &mise_bin,
+        force || shim_mode_changed || shim_version_changed,
+    )?;
+
+    Ok(())
+}
+
+fn sync_command_wrapper_shims(config: &Config, mise_bin: &Path, force: bool) -> Result<()> {
+    if force {
+        if cfg!(windows) {
+            remove_shims_individually(&dirs::COMMAND_WRAPPERS)?;
+        } else {
+            file::remove_all(&*dirs::COMMAND_WRAPPERS)?;
+        }
+    }
+    file::create_dir_all(&*dirs::COMMAND_WRAPPERS)?;
+
+    let wrappers = load_command_wrappers(&config.config_files)?;
+    let mut desired = HashSet::new();
+    for name in wrappers.keys() {
+        validate_wrapper_name(name)?;
+        desired.extend(platform_shim_names(mise_bin, name));
+    }
+    let actual = list_shims_in(&dirs::COMMAND_WRAPPERS)?;
+    for shim in desired.difference(&actual) {
+        let path = dirs::COMMAND_WRAPPERS.join(shim);
+        if cfg!(windows) && path.exists() {
+            remove_shim_with_rename_fallback(&path)?;
+        }
+        add_shim(mise_bin, &path, shim)?;
+    }
+    for shim in actual.difference(&desired) {
+        let path = dirs::COMMAND_WRAPPERS.join(shim);
+        if cfg!(windows) {
+            remove_shim_with_rename_fallback(&path)?;
+        } else {
+            file::remove_all(&path)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_wrapper_name(name: &str) -> Result<()> {
+    if name.is_empty() || name == "." || name == ".." || name.contains('/') || name.contains('\\') {
+        bail!("invalid command wrapper name: {name:?}");
+    }
     Ok(())
 }
 
@@ -713,7 +784,11 @@ fn list_executables_in_dir(dir: &Path) -> Result<HashSet<String>> {
 }
 
 fn list_shims() -> Result<HashSet<String>> {
-    Ok(dirs::SHIMS
+    list_shims_in(&dirs::SHIMS)
+}
+
+fn list_shims_in(dir: &Path) -> Result<HashSet<String>> {
+    Ok(dir
         .read_dir()?
         .map(|bin| {
             let bin = bin?;
@@ -772,45 +847,36 @@ async fn get_desired_shims(
                 warn!("Error listing bin paths for {}: {:#}", tv, e);
                 Vec::new()
             });
-        if cfg!(windows) {
-            #[cfg(windows)]
-            let shim_mode = effective_shim_mode(_mise_bin);
-            #[cfg(not(windows))]
-            let shim_mode = String::new();
-            shims.extend(bins.into_iter().flat_map(|b| {
-                let p = PathBuf::from(&b);
-                match shim_mode.as_ref() {
-                    "hardlink" | "symlink" => {
-                        vec![p.with_extension("exe").to_string_lossy().to_string()]
-                    }
-                    "exe" => {
-                        // Only the native <tool>.exe is needed. Git Bash / Cygwin /
-                        // MSYS2 resolve a bare `tool` to `tool.exe` via their `.exe`
-                        // magic, and mise-shim.exe derives the tool from its own file
-                        // name, so it runs correctly however it is invoked. We do NOT
-                        // emit an extension-less bash shim here: that variant is only
-                        // required in "file" mode (no .exe, and Cygwin won't auto-append
-                        // .cmd) and is what leaked into WSL via /mnt/c PATH interop
-                        // (#10299).
-                        vec![p.with_extension("exe").to_string_lossy().to_string()]
-                    }
-                    "file" => {
-                        vec![
-                            p.with_extension("").to_string_lossy().to_string(),
-                            p.with_extension("cmd").to_string_lossy().to_string(),
-                        ]
-                    }
-                    _ => panic!("Unknown shim mode"),
-                }
-            }));
-        } else if cfg!(macos) {
-            // some bins might be uppercased but on mac APFS is case-insensitive
-            shims.extend(bins.into_iter().map(|b| b.to_lowercase()));
-        } else {
-            shims.extend(bins);
-        }
+        shims.extend(
+            bins.into_iter()
+                .flat_map(|b| platform_shim_names(_mise_bin, &b)),
+        );
     }
     Ok(shims)
+}
+
+fn platform_shim_names(_mise_bin: &Path, bin: &str) -> Vec<String> {
+    if cfg!(windows) {
+        #[cfg(windows)]
+        let shim_mode = effective_shim_mode(_mise_bin);
+        #[cfg(not(windows))]
+        let shim_mode = String::new();
+        let p = PathBuf::from(bin);
+        match shim_mode.as_ref() {
+            "hardlink" | "symlink" | "exe" => {
+                vec![p.with_extension("exe").to_string_lossy().to_string()]
+            }
+            "file" => vec![
+                p.with_extension("").to_string_lossy().to_string(),
+                p.with_extension("cmd").to_string_lossy().to_string(),
+            ],
+            _ => panic!("Unknown shim mode"),
+        }
+    } else if cfg!(macos) {
+        vec![bin.to_lowercase()]
+    } else {
+        vec![bin.to_string()]
+    }
 }
 
 // lists all the paths to bins in a tv that shims will be needed for

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -144,13 +144,13 @@ async fn which_shim(
     let wrapper = if cfg!(macos) {
         wrappers
             .iter()
-            .find(|(name, _)| name.to_lowercase() == bin_stem)
+            .find(|(name, _)| command_names_eq(name, bin_stem))
             .map(|(_, wrapper)| wrapper)
     } else {
         wrappers.get(bin_stem)
     };
     if let Some(wrapper) = wrapper {
-        if wrapper.command() == bin_stem {
+        if command_names_eq(wrapper.command(), bin_stem) {
             bail!("command wrapper for {bin_stem} cannot delegate to itself");
         }
         trace!("shim[{bin_name}] WRAPPER command: {}", wrapper.command());
@@ -379,8 +379,9 @@ fn sync_command_wrapper_shims(config: &Config, mise_bin: &Path, force: bool) -> 
     if wrappers.is_empty() {
         if cfg!(windows) {
             remove_shims_individually(&dirs::COMMAND_WRAPPERS)?;
+        } else {
+            file::remove_all(&*dirs::COMMAND_WRAPPERS)?;
         }
-        file::remove_all(&*dirs::COMMAND_WRAPPERS)?;
         return Ok(());
     }
     if force {
@@ -414,6 +415,14 @@ fn sync_command_wrapper_shims(config: &Config, mise_bin: &Path, force: bool) -> 
         }
     }
     Ok(())
+}
+
+fn command_names_eq(a: &str, b: &str) -> bool {
+    if cfg!(macos) {
+        a.to_lowercase() == b.to_lowercase()
+    } else {
+        a == b
+    }
 }
 
 fn validate_wrapper_name(name: &str) -> Result<()> {

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -140,7 +140,16 @@ async fn which_shim(
         .with_resolve_options(resolve_options)
         .build(config)
         .await?;
-    if let Some(wrapper) = load_command_wrappers(&config.config_files)?.get(bin_stem) {
+    let wrappers = load_command_wrappers(&config.config_files)?;
+    let wrapper = if cfg!(macos) {
+        wrappers
+            .iter()
+            .find(|(name, _)| name.to_lowercase() == bin_stem)
+            .map(|(_, wrapper)| wrapper)
+    } else {
+        wrappers.get(bin_stem)
+    };
+    if let Some(wrapper) = wrapper {
         if wrapper.command() == bin_stem {
             bail!("command wrapper for {bin_stem} cannot delegate to itself");
         }
@@ -366,6 +375,14 @@ pub(crate) async fn reshim(config: &Arc<Config>, ts: &Toolset, force: bool) -> R
 }
 
 fn sync_command_wrapper_shims(config: &Config, mise_bin: &Path, force: bool) -> Result<()> {
+    let wrappers = load_command_wrappers(&config.config_files)?;
+    if wrappers.is_empty() {
+        if cfg!(windows) {
+            remove_shims_individually(&dirs::COMMAND_WRAPPERS)?;
+        }
+        file::remove_all(&*dirs::COMMAND_WRAPPERS)?;
+        return Ok(());
+    }
     if force {
         if cfg!(windows) {
             remove_shims_individually(&dirs::COMMAND_WRAPPERS)?;
@@ -375,7 +392,6 @@ fn sync_command_wrapper_shims(config: &Config, mise_bin: &Path, force: bool) -> 
     }
     file::create_dir_all(&*dirs::COMMAND_WRAPPERS)?;
 
-    let wrappers = load_command_wrappers(&config.config_files)?;
     let mut desired = HashSet::new();
     for name in wrappers.keys() {
         validate_wrapper_name(name)?;

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -141,6 +141,7 @@ async fn which_shim(
         .build(config)
         .await?;
     let wrappers = load_command_wrappers(&config.config_files)?;
+    validate_wrapper_names(wrappers.keys())?;
     let wrapper = if cfg!(macos) {
         wrappers
             .iter()
@@ -376,6 +377,7 @@ pub(crate) async fn reshim(config: &Arc<Config>, ts: &Toolset, force: bool) -> R
 
 fn sync_command_wrapper_shims(config: &Config, mise_bin: &Path, force: bool) -> Result<()> {
     let wrappers = load_command_wrappers(&config.config_files)?;
+    validate_wrapper_names(wrappers.keys())?;
     if wrappers.is_empty() {
         if cfg!(windows) {
             remove_shims_individually(&dirs::COMMAND_WRAPPERS)?;
@@ -395,7 +397,6 @@ fn sync_command_wrapper_shims(config: &Config, mise_bin: &Path, force: bool) -> 
 
     let mut desired = HashSet::new();
     for name in wrappers.keys() {
-        validate_wrapper_name(name)?;
         desired.extend(platform_shim_names(mise_bin, name));
     }
     let actual = list_shims_in(&dirs::COMMAND_WRAPPERS)?;
@@ -428,6 +429,20 @@ fn command_names_eq(a: &str, b: &str) -> bool {
 fn validate_wrapper_name(name: &str) -> Result<()> {
     if name.is_empty() || name == "." || name == ".." || name.contains('/') || name.contains('\\') {
         bail!("invalid command wrapper name: {name:?}");
+    }
+    if cfg!(windows) && name.contains('.') {
+        bail!("command wrapper names cannot contain dots on Windows: {name:?}");
+    }
+    Ok(())
+}
+
+fn validate_wrapper_names<'a>(names: impl IntoIterator<Item = &'a String>) -> Result<()> {
+    let mut normalized = HashSet::new();
+    for name in names {
+        validate_wrapper_name(name)?;
+        if cfg!(macos) && !normalized.insert(name.to_lowercase()) {
+            bail!("command wrapper names collide on macOS after case normalization: {name:?}");
+        }
     }
     Ok(())
 }
@@ -1151,6 +1166,20 @@ mod tests {
             old_shim_path(Path::new("foo.cmd")),
             PathBuf::from("foo.cmd.old")
         );
+    }
+
+    #[cfg(macos)]
+    #[test]
+    fn case_colliding_macos_wrapper_names_are_rejected() {
+        let names = ["Foo".to_string(), "foo".to_string()];
+        assert!(validate_wrapper_names(&names).is_err());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn dotted_windows_wrapper_names_are_rejected() {
+        let names = ["foo.bar".to_string()];
+        assert!(validate_wrapper_names(&names).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add `[wrappers]` config for intercepting ordinary command names with a configured command, arguments, and environment
- keep wrappers ahead of mise-managed tools while stripping dispatch directories before delegation, so the underlying tool may come from mise or the system
- support normal activation, `activate --shims`, and `mise exec`, with managed wrapper shims refreshed by `mise reshim`
- document the mr-boxington 1.1.0 Cargo setup

## Example

```toml
[tools]
mr-boxington = "1.1.0"

[wrappers.cargo]
command = "mbx"
env = { MBX_CARGO_SHIM_MODE = "1" }
```

## Testing

- `mise run test:e2e -- e2e/cli/test_command_wrappers`
- `mise run lint-fix`

The e2e coverage checks raw `cargo`, `mise x -- cargo`, both activation modes, a mise-managed Cargo provider, and a system Cargo provider.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shim dispatch, PATH prepending, and exec resolution—core runtime paths—with broad e2e coverage but meaningful regression risk if PATH ordering or delegation is wrong.
> 
> **Overview**
> Adds **`[wrappers]`** in `mise.toml` so a command name (e.g. `cargo`) can run through another program with optional **`command`**, **`args`**, and **`env`**, including a short form like `terraform = "tofu"`.
> 
> **`mise reshim`** syncs dispatch shims under `~/.local/share/mise/command-wrappers/bin`. Wrapper shims take precedence over tool binaries; on delegation, mise strips shim and wrapper dirs from `PATH` so the target resolves from managed tools or the system without re-entering the wrapper. PATH activation, `activate --shims`, and `mise exec`/`mise x` are updated accordingly; internal `which`/exec logic treats wrapper dirs like shims via `is_mise_dispatch_dir`.
> 
> Config loading merges wrappers (with validation for blank commands and platform naming rules), schema and docs are updated, and a new e2e test covers activation modes and delegation. Windows CI unit job timeout is bumped from 30 to 40 minutes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc497e1452b0eee8a7f3c2952411abcd0dc07727. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable command wrappers supporting command redirection, argument injection, and environment variables.
  * Wrappers work across activated shells, tool execution, and direct commands.
  * Added automatic wrapper shim and PATH management through `mise reshim`, including cleanup when wrappers are removed.
  * Added validation for blank commands and platform-specific naming conflicts.

* **Documentation**
  * Added configuration examples, precedence details, delegation behavior, and wrapper directory guidance.

* **Tests**
  * Added coverage for wrapper execution, environment handling, PATH behavior, and invalid configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->