### PR TITLE
fix(task): preserve double-dash task arguments

### DIFF
--- a/docs/tasks/task-arguments.md
+++ b/docs/tasks/task-arguments.md
@@ -242,6 +242,9 @@ arg "<file>" double_dash="optional"
 
 // After first arg, behaves as if -- was used
 arg "<files>" double_dash="automatic"
+
+// Keep double dashes as values in a variadic argument
+arg "<args>..." double_dash="preserve"
 ```
 
 ### Flags (`flag`)

--- a/e2e/tasks/test_task_usage_double_dash
+++ b/e2e/tasks/test_task_usage_double_dash
@@ -31,3 +31,17 @@ EOF
 output=$(mise run extract bundle -- --mode=universal 2>&1)
 assert_contains "echo \"$output\"" "dependency=--mode=universal"
 assert_contains "echo \"$output\"" "bundletool=--mode=universal"
+
+cat <<'EOF' >mise.toml
+[tasks.preserve]
+usage = '''
+flag "--base <ref>"
+arg "<cmd>..." double_dash="preserve"
+'''
+run = 'echo "cmd=[$usage_cmd] base=[$usage_base]"'
+EOF
+
+assert "mise preserve foo -- bar" "cmd=[foo -- bar] base=[]"
+assert "mise run preserve foo -- bar" "cmd=[foo -- bar] base=[]"
+assert "mise preserve --base X -- foo -- bar" "cmd=[-- foo -- bar] base=[X]"
+assert "mise run preserve --base X -- foo -- bar" "cmd=[-- foo -- bar] base=[X]"

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1908,8 +1908,8 @@ impl Task {
             .any(|a| a == "--help" || a == "-h")
     }
 
-    /// Reconstruct the command-line separator clap consumed before populating
-    /// `trailing_args` when the active usage command requires it.
+    /// Reconstruct the command-line separator the outer CLI consumed before populating
+    /// `trailing_args` when the active usage command requires or preserves it.
     pub(crate) fn args_for_usage_parser(&self, spec: &usage::Spec, args: &[String]) -> Vec<String> {
         if self.trailing_args.is_empty() {
             return args.to_vec();
@@ -1932,7 +1932,12 @@ impl Task {
         if !usage_command_for_args(spec, task_prefix)
             .args
             .iter()
-            .any(|arg| arg.double_dash == usage::SpecDoubleDashChoices::Required)
+            .any(|arg| {
+                matches!(
+                    arg.double_dash,
+                    usage::SpecDoubleDashChoices::Required | usage::SpecDoubleDashChoices::Preserve
+                )
+            })
         {
             return args.to_vec();
         }


### PR DESCRIPTION
## Summary
- reconstruct the outer CLI separator for task arguments using `double_dash="preserve"`
- cover shorthand and explicit `mise run` forms with one and multiple separators
- document the supported `preserve` mode alongside the other double-dash behaviors

## Root cause
The outer mise usage-rs parser consumes the first explicit `--` and records only its trailing values. Task usage parsing already reconstructed that separator for `double_dash="required"`, but not for `preserve`, so the task parser silently lost the first separator.

## Testing
- `mise run test:e2e e2e/tasks/test_task_usage_double_dash`
- `mise run lint-fix`

Refs: https://github.com/jdx/mise/discussions/12623

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to task argument reconstruction for one usage spec mode, with e2e coverage and no auth or data-path impact.
> 
> **Overview**
> Fixes task usage parsing when a variadic argument uses `double_dash="preserve"`: the outer mise CLI strips the first `--` into `trailing_args`, and task parsing now **re-inserts** that separator for `preserve` the same way it already did for `double_dash="required"`.
> 
> **`args_for_usage_parser`** in `src/task/mod.rs` treats `SpecDoubleDashChoices::Preserve` like `Required` when deciding whether to chain `--` back before `trailing_args`, so values like `foo -- bar` (and `-- foo -- bar` after flags) reach the task unchanged.
> 
> Docs add the `preserve` example under double-dash behavior; e2e covers `mise preserve` / `mise run preserve` with optional `--base` and multiple `--` separators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c44548ccedd1e7f755df328694eb4995c5d2be3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for preserving `--` as an argument value separator in variadic task arguments.
  - Arguments following `--` are now correctly retained when using tasks with preserved double-dash handling.

- **Documentation**
  - Documented the `double_dash="preserve"` behavior for variadic arguments.

- **Tests**
  - Added coverage for preserved arguments with and without additional task options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->