### PR TITLE
feat(erlang): add precompiled OS override

### DIFF
--- a/docs/lang/erlang.md
+++ b/docs/lang/erlang.md
@@ -23,11 +23,10 @@ See available versions with `mise ls-remote erlang`.
 The plugin uses [kerl](https://github.com/kerl/kerl) under the hood to build erlang.
 See kerl's docs for information on configuring kerl.
 
-On GitHub Actions Linux runners, `ImageOS=ubuntu26`, `ImageOS=ubuntu24`,
-`ImageOS=ubuntu22`, and `ImageOS=ubuntu20` map to their corresponding precompiled
-Erlang build targets. In the default `erlang.compile` mode, unsupported values record
-the Erlang/OTP source archive as the platform's locked input so installs can reproduce
-the kerl fallback.
+On GitHub Actions Linux runners, `ImageOS=ubuntu24`, `ImageOS=ubuntu22`, and
+`ImageOS=ubuntu20` map to their corresponding precompiled Erlang build targets. In the
+default `erlang.compile` mode, unsupported values record the Erlang/OTP source archive
+as the platform's locked input so installs can reproduce the kerl fallback.
 
 The builds published by [Bob](https://github.com/hexpm/bob#erlang-builds) target Ubuntu,
 but may also run on another glibc-based Linux distribution with compatible system
@@ -37,6 +36,9 @@ libraries. Set `erlang.precompiled_os` to opt in to one of Bob's Ubuntu targets:
 [settings.erlang]
 precompiled_os = "ubuntu-22.04"
 ```
+
+Accepted targets are `ubuntu-20.04`, `ubuntu-22.04`, `ubuntu-24.04`, and
+`ubuntu-26.04`.
 
 Precompiled builds link to system libraries such as OpenSSL, ncurses, ODBC, and
 wxWidgets. A compatible glibc version alone does not guarantee that every optional

--- a/docs/lang/erlang.md
+++ b/docs/lang/erlang.md
@@ -23,11 +23,25 @@ See available versions with `mise ls-remote erlang`.
 The plugin uses [kerl](https://github.com/kerl/kerl) under the hood to build erlang.
 See kerl's docs for information on configuring kerl.
 
-On GitHub Actions Linux runners, `ImageOS=ubuntu24`, `ImageOS=ubuntu22`, and `ImageOS=ubuntu20`
-map to the precompiled Erlang build targets `ubuntu-24.04`, `ubuntu-22.04`, and
-`ubuntu-20.04`. In the default `erlang.compile` mode, unsupported values record the
-Erlang/OTP source archive as the platform's locked input so installs can reproduce the
-kerl fallback.
+On GitHub Actions Linux runners, `ImageOS=ubuntu26`, `ImageOS=ubuntu24`,
+`ImageOS=ubuntu22`, and `ImageOS=ubuntu20` map to their corresponding precompiled
+Erlang build targets. In the default `erlang.compile` mode, unsupported values record
+the Erlang/OTP source archive as the platform's locked input so installs can reproduce
+the kerl fallback.
+
+The builds published by [Bob](https://github.com/hexpm/bob#erlang-builds) target Ubuntu,
+but may also run on another glibc-based Linux distribution with compatible system
+libraries. Set `erlang.precompiled_os` to opt in to one of Bob's Ubuntu targets:
+
+```toml
+[settings.erlang]
+precompiled_os = "ubuntu-22.04"
+```
+
+Precompiled builds link to system libraries such as OpenSSL, ncurses, ODBC, and
+wxWidgets. A compatible glibc version alone does not guarantee that every optional
+Erlang application will work. The selected target is recorded in `mise.lock`; use a
+target compatible with every machine that consumes the lockfile.
 
 ## Tool Options
 

--- a/e2e/core/test_erlang_precompiled_strict
+++ b/e2e/core/test_erlang_precompiled_strict
@@ -19,3 +19,26 @@ fi
 
 [[ $output != *"build-install"* ]] ||
   fail "erlang.compile=false should not fall back to kerl build-install: $output"
+
+export MISE_LOCKFILE=1
+detect_platform
+
+cat <<'EOF' >mise.toml
+[tools]
+erlang = "28.5"
+
+[settings.erlang]
+compile = false
+precompiled_os = "ubuntu-22.04"
+EOF
+
+mise lock --platform "$MISE_PLATFORM"
+assert_contains "cat mise.lock" 'precompiled_os = "ubuntu-22.04"'
+assert_matches "cat mise.lock" 'url = "https://builds\.hex\.pm/builds/otp/(amd64|arm64)/ubuntu-22\.04/OTP-28\.5\.tar\.gz"'
+
+rm -f mise.lock
+sed -i '/precompiled_os/d' mise.toml
+export ImageOS=ubuntu26
+mise lock --platform "$MISE_PLATFORM"
+assert_contains "cat mise.lock" 'precompiled_os = "ubuntu-26.04"'
+assert_matches "cat mise.lock" 'url = "https://builds\.hex\.pm/builds/otp/(amd64|arm64)/ubuntu-26\.04/OTP-28\.5\.tar\.gz"'

--- a/e2e/core/test_erlang_precompiled_strict
+++ b/e2e/core/test_erlang_precompiled_strict
@@ -37,8 +37,7 @@ assert_contains "cat mise.lock" 'precompiled_os = "ubuntu-22.04"'
 assert_matches "cat mise.lock" 'url = "https://builds\.hex\.pm/builds/otp/(amd64|arm64)/ubuntu-22\.04/OTP-28\.5\.tar\.gz"'
 
 rm -f mise.lock
-sed -i '/precompiled_os/d' mise.toml
-export ImageOS=ubuntu26
+sed -i 's/ubuntu-22\.04/ubuntu-26.04/' mise.toml
 mise lock --platform "$MISE_PLATFORM"
 assert_contains "cat mise.lock" 'precompiled_os = "ubuntu-26.04"'
 assert_matches "cat mise.lock" 'url = "https://builds\.hex\.pm/builds/otp/(amd64|arm64)/ubuntu-26\.04/OTP-28\.5\.tar\.gz"'

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -860,6 +860,10 @@
             "compile": {
               "description": "If true, compile erlang from source. If false, use precompiled binaries. If not set, use precompiled binaries if available.",
               "type": "boolean"
+            },
+            "precompiled_os": {
+              "description": "Ubuntu release target to use for precompiled Erlang builds from builds.hex.pm.",
+              "type": "string"
             }
           }
         },

--- a/settings.toml
+++ b/settings.toml
@@ -758,6 +758,12 @@ env = "MISE_ERLANG_COMPILE"
 optional = true
 type = "Bool"
 
+[erlang.precompiled_os]
+description = "Ubuntu release target to use for precompiled Erlang builds from builds.hex.pm."
+env = "MISE_ERLANG_PRECOMPILED_OS"
+optional = true
+type = "String"
+
 [exec_auto_install]
 default = true
 description = "Automatically install missing tools when running `mise x`."

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -211,11 +211,20 @@ impl ErlangPlugin {
 
     fn linux_precompiled_os_version() -> Result<String> {
         let os_ver = if let Some(os) = Settings::get().erlang.precompiled_os.clone() {
-            os
+            if ![
+                "ubuntu-20.04",
+                "ubuntu-22.04",
+                "ubuntu-24.04",
+                "ubuntu-26.04",
+            ]
+            .contains(&os.as_str())
+            {
+                bail!("unsupported OS version: {os}");
+            }
+            return Ok(os);
         } else if Platform::current().is_linux() {
             if let Ok(os) = std::env::var("ImageOS") {
                 match os.as_str() {
-                    "ubuntu26" => "ubuntu-26.04".to_string(),
                     "ubuntu24" => "ubuntu-24.04".to_string(),
                     "ubuntu22" => "ubuntu-22.04".to_string(),
                     "ubuntu20" => "ubuntu-20.04".to_string(),
@@ -232,16 +241,9 @@ impl ErlangPlugin {
             "ubuntu-24.04".to_string()
         };
 
-        // Bob's builds target Ubuntu. Other glibc distributions can opt in to a compatible
-        // target with erlang.precompiled_os, but the target must exist upstream.
-        if ![
-            "ubuntu-20.04",
-            "ubuntu-22.04",
-            "ubuntu-24.04",
-            "ubuntu-26.04",
-        ]
-        .contains(&os_ver.as_str())
-        {
+        // Keep automatic targets stable so existing optionless source locks continue to match.
+        // Other targets and glibc distributions can opt in with erlang.precompiled_os.
+        if !["ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04"].contains(&os_ver.as_str()) {
             bail!("unsupported OS version: {os_ver}");
         }
         Ok(os_ver)

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -210,9 +210,12 @@ impl ErlangPlugin {
     }
 
     fn linux_precompiled_os_version() -> Result<String> {
-        let os_ver = if Platform::current().is_linux() {
+        let os_ver = if let Some(os) = Settings::get().erlang.precompiled_os.clone() {
+            os
+        } else if Platform::current().is_linux() {
             if let Ok(os) = std::env::var("ImageOS") {
                 match os.as_str() {
+                    "ubuntu26" => "ubuntu-26.04".to_string(),
                     "ubuntu24" => "ubuntu-24.04".to_string(),
                     "ubuntu22" => "ubuntu-22.04".to_string(),
                     "ubuntu20" => "ubuntu-20.04".to_string(),
@@ -229,9 +232,16 @@ impl ErlangPlugin {
             "ubuntu-24.04".to_string()
         };
 
-        // Currently, Bob only builds for Ubuntu, so we have to check that we're on Ubuntu,
-        // and on a supported version.
-        if !["ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04"].contains(&os_ver.as_str()) {
+        // Bob's builds target Ubuntu. Other glibc distributions can opt in to a compatible
+        // target with erlang.precompiled_os, but the target must exist upstream.
+        if ![
+            "ubuntu-20.04",
+            "ubuntu-22.04",
+            "ubuntu-24.04",
+            "ubuntu-26.04",
+        ]
+        .contains(&os_ver.as_str())
+        {
             bail!("unsupported OS version: {os_ver}");
         }
         Ok(os_ver)


### PR DESCRIPTION
## Summary
- add `erlang.precompiled_os` / `MISE_ERLANG_PRECOMPILED_OS` to opt into a Bob Ubuntu build target on compatible glibc distributions
- support explicit selection of Bob targets through Ubuntu 26.04 without changing automatic target identity for existing configurations
- document shared-library and lockfile portability constraints
- cover explicit cross-distro and Ubuntu 26.04 lock resolution

This addresses the opt-in path proposed in [discussion #12636](https://github.com/jdx/mise/discussions/12636). Runtime glibc selection is intentionally not automatic because the archives also depend on system-library SONAMEs and the lockfile platform key does not encode a glibc generation.

## Testing
- `mise run lint-fix`
- `mise run lint`
- `mise run test:e2e e2e/core/test_erlang_precompiled_strict`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Unable to generate summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2f935341be325d1ae7a4d8064cf0502312cab9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `erlang.precompiled_os` to select a supported Ubuntu release for precompiled Erlang builds, including Ubuntu 26.04.
  - Lockfiles now preserve the selected precompiled operating system for consistent builds.
  - Automatic Linux detection continues to use Ubuntu 20.04, 22.04, and 24.04 targets.

- **Documentation**
  - Clarified supported runner images, Ubuntu targets, system-library compatibility, and lockfile behavior for precompiled Erlang builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->