### PR TITLE
chore(release): improve sponsor message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -480,9 +480,9 @@ jobs:
 
           ## 💚 Sponsor mise
 
-          mise is maintained by [@jdx](https://github.com/jdx), an open source developer for [**entire.io**](https://entire.io), the title sponsor of the [jdx.dev](https://jdx.dev) open source tools. Development is funded by sponsors.
+          mise is built and maintained by [@jdx](https://github.com/jdx), an open source developer at [**entire.io**](https://entire.io/), the title sponsor of his open source work.
 
-          If mise saves you or your team time, please consider sponsoring at [jdx.dev](https://jdx.dev/sponsors.html). Individual and company sponsorships keep mise fast, free, and independent.
+          If mise saves you or your team time, please consider becoming an [individual or company sponsor](https://jdx.dev/sponsors.html). Your support funds ongoing development and helps keep mise fast, free, and independent.
           EOF
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

- clarify Entire's sponsorship of jdx's open source work
- link the sponsorship call to action directly to the individual and company sponsor page
- tighten the release-note copy while preserving each CLI's tailored message

## Testing

- git diff --check
- parsed the updated workflow as YAML

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to release note text; no build, publish, or runtime behavior is affected.
> 
> **Overview**
> Updates the **💚 Sponsor mise** footer that the release workflow appends to generated GitHub release notes after stripping any duplicate sponsor section.
> 
> The intro now says mise is **built and maintained** by @jdx as a developer **at** entire.io, framing Entire as the title sponsor of his open source work (with a tightened entire.io link). The sponsorship ask now points readers to become an **[individual or company sponsor](https://jdx.dev/sponsors.html)** instead of a generic jdx.dev sponsorship mention, with slightly shorter supporting copy about funding development.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d0ffabe00a1a02497296d0da0667facd79d218b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the release notes sponsor section with revised sponsor information and refreshed call-to-action wording.
  * Directed readers to the updated sponsorship information page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->