### PR TITLE
fix(task): stop pre-converting PATH for POSIX shells; the shell already does it

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -227,30 +227,20 @@ shell = '"C:\Program Files\Git\bin\bash.exe" -c'
 
 #### Cygwin
 
-mise also detects Cygwin bash (by a `cygwin` / `cygwin64` / `cygwin32` segment in its path) and
-converts PATH using Cygwin's `/cygdrive/c/...` form instead of Git Bash's `/c/...`,
-so binaries on PATH resolve correctly. Point `MISE_BASH_PATH` at your Cygwin bash so
-the intended one is used:
+Point `MISE_BASH_PATH` at your Cygwin bash so the intended one is used:
 
 ```powershell
 $env:MISE_BASH_PATH = "C:\cygwin64\bin\bash.exe"
 ```
 
-#### Custom `cygdrive` mount root (Cygwin **and** Git Bash / MSYS2)
+mise passes PATH through unchanged. Git Bash, MSYS2 and Cygwin all convert it to Unix form on the
+way into the shell and back to Windows form on the way out to a native program, so nothing needs
+configuring for any of them.
 
-The `cygdrive` automount mechanism is shared by Cygwin and MSYS2 / Git Bash — both let
-you change the mount root in `/etc/fstab` (Cygwin's default is `/cygdrive`, Git Bash /
-MSYS2's is `/`, i.e. `/c/...`). mise does not read `/etc/fstab`, so if you changed it,
-set `MISE_CYGDRIVE_PREFIX` to match — this works for **either** shell:
-
-```powershell
-# e.g. for an fstab that mounts drives under /mnt
-$env:MISE_CYGDRIVE_PREFIX = "/mnt"
-```
-
-The prefix must be absolute (start with `/`); a relative value like `mnt` is rejected
-with a warning and the shell's default is used instead. `MISE_CYGDRIVE_PREFIX=/`
-collapses to the Git Bash `/c/...` form.
+Where they differ is everything _except_ PATH: MSYS2 / Git Bash rewrites POSIX-looking arguments and
+other environment variables on the way to a native program — `/c` becomes `C:/` — while Cygwin
+leaves both untouched. So a native program launched from a Git Bash task may see an argument you did
+not intend; `MSYS_NO_PATHCONV=1` suppresses that for a single command.
 
 ## mise isn't working when calling from tmux or another shell initialization script
 

--- a/e2e-win/task.Tests.ps1
+++ b/e2e-win/task.Tests.ps1
@@ -178,105 +178,101 @@ echo "from-posix"
         mise run testtask | Select -Last 1 | Should -Be 'windows'
     }
 
