### PR TITLE
fix(shim): support shared executable directories

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 zipsign.pub binary
+crates/mise-shim/native-shim-marker binary
 src/gpg_testdata/node_v20.11.0_SHASUMS256.txt text eol=lf
 src/system/remote_testdata/* text eol=lf
 vendor/aqua-registry/** linguist-vendored

--- a/crates/mise-shim/native-shim-marker
+++ b/crates/mise-shim/native-shim-marker
@@ -1,0 +1,1 @@
+mise generated native shim v1

--- a/crates/mise-shim/src/main.rs
+++ b/crates/mise-shim/src/main.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use std::process::{Command, ExitCode};
 
 const MISE_SHIM_PATH_ENV: &str = "__MISE_SHIM_PATH";
+const NATIVE_SHIM_MARKER: &[u8] = b"mise generated native shim v1";
 
 fn paths_eq(a: &Path, b: &Path) -> bool {
     let lexical_eq = |a: &Path, b: &Path| {
@@ -28,6 +29,9 @@ fn paths_eq(a: &Path, b: &Path) -> bool {
 }
 
 fn main() -> ExitCode {
+    // Keep a stable ownership marker in every native shim binary. mise reads
+    // this without executing the file when maintaining a shared shim directory.
+    std::hint::black_box(NATIVE_SHIM_MARKER);
     match run() {
         Ok(code) => ExitCode::from(code as u8),
         Err(err) => {

--- a/crates/mise-shim/src/main.rs
+++ b/crates/mise-shim/src/main.rs
@@ -8,7 +8,8 @@ use std::path::Path;
 use std::process::{Command, ExitCode};
 
 const MISE_SHIM_PATH_ENV: &str = "__MISE_SHIM_PATH";
-const NATIVE_SHIM_MARKER: &[u8] = b"mise generated native shim v1";
+#[used]
+static NATIVE_SHIM_MARKER: [u8; 30] = *include_bytes!("../native-shim-marker");
 
 fn paths_eq(a: &Path, b: &Path) -> bool {
     let lexical_eq = |a: &Path, b: &Path| {
@@ -29,9 +30,6 @@ fn paths_eq(a: &Path, b: &Path) -> bool {
 }
 
 fn main() -> ExitCode {
-    // Keep a stable ownership marker in every native shim binary. mise reads
-    // this without executing the file when maintaining a shared shim directory.
-    std::hint::black_box(NATIVE_SHIM_MARKER);
     match run() {
         Ok(code) => ExitCode::from(code as u8),
         Err(err) => {

--- a/docs/cli/reshim.md
+++ b/docs/cli/reshim.md
@@ -28,7 +28,7 @@ Note that this creates shims for _all_ installed tools, not just the ones that a
 currently active in mise.toml.
 
 ## Flags
-- **`-f --force`** — Removes all shims before reshimming
+- **`-f --force`** — Rebuilds all mise-owned shims
 - **`--system`** — Rebuild the system shim farm
 - **`-h --help`** — Print help
 

--- a/docs/dev-tools/shims.md
+++ b/docs/dev-tools/shims.md
@@ -174,10 +174,12 @@ Note that `mise` already runs a reshim anytime a tool is installed/updated/remov
 `mise reshim` only creates/removes the shims. Some users sometimes use it as a
 "fix it" button, but it is only necessary if `~/.local/share/mise/shims` doesn't contain something it should.
 
-The configured shim directory can safely be a shared executable directory such as `~/.local/bin`
-or `/usr/local/bin`. `mise reshim` only replaces or removes entries it recognizes as mise shims.
-When an unmanaged file has the same name as a desired shim, mise keeps the existing file and prints
-a warning.
+For `mise reshim`, the configured shim directory may be a shared executable directory such as
+`~/.local/bin` or `/usr/local/bin`: reshim only replaces or removes entries it recognizes as mise
+shims, and leaves a same-named unmanaged file in place. Other mise features still identify shim
+directories as whole `PATH` entries, however, so a shared directory is not yet supported with
+`mise activate`, hook-env, or internal dependency lookups. Use a dedicated `shims_dir` if you use
+those features.
 
 ## Command wrappers
 

--- a/docs/dev-tools/shims.md
+++ b/docs/dev-tools/shims.md
@@ -174,7 +174,10 @@ Note that `mise` already runs a reshim anytime a tool is installed/updated/remov
 `mise reshim` only creates/removes the shims. Some users sometimes use it as a
 "fix it" button, but it is only necessary if `~/.local/share/mise/shims` doesn't contain something it should.
 
-Do not add additional executable in the `mise` directory, `mise` will delete them with the next reshim.
+The configured shim directory can safely be a shared executable directory such as `~/.local/bin`
+or `/usr/local/bin`. `mise reshim` only replaces or removes entries it recognizes as mise shims.
+When an unmanaged file has the same name as a desired shim, mise keeps the existing file and prints
+a warning.
 
 ## Command wrappers
 

--- a/docs/directories.md
+++ b/docs/directories.md
@@ -97,9 +97,10 @@ does not work for some reason.
 
 The setting is global-only, expands `~`, and must resolve to an absolute path.
 
-The shim directory may also be a shared executable directory such as `~/.local/bin` or
-`/usr/local/bin`. `mise reshim` only replaces or removes entries it recognizes as mise shims. A
-same-named file owned by you or another package manager is preserved.
+`mise reshim` can publish into a shared executable directory such as `~/.local/bin` or
+`/usr/local/bin`; it only replaces or removes entries it recognizes as mise shims. Other mise
+features still filter shim directories as whole `PATH` entries, so use a dedicated directory when
+using `mise activate`, hook-env, or internal dependency lookups.
 
 ## System installs and shims
 

--- a/docs/directories.md
+++ b/docs/directories.md
@@ -97,6 +97,10 @@ does not work for some reason.
 
 The setting is global-only, expands `~`, and must resolve to an absolute path.
 
+The shim directory may also be a shared executable directory such as `~/.local/bin` or
+`/usr/local/bin`. `mise reshim` only replaces or removes entries it recognizes as mise shims. A
+same-named file owned by you or another package manager is preserved.
+
 ## System installs and shims
 
 System installs default to `/usr/local/share/mise/installs` and system shims

--- a/e2e/cli/test_shims
+++ b/e2e/cli/test_shims
@@ -12,3 +12,21 @@ assert \
 
 mise uninstall -a dummy
 assert_fail "which dummy"
+
+# A shared executable directory keeps a same-named unmanaged command without
+# reporting a shim state that reshim can never repair.
+shared_bin="$HOME/.local/bin"
+mkdir -p "$shared_bin"
+printf '%s\n' '#!/bin/sh' 'echo unmanaged-dummy' >"$shared_bin/dummy"
+chmod +x "$shared_bin/dummy"
+export MISE_SHIMS_DIR="$shared_bin"
+export PATH="$shared_bin:$PATH"
+
+mise i dummy@latest
+mise reshim
+assert "dummy" "unmanaged-dummy"
+assert_not_contains "mise doctor" "shims are missing"
+
+# Force remains conservative in a shared directory.
+mise reshim --force
+assert "dummy" "unmanaged-dummy"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -4158,7 +4158,7 @@ currently active in mise.toml.
 .PP
 .TP
 \fB\-f, \-\-force\fR
-Removes all shims before reshimming
+Rebuilds all mise-owned shims
 .TP
 \fB\-\-system\fR
 Rebuild the system shim farm

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -4158,7 +4158,7 @@ currently active in mise.toml.
 .PP
 .TP
 \fB\-f, \-\-force\fR
-Rebuilds all mise-owned shims
+Rebuilds all mise\-owned shims
 .TP
 \fB\-\-system\fR
 Rebuild the system shim farm

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3070,7 +3070,7 @@ Note that this creates shims for _all_ installed tools, not just the ones that a
 currently active in mise.toml.
 """#
     after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise reshim\u{1b}[22m\n    $ \u{1b}[1m~/.local/share/mise/shims/node -v\u{1b}[22m\n    v20.0.0\n"
-    flag "-f --force" help="Removes all shims before reshimming"
+    flag "-f --force" help="Rebuilds all mise-owned shims"
     flag --system help="Rebuild the system shim farm"
     flag "-h --help" help="Print help" action=help builtin=#true
     arg "[TOOL]" required=#false hide=#true

--- a/settings.toml
+++ b/settings.toml
@@ -2589,8 +2589,9 @@ description = "Directory containing user shims."
 docs = """
 The user shim farm. Lazy tools declared in user config publish their bootstrap shims here.
 The directory must be absolute after `~` expansion.
-It may be a shared executable directory such as `~/.local/bin`; mise only replaces or removes
-entries it recognizes as mise shims.
+`mise reshim` may publish into a shared executable directory such as `~/.local/bin`; it only
+replaces or removes entries it recognizes as mise shims. Other mise features filter this directory
+as one PATH entry, so use a dedicated directory with activation and internal dependency lookups.
 """
 env = "MISE_SHIMS_DIR"
 global_only = true

--- a/settings.toml
+++ b/settings.toml
@@ -2589,6 +2589,8 @@ description = "Directory containing user shims."
 docs = """
 The user shim farm. Lazy tools declared in user config publish their bootstrap shims here.
 The directory must be absolute after `~` expansion.
+It may be a shared executable directory such as `~/.local/bin`; mise only replaces or removes
+entries it recognizes as mise shims.
 """
 env = "MISE_SHIMS_DIR"
 global_only = true

--- a/src/cli/reshim.rs
+++ b/src/cli/reshim.rs
@@ -31,7 +31,7 @@ pub(crate) struct Reshim {
     #[usage(hide = true)]
     pub version: Option<String>,
 
-    /// Removes all shims before reshimming
+    /// Rebuilds all mise-owned shims
     #[usage(long, short)]
     pub force: bool,
 

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -518,9 +518,26 @@ fn is_mise_shim(path: &Path, mise_bin: &Path) -> Result<bool> {
 
     #[cfg(windows)]
     {
-        // Native copy and hardlink shims do not carry an ownership marker.
-        // Retain the existing Windows shim-farm behavior.
-        return Ok(path.is_file());
+        if !path.is_file() {
+            return Ok(false);
+        }
+        let parent = path.parent().unwrap_or_else(|| Path::new("."));
+        let is_default_farm = file::storage_paths_eq(parent, &dirs::DATA.join("shims"))
+            || file::storage_paths_eq(parent, &env::MISE_SYSTEM_DATA_DIR.join("shims"));
+        if is_default_farm {
+            // Preserve the existing upgrade behavior in mise's dedicated
+            // farms. Native copies from an older mise cannot be identified by
+            // their contents after mise-shim.exe changes.
+            return Ok(true);
+        }
+
+        if is_generated_windows_file_shim(path) {
+            return Ok(true);
+        }
+        let matches_mise = files_identical(path, mise_bin).unwrap_or(false);
+        let matches_launcher = find_mise_shim_bin(mise_bin)
+            .is_some_and(|launcher| files_identical(path, &launcher).unwrap_or(false));
+        return Ok(matches_mise || matches_launcher);
     }
 
     #[cfg(not(windows))]
@@ -532,6 +549,29 @@ fn is_mise_shim(path: &Path, mise_bin: &Path) -> Result<bool> {
         Ok(contents.starts_with("#!/bin/sh\n# mise generated shim\n")
             || (contents.starts_with("#!/bin/sh\nexport ASDF_DATA_DIR=")
                 && contents.contains("\nmise x -- ")))
+    }
+}
+
+#[cfg(any(windows, test))]
+fn is_generated_windows_file_shim(path: &Path) -> bool {
+    let Some(name) = path.file_stem().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    let Ok(contents) = fs::read_to_string(path) else {
+        return false;
+    };
+    if path
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("cmd"))
+    {
+        contents == windows_file_shim_body(name)
+    } else if path.extension().is_none() {
+        #[cfg(windows)]
+        return contents == bash_shim_script(name);
+        #[cfg(not(windows))]
+        return false;
+    } else {
+        false
     }
 }
 
@@ -1613,6 +1653,17 @@ mod tests {
         let body = windows_file_shim_body("gh");
         assert!(body.ends_with("\r\n"));
         assert_eq!(body.matches('\n').count(), body.matches("\r\n").count());
+    }
+
+    #[test]
+    fn windows_file_shim_detection_requires_the_exact_generated_body() {
+        let dir = tempfile::tempdir().unwrap();
+        let shim = dir.path().join("gh.cmd");
+        fs::write(&shim, windows_file_shim_body("gh")).unwrap();
+        assert!(is_generated_windows_file_shim(&shim));
+
+        fs::write(&shim, "@echo off\r\necho user script\r\n").unwrap();
+        assert!(!is_generated_windows_file_shim(&shim));
     }
 
     #[cfg(windows)]

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -17,13 +17,15 @@ use crate::toolset::{ResolveOptions, ToolVersion, Toolset, ToolsetBuilder};
 use crate::{backend, dirs, env, fake_asdf, file};
 use color_eyre::eyre::{Result, bail, eyre};
 use eyre::WrapErr;
+#[cfg(windows)]
 use indoc::formatdoc;
 use itertools::Itertools;
 use path_absolutize::Absolutize;
 use tokio::task::JoinSet;
 
 #[cfg(any(windows, test))]
-const NATIVE_SHIM_MARKER: &[u8] = b"mise generated native shim v1";
+const NATIVE_SHIM_MARKER: &[u8] = include_bytes!("../crates/mise-shim/native-shim-marker");
+const GENERATED_SHELL_SHIM_HEADER: &str = "#!/bin/sh\n# mise generated shim\n";
 
 // executes as if it was a shim if the command is not "mise", e.g.: "node"
 pub(crate) async fn handle_shim() -> Result<()> {
@@ -344,15 +346,19 @@ pub(crate) async fn reshim_for(
     let full_rebuild = force || shim_mode_changed || shim_version_changed;
     file::create_dir_all(&shims_dir)?;
 
-    // Always materialize the complete farm first. Besides keeping publication
-    // atomic per shim, this gives us the exact content used to decide whether a
-    // same-named entry in a shared directory is ours or a collision.
-    let desired = get_desired_shims(config, &mise_bin, ts, scope).await?;
+    let (desired, shims_to_stage) = if full_rebuild {
+        let desired = get_desired_shims(config, &mise_bin, ts, scope).await?;
+        let shims_to_stage = desired.iter().cloned().collect();
+        (desired, shims_to_stage)
+    } else {
+        let diffs = get_shim_diffs(config, &mise_bin, ts, &shims_dir, scope).await?;
+        (diffs.desired, diffs.missing)
+    };
     let staging = stage_shim_farm(
         &shims_dir,
         &mise_bin,
         scope,
-        &desired.into_iter().collect::<BTreeSet<_>>(),
+        &shims_to_stage,
         &shim_mode,
         shim_version,
     )
@@ -361,6 +367,7 @@ pub(crate) async fn reshim_for(
         &shims_dir,
         &mise_bin,
         staging,
+        desired,
         is_dedicated_shims_dir(&shims_dir),
     )?;
 
@@ -437,6 +444,7 @@ fn publish_staged_shim_farm(
     shims_dir: &Path,
     mise_bin: &Path,
     staging: tempfile::TempDir,
+    mut desired: HashSet<String>,
     prune_unmanaged: bool,
 ) -> Result<()> {
     let mut entries = staging
@@ -453,16 +461,17 @@ fn publish_staged_shim_farm(
     // the next reshim retry instead of treating a partially published farm as
     // current.
     entries.sort_by_key(|entry| is_hidden_shim_name(&entry.file_name()));
-    let desired = entries
-        .iter()
-        .filter_map(|entry| entry.file_name().into_string().ok())
-        .collect::<HashSet<_>>();
+    desired.extend(
+        entries
+            .iter()
+            .filter_map(|entry| entry.file_name().into_string().ok()),
+    );
     for entry in entries {
         let source = entry.path();
         let destination = shims_dir.join(entry.file_name());
         if (destination.exists() || destination.is_symlink())
             && !is_mise_shim(&destination, mise_bin)?
-            && !files_identical(&source, &destination)?
+            && !files_identical(&source, &destination).unwrap_or(false)
         {
             warn!(
                 "not replacing unmanaged file in shims directory: {}",
@@ -506,8 +515,13 @@ fn publish_staged_shim_farm(
 }
 
 fn is_dedicated_shims_dir(path: &Path) -> bool {
-    file::storage_paths_eq(path, &dirs::DATA.join("shims"))
-        || file::storage_paths_eq(path, &env::MISE_SYSTEM_DATA_DIR.join("shims"))
+    matches_unredirected_dedicated_dir(path, &dirs::DATA.join("shims"))
+        || matches_unredirected_dedicated_dir(path, &env::MISE_SYSTEM_DATA_DIR.join("shims"))
+}
+
+fn matches_unredirected_dedicated_dir(path: &Path, dedicated: &Path) -> bool {
+    file::paths_eq(path, dedicated)
+        && fs::canonicalize(path).is_ok_and(|resolved| file::paths_eq(&resolved, path))
 }
 
 fn files_identical(a: &Path, b: &Path) -> Result<bool> {
@@ -585,6 +599,7 @@ fn is_mise_shim(path: &Path, mise_bin: &Path) -> Result<bool> {
     }
 }
 
+#[cfg(any(windows, test))]
 fn bytes_contain(haystack: &[u8], needle: &[u8]) -> bool {
     !needle.is_empty()
         && haystack
@@ -593,9 +608,25 @@ fn bytes_contain(haystack: &[u8], needle: &[u8]) -> bool {
 }
 
 fn is_generated_shell_shim(contents: &[u8]) -> bool {
-    contents.starts_with(b"#!/bin/sh\n# mise generated shim\n")
-        || (contents.starts_with(b"#!/bin/sh\nexport ASDF_DATA_DIR=")
-            && bytes_contain(contents, b"\nmise x -- "))
+    contents.starts_with(GENERATED_SHELL_SHIM_HEADER.as_bytes()) || is_legacy_plugin_shim(contents)
+}
+
+fn is_legacy_plugin_shim(contents: &[u8]) -> bool {
+    let Ok(contents) = std::str::from_utf8(contents) else {
+        return false;
+    };
+    let mut lines = contents.lines();
+    lines.next() == Some("#!/bin/sh")
+        && lines
+            .next()
+            .is_some_and(|line| line.starts_with("export ASDF_DATA_DIR=") && line.len() > 21)
+        && lines
+            .next()
+            .is_some_and(|line| line.starts_with("export PATH=\"") && line.ends_with(":$PATH\""))
+        && lines
+            .next()
+            .is_some_and(|line| line.starts_with("mise x -- ") && line.ends_with(" \"$@\""))
+        && lines.next().is_none()
 }
 
 #[cfg(any(windows, test))]
@@ -1060,8 +1091,27 @@ async fn get_actual_shims(mise_bin: impl AsRef<Path>, shims_dir: &Path) -> Resul
 
     Ok(list_shims_in(shims_dir)?
         .into_iter()
-        .filter(|bin| is_mise_shim(&shims_dir.join(bin), mise_bin).unwrap_or(false))
+        .filter(|bin| is_current_mise_shim(&shims_dir.join(bin), mise_bin).unwrap_or(false))
         .collect::<HashSet<_>>())
+}
+
+fn is_current_mise_shim(path: &Path, mise_bin: &Path) -> Result<bool> {
+    if !is_mise_shim(path, mise_bin)? {
+        return Ok(false);
+    }
+    if !path.is_symlink() {
+        return Ok(true);
+    }
+    let target = fs::read_link(path)?;
+    let target = if target.is_absolute() {
+        target
+    } else {
+        path.parent().unwrap_or_else(|| Path::new(".")).join(target)
+    };
+    Ok(file::paths_eq(
+        &file::canonicalize_or_self(&target),
+        &file::canonicalize_or_self(mise_bin),
+    ))
 }
 
 fn list_executables_in_dir(dir: &Path) -> Result<HashSet<String>> {
@@ -1240,16 +1290,12 @@ async fn make_shim(target: &Path, shim: &Path) -> Result<()> {
     file::remove_file_async_if_exists(shim).await?;
     file::write_async(
         shim,
-        formatdoc! {r#"
-        #!/bin/sh
-        # mise generated shim
-        export ASDF_DATA_DIR={data_dir}
-        export PATH="{fake_asdf_dir}:$PATH"
-        mise x -- {target} "$@"
-        "#,
+        format!(
+            "{GENERATED_SHELL_SHIM_HEADER}export ASDF_DATA_DIR={data_dir}\nexport PATH=\"{fake_asdf_dir}:$PATH\"\nmise x -- {target} \"$@\"\n",
         data_dir = dirs::DATA.display(),
         fake_asdf_dir = fake_asdf::setup()?.display(),
-        target = target.display()},
+        target = target.display()
+        ),
     )
     .await?;
     file::make_executable_async(shim).await?;
@@ -1790,7 +1836,7 @@ mod tests {
             "#!/bin/sh\n# mise generated shim\nmise x -- owned \"$@\"\n",
         )
         .unwrap();
-        publish_staged_shim_farm(live.path(), &mise_bin, staging, false).unwrap();
+        publish_staged_shim_farm(live.path(), &mise_bin, staging, HashSet::new(), false).unwrap();
 
         assert_eq!(
             fs::read_to_string(&unmanaged).unwrap(),
@@ -1808,7 +1854,8 @@ mod tests {
             .prefix(".mise-shims-stage-")
             .tempdir_in(live.path())
             .unwrap();
-        publish_staged_shim_farm(live.path(), &mise_bin, empty_staging, false).unwrap();
+        publish_staged_shim_farm(live.path(), &mise_bin, empty_staging, HashSet::new(), false)
+            .unwrap();
 
         assert_eq!(
             fs::read_to_string(live.path().join("owned")).unwrap(),
@@ -1830,13 +1877,14 @@ mod tests {
             "#!/bin/sh\n# mise generated shim\nmise x -- owned \"$@\"\n",
         )
         .unwrap();
-        publish_staged_shim_farm(live.path(), &mise_bin, staging, false).unwrap();
+        publish_staged_shim_farm(live.path(), &mise_bin, staging, HashSet::new(), false).unwrap();
 
         let empty_staging = tempfile::Builder::new()
             .prefix(".mise-shims-stage-")
             .tempdir_in(live.path())
             .unwrap();
-        publish_staged_shim_farm(live.path(), &mise_bin, empty_staging, false).unwrap();
+        publish_staged_shim_farm(live.path(), &mise_bin, empty_staging, HashSet::new(), false)
+            .unwrap();
 
         assert!(!live.path().join("owned").exists());
     }
@@ -1854,9 +1902,51 @@ mod tests {
             .tempdir_in(live.path())
             .unwrap();
 
-        publish_staged_shim_farm(live.path(), &mise_bin, staging, true).unwrap();
+        publish_staged_shim_farm(live.path(), &mise_bin, staging, HashSet::new(), true).unwrap();
 
         assert!(!orphan.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_dedicated_farm_is_treated_as_shared() {
+        let root = tempfile::tempdir().unwrap();
+        let shared = root.path().join("shared");
+        let dedicated = root.path().join("shims");
+        fs::create_dir(&shared).unwrap();
+        std::os::unix::fs::symlink(&shared, &dedicated).unwrap();
+
+        assert!(!matches_unredirected_dedicated_dir(&dedicated, &dedicated));
+        assert!(matches_unredirected_dedicated_dir(&shared, &shared));
+    }
+
+    #[test]
+    fn staged_shim_publication_preserves_unstaged_desired_shims() {
+        let live = tempfile::tempdir().unwrap();
+        let mise_bin = live.path().join("mise");
+        fs::write(&mise_bin, "mise").unwrap();
+        let existing = live.path().join("existing");
+        fs::write(
+            &existing,
+            "#!/bin/sh\n# mise generated shim\nmise x -- existing \"$@\"\n",
+        )
+        .unwrap();
+        file::make_executable(&existing).unwrap();
+        let staging = tempfile::Builder::new()
+            .prefix(".mise-shims-stage-")
+            .tempdir_in(live.path())
+            .unwrap();
+
+        publish_staged_shim_farm(
+            live.path(),
+            &mise_bin,
+            staging,
+            HashSet::from(["existing".to_string()]),
+            false,
+        )
+        .unwrap();
+
+        assert!(existing.exists());
     }
 
     #[cfg(unix)]
@@ -1881,6 +1971,7 @@ mod tests {
         fs::remove_file(&shim).unwrap();
         std::os::unix::fs::symlink(dir.path().join("old/bin/mise"), &shim).unwrap();
         assert!(is_mise_shim(&shim, &mise_bin).unwrap());
+        assert!(!is_current_mise_shim(&shim, &mise_bin).unwrap());
 
         // The real mise dispatcher may itself be installed as a symlink in a
         // shared bin directory; its own name keeps it out of shim pruning.
@@ -1899,14 +1990,21 @@ mod tests {
 
         fs::write(
             &shim,
-            "#!/bin/sh\n# mise generated shim\nmise x -- foo \"$@\"\n",
+            format!("{GENERATED_SHELL_SHIM_HEADER}mise x -- foo \"$@\"\n"),
         )
         .unwrap();
         assert!(is_mise_shim(&shim, &mise_bin).unwrap());
 
         fs::write(
             &shim,
-            "#!/bin/sh\nexport ASDF_DATA_DIR=/tmp/mise\nexport PATH=x\nmise x -- foo \"$@\"\n",
+            "#!/bin/sh\nexport ASDF_DATA_DIR=/tmp/mise\necho user-wrapper\nmise x -- foo \"$@\"\n",
+        )
+        .unwrap();
+        assert!(!is_mise_shim(&shim, &mise_bin).unwrap());
+
+        fs::write(
+            &shim,
+            "#!/bin/sh\nexport ASDF_DATA_DIR=/tmp/mise\nexport PATH=\"x:$PATH\"\nmise x -- foo \"$@\"\n",
         )
         .unwrap();
         assert!(is_mise_shim(&shim, &mise_bin).unwrap());
@@ -1918,7 +2016,7 @@ mod tests {
     #[test]
     fn native_shim_fingerprint_recognizes_current_and_transition_binaries() {
         assert!(has_mise_native_shim_fingerprint(
-            b"PE\0mise generated native shim v1\0"
+            b"PE\0mise generated native shim v1\n\0"
         ));
         assert!(has_mise_native_shim_fingerprint(
             b"mise-shim: failed to determine executable path\0mise-shim: failed to execute mise"

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -341,43 +341,20 @@ pub(crate) async fn reshim_for(
     let full_rebuild = force || shim_mode_changed || shim_version_changed;
     file::create_dir_all(&shims_dir)?;
 
-    if full_rebuild {
-        // Resolve and materialize the complete target farm before moving any
-        // working shim. Configuration, metadata, and shim creation errors must
-        // all leave the live farm intact.
-        let desired = get_desired_shims(config, &mise_bin, ts, scope).await?;
-        let staging = stage_shim_farm(
-            &shims_dir,
-            &mise_bin,
-            scope,
-            &desired.into_iter().collect::<BTreeSet<_>>(),
-            &shim_mode,
-            shim_version,
-        )
-        .await?;
-        publish_staged_shim_farm(&shims_dir, staging)?;
-    } else {
-        let diffs = get_shim_diffs(config, &mise_bin, ts, &shims_dir, scope).await?;
-        write_shim_metadata(&shims_dir, &shim_mode, shim_version)?;
-        for shim in diffs.missing {
-            let symlink_path = shims_dir.join(&shim);
-            // On Windows, remove the old shim first (with rename fallback for
-            // locked .exe files) so the new one can be written.
-            if cfg!(windows) && symlink_path.exists() {
-                remove_shim_with_rename_fallback(&symlink_path)?;
-            }
-            add_shim(&mise_bin, &symlink_path, &shim)?;
-        }
-        for shim in diffs.extra {
-            let symlink_path = shims_dir.join(shim);
-            if cfg!(windows) {
-                remove_shim_with_rename_fallback(&symlink_path)?;
-            } else {
-                file::remove_all(&symlink_path)?;
-            }
-        }
-        add_plugin_shims(&shims_dir, scope).await?;
-    }
+    // Always materialize the complete farm first. Besides keeping publication
+    // atomic per shim, this gives us the exact content used to decide whether a
+    // same-named entry in a shared directory is ours or a collision.
+    let desired = get_desired_shims(config, &mise_bin, ts, scope).await?;
+    let staging = stage_shim_farm(
+        &shims_dir,
+        &mise_bin,
+        scope,
+        &desired.into_iter().collect::<BTreeSet<_>>(),
+        &shim_mode,
+        shim_version,
+    )
+    .await?;
+    publish_staged_shim_farm(&shims_dir, &mise_bin, staging)?;
 
     if matches!(requested_scope, ShimScope::User | ShimScope::Both) {
         sync_command_wrapper_shims(config, &mise_bin, full_rebuild)?;
@@ -448,8 +425,11 @@ async fn add_plugin_shims(shims_dir: &Path, scope: ShimScope) -> Result<()> {
     Ok(())
 }
 
-fn publish_staged_shim_farm(shims_dir: &Path, staging: tempfile::TempDir) -> Result<()> {
-    let desired = list_shims_in(staging.path())?;
+fn publish_staged_shim_farm(
+    shims_dir: &Path,
+    mise_bin: &Path,
+    staging: tempfile::TempDir,
+) -> Result<()> {
     let mut entries = staging
         .path()
         .read_dir()
@@ -464,9 +444,23 @@ fn publish_staged_shim_farm(shims_dir: &Path, staging: tempfile::TempDir) -> Res
     // the next reshim retry instead of treating a partially published farm as
     // current.
     entries.sort_by_key(|entry| is_hidden_shim_name(&entry.file_name()));
+    let desired = entries
+        .iter()
+        .filter_map(|entry| entry.file_name().into_string().ok())
+        .collect::<HashSet<_>>();
     for entry in entries {
         let source = entry.path();
         let destination = shims_dir.join(entry.file_name());
+        if (destination.exists() || destination.is_symlink())
+            && !is_mise_shim(&destination, mise_bin)?
+            && !files_identical(&source, &destination)?
+        {
+            warn!(
+                "not replacing unmanaged file in shims directory: {}",
+                display_path(&destination)
+            );
+            continue;
+        }
         // Rename replaces a same-named file atomically. A publication error
         // therefore leaves that live shim untouched; an interrupted rebuild can
         // leave a mixture of old and new shims, but never evacuates the farm.
@@ -479,14 +473,16 @@ fn publish_staged_shim_farm(shims_dir: &Path, staging: tempfile::TempDir) -> Res
         })?;
     }
 
-    // Only prune obsolete shims after every desired replacement is live. A
-    // pruning error may leave harmless extras, but cannot remove a required shim.
+    // A shared executable directory can contain arbitrary user and package
+    // manager files. Only prune entries that can be identified as mise shims.
     for shim in list_shims_in(shims_dir)?.difference(&desired) {
         let path = shims_dir.join(shim);
-        if cfg!(windows) {
-            remove_shim_with_rename_fallback(&path)?;
-        } else {
-            file::remove_all(&path)?;
+        if is_mise_shim(&path, mise_bin)? {
+            if cfg!(windows) {
+                remove_shim_with_rename_fallback(&path)?;
+            } else {
+                file::remove_all(&path)?;
+            }
         }
     }
 
@@ -494,6 +490,49 @@ fn publish_staged_shim_farm(shims_dir: &Path, staging: tempfile::TempDir) -> Res
         warn!("failed to remove shim staging directory: {err}");
     }
     Ok(())
+}
+
+fn files_identical(a: &Path, b: &Path) -> Result<bool> {
+    if a.is_symlink() || b.is_symlink() {
+        return Ok(a.is_symlink() && b.is_symlink() && fs::read_link(a)? == fs::read_link(b)?);
+    }
+    if !a.is_file() || !b.is_file() {
+        return Ok(false);
+    }
+    Ok(fs::read(a)? == fs::read(b)?)
+}
+
+fn is_mise_shim(path: &Path, mise_bin: &Path) -> Result<bool> {
+    if path.is_symlink() {
+        let target = fs::read_link(path)?;
+        let target = if target.is_absolute() {
+            target
+        } else {
+            path.parent().unwrap_or_else(|| Path::new(".")).join(target)
+        };
+        return Ok(file::paths_eq(
+            &file::canonicalize_or_self(&target),
+            &file::canonicalize_or_self(mise_bin),
+        ));
+    }
+
+    #[cfg(windows)]
+    {
+        // Native copy and hardlink shims do not carry an ownership marker.
+        // Retain the existing Windows shim-farm behavior.
+        return Ok(path.is_file());
+    }
+
+    #[cfg(not(windows))]
+    {
+        if !path.is_file() {
+            return Ok(false);
+        }
+        let contents = fs::read_to_string(path).unwrap_or_default();
+        Ok(contents.starts_with("#!/bin/sh\n# mise generated shim\n")
+            || (contents.starts_with("#!/bin/sh\nexport ASDF_DATA_DIR=")
+                && contents.contains("\nmise x -- ")))
+    }
 }
 
 fn sync_command_wrapper_shims(config: &Config, mise_bin: &Path, force: bool) -> Result<()> {
@@ -920,11 +959,7 @@ async fn get_actual_shims(mise_bin: impl AsRef<Path>, shims_dir: &Path) -> Resul
 
     Ok(list_shims_in(shims_dir)?
         .into_iter()
-        .filter(|bin| {
-            let path = shims_dir.join(bin);
-
-            !path.is_symlink() || path.read_link().is_ok_and(|p| p == mise_bin)
-        })
+        .filter(|bin| is_mise_shim(&shims_dir.join(bin), mise_bin).unwrap_or(false))
         .collect::<HashSet<_>>())
 }
 
@@ -1106,6 +1141,7 @@ async fn make_shim(target: &Path, shim: &Path) -> Result<()> {
         shim,
         formatdoc! {r#"
         #!/bin/sh
+        # mise generated shim
         export ASDF_DATA_DIR={data_dir}
         export PATH="{fake_asdf_dir}:$PATH"
         mise x -- {target} "$@"
@@ -1621,6 +1657,120 @@ mod tests {
 
         assert!(bins.contains(visible_name));
         assert!(!bins.contains(".librsvg-post-link.exe"));
+    }
+
+    #[test]
+    fn staged_shim_publication_preserves_unmanaged_and_modified_files() {
+        let live = tempfile::tempdir().unwrap();
+        let mise_bin = live.path().join("mise");
+        fs::write(&mise_bin, "mise").unwrap();
+        let unmanaged = live.path().join("unmanaged");
+        fs::write(&unmanaged, "from another package manager").unwrap();
+        file::make_executable(&unmanaged).unwrap();
+
+        let staging = tempfile::Builder::new()
+            .prefix(".mise-shims-stage-")
+            .tempdir_in(live.path())
+            .unwrap();
+        fs::write(staging.path().join("unmanaged"), "mise shim").unwrap();
+        fs::write(
+            staging.path().join("owned"),
+            "#!/bin/sh\n# mise generated shim\nmise x -- owned \"$@\"\n",
+        )
+        .unwrap();
+        publish_staged_shim_farm(live.path(), &mise_bin, staging).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&unmanaged).unwrap(),
+            "from another package manager"
+        );
+        assert_eq!(
+            fs::read_to_string(live.path().join("owned")).unwrap(),
+            "#!/bin/sh\n# mise generated shim\nmise x -- owned \"$@\"\n"
+        );
+
+        // Once an owned shim is changed outside mise, an otherwise empty
+        // reshim cedes ownership instead of deleting the replacement.
+        fs::write(live.path().join("owned"), "user replacement").unwrap();
+        let empty_staging = tempfile::Builder::new()
+            .prefix(".mise-shims-stage-")
+            .tempdir_in(live.path())
+            .unwrap();
+        publish_staged_shim_farm(live.path(), &mise_bin, empty_staging).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(live.path().join("owned")).unwrap(),
+            "user replacement"
+        );
+    }
+
+    #[test]
+    fn staged_shim_publication_removes_unchanged_owned_shims() {
+        let live = tempfile::tempdir().unwrap();
+        let mise_bin = live.path().join("mise");
+        fs::write(&mise_bin, "mise").unwrap();
+        let staging = tempfile::Builder::new()
+            .prefix(".mise-shims-stage-")
+            .tempdir_in(live.path())
+            .unwrap();
+        fs::write(
+            staging.path().join("owned"),
+            "#!/bin/sh\n# mise generated shim\nmise x -- owned \"$@\"\n",
+        )
+        .unwrap();
+        publish_staged_shim_farm(live.path(), &mise_bin, staging).unwrap();
+
+        let empty_staging = tempfile::Builder::new()
+            .prefix(".mise-shims-stage-")
+            .tempdir_in(live.path())
+            .unwrap();
+        publish_staged_shim_farm(live.path(), &mise_bin, empty_staging).unwrap();
+
+        assert!(!live.path().join("owned").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn mise_shim_detection_distinguishes_symlink_targets() {
+        let dir = tempfile::tempdir().unwrap();
+        let mise_bin = dir.path().join("mise");
+        let other_bin = dir.path().join("other");
+        fs::write(&mise_bin, "mise").unwrap();
+        fs::write(&other_bin, "other").unwrap();
+        let shim = dir.path().join("shim");
+
+        std::os::unix::fs::symlink(&mise_bin, &shim).unwrap();
+        assert!(is_mise_shim(&shim, &mise_bin).unwrap());
+
+        fs::remove_file(&shim).unwrap();
+        std::os::unix::fs::symlink(&other_bin, &shim).unwrap();
+        assert!(!is_mise_shim(&shim, &mise_bin).unwrap());
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn mise_shim_detection_recognizes_current_and_legacy_plugin_scripts() {
+        let dir = tempfile::tempdir().unwrap();
+        let mise_bin = dir.path().join("mise");
+        fs::write(&mise_bin, "mise").unwrap();
+        let shim = dir.path().join("shim");
+
+        fs::write(
+            &shim,
+            "#!/bin/sh\n# mise generated shim\nmise x -- foo \"$@\"\n",
+        )
+        .unwrap();
+        assert!(is_mise_shim(&shim, &mise_bin).unwrap());
+
+        fs::write(
+            &shim,
+            "#!/bin/sh\nexport ASDF_DATA_DIR=/tmp/mise\nexport PATH=x\nmise x -- foo \"$@\"\n",
+        )
+        .unwrap();
+        assert!(is_mise_shim(&shim, &mise_bin).unwrap());
+
+        fs::write(&shim, "#!/bin/sh\necho user-script\n").unwrap();
+        assert!(!is_mise_shim(&shim, &mise_bin).unwrap());
     }
 
     #[cfg(target_os = "linux")]

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -1198,7 +1198,9 @@ fn calculate_shim_diffs(
                 .iter()
                 .filter(|name| {
                     !actual.current.contains(*name)
-                        && (!actual.occupied.contains(*name) || actual.repairable.contains(*name))
+                        && (!actual.occupied.contains(*name)
+                            || actual.owned.contains(*name)
+                            || actual.repairable.contains(*name))
                 })
                 .cloned()
                 .collect(),
@@ -2220,6 +2222,23 @@ mod tests {
         assert!(extra.is_empty());
     }
 
+    #[test]
+    fn stale_owned_shim_is_missing_in_shared_directory() {
+        let actual = ActualShims {
+            current: HashSet::new(),
+            dedicated_present: HashSet::new(),
+            owned: HashSet::from(["node".to_string()]),
+            occupied: HashSet::from(["node".to_string()]),
+            repairable: HashSet::new(),
+        };
+        let desired = HashSet::from(["node".to_string()]);
+
+        let (missing, extra) = calculate_shim_diffs(&actual, &desired, false);
+
+        assert_eq!(missing, BTreeSet::from(["node".to_string()]));
+        assert!(extra.is_empty());
+    }
+
     #[cfg(unix)]
     #[test]
     fn symlinked_dedicated_farm_is_treated_as_shared() {
@@ -2304,8 +2323,8 @@ mod tests {
     }
 
     #[cfg(unix)]
-    #[test]
-    fn current_shim_check_migrates_to_stable_launcher_path() {
+    #[tokio::test]
+    async fn current_shim_check_migrates_to_stable_launcher_path() {
         let dir = tempfile::tempdir().unwrap();
         let versioned = dir.path().join("Cellar/mise/1/bin/mise");
         fs::create_dir_all(versioned.parent().unwrap()).unwrap();
@@ -2319,6 +2338,14 @@ mod tests {
 
         assert!(is_mise_shim(&shim, &launcher).unwrap());
         assert!(!is_current_owned_mise_shim(&shim, &launcher).unwrap());
+
+        let actual = get_actual_shims(&launcher, shim.parent().unwrap())
+            .await
+            .unwrap();
+        let desired = HashSet::from(["node".to_string()]);
+        let (missing, extra) = calculate_shim_diffs(&actual, &desired, false);
+        assert_eq!(missing, BTreeSet::from(["node".to_string()]));
+        assert!(extra.is_empty());
     }
 
     #[test]

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -357,7 +357,12 @@ pub(crate) async fn reshim_for(
         shim_version,
     )
     .await?;
-    publish_staged_shim_farm(&shims_dir, &mise_bin, staging)?;
+    publish_staged_shim_farm(
+        &shims_dir,
+        &mise_bin,
+        staging,
+        is_dedicated_shims_dir(&shims_dir),
+    )?;
 
     if matches!(requested_scope, ShimScope::User | ShimScope::Both) {
         sync_command_wrapper_shims(config, &mise_bin, full_rebuild)?;
@@ -432,6 +437,7 @@ fn publish_staged_shim_farm(
     shims_dir: &Path,
     mise_bin: &Path,
     staging: tempfile::TempDir,
+    prune_unmanaged: bool,
 ) -> Result<()> {
     let mut entries = staging
         .path()
@@ -481,9 +487,10 @@ fn publish_staged_shim_farm(
 
     // A shared executable directory can contain arbitrary user and package
     // manager files. Only prune entries that can be identified as mise shims.
+    // Mise's default, dedicated farms retain their historical full cleanup.
     for shim in list_shims_in(shims_dir)?.difference(&desired) {
         let path = shims_dir.join(shim);
-        if is_mise_shim(&path, mise_bin)? {
+        if prune_unmanaged || is_mise_shim(&path, mise_bin)? {
             if cfg!(windows) {
                 remove_shim_with_rename_fallback(&path)?;
             } else {
@@ -496,6 +503,11 @@ fn publish_staged_shim_farm(
         warn!("failed to remove shim staging directory: {err}");
     }
     Ok(())
+}
+
+fn is_dedicated_shims_dir(path: &Path) -> bool {
+    file::storage_paths_eq(path, &dirs::DATA.join("shims"))
+        || file::storage_paths_eq(path, &env::MISE_SYSTEM_DATA_DIR.join("shims"))
 }
 
 fn files_identical(a: &Path, b: &Path) -> Result<bool> {
@@ -1778,7 +1790,7 @@ mod tests {
             "#!/bin/sh\n# mise generated shim\nmise x -- owned \"$@\"\n",
         )
         .unwrap();
-        publish_staged_shim_farm(live.path(), &mise_bin, staging).unwrap();
+        publish_staged_shim_farm(live.path(), &mise_bin, staging, false).unwrap();
 
         assert_eq!(
             fs::read_to_string(&unmanaged).unwrap(),
@@ -1796,7 +1808,7 @@ mod tests {
             .prefix(".mise-shims-stage-")
             .tempdir_in(live.path())
             .unwrap();
-        publish_staged_shim_farm(live.path(), &mise_bin, empty_staging).unwrap();
+        publish_staged_shim_farm(live.path(), &mise_bin, empty_staging, false).unwrap();
 
         assert_eq!(
             fs::read_to_string(live.path().join("owned")).unwrap(),
@@ -1818,15 +1830,33 @@ mod tests {
             "#!/bin/sh\n# mise generated shim\nmise x -- owned \"$@\"\n",
         )
         .unwrap();
-        publish_staged_shim_farm(live.path(), &mise_bin, staging).unwrap();
+        publish_staged_shim_farm(live.path(), &mise_bin, staging, false).unwrap();
 
         let empty_staging = tempfile::Builder::new()
             .prefix(".mise-shims-stage-")
             .tempdir_in(live.path())
             .unwrap();
-        publish_staged_shim_farm(live.path(), &mise_bin, empty_staging).unwrap();
+        publish_staged_shim_farm(live.path(), &mise_bin, empty_staging, false).unwrap();
 
         assert!(!live.path().join("owned").exists());
+    }
+
+    #[test]
+    fn staged_shim_publication_prunes_unmanaged_files_in_dedicated_farm() {
+        let live = tempfile::tempdir().unwrap();
+        let mise_bin = live.path().join("mise");
+        fs::write(&mise_bin, "mise").unwrap();
+        let orphan = live.path().join("orphan");
+        fs::write(&orphan, "not a mise shim").unwrap();
+        file::make_executable(&orphan).unwrap();
+        let staging = tempfile::Builder::new()
+            .prefix(".mise-shims-stage-")
+            .tempdir_in(live.path())
+            .unwrap();
+
+        publish_staged_shim_farm(live.path(), &mise_bin, staging, true).unwrap();
+
+        assert!(!orphan.exists());
     }
 
     #[cfg(unix)]

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -578,12 +578,12 @@ fn is_mise_shim(path: &Path, mise_bin: &Path) -> Result<bool> {
             return Ok(false);
         }
         let parent = path.parent().unwrap_or_else(|| Path::new("."));
-        let is_default_farm = file::storage_paths_eq(parent, &dirs::DATA.join("shims"))
-            || file::storage_paths_eq(parent, &env::MISE_SYSTEM_DATA_DIR.join("shims"));
-        if is_default_farm {
+        if is_dedicated_shims_dir(parent) {
             // Preserve the existing upgrade behavior in mise's dedicated
             // farms. Native copies from an older mise cannot be identified by
-            // their contents after mise-shim.exe changes.
+            // their contents after mise-shim.exe changes. Use the same
+            // unredirected check as pruning so a junction to a shared bin
+            // directory never grants ownership of every regular file there.
             return Ok(true);
         }
 

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -461,6 +461,9 @@ fn publish_staged_shim_farm(
             );
             continue;
         }
+        if cfg!(windows) && (destination.exists() || destination.is_symlink()) {
+            remove_shim_with_rename_fallback(&destination)?;
+        }
         // Rename replaces a same-named file atomically. A publication error
         // therefore leaves that live shim untouched; an interrupted rebuild can
         // leave a mixture of old and new shims, but never evacuates the farm.
@@ -503,6 +506,15 @@ fn files_identical(a: &Path, b: &Path) -> Result<bool> {
 }
 
 fn is_mise_shim(path: &Path, mise_bin: &Path) -> Result<bool> {
+    if path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(env::is_mise_binary)
+    {
+        // A package manager may install mise itself as a symlink in the shared
+        // directory. It is the dispatcher, not one of its shims.
+        return Ok(false);
+    }
     if path.is_symlink() {
         let target = fs::read_link(path)?;
         let target = if target.is_absolute() {
@@ -510,10 +522,15 @@ fn is_mise_shim(path: &Path, mise_bin: &Path) -> Result<bool> {
         } else {
             path.parent().unwrap_or_else(|| Path::new(".")).join(target)
         };
-        return Ok(file::paths_eq(
-            &file::canonicalize_or_self(&target),
-            &file::canonicalize_or_self(mise_bin),
-        ));
+        let target_names_mise = target
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(env::is_mise_binary);
+        return Ok(target_names_mise
+            || file::paths_eq(
+                &file::canonicalize_or_self(&target),
+                &file::canonicalize_or_self(mise_bin),
+            ));
     }
 
     #[cfg(windows)]
@@ -1796,6 +1813,19 @@ mod tests {
         fs::remove_file(&shim).unwrap();
         std::os::unix::fs::symlink(&other_bin, &shim).unwrap();
         assert!(!is_mise_shim(&shim, &mise_bin).unwrap());
+
+        // A dangling shim left after mise moved can still be identified by its
+        // target name and repaired.
+        fs::remove_file(&shim).unwrap();
+        std::os::unix::fs::symlink(dir.path().join("old/bin/mise"), &shim).unwrap();
+        assert!(is_mise_shim(&shim, &mise_bin).unwrap());
+
+        // The real mise dispatcher may itself be installed as a symlink in a
+        // shared bin directory; its own name keeps it out of shim pruning.
+        let dispatcher = dir.path().join("mise");
+        fs::remove_file(&dispatcher).unwrap();
+        std::os::unix::fs::symlink(&other_bin, &dispatcher).unwrap();
+        assert!(!is_mise_shim(&dispatcher, &mise_bin).unwrap());
     }
 
     #[cfg(not(windows))]

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -22,6 +22,9 @@ use itertools::Itertools;
 use path_absolutize::Absolutize;
 use tokio::task::JoinSet;
 
+#[cfg(any(windows, test))]
+const NATIVE_SHIM_MARKER: &[u8] = b"mise generated native shim v1";
+
 // executes as if it was a shim if the command is not "mise", e.g.: "node"
 pub(crate) async fn handle_shim() -> Result<()> {
     // TODO: instead, check if bin is in shims dir
@@ -548,7 +551,11 @@ fn is_mise_shim(path: &Path, mise_bin: &Path) -> Result<bool> {
             return Ok(true);
         }
 
-        if is_generated_windows_file_shim(path) {
+        let contents = fs::read(path).unwrap_or_default();
+        if is_generated_shell_shim(&contents)
+            || is_generated_windows_file_shim_contents(path, &contents)
+            || has_mise_native_shim_fingerprint(&contents)
+        {
             return Ok(true);
         }
         let matches_mise = files_identical(path, mise_bin).unwrap_or(false);
@@ -562,29 +569,54 @@ fn is_mise_shim(path: &Path, mise_bin: &Path) -> Result<bool> {
         if !path.is_file() {
             return Ok(false);
         }
-        let contents = fs::read_to_string(path).unwrap_or_default();
-        Ok(contents.starts_with("#!/bin/sh\n# mise generated shim\n")
-            || (contents.starts_with("#!/bin/sh\nexport ASDF_DATA_DIR=")
-                && contents.contains("\nmise x -- ")))
+        Ok(is_generated_shell_shim(&fs::read(path).unwrap_or_default()))
     }
+}
+
+fn bytes_contain(haystack: &[u8], needle: &[u8]) -> bool {
+    !needle.is_empty()
+        && haystack
+            .windows(needle.len())
+            .any(|window| window == needle)
+}
+
+fn is_generated_shell_shim(contents: &[u8]) -> bool {
+    contents.starts_with(b"#!/bin/sh\n# mise generated shim\n")
+        || (contents.starts_with(b"#!/bin/sh\nexport ASDF_DATA_DIR=")
+            && bytes_contain(contents, b"\nmise x -- "))
+}
+
+#[cfg(any(windows, test))]
+fn has_mise_native_shim_fingerprint(contents: &[u8]) -> bool {
+    bytes_contain(contents, NATIVE_SHIM_MARKER)
+        // Transition shims made by mise versions predating the stable marker.
+        || (bytes_contain(
+            contents,
+            b"mise-shim: failed to determine executable path",
+        ) && bytes_contain(contents, b"mise-shim: failed to execute mise"))
+        || (bytes_contain(contents, b"__MISE_SHIM_PATH")
+            && bytes_contain(contents, b"recursive shim invocation detected")
+            && bytes_contain(contents, b"mise x --"))
 }
 
 #[cfg(any(windows, test))]
 fn is_generated_windows_file_shim(path: &Path) -> bool {
+    fs::read(path).is_ok_and(|contents| is_generated_windows_file_shim_contents(path, &contents))
+}
+
+#[cfg(any(windows, test))]
+fn is_generated_windows_file_shim_contents(path: &Path, contents: &[u8]) -> bool {
     let Some(name) = path.file_stem().and_then(|name| name.to_str()) else {
-        return false;
-    };
-    let Ok(contents) = fs::read_to_string(path) else {
         return false;
     };
     if path
         .extension()
         .is_some_and(|ext| ext.eq_ignore_ascii_case("cmd"))
     {
-        contents == windows_file_shim_body(name)
+        contents == windows_file_shim_body(name).as_bytes()
     } else if path.extension().is_none() {
         #[cfg(windows)]
-        return contents == bash_shim_script(name);
+        return contents == bash_shim_script(name).as_bytes();
         #[cfg(not(windows))]
         return false;
     } else {
@@ -1828,7 +1860,6 @@ mod tests {
         assert!(!is_mise_shim(&dispatcher, &mise_bin).unwrap());
     }
 
-    #[cfg(not(windows))]
     #[test]
     fn mise_shim_detection_recognizes_current_and_legacy_plugin_scripts() {
         let dir = tempfile::tempdir().unwrap();
@@ -1852,6 +1883,22 @@ mod tests {
 
         fs::write(&shim, "#!/bin/sh\necho user-script\n").unwrap();
         assert!(!is_mise_shim(&shim, &mise_bin).unwrap());
+    }
+
+    #[test]
+    fn native_shim_fingerprint_recognizes_current_and_transition_binaries() {
+        assert!(has_mise_native_shim_fingerprint(
+            b"PE\0mise generated native shim v1\0"
+        ));
+        assert!(has_mise_native_shim_fingerprint(
+            b"mise-shim: failed to determine executable path\0mise-shim: failed to execute mise"
+        ));
+        assert!(has_mise_native_shim_fingerprint(
+            b"__MISE_SHIM_PATH\0recursive shim invocation detected\0mise x --"
+        ));
+        assert!(!has_mise_native_shim_fingerprint(
+            b"an unrelated executable mentioning mise x --"
+        ));
     }
 
     #[cfg(target_os = "linux")]

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -520,8 +520,18 @@ fn is_dedicated_shims_dir(path: &Path) -> bool {
 }
 
 fn matches_unredirected_dedicated_dir(path: &Path, dedicated: &Path) -> bool {
-    file::paths_eq(path, dedicated)
-        && dunce::canonicalize(path).is_ok_and(|resolved| file::paths_eq(&resolved, path))
+    if !file::paths_eq(path, dedicated) {
+        return false;
+    }
+    let Some((parent, file_name)) = path.parent().zip(path.file_name()) else {
+        return false;
+    };
+    match (dunce::canonicalize(path), dunce::canonicalize(parent)) {
+        (Ok(resolved), Ok(resolved_parent)) => {
+            file::paths_eq(&resolved, &resolved_parent.join(file_name))
+        }
+        _ => false,
+    }
 }
 
 fn files_identical(a: &Path, b: &Path) -> Result<bool> {

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -599,7 +599,7 @@ fn has_mise_native_shim_fingerprint(contents: &[u8]) -> bool {
             && bytes_contain(contents, b"mise x --"))
 }
 
-#[cfg(any(windows, test))]
+#[cfg(test)]
 fn is_generated_windows_file_shim(path: &Path) -> bool {
     fs::read(path).is_ok_and(|contents| is_generated_windows_file_shim_contents(path, &contents))
 }

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -521,7 +521,7 @@ fn is_dedicated_shims_dir(path: &Path) -> bool {
 
 fn matches_unredirected_dedicated_dir(path: &Path, dedicated: &Path) -> bool {
     file::paths_eq(path, dedicated)
-        && fs::canonicalize(path).is_ok_and(|resolved| file::paths_eq(&resolved, path))
+        && dunce::canonicalize(path).is_ok_and(|resolved| file::paths_eq(&resolved, path))
 }
 
 fn files_identical(a: &Path, b: &Path) -> Result<bool> {

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -1,5 +1,6 @@
 use crate::request_exit;
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{
@@ -26,6 +27,11 @@ use tokio::task::JoinSet;
 #[cfg(any(windows, test))]
 const NATIVE_SHIM_MARKER: &[u8] = include_bytes!("../crates/mise-shim/native-shim-marker");
 const GENERATED_SHELL_SHIM_HEADER: &str = "#!/bin/sh\n# mise generated shim\n";
+#[cfg(any(windows, test))]
+const GENERATED_WINDOWS_CMD_SHIM_HEADER: &str = "@echo off\r\nrem mise generated shim\r\n";
+#[cfg(any(windows, test))]
+const GENERATED_WINDOWS_BASH_SHIM_HEADER: &str = "#!/bin/bash\n# mise generated shim\n";
+const SHIM_SCRIPT_INSPECTION_LIMIT: u64 = 16 * 1024;
 
 // executes as if it was a shim if the command is not "mise", e.g.: "node"
 pub(crate) async fn handle_shim() -> Result<()> {
@@ -346,13 +352,25 @@ pub(crate) async fn reshim_for(
     let full_rebuild = force || shim_mode_changed || shim_version_changed;
     file::create_dir_all(&shims_dir)?;
 
-    let (desired, shims_to_stage) = if full_rebuild {
+    let dedicated = is_dedicated_shims_dir(&shims_dir);
+    let (desired, shims_to_stage, known_owned, prune_entries) = if full_rebuild {
         let desired = get_desired_shims(config, &mise_bin, ts, scope).await?;
         let shims_to_stage = desired.iter().cloned().collect();
-        (desired, shims_to_stage)
+        if dedicated {
+            (desired, shims_to_stage, HashSet::new(), HashSet::new())
+        } else {
+            let actual = get_actual_shims(&mise_bin, &shims_dir).await?;
+            let prune_entries = actual.owned.difference(&desired).cloned().collect();
+            (desired, shims_to_stage, actual.owned, prune_entries)
+        }
     } else {
         let diffs = get_shim_diffs(config, &mise_bin, ts, &shims_dir, scope).await?;
-        (diffs.desired, diffs.missing)
+        (
+            diffs.desired,
+            diffs.missing,
+            diffs.owned,
+            diffs.extra.into_iter().collect(),
+        )
     };
     let staging = stage_shim_farm(
         &shims_dir,
@@ -368,7 +386,9 @@ pub(crate) async fn reshim_for(
         &mise_bin,
         staging,
         desired,
-        is_dedicated_shims_dir(&shims_dir),
+        known_owned,
+        prune_entries,
+        full_rebuild && dedicated,
     )?;
 
     if matches!(requested_scope, ShimScope::User | ShimScope::Both) {
@@ -445,6 +465,8 @@ fn publish_staged_shim_farm(
     mise_bin: &Path,
     staging: tempfile::TempDir,
     mut desired: HashSet<String>,
+    known_owned: HashSet<String>,
+    prune_entries: HashSet<String>,
     prune_unmanaged: bool,
 ) -> Result<()> {
     let mut entries = staging
@@ -469,8 +491,15 @@ fn publish_staged_shim_farm(
     for entry in entries {
         let source = entry.path();
         let destination = shims_dir.join(entry.file_name());
-        if (destination.exists() || destination.is_symlink())
-            && !is_mise_shim(&destination, mise_bin)?
+        let destination_exists = destination.exists() || destination.is_symlink();
+        let destination_owned = is_hidden_shim_name(&entry.file_name())
+            || known_owned.contains(&entry.file_name().to_string_lossy().into_owned())
+            || (destination_exists
+                && (is_mise_shim(&destination, mise_bin)?
+                    || symlink_target_names_mise(&destination)?));
+        if destination_exists
+            && !prune_unmanaged
+            && !destination_owned
             && !files_identical(&source, &destination).unwrap_or(false)
         {
             warn!(
@@ -479,7 +508,7 @@ fn publish_staged_shim_farm(
             );
             continue;
         }
-        if cfg!(windows) && (destination.exists() || destination.is_symlink()) {
+        if cfg!(windows) && destination_exists {
             remove_shim_with_rename_fallback(&destination)?;
         }
         // Rename replaces a same-named file atomically. A publication error
@@ -499,7 +528,7 @@ fn publish_staged_shim_farm(
     // Mise's default, dedicated farms retain their historical full cleanup.
     for shim in list_shims_in(shims_dir)?.difference(&desired) {
         let path = shims_dir.join(shim);
-        if prune_unmanaged || is_mise_shim(&path, mise_bin)? {
+        if prune_unmanaged || prune_entries.contains(shim) {
             if cfg!(windows) {
                 remove_shim_with_rename_fallback(&path)?;
             } else {
@@ -541,35 +570,65 @@ fn files_identical(a: &Path, b: &Path) -> Result<bool> {
     if !a.is_file() || !b.is_file() {
         return Ok(false);
     }
+    if fs::metadata(a)?.len() != fs::metadata(b)?.len() {
+        return Ok(false);
+    }
     Ok(fs::read(a)? == fs::read(b)?)
+}
+
+fn read_file_prefix(path: &Path) -> Result<Vec<u8>> {
+    let mut contents = Vec::new();
+    fs::File::open(path)?
+        .take(SHIM_SCRIPT_INSPECTION_LIMIT)
+        .read_to_end(&mut contents)?;
+    Ok(contents)
+}
+
+fn is_mise_dispatcher_name(name: &str) -> bool {
+    if cfg!(windows) {
+        name.eq_ignore_ascii_case("mise") || name.eq_ignore_ascii_case("mise.exe")
+    } else {
+        name == "mise"
+    }
+}
+
+fn resolved_symlink_target(path: &Path) -> Result<Option<PathBuf>> {
+    if !path.is_symlink() {
+        return Ok(None);
+    }
+    let target = fs::read_link(path)?;
+    Ok(Some(if target.is_absolute() {
+        target
+    } else {
+        path.parent().unwrap_or_else(|| Path::new(".")).join(target)
+    }))
+}
+
+fn symlink_target_names_mise(path: &Path) -> Result<bool> {
+    Ok(resolved_symlink_target(path)?.is_some_and(|target| {
+        target
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(is_mise_dispatcher_name)
+    }))
 }
 
 fn is_mise_shim(path: &Path, mise_bin: &Path) -> Result<bool> {
     if path
         .file_name()
         .and_then(|name| name.to_str())
-        .is_some_and(env::is_mise_binary)
+        .is_some_and(is_mise_dispatcher_name)
     {
         // A package manager may install mise itself as a symlink in the shared
         // directory. It is the dispatcher, not one of its shims.
         return Ok(false);
     }
     if path.is_symlink() {
-        let target = fs::read_link(path)?;
-        let target = if target.is_absolute() {
-            target
-        } else {
-            path.parent().unwrap_or_else(|| Path::new(".")).join(target)
-        };
-        let target_names_mise = target
-            .file_name()
-            .and_then(|name| name.to_str())
-            .is_some_and(env::is_mise_binary);
-        return Ok(target_names_mise
-            || file::paths_eq(
-                &file::canonicalize_or_self(&target),
-                &file::canonicalize_or_self(mise_bin),
-            ));
+        let target = resolved_symlink_target(path)?.expect("symlink target");
+        return Ok(file::paths_eq(
+            &file::canonicalize_or_self(&target),
+            &file::canonicalize_or_self(mise_bin),
+        ));
     }
 
     #[cfg(windows)]
@@ -587,17 +646,32 @@ fn is_mise_shim(path: &Path, mise_bin: &Path) -> Result<bool> {
             return Ok(true);
         }
 
-        let contents = fs::read(path).unwrap_or_default();
+        let is_script = path.extension().is_none()
+            || path
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("cmd"));
+        let contents = if is_script {
+            read_file_prefix(path).unwrap_or_default()
+        } else {
+            Vec::new()
+        };
         if is_generated_shell_shim(&contents)
             || is_generated_windows_file_shim_contents(path, &contents)
-            || has_mise_native_shim_fingerprint(&contents)
         {
             return Ok(true);
         }
         let matches_mise = files_identical(path, mise_bin).unwrap_or(false);
         let matches_launcher = find_mise_shim_bin(mise_bin)
             .is_some_and(|launcher| files_identical(path, &launcher).unwrap_or(false));
-        return Ok(matches_mise || matches_launcher);
+        if matches_mise || matches_launcher {
+            return Ok(true);
+        }
+        let contents = if is_script {
+            contents
+        } else {
+            fs::read(path).unwrap_or_default()
+        };
+        return Ok(has_mise_native_shim_fingerprint(&contents));
     }
 
     #[cfg(not(windows))]
@@ -605,7 +679,9 @@ fn is_mise_shim(path: &Path, mise_bin: &Path) -> Result<bool> {
         if !path.is_file() {
             return Ok(false);
         }
-        Ok(is_generated_shell_shim(&fs::read(path).unwrap_or_default()))
+        Ok(is_generated_shell_shim(
+            &read_file_prefix(path).unwrap_or_default(),
+        ))
     }
 }
 
@@ -666,8 +742,13 @@ fn is_generated_windows_file_shim_contents(path: &Path, contents: &[u8]) -> bool
         .extension()
         .is_some_and(|ext| ext.eq_ignore_ascii_case("cmd"))
     {
-        contents == windows_file_shim_body(name).as_bytes()
+        contents.starts_with(GENERATED_WINDOWS_CMD_SHIM_HEADER.as_bytes())
+            || contents == windows_file_shim_body(name).as_bytes()
+            || is_legacy_windows_cmd_shim(contents)
     } else if path.extension().is_none() {
+        if contents.starts_with(GENERATED_WINDOWS_BASH_SHIM_HEADER.as_bytes()) {
+            return true;
+        }
         #[cfg(windows)]
         return contents == bash_shim_script(name).as_bytes();
         #[cfg(not(windows))]
@@ -675,6 +756,15 @@ fn is_generated_windows_file_shim_contents(path: &Path, contents: &[u8]) -> bool
     } else {
         false
     }
+}
+
+#[cfg(any(windows, test))]
+fn is_legacy_windows_cmd_shim(contents: &[u8]) -> bool {
+    let normalized = String::from_utf8_lossy(contents).replace("\r\n", "\n");
+    matches!(
+        normalized.as_str(),
+        "@echo off\nsetlocal\nmise x -- %*\n" | "@echo off\nsetlocal\nmise x -- %*"
+    )
 }
 
 fn sync_command_wrapper_shims(config: &Config, mise_bin: &Path, force: bool) -> Result<()> {
@@ -898,6 +988,7 @@ fn effective_shim_mode(mise_bin: &Path) -> String {
 fn bash_shim_script(tool: &str) -> String {
     formatdoc! {r#"
         #!/bin/bash
+        # mise generated shim
 
         shim_dir=$(cd -- "$(dirname -- "$0")" && pwd -P)
         shim_path="$shim_dir/${{0##*/}}"
