### PR TITLE
feat(bootstrap): support additional systemd directives

### DIFF
--- a/docs/bootstrap/systemd.md
+++ b/docs/bootstrap/systemd.md
@@ -11,7 +11,11 @@ description = "sync files"
 exec_start = "~/.local/bin/my-sync --watch"
 after = ["network-online.target"]
 wants = ["network-online.target"]
+requires = ["credentials.service"]
 environment = { PATH = "/usr/local/bin:/usr/bin:/bin" }
+environment_file = ["-%h/.config/my-sync.env"]
+nice = 10
+umask = "0007"
 working_directory = "~"
 restart = "on-failure"
 restart_sec = "5s"
@@ -69,6 +73,7 @@ managed with `systemctl --user`. Unit names may contain letters, numbers, `.`,
 | `description`          | `Description`                  |
 | `after`                | `After`                        |
 | `wants`                | `Wants`                        |
+| `requires`             | `Requires`                     |
 | `exec_start`           | `ExecStart`                    |
 | `type`                 | `Type`                         |
 | `remain_after_exit`    | `RemainAfterExit`              |
@@ -78,6 +83,9 @@ managed with `systemctl --user`. Unit names may contain letters, numbers, `.`,
 | `no_new_privileges`    | `NoNewPrivileges`              |
 | `private_tmp`          | `PrivateTmp`                   |
 | `environment`          | `Environment`                  |
+| `environment_file`     | `EnvironmentFile`              |
+| `nice`                 | `Nice`                         |
+| `umask`                | `UMask`                        |
 | `working_directory`    | `WorkingDirectory`             |
 | `restart`              | `Restart`                      |
 | `restart_sec`          | `RestartSec`                   |
@@ -93,6 +101,12 @@ managed with `systemctl --user`. Unit names may contain letters, numbers, `.`,
 | `unit`                 | `Unit`                         |
 | `wanted_by`            | `WantedBy`                     |
 | `start`                | run `systemctl --user restart` |
+
+`requires` does not imply ordering; add the same unit to `after` when it must
+start first. `environment_file` accepts a list of absolute paths or paths using
+systemd specifiers such as `%h`; prefix a path with `-` to make it optional.
+systemd does not expand `~` or `$HOME` in these paths. Environment variables are
+not appropriate for secrets; use systemd credentials for sensitive values.
 
 `exec_start` and `working_directory` expand bare `~` and `~/` to the current
 user's home directory before writing the service file. `wanted_by` defaults to

--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -100,6 +100,10 @@ timeout_start_sec = "2min"
 timeout_stop_sec = "30s"
 no_new_privileges = true
 private_tmp = true
+requires = ["network-online.target"]
+environment_file = ["-%h/.config/sync.env"]
+nice = 10
+umask = "0007"
 
 [bootstrap.linux.systemd.units.sync-timer]
 on_boot_sec = "2min"
@@ -416,6 +420,8 @@ for unit in \
   '{ description = "service missing exec_start" }' \
   '{ persistent = true }' \
   '{ exec_start = "/bin/true", on_boot_sec = "1min" }' \
+  '{ exec_start = "/bin/true", nice = 20 }' \
+  '{ exec_start = "/bin/true", umask = "0888" }' \
   '{ exec_start = "/bin/true", type = "daemon" }'; do
   cat >"$HOME/workdir/mise-bad-systemd.toml" <<TOML
 [bootstrap.linux.systemd.units]

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -4589,6 +4589,13 @@
                           "type": "string"
                         }
                       },
