### PR TITLE
registry(libsql-server): no backend on windows, where it has no build

### DIFF
--- a/e2e-win/install_no_backend_for_platform.Tests.ps1
+++ b/e2e-win/install_no_backend_for_platform.Tests.ps1
@@ -1,0 +1,55 @@
+Describe 'a tool whose backends are all ruled out on this platform' {
+    # `mise install libsql-server@latest` on Windows used to exit 0 and unpack a source checkout --
+    # the release builds for linux and darwin only, and its `source.tar.gz` was the last asset left
+    # above zero in scoring.
+
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        $script:Saved = @{}
+        foreach ($v in 'MISE_DATA_DIR', 'MISE_CONFIG_DIR', 'MISE_CACHE_DIR', 'MISE_TRUSTED_CONFIG_PATHS') {
+            $script:Saved[$v] = [Environment]::GetEnvironmentVariable($v, 'Process')
+        }
+
+        $script:Root = Join-Path $TestDrive 'nobackend'
+        $cfg = Join-Path $script:Root 'cfg'
+        $cache = Join-Path $script:Root 'cache'
+        $script:Data = Join-Path $script:Root 'data'
+        $proj = Join-Path $script:Root 'proj'
+        New-Item -ItemType Directory -Path $cfg, $cache, $script:Data, $proj -Force | Out-Null
+
+        $env:MISE_DATA_DIR = $script:Data
+        $env:MISE_CONFIG_DIR = $cfg
+        $env:MISE_CACHE_DIR = $cache
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:Root
+        Set-Location $proj
+        '' | Out-File -FilePath 'mise.toml' -Encoding utf8NoBOM
+
+        $script:Out = mise install libsql-server@latest 2>&1 | Out-String
+        $script:Exit = $LASTEXITCODE
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        foreach ($v in $script:Saved.Keys) {
+            if ($null -ne $script:Saved[$v]) { Set-Item "Env:\$v" $script:Saved[$v] }
+            else { Remove-Item "Env:\$v" -ErrorAction SilentlyContinue }
+        }
+    }
+
+    It 'refuses instead of reporting a successful install' {
+        $script:Exit | Should -Not -Be 0
+    }
+
+    It 'says the tool is registered but has no backend usable here' {
+        $script:Out | Should -Match 'none of its backends'
+    }
+
+    It 'leaves no source checkout behind' {
+        # The assertion that would have caught the original defect on its own: whatever mise did or
+        # did not report, a repository must not appear under installs/.
+        $installed = Join-Path $script:Data 'installs\libsql-server'
+        if (Test-Path $installed) {
+            @(Get-ChildItem -Path $installed -Recurse -Filter 'Cargo.toml') | Should -HaveCount 0
+        }
+    }
+}

--- a/registry/libsql-server.toml
+++ b/registry/libsql-server.toml
@@ -4,8 +4,13 @@ test = { cmd = "sqld --version", expected = "sqld sqld {{version}}" }
 version_order = "semver"
 
 bins = ["sqld"]
+
+# Builds for linux and darwin only. Without this, `mise install libsql-server` on Windows picked
+# the release's `source.tar.gz` and reported a successful install. `os` above does not cover it --
+# it filters config-declared tools, not an explicit install.
 [[backends]]
 full = "github:tursodatabase/libsql"
+platforms = ["linux", "macos"]
 
 [backends.options]
 version_prefix = "libsql-server-v"

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1244,6 +1244,35 @@ idiomatic_files = [{ path = ".example-version", parser = "shell" }]
         );
     }
 
