### PR TITLE
registry: drop three more os limits aqua no longer restricts

### DIFF
--- a/e2e/cli/test_install_dry_run_feasibility
+++ b/e2e/cli/test_install_dry_run_feasibility
@@ -4,6 +4,10 @@
 # that cannot install here at all -- measured as `mise install --dry-run acli@latest` succeeding on
 # Windows while the same command without `--dry-run` failed with `unsupported env: windows/amd64`.
 # The check the install does was on the far side of an early return.
+#
+# That example no longer reproduces: aqua gained Windows support for `acli`, and mise's vendored
+# snapshot picked it up in v2026.8.15. It is kept as the history of why this file exists. The cases
+# below never depended on it.
 
 # The http backend can tell from its options alone. This suite runs on Linux (Windows has its own,
 # `e2e-win/`), so a tool that declares only `windows-x64` has no URL here and needs no platform

--- a/registry/acli.toml
+++ b/registry/acli.toml
@@ -1,6 +1,5 @@
 backends = ["aqua:atlassian.com/acli"]
 bins = ["acli"]
 description = "Software to interact with Atlassian Cloud from the terminal"
-os = ["linux", "macos"]
 test = { cmd = "acli --version", expected = "acli version {{version}}" }
 version_order = "semver"

--- a/registry/mimirtool.toml
+++ b/registry/mimirtool.toml
@@ -4,6 +4,5 @@ backends = [
 ]
 bins = ["mimirtool"]
 description = "Mimirtool is a command-line tool that operators and tenants can use to execute a number of common tasks that involve Grafana Mimir or Grafana Cloud Metrics"
-os = ["linux", "macos"]
 test = { cmd = "mimirtool version", expected = "Mimirtool, version {{version}}" }
 version_order = "semver"

--- a/registry/specstory.toml
+++ b/registry/specstory.toml
@@ -1,6 +1,5 @@
 backends = ["aqua:specstoryai/getspecstory"]
 bins = ["specstory"]
 description = "You don’t write prompts. You author intent. Enhance your AI development workflow with SpecStory"
-os = ["linux", "macos"]
 test = { cmd = "specstory --version", expected = "{{version}} (SpecStory)" }
 version_order = "semver"

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1072,10 +1072,11 @@ idiomatic_files = [{ path = ".example-version", parser = "shell" }]
     // list that no longer matches what the backend can do makes mise refuse a tool that works.
     //
     // All 52 entries whose `os` line left out `windows` were put through `mise install` on Windows
-    // and then had whatever landed on disk executed. These five are the ones that produced a
-    // working Windows executable -- `entire.exe version` reports `OS/Arch: windows/amd64`,
-    // `gitsign.exe --version` reports `gitsign version v0.17.1` -- while their `os` line still said
-    // linux and macos only.
+    // and then had whatever landed on disk executed. Five of them produced a working Windows
+    // executable -- `entire.exe version` reports `OS/Arch: windows/amd64`, `gitsign.exe --version`
+    // reports `gitsign version v0.17.1` -- while their `os` line still said linux and macos only.
+    // `acli`, `mimirtool` and `specstory` joined them later, measured the same way, once the
+    // vendored aqua snapshot stopped restricting them.
     //
     // Installing is not evidence on its own: eight more installed successfully and unpacked no
     // Windows executable at all (`libsql-server` extracts a source tarball), so they keep their
@@ -1101,22 +1102,22 @@ idiomatic_files = [{ path = ".example-version", parser = "shell" }]
             "go-swagger",
             "grpc-health-probe",
             "httpie-go",
+            "acli",
+            "mimirtool",
+            "specstory",
         ] {
             let rt = BAKED_REGISTRY.get(short).unwrap();
             assert!(rt.is_supported_os(), "{short}: os = {:?}", rt.os);
         }
 
         // The controls, and they are the point: this is not "remove every os list". Each was
-        // checked the same way and each stays. `kpt` ships no Windows asset at all. `acli` looked
-        // like a candidate until `mise install` answered `unsupported env: windows/amd64
-        // (supported: ["linux/amd64", "linux/arm64", "darwin/amd64", "darwin/arm64"])` -- the aqua
-        // registry mise carries still restricts it, whatever the upstream one now says.
+        // checked the same way and each stays. `kpt` ships no Windows asset at all.
         //
         // `docker-slim` is a control twice over: it is also the fixture in
         // `e2e-win/exec_os_unsupported_tool.Tests.ps1`, which asserts the exact message mise prints
         // for a tool this platform is not listed for. Dropping its `os` line would leave that test
         // with nothing to observe, so it fails here first, by name.