+                      "requires": {
+                        "type": "array",
+                        "description": "write Requires dependencies in the [Unit] section",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
                       "exec_start": {
                         "type": "string",
                         "minLength": 1,
@@ -4639,6 +4646,24 @@
                         "additionalProperties": {
                           "type": "string"
                         }
+                      },
+                      "environment_file": {
+                        "type": "array",
+                        "description": "write one EnvironmentFile entry per path in the [Service] section",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "nice": {
+                        "type": "integer",
+                        "minimum": -20,
+                        "maximum": 19,
+                        "description": "write Nice in the [Service] section"
+                      },
+                      "umask": {
+                        "type": "string",
+                        "pattern": "^(?:[0-7]{1,3}|0[0-7]{3})$",
+                        "description": "write UMask in the [Service] section"
                       },
                       "working_directory": {
                         "type": "string",
@@ -4787,6 +4812,21 @@
                                   "minProperties": 1
                                 }
                               }
+                            },
+                            {
+                              "required": ["environment_file"],
+                              "properties": {
+                                "environment_file": {
+                                  "type": "array",
+                                  "minItems": 1
+                                }
+                              }
+                            },
+                            {
+                              "required": ["nice"]
+                            },
+                            {
+                              "required": ["umask"]
                             },
                             {
                               "required": ["working_directory"]

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -5625,6 +5625,7 @@ run = 'echo "template"'
         description = "sync files"
         after = ["network-online.target"]
         wants = ["network-online.target"]
+        requires = ["credentials.service"]
         exec_start = "~/.local/bin/my-sync --watch"
         type = "oneshot"
         remain_after_exit = true
@@ -5634,6 +5635,9 @@ run = 'echo "template"'
         no_new_privileges = true
         private_tmp = true
         environment = { PATH = "/usr/bin:/bin" }
+        environment_file = ["-%h/.config/my-sync.env"]
+        nice = 10
+        umask = "0007"
         working_directory = "~"
         restart = "on-failure"
         restart_sec = "5s"
@@ -5658,6 +5662,7 @@ run = 'echo "template"'
         assert_eq!(unit.description.as_deref(), Some("sync files"));
         assert_eq!(unit.after, vec!["network-online.target"]);
         assert_eq!(unit.wants, vec!["network-online.target"]);
+        assert_eq!(unit.requires, vec!["credentials.service"]);
         assert_eq!(
             unit.exec_start.as_deref(),
             Some("~/.local/bin/my-sync --watch")
@@ -5676,6 +5681,9 @@ run = 'echo "template"'
             unit.environment.get("PATH").map(String::as_str),
             Some("/usr/bin:/bin")
         );
+        assert_eq!(unit.environment_file, vec!["-%h/.config/my-sync.env"]);
+        assert_eq!(unit.nice, Some(10));
+        assert_eq!(unit.umask.as_deref(), Some("0007"));
         assert_eq!(unit.working_directory.as_deref(), Some("~"));
         assert_eq!(unit.restart.as_deref(), Some("on-failure"));
         assert_eq!(unit.restart_sec.as_deref(), Some("5s"));

--- a/src/system/systemd.rs
+++ b/src/system/systemd.rs
@@ -22,6 +22,8 @@ pub(crate) struct SystemdTomlConfig {
     #[serde(default)]
     pub wants: Vec<String>,
     #[serde(default)]
+    pub requires: Vec<String>,
+    #[serde(default)]
     pub exec_start: Option<String>,
     #[serde(default, rename = "type")]
     pub service_type: Option<String>,
@@ -39,6 +41,12 @@ pub(crate) struct SystemdTomlConfig {
     pub private_tmp: Option<bool>,
     #[serde(default)]
     pub environment: IndexMap<String, String>,
+    #[serde(default)]
+    pub environment_file: Vec<String>,
+    #[serde(default)]
+    pub nice: Option<i8>,
+    #[serde(default)]
+    pub umask: Option<String>,
     #[serde(default)]
     pub working_directory: Option<String>,
     #[serde(default)]
@@ -85,6 +93,7 @@ pub(crate) struct SystemdRequest {
     pub description: Option<String>,
     pub after: Vec<String>,
     pub wants: Vec<String>,
+    pub requires: Vec<String>,
     pub exec_start: Option<String>,
     pub service_type: Option<String>,
     pub remain_after_exit: Option<bool>,
@@ -94,6 +103,9 @@ pub(crate) struct SystemdRequest {
     pub no_new_privileges: Option<bool>,
     pub private_tmp: Option<bool>,
     pub environment: IndexMap<String, String>,
+    pub environment_file: Vec<String>,
+    pub nice: Option<i8>,
+    pub umask: Option<String>,
     pub working_directory: Option<String>,
     pub restart: Option<String>,
     pub restart_sec: Option<String>,
@@ -171,6 +183,9 @@ impl SystemdRequest {
                 (config.no_new_privileges.is_some(), "no_new_privileges"),
                 (config.private_tmp.is_some(), "private_tmp"),
                 (!config.environment.is_empty(), "environment"),
+                (!config.environment_file.is_empty(), "environment_file"),
+                (config.nice.is_some(), "nice"),
+                (config.umask.is_some(), "umask"),
                 (config.working_directory.is_some(), "working_directory"),
                 (config.restart.is_some(), "restart"),
                 (config.restart_sec.is_some(), "restart_sec"),
@@ -197,6 +212,18 @@ impl SystemdRequest {
                 );
             }
         }
+        if let Some(nice) = config.nice
+            && !(-20..=19).contains(&nice)
+        {
+            bail!("service unit '{name}' has invalid `nice` value {nice}; expected -20 through 19");
+        }
+        if let Some(umask) = &config.umask
+            && !valid_umask(umask)
+        {
+            bail!(
+                "service unit '{name}' has invalid `umask` value '{umask}'; expected an octal access mask from 0000 through 0777"
+            );
+        }
         let wanted_by = config.wanted_by.unwrap_or_else(|| match kind {
             SystemdUnitKind::Service => vec!["default.target".to_string()],
             SystemdUnitKind::Timer => vec!["timers.target".to_string()],
@@ -214,6 +241,7 @@ impl SystemdRequest {
             description: config.description,
             after: config.after,
             wants: config.wants,
+            requires: config.requires,
             exec_start,
             service_type: config.service_type,
             remain_after_exit: config.remain_after_exit,
@@ -223,6 +251,9 @@ impl SystemdRequest {
             no_new_privileges: config.no_new_privileges,
             private_tmp: config.private_tmp,
             environment: config.environment,
+            environment_file: config.environment_file,
+            nice: config.nice,
+            umask: config.umask,
             working_directory: config.working_directory,
             restart: config.restart,
             restart_sec: config.restart_sec,
@@ -460,6 +491,9 @@ pub(crate) fn render_unit(request: &SystemdRequest) -> String {
     if !request.wants.is_empty() {
         out.push_str(&format!("Wants={}\n", request.wants.join(" ")));
     }
+    if !request.requires.is_empty() {
+        out.push_str(&format!("Requires={}\n", request.requires.join(" ")));
+    }
     match request.kind {
         SystemdUnitKind::Service => render_service(request, &mut out),
         SystemdUnitKind::Timer => render_timer(request, &mut out),
@@ -506,6 +540,15 @@ fn render_service(request: &SystemdRequest, out: &mut String) {
             quote_environment(&format!("{key}={value}"))
         ));
     }
+    for environment_file in &request.environment_file {
+        out.push_str(&format!("EnvironmentFile={environment_file}\n"));
+    }
+    if let Some(nice) = request.nice {
+        out.push_str(&format!("Nice={nice}\n"));
+    }
+    if let Some(umask) = &request.umask {
+        out.push_str(&format!("UMask={umask}\n"));
+    }
     if let Some(restart) = &request.restart {
         out.push_str(&format!("Restart={restart}\n"));
     }
@@ -518,6 +561,13 @@ fn render_service(request: &SystemdRequest, out: &mut String) {
     if let Some(standard_error) = &request.standard_error {
         out.push_str(&format!("StandardError={standard_error}\n"));
     }
+}
+
+fn valid_umask(umask: &str) -> bool {
+    let valid_width = (1..=3).contains(&umask.len()) || umask.len() == 4 && umask.starts_with('0');
+    valid_width
+        && umask.chars().all(|c| matches!(c, '0'..='7'))
+        && u16::from_str_radix(umask, 8).is_ok_and(|value| value <= 0o777)
 }
 
 fn render_timer(request: &SystemdRequest, out: &mut String) {
@@ -811,12 +861,36 @@ mod tests {
                 on_boot_sec: Some("1min".to_string()),
                 restart: Some("on-failure".to_string()),
                 environment: IndexMap::from([("KEY".to_string(), "value".to_string())]),
+                environment_file: vec!["%h/.config/service.env".to_string()],
                 ..Default::default()
             },
         )
         .unwrap_err();
         assert!(err.to_string().contains("restart"));
         assert!(err.to_string().contains("environment"));
+        assert!(err.to_string().contains("environment_file"));
+
+        let err = SystemdRequest::from_toml(
+            "invalid-nice".to_string(),
+            SystemdTomlConfig {
+                exec_start: Some("/bin/true".to_string()),
+                nice: Some(20),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("-20 through 19"));
+
+        let err = SystemdRequest::from_toml(
+            "invalid-umask".to_string(),
+            SystemdTomlConfig {
+                exec_start: Some("/bin/true".to_string()),
+                umask: Some("0888".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("octal access mask"));
     }
 
     #[test]
@@ -830,6 +904,7 @@ mod tests {
                 description: Some("sync files".to_string()),
                 after: vec!["network-online.target".to_string()],
                 wants: vec!["network-online.target".to_string()],
+                requires: vec!["credentials.service".to_string()],
                 exec_start: Some("~/.local/bin/sync --watch".to_string()),
                 service_type: Some("oneshot".to_string()),
                 remain_after_exit: Some(true),
@@ -839,6 +914,9 @@ mod tests {
                 no_new_privileges: Some(true),
                 private_tmp: Some(true),
                 environment,
+                environment_file: vec!["-%h/.config/sync.env".to_string()],
+                nice: Some(10),
+                umask: Some("0007".to_string()),
                 working_directory: Some("~".to_string()),
                 restart: Some("on-failure".to_string()),
                 restart_sec: Some("5s".to_string()),
@@ -855,6 +933,7 @@ mod tests {
         assert!(unit.contains("Description=sync files\n"));
         assert!(unit.contains("After=network-online.target\n"));
         assert!(unit.contains("Wants=network-online.target\n"));
+        assert!(unit.contains("Requires=credentials.service\n"));
         assert!(unit.contains(&format!(
             "ExecStart={}\n",
             expand_path_string("~/.local/bin/sync --watch")
@@ -872,6 +951,9 @@ mod tests {
         assert!(unit.contains(&format!("WorkingDirectory={}\n", expand_path_string("~"))));
         assert!(unit.contains("Environment=\"PATH=/usr/bin:/bin\"\n"));
         assert!(unit.contains("Environment=\"QUOTED=hello \\\"there\\\"\"\n"));
+        assert!(unit.contains("EnvironmentFile=-%h/.config/sync.env\n"));
+        assert!(unit.contains("Nice=10\n"));
+        assert!(unit.contains("UMask=0007\n"));
         assert!(unit.contains("Restart=on-failure\n"));
         assert!(unit.contains("RestartSec=5s\n"));
         assert!(unit.contains("StandardOutput=append:%h/.local/state/sync.log\n"));
@@ -884,6 +966,7 @@ mod tests {
         let request = SystemdRequest::from_toml(
             "healthcheck".to_string(),
             SystemdTomlConfig {
+                requires: vec!["network-online.target".to_string()],
                 on_boot_sec: Some("2min".to_string()),
                 on_unit_inactive_sec: Some("5min".to_string()),
                 randomized_delay_sec: Some("30s".to_string()),
@@ -900,7 +983,7 @@ mod tests {
         assert_eq!(request.wanted_by, vec!["timers.target"]);
         assert_eq!(
             render_unit(&request),
-            "[Unit]\n\n[Timer]\nOnBootSec=2min\nOnUnitInactiveSec=5min\nRandomizedDelaySec=30s\nAccuracySec=1s\nPersistent=yes\nUnit=dev.mise.healthcheck.service\n\n[Install]\nWantedBy=timers.target\n"
+            "[Unit]\nRequires=network-online.target\n\n[Timer]\nOnBootSec=2min\nOnUnitInactiveSec=5min\nRandomizedDelaySec=30s\nAccuracySec=1s\nPersistent=yes\nUnit=dev.mise.healthcheck.service\n\n[Install]\nWantedBy=timers.target\n"
         );
     }
 

--- a/src/system/systemd.rs
+++ b/src/system/systemd.rs
@@ -541,10 +541,9 @@ fn render_service(request: &SystemdRequest, out: &mut String) {
         ));
     }
     for environment_file in &request.environment_file {
-        out.push_str(&format!(
-            "EnvironmentFile={}\n",
-            quote_environment(environment_file)
-        ));
+        // EnvironmentFile treats the entire value as a path, including spaces.
+        // Quotes are literal here and make an absolute path invalid.
+        out.push_str(&format!("EnvironmentFile={environment_file}\n"));
     }
     if let Some(nice) = request.nice {
         out.push_str(&format!("Nice={nice}\n"));
@@ -957,8 +956,8 @@ mod tests {
         assert!(unit.contains(&format!("WorkingDirectory={}\n", expand_path_string("~"))));
         assert!(unit.contains("Environment=\"PATH=/usr/bin:/bin\"\n"));
         assert!(unit.contains("Environment=\"QUOTED=hello \\\"there\\\"\"\n"));
-        assert!(unit.contains("EnvironmentFile=\"-%h/.config/sync.env\"\n"));
-        assert!(unit.contains("EnvironmentFile=\"%h/.config/sync config.env\"\n"));
+        assert!(unit.contains("EnvironmentFile=-%h/.config/sync.env\n"));
+        assert!(unit.contains("EnvironmentFile=%h/.config/sync config.env\n"));
         assert!(unit.contains("Nice=10\n"));
         assert!(unit.contains("UMask=0007\n"));
         assert!(unit.contains("Restart=on-failure\n"));

--- a/src/system/systemd.rs
+++ b/src/system/systemd.rs
@@ -541,7 +541,10 @@ fn render_service(request: &SystemdRequest, out: &mut String) {
         ));
     }
     for environment_file in &request.environment_file {
-        out.push_str(&format!("EnvironmentFile={environment_file}\n"));
+        out.push_str(&format!(
+            "EnvironmentFile={}\n",
+            quote_environment(environment_file)
+        ));
     }
     if let Some(nice) = request.nice {
         out.push_str(&format!("Nice={nice}\n"));
@@ -914,7 +917,10 @@ mod tests {
                 no_new_privileges: Some(true),
                 private_tmp: Some(true),
                 environment,
-                environment_file: vec!["-%h/.config/sync.env".to_string()],
+                environment_file: vec![
+                    "-%h/.config/sync.env".to_string(),
+                    "%h/.config/sync config.env".to_string(),
+                ],
                 nice: Some(10),
                 umask: Some("0007".to_string()),
                 working_directory: Some("~".to_string()),
@@ -951,7 +957,8 @@ mod tests {
         assert!(unit.contains(&format!("WorkingDirectory={}\n", expand_path_string("~"))));
         assert!(unit.contains("Environment=\"PATH=/usr/bin:/bin\"\n"));
         assert!(unit.contains("Environment=\"QUOTED=hello \\\"there\\\"\"\n"));
-        assert!(unit.contains("EnvironmentFile=-%h/.config/sync.env\n"));
+        assert!(unit.contains("EnvironmentFile=\"-%h/.config/sync.env\"\n"));
+        assert!(unit.contains("EnvironmentFile=\"%h/.config/sync config.env\"\n"));
         assert!(unit.contains("Nice=10\n"));
         assert!(unit.contains("UMask=0007\n"));
         assert!(unit.contains("Restart=on-failure\n"));


### PR DESCRIPTION
## Summary
- support `Requires=`, repeatable `EnvironmentFile=`, `Nice=`, and `UMask=` in bootstrap systemd units
- validate service-only directives, nice ranges, and octal umasks at runtime and in the JSON schema
- document systemd path, ordering, and secret-handling semantics

Discussion: https://github.com/jdx/mise/discussions/12681

## Tests
- `mise exec -- cargo test --all-features systemd`
- `mise run test:e2e e2e/config/test_schema_tombi`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: 0.149.1.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive bootstrap/systemd configuration with validation and tests; only affects units that opt into the new keys and does not change apply logic beyond emitted unit file content.
> 
> **Overview**
> Extends **`[bootstrap.linux.systemd.units]`** with four new TOML keys that map into generated user unit files: **`requires`** (`Requires=` in `[Unit]`), **`environment_file`** (one `EnvironmentFile=` line per path, including optional `-` prefix and `%h` specifiers), **`nice`**, and **`umask`**.
> 
> Runtime parsing, unit rendering, and JSON schema now cover these fields. **`nice`** is limited to **-20–19**; **`umask`** must be a valid octal mask up to **0777**. **`environment_file`**, **`nice`**, and **`umask`** are treated as **service-only** (rejected on timer units, same as existing service directives). Docs add examples, the supported-keys table, and notes that **`requires` does not imply ordering** (use **`after`**) and that secrets should use systemd credentials, not env files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a9f8f32ea3f6b5a45aa89d0c28fb38524696c8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring systemd unit dependencies, environment files, process priority, and file-creation masks.
  - Generated units now include the corresponding systemd directives.
  - Added validation for supported priority and umask ranges.
  - Service-only settings are rejected for timer units.

- **Documentation**
  - Expanded systemd bootstrap documentation with supported keys, examples, syntax details, dependency behavior, and security guidance for environment variables.

- **Bug Fixes**
  - Improved environment-file handling to preserve systemd paths and specifiers as configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->