### PR TITLE
chore(deps): bump aube workspace crates to 2.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "2.2.3"
+version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5b0634983cf0a031bb2b32a24403e2c3faa2b68b9981799fac3e56992be44e"
+checksum = "3224f21cae2844ac34a0eb189c500525e1cfd40f6a7a914fab222e399056ec9c"
 dependencies = [
  "serde",
  "serde_json",
@@ -629,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "2.2.3"
+version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0035e5f61eb75111fe08889246254b3376729890181ef7790bf8a368e5c10f13"
+checksum = "7ba1221a16a85a078335bcc2f9a31c3fde7d263bb325e31230bd3bbe8f770826"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -641,6 +641,7 @@ dependencies = [
  "glob",
  "hex",
  "junction",
+ "libc",
  "miette",
  "pathdiff",
  "rayon",
@@ -657,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "2.2.3"
+version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1538e9f6f47070c9ff5707bde54d717c6f539d0bb260bf1c33effd59c1dc192c"
+checksum = "c986b6cae006a67e0b23546235880bd63d033f4bc3f2a43c77dd698f8c0d46e3"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -683,9 +684,9 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "2.2.3"
+version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f06b11db1fc0b120f913153eed8f86b03c82b40aa6a74120a7c72de811951b3"
+checksum = "2c972004c3d3c1ace55c58eadb746461e0158dcd76ef40af08557ae394257901"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -726,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "2.2.3"
+version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e14ec5bb87851bec85fc487392c28817db9a4b5344c8c8d457adbf7403cbfc9"
+checksum = "3553cc3e7a2fa121297461548c0a23ec5d2851c079f2abc41c2b2f3f14252585"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -756,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "aube-runtime"
-version = "2.2.3"
+version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6a0124b8cc758795b93b76a84f79666ef5417bf3352ffb5428f8bf03c83b43"
+checksum = "ac05125536a3b55bbd50ccf37210c005576ee6969bacdcc263ddd939d67e2509"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -781,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "2.2.3"
+version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1595489fdb04691378dc9016da8dd689d45498f61d67c5b8f019ca66d657c581"
+checksum = "767c6e3fc27a056aa6718e83a03f5e505d7d7089982947af6c1bf0566c036c69"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -801,9 +802,9 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "2.2.3"
+version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd560ba7730813787cdfd076547e0769b269e874d3b0deb723d50262d043ec9"
+checksum = "7f38a9a5547a39c50a2b9d594f1b66ef2680998b5996cfa4071a0c0050ea4ead"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -815,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "2.2.3"
+version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9412040812cee6ea03e7c9012f509a1a584a6718a250ed0854bd88c57435f0a"
+checksum = "b36160d63de4425a9bdf518c7c81da8f0f0d04218014cac655b99d59daa888de"
 dependencies = [
  "aube-util",
  "base64 0.23.1",
@@ -842,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "2.2.3"
+version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d486e95b7ba4e4cbb514863e56968441da1f33c534ad0fde881505ad0e28a576"
+checksum = "fbc7fd0e85447f421f6f8195c10bb37975120ce2d5b220fd866bd0d152b25c35"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -864,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "2.2.3"
+version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6123abcba771fba32cdea01e694f9038a8d15320b1e0b6a45013c161ae970b"
+checksum = "5dafdd27480bedff7bcb528a625c2f8bc402fbf88f5e0ff721917860def2d12a"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -1483,7 +1484,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -9504,7 +9505,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.3.14",
+ "errno 0.2.8",
  "libc",
 ]
 


### PR DESCRIPTION
## Summary
- refresh all embedded aube workspace crates to 2.2.4
- include required lockfile dependency-edge changes
- leave the standalone aube tool in `mise.lock` unchanged

Upstream 2.2.4 trusts versions already recorded in the active lockfile without re-fetching publishing trust evidence under the default `no-downgrade` policy, while retaining full validation for newly resolved versions and `paranoid` mode. It also includes store and linker performance improvements. No embedder API changes were required in mise.

## Tests
- `cargo check --locked`
- `cargo test --locked --bin mise aube`
- `cargo test --locked --bin mise task::workspace::node::tests`
- `mise run test:e2e e2e/backend/test_npm_aube`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency bump with no application code changes; main risk is upstream aube lockfile/trust and linker behavior in npm/aube workflows, which the PR’s listed tests target.
> 
> **Overview**
> **Dependency-only update:** `Cargo.lock` refreshes every embedded **aube** workspace crate from **2.2.3** to **2.2.4** (codes, linker, lockfile, manifest, resolver, runtime, scripts, settings, store, util, workspace). The standalone **aube** CLI version in `mise.lock` is intentionally left as-is.
> 
> Lock resolution also shifts a few transitive edges pulled in by the new crate graph—notably **aube-linker** now depends on **libc**, and **bindgen** / **signal-hook-registry** resolve to different **itertools** and **errno** versions. No mise source changes are in this diff.
> 
> Behavior-wise, upstream **2.2.4** is described as trusting versions already present in an active lockfile without re-fetching publishing trust evidence under the default **no-downgrade** policy, while still validating newly resolved versions and **paranoid** mode, plus store/linker performance work. Embedder APIs were not adjusted in mise for this bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 730137f872615e79315bc2896bbb451ca389192b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->