### PR TITLE
fix(bootstrap): respect jobs for repo status checks

### DIFF
--- a/e2e/cli/test_bootstrap_repos
+++ b/e2e/cli/test_bootstrap_repos
@@ -72,6 +72,62 @@ assert_succeed "mise bootstrap --skip-dirty --yes --only repos"
 assert_directory_exists "$HOME/src/top-level-missing"
 rm -f "$HOME/src/dotfiles/local.txt"
 
+# Read-only status checks honor the global job limit. A serial run must not
+# overlap ls-remote processes, while two jobs must allow both checks to start.
+real_git="$(command -v git)"
+git_wrapper_dir="$PWD/git-wrapper"
+git_concurrency_dir="$PWD/git-concurrency"
+mkdir -p "$git_wrapper_dir" "$git_concurrency_dir"
+cat <<'EOF' >"$git_wrapper_dir/git"
+#!/usr/bin/env bash
+is_ls_remote=0
+for arg in "$@"; do
+  if [[ $arg == ls-remote ]]; then
+    is_ls_remote=1
+    break
+  fi
+done
+if ((is_ls_remote)); then
+  case "$GIT_CONCURRENCY_MODE" in
+    serial)
+      owns_lock=0
+      if mkdir "$GIT_CONCURRENCY_DIR/lock" 2>/dev/null; then
+        owns_lock=1
+      else
+        touch "$GIT_CONCURRENCY_DIR/overlap"
+      fi
+      sleep 0.2
+      if ((owns_lock)); then
+        rmdir "$GIT_CONCURRENCY_DIR/lock"
+      fi
+      ;;
+    parallel)
+      touch "$GIT_CONCURRENCY_DIR/started.$$"
+      count=0
+      for _ in {1..100}; do
+        count="$(find "$GIT_CONCURRENCY_DIR" -name 'started.*' | wc -l | tr -d ' ')"
+        if ((count >= 2)); then
+          break
+        fi
+        sleep 0.05
+      done
+      if ((count < 2)); then
+        touch "$GIT_CONCURRENCY_DIR/timed-out"
+      fi
+      ;;
+  esac
+fi
+exec "$REAL_GIT" "$@"
+EOF
+chmod +x "$git_wrapper_dir/git"
+
+assert_succeed "PATH='$git_wrapper_dir:$PATH' REAL_GIT='$real_git' GIT_CONCURRENCY_DIR='$git_concurrency_dir' GIT_CONCURRENCY_MODE=serial mise --jobs 1 bootstrap repos status --missing"
+[[ ! -e $git_concurrency_dir/overlap ]] || fail "--jobs 1 allowed repo status checks to overlap"
+
+rm -f "$git_concurrency_dir"/started.*
+assert_succeed "PATH='$git_wrapper_dir:$PATH' REAL_GIT='$real_git' GIT_CONCURRENCY_DIR='$git_concurrency_dir' GIT_CONCURRENCY_MODE=parallel mise --jobs 2 bootstrap repos status --missing"
+[[ ! -e $git_concurrency_dir/timed-out ]] || fail "--jobs 2 did not run repo status checks concurrently"
+
 # full branch refs update without detaching or skipping the pull
 cat <<EOF >mise.toml
 [bootstrap.repos]

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -1375,9 +1375,9 @@ impl Bootstrap {
             } else {
                 info!("bootstrap: repos");
                 if self.update {
-                    install::update_repos(repos, self.dry_run, self.yes, self.skip_dirty)?;
+                    install::update_repos(repos, self.dry_run, self.yes, self.skip_dirty).await?;
                 } else {
-                    install::apply_repos(repos, self.dry_run, self.yes, self.skip_dirty)?;
+                    install::apply_repos(repos, self.dry_run, self.yes, self.skip_dirty).await?;
                 }
             }
             self.run_hooks(&hooks, BootstrapHookPhase::PostRepos)
