### PR TITLE
docs(bootstrap): explain that Homebrew does not generate tap API metadata

### DIFF
--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -20,18 +20,72 @@ bottle. Formulae without a usable bottle are built from source, also without
 Homebrew (see [Source formulae](#source-formulae)). mise never shells out to
 `brew` for homebrew/core formulae.
 
-Third-party taps are supported directly when the tap publishes Homebrew API
-metadata (`api/formula/<name>.json` or `api/cask/<token>.json`). Use the same
-fully-qualified name you would pass to Homebrew:
+## Third-party taps
+
+A third-party tap works with the fully-qualified name — the same name you
+would pass to Homebrew — but only when the tap publishes Homebrew API
+metadata for that formula or cask:
 
 ```toml
 [bootstrap.packages]
-"brew:railwaycat/emacsmacport/emacs-mac" = "latest"
-"brew-cask:owner/tap/app" = "latest"
+"brew:acme/tools/widget" = "latest"
+"brew-cask:acme/tools/widget-app" = "latest"
 ```
 
-For taps whose GitHub URL cannot be inferred, add a tap source. This mirrors
-`[plugins]`: the key is the tap name and the value is the GitHub git URL.
+mise fetches that metadata from the tap repository itself — for the entries
+above, `api/formula/widget.json` and `api/cask/widget-app.json` on the
+default branch of `github.com/acme/homebrew-tools`. If the file is not
+there, the install fails: mise does not clone the tap, does not evaluate
+Ruby, and never falls back to the `brew` CLI. Formulae and casks work the
+same way here — neither is a special case.
+
+Most taps do not publish this metadata. Homebrew generates it only for
+homebrew/core and homebrew/cask, which is what backs formulae.brew.sh;
+there is no `brew` command that produces it for a third-party tap, and
+`brew` itself does not need it — it clones the tap and evaluates the `.rb`
+file. A tap that ships only `Formula/*.rb` or `Casks/*.rb` therefore cannot
+be installed by mise. Install those with `brew`, or ask the tap owner to
+publish metadata.
+
+### Publishing tap metadata
+
+If you own a tap, you can make it installable by mise by committing one
+JSON file per formula or cask to the tap's default branch:
+
+- `api/formula/<name>.json` for each formula in `Formula/`
+- `api/cask/<token>.json` for each cask in `Casks/`
+
+Each file holds a single JSON object in the same shape the Homebrew API
+uses — the object `brew info --json=v2 <name>` returns under `.formulae[0]`
+for a formula or `.casks[0]` for a cask. mise ignores fields it does not
+recognize, so extra keys are harmless.
+
+A formula mise has to build from source — one your tap ships no usable
+bottle for — needs more than a bottled one: mise fetches the formula's
+`.rb` from `tap_git_head` at `ruby_source_path`, verifies it against
+`ruby_source_checksum`, then downloads `urls.stable` and verifies its
+checksum too. If any of those is missing the install stops at
+`widget: API metadata has no ruby_source_path` rather than building.
+
+`ruby_source_checksum` is computed from the `.rb` Homebrew read, so it
+arrives correct. The other two are derived from the tap clone, so a
+generator that loads the file straight from a checkout has to set
+`ruby_source_path` to the path relative to the tap root
+(`Formula/widget.rb`) and `tap_git_head` to a commit the `.rb` can be
+fetched from. Prefer the commit you generated at over `HEAD` — the
+checksum describes the file as it was then, so a moving ref stops matching
+the first time the formula changes. Casks have no equivalent, and a formula
+installed from a bottle needs none of it.
+
+Regenerating the files in CI on every release keeps them in step with the
+Ruby definitions.
+
+### Tap sources
+
+mise infers a tap's repository from its name: `acme/tools` means
+`https://github.com/acme/homebrew-tools`. For taps whose GitHub URL cannot
+be inferred, add a tap source. This mirrors `[plugins]`: the key is the tap
+name and the value is the GitHub git URL.
 
 ```toml
 [bootstrap.brew.taps]
@@ -45,13 +99,18 @@ For taps whose GitHub URL cannot be inferred, add a tap source. This mirrors
 `mise bootstrap packages brew tap` and `mise bootstrap packages brew untap`
 manage `[bootstrap.brew.taps]` in `mise.toml`; they do not mutate a Homebrew
 installation. Non-GitHub taps are not currently supported because mise needs
-direct raw access to the generated API metadata.
+direct raw access to the published API metadata.
 
 ```sh
-mise bootstrap packages brew tap railwaycat/emacsmacport
+mise bootstrap packages brew tap acme/tools
 mise bootstrap packages brew tap acme/tools https://github.com/acme/homebrew-tools.git
 mise bootstrap packages brew untap acme/tools
 ```
+
+A tap source only tells mise where to look; it does not change what has to
+be there — a tap that publishes no `api/` metadata still cannot be
+installed. Tap sources also apply only to fully-qualified names:
+`brew:widget` resolves from homebrew/core even when `acme/tools` is tapped.
 
 ## Casks
 
@@ -422,6 +481,11 @@ operation.
   implements the widely-used subset of the DSL (see
   [Source formulae](#source-formulae)); formulae that reach beyond it fail
   with a clear error naming the unsupported feature.
+- **Third-party taps must publish API metadata.** mise reads
+  `api/formula/<name>.json` / `api/cask/<token>.json` straight from the tap
+  repository and never shells out to `brew`, so a tap that ships only Ruby
+  definitions cannot be installed — see
+  [Third-party taps](#third-party-taps).
 - **Use canonical formula names.** `postgresql@17` is a formula name, not a
   mise version pin — the API's current stable version decides what gets
   installed. Aliases (`postgres`) install correctly but `mise bootstrap packages status`


### PR DESCRIPTION
`mise bootstrap packages` supports third-party taps, and the docs said so:

> Third-party taps are supported directly when the tap publishes Homebrew API
> metadata (`api/formula/<name>.json` or `api/cask/<token>.json`).

That sentence is true and, on its own, misleading. It never says who is
supposed to produce that metadata — and the answer is that nobody does.

## Homebrew does not generate it for third-party taps

`brew generate-formula-api` and `brew generate-cask-api` are hidden dev
commands hardcoded to `CoreTap.instance`; they exist to build formulae.brew.sh
for homebrew/core and homebrew/cask. `brew tap-new` scaffolds test-bot,
pr-pull and autobump workflows and nothing else. `brew` itself never needs the
API for a third-party tap: it clones the tap and evaluates the `.rb`.

So a tap that ships only `Formula/*.rb` and `Casks/*.rb` — nearly every tap —
cannot be installed by mise, and the page left the reader to discover that
from a 404.

## The example did not work either

`"brew:railwaycat/emacsmacport/emacs-mac"` is the page's illustration of a
tapped install. That tap publishes no `api/formula/emacs-mac.json`, on any
branch, so the entry fails. The same is true of `jdx/homebrew-tap`, which is
why `e2e/cli/test_system_install_brew_macos_slow` guards its tapped-formula
assertion behind a live `curl` for `api/formula/aube.json` rather than
asserting it.

Both real tap names are now placeholders from the `acme/tools` family the page
already used, so the docs cannot go stale when a third-party repository
changes.

## Not a formula-vs-cask difference

This came up in #995, where the reporter reasonably concluded that casks take a
different code path. They do not. Measured with 2026.8.14:

| entry | result |
| --- | --- |
| `brew:tobi/try/try` | 404 `api/formula/try.json` |
| `brew:jacobbednarz/tap/cf-vault` | 404 `api/formula/cf-vault.json` |
| `brew:jacobbednarz/tap/starship` | 404 — and `starship` is in homebrew/core |
| `brew-cask:jacobbednarz/tap/little-snitch` | 404 — and `little-snitch` is in homebrew/cask |
| `brew-cask:ctrlspice/otel-desktop-viewer/otel-desktop-viewer` | 404 `api/cask/otel-desktop-viewer.json` |
| `brew:<tap>/mli`, `brew-cask:<tap>/font-ndot` on a tap that publishes `api/` | resolves — formula **and** cask |

What looked like working taps were unqualified entries: those never consult
`[bootstrap.brew.taps]` at all — `tap_url` is attached only to three-part names
(`brew_tap_name`, `src/system/mod.rs`) — so `brew:try` installs homebrew/core's
`try`, not the tap's. That gotcha is now documented too, along with the tap
URL inference rule (`acme/tools` → `github.com/acme/homebrew-tools`) that
`default_tap_url` implements but the page never stated.

## What the page now says

- A new `## Third-party taps` section replaces the untitled prose, stating the
  requirement, that Homebrew will not satisfy it, and that `brew` is the
  workaround for a tap that only ships Ruby.
- `### Publishing tap metadata` tells a tap owner exactly what to commit and
  where: one JSON object per formula or cask at `api/formula/<name>.json` /
  `api/cask/<token>.json` on the default branch, in the shape
  `brew info --json=v2` returns under `.formulae[0]` / `.casks[0]`. mise
  ignores fields it does not read — there is no `deny_unknown_fields` in the
  brew module — so that output can be committed as-is. Taps that do this today
  work with mise, which is how the last row of the table above was measured.
- `### Tap sources` keeps the existing `[bootstrap.brew.taps]` material, plus
  the inference rule and the fully-qualified-name caveat.
- One `## Limitations` bullet, so a reader who skims the list still learns it.

## Notes

- Docs only; no behaviour change. The lead paragraph is untouched, so
  `render:llms` output is unchanged and `mise run render` stays diff-free.
- `src/cli/system/brew/tap.rs` carries the same `railwaycat/emacsmacport`
  example in its `--help` text. It is left alone deliberately: that command
  only writes `[bootstrap.brew.taps]` and works for any tap, and changing it
  regenerates `docs/cli/`. Happy to follow up if you would rather it match.
- A follow-up PR improves the two runtime error messages to say the same thing
  and link to the new `#third-party-taps` anchor; it is opened separately so
  this one can merge first.

## Verification

- `prettier --check docs/bootstrap/packages/brew.md`
- `markdownlint docs/bootstrap/packages/brew.md` — MD001 is enabled, so the new
  section is `##` under the `#` title, not `###`; MD051 checks the
  `[Third-party taps](#third-party-taps)` fragment against the new heading.
- Existing anchors other pages deep-link to (`#casks`,
  `#macos-privacy-security-tcc`, `#source-formulae`) are unchanged.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.251.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Homebrew third-party tap guidance, including required API metadata on the default branch.
  * Clarified that taps are read from published metadata and are not evaluated through Ruby or the Homebrew CLI.
  * Clarified that tap sources only identify where to look and apply to fully qualified names.
  * Added instructions for tap maintainers to publish and regenerate metadata through CI.
  * Documented the limitation that most third-party taps do not provide the required metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->