### PR TITLE
chore(ci): update mbx to 1.4.1

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
     - uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
       with:
-        version: 1.4.0
+        version: 1.4.1
         cache-generation: v2
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
         server-url: https://cache.mise.jdx.dev

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
     - uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
       with:
-        version: 1.3.2
+        version: 1.4.0
         cache-generation: v2
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
         server-url: https://cache.mise.jdx.dev

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## mbx build cache
 
-`mise install` installs mbx 1.3. `mise run` activates the project's transparent
+`mise install` installs mbx 1.4. `mise run` activates the project's transparent
 Cargo wrapper, so compilation-heavy mise tasks and hk checks use ordinary
 `cargo` commands. Standalone Cargo commands require an activated mise shell. If
 the wrapper fails or creates a development papercut, rerun the exact equivalent

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ See the [contributing guide](https://mise.jdx.dev/contributing).
 
 ## mbx build cache
 
-`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.3. The normal
+`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.4. The normal
 `mise run build`, `mise run test:unit`, and `mise run lint` workflows activate
 its transparent Cargo wrapper and therefore use the cache while invoking Cargo
 normally. Standalone Cargo commands require an activated mise shell. To bypass

--- a/docs/dev-tools/shims.md
+++ b/docs/dev-tools/shims.md
@@ -196,7 +196,7 @@ through [Mr Boxington](https://github.com/jdx/mr-boxington):
 
 ```toml
 [tools]
-mr-boxington = "1.3.0"
+mr-boxington = "1.4.1"
 
 [wrappers.cargo]
 command = "mbx"

--- a/mise.lock
+++ b/mise.lock
@@ -699,62 +699,62 @@ url = "https://github.com/LuaLS/lua-language-server/releases/download/3.19.1/lua
 url_api = "https://api.github.com/repos/LuaLS/lua-language-server/releases/assets/513572668"
 
 [[tools.mr-boxington]]
-version = "1.4.0"
+version = "1.4.1"
 backend = "github:jdx/mr-boxington"
 
 [tools.mr-boxington."platforms.linux-arm64"]
-checksum = "sha256:7c2771c6da3e9f63d5bd27b22be21101f928e71b09d8e3cf94d93c16df590a7b"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540435998"
+checksum = "sha256:7ca1deeb64ad22bd5ddc9f45c749c78d3eb32608562c363727de3f0c595df0f0"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505948"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-arm64-musl"]
-checksum = "sha256:50e2bac80ca8902dccf25b5fc964237cc7cf1c1cda386abe210bac306d8cd7f1"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540435997"
+checksum = "sha256:3113dfce87c8ee6d3485f7eb99f87ae130b9b9f2c73224720edf2cef7279b5d1"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505946"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64"]
-checksum = "sha256:ca2e02ba52583e5617344c5be849e1c5efc1d82eac0977d716a8f486a3287289"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540436013"
+checksum = "sha256:5bc7434333a941f664bbe73ae229edf6111c9fb5f771f959ca411a11358baf8a"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505965"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools.mr-boxington."platforms.linux-x64-baseline"]
-checksum = "sha256:ca2e02ba52583e5617344c5be849e1c5efc1d82eac0977d716a8f486a3287289"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540436013"
+checksum = "sha256:5bc7434333a941f664bbe73ae229edf6111c9fb5f771f959ca411a11358baf8a"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505965"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64-musl"]
-checksum = "sha256:2416466f524730f75c08026553b3e6f730e637f0d216121da165d4fecfedc656"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540436016"
+checksum = "sha256:7277ceabefae1b444b39200c2cb944018a87da628ff77aa94291a8cc338546e6"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505964"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:2416466f524730f75c08026553b3e6f730e637f0d216121da165d4fecfedc656"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540436016"
+checksum = "sha256:7277ceabefae1b444b39200c2cb944018a87da628ff77aa94291a8cc338546e6"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505964"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.macos-arm64"]
-checksum = "sha256:0556a8dfd32466ab9147b03cf1c722499bd68bfb24f712d8dd9c0a046a0fedaa"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540435994"
+checksum = "sha256:57f1cac111d9972ad675aa80cbedf4c86b3423dfb11091383175db0f6341847e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505945"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64"]
-checksum = "sha256:7eaab88593c03dafb0ff0e78668b81f06b7530d62bafa466193e6b3f0ccbd50c"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540436009"
+checksum = "sha256:346cb0405129bbca4f7a24fc916b036cfd806d497d52ba47fc8bb0a0531b4382"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505963"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64-baseline"]
-checksum = "sha256:7eaab88593c03dafb0ff0e78668b81f06b7530d62bafa466193e6b3f0ccbd50c"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540436009"
+checksum = "sha256:346cb0405129bbca4f7a24fc916b036cfd806d497d52ba47fc8bb0a0531b4382"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505963"
 provenance = "github-attestations"
 
 [[tools.node]]

--- a/mise.lock
+++ b/mise.lock
@@ -699,62 +699,62 @@ url = "https://github.com/LuaLS/lua-language-server/releases/download/3.19.1/lua
 url_api = "https://api.github.com/repos/LuaLS/lua-language-server/releases/assets/513572668"
 
 [[tools.mr-boxington]]
-version = "1.3.2"
+version = "1.4.0"
 backend = "github:jdx/mr-boxington"
 
 [tools.mr-boxington."platforms.linux-arm64"]
-checksum = "sha256:18aabfdfaced4316b9e9fd488d65df0915b241aa3af8e761b4df0fc0bdc1a4f7"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849887"
+checksum = "sha256:7c2771c6da3e9f63d5bd27b22be21101f928e71b09d8e3cf94d93c16df590a7b"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540435998"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-arm64-musl"]
-checksum = "sha256:abbbcc8cc7c080febc5f6c77e1ae7af89faf15476248282f7bf4c331e836ee1b"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849885"
+checksum = "sha256:50e2bac80ca8902dccf25b5fc964237cc7cf1c1cda386abe210bac306d8cd7f1"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540435997"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64"]
-checksum = "sha256:6096035ae9bb47d718b7c0ca2860e1142047ebf724b37c02d3a520a4b9804d2d"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849911"
+checksum = "sha256:ca2e02ba52583e5617344c5be849e1c5efc1d82eac0977d716a8f486a3287289"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540436013"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools.mr-boxington."platforms.linux-x64-baseline"]
-checksum = "sha256:6096035ae9bb47d718b7c0ca2860e1142047ebf724b37c02d3a520a4b9804d2d"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849911"
+checksum = "sha256:ca2e02ba52583e5617344c5be849e1c5efc1d82eac0977d716a8f486a3287289"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540436013"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64-musl"]
-checksum = "sha256:a31a332095ac291686777736d450b2f62658145ac173ff543f83271e44850df7"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849909"
+checksum = "sha256:2416466f524730f75c08026553b3e6f730e637f0d216121da165d4fecfedc656"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540436016"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:a31a332095ac291686777736d450b2f62658145ac173ff543f83271e44850df7"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849909"
+checksum = "sha256:2416466f524730f75c08026553b3e6f730e637f0d216121da165d4fecfedc656"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540436016"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.macos-arm64"]
-checksum = "sha256:3a91ecb2d6ff4ad84662e79599d11e79eff4738c222a35ed432db4b15ade4d1e"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849886"
+checksum = "sha256:0556a8dfd32466ab9147b03cf1c722499bd68bfb24f712d8dd9c0a046a0fedaa"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540435994"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64"]
-checksum = "sha256:49e3a4570034612fd7b193e4f56830bdece32c73ac92eb7f0d580c85695492df"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849907"
+checksum = "sha256:7eaab88593c03dafb0ff0e78668b81f06b7530d62bafa466193e6b3f0ccbd50c"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540436009"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64-baseline"]
-checksum = "sha256:49e3a4570034612fd7b193e4f56830bdece32c73ac92eb7f0d580c85695492df"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849907"
+checksum = "sha256:7eaab88593c03dafb0ff0e78668b81f06b7530d62bafa466193e6b3f0ccbd50c"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540436009"
 provenance = "github-attestations"
 
 [[tools.node]]

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,7 @@ _.path = ["./target/debug", "./node_modules/.bin"]
 
 [tools]
 actionlint = "latest"
-mr-boxington = "1.3.2"
+mr-boxington = "1.4.0"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
 # in mise's numbers, indistinguishable from a real regression. Bump

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,7 @@ _.path = ["./target/debug", "./node_modules/.bin"]
 
 [tools]
 actionlint = "latest"
-mr-boxington = "1.4.0"
+mr-boxington = "1.4.1"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
 # in mise's numbers, indistinguishable from a real regression. Bump


### PR DESCRIPTION
## Summary

- update mr-boxington from 1.3.2 to 1.4.1 in mise.toml and the generated lockfile
- update the explicit composite-action binary version and keep contributor guidance on the mbx 1.4 line
- include the grouped-export GC fix released in mbx 1.4.1

## Validation

- mise lock mr-boxington
- verified the published v1.4.1 release has all eight platform assets
- verified the locked release installs and reports mbx 1.4.1
- git diff --check
- verified no changelog files changed

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project mbx tooling to version 1.4.1.
  * Updated the build automation action to version 1.4.1.
  * Updated the development-tool wrapper dependency to version 1.4.1.
  * Updated build cache setup to install mbx 1.4.

* **Documentation**
  * Updated contributor and setup guidance to reference mbx 1.4.
  * Updated development tooling guidance to reference the newer mbx version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and documentation version alignment only; no application logic changes, with lockfile checksums updated for the new release binaries.
> 
> **Overview**
> Bumps **mr-boxington** (`mbx`) from **1.3.2** to **1.4.1** across local dev and CI: `mise.toml`, regenerated `mise.lock` (all platform checksums/URLs), and the composite **mbx** GitHub Action’s `version` input.
> 
> Contributor and agent docs (`CONTRIBUTING.md`, `AGENTS.md`) and the shims doc example now describe the **1.4** line instead of **1.3**. The PR notes this picks up the grouped-export GC fix shipped in **1.4.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27ca8b0508dcc892c6b32371185bd29e66b986e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->