@@ -964,6 +1055,7 @@ pub(crate) fn windows_file_shim_body(shim: &str) -> String {
     let run = format!("mise x -- {shim} {sentinel} %*");
     [
         "@echo off",
+        "rem mise generated shim",
         // `%~f0` is captured before delayed expansion is on, so a `!` in the path survives.
         "setlocal DisableDelayedExpansion",
         "set \"shim_path=%~f0\"",
@@ -1069,6 +1161,51 @@ pub(crate) struct ShimDiffs {
     pub missing: BTreeSet<String>,
     pub extra: BTreeSet<String>,
     pub desired: HashSet<String>,
+    owned: HashSet<String>,
+}
+
+struct ActualShims {
+    current: HashSet<String>,
+    dedicated_present: HashSet<String>,
+    owned: HashSet<String>,
+    occupied: HashSet<String>,
+    repairable: HashSet<String>,
+}
+
+fn calculate_shim_diffs(
+    actual: &ActualShims,
+    desired: &HashSet<String>,
+    dedicated: bool,
+) -> (BTreeSet<String>, BTreeSet<String>) {
+    // In a shared executable directory, a same-named unmanaged entry is an
+    // intentional collision, not a missing shim that reshim can repair. Treat
+    // it as occupied so doctor and automatic post-install reshims stay quiet.
+    let (missing, extra) = if dedicated {
+        (
+            desired
+                .difference(&actual.dedicated_present)
+                .cloned()
+                .collect(),
+            actual
+                .dedicated_present
+                .difference(desired)
+                .cloned()
+                .collect(),
+        )
+    } else {
+        (
+            desired
+                .iter()
+                .filter(|name| {
+                    !actual.current.contains(*name)
+                        && (!actual.occupied.contains(*name) || actual.repairable.contains(*name))
+                })
+                .cloned()
+                .collect(),
+            actual.owned.difference(desired).cloned().collect(),
+        )
+    };
+    (missing, extra)
 }
 
 // get_shim_diffs contrasts the actual shims on disk
@@ -1086,42 +1223,59 @@ pub(crate) async fn get_shim_diffs(
         get_desired_shims(config, mise_bin, toolset, scope)
     );
     let (actual_shims, desired_shims) = (actual_shims?, desired_shims?);
-    let missing: BTreeSet<_> = desired_shims.difference(&actual_shims).cloned().collect();
-    let extra: BTreeSet<_> = actual_shims.difference(&desired_shims).cloned().collect();
+    let (missing, extra) = calculate_shim_diffs(
+        &actual_shims,
+        &desired_shims,
+        is_dedicated_shims_dir(shims_dir),
+    );
     time!("get_shim_diffs sizes: ({},{})", missing.len(), extra.len());
     Ok(ShimDiffs {
         missing,
         extra,
         desired: desired_shims,
+        owned: actual_shims.owned,
     })
 }
 
-async fn get_actual_shims(mise_bin: impl AsRef<Path>, shims_dir: &Path) -> Result<HashSet<String>> {
+async fn get_actual_shims(mise_bin: impl AsRef<Path>, shims_dir: &Path) -> Result<ActualShims> {
     let mise_bin = mise_bin.as_ref();
-
-    Ok(list_shims_in(shims_dir)?
-        .into_iter()
-        .filter(|bin| is_current_mise_shim(&shims_dir.join(bin), mise_bin).unwrap_or(false))
-        .collect::<HashSet<_>>())
+    let occupied = list_shims_in(shims_dir)?;
+    let mut current = HashSet::new();
+    let mut dedicated_present = HashSet::new();
+    let mut owned = HashSet::new();
+    let mut repairable = HashSet::new();
+    for bin in &occupied {
+        let path = shims_dir.join(bin);
+        if is_mise_shim(&path, mise_bin).unwrap_or(false) {
+            owned.insert(bin.clone());
+            if is_current_owned_mise_shim(&path, mise_bin).unwrap_or(false) {
+                current.insert(bin.clone());
+            }
+        } else if symlink_target_names_mise(&path).unwrap_or(false) {
+            repairable.insert(bin.clone());
+        }
+        if !path.is_symlink() || current.contains(bin) {
+            dedicated_present.insert(bin.clone());
+        }
+    }
+    Ok(ActualShims {
+        current,
+        dedicated_present,
+        owned,
+        occupied,
+        repairable,
+    })
 }
 
-fn is_current_mise_shim(path: &Path, mise_bin: &Path) -> Result<bool> {
-    if !is_mise_shim(path, mise_bin)? {
-        return Ok(false);
-    }
+fn is_current_owned_mise_shim(path: &Path, mise_bin: &Path) -> Result<bool> {
     if !path.is_symlink() {
         return Ok(true);
     }
-    let target = fs::read_link(path)?;
-    let target = if target.is_absolute() {
-        target
-    } else {
-        path.parent().unwrap_or_else(|| Path::new(".")).join(target)
-    };
-    Ok(file::paths_eq(
-        &file::canonicalize_or_self(&target),
-        &file::canonicalize_or_self(mise_bin),
-    ))
+    let target = resolved_symlink_target(path)?.expect("symlink target");
+    // Raw path equality is deliberate. A shim that points through to the same
+    // binary but bypasses the stable package-manager launcher must be migrated
+    // before the versioned path disappears during an upgrade.
+    Ok(file::paths_eq(&target, mise_bin))
 }
 
 fn list_executables_in_dir(dir: &Path) -> Result<HashSet<String>> {
@@ -1773,14 +1927,32 @@ mod tests {
     }
 
     #[test]
-    fn windows_file_shim_detection_requires_the_exact_generated_body() {
+    fn windows_file_shim_detection_uses_stable_markers_and_legacy_body() {
         let dir = tempfile::tempdir().unwrap();
         let shim = dir.path().join("gh.cmd");
         fs::write(&shim, windows_file_shim_body("gh")).unwrap();
         assert!(is_generated_windows_file_shim(&shim));
 
+        fs::write(
+            &shim,
+            format!("{GENERATED_WINDOWS_CMD_SHIM_HEADER}echo future body\r\n"),
+        )
+        .unwrap();
+        assert!(is_generated_windows_file_shim(&shim));
+
+        fs::write(&shim, "@echo off\r\nsetlocal\r\nmise x -- %*\r\n").unwrap();
+        assert!(is_generated_windows_file_shim(&shim));
+
         fs::write(&shim, "@echo off\r\necho user script\r\n").unwrap();
         assert!(!is_generated_windows_file_shim(&shim));
+
+        let bash_shim = dir.path().join("gh");
+        fs::write(
+            &bash_shim,
+            format!("{GENERATED_WINDOWS_BASH_SHIM_HEADER}echo future body\n"),
+        )
+        .unwrap();
+        assert!(is_generated_windows_file_shim(&bash_shim));
     }
 
     #[cfg(windows)]
@@ -1846,7 +2018,16 @@ mod tests {
             "#!/bin/sh\n# mise generated shim\nmise x -- owned \"$@\"\n",
         )
         .unwrap();
-        publish_staged_shim_farm(live.path(), &mise_bin, staging, HashSet::new(), false).unwrap();
+        publish_staged_shim_farm(
+            live.path(),
+            &mise_bin,
+            staging,
+            HashSet::new(),
+            HashSet::new(),
+            HashSet::new(),
+            false,
+        )
+        .unwrap();
 
         assert_eq!(
             fs::read_to_string(&unmanaged).unwrap(),
@@ -1864,8 +2045,16 @@ mod tests {
             .prefix(".mise-shims-stage-")
             .tempdir_in(live.path())
             .unwrap();
-        publish_staged_shim_farm(live.path(), &mise_bin, empty_staging, HashSet::new(), false)
-            .unwrap();
+        publish_staged_shim_farm(
+            live.path(),
+            &mise_bin,
+            empty_staging,
+            HashSet::new(),
+            HashSet::new(),
+            HashSet::new(),
+            false,
+        )
+        .unwrap();
 
         assert_eq!(
             fs::read_to_string(live.path().join("owned")).unwrap(),
@@ -1887,14 +2076,31 @@ mod tests {
             "#!/bin/sh\n# mise generated shim\nmise x -- owned \"$@\"\n",
         )
         .unwrap();
-        publish_staged_shim_farm(live.path(), &mise_bin, staging, HashSet::new(), false).unwrap();
+        publish_staged_shim_farm(
+            live.path(),
+            &mise_bin,
+            staging,
+            HashSet::new(),
+            HashSet::new(),
+            HashSet::new(),
+            false,
+        )
+        .unwrap();
 
         let empty_staging = tempfile::Builder::new()
             .prefix(".mise-shims-stage-")
             .tempdir_in(live.path())
             .unwrap();
-        publish_staged_shim_farm(live.path(), &mise_bin, empty_staging, HashSet::new(), false)
-            .unwrap();
+        publish_staged_shim_farm(
+            live.path(),
+            &mise_bin,
+            empty_staging,
+            HashSet::new(),
+            HashSet::from(["owned".to_string()]),
+            HashSet::from(["owned".to_string()]),
+            false,
+        )
+        .unwrap();
 
         assert!(!live.path().join("owned").exists());
     }
@@ -1911,10 +2117,107 @@ mod tests {
             .prefix(".mise-shims-stage-")
             .tempdir_in(live.path())
             .unwrap();
+        let collision = live.path().join("collision");
+        fs::write(&collision, "unmanaged old file").unwrap();
+        fs::write(staging.path().join("collision"), "replacement shim").unwrap();
 
-        publish_staged_shim_farm(live.path(), &mise_bin, staging, HashSet::new(), true).unwrap();
+        publish_staged_shim_farm(
+            live.path(),
+            &mise_bin,
+            staging,
+            HashSet::new(),
+            HashSet::new(),
+            HashSet::new(),
+            true,
+        )
+        .unwrap();
 
         assert!(!orphan.exists());
+        assert_eq!(fs::read_to_string(collision).unwrap(), "replacement shim");
+    }
+
+    #[test]
+    fn staged_shim_publication_updates_metadata_in_shared_directory() {
+        let live = tempfile::tempdir().unwrap();
+        let mise_bin = live.path().join("mise");
+        fs::write(&mise_bin, "mise").unwrap();
+        fs::write(live.path().join(".version"), "old").unwrap();
+        let staging = tempfile::Builder::new()
+            .prefix(".mise-shims-stage-")
+            .tempdir_in(live.path())
+            .unwrap();
+        fs::write(staging.path().join(".version"), "new").unwrap();
+
+        publish_staged_shim_farm(
+            live.path(),
+            &mise_bin,
+            staging,
+            HashSet::new(),
+            HashSet::new(),
+            HashSet::new(),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(live.path().join(".version")).unwrap(),
+            "new"
+        );
+    }
+
+    #[test]
+    fn shared_collision_is_not_missing_or_extra() {
+        let actual = ActualShims {
+            current: HashSet::new(),
+            dedicated_present: HashSet::new(),
+            owned: HashSet::new(),
+            occupied: HashSet::from(["black".to_string()]),
+            repairable: HashSet::new(),
+        };
+        let desired = HashSet::from(["black".to_string()]);
+
+        let (missing, extra) = calculate_shim_diffs(&actual, &desired, false);
+
+        assert!(missing.is_empty());
+        assert!(extra.is_empty());
+    }
+
+    #[test]
+    fn dedicated_diff_reports_the_same_entries_incremental_pruning_removes() {
+        let actual = ActualShims {
+            current: HashSet::from(["node".to_string()]),
+            dedicated_present: HashSet::from(["node".to_string(), "orphan".to_string()]),
+            owned: HashSet::from(["node".to_string()]),
+            occupied: HashSet::from([
+                "node".to_string(),
+                "orphan".to_string(),
+                "foreign-symlink".to_string(),
+            ]),
+            repairable: HashSet::new(),
+        };
+        let desired = HashSet::from(["node".to_string()]);
+
+        let (missing, extra) = calculate_shim_diffs(&actual, &desired, true);
+
+        assert!(missing.is_empty());
+        assert_eq!(extra, BTreeSet::from(["orphan".to_string()]));
+    }
+
+    #[test]
+    fn dangling_desired_mise_symlink_remains_missing_in_shared_directory() {
+        let actual = ActualShims {
+            current: HashSet::new(),
+            dedicated_present: HashSet::new(),
+            owned: HashSet::new(),
+            occupied: HashSet::from(["node".to_string()]),
+            repairable: HashSet::from(["node".to_string()]),
+        };
+        let desired = HashSet::from(["node".to_string()]);
+
+        let (missing, extra) = calculate_shim_diffs(&actual, &desired, false);
+
+        assert_eq!(missing, BTreeSet::from(["node".to_string()]));
+        assert!(extra.is_empty());
     }
 
     #[cfg(unix)]
@@ -1952,6 +2255,8 @@ mod tests {
             &mise_bin,
             staging,
             HashSet::from(["existing".to_string()]),
+            HashSet::from(["existing".to_string()]),
+            HashSet::new(),
             false,
         )
         .unwrap();
@@ -1976,12 +2281,19 @@ mod tests {
         std::os::unix::fs::symlink(&other_bin, &shim).unwrap();
         assert!(!is_mise_shim(&shim, &mise_bin).unwrap());
 
-        // A dangling shim left after mise moved can still be identified by its
-        // target name and repaired.
+        // A dangling target name alone is not proof of ownership: an unrelated
+        // symlink in a shared directory may also point at a file named `mise`.
+        // Publication uses this weaker signal only for a desired collision.
         fs::remove_file(&shim).unwrap();
         std::os::unix::fs::symlink(dir.path().join("old/bin/mise"), &shim).unwrap();
-        assert!(is_mise_shim(&shim, &mise_bin).unwrap());
-        assert!(!is_current_mise_shim(&shim, &mise_bin).unwrap());
+        assert!(!is_mise_shim(&shim, &mise_bin).unwrap());
+        assert!(symlink_target_names_mise(&shim).unwrap());
+        assert!(!is_current_owned_mise_shim(&shim, &mise_bin).unwrap());
+
+        fs::remove_file(&shim).unwrap();
+        std::os::unix::fs::symlink(dir.path().join("scripts/mise-wrapper.sh"), &shim).unwrap();
+        assert!(!is_mise_shim(&shim, &mise_bin).unwrap());
+        assert!(!symlink_target_names_mise(&shim).unwrap());
 
         // The real mise dispatcher may itself be installed as a symlink in a
         // shared bin directory; its own name keeps it out of shim pruning.
@@ -1989,6 +2301,24 @@ mod tests {
         fs::remove_file(&dispatcher).unwrap();
         std::os::unix::fs::symlink(&other_bin, &dispatcher).unwrap();
         assert!(!is_mise_shim(&dispatcher, &mise_bin).unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn current_shim_check_migrates_to_stable_launcher_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let versioned = dir.path().join("Cellar/mise/1/bin/mise");
+        fs::create_dir_all(versioned.parent().unwrap()).unwrap();
+        fs::write(&versioned, "mise").unwrap();
+        let launcher = dir.path().join("bin/mise");
+        fs::create_dir_all(launcher.parent().unwrap()).unwrap();
+        std::os::unix::fs::symlink(&versioned, &launcher).unwrap();
+        let shim = dir.path().join("shims/node");
+        fs::create_dir_all(shim.parent().unwrap()).unwrap();
+        std::os::unix::fs::symlink(&versioned, &shim).unwrap();
+
+        assert!(is_mise_shim(&shim, &launcher).unwrap());
+        assert!(!is_current_owned_mise_shim(&shim, &launcher).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- identify mise shims directly instead of treating every executable in `shims_dir` as managed
- preserve unmanaged files and symlinks when publishing or pruning a shared shim directory
- mark generated plugin scripts while recognizing the legacy script format
- document `~/.local/bin` and `/usr/local/bin` as supported shim directories

## Tests
- `cargo test --bin mise mise_shim_detection`
- `cargo test --bin mise staged_shim_publication`
- `mise run lint`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reshim and shim pruning logic changes how files in `shims_dir` are classified and deleted, which can affect users who pointed `MISE_SHIMS_DIR` at a shared PATH directory or relied on old `--force` wiping the whole farm.
> 
> **Overview**
> **`mise reshim`** can target shared bins like `~/.local/bin` without wiping unrelated executables. It now **identifies mise-owned shims** (generated script headers, native shim marker, symlink targets, legacy plugin layout) and only **replaces or prunes** those entries; unmanaged same-name files are left in place, with warnings when a collision would overwrite different content.
> 
> **Dedicated** default shim farms keep **full cleanup** on force rebuild; **shared** directories use conservative pruning and treat intentional name collisions as occupied so `mise doctor` and post-install reshims do not report false “missing shims.” **`--force`** is documented as rebuilding mise-owned shims rather than deleting everything in the directory first.
> 
> Generated shims add stable **“mise generated shim”** markers; **`mise-shim`** embeds a **native shim marker** byte sequence for Windows exe-shim fingerprinting. Docs and settings clarify that activation/hook-env still expect a **dedicated** `shims_dir`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58ba6493845f8a694d83ab7ff2f1e11298666c57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `mise reshim` supports shared executable directories.
  - Native shims now include an ownership marker.

- **Bug Fixes**
  - Preserves unmanaged or externally modified executables.
  - Removes or replaces only recognized mise-owned shims.
  - `--force` now rebuilds mise-owned shims instead of removing all entries.
  - Improved handling of shims in symlinked directories.

- **Documentation**
  - Updated CLI help, man pages, and configuration guidance to describe safer shim handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->