### PR TITLE
fix(dotnet): parse global.json via registry metadata

### DIFF
--- a/registry/dotnet.toml
+++ b/registry/dotnet.toml
@@ -5,5 +5,5 @@ backends = [
   "asdf:mise-plugins/mise-dotnet",
 ]
 description = ".NET SDK"
-idiomatic_files = ["global.json"]
+idiomatic_files = [{ path = "global.json", version_json_path = ".sdk.version" }]
 version_order = "semver"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1181,6 +1181,23 @@ mod tests {
     }
 
     #[test]
+    fn test_dotnet_registry_parses_global_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("global.json");
+        fs::write(
+            &path,
+            r#"{"sdk":{"version":"10.0.400","rollForward":"latestFeature"}}"#,
+        )
+        .unwrap();
+        let specs = REGISTRY.get("dotnet").unwrap().idiomatic_files;
+
+        assert_eq!(
+            parse_matching_registry_idiomatic_file(&path, specs).unwrap(),
+            Some(vec!["10.0.400".to_string()])
+        );
+    }
+
+    #[test]
     fn test_registry_idiomatic_file_without_parser_uses_backend_fallback() {
         let spec = RegistryIdiomaticFile {
             path: ".tool-version",


### PR DESCRIPTION
## Summary

- declare `.sdk.version` as the parser for the dotnet registry's `global.json` idiomatic file
- add a regression test using a realistic `global.json` with `rollForward`
- ensure `global.json` is parsed structurally during configuration discovery

## Problem

The registry has declared `global.json` as a dotnet idiomatic file since #11341, but it does not declare how to extract the SDK version. During configuration discovery, the file can reach the default idiomatic-file parser, which splits JSON by whitespace and attempts to use `"sdk":` as a tool version:

```text
mise ERROR error parsing config file: ./global.json
mise ERROR invalid tool version request: "sdk":
```

This reproduces with a completely empty `MISE_DATA_DIR`, so no asdf or vfox plugin is required. Adding `version_json_path = ".sdk.version"` makes the registry-level structured parser extract the version before backend fallback.

The fatal error first reproduces in v2026.7.15, the first release containing #11341. It does not reproduce in v2026.7.14. Commit `f9ef2940b8da5ac158598e09ec8c586bc0f85adf` is unrelated; it changes post-install validation from `dotnet --version` to `dotnet --list-sdks` and does not alter `global.json` parsing.

## Reproduction

1. Enable dotnet idiomatic files.
2. Use a new, empty `MISE_DATA_DIR` with no plugins installed.
3. Enter a directory containing:

```json
{
  "sdk": {
    "version": "10.0.400",
    "rollForward": "latestFeature"
  }
}
```

Released v2026.9.0 fails with `invalid tool version request: "sdk":`; this branch resolves `10.0.400`.

## Validation

- `cargo test test_dotnet_registry_parses_global_json -- --nocapture`
- `mise exec go@latest -- mise run lint:hk`
- `git diff --check`
- end-to-end comparison using an empty isolated data directory: released v2026.9.0 fails and the patched binary resolves `10.0.400`