### PR TITLE
fix(task): install lazy tools invoked from tasks and mise x

### DIFF
--- a/docs/dev-tools/shims.md
+++ b/docs/dev-tools/shims.md
@@ -102,6 +102,13 @@ installed, normal `mise activate` places the real tool path ahead of the shim
 farms, so later calls have no shim dispatch overhead. `mise activate --shims`
 remains project-aware and dispatches every call through mise by design.
 
+Tasks and `mise x` work the same way. `mise run` does not preinstall lazy tools.
+Instead, whenever the toolset has a lazy declaration, the environment mise
+builds for a task (and for `mise x` and `mise env`) places the shim farms behind
+the tool paths if they are not already on PATH, and any missing bootstrap shims
+are created first. The task installs the tool the first time it runs one of its
+commands. `mise x -- <command>` installs the provider of a lazy command directly.
+
 ::: tip
 [`mise activate --shims`](/cli/activate.html#shims) is a shorthand for adding the shims directory to PATH.
 :::

--- a/e2e/cli/test_lazy_tools_system
+++ b/e2e/cli/test_lazy_tools_system
@@ -14,6 +14,14 @@ EOF
 mise reshim --system
 assert_succeed "test -e '$MISE_SYSTEM_SHIMS_DIR/dummy'"
 assert_fail "test -e '$MISE_SHIMS_DIR/dummy'"
+# If only the user farm is already on PATH, the missing system farm follows it
+# at the same fallback boundary rather than being promoted ahead of it.
+path_without_farms="${PATH#"$MISE_SHIMS_DIR:$MISE_SYSTEM_SHIMS_DIR:"}"
+mise_path="$(PATH="$MISE_SHIMS_DIR:$path_without_farms" mise env -s bash | sed -n 's/^export PATH=//p' | tr -d "'\"")"
+case "$mise_path" in
+  *"$MISE_SHIMS_DIR:$MISE_SYSTEM_SHIMS_DIR:"*) ;;
+  *) fail "expected user shims before system shims: $mise_path" ;;
+esac
 assert_contains "dummy --version" "This is Dummy 1.0.0"
 assert_directory_exists "$MISE_SYSTEM_INSTALLS_DIR/dummy/1.0.0"
 assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"

--- a/e2e/cli/test_lazy_tools_task
+++ b/e2e/cli/test_lazy_tools_task
@@ -54,7 +54,14 @@ assert "printf '%s' \"$mise_path\" | tr ':' '\\n' | grep -c -x \"$MISE_SHIMS_DIR
 # `mise x -- <cmd>` names the lazy command directly and installs its provider.
 mise uninstall --all dummy
 rm -f "$MISE_SHIMS_DIR/dummy"
-assert_contains "MISE_NOT_FOUND_AUTO_INSTALL=0 mise x -- dummy --version" "This is Dummy 1.0.0"
+output=$(MISE_NOT_FOUND_AUTO_INSTALL=0 mise x -- dummy --version 2>&1)
+case "$output" in
+  *"missing: dummy@1.0.0"*) fail "lazy provider was reported missing after installation: $output" ;;
+esac
+case "$output" in
+  *"This is Dummy 1.0.0"*) ;;
+  *) fail "lazy provider did not run: $output" ;;
+esac
 assert_directory_exists "$MISE_DATA_DIR/installs/dummy/1.0.0"
 
 # Commands started by the child reach the tool through its bootstrap shim.
@@ -62,6 +69,19 @@ mise uninstall --all dummy
 rm -f "$MISE_SHIMS_DIR/dummy"
 assert_contains "MISE_NOT_FOUND_AUTO_INSTALL=0 mise x -- sh -c 'dummy --version'" "This is Dummy 1.0.0"
 assert_directory_exists "$MISE_DATA_DIR/installs/dummy/1.0.0"
+
+# Lazy declarations that exist only in a task also get bootstrap shims after
+# task tools are collected, not just those in the project toolset.
+mise uninstall --all dummy
+rm -f "$MISE_SHIMS_DIR/dummy"
+cat >mise.toml <<'EOF'
+[tasks.task-local]
+tools = { dummy = { version = "1.0.0", lazy = true, lazy_bins = ["dummy"] } }
+run = "dummy --version"
+EOF
+assert_contains "MISE_NOT_FOUND_AUTO_INSTALL=0 mise run task-local" "This is Dummy 1.0.0"
+assert_directory_exists "$MISE_DATA_DIR/installs/dummy/1.0.0"
+assert_succeed "test -e '$MISE_SHIMS_DIR/dummy'"
 
 # Without a lazy declaration the child environment leaves the farm off PATH.
 cat >mise.toml <<'EOF'

