### PR TITLE
fix(upgrade): prevent recursive deferred pruning

### DIFF
--- a/e2e/cli/test_upgrade_no_prune
+++ b/e2e/cli/test_upgrade_no_prune
@@ -120,4 +120,48 @@ assert_fail "test -L '$MISE_DATA_DIR/installs/dummy/retired'"
 assert_fail "test -e '$MISE_DATA_DIR/shims/deferred-prune-orphan'"
 assert_fail "test -f '$MISE_STATE_DIR/tool-purgatory.json'"
 
+# Recreate a due receipt and verify that prompt-critical shell integration
+# leaves it for an ordinary command. Loading every tracked project from a
+# prompt hook can otherwise freeze every newly opened terminal.
+cat <<'EOF' >mise.toml
+[tools]
+dummy = "1"
+
+[settings]
+upgrade.prune_after = "0s"
+EOF
+mise uninstall dummy --all
+mise install dummy@1.0.0
+mise upgrade dummy
+mise hook-env >/dev/null
+assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
+assert "test -f '$MISE_STATE_DIR/tool-purgatory.json'"
+
+# Tracked config resolution may execute a template that invokes mise. The
+# nested process must skip the cleanup already in progress instead of starting
+# the same tracked-config scan recursively.
+cat <<'EOF' >nested-mise-version
+#!/usr/bin/env bash
+echo invocation >>"$MISE_STATE_DIR/deferred-prune-invocations"
+mise completion bash >/dev/null
+echo 1.1.0
+EOF
+cat <<'EOF' >mise.toml
+[tools]
+dummy = "{{ exec(command='bash nested-mise-version') }}"
+
+[settings]
+upgrade.prune_after = "0s"
+EOF
+
+# --no-config must not make automatic cleanup load this tracked config.
+mise --no-config config ls >/dev/null
+assert_fail "test -f '$MISE_STATE_DIR/deferred-prune-invocations'"
+assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
+
+timeout 15 mise config ls >/dev/null
+assert "awk 'END { print NR < 10 }' '$MISE_STATE_DIR/deferred-prune-invocations'" "1"
+assert_fail "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
+assert_fail "test -f '$MISE_STATE_DIR/tool-purgatory.json'"
+
 rm -f mise.toml

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -330,6 +330,16 @@ impl Commands {
         )
     }
 
+    /// Shell integration runs on startup and every prompt, so it must not do
+    /// an all-project tracked-config scan or mutate installed tools. Deferred
+    /// cleanup will run on the next ordinary command instead.
+    fn allows_tool_purgatory_auto_prune(&self) -> bool {
+        !matches!(
+            self,
+            Self::Activate(_) | Self::Deactivate(_) | Self::HookEnv(_) | Self::HookNotFound(_)
+        )
+    }
+
     fn implicitly_trusts_active_config(&self) -> bool {
         matches!(
             self,
@@ -900,6 +910,11 @@ impl Cli {
             );
         if !print_version
             && !dry_run_requested
+            && !Settings::no_config()
+            && cli
+                .command
+                .as_ref()
+                .is_none_or(Commands::allows_tool_purgatory_auto_prune)
             && let Err(err) = crate::tool_purgatory::auto_prune().await
         {
             warn!("tool purgatory cleanup failed: {err:#}");

--- a/src/lock_file.rs
+++ b/src/lock_file.rs
@@ -44,7 +44,6 @@ impl LockFile {
         Ok(lock)
     }
 
-    #[cfg(feature = "self_update")]
     pub(crate) fn try_lock(self) -> Result<Option<fslock::LockFile>> {
         if let Some(parent) = self.path.parent() {
             create_dir_all(parent)?;

--- a/src/tool_purgatory.rs
+++ b/src/tool_purgatory.rs
@@ -124,6 +124,17 @@ pub(crate) async fn auto_prune() -> Result<()> {
     if !state_path().exists() {
         return Ok(());
     }
+    // Config resolution below may execute trusted templates. If one of those
+    // templates invokes mise, the child reaches auto-prune before the parent
+    // has removed the due receipt. Serialize the whole cleanup separately
+    // from the short state-file lock so nested and concurrent invocations can
+    // skip it without blocking commands that legitimately update the state.
+    let cleanup_lock_path = state_path().with_extension("auto-prune");
+    let Some(_cleanup_lock) = crate::lock_file::LockFile::new(&cleanup_lock_path).try_lock()?
+    else {
+        debug!("skipping deferred pruning because another invocation is handling it");
+        return Ok(());
+    };
     let now = now_epoch_seconds()?;
     let due = {
         let _lock = crate::lock_file::get(state_path(), false)?;


### PR DESCRIPTION
## Summary
- serialize opportunistic deferred pruning with a dedicated non-blocking process lock
- skip deferred pruning for shell integration and `--no-config` commands
- cover nested mise invocation, prompt-hook deferral, and no-config behavior in the upgrade E2E test

This addresses the recursive tracked-config scan reported in https://github.com/jdx/mise/discussions/12673.

## Tests
- `mise run test:e2e e2e/cli/test_upgrade_no_prune`
- `mise run test:unit tool_purgatory`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-command startup for most CLI invocations (locking, config load, and install mutation), including shell-adjacent paths where regressions would affect every new terminal.
> 
> **Overview**
> Fixes **recursive deferred tool pruning** that could hang new terminals when prompt hooks ran full tracked-config scans during cleanup.
> 
> **Deferred cleanup** now takes a dedicated **non-blocking process lock** (`tool-purgatory.auto-prune`). A nested or concurrent `mise` invocation skips opportunistic pruning instead of re-entering the same scan while config templates call back into `mise`. `LockFile::try_lock` is always built (not only with `self_update`).
> 
> **When auto-prune runs** is tightened: it is skipped for **`--no-config`** and for shell-integration commands (`activate`, `deactivate`, `hook-env`, `hook-not-found`), so prompt hooks leave due receipts for the next normal command.
> 
> E2E coverage adds **`hook-env` deferral**, **nested mise via exec template**, and **`--no-config` not loading tracked config** for automatic cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10435b5764647d412f6d5ab7bba4e956d74c3d32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automatic cleanup from running during shell integration and activation-related commands.
  * Ensured configuration-free commands do not load tracked configuration or trigger nested cleanup unexpectedly.
  * Improved handling of concurrent and nested cleanup operations to avoid conflicts and unnecessary blocking.
  * Preserved deferred installations until a safe cleanup opportunity is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->