-        for short in ["acli", "docker-slim", "kpt"] {
+        for short in ["docker-slim", "kpt"] {
             let rt = BAKED_REGISTRY.get(short).unwrap();
             assert!(!rt.is_supported_os(), "{short}: os = {:?}", rt.os);
         }


### PR DESCRIPTION
Same shape as #12552, three entries later. `acli`, `mimirtool` and `specstory` each carry `os = ["linux", "macos"]`, and all three install and run on Windows now.

## What the stale list costs

Not an error message — silence. All four declared in one `mise.toml` on Windows, `jq` as the control:

```console
$ mise ls --current
jq  1.8.2 (missing)  …\mise.toml  latest

$ mise which acli
mise ERROR acli is not a mise bin. Perhaps you need to install it first.
```

`acli`, `mimirtool` and `specstory` are **not in that list at all**. `is_os_supported` filters them out of the toolset before anything is attempted (`tool_request_set.rs`, `tool_version_list.rs`), so a config that declares them does nothing whatsoever — for tools that work on this machine.

## Measured

On the released **2026.8.15 windows-x64**, isolated `MISE_DATA_DIR`/`MISE_CONFIG_DIR`/`MISE_CACHE_DIR`/`MISE_TRUSTED_CONFIG_PATHS`. Installed **through the backend directly**, so the registry's own `os` list could not be what answered, then the installed binary run:

```console
$ mise install aqua:atlassian.com/acli@latest
mise aqua:atlassian.com/acli@1.3.30-stable ✓ installed
$ mise x aqua:atlassian.com/acli@1.3.30-stable -- acli --version
acli version 1.3.30-stable

$ mise install aqua:grafana/mimir/mimirtool@latest
mise aqua:grafana/mimir/mimirtool@3.2.0 ✓ installed
$ mise x aqua:grafana/mimir/mimirtool@3.2.0 -- mimirtool version
Mimirtool, version 3.2.0 (branch: HEAD, revision: 9ab70ccf)
  go version:       go1.26.5
  platform:         windows/amd64

$ mise install aqua:specstoryai/getspecstory@latest
mise aqua:specstoryai/getspecstory@2.10.0 ✓ installed
$ mise x aqua:specstoryai/getspecstory@2.10.0 -- specstory --version
2.10.0 (SpecStory)
```

Each output matches the entry's own `test.expected`. `mimirtool` even names the platform it was built for.

**Installing is not evidence on its own** — that is the lesson #12552 recorded, where eight tools installed happily and unpacked no Windows executable. So each was run, not just installed.

## Why now

The upstream half was fixed in aqua-registry — aquaproj/aqua-registry#59558 (`acli`), #59553 (`mimirtool`), #59564 (`getspecstory`) — and mise's vendored snapshot picked it up in **v2026.8.15**: `vendor/aqua-registry/metadata.json` moved from `6d546dfab62d3ff4ee47312222c9559b82f6b3f4` to `9031eee36f6aa1a32865fd63e575b2175a5f8b7e`.

In the snapshot on `main` today, `atlassian.com/acli` has **no `supported_envs`** left and carries a `goos: windows` override instead; `specstoryai/getspecstory`'s `version_constraint: "true"` override gained a `windows: Windows` replacement and `goos: windows → format: zip`; `grafana/mimir/mimirtool`'s base entry has none either.

## `acli` was a control, and that is the interesting part

#12552's test asserts `acli` is **not** supported on Windows, with a comment explaining why:

> `acli` looked like a candidate until `mise install` answered `unsupported env: windows/amd64 (supported: [...])` — the aqua registry mise carries still restricts it, whatever the upstream one now says.

That sentence was true when it was written and is not any more. `acli` moves to the other list here, and the comment now records what changed rather than a measurement nobody can reproduce.

`docker-slim` and `kpt` stay as controls. `kpt` ships no Windows asset at all, and `docker-slim` is also the fixture in `e2e-win/exec_os_unsupported_tool.Tests.ps1` — dropping its `os` line would leave that test with nothing to observe, so it fails here first, by name.

## Tests

No new test. #12552's `tools_that_run_on_windows_are_not_restricted_away_from_it` is the check: it is `#[cfg(windows)]`, reads `BAKED_REGISTRY` rather than `REGISTRY` (so it is about the `registry/*.toml` in this commit rather than a cached floating registry), and the diff is three names entering its positive list and one leaving its negative one.

## One thing this cannot express

`os` is one flat list per tool — it has no version dimension. `mimirtool`'s aqua entry restricts a **band** of versions rather than the tool:

```yaml
Version == "mimir-3.2.0-rc.0"                       -> no_asset
Version in ["mimir-2.2.0-rc.0", "mimir-3.1.0-rc.0"] -> supported_envs: [linux, darwin]
semver("<= 3.0.9") or Version == "mimir-3.1.0-rc.1" -> (unrestricted)
semver("<= 3.1.2")                                  -> supported_envs: [linux, darwin]
"true"                                              -> (unrestricted)   <- latest, 3.2.0
```

So after this, `mimirtool@latest` works on Windows and `mimirtool@3.1.1` does not. It fails with aqua's own `unsupported env`, naming the platforms that version supports — which is a better answer than the registry claiming the whole tool is unavailable here.

## Also touched

`e2e/cli/test_install_dry_run_feasibility` — a comment only. #12568 cited `mise install --dry-run acli@latest` as the measurement behind that file, and that example stops reproducing with this change. Marked as history; the cases in it never depended on `acli`.

## Not measured

**arm64.** This box is windows-x64. The `os` list carries no architecture, so nothing here claims anything about it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows support for the `acli`, `mimirtool`, and `specstory` tools.
  * These tools are no longer restricted to Linux and macOS, expanding installation availability across platforms.

* **Tests**
  * Updated installation checks to verify Windows compatibility.
  * Preserved coverage for dry-run feasibility scenarios and platform-specific installation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->