### PR TITLE
registry: add mkd

### DIFF
--- a/registry/mkd.toml
+++ b/registry/mkd.toml
@@ -1,0 +1,13 @@
+# mkd — cross-platform directory bookmark manager with a Rust TUI
+description = "A directory bookmark tool: TUI-managed, shell-integrated jumps"
+test = { cmd = "mkd --version", expected = "mkd {{version}}" }
+version_order = "semver"
+
+bins = ["mkd"]
+
+[[backends]]
+full = "github:821869798/markd"
+
+[backends.options]
+archive_name = 'mkd-{{ arch(x64="x86_64", arm64="aarch64") }}-{{ os(macos="apple-darwin", linux="unknown-linux-gnu", windows="pc-windows-msvc") }}.tar.gz'
+bin_path = 'mkd-{{ arch(x64="x86_64", arm64="aarch64") }}-{{ os(macos="apple-darwin", linux="unknown-linux-gnu", windows="pc-windows-msvc") }}/mkd'

--- a/registry/mkd.toml
+++ b/registry/mkd.toml
@@ -7,7 +7,11 @@ bins = ["mkd"]
 
 [[backends]]
 full = "github:821869798/markd"
+platforms = ["windows-x64", "windows-arm64", "macos-arm64", "linux-x64", "linux-arm64"]
 
-[backends.options]
-archive_name = 'mkd-{{ arch(x64="x86_64", arm64="aarch64") }}-{{ os(macos="apple-darwin", linux="unknown-linux-gnu", windows="pc-windows-msvc") }}.tar.gz'
-bin_path = 'mkd-{{ arch(x64="x86_64", arm64="aarch64") }}-{{ os(macos="apple-darwin", linux="unknown-linux-gnu", windows="pc-windows-msvc") }}/mkd'
+[backends.options.platforms]
+windows-x64 = { archive_name = "mkd-x86_64-pc-windows-msvc.zip", bin_path = "mkd-x86_64-pc-windows-msvc/mkd.exe" }
+windows-arm64 = { archive_name = "mkd-aarch64-pc-windows-msvc.zip", bin_path = "mkd-aarch64-pc-windows-msvc/mkd.exe" }
+macos-arm64 = { archive_name = "mkd-aarch64-apple-darwin.tar.gz", bin_path = "mkd-aarch64-apple-darwin/mkd" }
+linux-x64 = { archive_name = "mkd-x86_64-unknown-linux-gnu.tar.gz", bin_path = "mkd-x86_64-unknown-linux-gnu/mkd" }
+linux-arm64 = { archive_name = "mkd-aarch64-unknown-linux-gnu.tar.gz", bin_path = "mkd-aarch64-unknown-linux-gnu/mkd" }


### PR DESCRIPTION
Adds [mkd](https://github.com/821869798/markd) — a cross-platform directory bookmark manager written in Rust with a TUI and shell integration (works with Bash/Zsh/Fish/PowerShell).

**Popularity:** 0 stars on GitHub (repo created today; homebrew tap, scoop bucket, and asdf plugin already published: https://github.com/821869798/homebrew-mkd, https://github.com/821869798/scoop-bucket, https://github.com/821869798/asdf-mkd)

- Uses the `github` backend (Tier 1) against our own GitHub Releases — no new asdf plugin (per the registry policy)
- Publishes binaries for: Windows x64/ARM64 (.zip), macOS ARM64, Linux x64/ARM64 (.tar.gz)
- Platform-specific `archive_name`/`bin_path` per review feedback, matching the five shipped targets exactly
- v0.1.0 is out: https://github.com/821869798/markd/releases/tag/v0.1.0

```console
$ mise use mkd@0.1.0
$ mkd --version
mkd 0.1.0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing and tracking the `mkd` directory bookmark manager.
  * Included version detection and update support across macOS, Linux, and Windows.
  * Added architecture-specific downloads for Windows x64/ARM64, Linux x64/ARM64, and macOS ARM64.
* **Updates**
  * Downloads now use the appropriate archive and executable format for each supported platform.
  * macOS x64 downloads are no longer provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->