### PR TITLE
fix(install): expose postinstall tool to nested mise

### DIFF
--- a/e2e/cli/test_use_postinstall
+++ b/e2e/cli/test_use_postinstall
@@ -51,6 +51,9 @@ mkdir write-options
   mise use --path path.toml --postinstall "touch path-hook" dummy@1.0.0
   assert_contains "cat path.toml" "postinstall"
 
+  mise use --force --path nested.toml --postinstall "mise which dummy >nested-which" dummy@2.0.0
+  assert_contains "cat nested-which" "$MISE_DATA_DIR/installs/dummy/2.0.0/bin/dummy"
+
   mise use --env ci --postinstall "touch env-hook" dummy@1.0.0
   assert_contains "cat mise.ci.toml" "postinstall"
 

--- a/e2e/cli/test_use_postinstall
+++ b/e2e/cli/test_use_postinstall
@@ -51,8 +51,11 @@ mkdir write-options
   mise use --path path.toml --postinstall "touch path-hook" dummy@1.0.0
   assert_contains "cat path.toml" "postinstall"
 
-  mise use --force --path nested.toml --postinstall "mise which dummy >nested-which" dummy@2.0.0
+  mise use --force --path nested.toml \
+    --postinstall "mise which dummy >nested-which; mise ls dummy --json --current | jq -r '.[0].version' >nested-ls" \
+    dummy@2.0.0
   assert_contains "cat nested-which" "$MISE_DATA_DIR/installs/dummy/2.0.0/bin/dummy"