--- a/e2e/cli/test_lazy_tools_task
+++ b/e2e/cli/test_lazy_tools_task
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+export MISE_SHIMS_DIR="$HOME/.local/share/mise/user-shims"
+
+# A lazy tool must install the first time a task runs one of its commands, the
+# same way it does when the command is typed into an activated shell. Neither a
+# shim farm on PATH nor a prior `mise reshim` is required: a hand-edited
+# `lazy = true` entry has no shim yet, and a task's shell has no
+# command-not-found handler to fall back on (discussion #12678).
+case ":$PATH:" in
+  *":$MISE_SHIMS_DIR:"*) fail "expected user shims to be absent from PATH: $PATH" ;;
+esac
+mise use tiny@1.0.0
+assert_directory_exists "$MISE_DATA_DIR/installs/tiny/1.0.0"
+# Edited by hand: nothing rebuilds the shim farm, so no `dummy` shim exists.
+cat >mise.toml <<'EOF'
+[tools]
+tiny = "1.0.0"
+dummy = { version = "1.0.0", lazy = true, lazy_bins = ["dummy"] }
+
+[tasks.check]
+run = "dummy --version"
+EOF
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
+assert_fail "test -e '$MISE_SHIMS_DIR/dummy'"
+
+# With a lazy declaration, the child PATH keeps the shim farm behind tool paths.
+mise_path="$(mise env -s bash | sed -n 's/^export PATH=//p' | tr -d "'\"")"
+case "$mise_path" in
+  "$MISE_DATA_DIR/installs/tiny/1.0.0/bin:$MISE_SHIMS_DIR:"*) ;;
+  *) fail "expected tool paths, then the shim farm, then the rest: $mise_path" ;;
+esac
+
+assert_contains "MISE_NOT_FOUND_AUTO_INSTALL=0 mise run check" "This is Dummy 1.0.0"
+assert_directory_exists "$MISE_DATA_DIR/installs/dummy/1.0.0"
+assert_succeed "test -e '$MISE_SHIMS_DIR/dummy'"
+
+# Once installed, the real bin directory precedes the farm.
+mise_path="$(mise env -s bash | sed -n 's/^export PATH=//p' | tr -d "'\"")"
+case "$mise_path" in
+  *"$MISE_DATA_DIR/installs/dummy/1.0.0/bin:"*"$MISE_SHIMS_DIR:"*) ;;
+  *) fail "expected the tool bin dir ahead of the shim farm: $mise_path" ;;
+esac
+assert_contains "mise run check" "This is Dummy 1.0.0"
+
+# A farm already on PATH keeps its place and is not duplicated.
+mise_path="$(PATH="$MISE_SHIMS_DIR:$PATH" mise env -s bash | sed -n 's/^export PATH=//p' | tr -d "'\"")"
+case "$mise_path" in
+  "$MISE_DATA_DIR/installs/tiny/1.0.0/bin:$MISE_DATA_DIR/installs/dummy/1.0.0/bin:$MISE_SHIMS_DIR:"*) ;;
+  *) fail "expected tool paths, then the farm from the original PATH: $mise_path" ;;
+esac
+assert "printf '%s' \"$mise_path\" | tr ':' '\\n' | grep -c -x \"$MISE_SHIMS_DIR\"" "1"
+
+# `mise x -- <cmd>` names the lazy command directly and installs its provider.
+mise uninstall --all dummy
+rm -f "$MISE_SHIMS_DIR/dummy"
+assert_contains "MISE_NOT_FOUND_AUTO_INSTALL=0 mise x -- dummy --version" "This is Dummy 1.0.0"
+assert_directory_exists "$MISE_DATA_DIR/installs/dummy/1.0.0"
+
+# Commands started by the child reach the tool through its bootstrap shim.
+mise uninstall --all dummy
+rm -f "$MISE_SHIMS_DIR/dummy"
+assert_contains "MISE_NOT_FOUND_AUTO_INSTALL=0 mise x -- sh -c 'dummy --version'" "This is Dummy 1.0.0"
+assert_directory_exists "$MISE_DATA_DIR/installs/dummy/1.0.0"
+
+# Without a lazy declaration the child environment leaves the farm off PATH.
+cat >mise.toml <<'EOF'
+[tools]
+dummy = "1.0.0"
+EOF
+assert_not_contains "mise env -s bash" "$MISE_SHIMS_DIR"

--- a/e2e/cli/test_lazy_tools_task
+++ b/e2e/cli/test_lazy_tools_task
@@ -52,8 +52,14 @@ esac
 assert "printf '%s' \"$mise_path\" | tr ':' '\\n' | grep -c -x \"$MISE_SHIMS_DIR\"" "1"
 
 # `mise x -- <cmd>` names the lazy command directly and installs its provider.
+cat >mise.toml <<'EOF'
+[tools]
+tiny = { version = "1.0.0", lazy = true, lazy_bins = ["rtx-tiny"] }
+dummy = { version = "1.0.0", lazy = true, lazy_bins = ["dummy"] }
+EOF
+mise uninstall --all tiny
 mise uninstall --all dummy
-rm -f "$MISE_SHIMS_DIR/dummy"
+rm -f "$MISE_SHIMS_DIR/rtx-tiny" "$MISE_SHIMS_DIR/dummy"
 output=$(MISE_NOT_FOUND_AUTO_INSTALL=0 mise x -- dummy --version 2>&1)
 case "$output" in
   *"missing: dummy@1.0.0"*) fail "lazy provider was reported missing after installation: $output" ;;
@@ -63,6 +69,8 @@ case "$output" in
   *) fail "lazy provider did not run: $output" ;;
 esac
 assert_directory_exists "$MISE_DATA_DIR/installs/dummy/1.0.0"
+assert_fail "test -d '$MISE_DATA_DIR/installs/tiny/1.0.0'"
+assert_succeed "test -e '$MISE_SHIMS_DIR/rtx-tiny'"
 
 # Commands started by the child reach the tool through its bootstrap shim.
 mise uninstall --all dummy

--- a/e2e/cli/test_lazy_tools_task
+++ b/e2e/cli/test_lazy_tools_task
@@ -72,6 +72,22 @@ assert_directory_exists "$MISE_DATA_DIR/installs/dummy/1.0.0"
 assert_fail "test -d '$MISE_DATA_DIR/installs/tiny/1.0.0'"
 assert_succeed "test -e '$MISE_SHIMS_DIR/rtx-tiny'"
 
+# A lazy declaration without bin metadata reports its own error without
+# preventing bootstrap shims for the remaining valid declarations.
+mise uninstall --all dummy
+rm -f "$MISE_SHIMS_DIR/dummy"
+cat >mise.toml <<'EOF'
+[tools]
+"aqua:tinygo-org/tinygo" = { version = "0.39.0", lazy = true }
+dummy = { version = "1.0.0", lazy = true, lazy_bins = ["dummy"] }
+
+[tasks.valid-lazy]
+run = "dummy --version"
+EOF
+assert_contains "MISE_NOT_FOUND_AUTO_INSTALL=0 mise run valid-lazy 2>&1" "This is Dummy 1.0.0"
+assert_directory_exists "$MISE_DATA_DIR/installs/dummy/1.0.0"
+assert_succeed "test -e '$MISE_SHIMS_DIR/dummy'"
+
 # Commands started by the child reach the tool through its bootstrap shim.
 mise uninstall --all dummy
 rm -f "$MISE_SHIMS_DIR/dummy"

