### PR TITLE
ci(perf): normalize mr-boxington tool path

### DIFF
--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -82,7 +82,9 @@ jobs:
           esac
           hash -r
           command -v cargo
-          clean_path=$(printf '%s\n' "$PATH" | tr ':' '\n' | grep -v '/mbx/bin$' | paste -sd:)
+          clean_path=$(printf '%s\n' "$PATH" | tr ':' '\n' \
+            | grep -v -e '/mbx/bin$' -e '/mise/installs/mr-boxington/' \
+            | paste -sd:)
           echo "PATH=$clean_path" >> "$GITHUB_ENV"
 
       - name: Install valgrind

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -64,7 +64,9 @@ jobs:
           esac
           hash -r
           command -v cargo
-          clean_path=$(printf '%s\n' "$PATH" | tr ':' '\n' | grep -v '/mbx/bin$' | paste -sd:)
+          clean_path=$(printf '%s\n' "$PATH" | tr ':' '\n' \
+            | grep -v -e '/mbx/bin$' -e '/mise/installs/mr-boxington/' \
+            | paste -sd:)
           echo "PATH=$clean_path" >> "$GITHUB_ENV"
 
       # cachegrind is the whole point: it counts instructions, which reproduce


### PR DESCRIPTION
The mr-boxington rollout exports both the persistent Cargo shim directory and the installed tool directory into the perf runner PATH. #12615 removed only the shim directory, leaving config-resolving benchmarks about 2.5% above their historical fixture.

Remove both mbx-related entries before measuring so the fixture remains comparable to existing instruction-count history.

Validated with actionlint and git diff --check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only PATH sanitization for perf jobs; no runtime product or auth behavior changes.
> 
> **Overview**
> Perf workflows on `main` and PR comparison now drop **`/mise/installs/mr-boxington/`** from `PATH` alongside the existing **`/mbx/bin`** filter when removing mbx benchmark activation.
> 
> After the mr-boxington rollout, only stripping the Cargo shim left the installed tool directory on `PATH`, which inflated config-resolving instruction counts (~2.5%) versus historical fixtures. Both paths are excluded before `mise run perf:record` so measurements stay aligned with prior tak history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e9a220ed67e9000a4a66a10828e9670d3415bd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated performance-testing workflows to remove additional benchmark tooling paths from the test environment.
  * Improved consistency between pull-request and standard performance test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->