-    It 'converts PATH to MSYS Unix form for bash subshell tasks' {
-        # Repro for the per-task `tools = {...}` + `shell = "bash -c"` case.
-        # When mise on Windows spawns bash for a task, PATH must be `:`-separated
-        # `/c/...` form, not `;`-separated `C:\...` form, or bash cannot resolve
-        # any command, including the one mise just installed for the task.
+    It 'leaves a bash task PATH that both bash and a native grandchild can use' {
+        # mise used to convert PATH to MSYS Unix form before spawning bash. A shell that sets
+        # MSYSTEM -- `C:\Program Files\Git\bin\bash.exe`, which is what `bash` resolves to and
+        # what mise picks by default -- prepends its own entries at startup and keeps the
+        # inherited POSIX string as a single opaque element. Everything mise had put on PATH
+        # then reached the next native process buried inside one entry: measured on CI, 78
+        # entries became 4 and a native grandchild could resolve none of them.
         #
-        # We assert on the PATH the task observes, not on a tool install, so the
-        # test runs without depending on rust/cargo or any toolchain backend.
+        # A shell that leaves MSYSTEM unset re-parses the converted value and survives it, so
+        # this pins itself to a shell that sets MSYSTEM rather than quietly turning into a test
+        # that cannot fail on a host where `bash` resolves somewhere else.
 
-        if (-not (Get-Command bash.exe -ErrorAction SilentlyContinue)) {
-            Set-ItResult -Skipped -Because "bash.exe (Git Bash / MSYS) not on PATH"
+        # Mirror the task executor's own resolution rather than accepting anything named
+        # bash.exe: it refuses the WSL launcher at System32, and on a host that offers only
+        # that one there is no shell for this test to run.
+        $bashCandidates = @($env:MISE_BASH_PATH) + @(
+            'C:\Program Files\Git\bin\bash.exe',
+            'C:\Program Files (x86)\Git\bin\bash.exe',
+            "$env:LOCALAPPDATA\Programs\Git\bin\bash.exe",
+            'C:\msys64\usr\bin\bash.exe',
+            'C:\msys32\usr\bin\bash.exe'
+        ) + @(Get-Command bash.exe -All -ErrorAction SilentlyContinue | ForEach-Object { $_.Source })
+        $wslLauncher = Join-Path $env:SystemRoot 'System32\bash.exe'
+        $posixBash = $bashCandidates |
+            Where-Object { $_ -and ($_ -ne $wslLauncher) -and (Test-Path $_) } |
+            Select-Object -First 1
+        if (-not $posixBash) {
+            Set-ItResult -Skipped -Because "no POSIX bash (Git Bash / MSYS2) on this host; the WSL launcher does not count"
             return
         }
 
-        @'
-[tasks.path_repro]
-shell = "bash -c"
-run = '''
-case "$PATH" in
-  *\;*)
-    echo "PATH-still-windows-style"
-    ;;
-  *)
-    echo "PATH-unix-style"
-    ;;
-esac
-'''
-'@ | Out-File -FilePath "mise.path_repro.toml" -Encoding utf8NoBOM
-
-        $env:MISE_CONFIG_FILE = "$TestDrive\mise.path_repro.toml"
-        try {
-            $output = mise run path_repro 2>&1 | Select -Last 1
-            $output | Should -Be 'PATH-unix-style'
-        }
-        finally {
-            Remove-Item -Path Env:\MISE_CONFIG_FILE -ErrorAction SilentlyContinue
-            Remove-Item -Path "$TestDrive\mise.path_repro.toml" -ErrorAction SilentlyContinue
-        }
-    }
-
-    It 'converts PATH to /cygdrive form for a Cygwin bash subshell task' {
-        # Cygwin resolves drives via `/cygdrive/c/...`, not Git Bash's `/c/...`.
-        # When mise detects a Cygwin bash (here pinned via MISE_BASH_PATH), the
-        # task's PATH must use the `/cygdrive/` form or commands won't resolve.
-        # Skipped unless Cygwin is actually installed, since CI runners lack it.
-
-        $cygwinBash = "C:\cygwin64\bin\bash.exe"
-        if (-not (Test-Path $cygwinBash)) {
-            Set-ItResult -Skipped -Because "Cygwin bash not installed at $cygwinBash"
-            return
-        }
+        # A directory only this test puts on PATH, so its arrival at the far end is evidence
+        # that the whole list survived rather than that something else happened to be there.
+        $markerDir = Join-Path $TestDrive 'marker dir'
+        New-Item -ItemType Directory -Path $markerDir -Force | Out-Null
 
         @'
-[tasks.cygdrive_repro]
+[tasks.shell_env]
 shell = "bash -c"
-run = '''
-case "$PATH" in
-  */cygdrive/*)
-    echo "PATH-cygdrive-style"
-    ;;
-  *)
-    echo "PATH-not-cygdrive"
-    ;;
-esac
-'''
-'@ | Out-File -FilePath "mise.cygdrive_repro.toml" -Encoding utf8NoBOM
+run = 'echo "MSYSTEM=${MSYSTEM-<unset>}"'
 
-        # Save and restore the env vars we override so a dev machine's real
-        # settings (a developer may export MISE_BASH_PATH / MISE_CYGDRIVE_PREFIX)
-        # and later tests are not disturbed. Pin MISE_CYGDRIVE_PREFIX to the
-        # default so the `/cygdrive` assertion holds even when the caller has
-        # exported a custom prefix such as `/mnt` (which the feature honors).
+[tasks.bash_sees]
+shell = "bash -c"
+run = 'echo "$PATH"'
+
+[tasks.grandchild_sees]
+shell = "bash -c"
+run = "powershell -NoProfile -Command '$env:PATH'"
+'@ | Out-File -FilePath "$TestDrive\mise.path_shape.toml" -Encoding utf8NoBOM
+
         $oldConfig = $env:MISE_CONFIG_FILE
-        $oldBashPath = $env:MISE_BASH_PATH
-        $oldCygPrefix = $env:MISE_CYGDRIVE_PREFIX
-        $env:MISE_CONFIG_FILE = "$TestDrive\mise.cygdrive_repro.toml"
-        $env:MISE_BASH_PATH = $cygwinBash
-        $env:MISE_CYGDRIVE_PREFIX = "/cygdrive"
+        $oldPath = $env:PATH
+        $env:MISE_CONFIG_FILE = "$TestDrive\mise.path_shape.toml"
+        $env:PATH = "$markerDir;$oldPath"
         try {
-            $output = mise run cygdrive_repro 2>&1 | Select -Last 1
-            $output | Should -Be 'PATH-cygdrive-style'
+            $shellEnv = "$(mise run shell_env 2>&1 | Select -Last 1)"
+            $LASTEXITCODE | Should -Be 0
+            $shellEnv | Should -Match '^MSYSTEM='
+            if ($shellEnv -eq 'MSYSTEM=<unset>') {
+                Set-ItResult -Skipped -Because "the resolved bash leaves MSYSTEM unset; the regression this covers only reaches a shell that sets it"
+                return
+            }
+
+            # Exit code and emptiness first: `Should -Not -Match` holds for no output at all, and a
+            # test that passes when the task never ran is the shape this PR is removing.
+            $inBash = "$(mise run bash_sees 2>&1 | Select -Last 1)"
+            $LASTEXITCODE | Should -Be 0
+            $inBash | Should -Not -BeNullOrEmpty
+            $inBash | Should -Not -Match ';'
+
+            $inGrandchild = "$(mise run grandchild_sees 2>&1 | Select -Last 1)"
+            $LASTEXITCODE | Should -Be 0
+            $inGrandchild | Should -Not -BeNullOrEmpty
+            # A trailing ';' is ordinary, so empty entries are not the subject here.
+            $entries = @($inGrandchild -split ';' | Where-Object { $_ -ne '' })
+            $entries.Count | Should -BeGreaterThan 1
+            # Every entry a Windows path -- a drive letter or a UNC share, both of which PATH
+            # takes. The defect put a whole ':'-joined list in one of them.
+            foreach ($e in $entries) {
+                $e | Should -Match '^(?:[A-Za-z]:|\\\\)'
+                $e.Substring(2) | Should -Not -Match ':'
+            }
+            # The shape assertions above would still hold if the list had been truncated to the
+            # shell's own entries, which is exactly what the defect did. This is the one that
+            # says nothing was dropped on the way.
+            $inGrandchild | Should -Match ([regex]::Escape($markerDir))
         }
         finally {
+            $env:PATH = $oldPath
             if ($null -eq $oldConfig) {
                 Remove-Item -Path Env:\MISE_CONFIG_FILE -ErrorAction SilentlyContinue
             } else {
                 $env:MISE_CONFIG_FILE = $oldConfig
             }
-            if ($null -eq $oldBashPath) {
-                Remove-Item -Path Env:\MISE_BASH_PATH -ErrorAction SilentlyContinue
-            } else {
-                $env:MISE_BASH_PATH = $oldBashPath
-            }
-            if ($null -eq $oldCygPrefix) {
-                Remove-Item -Path Env:\MISE_CYGDRIVE_PREFIX -ErrorAction SilentlyContinue
-            } else {
-                $env:MISE_CYGDRIVE_PREFIX = $oldCygPrefix
-            }
-            Remove-Item -Path "$TestDrive\mise.cygdrive_repro.toml" -ErrorAction SilentlyContinue
+            Remove-Item -Path "$TestDrive\mise.path_shape.toml" -ErrorAction SilentlyContinue
         }
     }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -575,7 +575,7 @@ pub(crate) fn is_mise_binary(bin_name: &str) -> bool {
 /// `get_temp_executable_name` builds `.{exe stem}.{32 random}{suffix}`.
 ///
 /// This and the predicates below are compiled off Windows too, like
-/// [`crate::path::windows_path_list_to_unix`], so they stay unit-tested everywhere rather than only
+/// [`crate::path::unix_path_to_windows`], so they stay unit-tested everywhere rather than only
 /// on the platform that runs them. Their callers are all `#[cfg(windows)]`, hence the allow.
 #[cfg_attr(not(windows), allow(dead_code))]
 pub(crate) const SELF_REPLACE_SUFFIXES: [&str; 2] = [".__selfdelete__.exe", ".__relocated__.exe"];

--- a/src/path.rs
+++ b/src/path.rs
@@ -115,96 +115,6 @@ impl PathExt for Path {
     }
 }
 
-/// Convert a Windows-style path list (`;`-separated, drive-letter prefix, `\` or `/`
-/// separator) into a POSIX Unix-style path list (`:`-separated, `/` separator) for a
-/// shell that resolves commands from PATH itself.
-///
-/// `drive_prefix` selects the cygdrive mount style inserted before the drive letter
-/// (no trailing slash):
-///
-/// - `""` → `/c/foo` — MSYS2 / Git Bash (the dominant case, and the default).
-/// - `"/cygdrive"` → `/cygdrive/c/foo` — Cygwin's default mount.
-/// - any other value (e.g. from `MISE_CYGDRIVE_PREFIX`) → a custom Cygwin `cygdrive`
-///   prefix configured via `/etc/fstab`.
-///
-/// Pure Rust, no subprocess. Designed for the case where mise on Windows spawns a
-/// POSIX shell (`bash -c`, `sh -c`, ...) for a task — that shell uses PATH itself to
-/// resolve commands, and cannot read `C:\foo;D:\bar`.
-///
-/// Conversion rules per entry, applied independently:
-///
-/// - `<drive>:[\\/]...` (canonical Windows drive path) → `<drive_prefix>/<drive lowercase>/<rest with `/` separator>`
-/// - already-Unix entries (start with `/`) → pass through unchanged
-/// - empty entries (e.g. trailing `;`) → preserved as empty
-/// - UNC (`\\?\...`, `\\server\share\...`) → pass through unchanged. bash will fail
-///   to use them, which matches what would happen without conversion.
-/// - other entries (relative paths, bare names, drive-relative `C:foo`, etc.) →
-///   `\` is replaced with `/` so that bash can resolve entries like
-///   `node_modules\.bin` or `.\bin` injected by tools that emit Windows separators.
-///
-/// `drive_prefix` only affects canonical drive entries; every other shape above is
-/// prefix-independent.
-///
-/// Out of scope (kept narrow per maintainer guidance):
-///
-/// - Cygwin's `/etc/fstab` mount table is not parsed. A non-default `cygdrive` prefix
-///   is supplied explicitly via `MISE_CYGDRIVE_PREFIX` (resolved by the caller) rather
-///   than discovered from fstab.
-/// - Git Bash's "magic" mount of `/usr` to its install dir — `/c/Program Files/Git/usr/bin`
-///   is resolved by bash to the same executable as `/usr/bin`, so no remapping is needed
-///   for PATH-resolution to succeed.
-#[cfg_attr(not(windows), allow(dead_code))]
-pub(crate) fn windows_path_list_to_unix(path_list: &str, drive_prefix: &str) -> String {
-    let mut out = String::with_capacity(path_list.len());
-    let mut first = true;
-    for entry in path_list.split(WINDOWS_PATH_SEP) {
-        if !first {
-            out.push(':');
-        }
-        append_single_windows_path_to_unix(&mut out, entry, drive_prefix);
-        first = false;
-    }
-    out
-}
-
-#[cfg_attr(not(windows), allow(dead_code))]
-const WINDOWS_PATH_SEP: char = ';';
-
-#[cfg_attr(not(windows), allow(dead_code))]
-fn append_single_windows_path_to_unix(out: &mut String, entry: &str, drive_prefix: &str) {
-    if entry.is_empty() {
-        return;
-    }
-    // Already-Unix entries and UNC paths are passed through verbatim.
-    if entry.starts_with('/') || entry.starts_with("\\\\") {
-        out.push_str(entry);
-        return;
-    }
-
-    let bytes = entry.as_bytes();
-    let is_canonical_drive = bytes.len() >= 3
-        && bytes[0].is_ascii_alphabetic()
-        && bytes[1] == b':'
-        && (bytes[2] == b'\\' || bytes[2] == b'/');
-
-    let rest = if is_canonical_drive {
-        // C:\foo → <prefix>/c/foo : emit the cygdrive prefix (empty for MSYS/Git
-        // Bash, `/cygdrive` for Cygwin), then `/<drive lowercase>`, then the tail
-        // with `\` → `/`.
-        out.push_str(drive_prefix);
-        out.push('/');
-        out.push((bytes[0] as char).to_ascii_lowercase());
-        &entry[2..]
-    } else {
-        // Other shapes (relative paths, bare names, `C:foo`) — keep as-is but
-        // still translate `\` → `/` so bash can resolve them.
-        entry
-    };
-    for c in rest.chars() {
-        out.push(if c == '\\' { '/' } else { c });
-    }
-}
-
 /// Returns the lowercase stem of `program`'s basename, with any final `.exe`
 /// (case-insensitive) stripped. Splits on both `/` and `\` so the result is the
 /// same regardless of host `Path` separator — important since this is
@@ -223,9 +133,9 @@ pub(crate) fn program_stem(program: &Path) -> Option<String> {
     Some(stem.to_ascii_lowercase())
 }
 
-/// Returns true if `program` is the path or basename of a POSIX-style shell that
-/// expects a Unix-style PATH. Used on Windows to decide whether to convert the
-/// child's PATH before spawning.
+/// Returns true if `program` is the path or basename of a POSIX-style shell.
+/// Used on Windows to decide how a task's command line is built and which program
+/// to resolve to an absolute path before spawning.
 #[cfg_attr(not(windows), allow(dead_code))]
 pub(crate) fn is_posix_shell_program(program: &Path) -> bool {
     // `ash` is here because it is what `/bin/sh` is on Alpine, which mise ships musl builds
@@ -505,40 +415,15 @@ fn split_shell_command_windows(s: &str) -> eyre::Result<Vec<String>> {
     Ok(args)
 }
 
-/// Returns true if `program` (typically a resolved absolute bash path) is a Cygwin
-/// shell, detected by a `cygwin` / `cygwin64` / `cygwin32` path segment — Cygwin's
-/// default install dirs are `C:\cygwin64` and `C:\cygwin`. Used on Windows to pick
-/// the `/cygdrive/c/` PATH form instead of MSYS2 / Git Bash's `/c/`.
-///
-/// Splits on both `/` and `\` and compares segments case-insensitively, so it works
-/// for backslash paths (`MISE_BASH_PATH`, `bash_candidates`) and forward-slash paths
-/// (`which::which_in`) without allocating any temporaries. Matches whole path segments
-/// so a directory that merely contains "cygwin" as a substring (e.g.
-/// `my-cygwinish-tools`) does not trip it. `MSYSTEM` is deliberately not consulted —
-/// PowerShell-launched mise inherits none, so it is not a reliable signal.
-#[cfg_attr(not(windows), allow(dead_code))]
-pub(crate) fn is_cygwin_shell(program: &Path) -> bool {
-    let Some(s) = program.to_str() else {
-        return false;
-    };
-    s.split(['/', '\\']).any(|seg| {
-        seg.eq_ignore_ascii_case("cygwin")
-            || seg.eq_ignore_ascii_case("cygwin64")
-            || seg.eq_ignore_ascii_case("cygwin32")
-    })
-}
-
 /// Convert a single MSYS2/Git Bash (`/c/foo`) or Cygwin (`/cygdrive/c/foo`) style
-/// absolute path entry back to Windows form (`C:\foo`). The per-entry inverse of
-/// [`windows_path_list_to_unix`] for canonical drive paths, used when reading
-/// paths *back* from a POSIX shell (e.g. PATH entries a sourced `[env] _.source`
+/// absolute path entry back to Windows form (`C:\foo`), used when reading paths
+/// *back* from a POSIX shell (e.g. PATH entries a sourced `[env] _.source`
 /// script prepended).
 ///
 /// Returns `None` when the entry has no recognizable Windows equivalent
 /// (`/usr/bin`, `/mingw64/bin`, relative paths, empty strings, ...). A custom
 /// fstab cygdrive mount root (e.g. `/mnt`) is not recognized either — callers
-/// skip such entries; symmetric with the forward converter, which leaves
-/// non-default mount discovery to `MISE_CYGDRIVE_PREFIX` rather than fstab.
+/// skip such entries.
 #[cfg_attr(not(windows), allow(dead_code))]
 pub(crate) fn unix_path_to_windows(entry: &str) -> Option<String> {
     // UNC round-trip: bash represents `\\server\share` as `//server/share`.
@@ -571,16 +456,14 @@ pub(crate) fn unix_path_to_windows(entry: &str) -> Option<String> {
     None
 }
 
-/// On Windows, when about to spawn a POSIX shell — for a task whose PATH we are
-/// about to convert to Unix form, or to source an `[env] _.source` script —
-/// resolve the program to its absolute path using the pre-conversion
-/// (Windows-form) PATH from the child env.
+/// On Windows, when about to spawn a POSIX shell — for a task, or to source an
+/// `[env] _.source` script — resolve the program to its absolute path using the
+/// PATH from the child env.
 ///
 /// Why: `Command::spawn` on Windows uses the *child* env's PATH (when set via
-/// `.envs(...)`) to locate the program. If we hand it the converted
-/// `/c/foo:/d/bar` PATH, Win32 cannot find `bash.exe`. Resolving here means
-/// the child process gets an absolute path argument and does not need PATH
-/// search at the OS level.
+/// `.envs(...)`) to locate the program, so which `bash` runs would otherwise
+/// depend on how Win32 happens to search that PATH. Resolving here pins the
+/// choice and hands the child an absolute path instead. See discussion #6513.
 ///
 /// For `bash` specifically, prefer a real POSIX bash (Git Bash / MSYS2) over
 /// the WSL launcher at `C:\Windows\System32\bash.exe`. The WSL launcher is on
@@ -601,7 +484,8 @@ pub(crate) fn unix_path_to_windows(entry: &str) -> Option<String> {
 /// Returns `None` when the program is not a POSIX shell, the program is already
 /// an explicit path (absolute, or relative with a directory component — that is
 /// honored verbatim and never re-resolved), the env has no PATH, the PATH is
-/// already in Unix form (no `;` and no `\`, so no conversion will fire), `which`
+/// already in Unix form (no `;` and no `\`, meaning mise is itself running
+/// inside a POSIX shell, whose own lookup is the one to use), `which`
 /// finds nothing, or every PATH match for `bash` is the WSL launcher — in those
 /// cases the caller keeps the original program string and lets the stdlib spawn
 /// it (which will then fail loudly rather than silently routing into WSL).
@@ -758,16 +642,6 @@ mod tests {
         env
     }
 
-    /// MSYS2 / Git Bash style (`/c/...`) — the empty cygdrive prefix (the default).
-    fn msys(s: &str) -> String {
-        windows_path_list_to_unix(s, "")
-    }
-
-    /// Cygwin default style (`/cygdrive/c/...`).
-    fn cygwin(s: &str) -> String {
-        windows_path_list_to_unix(s, "/cygdrive")
-    }
-
     /// `canonicalize` hands back an extended-length path on Windows, and mise used to print it.
     /// Only the drive form is simplified -- see the negative cases, which name shapes that do not
     /// resolve without the prefix.
@@ -873,135 +747,6 @@ mod tests {
         if dirs::HOME.as_os_str() != "/" {
             assert_eq!(dirs::HOME.join("proj").display_user(), "~/proj");
         }
-    }
-
-    #[test]
-    fn test_windows_path_list_to_unix_basic() {
-        assert_eq!(msys(r"C:\foo;D:\bar"), "/c/foo:/d/bar");
-    }
-
-    #[test]
-    fn test_windows_path_list_to_unix_forward_slash() {
-        assert_eq!(msys("C:/foo;D:/bar"), "/c/foo:/d/bar");
-    }
-
-    #[test]
-    fn test_windows_path_list_to_unix_mixed_separators() {
-        assert_eq!(msys(r"C:\foo\bar;D:/baz/qux"), "/c/foo/bar:/d/baz/qux");
-    }
-
-    #[test]
-    fn test_windows_path_list_to_unix_passthrough_unix_entries() {
-        assert_eq!(msys("/usr/bin;C:\\foo;/c/bar"), "/usr/bin:/c/foo:/c/bar");
-    }
-
-    #[test]
-    fn test_windows_path_list_to_unix_passthrough_unc() {
-        // UNC entries are passed through verbatim (they contain `:` themselves,
-        // so we cannot split the result on `:` to inspect entries — bash receives
-        // the whole string and will fail to use the UNC entry, which matches what
-        // would happen without conversion).
-        assert_eq!(msys(r"\\?\C:\foo;C:\bar"), r"\\?\C:\foo:/c/bar");
-    }
-
-    #[test]
-    fn test_windows_path_list_to_unix_empty_entries() {
-        assert_eq!(msys("C:\\foo;"), "/c/foo:");
-        assert_eq!(msys(";C:\\foo"), ":/c/foo");
-        assert_eq!(msys(""), "");
-    }
-
-    #[test]
-    fn test_windows_path_list_to_unix_drive_letter_case() {
-        assert_eq!(msys(r"C:\foo"), "/c/foo");
-        assert_eq!(msys(r"c:\foo"), "/c/foo");
-    }
-
-    #[test]
-    fn test_windows_path_list_to_unix_program_files_with_spaces() {
-        assert_eq!(
-            msys(r"C:\Program Files\Git\bin"),
-            "/c/Program Files/Git/bin"
-        );
-    }
-
-    #[test]
-    fn test_windows_path_list_to_unix_bare_drive_letter_passthrough() {
-        // Bare "C:" or "C:foo" (relative-to-drive) is unrecognized — pass through.
-        assert_eq!(msys("C:"), "C:");
-        assert_eq!(msys("C:foo"), "C:foo");
-    }
-
-    #[test]
-    fn test_windows_path_list_to_unix_relative_paths_with_backslashes() {
-        // mise can inject relative entries via `[env] _.path = ["./node_modules/.bin"]`,
-        // and tools that emit Windows separators may produce backslash forms. bash
-        // does not treat `\` as a separator, so we translate `\` → `/` for non-UNC,
-        // non-canonical-drive entries too.
-        assert_eq!(msys(r"node_modules\.bin"), "node_modules/.bin");
-        assert_eq!(msys(r".\bin"), "./bin");
-        assert_eq!(
-            msys(r"node_modules\.bin;C:\tools\bin"),
-            "node_modules/.bin:/c/tools/bin"
-        );
-    }
-
-    #[test]
-    fn test_windows_path_list_to_unix_single_entry() {
-        assert_eq!(msys(r"C:\foo"), "/c/foo");
-    }
-
-    #[test]
-    fn test_windows_path_list_to_unix_cygwin_basic() {
-        assert_eq!(cygwin(r"C:\foo;D:\bar"), "/cygdrive/c/foo:/cygdrive/d/bar");
-    }
-
-    #[test]
-    fn test_windows_path_list_to_unix_cygwin_forward_slash() {
-        assert_eq!(cygwin("C:/foo;D:/bar"), "/cygdrive/c/foo:/cygdrive/d/bar");
-    }
-
-    #[test]
-    fn test_windows_path_list_to_unix_cygwin_drive_letter_case() {
-        assert_eq!(cygwin(r"c:\foo"), "/cygdrive/c/foo");
-    }
-
-    #[test]
-    fn test_windows_path_list_to_unix_cygwin_program_files_with_spaces() {
-        assert_eq!(
-            cygwin(r"C:\Program Files\Git\bin"),
-            "/cygdrive/c/Program Files/Git/bin"
-        );
-    }
-
-    #[test]
-    fn test_windows_path_list_to_unix_cygwin_passthrough_unix_and_unc() {
-        // The cygdrive prefix only affects canonical drive entries; already-Unix
-        // and UNC entries are still passed through verbatim.
-        assert_eq!(
-            cygwin(r"/usr/bin;\\?\C:\x;C:\y"),
-            r"/usr/bin:\\?\C:\x:/cygdrive/c/y"
-        );
-    }
-
-    #[test]
-    fn test_windows_path_list_to_unix_cygwin_empty_entries() {
-        assert_eq!(cygwin("C:\\foo;"), "/cygdrive/c/foo:");
-    }
-
-    #[test]
-    fn test_windows_path_list_to_unix_cygwin_relative_paths_unprefixed() {
-        // Non-drive entries get no cygdrive prefix — only `\` → `/`.
-        assert_eq!(cygwin(r"node_modules\.bin"), "node_modules/.bin");
-    }
-
-    #[test]
-    fn test_windows_path_list_to_unix_custom_cygdrive_prefix() {
-        // A custom prefix such as `MISE_CYGDRIVE_PREFIX=/mnt` (fstab-configured).
-        assert_eq!(
-            windows_path_list_to_unix(r"C:\foo;D:\bar", "/mnt"),
-            "/mnt/c/foo:/mnt/d/bar"
-        );
     }
 
     #[test]
@@ -1321,34 +1066,6 @@ mod tests {
             sv(&["bash script", "-c"])
         );
         assert_eq!(split_shell_command("'a b' c").unwrap(), sv(&["a b", "c"]));
-    }
-
-    #[test]
-    fn test_is_cygwin_shell_detects_cygwin_paths() {
-        assert!(is_cygwin_shell(Path::new(r"C:\cygwin64\bin\bash.exe")));
-        assert!(is_cygwin_shell(Path::new(r"C:\cygwin\bin\bash.exe")));
-        assert!(is_cygwin_shell(Path::new(
-            r"D:\tools\cygwin64\bin\bash.exe"
-        )));
-        assert!(is_cygwin_shell(Path::new("C:/cygwin64/bin/bash.exe")));
-        // Case-insensitive in both the drive and the `cygwin` segment.
-        assert!(is_cygwin_shell(Path::new(r"C:\CygWin64\bin\BASH.EXE")));
-    }
-
-    #[test]
-    fn test_is_cygwin_shell_rejects_non_cygwin() {
-        assert!(!is_cygwin_shell(Path::new(
-            r"C:\Program Files\Git\bin\bash.exe"
-        )));
-        assert!(!is_cygwin_shell(Path::new(r"C:\msys64\usr\bin\bash.exe")));
-        assert!(!is_cygwin_shell(Path::new("bash")));
-        assert!(!is_cygwin_shell(Path::new(
-            r"C:\Users\me\scoop\apps\git\current\bin\bash.exe"
-        )));
-        // A substring that is not a whole path segment must not match.
-        assert!(!is_cygwin_shell(Path::new(
-            r"C:\my-cygwinish-tools\bash.exe"
-        )));
     }
 
     #[test]

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -1430,7 +1430,6 @@ impl TaskExecutor {
             #[cfg(windows)]
             let program = crate::path::resolve_posix_shell_program_path(&program, &filtered_env)
                 .unwrap_or(program);
-            let env = maybe_convert_env_for_msys_shell(Path::new(&program), &filtered_env);
             let runner = CmdLineRunner::new(program);
             #[cfg(windows)]
             let runner = if cmd_verbatim {
@@ -1443,7 +1442,7 @@ impl TaskExecutor {
             let mut runner = runner
                 .current_dir(&root)
                 .env_clear()
-                .envs(env.as_ref())
+                .envs(&filtered_env)
                 .with_timeout(timeout)
                 .with_sandbox(sandbox.clone());
             runner.apply_sandbox().await?;
@@ -1566,14 +1565,11 @@ impl TaskExecutor {
         } else {
             env
         };
-        // On Windows, when about to spawn a POSIX shell, resolve the program to
-        // an absolute path *before* converting PATH for the child. Otherwise the
-        // converted Unix-form PATH is also what Win32 CreateProcess uses to find
-        // the program, and `bash` cannot be located in `/c/...:/c/...` entries.
+        // On Windows, resolve a POSIX shell to an absolute path before spawning it, so which
+        // `bash` runs does not depend on how Win32 searches PATH. See discussion #6513.
         #[cfg(windows)]
         let program =
             crate::path::resolve_posix_shell_program_path(&program, env).unwrap_or(program);
-        let env = maybe_convert_env_for_msys_shell(Path::new(&program), env);
         let audit = if raw || self.dry_run {
             None
         } else {
@@ -1603,8 +1599,7 @@ impl TaskExecutor {
         let inherited_usage_keys = std::env::vars_os()
             .filter(|(key, _)| {
                 let key = key.to_string_lossy();
-                crate::task::is_usage_env_key(&key)
-                    && !crate::task::env_contains_key(env.as_ref(), &key)
+                crate::task::is_usage_env_key(&key) && !crate::task::env_contains_key(env, &key)
             })
             .map(|(key, _)| key);
         let runner = inherited_usage_keys.fold(runner, |runner, key| runner.env_remove(key));
@@ -1612,7 +1607,7 @@ impl TaskExecutor {
             .iter()
             .fold(runner, |runner, key| runner.env_remove(key));
         let mut cmd = runner
-            .envs(env.as_ref())
+            .envs(env)
             .redact(redactions.deref().clone())
             .raw(raw)
             .with_sandbox(sandbox);
@@ -2459,92 +2454,6 @@ fn task_shell_parts<'a>(shell: &'a [String], shell_kind: &str) -> Result<(&'a st
         })
 }
 
-/// On Windows, when spawning a POSIX-style shell (bash/sh/zsh/...) for a task, the
-/// child needs PATH in MSYS Unix format — `/c/foo:/d/bar` rather than `C:\foo;D:\bar`.
-/// PowerShell-launched mise inherits no `MSYSTEM`, so the conversion has to happen
-/// here at the spawn boundary (driven by the target program), not in mise's own env.
-///
-/// The cfg-attribute pattern keeps the call site OS-agnostic and avoids cloning the
-/// env on the common path (Windows + non-POSIX-shell, or any non-Windows host).
-fn maybe_convert_env_for_msys_shell<'a>(
-    program: &Path,
-    env: &'a BTreeMap<String, String>,
-) -> std::borrow::Cow<'a, BTreeMap<String, String>> {
-    #[cfg(windows)]
-    {
-        if crate::path::is_posix_shell_program(program)
-            && let Some(path_val) = env.get(&*crate::env::PATH_KEY)
-            // Skip the clone+convert cycle when PATH is already in Unix form (no
-            // `;` separator, no `\` to translate). This is the common case when
-            // mise itself runs inside Git Bash and spawns another bash subshell.
-            && (path_val.contains(';') || path_val.contains('\\'))
-        {
-            let drive_prefix = msys_drive_prefix_for(program, env);
-            let converted = crate::path::windows_path_list_to_unix(path_val, &drive_prefix);
-            let mut new_env = env.clone();
-            new_env.insert((*crate::env::PATH_KEY).to_string(), converted);
-            return std::borrow::Cow::Owned(new_env);
-        }
-    }
-    #[cfg(not(windows))]
-    {
-        let _ = program;
-    }
-    std::borrow::Cow::Borrowed(env)
-}
-
-/// The cygdrive prefix inserted before drive letters when converting PATH for a
-/// POSIX shell. `is_cygwin_shell` only selects the *default* when no override is set:
-/// empty for MSYS2 / Git Bash (`/c/...`), `/cygdrive` for Cygwin (`/cygdrive/c/...`).
-///
-/// The `cygdrive` automount mechanism is shared by Cygwin and MSYS2 / Git Bash — both
-/// let the user change the mount root in `/etc/fstab` (Cygwin's default is `/cygdrive`,
-/// MSYS2's is `/`). mise does not parse fstab, so `MISE_CYGDRIVE_PREFIX` is an explicit
-/// override honored for *both* shells. A trailing `/` is trimmed since the converter
-/// emits its own separator after the prefix, so `MISE_CYGDRIVE_PREFIX=/` collapses to
-/// the MSYS `/c/...` form. A non-empty value that is not absolute (no leading `/`, e.g.
-/// `mnt`) would produce relative PATH entries that bash silently ignores, so it is
-/// rejected with a warning and the shell's default is used instead.
-#[cfg(windows)]
-fn msys_drive_prefix_for(program: &Path, env: &BTreeMap<String, String>) -> String {
-    // Default automount root when no override is set: empty for Git Bash / MSYS2
-    // (`/c/...`), `/cygdrive` for Cygwin (`/cygdrive/c/...`).
-    let default = if crate::path::is_cygwin_shell(program) {
-        "/cygdrive"
-    } else {
-        ""
-    };
-    let raw = env
-        .get("MISE_CYGDRIVE_PREFIX")
-        .cloned()
-        .or_else(|| std::env::var("MISE_CYGDRIVE_PREFIX").ok())
-        .filter(|s| !s.is_empty());
-    let Some(mut s) = raw else {
-        return default.to_string();
-    };
-    // Trim trailing slashes in place — the converter appends its own separator.
-    s.truncate(s.trim_end_matches('/').len());
-    if s.is_empty() {
-        // `MISE_CYGDRIVE_PREFIX=/` → empty prefix → MSYS `/c/...` form.
-        String::new()
-    } else if s.starts_with('/') {
-        s
-    } else {
-        // Describe the default clearly: an empty prefix is the Git Bash `/c/...` form,
-        // otherwise the Cygwin `/cygdrive` root.
-        let default_desc = if default.is_empty() {
-            "the Git Bash `/c/...` form".to_string()
-        } else {
-            format!("the default `{default}`")
-        };
-        warn!(
-            "MISE_CYGDRIVE_PREFIX={s:?} is not absolute (must start with `/`); \
-             using {default_desc}"
-        );
-        default.to_string()
-    }
-}
-
 /// Read the shebang from a file and parse it into a shell command.
 /// e.g. `#!/usr/bin/env bash` → `["bash"]`
 /// e.g. `#!/bin/bash` → `["/bin/bash"]`
@@ -2613,13 +2522,6 @@ mod tests {
         assert_eq!(stats.misses, 1);
         assert_eq!(stats.restored_bytes, 768);
         assert_eq!(stats.time_saved, Duration::from_millis(40));
-    }
-
-    fn env_with_path(path: &str) -> BTreeMap<String, String> {
-        let mut env = BTreeMap::new();
-        env.insert((*crate::env::PATH_KEY).to_string(), path.to_string());
-        env.insert("OTHER".to_string(), "unchanged".to_string());
-        env
     }
 
     /// Not gated on Windows: the mark reaches a shared repository from any platform, and the
@@ -2844,139 +2746,6 @@ mod tests {
             append_inline_args("Write-Output $args", &args, InlineArgsStyle::SeparateArgv),
             "Write-Output $args"
         );
-    }
-
-    #[test]
-    #[cfg(windows)]
-    fn test_maybe_convert_env_for_msys_shell_converts_for_bash() {
-        let env = env_with_path(r"C:\Users\me\.rustup\bin;D:\tools\bin");
-        let out = maybe_convert_env_for_msys_shell(Path::new("bash.exe"), &env);
-        assert_eq!(
-            out.get(&*crate::env::PATH_KEY).unwrap(),
-            "/c/Users/me/.rustup/bin:/d/tools/bin"
-        );
-        assert_eq!(out.get("OTHER").unwrap(), "unchanged");
-    }
-
-    #[test]
-    #[cfg(windows)]
-    fn test_maybe_convert_env_for_msys_shell_skips_for_cmd() {
-        let env = env_with_path(r"C:\Users\me\.rustup\bin;D:\tools\bin");
-        let out = maybe_convert_env_for_msys_shell(Path::new("cmd.exe"), &env);
-        assert_eq!(
-            out.get(&*crate::env::PATH_KEY).unwrap(),
-            r"C:\Users\me\.rustup\bin;D:\tools\bin"
-        );
-    }
-
-    #[test]
-    #[cfg(windows)]
-    fn test_maybe_convert_env_for_msys_shell_full_path_to_bash() {
-        let env = env_with_path(r"C:\foo;D:\bar");
-        let out =
-            maybe_convert_env_for_msys_shell(Path::new(r"C:\Program Files\Git\bin\bash.exe"), &env);
-        assert_eq!(out.get(&*crate::env::PATH_KEY).unwrap(), "/c/foo:/d/bar");
-    }
-
-    #[test]
-    #[cfg(windows)]
-    fn test_maybe_convert_env_for_msys_shell_uses_cygdrive_for_cygwin_bash() {
-        // A Cygwin bash (detected by the `cygwin64` path segment) needs the
-        // `/cygdrive/c/...` form, not Git Bash's `/c/...`.
-        let env = env_with_path(r"C:\foo;D:\bar");
-        let out = maybe_convert_env_for_msys_shell(Path::new(r"C:\cygwin64\bin\bash.exe"), &env);
-        assert_eq!(
-            out.get(&*crate::env::PATH_KEY).unwrap(),
-            "/cygdrive/c/foo:/cygdrive/d/bar"
-        );
-    }
-
-    #[test]
-    #[cfg(windows)]
-    fn test_maybe_convert_env_for_msys_shell_honors_cygdrive_prefix_override() {
-        // A non-default cygdrive mount (e.g. fstab `/mnt`) is supplied via
-        // MISE_CYGDRIVE_PREFIX in the task env rather than parsed from fstab.
-        let mut env = env_with_path(r"C:\foo;D:\bar");
-        env.insert("MISE_CYGDRIVE_PREFIX".to_string(), "/mnt".to_string());
-        let out = maybe_convert_env_for_msys_shell(Path::new(r"C:\cygwin64\bin\bash.exe"), &env);
-        assert_eq!(
-            out.get(&*crate::env::PATH_KEY).unwrap(),
-            "/mnt/c/foo:/mnt/d/bar"
-        );
-    }
-
-    #[test]
-    #[cfg(windows)]
-    fn test_maybe_convert_env_for_msys_shell_honors_cygdrive_prefix_for_git_bash() {
-        // The cygdrive automount root is configurable in MSYS2 / Git Bash too (not just
-        // Cygwin). A Git Bash user with a non-default fstab mount supplies it via
-        // MISE_CYGDRIVE_PREFIX; without it the default would (wrongly) be `/c/...`.
-        let mut env = env_with_path(r"C:\foo;D:\bar");
-        env.insert("MISE_CYGDRIVE_PREFIX".to_string(), "/mnt".to_string());
-        let out =
-            maybe_convert_env_for_msys_shell(Path::new(r"C:\Program Files\Git\bin\bash.exe"), &env);
-        assert_eq!(
-            out.get(&*crate::env::PATH_KEY).unwrap(),
-            "/mnt/c/foo:/mnt/d/bar"
-        );
-    }
-
-    #[test]
-    #[cfg(windows)]
-    fn test_maybe_convert_env_for_msys_shell_rejects_relative_cygdrive_prefix() {
-        // A prefix without a leading slash (e.g. `mnt`) would yield relative PATH
-        // entries bash ignores; fall back to the shell's default instead. For the
-        // Cygwin binary used here that default is `/cygdrive` (Git Bash would fall
-        // back to an empty prefix, i.e. the `/c/...` form).
-        let mut env = env_with_path(r"C:\foo;D:\bar");
-        env.insert("MISE_CYGDRIVE_PREFIX".to_string(), "mnt".to_string());
-        let out = maybe_convert_env_for_msys_shell(Path::new(r"C:\cygwin64\bin\bash.exe"), &env);
-        assert_eq!(
-            out.get(&*crate::env::PATH_KEY).unwrap(),
-            "/cygdrive/c/foo:/cygdrive/d/bar"
-        );
-    }
-
-    #[test]
-    #[cfg(windows)]
-    fn test_maybe_convert_env_for_msys_shell_cygdrive_prefix_slash_is_msys() {
-        // `MISE_CYGDRIVE_PREFIX=/` trims to empty → MSYS `/c/...` form.
-        let mut env = env_with_path(r"C:\foo;D:\bar");
-        env.insert("MISE_CYGDRIVE_PREFIX".to_string(), "/".to_string());
-        let out = maybe_convert_env_for_msys_shell(Path::new(r"C:\cygwin64\bin\bash.exe"), &env);
-        assert_eq!(out.get(&*crate::env::PATH_KEY).unwrap(), "/c/foo:/d/bar");
-    }
-
-    #[test]
-    #[cfg(windows)]
-    fn test_maybe_convert_env_for_msys_shell_borrows_when_path_already_unix() {
-        // PATH already in Unix form (no `;` and no `\`) — Cow stays Borrowed,
-        // env is not cloned. Common when mise runs from Git Bash itself.
-        let env = env_with_path("/c/foo:/d/bar:/usr/bin");
-        let out = maybe_convert_env_for_msys_shell(Path::new("bash.exe"), &env);
-        assert!(matches!(out, std::borrow::Cow::Borrowed(_)));
-        assert_eq!(
-            out.get(&*crate::env::PATH_KEY).unwrap(),
-            "/c/foo:/d/bar:/usr/bin"
-        );
-    }
-
-    #[test]
-    #[cfg(windows)]
-    fn test_maybe_convert_env_for_msys_shell_borrows_when_path_missing() {
-        // No PATH at all — also no clone.
-        let mut env = BTreeMap::new();
-        env.insert("OTHER".to_string(), "unchanged".to_string());
-        let out = maybe_convert_env_for_msys_shell(Path::new("bash.exe"), &env);
-        assert!(matches!(out, std::borrow::Cow::Borrowed(_)));
-    }
-
-    #[test]
-    #[cfg(not(windows))]
-    fn test_maybe_convert_env_for_msys_shell_noop_on_unix() {
-        let env = env_with_path("/usr/bin:/bin");
-        let out = maybe_convert_env_for_msys_shell(Path::new("bash"), &env);
-        assert_eq!(out.get(&*crate::env::PATH_KEY).unwrap(), "/usr/bin:/bin");
     }
 
     #[test]


### PR DESCRIPTION
Raised by @cspotcode in [#3961](https://github.com/jdx/mise/discussions/3961#discussioncomment-18239852):

> Are we sure tickets #9547, #10147, and #10190 were actually fixing anything? As opposed to imperfectly duplicating a conversion that cygwin executables already do internally?

Measured, and the answer is worse than "not fixing anything": on the shell mise resolves by default, the conversion destroys the PATH on the way back out to a native program.

## The measurement

A standalone workflow on a throwaway branch, kept until this PR is decided: **[run 33701801463](https://github.com/JamBalaya56562/mise/actions/runs/33701801463)** ([workflow](https://github.com/JamBalaya56562/mise/blob/probe/win-path-truth/.github/workflows/win-path-probe.yml), [what it does and why](https://github.com/JamBalaya56562/mise/blob/probe/win-path-truth/probe/README.md)). Both jobs green; the claims are assertions, so green *is* the evidence.

Four shells — Git Bash `bin\bash.exe`, Git Bash `usr\bin\bash.exe`, MSYS2, Cygwin — against three inbound PATH forms, first with no mise anywhere, then the same instrument driven through `mise run` for released 2026.9.0 (pre-converts) and this branch (does not). One controlled PATH throughout, containing a directory with a space, a UNC entry, and a marker binary that both the shell and a native grandchild are asked to actually *run*, not merely to see.

Driven from pwsh, never from `shell: bash` — a bash-driven probe is already inside MSYS and its parent process is the wrong one.

## What it found

**The conversion is what breaks, and only where the shell sets `MSYSTEM`.**

| shell | `MSYSTEM` | pre-converted PATH in |
|---|---|---|
| `Git\bin\bash.exe` | `MINGW64` | **78 entries → 4; 73 lost inside one of them; native grandchild resolves nothing** |
| `Git\usr\bin\bash.exe` | unset | re-parsed, round trip survives |
| `msys64\usr\bin\bash.exe` | unset | re-parsed, round trip survives |
| Cygwin | unset | re-parsed, round trip survives |

A shell that sets `MSYSTEM` prepends its own entries at startup and keeps the inherited POSIX string as **one opaque element**, then hands that element through verbatim when it spawns a native child. `Get-Command bash.exe` and mise's own resolution both land on that shell, so this is the default experience, not a corner case — through `mise run`:

```
old-2026.9.0  mise-default   MSYSTEM=MINGW64   entries=4    blobs=1   native could not run a PATH binary
new-this-pr   mise-default   MSYSTEM=MINGW64   entries=77   blobs=0   native ran it
```

**Passing the Windows form through is lossless on all four shells** — every entry arrives, UNC included, the shell sees POSIX form unaided and can run what is on it, and so can a native grandchild.

## Why the conversion goes rather than gets fixed

1. **It is not needed.** Every shell converts in both directions by itself. Where `MSYSTEM` is unset the conversion changed nothing; where it is set, it was the defect.
2. **A correct converter would not help.** The `cygpath -u -p` rows use the shell's *own* converter — the best case any implementation could reach — and still lose entries that pass-through keeps: `\\zzzserver\zzzshare\bin` comes back as `D:\zzzserver\zzzshare\bin`. Pass-through loses zero.
3. **Guessing the prefix takes the shell out entirely.** `is_posix_shell_program` matched on basename, so a Cygwin bash got Git Bash's `/c/...`: in that row the shell resolves *nothing at all* — `out_entries=0`. @pjeby raised the same shape for WSL's `bash.exe`, which wants `/mnt/c/...`.

## Was #9547 ever fixing anything?

No. Its own description records that the repro was never run — *"`pwsh` repro … not run locally … Deferred to CI"* — and the test CI then ran asserted only that the conversion had *happened*. The half it claimed to fix (the shell seeing a Unix-form PATH) works unaided on every shell measured; the half it did not look at (what the next native process receives) is the one it broke.

## What this removes

`maybe_convert_env_for_msys_shell`, `msys_drive_prefix_for`, `windows_path_list_to_unix`, `is_cygwin_shell`, `MISE_CYGDRIVE_PREFIX` and their tests — the runtime behaviour of #9547, #10147 and #10190.

`is_posix_shell_program` and `resolve_posix_shell_program_path` stay: both have uses unrelated to PATH conversion (command-line construction, and #6513's `env_diff` bash lookup). Their doc comments no longer justify themselves by a conversion that is gone.

## The tests it replaces

Both removed Pester cases asserted that the conversion **happened**, not that anything worked, and neither could fail while the conversion existed. Their own comment says so:

> We assert on the PATH the task observes, not on a tool install, so the test runs without depending on rust/cargo or any toolchain backend.

The replacement asserts both ends of the chain and, because the shape assertions would still hold on a *truncated* list — which is exactly what the defect produced — it also puts a marker directory on PATH and requires it to arrive at the native grandchild. It pins itself to a shell that sets `MSYSTEM` and skips with a reason otherwise, rather than quietly becoming a test that cannot fail.

## Docs

The Cygwin section said to run `cygpath -pw "$PATH"` when a native program cannot resolve something. That is measurably unnecessary — Cygwin hands a native child a Windows-form PATH like the others — so it is gone. In its place, the difference that *is* real and did cause confusion in review: MSYS rewrites POSIX-looking arguments and non-PATH environment variables on the way to a native program (`/c` becomes `C:/`), while Cygwin leaves both alone. Both halves measured (C7/C8 in the run above).

## Scope

This is the task spawn path only. #3961 is largely about `mise activate` under Git Bash, which this does not touch and does not claim to fix.

---

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Windows task execution now preserves Windows-style PATH values for native processes.
  * Bash-compatible shells handle PATH conversion themselves, improving compatibility across mixed shell and native-process workflows.
  * Added clearer handling for PATH values passed between Bash and native Windows programs.

* **Documentation**
  * Updated Cygwin troubleshooting guidance to recommend `MISE_BASH_PATH`.
  * Clarified that Git Bash, MSYS2, and Cygwin automatically convert PATH values.
  * Documented `MSYS_NO_PATHCONV=1` for suppressing argument and environment-variable rewriting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->