### PR TITLE
fix(brew): say why a tapped install found no API metadata

### DIFF
--- a/src/system/packages/brew/api.rs
+++ b/src/system/packages/brew/api.rs
@@ -171,8 +171,10 @@ pub(super) async fn formula_with_tap_name(
         .wrap_err_with(|| {
             format!(
                 "failed to fetch Homebrew tap formula '{name}' directly. \
-                 The tap must publish API metadata at api/formula/{formula_name}.json; \
-                 mise will not proxy to the brew CLI"
+                 mise needs API metadata at api/formula/{formula_name}.json on the \
+                 tap's default branch, which most taps do not publish; mise will not \
+                 proxy to the brew CLI. Install it with `brew`, or see \
+                 https://mise.jdx.dev/bootstrap/packages/brew.html#third-party-taps"
             )
         })
 }

--- a/src/system/packages/brew/cask/fetch.rs
+++ b/src/system/packages/brew/cask/fetch.rs
@@ -67,7 +67,11 @@ pub(super) async fn fetch_cask_url(
         .wrap_err_with(|| {
             format!(
                 "failed to fetch Homebrew cask '{requested_token}' directly. \
-                 Tapped casks must publish API metadata at api/cask/<token>.json"
+                 mise needs API metadata at api/cask/{requested_token}.json; for a \
+                 third-party tap that means a JSON file on the tap's default branch, \
+                 which most taps do not publish. mise will not proxy to the brew CLI; \
+                 install it with `brew`, or see \
+                 https://mise.jdx.dev/bootstrap/packages/brew.html#third-party-taps"
             )
         })?;
     cask.raw_base = raw_base;


### PR DESCRIPTION
Follow-up to #12644, which documents the same thing. **That PR should merge
first** — the `#third-party-taps` anchor these messages link to is added there.

Installing a fully-qualified third-party tap entry that the tap has no API
metadata for fails like this today:

```
$ mise bootstrap packages apply
mise ERROR failed to fetch Homebrew tap formula 'jacobbednarz/tap/cf-vault' directly.
           The tap must publish API metadata at api/formula/cf-vault.json;
           mise will not proxy to the brew CLI
mise ERROR HTTP status client error (404 Not Found) for url (https://raw.githubusercontent.com/jacobbednarz/homebrew-tap/HEAD/api/formula/cf-vault.json)
```

"The tap must publish API metadata" reads as something the user forgot to do.
It is not: Homebrew has no command that produces that metadata for a
third-party tap. `brew generate-formula-api` and `brew generate-cask-api` are
hidden dev commands hardcoded to `CoreTap.instance` — they build
formulae.brew.sh for the core taps — and `brew tap-new` does not scaffold it.
`brew` itself does not need it, because it clones the tap and evaluates the
`.rb`. So nearly every tap will fail here, and the message gave no way out.

Both messages now name the cause, name `brew` as the way to install from such a
tap, and link to the docs section that tells a tap owner what to commit:

```
failed to fetch Homebrew tap formula 'jacobbednarz/tap/cf-vault' directly.
mise needs API metadata at api/formula/cf-vault.json on the tap's default
branch, which most taps do not publish; mise will not proxy to the brew CLI.
Install it with `brew`, or see
https://mise.jdx.dev/bootstrap/packages/brew.html#third-party-taps
```

## The cask message was also wrong on one path

`fetch_cask_url` is shared: `fetch_cask` reaches it with `official_api = true`
for `brew-cask:firefox` and `brew-cask:homebrew/cask/<token>`, not only for
taps. So a mistyped official token was answered with "Tapped casks must publish
API metadata at api/cask/<token>.json" — advice about a tap that is not
involved.

The rewrite states the requirement first and then scopes the tap explanation
("for a third-party tap that means a JSON file on the tap's default branch"),
which reads correctly on both paths without branching on the `official_api`
flag that is already in scope. The literal `<token>` also becomes the
interpolated `{requested_token}`, which is accurate on both paths —
`api/cask/firefox.json` is the official URL too.

## Scope

Message strings only. No probe, no new request, no control flow: the failing
URL is still surfaced by the existing error chain, as in the transcript above,
so the messages do not repeat it.

The `bail!` above the formula site — the one about a missing GitHub tap URL in
`[bootstrap.brew.taps]` — is left alone. It is a different failure and it is
already actionable.

## Tests

None to update: nothing in `src/`, `e2e/`, or the insta snapshots asserts on
either string. `e2e/cli/test_system_install_brew_*` assert success-path output
only, and the macOS test's `api/formula/aube.json` reference is a skip guard,
not an assertion.

`cargo fmt --all -- --check` is clean; the rest is left to CI.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.251.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Homebrew formula and cask fetch error messages.
  * Added clearer explanations for missing metadata from third-party taps.
  * Provided guidance to install packages with Homebrew or consult the relevant documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->