### PR TITLE
fix(npm): isolate aube installs from enclosing workspaces

### DIFF
--- a/e2e/backend/test_npm_aube
+++ b/e2e/backend/test_npm_aube
@@ -1,5 +1,21 @@
 #!/usr/bin/env bash
 
+# Keep mise's data inside a pnpm workspace, as GitLab CI commonly does so the
+# directory can be cached. The synthetic npm tool project must not be adopted
+# by this enclosing workspace.
+MISE_DATA_DIR="$PWD/.mise-data"
+mkdir -p pkg
+cat >package.json <<'EOF'
+{"name":"root","private":true}
+EOF
+cat >pnpm-workspace.yaml <<'EOF'
+packages:
+  - pkg
+EOF
+cat >pkg/package.json <<'EOF'
+{"name":"pkg","version":"0.0.0","dependencies":{"is-number":"7.0.0"}}
+EOF
+
 install_dir="$MISE_DATA_DIR/installs/npm-cowsay/1.6.0"
 
 # npm: tools install via the embedded aube package manager in-process — no
@@ -11,9 +27,12 @@ assert_contains "mise x node@20.11.1 npm:cowsay@1.6.0 -- cowsay hello" "hello"
 assert_succeed "test -d '$install_dir/node_modules'"
 assert_succeed "test -x '$install_dir/node_modules/.bin/cowsay'"
 assert_succeed "test -f '$install_dir/aube-lock.yaml'"
+assert_succeed "test -f '$install_dir/aube-workspace.yaml'"
 assert_contains "cat '$install_dir/aube-lock.yaml'" "cowsay@1.6.0"
 assert_succeed "test -f '$install_dir/.config/aube/config.toml'"
 assert_succeed "test ! -e '$install_dir/.npmrc'"
+assert_succeed "test ! -e '$PWD/node_modules'"
+assert_succeed "test ! -e '$PWD/aube-lock.yaml'"
 
 # Regenerable aube state stays under mise's npm cache root, where
 # `mise cache prune npm` owns its lifecycle.

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -1185,11 +1185,11 @@ impl NPMBackend {
         }
     }
 
-    /// Write the throwaway project's `package.json` + aube config for an
-    /// embedded aube install. `allowBuilds` package lists go in `package.json`
-    /// (aube's manifest namespace); release age and trust-policy excludes go
-    /// in `.config/aube/config.toml`, which keeps aube-only keys out of npm's
-    /// config.
+    /// Write the throwaway project's manifest, workspace boundary, and aube
+    /// config for an embedded aube install. `allowBuilds` package lists go in
+    /// `package.json` (aube's manifest namespace); release age and trust-policy
+    /// excludes go in `.config/aube/config.toml`, which keeps aube-only keys out
+    /// of npm's config.
     fn write_aube_embed_project(
         &self,
         install_path: &Path,
@@ -1216,6 +1216,15 @@ impl NPMBackend {
         crate::file::write(
             install_path.join("package.json"),
             format!("{}\n", serde_json::to_string_pretty(&manifest)?),
+        )?;
+        // MISE_DATA_DIR may live inside a user's Node workspace (notably when
+        // GitLab CI caches it below CI_PROJECT_DIR). Aube otherwise walks up
+        // from this synthetic project and installs the enclosing workspace
+        // instead of the requested tool. Make the install prefix its own
+        // one-package workspace so discovery cannot escape it.
+        crate::file::write(
+            install_path.join("aube-workspace.yaml"),
+            "packages:\n  - .\n",
         )?;
 
         let config_dir = install_path.join(".config/aube");
@@ -2713,6 +2722,10 @@ pkg@1.2.0 '1.2.0'
         assert_eq!(
             manifest["aube"]["allowBuilds"],
             serde_json::json!({ "esbuild": true })
+        );
+        assert_eq!(
+            std::fs::read_to_string(install_path.join("aube-workspace.yaml")).unwrap(),
+            "packages:\n  - .\n"
         );
     }
 


### PR DESCRIPTION
## Summary

- make each embedded Aube npm install a one-package workspace
- prevent `MISE_DATA_DIR` inside pnpm workspaces from adopting or installing the outer workspace
- cover the GitLab-cacheable data-directory layout in the npm Aube e2e test

## Why this is in mise

Embedded Aube intentionally walks from a project to its workspace root. mise's npm install prefix is a synthetic standalone project, so when `MISE_DATA_DIR` is under `CI_PROJECT_DIR`, an enclosing `pnpm-workspace.yaml` can redirect the install into the user's workspace. That leaves the requested npm tool without its own `node_modules/.bin` and can mutate the outer workspace.

Aube's workspace-member behavior is appropriate for normal projects, and its current embedder API has no workspace-isolation option. mise now makes its synthetic project's intended boundary explicit with a local `aube-workspace.yaml`.

Addresses https://github.com/jdx/mise/discussions/12620

## Tests

- `mbx test --locked --bin mise backend::npm::tests::test_write_aube_embed_project_emits_aube_config_and_manifest`
- `mise run test:e2e e2e/backend/test_npm_aube`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedded npm project setup to prevent accidental discovery of enclosing workspaces.
  * Prevented unintended creation of workspace-level `node_modules` and lockfiles.
  * Added workspace boundary configuration for more reliable package installation in nested project environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->