### PR TITLE
chore: release 2026.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,226 @@
 # Changelog
 
+## [2026.9.2](https://github.com/jdx/mise/compare/v2026.9.1..v2026.9.2) - 2026-09-07
+
+### 🚀 Features
+
+- **(activate)** add an explicit tool shims opt-out by @jdx in [#12926](https://github.com/jdx/mise/pull/12926)
+- **(backend)** apply install_env when resolving and downloading tools by @rabadin in [#12777](https://github.com/jdx/mise/pull/12777)
+- **(bootstrap)** load global config repository with --from-git by @jdx in [#12715](https://github.com/jdx/mise/pull/12715)
+- **(bootstrap)** support absent pacman packages by @jdx in [#12716](https://github.com/jdx/mise/pull/12716)
+- **(bootstrap)** add AUR package manager by @jdx in [#12718](https://github.com/jdx/mise/pull/12718)
+- **(bootstrap)** report selected root declarations by @jdx in [#12770](https://github.com/jdx/mise/pull/12770)
+- **(bootstrap)** track dotfiles with one synchronized git history by @jdx in [#12918](https://github.com/jdx/mise/pull/12918)
+- **(brew)** evaluate ordinary third-party taps by @jdx in [#12774](https://github.com/jdx/mise/pull/12774)
+- **(completion)** load packslip completions in activated shells by @jdx in [#12848](https://github.com/jdx/mise/pull/12848)
+- **(core)** add rust mr_boxington tool option and use flag by @jdx in [#12908](https://github.com/jdx/mise/pull/12908)
+- **(install)** concise fractional install progress for non-TTY output by @jdx in [#12902](https://github.com/jdx/mise/pull/12902)
+- **(install)** live install region for interactive terminals by @jdx in [#12906](https://github.com/jdx/mise/pull/12906)
+- **(install)** show resolver hosts and retry progress by @jdx in [#12907](https://github.com/jdx/mise/pull/12907)
+- **(packslip)** install from a vendor's signed release manifest by @jdx in [#12778](https://github.com/jdx/mise/pull/12778)
+- **(packslip)** shell completions from a tool's packslip by @jdx in [#12779](https://github.com/jdx/mise/pull/12779)
+- **(packslip)** agent skills from a tool's packslip by @jdx in [#12780](https://github.com/jdx/mise/pull/12780)
+- **(packslip)** install only what a trusted stamper lists by @jdx in [#12782](https://github.com/jdx/mise/pull/12782)
+- **(packslip)** pin signers globally and in the lockfile by @jdx in [#12783](https://github.com/jdx/mise/pull/12783)
+- **(packslip)** check declared host requirements before install by @jdx in [#12804](https://github.com/jdx/mise/pull/12804)
+- **(packslip)** resolve latest from verified vendor recommendations by @jdx in [#12805](https://github.com/jdx/mise/pull/12805)
+- **(packslip)** the backend is no longer experimental by @jdx in [#12811](https://github.com/jdx/mise/pull/12811)
+- **(ruby)** support bundler ruby file: in Gemfile by @jdx in [#12914](https://github.com/jdx/mise/pull/12914)
+- **(self-update)** allow curated github release sources by @jdx in [#12735](https://github.com/jdx/mise/pull/12735)
+- **(ssh)** add read-only github relay and remote git onboarding by @jdx in [#12830](https://github.com/jdx/mise/pull/12830)
+
+### 🐛 Bug Fixes
+
+- **(activate)** translate paths for the calling windows posix shell by @jdx in [#12736](https://github.com/jdx/mise/pull/12736)
+- **(activate)** forward PowerShell pipeline input by @jdx in [#12925](https://github.com/jdx/mise/pull/12925)
+- **(aqua)** handle repository transfers in attestations by @jdx in [#12766](https://github.com/jdx/mise/pull/12766)
+- **(backend)** exclude disabled plugins from shorthand resolution by @jdx in [#12927](https://github.com/jdx/mise/pull/12927)
+- **(bootstrap)** pin relative config dir during reexec by @jdx in [#12721](https://github.com/jdx/mise/pull/12721)
+- **(bootstrap)** render tera templates in hooks by @jdx in [#12727](https://github.com/jdx/mise/pull/12727)
+- **(bootstrap)** expand tilde in managed file sources by @jdx in [#12768](https://github.com/jdx/mise/pull/12768)
+- **(brew)** say why a tapped install found no API metadata by @Marukome0743 in [#12645](https://github.com/jdx/mise/pull/12645)
+- **(brew)** support all tap formula layouts by @soodoh in [#12837](https://github.com/jdx/mise/pull/12837)
+- **(brew-cask)** upgrade brew-cask packages whose `auto_updates` is enabled by @himkt in [#12857](https://github.com/jdx/mise/pull/12857)
+- **(completions)** include installed plugins in plugin completion by @jdx in [#12720](https://github.com/jdx/mise/pull/12720)
+- **(config)** terminate every newly added .tool-versions line by @dylanpulver in [#12740](https://github.com/jdx/mise/pull/12740)
+- **(dotfiles)** tolerate a stale directory the deeper walk already removed by @vladbisceanu in [#12697](https://github.com/jdx/mise/pull/12697)
+- **(env)** avoid duplicate unset in hook output by @jdx in [#12707](https://github.com/jdx/mise/pull/12707)
+- **(env)** create bootstrap shims for lazy tools when printing the env by @hktitof in [#12726](https://github.com/jdx/mise/pull/12726)
+- **(github)** omit releases with no assets from the version list by @Marukome0743 in [#12572](https://github.com/jdx/mise/pull/12572)
+- **(github)** silence oauth refresh warnings during env export by @jdx in [#12855](https://github.com/jdx/mise/pull/12855)
+- **(github)** warn only once when oauth refresh is rejected by @jdx in [#12911](https://github.com/jdx/mise/pull/12911)
+- **(go)** resolve private modules via Go by @kejne in [#12731](https://github.com/jdx/mise/pull/12731)
+- **(go)** use loong64 artifact architecture by @jdx in [#12767](https://github.com/jdx/mise/pull/12767)
+- **(http)** flush a failed download's partial file before giving up by @Marukome0743 in [#12823](https://github.com/jdx/mise/pull/12823)
+- **(install)** serialize install-into destination replacement by @jdx in [#12901](https://github.com/jdx/mise/pull/12901)
+- **(lockfile)** drop deferred provenance baseline once auto-lock verifies the upgrade by @jdx in [#12825](https://github.com/jdx/mise/pull/12825)
+- **(nix)** skip macOS sandbox and cask tests in checkPhase by @laozc in [#12856](https://github.com/jdx/mise/pull/12856)
+- **(nix)** skip aube node-gyp bootstrap test in checkPhase by @laozc in [#12858](https://github.com/jdx/mise/pull/12858)
+- **(npm)** support pnpm 12 global installs by @jdx in [#12717](https://github.com/jdx/mise/pull/12717)
+- **(nushell)** preserve PATH list type in activation prelude by @Junaid-PK in [#12754](https://github.com/jdx/mise/pull/12754)
+- **(oci)** preserve paths for reused tool layers by @jdx in [#12749](https://github.com/jdx/mise/pull/12749)
+- **(packslip)** isolate completion resources and bound exec generation by @jdx in [#12798](https://github.com/jdx/mise/pull/12798)
+- **(packslip)** enforce signed list continuity and verified release age by @jdx in [#12799](https://github.com/jdx/mise/pull/12799)
+- **(packslip)** preserve vendor policy across trusted stamps by @jdx in [#12802](https://github.com/jdx/mise/pull/12802)
+- **(packslip)** bound resource output and clean up child processes by @jdx in [#12803](https://github.com/jdx/mise/pull/12803)
+- **(packslip)** ask for a completion at the tab, not at shell startup by @jdx in [#12808](https://github.com/jdx/mise/pull/12808)
+- **(rust)** reconcile incomplete rustup toolchains by @jdx in [#12771](https://github.com/jdx/mise/pull/12771)
+- **(sandbox)** omit SYS_fork/SYS_vfork on aarch64 by @jamescassell in [#12807](https://github.com/jdx/mise/pull/12807)
+- **(schema)** support absent bootstrap packages by @nettlesh in [#12785](https://github.com/jdx/mise/pull/12785)
+- **(schema)** model inline dotfile content by @risu729 in [#12738](https://github.com/jdx/mise/pull/12738)
+- **(schema)** add missing built-in deps providers by @risu729 in [#12739](https://github.com/jdx/mise/pull/12739)
+- **(shim)** match lazy tool names on windows by @jdx in [#12699](https://github.com/jdx/mise/pull/12699)
+- **(shim)** resolve mise-shim.exe through a symlinked mise.exe on Windows by @acooler15 in [#12915](https://github.com/jdx/mise/pull/12915)
+- **(task)** prevent symlink loops in task globs by @jdx in [#12711](https://github.com/jdx/mise/pull/12711)
+- **(task)** stop pre-converting PATH for POSIX shells; the shell already does it by @JamBalaya56562 in [#12696](https://github.com/jdx/mise/pull/12696)
+- **(task)** preserve task status when cache audit tracer fails by @jdx in [#12769](https://github.com/jdx/mise/pull/12769)
+- **(task)** accept a single string for sources by @risu729 in [#12530](https://github.com/jdx/mise/pull/12530)
+- **(task)** colorize task usage help by @jdx in [#12897](https://github.com/jdx/mise/pull/12897)
+- **(vfox)** preserve tool name from legacy lockfiles by @jdx in [#12745](https://github.com/jdx/mise/pull/12745)
+- finish cache compression before publishing files by @jdx in [#12894](https://github.com/jdx/mise/pull/12894)
+
+### 🚜 Refactor
+
+- **(brew-cask)** split implementation into modules by @jdx in [#12698](https://github.com/jdx/mise/pull/12698)
+- remove obsolete naming compatibility and migration guide by @jdx in [#12877](https://github.com/jdx/mise/pull/12877)
+- simplify match guards for rust 1.95 clippy by @jdx in [#12916](https://github.com/jdx/mise/pull/12916)
+
+### 📚 Documentation
+
+- **(backend)** promote packslip to tier 1 and improve guides by @jdx in [#12840](https://github.com/jdx/mise/pull/12840)
+- **(bootstrap)** clarify landing page examples by @jdx in [#12713](https://github.com/jdx/mise/pull/12713)
+- **(bootstrap)** prevent blank guide page by @jdx in [#12755](https://github.com/jdx/mise/pull/12755)
+- **(cli)** improve command help prose and fill gaps by @jdx in [#12700](https://github.com/jdx/mise/pull/12700)
+- **(cli)** declare structured command examples by @jdx in [#12889](https://github.com/jdx/mise/pull/12889)
+- **(config)** clarify environments and repair secret setup guides by @jdx in [#12862](https://github.com/jdx/mise/pull/12862)
+- **(packslip)** reorganize backend and resource guides by @jdx in [#12809](https://github.com/jdx/mise/pull/12809)
+- **(plugins)** document ls filtering flags by @jdx in [#12724](https://github.com/jdx/mise/pull/12724)
+- **(settings)** fix stale python.uv_venv_auto deprecation text by @jdx in [#12695](https://github.com/jdx/mise/pull/12695)
+- **(task)** correct examples and reorganize task guides by @jdx in [#12861](https://github.com/jdx/mise/pull/12861)
+- improve prose across documentation by @jdx in [#12691](https://github.com/jdx/mise/pull/12691)
+- fix content errors across documentation by @jdx in [#12693](https://github.com/jdx/mise/pull/12693)
+- promote mr boxington and aube by @jdx in [#12701](https://github.com/jdx/mise/pull/12701)
+- preserve code spans when flattening markdown for llms.txt by @jdx in [#12704](https://github.com/jdx/mise/pull/12704)
+- redesign landing page around one config file by @jdx in [#12708](https://github.com/jdx/mise/pull/12708)
+- add open graph share image by @jdx in [#12743](https://github.com/jdx/mise/pull/12743)
+- complete social and search metadata by @jdx in [#12806](https://github.com/jdx/mise/pull/12806)
+- generate page-specific social preview images by @jdx in [#12832](https://github.com/jdx/mise/pull/12832)
+- link packslip announcement from backend guide by @jdx in [#12850](https://github.com/jdx/mise/pull/12850)
+- clarify onboarding and improve website guidance by @jdx in [#12859](https://github.com/jdx/mise/pull/12859)
+- refresh website theme and landing page by @jdx in [#12860](https://github.com/jdx/mise/pull/12860)
+- regenerate llms index by @jdx in [1fc6677](https://github.com/jdx/mise/commit/1fc66772ed05e99f58fa6cf9d9d36ad9a0482282)
+- make language setup guides project focused and accurate by @jdx in [#12864](https://github.com/jdx/mise/pull/12864)
+- make cookbook recipes complete and reproducible by @jdx in [#12863](https://github.com/jdx/mise/pull/12863)
+- clarify tool selection, shims, and dependency workflows by @jdx in [#12866](https://github.com/jdx/mise/pull/12866)
+- explain lockfile guarantees and GitHub authentication by @jdx in [#12867](https://github.com/jdx/mise/pull/12867)
+- clarify tool stub and OCI distribution workflows by @jdx in [#12868](https://github.com/jdx/mise/pull/12868)
+- restore TOML 1.1 inline table examples by @jdx in [#12869](https://github.com/jdx/mise/pull/12869)
+- clarify download backend setup and verification by @jdx in [#12870](https://github.com/jdx/mise/pull/12870)
+- clarify bootstrap package ownership and workflows by @jdx in [#12873](https://github.com/jdx/mise/pull/12873)
+- clarify package backend runtimes and installation by @jdx in [#12871](https://github.com/jdx/mise/pull/12871)
+- improve bootstrap workflows and resource examples by @jdx in [#12872](https://github.com/jdx/mise/pull/12872)
+- deepen onboarding and installation guidance by @jdx in [#12874](https://github.com/jdx/mise/pull/12874)
+- repair shared reference links and refresh CI examples by @jdx in [#12886](https://github.com/jdx/mise/pull/12886)
+- correct plugin authoring contracts and examples by @jdx in [#12881](https://github.com/jdx/mise/pull/12881)
+- clarify dotfile ownership and application workflows by @jdx in [#12884](https://github.com/jdx/mise/pull/12884)
+- reorganize FAQs and deepen workflow recipes by @jdx in [#12878](https://github.com/jdx/mise/pull/12878)
+- clarify plugin selection and maintenance by @jdx in [#12880](https://github.com/jdx/mise/pull/12880)
+- deepen diagnostics and correct cache guidance by @jdx in [#12876](https://github.com/jdx/mise/pull/12876)
+- ground contributor workflows in current implementation by @jdx in [#12883](https://github.com/jdx/mise/pull/12883)
+- clarify CI editor and MCP integration by @jdx in [#12875](https://github.com/jdx/mise/pull/12875)
+- deepen and regenerate the CLI reference by @jdx in [#12885](https://github.com/jdx/mise/pull/12885)
+- remove homepage tagline by @jdx in [#12917](https://github.com/jdx/mise/pull/12917)
+- improve social previews with page summaries by @jdx in [#12929](https://github.com/jdx/mise/pull/12929)
+
+### ⚡ Performance
+
+- **(ci)** reuse appliance-local mbx cache by @jdx in [#12703](https://github.com/jdx/mise/pull/12703)
+- **(ci)** speed up test workflow by @jdx in [#12912](https://github.com/jdx/mise/pull/12912)
+- **(shim)** skip the mise binary lookup when no lazy tool needs a shim by @jdx in [#12742](https://github.com/jdx/mise/pull/12742)
+
+### 🧪 Testing
+
+- fix unit-macos link and packslip e2e under the release workflow by @jdx in [#12818](https://github.com/jdx/mise/pull/12818)
+- improve Windows shim failure diagnostics and cleanup by @jdx in [#12899](https://github.com/jdx/mise/pull/12899)
+
+### 📦️ Dependency Updates
+
+- bump self_update to 1.3 to clear quick-xml advisories by @Svector-anu in [#12714](https://github.com/jdx/mise/pull/12714)
+- update rust crate sevenz-rust2 to 0.22 by @renovate[bot] in [#12656](https://github.com/jdx/mise/pull/12656)
+- update rust crate aube-registry to v2.2.5 by @renovate[bot] in [#12752](https://github.com/jdx/mise/pull/12752)
+- update rust crate aube-registry to v2.2.6 by @renovate[bot] in [#12753](https://github.com/jdx/mise/pull/12753)
+- update rust crate aube-registry to v2.2.9 by @renovate[bot] in [#12757](https://github.com/jdx/mise/pull/12757)
+- bump aube to 2.2.9 by @jdx in [#12772](https://github.com/jdx/mise/pull/12772)
+- update rust crate usage-cli to v6.7.0 by @renovate[bot] in [#12556](https://github.com/jdx/mise/pull/12556)
+- update rust crate usage-lib to v6.7.1 by @renovate[bot] in [#12608](https://github.com/jdx/mise/pull/12608)
+- update rust crate aube to v2.2.10 by @renovate[bot] in [#12751](https://github.com/jdx/mise/pull/12751)
+- update rust crate aube-registry to v2.2.10 by @renovate[bot] in [#12842](https://github.com/jdx/mise/pull/12842)
+- update rust crate usage-cli to v6.7.1 by @renovate[bot] in [#12844](https://github.com/jdx/mise/pull/12844)
+- update rust crate aube-registry to v2.2.11 by @renovate[bot] in [#12847](https://github.com/jdx/mise/pull/12847)
+- update rust crate aube to v2.2.11 by @renovate[bot] in [#12846](https://github.com/jdx/mise/pull/12846)
+- update rust crate aube-registry to v2.2.12 by @renovate[bot] in [#12853](https://github.com/jdx/mise/pull/12853)
+- update rust crate aube to v2.2.12 by @renovate[bot] in [#12852](https://github.com/jdx/mise/pull/12852)
+- bump mr-boxington to 1.8.3 by @jdx in [#12854](https://github.com/jdx/mise/pull/12854)
+- disable unused gix and color-eyre features by @jdx in [#12909](https://github.com/jdx/mise/pull/12909)
+- lock file maintenance by @renovate[bot] in [#12910](https://github.com/jdx/mise/pull/12910)
+
+### 📦 Registry
+
+- use canonical Crossplane CLI package by @jamescassell in [#12748](https://github.com/jdx/mise/pull/12748)
+- compile baked registry in release tests by @esteve in [#12776](https://github.com/jdx/mise/pull/12776)
+- add packslip by @jdx in [#12810](https://github.com/jdx/mise/pull/12810)
+- pin packslip release and index workflows by @jdx in [#12841](https://github.com/jdx/mise/pull/12841)
+- support minimum backend versions and adopt packslip by @jdx in [#12845](https://github.com/jdx/mise/pull/12845)
+- add muse code by @jdx in [#12900](https://github.com/jdx/mise/pull/12900)
+
+### Chore
+
+- **(ci)** update performance runner image by @jdx in [#12712](https://github.com/jdx/mise/pull/12712)
+- **(ci)** attest release artifacts by @jdx in [#12728](https://github.com/jdx/mise/pull/12728)
+- **(ci)** bump packslip to v1.1.1 by @jdx in [#12836](https://github.com/jdx/mise/pull/12836)
+- **(release)** only run the release PR dry run once auto-merge is enabled by @jdx in [#12827](https://github.com/jdx/mise/pull/12827)
+- **(release)** simplify the packslip job with upstream v1.0.0 fixes by @jdx in [#12829](https://github.com/jdx/mise/pull/12829)
+- **(render)** run markdown-magic non-interactively by @jdx in [#12820](https://github.com/jdx/mise/pull/12820)
+- configure Entire search by @jdx in [#12773](https://github.com/jdx/mise/pull/12773)
+
+### Ci
+
+- **(release)** publish a signed packslip with each release by @jdx in [#12812](https://github.com/jdx/mise/pull/12812)
+- **(release)** bump packslip to v1.0.2 by @jdx in [#12831](https://github.com/jdx/mise/pull/12831)
+- **(release)** skip e2e tests when publishing tags by @jdx in [#12930](https://github.com/jdx/mise/pull/12930)
+- route mbx caching by runner provider by @jdx in [#12705](https://github.com/jdx/mise/pull/12705)
+- restore rust-cache by @jdx in [#12723](https://github.com/jdx/mise/pull/12723)
+- enforce conventional commits by @jdx in [#12828](https://github.com/jdx/mise/pull/12828)
+- enable local mbx caching for performance builds by @jdx in [#12898](https://github.com/jdx/mise/pull/12898)
+
+### Security
+
+- **(http)** prevent credential downgrade in URL replacements by @jdx in [#12879](https://github.com/jdx/mise/pull/12879)
+- **(self-update)** require secure release sources by @jdx in [#12737](https://github.com/jdx/mise/pull/12737)
+
+### New Contributors
+
+- @acooler15 made their first contribution in [#12915](https://github.com/jdx/mise/pull/12915)
+- @soodoh made their first contribution in [#12837](https://github.com/jdx/mise/pull/12837)
+- @jamescassell made their first contribution in [#12807](https://github.com/jdx/mise/pull/12807)
+- @nettlesh made their first contribution in [#12785](https://github.com/jdx/mise/pull/12785)
+- @Junaid-PK made their first contribution in [#12754](https://github.com/jdx/mise/pull/12754)
+- @kejne made their first contribution in [#12731](https://github.com/jdx/mise/pull/12731)
+- @dylanpulver made their first contribution in [#12740](https://github.com/jdx/mise/pull/12740)
+- @Svector-anu made their first contribution in [#12714](https://github.com/jdx/mise/pull/12714)
+- @vladbisceanu made their first contribution in [#12697](https://github.com/jdx/mise/pull/12697)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (1)
+
+- [`rancher-archives/rke`](https://github.com/rancher-archives/rke)
+
+#### Updated Packages (2)
+
+- [`charmbracelet/gum`](https://github.com/charmbracelet/gum)
+- [`sharkdp/fd`](https://github.com/sharkdp/fd)
+
 ## [2026.9.1](https://github.com/jdx/mise/compare/v2026.9.0..v2026.9.1) - 2026-09-02
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6271,7 +6271,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "age 0.12.1",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.9.1"
+version = "2026.9.2"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.9.1";
+  version = "2026.9.2";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "33.3k",
+      stars: "33.6k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.9.1
+Version: 2026.9.2
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.9.1"
+version: "2026.9.2"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "e5290615d37d083d0ce31e5378a2ce52d855264b"
+  "tag": "66fcd35225f63e49cd7f9522e96ed645390bdc28"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -25098,6 +25098,16 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity
+              - https://github.com/charmbracelet/meta/.github/workflows/goreleaser.yml@refs/heads/main
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --certificate
+              - https://github.com/charmbracelet/gum/releases/download/{{.Version}}/checksums.txt.pem
+              - --signature
+              - https://github.com/charmbracelet/gum/releases/download/{{.Version}}/checksums.txt.sig
         overrides:
           - goos: windows
             format: zip
@@ -25114,6 +25124,45 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity
+              - https://github.com/charmbracelet/meta/.github/workflows/goreleaser.yml@refs/heads/main
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --certificate
+              - https://github.com/charmbracelet/gum/releases/download/{{.Version}}/checksums.txt.pem
+              - --signature
+              - https://github.com/charmbracelet/gum/releases/download/{{.Version}}/checksums.txt.sig
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("< 2.0.0")
+        asset: gum_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: gum
+            src: "{{.AssetWithoutExt}}/gum"
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity
+              - https://github.com/charmbracelet/meta/.github/workflows/goreleaser.yml@refs/heads/main
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --certificate
+              - https://github.com/charmbracelet/gum/releases/download/{{.Version}}/checksums.txt.pem
+              - --signature
+              - https://github.com/charmbracelet/gum/releases/download/{{.Version}}/checksums.txt.sig
         overrides:
           - goos: windows
             format: zip
@@ -25133,6 +25182,15 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity
+              - https://github.com/charmbracelet/meta/.github/workflows/goreleaser.yml@refs/heads/main
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         overrides:
           - goos: windows
             format: zip
@@ -79493,48 +79551,10 @@ packages:
           asset: kubectl-whoami_{{trimV .Version}}_checksums.txt
           algorithm: sha256
   - type: github_release
-    repo_owner: rancher
-    repo_name: cli
-    description: Rancher CLI
-    rosetta2: true
-    supported_envs:
-      - darwin
-      - amd64
-    asset: rancher-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
-    format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
-    files:
-      - name: rancher
-        src: rancher-{{.Version}}/rancher
-    checksum:
-      type: github_release
-      asset: sha256sum.txt
-      algorithm: sha256
-  - type: github_release
-    repo_owner: rancher
-    repo_name: kim
-    description: In ur kubernetes, buildin ur imagez
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: semver("<= 0.1.0-alpha.3")
-        asset: kim-{{.OS}}-{{.Arch}}
-        format: raw
-        windows_arm_emulation: true
-      - version_constraint: semver("<= 0.1.0-alpha.6")
-        no_asset: true
-      - version_constraint: "true"
-        asset: kim-{{.OS}}-{{.Arch}}
-        format: raw
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: sha256sum.txt
-          algorithm: sha256
-  - type: github_release
-    repo_owner: rancher
+    repo_owner: rancher-archives
     repo_name: rke
+    aliases:
+      - name: rancher/rke
     description: Rancher Kubernetes Engine (RKE), an extremely simple, lightning fast Kubernetes distribution that runs entirely within containers
     version_constraint: "false"
     version_overrides:
@@ -79660,6 +79680,46 @@ packages:
         format: raw
         rosetta2: true
         windows_arm_emulation: true
+  - type: github_release
+    repo_owner: rancher
+    repo_name: cli
+    description: Rancher CLI
+    rosetta2: true
+    supported_envs:
+      - darwin
+      - amd64
+    asset: rancher-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: rancher
+        src: rancher-{{.Version}}/rancher
+    checksum:
+      type: github_release
+      asset: sha256sum.txt
+      algorithm: sha256
+  - type: github_release
+    repo_owner: rancher
+    repo_name: kim
+    description: In ur kubernetes, buildin ur imagez
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.0-alpha.3")
+        asset: kim-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+      - version_constraint: semver("<= 0.1.0-alpha.6")
+        no_asset: true
+      - version_constraint: "true"
+        asset: kim-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: sha256sum.txt
+          algorithm: sha256
   - type: github_release
     repo_owner: raviqqe
     repo_name: muffet
@@ -84647,7 +84707,7 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: "true"
+      - version_constraint: semver("<= 10.4.2")
         asset: fd-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         replacements:
@@ -84666,6 +84726,18 @@ packages:
           - linux
           - darwin/arm64
           - windows
+      - version_constraint: "true"
+        asset: fd-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: sharkdp
     repo_name: hexyl


### PR DESCRIPTION
### 🚀 Features

- **(activate)** add an explicit tool shims opt-out by @jdx in [#12926](https://github.com/jdx/mise/pull/12926)
- **(backend)** apply install_env when resolving and downloading tools by @rabadin in [#12777](https://github.com/jdx/mise/pull/12777)
- **(bootstrap)** load global config repository with --from-git by @jdx in [#12715](https://github.com/jdx/mise/pull/12715)
- **(bootstrap)** support absent pacman packages by @jdx in [#12716](https://github.com/jdx/mise/pull/12716)
- **(bootstrap)** add AUR package manager by @jdx in [#12718](https://github.com/jdx/mise/pull/12718)
- **(bootstrap)** report selected root declarations by @jdx in [#12770](https://github.com/jdx/mise/pull/12770)
- **(bootstrap)** track dotfiles with one synchronized git history by @jdx in [#12918](https://github.com/jdx/mise/pull/12918)
- **(brew)** evaluate ordinary third-party taps by @jdx in [#12774](https://github.com/jdx/mise/pull/12774)
- **(completion)** load packslip completions in activated shells by @jdx in [#12848](https://github.com/jdx/mise/pull/12848)
- **(core)** add rust mr_boxington tool option and use flag by @jdx in [#12908](https://github.com/jdx/mise/pull/12908)
- **(install)** concise fractional install progress for non-TTY output by @jdx in [#12902](https://github.com/jdx/mise/pull/12902)
- **(install)** live install region for interactive terminals by @jdx in [#12906](https://github.com/jdx/mise/pull/12906)
- **(install)** show resolver hosts and retry progress by @jdx in [#12907](https://github.com/jdx/mise/pull/12907)
- **(packslip)** install from a vendor's signed release manifest by @jdx in [#12778](https://github.com/jdx/mise/pull/12778)
- **(packslip)** shell completions from a tool's packslip by @jdx in [#12779](https://github.com/jdx/mise/pull/12779)
- **(packslip)** agent skills from a tool's packslip by @jdx in [#12780](https://github.com/jdx/mise/pull/12780)
- **(packslip)** install only what a trusted stamper lists by @jdx in [#12782](https://github.com/jdx/mise/pull/12782)
- **(packslip)** pin signers globally and in the lockfile by @jdx in [#12783](https://github.com/jdx/mise/pull/12783)
- **(packslip)** check declared host requirements before install by @jdx in [#12804](https://github.com/jdx/mise/pull/12804)
- **(packslip)** resolve latest from verified vendor recommendations by @jdx in [#12805](https://github.com/jdx/mise/pull/12805)
- **(packslip)** the backend is no longer experimental by @jdx in [#12811](https://github.com/jdx/mise/pull/12811)
- **(ruby)** support bundler ruby file: in Gemfile by @jdx in [#12914](https://github.com/jdx/mise/pull/12914)
- **(self-update)** allow curated github release sources by @jdx in [#12735](https://github.com/jdx/mise/pull/12735)
- **(ssh)** add read-only github relay and remote git onboarding by @jdx in [#12830](https://github.com/jdx/mise/pull/12830)

### 🐛 Bug Fixes

- **(activate)** translate paths for the calling windows posix shell by @jdx in [#12736](https://github.com/jdx/mise/pull/12736)
- **(activate)** forward PowerShell pipeline input by @jdx in [#12925](https://github.com/jdx/mise/pull/12925)
- **(aqua)** handle repository transfers in attestations by @jdx in [#12766](https://github.com/jdx/mise/pull/12766)
- **(backend)** exclude disabled plugins from shorthand resolution by @jdx in [#12927](https://github.com/jdx/mise/pull/12927)
- **(bootstrap)** pin relative config dir during reexec by @jdx in [#12721](https://github.com/jdx/mise/pull/12721)
- **(bootstrap)** render tera templates in hooks by @jdx in [#12727](https://github.com/jdx/mise/pull/12727)
- **(bootstrap)** expand tilde in managed file sources by @jdx in [#12768](https://github.com/jdx/mise/pull/12768)
- **(brew)** say why a tapped install found no API metadata by @Marukome0743 in [#12645](https://github.com/jdx/mise/pull/12645)
- **(brew)** support all tap formula layouts by @soodoh in [#12837](https://github.com/jdx/mise/pull/12837)
- **(brew-cask)** upgrade brew-cask packages whose `auto_updates` is enabled by @himkt in [#12857](https://github.com/jdx/mise/pull/12857)
- **(completions)** include installed plugins in plugin completion by @jdx in [#12720](https://github.com/jdx/mise/pull/12720)
- **(config)** terminate every newly added .tool-versions line by @dylanpulver in [#12740](https://github.com/jdx/mise/pull/12740)
- **(dotfiles)** tolerate a stale directory the deeper walk already removed by @vladbisceanu in [#12697](https://github.com/jdx/mise/pull/12697)
- **(env)** avoid duplicate unset in hook output by @jdx in [#12707](https://github.com/jdx/mise/pull/12707)
- **(env)** create bootstrap shims for lazy tools when printing the env by @hktitof in [#12726](https://github.com/jdx/mise/pull/12726)
- **(github)** omit releases with no assets from the version list by @Marukome0743 in [#12572](https://github.com/jdx/mise/pull/12572)
- **(github)** silence oauth refresh warnings during env export by @jdx in [#12855](https://github.com/jdx/mise/pull/12855)
- **(github)** warn only once when oauth refresh is rejected by @jdx in [#12911](https://github.com/jdx/mise/pull/12911)
- **(go)** resolve private modules via Go by @kejne in [#12731](https://github.com/jdx/mise/pull/12731)
- **(go)** use loong64 artifact architecture by @jdx in [#12767](https://github.com/jdx/mise/pull/12767)
- **(http)** flush a failed download's partial file before giving up by @Marukome0743 in [#12823](https://github.com/jdx/mise/pull/12823)
- **(install)** serialize install-into destination replacement by @jdx in [#12901](https://github.com/jdx/mise/pull/12901)
- **(lockfile)** drop deferred provenance baseline once auto-lock verifies the upgrade by @jdx in [#12825](https://github.com/jdx/mise/pull/12825)
- **(nix)** skip macOS sandbox and cask tests in checkPhase by @laozc in [#12856](https://github.com/jdx/mise/pull/12856)
- **(nix)** skip aube node-gyp bootstrap test in checkPhase by @laozc in [#12858](https://github.com/jdx/mise/pull/12858)
- **(npm)** support pnpm 12 global installs by @jdx in [#12717](https://github.com/jdx/mise/pull/12717)
- **(nushell)** preserve PATH list type in activation prelude by @Junaid-PK in [#12754](https://github.com/jdx/mise/pull/12754)
- **(oci)** preserve paths for reused tool layers by @jdx in [#12749](https://github.com/jdx/mise/pull/12749)
- **(packslip)** isolate completion resources and bound exec generation by @jdx in [#12798](https://github.com/jdx/mise/pull/12798)
- **(packslip)** enforce signed list continuity and verified release age by @jdx in [#12799](https://github.com/jdx/mise/pull/12799)
- **(packslip)** preserve vendor policy across trusted stamps by @jdx in [#12802](https://github.com/jdx/mise/pull/12802)
- **(packslip)** bound resource output and clean up child processes by @jdx in [#12803](https://github.com/jdx/mise/pull/12803)
- **(packslip)** ask for a completion at the tab, not at shell startup by @jdx in [#12808](https://github.com/jdx/mise/pull/12808)
- **(rust)** reconcile incomplete rustup toolchains by @jdx in [#12771](https://github.com/jdx/mise/pull/12771)
- **(sandbox)** omit SYS_fork/SYS_vfork on aarch64 by @jamescassell in [#12807](https://github.com/jdx/mise/pull/12807)
- **(schema)** support absent bootstrap packages by @nettlesh in [#12785](https://github.com/jdx/mise/pull/12785)
- **(schema)** model inline dotfile content by @risu729 in [#12738](https://github.com/jdx/mise/pull/12738)
- **(schema)** add missing built-in deps providers by @risu729 in [#12739](https://github.com/jdx/mise/pull/12739)
- **(shim)** match lazy tool names on windows by @jdx in [#12699](https://github.com/jdx/mise/pull/12699)
- **(shim)** resolve mise-shim.exe through a symlinked mise.exe on Windows by @acooler15 in [#12915](https://github.com/jdx/mise/pull/12915)
- **(task)** prevent symlink loops in task globs by @jdx in [#12711](https://github.com/jdx/mise/pull/12711)
- **(task)** stop pre-converting PATH for POSIX shells; the shell already does it by @JamBalaya56562 in [#12696](https://github.com/jdx/mise/pull/12696)
- **(task)** preserve task status when cache audit tracer fails by @jdx in [#12769](https://github.com/jdx/mise/pull/12769)
- **(task)** accept a single string for sources by @risu729 in [#12530](https://github.com/jdx/mise/pull/12530)
- **(task)** colorize task usage help by @jdx in [#12897](https://github.com/jdx/mise/pull/12897)
- **(vfox)** preserve tool name from legacy lockfiles by @jdx in [#12745](https://github.com/jdx/mise/pull/12745)
- finish cache compression before publishing files by @jdx in [#12894](https://github.com/jdx/mise/pull/12894)

### 🚜 Refactor

- **(brew-cask)** split implementation into modules by @jdx in [#12698](https://github.com/jdx/mise/pull/12698)
- remove obsolete naming compatibility and migration guide by @jdx in [#12877](https://github.com/jdx/mise/pull/12877)
- simplify match guards for rust 1.95 clippy by @jdx in [#12916](https://github.com/jdx/mise/pull/12916)

### 📚 Documentation

- **(backend)** promote packslip to tier 1 and improve guides by @jdx in [#12840](https://github.com/jdx/mise/pull/12840)
- **(bootstrap)** clarify landing page examples by @jdx in [#12713](https://github.com/jdx/mise/pull/12713)
- **(bootstrap)** prevent blank guide page by @jdx in [#12755](https://github.com/jdx/mise/pull/12755)
- **(cli)** improve command help prose and fill gaps by @jdx in [#12700](https://github.com/jdx/mise/pull/12700)
- **(cli)** declare structured command examples by @jdx in [#12889](https://github.com/jdx/mise/pull/12889)
- **(config)** clarify environments and repair secret setup guides by @jdx in [#12862](https://github.com/jdx/mise/pull/12862)
- **(packslip)** reorganize backend and resource guides by @jdx in [#12809](https://github.com/jdx/mise/pull/12809)
- **(plugins)** document ls filtering flags by @jdx in [#12724](https://github.com/jdx/mise/pull/12724)
- **(settings)** fix stale python.uv_venv_auto deprecation text by @jdx in [#12695](https://github.com/jdx/mise/pull/12695)
- **(task)** correct examples and reorganize task guides by @jdx in [#12861](https://github.com/jdx/mise/pull/12861)
- improve prose across documentation by @jdx in [#12691](https://github.com/jdx/mise/pull/12691)
- fix content errors across documentation by @jdx in [#12693](https://github.com/jdx/mise/pull/12693)
- promote mr boxington and aube by @jdx in [#12701](https://github.com/jdx/mise/pull/12701)
- preserve code spans when flattening markdown for llms.txt by @jdx in [#12704](https://github.com/jdx/mise/pull/12704)
- redesign landing page around one config file by @jdx in [#12708](https://github.com/jdx/mise/pull/12708)
- add open graph share image by @jdx in [#12743](https://github.com/jdx/mise/pull/12743)
- complete social and search metadata by @jdx in [#12806](https://github.com/jdx/mise/pull/12806)
- generate page-specific social preview images by @jdx in [#12832](https://github.com/jdx/mise/pull/12832)
- link packslip announcement from backend guide by @jdx in [#12850](https://github.com/jdx/mise/pull/12850)
- clarify onboarding and improve website guidance by @jdx in [#12859](https://github.com/jdx/mise/pull/12859)
- refresh website theme and landing page by @jdx in [#12860](https://github.com/jdx/mise/pull/12860)
- regenerate llms index by @jdx in [1fc6677](https://github.com/jdx/mise/commit/1fc66772ed05e99f58fa6cf9d9d36ad9a0482282)
- make language setup guides project focused and accurate by @jdx in [#12864](https://github.com/jdx/mise/pull/12864)
- make cookbook recipes complete and reproducible by @jdx in [#12863](https://github.com/jdx/mise/pull/12863)
- clarify tool selection, shims, and dependency workflows by @jdx in [#12866](https://github.com/jdx/mise/pull/12866)
- explain lockfile guarantees and GitHub authentication by @jdx in [#12867](https://github.com/jdx/mise/pull/12867)
- clarify tool stub and OCI distribution workflows by @jdx in [#12868](https://github.com/jdx/mise/pull/12868)
- restore TOML 1.1 inline table examples by @jdx in [#12869](https://github.com/jdx/mise/pull/12869)
- clarify download backend setup and verification by @jdx in [#12870](https://github.com/jdx/mise/pull/12870)
- clarify bootstrap package ownership and workflows by @jdx in [#12873](https://github.com/jdx/mise/pull/12873)
- clarify package backend runtimes and installation by @jdx in [#12871](https://github.com/jdx/mise/pull/12871)
- improve bootstrap workflows and resource examples by @jdx in [#12872](https://github.com/jdx/mise/pull/12872)
- deepen onboarding and installation guidance by @jdx in [#12874](https://github.com/jdx/mise/pull/12874)
- repair shared reference links and refresh CI examples by @jdx in [#12886](https://github.com/jdx/mise/pull/12886)
- correct plugin authoring contracts and examples by @jdx in [#12881](https://github.com/jdx/mise/pull/12881)
- clarify dotfile ownership and application workflows by @jdx in [#12884](https://github.com/jdx/mise/pull/12884)
- reorganize FAQs and deepen workflow recipes by @jdx in [#12878](https://github.com/jdx/mise/pull/12878)
- clarify plugin selection and maintenance by @jdx in [#12880](https://github.com/jdx/mise/pull/12880)
- deepen diagnostics and correct cache guidance by @jdx in [#12876](https://github.com/jdx/mise/pull/12876)
- ground contributor workflows in current implementation by @jdx in [#12883](https://github.com/jdx/mise/pull/12883)
- clarify CI editor and MCP integration by @jdx in [#12875](https://github.com/jdx/mise/pull/12875)
- deepen and regenerate the CLI reference by @jdx in [#12885](https://github.com/jdx/mise/pull/12885)
- remove homepage tagline by @jdx in [#12917](https://github.com/jdx/mise/pull/12917)
- improve social previews with page summaries by @jdx in [#12929](https://github.com/jdx/mise/pull/12929)

### ⚡ Performance

- **(ci)** reuse appliance-local mbx cache by @jdx in [#12703](https://github.com/jdx/mise/pull/12703)
- **(ci)** speed up test workflow by @jdx in [#12912](https://github.com/jdx/mise/pull/12912)
- **(shim)** skip the mise binary lookup when no lazy tool needs a shim by @jdx in [#12742](https://github.com/jdx/mise/pull/12742)

### 🧪 Testing

- fix unit-macos link and packslip e2e under the release workflow by @jdx in [#12818](https://github.com/jdx/mise/pull/12818)
- improve Windows shim failure diagnostics and cleanup by @jdx in [#12899](https://github.com/jdx/mise/pull/12899)

### 📦️ Dependency Updates

- bump self_update to 1.3 to clear quick-xml advisories by @Svector-anu in [#12714](https://github.com/jdx/mise/pull/12714)
- update rust crate sevenz-rust2 to 0.22 by @renovate[bot] in [#12656](https://github.com/jdx/mise/pull/12656)
- update rust crate aube-registry to v2.2.5 by @renovate[bot] in [#12752](https://github.com/jdx/mise/pull/12752)
- update rust crate aube-registry to v2.2.6 by @renovate[bot] in [#12753](https://github.com/jdx/mise/pull/12753)
- update rust crate aube-registry to v2.2.9 by @renovate[bot] in [#12757](https://github.com/jdx/mise/pull/12757)
- bump aube to 2.2.9 by @jdx in [#12772](https://github.com/jdx/mise/pull/12772)
- update rust crate usage-cli to v6.7.0 by @renovate[bot] in [#12556](https://github.com/jdx/mise/pull/12556)
- update rust crate usage-lib to v6.7.1 by @renovate[bot] in [#12608](https://github.com/jdx/mise/pull/12608)
- update rust crate aube to v2.2.10 by @renovate[bot] in [#12751](https://github.com/jdx/mise/pull/12751)
- update rust crate aube-registry to v2.2.10 by @renovate[bot] in [#12842](https://github.com/jdx/mise/pull/12842)
- update rust crate usage-cli to v6.7.1 by @renovate[bot] in [#12844](https://github.com/jdx/mise/pull/12844)
- update rust crate aube-registry to v2.2.11 by @renovate[bot] in [#12847](https://github.com/jdx/mise/pull/12847)
- update rust crate aube to v2.2.11 by @renovate[bot] in [#12846](https://github.com/jdx/mise/pull/12846)
- update rust crate aube-registry to v2.2.12 by @renovate[bot] in [#12853](https://github.com/jdx/mise/pull/12853)
- update rust crate aube to v2.2.12 by @renovate[bot] in [#12852](https://github.com/jdx/mise/pull/12852)
- bump mr-boxington to 1.8.3 by @jdx in [#12854](https://github.com/jdx/mise/pull/12854)
- disable unused gix and color-eyre features by @jdx in [#12909](https://github.com/jdx/mise/pull/12909)
- lock file maintenance by @renovate[bot] in [#12910](https://github.com/jdx/mise/pull/12910)

### 📦 Registry

- use canonical Crossplane CLI package by @jamescassell in [#12748](https://github.com/jdx/mise/pull/12748)
- compile baked registry in release tests by @esteve in [#12776](https://github.com/jdx/mise/pull/12776)
- add packslip by @jdx in [#12810](https://github.com/jdx/mise/pull/12810)
- pin packslip release and index workflows by @jdx in [#12841](https://github.com/jdx/mise/pull/12841)
- support minimum backend versions and adopt packslip by @jdx in [#12845](https://github.com/jdx/mise/pull/12845)
- add muse code by @jdx in [#12900](https://github.com/jdx/mise/pull/12900)

### Chore

- **(ci)** update performance runner image by @jdx in [#12712](https://github.com/jdx/mise/pull/12712)
- **(ci)** attest release artifacts by @jdx in [#12728](https://github.com/jdx/mise/pull/12728)
- **(ci)** bump packslip to v1.1.1 by @jdx in [#12836](https://github.com/jdx/mise/pull/12836)
- **(release)** only run the release PR dry run once auto-merge is enabled by @jdx in [#12827](https://github.com/jdx/mise/pull/12827)
- **(release)** simplify the packslip job with upstream v1.0.0 fixes by @jdx in [#12829](https://github.com/jdx/mise/pull/12829)
- **(render)** run markdown-magic non-interactively by @jdx in [#12820](https://github.com/jdx/mise/pull/12820)
- configure Entire search by @jdx in [#12773](https://github.com/jdx/mise/pull/12773)

### Ci

- **(release)** publish a signed packslip with each release by @jdx in [#12812](https://github.com/jdx/mise/pull/12812)
- **(release)** bump packslip to v1.0.2 by @jdx in [#12831](https://github.com/jdx/mise/pull/12831)
- **(release)** skip e2e tests when publishing tags by @jdx in [#12930](https://github.com/jdx/mise/pull/12930)
- route mbx caching by runner provider by @jdx in [#12705](https://github.com/jdx/mise/pull/12705)
- restore rust-cache by @jdx in [#12723](https://github.com/jdx/mise/pull/12723)
- enforce conventional commits by @jdx in [#12828](https://github.com/jdx/mise/pull/12828)
- enable local mbx caching for performance builds by @jdx in [#12898](https://github.com/jdx/mise/pull/12898)

### Security

- **(http)** prevent credential downgrade in URL replacements by @jdx in [#12879](https://github.com/jdx/mise/pull/12879)
- **(self-update)** require secure release sources by @jdx in [#12737](https://github.com/jdx/mise/pull/12737)

### New Contributors

- @acooler15 made their first contribution in [#12915](https://github.com/jdx/mise/pull/12915)
- @soodoh made their first contribution in [#12837](https://github.com/jdx/mise/pull/12837)
- @jamescassell made their first contribution in [#12807](https://github.com/jdx/mise/pull/12807)
- @nettlesh made their first contribution in [#12785](https://github.com/jdx/mise/pull/12785)
- @Junaid-PK made their first contribution in [#12754](https://github.com/jdx/mise/pull/12754)
- @kejne made their first contribution in [#12731](https://github.com/jdx/mise/pull/12731)
- @dylanpulver made their first contribution in [#12740](https://github.com/jdx/mise/pull/12740)
- @Svector-anu made their first contribution in [#12714](https://github.com/jdx/mise/pull/12714)
- @vladbisceanu made their first contribution in [#12697](https://github.com/jdx/mise/pull/12697)

## 📦 Aqua Registry Updates

### New Packages (1)

- [`rancher-archives/rke`](https://github.com/rancher-archives/rke)

### Updated Packages (2)

- [`charmbracelet/gum`](https://github.com/charmbracelet/gum)
- [`sharkdp/fd`](https://github.com/sharkdp/fd)