### PR TITLE
fix(dotfiles): tolerate a stale directory the deeper walk already removed

### DIFF
--- a/e2e/cli/test_dotfiles_files
+++ b/e2e/cli/test_dotfiles_files
@@ -278,6 +278,20 @@ assert "ls ~/.local/mybin/unmanaged" "$HOME/.local/mybin/unmanaged"
 assert "readlink ~/.local/mybin/user-link" "/nonexistent-elsewhere"
 assert "readlink ~/.local/mybin/my-alias" "$PWD/dotfiles/bin/two"
 assert_succeed "mise dotfiles status --missing"
+
+# a removed directory whose links sat at two depths: the walk up from the
+# deeper link empties and removes the parent before the shallower link's
+# turn comes, and the second visit must not trip on the directory being gone
+mkdir -p dotfiles/bin/pkg/refs
+echo "four" >dotfiles/bin/pkg/four
+echo "five" >dotfiles/bin/pkg/refs/five
+assert_succeed "mise dotfiles apply --yes"
+assert "readlink ~/.local/mybin/pkg/refs/five" "$PWD/dotfiles/bin/pkg/refs/five"
+rm -r dotfiles/bin/pkg
+assert_succeed "mise dotfiles apply --yes"
+assert_directory_not_exists "$HOME/.local/mybin/pkg"
+assert "readlink ~/.local/mybin/one" "$PWD/dotfiles/bin/one"
+assert_succeed "mise dotfiles status --missing"
 rm ~/.local/mybin/user-link ~/.local/mybin/my-alias
 
 # copy entries pick up source changes on reapply

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -2612,7 +2612,7 @@ fn prune_stale_links(req: &FileRequest) -> Result<()> {
     {
         let mut dir = dir;
         while dir != req.target && dir.starts_with(&req.target) && !needed.contains(dir) {
-            if dir.read_dir()?.next().is_some() {
+            if !dir.is_dir() || dir.read_dir()?.next().is_some() {
                 break;
             }
             file::remove_dir(dir)?;


### PR DESCRIPTION
## Problem

A `symlink-each` entry fails with `No such file or directory (os error 2)` on the apply that removes a source directory whose links sat at two depths, e.g. a skill directory holding `SKILL.md` and `references/doc.md`. The links are removed, the directories are removed, but the apply aborts, and every stale link after that entry in the same apply is left behind. The next apply succeeds.

Reproduces on 2026.9.0 and main:

```toml
[dotfiles]
"/tmp/target" = { source = "skills", mode = "symlink-each", manifest = "git" }
```

1. `skills/nested/SKILL.md` and `skills/nested/references/doc.md` exist, apply: clean.
2. Delete `skills/nested/`, commit, apply: `No such file or directory (os error 2)`, exit 1.
3. Apply again: `all files are applied`.

Deleting a flat directory (only `SKILL.md`) is fine, so the trigger is the second depth.

## Cause

`prune_stale_links` walks each stale link's parent deepest first and climbs while the directory is empty. The walk from `references/doc.md` removes `references/` and then `nested/`. The loop then visits `nested/` again as the parent of `SKILL.md` and calls `read_dir` on the directory it just removed.

## Fix

Break when the directory is already gone, using the same `!dir.is_dir() ||` guard the two sibling walks in this file (`cleanup_reconciled_directories` and the unapply cleanup) already use.

The added e2e case in `test_dotfiles_files` mirrors the scenario: two links at two depths under one directory, the directory removed, apply succeeds and the directory is gone. It fails on main with the error above and passes with the fix. `cli/test_dotfiles_files` passes locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of stale dotfile links when nested directories are removed.
  * Prevented cleanup checks from failing when an expected directory has already been removed.
  * Preserved unrelated links during stale-link cleanup.
* **Tests**
  * Added coverage for removing nested source files and verifying successful status checks afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->