### PR TITLE
fix(env): unset inherited environment variables

### DIFF
--- a/e2e/env/test_env_unset_inherited
+++ b/e2e/env/test_env_unset_inherited
@@ -6,9 +6,17 @@ cat >mise.toml <<'EOF'
 UNSET_ENV = false
 UNSET_TOOLS_ENV = { value = false, tools = true }
 
+[deps.check-env]
+auto = true
+run = 'printf "%s|%s" "${UNSET_ENV-absent}" "${UNSET_TOOLS_ENV-absent}" > deps-env'
+outputs = ["deps-env"]
+
 [tasks.check]
 run = 'printf "%s|%s" "${UNSET_ENV-absent}" "${UNSET_TOOLS_ENV-absent}"'
 EOF
+
+UNSET_ENV=parent UNSET_TOOLS_ENV=parent mise exec -- true
+assert "cat deps-env" "absent|absent"
 
 assert \
   "UNSET_ENV=parent UNSET_TOOLS_ENV=parent mise exec -- sh -c 'printf \"%s|%s\" \"\${UNSET_ENV-absent}\" \"\${UNSET_TOOLS_ENV-absent}\"'" \

--- a/e2e/env/test_env_unset_inherited
+++ b/e2e/env/test_env_unset_inherited
@@ -5,6 +5,7 @@ cat >mise.toml <<'EOF'
 [env]
 UNSET_ENV = false
 UNSET_TOOLS_ENV = { value = false, tools = true }
+UNSET_SECRET = false
 
 [deps.check-env]
 auto = true
@@ -24,6 +25,9 @@ assert \
 assert \
   "UNSET_ENV=parent UNSET_TOOLS_ENV=parent mise run check" \
   "absent|absent"
+assert \
+  "UNSET_SECRET=super-secret mise exec -- python3 -c 'import base64, os, zlib; raw = os.environ[\"__MISE_DIFF\"]; print(b\"super-secret\" in zlib.decompress(base64.b64decode(raw + \"=\" * (-len(raw) % 4))))'" \
+  "False"
 assert_contains \
   "UNSET_ENV=parent UNSET_TOOLS_ENV=parent mise env -s bash" \
   "unset UNSET_ENV"

--- a/e2e/env/test_env_unset_inherited
+++ b/e2e/env/test_env_unset_inherited
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cat >mise.toml <<'EOF'
+[env]
+UNSET_ENV = false
+UNSET_TOOLS_ENV = { value = false, tools = true }
+
+[tasks.check]
+run = 'printf "%s|%s" "${UNSET_ENV-absent}" "${UNSET_TOOLS_ENV-absent}"'
+EOF
+
+assert \
+  "UNSET_ENV=parent UNSET_TOOLS_ENV=parent mise exec -- sh -c 'printf \"%s|%s\" \"\${UNSET_ENV-absent}\" \"\${UNSET_TOOLS_ENV-absent}\"'" \
+  "absent|absent"
+assert \
+  "UNSET_ENV=parent UNSET_TOOLS_ENV=parent mise run check" \
+  "absent|absent"
+assert_contains \
+  "UNSET_ENV=parent UNSET_TOOLS_ENV=parent mise env -s bash" \
+  "unset UNSET_ENV"
+assert_contains \
+  "UNSET_ENV=parent UNSET_TOOLS_ENV=parent mise env -s bash" \
+  "unset UNSET_TOOLS_ENV"
+assert \
+  "UNSET_ENV=parent UNSET_TOOLS_ENV=parent mise env --json | jq -r 'has(\"UNSET_ENV\") or has(\"UNSET_TOOLS_ENV\")'" \
+  "false"
+
+# A forced refresh should apply the unset to an activated shell.
+export UNSET_ENV=parent
+export UNSET_TOOLS_ENV=parent
+eval "$(mise hook-env -s bash --force)"
+# shellcheck disable=SC2016
+assert \
+  'printf "%s|%s" "${UNSET_ENV-absent}" "${UNSET_TOOLS_ENV-absent}"' \
+  "absent|absent"
+
+# Removals must survive the full environment cache, not only initial resolution.
+export UNSET_ENV=parent
+export UNSET_TOOLS_ENV=parent
+MISE_ENV_CACHE=true mise env -s bash >/dev/null
+assert_contains "MISE_ENV_CACHE=true mise env -s bash" "unset UNSET_ENV"
+assert_contains "MISE_ENV_CACHE=true mise env -s bash" "unset UNSET_TOOLS_ENV"

--- a/e2e/tasks/test_task_env_directives
+++ b/e2e/tasks/test_task_env_directives
@@ -89,7 +89,7 @@ assert_contains "mise run test-env-types" "BOOL_TRUE_VAR=true"
 assert_contains "mise run test-env-types" "INT_VAR=42"
 assert_contains "mise run test-env-types" "STRING_VAR=test_string"
 # false values should unset the variable, so BOOL_FALSE_VAR should not be present
-assert_not_contains "mise run test-env-types" "BOOL_FALSE_VAR"
+assert_not_contains "BOOL_FALSE_VAR=inherited mise run test-env-types" "BOOL_FALSE_VAR"
 
 # Test 7: Verify task info shows correct directive syntax
 cat <<EOF >mise.toml

