### PR TITLE
chore: release 2026.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## [2026.9.0](https://github.com/jdx/mise/compare/v2026.8.16..v2026.9.0) - 2026-09-01
+
+### 🚀 Features
+
+- **(erlang)** add precompiled OS override by @jdx in [#12637](https://github.com/jdx/mise/pull/12637)
+- **(tools)** add lazy tool shims by @jdx in [#12594](https://github.com/jdx/mise/pull/12594)
+
+### 🐛 Bug Fixes
+
+- **(install)** expose postinstall tool to nested mise by @jdx in [#12635](https://github.com/jdx/mise/pull/12635)
+
+### 📦️ Dependency Updates
+
+- update rust crate aube to v2.2.4 by @renovate[bot] in [#12639](https://github.com/jdx/mise/pull/12639)
+- update rust crate aube-registry to v2.2.4 by @renovate[bot] in [#12640](https://github.com/jdx/mise/pull/12640)
+- bump aube workspace crates to 2.2.4 by @jdx in [#12643](https://github.com/jdx/mise/pull/12643)
+
+### 📦 Registry
+
+- add engram by @AndryOre in [#12480](https://github.com/jdx/mise/pull/12480)
+- add gentle-ai ([aqua:Gentleman-Programming/gentle-ai](https://github.com/Gentleman-Programming/gentle-ai)) by @AndryOre in [#12444](https://github.com/jdx/mise/pull/12444)
+
+### Chore
+
+- bump mr-boxington to 1.2.0 by @jdx in [#12633](https://github.com/jdx/mise/pull/12633)
+
+### Ci
+
+- **(perf)** move benchmarks to dedicated runner by @jdx in [#12616](https://github.com/jdx/mise/pull/12616)
+
+### New Contributors
+
+- @AndryOre made their first contribution in [#12444](https://github.com/jdx/mise/pull/12444)
+
+### 📦 Aqua Registry Updates
+
+#### Updated Packages (3)
+
+- [`KeisukeYamashita/commitlint-rs`](https://github.com/KeisukeYamashita/commitlint-rs)
+- [`keilerkonzept/terraform-module-versions`](https://github.com/keilerkonzept/terraform-module-versions)
+- [`linebender/resvg`](https://github.com/linebender/resvg)
+
 ## [2026.8.16](https://github.com/jdx/mise/compare/v2026.8.15..v2026.8.16) - 2026-08-31
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6321,7 +6321,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.8.16"
+version = "2026.9.0"
 dependencies = [
  "age 0.12.1",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.8.16"
+version = "2026.9.0"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.8.16 macos-arm64 (2026-08-31)
+2026.9.0 macos-arm64 (2026-09-01)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.8.16";
+  version = "2026.9.0";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.8.16
+Version: 2026.9.0
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.8.16"
+version: "2026.9.0"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "ee2a510b062d9ec205c7dbfb8431463f7f854a8b"
+  "tag": "9204729a22ae282c1ae1277d74c1e991da5d6e51"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -4957,6 +4957,9 @@ packages:
           - windows
       - version_constraint: semver("<= 0.2.1")
         no_asset: true
+      - version_constraint: Version in ["v0.2.3", "v0.2.4"]
+        type: cargo
+        crate: commitlint-rs
       - version_constraint: "true"
         asset: commitlint-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -57386,26 +57389,36 @@ packages:
     repo_owner: keilerkonzept
     repo_name: terraform-module-versions
     description: "CLI tool that checks Terraform code for module updates. Single binary, no dependencies. linux, osx, windows. #golang #cli #terraform"
-    asset: terraform-module-versions_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
-    replacements:
-      amd64: x86_64
-      darwin: osx
-    supported_envs:
-      - darwin
-    rosetta2: true
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["3.0.29", "3.1.14"]
+      - version_constraint: Version in ["v3.2.1", "3.1.14", "3.0.29"]
         no_asset: true
-      - version_constraint: semver("< 3.1.14")
+      - version_constraint: semver("<= 3.2.1")
+        asset: terraform-module-versions_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: osx
         overrides:
           - goos: windows
             format: zip
-        supported_envs:
-          - darwin
-          - linux
-          - amd64
+      - version_constraint: "true"
+        asset: terraform-module-versions_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: terraform-module-versions_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: keisku
     repo_name: kubectl-explore
@@ -62985,6 +62998,19 @@ packages:
         supported_envs:
           - linux/amd64
           - windows/amd64
+      - version_constraint: semver(">= 0.48.0")
+        asset: resvg-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - darwin
+          - linux/amd64
       - version_constraint: "true"
         asset: resvg-{{.OS}}.{{.Format}}
         format: zip


### PR DESCRIPTION
### 🚀 Features

- **(erlang)** add precompiled OS override by @jdx in [#12637](https://github.com/jdx/mise/pull/12637)
- **(tools)** add lazy tool shims by @jdx in [#12594](https://github.com/jdx/mise/pull/12594)

### 🐛 Bug Fixes

- **(install)** expose postinstall tool to nested mise by @jdx in [#12635](https://github.com/jdx/mise/pull/12635)

### 📦️ Dependency Updates

- update rust crate aube to v2.2.4 by @renovate[bot] in [#12639](https://github.com/jdx/mise/pull/12639)
- update rust crate aube-registry to v2.2.4 by @renovate[bot] in [#12640](https://github.com/jdx/mise/pull/12640)
- bump aube workspace crates to 2.2.4 by @jdx in [#12643](https://github.com/jdx/mise/pull/12643)

### 📦 Registry

- add engram by @AndryOre in [#12480](https://github.com/jdx/mise/pull/12480)
- add gentle-ai ([aqua:Gentleman-Programming/gentle-ai](https://github.com/Gentleman-Programming/gentle-ai)) by @AndryOre in [#12444](https://github.com/jdx/mise/pull/12444)

### Chore

- bump mr-boxington to 1.2.0 by @jdx in [#12633](https://github.com/jdx/mise/pull/12633)

### Ci

- **(perf)** move benchmarks to dedicated runner by @jdx in [#12616](https://github.com/jdx/mise/pull/12616)

### New Contributors

- @AndryOre made their first contribution in [#12444](https://github.com/jdx/mise/pull/12444)

## 📦 Aqua Registry Updates

### Updated Packages (3)

- [`KeisukeYamashita/commitlint-rs`](https://github.com/KeisukeYamashita/commitlint-rs)
- [`keilerkonzept/terraform-module-versions`](https://github.com/keilerkonzept/terraform-module-versions)
- [`linebender/resvg`](https://github.com/linebender/resvg)