### PR TITLE
fix(shim): match lazy tool names on windows

### DIFF
--- a/e2e-win/lazy_shim.Tests.ps1
+++ b/e2e-win/lazy_shim.Tests.ps1
@@ -1,0 +1,71 @@
+Describe 'lazy shim' {
+    BeforeAll {
+        $originalLocation = Get-Location
+        $originalPath = $env:PATH
+        $originalDataDir = [Environment]::GetEnvironmentVariable('MISE_DATA_DIR', 'Process')
+        $originalConfigFile = [Environment]::GetEnvironmentVariable('MISE_CONFIG_FILE', 'Process')
+        $originalTrustedConfigPaths = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+        $originalShimMode = [Environment]::GetEnvironmentVariable('MISE_WINDOWS_SHIM_MODE', 'Process')
+
+        Set-Location TestDrive:
+        $env:MISE_DATA_DIR = Join-Path $TestDrive 'data'
+        $env:MISE_CONFIG_FILE = Join-Path $TestDrive 'mise.toml'
+        $env:MISE_TRUSTED_CONFIG_PATHS = $TestDrive
+        $env:MISE_WINDOWS_SHIM_MODE = 'exe'
+        $shimDir = Join-Path $env:MISE_DATA_DIR 'shims'
+        $env:PATH = "$shimDir;$originalPath"
+
+        @'
+[tools]
+jq = { version = "1.7.1", lazy = true, lazy_bins = ["JQ.EXE"] }
+'@ | Out-File -FilePath $env:MISE_CONFIG_FILE -Encoding utf8NoBOM
+    }
+
+    AfterAll {
+        Set-Location $originalLocation
+        $env:PATH = $originalPath
+        foreach ($saved in @(
+            @{ Name = 'MISE_DATA_DIR'; Value = $originalDataDir },
+            @{ Name = 'MISE_CONFIG_FILE'; Value = $originalConfigFile },
+            @{ Name = 'MISE_TRUSTED_CONFIG_PATHS'; Value = $originalTrustedConfigPaths },
+            @{ Name = 'MISE_WINDOWS_SHIM_MODE'; Value = $originalShimMode }
+        )) {
+            if ($null -eq $saved.Value) {
+                Remove-Item -Path "Env:\$($saved.Name)" -ErrorAction SilentlyContinue
+            } else {
+                [Environment]::SetEnvironmentVariable($saved.Name, $saved.Value, 'Process')
+            }
+        }
+    }
+
+    It 'installs and runs a lazy tool through native and hardlink shims' {
+        mise reshim --force
+        $LASTEXITCODE | Should -Be 0
+        $shim = Join-Path $env:MISE_DATA_DIR 'shims\jq.exe'
+        Test-Path $shim -PathType Leaf | Should -BeTrue
+        Test-Path (Join-Path $env:MISE_DATA_DIR 'installs\jq\1.7.1') | Should -BeFalse
+
+        $output = & $shim --version 2>&1
+        $LASTEXITCODE | Should -Be 0
+        ($output | Out-String) | Should -Match 'jq-1\.7.1'
+        Test-Path (Join-Path $env:MISE_DATA_DIR 'installs\jq\1.7.1') | Should -BeTrue
+
+        mise uninstall --all jq
+        $LASTEXITCODE | Should -Be 0
+        $env:MISE_WINDOWS_SHIM_MODE = 'hardlink'
+        $binDir = Join-Path $env:MISE_DATA_DIR 'bin'
+        $hardlinkMise = Join-Path $binDir 'mise.exe'
+        New-Item -ItemType Directory -Path $binDir -Force | Out-Null
+        $misePath = (Get-Command -Type Application mise -All | Select-Object -First 1).Source
+        Copy-Item $misePath $hardlinkMise
+        & $hardlinkMise reshim --force
+        $LASTEXITCODE | Should -Be 0
+        (Get-Item -Path $shim).LinkType | Should -Be 'HardLink'
+        Test-Path (Join-Path $env:MISE_DATA_DIR 'installs\jq\1.7.1') | Should -BeFalse
+
+        $output = & $shim --version 2>&1
+        $LASTEXITCODE | Should -Be 0
+        ($output | Out-String) | Should -Match 'jq-1\.7\.1'
+        Test-Path (Join-Path $env:MISE_DATA_DIR 'installs\jq\1.7.1') | Should -BeTrue
+    }
+}

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -197,11 +197,13 @@ async fn which_shim(
     // tool version or auto-install over the network while the user is pressing
     // tab. On Windows the shim is invoked as `usage.exe`, so strip the platform
     // executable suffix before comparing.
-    let bin_stem = bin_name
-        .strip_suffix(std::env::consts::EXE_SUFFIX)
-        .unwrap_or(bin_name);
-    let completion_offline =
-        bin_stem == "usage" && args.get(1).is_some_and(|arg| arg == "complete-word");
+    let shim_name = command_name_without_exe_suffix(bin_name);
+    let is_usage = if cfg!(windows) {
+        shim_name.eq_ignore_ascii_case("usage")
+    } else {
+        shim_name == "usage"
+    };
+    let completion_offline = is_usage && args.get(1).is_some_and(|arg| arg == "complete-word");
     let resolve_options = if completion_offline {
         ResolveOptions {
             offline: true,
@@ -221,14 +223,14 @@ async fn which_shim(
     let wrapper = if cfg!(macos) {
         wrappers
             .iter()
-            .find(|(name, _)| command_names_eq(name, bin_stem))
+            .find(|(name, _)| command_names_eq(name, shim_name))
             .map(|(_, wrapper)| wrapper)
     } else {
-        wrappers.get(bin_stem)
+        wrappers.get(shim_name)
     };
     if let Some(wrapper) = wrapper {
-        if command_names_eq(wrapper.command(), bin_stem) {
-            bail!("command wrapper for {bin_stem} cannot delegate to itself");
+        if command_names_eq(wrapper.command(), shim_name) {
+            bail!("command wrapper for {shim_name} cannot delegate to itself");
         }
         trace!("shim[{bin_name}] WRAPPER command: {}", wrapper.command());
         return Ok((PathBuf::from(wrapper.command()), ts, Some(wrapper.clone())));
@@ -239,16 +241,18 @@ async fn which_shim(
     if !completion_offline
         && Settings::get().not_found_auto_install
         && ts
-            .should_install_missing_registry_bin_provider(config, bin_name)
+            .should_install_missing_registry_bin_provider(config, shim_name)
             .await?
     {
         for tv in ts
-            .install_missing_bin(config, bin_name)
+            .install_missing_bin(config, shim_name)
             .await?
             .unwrap_or_default()
         {
             let p = tv.backend()?;
-            if let Some(bin) = p.which(config, &tv, bin_name).await? {
+            if let Some(bin) =
+                backend_which_shim(p.as_ref(), config, &tv, shim_name, bin_name).await?
+            {
                 trace!(
                     "shim[{bin_name}] REGISTRY ToolVersion: {tv} bin: {bin}",
                     bin = display_path(&bin)
@@ -257,26 +261,30 @@ async fn which_shim(
             }
         }
     }
-    if let Some((p, tv)) = ts.which(config, bin_name).await
-        && let Some(bin) = p.which(config, &tv, bin_name).await?
-    {
-        trace!(
-            "shim[{bin_name}] ToolVersion: {tv} bin: {bin}",
-            bin = display_path(&bin)
-        );
-        return Ok((bin, ts, None));
+    for lookup_name in [shim_name, bin_name].into_iter().unique() {
+        if let Some((p, tv)) = ts.which(config, lookup_name).await
+            && let Some(bin) = p.which(config, &tv, lookup_name).await?
+        {
+            trace!(
+                "shim[{bin_name}] ToolVersion: {tv} bin: {bin}",
+                bin = display_path(&bin)
+            );
+            return Ok((bin, ts, None));
+        }
     }
     // Lazy tools are explicit fallback providers. They install on first shim use even when
     // general not-found auto-install is disabled, but only after configured/project providers
     // and already-installed tools have had a chance to win.
-    if !completion_offline && ts.has_missing_lazy_bin_provider(config, bin_name).await? {
+    if !completion_offline && ts.has_missing_lazy_bin_provider(config, shim_name).await? {
         for tv in ts
-            .install_missing_lazy_bin(config, bin_name)
+            .install_missing_lazy_bin(config, shim_name)
             .await?
             .unwrap_or_default()
         {
             let backend = tv.backend()?;
-            if let Some(bin) = backend.which(config, &tv, bin_name).await? {
+            if let Some(bin) =
+                backend_which_shim(backend.as_ref(), config, &tv, shim_name, bin_name).await?
+            {
                 trace!(
                     "shim[{bin_name}] LAZY ToolVersion: {tv} bin: {bin}",
                     bin = display_path(&bin)
@@ -289,12 +297,14 @@ async fn which_shim(
     // offline completion so `usage complete-word` fails locally instead.
     if !completion_offline && Settings::get().not_found_auto_install {
         for tv in ts
-            .install_missing_bin(config, bin_name)
+            .install_missing_bin(config, shim_name)
             .await?
             .unwrap_or_default()
         {
             let p = tv.backend()?;
-            if let Some(bin) = p.which(config, &tv, bin_name).await? {
+            if let Some(bin) =
+                backend_which_shim(p.as_ref(), config, &tv, shim_name, bin_name).await?
+            {
                 trace!(
                     "shim[{bin_name}] NOT_FOUND ToolVersion: {tv} bin: {bin}",
                     bin = display_path(&bin)
@@ -324,11 +334,31 @@ async fn which_shim(
             }
         }
     }
-    let tvs = ts.list_rtvs_with_bin(config, bin_name).await?;
-    match err_no_version_set(config, ts, bin_name, tvs).await {
+    let mut tvs = ts.list_rtvs_with_bin(config, shim_name).await?;
+    if tvs.is_empty() && shim_name != bin_name {
+        tvs = ts.list_rtvs_with_bin(config, bin_name).await?;
+    }
+    match err_no_version_set(config, ts, shim_name, tvs).await {
         Ok(_) => unreachable!("err_no_version_set always returns an error"),
         Err(err) => Err(err),
     }
+}
+
+async fn backend_which_shim(
+    backend: &dyn Backend,
+    config: &Arc<Config>,
+    tv: &ToolVersion,
+    shim_name: &str,
+    bin_name: &str,
+) -> Result<Option<PathBuf>> {
+    // The extensionless name preserves normal Windows extension expansion (including `.cmd`),
+    // while the original name is required for dotted stems such as `python3.12.exe`.
+    for lookup_name in [shim_name, bin_name].into_iter().unique() {
+        if let Some(bin) = backend.which(config, tv, lookup_name).await? {
+            return Ok(Some(bin));
+        }
+    }
+    Ok(None)
 }
 
 /// Build the actionable, `which_shim`-style resolution error for a bin that a
@@ -944,6 +974,18 @@ fn command_names_eq(a: &str, b: &str) -> bool {
         a.to_lowercase() == b.to_lowercase()
     } else {
         a == b
+    }
+}
+
+pub(crate) fn command_name_without_exe_suffix(bin_name: &str) -> &str {
+    let suffix = std::env::consts::EXE_SUFFIX;
+    if suffix.is_empty() {
+        return bin_name;
+    }
+    let suffix_start = bin_name.len().saturating_sub(suffix.len());
+    match (bin_name.get(..suffix_start), bin_name.get(suffix_start..)) {
+        (Some(name), Some(actual_suffix)) if actual_suffix.eq_ignore_ascii_case(suffix) => name,
+        _ => bin_name,
     }
 }
 
@@ -1820,6 +1862,18 @@ mod tests {
     fn dotted_windows_wrapper_names_are_rejected() {
         let names = ["foo.bar".to_string()];
         assert!(validate_wrapper_names(&names).is_err());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_shim_command_names_drop_exe_suffix_case_insensitively() {
+        assert_eq!(command_name_without_exe_suffix("dummy.exe"), "dummy");
+        assert_eq!(command_name_without_exe_suffix("DUMMY.EXE"), "DUMMY");
+        assert_eq!(
+            command_name_without_exe_suffix("python3.12.exe"),
+            "python3.12"
+        );
+        assert_eq!(command_name_without_exe_suffix("dummy.cmd"), "dummy.cmd");
     }
 
     #[test]

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -24,7 +24,7 @@ use crate::toolset::tool_request::ToolRequest;
 use crate::toolset::tool_source::ToolSource;
 use crate::toolset::tool_version::{ResolveOptions, ToolVersion};
 use crate::ui::multi_progress_report::MultiProgressReport;
-use crate::{backend, config, hooks, runtime_symlinks};
+use crate::{backend, config, hooks, runtime_symlinks, shims};
 
 impl Toolset {
     async fn missing_lazy_bin_provider(
@@ -40,7 +40,11 @@ impl Toolset {
                 let options = tv.request.options();
                 if options.lazy == Some(true) {
                     match tv.request.lazy_bins() {
-                        Ok(Some(bins)) if bins.iter().any(|bin| bin == bin_name) => Some(Ok(tv)),
+                        Ok(Some(bins))
+                            if bins.iter().any(|bin| lazy_bin_names_eq(bin, bin_name)) =>
+                        {
+                            Some(Ok(tv))
+                        }
                         Ok(_) => None,
                         // Missing metadata for one lazy declaration says nothing
                         // about whether another declaration provides this command.
@@ -829,6 +833,15 @@ impl Toolset {
     }
 }
 
+fn lazy_bin_names_eq(configured: &str, requested: &str) -> bool {
+    if cfg!(windows) {
+        shims::command_name_without_exe_suffix(configured)
+            .eq_ignore_ascii_case(shims::command_name_without_exe_suffix(requested))
+    } else {
+        configured == requested
+    }
+}
+
 fn ensure_safe_install_options(versions: &[ToolRequest]) -> Result<()> {
     for request in versions {
         request.ensure_safe_install_options()?;
@@ -888,6 +901,15 @@ mod tests {
     use super::*;
     use crate::cli::args::BackendArg;
     use crate::toolset::parse_tool_options;
+
+    #[cfg(windows)]
+    #[test]
+    fn lazy_bin_names_match_windows_command_case() {
+        assert!(lazy_bin_names_eq("dummy", "DUMMY"));
+        assert!(lazy_bin_names_eq("dummy.exe", "DUMMY"));
+        assert!(lazy_bin_names_eq("DUMMY.EXE", "dummy.exe"));
+        assert!(!lazy_bin_names_eq("dummy", "other"));
+    }
 
     #[tokio::test]
     async fn test_init_request_options_preserves_unmatched_request_options() {


### PR DESCRIPTION
Fixes the lazy-tool shim behavior reported in #12690.

Windows invokes direct hardlink and symlink shims with an `.exe` suffix, while lazy tool metadata stores extensionless command names. Normalize the Windows executable suffix before shim lookup and compare lazy command names case-insensitively on Windows.

This also adds a native Windows Pester test covering first invocation through both exe and hardlink shims.

## Testing
- `mise run lint-fix`
- `mise run test:unit -- shims::tests`
- `mise run test:e2e e2e/cli/test_lazy_tools`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core shim dispatch and lazy auto-install paths on Windows; mistakes could break tool resolution or trigger wrong installs, though scope is platform-specific and covered by new tests.
> 
> **Overview**
> Fixes lazy-tool shim resolution on Windows when shims run as `*.exe` and `lazy_bins` entries differ in casing or extension (e.g. `JQ.EXE` vs `jq.exe`).
> 
> **Shim lookup** normalizes the invoked name with a new `command_name_without_exe_suffix` (case-insensitive `.exe` stripping, preserves stems like `python3.12.exe`), uses that stem for wrappers, auto-install, and lazy providers, and falls back to the raw name when needed via `backend_which_shim`. The `usage` completion shim is matched case-insensitively on Windows.
> 
> **Lazy install matching** compares configured `lazy_bins` to the requested command with `lazy_bin_names_eq` on Windows (same suffix normalization + ASCII case fold).
> 
> Adds Windows unit tests and a Pester e2e that defers `jq` install until first shim run under **exe** and **hardlink** shim modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bf6f1d95b45ccbafda3164b4f10f20e86c0cb38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows command handling by recognizing executable names regardless of `.exe` suffix casing.
  - Fixed case-insensitive matching for lazily configured tool commands on Windows.
  - Improved reliability when running lazily installed tools through native and hardlink shims.

- **Tests**
  - Added Windows end-to-end coverage for deferred `jq` installation and execution across shim modes.
  - Added coverage for Windows command-name and casing variations.
  - Added checks for successful command execution and environment cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->