@@ -2691,7 +2691,7 @@ impl BootstrapStatus {
         self.collect_services(&service_requests, &notified_services, &mut report);
         self.collect_firewall(firewall_request.as_ref(), &mut report);
         self.collect_compose(&compose_requests, &mut report);
-        self.collect_repos(config, &mut report)?;
+        self.collect_repos(config, &mut report).await?;
         self.collect_dotfiles(config, &mut report)?;
         self.collect_shell(config, &mut report)?;
         self.collect_defaults(config, &mut report).await?;
@@ -2978,14 +2978,14 @@ impl BootstrapStatus {
         Ok(())
     }
 
-    fn collect_repos(
+    async fn collect_repos(
         &self,
         config: &Arc<Config>,
         report: &mut BootstrapStatusReport,
     ) -> Result<()> {
         let repos = system::repos_from_config(config);
         let mut json_entries = vec![];
-        for s in system::repos::status(&repos)? {
+        for s in system::repos::status(&repos).await? {
             let state = s.state.as_str();
             let (row_state, reason, missing) = match &s.state {
                 RepoState::Current => ("current".to_string(), "".to_string(), false),
@@ -3633,6 +3633,7 @@ impl BootstrapReposApply {
             self.yes,
             self.skip_dirty,
         )
+        .await
     }
 }
 
@@ -3640,7 +3641,7 @@ impl BootstrapReposUpdate {
     async fn run(self) -> Result<()> {
         let config = Config::get().await?;
         let repos = filter_repos(system::repos_from_config(&config), &self.paths)?;
-        install::update_repos(repos, self.dry_run, self.yes, self.skip_dirty)
+        install::update_repos(repos, self.dry_run, self.yes, self.skip_dirty).await
     }
 }
 
@@ -3648,7 +3649,7 @@ impl BootstrapReposExec {
     async fn run(self) -> Result<()> {
         let config = Config::get().await?;
         let repos = filter_repos(system::repos_from_config(&config), &self.paths)?;
-        system::repos::exec(&repos, &self.command, self.dry_run, self.continue_on_error)
+        system::repos::exec(&repos, &self.command, self.dry_run, self.continue_on_error).await
     }
 }
 
@@ -3685,7 +3686,7 @@ impl BootstrapReposStatus {
         let mut any_missing = false;
         let mut rows: Vec<Vec<String>> = vec![];
         let mut json_entries = vec![];
-        for s in system::repos::status(&repos)? {
+        for s in system::repos::status(&repos).await? {
             if !s.state.is_current() {
                 any_missing = true;
             }

--- a/src/cli/system/install.rs
+++ b/src/cli/system/install.rs
@@ -220,7 +220,7 @@ pub(crate) fn apply_shell_activation(
 }
 
 /// Apply `[bootstrap.repos]` entries that are missing or differ.
-pub(crate) fn apply_repos(
+pub(crate) async fn apply_repos(
     repos: Vec<system::repos::RepoRequest>,
     dry_run: bool,
     yes: bool,
@@ -240,10 +240,11 @@ pub(crate) fn apply_repos(
         |status| !status.state.is_current(),
         system::repos::apply_statuses,
     )
+    .await
 }
 
 /// Update `[bootstrap.repos]` entries, including unpinned repos.
-pub(crate) fn update_repos(
+pub(crate) async fn update_repos(
     repos: Vec<system::repos::RepoRequest>,
     dry_run: bool,
     yes: bool,
@@ -263,6 +264,7 @@ pub(crate) fn update_repos(
         |status| !status.state.is_current() || status.request.git_ref.is_none(),
         system::repos::update_statuses,
     )
+    .await
 }
 
 struct RepoMutation {
@@ -272,7 +274,7 @@ struct RepoMutation {
     report_all_current: bool,
 }
 
-fn mutate_repos(
+async fn mutate_repos(
     repos: Vec<system::repos::RepoRequest>,
     dry_run: bool,
     yes: bool,
@@ -285,7 +287,7 @@ fn mutate_repos(
     if repos.is_empty() {
         return Ok(());
     }
-    let mut statuses = repos::status(&repos)?;
+    let mut statuses = repos::status(&repos).await?;
     let mut skipped_dirty = false;
     if skip_dirty {
         statuses.retain(|status| {

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1228,6 +1228,9 @@ impl Settings {
         if let Some(cd) = &cli.cd {
             s.cd = Some(cd.clone());
         }
+        if let Some(jobs) = cli.jobs {
+            s.jobs = Some(jobs);
+        }
         if cli.profile.is_some() {
             s.env = cli.profile.clone();
         }

--- a/src/system/repos.rs
+++ b/src/system/repos.rs
@@ -150,8 +150,11 @@ impl std::fmt::Display for RepoRequest {
     }
 }
 
-pub(crate) fn status(requests: &[RepoRequest]) -> Result<Vec<RepoStatus>> {
-    requests.iter().map(status_one).collect()
+pub(crate) async fn status(requests: &[RepoRequest]) -> Result<Vec<RepoStatus>> {
+    crate::parallel::parallel(requests.to_vec(), |request| async move {
+        tokio::task::spawn_blocking(move || status_one(&request)).await?
+    })
+    .await
 }
 
 pub(crate) fn preflight_statuses(statuses: &[RepoStatus]) -> Result<()> {
@@ -205,7 +208,7 @@ pub(crate) fn update_statuses(statuses: &[RepoStatus], dry_run: bool) -> Result<
     Ok(())
 }
 
-pub(crate) fn exec(
+pub(crate) async fn exec(
     requests: &[RepoRequest],
     command: &[String],
     dry_run: bool,
@@ -214,7 +217,7 @@ pub(crate) fn exec(
     let Some((program, args)) = command.split_first() else {
         bail!("repos: command is required");
     };
-    let statuses = status(requests)?;
+    let statuses = status(requests).await?;
     let mut failures = vec![];
     for status in statuses {
         match &status.state {
@@ -1160,8 +1163,8 @@ mod tests {
         assert!(!missing_path.exists());
     }
 
-    #[test]
-    fn ref_less_update_pulls_current_branch() {
+    #[tokio::test]
+    async fn ref_less_update_pulls_current_branch() {
         let tmp = tempfile::tempdir().unwrap();
         let source = tmp.path().join("source");
         let target = tmp.path().join("target");
@@ -1176,7 +1179,7 @@ mod tests {
             git_ref: None,
         };
 
-        let statuses = status(&[request]).unwrap();
+        let statuses = status(&[request]).await.unwrap();
         assert_eq!(statuses[0].state, RepoState::Current);
         update_statuses(&statuses, false).unwrap();
 
@@ -1186,8 +1189,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn ref_less_update_skips_detached_head() {
+    #[tokio::test]
+    async fn ref_less_update_skips_detached_head() {
         let tmp = tempfile::tempdir().unwrap();
         let source = tmp.path().join("source");
         let target = tmp.path().join("target");
@@ -1203,7 +1206,7 @@ mod tests {
             git_ref: None,
         };
 
-        update_statuses(&status(&[request]).unwrap(), false).unwrap();
+        update_statuses(&status(&[request]).await.unwrap(), false).unwrap();
 
         assert_eq!(
             fs::read_to_string(target.join("version.txt")).unwrap(),
@@ -1253,8 +1256,8 @@ mod tests {
         assert!(format!("{err:#}").contains("local changes"));
     }
 
-    #[test]
-    fn update_unpinned_repo_rechecks_clean_worktree_before_mutating() {
+    #[tokio::test]
+    async fn update_unpinned_repo_rechecks_clean_worktree_before_mutating() {
         let tmp = tempfile::tempdir().unwrap();
         let source = tmp.path().join("source");
         let target = tmp.path().join("target");
@@ -1267,7 +1270,7 @@ mod tests {
             url,
             git_ref: None,
         };
-        let statuses = status(&[request]).unwrap();
+        let statuses = status(&[request]).await.unwrap();
         let original_origin_sha = local_ref_sha(&target, "origin/main").unwrap();
         commit_version(&source, "v2");
         fs::write(target.join("local.txt"), "local").unwrap();
@@ -1281,9 +1284,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn exec_rejects_an_empty_command() {
-        let err = exec(&[], &[], false, false).unwrap_err();
+    #[tokio::test]
+    async fn exec_rejects_an_empty_command() {
+        let err = exec(&[], &[], false, false).await.unwrap_err();
         assert!(format!("{err:#}").contains("command is required"));
     }
 
@@ -1351,8 +1354,8 @@ cccccccccccccccccccccccccccccccccccccccc\trefs/tags/release^{}
         assert_eq!(parse_remote_exact_ref_sha(out, "refs/heads/missing"), None);
     }
 
-    #[test]
-    fn empty_directory_is_missing() {
+    #[tokio::test]
+    async fn empty_directory_is_missing() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("target");
         fs::create_dir(&path).unwrap();
@@ -1362,12 +1365,12 @@ cccccccccccccccccccccccccccccccccccccccc\trefs/tags/release^{}
             url: "https://github.com/jdx/mise.git".to_string(),
             git_ref: None,
         };
-        let status = status(&[request]).unwrap();
+        let status = status(&[request]).await.unwrap();
         assert_eq!(status[0].state, RepoState::Missing);
     }
 
-    #[test]
-    fn nested_directory_inside_parent_repo_is_missing() {
+    #[tokio::test]
+    async fn nested_directory_inside_parent_repo_is_missing() {
         let tmp = tempfile::tempdir().unwrap();
         let parent = tmp.path().join("parent");
         let nested = parent.join("nested");
@@ -1385,7 +1388,7 @@ cccccccccccccccccccccccccccccccccccccccc\trefs/tags/release^{}
             url: "https://github.com/jdx/mise.git".to_string(),
             git_ref: None,
         };
-        let status = status(&[request]).unwrap();
+        let status = status(&[request]).await.unwrap();
         assert_eq!(status[0].state, RepoState::Missing);
     }
 


### PR DESCRIPTION
## Summary
- run independent repository status checks with bounded concurrency
- propagate the global `--jobs` value into shared settings
- preserve deterministic status ordering and serialized repository mutations
- add an e2e regression covering `--jobs 1` and `--jobs 2`

Addresses https://github.com/jdx/mise/discussions/12619

## Tests
- `mise run format`
- `mise run lint`
- `mise run test:unit -- system::repos::tests`
- `mise run test:e2e e2e/cli/test_bootstrap_repos`

*AI-assisted — Tool: Codex; model: OpenAI/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrency for bootstrap repo status (git/remote checks); behavior is bounded by `--jobs` but timing and load on remotes can differ from the previous serial checks.
> 
> **Overview**
> Bootstrap **repository status** (`repos::status`, aggregate `bootstrap status`, apply/update preflight) now runs checks through the shared **`parallel`** helper with blocking git work on a thread pool, so **`--jobs` / `-j`** actually caps how many repos are checked at once. The global CLI **`jobs`** flag is wired into **`Settings`** so that limit applies to these read-only paths.
> 
> Apply, update, and exec call sites are **`async`** and **`.await`** status; clone/pull mutation paths are unchanged and stay serialized. Unit tests move to **`#[tokio::test]`**; e2e adds a **git wrapper** that asserts **`--jobs 1`** does not overlap `ls-remote` and **`--jobs 2`** can run checks concurrently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39e635ec0a2c6d269fba7a18805a8885b7540270. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repository status checks now honor the global `--jobs` limit, allowing controlled parallel execution.
  * Bootstrap repository status, apply, and update operations support asynchronous processing for improved responsiveness.
* **Bug Fixes**
  * Corrected handling of the CLI `--jobs` setting so it is applied consistently to repository checks.
  * Added coverage confirming serial checks do not overlap while parallel checks can run concurrently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->