### PR TITLE
fix(install): name the file when the install marker cannot be created

### DIFF
--- a/e2e-win/install_marker_error_context.Tests.ps1
+++ b/e2e-win/install_marker_error_context.Tests.ps1
@@ -1,0 +1,79 @@
+Describe 'the install marker file names itself when it cannot be written' {
+    # `create_install_dirs` creates three directories and then writes
+    # `<CACHE>/<short>/<version>/incomplete` underneath. `std::fs::create_dir_all` answers Ok for a
+    # path Windows will not take -- one ending in `nul` -- and creates nothing, so the first thing
+    # to notice is that write, three calls away from the cause. Through `File::create` it was a bare
+    # `(os error 3)` naming neither the file nor the operation:
+    #
+    #     mise ERROR Failed to install aqua:jqlang/jq@nul: The system cannot find the path
+    #                specified. (os error 3)
+    #
+    # `file::create` wraps it with the path. This does not make `nul` a usable version, and
+    # `create_dir_all` still answers Ok for it; only the report changes.
+
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        # All four, every time. Pester runs every suite in one process, so an inherited value has to
+        # come back afterwards rather than simply being removed.
+        $script:Saved = @{}
+        foreach ($v in 'MISE_DATA_DIR', 'MISE_CONFIG_DIR', 'MISE_CACHE_DIR', 'MISE_TRUSTED_CONFIG_PATHS') {
+            $script:Saved[$v] = [Environment]::GetEnvironmentVariable($v, 'Process')
+        }
+
+        # Not named for a device itself: `nul` as the probe root cannot be created, which would
+        # break the isolation rather than the subject.
+        $script:Root = Join-Path $TestDrive 'marker'
+        $cfg = Join-Path $script:Root 'cfg'
+        $cache = Join-Path $script:Root 'cache'
+        $data = Join-Path $script:Root 'data'
+        $proj = Join-Path $script:Root 'proj'
+        New-Item -ItemType Directory -Path $cfg, $cache, $data, $proj -Force | Out-Null
+
+        $env:MISE_DATA_DIR = $data
+        $env:MISE_CONFIG_DIR = $cfg
+        $env:MISE_CACHE_DIR = $cache
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:Root
+        Set-Location $proj
+        '' | Out-File -FilePath 'mise.toml' -Encoding utf8NoBOM
+
+        # Both must fail; the question is what they say. The control is `1.2` rather than an
+        # invented string: aqua's jq entry opens with `version_constraint: semver("<= 1.2")` and
+        # `no_asset: true`, so a real semver comparison selects that override. An unparseable
+        # version would reach the same message here, but by a route that depends on how a
+        # non-semver string is compared, which is not what this control is about.
+        $script:Device = mise install jq@nul 2>&1 | Out-String
+        $script:DeviceExit = $LASTEXITCODE
+        $script:Control = mise install jq@1.2 2>&1 | Out-String
+        $script:ControlExit = $LASTEXITCODE
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        foreach ($v in $script:Saved.Keys) {
+            if ($null -ne $script:Saved[$v]) { Set-Item "Env:\$v" $script:Saved[$v] }
+            else { Remove-Item "Env:\$v" -ErrorAction SilentlyContinue }
+        }
+    }
+
+    It 'still fails, because the file genuinely cannot be written' {
+        $script:DeviceExit | Should -Not -Be 0
+    }
+
+    It 'names the file and the operation instead of only an OS error number' {
+        # All three are mise's own words. The OS error text is not asserted because it is
+        # localised: the machine this was measured on returns the Japanese form, not "The system
+        # cannot find the path specified".
+        $script:Device | Should -Match 'failed create'
+        $script:Device | Should -Match 'incomplete'
+        $script:Device | Should -Match 'nul'
+    }
+
+    It 'leaves an ordinary missing version reporting what it always did' {
+        # The control. A change that rewrapped every install failure would pass the assertions above
+        # and fail here: `1.2` writes its marker file fine and is refused by the aqua registry
+        # afterwards, which is a different answer arrived at by a different route.
+        $script:ControlExit | Should -Not -Be 0
+        $script:Control | Should -Match 'no asset released'
+        $script:Control | Should -Not -Match 'failed create'
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,7 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 use std::ffi::OsString;
 use std::fmt::{Debug, Display, Formatter};
-use std::fs::File;
 use std::hash::Hash;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
@@ -3752,7 +3751,13 @@ pub(crate) trait Backend: Debug + Send + Sync {
         file::create_dir_all(tv.install_path())?;
         file::create_dir_all(tv.download_path())?;
         file::create_dir_all(tv.cache_path())?;
-        File::create(self.incomplete_file_path(tv))?;
+        // `file::create` rather than `File::create`: it names the path in the error. The three
+        // calls above can return Ok without having created anything -- `std::fs::create_dir_all`
+        // does that for a path Windows refuses, such as one ending in `nul` -- and the first thing
+        // to notice is this write, three calls away from the cause. Unwrapped it was a bare
+        // `The system cannot find the path specified. (os error 3)` naming neither the file nor
+        // the operation.
+        file::create(&self.incomplete_file_path(tv))?;
         Ok(())
     }
     fn cleanup_install_dirs_on_error(&self, tv: &ToolVersion) {


### PR DESCRIPTION
This is the narrow half of #12573, which you closed with:

> I don't think we should add Windows device-name handling and additional filesystem checks to this widely used helper for this case. The extra metadata calls also add overhead while holding the global directory-creation lock. **A narrowly scoped improvement to the marker-file error context would be preferable**, but this change is too broad and complex as written.

So: `src/file.rs` is untouched, there is no device-name handling, and no filesystem call is added on any path. What is left is the one line you named.

## The measurement

On the released **2026.8.15 windows-x64**, isolated `MISE_*` dirs:

```console
$ mise install jq@nul
mise ERROR Failed to install aqua:jqlang/jq@nul: The system cannot find the path specified. (os error 3)
                                                                                    # exit 1

$ mise install jq@1.2                                                               # the control
mise ERROR Failed to install aqua:jqlang/jq@1.2: no asset released
                                                                                    # exit 1
```

Two versions that cannot be installed, and one of them reports something that names neither a path nor an operation.

## Where it comes from

`create_install_dirs` makes three directory calls and then writes a marker file underneath — `install_state::incomplete_file_path` is `<CACHE>/<short>/<version>/incomplete`, whose parent is the `cache_path` from the call just above:

```rust
file::create_dir_all(tv.install_path())?;   // installs/jq/nul  -> Ok, nothing created
file::create_dir_all(tv.download_path())?;  // ditto
file::create_dir_all(tv.cache_path())?;     // <CACHE>/jq/nul   -> Ok, nothing created
File::create(self.incomplete_file_path(tv))?;   // parent missing -> os error 3, unwrapped
```

`std::fs::create_dir_all` answering Ok for a path ending in `nul` is measured, from a standalone rustc probe on the exact path shape mise builds:

```
installs/jq/zzz   exists()=false  create_dir_all=Ok  after: is_dir()=true
installs/jq/aux   exists()=false  create_dir_all=Ok  after: is_dir()=true
installs/jq/nul   exists()=false  create_dir_all=Ok  after: is_dir()=false     <- nothing there
```

**That part is not fixed here**, and `nul` is still not a usable version. The failure is real; what changes is that it says which file it was about.

## The change

```diff
-        File::create(self.incomplete_file_path(tv))?;
+        file::create(&self.incomplete_file_path(tv))?;
```

`file::create` is already exactly this:

```rust
pub(crate) fn create(path: &Path) -> Result<File> {
    if let Some(parent) = path.parent() {
        create_dir_all(parent)?;
    }
    File::create(path).wrap_err_with(|| format!("failed create: {}", display_path(path)))
}
```

**No call is added on any path.** `create_dir_all(parent)` is work the old code reached anyway — it is the `cache_path()` call two lines up, for the same directory. Nothing new runs inside the global lock.

`use std::fs::File` goes with it: `File` had exactly one other match in the file and it is inside a comment (`pwsh -File`), so leaving the import would fail `-D unused`.

## Test

One Windows e2e, `e2e-win/install_marker_error_context.Tests.ps1`, asserting the message names the file and the operation, with `jq@1.2` as the control — it writes its marker fine and is refused by the aqua registry afterwards, so a change that rewrapped every install failure would pass the first assertions and fail there.

`1.2` rather than an invented version string, because it lands on that refusal through a comparison anyone can read off the registry entry:

```yaml
    repo_owner: jqlang
    repo_name: jq
    version_constraint: "false"
    version_prefix: jq-
    version_overrides:
      - version_constraint: semver("<= 1.2")
        no_asset: true
```

Measured, one run: `jq@1.2`, `jq@1.0` and `jq@zzz` all give `no asset released` and exit 1. The first two get there by semver; the third depends on how an unparseable version is compared, which is not what a control should rest on.

The assertions are on mise's own words (`failed create`, `incomplete`, `nul`) rather than the OS error text, because **that string is localised** — the machine this was measured on returns the Japanese form rather than "The system cannot find the path specified".

No unit test: the product change is one line whose only effect is in a message, which is what the e2e reads.

## Not verified locally

The `failed create: …` wording was matched against the format string in `file::create`, not against output from a build containing this change — mise here is `2026.8.15`, which predates it. CI is what checks the real output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation errors when the install marker cannot be created, including the affected file and operation.
  * Windows installations using invalid device-name versions now provide clearer, more actionable error messages.
  * Preserved the existing “no asset released” message for ordinary missing versions.
  * Improved handling of executable lookup paths during installation and dependency setup.

* **Tests**
  * Added coverage to ensure installation errors remain accurate across Windows scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
