### PR TITLE
docs(settings): fix stale python.uv_venv_auto deprecation text

### DIFF
--- a/settings.toml
+++ b/settings.toml
@@ -69,8 +69,7 @@ explicitly.
 Do not use precompiled binaries for all languages. Useful if running on a Linux distribution
 like Alpine that does not use glibc and therefore likely won't be able to run precompiled binaries.
 
-Note that this needs to be setup for each language. File a ticket if you notice a language that is
-not
+This needs to be set up for each language. File a ticket if you notice a language that is not
 working with this config.
 """
 env = "MISE_ALL_COMPILE"
@@ -2279,14 +2278,16 @@ description = "Integrate with uv to manage project venvs when uv.lock is present
 docs = """
 Controls how mise handles uv project venvs when a uv.lock file is present.
 
-The legacy `true` value (will be deprecated in a future release) is treated like "create|source", with one difference:
-When using this, mise also exports `UV_PYTHON` to force uv to use the python version managed by mise.
+The legacy `true` value is deprecated: it warns since mise 2026.7.0 and will be removed in
+mise 2027.7.0. It is treated like "create|source", with one difference: mise also exports
+`UV_PYTHON` to force uv to use the python version managed by mise. Prefer "source" or
+"create|source".
 """
 enum = [
   { value = false, description = "disable uv venv integration" },
   { value = "source", description = "only source an existing `.venv`" },
   { value = "create|source", description = "create the venv if missing and source it" },
-  { value = true, description = "(create|source) with UV_PYTHON export (legacy)" },
+  { value = true, description = "(create|source) with UV_PYTHON export (deprecated)" },
 ]
 env = "MISE_PYTHON_UV_VENV_AUTO"
 rust_type = "PythonUvVenvAuto"


### PR DESCRIPTION
## Summary

Third PR in the docs cleanup stack (#12691 → #12693 → this). Fixes the one leftover flagged in #12693.

- `python.uv_venv_auto`: the docs said the `true` value "will be deprecated in a future release (planned for mise 2026.7)". Per `deprecated_at!("2026.7.0", "2027.7.0", …)` in `src/config/settings.rs`, it has warned since 2026.7.0 and is scheduled for removal in 2027.7.0. The `docs` text and the enum item label now say so.
- `all_compile`: repaired a broken line wrap ("a language that is / not / working") and "setup" → "set up".

Only `settings.toml` changes. `mise run render:schema` produces no diff because the schema only embeds `description`, not `docs`; the settings page picks the new text up at docs build time via `settings.data.ts`.

## Verification

- `settings.toml` parses.
- `mise run render:schema`: no changes.
- `mise run docs:build` succeeds.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5-1; version: unavailable.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only user-facing documentation in settings.toml; no runtime or schema behavior changes.
> 
> **Overview**
> Documentation-only updates in **`settings.toml`** so setting docs match runtime deprecation behavior and read cleanly on the settings page.
> 
> For **`python.uv_venv_auto`**, the **`docs`** block and enum label for `true` no longer say the value “will be deprecated in a future release.” They now state it **warns since mise 2026.7.0**, will be **removed in 2027.7.0** (consistent with `deprecated_at!` in `settings.rs`), and point users to **`"source"`** or **`"create|source"`** instead of boolean `true`. The enum description changes from “legacy” to **“deprecated.”**
> 
> For **`all_compile`**, a broken sentence wrap is fixed (“a language that is not working…”) and **“setup”** is corrected to **“set up.”**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98da2e4c684f684d1b0e474a9c2821f9e64ddbc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->