--- a/e2e/cli/test_lazy_tools_task
+++ b/e2e/cli/test_lazy_tools_task
@@ -74,14 +74,29 @@ assert_directory_exists "$MISE_DATA_DIR/installs/dummy/1.0.0"
 # task tools are collected, not just those in the project toolset.
 mise uninstall --all dummy
 rm -f "$MISE_SHIMS_DIR/dummy"
+ln -s "$(command -v mise)" "$MISE_SHIMS_DIR/unrelated"
 cat >mise.toml <<'EOF'
 [tasks.task-local]
 tools = { dummy = { version = "1.0.0", lazy = true, lazy_bins = ["dummy"] } }
-run = "dummy --version"
+run = 'test -e "$MISE_SHIMS_DIR/unrelated" && dummy --version'
 EOF
 assert_contains "MISE_NOT_FOUND_AUTO_INSTALL=0 mise run task-local" "This is Dummy 1.0.0"
 assert_directory_exists "$MISE_DATA_DIR/installs/dummy/1.0.0"
 assert_succeed "test -e '$MISE_SHIMS_DIR/dummy'"
+
+# A nested task without runtime tools must not inherit its parent's serialized
+# task toolset. The parent's unused lazy tool remains uninstalled.
+mise uninstall --all dummy
+cat >mise.toml <<'EOF'
+[tasks.parent]
+tools = { dummy = { version = "1.0.0", lazy = true, lazy_bins = ["dummy"] } }
+run = "mise run no-tools"
+
+[tasks.no-tools]
+run = 'test -z "${__MISE_TASK_TOOL_ARGS-}" && echo cleared'
+EOF
+assert_contains "mise run parent" "cleared"
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
 
 # Without a lazy declaration the child environment leaves the farm off PATH.
 cat >mise.toml <<'EOF'

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -822,7 +822,8 @@ impl Doctor {
         } else {
             shims::ShimScope::User
         };
