### PR TITLE
fix(install): stop s3 --dry-run claiming it would install what it cannot

### DIFF
--- a/e2e/cli/test_install_dry_run_feasibility
+++ b/e2e/cli/test_install_dry_run_feasibility
@@ -26,6 +26,18 @@ assert_fail "mise install --dry-run" "No URL for platform"
 # and it names what the tool does declare, since adding that key is usually the fix
 assert_fail "mise install --dry-run" "Available: windows-x64"
 
+# The s3 backend is structurally the same question as http: a tool that declares a URL for
+# another platform only cannot install here, and its options say so before any request. It used
+# to answer "would install" like http did before the feasibility hook reached it.
+cat <<EOF >mise.toml
+[tools."s3:dry-run-no-url-here"]
+version = "1.0.0"
+platforms = { windows-x64 = { url = "s3://example/tool-{{version}}.tar.gz" } }
+EOF
+assert_fail "mise install --dry-run" "No URL for platform"
+# and it names what the tool does declare, since adding that key is usually the fix
+assert_fail "mise install --dry-run" "Available: windows-x64"
+
 # aqua can tell from the registry entry. Specific versions are marked `no_asset` there regardless
 # of platform, which is what makes this runnable on any runner: `unsupported env` depends on the
 # host, and aqua reads the host from `env::consts::OS` rather than from settings, so `MISE_OS`

--- a/src/backend/s3.rs
+++ b/src/backend/s3.rs
@@ -165,6 +165,10 @@ impl<'a> S3Options<'a> {
     fn version_expr(&self) -> Option<String> {
         self.values.platform_string("version_expr")
     }
+
+    fn url_platforms(&self) -> Vec<String> {
+        self.values.available_platforms_with_key("url")
+    }
 }
 
 impl S3Backend {
@@ -188,13 +192,26 @@ impl S3Backend {
 
     /// Resolve the download URL from options and version
     fn resolve_url(&self, tv: &ToolVersion, opts: &S3Options<'_>) -> Result<String> {
-        let url_template = opts.url().ok_or_else(|| {
-            eyre!(
-                "S3 backend requires 'url' option. Example: url = \"s3://bucket/tool-{{version}}.tar.gz\""
-            )
-        })?;
+        let url_template = opts.url().ok_or_else(|| self.missing_url_error(opts))?;
 
         Ok(template_string(&url_template, tv))
+    }
+
+    /// Built in one place so the dry-run check and the install itself cannot drift apart.
+    /// Names the platform it looked for and the ones the tool does declare, because the fix is
+    /// usually to add that key rather than to pick a different tool.
+    fn missing_url_error(&self, opts: &S3Options<'_>) -> eyre::Report {
+        let platform_key = self.get_platform_key();
+        let available = opts.url_platforms();
+        if available.is_empty() {
+            eyre::eyre!("S3 backend requires 'url' option")
+        } else {
+            eyre::eyre!(
+                "No URL for platform {platform_key}. Available: {}. \
+                 Provide 'url' or add 'platforms.{platform_key}.url'",
+                available.join(", ")
+            )
+        }
     }
 
     fn lock_url_for_target(
@@ -555,6 +572,18 @@ impl Backend for S3Backend {
             .collect())
     }
 
+    /// An s3 tool with no URL for this platform cannot be installed, and the options say so
+    /// without a single request. `--dry-run` used to answer "would install" for exactly the case
+    /// the real install rejects on its first line (the same gap http and aqua closed in #12568).
+    async fn verify_install_feasible(&self, _ctx: &InstallContext, tv: &ToolVersion) -> Result<()> {
+        let raw_opts = tv.request.options();
+        let opts = S3Options::new(&raw_opts);
+        match opts.url() {
+            Some(_) => Ok(()),
+            None => Err(self.missing_url_error(&opts)),
+        }
+    }
+
     async fn install_version_(
         &self,
         ctx: &InstallContext,
@@ -815,5 +844,28 @@ checksum = "sha256:abc123"
     fn test_s3_url_missing_bucket() {
         let result = S3Url::parse("s3:///path/to/file");
         assert!(result.is_err());
+    }
+
+    // The message `--dry-run` now produces before claiming it would install. Built by
+    // `missing_url_error` so the dry-run check and the install itself cannot drift apart; this
+    // asserts both of its branches, which are two different mistakes with two different fixes.
+    #[test]
+    fn missing_url_error_names_this_platform_and_the_ones_declared() {
+        let backend = s3_test_backend();
+
+        let declared = crate::toolset::parse_tool_options("platforms_linux_x64_url=s3://bucket/t");
+        let declared = S3Options::new(&declared);
+        let err = backend.missing_url_error(&declared).to_string();
+        assert!(err.contains(&backend.get_platform_key()), "{err}");
+        assert!(err.contains("linux-x64"), "{err}");
+
+        // A tool that declares no URL anywhere is a different mistake: there is no list to print
+        // and nothing platform-specific to say.
+        let none = ToolVersionOptions::default();
+        let none = S3Options::new(&none);
+        assert_eq!(
+            backend.missing_url_error(&none).to_string(),
+            "S3 backend requires 'url' option"
+        );
     }
 }


### PR DESCRIPTION
fixes the same gap #12568 just closed for aqua and http, for the s3 backend

`mise install --dry-run` on an s3 tool that declares a URL only for another platform answered "would install", even though the real install rejects it on its first line
example:

```toml
[tools."s3:dry-run-no-url-here"]
version = "1.0.0"
platforms = { windows-x64 = { url = "s3://example/tool-{{version}}.tar.gz" } }
```

before: `s3:dry-run-no-url-here@1.0.0 ⇢ would install`
after: `No URL for platform linux-x64. Available: windows-x64. Provide 'url' or add 'platforms.linux-x64.url'`

this adds the `verify_install_feasible` override to the s3 backend, mirroring the http one from #12568, so the dry-run asks the same question the install does, they cannot drift apart

## Testing

- `cargo test --all-features --bin mise backend::s3` → 9 passed (new unit test asserts both branches of `missing_url_error`)
- full suites: backend 631 passed, shell 73 passed, http 22 passed
- `mise run test:e2e e2e/cli/test_install_dry_run_feasibility` → all assertions green, incl the new s3 case (fail + `Available:` listing) and the controls (installable tool still reports "would install", installed tool reports "already installed")
- pre-change probe: with the fix reverted, the s3 case reports "would install" and fails the new assertion, with the fix it errors correctly
- `cargo fmt --check` clean, `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean

AI-assisted Tool: i have used dsh with the model GLM 5.3 Flash



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3 installation errors when a tool lacks a URL for the current platform.
  * Error messages now identify the missing platform and list platforms with available downloads.
  * Dry-run feasibility checks now correctly fail when installation cannot proceed on the host platform.

* **Tests**
  * Added end-to-end coverage for S3 dry-run failures caused by unavailable platform URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->