### PR TITLE
fix(lockfile): pick the newest unbound entry when the backend has no version order

### DIFF
--- a/e2e/lockfile/test_lockfile_version
+++ b/e2e/lockfile/test_lockfile_version
@@ -186,6 +186,30 @@ EOF
 
 assert "cd unbound-versioned && mise ls dummy --json --current | jq -r '.[0].version'" "2.0.0"
 
+echo "=== unbound entries are ordered by version, not by where they sit ==="
+# The case above passes either way: entries are written in lexicographic order of
+# the version string, so for 1.0.0/2.0.0 the last one is also the newest. Here it
+# is not. `asdf:dummy` does not opt into a version order, so nothing reorders the
+# stored list and reading off its end would answer 1.9.0.
+mkdir unbound-versioned-order
+cat >unbound-versioned-order/mise.toml <<'EOF'
+[tools]
+dummy = "latest"
+EOF
+cat >unbound-versioned-order/mise.lock <<'EOF'
+lockfile_version = 1
+
+[[tools.dummy]]
+version = "1.10.0"
+backend = "asdf:dummy"
+
+[[tools.dummy]]
+version = "1.9.0"
+backend = "asdf:dummy"
+EOF
+
+assert "cd unbound-versioned-order && mise ls dummy --json --current | jq -r '.[0].version'" "1.10.0"
+
 echo "=== legacy latest picks the newer of two versions that compare equal ==="
 # `versions` compares an alphanumeric chunk by its leading digits and stops, so
 # 3.7b and 3.7c both reduce to 7 and tie. Entries are written in lexicographic

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1,6 +1,7 @@
 use crate::backend::Backend;
 use crate::backend::backend_type::BackendType;
 use crate::backend::conda::CondaBackend;
+use crate::backend::options::VersionOrder;
 use crate::backend::pkgx::PkgxBackend;
 use crate::backend::platform_target::PlatformTarget;
 use crate::config::{Config, Settings};
@@ -3617,14 +3618,36 @@ fn select_unbound_lockfile_tool<'a>(
     backend: Option<&dyn Backend>,
     selection_options: &ToolVersionOptions,
 ) -> Result<Option<&'a LockfileTool>> {