-        if let Ok(diffs) = shims::get_shim_diffs(config, mise_bin, toolset, &shims_dir, scope).await
+        if let Ok(diffs) =
+            shims::get_shim_diffs(config, mise_bin, toolset, &shims_dir, scope, false).await
         {
             let cmd = style::nyellow("mise reshim");
 

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -231,7 +231,8 @@ impl Exec {
             // was installed. Refresh it so a successful install is not reported
             // as missing below.
             missing = ts.list_missing_versions(&config).await;
-        } else if ts.has_lazy_declarations()
+        }
+        if ts.has_lazy_declarations()
             && !opts.dry_run
             && let Err(err) = crate::shims::ensure_lazy_shims(&missing)
         {

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -207,7 +207,7 @@ impl Exec {
             resolve_options,
             ..Default::default()
         };
-        let (_, missing) = measure!("install_arg_versions", {
+        let (_, mut missing) = measure!("install_arg_versions", {
             ts.install_missing_versions(&mut config, &opts).await?
         });
 
@@ -227,6 +227,10 @@ impl Exec {
             && ts.has_missing_lazy_bin_provider(&config, &program).await?
         {
             ts.install_missing_lazy_bin(&mut config, &program).await?;
+            // The original list was computed before the command's lazy provider
+            // was installed. Refresh it so a successful install is not reported
+            // as missing below.
+            missing = ts.list_missing_versions(&config).await;
         } else if ts.has_lazy_declarations()
             && !opts.dry_run
             && let Err(err) = crate::shims::ensure_lazy_shims(&config, &ts, &missing).await

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -216,11 +216,29 @@ impl Exec {
             ts.resolve_with_opts(&config, &opts.resolve_options).await?;
         }
 
+        let (program, mut args) = parse_command(&env::SHELL, &self.command, &self.c);
+
+        // Running a lazy tool's command is what installs it, and `mise x -- <cmd>`
+        // names that command directly. Install its provider here: program resolution
+        // below deliberately looks past shim directories, so the bootstrap shim that
+        // would otherwise do this never gets the chance.
+        if ts.has_lazy_declarations()
+            && !program.contains(['/', '\\'])
+            && ts.has_missing_lazy_bin_provider(&config, &program).await?
+        {
+            ts.install_missing_lazy_bin(&mut config, &program).await?;
+        } else if ts.has_lazy_declarations()
+            && !opts.dry_run
+            && let Err(err) = crate::shims::ensure_lazy_shims(&config, &ts, &missing).await
+        {
+            // Commands started by the child (a shell, a script) reach lazy tools
+            // through their bootstrap shims, which a hand-edited declaration lacks.
+            warn!("failed to create shims for lazy tools: {err:#}");
+        }
+
         measure!("notify_if_versions_missing", {
             ts.notify_missing_versions(missing);
         });
-
-        let (program, mut args) = parse_command(&env::SHELL, &self.command, &self.c);
 
         let (mut env, env_remove) = measure!("env_with_path", {
             ts.env_with_path_and_removals(&config).await?

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -233,7 +233,7 @@ impl Exec {
             missing = ts.list_missing_versions(&config).await;
         } else if ts.has_lazy_declarations()
             && !opts.dry_run
-            && let Err(err) = crate::shims::ensure_lazy_shims(&config, &ts, &missing).await
+            && let Err(err) = crate::shims::ensure_lazy_shims(&missing)
         {
             // Commands started by the child (a shell, a script) reach lazy tools
             // through their bootstrap shims, which a hand-edited declaration lacks.

--- a/src/cli/hook_env.rs
+++ b/src/cli/hook_env.rs
@@ -8,7 +8,7 @@ use crate::hook_env::{PREV_SESSION, WatchFilePattern};
 use crate::shell::{EXAMPLE_SHELL, ShellType, require_shell};
 use crate::toolset::{ResolveOptions, Toolset, ToolsetBuilder};
 use crate::ui::style;
-use crate::{dirs, env, hook_env, hooks, watch_files};
+use crate::{env, hook_env, hooks, watch_files};
 use console::truncate_str;
 use eyre::Result;
 use indexmap::IndexSet;
@@ -181,11 +181,7 @@ impl HookEnv {
             .chain(env_watch_files.iter().map(|p| p.as_path().into()))
             .collect();
 
-        let retain_shims = Settings::get().not_found_auto_install
-            || ts
-                .list_current_requests()
-                .iter()
-                .any(|request| request.options().lazy == Some(true));
+        let retain_shims = Settings::get().not_found_auto_install || ts.has_lazy_declarations();
         patches.extend(self.build_path_operations(
             &user_paths,
             &tool_paths,
@@ -463,15 +459,11 @@ impl HookEnv {
             .cloned()
             .collect();
 
-        let user_shims = dirs::shims();
-        let system_shims = dirs::system_shims();
-        let mut shim_dirs = retain_shims.then_some(user_shims).into_iter().collect_vec();
-        if retain_shims
-            && system_shims.is_dir()
-            && !file::storage_paths_eq(&shim_dirs[0], &system_shims)
-        {
-            shim_dirs.push(system_shims);
-        }
+        let shim_dirs = if retain_shims {
+            crate::shims::shim_farm_dirs()
+        } else {
+            vec![]
+        };
 
         // Combine paths in the correct order:
         // pre (user shell prepends) -> user_paths (from config) -> tool_paths ->

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -798,7 +798,7 @@ impl Run {
             // only works if their bootstrap shims exist. A hand-edited `lazy = true`
             // entry has none until the farm is rebuilt (discussion #12678).
             if !self.dry_run
-                && let Err(err) = crate::shims::ensure_lazy_shims(&config, &ts, &missing).await
+                && let Err(err) = crate::shims::ensure_lazy_shims(&missing)
             {
                 warn!("failed to create shims for lazy tools: {err:#}");
             }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -793,7 +793,15 @@ impl Run {
             ..Default::default()
         };
         let previewed_tools = if !self.skip_tools {
-            let (installed, _) = ts.install_missing_versions(&mut config, &opts).await?;
+            let (installed, missing) = ts.install_missing_versions(&mut config, &opts).await?;
+            // Lazy tools stay uninstalled until a task runs one of their commands, which
+            // only works if their bootstrap shims exist. A hand-edited `lazy = true`
+            // entry has none until the farm is rebuilt (discussion #12678).
+            if !self.dry_run
+                && let Err(err) = crate::shims::ensure_lazy_shims(&config, &ts, &missing).await
+            {
+                warn!("failed to create shims for lazy tools: {err:#}");
+            }
             if self.dry_run {
                 installed.into_iter().collect()
             } else {

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -298,6 +298,62 @@ pub(crate) enum ShimScope {
     Both,
 }
 
+/// The shim farms that serve as the lazy-install fallback boundary on PATH: the user
+/// farm, plus the system farm when it exists as separate storage.
+pub(crate) fn shim_farm_dirs() -> Vec<PathBuf> {
+    let user_shims = dirs::shims();
+    let system_shims = dirs::system_shims();
+    let mut dirs = vec![user_shims];
+    if system_shims.is_dir() && !file::storage_paths_eq(&dirs[0], &system_shims) {
+        dirs.push(system_shims);
+    }
+    dirs
+}
+
+/// Reconcile the shim farms whose missing lazy declarations lack a bootstrap shim.
+///
+/// A `lazy = true` entry written by hand has no shim until something rebuilds the farm.
+/// An interactive shell still recovers, because its not-found handler installs the
+/// tool, but a task or `mise x` child has no such handler and fails with "command not
+/// found" (discussion #12678). `missing` is the toolset's already-computed missing
+/// version list, so the common case costs only a few file existence checks.
+pub(crate) async fn ensure_lazy_shims(
+    config: &Arc<Config>,
+    ts: &Toolset,
+    missing: &[ToolVersion],
+) -> Result<()> {
+    let mise_bin = mise_bin_for_shims();
+    let mut scopes = Vec::new();
+    for tv in missing {
+        if tv.request.options().lazy != Some(true) {
+            continue;
+        }
+        let Some(bins) = tv.request.lazy_bins()? else {
+            continue;
+        };
+        let scope = if shim_scope_contains_request(ShimScope::System, &tv.request) {
+            ShimScope::System
+        } else {
+            ShimScope::User
+        };
+        let shims_dir = match scope {
+            ShimScope::System => dirs::system_shims(),
+            ShimScope::User | ShimScope::Both => dirs::shims(),
+        };
+        let has_missing_shim = bins
+            .iter()
+            .flat_map(|bin| platform_shim_names(&mise_bin, bin))
+            .any(|shim| !shims_dir.join(shim).exists());
+        if has_missing_shim && !scopes.contains(&scope) {
+            scopes.push(scope);
+        }
+    }
+    for scope in scopes {
+        reshim_for(config, ts, false, scope).await?;
+    }
+    Ok(())
+}
+
 pub(crate) async fn reshim_for(
     config: &Arc<Config>,
     ts: &Toolset,

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -4,7 +4,7 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{
-    collections::{BTreeSet, HashSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     sync::atomic::Ordering,
 };
 
@@ -375,20 +375,16 @@ pub(crate) fn shim_farm_dirs() -> Vec<PathBuf> {
     dirs
 }
 
-/// Reconcile the shim farms whose missing lazy declarations lack a bootstrap shim.
+/// Add bootstrap shims for missing lazy declarations without pruning either farm.
 ///
 /// A `lazy = true` entry written by hand has no shim until something rebuilds the farm.
 /// An interactive shell still recovers, because its not-found handler installs the
 /// tool, but a task or `mise x` child has no such handler and fails with "command not
 /// found" (discussion #12678). `missing` is the toolset's already-computed missing
 /// version list, so the common case costs only a few file existence checks.
-pub(crate) async fn ensure_lazy_shims(
-    config: &Arc<Config>,
-    ts: &Toolset,
-    missing: &[ToolVersion],
-) -> Result<()> {
-    let mise_bin = mise_bin_for_shims();
-    let mut scopes = Vec::new();
+pub(crate) fn ensure_lazy_shims(missing: &[ToolVersion]) -> Result<()> {
+    let mise_bin = mise_bin_for_shims().absolutize()?.into_owned();
+    let mut shims_by_dir = BTreeMap::<PathBuf, BTreeSet<String>>::new();
     for tv in missing {
         if tv.request.options().lazy != Some(true) {
             continue;
@@ -396,25 +392,25 @@ pub(crate) async fn ensure_lazy_shims(
         let Some(bins) = tv.request.lazy_bins()? else {
             continue;
         };
-        let scope = if shim_scope_contains_request(ShimScope::System, &tv.request) {
-            ShimScope::System
+        let shims_dir = if shim_scope_contains_request(ShimScope::System, &tv.request) {
+            dirs::system_shims()
         } else {
-            ShimScope::User
+            dirs::shims()
         };
-        let shims_dir = match scope {
-            ShimScope::System => dirs::system_shims(),
-            ShimScope::User | ShimScope::Both => dirs::shims(),
-        };
-        let has_missing_shim = bins
-            .iter()
-            .flat_map(|bin| platform_shim_names(&mise_bin, bin))
-            .any(|shim| !shims_dir.join(shim).exists());
-        if has_missing_shim && !scopes.contains(&scope) {
-            scopes.push(scope);
-        }
+        shims_by_dir.entry(shims_dir).or_default().extend(
+            bins.iter()
+                .flat_map(|bin| platform_shim_names(&mise_bin, bin)),
+        );
     }
-    for scope in scopes {
-        reshim_for(config, ts, false, scope).await?;
+    for (shims_dir, shims) in shims_by_dir {
+        file::create_dir_all(&shims_dir)?;
+        let _lock = LockFile::new(&shims_dir).lock();
+        for shim in shims {
+            let path = shims_dir.join(&shim);
+            if !path.exists() {
+                add_shim(&mise_bin, &path, &shim)?;
+            }
+        }
     }
     Ok(())
 }

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use crate::backend::Backend;
-use crate::cli::args::BackendArg;
+use crate::cli::args::{BackendArg, ToolArg};
 use crate::cli::exec::Exec;
 use crate::config::{CommandWrapper, Config, Settings, load_command_wrappers};
 use crate::file::display_path;
@@ -32,6 +32,69 @@ const GENERATED_WINDOWS_CMD_SHIM_HEADER: &str = "@echo off\r\nrem mise generated
 #[cfg(any(windows, test))]
 const GENERATED_WINDOWS_BASH_SHIM_HEADER: &str = "#!/bin/bash\n# mise generated shim\n";
 const SHIM_SCRIPT_INSPECTION_LIMIT: u64 = 16 * 1024;
+
+pub(crate) const TASK_TOOL_ARGS_ENV: &str = "__MISE_TASK_TOOL_ARGS";
+
+#[derive(serde::Deserialize, serde::Serialize)]
+struct TaskToolArg {
+    backend: String,
+    version: Option<String>,
+    options: crate::toolset::ToolVersionOptions,
+}
+
+/// Preserve runtime-only task tool requests for a shim process. A task's `tools`
+/// entries are not part of the config that a shim reloads, so without this context
+/// a bootstrap shim cannot find a lazy provider declared only on the task.
+pub(crate) fn task_tool_args_env(tools: &[ToolArg]) -> Result<Option<String>> {
+    let tools = tools
+        .iter()
+        .map(|tool| TaskToolArg {
+            backend: tool.ba.short.clone(),
+            version: tool.version.clone(),
+            options: tool
+                .tvr
+                .as_ref()
+                .map(|request| request.options())
+                .unwrap_or_default(),
+        })
+        .collect_vec();
+    if tools.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(serde_json::to_string(&tools)?))
+    }
+}
+
+fn task_tool_args_from_env() -> Result<Vec<ToolArg>> {
+    let Ok(serialized) = env::var(TASK_TOOL_ARGS_ENV) else {
+        return Ok(vec![]);
+    };
+    serde_json::from_str::<Vec<TaskToolArg>>(&serialized)?
+        .into_iter()
+        .map(|tool| {
+            let input = tool.version.as_ref().map_or_else(
+                || tool.backend.clone(),
+                |version| format!("{}@{version}", tool.backend),
+            );
+            let mut arg: ToolArg = input.parse()?;
+            if !tool.options.is_empty() {
+                Arc::make_mut(&mut arg.ba).set_opts(Some(tool.options));
+            }
+            arg.tvr = arg
+                .version
+                .as_ref()
+                .map(|version| {
+                    crate::toolset::ToolRequest::new(
+                        arg.ba.clone(),
+                        version,
+                        crate::toolset::ToolSource::Argument,
+                    )
+                })
+                .transpose()?;
+            Ok(arg)
+        })
+        .collect()
+}
 
 // executes as if it was a shim if the command is not "mise", e.g.: "node"
 pub(crate) async fn handle_shim() -> Result<()> {
@@ -147,7 +210,9 @@ async fn which_shim(
     } else {
         ResolveOptions::default()
     };
+    let task_tools = task_tool_args_from_env()?;
     let mut ts = ToolsetBuilder::new()
+        .with_args(&task_tools)
         .with_resolve_options(resolve_options)
         .build(config)
         .await?;

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -385,12 +385,20 @@ pub(crate) fn shim_farm_dirs() -> Vec<PathBuf> {
 pub(crate) fn ensure_lazy_shims(missing: &[ToolVersion]) -> Result<()> {
     let mise_bin = mise_bin_for_shims().absolutize()?.into_owned();
     let mut shims_by_dir = BTreeMap::<PathBuf, BTreeSet<String>>::new();
+    let mut lazy_bins_error = None;
     for tv in missing {
         if tv.request.options().lazy != Some(true) {
             continue;
         }
-        let Some(bins) = tv.request.lazy_bins()? else {
-            continue;
+        let bins = match tv.request.lazy_bins() {
+            Ok(Some(bins)) => bins,
+            Ok(None) => continue,
+            Err(err) => {
+                // One malformed lazy declaration must not prevent bootstrap shims
+                // from being written for every other declaration in the toolset.
+                lazy_bins_error.get_or_insert(err);
+                continue;
+            }
         };
         let shims_dir = if shim_scope_contains_request(ShimScope::System, &tv.request) {
             dirs::system_shims()
@@ -412,7 +420,11 @@ pub(crate) fn ensure_lazy_shims(missing: &[ToolVersion]) -> Result<()> {
             }
         }
     }
-    Ok(())
+    if let Some(err) = lazy_bins_error {
+        Err(err)
+    } else {
+        Ok(())
+    }
 }
 
 pub(crate) async fn reshim_for(
@@ -471,7 +483,7 @@ pub(crate) async fn reshim_for(
 
     let dedicated = is_dedicated_shims_dir(&shims_dir);
     let (desired, shims_to_stage, known_owned, prune_entries) = if full_rebuild {
-        let desired = get_desired_shims(config, &mise_bin, ts, scope).await?;
+        let desired = get_desired_shims(config, &mise_bin, ts, scope, force).await?;
         let shims_to_stage = desired.iter().cloned().collect();
         if dedicated {
             (desired, shims_to_stage, HashSet::new(), HashSet::new())
@@ -481,7 +493,7 @@ pub(crate) async fn reshim_for(
             (desired, shims_to_stage, actual.owned, prune_entries)
         }
     } else {
-        let diffs = get_shim_diffs(config, &mise_bin, ts, &shims_dir, scope).await?;
+        let diffs = get_shim_diffs(config, &mise_bin, ts, &shims_dir, scope, false).await?;
         (
             diffs.desired,
             diffs.missing,
@@ -1335,11 +1347,12 @@ pub(crate) async fn get_shim_diffs(
     toolset: &Toolset,
     shims_dir: &Path,
     scope: ShimScope,
+    strict_lazy_bins: bool,
 ) -> Result<ShimDiffs> {
     let mise_bin = mise_bin.as_ref();
     let (actual_shims, desired_shims) = tokio::join!(
         get_actual_shims(mise_bin, shims_dir),
-        get_desired_shims(config, mise_bin, toolset, scope)
+        get_desired_shims(config, mise_bin, toolset, scope, strict_lazy_bins)
     );
     let (actual_shims, desired_shims) = (actual_shims?, desired_shims?);
     let (missing, extra) = calculate_shim_diffs(
@@ -1495,6 +1508,7 @@ async fn get_desired_shims(
     mise_bin: &Path,
     toolset: &Toolset,
     scope: ShimScope,
+    strict_lazy_bins: bool,
 ) -> Result<HashSet<String>> {
     let _mise_bin = mise_bin; // used on Windows only
     let mut shims = HashSet::new();
@@ -1517,11 +1531,14 @@ async fn get_desired_shims(
         if !shim_scope_contains_request(scope, request) {
             continue;
         }
-        if let Some(bins) = request.lazy_bins()? {
-            shims.extend(
+        match request.lazy_bins() {
+            Ok(Some(bins)) => shims.extend(
                 bins.into_iter()
                     .flat_map(|bin| platform_shim_names(_mise_bin, &bin)),
-            );
+            ),
+            Ok(None) => {}
+            Err(err) if strict_lazy_bins => return Err(err),
+            Err(err) => warn!("Skipping invalid lazy shim declaration: {err:#}"),
         }
     }
     Ok(shims)

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -2078,6 +2078,7 @@ impl TaskExecutor {
     ) -> Result<PreparedTaskContext> {
         let mut tools = self.tool.clone();
         tools.extend(task.tool_args()?);
+        let task_tool_args_env = crate::shims::task_tool_args_env(&tools)?;
         let ts_build_start = std::time::Instant::now();
 
         // Remote tasks need tools from the full config hierarchy rather than a
@@ -2206,6 +2207,14 @@ impl TaskExecutor {
                 &mut nested_mise_diff_exclude_keys,
                 "MISE_CONFIG_ROOT",
                 task_env_path(config_root),
+            );
+        }
+        if let Some(task_tool_args) = task_tool_args_env {
+            Self::insert_env_excluded_from_nested_mise_diff(
+                &mut env,
+                &mut nested_mise_diff_exclude_keys,
+                crate::shims::TASK_TOOL_ARGS_ENV,
+                task_tool_args,
             );
         }
         if Settings::get().env_cache {

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -2100,7 +2100,7 @@ impl TaskExecutor {
 
         let env_render_start = std::time::Instant::now();
         // extra_vars contains resolved vars from the task's config hierarchy.
-        let (mut env, task_env, extra_vars, env_remove) = if let Some(task_cf) = task_cf {
+        let (mut env, task_env, extra_vars, mut env_remove) = if let Some(task_cf) = task_cf {
             let (env, task_env, extra_vars, env_remove) = self
                 .context_builder
                 .resolve_task_env_with_config(config, task, task_cf, &toolset)
@@ -2216,6 +2216,9 @@ impl TaskExecutor {
                 crate::shims::TASK_TOOL_ARGS_ENV,
                 task_tool_args,
             );
+        } else {
+            env.remove(crate::shims::TASK_TOOL_ARGS_ENV);
+            env_remove.insert(crate::shims::TASK_TOOL_ARGS_ENV.to_string());
         }
         if Settings::get().env_cache {
             let key = CachedEnv::ensure_encryption_key();

--- a/src/task/task_tool_installer.rs
+++ b/src/task/task_tool_installer.rs
@@ -205,7 +205,7 @@ impl<'a> TaskToolInstaller<'a> {
                 tvl.versions.retain(|tv| !previewed_tools.contains(tv));
             }
         }
-        let _ = ts
+        let (_, missing) = ts
             .install_missing_versions(
                 config,
                 &InstallOptions {
@@ -217,6 +217,9 @@ impl<'a> TaskToolInstaller<'a> {
                 },
             )
             .await?;
+        if !dry_run && let Err(err) = crate::shims::ensure_lazy_shims(config, &ts, &missing).await {
+            warn!("failed to create shims for lazy tools: {err:#}");
+        }
 
         Ok(())
     }

--- a/src/task/task_tool_installer.rs
+++ b/src/task/task_tool_installer.rs
@@ -217,7 +217,7 @@ impl<'a> TaskToolInstaller<'a> {
                 },
             )
             .await?;
-        if !dry_run && let Err(err) = crate::shims::ensure_lazy_shims(config, &ts, &missing).await {
+        if !dry_run && let Err(err) = crate::shims::ensure_lazy_shims(&missing) {
             warn!("failed to create shims for lazy tools: {err:#}");
         }
 

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -291,6 +291,15 @@ impl Toolset {
             .collect()
     }
 
+    /// Whether any configured tool is declared `lazy = true`. Such a tool installs the
+    /// first time one of its bootstrap shims runs, so environments mise builds for this
+    /// toolset have to make those shims reachable behind the real tool paths.
+    pub(crate) fn has_lazy_declarations(&self) -> bool {
+        self.list_current_requests()
+            .iter()
+            .any(|request| request.options().lazy == Some(true))
+    }
+
     pub(crate) fn list_versions_by_plugin(&self) -> Vec<(Arc<dyn Backend>, &ToolVersionList)> {
         self.versions
             .iter()

--- a/src/toolset/toolset_env.rs
+++ b/src/toolset/toolset_env.rs
@@ -14,7 +14,7 @@ use crate::path_env::PathEnv;
 use crate::toolset::Toolset;
 use crate::toolset::env_cache::{CachedEnv, compute_settings_hash, get_file_mtime};
 use crate::toolset::tool_request::ToolRequest;
-use crate::{env, github, parallel, uv};
+use crate::{env, file, github, parallel, uv};
 
 /// PATH with mise-managed install dirs filtered out. mise re-adds the current
 /// toolset's bin dirs below, so a stale `installs/<tool>/<ver>/bin` left on PATH
@@ -31,6 +31,40 @@ fn pristine_path_without_install_dirs() -> Vec<PathBuf> {
 }
 
 impl Toolset {
+    /// PATH for an environment mise hands to a child process or prints (`mise x`,
+    /// `mise run`, `mise env`): the pristine PATH with the given mise-managed paths
+    /// ahead of it.
+    ///
+    /// The pristine PATH never contains a shim farm that PATH activation added on its
+    /// own, and a shell without activation may not have one at all. A `lazy = true`
+    /// tool relies on its bootstrap shim being found, so when the toolset declares one
+    /// the farms follow the tool paths, mirroring the fallback boundary hook-env retains
+    /// in the interactive shell. Installed tools still resolve to their real bin
+    /// directories first. A farm already on the pristine PATH keeps its place: `PathEnv`
+    /// already puts tool paths ahead of it, and a shared directory such as
+    /// `~/.local/bin` must not be reordered.
+    fn child_path(&self, paths: impl IntoIterator<Item = PathBuf>) -> String {
+        let pristine = pristine_path_without_install_dirs();
+        let mut path_env = PathEnv::from_iter(pristine.iter().cloned());
+        for p in paths {
+            path_env.add(p);
+        }
+        if self.has_lazy_declarations() {
+            for dir in crate::shims::shim_farm_dirs() {
+                let on_path = pristine.iter().any(|p| {
+                    file::paths_eq(
+                        &file::canonicalize_or_self(p),
+                        &file::canonicalize_or_self(&dir),
+                    )
+                });
+                if !on_path {
+                    path_env.add(dir);
+                }
+            }
+        }
+        path_env.to_string()
+    }
+
     pub(crate) async fn full_env(&self, config: &Arc<Config>) -> Result<EnvMap> {
         Ok(self.full_env_with_removals(config).await?.0)
     }
@@ -132,15 +166,14 @@ impl Toolset {
         }
 
         let (mut env, env_results) = self.final_env(config).await?;
-        let mut path_env = PathEnv::from_iter(pristine_path_without_install_dirs());
         // Use split paths so we save a cache compatible with env_with_path_and_split
         let (user_paths, tool_paths) = self
             .list_final_paths_split(config, env_results.clone())
             .await?;
-        for p in user_paths.iter().chain(tool_paths.iter()) {
-            path_env.add(p.clone());
-        }
-        env.insert(PATH_KEY.to_string(), path_env.to_string());
+        env.insert(
+            PATH_KEY.to_string(),
+            self.child_path(user_paths.iter().chain(tool_paths.iter()).cloned()),
+        );
 
         // Save to cache if enabled and no uncacheable directives
         // Use save_env_cache_split to ensure cache is compatible with env_with_path_and_split
@@ -248,11 +281,10 @@ impl Toolset {
             Some(cached) => {
                 let mut env = cached.env;
                 // Reconstruct PATH from cached paths
-                let mut path_env = PathEnv::from_iter(pristine_path_without_install_dirs());
-                for p in cached.user_paths.into_iter().chain(cached.tool_paths) {
-                    path_env.add(p);
-                }
-                env.insert(PATH_KEY.to_string(), path_env.to_string());
+                env.insert(
+                    PATH_KEY.to_string(),
+                    self.child_path(cached.user_paths.into_iter().chain(cached.tool_paths)),
+                );
                 Ok(Some((env, cached.env_remove)))
             }
             None => Ok(None),

--- a/src/toolset/toolset_env.rs
+++ b/src/toolset/toolset_env.rs
@@ -44,22 +44,40 @@ impl Toolset {
     /// already puts tool paths ahead of it, and a shared directory such as
     /// `~/.local/bin` must not be reordered.
     fn child_path(&self, paths: impl IntoIterator<Item = PathBuf>) -> String {
-        let pristine = pristine_path_without_install_dirs();
+        let mut pristine = pristine_path_without_install_dirs();
+        let mut shim_farms = Vec::new();
+        let mut shim_boundary = None;
+        if self.has_lazy_declarations() {
+            shim_farms = crate::shims::shim_farm_dirs();
+            for (index, path) in pristine.iter().enumerate() {
+                if shim_farms.iter().any(|farm| {
+                    file::paths_eq(
+                        &file::canonicalize_or_self(path),
+                        &file::canonicalize_or_self(farm),
+                    )
+                }) {
+                    shim_boundary.get_or_insert(index);
+                }
+            }
+            if let Some(boundary) = shim_boundary {
+                pristine.retain(|path| {
+                    !shim_farms.iter().any(|farm| {
+                        file::paths_eq(
+                            &file::canonicalize_or_self(path),
+                            &file::canonicalize_or_self(farm),
+                        )
+                    })
+                });
+                pristine.splice(boundary..boundary, shim_farms.iter().cloned());
+            }
+        }
         let mut path_env = PathEnv::from_iter(pristine.iter().cloned());
         for p in paths {
             path_env.add(p);
         }
-        if self.has_lazy_declarations() {
-            for dir in crate::shims::shim_farm_dirs() {
-                let on_path = pristine.iter().any(|p| {
-                    file::paths_eq(
-                        &file::canonicalize_or_self(p),
-                        &file::canonicalize_or_self(&dir),
-                    )
-                });
-                if !on_path {
-                    path_env.add(dir);
-                }
+        if shim_boundary.is_none() {
+            for dir in shim_farms {
+                path_env.add(dir);
             }
         }
         path_env.to_string()

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -42,7 +42,11 @@ impl Toolset {
                     match tv.request.lazy_bins() {
                         Ok(Some(bins)) if bins.iter().any(|bin| bin == bin_name) => Some(Ok(tv)),
                         Ok(_) => None,
-                        Err(err) => Some(Err(err)),
+                        // Missing metadata for one lazy declaration says nothing
+                        // about whether another declaration provides this command.
+                        // ensure_lazy_shims reports that declaration's error while
+                        // still materializing the valid providers' shims.
+                        Err(_) => None,
                     }
                 } else if tv.ba().matches_bin_name(bin_name)
                     || tv


### PR DESCRIPTION
## Summary

Fixes https://github.com/jdx/mise/discussions/12678: a tool declared `lazy = true` installed when its command was typed into the shell, but not when a mise task ran the same command.

A lazy tool installs when one of its bootstrap shims runs. A task runs through `sh -c`, and two things kept the shim from running there:

- A `lazy = true` entry added by hand has no shim until `mise reshim`. The interactive shell hides this because `mise activate`'s command-not-found handler installs the tool anyway; the task shell has no handler.
- `mise run` builds the task PATH from the pristine, pre-activation PATH, so the shim farm is often absent even when the shim exists (CI, non-activated shells).

Both reproduce with the discussion's config: `helm version` in an activated shell installs helm, `mise run lint` in the same shell fails with `helm: not found`.

## Fix

- When the toolset has a lazy declaration, the environment mise builds for `mise run`, `mise x`, and `mise env` places the user and system shim farms behind the tool paths when they are not already on PATH. This mirrors the fallback boundary hook-env already retains in the interactive shell for lazy users (#12594), so tasks behave like the shell. Installed tools still resolve to their real bin dirs first, a farm already on PATH keeps its position (so a shared `shims_dir` such as `~/.local/bin` from #12675 is never reordered), and toolsets without a lazy declaration are unchanged.
- `mise run` and `mise x` reconcile the farm when a missing lazy tool lacks its bootstrap shim (a hand-edited declaration). In the common case this is a few file existence checks; a failure is a warning, not an abort.
- `mise x -- <cmd>` installs the lazy provider for the named command directly, since exec deliberately resolves programs past shim directories.
- Hook-env reuses the new `Toolset::has_lazy_declarations` and `shims::shim_farm_dirs` helpers; its behavior is unchanged.

Tradeoff, discussed with @jdx: in a project with a lazy tool, task commands not provided by a configured tool now go through the farm before the system PATH, the same as they already do for shim users and for lazy users in an activated shell.

## Validation

- `mise run lint`, `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --bin mise -- shims file::tests path_env toolset_env hook_env`
- `mise run test:e2e e2e/cli/test_lazy_tools_task e2e/cli/test_lazy_tools e2e/cli/test_lazy_tools_system e2e/shell/test_shims_activation_conditional e2e/tools/test_path_order e2e/cli/test_activate_aggressive e2e/cli/test_exec e2e/cli/test_run e2e/env/test_env_cache e2e/env/test_env_path e2e/config/test_env_path_ordering`
- Manual repro with the discussion's `helm = { version = "latest", lazy = true }` config and no reshim: first `mise run lint` installs helm and runs it; later runs execute the real binary directly.

Windows is untested here; the code reuses the platform shim helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5-1; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PATH construction and install timing for `mise run`/`mise x`/`mise env` whenever lazy tools are configured; behavior is broad but aligned with activated-shell semantics and covered by new e2e tests.
> 
> **Overview**
> Fixes lazy tools (`lazy = true`) not installing when **`mise run`** or **`mise x`** runs their commands, even though an activated shell could install them via shims or command-not-found handling.
> 
> **PATH for child environments** (`mise run`, `mise x`, `mise env`): when the toolset has any lazy declaration, shim farms are inserted **after** real tool install dirs (same fallback idea as hook-env), including when farms were missing from the pristine PATH. Farms already on PATH keep their position; toolsets without lazy tools are unchanged.
> 
> **Bootstrap shims without `mise reshim`**: `ensure_lazy_shims` writes missing lazy bootstrap shims from the already-computed missing-version list (hand-edited `lazy = true` entries). **`mise run`**, task install paths, and **`mise x`** call this before executing; shim creation failures warn instead of aborting.
> 
> **`mise x -- <cmd>`** installs the lazy provider for the invoked command directly (exec resolves past shim dirs), then refreshes the missing-tools list.
> 
> **Task-only lazy tools**: `__MISE_TASK_TOOL_ARGS` carries serialized task `tools` into shim dispatch; nested tasks clear it so parent lazy tools are not inherited.
> 
> Docs and e2e coverage (`test_lazy_tools_task`, system PATH ordering) validate PATH layout, first-run install, and `mise x` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2045a28299ff030a3988a836e66b330828b4298a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lazy tools are now installed automatically when first used by tasks or commands.
  * Missing lazy tools receive temporary bootstrap paths until their real executables are available.
  * Direct command execution installs the appropriate lazy-tool provider on demand.
  * Lazy-tool support works with hand-configured entries, task-specific tools, and user or system tool locations.
  * Nested tasks no longer inherit unused lazy tools from parent tasks.
  * Tool installation continues if bootstrap shim creation encounters a warning.

* **Documentation**
  * Updated developer documentation to explain lazy-tool behavior for `mise run`, `mise x`, and `mise env`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