--- a/src/cli/deps/add.rs
+++ b/src/cli/deps/add.rs
@@ -43,7 +43,7 @@ impl DepsAdd {
         ts.install_missing_versions(&mut config, &install_opts)
             .await?;
 
-        let env = ts.env_with_path(&config).await?;
+        let (env, env_remove) = ts.env_with_path_and_removals(&config).await?;
 
         let project_root = config
             .project_root
@@ -65,7 +65,7 @@ impl DepsAdd {
 
             let pkg_refs: Vec<&str> = packages.iter().map(|s| s.as_str()).collect();
             let cmd = provider.add_command(&pkg_refs, self.dev)?;
-            DepsEngine::execute_command(&cmd, &env, provider.timeout(), None, None)?;
+            DepsEngine::execute_command(&cmd, &env, &env_remove, provider.timeout(), None, None)?;
         }
 
         Ok(())

--- a/src/cli/deps/install.rs
+++ b/src/cli/deps/install.rs
@@ -124,7 +124,7 @@ impl DepsInstall {
             .await?;
 
         // Get toolset environment with PATH
-        let env = ts.env_with_path(&install_config).await?;
+        let (env, env_remove) = ts.env_with_path_and_removals(&install_config).await?;
 
         let opts = DepsOptions {
             dry_run: self.dry_run,
@@ -132,6 +132,7 @@ impl DepsInstall {
             only,
             skip,
             env,
+            env_remove,
             ..Default::default()
         };
 

--- a/src/cli/deps/remove.rs
+++ b/src/cli/deps/remove.rs
@@ -39,7 +39,7 @@ impl DepsRemove {
         ts.install_missing_versions(&mut config, &install_opts)
             .await?;
 
-        let env = ts.env_with_path(&config).await?;
+        let (env, env_remove) = ts.env_with_path_and_removals(&config).await?;
 
         let project_root = config
             .project_root
@@ -61,7 +61,7 @@ impl DepsRemove {
 
             let pkg_refs: Vec<&str> = packages.iter().map(|s| s.as_str()).collect();
             let cmd = provider.remove_command(&pkg_refs)?;
-            DepsEngine::execute_command(&cmd, &env, provider.timeout(), None, None)?;
+            DepsEngine::execute_command(&cmd, &env, &env_remove, provider.timeout(), None, None)?;
         }
 
         Ok(())

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -182,12 +182,16 @@ impl Env {
     ) -> Result<()> {
         let default_shell = get_shell(Some(fallback_shell())).unwrap();
         let shell = get_shell(self.shell).unwrap_or(default_shell);
-        let mut env = ts.env_with_path(config).await?;
+        let (mut env, mut env_remove) = ts.env_with_path_and_removals(config).await?;
 
         if let Some(keys) = redacted_keys {
             env.retain(|k, _| self.should_include_key(k, keys));
+            env_remove.retain(|k| self.should_include_key(k, keys));
         }
 
+        for k in env_remove {
+            miseprint!("{}", shell.unset_env(&k))?;
+        }
         for (k, v) in env {
             let k = k.to_string();
             let v = v.to_string();

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -222,7 +222,9 @@ impl Exec {
 
         let (program, mut args) = parse_command(&env::SHELL, &self.command, &self.c);
 
-        let mut env = measure!("env_with_path", { ts.env_with_path(&config).await? });
+        let (mut env, env_remove) = measure!("env_with_path", {
+            ts.env_with_path_and_removals(&config).await?
+        });
         env.extend(wrapper_env);
         if strip_dispatch_dirs && let Some(path) = env.get_mut(&*env::PATH_KEY) {
             *path = crate::file::strip_dispatch_dirs_from_path(path);
@@ -265,7 +267,12 @@ impl Exec {
             None
         };
         env.remove("__MISE_DIFF");
-        let serialized = EnvDiff::from_final_env(&env::PRISTINE_ENV, &env).serialize();
+        let mut final_env = env::PRISTINE_ENV.clone();
+        for key in &env_remove {
+            final_env.remove(key);
+        }
+        final_env.extend(env.clone());
+        let serialized = EnvDiff::from_final_env(&env::PRISTINE_ENV, &final_env).serialize();
         if let Some(mise_env) = removed_mise_env {
             env.insert("MISE_ENV".to_string(), mise_env);
         }
@@ -321,7 +328,7 @@ impl Exec {
         // shell_body_mode: true only for the `-c`/`--command` path, where
         // parse_command synthesized `shell + [flags.., body]`. A positional
         // command must not be reinterpreted as a shell body.
-        exec_program(program, args, env, &sandbox, self.c.is_some()).await
+        exec_program(program, args, env, env_remove, &sandbox, self.c.is_some()).await
     }
 }
 
@@ -330,6 +337,7 @@ pub(crate) async fn exec_program<T, U>(
     program: T,
     args: U,
     env: BTreeMap<String, String>,
+    env_remove: std::collections::BTreeSet<String>,
     sandbox: &SandboxConfig,
     _shell_body_mode: bool,
 ) -> Result<()>
@@ -341,6 +349,9 @@ where
     // Capture the marker before deny-env removes variables from the process.
     // The lazy state must retain the dispatching shim for candidate filtering.
     drop(env::MISE_SHIM_PATH.read().unwrap());
+    for key in env_remove {
+        env::remove_var(key);
+    }
     if sandbox.effective_deny_env() {
         // When env is sandboxed, clear all vars and only set the filtered ones.
         //
@@ -497,6 +508,7 @@ pub(crate) async fn exec_program<T, U>(
     program: T,
     args: U,
     env: BTreeMap<String, String>,
+    env_remove: std::collections::BTreeSet<String>,
     sandbox: &SandboxConfig,
     shell_body_mode: bool,
 ) -> Result<()>
@@ -507,6 +519,9 @@ where
 {
     if sandbox.is_active() {
         warn!("sandbox is not supported on Windows, running unsandboxed");
+    }
+    for key in env_remove {
+        env::remove_var(key);
     }
     for (k, v) in env.iter() {
         env::set_var(k, v);
@@ -632,6 +647,7 @@ pub(crate) async fn exec_program<T, U>(
     program: T,
     args: U,
     env: BTreeMap<String, String>,
+    env_remove: std::collections::BTreeSet<String>,
     _sandbox: &SandboxConfig,
     _shell_body_mode: bool,
 ) -> Result<()>
@@ -643,6 +659,9 @@ where
     let mut cmd = cmd::cmd(program, args);
     for (k, v) in env.iter() {
         cmd = cmd.env(k, v);
+    }
+    for key in env_remove {
+        cmd = cmd.env_remove(key);
     }
     let res = cmd.unchecked().run()?;
     match res.status.code() {

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -273,8 +273,7 @@ impl Exec {
             final_env.remove(key);
         }
         final_env.extend(env.clone());
-        let serialized =
-            EnvDiff::from_final_env(&env::PRISTINE_ENV, &final_env, &env_remove).serialize();
+        let serialized = EnvDiff::from_final_env(&env::PRISTINE_ENV, &final_env).serialize();
         if let Some(mise_env) = removed_mise_env {
             env.insert("MISE_ENV".to_string(), mise_env);
         }

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -237,6 +237,7 @@ impl Exec {
                 .run(DepsOptions {
                     auto_only: true, // Only run providers with auto=true
                     env: env.clone(),
+                    env_remove: env_remove.clone(),
                     ..Default::default()
                 })
                 .await?;
@@ -272,7 +273,8 @@ impl Exec {
             final_env.remove(key);
         }
         final_env.extend(env.clone());
-        let serialized = EnvDiff::from_final_env(&env::PRISTINE_ENV, &final_env).serialize();
+        let serialized =
+            EnvDiff::from_final_env(&env::PRISTINE_ENV, &final_env, &env_remove).serialize();
         if let Some(mise_env) = removed_mise_env {
             env.insert("MISE_ENV".to_string(), mise_env);
         }

--- a/src/cli/hook_env.rs
+++ b/src/cli/hook_env.rs
@@ -129,7 +129,7 @@ impl HookEnv {
         miseprint!("{}", hook_env::clear_old_env(&*shell))?;
 
         // Use env_with_path_and_split which handles caching internally
-        let (mut mise_env, user_paths, tool_paths, env_watch_files) =
+        let (mut mise_env, env_remove, user_paths, tool_paths, env_watch_files) =
             ts.env_with_path_and_split(&config).await?;
         mise_env.remove(&*PATH_KEY);
 
@@ -139,6 +139,11 @@ impl HookEnv {
             .await?;
 
         let mut diff = EnvDiff::new(&env::PRISTINE_ENV, mise_env.clone());
+        for key in env_remove {
+            if let Some(value) = env::PRISTINE_ENV.get(&key) {
+                diff.old.insert(key, value.clone());
+            }
+        }
         let mut patches = diff.to_patches();
 
         // For fish shell, filter out PATH operations from diff patches because

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -805,12 +805,13 @@ impl Run {
 
         // Run auto-enabled deps steps (unless --no-deps)
         if let Some(engine) = deps_engine {
-            let env = ts.env_with_path(&config).await?;
+            let (env, env_remove) = ts.env_with_path_and_removals(&config).await?;
             let result = engine
                 .run(DepsOptions {
                     auto_only: true, // Only run providers with auto=true
                     dry_run: self.dry_run,
                     env,
+                    env_remove,
                     ..Default::default()
                 })
                 .await?;

--- a/src/cli/tool_stub.rs
+++ b/src/cli/tool_stub.rs
@@ -568,7 +568,7 @@ async fn execute_with_tool_request(
         Ok(bin_path) => {
             // env_with_path already has _.path and filters outer install dirs.
             // Prepend backend dependency bins (e.g. node for npm); see #7777.
-            let mut env = toolset.env_with_path(config).await?;
+            let (mut env, env_remove) = toolset.env_with_path_and_removals(config).await?;
             if let Some((backend, _tv)) = toolset.list_current_installed_versions(config).first() {
                 let dep_paths = backend
                     .dependency_toolset(config)
@@ -588,7 +588,15 @@ async fn execute_with_tool_request(
                     );
                 }
             }
-            crate::cli::exec::exec_program(bin_path, args, env, &Default::default(), false).await
+            crate::cli::exec::exec_program(
+                bin_path,
+                args,
+                env,
+                env_remove,
+                &Default::default(),
+                false,
+            )
+            .await
         }
         Err(e) => match e {
             BinPathError::ToolNotFound(tool_name) => {
@@ -723,6 +731,7 @@ pub(crate) async fn short_circuit_stub(args: &[String]) -> Result<()> {
             bin_path,
             args,
             BTreeMap::new(),
+            Default::default(),
             &Default::default(),
             false,
         )

--- a/src/deps/engine.rs
+++ b/src/deps/engine.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -153,6 +153,8 @@ pub(crate) struct DepsOptions {
     pub skip: Vec<String>,
     /// Environment variables to pass to deps commands (e.g., toolset PATH)
     pub env: BTreeMap<String, String>,
+    /// Environment variables explicitly removed by config directives
+    pub env_remove: BTreeSet<String>,
     /// If true, only run providers with auto=true
     pub auto_only: bool,
 }
@@ -751,7 +753,7 @@ impl DepsEngine {
 
             if has_deps {
                 let run_results = self
-                    .run_with_deps(to_run, &satisfied_ids, &opts.env)
+                    .run_with_deps(to_run, &satisfied_ids, &opts.env, &opts.env_remove)
                     .await?;
                 for (step_result, outputs) in run_results {
                     for output in &outputs {
@@ -761,7 +763,9 @@ impl DepsEngine {
                 }
             } else {
                 // No dependencies — use simple parallel execution
-                let run_results = self.run_parallel(to_run, &opts.env).await?;
+                let run_results = self
+                    .run_parallel(to_run, &opts.env, &opts.env_remove)
+                    .await?;
                 for (step_result, outputs) in run_results {
                     for output in &outputs {
                         super::clear_output_stale(output);
@@ -811,34 +815,39 @@ impl DepsEngine {
         &self,
         to_run: Vec<DepsJob>,
         toolset_env: &BTreeMap<String, String>,
+        env_remove: &BTreeSet<String>,
     ) -> Result<Vec<(DepsStepResult, Vec<PathBuf>)>> {
         let mpr = MultiProgressReport::get();
 
         let to_run_with_context: Vec<_> = to_run
             .into_iter()
-            .map(|job| (job, mpr.clone(), toolset_env.clone()))
+            .map(|job| (job, mpr.clone(), toolset_env.clone(), env_remove.clone()))
             .collect();
 
-        crate::parallel::parallel(to_run_with_context, |(job, mpr, toolset_env)| async move {
-            let (stdout_prefix, stderr_prefix) = Self::deps_prefixes(&job.id);
-            let pr = mpr.add(&stderr_prefix);
-            match Self::execute_command(
-                &job.cmd,
-                &toolset_env,
-                job.timeout,
-                Some((&stdout_prefix, &stderr_prefix)),
-                Some(pr.as_ref()),
-            ) {
-                Ok(()) => {
-                    pr.finish_with_message("done".to_string());
-                    Ok((DepsStepResult::Ran(job.id), job.outputs))
+        crate::parallel::parallel(
+            to_run_with_context,
+            |(job, mpr, toolset_env, env_remove)| async move {
+                let (stdout_prefix, stderr_prefix) = Self::deps_prefixes(&job.id);
+                let pr = mpr.add(&stderr_prefix);
+                match Self::execute_command(
+                    &job.cmd,
+                    &toolset_env,
+                    &env_remove,
+                    job.timeout,
+                    Some((&stdout_prefix, &stderr_prefix)),
+                    Some(pr.as_ref()),
+                ) {
+                    Ok(()) => {
+                        pr.finish_with_message("done".to_string());
+                        Ok((DepsStepResult::Ran(job.id), job.outputs))
+                    }
+                    Err(e) => {
+                        pr.finish_with_message(format!("failed: {e}"));
+                        Err(e)
+                    }
                 }
-                Err(e) => {
-                    pr.finish_with_message(format!("failed: {e}"));
-                    Err(e)
-                }
-            }
-        })
+            },
+        )
         .await
     }
 
@@ -848,6 +857,7 @@ impl DepsEngine {
         to_run: Vec<DepsJob>,
         satisfied_ids: &HashSet<String>,
         toolset_env: &BTreeMap<String, String>,
+        env_remove: &BTreeSet<String>,
     ) -> Result<Vec<StepOutput>> {
         let mpr = MultiProgressReport::get();
         let mut results: Vec<StepOutput> = vec![];
@@ -970,6 +980,7 @@ impl DepsEngine {
                     let permit = semaphore.clone().acquire_owned().await.unwrap();
                     let mpr = mpr.clone();
                     let toolset_env = toolset_env.clone();
+                    let env_remove = env_remove.clone();
 
                     let handle = join_set.spawn(async move {
                         let id = job.id;
@@ -979,6 +990,7 @@ impl DepsEngine {
                             Self::execute_command(
                                 &job.cmd,
                                 &toolset_env,
+                                &env_remove,
                                 job.timeout,
                                 Some((&stdout_prefix, &stderr_prefix)),
                                 Some(pr.as_ref()),
@@ -1195,6 +1207,7 @@ impl DepsEngine {
     pub(crate) fn execute_command(
         cmd: &super::DepsCommand,
         toolset_env: &BTreeMap<String, String>,
+        env_remove: &BTreeSet<String>,
         timeout: Option<std::time::Duration>,
         prefixes: Option<(&str, &str)>,
         progress: Option<&dyn SingleReport>,
@@ -1222,6 +1235,9 @@ impl DepsEngine {
         // Apply toolset environment (includes PATH with installed tools)
         for (k, v) in toolset_env {
             runner = runner.env(k, v);
+        }
+        for key in env_remove {
+            runner = runner.env_remove(key);
         }
 
         // Apply command-specific environment (can override toolset env).

--- a/src/deps/engine.rs
+++ b/src/deps/engine.rs
@@ -1232,12 +1232,12 @@ impl DepsEngine {
             runner = runner.with_timeout(timeout);
         }
 
+        for key in env_remove {
+            runner = runner.env_remove(key);
+        }
         // Apply toolset environment (includes PATH with installed tools)
         for (k, v) in toolset_env {
             runner = runner.env(k, v);
-        }
-        for key in env_remove {
-            runner = runner.env_remove(key);
         }
 
         // Apply command-specific environment (can override toolset env).

--- a/src/env_diff.rs
+++ b/src/env_diff.rs
@@ -237,7 +237,11 @@ impl EnvDiff {
     /// write. This mirrors what `mise hook-env` writes during shell activation,
     /// so nested `mise` invocations can reverse it via `get_pristine_env` and
     /// avoid stacking outer tool paths on top of inner ones.
-    pub(crate) fn from_final_env(pristine: &EnvMap, final_env: &EnvMap) -> EnvDiff {
+    pub(crate) fn from_final_env<'a>(
+        pristine: &EnvMap,
+        final_env: &EnvMap,
+        removals: impl IntoIterator<Item = &'a String>,
+    ) -> EnvDiff {
         use std::collections::HashSet;
 
         let path_key = PATH_KEY.as_str();
@@ -246,6 +250,14 @@ impl EnvDiff {
             .filter(|(k, _)| k.as_str() != path_key && k.as_str() != "__MISE_DIFF")
             .map(|(k, v)| (k.clone(), v.clone()));
         let mut diff = EnvDiff::new(pristine, additions);
+        for key in removals {
+            if key.as_str() != path_key
+                && key.as_str() != "__MISE_DIFF"
+                && let Some(value) = pristine.get(key)
+            {
+                diff.old.insert(key.clone(), value.clone());
+            }
+        }
 
         let pristine_paths: HashSet<PathBuf> = pristine
             .get(path_key)
@@ -566,6 +578,7 @@ mod tests {
         let pristine: EnvMap = [
             (path_key, pristine_path.as_str()),
             ("EXISTING", "old"),
+            ("REMOVED", "gone"),
             ("__MISE_DIFF", "outer-diff"),
         ]
         .into_iter()
@@ -581,7 +594,8 @@ mod tests {
         .map(|(k, v)| (k.into(), v.into()))
         .collect();
 
-        let diff = EnvDiff::from_final_env(&pristine, &final_env);
+        let removals = ["REMOVED".to_string()];
+        let diff = EnvDiff::from_final_env(&pristine, &final_env, &removals);
 
         // PATH entries new in final_env land in diff.path; shared entries don't.
         assert_eq!(diff.path, vec![PathBuf::from("/tool/bin")]);
@@ -589,6 +603,8 @@ mod tests {
         assert_eq!(diff.new.get("ADDED"), Some(&"yes".to_string()));
         assert_eq!(diff.new.get("EXISTING"), Some(&"new".to_string()));
         assert_eq!(diff.old.get("EXISTING"), Some(&"old".to_string()));
+        assert_eq!(diff.old.get("REMOVED"), Some(&"gone".to_string()));
+        assert!(!diff.new.contains_key("REMOVED"));
         // PATH and __MISE_DIFF are filtered out of old/new.
         assert!(!diff.new.contains_key(path_key));
         assert!(!diff.old.contains_key(path_key));
@@ -611,6 +627,7 @@ mod tests {
             }
         }
         assert_eq!(restored.get("EXISTING"), Some(&"old".to_string()));
+        assert_eq!(restored.get("REMOVED"), Some(&"gone".to_string()));
         assert!(!restored.contains_key("ADDED"));
         let to_remove: std::collections::HashSet<_> = diff.path.iter().collect();
         let restored_path: Vec<PathBuf> = crate::env::split_paths(&final_env[path_key])

--- a/src/env_diff.rs
+++ b/src/env_diff.rs
@@ -237,11 +237,7 @@ impl EnvDiff {
     /// write. This mirrors what `mise hook-env` writes during shell activation,
     /// so nested `mise` invocations can reverse it via `get_pristine_env` and
     /// avoid stacking outer tool paths on top of inner ones.
-    pub(crate) fn from_final_env<'a>(
-        pristine: &EnvMap,
-        final_env: &EnvMap,
-        removals: impl IntoIterator<Item = &'a String>,
-    ) -> EnvDiff {
+    pub(crate) fn from_final_env(pristine: &EnvMap, final_env: &EnvMap) -> EnvDiff {
         use std::collections::HashSet;
 
         let path_key = PATH_KEY.as_str();
@@ -250,14 +246,6 @@ impl EnvDiff {
             .filter(|(k, _)| k.as_str() != path_key && k.as_str() != "__MISE_DIFF")
             .map(|(k, v)| (k.clone(), v.clone()));
         let mut diff = EnvDiff::new(pristine, additions);
-        for key in removals {
-            if key.as_str() != path_key
-                && key.as_str() != "__MISE_DIFF"
-                && let Some(value) = pristine.get(key)
-            {
-                diff.old.insert(key.clone(), value.clone());
-            }
-        }
 
         let pristine_paths: HashSet<PathBuf> = pristine
             .get(path_key)
@@ -578,7 +566,6 @@ mod tests {
         let pristine: EnvMap = [
             (path_key, pristine_path.as_str()),
             ("EXISTING", "old"),
-            ("REMOVED", "gone"),
             ("__MISE_DIFF", "outer-diff"),
         ]
         .into_iter()
@@ -594,8 +581,7 @@ mod tests {
         .map(|(k, v)| (k.into(), v.into()))
         .collect();
 
-        let removals = ["REMOVED".to_string()];
-        let diff = EnvDiff::from_final_env(&pristine, &final_env, &removals);
+        let diff = EnvDiff::from_final_env(&pristine, &final_env);
 
         // PATH entries new in final_env land in diff.path; shared entries don't.
         assert_eq!(diff.path, vec![PathBuf::from("/tool/bin")]);
@@ -603,8 +589,6 @@ mod tests {
         assert_eq!(diff.new.get("ADDED"), Some(&"yes".to_string()));
         assert_eq!(diff.new.get("EXISTING"), Some(&"new".to_string()));
         assert_eq!(diff.old.get("EXISTING"), Some(&"old".to_string()));
-        assert_eq!(diff.old.get("REMOVED"), Some(&"gone".to_string()));
-        assert!(!diff.new.contains_key("REMOVED"));
         // PATH and __MISE_DIFF are filtered out of old/new.
         assert!(!diff.new.contains_key(path_key));
         assert!(!diff.old.contains_key(path_key));
@@ -627,7 +611,6 @@ mod tests {
             }
         }
         assert_eq!(restored.get("EXISTING"), Some(&"old".to_string()));
-        assert_eq!(restored.get("REMOVED"), Some(&"gone".to_string()));
         assert!(!restored.contains_key("ADDED"));
         let to_remove: std::collections::HashSet<_> = diff.path.iter().collect();
         let restored_path: Vec<PathBuf> = crate::env::split_paths(&final_env[path_key])

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -2872,9 +2872,9 @@ impl Task {
         &self,
         config: &Arc<Config>,
         ts: &Toolset,
-    ) -> Result<(EnvMap, Vec<(String, String)>)> {
+    ) -> Result<(EnvMap, Vec<(String, String)>, BTreeSet<String>)> {
         let mut tera_ctx = ts.tera_ctx(config).await?.clone();
-        let mut env = ts.full_env(config).await?;
+        let (mut env, mut env_remove) = ts.full_env_with_removals(config).await?;
         if let Some(root) = &config.project_root {
             tera_ctx.insert("config_root", &root);
         }
@@ -2928,6 +2928,9 @@ impl Task {
         );
 
         let task_env = env_results.env.into_iter().map(|(k, (v, _))| (k, v));
+        for (key, _) in task_env.clone() {
+            env_remove.remove(&key);
+        }
         // Apply the resolved environment variables
         env.extend(task_env.clone());
 
@@ -2935,6 +2938,7 @@ impl Task {
         for key in &env_results.env_remove {
             env.remove(key);
         }
+        env_remove.extend(env_results.env_remove);
 
         // Apply path additions from _.path directives
         if !env_results.env_paths.is_empty() {
@@ -2947,7 +2951,7 @@ impl Task {
             env.insert(env::PATH_KEY.to_string(), path_env.to_string());
         }
 
-        Ok((env, task_env.collect()))
+        Ok((env, task_env.collect(), env_remove))
     }
 }
 
@@ -4564,7 +4568,7 @@ echo "Hello $USR"
         let task = Task::from_path(&config, &task_path, temp_dir.path(), temp_dir.path())
             .await
             .unwrap();
-        let (env, task_env) = task.render_env(&config, ts).await.unwrap();
+        let (env, task_env, _) = task.render_env(&config, ts).await.unwrap();
 
         assert_eq!(task_env, vec![("USR".to_string(), "World!".to_string())]);
         assert_eq!(env.get("USR"), Some(&"World!".to_string()));

--- a/src/task/task_context_builder.rs
+++ b/src/task/task_context_builder.rs
@@ -8,7 +8,7 @@ use crate::task::task_helpers::canonicalize_path;
 use crate::toolset::{Toolset, ToolsetBuilder};
 use eyre::Result;
 use indexmap::IndexMap;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
@@ -16,6 +16,7 @@ type EnvResolutionResult = (
     BTreeMap<String, String>,
     Vec<(String, String)>,
     Option<IndexMap<String, String>>,
+    BTreeSet<String>,
 );
 
 /// Builds toolset and environment context for task execution
@@ -151,6 +152,7 @@ impl TaskContextBuilder {
         BTreeMap<String, String>,
         Vec<(String, String)>,
         Option<IndexMap<String, String>>,
+        BTreeSet<String>,
     )> {
         // Determine if this is a monorepo task (task config differs from current project root)
         let is_monorepo_task = task_cf.project_root() != config.project_root;
@@ -219,8 +221,8 @@ impl TaskContextBuilder {
         // Check using task_cf entries for compatibility with existing logic
         let task_cf_env_entries = task_cf.env_entries()?;
         if self.should_use_standard_env_resolution(task, task_cf, config, &task_cf_env_entries) {
-            let (env, task_env) = task.render_env(config, ts).await?;
-            return Ok((env, task_env, None));
+            let (env, task_env, env_remove) = task.render_env(config, ts).await?;
+            return Ok((env, task_env, None, env_remove));
         }
 
         let config_path = canonicalize_path(task_cf.get_path());
@@ -245,7 +247,7 @@ impl TaskContextBuilder {
             }
         }
 
-        let mut env = ts.full_env(config).await?;
+        let (mut env, mut env_remove) = ts.full_env_with_removals(config).await?;
         let (tera_ctx, resolved_vars) = self
             .build_tera_context(task_cf, ts, config, task_config_files.as_ref())
             .await?;
@@ -254,7 +256,7 @@ impl TaskContextBuilder {
         let config_env_results = self
             .resolve_env_directives(config, &tera_ctx, &env, all_config_env_entries)
             .await?;
-        Self::apply_env_results(&mut env, &config_env_results);
+        Self::apply_env_results(&mut env, &mut env_remove, &config_env_results);
 
         // Register config-level redactions resolved through the task context
         if !config_env_results.redactions.is_empty() {
@@ -271,7 +273,7 @@ impl TaskContextBuilder {
             .await?;
 
         let task_env = self.extract_task_env(&task_env_results);
-        Self::apply_env_results(&mut env, &task_env_results);
+        Self::apply_env_results(&mut env, &mut env_remove, &task_env_results);
 
         // Register task-specific redactions with the global redactor
         // Include both task-level redact=true keys and config-level redaction patterns
@@ -304,11 +306,16 @@ impl TaskContextBuilder {
                     task.name,
                     config_path.display()
                 );
-                (env.clone(), task_env.clone(), resolved_vars.clone())
+                (
+                    env.clone(),
+                    task_env.clone(),
+                    resolved_vars.clone(),
+                    env_remove.clone(),
+                )
             });
         }
 
-        Ok((env, task_env, resolved_vars))
+        Ok((env, task_env, resolved_vars, env_remove))
     }
 
     /// Check if standard env resolution should be used instead of special context
@@ -444,16 +451,22 @@ impl TaskContextBuilder {
 
     /// Apply EnvResults to an environment map
     /// Handles env vars, env_remove, and env_paths (PATH modifications)
-    fn apply_env_results(env: &mut BTreeMap<String, String>, results: &EnvResults) {
+    fn apply_env_results(
+        env: &mut BTreeMap<String, String>,
+        env_remove: &mut BTreeSet<String>,
+        results: &EnvResults,
+    ) {
         // Apply environment variables
         for (k, (v, _)) in &results.env {
             env.insert(k.clone(), v.clone());
+            env_remove.remove(k);
         }
 
         // Remove explicitly unset variables
         for key in &results.env_remove {
             env.remove(key);
         }
+        env_remove.extend(results.env_remove.iter().cloned());
 
         // Apply path additions
         if !results.env_paths.is_empty() {
@@ -505,7 +518,7 @@ mod tests {
             ("new_value".to_string(), PathBuf::from("/test")),
         );
 
-        TaskContextBuilder::apply_env_results(&mut env, &results);
+        TaskContextBuilder::apply_env_results(&mut env, &mut BTreeSet::new(), &results);
 
         assert_eq!(env.get("EXISTING"), Some(&"value".to_string()));
         assert_eq!(env.get("NEW_VAR"), Some(&"new_value".to_string()));
@@ -520,10 +533,12 @@ mod tests {
         let mut results = EnvResults::default();
         results.env_remove.insert("TO_REMOVE".to_string());
 
-        TaskContextBuilder::apply_env_results(&mut env, &results);
+        let mut env_remove = BTreeSet::new();
+        TaskContextBuilder::apply_env_results(&mut env, &mut env_remove, &results);
 
         assert_eq!(env.get("TO_REMOVE"), None);
         assert_eq!(env.get("TO_KEEP"), Some(&"value".to_string()));
+        assert!(env_remove.contains("TO_REMOVE"));
     }
 
     #[test]
@@ -536,7 +551,7 @@ mod tests {
             .env_paths
             .push(PathBuf::from("/new/path").to_path_buf());
 
-        TaskContextBuilder::apply_env_results(&mut env, &results);
+        TaskContextBuilder::apply_env_results(&mut env, &mut BTreeSet::new(), &results);
 
         let path = env.get(&*env::PATH_KEY).unwrap();
         assert!(path.contains("/new/path"));

--- a/src/task/task_context_builder.rs
+++ b/src/task/task_context_builder.rs
@@ -253,8 +253,26 @@ impl TaskContextBuilder {
             .await?;
 
         // Resolve config-level env from ALL config files, not just task_cf
+        //
+        // This path replays config directives to resolve them relative to the task's
+        // config hierarchy. Start that replay with caller values that the already
+        // resolved config removed: a `required` directive must still be able to
+        // validate the original caller value before a later directive removes it.
+        // The replay's EnvResults and env_remove set keep those values out of the
+        // final task environment.
+        let mut config_resolution_env = env.clone();
+        for key in &env_remove {
+            if let Some(value) = env::PRISTINE_ENV.get(key) {
+                config_resolution_env.insert(key.clone(), value.clone());
+            }
+        }
         let config_env_results = self
-            .resolve_env_directives(config, &tera_ctx, &env, all_config_env_entries)
+            .resolve_env_directives(
+                config,
+                &tera_ctx,
+                &config_resolution_env,
+                all_config_env_entries,
+            )
             .await?;
         Self::apply_env_results(&mut env, &mut env_remove, &config_env_results);
 

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -2220,7 +2220,8 @@ impl TaskExecutor {
 
         let env_for_diff = self.env_for_nested_mise_diff(&env, &nested_mise_diff_exclude_keys);
         if let Ok(serialized) =
-            EnvDiff::from_final_env(&crate::env::PRISTINE_ENV, &env_for_diff).serialize()
+            EnvDiff::from_final_env(&crate::env::PRISTINE_ENV, &env_for_diff, &env_remove)
+                .serialize()
         {
             env.insert("__MISE_DIFF".into(), serialized);
         }

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -36,7 +36,7 @@ use indoc::formatdoc;
 use itertools::Itertools;
 #[cfg(unix)]
 use nix::errno::Errno;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::iter::once;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
@@ -72,6 +72,7 @@ pub(crate) struct TaskRunContext<'a> {
 struct TaskExecContext<'a> {
     task: &'a Task,
     env: &'a BTreeMap<String, String>,
+    env_remove: &'a BTreeSet<String>,
     prefix: &'a str,
     output_capture: Option<&'a TaskOutputCapture>,
     allow_during_interruption: bool,
@@ -91,6 +92,7 @@ struct TaskRunEntriesContext<'a> {
 struct PreparedTaskContext {
     toolset: Toolset,
     env: BTreeMap<String, String>,
+    env_remove: BTreeSet<String>,
     task_env: Vec<(String, String)>,
     extra_vars: Option<IndexMap<String, String>>,
 }
@@ -524,6 +526,7 @@ impl TaskExecutor {
         let PreparedTaskContext {
             toolset: ts,
             mut env,
+            env_remove,
             task_env,
             extra_vars,
         } = self.prepare_task_context(config, task).await?;
@@ -692,6 +695,7 @@ impl TaskExecutor {
         let exec_ctx = TaskExecContext {
             task,
             env: &env,
+            env_remove: &env_remove,
             prefix: &prefix,
             output_capture: output_capture.as_ref(),
             allow_during_interruption,
@@ -1539,6 +1543,7 @@ impl TaskExecutor {
         let TaskExecContext {
             task,
             env,
+            env_remove,
             prefix,
             output_capture,
             allow_during_interruption,
@@ -1603,6 +1608,9 @@ impl TaskExecutor {
             })
             .map(|(key, _)| key);
         let runner = inherited_usage_keys.fold(runner, |runner, key| runner.env_remove(key));
+        let runner = env_remove
+            .iter()
+            .fold(runner, |runner, key| runner.env_remove(key));
         let mut cmd = runner
             .envs(env.as_ref())
             .redact(redactions.deref().clone())
@@ -2091,13 +2099,15 @@ impl TaskExecutor {
 
         let env_render_start = std::time::Instant::now();
         // extra_vars contains resolved vars from the task's config hierarchy.
-        let (mut env, task_env, extra_vars) = if let Some(task_cf) = task_cf {
-            self.context_builder
+        let (mut env, task_env, extra_vars, env_remove) = if let Some(task_cf) = task_cf {
+            let (env, task_env, extra_vars, env_remove) = self
+                .context_builder
                 .resolve_task_env_with_config(config, task, task_cf, &toolset)
-                .await?
+                .await?;
+            (env, task_env, extra_vars, env_remove)
         } else {
-            let (env, task_env) = task.render_env(config, &toolset).await?;
-            (env, task_env, None)
+            let (env, task_env, env_remove) = task.render_env(config, &toolset).await?;
+            (env, task_env, None, env_remove)
         };
         trace!(
             "task {} render_env took {}ms",
@@ -2218,6 +2228,7 @@ impl TaskExecutor {
         Ok(PreparedTaskContext {
             toolset,
             env,
+            env_remove,
             task_env,
             extra_vars,
         })

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -2220,8 +2220,7 @@ impl TaskExecutor {
 
         let env_for_diff = self.env_for_nested_mise_diff(&env, &nested_mise_diff_exclude_keys);
         if let Ok(serialized) =
-            EnvDiff::from_final_env(&crate::env::PRISTINE_ENV, &env_for_diff, &env_remove)
-                .serialize()
+            EnvDiff::from_final_env(&crate::env::PRISTINE_ENV, &env_for_diff).serialize()
         {
             env.insert("__MISE_DIFF".into(), serialized);
         }

--- a/src/toolset/env_cache.rs
+++ b/src/toolset/env_cache.rs
@@ -157,6 +157,9 @@ impl CachedEnv {
     ) -> String {
         let mut hasher = Hasher::new();
 
+        // Bump when CachedEnv gains fields whose absence changes behavior.
+        hasher.update(b"env-cache-v2");
+
         // mise version
         hasher.update(env!("CARGO_PKG_VERSION").as_bytes());
 

--- a/src/toolset/env_cache.rs
+++ b/src/toolset/env_cache.rs
@@ -89,6 +89,9 @@ fn validate_watch_files(watch_files: &[PathBuf], expected_mtimes: &[u64]) -> Res
 pub(crate) struct CachedEnv {
     /// Cached environment variables
     pub env: BTreeMap<String, String>,
+    /// Variables explicitly removed by env directives
+    #[serde(default)]
+    pub env_remove: BTreeSet<String>,
     /// User-configured paths from env._.path directives
     pub user_paths: Vec<PathBuf>,
     /// Tool paths from installations

--- a/src/toolset/toolset_env.rs
+++ b/src/toolset/toolset_env.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -32,9 +32,20 @@ fn pristine_path_without_install_dirs() -> Vec<PathBuf> {
 
 impl Toolset {
     pub(crate) async fn full_env(&self, config: &Arc<Config>) -> Result<EnvMap> {
+        Ok(self.full_env_with_removals(config).await?.0)
+    }
+
+    pub(crate) async fn full_env_with_removals(
+        &self,
+        config: &Arc<Config>,
+    ) -> Result<(EnvMap, BTreeSet<String>)> {
+        let (mise_env, env_remove) = self.env_with_path_and_removals(config).await?;
         let mut env = env::PRISTINE_ENV.clone().into_iter().collect::<EnvMap>();
-        env.extend(self.env_with_path(config).await?.clone());
-        Ok(env)
+        for key in &env_remove {
+            env.remove(key);
+        }
+        env.extend(mise_env);
+        Ok((env, env_remove))
     }
 
     /// Like full_env but skips `tools=true` env directives (load_post_env).
@@ -43,6 +54,9 @@ impl Toolset {
     /// would trigger spurious errors from modules expecting the full PATH.
     pub(crate) async fn full_env_without_tools(&self, config: &Arc<Config>) -> Result<EnvMap> {
         let mut env = env::PRISTINE_ENV.clone().into_iter().collect::<EnvMap>();
+        for key in &config.env_results().await?.env_remove {
+            env.remove(key);
+        }
         env.extend(self.env_with_path_without_tools(config).await?);
         Ok(env)
     }
@@ -55,6 +69,9 @@ impl InstallDependencyContext {
     /// evaluate arbitrary modules.
     pub(crate) async fn base_env_for_install(&self, config: &Arc<Config>) -> Result<EnvMap> {
         let mut full_env = env::PRISTINE_ENV.clone().into_iter().collect::<EnvMap>();
+        for key in &config.env_results().await?.env_remove {
+            full_env.remove(key);
+        }
         let (mut env, add_paths) = self.toolset.env(config).await?;
         let mut path_env = PathEnv::new();
         for path in &self.paths {
@@ -98,13 +115,20 @@ impl Toolset {
 
     /// the full mise environment including all tool paths
     pub(crate) async fn env_with_path(&self, config: &Arc<Config>) -> Result<EnvMap> {
+        Ok(self.env_with_path_and_removals(config).await?.0)
+    }
+
+    pub(crate) async fn env_with_path_and_removals(
+        &self,
+        config: &Arc<Config>,
+    ) -> Result<(EnvMap, BTreeSet<String>)> {
         // Try to load from cache if enabled
         if CachedEnv::is_enabled()
-            && let Some(mut cached) = self.try_load_env_cache(config).await?
+            && let Some((mut cached, env_remove)) = self.try_load_env_cache(config).await?
         {
             trace!("env_cache: using cached environment");
             github::oauth::inject_token_env(&mut cached);
-            return Ok(cached);
+            return Ok((cached, env_remove));
         }
 
         let (mut env, env_results) = self.final_env(config).await?;
@@ -132,7 +156,7 @@ impl Toolset {
         // ephemeral token is never persisted to disk.
         github::oauth::inject_token_env(&mut env);
 
-        Ok(env)
+        Ok((env, env_results.env_remove))
     }
 
     /// Get environment with split paths (user_paths and tool_paths separate)
@@ -141,7 +165,13 @@ impl Toolset {
     pub(crate) async fn env_with_path_and_split(
         &self,
         config: &Arc<Config>,
-    ) -> Result<(EnvMap, Vec<PathBuf>, Vec<PathBuf>, Vec<PathBuf>)> {
+    ) -> Result<(
+        EnvMap,
+        BTreeSet<String>,
+        Vec<PathBuf>,
+        Vec<PathBuf>,
+        Vec<PathBuf>,
+    )> {
         // Try to load from cache if enabled
         if CachedEnv::is_enabled()
             && let Some(cached) = self.try_load_env_cache_full(config).await?
@@ -157,6 +187,7 @@ impl Toolset {
             github::oauth::inject_token_env(&mut env);
             return Ok((
                 env,
+                cached.env_remove,
                 cached.user_paths,
                 cached.tool_paths,
                 cached.watch_files,
@@ -189,7 +220,13 @@ impl Toolset {
         // ephemeral token is never persisted to disk.
         github::oauth::inject_token_env(&mut env);
 
-        Ok((env, user_paths, tool_paths, env_results.watch_files))
+        Ok((
+            env,
+            env_results.env_remove,
+            user_paths,
+            tool_paths,
+            env_results.watch_files,
+        ))
     }
 
     /// Try to load environment from cache (returns full CachedEnv)
@@ -203,7 +240,10 @@ impl Toolset {
     }
 
     /// Try to load environment from cache (returns reconstructed EnvMap)
-    async fn try_load_env_cache(&self, config: &Arc<Config>) -> Result<Option<EnvMap>> {
+    async fn try_load_env_cache(
+        &self,
+        config: &Arc<Config>,
+    ) -> Result<Option<(EnvMap, BTreeSet<String>)>> {
         match self.try_load_env_cache_full(config).await? {
             Some(cached) => {
                 let mut env = cached.env;
@@ -213,7 +253,7 @@ impl Toolset {
                     path_env.add(p);
                 }
                 env.insert(PATH_KEY.to_string(), path_env.to_string());
-                Ok(Some(env))
+                Ok(Some((env, cached.env_remove)))
             }
             None => Ok(None),
         }
@@ -265,6 +305,7 @@ impl Toolset {
 
         let cached = CachedEnv {
             env: env_without_path,
+            env_remove: env_results.env_remove.clone(),
             user_paths: user_paths.to_vec(),
             tool_paths: tool_paths.to_vec(),
             created_at: now,
@@ -400,13 +441,20 @@ impl Toolset {
                 env.insert(k, v);
             }
         }
+        for key in &config.env_results().await?.env_remove {
+            env.remove(key);
+        }
         time!("env end");
         Ok((env, paths_to_add))
     }
 
     pub(crate) async fn final_env(&self, config: &Arc<Config>) -> Result<(EnvMap, EnvResults)> {
         let (mut env, add_paths) = self.env(config).await?;
+        let non_tool_env = config.env_results().await?;
         let mut tera_env = env::PRISTINE_ENV.clone().into_iter().collect::<EnvMap>();
+        for key in &non_tool_env.env_remove {
+            tera_env.remove(key);
+        }
         tera_env.extend(env.clone());
         let mut path_env = PathEnv::from_iter(pristine_path_without_install_dirs());
 
@@ -446,6 +494,16 @@ impl Toolset {
                 .iter()
                 .map(|(k, v)| (k.clone(), v.0.clone())),
         );
+        for key in &env_results.env_remove {
+            env.remove(key);
+        }
+
+        let mut effective_removals = non_tool_env.env_remove.clone();
+        for key in env_results.env.keys() {
+            effective_removals.remove(key);
+        }
+        effective_removals.extend(env_results.env_remove.clone());
+        env_results.env_remove = effective_removals;
 
         // Apply redactions from tools-only env vars (e.g. redact=true + tools=true)
         if !env_results.redactions.is_empty() {


### PR DESCRIPTION
## Summary
- carry explicit environment removals alongside resolved values and cache them
- apply removals to exec, task, shell env, hook-env, and tool-stub execution paths
- preserve correct precedence across regular and `tools = true` directives

Addresses https://github.com/jdx/mise/discussions/12659

## Tests
- `mise run lint`
- `cargo check --tests`
- `mise run build`
- `cargo test --bin mise task::task_context_builder`
- `mise run test:e2e e2e/env/test_env_unset_inherited e2e/tasks/test_task_env_directives`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core environment resolution and every command-spawn path; incorrect removal handling could drop required vars or leak secrets, though behavior is heavily e2e-tested.
> 
> **Overview**
> **Config-driven env removals** (e.g. `false` values and unset directives, including `tools = true`) are now tracked as an explicit `env_remove` set alongside resolved values, not only omitted from the env map.
> 
> That set is applied end-to-end: **`mise exec`**, **tasks**, **`mise env` / `hook-env`**, **deps** commands, and **tool stubs** unset keys in the child process (and emit shell `unset` where relevant). **`__MISE_DIFF`** and monorepo **task env replay** treat removals correctly so parent values are not leaked back through diffs or validation.
> 
> **Environment caching** persists `env_remove` and bumps the cache key (`env-cache-v2`). New e2e coverage checks inherited vars stay absent under exec, tasks, deps, activation refresh, and cached `mise env`; task env e2e now asserts `BOOL_FALSE_VAR` is cleared when inherited from the shell.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f765a4a790f40bce7c4daf782eef061923a59a11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment variables configured for removal are now consistently unset across command execution, task runs, dependency commands, shell environment output, and tool stubs.
  * Environment refreshes and activated shells now correctly apply removed variables.
  * Environment removal behavior is preserved when using environment caching.

* **Bug Fixes**
  * Prevented removed or secret variables from being restored through child processes or serialized environment differences.
  * Corrected environment assertions for task commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->