-    let Some(backend) = backend else {
-        return Ok(matching.first().copied());
+    let order = match backend {
+        Some(backend) => backend.version_order(selection_options)?,
+        None => VersionOrder::default(),
     };
-    Ok(backend
-        .version_order(selection_options)?
-        .order_by(matching, |tool| tool.version.as_str())
-        .last()
-        .copied())
+    Ok(select_newest_unbound_tool(matching, order))
+}
+
+/// Pick the newest of several unbound entries that all satisfy one request.
+///
+/// Split from [`select_unbound_lockfile_tool`] so the choice can be tested
+/// without building a `Backend`.
+///
+/// `VersionOrder::Source` is not an opinion about order here. It means "the
+/// order the source listed them", and the source is `merge_tool_entries`, which
+/// writes entries sorted by the version *string* — so reading off the end of
+/// that list answers `1.9.0` for a pair of `1.9.0` and `1.10.0`. Only a backend
+/// that has opted into an ordering gets to decide; everything else compares the
+/// versions, the same way the unversioned branch of `get_locked_version` does.
+fn select_newest_unbound_tool(
+    mut matching: Vec<&LockfileTool>,
+    order: VersionOrder,
+) -> Option<&LockfileTool> {
+    if order != VersionOrder::Source {
+        return order
+            .order_by(matching, |tool| tool.version.as_str())
+            .last()
+            .copied();
+    }
+    matching.sort_by(|a, b| cmp_lockfile_versions_newest_first(&a.version, &b.version));
+    matching.first().copied()
 }
 
 fn lockfile_tool_with_request_options(
@@ -4649,6 +4672,60 @@ options = { exe = "rg" }
         let mut entries = ["3.7b", "3.7c"];
         entries.sort_by(|a, b| cmp_lockfile_versions_newest_first(a, b));
         assert_eq!(entries.first(), Some(&"3.7c"));
+    }
+
+    /// Selects from entries in the order `merge_tool_entries` writes them —
+    /// sorted by the version *string* — because that is the order the selection
+    /// actually receives them in.
+    fn select_unbound(versions: &[&str], order: VersionOrder) -> Option<String> {
+        let entries: Vec<LockfileTool> = versions
+            .iter()
+            .sorted()
+            .map(|version| basic_tool(version, "asdf:dummy"))
+            .collect();
+        select_newest_unbound_tool(entries.iter().collect(), order).map(|tool| tool.version.clone())
+    }
+
+    #[test]
+    fn test_unbound_selection_without_a_backend_order() {
+        // `Source` is the default for every backend that has not opted in --
+        // asdf, cargo, npm, pipx, gem, go, dotnet, conda and the core plugins.
+        // It returns its input untouched, so reading off the end of the stored
+        // order answers with the lexicographically largest string.
+        assert_eq!(
+            select_unbound(&["1.9.0", "1.10.0"], VersionOrder::Source),
+            Some("1.10.0".to_string())
+        );
+
+        // The pair where the stored order happens to agree, which is why the
+        // existing e2e case never caught this.
+        assert_eq!(
+            select_unbound(&["1.0.0", "2.0.0"], VersionOrder::Source),
+            Some("2.0.0".to_string())
+        );
+
+        // Non-semver still orders, through the same comparator the unversioned
+        // branch uses.
+        assert_eq!(
+            select_unbound(&["3.7b", "3.7c"], VersionOrder::Source),
+            Some("3.7c".to_string())
+        );
+
+        assert_eq!(select_unbound(&[], VersionOrder::Source), None);
+    }
+
+    #[test]
+    fn test_unbound_selection_defers_to_a_declared_semver_order() {
+        // A backend that opted in still decides. `order_by` sorts ascending, so
+        // the end of its list is the newest -- unchanged by this fix.
+        assert_eq!(
+            select_unbound(&["1.9.0", "1.10.0"], VersionOrder::Semver),
+            Some("1.10.0".to_string())
+        );
+        assert_eq!(
+            select_unbound(&["1.0.0", "2.0.0"], VersionOrder::Semver),
+            Some("2.0.0".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #12583, which fixed the same question in the other branch of `get_locked_version`. I flagged this one in that PR's body as out of scope; this is it.

## The defect

`select_unbound_lockfile_tool` picks among the unbound entries of a versioned lockfile:

```rust
let Some(backend) = backend else {
    return Ok(matching.first().copied());
};
Ok(backend
    .version_order(selection_options)?
    .order_by(matching, |tool| tool.version.as_str())
    .last()
    .copied())
```

Neither branch has a way to identify the newest version. Three facts combine:

- Entries are written sorted by the version **string** — `a.version.cmp(&b.version)` in `merge_tool_entries` and `preserve_absent_tool_entries`.
- `VersionOrder::Source`'s `order_by` returns its input untouched (`src/backend/options.rs`).
- `Source` is the **default**. Only aqua, github and http override `Backend::version_order`; asdf, cargo, npm, pipx, gem, go, dotnet, conda and the core plugins all get it.

So both branches read an end of a lexicographically sorted list:

| entries (as stored) | no backend, `.first()` | default `Source`, `.last()` | newest |
| --- | --- | --- | --- |
| `1.10.0`, `1.9.0` | `1.10.0` | **`1.9.0`** | `1.10.0` |
| `1.0.0`, `2.0.0` | **`1.0.0`** | `2.0.0` | `2.0.0` |

Neither is consistently wrong, which is the point — there is no mechanism producing the right answer, only pairs where an end happens to coincide with it.

## Reachable, and the existing test hides it

The path is the one the code's own comment describes: *"Mixed-format monorepo migration can temporarily place legacy entries without bindings in a version-1 file."*

`e2e/lockfile/test_lockfile_version` already exercises it under `=== unbound versioned entries use backend version order ===` — with `1.0.0` and `2.0.0`, where `.last()` is accidentally correct. That is row 2 of the table.

## Fix

Ask the backend only when it has an opinion; otherwise compare the versions, using the comparator #12583 added for the unversioned branch.

```rust
fn select_newest_unbound_tool<'a>(
    mut matching: Vec<&'a LockfileTool>,
    order: VersionOrder,
) -> Option<&'a LockfileTool> {
    if order != VersionOrder::Source {
        return order.order_by(matching, |tool| tool.version.as_str()).last().copied();
    }
    matching.sort_by(|a, b| cmp_lockfile_versions_newest_first(&a.version, &b.version));
    matching.first().copied()
}
```

`sort_by` + `.first()` rather than `max_by`, to match the unversioned branch exactly: both are stable, so duplicate entries keep the order they were read in. No new comparison logic is introduced.

**A backend that declares `Semver` is unaffected** — `order_by` sorts ascending and `.last()` is still the highest. What changes is `Source` (now compares versions instead of reading the end) and the no-backend case (now compares versions instead of reading the other end).

## Tests

- `test_unbound_selection_without_a_backend_order` — `1.9.0` / `1.10.0` (fails before this change), `1.0.0` / `2.0.0` as the no-regression case, `3.7b` / `3.7c` for the non-semver path, and the empty case. Entries are built in the order `merge_tool_entries` writes them, since that is the order the selection receives.
- `test_unbound_selection_defers_to_a_declared_semver_order` — pins that the delegated path is untouched.
- A new e2e block beside the existing one, with `1.10.0` / `1.9.0` under `asdf:dummy`, which does not opt into an order. Before this change it resolves to `1.9.0`.

I cannot build locally, so CI is the first execution.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.236.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected `latest` lockfile resolution to select the newest semantic version instead of relying on entry position.
  - Preserved explicitly configured ordering for backends that provide it.
  - Improved handling of non-semantic versions, tied versions, and empty lockfile entries.

- **Tests**
  - Added coverage verifying correct version selection across supported lockfile scenarios, including semantic version ordering and `latest` resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->