+    // Nothing is left to try: the github backend is gone by `platforms`, the asdf one by
+    // `cfg!(windows)` in `backends()`. That is the claim, so it is asserted rather than described.
+    // `MISE_BACKENDS_LIBSQL_SERVER` would bypass every filter, so both tests check it is unset.
+    #[cfg(windows)]
+    #[test]
+    fn libsql_server_has_no_backend_left_on_windows() {
+        use super::*;
+
+        assert!(env::var("MISE_BACKENDS_LIBSQL_SERVER").is_err());
+        let backends = BAKED_REGISTRY.get("libsql-server").unwrap().backends();
+        assert!(backends.is_empty(), "{backends:?}");
+    }
+
+    // The control. Not `not(windows)`: on Android `backend_matches_platform` sees `android` and
+    // drops the github backend too, so this expectation would be wrong there.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn libsql_server_keeps_its_github_backend_off_windows() {
+        use super::*;
+
+        assert!(env::var("MISE_BACKENDS_LIBSQL_SERVER").is_err());
+        let backends = BAKED_REGISTRY.get("libsql-server").unwrap().backends();
+        assert_eq!(
+            backends.first().copied(),
+            Some("github:tursodatabase/libsql"),
+            "{backends:?}"
+        );
+    }
+
     #[test]
     fn test_backend_platform_matching_preserves_os_only_and_order() {
         use super::*;


### PR DESCRIPTION
#12625 proposed excluding a release's `source.tar.gz` in `AssetPicker`, and you closed it with:

> this should not be part of the backend

So this is the other half of the direction you gave on #12569 — the specific registry entry. Nothing in `src/backend/`.

## The defect

```console
$ mise install libsql-server@latest        # Windows, isolated MISE_* dirs, 2026.8.15
mise libsql-server@0.24.32 ✓ installed     # exit 0

$ ls <data>/installs/libsql-server/0.24.32/
CODE_OF_CONDUCT.md  CONTRIBUTING.md  Cargo.lock  Cargo.toml  Dockerfile ...
```

A source checkout, reported as a successful install. The release builds for linux and darwin only; its `source.tar.gz` names no OS, so nothing subtracts for it in asset scoring, and on a platform with no real asset it was the last candidate above zero.

## Why the existing `os` line did not stop it

`registry/libsql-server.toml` already carried `os = ["linux", "macos"]` — it was there at `v2026.8.14`, before that measurement. It does not apply here: `os` drops a tool from a config's tool request set (`tool_request_set.rs`, `tool_version_list.rs`), and an explicit `mise install libsql-server` never consults it. Measured on the same build:

```console
$ mise ls --current            # acli, mimirtool, specstory, jq all declared in mise.toml
jq  1.8.2 (missing)  …  latest # the os-restricted three are simply absent

$ mise install <one of them>@latest
✓ installed                    # the same list does not apply here
```

`platforms` on the backend does apply, because `backend_matches_platform` runs before a backend is asked anything. Same mechanism `azure` and `pre-commit` (#12549) already use.

With the github backend gone and the asdf one removed by `cfg!(windows)` inside `backends()`, nothing is left to try:

```
mise ERROR Failed to install libsql-server@latest: libsql-server is in the mise tool registry
but none of its backends (github:tursodatabase/libsql) are supported in the current configuration
```

## Verified on a real Windows build, not inferred

The claim "no backend is left" cannot be staged with `MISE_OS` — the asdf removal is a compile-time `cfg!(windows)` — so it was built and run on CI rather than argued. Both directions passed **by name**:

```
windows-unit:  test registry::tests::libsql_server_has_no_backend_left_on_windows ... ok
unit-macos:    test registry::tests::libsql_server_keeps_its_github_backend_off_windows ... ok
```

The first asserts `backends()` is **empty**. The second is the control — on linux and macos `github:tursodatabase/libsql` is still first, so this is not "remove the backend everywhere". It is `cfg(any(target_os = "linux", target_os = "macos"))` rather than `not(windows)` because on Android `backend_matches_platform` drops the github backend too.

Both check `MISE_BACKENDS_LIBSQL_SERVER` is unset first: `backends()` returns that override ahead of every filter, so a process carrying one would make them pass or fail without touching the registry.

## And what a user sees

`e2e-win/install_no_backend_for_platform.Tests.ps1` drives the real command:

- it fails rather than reporting a successful install
- the message says `none of its backends`
- **no `Cargo.toml` appears anywhere under `installs/`** — the assertion that would have caught the original defect on its own

Pester prints no per-test names on success, so the count is the evidence that these ran: **254 passed** on the upstream run of `main` at the time, **257** here — exactly the three `It` blocks added.

## What this does not do

It fixes `libsql-server`. Any other release with the same shape — a `source.tar.gz` and no build for the host — still resolves to the source archive, because the scoring is unchanged. That is the general fix #12625 attempted; this is the per-entry one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented the unsupported libSQL Server backend from being selected on Windows.
  - Explicit installation on unsupported platforms now fails clearly when no backend is available.
  - Confirmed Linux and macOS continue using the available backend.
  - Restored Windows support for ACLI, MimirTool, and SpecStory.

- **Tests**
  - Added coverage for platform-specific backend availability and verified failed Windows installations leave no source files behind.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->