+  assert "cat nested-ls" "2.0.0"
 
   mise use --env ci --postinstall "touch env-hook" dummy@1.0.0
   assert_contains "cat mise.ci.toml" "postinstall"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -38,7 +38,7 @@ use crate::tera::{contains_template_syntax, get_tera, render_str};
 use crate::toolset::outdated_info::OutdatedInfo;
 use crate::toolset::{
     ResolveOptions, ToolOptionSource, ToolRequest, ToolVersion, ToolVersionOptions, Toolset,
-    install_state, is_outdated_version, tool_env_var_name,
+    install_state, is_outdated_version,
 };
 use crate::ui::progress_report::SingleReport;
 use crate::{
@@ -3558,12 +3558,7 @@ pub(crate) trait Backend: Debug + Send + Sync {
             .env(env::MISE_TOOL_VERSION_ENV_VAR, tv.version.clone())
             .with_pr(ctx.pr.as_ref())
             .cmd_body_args(shell_args, &rendered_script)
-            .envs(env_vars)
-            // Keep the concrete version being installed active for nested mise
-            // invocations. The declaring config may have a nonstandard filename
-            // (for example, `mise use --path custom.toml`), so config discovery
-            // alone cannot reliably reconstruct this tool request during its hook.
-            .env(tool_env_var_name(&tv.ba().short), tv.version.clone());
+            .envs(env_vars);
         for key in install_env_removals {
             runner = runner.env_remove(key);
         }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -38,7 +38,7 @@ use crate::tera::{contains_template_syntax, get_tera, render_str};
 use crate::toolset::outdated_info::OutdatedInfo;
 use crate::toolset::{
     ResolveOptions, ToolOptionSource, ToolRequest, ToolVersion, ToolVersionOptions, Toolset,
-    install_state, is_outdated_version,
+    install_state, is_outdated_version, tool_env_var_name,
 };
 use crate::ui::progress_report::SingleReport;
 use crate::{
@@ -3558,7 +3558,12 @@ pub(crate) trait Backend: Debug + Send + Sync {
             .env(env::MISE_TOOL_VERSION_ENV_VAR, tv.version.clone())
             .with_pr(ctx.pr.as_ref())
             .cmd_body_args(shell_args, &rendered_script)
-            .envs(env_vars);
+            .envs(env_vars)
+            // Keep the concrete version being installed active for nested mise
+            // invocations. The declaring config may have a nonstandard filename
+            // (for example, `mise use --path custom.toml`), so config discovery
+            // alone cannot reliably reconstruct this tool request during its hook.
+            .env(tool_env_var_name(&tv.ba().short), tv.version.clone());
         for key in install_env_removals {
             runner = runner.env_remove(key);
         }

--- a/src/toolset/builder.rs
+++ b/src/toolset/builder.rs
@@ -7,7 +7,9 @@ use crate::cli::args::{BackendArg, ToolArg};
 use crate::config::{Config, ConfigMap};
 use crate::env_diff::EnvMap;
 use crate::errors::Error;
-use crate::toolset::tool_request_set::configured_options_for_runtime_request;
+use crate::toolset::tool_request_set::{
+    configured_options_for_runtime_request, postinstall_tool_request,
+};
 use crate::toolset::{ResolveOptions, ToolRequest, ToolSource, Toolset, tool_from_env_var_name};
 use crate::{config, env};
 
@@ -111,7 +113,16 @@ impl ToolsetBuilder {
             // LocalOnly excludes env-based tool versions (MISE_*_VERSION).
             return Ok(());
         }
-        let postinstall = postinstall_tool_request(&env)?;
+        let postinstall = postinstall_tool_request(&env)?.map(|(mut request, source)| {
+            if let Some(config_options) = ts
+                .versions
+                .get(request.ba())
+                .and_then(|tvl| configured_options_for_runtime_request(&tvl.requests, &request))
+            {
+                request.apply_config_options(config_options);
+            }
+            (request, source)
+        });
         for (k, v) in env {
             if let Some(tool_name) = tool_from_env_var_name(&k) {
                 let ba: Arc<BackendArg> = Arc::new(tool_name.as_str().into());
@@ -187,43 +198,37 @@ impl ToolsetBuilder {
     }
 }
 
-/// Keep the exact tool currently running its postinstall hook active for
-/// nested mise invocations. Unlike `MISE_<TOOL>_VERSION`, this pair keeps
-/// backend-qualified names containing `:` or `/` intact.
-fn postinstall_tool_request(env: &EnvMap) -> eyre::Result<Option<(ToolRequest, ToolSource)>> {
-    if !env.contains_key("MISE_TOOL_INSTALL_PATH") {
-        return Ok(None);
-    }
-    let (Some(name), Some(version)) = (
-        env.get("MISE_TOOL_NAME"),
-        env.get(env::MISE_TOOL_VERSION_ENV_VAR),
-    ) else {
-        return Ok(None);
-    };
-    let backend = Arc::new(BackendArg::from(name));
-    let source =
-        ToolSource::Environment(env::MISE_TOOL_VERSION_ENV_VAR.into(), version.to_string());
-    let request = ToolRequest::new(backend, version, source.clone())?;
-    Ok(Some((request, source)))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::toolset::parse_tool_options;
 
-    #[test]
-    fn test_postinstall_tool_request_preserves_backend_identity() {
+    #[tokio::test]
+    async fn test_postinstall_request_preserves_configured_options() {
+        crate::toolset::install_state::init().await.unwrap();
+        let ba = Arc::new(BackendArg::from("dummy"));
+        let configured = ToolRequest::new_with_options(
+            ba.clone(),
+            "1.0.0",
+            parse_tool_options(r#"selected="configured""#),
+            ToolSource::Unknown,
+        )
+        .unwrap();
+        let mut ts = Toolset::new(ToolSource::Unknown);
+        ts.add_version(configured);
         let env = EnvMap::from_iter([
-            ("MISE_TOOL_INSTALL_PATH".into(), "/tmp/aws-cli".into()),
-            ("MISE_TOOL_NAME".into(), "aqua:aws/aws-cli".into()),
-            (env::MISE_TOOL_VERSION_ENV_VAR.into(), "2.31.0".into()),
+            ("MISE_TOOL_INSTALL_PATH".into(), "/tmp/dummy".into()),
+            ("MISE_TOOL_NAME".into(), "dummy".into()),
+            (env::MISE_TOOL_VERSION_ENV_VAR.into(), "2.0.0".into()),
         ]);
 
-        let (request, _) = postinstall_tool_request(&env).unwrap().unwrap();
+        ToolsetBuilder::new()
+            .load_runtime_env(&mut ts, env)
+            .unwrap();
 
-        assert_eq!(request.ba().short, "aqua:aws/aws-cli");
-        assert_eq!(request.version(), "2.31.0");
+        let request = &ts.versions.get(&ba).unwrap().requests[0];
+        assert_eq!(request.version(), "2.0.0");
+        assert_eq!(request.options().get("selected"), Some("configured"));
     }
 
     #[tokio::test]

--- a/src/toolset/builder.rs
+++ b/src/toolset/builder.rs
@@ -111,6 +111,7 @@ impl ToolsetBuilder {
             // LocalOnly excludes env-based tool versions (MISE_*_VERSION).
             return Ok(());
         }
+        let postinstall = postinstall_tool_request(&env)?;
         for (k, v) in env {
             if let Some(tool_name) = tool_from_env_var_name(&k) {
                 let ba: Arc<BackendArg> = Arc::new(tool_name.as_str().into());
@@ -122,6 +123,11 @@ impl ToolsetBuilder {
                 }
                 ts.merge(env_ts);
             }
+        }
+        if let Some((request, source)) = postinstall {
+            let mut postinstall_ts = Toolset::new(source);
+            postinstall_ts.add_version(request);
+            ts.merge(postinstall_ts);
         }
         Ok(())
     }
@@ -181,10 +187,44 @@ impl ToolsetBuilder {
     }
 }
 
+/// Keep the exact tool currently running its postinstall hook active for
+/// nested mise invocations. Unlike `MISE_<TOOL>_VERSION`, this pair keeps
+/// backend-qualified names containing `:` or `/` intact.
+fn postinstall_tool_request(env: &EnvMap) -> eyre::Result<Option<(ToolRequest, ToolSource)>> {
+    if !env.contains_key("MISE_TOOL_INSTALL_PATH") {
+        return Ok(None);
+    }
+    let (Some(name), Some(version)) = (
+        env.get("MISE_TOOL_NAME"),
+        env.get(env::MISE_TOOL_VERSION_ENV_VAR),
+    ) else {
+        return Ok(None);
+    };
+    let backend = Arc::new(BackendArg::from(name));
+    let source =
+        ToolSource::Environment(env::MISE_TOOL_VERSION_ENV_VAR.into(), version.to_string());
+    let request = ToolRequest::new(backend, version, source.clone())?;
+    Ok(Some((request, source)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::toolset::parse_tool_options;
+
+    #[test]
+    fn test_postinstall_tool_request_preserves_backend_identity() {
+        let env = EnvMap::from_iter([
+            ("MISE_TOOL_INSTALL_PATH".into(), "/tmp/aws-cli".into()),
+            ("MISE_TOOL_NAME".into(), "aqua:aws/aws-cli".into()),
+            (env::MISE_TOOL_VERSION_ENV_VAR.into(), "2.31.0".into()),
+        ]);
+
+        let (request, _) = postinstall_tool_request(&env).unwrap().unwrap();
+
+        assert_eq!(request.ba().short, "aqua:aws/aws-cli");
+        assert_eq!(request.version(), "2.31.0");
+    }
 
     #[tokio::test]
     async fn test_bare_runtime_arg_uses_platform_supported_configured_version() {

--- a/src/toolset/tool_request_set.rs
+++ b/src/toolset/tool_request_set.rs
@@ -8,6 +8,7 @@ use crate::backend::backend_type::BackendType;
 use crate::cli::args::{BackendArg, ToolArg};
 use crate::config::{Config, ConfigMap, Settings};
 use crate::env;
+use crate::env_diff::EnvMap;
 use crate::registry::{REGISTRY, tool_enabled};
 use crate::toolset::{ToolRequest, ToolSource, Toolset};
 use heck::{ToKebabCase, ToShoutySnakeCase};
@@ -231,8 +232,22 @@ impl ToolRequestSetBuilder {
         Ok(trs)
     }
 
-    fn load_runtime_env(&self, mut trs: ToolRequestSet) -> eyre::Result<ToolRequestSet> {
-        for (short, k, v) in tool_env_vars() {
+    fn load_runtime_env(&self, trs: ToolRequestSet) -> eyre::Result<ToolRequestSet> {
+        let env = env::vars_safe().collect();
+        self.load_runtime_env_from(trs, env)
+    }
+
+    fn load_runtime_env_from(
+        &self,
+        mut trs: ToolRequestSet,
+        env: EnvMap,
+    ) -> eyre::Result<ToolRequestSet> {
+        let postinstall = postinstall_tool_request(&env)?
+            .map(|(request, source)| (apply_config_options_to_runtime_arg(&trs, request), source));
+        for (k, v) in env {
+            let Some(short) = tool_from_env_var_name(&k) else {
+                continue;
+            };
             let ba: Arc<BackendArg> = Arc::new(short.as_str().into());
             let source = ToolSource::Environment(k, v.clone());
             let mut env_ts = ToolRequestSet::new();
@@ -241,6 +256,11 @@ impl ToolRequestSetBuilder {
                 env_ts.add_version(tvr, &source);
             }
             trs = merge(trs, env_ts);
+        }
+        if let Some((request, source)) = postinstall {
+            let mut postinstall_trs = ToolRequestSet::new();
+            postinstall_trs.add_version(request, &source);
+            trs = merge(trs, postinstall_trs);
         }
         Ok(trs)
     }
@@ -328,6 +348,28 @@ pub(super) fn configured_options_for_runtime_request(
         .map(ToolRequest::options)
 }
 
+/// Keep the exact tool currently running its postinstall hook active for
+/// nested mise invocations. Unlike `MISE_<TOOL>_VERSION`, this pair keeps
+/// backend-qualified names containing `:` or `/` intact.
+pub(super) fn postinstall_tool_request(
+    env: &EnvMap,
+) -> eyre::Result<Option<(ToolRequest, ToolSource)>> {
+    if !env.contains_key("MISE_TOOL_INSTALL_PATH") {
+        return Ok(None);
+    }
+    let (Some(name), Some(version)) = (
+        env.get("MISE_TOOL_NAME"),
+        env.get(env::MISE_TOOL_VERSION_ENV_VAR),
+    ) else {
+        return Ok(None);
+    };
+    let backend = Arc::new(BackendArg::from(name));
+    let source =
+        ToolSource::Environment(env::MISE_TOOL_VERSION_ENV_VAR.into(), version.to_string());
+    let request = ToolRequest::new(backend, version, source.clone())?;
+    Ok(Some((request, source)))
+}
+
 fn merge(mut a: ToolRequestSet, mut b: ToolRequestSet) -> ToolRequestSet {
     // move things around such that the tools are in the config order
     a.tools.retain(|ba, _| !b.tools.contains_key(ba));
@@ -372,6 +414,48 @@ pub(crate) fn tool_env_vars() -> impl Iterator<Item = (String, String, String)> 
 mod tests {
     use super::*;
     use crate::toolset::{CoreToolOptions, ToolVersionOptions, parse_tool_options};
+
+    #[test]
+    fn test_postinstall_tool_request_preserves_backend_identity() {
+        let env = EnvMap::from_iter([
+            ("MISE_TOOL_INSTALL_PATH".into(), "/tmp/aws-cli".into()),
+            ("MISE_TOOL_NAME".into(), "aqua:aws/aws-cli".into()),
+            (env::MISE_TOOL_VERSION_ENV_VAR.into(), "2.31.0".into()),
+        ]);
+
+        let (request, _) = postinstall_tool_request(&env).unwrap().unwrap();
+
+        assert_eq!(request.ba().short, "aqua:aws/aws-cli");
+        assert_eq!(request.version(), "2.31.0");
+    }
+
+    #[tokio::test]
+    async fn test_postinstall_request_set_preserves_configured_options() {
+        crate::toolset::install_state::init().await.unwrap();
+        let ba = Arc::new(BackendArg::from("dummy"));
+        let configured = ToolRequest::new_with_options(
+            ba.clone(),
+            "1.0.0",
+            parse_tool_options(r#"selected="configured""#),
+            ToolSource::Unknown,
+        )
+        .unwrap();
+        let mut trs = ToolRequestSet::new();
+        trs.add_version(configured, &ToolSource::Unknown);
+        let env = EnvMap::from_iter([
+            ("MISE_TOOL_INSTALL_PATH".into(), "/tmp/dummy".into()),
+            ("MISE_TOOL_NAME".into(), "dummy".into()),
+            (env::MISE_TOOL_VERSION_ENV_VAR.into(), "2.0.0".into()),
+        ]);
+
+        let trs = ToolRequestSetBuilder::new()
+            .load_runtime_env_from(trs, env)
+            .unwrap();
+
+        let request = &trs.tools.get(&ba).unwrap()[0];
+        assert_eq!(request.version(), "2.0.0");
+        assert_eq!(request.options().get("selected"), Some("configured"));
+    }
 
     #[test]
     fn test_tool_env_var_name_round_trip() {


### PR DESCRIPTION
## Summary
- activate the concrete tool version while its postinstall hook runs
- keep nested `mise` invocations from selecting an older discoverable version or losing a tool declared through a custom config path
- add an end-to-end regression test covering `mise use --path` with `mise which` in postinstall

## Testing
- `mise run test:e2e e2e/cli/test_use_postinstall e2e/config/test_hooks_tool_env`
- `mise run lint-fix`
- `cargo fmt --all -- --check`
- `mise run test:e2e e2e/cli/test_use_postinstall`

*AI-assisted — Tool: Codex; model: OpenAI/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core toolset resolution during installs and postinstall hooks; behavior is scoped to the hook env sentinel but affects every nested mise invocation in that context.
> 
> **Overview**
> Fixes **nested `mise` during postinstall** so commands like `mise which` and `mise ls` resolve the version being installed, not an older config or a missing tool when using `--path`.
> 
> Runtime toolset building now recognizes the postinstall hook environment (`MISE_TOOL_INSTALL_PATH`, `MISE_TOOL_NAME`, and the tool version var) via new **`postinstall_tool_request`**, merged into both **`ToolRequestSetBuilder`** and **`ToolsetBuilder`** after normal `MISE_<TOOL>_VERSION` handling. That path keeps **backend-qualified names** (e.g. `aqua:aws/aws-cli`) intact and **reapplies configured tool options** from the active config onto the postinstall version request.
> 
> An e2e case exercises **`mise use --force --path nested.toml --postinstall`** with nested `mise which` / `mise ls`; unit tests cover backend identity and option preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63190eb70c4d4ddc52d8e0f21e12632249c303be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post-installation handling for tools configured through nested paths.
  * Preserved configured tool options, including custom installation paths and dependencies, during post-installation.
  * Ensured backend-qualified tool names remain intact during installation.
  * Verified forced installations correctly resolve the expected executable version.

* **Tests**
  * Added coverage for configured options, backend identity, nested configuration paths, and post-install tool resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->