### PR TITLE
docs(cli): improve command help prose and fill gaps

### DIFF
--- a/docs/cli/activate.md
+++ b/docs/cli/activate.md
@@ -5,10 +5,10 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/activate.rs`](https://github.com/jdx/mise/blob/main/src/cli/activate.rs)
 
-Initializes mise in the current shell session
+Initialize mise in the current shell session
 
-This should go into your shell's rc file or login shell.
-Otherwise, it will only take effect in the current session.
+Add this to your shell's rc or profile file so it runs in every new shell.
+Otherwise, it only takes effect in the current session.
 (e.g. ~/.zshrc, ~/.zprofile, ~/.zshenv, ~/.bashrc, ~/.bash_profile, ~/.profile, ~/.config/fish/config.fish, or $PROFILE for powershell)
 
 Typically, this can be added with something like the following:
@@ -37,6 +37,7 @@ Customize status output with `status` settings.
 
   This can be helpful for debugging mise. If you run `eval "$(mise activate --no-hook-env)"`, then you can call `mise hook-env` manually which will output the env vars to stdout without actually modifying the environment. That way you can do things like `mise hook-env --trace` to get more information or just see the values that hook-env is outputting.
 - **`--shims`** — Use shims instead of modifying PATH
+
   Effectively the same as:
 
   ```

--- a/docs/cli/bootstrap/launchd/apply.md
+++ b/docs/cli/bootstrap/launchd/apply.md
@@ -5,6 +5,8 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
+Install and load LaunchAgents from `[bootstrap.macos.launchd.agents]`
+
 ## Flags
 - **`-n --dry-run`** — Print the commands that would run without running them
 - **`-y --yes`** — Skip the confirmation prompt

--- a/docs/cli/bootstrap/launchd/status.md
+++ b/docs/cli/bootstrap/launchd/status.md
@@ -5,6 +5,8 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
+Show the state of LaunchAgents from `[bootstrap.macos.launchd.agents]`
+
 ## Flags
 - **`-J --json`** — Output in JSON format
 - **`--missing`** — Exit with code 1 if any configured LaunchAgent is not in its desired state

--- a/docs/cli/bootstrap/linux/systemd-units/apply.md
+++ b/docs/cli/bootstrap/linux/systemd-units/apply.md
@@ -5,6 +5,8 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
+Install and start systemd user services from `[bootstrap.linux.systemd.units]`
+
 ## Flags
 - **`-n --dry-run`** — Print the commands that would run without running them
 - **`-y --yes`** — Skip the confirmation prompt

--- a/docs/cli/bootstrap/linux/systemd-units/status.md
+++ b/docs/cli/bootstrap/linux/systemd-units/status.md
@@ -5,6 +5,8 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
+Show the state of systemd user services from `[bootstrap.linux.systemd.units]`
+
 ## Flags
 - **`-J --json`** — Output in JSON format
 - **`--missing`** — Exit with code 1 if any configured systemd user service is not in its desired state

--- a/docs/cli/bootstrap/macos-defaults/apply.md
+++ b/docs/cli/bootstrap/macos-defaults/apply.md
@@ -5,6 +5,8 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
+Write macOS defaults from `[bootstrap.macos.defaults]`
+
 ## Flags
 - **`-n --dry-run`** — Print the commands that would run without running them
 - **`-y --yes`** — Skip the confirmation prompt

--- a/docs/cli/bootstrap/macos-defaults/status.md
+++ b/docs/cli/bootstrap/macos-defaults/status.md
@@ -5,6 +5,8 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
+Show whether macOS defaults match `[bootstrap.macos.defaults]`
+
 ## Flags
 - **`-J --json`** — Output in JSON format
 - **`--missing`** — Exit with code 1 if any configured defaults are not in their desired state

--- a/docs/cli/bootstrap/macos/defaults/apply.md
+++ b/docs/cli/bootstrap/macos/defaults/apply.md
@@ -5,6 +5,8 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
+Write macOS defaults from `[bootstrap.macos.defaults]`
+
 ## Flags
 - **`-n --dry-run`** — Print the commands that would run without running them
 - **`-y --yes`** — Skip the confirmation prompt

--- a/docs/cli/bootstrap/macos/defaults/status.md
+++ b/docs/cli/bootstrap/macos/defaults/status.md
@@ -5,6 +5,8 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
+Show whether macOS defaults match `[bootstrap.macos.defaults]`
+
 ## Flags
 - **`-J --json`** — Output in JSON format
 - **`--missing`** — Exit with code 1 if any configured defaults are not in their desired state

--- a/docs/cli/bootstrap/macos/launchd-agents/apply.md
+++ b/docs/cli/bootstrap/macos/launchd-agents/apply.md
@@ -5,6 +5,8 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
+Install and load LaunchAgents from `[bootstrap.macos.launchd.agents]`
+
 ## Flags
 - **`-n --dry-run`** — Print the commands that would run without running them
 - **`-y --yes`** — Skip the confirmation prompt

--- a/docs/cli/bootstrap/macos/launchd-agents/status.md
+++ b/docs/cli/bootstrap/macos/launchd-agents/status.md
@@ -5,6 +5,8 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
+Show the state of LaunchAgents from `[bootstrap.macos.launchd.agents]`
+
 ## Flags
 - **`-J --json`** — Output in JSON format
 - **`--missing`** — Exit with code 1 if any configured LaunchAgent is not in its desired state

--- a/docs/cli/bootstrap/mise-shell-activate/apply.md
+++ b/docs/cli/bootstrap/mise-shell-activate/apply.md
@@ -5,6 +5,8 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
+Configure shell activation from `[bootstrap.mise_shell_activate]`
+
 ## Flags
 - **`-n --dry-run`** — Print the actions that would run without writing anything
 - **`-y --yes`** — Skip the confirmation prompt

--- a/docs/cli/bootstrap/mise-shell-activate/status.md
+++ b/docs/cli/bootstrap/mise-shell-activate/status.md
@@ -5,6 +5,8 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
+Show whether shell activation matches `[bootstrap.mise_shell_activate]`
+
 ## Flags
 - **`-J --json`** — Output in JSON format
 - **`--missing`** — Exit with code 1 if any configured shell activation is not in its desired state

--- a/docs/cli/bootstrap/plugins/apply.md
+++ b/docs/cli/bootstrap/plugins/apply.md
@@ -5,6 +5,8 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
+Install package manager plugins declared in `[bootstrap.plugins]`
+
 ## Flags
 - **`-n --dry-run`** — Print what would happen without installing plugins
 - **`-h --help`** — Print help

--- a/docs/cli/bootstrap/plugins/status.md
+++ b/docs/cli/bootstrap/plugins/status.md
@@ -5,6 +5,8 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
+Show whether declared package manager plugins are installed
+
 ## Flags
 - **`--missing`** — Exit with code 1 if a declared plugin is missing
 - **`-h --help`** — Print help

--- a/docs/cli/bootstrap/repos/apply.md
+++ b/docs/cli/bootstrap/repos/apply.md
@@ -5,6 +5,8 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
+Clone and converge git repos from `[bootstrap.repos]`
+
 ## Flags
 - **`-n --dry-run`** — Print the commands that would run without running them
 - **`-y --yes`** — Skip the confirmation prompt

--- a/docs/cli/bootstrap/repos/exec.md
+++ b/docs/cli/bootstrap/repos/exec.md
@@ -4,6 +4,8 @@
 - **Usage:** `mise bootstrap repos exec [-c --continue-on-error] [-n --dry-run] [PATH]… <-- COMMAND>…`
 - **Source code:** [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
+Run a command in each configured git repo
+
 ## Arguments
 - **`[PATH]…`** — Run only in matching configured or expanded paths
 - **`<-- COMMAND>…`** — Command and arguments to run in each repo

--- a/docs/cli/bootstrap/repos/status.md
+++ b/docs/cli/bootstrap/repos/status.md
@@ -5,6 +5,8 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
+Show the state of git repos from `[bootstrap.repos]`
+
 ## Flags
 - **`-J --json`** — Output in JSON format
 - **`--missing`** — Exit with code 1 if any configured repo is not in its desired state

--- a/docs/cli/bootstrap/repos/update.md
+++ b/docs/cli/bootstrap/repos/update.md
@@ -5,6 +5,8 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
+Pull the latest changes into configured git repos
+
 ## Arguments
 - **`[PATH]…`** — Update only matching configured or expanded paths
 

--- a/docs/cli/bootstrap/systemd/apply.md
+++ b/docs/cli/bootstrap/systemd/apply.md
@@ -5,6 +5,8 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
+Install and start systemd user services from `[bootstrap.linux.systemd.units]`
+
 ## Flags
 - **`-n --dry-run`** — Print the commands that would run without running them
 - **`-y --yes`** — Skip the confirmation prompt

--- a/docs/cli/bootstrap/systemd/status.md
+++ b/docs/cli/bootstrap/systemd/status.md
@@ -5,6 +5,8 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
+Show the state of systemd user services from `[bootstrap.linux.systemd.units]`
+
 ## Flags
 - **`-J --json`** — Output in JSON format
 - **`--missing`** — Exit with code 1 if any configured systemd user service is not in its desired state

--- a/docs/cli/bootstrap/user/apply.md
+++ b/docs/cli/bootstrap/user/apply.md
@@ -5,6 +5,8 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
+Apply current-user settings from `[bootstrap.user]`
+
 ## Flags
 - **`-n --dry-run`** — Print the commands that would run without running them
 - **`-y --yes`** — Skip the confirmation prompt

--- a/docs/cli/bootstrap/user/status.md
+++ b/docs/cli/bootstrap/user/status.md
@@ -5,6 +5,8 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
+Show whether current-user settings match `[bootstrap.user]`
+
 ## Flags
 - **`-J --json`** — Output in JSON format
 - **`--missing`** — Exit with code 1 if any configured user setting is not in its desired state

--- a/docs/cli/cache/clear.md
+++ b/docs/cli/cache/clear.md
@@ -6,7 +6,7 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/cache/clear.rs`](https://github.com/jdx/mise/blob/main/src/cli/cache/clear.rs)
 
-Deletes all cache files in mise
+Delete all cache files
 
 ## Arguments
 - **`[TOOL]…`** — Tool(s) to clear cache for e.g.: node, python

--- a/docs/cli/cache/prune.md
+++ b/docs/cli/cache/prune.md
@@ -6,7 +6,7 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/cache/prune.rs`](https://github.com/jdx/mise/blob/main/src/cli/cache/prune.rs)
 
-Removes stale mise cache files
+Remove stale cache files
 
 By default, this command will remove files that have not been accessed in 30 days.
 Change this with the MISE_CACHE_PRUNE_AGE environment variable.
@@ -16,5 +16,5 @@ Change this with the MISE_CACHE_PRUNE_AGE environment variable.
 
 ## Flags
 - **`-v --verbose`** — Show pruned files
-- **`--dry-run`** — Just show what would be pruned
+- **`--dry-run`** — Show what would be pruned without deleting anything
 - **`-h --help`** — Print help

--- a/docs/cli/config/get.md
+++ b/docs/cli/config/get.md
@@ -5,10 +5,10 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/config/get.rs`](https://github.com/jdx/mise/blob/main/src/cli/config/get.rs)
 
-Display the value of a setting in a mise.toml file
+Display a value from a mise.toml file
 
 ## Arguments
-- **`[KEY]`** — The path of the config to display
+- **`[KEY]`** — Dotted key path to display, e.g. `tools.python`; omit to print the whole file
 
 ## Flags
 - **`-f --file <FILE>`** — The path to the mise.toml file to read

--- a/docs/cli/config/set.md
+++ b/docs/cli/config/set.md
@@ -5,10 +5,10 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/config/set.rs`](https://github.com/jdx/mise/blob/main/src/cli/config/set.rs)
 
-Set the value of a setting in a mise.toml file
+Set a value in a mise.toml file
 
 ## Arguments
-- **`<KEY>`** — The path of the config to display
+- **`<KEY>`** — Dotted key path to set, e.g. `tools.python`
 - **`[VALUE]`** — The value to set the key to (optional if provided as KEY=VALUE)
 
 ## Flags
@@ -23,7 +23,7 @@ Set the value of a setting in a mise.toml file
 - **`--system`** — Edit the system config file.
 - **`--append`** — Append the value without duplicating an existing entry.
 - **`--remove`** — Remove the value from an existing collection.
-- **`-t --type <TYPE>`**
+- **`-t --type <TYPE>`** — TOML type to store the value as; inferred from the value by default
 
   **Choices:** `infer`, `string`, `integer`, `float`, `bool`, `list`, `set`
 

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -9,7 +9,7 @@
 Check mise installation for possible problems
 
 ## Flags
-- **`-J --json`**
+- **`-J --json`** — Output in JSON format
 - **`-h --help`** — Print help
 
 ## Subcommands

--- a/docs/cli/en.md
+++ b/docs/cli/en.md
@@ -4,11 +4,11 @@
 - **Usage:** `mise en [-s --shell <SHELL>] [DIR]`
 - **Source code:** [`src/cli/en.rs`](https://github.com/jdx/mise/blob/main/src/cli/en.rs)
 
-Starts a new shell with the mise environment built from the current configuration
+Start a new shell with the mise environment built from the current configuration
 
-This is an alternative to `mise activate` that allows you to explicitly start a mise session.
-It will have the tools and environment variables in the configs loaded.
-Note that changing directories will not update the mise environment.
+This is an alternative to `mise activate` for starting a mise session explicitly.
+The new shell has the tools and environment variables from the config loaded.
+Unlike an activated shell, changing directories does not update the environment.
 
 ## Arguments
 - **`[DIR]`** — Directory to start the shell in

--- a/docs/cli/env.md
+++ b/docs/cli/env.md
@@ -6,13 +6,13 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/env.rs`](https://github.com/jdx/mise/blob/main/src/cli/env.rs)
 
-Exports env vars to activate mise a single time
+Export env vars to activate mise a single time
 
-Use this if you don't want to permanently install mise. It's not necessary to
-use this if you have `mise activate` in your shell rc file.
+Use this to load the environment into one shell without adding `mise activate` to
+your shell rc file. It is not needed in shells where mise is already activated.
 
 ## Arguments
-- **`[TOOL@VERSION]…`** — Tool(s) to use
+- **`[TOOL@VERSION]…`** — Tool(s) to include in addition to those in config, e.g. node@20
 
 ## Flags
 - **`-D --dotenv`** — Output in dotenv format

--- a/docs/cli/exec.md
+++ b/docs/cli/exec.md
@@ -7,23 +7,24 @@
 
 Execute a command with tool(s) set
 
-use this to avoid modifying the shell session or running ad-hoc commands with mise tools set.
+Use this to run a command with mise's tools and environment without modifying the shell
+session, or to run ad-hoc commands with tools that are not in the config.
 
-Tools will be loaded from mise.toml, though they can be overridden with &lt;RUNTIME> args
-Note that only the plugin specified will be overridden, so if a `mise.toml` file
-includes "node 20" but you run `mise exec python@3.11`; it will still load node@20.
+Tools are loaded from mise.toml and can be overridden with &lt;TOOL@VERSION> args. Only the
+tools you name are overridden: if `mise.toml` includes `node = "20"` and you run
+`mise exec python@3.11`, node@20 is still loaded.
 
-The "--" separates runtimes from the commands to pass along to the subprocess.
+The "--" separates tools from the command to pass along to the subprocess.
 
 ## Arguments
-- **`[TOOL@VERSION]…`** — Tool(s) to start e.g.: node@20 python@3.10
+- **`[TOOL@VERSION]…`** — Tool(s) to load e.g.: node@20 python@3.10
 - **`[-- COMMAND]…`** — Command string to execute (same as --command)
 
 ## Flags
 - **`-c --command <COMMAND>`** — Command string to execute
 - **`-j --jobs <JOBS>`** — Number of jobs to run in parallel
   Values below 1 are treated as 1
-  [default: 4]
+  Defaults to the `jobs` setting
 
   **Environment Variable:** `MISE_JOBS`
 - **`--allow-env <VAR>`** — Allow specific env var through (implies --deny-env for everything else)
@@ -39,7 +40,7 @@ The "--" separates runtimes from the commands to pass along to the subprocess.
 - **`--deny-write`** — Block all filesystem writes
 - **`--fresh-env`** — Bypass the environment cache and recompute the environment
 - **`--no-deps`** — Skip automatic dependency preparation
-- **`--raw`** — Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
+- **`--raw`** — Connect backend install command stdin/stdout/stderr directly to the terminal. Implies `--jobs=1`
 - **`-h --help`** — Print help
 
 Examples:

--- a/docs/cli/fmt.md
+++ b/docs/cli/fmt.md
@@ -5,13 +5,13 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/fmt.rs`](https://github.com/jdx/mise/blob/main/src/cli/fmt.rs)
 
-Formats mise.toml
+Format mise.toml
 
 Sorts keys and cleans up whitespace in mise.toml
 
 ## Flags
-- **`-a --all`** — Format all files from the current directory
-- **`-c --check`** — Check if the configs are formatted, no formatting is done
+- **`-a --all`** — Format every config file mise currently loads, not just those in the current directory
+- **`-c --check`** — Check whether the configs are formatted without rewriting them; exits 1 if any are not
 - **`-s --stdin`** — Read config from stdin and write its formatted version into stdout
 - **`-h --help`** — Print help
 

--- a/docs/cli/generate/devcontainer.md
+++ b/docs/cli/generate/devcontainer.md
@@ -11,7 +11,7 @@ Generate a devcontainer to execute mise
 - **`-i --image <IMAGE>`** — The image to use for the devcontainer
 - **`-m --mount-mise-data`** — Bind the mise-data-volume to the devcontainer
 - **`-n --name <NAME>`** — The name of the devcontainer
-- **`-w --write`** — write to .devcontainer/devcontainer.json
+- **`-w --write`** — Write to .devcontainer/devcontainer.json
 - **`-h --help`** — Print help
 
 Examples:

--- a/docs/cli/generate/git-pre-commit.md
+++ b/docs/cli/generate/git-pre-commit.md
@@ -26,7 +26,7 @@ For more advanced pre-commit functionality, see mise's sister project: <https://
 - **`-t --task <TASK>`** — The task to run when the pre-commit hook is triggered
 
   **Default:** `pre-commit`
-- **`-w --write`** — write to .git/hooks/pre-commit and make it executable
+- **`-w --write`** — Write to .git/hooks/pre-commit and make it executable
 - **`--hook <HOOK>`** — Which hook to generate (saves to .git/hooks/$hook)
 
   **Default:** `pre-commit`

--- a/docs/cli/generate/github-action.md
+++ b/docs/cli/generate/github-action.md
@@ -14,8 +14,8 @@ when you push changes to your repository.
 - **`-t --task <TASK>`** — The task to run when the workflow is triggered
 
   **Default:** `ci`
-- **`-w --write`** — write to .github/workflows/$name.yml
-- **`--name <NAME>`** — the name of the workflow to generate
+- **`-w --write`** — Write to .github/workflows/$name.yml
+- **`--name <NAME>`** — The name of the workflow to generate
 
   **Default:** `ci`
 - **`-h --help`** — Print help

--- a/docs/cli/generate/install-script.md
+++ b/docs/cli/generate/install-script.md
@@ -13,7 +13,7 @@ Renamed from `mise generate bootstrap`, which read as a form of `mise bootstrap`
 setup). The old name still works but is deprecated and will be removed in mise 2027.9.0.
 
 ## Flags
-- **`-l --localize`** — Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project
+- **`-l --localize`** — Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a project-local directory (`.mise` by default, set with `--localized-dir`)
 
   This is necessary if users may use a different version of mise outside the project.
 - **`-V --version <VERSION>`** — Specify mise version to fetch

--- a/docs/cli/generate/install-script.md
+++ b/docs/cli/generate/install-script.md
@@ -13,11 +13,11 @@ Renamed from `mise generate bootstrap`, which read as a form of `mise bootstrap`
 setup). The old name still works but is deprecated and will be removed in mise 2027.9.0.
 
 ## Flags
-- **`-l --localize`** — Sandboxes mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project
+- **`-l --localize`** — Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project
 
   This is necessary if users may use a different version of mise outside the project.
 - **`-V --version <VERSION>`** — Specify mise version to fetch
-- **`-w --write [WRITE]`** — instead of outputting the script to stdout, write to a file and make it executable
+- **`-w --write [WRITE]`** — Write the script to a file and make it executable instead of printing it to stdout
 - **`--localized-dir <LOCALIZED_DIR>`** — Directory to put localized data into
 
   **Default:** `.mise`

--- a/docs/cli/generate/task-docs.md
+++ b/docs/cli/generate/task-docs.md
@@ -8,17 +8,17 @@
 Generate documentation for tasks in a project
 
 ## Flags
-- **`-i --inject`** — inserts the documentation into an existing file
+- **`-i --inject`** — Insert the documentation into an existing file
 
   This will look for a special comment, `<!-- mise-tasks -->`, and replace it with the generated documentation.
   It will replace everything between the comment and the next comment, `<!-- /mise-tasks -->` so it can be
   run multiple times on the same file to update the documentation.
   The file must already contain both comments; mise errors instead of modifying the file if they are missing.
-- **`-I --index`** — write only an index of tasks, intended for use with `--multi`
-- **`-m --multi`** — render each task as a separate document, requires `--output` to be a directory
-- **`-o --output <OUTPUT>`** — writes the generated docs to a file/directory
-- **`-r --root <ROOT>`** — root directory to search for tasks
-- **`-s --style <STYLE>`**
+- **`-I --index`** — Write only an index of tasks, intended for use with `--multi`
+- **`-m --multi`** — Render each task as a separate document; requires `--output` to be a directory
+- **`-o --output <OUTPUT>`** — Write the generated docs to a file or directory
+- **`-r --root <ROOT>`** — Root directory to search for tasks
+- **`-s --style <STYLE>`** — Documentation style: `simple` lists tasks, `detailed` documents each task's usage
 
   **Choices:** `simple`, `detailed`
 

--- a/docs/cli/generate/task-stubs.md
+++ b/docs/cli/generate/task-stubs.md
@@ -5,7 +5,7 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/generate/task_stubs.rs`](https://github.com/jdx/mise/blob/main/src/cli/generate/task_stubs.rs)
 
-Generates shims to run mise tasks
+Generate shims to run mise tasks
 
 By default, this will build shims like ./bin/&lt;task>. These can be paired with `mise generate install-script`
 so contributors to a project can execute mise tasks without installing mise into their system.

--- a/docs/cli/implode.md
+++ b/docs/cli/implode.md
@@ -5,9 +5,9 @@
 - **Effect:** destructive — may delete or irreversibly overwrite
 - **Source code:** [`src/cli/implode.rs`](https://github.com/jdx/mise/blob/main/src/cli/implode.rs)
 
-Removes mise CLI and all related data
+Remove the mise CLI and all related data
 
-Skips config directory by default.
+The config directory is kept unless `--config` is passed.
 
 ## Flags
 - **`-n --dry-run`** — List directories that would be removed without actually removing them

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -41,7 +41,6 @@
 - **`--no-hooks`** — Do not execute hooks from config files
 
   Can also use `MISE_NO_HOOKS=1`
-- **`--output <OUTPUT>`**
 - **`-h --help`** — Print help
 
 ## Subcommands

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -8,8 +8,10 @@
 
 Install a tool version
 
-Installs a tool version to `~/.local/share/mise/installs/<TOOL>/<VERSION>`.
-Installing alone does not activate the tool, so it will not be on PATH.
+Installs a tool version under the mise data directory, by default
+`~/.local/share/mise/installs/<TOOL>/<VERSION>`.
+Installing alone does not add the tool to your config, so a tool that is not
+already configured will not be on PATH.
 To install and activate in one command, use `mise use`, which also writes the version to
 `mise.toml` in the current directory so the tool is active inside it.
 To run a tool once without touching any config, use `mise exec <TOOL>@<VERSION> -- <COMMAND>`.

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -8,13 +8,13 @@
 
 Install a tool version
 
-Installs a tool version to `~/.local/share/mise/installs/<TOOL>/<VERSION>`
-Installing alone will not activate the tools so they won't be in PATH.
-To install and/or activate in one command, use `mise use` which will create a `mise.toml` file
-in the current directory to activate this tool when inside the directory.
-Alternatively, run `mise exec <TOOL>@<VERSION> -- <COMMAND>` to execute a tool without creating config files.
+Installs a tool version to `~/.local/share/mise/installs/<TOOL>/<VERSION>`.
+Installing alone does not activate the tool, so it will not be on PATH.
+To install and activate in one command, use `mise use`, which also writes the version to
+`mise.toml` in the current directory so the tool is active inside it.
+To run a tool once without touching any config, use `mise exec <TOOL>@<VERSION> -- <COMMAND>`.
 
-Tools will be installed in parallel. To disable, set `--jobs=1` or `MISE_JOBS=1`
+Tools are installed in parallel. To disable, set `--jobs=1` or `MISE_JOBS=1`.
 
 ## Arguments
 - **`[TOOL@VERSION]…`** — Tool(s) to install e.g.: node@20
@@ -24,7 +24,7 @@ Tools will be installed in parallel. To disable, set `--jobs=1` or `MISE_JOBS=1`
   With no tools specified, reinstall all configured tools
 - **`-j --jobs <JOBS>`** — Number of jobs to run in parallel
   Values below 1 are treated as 1
-  [default: 4]
+  Defaults to the `jobs` setting
 
   **Environment Variable:** `MISE_JOBS`
 - **`-n --dry-run`** — Show what would be installed without actually installing
@@ -50,7 +50,7 @@ Tools will be installed in parallel. To disable, set `--jobs=1` or `MISE_JOBS=1`
   [monorepo].config_roots in the monorepo root config.
 
   **Environment Variable:** `MISE_MONOREPO`
-- **`--raw`** — Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
+- **`--raw`** — Connect backend install command stdin/stdout/stderr directly to the terminal. Implies `--jobs=1`
 - **`--shared <SHARED>`** — Install tool(s) to a shared directory
 
   Installs to the specified directory instead of the default install location.
@@ -64,10 +64,10 @@ Tools will be installed in parallel. To disable, set `--jobs=1` or `MISE_JOBS=1`
 Examples:
 
 ```
-mise install node@20.0.0  # install specific node version
-mise install node@20      # install fuzzy node version
-mise install node         # install version specified in mise.toml
-mise install              # installs everything specified in mise.toml
+mise install node@20.0.0  # install a specific node version
+mise install node@20      # install the latest node 20.x
+mise install node         # install the version specified in mise.toml
+mise install              # install everything specified in mise.toml
 mise install --include-lazy # also install tools configured for lazy installation
 mise install --include-task-tools # also install tools required by tasks
 ```

--- a/docs/cli/latest.md
+++ b/docs/cli/latest.md
@@ -5,7 +5,7 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/latest.rs`](https://github.com/jdx/mise/blob/main/src/cli/latest.rs)
 
-Gets the latest available version for a plugin
+Get the latest available version of a tool
 
 Supports prefixes such as `node@20` to get the latest version of node 20.
 

--- a/docs/cli/link.md
+++ b/docs/cli/link.md
@@ -6,9 +6,9 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/link.rs`](https://github.com/jdx/mise/blob/main/src/cli/link.rs)
 
-Symlinks a tool version into mise
+Symlink a tool version into mise
 
-Use this for adding installs either custom compiled outside mise or built with a different tool.
+Use this to register an install that was compiled by hand or built with another tool.
 
 ## Arguments
 - **`<TOOL@VERSION>`** — Tool name and version to create a symlink for

--- a/docs/cli/ls-remote.md
+++ b/docs/cli/ls-remote.md
@@ -6,9 +6,9 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/ls_remote.rs`](https://github.com/jdx/mise/blob/main/src/cli/ls_remote.rs)
 
-List runtime versions available for install.
+List tool versions available to install
 
-Note that the results may be cached, run `mise cache clean` to clear the cache and get fresh results.
+Results may be cached; run `mise cache clear` to fetch fresh results.
 
 ## Arguments
 - **`[TOOL@VERSION]`** — Tool to get versions for

--- a/docs/cli/ls.md
+++ b/docs/cli/ls.md
@@ -8,11 +8,8 @@
 
 List installed and active tool versions
 
-This command lists tools that mise "knows about".
-These may be tools that are currently installed, or those
-that are in a config file (active) but may or may not be installed.
-
-It's a useful command to get the current state of your tools.
+Lists the tools mise knows about: versions that are installed, and versions requested
+by a config file (active) whether or not they are installed.
 
 ## Arguments
 - **`[INSTALLED_TOOL]…`** — Only show tool versions from [TOOL]

--- a/docs/cli/outdated.md
+++ b/docs/cli/outdated.md
@@ -5,7 +5,7 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/outdated.rs`](https://github.com/jdx/mise/blob/main/src/cli/outdated.rs)
 
-Shows outdated tool versions
+Show outdated tool versions
 
 See `mise upgrade` to upgrade these versions.
 
@@ -15,12 +15,10 @@ See `mise upgrade` to upgrade these versions.
   If not specified, all tools in global and local configs will be shown
 
 ## Flags
-- **`-b --bump`** — Compares against the latest versions available, not what matches the current config
+- **`-b --bump`** — Compare against the latest versions available, not just those matching the current config
 
-  For example, if you have `node = "20"` in your config by default `mise outdated` will only
-  show other 20.x versions, not 21.x or 22.x versions.
-
-  Using this flag, if there are 21.x or newer versions it will display those instead of 20.x.
+  For example, with `node = "20"` in your config, `mise outdated` normally only reports newer
+  20.x versions. With this flag it reports the newest version overall, such as 22.x.
 - **`-J --json`** — Output in JSON format
 - **`--inactive`** — Show outdated tools including installed-but-inactive tools not present in the current config
 

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -9,8 +9,8 @@
 Manage plugins
 
 ## Flags
-- **`-c --core`** — The built-in plugins only
-  Normally these are not shown
+- **`-c --core`** — Only show built-in (core) plugins
+  These are hidden by default
 - **`-u --urls`** — Show the git url for each plugin
   e.g.: <https://github.com/mise-plugins/vfox-cmake.git>
 - **`--user`** — List installed plugins

--- a/docs/cli/plugins/install.md
+++ b/docs/cli/plugins/install.md
@@ -8,10 +8,9 @@
 
 Install a plugin
 
-note that mise can automatically install plugins when you install a tool
-e.g.: `mise install cmake@3.30` will autoinstall the cmake plugin
-
-This behavior can be modified in ~/.config/mise/config.toml
+Note that mise installs plugins automatically when you install a tool that needs one,
+e.g.: `mise install cmake@3.30` installs the cmake plugin first. This command is only
+needed to install a plugin ahead of time or from a custom git URL.
 
 ## Arguments
 - **`[NEW_PLUGIN]`** — The name of the plugin to install

--- a/docs/cli/plugins/link.md
+++ b/docs/cli/plugins/link.md
@@ -6,7 +6,7 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/plugins/link.rs`](https://github.com/jdx/mise/blob/main/src/cli/plugins/link.rs)
 
-Symlinks a plugin into mise
+Symlink a plugin into mise
 
 This is used for developing a plugin.
 

--- a/docs/cli/plugins/ls-remote.md
+++ b/docs/cli/plugins/ls-remote.md
@@ -8,15 +8,15 @@
 
 List all available remote plugins
 
-The full list is here: <https://github.com/jdx/mise/blob/main/registry/>
+These are the shorthand names from the registry: <https://github.com/jdx/mise/blob/main/registry/>
+
+## Flags
+- **`-u --urls`** — Show the git url for each plugin, e.g. <https://github.com/mise-plugins/mise-poetry.git>
+- **`--only-names`** — Only show the name of each plugin, without the "*" marking installed plugins
+- **`-h --help`** — Print help
 
 Examples:
 
 ```
 mise plugins ls-remote
 ```
-
-## Flags
-- **`-u --urls`** — Show the git url for each plugin e.g.: <https://github.com/mise-plugins/mise-poetry.git>
-- **`--only-names`** — Only show the name of each plugin by default it will show a "*" next to installed plugins
-- **`-h --help`** — Print help

--- a/docs/cli/plugins/uninstall.md
+++ b/docs/cli/plugins/uninstall.md
@@ -6,7 +6,7 @@
 - **Effect:** destructive — may delete or irreversibly overwrite
 - **Source code:** [`src/cli/plugins/uninstall.rs`](https://github.com/jdx/mise/blob/main/src/cli/plugins/uninstall.rs)
 
-Removes a plugin
+Remove a plugin
 
 ## Arguments
 - **`[PLUGIN]…`** — Plugin(s) to remove

--- a/docs/cli/plugins/update.md
+++ b/docs/cli/plugins/update.md
@@ -6,9 +6,9 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/plugins/update.rs`](https://github.com/jdx/mise/blob/main/src/cli/plugins/update.rs)
 
-Updates a plugin to the latest version
+Update a plugin to the latest version
 
-note: this updates the plugin itself, not the runtime versions
+Note: this updates the plugin itself, not the tool versions it manages
 
 ## Arguments
 - **`[PLUGIN]…`** — Plugin(s) to update
@@ -16,7 +16,7 @@ note: this updates the plugin itself, not the runtime versions
 ## Flags
 - **`-j --jobs <JOBS>`** — Number of jobs to run in parallel
   Values below 1 are treated as 1
-  Default: 4
+  Defaults to the `jobs` setting
 - **`-h --help`** — Print help
 
 Examples:

--- a/docs/cli/registry.md
+++ b/docs/cli/registry.md
@@ -18,7 +18,7 @@ For example, `poetry` is shorthand for `asdf:mise-plugins/mise-poetry`.
 - **`-b --backend <BACKEND>`** — Show only tools for this backend
 - **`--hide-aliased`** — Hide aliased tools
 - **`-J --json`** — Output in JSON format
-- **`--security`** — Include security features for each tool's backends in JSON output.
+- **`--security`** — Include security features for each tool's backends in JSON output
 
   Requires --json. Security info is de-duplicated across all of a tool's backends. This can add noticeable time for large listings since each backend's security info is resolved individually.
 - **`-h --help`** — Print help

--- a/docs/cli/reshim.md
+++ b/docs/cli/reshim.md
@@ -5,13 +5,12 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/reshim.rs`](https://github.com/jdx/mise/blob/main/src/cli/reshim.rs)
 
-Creates new shims based on bin paths from currently installed tools.
+Create shims for the executables of currently installed tools
 
-This creates new shims in the configured user shim directory for CLIs that have been added.
-With `--system`, it rebuilds the configured system shim farm instead.
-mise will try to do this automatically for commands like `npm i -g` but there are
-other ways to install things (like using yarn or pnpm for node) that mise does
-not know about and so it will be necessary to call this explicitly.
+This creates shims in the user shim directory for executables that have been added since
+the last reshim. With `--system`, it rebuilds the system shim farm instead.
+mise runs this automatically after commands like `npm i -g`, but other ways of installing
+executables (such as yarn or pnpm for node) are not detected, so call this explicitly then.
 
 If you think mise should automatically call this for a particular command, please
 open an issue on the mise repo. You can also set up a shell function to reshim
@@ -28,7 +27,7 @@ Note that this creates shims for _all_ installed tools, not just the ones that a
 currently active in mise.toml.
 
 ## Flags
-- **`-f --force`** — Rebuilds all mise-owned shims
+- **`-f --force`** — Rebuild all mise-owned shims
 - **`--system`** — Rebuild the system shim farm
 - **`-h --help`** — Print help
 

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -7,10 +7,9 @@
 
 Run task(s)
 
-This command will run a task, or multiple tasks in parallel.
-Tasks may have dependencies on other tasks or on source files.
-If source is configured on a task, it will only run if the source
-files have changed.
+Runs one task, or several tasks in parallel.
+Tasks may depend on other tasks and on source files.
+If a task has `sources` configured, it only runs when those files have changed.
 
 Tasks can be defined in mise.toml or as standalone scripts.
 In mise.toml, tasks take this form:
@@ -25,7 +24,7 @@ outputs = ["dist/**/*.js"]
 Alternatively, tasks can be defined as standalone scripts.
 These must be located in `mise-tasks`, `.mise-tasks`, `.mise/tasks`, `mise/tasks` or
 `.config/mise/tasks`.
-The name of the script will be the name of the tasks.
+The name of the script becomes the name of the task.
 
 ```
 $ cat .mise/tasks/build<<EOF
@@ -49,12 +48,11 @@ $ mise run build
 - **`-f --force`** — Force the tasks to run even if outputs are up to date
 - **`-j --jobs <JOBS>`** — Number of tasks to run in parallel
   Values below 1 are treated as 1
-  [default: 4]
-  Configure with `jobs` config or `MISE_JOBS` env var
+  Defaults to the `jobs` setting or the `MISE_JOBS` env var
 
   **Environment Variable:** `MISE_JOBS`
 - **`-n --dry-run`** — Don't actually run the task(s), just print them in order of execution
-- **`-o --output <OUTPUT>`** — Change how tasks information is output when running tasks
+- **`-o --output <OUTPUT>`** — How task output is displayed
 
   - `prefix` - Print stdout/stderr by line, prefixed with the task's label
   - `interleave` - Print directly to stdout/stderr instead of by line
@@ -95,9 +93,9 @@ $ mise run build
 
   **Environment Variable:** `MISE_TASK_REMOTE_NO_CACHE`
 - **`--no-deps`** — Skip automatic dependency preparation
-- **`--no-timings`** — Hides elapsed time after each task completes
+- **`--no-timings`** — Hide the elapsed time printed after each task completes
 
-  Default to always hide with `MISE_TASK_TIMINGS=0`
+  Set `MISE_TASK_TIMINGS=0` to hide it by default
 - **`--skip-deps`** — Run only the specified tasks skipping all dependencies
 
   **Environment Variable:** `MISE_TASK_SKIP_DEPENDS`
@@ -127,20 +125,19 @@ $ mise run build
 Examples:
 
 ```
-# Runs the "lint" tasks. This needs to either be defined in mise.toml
-# or as a standalone script. See the project README for more information.
+# Run the "lint" task, defined either in mise.toml or as a standalone script.
 $ mise run lint
 
-# Forces the "build" tasks to run even if its sources are up-to-date.
+# Force the "build" task to run even if its sources are up-to-date.
 $ mise run --force build
 
 # Run "test" with stdin/stdout/stderr all connected to the current terminal.
 # This forces `--jobs=1` to prevent interleaving of output.
 $ mise run --raw test
 
-# Runs the "lint", "test", and "check" tasks in parallel.
+# Run the "lint", "test", and "check" tasks in parallel.
 $ mise run lint ::: test ::: check
 
-# Execute multiple tasks each with their own arguments.
+# Run multiple tasks, each with its own arguments.
 $ mise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2
 ```

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -128,7 +128,7 @@ Examples:
 # Run the "lint" task, defined either in mise.toml or as a standalone script.
 $ mise run lint
 
-# Force the "build" task to run even if its sources are up-to-date.
+# Force the "build" task to run even if its sources are up to date.
 $ mise run --force build
 
 # Run "test" with stdin/stdout/stderr all connected to the current terminal.

--- a/docs/cli/search.md
+++ b/docs/cli/search.md
@@ -7,7 +7,7 @@
 
 Search for tools in the registry
 
-This command searches a tool in the registry.
+Searches the registry for tools matching NAME.
 
 By default, it will show all tools that fuzzy match the search term. For
 non-fuzzy matches, use the `--match-type` flag.
@@ -16,7 +16,7 @@ non-fuzzy matches, use the `--match-type` flag.
 - **`[NAME]`** — The tool to search for
 
 ## Flags
-- **`-i --interactive`** — Show interactive search
+- **`-i --interactive`** — Pick a tool from an interactive search menu
 - **`-m --match-type <MATCH_TYPE>`** — Match type: equal, contains, or fuzzy
 
   **Choices:** `equal`, `contains`, `fuzzy`

--- a/docs/cli/search.md
+++ b/docs/cli/search.md
@@ -16,7 +16,7 @@ non-fuzzy matches, use the `--match-type` flag.
 - **`[NAME]`** — The tool to search for
 
 ## Flags
-- **`-i --interactive`** — Pick a tool from an interactive search menu
+- **`-i --interactive`** — Show an interactive search menu
 - **`-m --match-type <MATCH_TYPE>`** — Match type: equal, contains, or fuzzy
 
   **Choices:** `equal`, `contains`, `fuzzy`

--- a/docs/cli/self-update.md
+++ b/docs/cli/self-update.md
@@ -5,7 +5,7 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/self_update.rs`](https://github.com/jdx/mise/blob/main/src/cli/self_update.rs)
 
-Updates mise itself.
+Update mise itself
 
 Uses the GitHub Releases API to find the latest release and binary.
 By default, this will also update any installed plugins.

--- a/docs/cli/settings/add.md
+++ b/docs/cli/settings/add.md
@@ -5,10 +5,10 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/settings/add.rs`](https://github.com/jdx/mise/blob/main/src/cli/settings/add.rs)
 
-Adds a setting to the configuration file
+Append a value to an array setting
 
-Used with an array setting, this will append the value to the array.
-This modifies the contents of ~/.config/mise/config.toml
+Adds the value to an array setting such as `disable_hints`, keeping existing entries.
+This modifies ~/.config/mise/config.toml by default, or the local config with `--local`.
 
 ## Arguments
 - **`<SETTING>`** — The setting to set

--- a/docs/cli/settings/unset.md
+++ b/docs/cli/settings/unset.md
@@ -6,9 +6,9 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/settings/unset.rs`](https://github.com/jdx/mise/blob/main/src/cli/settings/unset.rs)
 
-Clears a setting
+Clear a setting
 
-This modifies the contents of ~/.config/mise/config.toml
+This modifies ~/.config/mise/config.toml by default, or the local config with `--local`.
 
 ## Arguments
 - **`<KEY>`** — The setting to remove

--- a/docs/cli/shell-alias.md
+++ b/docs/cli/shell-alias.md
@@ -5,7 +5,7 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/shell_alias/mod.rs`](https://github.com/jdx/mise/blob/main/src/cli/shell_alias/mod.rs)
 
-Manage shell aliases.
+Manage shell aliases
 
 ## Flags
 - **`--no-header`** — Don't show table header

--- a/docs/cli/shell-alias/unset.md
+++ b/docs/cli/shell-alias/unset.md
@@ -6,7 +6,7 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/shell_alias/unset.rs`](https://github.com/jdx/mise/blob/main/src/cli/shell_alias/unset.rs)
 
-Removes a shell alias
+Remove a shell alias
 
 This modifies the contents of ~/.config/mise/config.toml
 

--- a/docs/cli/shell.md
+++ b/docs/cli/shell.md
@@ -6,7 +6,7 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/shell.rs`](https://github.com/jdx/mise/blob/main/src/cli/shell.rs)
 
-Sets a tool version for the current session.
+Set a tool version for the current shell session
 
 Only works in a session where mise is already activated.
 
@@ -19,11 +19,11 @@ such as `MISE_NODE_VERSION=20` which is "eval"ed as a shell function created by 
 ## Flags
 - **`-j --jobs <JOBS>`** — Number of jobs to run in parallel
   Values below 1 are treated as 1
-  [default: 4]
+  Defaults to the `jobs` setting
 
   **Environment Variable:** `MISE_JOBS`
-- **`-u --unset`** — Removes a previously set version
-- **`--raw`** — Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
+- **`-u --unset`** — Remove a previously set version
+- **`--raw`** — Connect backend install command stdin/stdout/stderr directly to the terminal. Implies `--jobs=1`
 - **`-h --help`** — Print help
 
 Examples:

--- a/docs/cli/sync/node.md
+++ b/docs/cli/sync/node.md
@@ -5,9 +5,9 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/sync/node.rs`](https://github.com/jdx/mise/blob/main/src/cli/sync/node.rs)
 
-Symlinks all tool versions from an external tool into mise
+Symlink node versions installed by nvm, nodenv, or Homebrew into mise
 
-For example, use this to import all Homebrew node installs into mise
+Use this to make versions installed by another version manager available to mise.
 
 This won't overwrite managed installs, runtime aliases, or links from other providers.
 

--- a/docs/cli/sync/python.md
+++ b/docs/cli/sync/python.md
@@ -5,9 +5,9 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/sync/python.rs`](https://github.com/jdx/mise/blob/main/src/cli/sync/python.rs)
 
-Symlinks all tool versions from an external tool into mise
+Symlink python versions installed by pyenv or uv into mise
 
-For example, use this to import all pyenv installs into mise
+Use this to make versions installed by another version manager available to mise.
 
 This won't overwrite managed installs, runtime aliases, or links from other providers.
 

--- a/docs/cli/sync/ruby.md
+++ b/docs/cli/sync/ruby.md
@@ -5,7 +5,7 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/sync/ruby.rs`](https://github.com/jdx/mise/blob/main/src/cli/sync/ruby.rs)
 
-Symlinks all ruby tool versions from an external tool into mise
+Symlink ruby versions installed by Homebrew into mise
 
 ## Flags
 - **`--brew`** — Get tool versions from Homebrew

--- a/docs/cli/tasks.md
+++ b/docs/cli/tasks.md
@@ -9,7 +9,7 @@
 Manage tasks
 
 ## Arguments
-- **`[TASK]`** — Task name to get info of
+- **`[TASK]`** — Task name to show info for
 
 ## Flags
 - **`-g --global`** — Only show global tasks

--- a/docs/cli/tasks/add.md
+++ b/docs/cli/tasks/add.md
@@ -11,8 +11,8 @@ Adds a task to the local mise.toml file.
 See <https://mise.jdx.dev/configuration.html#target-file-for-write-operations>
 
 ## Arguments
-- **`<TASK>`** — Tasks name to add
-- **`[-- RUN]…`**
+- **`<TASK>`** — Name of the task to add
+- **`[-- RUN]…`** — Command to run, given after `--`
 
 ## Flags
 - **`-a --alias <ALIAS>`** — Other names for the task
@@ -23,11 +23,11 @@ See <https://mise.jdx.dev/configuration.html#target-file-for-write-operations>
 - **`-q --quiet`** — Do not print the command before running
 - **`-r --raw`** — Directly connect stdin/stdout/stderr
 - **`-s --sources <SOURCES>`** — Glob patterns of files this task uses as input
-- **`-w --wait-for <WAIT_FOR>`** — Wait for these tasks to complete if they are to run
+- **`-w --wait-for <WAIT_FOR>`** — Wait for these tasks to finish if they are also being run
 - **`--depends-post <DEPENDS_POST>`** — Dependencies to run after the task runs
 - **`--description <DESCRIPTION>`** — Description of the task
-- **`--outputs <OUTPUTS>`** — Glob patterns of files this task creates, to skip if they are not modified
-- **`--run-windows <RUN_WINDOWS>`** — Command to run on windows
+- **`--outputs <OUTPUTS>`** — Glob patterns of files this task creates, used to skip it when they are up to date
+- **`--run-windows <RUN_WINDOWS>`** — Command to run on Windows
 - **`--shell <SHELL>`** — Run the task in a specific shell
 - **`--silent`** — Do not print the command or its output
 - **`-h --help`** — Print help

--- a/docs/cli/tasks/ls.md
+++ b/docs/cli/tasks/ls.md
@@ -5,9 +5,10 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/tasks/ls.rs`](https://github.com/jdx/mise/blob/main/src/cli/tasks/ls.rs)
 
-List available tasks to execute
-These may be included from the config file or from the project's .mise/tasks directory
-mise will merge all tasks from all parent directories into this list.
+List available tasks
+
+Tasks come from config files and from task directories such as `.mise/tasks`.
+Tasks from all parent directories are merged into this list.
 
 So if you have global tasks in `~/.config/mise/tasks/*` and project-specific tasks in
 ~/myproject/.mise/tasks/*, then they'll both be available but the project-specific

--- a/docs/cli/tasks/run.md
+++ b/docs/cli/tasks/run.md
@@ -7,10 +7,9 @@
 
 Run task(s)
 
-This command will run a task, or multiple tasks in parallel.
-Tasks may have dependencies on other tasks or on source files.
-If source is configured on a task, it will only run if the source
-files have changed.
+Runs one task, or several tasks in parallel.
+Tasks may depend on other tasks and on source files.
+If a task has `sources` configured, it only runs when those files have changed.
 
 Tasks can be defined in mise.toml or as standalone scripts.
 In mise.toml, tasks take this form:
@@ -25,7 +24,7 @@ outputs = ["dist/**/*.js"]
 Alternatively, tasks can be defined as standalone scripts.
 These must be located in `mise-tasks`, `.mise-tasks`, `.mise/tasks`, `mise/tasks` or
 `.config/mise/tasks`.
-The name of the script will be the name of the tasks.
+The name of the script becomes the name of the task.
 
 ```
 $ cat .mise/tasks/build<<EOF
@@ -49,12 +48,11 @@ $ mise run build
 - **`-f --force`** — Force the tasks to run even if outputs are up to date
 - **`-j --jobs <JOBS>`** — Number of tasks to run in parallel
   Values below 1 are treated as 1
-  [default: 4]
-  Configure with `jobs` config or `MISE_JOBS` env var
+  Defaults to the `jobs` setting or the `MISE_JOBS` env var
 
   **Environment Variable:** `MISE_JOBS`
 - **`-n --dry-run`** — Don't actually run the task(s), just print them in order of execution
-- **`-o --output <OUTPUT>`** — Change how tasks information is output when running tasks
+- **`-o --output <OUTPUT>`** — How task output is displayed
 
   - `prefix` - Print stdout/stderr by line, prefixed with the task's label
   - `interleave` - Print directly to stdout/stderr instead of by line
@@ -95,9 +93,9 @@ $ mise run build
 
   **Environment Variable:** `MISE_TASK_REMOTE_NO_CACHE`
 - **`--no-deps`** — Skip automatic dependency preparation
-- **`--no-timings`** — Hides elapsed time after each task completes
+- **`--no-timings`** — Hide the elapsed time printed after each task completes
 
-  Default to always hide with `MISE_TASK_TIMINGS=0`
+  Set `MISE_TASK_TIMINGS=0` to hide it by default
 - **`--skip-deps`** — Run only the specified tasks skipping all dependencies
 
   **Environment Variable:** `MISE_TASK_SKIP_DEPENDS`
@@ -127,20 +125,19 @@ $ mise run build
 Examples:
 
 ```
-# Runs the "lint" tasks. This needs to either be defined in mise.toml
-# or as a standalone script. See the project README for more information.
+# Run the "lint" task, defined either in mise.toml or as a standalone script.
 $ mise run lint
 
-# Forces the "build" tasks to run even if its sources are up-to-date.
+# Force the "build" task to run even if its sources are up-to-date.
 $ mise run --force build
 
 # Run "test" with stdin/stdout/stderr all connected to the current terminal.
 # This forces `--jobs=1` to prevent interleaving of output.
 $ mise run --raw test
 
-# Runs the "lint", "test", and "check" tasks in parallel.
+# Run the "lint", "test", and "check" tasks in parallel.
 $ mise run lint ::: test ::: check
 
-# Execute multiple tasks each with their own arguments.
+# Run multiple tasks, each with its own arguments.
 $ mise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2
 ```

--- a/docs/cli/tasks/run.md
+++ b/docs/cli/tasks/run.md
@@ -128,7 +128,7 @@ Examples:
 # Run the "lint" task, defined either in mise.toml or as a standalone script.
 $ mise run lint
 
-# Force the "build" task to run even if its sources are up-to-date.
+# Force the "build" task to run even if its sources are up to date.
 $ mise run --force build
 
 # Run "test" with stdin/stdout/stderr all connected to the current terminal.

--- a/docs/cli/test-tool.md
+++ b/docs/cli/test-tool.md
@@ -4,7 +4,7 @@
 - **Usage:** `mise test-tool [FLAGS] [TOOLS]…`
 - **Source code:** [`src/cli/test_tool.rs`](https://github.com/jdx/mise/blob/main/src/cli/test_tool.rs)
 
-Test a tool installs and executes
+Test that a tool installs and runs
 
 ## Arguments
 - **`[TOOLS]…`** — Tool(s) to test
@@ -17,8 +17,8 @@ Test a tool installs and executes
 
   **Environment Variable:** `MISE_TEST_TOOL_JOBS`
 - **`--all-config`** — Test all tools specified in config files
-- **`--include-non-defined`** — Also test tools not defined in registry/, guessing how to test it
-- **`--raw`** — Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
+- **`--include-non-defined`** — Also test tools not defined in registry/, guessing how to test them
+- **`--raw`** — Connect backend install command stdin/stdout/stderr directly to the terminal. Implies `--jobs=1`
 - **`-h --help`** — Print help
 
 Examples:

--- a/docs/cli/tool-alias.md
+++ b/docs/cli/tool-alias.md
@@ -6,7 +6,7 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/tool_alias/mod.rs`](https://github.com/jdx/mise/blob/main/src/cli/tool_alias/mod.rs)
 
-Manage tool version aliases.
+Manage tool version aliases
 
 ## Flags
 - **`-p --tool <TOOL>`** — Filter aliases by tool

--- a/docs/cli/tool-alias/ls.md
+++ b/docs/cli/tool-alias/ls.md
@@ -7,10 +7,10 @@
 - **Source code:** [`src/cli/tool_alias/ls.rs`](https://github.com/jdx/mise/blob/main/src/cli/tool_alias/ls.rs)
 
 List tool version aliases
-Shows the aliases that can be specified.
-These can come from user config or from plugins in `bin/list-aliases`.
 
-For user config, aliases are defined like the following in `~/.config/mise/config.toml`:
+Aliases can be defined in user config or provided by plugins via `bin/list-aliases`.
+
+In user config, aliases are defined like the following in `~/.config/mise/config.toml`:
 
 ```
 [tool_alias.node.versions]

--- a/docs/cli/tool-alias/unset.md
+++ b/docs/cli/tool-alias/unset.md
@@ -6,7 +6,7 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/tool_alias/unset.rs`](https://github.com/jdx/mise/blob/main/src/cli/tool_alias/unset.rs)
 
-Clears an alias for a tool/backend
+Clear an alias for a tool/backend
 
 This modifies the contents of ~/.config/mise/config.toml
 

--- a/docs/cli/tool-stub.md
+++ b/docs/cli/tool-stub.md
@@ -6,11 +6,16 @@
 
 Execute a tool stub
 
-Tool stubs are executable files containing TOML configuration that specify which tool to run and how to run it. They provide a convenient way to create portable, self-contained executables that automatically manage tool installation and execution.
+Tool stubs are executable files containing TOML configuration that specify
+which tool to run and how to run it. They provide a convenient way to create
+portable, self-contained executables that automatically manage tool installation
+and execution.
 
 A tool stub consists of:
 
-- A shebang line: #!/usr/bin/env -S mise tool-stub - TOML configuration specifying the tool, version, and options - Optional comments describing the tool's purpose
+- A shebang line: #!/usr/bin/env -S mise tool-stub
+- TOML configuration specifying the tool, version, and options
+- Optional comments describing the tool's purpose
 
 Example stub file:
 
@@ -23,7 +28,8 @@ version = "20.0.0"
 bin = "node"
 ```
 
-The stub will automatically install the specified tool version if missing and execute it with any arguments passed to the stub.
+The stub will automatically install the specified tool version if missing
+and execute it with any arguments passed to the stub.
 
 For more information, see: <https://mise.jdx.dev/dev-tools/tool-stubs.html>
 

--- a/docs/cli/tool.md
+++ b/docs/cli/tool.md
@@ -5,7 +5,7 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/tool.rs`](https://github.com/jdx/mise/blob/main/src/cli/tool.rs)
 
-Gets information about a tool
+Show information about a tool
 
 ## Arguments
 - **`<TOOL>`** — Tool name to get information about

--- a/docs/cli/trust.md
+++ b/docs/cli/trust.md
@@ -5,7 +5,7 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/trust.rs`](https://github.com/jdx/mise/blob/main/src/cli/trust.rs)
 
-Marks a config file as trusted
+Mark a config file as trusted
 
 This means mise is allowed to parse the file when it needs to read config
 that may execute code or affect the environment. Without trust, mise may

--- a/docs/cli/uninstall.md
+++ b/docs/cli/uninstall.md
@@ -5,9 +5,10 @@
 - **Effect:** destructive — may delete or irreversibly overwrite
 - **Source code:** [`src/cli/uninstall.rs`](https://github.com/jdx/mise/blob/main/src/cli/uninstall.rs)
 
-Removes installed tool versions
+Remove installed tool versions
 
-This only removes the installed version, it does not modify mise.toml.
+This only removes the installed version; it does not modify mise.toml.
+Use `mise unuse` to remove a tool from mise.toml and uninstall it.
 
 ## Arguments
 - **`[INSTALLED_TOOL@VERSION]…`** — Tool(s) to remove
@@ -23,12 +24,12 @@ This only removes the installed version, it does not modify mise.toml.
 Examples:
 
 ```
-# will uninstall specific version
+# uninstall a specific version
 $ mise uninstall node@18.0.0
 
-# will uninstall the current node version (if only one version is installed)
+# uninstall the current node version (if only one version is installed)
 $ mise uninstall node
 
-# will uninstall all installed versions of node
-$ mise uninstall --all node@18.0.0 # will uninstall all node versions
+# uninstall every installed version of node
+$ mise uninstall --all node
 ```

--- a/docs/cli/unset.md
+++ b/docs/cli/unset.md
@@ -5,7 +5,7 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/unset.rs`](https://github.com/jdx/mise/blob/main/src/cli/unset.rs)
 
-Remove environment variable(s) from the config file.
+Remove environment variable(s) from the config file
 
 By default, this command modifies `mise.toml` in the current directory.
 

--- a/docs/cli/unuse.md
+++ b/docs/cli/unuse.md
@@ -6,7 +6,7 @@
 - **Effect:** destructive — may delete or irreversibly overwrite
 - **Source code:** [`src/cli/unuse.rs`](https://github.com/jdx/mise/blob/main/src/cli/unuse.rs)
 
-Removes installed tool versions from mise.toml
+Remove tool versions from mise.toml and uninstall them
 
 By default, this will use the `mise.toml` file that has the tool defined.
 If multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),
@@ -18,12 +18,12 @@ In the following order:
 - If `--path` is set, it will use the config file at the given path.
 - If `--env` is set, it will use `mise.<env>.toml`.
 - If [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) is set, it will use that instead.
-- If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will the first from that list.
+- If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will use the first from that list.
 - Otherwise just "mise.toml" or global config if cwd is home directory.
 
 Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
 
-Will also prune the installed version if no other configurations are using it.
+The installed version is also removed unless another config still uses it or `--no-prune` is passed.
 
 ## Arguments
 - **`<INSTALLED_TOOL@VERSION>…`** — Tool(s) to remove
@@ -42,15 +42,15 @@ Will also prune the installed version if no other configurations are using it.
 Examples:
 
 ```
-# will uninstall specific version
+# remove node@18.0.0 from mise.toml and uninstall it
 $ mise unuse node@18.0.0
 
-# will uninstall specific version from global config
+# remove it from the global config instead
 $ mise unuse -g node@18.0.0
 
-# will uninstall specific version from .mise.local.toml
+# remove node@20 from .mise.local.toml
 $ mise unuse --env local node@20
 
-# will uninstall specific version from .mise.staging.toml
+# remove node@20 from .mise.staging.toml
 $ mise unuse --env staging node@20
 ```

--- a/docs/cli/upgrade.md
+++ b/docs/cli/upgrade.md
@@ -6,13 +6,13 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/upgrade.rs`](https://github.com/jdx/mise/blob/main/src/cli/upgrade.rs)
 
-Upgrades outdated tools
+Upgrade outdated tools
 
-By default, this keeps the range specified in mise.toml. So if you have node@20 set, it will
-upgrade to the latest 20.x.x version available. See the `--bump` flag to use the latest version
-and bump the version in mise.toml.
+By default, this keeps the range specified in mise.toml: with node@20 set, it upgrades to
+the latest 20.x.x available. Use `--bump` to upgrade to the latest version overall and
+rewrite the version in mise.toml.
 
-This will update mise.lock if it is enabled, see <https://mise.jdx.dev/configuration/settings.html#lockfile>
+This also updates mise.lock if lockfiles are enabled, see <https://mise.jdx.dev/configuration/settings.html#lockfile>
 
 ## Arguments
 - **`[INSTALLED_TOOL@VERSION]…`** — Tool(s) to upgrade
@@ -20,20 +20,20 @@ This will update mise.lock if it is enabled, see <https://mise.jdx.dev/configura
   If not specified, all current tools will be upgraded
 
 ## Flags
-- **`-b --bump`** — Upgrades to the latest version available, bumping the version in mise.toml
+- **`-b --bump`** — Upgrade to the latest version available, bumping the version in mise.toml
 
   For example, if you have `node = "20.0.0"` in your mise.toml but 22.1.0 is the latest available,
   this will install 22.1.0 and set `node = "22.1.0"` in your config.
 
   It keeps the same precision as what was there before, so if you instead had `node = "20"`, it
   would change your config to `node = "22"`.
-- **`-i --interactive`** — Display multiselect menu to choose which tools to upgrade
+- **`-i --interactive`** — Choose which tools to upgrade from a multiselect menu
 - **`-j --jobs <JOBS>`** — Number of jobs to run in parallel
   Values below 1 are treated as 1
-  [default: 4]
+  Defaults to the `jobs` setting
 
   **Environment Variable:** `MISE_JOBS`
-- **`-n --dry-run`** — Just print what would be done, don't actually do it
+- **`-n --dry-run`** — Print what would be done without doing it
 - **`-x --exclude <INSTALLED_TOOL>`** — Tool(s) to exclude from upgrading
   e.g.: go python
 - **`--dry-run-code`** — Like --dry-run but exits with code 1 if there are outdated tools
@@ -62,7 +62,7 @@ This will update mise.lock if it is enabled, see <https://mise.jdx.dev/configura
 
   Use this to bypass `upgrade.prune_after`, or to override
   `upgrade.auto_prune = false` for a single run.
-- **`--raw`** — Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
+- **`--raw`** — Connect backend install command stdin/stdout/stderr directly to the terminal. Implies `--jobs=1`
 - **`-h --help`** — Print help
 
 Deprecation:

--- a/docs/cli/use.md
+++ b/docs/cli/use.md
@@ -6,10 +6,10 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/use.rs`](https://github.com/jdx/mise/blob/main/src/cli/use.rs)
 
-Installs a tool and adds the version to mise.toml.
+Install a tool and add it to mise.toml
 
-This will install the tool version if it is not already installed.
-By default, this will use a `mise.toml` file in the current directory.
+Installs the tool version if it is not already installed, then writes it to a config file.
+By default, this is `mise.toml` in the current directory.
 If multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),
 the lowest precedence file (`mise.toml`) will be used.
 See <https://mise.jdx.dev/configuration.html#target-file-for-write-operations>
@@ -19,23 +19,21 @@ In the following order:
 - If `--path` is set, it will use the config file at the given path.
 - If `--env` is set, it will use `mise.<env>.toml`.
 - If [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) is set, it will use that instead.
-- If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will the first from that list.
+- If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will use the first from that list.
 - Otherwise just "mise.toml" or global config if cwd is home directory.
 
 Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
 
-Use the `--global` flag to use the global config file instead.
-
 ## Arguments
 - **`<TOOL@VERSION>`** — Tool to add to config file
 
-  e.g.: node@20, cargo:ripgrep@latest npm:prettier@3
-  If no version is specified, it will default to @latest
+  e.g.: node@20, cargo:ripgrep@latest, npm:prettier@3
+  If no version is specified, it defaults to @latest
 
   Tool options can be set with this syntax:
 
   ```
-  mise use ubi:BurntSushi/ripgrep[exe=rg]
+  mise use "cargo:ripgrep[features=pcre2]"
   ```
 
 ## Flags
@@ -44,7 +42,7 @@ Use the `--global` flag to use the global config file instead.
 - **`-g --global`** — Use the global config file (`~/.config/mise/config.toml`) instead of the local one
 - **`-j --jobs <JOBS>`** — Number of jobs to run in parallel
   Values below 1 are treated as 1
-  [default: 4]
+  Defaults to the `jobs` setting
 
   **Environment Variable:** `MISE_JOBS`
 - **`-n --dry-run`** — Perform a dry run, showing what would be installed and modified without making changes
@@ -56,8 +54,8 @@ Use the `--global` flag to use the global config file instead.
   This is useful for scripts to check if tools need to be added or removed.
 - **`--fuzzy`** — Save fuzzy version to config file
 
-  e.g.: `mise use --fuzzy node@20` will save 20 as the version
-  this is the default behavior unless `MISE_PIN=1`
+  e.g.: `mise use --fuzzy node@20` will save `20` as the version.
+  This is the default behavior unless `MISE_PIN=1`
 - **`--minimum-release-age <MINIMUM_RELEASE_AGE>`** — Only install versions released before this date or older than this duration
 
   Supports absolute dates like "2024-06-01" and relative durations like "90d" or "1y".
@@ -70,7 +68,7 @@ Use the `--global` flag to use the global config file instead.
 
   Consider using mise.lock as a better alternative to pinning in mise.toml:
   <https://mise.jdx.dev/configuration/settings.html#lockfile>
-- **`--raw`** — Connect backend install command stdin/stdout/stderr directly to the terminal Implies `--jobs=1`
+- **`--raw`** — Connect backend install command stdin/stdout/stderr directly to the terminal. Implies `--jobs=1`
 - **`--remove <TOOL>`** — Remove the tool(s) from config file
 - **`-h --help`** — Print help
 - **`--postinstall <COMMAND>`** — Command to run after installing this tool

--- a/docs/cli/watch.md
+++ b/docs/cli/watch.md
@@ -5,10 +5,10 @@
 - **Aliases:** `w`
 - **Source code:** [`src/cli/watch.rs`](https://github.com/jdx/mise/blob/main/src/cli/watch.rs)
 
-Run task(s) and watch for changes to rerun it
+Run task(s) and rerun them when files change
 
-This command uses the `watchexec` tool to watch for changes to files and rerun the specified task(s).
-It must be installed for this command to work, but you can install it with `mise use -g watchexec@latest`.
+Uses `watchexec` to watch for file changes and rerun the given task(s).
+watchexec must be installed; `mise use -g watchexec@latest` installs it.
 
 For more advanced process management (daemon management, auto-restart, readiness checks,
 cron scheduling), see mise's sister project: https://pitchfork.jdx.dev
@@ -16,7 +16,7 @@ cron scheduling), see mise's sister project: https://pitchfork.jdx.dev
 ## Arguments
 - **`[TASK]`** — Tasks to run
   Can specify multiple tasks by separating with `:::`
-  e.g.: `mise run task1 arg1 arg2 ::: task2 arg1 arg2`
+  e.g.: `mise watch task1 arg1 arg2 ::: task2 arg1 arg2`
   Defaults to `default`
 - **`[ARGS]…`** — Task and arguments to run
 
@@ -485,16 +485,16 @@ Examples:
 
 ```
 $ mise watch build
-Runs the "build" tasks. Will re-run the tasks when any of its sources change.
-Uses "sources" from the tasks definition to determine which files to watch.
+Runs the "build" task and reruns it whenever one of its sources changes.
+The task's "sources" determine which files are watched.
 
 $ mise watch build --glob src/**/*.rs
-Runs the "build" tasks but specify the files to watch with a glob pattern.
-This overrides the "sources" from the tasks definition.
+Runs the "build" task, watching the files matched by the glob instead of
+the task's "sources".
 
 $ mise watch build --clear
 Extra arguments are passed to watchexec. See `watchexec --help` for details.
 
 $ mise watch serve --watch src --exts rs --restart
-Starts an api server, watching for changes to "*.rs" files in "./src" and kills/restarts the server when they change.
+Starts an API server, watching "*.rs" files in "./src", and restarts the server when they change.
 ```

--- a/docs/cli/watch.md
+++ b/docs/cli/watch.md
@@ -488,7 +488,7 @@ $ mise watch build
 Runs the "build" task and reruns it whenever one of its sources changes.
 The task's "sources" determine which files are watched.
 
-$ mise watch build --glob src/**/*.rs
+$ mise watch build --glob 'src/**/*.rs'
 Runs the "build" task, watching the files matched by the glob instead of
 the task's "sources".
 

--- a/docs/cli/where.md
+++ b/docs/cli/where.md
@@ -10,11 +10,10 @@ Display the installation path for a tool
 The tool must be installed for this to work.
 
 ## Arguments
-- **`<TOOL@VERSION>`** — Tool(s) to look up
+- **`<TOOL@VERSION>`** — Tool to look up
   e.g.: ruby@3
-  if "@&lt;PREFIX>" is specified, it will show the latest installed version
-  that matches the prefix
-  otherwise, it will show the current, active installed version
+  With "@&lt;PREFIX>", shows the latest installed version matching the prefix.
+  Otherwise, shows the current, active installed version.
 
 ## Flags
 - **`-h --help`** — Print help
@@ -22,13 +21,13 @@ The tool must be installed for this to work.
 Examples:
 
 ```
-# Show the latest installed version of node
-# If it is is not installed, errors
+# Show the latest installed node 20.x
+# Errors if no matching version is installed
 $ mise where node@20
 /home/jdx/.local/share/mise/installs/node/20.0.0
 
-# Show the current, active install directory of node
-# Errors if node is not referenced in any .tool-version file
+# Show the install directory of the currently active node
+# Errors if node is not requested by any config file
 $ mise where node
 /home/jdx/.local/share/mise/installs/node/20.0.0
 ```

--- a/docs/cli/where.md
+++ b/docs/cli/where.md
@@ -26,8 +26,9 @@ Examples:
 $ mise where node@20
 /home/jdx/.local/share/mise/installs/node/20.0.0
 
-# Show the install directory of the currently active node
-# Errors if node is not requested by any config file
+# Show the install directory of the active node, or of the latest
+# installed version if no config requests node
+# Errors if no matching version is installed
 $ mise where node
 /home/jdx/.local/share/mise/installs/node/20.0.0
 ```

--- a/docs/cli/which.md
+++ b/docs/cli/which.md
@@ -5,12 +5,12 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/which.rs`](https://github.com/jdx/mise/blob/main/src/cli/which.rs)
 
-Shows the path that a tool's bin points to.
+Show the path a tool's executable resolves to
 
 Use this to figure out what version of a tool is currently active.
 
 ## Arguments
-- **`[BIN_NAME]`** — The bin to look up
+- **`[BIN_NAME]`** — The executable to look up
 
 ## Flags
 - **`-t --tool <TOOL@VERSION>`** — Use a specific tool@version

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -160,7 +160,7 @@
 ## CLI Reference
 
 - [CLI Overview](https://mise.jdx.dev/cli/): Usage: mise [FLAGS] [TASK]
-- [mise activate](https://mise.jdx.dev/cli/activate.html): Initializes mise in the current shell session
+- [mise activate](https://mise.jdx.dev/cli/activate.html): Initialize mise in the current shell session
 - [mise backends](https://mise.jdx.dev/cli/backends.html): Manage backends
 - [mise backends ls](https://mise.jdx.dev/cli/backends/ls.html): List built-in backends
 - [mise bin-paths](https://mise.jdx.dev/cli/bin-paths.html): List all the active runtime bin paths
@@ -183,15 +183,15 @@
 - [mise bootstrap status](https://mise.jdx.dev/cli/bootstrap/status.html): Show the aggregate bootstrap status
 - [mise bootstrap user](https://mise.jdx.dev/cli/bootstrap/user.html): Manage current-user bootstrap settings from [bootstrap.user]
 - [mise cache](https://mise.jdx.dev/cli/cache.html): Manage the mise cache
-- [mise cache clear](https://mise.jdx.dev/cli/cache/clear.html): Deletes all cache files in mise
+- [mise cache clear](https://mise.jdx.dev/cli/cache/clear.html): Delete all cache files
 - [mise cache path](https://mise.jdx.dev/cli/cache/path.html): Show the cache directory path
-- [mise cache prune](https://mise.jdx.dev/cli/cache/prune.html): Removes stale mise cache files
+- [mise cache prune](https://mise.jdx.dev/cli/cache/prune.html): Remove stale cache files
 - [mise cache task](https://mise.jdx.dev/cli/cache/task.html): Inspect output cache entries for a task
 - [mise completion](https://mise.jdx.dev/cli/completion.html): Generate shell completions
 - [mise config](https://mise.jdx.dev/cli/config.html): Manage config files
-- [mise config get](https://mise.jdx.dev/cli/config/get.html): Display the value of a setting in a mise.toml file
+- [mise config get](https://mise.jdx.dev/cli/config/get.html): Display a value from a mise.toml file
 - [mise config ls](https://mise.jdx.dev/cli/config/ls.html): List config files currently in use
-- [mise config set](https://mise.jdx.dev/cli/config/set.html): Set the value of a setting in a mise.toml file
+- [mise config set](https://mise.jdx.dev/cli/config/set.html): Set a value in a mise.toml file
 - [mise deactivate](https://mise.jdx.dev/cli/deactivate.html): Disable mise for current shell session
 - [mise deps](https://mise.jdx.dev/cli/deps.html): [experimental] Manage project dependencies
 - [mise deps add](https://mise.jdx.dev/cli/deps/add.html): Add a dependency
@@ -200,10 +200,10 @@
 - [mise doctor](https://mise.jdx.dev/cli/doctor.html): Check mise installation for possible problems
 - [mise doctor path](https://mise.jdx.dev/cli/doctor/path.html): Print the current PATH entries mise is providing
 - [mise edit](https://mise.jdx.dev/cli/edit.html): Edit mise.toml interactively
-- [mise en](https://mise.jdx.dev/cli/en.html): Starts a new shell with the mise environment built from the current configuration
-- [mise env](https://mise.jdx.dev/cli/env.html): Exports env vars to activate mise a single time
+- [mise en](https://mise.jdx.dev/cli/en.html): Start a new shell with the mise environment built from the current configuration
+- [mise env](https://mise.jdx.dev/cli/env.html): Export env vars to activate mise a single time
 - [mise exec](https://mise.jdx.dev/cli/exec.html): Execute a command with tool(s) set
-- [mise fmt](https://mise.jdx.dev/cli/fmt.html): Formats mise.toml
+- [mise fmt](https://mise.jdx.dev/cli/fmt.html): Format mise.toml
 - [mise generate](https://mise.jdx.dev/cli/generate.html): Generate files for various tools/services
 - [mise generate config](https://mise.jdx.dev/cli/generate/config.html): Generate a mise.toml file
 - [mise generate devcontainer](https://mise.jdx.dev/cli/generate/devcontainer.html): Generate a devcontainer to execute mise
@@ -211,83 +211,83 @@
 - [mise generate github-action](https://mise.jdx.dev/cli/generate/github-action.html): Generate a GitHub Action workflow file
 - [mise generate install-script](https://mise.jdx.dev/cli/generate/install-script.html): Generate a script to download+execute mise
 - [mise generate task-docs](https://mise.jdx.dev/cli/generate/task-docs.html): Generate documentation for tasks in a project
-- [mise generate task-stubs](https://mise.jdx.dev/cli/generate/task-stubs.html): Generates shims to run mise tasks
+- [mise generate task-stubs](https://mise.jdx.dev/cli/generate/task-stubs.html): Generate shims to run mise tasks
 - [mise generate tool-stub](https://mise.jdx.dev/cli/generate/tool-stub.html): Generate a tool stub for HTTP-based tools
-- [mise implode](https://mise.jdx.dev/cli/implode.html): Removes mise CLI and all related data
+- [mise implode](https://mise.jdx.dev/cli/implode.html): Remove the mise CLI and all related data
 - [mise install](https://mise.jdx.dev/cli/install.html): Install a tool version
 - [mise install-into](https://mise.jdx.dev/cli/install-into.html): Install a tool version to a specific path
-- [mise latest](https://mise.jdx.dev/cli/latest.html): Gets the latest available version for a plugin
-- [mise link](https://mise.jdx.dev/cli/link.html): Symlinks a tool version into mise
+- [mise latest](https://mise.jdx.dev/cli/latest.html): Get the latest available version of a tool
+- [mise link](https://mise.jdx.dev/cli/link.html): Symlink a tool version into mise
 - [mise lock](https://mise.jdx.dev/cli/lock.html): Update lockfile checksums and URLs for all specified platforms
 - [mise ls](https://mise.jdx.dev/cli/ls.html): List installed and active tool versions
-- [mise ls-remote](https://mise.jdx.dev/cli/ls-remote.html): List runtime versions available for install.
+- [mise ls-remote](https://mise.jdx.dev/cli/ls-remote.html): List tool versions available to install
 - [mise mcp](https://mise.jdx.dev/cli/mcp.html): Run Model Context Protocol (MCP) server
 - [mise oci](https://mise.jdx.dev/cli/oci.html): [experimental] Build OCI container images from a mise.toml
 - [mise oci build](https://mise.jdx.dev/cli/oci/build.html): [experimental] Build an OCI image from the current mise.toml
 - [mise oci push](https://mise.jdx.dev/cli/oci/push.html): [experimental] Build an OCI image and push it to a registry
 - [mise oci run](https://mise.jdx.dev/cli/oci/run.html): [experimental] Build an OCI image from the current mise.toml and run a command in it
-- [mise outdated](https://mise.jdx.dev/cli/outdated.html): Shows outdated tool versions
+- [mise outdated](https://mise.jdx.dev/cli/outdated.html): Show outdated tool versions
 - [mise patrons](https://mise.jdx.dev/cli/patrons.html): Show the individuals supporting mise as Patron-tier members
 - [mise plugins](https://mise.jdx.dev/cli/plugins.html): Manage plugins
 - [mise plugins install](https://mise.jdx.dev/cli/plugins/install.html): Install a plugin
-- [mise plugins link](https://mise.jdx.dev/cli/plugins/link.html): Symlinks a plugin into mise
+- [mise plugins link](https://mise.jdx.dev/cli/plugins/link.html): Symlink a plugin into mise
 - [mise plugins ls](https://mise.jdx.dev/cli/plugins/ls.html): List installed plugins
 - [mise plugins ls-remote](https://mise.jdx.dev/cli/plugins/ls-remote.html): List all available remote plugins
-- [mise plugins uninstall](https://mise.jdx.dev/cli/plugins/uninstall.html): Removes a plugin
-- [mise plugins update](https://mise.jdx.dev/cli/plugins/update.html): Updates a plugin to the latest version
+- [mise plugins uninstall](https://mise.jdx.dev/cli/plugins/uninstall.html): Remove a plugin
+- [mise plugins update](https://mise.jdx.dev/cli/plugins/update.html): Update a plugin to the latest version
 - [mise prune](https://mise.jdx.dev/cli/prune.html): Delete unused versions of tools
 - [mise registry](https://mise.jdx.dev/cli/registry.html): List available tools to install
-- [mise reshim](https://mise.jdx.dev/cli/reshim.html): Creates new shims based on bin paths from currently installed tools.
+- [mise reshim](https://mise.jdx.dev/cli/reshim.html): Create shims for the executables of currently installed tools
 - [mise run](https://mise.jdx.dev/cli/run.html): Run task(s)
 - [mise search](https://mise.jdx.dev/cli/search.html): Search for tools in the registry
-- [mise self-update](https://mise.jdx.dev/cli/self-update.html): Updates mise itself.
+- [mise self-update](https://mise.jdx.dev/cli/self-update.html): Update mise itself
 - [mise set](https://mise.jdx.dev/cli/set.html): Set environment variables in mise.toml
 - [mise settings](https://mise.jdx.dev/cli/settings.html): Manage settings
-- [mise settings add](https://mise.jdx.dev/cli/settings/add.html): Adds a setting to the configuration file
+- [mise settings add](https://mise.jdx.dev/cli/settings/add.html): Append a value to an array setting
 - [mise settings get](https://mise.jdx.dev/cli/settings/get.html): Show a current setting
 - [mise settings ls](https://mise.jdx.dev/cli/settings/ls.html): Show current settings
 - [mise settings set](https://mise.jdx.dev/cli/settings/set.html): Add/update a setting
-- [mise settings unset](https://mise.jdx.dev/cli/settings/unset.html): Clears a setting
-- [mise shell](https://mise.jdx.dev/cli/shell.html): Sets a tool version for the current session.
-- [mise shell-alias](https://mise.jdx.dev/cli/shell-alias.html): Manage shell aliases.
+- [mise settings unset](https://mise.jdx.dev/cli/settings/unset.html): Clear a setting
+- [mise shell](https://mise.jdx.dev/cli/shell.html): Set a tool version for the current shell session
+- [mise shell-alias](https://mise.jdx.dev/cli/shell-alias.html): Manage shell aliases
 - [mise shell-alias get](https://mise.jdx.dev/cli/shell-alias/get.html): Show the command for a shell alias
 - [mise shell-alias ls](https://mise.jdx.dev/cli/shell-alias/ls.html): List shell aliases
 - [mise shell-alias set](https://mise.jdx.dev/cli/shell-alias/set.html): Add/update a shell alias
-- [mise shell-alias unset](https://mise.jdx.dev/cli/shell-alias/unset.html): Removes a shell alias
+- [mise shell-alias unset](https://mise.jdx.dev/cli/shell-alias/unset.html): Remove a shell alias
 - [mise sponsors](https://mise.jdx.dev/cli/sponsors.html): Show the companies sponsoring mise and the jdx.dev open source tools
 - [mise sync](https://mise.jdx.dev/cli/sync.html): Synchronize tools from other version managers with mise
-- [mise sync node](https://mise.jdx.dev/cli/sync/node.html): Symlinks all tool versions from an external tool into mise
-- [mise sync python](https://mise.jdx.dev/cli/sync/python.html): Symlinks all tool versions from an external tool into mise
-- [mise sync ruby](https://mise.jdx.dev/cli/sync/ruby.html): Symlinks all ruby tool versions from an external tool into mise
+- [mise sync node](https://mise.jdx.dev/cli/sync/node.html): Symlink node versions installed by nvm, nodenv, or Homebrew into mise
+- [mise sync python](https://mise.jdx.dev/cli/sync/python.html): Symlink python versions installed by pyenv or uv into mise
+- [mise sync ruby](https://mise.jdx.dev/cli/sync/ruby.html): Symlink ruby versions installed by Homebrew into mise
 - [mise tasks](https://mise.jdx.dev/cli/tasks.html): Manage tasks
 - [mise tasks add](https://mise.jdx.dev/cli/tasks/add.html): Create a new task
 - [mise tasks deps](https://mise.jdx.dev/cli/tasks/deps.html): Display a tree visualization of a dependency graph
 - [mise tasks edit](https://mise.jdx.dev/cli/tasks/edit.html): Edit a task with $EDITOR
 - [mise tasks graph](https://mise.jdx.dev/cli/tasks/graph.html): [experimental] Inspect the workspace project graph
 - [mise tasks info](https://mise.jdx.dev/cli/tasks/info.html): Get information about a task
-- [mise tasks ls](https://mise.jdx.dev/cli/tasks/ls.html): List available tasks to execute These may be included from the config file or from the project's .mise/tasks directory mise will merge all tasks from all parent directories into this list.
+- [mise tasks ls](https://mise.jdx.dev/cli/tasks/ls.html): List available tasks
 - [mise tasks run](https://mise.jdx.dev/cli/tasks/run.html): Run task(s)
 - [mise tasks validate](https://mise.jdx.dev/cli/tasks/validate.html): Validate tasks for common errors and issues
-- [mise test-tool](https://mise.jdx.dev/cli/test-tool.html): Test a tool installs and executes
+- [mise test-tool](https://mise.jdx.dev/cli/test-tool.html): Test that a tool installs and runs
 - [mise token](https://mise.jdx.dev/cli/token.html): Display git provider tokens mise will use
 - [mise token forgejo](https://mise.jdx.dev/cli/token/forgejo.html): Display the Forgejo token mise will use for a given host
 - [mise token github](https://mise.jdx.dev/cli/token/github.html): Display the GitHub token mise will use for a given host
 - [mise token gitlab](https://mise.jdx.dev/cli/token/gitlab.html): Display the GitLab token mise will use for a given host
-- [mise tool](https://mise.jdx.dev/cli/tool.html): Gets information about a tool
-- [mise tool-alias](https://mise.jdx.dev/cli/tool-alias.html): Manage tool version aliases.
+- [mise tool](https://mise.jdx.dev/cli/tool.html): Show information about a tool
+- [mise tool-alias](https://mise.jdx.dev/cli/tool-alias.html): Manage tool version aliases
 - [mise tool-alias get](https://mise.jdx.dev/cli/tool-alias/get.html): Show an alias for a tool
-- [mise tool-alias ls](https://mise.jdx.dev/cli/tool-alias/ls.html): List tool version aliases Shows the aliases that can be specified. These can come from user config or from plugins in bin/list-aliases.
+- [mise tool-alias ls](https://mise.jdx.dev/cli/tool-alias/ls.html): List tool version aliases
 - [mise tool-alias set](https://mise.jdx.dev/cli/tool-alias/set.html): Add/update an alias for a tool/backend
-- [mise tool-alias unset](https://mise.jdx.dev/cli/tool-alias/unset.html): Clears an alias for a tool/backend
+- [mise tool-alias unset](https://mise.jdx.dev/cli/tool-alias/unset.html): Clear an alias for a tool/backend
 - [mise tool-stub](https://mise.jdx.dev/cli/tool-stub.html): Execute a tool stub
-- [mise trust](https://mise.jdx.dev/cli/trust.html): Marks a config file as trusted
-- [mise uninstall](https://mise.jdx.dev/cli/uninstall.html): Removes installed tool versions
-- [mise unset](https://mise.jdx.dev/cli/unset.html): Remove environment variable(s) from the config file.
+- [mise trust](https://mise.jdx.dev/cli/trust.html): Mark a config file as trusted
+- [mise uninstall](https://mise.jdx.dev/cli/uninstall.html): Remove installed tool versions
+- [mise unset](https://mise.jdx.dev/cli/unset.html): Remove environment variable(s) from the config file
 - [mise untrust](https://mise.jdx.dev/cli/untrust.html): Remove explicit trust for a config
-- [mise unuse](https://mise.jdx.dev/cli/unuse.html): Removes installed tool versions from mise.toml
-- [mise upgrade](https://mise.jdx.dev/cli/upgrade.html): Upgrades outdated tools
-- [mise use](https://mise.jdx.dev/cli/use.html): Installs a tool and adds the version to mise.toml.
+- [mise unuse](https://mise.jdx.dev/cli/unuse.html): Remove tool versions from mise.toml and uninstall them
+- [mise upgrade](https://mise.jdx.dev/cli/upgrade.html): Upgrade outdated tools
+- [mise use](https://mise.jdx.dev/cli/use.html): Install a tool and add it to mise.toml
 - [mise version](https://mise.jdx.dev/cli/version.html): Display the version of mise
-- [mise watch](https://mise.jdx.dev/cli/watch.html): Run task(s) and watch for changes to rerun it
+- [mise watch](https://mise.jdx.dev/cli/watch.html): Run task(s) and rerun them when files change
 - [mise where](https://mise.jdx.dev/cli/where.html): Display the installation path for a tool
-- [mise which](https://mise.jdx.dev/cli/which.html): Shows the path that a tool's bin points to.
+- [mise which](https://mise.jdx.dev/cli/which.html): Show the path a tool's executable resolves to

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2854,7 +2854,7 @@ setup). The old name still works but is deprecated and will be removed in mise 2
 .PP
 .TP
 \fB\-l, \-\-localize\fR
-Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project
+Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a project\-local directory (`.mise` by default, set with `\-\-localized\-dir`)
 
 This is necessary if users may use a different version of mise outside the project.
 .TP
@@ -3102,8 +3102,10 @@ Path to the config file to create
 .SH "MISE INSTALL"
 Install a tool version
 
-Installs a tool version to `~/.local/share/mise/installs/<TOOL>/<VERSION>`.
-Installing alone does not activate the tool, so it will not be on PATH.
+Installs a tool version under the mise data directory, by default
+`~/.local/share/mise/installs/<TOOL>/<VERSION>`.
+Installing alone does not add the tool to your config, so a tool that is not
+already configured will not be on PATH.
 To install and activate in one command, use `mise use`, which also writes the version to
 `mise.toml` in the current directory so the tool is active inside it.
 To run a tool once without touching any config, use `mise exec <TOOL>@<VERSION> \-\- <COMMAND>`.
@@ -4424,7 +4426,7 @@ non\-fuzzy matches, use the `\-\-match\-type` flag.
 .PP
 .TP
 \fB\-i, \-\-interactive\fR
-Pick a tool from an interactive search menu
+Show an interactive search menu
 .TP
 \fB\-m, \-\-match\-type\fR \fI<MATCH_TYPE>\fR
 Match type: equal, contains, or fuzzy

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -4,7 +4,9 @@ mise \- Dev tools, env vars, and tasks in one CLI
 .SH SYNOPSIS
 \fBmise\fR [OPTIONS] [<TASK>] [<TASK_ARGS>] ... [<TASK_ARGS_LAST>] ... [COMMAND]
 .SH DESCRIPTION
-mise prepares your development environment before each command runs. https://github.com/jdx/mise
+mise installs the dev tools your projects need, sets their environment variables, and runs their tasks.
+.PP
+Tools, env vars, and tasks are declared in mise.toml. `mise use <TOOL>` adds a tool to the project in the current directory, `mise install` installs everything the config asks for, and `mise run <TASK>` runs a task. Docs: https://mise.jdx.dev
 .PP
 .SH OPTIONS
 .TP
@@ -52,7 +54,7 @@ Show extra output (use \-vv for even more)
 Answer yes to all confirmation prompts
 .TP
 \fB\-\-debug\fR
-Sets log level to debug
+Set the log level to debug
 .TP
 \fB\-\-log\-level\fR \fI<LEVEL>\fR
 .TP
@@ -72,11 +74,12 @@ Do not execute hooks from config files
 Can also use `MISE_NO_HOOKS=1`
 .TP
 \fB\-\-no\-timings\fR
-Hides elapsed time after each task completes
+Hide the elapsed time printed after each task completes
 
-Default to always hide with `MISE_TASK_TIMINGS=0`
+Set `MISE_TASK_TIMINGS=0` to hide it by default
 .TP
 \fB\-\-output\fR \fI<OUTPUT>\fR
+How task output is displayed when running a task (same as `mise run \-\-output`)
 .TP
 \fB\-\-raw\fR
 Read/write directly to stdin/stdout/stderr instead of by line
@@ -92,12 +95,12 @@ Can also be enabled via MISE_LOCKED=1 or settings.locked=true
 Suppress all task output and mise non\-error messages
 .TP
 \fB\-\-timings\fR
-Shows elapsed time after each task completes
+Show the elapsed time after each task completes
 
-Default to always show with `MISE_TASK_TIMINGS=1`
+Set `MISE_TASK_TIMINGS=1` to show it by default
 .TP
 \fB\-\-trace\fR
-Sets log level to trace
+Set the log level to trace
 .TP
 \fB\-h, \-\-help\fR
 Print help
@@ -113,10 +116,10 @@ Task arguments
 .SH COMMANDS
 .TP
 \fBactivate\fR
-Initializes mise in the current shell session
+Initialize mise in the current shell session
 .TP
 \fBtool\-alias\fR
-Manage tool version aliases.
+Manage tool version aliases
 .RS
 \fIAliases: \fRalias, aliases
 .RE
@@ -137,7 +140,7 @@ Add/update an alias for a tool/backend
 .RE
 .TP
 \fBtool\-alias unset\fR
-Clears an alias for a tool/backend
+Clear an alias for a tool/backend
 .RS
 \fIAliases: \fRrm, remove, delete, del
 .RE
@@ -233,8 +236,10 @@ Manage systemd user services from `[bootstrap.linux.systemd.units]`
 .RE
 .TP
 \fBbootstrap linux systemd\-units apply\fR
+Install and start systemd user services from `[bootstrap.linux.systemd.units]`
 .TP
 \fBbootstrap linux systemd\-units status\fR
+Show the state of systemd user services from `[bootstrap.linux.systemd.units]`
 .TP
 \fBbootstrap macos\fR
 Manage macOS bootstrap config from `[bootstrap.macos]`
@@ -243,8 +248,10 @@ Manage macOS bootstrap config from `[bootstrap.macos]`
 Manage macOS defaults from `[bootstrap.macos.defaults]`
 .TP
 \fBbootstrap macos defaults apply\fR
+Write macOS defaults from `[bootstrap.macos.defaults]`
 .TP
 \fBbootstrap macos defaults status\fR
+Show whether macOS defaults match `[bootstrap.macos.defaults]`
 .TP
 \fBbootstrap macos launchd\-agents\fR
 Manage macOS LaunchAgents from `[bootstrap.macos.launchd.agents]`
@@ -253,8 +260,10 @@ Manage macOS LaunchAgents from `[bootstrap.macos.launchd.agents]`
 .RE
 .TP
 \fBbootstrap macos launchd\-agents apply\fR
+Install and load LaunchAgents from `[bootstrap.macos.launchd.agents]`
 .TP
 \fBbootstrap macos launchd\-agents status\fR
+Show the state of LaunchAgents from `[bootstrap.macos.launchd.agents]`
 .TP
 \fBbootstrap mise\-shell\-activate\fR
 Manage mise shell activation from `[bootstrap.mise_shell_activate]`
@@ -263,8 +272,10 @@ Manage mise shell activation from `[bootstrap.mise_shell_activate]`
 .RE
 .TP
 \fBbootstrap mise\-shell\-activate apply\fR
+Configure shell activation from `[bootstrap.mise_shell_activate]`
 .TP
 \fBbootstrap mise\-shell\-activate status\fR
+Show whether shell activation matches `[bootstrap.mise_shell_activate]`
 .TP
 \fBbootstrap packages\fR
 Manage bootstrap system packages from `[bootstrap.packages]`
@@ -318,8 +329,10 @@ Show the changes declarative bootstrap resources would make
 Manage package manager plugins declared in `[bootstrap.plugins]`
 .TP
 \fBbootstrap plugins apply\fR
+Install package manager plugins declared in `[bootstrap.plugins]`
 .TP
 \fBbootstrap plugins status\fR
+Show whether declared package manager plugins are installed
 .TP
 \fBbootstrap remote\fR
 Bootstrap one or more machines over OpenSSH
@@ -328,12 +341,16 @@ Bootstrap one or more machines over OpenSSH
 Manage git repo checkouts from `[bootstrap.repos]`
 .TP
 \fBbootstrap repos apply\fR
+Clone and converge git repos from `[bootstrap.repos]`
 .TP
 \fBbootstrap repos exec\fR
+Run a command in each configured git repo
 .TP
 \fBbootstrap repos status\fR
+Show the state of git repos from `[bootstrap.repos]`
 .TP
 \fBbootstrap repos update\fR
+Pull the latest changes into configured git repos
 .TP
 \fBbootstrap secrets\fR
 Inspect bootstrap secret inputs without revealing their values
@@ -360,14 +377,16 @@ Show the aggregate bootstrap status
 Manage current\-user bootstrap settings from `[bootstrap.user]`
 .TP
 \fBbootstrap user apply\fR
+Apply current\-user settings from `[bootstrap.user]`
 .TP
 \fBbootstrap user status\fR
+Show whether current\-user settings match `[bootstrap.user]`
 .TP
 \fBcache\fR
 Manage the mise cache
 .TP
 \fBcache clear\fR
-Deletes all cache files in mise
+Delete all cache files
 .RS
 \fIAliases: \fRc, clean
 .RE
@@ -379,7 +398,7 @@ Show the cache directory path
 .RE
 .TP
 \fBcache prune\fR
-Removes stale mise cache files
+Remove stale cache files
 .RS
 \fIAliases: \fRp
 .RE
@@ -400,7 +419,7 @@ Manage config files
 .RE
 .TP
 \fBconfig get\fR
-Display the value of a setting in a mise.toml file
+Display a value from a mise.toml file
 .TP
 \fBconfig ls\fR
 List config files currently in use
@@ -409,7 +428,7 @@ List config files currently in use
 .RE
 .TP
 \fBconfig set\fR
-Set the value of a setting in a mise.toml file
+Set a value in a mise.toml file
 .TP
 \fBdeactivate\fR
 Disable mise for current shell session
@@ -427,10 +446,10 @@ Print the current PATH entries mise is providing
 .RE
 .TP
 \fBen\fR
-Starts a new shell with the mise environment built from the current configuration
+Start a new shell with the mise environment built from the current configuration
 .TP
 \fBenv\fR
-Exports env vars to activate mise a single time
+Export env vars to activate mise a single time
 .RS
 \fIAliases: \fRe
 .RE
@@ -442,7 +461,7 @@ Execute a command with tool(s) set
 .RE
 .TP
 \fBfmt\fR
-Formats mise.toml
+Format mise.toml
 .TP
 \fBgenerate\fR
 Generate files for various tools/services
@@ -472,13 +491,13 @@ Generate a script to download+execute mise
 Generate documentation for tasks in a project
 .TP
 \fBgenerate task\-stubs\fR
-Generates shims to run mise tasks
+Generate shims to run mise tasks
 .TP
 \fBgenerate tool\-stub\fR
 Generate a tool stub for HTTP\-based tools
 .TP
 \fBimplode\fR
-Removes mise CLI and all related data
+Remove the mise CLI and all related data
 .TP
 \fBedit\fR
 Edit mise.toml interactively
@@ -493,10 +512,10 @@ Install a tool version
 Install a tool version to a specific path
 .TP
 \fBlatest\fR
-Gets the latest available version for a plugin
+Get the latest available version of a tool
 .TP
 \fBlink\fR
-Symlinks a tool version into mise
+Symlink a tool version into mise
 .RS
 \fIAliases: \fRln
 .RE
@@ -511,7 +530,7 @@ List installed and active tool versions
 .RE
 .TP
 \fBls\-remote\fR
-List runtime versions available for install.
+List tool versions available to install
 .RS
 \fIAliases: \fRlist\-all, list\-remote
 .RE
@@ -532,7 +551,7 @@ Run Model Context Protocol (MCP) server
 [experimental] Build an OCI image from the current mise.toml and run a command in it
 .TP
 \fBoutdated\fR
-Shows outdated tool versions
+Show outdated tool versions
 .TP
 \fBpatrons\fR
 Show the individuals supporting mise as Patron\-tier members
@@ -550,7 +569,7 @@ Install a plugin
 .RE
 .TP
 \fBplugins link\fR
-Symlinks a plugin into mise
+Symlink a plugin into mise
 .RS
 \fIAliases: \fRln
 .RE
@@ -562,19 +581,19 @@ List installed plugins
 .RE
 .TP
 \fBplugins ls\-remote\fR
-
+List all available remote plugins
 .RS
 \fIAliases: \fRlist\-remote, list\-all
 .RE
 .TP
 \fBplugins uninstall\fR
-Removes a plugin
+Remove a plugin
 .RS
 \fIAliases: \fRremove, rm
 .RE
 .TP
 \fBplugins update\fR
-Updates a plugin to the latest version
+Update a plugin to the latest version
 .RS
 \fIAliases: \fRup, upgrade
 .RE
@@ -601,7 +620,7 @@ Delete unused versions of tools
 List available tools to install
 .TP
 \fBreshim\fR
-Creates new shims based on bin paths from currently installed tools.
+Create shims for the executables of currently installed tools
 .TP
 \fBrun\fR
 Run task(s)
@@ -613,7 +632,7 @@ Run task(s)
 Search for tools in the registry
 .TP
 \fBself\-update\fR
-Updates mise itself.
+Update mise itself
 .TP
 \fBset\fR
 Set environment variables in mise.toml
@@ -625,7 +644,7 @@ Set environment variables in mise.toml
 Manage settings
 .TP
 \fBsettings add\fR
-Adds a setting to the configuration file
+Append a value to an array setting
 .TP
 \fBsettings get\fR
 Show a current setting
@@ -643,19 +662,19 @@ Add/update a setting
 .RE
 .TP
 \fBsettings unset\fR
-Clears a setting
+Clear a setting
 .RS
 \fIAliases: \fRrm, remove, delete, del
 .RE
 .TP
 \fBshell\fR
-Sets a tool version for the current session.
+Set a tool version for the current shell session
 .RS
 \fIAliases: \fRsh
 .RE
 .TP
 \fBshell\-alias\fR
-Manage shell aliases.
+Manage shell aliases
 .TP
 \fBshell\-alias get\fR
 Show the command for a shell alias
@@ -673,7 +692,7 @@ Add/update a shell alias
 .RE
 .TP
 \fBshell\-alias unset\fR
-Removes a shell alias
+Remove a shell alias
 .RS
 \fIAliases: \fRrm, remove, delete, del
 .RE
@@ -685,13 +704,13 @@ Show the companies sponsoring mise and the jdx.dev open source tools
 Synchronize tools from other version managers with mise
 .TP
 \fBsync node\fR
-Symlinks all tool versions from an external tool into mise
+Symlink node versions installed by nvm, nodenv, or Homebrew into mise
 .TP
 \fBsync python\fR
-Symlinks all tool versions from an external tool into mise
+Symlink python versions installed by pyenv or uv into mise
 .TP
 \fBsync ruby\fR
-Symlinks all ruby tool versions from an external tool into mise
+Symlink ruby versions installed by Homebrew into mise
 .TP
 \fBtasks\fR
 Manage tasks
@@ -715,7 +734,7 @@ Edit a task with $EDITOR
 Get information about a task
 .TP
 \fBtasks ls\fR
-List available tasks to execute
+List available tasks
 .TP
 \fBtasks run\fR
 Run task(s)
@@ -727,7 +746,7 @@ Run task(s)
 Validate tasks for common errors and issues
 .TP
 \fBtest\-tool\fR
-Test a tool installs and executes
+Test that a tool installs and runs
 .TP
 \fBtoken\fR
 Display git provider tokens mise will use
@@ -742,37 +761,37 @@ Display the GitHub token mise will use for a given host
 Display the GitLab token mise will use for a given host
 .TP
 \fBtool\fR
-Gets information about a tool
+Show information about a tool
 .TP
 \fBtool\-stub\fR
 Execute a tool stub
 .TP
 \fBtrust\fR
-Marks a config file as trusted
+Mark a config file as trusted
 .TP
 \fBuninstall\fR
-Removes installed tool versions
+Remove installed tool versions
 .TP
 \fBunset\fR
-Remove environment variable(s) from the config file.
+Remove environment variable(s) from the config file
 .TP
 \fBuntrust\fR
 Remove explicit trust for a config
 .TP
 \fBunuse\fR
-Removes installed tool versions from mise.toml
+Remove tool versions from mise.toml and uninstall them
 .RS
 \fIAliases: \fRrm, remove
 .RE
 .TP
 \fBupgrade\fR
-Upgrades outdated tools
+Upgrade outdated tools
 .RS
 \fIAliases: \fRup
 .RE
 .TP
 \fBuse\fR
-Installs a tool and adds the version to mise.toml.
+Install a tool and add it to mise.toml
 .RS
 \fIAliases: \fRu
 .RE
@@ -784,7 +803,7 @@ Display the version of mise
 .RE
 .TP
 \fBwatch\fR
-Run task(s) and watch for changes to rerun it
+Run task(s) and rerun them when files change
 .RS
 \fIAliases: \fRw
 .RE
@@ -793,12 +812,12 @@ Run task(s) and watch for changes to rerun it
 Display the installation path for a tool
 .TP
 \fBwhich\fR
-Shows the path that a tool's bin points to.
+Show the path a tool's executable resolves to
 .SH "MISE ACTIVATE"
-Initializes mise in the current shell session
+Initialize mise in the current shell session
 
-This should go into your shell's rc file or login shell.
-Otherwise, it will only take effect in the current session.
+Add this to your shell's rc or profile file so it runs in every new shell.
+Otherwise, it only takes effect in the current session.
 (e.g. ~/.zshrc, ~/.zprofile, ~/.zshenv, ~/.bashrc, ~/.bash_profile, ~/.profile, ~/.config/fish/config.fish, or $PROFILE for powershell)
 
 Typically, this can be added with something like the following:
@@ -830,6 +849,7 @@ This can be helpful for debugging mise. If you run `eval "$(mise activate \-\-no
 .TP
 \fB\-\-shims\fR
 Use shims instead of modifying PATH
+
 Effectively the same as:
 
     PATH="$HOME/.local/share/mise/shims:$PATH"
@@ -848,7 +868,7 @@ Print help
 \fB<SHELL_TYPE>\fR
 Shell type to generate the script for
 .SH "MISE TOOL-ALIAS"
-Manage tool version aliases.
+Manage tool version aliases
 .PP
 \fBUsage:\fR mise tool\-alias [OPTIONS] [COMMAND]
 .PP
@@ -885,10 +905,10 @@ The tool to show the alias for
 The alias to show
 .SH "MISE TOOL-ALIAS LS"
 List tool version aliases
-Shows the aliases that can be specified.
-These can come from user config or from plugins in `bin/list\-aliases`.
 
-For user config, aliases are defined like the following in `~/.config/mise/config.toml`:
+Aliases can be defined in user config or provided by plugins via `bin/list\-aliases`.
+
+In user config, aliases are defined like the following in `~/.config/mise/config.toml`:
 
     [tool_alias.node.versions]
     lts = "22.0.0"
@@ -932,7 +952,7 @@ The alias to set
 \fB<VALUE>\fR
 The value to set the alias to
 .SH "MISE TOOL-ALIAS UNSET"
-Clears an alias for a tool/backend
+Clear an alias for a tool/backend
 
 This modifies the contents of ~/.config/mise/config.toml
 .PP
@@ -1460,6 +1480,8 @@ Manage systemd user services from `[bootstrap.linux.systemd.units]`
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE BOOTSTRAP LINUX SYSTEMD-UNITS APPLY"
+Install and start systemd user services from `[bootstrap.linux.systemd.units]`
+.PP
 \fBUsage:\fR mise bootstrap linux systemd\-units apply [OPTIONS]
 .PP
 \fBOptions:\fR
@@ -1474,6 +1496,8 @@ Skip the confirmation prompt
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE BOOTSTRAP LINUX SYSTEMD-UNITS STATUS"
+Show the state of systemd user services from `[bootstrap.linux.systemd.units]`
+.PP
 \fBUsage:\fR mise bootstrap linux systemd\-units status [OPTIONS]
 .PP
 \fBOptions:\fR
@@ -1508,6 +1532,8 @@ Manage macOS defaults from `[bootstrap.macos.defaults]`
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE BOOTSTRAP MACOS DEFAULTS APPLY"
+Write macOS defaults from `[bootstrap.macos.defaults]`
+.PP
 \fBUsage:\fR mise bootstrap macos defaults apply [OPTIONS]
 .PP
 \fBOptions:\fR
@@ -1522,6 +1548,8 @@ Skip the confirmation prompt
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE BOOTSTRAP MACOS DEFAULTS STATUS"
+Show whether macOS defaults match `[bootstrap.macos.defaults]`
+.PP
 \fBUsage:\fR mise bootstrap macos defaults status [OPTIONS]
 .PP
 \fBOptions:\fR
@@ -1546,6 +1574,8 @@ Manage macOS LaunchAgents from `[bootstrap.macos.launchd.agents]`
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE BOOTSTRAP MACOS LAUNCHD-AGENTS APPLY"
+Install and load LaunchAgents from `[bootstrap.macos.launchd.agents]`
+.PP
 \fBUsage:\fR mise bootstrap macos launchd\-agents apply [OPTIONS]
 .PP
 \fBOptions:\fR
@@ -1560,6 +1590,8 @@ Skip the confirmation prompt
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE BOOTSTRAP MACOS LAUNCHD-AGENTS STATUS"
+Show the state of LaunchAgents from `[bootstrap.macos.launchd.agents]`
+.PP
 \fBUsage:\fR mise bootstrap macos launchd\-agents status [OPTIONS]
 .PP
 \fBOptions:\fR
@@ -1584,6 +1616,8 @@ Manage mise shell activation from `[bootstrap.mise_shell_activate]`
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE BOOTSTRAP MISE-SHELL-ACTIVATE APPLY"
+Configure shell activation from `[bootstrap.mise_shell_activate]`
+.PP
 \fBUsage:\fR mise bootstrap mise\-shell\-activate apply [OPTIONS]
 .PP
 \fBOptions:\fR
@@ -1598,6 +1632,8 @@ Skip the confirmation prompt
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE BOOTSTRAP MISE-SHELL-ACTIVATE STATUS"
+Show whether shell activation matches `[bootstrap.mise_shell_activate]`
+.PP
 \fBUsage:\fR mise bootstrap mise\-shell\-activate status [OPTIONS]
 .PP
 \fBOptions:\fR
@@ -1904,6 +1940,8 @@ Manage package manager plugins declared in `[bootstrap.plugins]`
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE BOOTSTRAP PLUGINS APPLY"
+Install package manager plugins declared in `[bootstrap.plugins]`
+.PP
 \fBUsage:\fR mise bootstrap plugins apply [OPTIONS]
 .PP
 \fBOptions:\fR
@@ -1915,6 +1953,8 @@ Print what would happen without installing plugins
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE BOOTSTRAP PLUGINS STATUS"
+Show whether declared package manager plugins are installed
+.PP
 \fBUsage:\fR mise bootstrap plugins status [OPTIONS]
 .PP
 \fBOptions:\fR
@@ -2034,6 +2074,8 @@ Manage git repo checkouts from `[bootstrap.repos]`
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE BOOTSTRAP REPOS APPLY"
+Clone and converge git repos from `[bootstrap.repos]`
+.PP
 \fBUsage:\fR mise bootstrap repos apply [OPTIONS]
 .PP
 \fBOptions:\fR
@@ -2051,6 +2093,8 @@ Skip repos with local changes instead of failing
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE BOOTSTRAP REPOS EXEC"
+Run a command in each configured git repo
+.PP
 \fBUsage:\fR mise bootstrap repos exec [OPTIONS] [<PATH>] ... <COMMAND> ...
 .PP
 \fBOptions:\fR
@@ -2073,6 +2117,8 @@ Run only in matching configured or expanded paths
 \fB<COMMAND>\fR
 Command and arguments to run in each repo
 .SH "MISE BOOTSTRAP REPOS STATUS"
+Show the state of git repos from `[bootstrap.repos]`
+.PP
 \fBUsage:\fR mise bootstrap repos status [OPTIONS]
 .PP
 \fBOptions:\fR
@@ -2087,6 +2133,8 @@ Exit with code 1 if any configured repo is not in its desired state
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE BOOTSTRAP REPOS UPDATE"
+Pull the latest changes into configured git repos
+.PP
 \fBUsage:\fR mise bootstrap repos update [OPTIONS] [<PATH>] ...
 .PP
 \fBOptions:\fR
@@ -2206,6 +2254,8 @@ Manage current\-user bootstrap settings from `[bootstrap.user]`
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE BOOTSTRAP USER APPLY"
+Apply current\-user settings from `[bootstrap.user]`
+.PP
 \fBUsage:\fR mise bootstrap user apply [OPTIONS]
 .PP
 \fBOptions:\fR
@@ -2220,6 +2270,8 @@ Skip the confirmation prompt
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE BOOTSTRAP USER STATUS"
+Show whether current\-user settings match `[bootstrap.user]`
+.PP
 \fBUsage:\fR mise bootstrap user status [OPTIONS]
 .PP
 \fBOptions:\fR
@@ -2246,7 +2298,7 @@ Run `mise cache` with no args to view the current cache directory.
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE CACHE CLEAR"
-Deletes all cache files in mise
+Delete all cache files
 .PP
 \fBUsage:\fR mise cache clear [OPTIONS] [<TOOL>] ...
 .PP
@@ -2277,7 +2329,7 @@ Show the cache directory path
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE CACHE PRUNE"
-Removes stale mise cache files
+Remove stale cache files
 
 By default, this command will remove files that have not been accessed in 30 days.
 Change this with the MISE_CACHE_PRUNE_AGE environment variable.
@@ -2291,7 +2343,7 @@ Change this with the MISE_CACHE_PRUNE_AGE environment variable.
 Show pruned files
 .TP
 \fB\-\-dry\-run\fR
-Just show what would be pruned
+Show what would be pruned without deleting anything
 .TP
 \fB\-h, \-\-help\fR
 Print help
@@ -2376,7 +2428,7 @@ List all tracked config files
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE CONFIG GET"
-Display the value of a setting in a mise.toml file
+Display a value from a mise.toml file
 .PP
 \fBUsage:\fR mise config get [OPTIONS] [<KEY>]
 .PP
@@ -2402,7 +2454,7 @@ Print help
 .PP
 .TP
 \fB<KEY>\fR
-The path of the config to display
+Dotted key path to display, e.g. `tools.python`; omit to print the whole file
 .SH "MISE CONFIG LS"
 List config files currently in use
 .PP
@@ -2423,7 +2475,7 @@ List all tracked config files
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE CONFIG SET"
-Set the value of a setting in a mise.toml file
+Set a value in a mise.toml file
 .PP
 \fBUsage:\fR mise config set [OPTIONS] <KEY> [<VALUE>]
 .PP
@@ -2450,6 +2502,7 @@ Append the value without duplicating an existing entry.
 Remove the value from an existing collection.
 .TP
 \fB\-t, \-\-type\fR \fI<TYPE>\fR
+TOML type to store the value as; inferred from the value by default
 .RS
 \fIDefault: \fRinfer
 .RE
@@ -2460,7 +2513,7 @@ Print help
 .PP
 .TP
 \fB<KEY>\fR
-The path of the config to display
+Dotted key path to set, e.g. `tools.python`
 .TP
 \fB<VALUE>\fR
 The value to set the key to (optional if provided as KEY=VALUE)
@@ -2485,6 +2538,7 @@ Check mise installation for possible problems
 .PP
 .TP
 \fB\-J, \-\-json\fR
+Output in JSON format
 .TP
 \fB\-h, \-\-help\fR
 Print help
@@ -2502,11 +2556,11 @@ Print all entries including those not provided by mise
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE EN"
-Starts a new shell with the mise environment built from the current configuration
+Start a new shell with the mise environment built from the current configuration
 
-This is an alternative to `mise activate` that allows you to explicitly start a mise session.
-It will have the tools and environment variables in the configs loaded.
-Note that changing directories will not update the mise environment.
+This is an alternative to `mise activate` for starting a mise session explicitly.
+The new shell has the tools and environment variables from the config loaded.
+Unlike an activated shell, changing directories does not update the environment.
 .PP
 \fBUsage:\fR mise en [OPTIONS] [<DIR>]
 .PP
@@ -2529,10 +2583,10 @@ Directory to start the shell in
 \fIDefault: \fR.
 .RE
 .SH "MISE ENV"
-Exports env vars to activate mise a single time
+Export env vars to activate mise a single time
 
-Use this if you don't want to permanently install mise. It's not necessary to
-use this if you have `mise activate` in your shell rc file.
+Use this to load the environment into one shell without adding `mise activate` to
+your shell rc file. It is not needed in shells where mise is already activated.
 .PP
 \fBUsage:\fR mise env [OPTIONS] [<TOOL@VERSION>] ...
 .PP
@@ -2563,17 +2617,18 @@ Print help
 .PP
 .TP
 \fB<TOOL@VERSION>\fR
-Tool(s) to use
+Tool(s) to include in addition to those in config, e.g. node@20
 .SH "MISE EXEC"
 Execute a command with tool(s) set
 
-use this to avoid modifying the shell session or running ad\-hoc commands with mise tools set.
+Use this to run a command with mise's tools and environment without modifying the shell
+session, or to run ad\-hoc commands with tools that are not in the config.
 
-Tools will be loaded from mise.toml, though they can be overridden with <RUNTIME> args
-Note that only the plugin specified will be overridden, so if a `mise.toml` file
-includes "node 20" but you run `mise exec python@3.11`; it will still load node@20.
+Tools are loaded from mise.toml and can be overridden with <TOOL@VERSION> args. Only the
+tools you name are overridden: if `mise.toml` includes `node = "20"` and you run
+`mise exec python@3.11`, node@20 is still loaded.
 
-The "\-\-" separates runtimes from the commands to pass along to the subprocess.
+The "\-\-" separates tools from the command to pass along to the subprocess.
 .PP
 \fBUsage:\fR mise exec [OPTIONS] [<TOOL@VERSION>] ... [<COMMAND>] ...
 .PP
@@ -2586,7 +2641,7 @@ Command string to execute
 \fB\-j, \-\-jobs\fR \fI<JOBS>\fR
 Number of jobs to run in parallel
 Values below 1 are treated as 1
-[default: 4]
+Defaults to the `jobs` setting
 .RS
 \fIEnvironment: \fR\fBMISE_JOBS\fR
 .RE
@@ -2627,7 +2682,7 @@ Bypass the environment cache and recompute the environment
 Skip automatic dependency preparation
 .TP
 \fB\-\-raw\fR
-Connect backend install command stdin/stdout/stderr directly to the terminal Implies \-\-jobs=1
+Connect backend install command stdin/stdout/stderr directly to the terminal. Implies `\-\-jobs=1`
 .TP
 \fB\-h, \-\-help\fR
 Print help
@@ -2635,12 +2690,12 @@ Print help
 .PP
 .TP
 \fB<TOOL@VERSION>\fR
-Tool(s) to start e.g.: node@20 python@3.10
+Tool(s) to load e.g.: node@20 python@3.10
 .TP
 \fB<COMMAND>\fR
 Command string to execute (same as \-\-command)
 .SH "MISE FMT"
-Formats mise.toml
+Format mise.toml
 
 Sorts keys and cleans up whitespace in mise.toml
 .PP
@@ -2650,10 +2705,10 @@ Sorts keys and cleans up whitespace in mise.toml
 .PP
 .TP
 \fB\-a, \-\-all\fR
-Format all files from the current directory
+Format every config file mise currently loads, not just those in the current directory
 .TP
 \fB\-c, \-\-check\fR
-Check if the configs are formatted, no formatting is done
+Check whether the configs are formatted without rewriting them; exits 1 if any are not
 .TP
 \fB\-s, \-\-stdin\fR
 Read config from stdin and write its formatted version into stdout
@@ -2712,7 +2767,7 @@ Bind the mise\-data\-volume to the devcontainer
 The name of the devcontainer
 .TP
 \fB\-w, \-\-write\fR
-write to .devcontainer/devcontainer.json
+Write to .devcontainer/devcontainer.json
 .TP
 \fB\-h, \-\-help\fR
 Print help
@@ -2738,7 +2793,7 @@ The task to run when the pre\-commit hook is triggered
 .RE
 .TP
 \fB\-w, \-\-write\fR
-write to .git/hooks/pre\-commit and make it executable
+Write to .git/hooks/pre\-commit and make it executable
 .TP
 \fB\-\-hook\fR \fI<HOOK>\fR
 Which hook to generate (saves to .git/hooks/$hook)
@@ -2775,10 +2830,10 @@ The task to run when the workflow is triggered
 .RE
 .TP
 \fB\-w, \-\-write\fR
-write to .github/workflows/$name.yml
+Write to .github/workflows/$name.yml
 .TP
 \fB\-\-name\fR \fI<NAME>\fR
-the name of the workflow to generate
+The name of the workflow to generate
 .RS
 \fIDefault: \fRci
 .RE
@@ -2799,7 +2854,7 @@ setup). The old name still works but is deprecated and will be removed in mise 2
 .PP
 .TP
 \fB\-l, \-\-localize\fR
-Sandboxes mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project
+Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project
 
 This is necessary if users may use a different version of mise outside the project.
 .TP
@@ -2807,7 +2862,7 @@ This is necessary if users may use a different version of mise outside the proje
 Specify mise version to fetch
 .TP
 \fB\-w, \-\-write\fR \fI<WRITE>\fR
-instead of outputting the script to stdout, write to a file and make it executable
+Write the script to a file and make it executable instead of printing it to stdout
 .TP
 \fB\-\-localized\-dir\fR \fI<LOCALIZED_DIR>\fR
 Directory to put localized data into
@@ -2836,7 +2891,7 @@ Generate documentation for tasks in a project
 .PP
 .TP
 \fB\-i, \-\-inject\fR
-inserts the documentation into an existing file
+Insert the documentation into an existing file
 
 This will look for a special comment, `<!\-\- mise\-tasks \-\->`, and replace it with the generated documentation.
 It will replace everything between the comment and the next comment, `<!\-\- /mise\-tasks \-\->` so it can be
@@ -2844,18 +2899,19 @@ run multiple times on the same file to update the documentation.
 The file must already contain both comments; mise errors instead of modifying the file if they are missing.
 .TP
 \fB\-I, \-\-index\fR
-write only an index of tasks, intended for use with `\-\-multi`
+Write only an index of tasks, intended for use with `\-\-multi`
 .TP
 \fB\-m, \-\-multi\fR
-render each task as a separate document, requires `\-\-output` to be a directory
+Render each task as a separate document; requires `\-\-output` to be a directory
 .TP
 \fB\-o, \-\-output\fR \fI<OUTPUT>\fR
-writes the generated docs to a file/directory
+Write the generated docs to a file or directory
 .TP
 \fB\-r, \-\-root\fR \fI<ROOT>\fR
-root directory to search for tasks
+Root directory to search for tasks
 .TP
 \fB\-s, \-\-style\fR \fI<STYLE>\fR
+Documentation style: `simple` lists tasks, `detailed` documents each task's usage
 .RS
 \fIDefault: \fRsimple
 .RE
@@ -2863,7 +2919,7 @@ root directory to search for tasks
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE GENERATE TASK-STUBS"
-Generates shims to run mise tasks
+Generate shims to run mise tasks
 
 By default, this will build shims like ./bin/<task>. These can be paired with `mise generate install\-script`
 so contributors to a project can execute mise tasks without installing mise into their system.
@@ -3002,9 +3058,9 @@ Print help
 \fB<OUTPUT>\fR
 Output file path for the tool stub
 .SH "MISE IMPLODE"
-Removes mise CLI and all related data
+Remove the mise CLI and all related data
 
-Skips config directory by default.
+The config directory is kept unless `\-\-config` is passed.
 .PP
 \fBUsage:\fR mise implode [OPTIONS]
 .PP
@@ -3046,13 +3102,13 @@ Path to the config file to create
 .SH "MISE INSTALL"
 Install a tool version
 
-Installs a tool version to `~/.local/share/mise/installs/<TOOL>/<VERSION>`
-Installing alone will not activate the tools so they won't be in PATH.
-To install and/or activate in one command, use `mise use` which will create a `mise.toml` file
-in the current directory to activate this tool when inside the directory.
-Alternatively, run `mise exec <TOOL>@<VERSION> \-\- <COMMAND>` to execute a tool without creating config files.
+Installs a tool version to `~/.local/share/mise/installs/<TOOL>/<VERSION>`.
+Installing alone does not activate the tool, so it will not be on PATH.
+To install and activate in one command, use `mise use`, which also writes the version to
+`mise.toml` in the current directory so the tool is active inside it.
+To run a tool once without touching any config, use `mise exec <TOOL>@<VERSION> \-\- <COMMAND>`.
 
-Tools will be installed in parallel. To disable, set `\-\-jobs=1` or `MISE_JOBS=1`
+Tools are installed in parallel. To disable, set `\-\-jobs=1` or `MISE_JOBS=1`.
 .PP
 \fBUsage:\fR mise install [OPTIONS] [<TOOL@VERSION>] ...
 .PP
@@ -3066,7 +3122,7 @@ With no tools specified, reinstall all configured tools
 \fB\-j, \-\-jobs\fR \fI<JOBS>\fR
 Number of jobs to run in parallel
 Values below 1 are treated as 1
-[default: 4]
+Defaults to the `jobs` setting
 .RS
 \fIEnvironment: \fR\fBMISE_JOBS\fR
 .RE
@@ -3110,7 +3166,7 @@ Uses the active MISE_ENV and requires monorepo_root = true plus explicit
 .RE
 .TP
 \fB\-\-raw\fR
-Connect backend install command stdin/stdout/stderr directly to the terminal Implies \-\-jobs=1
+Connect backend install command stdin/stdout/stderr directly to the terminal. Implies `\-\-jobs=1`
 .TP
 \fB\-\-shared\fR \fI<SHARED>\fR
 Install tool(s) to a shared directory
@@ -3152,7 +3208,7 @@ Tool to install e.g.: node@20
 \fB<PATH>\fR
 Path to install the tool into
 .SH "MISE LATEST"
-Gets the latest available version for a plugin
+Get the latest available version of a tool
 
 Supports prefixes such as `node@20` to get the latest version of node 20.
 .PP
@@ -3181,9 +3237,9 @@ Tool to get the latest version of
 \fB<ASDF_VERSION>\fR
 The version prefix to use when querying the latest version same as the first argument after the "@" used for asdf compatibility
 .SH "MISE LINK"
-Symlinks a tool version into mise
+Symlink a tool version into mise
 
-Use this for adding installs either custom compiled outside mise or built with a different tool.
+Use this to register an install that was compiled by hand or built with another tool.
 .PP
 \fBUsage:\fR mise link [OPTIONS] <TOOL@VERSION> <PATH>
 .PP
@@ -3292,11 +3348,8 @@ If not specified, all configured and task\-specific tools will be updated
 .SH "MISE LS"
 List installed and active tool versions
 
-This command lists tools that mise "knows about".
-These may be tools that are currently installed, or those
-that are in a config file (active) but may or may not be installed.
-
-It's a useful command to get the current state of your tools.
+Lists the tools mise knows about: versions that are installed, and versions requested
+by a config file (active) whether or not they are installed.
 .PP
 \fBUsage:\fR mise ls [OPTIONS] [<INSTALLED_TOOL>] ...
 .PP
@@ -3358,9 +3411,9 @@ Print help
 \fB<INSTALLED_TOOL>\fR
 Only show tool versions from [TOOL]
 .SH "MISE LS-REMOTE"
-List runtime versions available for install.
+List tool versions available to install
 
-Note that the results may be cached, run `mise cache clean` to clear the cache and get fresh results.
+Results may be cached; run `mise cache clear` to fetch fresh results.
 .PP
 \fBUsage:\fR mise ls\-remote [OPTIONS] [<TOOL@VERSION>] [<PREFIX>]
 .PP
@@ -3649,7 +3702,7 @@ Print help
 \fB<CMD>\fR
 Command and arguments to run inside the container (after `\-\-`)
 .SH "MISE OUTDATED"
-Shows outdated tool versions
+Show outdated tool versions
 
 See `mise upgrade` to upgrade these versions.
 .PP
@@ -3659,12 +3712,10 @@ See `mise upgrade` to upgrade these versions.
 .PP
 .TP
 \fB\-b, \-\-bump\fR
-Compares against the latest versions available, not what matches the current config
+Compare against the latest versions available, not just those matching the current config
 
-For example, if you have `node = "20"` in your config by default `mise outdated` will only
-show other 20.x versions, not 21.x or 22.x versions.
-
-Using this flag, if there are 21.x or newer versions it will display those instead of 20.x.
+For example, with `node = "20"` in your config, `mise outdated` normally only reports newer
+20.x versions. With this flag it reports the newest version overall, such as 22.x.
 .TP
 \fB\-J, \-\-json\fR
 Output in JSON format
@@ -3729,13 +3780,13 @@ Manage plugins
 .PP
 .TP
 \fB\-a, \-\-all\fR
-list all available remote plugins
+List all available remote plugins
 
-same as `mise plugins ls\-remote`
+Same as `mise plugins ls\-remote`
 .TP
 \fB\-c, \-\-core\fR
-The built\-in plugins only
-Normally these are not shown
+Only show built\-in (core) plugins
+These are hidden by default
 .TP
 \fB\-u, \-\-urls\fR
 Show the git url for each plugin
@@ -3756,10 +3807,9 @@ Print help
 .SH "MISE PLUGINS INSTALL"
 Install a plugin
 
-note that mise can automatically install plugins when you install a tool
-e.g.: `mise install cmake@3.30` will autoinstall the cmake plugin
-
-This behavior can be modified in ~/.config/mise/config.toml
+Note that mise installs plugins automatically when you install a tool that needs one,
+e.g.: `mise install cmake@3.30` installs the cmake plugin first. This command is only
+needed to install a plugin ahead of time or from a custom git URL.
 .PP
 \fBUsage:\fR mise plugins install [OPTIONS] [<NEW_PLUGIN>] [<GIT_URL>] [<REST>] ...
 .PP
@@ -3794,7 +3844,7 @@ Can specify multiple plugins: `mise plugins install cmake poetry`
 \fB<GIT_URL>\fR
 The git url of the plugin
 .SH "MISE PLUGINS LINK"
-Symlinks a plugin into mise
+Symlink a plugin into mise
 
 This is used for developing a plugin.
 .PP
@@ -3833,8 +3883,8 @@ List all available remote plugins
 Same as `mise plugins ls\-remote`
 .TP
 \fB\-c, \-\-core\fR
-The built\-in plugins only
-Normally these are not shown
+Only show built\-in (core) plugins
+These are hidden by default
 .TP
 \fB\-o, \-\-outdated\fR
 Show plugins with available updates
@@ -3854,14 +3904,9 @@ List installed plugins
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE PLUGINS LS-REMOTE"
-
 List all available remote plugins
 
-The full list is here: https://github.com/jdx/mise/blob/main/registry/
-
-Examples:
-
-    $ mise plugins ls\-remote
+These are the shorthand names from the registry: https://github.com/jdx/mise/blob/main/registry/
 .PP
 \fBUsage:\fR mise plugins ls\-remote [OPTIONS]
 .PP
@@ -3869,15 +3914,15 @@ Examples:
 .PP
 .TP
 \fB\-u, \-\-urls\fR
-Show the git url for each plugin e.g.: https://github.com/mise\-plugins/mise\-poetry.git
+Show the git url for each plugin, e.g. https://github.com/mise\-plugins/mise\-poetry.git
 .TP
 \fB\-\-only\-names\fR
-Only show the name of each plugin by default it will show a "*" next to installed plugins
+Only show the name of each plugin, without the "*" marking installed plugins
 .TP
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE PLUGINS UNINSTALL"
-Removes a plugin
+Remove a plugin
 .PP
 \fBUsage:\fR mise plugins uninstall [OPTIONS] [<PLUGIN>] ...
 .PP
@@ -3898,9 +3943,9 @@ Print help
 \fB<PLUGIN>\fR
 Plugin(s) to remove
 .SH "MISE PLUGINS UPDATE"
-Updates a plugin to the latest version
+Update a plugin to the latest version
 
-note: this updates the plugin itself, not the runtime versions
+Note: this updates the plugin itself, not the tool versions it manages
 .PP
 \fBUsage:\fR mise plugins update [OPTIONS] [<PLUGIN>] ...
 .PP
@@ -3910,7 +3955,7 @@ note: this updates the plugin itself, not the runtime versions
 \fB\-j, \-\-jobs\fR \fI<JOBS>\fR
 Number of jobs to run in parallel
 Values below 1 are treated as 1
-Default: 4
+Defaults to the `jobs` setting
 .TP
 \fB\-h, \-\-help\fR
 Print help
@@ -4120,7 +4165,7 @@ Hide aliased tools
 Output in JSON format
 .TP
 \fB\-\-security\fR
-Include security features for each tool's backends in JSON output.
+Include security features for each tool's backends in JSON output
 
 Requires \-\-json. Security info is de\-duplicated across all of a tool's backends. This can add noticeable time for large listings since each backend's security info is resolved individually.
 .TP
@@ -4132,13 +4177,12 @@ Print help
 \fB<NAME>\fR
 Show only the specified tool's full name
 .SH "MISE RESHIM"
-Creates new shims based on bin paths from currently installed tools.
+Create shims for the executables of currently installed tools
 
-This creates new shims in the configured user shim directory for CLIs that have been added.
-With `\-\-system`, it rebuilds the configured system shim farm instead.
-mise will try to do this automatically for commands like `npm i \-g` but there are
-other ways to install things (like using yarn or pnpm for node) that mise does
-not know about and so it will be necessary to call this explicitly.
+This creates shims in the user shim directory for executables that have been added since
+the last reshim. With `\-\-system`, it rebuilds the system shim farm instead.
+mise runs this automatically after commands like `npm i \-g`, but other ways of installing
+executables (such as yarn or pnpm for node) are not detected, so call this explicitly then.
 
 If you think mise should automatically call this for a particular command, please
 open an issue on the mise repo. You can also set up a shell function to reshim
@@ -4158,7 +4202,7 @@ currently active in mise.toml.
 .PP
 .TP
 \fB\-f, \-\-force\fR
-Rebuilds all mise\-owned shims
+Rebuild all mise\-owned shims
 .TP
 \fB\-\-system\fR
 Rebuild the system shim farm
@@ -4168,10 +4212,9 @@ Print help
 .SH "MISE RUN"
 Run task(s)
 
-This command will run a task, or multiple tasks in parallel.
-Tasks may have dependencies on other tasks or on source files.
-If source is configured on a task, it will only run if the source
-files have changed.
+Runs one task, or several tasks in parallel.
+Tasks may depend on other tasks and on source files.
+If a task has `sources` configured, it only runs when those files have changed.
 
 Tasks can be defined in mise.toml or as standalone scripts.
 In mise.toml, tasks take this form:
@@ -4184,7 +4227,7 @@ In mise.toml, tasks take this form:
 Alternatively, tasks can be defined as standalone scripts.
 These must be located in `mise\-tasks`, `.mise\-tasks`, `.mise/tasks`, `mise/tasks` or
 `.config/mise/tasks`.
-The name of the script will be the name of the tasks.
+The name of the script becomes the name of the task.
 
     $ cat .mise/tasks/build<<EOF
     #!/usr/bin/env bash
@@ -4229,8 +4272,7 @@ Force the tasks to run even if outputs are up to date
 \fB\-j, \-\-jobs\fR \fI<JOBS>\fR
 Number of tasks to run in parallel
 Values below 1 are treated as 1
-[default: 4]
-Configure with `jobs` config or `MISE_JOBS` env var
+Defaults to the `jobs` setting or the `MISE_JOBS` env var
 .RS
 \fIEnvironment: \fR\fBMISE_JOBS\fR
 .RE
@@ -4239,7 +4281,7 @@ Configure with `jobs` config or `MISE_JOBS` env var
 Don't actually run the task(s), just print them in order of execution
 .TP
 \fB\-o, \-\-output\fR \fI<OUTPUT>\fR
-Change how tasks information is output when running tasks
+How task output is displayed
 
 \- `prefix` \- Print stdout/stderr by line, prefixed with the task's label
 \- `interleave` \- Print directly to stdout/stderr instead of by line
@@ -4320,9 +4362,9 @@ Do not use cache on remote tasks
 Skip automatic dependency preparation
 .TP
 \fB\-\-no\-timings\fR
-Hides elapsed time after each task completes
+Hide the elapsed time printed after each task completes
 
-Default to always hide with `MISE_TASK_TIMINGS=0`
+Set `MISE_TASK_TIMINGS=0` to hide it by default
 .TP
 \fB\-\-skip\-deps\fR
 Run only the specified tasks skipping all dependencies
@@ -4365,13 +4407,13 @@ Timeout for the task to complete
 e.g.: 30s, 5m
 .TP
 \fB\-\-timings\fR
-Shows elapsed time after each task completes
+Show the elapsed time after each task completes
 
-Default to always show with `MISE_TASK_TIMINGS=1`
+Set `MISE_TASK_TIMINGS=1` to show it by default
 .SH "MISE SEARCH"
 Search for tools in the registry
 
-This command searches a tool in the registry.
+Searches the registry for tools matching NAME.
 
 By default, it will show all tools that fuzzy match the search term. For
 non\-fuzzy matches, use the `\-\-match\-type` flag.
@@ -4382,7 +4424,7 @@ non\-fuzzy matches, use the `\-\-match\-type` flag.
 .PP
 .TP
 \fB\-i, \-\-interactive\fR
-Show interactive search
+Pick a tool from an interactive search menu
 .TP
 \fB\-m, \-\-match\-type\fR \fI<MATCH_TYPE>\fR
 Match type: equal, contains, or fuzzy
@@ -4401,7 +4443,7 @@ Print help
 \fB<NAME>\fR
 The tool to search for
 .SH "MISE SELF-UPDATE"
-Updates mise itself.
+Update mise itself
 
 Uses the GitHub Releases API to find the latest release and binary.
 By default, this will also update any installed plugins.
@@ -4542,10 +4584,10 @@ Name of setting
 \fB<VALUE>\fR
 Setting value to set
 .SH "MISE SETTINGS ADD"
-Adds a setting to the configuration file
+Append a value to an array setting
 
-Used with an array setting, this will append the value to the array.
-This modifies the contents of ~/.config/mise/config.toml
+Adds the value to an array setting such as `disable_hints`, keeping existing entries.
+This modifies ~/.config/mise/config.toml by default, or the local config with `\-\-local`.
 .PP
 \fBUsage:\fR mise settings add [OPTIONS] <SETTING> [<VALUE>]
 .PP
@@ -4652,9 +4694,9 @@ The setting to set
 \fB<VALUE>\fR
 The value to set (optional if provided as KEY=VALUE)
 .SH "MISE SETTINGS UNSET"
-Clears a setting
+Clear a setting
 
-This modifies the contents of ~/.config/mise/config.toml
+This modifies ~/.config/mise/config.toml by default, or the local config with `\-\-local`.
 .PP
 \fBUsage:\fR mise settings unset [OPTIONS] <KEY>
 .PP
@@ -4672,7 +4714,7 @@ Print help
 \fB<KEY>\fR
 The setting to remove
 .SH "MISE SHELL"
-Sets a tool version for the current session.
+Set a tool version for the current shell session
 
 Only works in a session where mise is already activated.
 
@@ -4687,16 +4729,16 @@ such as `MISE_NODE_VERSION=20` which is "eval"ed as a shell function created by 
 \fB\-j, \-\-jobs\fR \fI<JOBS>\fR
 Number of jobs to run in parallel
 Values below 1 are treated as 1
-[default: 4]
+Defaults to the `jobs` setting
 .RS
 \fIEnvironment: \fR\fBMISE_JOBS\fR
 .RE
 .TP
 \fB\-u, \-\-unset\fR
-Removes a previously set version
+Remove a previously set version
 .TP
 \fB\-\-raw\fR
-Connect backend install command stdin/stdout/stderr directly to the terminal Implies \-\-jobs=1
+Connect backend install command stdin/stdout/stderr directly to the terminal. Implies `\-\-jobs=1`
 .TP
 \fB\-h, \-\-help\fR
 Print help
@@ -4706,7 +4748,7 @@ Print help
 \fB<TOOL@VERSION>\fR
 Tool(s) to use
 .SH "MISE SHELL-ALIAS"
-Manage shell aliases.
+Manage shell aliases
 .PP
 \fBUsage:\fR mise shell\-alias [OPTIONS] [COMMAND]
 .PP
@@ -4770,7 +4812,7 @@ The alias name
 \fB<COMMAND>\fR
 The command to run (optional if provided as ALIAS=COMMAND)
 .SH "MISE SHELL-ALIAS UNSET"
-Removes a shell alias
+Remove a shell alias
 
 This modifies the contents of ~/.config/mise/config.toml
 .PP
@@ -4807,9 +4849,9 @@ Synchronize tools from other version managers with mise
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE SYNC NODE"
-Symlinks all tool versions from an external tool into mise
+Symlink node versions installed by nvm, nodenv, or Homebrew into mise
 
-For example, use this to import all Homebrew node installs into mise
+Use this to make versions installed by another version manager available to mise.
 
 This won't overwrite managed installs, runtime aliases, or links from other providers.
 .PP
@@ -4830,9 +4872,9 @@ Get tool versions from nvm
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE SYNC PYTHON"
-Symlinks all tool versions from an external tool into mise
+Symlink python versions installed by pyenv or uv into mise
 
-For example, use this to import all pyenv installs into mise
+Use this to make versions installed by another version manager available to mise.
 
 This won't overwrite managed installs, runtime aliases, or links from other providers.
 .PP
@@ -4850,7 +4892,7 @@ Sync tool versions with uv (2\-way sync)
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE SYNC RUBY"
-Symlinks all ruby tool versions from an external tool into mise
+Symlink ruby versions installed by Homebrew into mise
 .PP
 \fBUsage:\fR mise sync ruby [OPTIONS]
 .PP
@@ -4912,7 +4954,7 @@ Print help
 .PP
 .TP
 \fB<TASK>\fR
-Task name to get info of
+Task name to show info for
 .SH "MISE TASKS ADD"
 Create a new task
 
@@ -4949,7 +4991,7 @@ Directly connect stdin/stdout/stderr
 Glob patterns of files this task uses as input
 .TP
 \fB\-w, \-\-wait\-for\fR \fI<WAIT_FOR>\fR
-Wait for these tasks to complete if they are to run
+Wait for these tasks to finish if they are also being run
 .TP
 \fB\-\-depends\-post\fR \fI<DEPENDS_POST>\fR
 Dependencies to run after the task runs
@@ -4958,10 +5000,10 @@ Dependencies to run after the task runs
 Description of the task
 .TP
 \fB\-\-outputs\fR \fI<OUTPUTS>\fR
-Glob patterns of files this task creates, to skip if they are not modified
+Glob patterns of files this task creates, used to skip it when they are up to date
 .TP
 \fB\-\-run\-windows\fR \fI<RUN_WINDOWS>\fR
-Command to run on windows
+Command to run on Windows
 .TP
 \fB\-\-shell\fR \fI<SHELL>\fR
 Run the task in a specific shell
@@ -4975,7 +5017,10 @@ Print help
 .PP
 .TP
 \fB<TASK>\fR
-Tasks name to add
+Name of the task to add
+.TP
+\fB<RUN>\fR
+Command to run, given after `\-\-`
 .SH "MISE TASKS DEPS"
 Display a tree visualization of a dependency graph
 
@@ -5066,9 +5111,10 @@ Print help
 \fB<TASK>\fR
 Name of the task to get information about
 .SH "MISE TASKS LS"
-List available tasks to execute
-These may be included from the config file or from the project's .mise/tasks directory
-mise will merge all tasks from all parent directories into this list.
+List available tasks
+
+Tasks come from config files and from task directories such as `.mise/tasks`.
+Tasks from all parent directories are merged into this list.
 
 So if you have global tasks in `~/.config/mise/tasks/*` and project\-specific tasks in
 ~/myproject/.mise/tasks/*, then they'll both be available but the project\-specific
@@ -5120,10 +5166,9 @@ Print help
 .SH "MISE TASKS RUN"
 Run task(s)
 
-This command will run a task, or multiple tasks in parallel.
-Tasks may have dependencies on other tasks or on source files.
-If source is configured on a task, it will only run if the source
-files have changed.
+Runs one task, or several tasks in parallel.
+Tasks may depend on other tasks and on source files.
+If a task has `sources` configured, it only runs when those files have changed.
 
 Tasks can be defined in mise.toml or as standalone scripts.
 In mise.toml, tasks take this form:
@@ -5136,7 +5181,7 @@ In mise.toml, tasks take this form:
 Alternatively, tasks can be defined as standalone scripts.
 These must be located in `mise\-tasks`, `.mise\-tasks`, `.mise/tasks`, `mise/tasks` or
 `.config/mise/tasks`.
-The name of the script will be the name of the tasks.
+The name of the script becomes the name of the task.
 
     $ cat .mise/tasks/build<<EOF
     #!/usr/bin/env bash
@@ -5181,8 +5226,7 @@ Force the tasks to run even if outputs are up to date
 \fB\-j, \-\-jobs\fR \fI<JOBS>\fR
 Number of tasks to run in parallel
 Values below 1 are treated as 1
-[default: 4]
-Configure with `jobs` config or `MISE_JOBS` env var
+Defaults to the `jobs` setting or the `MISE_JOBS` env var
 .RS
 \fIEnvironment: \fR\fBMISE_JOBS\fR
 .RE
@@ -5191,7 +5235,7 @@ Configure with `jobs` config or `MISE_JOBS` env var
 Don't actually run the task(s), just print them in order of execution
 .TP
 \fB\-o, \-\-output\fR \fI<OUTPUT>\fR
-Change how tasks information is output when running tasks
+How task output is displayed
 
 \- `prefix` \- Print stdout/stderr by line, prefixed with the task's label
 \- `interleave` \- Print directly to stdout/stderr instead of by line
@@ -5272,9 +5316,9 @@ Do not use cache on remote tasks
 Skip automatic dependency preparation
 .TP
 \fB\-\-no\-timings\fR
-Hides elapsed time after each task completes
+Hide the elapsed time printed after each task completes
 
-Default to always hide with `MISE_TASK_TIMINGS=0`
+Set `MISE_TASK_TIMINGS=0` to hide it by default
 .TP
 \fB\-\-skip\-deps\fR
 Run only the specified tasks skipping all dependencies
@@ -5317,9 +5361,9 @@ Timeout for the task to complete
 e.g.: 30s, 5m
 .TP
 \fB\-\-timings\fR
-Shows elapsed time after each task completes
+Show the elapsed time after each task completes
 
-Default to always show with `MISE_TASK_TIMINGS=1`
+Set `MISE_TASK_TIMINGS=1` to show it by default
 .SH "MISE TASKS VALIDATE"
 Validate tasks for common errors and issues
 .PP
@@ -5343,7 +5387,7 @@ Print help
 Tasks to validate
 If not specified, validates all tasks
 .SH "MISE TEST-TOOL"
-Test a tool installs and executes
+Test that a tool installs and runs
 .PP
 \fBUsage:\fR mise test\-tool [OPTIONS] [<TOOLS>] ...
 .PP
@@ -5365,10 +5409,10 @@ Values below 1 are treated as 1
 Test all tools specified in config files
 .TP
 \fB\-\-include\-non\-defined\fR
-Also test tools not defined in registry/, guessing how to test it
+Also test tools not defined in registry/, guessing how to test them
 .TP
 \fB\-\-raw\fR
-Connect backend install command stdin/stdout/stderr directly to the terminal Implies \-\-jobs=1
+Connect backend install command stdin/stdout/stderr directly to the terminal. Implies `\-\-jobs=1`
 .TP
 \fB\-h, \-\-help\fR
 Print help
@@ -5469,7 +5513,7 @@ GitLab hostname
 \fIDefault: \fRgitlab.com
 .RE
 .SH "MISE TOOL"
-Gets information about a tool
+Show information about a tool
 .PP
 \fBUsage:\fR mise tool [OPTIONS] <TOOL>
 .PP
@@ -5510,11 +5554,16 @@ Tool name to get information about
 .SH "MISE TOOL-STUB"
 Execute a tool stub
 
-Tool stubs are executable files containing TOML configuration that specify which tool to run and how to run it. They provide a convenient way to create portable, self\-contained executables that automatically manage tool installation and execution.
+Tool stubs are executable files containing TOML configuration that specify
+which tool to run and how to run it. They provide a convenient way to create
+portable, self\-contained executables that automatically manage tool installation
+and execution.
 
 A tool stub consists of:
 
-\- A shebang line: #!/usr/bin/env \-S mise tool\-stub \- TOML configuration specifying the tool, version, and options \- Optional comments describing the tool's purpose
+\- A shebang line: #!/usr/bin/env \-S mise tool\-stub
+\- TOML configuration specifying the tool, version, and options
+\- Optional comments describing the tool's purpose
 
 Example stub file:
 
@@ -5527,7 +5576,8 @@ version = "20.0.0"
 bin = "node"
 ```
 
-The stub will automatically install the specified tool version if missing and execute it with any arguments passed to the stub.
+The stub will automatically install the specified tool version if missing
+and execute it with any arguments passed to the stub.
 
 For more information, see: https://mise.jdx.dev/dev\-tools/tool\-stubs.html
 .PP
@@ -5546,7 +5596,7 @@ Arguments to pass to the tool
 
 All arguments after the stub file path will be forwarded to the underlying tool. Use '\-\-' to separate mise arguments from tool arguments if needed.
 .SH "MISE TRUST"
-Marks a config file as trusted
+Mark a config file as trusted
 
 This means mise is allowed to parse the file when it needs to read config
 that may execute code or affect the environment. Without trust, mise may
@@ -5596,9 +5646,10 @@ Print help
 \fB<CONFIG_FILE>\fR
 The config file whose trust status to change
 .SH "MISE UNINSTALL"
-Removes installed tool versions
+Remove installed tool versions
 
-This only removes the installed version, it does not modify mise.toml.
+This only removes the installed version; it does not modify mise.toml.
+Use `mise unuse` to remove a tool from mise.toml and uninstall it.
 .PP
 \fBUsage:\fR mise uninstall [OPTIONS] [<INSTALLED_TOOL@VERSION>] ...
 .PP
@@ -5624,7 +5675,7 @@ Print help
 \fB<INSTALLED_TOOL@VERSION>\fR
 Tool(s) to remove
 .SH "MISE UNSET"
-Remove environment variable(s) from the config file.
+Remove environment variable(s) from the config file
 
 By default, this command modifies `mise.toml` in the current directory.
 .PP
@@ -5667,7 +5718,7 @@ Print help
 \fB<CONFIG_FILE>\fR
 The config file to untrust
 .SH "MISE UNUSE"
-Removes installed tool versions from mise.toml
+Remove tool versions from mise.toml and uninstall them
 
 By default, this will use the `mise.toml` file that has the tool defined.
 If multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),
@@ -5679,12 +5730,12 @@ In the following order:
   \- If `\-\-path` is set, it will use the config file at the given path.
   \- If `\-\-env` is set, it will use `mise.<env>.toml`.
   \- If [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) is set, it will use that instead.
-  \- If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will the first from that list.
+  \- If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will use the first from that list.
   \- Otherwise just "mise.toml" or global config if cwd is home directory.
 
 Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
 
-Will also prune the installed version if no other configurations are using it.
+The installed version is also removed unless another config still uses it or `\-\-no\-prune` is passed.
 .PP
 \fBUsage:\fR mise unuse [OPTIONS] <INSTALLED_TOOL@VERSION> ...
 .PP
@@ -5713,13 +5764,13 @@ Print help
 \fB<INSTALLED_TOOL@VERSION>\fR
 Tool(s) to remove
 .SH "MISE UPGRADE"
-Upgrades outdated tools
+Upgrade outdated tools
 
-By default, this keeps the range specified in mise.toml. So if you have node@20 set, it will
-upgrade to the latest 20.x.x version available. See the `\-\-bump` flag to use the latest version
-and bump the version in mise.toml.
+By default, this keeps the range specified in mise.toml: with node@20 set, it upgrades to
+the latest 20.x.x available. Use `\-\-bump` to upgrade to the latest version overall and
+rewrite the version in mise.toml.
 
-This will update mise.lock if it is enabled, see https://mise.jdx.dev/configuration/settings.html#lockfile
+This also updates mise.lock if lockfiles are enabled, see https://mise.jdx.dev/configuration/settings.html#lockfile
 .PP
 \fBUsage:\fR mise upgrade [OPTIONS] [<INSTALLED_TOOL@VERSION>] ...
 .PP
@@ -5727,7 +5778,7 @@ This will update mise.lock if it is enabled, see https://mise.jdx.dev/configurat
 .PP
 .TP
 \fB\-b, \-\-bump\fR
-Upgrades to the latest version available, bumping the version in mise.toml
+Upgrade to the latest version available, bumping the version in mise.toml
 
 For example, if you have `node = "20.0.0"` in your mise.toml but 22.1.0 is the latest available,
 this will install 22.1.0 and set `node = "22.1.0"` in your config.
@@ -5736,12 +5787,12 @@ It keeps the same precision as what was there before, so if you instead had `nod
 would change your config to `node = "22"`.
 .TP
 \fB\-i, \-\-interactive\fR
-Display multiselect menu to choose which tools to upgrade
+Choose which tools to upgrade from a multiselect menu
 .TP
 \fB\-j, \-\-jobs\fR \fI<JOBS>\fR
 Number of jobs to run in parallel
 Values below 1 are treated as 1
-[default: 4]
+Defaults to the `jobs` setting
 .RS
 \fIEnvironment: \fR\fBMISE_JOBS\fR
 .RE
@@ -5750,7 +5801,7 @@ Values below 1 are treated as 1
 Deprecated shorthand for \-\-bump
 .TP
 \fB\-n, \-\-dry\-run\fR
-Just print what would be done, don't actually do it
+Print what would be done without doing it
 .TP
 \fB\-x, \-\-exclude\fR \fI<INSTALLED_TOOL>\fR
 Tool(s) to exclude from upgrading
@@ -5797,7 +5848,7 @@ Use this to bypass `upgrade.prune_after`, or to override
 `upgrade.auto_prune = false` for a single run.
 .TP
 \fB\-\-raw\fR
-Connect backend install command stdin/stdout/stderr directly to the terminal Implies \-\-jobs=1
+Connect backend install command stdin/stdout/stderr directly to the terminal. Implies `\-\-jobs=1`
 .TP
 \fB\-h, \-\-help\fR
 Print help
@@ -5809,10 +5860,10 @@ Tool(s) to upgrade
 e.g.: node@20 python@3.10
 If not specified, all current tools will be upgraded
 .SH "MISE USE"
-Installs a tool and adds the version to mise.toml.
+Install a tool and add it to mise.toml
 
-This will install the tool version if it is not already installed.
-By default, this will use a `mise.toml` file in the current directory.
+Installs the tool version if it is not already installed, then writes it to a config file.
+By default, this is `mise.toml` in the current directory.
 If multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),
 the lowest precedence file (`mise.toml`) will be used.
 See https://mise.jdx.dev/configuration.html#target\-file\-for\-write\-operations
@@ -5822,12 +5873,10 @@ In the following order:
   \- If `\-\-path` is set, it will use the config file at the given path.
   \- If `\-\-env` is set, it will use `mise.<env>.toml`.
   \- If [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) is set, it will use that instead.
-  \- If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will the first from that list.
+  \- If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will use the first from that list.
   \- Otherwise just "mise.toml" or global config if cwd is home directory.
 
 Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
-
-Use the `\-\-global` flag to use the global config file instead.
 .PP
 \fBUsage:\fR mise use [OPTIONS] [TOOL@VERSION]…
 .PP
@@ -5846,7 +5895,7 @@ Use the global config file (`~/.config/mise/config.toml`) instead of the local o
 \fB\-j, \-\-jobs\fR \fI<JOBS>\fR
 Number of jobs to run in parallel
 Values below 1 are treated as 1
-[default: 4]
+Defaults to the `jobs` setting
 .RS
 \fIEnvironment: \fR\fBMISE_JOBS\fR
 .RE
@@ -5867,8 +5916,8 @@ This is useful for scripts to check if tools need to be added or removed.
 \fB\-\-fuzzy\fR
 Save fuzzy version to config file
 
-e.g.: `mise use \-\-fuzzy node@20` will save 20 as the version
-this is the default behavior unless `MISE_PIN=1`
+e.g.: `mise use \-\-fuzzy node@20` will save `20` as the version.
+This is the default behavior unless `MISE_PIN=1`
 .TP
 \fB\-\-minimum\-release\-age\fR \fI<MINIMUM_RELEASE_AGE>\fR
 Only install versions released before this date or older than this duration
@@ -5887,7 +5936,7 @@ Consider using mise.lock as a better alternative to pinning in mise.toml:
 https://mise.jdx.dev/configuration/settings.html#lockfile
 .TP
 \fB\-\-raw\fR
-Connect backend install command stdin/stdout/stderr directly to the terminal Implies `\-\-jobs=1`
+Connect backend install command stdin/stdout/stderr directly to the terminal. Implies `\-\-jobs=1`
 .TP
 \fB\-\-remove\fR \fI<TOOL>\fR
 Remove the tool(s) from config file
@@ -5903,12 +5952,12 @@ Command to run after installing this tool
 \fB<TOOL@VERSION>\fR
 Tool to add to config file
 
-e.g.: node@20, cargo:ripgrep@latest npm:prettier@3
-If no version is specified, it will default to @latest
+e.g.: node@20, cargo:ripgrep@latest, npm:prettier@3
+If no version is specified, it defaults to @latest
 
 Tool options can be set with this syntax:
 
-    mise use ubi:BurntSushi/ripgrep[exe=rg]
+    mise use "cargo:ripgrep[features=pcre2]"
 .SH "MISE VERSION"
 Display the version of mise
 
@@ -5927,10 +5976,10 @@ Print the version information in JSON format
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE WATCH"
-Run task(s) and watch for changes to rerun it
+Run task(s) and rerun them when files change
 
-This command uses the `watchexec` tool to watch for changes to files and rerun the specified task(s).
-It must be installed for this command to work, but you can install it with `mise use \-g watchexec@latest`.
+Uses `watchexec` to watch for file changes and rerun the given task(s).
+watchexec must be installed; `mise use \-g watchexec@latest` installs it.
 
 For more advanced process management (daemon management, auto\-restart, readiness checks,
 cron scheduling), see mise's sister project: https://pitchfork.jdx.dev
@@ -6479,7 +6528,7 @@ Print help
 \fB<TASK>\fR
 Tasks to run
 Can specify multiple tasks by separating with `:::`
-e.g.: `mise run task1 arg1 arg2 ::: task2 arg1 arg2`
+e.g.: `mise watch task1 arg1 arg2 ::: task2 arg1 arg2`
 Defaults to `default`
 .TP
 \fB<ARGS>\fR
@@ -6500,18 +6549,17 @@ Print help
 .PP
 .TP
 \fB<TOOL@VERSION>\fR
-Tool(s) to look up
+Tool to look up
 e.g.: ruby@3
-if "@<PREFIX>" is specified, it will show the latest installed version
-that matches the prefix
-otherwise, it will show the current, active installed version
+With "@<PREFIX>", shows the latest installed version matching the prefix.
+Otherwise, shows the current, active installed version.
 .TP
 \fB<ASDF_VERSION>\fR
 the version prefix to use when querying the latest version
 same as the first argument after the "@"
 used for asdf compatibility
 .SH "MISE WHICH"
-Shows the path that a tool's bin points to.
+Show the path a tool's executable resolves to
 
 Use this to figure out what version of a tool is currently active.
 .PP
@@ -6538,6 +6586,6 @@ Print help
 .PP
 .TP
 \fB<BIN_NAME>\fR
-The bin to look up
+The executable to look up
 .SH AUTHOR
 Jeff Dickey <@jdx>

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -41,7 +41,11 @@ source_code_link_template #"""
 {%- endif -%}
 https://github.com/jdx/mise/blob/main/src/cli/{{path}}
 """#
-long_about "mise prepares your development environment before each command runs. https://github.com/jdx/mise"
+long_about #"""
+mise installs the dev tools your projects need, sets their environment variables, and runs their tasks.
+
+Tools, env vars, and tasks are declared in mise.toml. `mise use <TOOL>` adds a tool to the project in the current directory, `mise install` installs everything the config asks for, and `mise run <TASK>` runs a task. Docs: https://mise.jdx.dev
+"""#
 after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise install node@20.0.0\u{1b}[22m       Install a specific node version\n    $ \u{1b}[1mmise install node@20\u{1b}[22m           Install a version matching a prefix\n    $ \u{1b}[1mmise install node\u{1b}[22m              Install the node version defined in config\n    $ \u{1b}[1mmise install\u{1b}[22m                   Install all plugins/tools defined in config\n\n    $ \u{1b}[1mmise install cargo:ripgrep\u{1b}[22m     Install something via cargo\n    $ \u{1b}[1mmise install npm:prettier\u{1b}[22m      Install something via npm\n\n    $ \u{1b}[1mmise use node@20\u{1b}[22m               Use node-20.x in current project\n    $ \u{1b}[1mmise use -g node@20\u{1b}[22m            Use node-20.x as default\n    $ \u{1b}[1mmise use node@latest\u{1b}[22m           Use latest node in current directory\n\n    $ \u{1b}[1mmise up --interactive\u{1b}[22m          Show a menu to upgrade tools\n\n    $ \u{1b}[1mmise x -- npm install\u{1b}[22m          `npm install` w/ config loaded into PATH\n    $ \u{1b}[1mmise x node@20 -- node app.js\u{1b}[22m  `node app.js` w/ config + node-20.x on PATH\n\n    $ \u{1b}[1mmise set NODE_ENV=production\u{1b}[22m   Set NODE_ENV=production in config\n\n    $ \u{1b}[1mmise run build\u{1b}[22m                 Run `build` tasks\n    $ \u{1b}[1mmise watch build\u{1b}[22m               Run `build` tasks repeatedly when files change\n\n    $ \u{1b}[1mmise settings\u{1b}[22m                  Show settings in use\n    $ \u{1b}[1mmise settings color=0\u{1b}[22m          Disable color by modifying global config file\n"
 unknown_flags error
 default_subcommand run
@@ -74,7 +78,7 @@ flag "-v --verbose" help="Show extra output (use -vv for even more)" var=#true g
 }
 flag "-V --version" hide=#true
 flag "-y --yes" help="Answer yes to all confirmation prompts" global=#true
-flag --debug help="Sets log level to debug" hide=#true global=#true {
+flag --debug help="Set the log level to debug" hide=#true global=#true {
     overrides "--quiet" "--trace" "--verbose" "--silent" "--log-level"
 }
 flag --log-level hide=#true global=#true {
@@ -110,15 +114,15 @@ Do not execute hooks from config files
 Can also use `MISE_NO_HOOKS=1`
 """#
 }
-flag --no-timings help="Hides elapsed time after each task completes" hide=#true {
+flag --no-timings help="Hide the elapsed time printed after each task completes" hide=#true {
     alias "--no-timing" hide=#true
     long_help #"""
-Hides elapsed time after each task completes
+Hide the elapsed time printed after each task completes
 
-Default to always hide with `MISE_TASK_TIMINGS=0`
+Set `MISE_TASK_TIMINGS=0` to hide it by default
 """#
 }
-flag --output {
+flag --output help="How task output is displayed when running a task (same as `mise run --output`)" hide=#true {
     arg <OUTPUT>
 }
 flag --raw help="Read/write directly to stdin/stdout/stderr instead of by line" global=#true
@@ -134,15 +138,15 @@ Can also be enabled via MISE_LOCKED=1 or settings.locked=true
 flag --silent help="Suppress all task output and mise non-error messages" global=#true {
     overrides "--quiet" "--trace" "--verbose" "--debug" "--log-level"
 }
-flag --timings help="Shows elapsed time after each task completes" hide=#true {
+flag --timings help="Show the elapsed time after each task completes" hide=#true {
     alias "--timing" hide=#true
     long_help #"""
-Shows elapsed time after each task completes
+Show the elapsed time after each task completes
 
-Default to always show with `MISE_TASK_TIMINGS=1`
+Set `MISE_TASK_TIMINGS=1` to show it by default
 """#
 }
-flag --trace help="Sets log level to trace" hide=#true global=#true {
+flag --trace help="Set the log level to trace" hide=#true global=#true {
     overrides "--quiet" "--silent" "--verbose" "--debug" "--log-level"
 }
 flag "-h --help" help="Print help" action=help builtin=#true
@@ -212,12 +216,12 @@ case $cur in
     ;;
 esac
 """#
-cmd activate help="Initializes mise in the current shell session" effect=read {
+cmd activate help="Initialize mise in the current shell session" effect=read {
     long_help #"""
-Initializes mise in the current shell session
+Initialize mise in the current shell session
 
-This should go into your shell's rc file or login shell.
-Otherwise, it will only take effect in the current session.
+Add this to your shell's rc or profile file so it runs in every new shell.
+Otherwise, it only takes effect in the current session.
 (e.g. ~/.zshrc, ~/.zprofile, ~/.zshenv, ~/.bashrc, ~/.bash_profile, ~/.profile, ~/.config/fish/config.fish, or $PROFILE for powershell)
 
 Typically, this can be added with something like the following:
@@ -255,12 +259,10 @@ Do not automatically call hook-env
 This can be helpful for debugging mise. If you run `eval "$(mise activate --no-hook-env)"`, then you can call `mise hook-env` manually which will output the env vars to stdout without actually modifying the environment. That way you can do things like `mise hook-env --trace` to get more information or just see the values that hook-env is outputting.
 """#
     }
-    flag --shims help=#"""
-Use shims instead of modifying PATH
-Effectively the same as:
-"""# {
+    flag --shims help="Use shims instead of modifying PATH" {
         long_help #"""
 Use shims instead of modifying PATH
+
 Effectively the same as:
 
     PATH="$HOME/.local/share/mise/shims:$PATH"
@@ -285,7 +287,7 @@ See https://mise.jdx.dev/dev-tools/shims.html#shims-vs-path for more information
         }
     }
 }
-cmd tool-alias help="Manage tool version aliases." effect=read {
+cmd tool-alias help="Manage tool version aliases" effect=read {
     alias alias aliases
     flag "-p --tool" help="Filter aliases by tool" {
         alias "--plugin" hide=#true
@@ -304,18 +306,14 @@ This is the contents of a tool_alias.<TOOL> entry in ~/.config/mise/config.toml
         arg <TOOL> help="The tool to show the alias for"
         arg <ALIAS> help="The alias to show"
     }
-    cmd ls help=#"""
-List tool version aliases
-Shows the aliases that can be specified.
-These can come from user config or from plugins in `bin/list-aliases`.
-"""# effect=read {
+    cmd ls help="List tool version aliases" effect=read {
         alias list
         long_help #"""
 List tool version aliases
-Shows the aliases that can be specified.
-These can come from user config or from plugins in `bin/list-aliases`.
 
-For user config, aliases are defined like the following in `~/.config/mise/config.toml`:
+Aliases can be defined in user config or provided by plugins via `bin/list-aliases`.
+
+In user config, aliases are defined like the following in `~/.config/mise/config.toml`:
 
     [tool_alias.node.versions]
     lts = "22.0.0"
@@ -338,10 +336,10 @@ This modifies the contents of ~/.config/mise/config.toml
         arg <ALIAS> help="The alias to set"
         arg "[VALUE]" help="The value to set the alias to" required=#false
     }
-    cmd unset help="Clears an alias for a tool/backend" effect=write {
+    cmd unset help="Clear an alias for a tool/backend" effect=write {
         alias rm remove delete del
         long_help #"""
-Clears an alias for a tool/backend
+Clear an alias for a tool/backend
 
 This modifies the contents of ~/.config/mise/config.toml
 """#
@@ -684,12 +682,12 @@ edits require `--force`.
     }
     cmd launchd hide=#true subcommand_required=#true help="Manage macOS LaunchAgents from `[bootstrap.macos.launchd.agents]`" effect=read {
         flag "-h --help" help="Print help" action=help builtin=#true
-        cmd apply effect=write {
+        cmd apply help="Install and load LaunchAgents from `[bootstrap.macos.launchd.agents]`" effect=write {
             flag "-n --dry-run" help="Print the commands that would run without running them"
             flag "-y --yes" help="Skip the confirmation prompt"
             flag "-h --help" help="Print help" action=help builtin=#true
         }
-        cmd status effect=read {
+        cmd status help="Show the state of LaunchAgents from `[bootstrap.macos.launchd.agents]`" effect=read {
             flag "-J --json" help="Output in JSON format"
             flag --missing help="Exit with code 1 if any configured LaunchAgent is not in its desired state"
             flag "-h --help" help="Print help" action=help builtin=#true
@@ -700,12 +698,12 @@ edits require `--force`.
         cmd systemd-units subcommand_required=#true help="Manage systemd user services from `[bootstrap.linux.systemd.units]`" effect=read {
             alias systemd
             flag "-h --help" help="Print help" action=help builtin=#true
-            cmd apply effect=write {
+            cmd apply help="Install and start systemd user services from `[bootstrap.linux.systemd.units]`" effect=write {
                 flag "-n --dry-run" help="Print the commands that would run without running them"
                 flag "-y --yes" help="Skip the confirmation prompt"
                 flag "-h --help" help="Print help" action=help builtin=#true
             }
-            cmd status effect=read {
+            cmd status help="Show the state of systemd user services from `[bootstrap.linux.systemd.units]`" effect=read {
                 flag "-J --json" help="Output in JSON format"
                 flag --missing help="Exit with code 1 if any configured systemd user service is not in its desired state"
                 flag "-h --help" help="Print help" action=help builtin=#true
@@ -716,12 +714,12 @@ edits require `--force`.
         flag "-h --help" help="Print help" action=help builtin=#true
         cmd defaults subcommand_required=#true help="Manage macOS defaults from `[bootstrap.macos.defaults]`" effect=read {
             flag "-h --help" help="Print help" action=help builtin=#true
-            cmd apply effect=write {
+            cmd apply help="Write macOS defaults from `[bootstrap.macos.defaults]`" effect=write {
                 flag "-n --dry-run" help="Print the commands that would run without running them"
                 flag "-y --yes" help="Skip the confirmation prompt"
                 flag "-h --help" help="Print help" action=help builtin=#true
             }
-            cmd status effect=read {
+            cmd status help="Show whether macOS defaults match `[bootstrap.macos.defaults]`" effect=read {
                 flag "-J --json" help="Output in JSON format"
                 flag --missing help="Exit with code 1 if any configured defaults are not in their desired state"
                 flag "-h --help" help="Print help" action=help builtin=#true
@@ -730,12 +728,12 @@ edits require `--force`.
         cmd launchd-agents subcommand_required=#true help="Manage macOS LaunchAgents from `[bootstrap.macos.launchd.agents]`" effect=read {
             alias launchd
             flag "-h --help" help="Print help" action=help builtin=#true
-            cmd apply effect=write {
+            cmd apply help="Install and load LaunchAgents from `[bootstrap.macos.launchd.agents]`" effect=write {
                 flag "-n --dry-run" help="Print the commands that would run without running them"
                 flag "-y --yes" help="Skip the confirmation prompt"
                 flag "-h --help" help="Print help" action=help builtin=#true
             }
-            cmd status effect=read {
+            cmd status help="Show the state of LaunchAgents from `[bootstrap.macos.launchd.agents]`" effect=read {
                 flag "-J --json" help="Output in JSON format"
                 flag --missing help="Exit with code 1 if any configured LaunchAgent is not in its desired state"
                 flag "-h --help" help="Print help" action=help builtin=#true
@@ -744,12 +742,12 @@ edits require `--force`.
     }
     cmd macos-defaults hide=#true subcommand_required=#true help="Manage macOS defaults from `[bootstrap.macos.defaults]`" effect=read {
         flag "-h --help" help="Print help" action=help builtin=#true
-        cmd apply effect=write {
+        cmd apply help="Write macOS defaults from `[bootstrap.macos.defaults]`" effect=write {
             flag "-n --dry-run" help="Print the commands that would run without running them"
             flag "-y --yes" help="Skip the confirmation prompt"
             flag "-h --help" help="Print help" action=help builtin=#true
         }
-        cmd status effect=read {
+        cmd status help="Show whether macOS defaults match `[bootstrap.macos.defaults]`" effect=read {
             flag "-J --json" help="Output in JSON format"
             flag --missing help="Exit with code 1 if any configured defaults are not in their desired state"
             flag "-h --help" help="Print help" action=help builtin=#true
@@ -758,12 +756,12 @@ edits require `--force`.
     cmd mise-shell-activate subcommand_required=#true help="Manage mise shell activation from `[bootstrap.mise_shell_activate]`" effect=read {
         alias shell
         flag "-h --help" help="Print help" action=help builtin=#true
-        cmd apply effect=write {
+        cmd apply help="Configure shell activation from `[bootstrap.mise_shell_activate]`" effect=write {
             flag "-n --dry-run" help="Print the actions that would run without writing anything"
             flag "-y --yes" help="Skip the confirmation prompt"
             flag "-h --help" help="Print help" action=help builtin=#true
         }
-        cmd status effect=read {
+        cmd status help="Show whether shell activation matches `[bootstrap.mise_shell_activate]`" effect=read {
             flag "-J --json" help="Output in JSON format"
             flag --missing help="Exit with code 1 if any configured shell activation is not in its desired state"
             flag "-h --help" help="Print help" action=help builtin=#true
@@ -942,11 +940,11 @@ a mise version selector. mas uses numeric ADAM IDs and does not support pins.
     }
     cmd plugins subcommand_required=#true help="Manage package manager plugins declared in `[bootstrap.plugins]`" effect=read {
         flag "-h --help" help="Print help" action=help builtin=#true
-        cmd apply effect=write {
+        cmd apply help="Install package manager plugins declared in `[bootstrap.plugins]`" effect=write {
             flag "-n --dry-run" help="Print what would happen without installing plugins"
             flag "-h --help" help="Print help" action=help builtin=#true
         }
-        cmd status effect=read {
+        cmd status help="Show whether declared package manager plugins are installed" effect=read {
             flag --missing help="Exit with code 1 if a declared plugin is missing"
             flag "-h --help" help="Print help" action=help builtin=#true
         }
@@ -1084,25 +1082,25 @@ Defaults to `~/.local/bin/mise`; pass `--install-mise=<PATH>` for another path.
     }
     cmd repos subcommand_required=#true help="Manage git repo checkouts from `[bootstrap.repos]`" effect=read {
         flag "-h --help" help="Print help" action=help builtin=#true
-        cmd apply effect=write {
+        cmd apply help="Clone and converge git repos from `[bootstrap.repos]`" effect=write {
             flag "-n --dry-run" help="Print the commands that would run without running them"
             flag "-y --yes" help="Skip the confirmation prompt"
             flag --skip-dirty help="Skip repos with local changes instead of failing"
             flag "-h --help" help="Print help" action=help builtin=#true
         }
-        cmd exec {
+        cmd exec help="Run a command in each configured git repo" {
             flag "-c --continue-on-error" help="Continue running in other repos after a command fails"
             flag "-n --dry-run" help="Print the commands that would run without running them"
             flag "-h --help" help="Print help" action=help builtin=#true
             arg "[PATH]…" help="Run only in matching configured or expanded paths" required=#false var=#true
             arg "<-- COMMAND>…" help="Command and arguments to run in each repo" var=#true
         }
-        cmd status effect=read {
+        cmd status help="Show the state of git repos from `[bootstrap.repos]`" effect=read {
             flag "-J --json" help="Output in JSON format"
             flag --missing help="Exit with code 1 if any configured repo is not in its desired state"
             flag "-h --help" help="Print help" action=help builtin=#true
         }
-        cmd update effect=write {
+        cmd update help="Pull the latest changes into configured git repos" effect=write {
             flag "-n --dry-run" help="Print the commands that would run without running them"
             flag "-y --yes" help="Skip the confirmation prompt"
             flag --skip-dirty help="Skip repos with local changes instead of failing"
@@ -1140,12 +1138,12 @@ Defaults to `~/.local/bin/mise`; pass `--install-mise=<PATH>` for another path.
     }
     cmd systemd hide=#true subcommand_required=#true help="Manage systemd user services from `[bootstrap.linux.systemd.units]`" effect=read {
         flag "-h --help" help="Print help" action=help builtin=#true
-        cmd apply effect=write {
+        cmd apply help="Install and start systemd user services from `[bootstrap.linux.systemd.units]`" effect=write {
             flag "-n --dry-run" help="Print the commands that would run without running them"
             flag "-y --yes" help="Skip the confirmation prompt"
             flag "-h --help" help="Print help" action=help builtin=#true
         }
-        cmd status effect=read {
+        cmd status help="Show the state of systemd user services from `[bootstrap.linux.systemd.units]`" effect=read {
             flag "-J --json" help="Output in JSON format"
             flag --missing help="Exit with code 1 if any configured systemd user service is not in its desired state"
             flag "-h --help" help="Print help" action=help builtin=#true
@@ -1153,12 +1151,12 @@ Defaults to `~/.local/bin/mise`; pass `--install-mise=<PATH>` for another path.
     }
     cmd user subcommand_required=#true help="Manage current-user bootstrap settings from `[bootstrap.user]`" effect=read {
         flag "-h --help" help="Print help" action=help builtin=#true
-        cmd apply effect=write {
+        cmd apply help="Apply current-user settings from `[bootstrap.user]`" effect=write {
             flag "-n --dry-run" help="Print the commands that would run without running them"
             flag "-y --yes" help="Skip the confirmation prompt"
             flag "-h --help" help="Print help" action=help builtin=#true
         }
-        cmd status effect=read {
+        cmd status help="Show whether current-user settings match `[bootstrap.user]`" effect=read {
             flag "-J --json" help="Output in JSON format"
             flag --missing help="Exit with code 1 if any configured user setting is not in its desired state"
             flag "-h --help" help="Print help" action=help builtin=#true
@@ -1172,7 +1170,7 @@ Manage the mise cache
 Run `mise cache` with no args to view the current cache directory.
 """#
     flag "-h --help" help="Print help" action=help builtin=#true
-    cmd clear help="Deletes all cache files in mise" effect=write {
+    cmd clear help="Delete all cache files" effect=write {
         alias c clean
         flag --outdate help="Mark all cache files as old" hide=#true
         flag --task help="Clear output cache entries for a task name or pattern" {
@@ -1186,16 +1184,16 @@ Run `mise cache` with no args to view the current cache directory.
         alias dir
         flag "-h --help" help="Print help" action=help builtin=#true
     }
-    cmd prune help="Removes stale mise cache files" effect=write {
+    cmd prune help="Remove stale cache files" effect=write {
         alias p
         long_help #"""
-Removes stale mise cache files
+Remove stale cache files
 
 By default, this command will remove files that have not been accessed in 30 days.
 Change this with the MISE_CACHE_PRUNE_AGE environment variable.
 """#
         flag "-v --verbose" help="Show pruned files" var=#true count=#true
-        flag --dry-run help="Just show what would be pruned"
+        flag --dry-run help="Show what would be pruned without deleting anything"
         flag "-h --help" help="Print help" action=help builtin=#true
         arg "[TOOL]…" help="Tool(s) to prune cache for e.g.: node, python" required=#false var=#true
     }
@@ -1264,7 +1262,7 @@ cmd config help="Manage config files" effect=read {
     }
     flag --tracked-configs help="List all tracked config files"
     flag "-h --help" help="Print help" action=help builtin=#true
-    cmd get help="Display the value of a setting in a mise.toml file" effect=read {
+    cmd get help="Display a value from a mise.toml file" effect=read {
         after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise toml get tools.python\u{1b}[22m\n    3.12\n"
         flag "-f --file --path" help="The path to the mise.toml file to read" {
             long_help #"""
@@ -1283,7 +1281,7 @@ If not provided, the nearest mise.toml file will be used
             conflicts "--file" "--global"
         }
         flag "-h --help" help="Print help" action=help builtin=#true
-        arg "[KEY]" help="The path of the config to display" required=#false
+        arg "[KEY]" help="Dotted key path to display, e.g. `tools.python`; omit to print the whole file" required=#false
         complete file type=path
     }
     cmd ls help="List config files currently in use" effect=read {
@@ -1296,7 +1294,7 @@ If not provided, the nearest mise.toml file will be used
         flag --tracked-configs help="List all tracked config files"
         flag "-h --help" help="Print help" action=help builtin=#true
     }
-    cmd set help="Set the value of a setting in a mise.toml file" effect=write {
+    cmd set help="Set a value in a mise.toml file" effect=write {
         after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise config set tools.python 3.12\u{1b}[22m\n    $ \u{1b}[1mmise config set settings.always_keep_download true\u{1b}[22m\n    $ \u{1b}[1mmise config set env.TEST_ENV_VAR ABC\u{1b}[22m\n    $ \u{1b}[1mmise config set settings.disable_tools node,rust\u{1b}[22m\n    $ \u{1b}[1mmise config set --append env._.path ~/.local/bin\u{1b}[22m\n    $ \u{1b}[1mmise config set --remove env._.path ~/.local/bin\u{1b}[22m\n\n    # Type for `settings` is inferred\n    $ \u{1b}[1mmise config set settings.jobs 4\u{1b}[22m\n"
         flag "-f --file --path" help="The path to the mise.toml file to edit" {
             long_help #"""
@@ -1316,7 +1314,7 @@ If not provided, the nearest mise.toml file will be used
         }
         flag --append help="Append the value without duplicating an existing entry." conflicts=--remove
         flag --remove help="Remove the value from an existing collection." conflicts=--append
-        flag "-t --type" default=infer {
+        flag "-t --type" help="TOML type to store the value as; inferred from the value by default" default=infer {
             arg <TYPE> {
                 choices {
                     choice infer
@@ -1330,7 +1328,7 @@ If not provided, the nearest mise.toml file will be used
             }
         }
         flag "-h --help" help="Print help" action=help builtin=#true
-        arg <KEY> help="The path of the config to display"
+        arg <KEY> help="Dotted key path to set, e.g. `tools.python`"
         arg "[VALUE]" help="The value to set the key to (optional if provided as KEY=VALUE)" required=#false
         complete file type=path
     }
@@ -1496,7 +1494,7 @@ edits require `--force`.
 cmd doctor help="Check mise installation for possible problems" effect=read {
     alias dr
     after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise doctor\u{1b}[22m\n    [WARN] plugin node is not installed\n"
-    flag "-J --json"
+    flag "-J --json" help="Output in JSON format"
     flag "-h --help" help="Print help" action=help builtin=#true
     cmd path help="Print the current PATH entries mise is providing" effect=read {
         alias paths
@@ -1505,13 +1503,13 @@ cmd doctor help="Check mise installation for possible problems" effect=read {
         flag "-h --help" help="Print help" action=help builtin=#true
     }
 }
-cmd en help="Starts a new shell with the mise environment built from the current configuration" {
+cmd en help="Start a new shell with the mise environment built from the current configuration" {
     long_help #"""
-Starts a new shell with the mise environment built from the current configuration
+Start a new shell with the mise environment built from the current configuration
 
-This is an alternative to `mise activate` that allows you to explicitly start a mise session.
-It will have the tools and environment variables in the configs loaded.
-Note that changing directories will not update the mise environment.
+This is an alternative to `mise activate` for starting a mise session explicitly.
+The new shell has the tools and environment variables from the config loaded.
+Unlike an activated shell, changing directories does not update the environment.
 """#
     after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise en .\u{1b}[22m\n    $ \u{1b}[1mnode -v\u{1b}[22m\n    v20.0.0\n\n    Skip loading bashrc:\n    $ \u{1b}[1mmise en -s \"bash --norc\"\u{1b}[22m\n\n    Skip loading zshrc:\n    $ \u{1b}[1mmise en -s \"zsh -f\"\u{1b}[22m\n"
     flag "-s --shell" help="Shell to start" {
@@ -1526,13 +1524,13 @@ Defaults to $SHELL
     arg "[DIR]" help="Directory to start the shell in" required=#false default=.
     complete dir type=dir
 }
-cmd env help="Exports env vars to activate mise a single time" effect=read {
+cmd env help="Export env vars to activate mise a single time" effect=read {
     alias e
     long_help #"""
-Exports env vars to activate mise a single time
+Export env vars to activate mise a single time
 
-Use this if you don't want to permanently install mise. It's not necessary to
-use this if you have `mise activate` in your shell rc file.
+Use this to load the environment into one shell without adding `mise activate` to
+your shell rc file. It is not needed in shells where mise is already activated.
 """#
     after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1meval \"$(mise env -s bash)\"\u{1b}[22m\n    $ \u{1b}[1meval \"$(mise env -s zsh)\"\u{1b}[22m\n    $ \u{1b}[1mmise env -s fish | source\u{1b}[22m\n    $ \u{1b}[1mexecx($(mise env -s xonsh))\u{1b}[22m\n"
     flag "-D --dotenv" help="Output in dotenv format" overrides=--shell
@@ -1556,20 +1554,21 @@ use this if you have `mise activate` in your shell rc file.
     flag --redacted help="Only show redacted environment variables"
     flag --values help="Only show values of environment variables"
     flag "-h --help" help="Print help" action=help builtin=#true
-    arg "[TOOL@VERSION]…" help="Tool(s) to use" required=#false var=#true
+    arg "[TOOL@VERSION]…" help="Tool(s) to include in addition to those in config, e.g. node@20" required=#false var=#true
 }
 cmd exec help="Execute a command with tool(s) set" {
     alias x
     long_help #"""
 Execute a command with tool(s) set
 
-use this to avoid modifying the shell session or running ad-hoc commands with mise tools set.
+Use this to run a command with mise's tools and environment without modifying the shell
+session, or to run ad-hoc commands with tools that are not in the config.
 
-Tools will be loaded from mise.toml, though they can be overridden with <RUNTIME> args
-Note that only the plugin specified will be overridden, so if a `mise.toml` file
-includes "node 20" but you run `mise exec python@3.11`; it will still load node@20.
+Tools are loaded from mise.toml and can be overridden with <TOOL@VERSION> args. Only the
+tools you name are overridden: if `mise.toml` includes `node = "20"` and you run
+`mise exec python@3.11`, node@20 is still loaded.
 
-The "--" separates runtimes from the commands to pass along to the subprocess.
+The "--" separates tools from the command to pass along to the subprocess.
 """#
     after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise exec node@20 -- node ./app.js\u{1b}[22m  # launch app.js using node-20.x\n    $ \u{1b}[1mmise x node@20 -- node ./app.js\u{1b}[22m     # shorter alias\n\n    # Specify command as a string:\n    $ \u{1b}[1mmise exec node@20 python@3.11 --command \"node -v && python -V\"\u{1b}[22m\n\n    # Run a command in a different directory:\n    $ \u{1b}[1mmise x -C /path/to/project node@20 -- node ./app.js\u{1b}[22m\n"
     flag "-c --command" help="Command string to execute" conflicts=COMMAND {
@@ -1578,7 +1577,7 @@ The "--" separates runtimes from the commands to pass along to the subprocess.
     flag "-j --jobs" help=#"""
 Number of jobs to run in parallel
 Values below 1 are treated as 1
-[default: 4]
+Defaults to the `jobs` setting
 """# env=MISE_JOBS {
         arg <JOBS>
     }
@@ -1607,21 +1606,21 @@ macOS only in v1; on Linux falls back to allowing all network
     flag --deny-write help="Block all filesystem writes"
     flag --fresh-env help="Bypass the environment cache and recompute the environment"
     flag --no-deps help="Skip automatic dependency preparation"
-    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1" overrides=--jobs
+    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal. Implies `--jobs=1`" overrides=--jobs
     flag "-h --help" help="Print help" action=help builtin=#true
-    arg "[TOOL@VERSION]…" help="Tool(s) to start e.g.: node@20 python@3.10" required=#false var=#true
+    arg "[TOOL@VERSION]…" help="Tool(s) to load e.g.: node@20 python@3.10" required=#false var=#true
     arg "[-- COMMAND]…" help="Command string to execute (same as --command)" required=#false var=#true conflicts=--command required_unless=--command
     complete command type=command
 }
-cmd fmt help="Formats mise.toml" effect=write {
+cmd fmt help="Format mise.toml" effect=write {
     long_help #"""
-Formats mise.toml
+Format mise.toml
 
 Sorts keys and cleans up whitespace in mise.toml
 """#
     after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise fmt\u{1b}[22m\n"
-    flag "-a --all" help="Format all files from the current directory"
-    flag "-c --check" help="Check if the configs are formatted, no formatting is done"
+    flag "-a --all" help="Format every config file mise currently loads, not just those in the current directory"
+    flag "-c --check" help="Check whether the configs are formatted without rewriting them; exits 1 if any are not"
     flag "-s --stdin" help="Read config from stdin and write its formatted version into stdout"
     flag "-h --help" help="Print help" action=help builtin=#true
 }
@@ -1638,9 +1637,9 @@ Renamed from `mise generate bootstrap`, which read as a form of `mise bootstrap`
 setup). The old name still works but is deprecated and will be removed in mise 2027.9.0.
 """#
         after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise generate install-script --write ./bin/mise\u{1b}[22m\n    $ \u{1b}[1m./bin/mise install\u{1b}[22m                                    \u{1b}[2m# downloads mise to .mise if not already installed\u{1b}[22m\n\n    \u{1b}[2m# add a launcher for contributors who clone the project on Windows\u{1b}[22m\n    $ \u{1b}[1mmise generate install-script --write ./bin/mise --windows\u{1b}[22m  \u{1b}[2m# also writes bin/mise.cmd\u{1b}[22m\n    $ \u{1b}[1m.\\bin\\mise.cmd install\u{1b}[22m\n"
-        flag "-l --localize" help="Sandboxes mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project" {
+        flag "-l --localize" help="Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project" {
             long_help #"""
-Sandboxes mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project
+Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project
 
 This is necessary if users may use a different version of mise outside the project.
 """#
@@ -1648,7 +1647,7 @@ This is necessary if users may use a different version of mise outside the proje
         flag "-V --version" help="Specify mise version to fetch" {
             arg <VERSION>
         }
-        flag "-w --write" help="instead of outputting the script to stdout, write to a file and make it executable" value_optional=#true default_missing="./bin/mise" {
+        flag "-w --write" help="Write the script to a file and make it executable instead of printing it to stdout" value_optional=#true default_missing="./bin/mise" {
             arg "[WRITE]" required=#false var_min=0 var_max=1
         }
         flag --localized-dir help="Directory to put localized data into" default=.mise {
@@ -1690,7 +1689,7 @@ carry two files.
         flag "-n --name" help="The name of the devcontainer" {
             arg <NAME>
         }
-        flag "-w --write" help="write to .devcontainer/devcontainer.json"
+        flag "-w --write" help="Write to .devcontainer/devcontainer.json"
         flag "-h --help" help="Print help" action=help builtin=#true
     }
     cmd git-pre-commit help="Generate a git pre-commit hook" effect=write {
@@ -1709,7 +1708,7 @@ For more advanced pre-commit functionality, see mise's sister project: https://h
         flag "-t --task" help="The task to run when the pre-commit hook is triggered" default=pre-commit {
             arg <TASK>
         }
-        flag "-w --write" help="write to .git/hooks/pre-commit and make it executable"
+        flag "-w --write" help="Write to .git/hooks/pre-commit and make it executable"
         flag --hook help="Which hook to generate (saves to .git/hooks/$hook)" default=pre-commit {
             arg <HOOK>
         }
@@ -1733,8 +1732,8 @@ when you push changes to your repository.
         flag "-t --task" help="The task to run when the workflow is triggered" default=ci {
             arg <TASK>
         }
-        flag "-w --write" help="write to .github/workflows/$name.yml"
-        flag --name help="the name of the workflow to generate" default=ci {
+        flag "-w --write" help="Write to .github/workflows/$name.yml"
+        flag --name help="The name of the workflow to generate" default=ci {
             arg <NAME>
         }
         flag "-h --help" help="Print help" action=help builtin=#true
@@ -1749,9 +1748,9 @@ Renamed from `mise generate bootstrap`, which read as a form of `mise bootstrap`
 setup). The old name still works but is deprecated and will be removed in mise 2027.9.0.
 """#
         after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise generate install-script --write ./bin/mise\u{1b}[22m\n    $ \u{1b}[1m./bin/mise install\u{1b}[22m                                    \u{1b}[2m# downloads mise to .mise if not already installed\u{1b}[22m\n\n    \u{1b}[2m# add a launcher for contributors who clone the project on Windows\u{1b}[22m\n    $ \u{1b}[1mmise generate install-script --write ./bin/mise --windows\u{1b}[22m  \u{1b}[2m# also writes bin/mise.cmd\u{1b}[22m\n    $ \u{1b}[1m.\\bin\\mise.cmd install\u{1b}[22m\n"
-        flag "-l --localize" help="Sandboxes mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project" {
+        flag "-l --localize" help="Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project" {
             long_help #"""
-Sandboxes mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project
+Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project
 
 This is necessary if users may use a different version of mise outside the project.
 """#
@@ -1759,7 +1758,7 @@ This is necessary if users may use a different version of mise outside the proje
         flag "-V --version" help="Specify mise version to fetch" {
             arg <VERSION>
         }
-        flag "-w --write" help="instead of outputting the script to stdout, write to a file and make it executable" value_optional=#true default_missing="./bin/mise" {
+        flag "-w --write" help="Write the script to a file and make it executable instead of printing it to stdout" value_optional=#true default_missing="./bin/mise" {
             arg "[WRITE]" required=#false var_min=0 var_max=1
         }
         flag --localized-dir help="Directory to put localized data into" default=.mise {
@@ -1782,9 +1781,9 @@ carry two files.
     }
     cmd task-docs help="Generate documentation for tasks in a project" effect=write {
         after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise generate task-docs\u{1b}[22m\n"
-        flag "-i --inject" help="inserts the documentation into an existing file" {
+        flag "-i --inject" help="Insert the documentation into an existing file" {
             long_help #"""
-inserts the documentation into an existing file
+Insert the documentation into an existing file
 
 This will look for a special comment, `<!-- mise-tasks -->`, and replace it with the generated documentation.
 It will replace everything between the comment and the next comment, `<!-- /mise-tasks -->` so it can be
@@ -1792,15 +1791,15 @@ run multiple times on the same file to update the documentation.
 The file must already contain both comments; mise errors instead of modifying the file if they are missing.
 """#
         }
-        flag "-I --index" help="write only an index of tasks, intended for use with `--multi`"
-        flag "-m --multi" help="render each task as a separate document, requires `--output` to be a directory"
-        flag "-o --output" help="writes the generated docs to a file/directory" {
+        flag "-I --index" help="Write only an index of tasks, intended for use with `--multi`"
+        flag "-m --multi" help="Render each task as a separate document; requires `--output` to be a directory"
+        flag "-o --output" help="Write the generated docs to a file or directory" {
             arg <OUTPUT>
         }
-        flag "-r --root" help="root directory to search for tasks" {
+        flag "-r --root" help="Root directory to search for tasks" {
             arg <ROOT>
         }
-        flag "-s --style" default=simple {
+        flag "-s --style" help="Documentation style: `simple` lists tasks, `detailed` documents each task's usage" default=simple {
             arg <STYLE> {
                 choices {
                     choice simple
@@ -1811,9 +1810,9 @@ The file must already contain both comments; mise errors instead of modifying th
         flag "-h --help" help="Print help" action=help builtin=#true
         complete root type=dir
     }
-    cmd task-stubs help="Generates shims to run mise tasks" effect=write {
+    cmd task-stubs help="Generate shims to run mise tasks" effect=write {
         long_help #"""
-Generates shims to run mise tasks
+Generate shims to run mise tasks
 
 By default, this will build shims like ./bin/<task>. These can be paired with `mise generate install-script`
 so contributors to a project can execute mise tasks without installing mise into their system.
@@ -2065,11 +2064,11 @@ cmd hook-not-found hide=#true help="[internal] called by shell when a command is
     flag "-h --help" help="Print help" action=help builtin=#true
     arg <BIN> help="Attempted bin to run"
 }
-cmd implode help="Removes mise CLI and all related data" effect=destructive {
+cmd implode help="Remove the mise CLI and all related data" effect=destructive {
     long_help #"""
-Removes mise CLI and all related data
+Remove the mise CLI and all related data
 
-Skips config directory by default.
+The config directory is kept unless `--config` is passed.
 """#
     flag "-n --dry-run" help="List directories that would be removed without actually removing them"
     flag --config help="Also remove config directory"
@@ -2092,15 +2091,15 @@ cmd install help="Install a tool version" effect=write {
     long_help #"""
 Install a tool version
 
-Installs a tool version to `~/.local/share/mise/installs/<TOOL>/<VERSION>`
-Installing alone will not activate the tools so they won't be in PATH.
-To install and/or activate in one command, use `mise use` which will create a `mise.toml` file
-in the current directory to activate this tool when inside the directory.
-Alternatively, run `mise exec <TOOL>@<VERSION> -- <COMMAND>` to execute a tool without creating config files.
+Installs a tool version to `~/.local/share/mise/installs/<TOOL>/<VERSION>`.
+Installing alone does not activate the tool, so it will not be on PATH.
+To install and activate in one command, use `mise use`, which also writes the version to
+`mise.toml` in the current directory so the tool is active inside it.
+To run a tool once without touching any config, use `mise exec <TOOL>@<VERSION> -- <COMMAND>`.
 
-Tools will be installed in parallel. To disable, set `--jobs=1` or `MISE_JOBS=1`
+Tools are installed in parallel. To disable, set `--jobs=1` or `MISE_JOBS=1`.
 """#
-    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise install node@20.0.0\u{1b}[22m  # install specific node version\n    $ \u{1b}[1mmise install node@20\u{1b}[22m      # install fuzzy node version\n    $ \u{1b}[1mmise install node\u{1b}[22m         # install version specified in mise.toml\n    $ \u{1b}[1mmise install\u{1b}[22m              # installs everything specified in mise.toml\n    $ \u{1b}[1mmise install --include-lazy\u{1b}[22m # also install tools configured for lazy installation\n    $ \u{1b}[1mmise install --include-task-tools\u{1b}[22m # also install tools required by tasks\n"
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise install node@20.0.0\u{1b}[22m  # install a specific node version\n    $ \u{1b}[1mmise install node@20\u{1b}[22m      # install the latest node 20.x\n    $ \u{1b}[1mmise install node\u{1b}[22m         # install the version specified in mise.toml\n    $ \u{1b}[1mmise install\u{1b}[22m              # install everything specified in mise.toml\n    $ \u{1b}[1mmise install --include-lazy\u{1b}[22m # also install tools configured for lazy installation\n    $ \u{1b}[1mmise install --include-task-tools\u{1b}[22m # also install tools required by tasks\n"
     flag "-f --force" help=#"""
 Force reinstall even if already installed
 With no tools specified, reinstall all configured tools
@@ -2108,7 +2107,7 @@ With no tools specified, reinstall all configured tools
     flag "-j --jobs" help=#"""
 Number of jobs to run in parallel
 Values below 1 are treated as 1
-[default: 4]
+Defaults to the `jobs` setting
 """# env=MISE_JOBS {
         arg <JOBS>
     }
@@ -2159,7 +2158,7 @@ Uses the active MISE_ENV and requires monorepo_root = true plus explicit
 [monorepo].config_roots in the monorepo root config.
 """#
     }
-    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1" overrides=--jobs
+    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal. Implies `--jobs=1`" overrides=--jobs
     flag --shared help="Install tool(s) to a shared directory" conflicts=--system {
         long_help #"""
 Install tool(s) to a shared directory
@@ -2193,9 +2192,9 @@ Used for building a tool to a directory for use outside of mise
     arg <PATH> help="Path to install the tool into"
     complete path type=dir
 }
-cmd latest help="Gets the latest available version for a plugin" effect=read {
+cmd latest help="Get the latest available version of a tool" effect=read {
     long_help #"""
-Gets the latest available version for a plugin
+Get the latest available version of a tool
 
 Supports prefixes such as `node@20` to get the latest version of node 20.
 """#
@@ -2215,12 +2214,12 @@ Overrides per-tool `minimum_release_age` options and the global `minimum_release
     arg <TOOL@VERSION> help="Tool to get the latest version of"
     arg "[ASDF_VERSION]" help="The version prefix to use when querying the latest version same as the first argument after the \"@\" used for asdf compatibility" required=#false hide=#true
 }
-cmd link help="Symlinks a tool version into mise" effect=write {
+cmd link help="Symlink a tool version into mise" effect=write {
     alias ln
     long_help #"""
-Symlinks a tool version into mise
+Symlink a tool version into mise
 
-Use this for adding installs either custom compiled outside mise or built with a different tool.
+Use this to register an install that was compiled by hand or built with another tool.
 """#
     after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # build node-20.0.0 with node-build and link it into mise\n    $ \u{1b}[1mnode-build 20.0.0 ~/.nodes/20.0.0\u{1b}[22m\n    $ \u{1b}[1mmise link node@20.0.0 ~/.nodes/20.0.0\u{1b}[22m\n\n    # have mise use the node version provided by Homebrew\n    $ \u{1b}[1mbrew install node\u{1b}[22m\n    $ \u{1b}[1mmise link node@brew $(brew --prefix node)\u{1b}[22m\n    $ \u{1b}[1mmise use node@brew\u{1b}[22m\n"
     flag "-f --force" help="Overwrite an existing tool version if it exists"
@@ -2359,11 +2358,8 @@ cmd ls help="List installed and active tool versions" effect=read {
     long_help #"""
 List installed and active tool versions
 
-This command lists tools that mise "knows about".
-These may be tools that are currently installed, or those
-that are in a config file (active) but may or may not be installed.
-
-It's a useful command to get the current state of your tools.
+Lists the tools mise knows about: versions that are installed, and versions requested
+by a config file (active) whether or not they are installed.
 """#
     after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise ls\u{1b}[22m\n    node    20.0.0 ~/src/myapp/.tool-versions latest\n    python  3.11.0 ~/.tool-versions           3.10\n    python  3.10.0\n\n    $ \u{1b}[1mmise ls --current\u{1b}[22m\n    node    20.0.0 ~/src/myapp/.tool-versions 20\n    python  3.11.0 ~/.tool-versions           3.11.0\n\n    $ \u{1b}[1mmise ls --json\u{1b}[22m\n    {\n      \"node\": [\n        {\n          \"version\": \"20.0.0\",\n          \"install_path\": \"/Users/jdx/.mise/installs/node/20.0.0\",\n          \"source\": {\n            \"type\": \"mise.toml\",\n            \"path\": \"/Users/jdx/mise.toml\"\n          }\n        }\n      ],\n      \"python\": [...]\n    }\n\n    $ \u{1b}[1mmise ls --all-sources\u{1b}[22m\n    node    20.0.0  ~/src/myapp/mise.toml  20\n                    ~/.config/mise/config.toml  latest\n"
     flag "-c --current" help="Only show tool versions currently specified in a mise.toml"
@@ -2399,12 +2395,12 @@ Uses the active MISE_ENV and requires monorepo_root = true plus explicit
     flag "-h --help" help="Print help" action=help builtin=#true
     arg "[INSTALLED_TOOL]…" help="Only show tool versions from [TOOL]" required=#false var=#true conflicts=--plugin
 }
-cmd ls-remote help="List runtime versions available for install." effect=read {
+cmd ls-remote help="List tool versions available to install" effect=read {
     alias list-all list-remote
     long_help #"""
-List runtime versions available for install.
+List tool versions available to install
 
-Note that the results may be cached, run `mise cache clean` to clear the cache and get fresh results.
+Results may be cached; run `mise cache clear` to fetch fresh results.
 """#
     after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise ls-remote node\u{1b}[22m\n    18.0.0\n    20.0.0\n\n    $ \u{1b}[1mmise ls-remote node@20\u{1b}[22m\n    20.0.0\n    20.1.0\n\n    $ \u{1b}[1mmise ls-remote node 20\u{1b}[22m\n    20.0.0\n    20.1.0\n\n    $ \u{1b}[1mmise ls-remote node --minimum-release-age 2024-01-01\u{1b}[22m\n    20.0.0\n\n    $ \u{1b}[1mmise ls-remote github:cli/cli --json\u{1b}[22m\n    [{\"version\":\"2.62.0\",\"created_at\":\"2024-11-14T15:40:35Z\",\"prerelease\":false},{\"version\":\"2.61.0\",\"created_at\":\"2024-10-23T19:22:15Z\",\"prerelease\":false}]\n"
     flag --all help="Show all installed plugins and versions" {
@@ -2683,21 +2679,19 @@ Note: unlike `docker run -v`, there's no `-v` short flag here because mise reser
         complete image_dir type=dir
     }
 }
-cmd outdated help="Shows outdated tool versions" effect=read {
+cmd outdated help="Show outdated tool versions" effect=read {
     long_help #"""
-Shows outdated tool versions
+Show outdated tool versions
 
 See `mise upgrade` to upgrade these versions.
 """#
     after_long_help "\u{1b}[1m\u{1b}[4mDeprecation:\u{1b}[22m\u{1b}[24m\n\nThe `-l` shorthand for `--bump` is deprecated and will be removed in mise 2027.8.5.\nAfter removal, `-l` will become shorthand for `--local`. Use `-b` or `--bump` instead.\n\n\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise outdated\u{1b}[22m\n    Plugin  Requested  Current  Latest\n    python  3.11       3.11.0   3.11.1\n    node    20         20.0.0   20.1.0\n\n    $ \u{1b}[1mmise outdated node\u{1b}[22m\n    Plugin  Requested  Current  Latest\n    node    20         20.0.0   20.1.0\n\n    $ \u{1b}[1mmise outdated --json\u{1b}[22m\n    {\"python\": {\"requested\": \"3.11\", \"current\": \"3.11.0\", \"latest\": \"3.11.1\"}, ...}\n\n    $ \u{1b}[1mmise outdated --local\u{1b}[22m\n    Plugin  Requested  Current  Latest\n    node    20         20.0.0   20.1.0\n"
-    flag "-b --bump" help="Compares against the latest versions available, not what matches the current config" {
+    flag "-b --bump" help="Compare against the latest versions available, not just those matching the current config" {
         long_help #"""
-Compares against the latest versions available, not what matches the current config
+Compare against the latest versions available, not just those matching the current config
 
-For example, if you have `node = "20"` in your config by default `mise outdated` will only
-show other 20.x versions, not 21.x or 22.x versions.
-
-Using this flag, if there are 21.x or newer versions it will display those instead of 20.x.
+For example, with `node = "20"` in your config, `mise outdated` normally only reports newer
+20.x versions. With this flag it reports the newest version overall, such as 22.x.
 """#
     }
     flag "-J --json" help="Output in JSON format"
@@ -2743,16 +2737,16 @@ To appear here, become a patron at <https://jdx.dev/sponsors.html>.
 }
 cmd plugins help="Manage plugins" effect=read {
     alias p plugin plugin-list
-    flag "-a --all" help="list all available remote plugins" hide=#true {
+    flag "-a --all" help="List all available remote plugins" hide=#true {
         long_help #"""
-list all available remote plugins
+List all available remote plugins
 
-same as `mise plugins ls-remote`
+Same as `mise plugins ls-remote`
 """#
     }
     flag "-c --core" help=#"""
-The built-in plugins only
-Normally these are not shown
+Only show built-in (core) plugins
+These are hidden by default
 """# conflicts=--all
     flag "-u --urls" help=#"""
 Show the git url for each plugin
@@ -2778,10 +2772,9 @@ to show core and user plugins
         long_help #"""
 Install a plugin
 
-note that mise can automatically install plugins when you install a tool
-e.g.: `mise install cmake@3.30` will autoinstall the cmake plugin
-
-This behavior can be modified in ~/.config/mise/config.toml
+Note that mise installs plugins automatically when you install a tool that needs one,
+e.g.: `mise install cmake@3.30` installs the cmake plugin first. This command is only
+needed to install a plugin ahead of time or from a custom git URL.
 """#
         after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # install the poetry via shorthand\n    $ \u{1b}[1mmise plugins install poetry\u{1b}[22m\n\n    # install the poetry plugin using a specific git url\n    $ \u{1b}[1mmise plugins install poetry https://github.com/mise-plugins/mise-poetry.git\u{1b}[22m\n\n    # install the poetry plugin using the git url only\n    # (poetry is inferred from the url)\n    $ \u{1b}[1mmise plugins install https://github.com/mise-plugins/mise-poetry.git\u{1b}[22m\n\n    # install the poetry plugin using a specific ref\n    $ \u{1b}[1mmise plugins install poetry https://github.com/mise-plugins/mise-poetry.git#11d0c1e\u{1b}[22m\n"
         flag "-a --all" help=#"""
@@ -2809,10 +2802,10 @@ Can specify multiple plugins: `mise plugins install cmake poetry`
         arg "[REST]…" required=#false var=#true hide=#true
         complete git_url type=url
     }
-    cmd link help="Symlinks a plugin into mise" effect=write {
+    cmd link help="Symlink a plugin into mise" effect=write {
         alias ln
         long_help #"""
-Symlinks a plugin into mise
+Symlink a plugin into mise
 
 This is used for developing a plugin.
 """#
@@ -2842,8 +2835,8 @@ List all available remote plugins
 Same as `mise plugins ls-remote`
 """# hide=#true
         flag "-c --core" help=#"""
-The built-in plugins only
-Normally these are not shown
+Only show built-in (core) plugins
+These are hidden by default
 """# hide=#true conflicts=--all
         flag "-o --outdated" help=#"""
 Show plugins with available updates
@@ -2865,21 +2858,16 @@ e.g.: main 1234abc
     cmd ls-remote help="List all available remote plugins" effect=read {
         alias list-remote list-all
         long_help #"""
-
 List all available remote plugins
 
-The full list is here: https://github.com/jdx/mise/blob/main/registry/
-
-Examples:
-
-    $ mise plugins ls-remote
-
+These are the shorthand names from the registry: https://github.com/jdx/mise/blob/main/registry/
 """#
-        flag "-u --urls" help="Show the git url for each plugin e.g.: https://github.com/mise-plugins/mise-poetry.git"
-        flag --only-names help="Only show the name of each plugin by default it will show a \"*\" next to installed plugins"
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise plugins ls-remote\u{1b}[22m\n"
+        flag "-u --urls" help="Show the git url for each plugin, e.g. https://github.com/mise-plugins/mise-poetry.git"
+        flag --only-names help="Only show the name of each plugin, without the \"*\" marking installed plugins"
         flag "-h --help" help="Print help" action=help builtin=#true
     }
-    cmd uninstall help="Removes a plugin" effect=destructive {
+    cmd uninstall help="Remove a plugin" effect=destructive {
         alias remove rm
         after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise plugins uninstall cmake\u{1b}[22m\n"
         flag "-a --all" help="Remove all plugins" conflicts=PLUGIN
@@ -2887,18 +2875,18 @@ Examples:
         flag "-h --help" help="Print help" action=help builtin=#true
         arg "[PLUGIN]…" help="Plugin(s) to remove" required=#false var=#true
     }
-    cmd update help="Updates a plugin to the latest version" effect=write {
+    cmd update help="Update a plugin to the latest version" effect=write {
         alias up upgrade
         long_help #"""
-Updates a plugin to the latest version
+Update a plugin to the latest version
 
-note: this updates the plugin itself, not the runtime versions
+Note: this updates the plugin itself, not the tool versions it manages
 """#
         after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise plugins update\u{1b}[22m              # update all plugins\n    $ \u{1b}[1mmise plugins update cmake\u{1b}[22m       # update only cmake\n    $ \u{1b}[1mmise plugins update cmake#beta\u{1b}[22m  # specify a ref\n"
         flag "-j --jobs" help=#"""
 Number of jobs to run in parallel
 Values below 1 are treated as 1
-Default: 4
+Defaults to the `jobs` setting
 """# {
             arg <JOBS>
         }
@@ -3034,9 +3022,9 @@ For example, `poetry` is shorthand for `asdf:mise-plugins/mise-poetry`.
     flag --complete help="Print all tools with descriptions for shell completions" hide=#true
     flag --hide-aliased help="Hide aliased tools"
     flag "-J --json" help="Output in JSON format"
-    flag --security help="Include security features for each tool's backends in JSON output." requires=--json {
+    flag --security help="Include security features for each tool's backends in JSON output" requires=--json {
         long_help #"""
-Include security features for each tool's backends in JSON output.
+Include security features for each tool's backends in JSON output
 
 Requires --json. Security info is de-duplicated across all of a tool's backends. This can add noticeable time for large listings since each backend's security info is resolved individually.
 """#
@@ -3047,15 +3035,14 @@ Requires --json. Security info is de-duplicated across all of a tool's backends.
 cmd render-help hide=#true help="internal command to generate markdown from help" effect=write {
     flag "-h --help" help="Print help" action=help builtin=#true
 }
-cmd reshim help="Creates new shims based on bin paths from currently installed tools." effect=write {
+cmd reshim help="Create shims for the executables of currently installed tools" effect=write {
     long_help #"""
-Creates new shims based on bin paths from currently installed tools.
+Create shims for the executables of currently installed tools
 
-This creates new shims in the configured user shim directory for CLIs that have been added.
-With `--system`, it rebuilds the configured system shim farm instead.
-mise will try to do this automatically for commands like `npm i -g` but there are
-other ways to install things (like using yarn or pnpm for node) that mise does
-not know about and so it will be necessary to call this explicitly.
+This creates shims in the user shim directory for executables that have been added since
+the last reshim. With `--system`, it rebuilds the system shim farm instead.
+mise runs this automatically after commands like `npm i -g`, but other ways of installing
+executables (such as yarn or pnpm for node) are not detected, so call this explicitly then.
 
 If you think mise should automatically call this for a particular command, please
 open an issue on the mise repo. You can also set up a shell function to reshim
@@ -3070,7 +3057,7 @@ Note that this creates shims for _all_ installed tools, not just the ones that a
 currently active in mise.toml.
 """#
     after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise reshim\u{1b}[22m\n    $ \u{1b}[1m~/.local/share/mise/shims/node -v\u{1b}[22m\n    v20.0.0\n"
-    flag "-f --force" help="Rebuilds all mise-owned shims"
+    flag "-f --force" help="Rebuild all mise-owned shims"
     flag --system help="Rebuild the system shim farm"
     flag "-h --help" help="Print help" action=help builtin=#true
     arg "[TOOL]" required=#false hide=#true
@@ -3081,10 +3068,9 @@ cmd run disable_help_flag=#true restart_token=::: help="Run task(s)" unknown_fla
     long_help #"""
 Run task(s)
 
-This command will run a task, or multiple tasks in parallel.
-Tasks may have dependencies on other tasks or on source files.
-If source is configured on a task, it will only run if the source
-files have changed.
+Runs one task, or several tasks in parallel.
+Tasks may depend on other tasks and on source files.
+If a task has `sources` configured, it only runs when those files have changed.
 
 Tasks can be defined in mise.toml or as standalone scripts.
 In mise.toml, tasks take this form:
@@ -3097,7 +3083,7 @@ In mise.toml, tasks take this form:
 Alternatively, tasks can be defined as standalone scripts.
 These must be located in `mise-tasks`, `.mise-tasks`, `.mise/tasks`, `mise/tasks` or
 `.config/mise/tasks`.
-The name of the script will be the name of the tasks.
+The name of the script becomes the name of the task.
 
     $ cat .mise/tasks/build<<EOF
     #!/usr/bin/env bash
@@ -3105,7 +3091,7 @@ The name of the script will be the name of the tasks.
     EOF
     $ mise run build
 """#
-    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Runs the \"lint\" tasks. This needs to either be defined in mise.toml\n    # or as a standalone script. See the project README for more information.\n    $ \u{1b}[1mmise run lint\u{1b}[22m\n\n    # Forces the \"build\" tasks to run even if its sources are up-to-date.\n    $ \u{1b}[1mmise run --force build\u{1b}[22m\n\n    # Run \"test\" with stdin/stdout/stderr all connected to the current terminal.\n    # This forces `--jobs=1` to prevent interleaving of output.\n    $ \u{1b}[1mmise run --raw test\u{1b}[22m\n\n    # Runs the \"lint\", \"test\", and \"check\" tasks in parallel.\n    $ \u{1b}[1mmise run lint ::: test ::: check\u{1b}[22m\n\n    # Execute multiple tasks each with their own arguments.\n    $ \u{1b}[1mmise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2\u{1b}[22m\n"
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Run the \"lint\" task, defined either in mise.toml or as a standalone script.\n    $ \u{1b}[1mmise run lint\u{1b}[22m\n\n    # Force the \"build\" task to run even if its sources are up-to-date.\n    $ \u{1b}[1mmise run --force build\u{1b}[22m\n\n    # Run \"test\" with stdin/stdout/stderr all connected to the current terminal.\n    # This forces `--jobs=1` to prevent interleaving of output.\n    $ \u{1b}[1mmise run --raw test\u{1b}[22m\n\n    # Run the \"lint\", \"test\", and \"check\" tasks in parallel.\n    $ \u{1b}[1mmise run lint ::: test ::: check\u{1b}[22m\n\n    # Run multiple tasks, each with its own arguments.\n    $ \u{1b}[1mmise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2\u{1b}[22m\n"
     flag --affected help="Run matching tasks only for projects affected by Git changes"
     flag --affected-base help=#"""
 Git base revision for --affected
@@ -3130,15 +3116,14 @@ Defaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD
     flag "-j --jobs" help=#"""
 Number of tasks to run in parallel
 Values below 1 are treated as 1
-[default: 4]
-Configure with `jobs` config or `MISE_JOBS` env var
+Defaults to the `jobs` setting or the `MISE_JOBS` env var
 """# env=MISE_JOBS {
         arg <JOBS>
     }
     flag "-n --dry-run" help="Don't actually run the task(s), just print them in order of execution"
-    flag "-o --output" help="Change how tasks information is output when running tasks" env=MISE_TASK_OUTPUT {
+    flag "-o --output" help="How task output is displayed" env=MISE_TASK_OUTPUT {
         long_help #"""
-Change how tasks information is output when running tasks
+How task output is displayed
 
 - `prefix` - Print stdout/stderr by line, prefixed with the task's label
 - `interleave` - Print directly to stdout/stderr instead of by line
@@ -3193,12 +3178,12 @@ Supports wildcards, e.g. --allow-env='MYAPP_*'
     flag --fresh-env help="Bypass the environment cache and recompute the environment"
     flag --no-cache help="Do not use cache on remote tasks" env=MISE_TASK_REMOTE_NO_CACHE
     flag --no-deps help="Skip automatic dependency preparation"
-    flag --no-timings help="Hides elapsed time after each task completes" {
+    flag --no-timings help="Hide the elapsed time printed after each task completes" {
         alias "--no-timing" hide=#true
         long_help #"""
-Hides elapsed time after each task completes
+Hide the elapsed time printed after each task completes
 
-Default to always hide with `MISE_TASK_TIMINGS=0`
+Set `MISE_TASK_TIMINGS=0` to hide it by default
 """#
     }
     flag --skip-deps help="Run only the specified tasks skipping all dependencies" env=MISE_TASK_SKIP_DEPENDS
@@ -3239,12 +3224,12 @@ e.g.: 30s, 5m
 """# {
         arg <TIMEOUT>
     }
-    flag --timings help="Shows elapsed time after each task completes" hide=#true {
+    flag --timings help="Show the elapsed time after each task completes" hide=#true {
         alias "--timing" hide=#true
         long_help #"""
-Shows elapsed time after each task completes
+Show the elapsed time after each task completes
 
-Default to always show with `MISE_TASK_TIMINGS=1`
+Set `MISE_TASK_TIMINGS=1` to show it by default
 """#
     }
     mount run="mise tasks --usage"
@@ -3254,13 +3239,13 @@ cmd search help="Search for tools in the registry" effect=read {
     long_help #"""
 Search for tools in the registry
 
-This command searches a tool in the registry.
+Searches the registry for tools matching NAME.
 
 By default, it will show all tools that fuzzy match the search term. For
 non-fuzzy matches, use the `--match-type` flag.
 """#
     after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise search jq\u{1b}[22m\n    Tool  Description\n    jq    Command-line JSON processor. https://github.com/jqlang/jq\n    jqp   A TUI playground to experiment with jq. https://github.com/noahgorstein/jqp\n    jiq   jid on jq - interactive JSON query tool using jq expressions. https://github.com/fiatjaf/jiq\n    gojq  Pure Go implementation of jq. https://github.com/itchyny/gojq\n\n    $ \u{1b}[1mmise search --interactive\u{1b}[22m\n    Tool\n    Search a tool\n    ❯ jq    Command-line JSON processor. https://github.com/jqlang/jq\n      jqp   A TUI playground to experiment with jq. https://github.com/noahgorstein/jqp\n      jiq   jid on jq - interactive JSON query tool using jq expressions. https://github.com/fiatjaf/jiq\n      gojq  Pure Go implementation of jq. https://github.com/itchyny/gojq\n    /jq \n    esc clear filter • enter confirm\n"
-    flag "-i --interactive" help="Show interactive search" {
+    flag "-i --interactive" help="Pick a tool from an interactive search menu" {
         conflicts "--match-type" "--no-header"
     }
     flag "-m --match-type" help="Match type: equal, contains, or fuzzy" default=fuzzy {
@@ -3278,9 +3263,9 @@ non-fuzzy matches, use the `--match-type` flag.
     flag "-h --help" help="Print help" action=help builtin=#true
     arg "[NAME]" help="The tool to search for" required=#false
 }
-cmd self-update help="Updates mise itself." effect=write {
+cmd self-update help="Update mise itself" effect=write {
     long_help #"""
-Updates mise itself.
+Update mise itself
 
 Uses the GitHub Releases API to find the latest release and binary.
 By default, this will also update any installed plugins.
@@ -3389,12 +3374,12 @@ cmd settings help="Manage settings" effect=write {
     arg "[SETTING]" help="Name of setting" required=#false
     arg "[VALUE]" help="Setting value to set" required=#false conflicts=all
     group output "--json" "--toml" "--json-extended"
-    cmd add help="Adds a setting to the configuration file" effect=write {
+    cmd add help="Append a value to an array setting" effect=write {
         long_help #"""
-Adds a setting to the configuration file
+Append a value to an array setting
 
-Used with an array setting, this will append the value to the array.
-This modifies the contents of ~/.config/mise/config.toml
+Adds the value to an array setting such as `disable_hints`, keeping existing entries.
+This modifies ~/.config/mise/config.toml by default, or the local config with `--local`.
 """#
         after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise settings add disable_hints python_multi\u{1b}[22m\n"
         flag "-l --local" help="Use the local config file instead of the global one"
@@ -3452,12 +3437,12 @@ See https://mise.jdx.dev/configuration.html#target-file-for-write-operations
         arg <SETTING> help="The setting to set"
         arg "[VALUE]" help="The value to set (optional if provided as KEY=VALUE)" required=#false
     }
-    cmd unset help="Clears a setting" effect=write {
+    cmd unset help="Clear a setting" effect=write {
         alias rm remove delete del
         long_help #"""
-Clears a setting
+Clear a setting
 
-This modifies the contents of ~/.config/mise/config.toml
+This modifies ~/.config/mise/config.toml by default, or the local config with `--local`.
 """#
         after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise settings unset idiomatic_version_file\u{1b}[22m\n"
         flag "-l --local" help="Use the local config file instead of the global one"
@@ -3465,10 +3450,10 @@ This modifies the contents of ~/.config/mise/config.toml
         arg <KEY> help="The setting to remove"
     }
 }
-cmd shell help="Sets a tool version for the current session." effect=read {
+cmd shell help="Set a tool version for the current shell session" effect=read {
     alias sh
     long_help #"""
-Sets a tool version for the current session.
+Set a tool version for the current shell session
 
 Only works in a session where mise is already activated.
 
@@ -3479,16 +3464,16 @@ such as `MISE_NODE_VERSION=20` which is "eval"ed as a shell function created by 
     flag "-j --jobs" help=#"""
 Number of jobs to run in parallel
 Values below 1 are treated as 1
-[default: 4]
+Defaults to the `jobs` setting
 """# env=MISE_JOBS {
         arg <JOBS>
     }
-    flag "-u --unset" help="Removes a previously set version"
-    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1" overrides=--jobs
+    flag "-u --unset" help="Remove a previously set version"
+    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal. Implies `--jobs=1`" overrides=--jobs
     flag "-h --help" help="Print help" action=help builtin=#true
     arg <TOOL@VERSION>… help="Tool(s) to use" var=#true
 }
-cmd shell-alias help="Manage shell aliases." effect=read {
+cmd shell-alias help="Manage shell aliases" effect=read {
     flag --no-header help="Don't show table header"
     flag "-h --help" help="Print help" action=help builtin=#true
     cmd get help="Show the command for a shell alias" effect=read {
@@ -3520,10 +3505,10 @@ This modifies the contents of ~/.config/mise/config.toml
         arg <shell_alias> help="The alias name"
         arg "[COMMAND]" help="The command to run (optional if provided as ALIAS=COMMAND)" required=#false
     }
-    cmd unset help="Removes a shell alias" effect=write {
+    cmd unset help="Remove a shell alias" effect=write {
         alias rm remove delete del
         long_help #"""
-Removes a shell alias
+Remove a shell alias
 
 This modifies the contents of ~/.config/mise/config.toml
 """#
@@ -3537,11 +3522,11 @@ cmd sponsors help="Show the companies sponsoring mise and the jdx.dev open sourc
 }
 cmd sync subcommand_required=#true help="Synchronize tools from other version managers with mise" effect=read {
     flag "-h --help" help="Print help" action=help builtin=#true
-    cmd node help="Symlinks all tool versions from an external tool into mise" effect=write {
+    cmd node help="Symlink node versions installed by nvm, nodenv, or Homebrew into mise" effect=write {
         long_help #"""
-Symlinks all tool versions from an external tool into mise
+Symlink node versions installed by nvm, nodenv, or Homebrew into mise
 
-For example, use this to import all Homebrew node installs into mise
+Use this to make versions installed by another version manager available to mise.
 
 This won't overwrite managed installs, runtime aliases, or links from other providers.
 """#
@@ -3552,11 +3537,11 @@ This won't overwrite managed installs, runtime aliases, or links from other prov
         flag "-h --help" help="Print help" action=help builtin=#true
         group sync-node-type "--brew" "--nodenv" "--nvm" required=#true multiple=#true
     }
-    cmd python help="Symlinks all tool versions from an external tool into mise" effect=write {
+    cmd python help="Symlink python versions installed by pyenv or uv into mise" effect=write {
         long_help #"""
-Symlinks all tool versions from an external tool into mise
+Symlink python versions installed by pyenv or uv into mise
 
-For example, use this to import all pyenv installs into mise
+Use this to make versions installed by another version manager available to mise.
 
 This won't overwrite managed installs, runtime aliases, or links from other providers.
 """#
@@ -3565,7 +3550,7 @@ This won't overwrite managed installs, runtime aliases, or links from other prov
         flag --uv help="Sync tool versions with uv (2-way sync)"
         flag "-h --help" help="Print help" action=help builtin=#true
     }
-    cmd ruby help="Symlinks all ruby tool versions from an external tool into mise" effect=write {
+    cmd ruby help="Symlink ruby versions installed by Homebrew into mise" effect=write {
         after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mbrew install ruby\u{1b}[22m\n    $ \u{1b}[1mmise sync ruby --brew\u{1b}[22m\n    $ \u{1b}[1mmise use -g ruby\u{1b}[22m - Use the latest version of Ruby installed by Homebrew\n"
         flag --brew help="Get tool versions from Homebrew" required=#true
         flag "-h --help" help="Print help" action=help builtin=#true
@@ -3609,7 +3594,7 @@ By default, only tasks from the current directory hierarchy are loaded.
     }
     flag --usage hide=#true
     flag "-h --help" help="Print help" action=help builtin=#true
-    arg "[TASK]" help="Task name to get info of" required=#false
+    arg "[TASK]" help="Task name to show info for" required=#false
     cmd add help="Create a new task" effect=write {
         long_help #"""
 Create a new task
@@ -3634,7 +3619,7 @@ See https://mise.jdx.dev/configuration.html#target-file-for-write-operations
         flag "-s --sources" help="Glob patterns of files this task uses as input" var=#true {
             arg <SOURCES>
         }
-        flag "-w --wait-for" help="Wait for these tasks to complete if they are to run" var=#true {
+        flag "-w --wait-for" help="Wait for these tasks to finish if they are also being run" var=#true {
             arg <WAIT_FOR>
         }
         flag --depends-post help="Dependencies to run after the task runs" var=#true {
@@ -3643,10 +3628,10 @@ See https://mise.jdx.dev/configuration.html#target-file-for-write-operations
         flag --description help="Description of the task" {
             arg <DESCRIPTION>
         }
-        flag --outputs help="Glob patterns of files this task creates, to skip if they are not modified" var=#true {
+        flag --outputs help="Glob patterns of files this task creates, used to skip it when they are up to date" var=#true {
             arg <OUTPUTS>
         }
-        flag --run-windows help="Command to run on windows" {
+        flag --run-windows help="Command to run on Windows" {
             arg <RUN_WINDOWS>
         }
         flag --shell help="Run the task in a specific shell" {
@@ -3654,8 +3639,8 @@ See https://mise.jdx.dev/configuration.html#target-file-for-write-operations
         }
         flag --silent help="Do not print the command or its output"
         flag "-h --help" help="Print help" action=help builtin=#true
-        arg <TASK> help="Tasks name to add"
-        arg "[-- RUN]…" required=#false var=#true
+        arg <TASK> help="Name of the task to add"
+        arg "[-- RUN]…" help="Command to run, given after `--`" required=#false var=#true
     }
     cmd deps help="Display a tree visualization of a dependency graph" effect=read {
         long_help #"""
@@ -3704,15 +3689,12 @@ The task will be created as a standalone script if it does not already exist.
         flag "-h --help" help="Print help" action=help builtin=#true
         arg <TASK> help="Name of the task to get information about"
     }
-    cmd ls help=#"""
-List available tasks to execute
-These may be included from the config file or from the project's .mise/tasks directory
-mise will merge all tasks from all parent directories into this list.
-"""# effect=read {
+    cmd ls help="List available tasks" effect=read {
         long_help #"""
-List available tasks to execute
-These may be included from the config file or from the project's .mise/tasks directory
-mise will merge all tasks from all parent directories into this list.
+List available tasks
+
+Tasks come from config files and from task directories such as `.mise/tasks`.
+Tasks from all parent directories are merged into this list.
 
 So if you have global tasks in `~/.config/mise/tasks/*` and project-specific tasks in
 ~/myproject/.mise/tasks/*, then they'll both be available but the project-specific
@@ -3761,10 +3743,9 @@ By default, only tasks from the current directory hierarchy are loaded.
         long_help #"""
 Run task(s)
 
-This command will run a task, or multiple tasks in parallel.
-Tasks may have dependencies on other tasks or on source files.
-If source is configured on a task, it will only run if the source
-files have changed.
+Runs one task, or several tasks in parallel.
+Tasks may depend on other tasks and on source files.
+If a task has `sources` configured, it only runs when those files have changed.
 
 Tasks can be defined in mise.toml or as standalone scripts.
 In mise.toml, tasks take this form:
@@ -3777,7 +3758,7 @@ In mise.toml, tasks take this form:
 Alternatively, tasks can be defined as standalone scripts.
 These must be located in `mise-tasks`, `.mise-tasks`, `.mise/tasks`, `mise/tasks` or
 `.config/mise/tasks`.
-The name of the script will be the name of the tasks.
+The name of the script becomes the name of the task.
 
     $ cat .mise/tasks/build<<EOF
     #!/usr/bin/env bash
@@ -3785,7 +3766,7 @@ The name of the script will be the name of the tasks.
     EOF
     $ mise run build
 """#
-        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Runs the \"lint\" tasks. This needs to either be defined in mise.toml\n    # or as a standalone script. See the project README for more information.\n    $ \u{1b}[1mmise run lint\u{1b}[22m\n\n    # Forces the \"build\" tasks to run even if its sources are up-to-date.\n    $ \u{1b}[1mmise run --force build\u{1b}[22m\n\n    # Run \"test\" with stdin/stdout/stderr all connected to the current terminal.\n    # This forces `--jobs=1` to prevent interleaving of output.\n    $ \u{1b}[1mmise run --raw test\u{1b}[22m\n\n    # Runs the \"lint\", \"test\", and \"check\" tasks in parallel.\n    $ \u{1b}[1mmise run lint ::: test ::: check\u{1b}[22m\n\n    # Execute multiple tasks each with their own arguments.\n    $ \u{1b}[1mmise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2\u{1b}[22m\n"
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Run the \"lint\" task, defined either in mise.toml or as a standalone script.\n    $ \u{1b}[1mmise run lint\u{1b}[22m\n\n    # Force the \"build\" task to run even if its sources are up-to-date.\n    $ \u{1b}[1mmise run --force build\u{1b}[22m\n\n    # Run \"test\" with stdin/stdout/stderr all connected to the current terminal.\n    # This forces `--jobs=1` to prevent interleaving of output.\n    $ \u{1b}[1mmise run --raw test\u{1b}[22m\n\n    # Run the \"lint\", \"test\", and \"check\" tasks in parallel.\n    $ \u{1b}[1mmise run lint ::: test ::: check\u{1b}[22m\n\n    # Run multiple tasks, each with its own arguments.\n    $ \u{1b}[1mmise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2\u{1b}[22m\n"
         flag --affected help="Run matching tasks only for projects affected by Git changes"
         flag --affected-base help=#"""
 Git base revision for --affected
@@ -3810,15 +3791,14 @@ Defaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD
         flag "-j --jobs" help=#"""
 Number of tasks to run in parallel
 Values below 1 are treated as 1
-[default: 4]
-Configure with `jobs` config or `MISE_JOBS` env var
+Defaults to the `jobs` setting or the `MISE_JOBS` env var
 """# env=MISE_JOBS {
             arg <JOBS>
         }
         flag "-n --dry-run" help="Don't actually run the task(s), just print them in order of execution"
-        flag "-o --output" help="Change how tasks information is output when running tasks" env=MISE_TASK_OUTPUT {
+        flag "-o --output" help="How task output is displayed" env=MISE_TASK_OUTPUT {
             long_help #"""
-Change how tasks information is output when running tasks
+How task output is displayed
 
 - `prefix` - Print stdout/stderr by line, prefixed with the task's label
 - `interleave` - Print directly to stdout/stderr instead of by line
@@ -3873,12 +3853,12 @@ Supports wildcards, e.g. --allow-env='MYAPP_*'
         flag --fresh-env help="Bypass the environment cache and recompute the environment"
         flag --no-cache help="Do not use cache on remote tasks" env=MISE_TASK_REMOTE_NO_CACHE
         flag --no-deps help="Skip automatic dependency preparation"
-        flag --no-timings help="Hides elapsed time after each task completes" {
+        flag --no-timings help="Hide the elapsed time printed after each task completes" {
             alias "--no-timing" hide=#true
             long_help #"""
-Hides elapsed time after each task completes
+Hide the elapsed time printed after each task completes
 
-Default to always hide with `MISE_TASK_TIMINGS=0`
+Set `MISE_TASK_TIMINGS=0` to hide it by default
 """#
         }
         flag --skip-deps help="Run only the specified tasks skipping all dependencies" env=MISE_TASK_SKIP_DEPENDS
@@ -3919,12 +3899,12 @@ e.g.: 30s, 5m
 """# {
             arg <TIMEOUT>
         }
-        flag --timings help="Shows elapsed time after each task completes" hide=#true {
+        flag --timings help="Show the elapsed time after each task completes" hide=#true {
             alias "--timing" hide=#true
             long_help #"""
-Shows elapsed time after each task completes
+Show the elapsed time after each task completes
 
-Default to always show with `MISE_TASK_TIMINGS=1`
+Set `MISE_TASK_TIMINGS=1` to show it by default
 """#
         }
         mount run="mise tasks --usage"
@@ -3941,7 +3921,7 @@ If not specified, validates all tasks
 """# required=#false var=#true
     }
 }
-cmd test-tool help="Test a tool installs and executes" {
+cmd test-tool help="Test that a tool installs and runs" {
     after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise test-tool ripgrep\u{1b}[22m\n"
     flag "-a --all" help="Test every tool specified in registry/" {
         conflicts TOOLS "--all-config"
@@ -3956,8 +3936,8 @@ Values below 1 are treated as 1
     flag --all-config help="Test all tools specified in config files" {
         conflicts TOOLS "--all"
     }
-    flag --include-non-defined help="Also test tools not defined in registry/, guessing how to test it"
-    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1" overrides=--jobs
+    flag --include-non-defined help="Also test tools not defined in registry/, guessing how to test them"
+    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal. Implies `--jobs=1`" overrides=--jobs
     flag "-h --help" help="Print help" action=help builtin=#true
     arg "[TOOLS]…" help="Tool(s) to test" required=#false var=#true {
         required_unless "--all" "--all-config"
@@ -3965,7 +3945,7 @@ Values below 1 are treated as 1
 }
 cmd token subcommand_required=#true help="Display git provider tokens mise will use" effect=read {
     flag "-h --help" help="Print help" action=help builtin=#true
-    cmd forgejo help="Forgejo token" effect=read {
+    cmd forgejo help="Show the Forgejo token mise will use" effect=read {
         long_help #"""
 Display the Forgejo token mise will use for a given host
 
@@ -3977,7 +3957,7 @@ authentication issues. The token is masked by default.
         flag "-h --help" help="Print help" action=help builtin=#true
         arg "[HOST]" help="Forgejo hostname" required=#false default=codeberg.org
     }
-    cmd github help="GitHub token" effect=read {
+    cmd github help="Show the GitHub token mise will use" effect=read {
         long_help #"""
 Display the GitHub token mise will use for a given host
 
@@ -3992,7 +3972,7 @@ authentication issues. The token is masked by default.
         flag "-h --help" help="Print help" action=help builtin=#true
         arg "[HOST]" help="GitHub hostname" required=#false default=github.com
     }
-    cmd gitlab help="GitLab token" effect=read {
+    cmd gitlab help="Show the GitLab token mise will use" effect=read {
         long_help #"""
 Display the GitLab token mise will use for a given host
 
@@ -4005,7 +3985,7 @@ authentication issues. The token is masked by default.
         arg "[HOST]" help="GitLab hostname" required=#false default=gitlab.com
     }
 }
-cmd tool help="Gets information about a tool" effect=read {
+cmd tool help="Show information about a tool" effect=read {
     after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise tool node\u{1b}[22m\n    Backend:            core\n    Installed Versions: 20.0.0 22.0.0\n    Active Version:     20.0.0\n    Requested Version:  20\n    Config Source:      ~/.config/mise/mise.toml\n    Tool Options:       [none]\n"
     flag "-J --json" help="Output in JSON format"
     flag --active help="Only show active versions"
@@ -4023,11 +4003,16 @@ cmd tool-stub disable_help_flag=#true disable_version_flag=#true help="Execute a
     long_help #"""
 Execute a tool stub
 
-Tool stubs are executable files containing TOML configuration that specify which tool to run and how to run it. They provide a convenient way to create portable, self-contained executables that automatically manage tool installation and execution.
+Tool stubs are executable files containing TOML configuration that specify
+which tool to run and how to run it. They provide a convenient way to create
+portable, self-contained executables that automatically manage tool installation
+and execution.
 
 A tool stub consists of:
 
-- A shebang line: #!/usr/bin/env -S mise tool-stub - TOML configuration specifying the tool, version, and options - Optional comments describing the tool's purpose
+- A shebang line: #!/usr/bin/env -S mise tool-stub
+- TOML configuration specifying the tool, version, and options
+- Optional comments describing the tool's purpose
 
 Example stub file:
 
@@ -4040,7 +4025,8 @@ version = "20.0.0"
 bin = "node"
 ```
 
-The stub will automatically install the specified tool version if missing and execute it with any arguments passed to the stub.
+The stub will automatically install the specified tool version if missing
+and execute it with any arguments passed to the stub.
 
 For more information, see: https://mise.jdx.dev/dev-tools/tool-stubs.html
 """#
@@ -4055,9 +4041,9 @@ Arguments to pass to the tool
 All arguments after the stub file path will be forwarded to the underlying tool. Use '--' to separate mise arguments from tool arguments if needed.
 """# required=#false double_dash=automatic var=#true
 }
-cmd trust help="Marks a config file as trusted" effect=write {
+cmd trust help="Mark a config file as trusted" effect=write {
     long_help #"""
-Marks a config file as trusted
+Mark a config file as trusted
 
 This means mise is allowed to parse the file when it needs to read config
 that may execute code or affect the environment. Without trust, mise may
@@ -4098,13 +4084,14 @@ Does not trust or untrust any files.
     arg "[CONFIG_FILE]" help="The config file whose trust status to change" required=#false
     complete config_file type=path
 }
-cmd uninstall help="Removes installed tool versions" effect=destructive {
+cmd uninstall help="Remove installed tool versions" effect=destructive {
     long_help #"""
-Removes installed tool versions
+Remove installed tool versions
 
-This only removes the installed version, it does not modify mise.toml.
+This only removes the installed version; it does not modify mise.toml.
+Use `mise unuse` to remove a tool from mise.toml and uninstall it.
 """#
-    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # will uninstall specific version\n    $ \u{1b}[1mmise uninstall node@18.0.0\u{1b}[22m\n\n    # will uninstall the current node version (if only one version is installed)\n    $ \u{1b}[1mmise uninstall node\u{1b}[22m\n\n    # will uninstall all installed versions of node\n    $ \u{1b}[1mmise uninstall --all node@18.0.0\u{1b}[22m # will uninstall all node versions\n"
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # uninstall a specific version\n    $ \u{1b}[1mmise uninstall node@18.0.0\u{1b}[22m\n\n    # uninstall the current node version (if only one version is installed)\n    $ \u{1b}[1mmise uninstall node\u{1b}[22m\n\n    # uninstall every installed version of node\n    $ \u{1b}[1mmise uninstall --all node\u{1b}[22m\n"
     flag "-a --all" help="Delete all installed versions"
     flag "-n --dry-run" help="Do not actually delete anything"
     flag --dry-run-code help="Like --dry-run but exits with code 1 if there are tools to uninstall" {
@@ -4117,9 +4104,9 @@ This is useful for scripts to check if tools need to be uninstalled.
     flag "-h --help" help="Print help" action=help builtin=#true
     arg "[INSTALLED_TOOL@VERSION]…" help="Tool(s) to remove" required=#false var=#true required_unless=--all
 }
-cmd unset help="Remove environment variable(s) from the config file." effect=write {
+cmd unset help="Remove environment variable(s) from the config file" effect=write {
     long_help #"""
-Remove environment variable(s) from the config file.
+Remove environment variable(s) from the config file
 
 By default, this command modifies `mise.toml` in the current directory.
 """#
@@ -4147,10 +4134,10 @@ cmd untrust help="Remove explicit trust for a config" effect=write {
     arg "[CONFIG_FILE]" help="The config file to untrust" required=#false
     complete config_file type=path
 }
-cmd unuse help="Removes installed tool versions from mise.toml" effect=destructive {
+cmd unuse help="Remove tool versions from mise.toml and uninstall them" effect=destructive {
     alias rm remove
     long_help #"""
-Removes installed tool versions from mise.toml
+Remove tool versions from mise.toml and uninstall them
 
 By default, this will use the `mise.toml` file that has the tool defined.
 If multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),
@@ -4162,14 +4149,14 @@ In the following order:
   - If `--path` is set, it will use the config file at the given path.
   - If `--env` is set, it will use `mise.<env>.toml`.
   - If [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) is set, it will use that instead.
-  - If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will the first from that list.
+  - If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will use the first from that list.
   - Otherwise just "mise.toml" or global config if cwd is home directory.
 
 Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
 
-Will also prune the installed version if no other configurations are using it.
+The installed version is also removed unless another config still uses it or `--no-prune` is passed.
 """#
-    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # will uninstall specific version\n    $ \u{1b}[1mmise unuse node@18.0.0\u{1b}[22m\n\n    # will uninstall specific version from global config\n    $ \u{1b}[1mmise unuse -g node@18.0.0\u{1b}[22m\n\n    # will uninstall specific version from .mise.local.toml\n    $ \u{1b}[1mmise unuse --env local node@20\u{1b}[22m\n\n    # will uninstall specific version from .mise.staging.toml\n    $ \u{1b}[1mmise unuse --env staging node@20\u{1b}[22m\n"
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # remove node@18.0.0 from mise.toml and uninstall it\n    $ \u{1b}[1mmise unuse node@18.0.0\u{1b}[22m\n\n    # remove it from the global config instead\n    $ \u{1b}[1mmise unuse -g node@18.0.0\u{1b}[22m\n\n    # remove node@20 from .mise.local.toml\n    $ \u{1b}[1mmise unuse --env local node@20\u{1b}[22m\n\n    # remove node@20 from .mise.staging.toml\n    $ \u{1b}[1mmise unuse --env staging node@20\u{1b}[22m\n"
     flag "-e --env" help="Create/modify an environment-specific config file like .mise.<env>.toml" {
         overrides "--global" "--path"
         arg <ENV>
@@ -4191,21 +4178,21 @@ If a directory is specified, it will look for a config file in that directory fo
     arg <INSTALLED_TOOL@VERSION>… help="Tool(s) to remove" var=#true
     complete path type=path
 }
-cmd upgrade help="Upgrades outdated tools" effect=write {
+cmd upgrade help="Upgrade outdated tools" effect=write {
     alias up
     long_help #"""
-Upgrades outdated tools
+Upgrade outdated tools
 
-By default, this keeps the range specified in mise.toml. So if you have node@20 set, it will
-upgrade to the latest 20.x.x version available. See the `--bump` flag to use the latest version
-and bump the version in mise.toml.
+By default, this keeps the range specified in mise.toml: with node@20 set, it upgrades to
+the latest 20.x.x available. Use `--bump` to upgrade to the latest version overall and
+rewrite the version in mise.toml.
 
-This will update mise.lock if it is enabled, see https://mise.jdx.dev/configuration/settings.html#lockfile
+This also updates mise.lock if lockfiles are enabled, see https://mise.jdx.dev/configuration/settings.html#lockfile
 """#
     after_long_help "\u{1b}[1m\u{1b}[4mDeprecation:\u{1b}[22m\u{1b}[24m\n\nThe `-l` shorthand for `--bump` is deprecated and will be removed in mise 2027.8.5.\nAfter removal, `-l` will become shorthand for `--local`. Use `-b` or `--bump` instead.\n\n\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Upgrades node to the latest version matching the range in mise.toml\n    $ \u{1b}[1mmise upgrade node\u{1b}[22m\n\n    # Upgrades node to the latest version and bumps the version in mise.toml\n    $ \u{1b}[1mmise upgrade node --bump\u{1b}[22m\n\n    # Upgrades all tools to the latest versions\n    $ \u{1b}[1mmise upgrade\u{1b}[22m\n\n    # Upgrades all tools to the latest versions and bumps the version in mise.toml\n    $ \u{1b}[1mmise upgrade --bump\u{1b}[22m\n\n    # Just print what would be done, don't actually do it\n    $ \u{1b}[1mmise upgrade --dry-run\u{1b}[22m\n\n    # Upgrades node and python to the latest versions\n    $ \u{1b}[1mmise upgrade node python\u{1b}[22m\n\n    # Upgrade all tools except go\n    $ \u{1b}[1mmise upgrade --exclude go\u{1b}[22m\n\n    # Show a multiselect menu to choose which tools to upgrade\n    $ \u{1b}[1mmise upgrade --interactive\u{1b}[22m\n\n    # Only upgrade tools defined in local mise.toml, not global ones\n    $ \u{1b}[1mmise upgrade --local\u{1b}[22m\n"
-    flag "-b --bump" help="Upgrades to the latest version available, bumping the version in mise.toml" {
+    flag "-b --bump" help="Upgrade to the latest version available, bumping the version in mise.toml" {
         long_help #"""
-Upgrades to the latest version available, bumping the version in mise.toml
+Upgrade to the latest version available, bumping the version in mise.toml
 
 For example, if you have `node = "20.0.0"` in your mise.toml but 22.1.0 is the latest available,
 this will install 22.1.0 and set `node = "22.1.0"` in your config.
@@ -4214,16 +4201,16 @@ It keeps the same precision as what was there before, so if you instead had `nod
 would change your config to `node = "22"`.
 """#
     }
-    flag "-i --interactive" help="Display multiselect menu to choose which tools to upgrade" conflicts=INSTALLED_TOOL@VERSION
+    flag "-i --interactive" help="Choose which tools to upgrade from a multiselect menu" conflicts=INSTALLED_TOOL@VERSION
     flag "-j --jobs" help=#"""
 Number of jobs to run in parallel
 Values below 1 are treated as 1
-[default: 4]
+Defaults to the `jobs` setting
 """# env=MISE_JOBS {
         arg <JOBS>
     }
     flag -l help="Deprecated shorthand for --bump" hide=#true
-    flag "-n --dry-run" help="Just print what would be done, don't actually do it"
+    flag "-n --dry-run" help="Print what would be done without doing it"
     flag "-x --exclude" help=#"""
 Tool(s) to exclude from upgrading
 e.g.: go python
@@ -4278,7 +4265,7 @@ Use this to bypass `upgrade.prune_after`, or to override
 `upgrade.auto_prune = false` for a single run.
 """#
     }
-    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1" overrides=--jobs
+    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal. Implies `--jobs=1`" overrides=--jobs
     flag "-h --help" help="Print help" action=help builtin=#true
     arg "[INSTALLED_TOOL@VERSION]…" help=#"""
 Tool(s) to upgrade
@@ -4294,13 +4281,13 @@ See https://usage.jdx.dev for more information on this specification.
 """#
     flag "-h --help" help="Print help" action=help builtin=#true
 }
-cmd use help="Installs a tool and adds the version to mise.toml." effect=write {
+cmd use help="Install a tool and add it to mise.toml" effect=write {
     alias u
     long_help #"""
-Installs a tool and adds the version to mise.toml.
+Install a tool and add it to mise.toml
 
-This will install the tool version if it is not already installed.
-By default, this will use a `mise.toml` file in the current directory.
+Installs the tool version if it is not already installed, then writes it to a config file.
+By default, this is `mise.toml` in the current directory.
 If multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),
 the lowest precedence file (`mise.toml`) will be used.
 See https://mise.jdx.dev/configuration.html#target-file-for-write-operations
@@ -4310,12 +4297,10 @@ In the following order:
   - If `--path` is set, it will use the config file at the given path.
   - If `--env` is set, it will use `mise.<env>.toml`.
   - If [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) is set, it will use that instead.
-  - If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will the first from that list.
+  - If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will use the first from that list.
   - Otherwise just "mise.toml" or global config if cwd is home directory.
 
 Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
-
-Use the `--global` flag to use the global config file instead.
 """#
     after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # run with no arguments to use the interactive selector\n    $ \u{1b}[1mmise use\u{1b}[22m\n\n    # set the current version of node to 20.x in mise.toml of current directory\n    # will write the fuzzy version (e.g.: 20)\n    $ \u{1b}[1mmise use node@20\u{1b}[22m\n\n    # run a command after installing a tool\n    $ \u{1b}[1mmise use --postinstall \"mbx setup --defaults\" mr-boxington\u{1b}[22m\n\n    # associate a different postinstall command with each tool\n    $ \u{1b}[1mmise use --postinstall \"setup-a\" tool-a --postinstall \"setup-b\" tool-b\u{1b}[22m\n\n    # set the current version of node to 20.x in ~/.config/mise/config.toml\n    # will write the precise version (e.g.: 20.0.0)\n    $ \u{1b}[1mmise use -g --pin node@20\u{1b}[22m\n\n    # sets .mise.local.toml (which is intended not to be committed to a project)\n    $ \u{1b}[1mmise use --env local node@20\u{1b}[22m\n\n    # sets .mise.staging.toml (which is used if MISE_ENV=staging)\n    $ \u{1b}[1mmise use --env staging node@20\u{1b}[22m\n"
     flag "-e --env" help="Create/modify an environment-specific config file like .mise.<env>.toml" {
@@ -4329,7 +4314,7 @@ Use the `--global` flag to use the global config file instead.
     flag "-j --jobs" help=#"""
 Number of jobs to run in parallel
 Values below 1 are treated as 1
-[default: 4]
+Defaults to the `jobs` setting
 """# env=MISE_JOBS {
         arg <JOBS>
     }
@@ -4354,8 +4339,8 @@ This is useful for scripts to check if tools need to be added or removed.
         long_help #"""
 Save fuzzy version to config file
 
-e.g.: `mise use --fuzzy node@20` will save 20 as the version
-this is the default behavior unless `MISE_PIN=1`
+e.g.: `mise use --fuzzy node@20` will save `20` as the version.
+This is the default behavior unless `MISE_PIN=1`
 """#
     }
     flag --minimum-release-age help="Only install versions released before this date or older than this duration" {
@@ -4380,7 +4365,7 @@ Consider using mise.lock as a better alternative to pinning in mise.toml:
 https://mise.jdx.dev/configuration/settings.html#lockfile
 """#
     }
-    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies `--jobs=1`" overrides=--jobs
+    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal. Implies `--jobs=1`" overrides=--jobs
     flag --remove help="Remove the tool(s) from config file" var=#true {
         alias "--rm" "--unset" hide=#true
         arg <TOOL>
@@ -4393,12 +4378,12 @@ https://mise.jdx.dev/configuration/settings.html#lockfile
         arg <TOOL@VERSION> help="Tool to add to config file" help_long=#"""
 Tool to add to config file
 
-e.g.: node@20, cargo:ripgrep@latest npm:prettier@3
-If no version is specified, it will default to @latest
+e.g.: node@20, cargo:ripgrep@latest, npm:prettier@3
+If no version is specified, it defaults to @latest
 
 Tool options can be set with this syntax:
 
-    mise use ubi:BurntSushi/ripgrep[exe=rg]
+    mise use "cargo:ripgrep[features=pcre2]"
 """#
     }
     complete path type=path
@@ -4416,18 +4401,18 @@ If the version is out of date, it will display a warning.
     flag "-J --json" help="Print the version information in JSON format"
     flag "-h --help" help="Print help" action=help builtin=#true
 }
-cmd watch help="Run task(s) and watch for changes to rerun it" unknown_flags=value {
+cmd watch help="Run task(s) and rerun them when files change" unknown_flags=value {
     alias w
     long_help #"""
-Run task(s) and watch for changes to rerun it
+Run task(s) and rerun them when files change
 
-This command uses the `watchexec` tool to watch for changes to files and rerun the specified task(s).
-It must be installed for this command to work, but you can install it with `mise use -g watchexec@latest`.
+Uses `watchexec` to watch for file changes and rerun the given task(s).
+watchexec must be installed; `mise use -g watchexec@latest` installs it.
 
 For more advanced process management (daemon management, auto-restart, readiness checks,
 cron scheduling), see mise's sister project: https://pitchfork.jdx.dev
 """#
-    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise watch build\u{1b}[22m\n    Runs the \"build\" tasks. Will re-run the tasks when any of its sources change.\n    Uses \"sources\" from the tasks definition to determine which files to watch.\n\n    $ \u{1b}[1mmise watch build --glob src/**/*.rs\u{1b}[22m\n    Runs the \"build\" tasks but specify the files to watch with a glob pattern.\n    This overrides the \"sources\" from the tasks definition.\n\n    $ \u{1b}[1mmise watch build --clear\u{1b}[22m\n    Extra arguments are passed to watchexec. See `watchexec --help` for details.\n\n    $ \u{1b}[1mmise watch serve --watch src --exts rs --restart\u{1b}[22m\n    Starts an api server, watching for changes to \"*.rs\" files in \"./src\" and kills/restarts the server when they change.\n"
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise watch build\u{1b}[22m\n    Runs the \"build\" task and reruns it whenever one of its sources changes.\n    The task's \"sources\" determine which files are watched.\n\n    $ \u{1b}[1mmise watch build --glob src/**/*.rs\u{1b}[22m\n    Runs the \"build\" task, watching the files matched by the glob instead of\n    the task's \"sources\".\n\n    $ \u{1b}[1mmise watch build --clear\u{1b}[22m\n    Extra arguments are passed to watchexec. See `watchexec --help` for details.\n\n    $ \u{1b}[1mmise watch serve --watch src --exts rs --restart\u{1b}[22m\n    Starts an API server, watching \"*.rs\" files in \"./src\", and restarts the server when they change.\n"
     flag "-t --task-flag" help="Tasks to run" var=#true hide=#true {
         arg <TASK_FLAG>
     }
@@ -5090,7 +5075,7 @@ This shows the manual page for Watchexec, if the output is a terminal and the 'm
     arg "[TASK]" help=#"""
 Tasks to run
 Can specify multiple tasks by separating with `:::`
-e.g.: `mise run task1 arg1 arg2 ::: task2 arg1 arg2`
+e.g.: `mise watch task1 arg1 arg2 ::: task2 arg1 arg2`
 Defaults to `default`
 """# required=#false
     arg "[ARGS]…" help="Task and arguments to run" required=#false double_dash=automatic var=#true
@@ -5103,14 +5088,13 @@ Display the installation path for a tool
 
 The tool must be installed for this to work.
 """#
-    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Show the latest installed version of node\n    # If it is is not installed, errors\n    $ \u{1b}[1mmise where node@20\u{1b}[22m\n    /home/jdx/.local/share/mise/installs/node/20.0.0\n\n    # Show the current, active install directory of node\n    # Errors if node is not referenced in any .tool-version file\n    $ \u{1b}[1mmise where node\u{1b}[22m\n    /home/jdx/.local/share/mise/installs/node/20.0.0\n"
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Show the latest installed node 20.x\n    # Errors if no matching version is installed\n    $ \u{1b}[1mmise where node@20\u{1b}[22m\n    /home/jdx/.local/share/mise/installs/node/20.0.0\n\n    # Show the install directory of the currently active node\n    # Errors if node is not requested by any config file\n    $ \u{1b}[1mmise where node\u{1b}[22m\n    /home/jdx/.local/share/mise/installs/node/20.0.0\n"
     flag "-h --help" help="Print help" action=help builtin=#true
     arg <TOOL@VERSION> help=#"""
-Tool(s) to look up
+Tool to look up
 e.g.: ruby@3
-if "@<PREFIX>" is specified, it will show the latest installed version
-that matches the prefix
-otherwise, it will show the current, active installed version
+With "@<PREFIX>", shows the latest installed version matching the prefix.
+Otherwise, shows the current, active installed version.
 """#
     arg "[ASDF_VERSION]" help=#"""
 the version prefix to use when querying the latest version
@@ -5118,9 +5102,9 @@ same as the first argument after the "@"
 used for asdf compatibility
 """# required=#false hide=#true
 }
-cmd which help="Shows the path that a tool's bin points to." effect=read {
+cmd which help="Show the path a tool's executable resolves to" effect=read {
     long_help #"""
-Shows the path that a tool's bin points to.
+Show the path a tool's executable resolves to
 
 Use this to figure out what version of a tool is currently active.
 """#
@@ -5135,5 +5119,5 @@ e.g.: `mise which npm --tool=node@20`
     flag --plugin help="Show the plugin name instead of the path" conflicts=--version
     flag --version help="Show the version instead of the path" conflicts=--plugin
     flag "-h --help" help="Print help" action=help builtin=#true
-    arg "[BIN_NAME]" help="The bin to look up" required=#false required_unless=--complete
+    arg "[BIN_NAME]" help="The executable to look up" required=#false required_unless=--complete
 }

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1637,9 +1637,9 @@ Renamed from `mise generate bootstrap`, which read as a form of `mise bootstrap`
 setup). The old name still works but is deprecated and will be removed in mise 2027.9.0.
 """#
         after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise generate install-script --write ./bin/mise\u{1b}[22m\n    $ \u{1b}[1m./bin/mise install\u{1b}[22m                                    \u{1b}[2m# downloads mise to .mise if not already installed\u{1b}[22m\n\n    \u{1b}[2m# add a launcher for contributors who clone the project on Windows\u{1b}[22m\n    $ \u{1b}[1mmise generate install-script --write ./bin/mise --windows\u{1b}[22m  \u{1b}[2m# also writes bin/mise.cmd\u{1b}[22m\n    $ \u{1b}[1m.\\bin\\mise.cmd install\u{1b}[22m\n"
-        flag "-l --localize" help="Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project" {
+        flag "-l --localize" help="Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a project-local directory (`.mise` by default, set with `--localized-dir`)" {
             long_help #"""
-Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project
+Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a project-local directory (`.mise` by default, set with `--localized-dir`)
 
 This is necessary if users may use a different version of mise outside the project.
 """#
@@ -1748,9 +1748,9 @@ Renamed from `mise generate bootstrap`, which read as a form of `mise bootstrap`
 setup). The old name still works but is deprecated and will be removed in mise 2027.9.0.
 """#
         after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise generate install-script --write ./bin/mise\u{1b}[22m\n    $ \u{1b}[1m./bin/mise install\u{1b}[22m                                    \u{1b}[2m# downloads mise to .mise if not already installed\u{1b}[22m\n\n    \u{1b}[2m# add a launcher for contributors who clone the project on Windows\u{1b}[22m\n    $ \u{1b}[1mmise generate install-script --write ./bin/mise --windows\u{1b}[22m  \u{1b}[2m# also writes bin/mise.cmd\u{1b}[22m\n    $ \u{1b}[1m.\\bin\\mise.cmd install\u{1b}[22m\n"
-        flag "-l --localize" help="Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project" {
+        flag "-l --localize" help="Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a project-local directory (`.mise` by default, set with `--localized-dir`)" {
             long_help #"""
-Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project
+Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a project-local directory (`.mise` by default, set with `--localized-dir`)
 
 This is necessary if users may use a different version of mise outside the project.
 """#
@@ -2091,8 +2091,10 @@ cmd install help="Install a tool version" effect=write {
     long_help #"""
 Install a tool version
 
-Installs a tool version to `~/.local/share/mise/installs/<TOOL>/<VERSION>`.
-Installing alone does not activate the tool, so it will not be on PATH.
+Installs a tool version under the mise data directory, by default
+`~/.local/share/mise/installs/<TOOL>/<VERSION>`.
+Installing alone does not add the tool to your config, so a tool that is not
+already configured will not be on PATH.
 To install and activate in one command, use `mise use`, which also writes the version to
 `mise.toml` in the current directory so the tool is active inside it.
 To run a tool once without touching any config, use `mise exec <TOOL>@<VERSION> -- <COMMAND>`.
@@ -3091,7 +3093,7 @@ The name of the script becomes the name of the task.
     EOF
     $ mise run build
 """#
-    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Run the \"lint\" task, defined either in mise.toml or as a standalone script.\n    $ \u{1b}[1mmise run lint\u{1b}[22m\n\n    # Force the \"build\" task to run even if its sources are up-to-date.\n    $ \u{1b}[1mmise run --force build\u{1b}[22m\n\n    # Run \"test\" with stdin/stdout/stderr all connected to the current terminal.\n    # This forces `--jobs=1` to prevent interleaving of output.\n    $ \u{1b}[1mmise run --raw test\u{1b}[22m\n\n    # Run the \"lint\", \"test\", and \"check\" tasks in parallel.\n    $ \u{1b}[1mmise run lint ::: test ::: check\u{1b}[22m\n\n    # Run multiple tasks, each with its own arguments.\n    $ \u{1b}[1mmise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2\u{1b}[22m\n"
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Run the \"lint\" task, defined either in mise.toml or as a standalone script.\n    $ \u{1b}[1mmise run lint\u{1b}[22m\n\n    # Force the \"build\" task to run even if its sources are up to date.\n    $ \u{1b}[1mmise run --force build\u{1b}[22m\n\n    # Run \"test\" with stdin/stdout/stderr all connected to the current terminal.\n    # This forces `--jobs=1` to prevent interleaving of output.\n    $ \u{1b}[1mmise run --raw test\u{1b}[22m\n\n    # Run the \"lint\", \"test\", and \"check\" tasks in parallel.\n    $ \u{1b}[1mmise run lint ::: test ::: check\u{1b}[22m\n\n    # Run multiple tasks, each with its own arguments.\n    $ \u{1b}[1mmise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2\u{1b}[22m\n"
     flag --affected help="Run matching tasks only for projects affected by Git changes"
     flag --affected-base help=#"""
 Git base revision for --affected
@@ -3245,7 +3247,7 @@ By default, it will show all tools that fuzzy match the search term. For
 non-fuzzy matches, use the `--match-type` flag.
 """#
     after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise search jq\u{1b}[22m\n    Tool  Description\n    jq    Command-line JSON processor. https://github.com/jqlang/jq\n    jqp   A TUI playground to experiment with jq. https://github.com/noahgorstein/jqp\n    jiq   jid on jq - interactive JSON query tool using jq expressions. https://github.com/fiatjaf/jiq\n    gojq  Pure Go implementation of jq. https://github.com/itchyny/gojq\n\n    $ \u{1b}[1mmise search --interactive\u{1b}[22m\n    Tool\n    Search a tool\n    ❯ jq    Command-line JSON processor. https://github.com/jqlang/jq\n      jqp   A TUI playground to experiment with jq. https://github.com/noahgorstein/jqp\n      jiq   jid on jq - interactive JSON query tool using jq expressions. https://github.com/fiatjaf/jiq\n      gojq  Pure Go implementation of jq. https://github.com/itchyny/gojq\n    /jq \n    esc clear filter • enter confirm\n"
-    flag "-i --interactive" help="Pick a tool from an interactive search menu" {
+    flag "-i --interactive" help="Show an interactive search menu" {
         conflicts "--match-type" "--no-header"
     }
     flag "-m --match-type" help="Match type: equal, contains, or fuzzy" default=fuzzy {
@@ -3766,7 +3768,7 @@ The name of the script becomes the name of the task.
     EOF
     $ mise run build
 """#
-        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Run the \"lint\" task, defined either in mise.toml or as a standalone script.\n    $ \u{1b}[1mmise run lint\u{1b}[22m\n\n    # Force the \"build\" task to run even if its sources are up-to-date.\n    $ \u{1b}[1mmise run --force build\u{1b}[22m\n\n    # Run \"test\" with stdin/stdout/stderr all connected to the current terminal.\n    # This forces `--jobs=1` to prevent interleaving of output.\n    $ \u{1b}[1mmise run --raw test\u{1b}[22m\n\n    # Run the \"lint\", \"test\", and \"check\" tasks in parallel.\n    $ \u{1b}[1mmise run lint ::: test ::: check\u{1b}[22m\n\n    # Run multiple tasks, each with its own arguments.\n    $ \u{1b}[1mmise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2\u{1b}[22m\n"
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Run the \"lint\" task, defined either in mise.toml or as a standalone script.\n    $ \u{1b}[1mmise run lint\u{1b}[22m\n\n    # Force the \"build\" task to run even if its sources are up to date.\n    $ \u{1b}[1mmise run --force build\u{1b}[22m\n\n    # Run \"test\" with stdin/stdout/stderr all connected to the current terminal.\n    # This forces `--jobs=1` to prevent interleaving of output.\n    $ \u{1b}[1mmise run --raw test\u{1b}[22m\n\n    # Run the \"lint\", \"test\", and \"check\" tasks in parallel.\n    $ \u{1b}[1mmise run lint ::: test ::: check\u{1b}[22m\n\n    # Run multiple tasks, each with its own arguments.\n    $ \u{1b}[1mmise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2\u{1b}[22m\n"
         flag --affected help="Run matching tasks only for projects affected by Git changes"
         flag --affected-base help=#"""
 Git base revision for --affected
@@ -4412,7 +4414,7 @@ watchexec must be installed; `mise use -g watchexec@latest` installs it.
 For more advanced process management (daemon management, auto-restart, readiness checks,
 cron scheduling), see mise's sister project: https://pitchfork.jdx.dev
 """#
-    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise watch build\u{1b}[22m\n    Runs the \"build\" task and reruns it whenever one of its sources changes.\n    The task's \"sources\" determine which files are watched.\n\n    $ \u{1b}[1mmise watch build --glob src/**/*.rs\u{1b}[22m\n    Runs the \"build\" task, watching the files matched by the glob instead of\n    the task's \"sources\".\n\n    $ \u{1b}[1mmise watch build --clear\u{1b}[22m\n    Extra arguments are passed to watchexec. See `watchexec --help` for details.\n\n    $ \u{1b}[1mmise watch serve --watch src --exts rs --restart\u{1b}[22m\n    Starts an API server, watching \"*.rs\" files in \"./src\", and restarts the server when they change.\n"
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise watch build\u{1b}[22m\n    Runs the \"build\" task and reruns it whenever one of its sources changes.\n    The task's \"sources\" determine which files are watched.\n\n    $ \u{1b}[1mmise watch build --glob 'src/**/*.rs'\u{1b}[22m\n    Runs the \"build\" task, watching the files matched by the glob instead of\n    the task's \"sources\".\n\n    $ \u{1b}[1mmise watch build --clear\u{1b}[22m\n    Extra arguments are passed to watchexec. See `watchexec --help` for details.\n\n    $ \u{1b}[1mmise watch serve --watch src --exts rs --restart\u{1b}[22m\n    Starts an API server, watching \"*.rs\" files in \"./src\", and restarts the server when they change.\n"
     flag "-t --task-flag" help="Tasks to run" var=#true hide=#true {
         arg <TASK_FLAG>
     }
@@ -5088,7 +5090,7 @@ Display the installation path for a tool
 
 The tool must be installed for this to work.
 """#
-    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Show the latest installed node 20.x\n    # Errors if no matching version is installed\n    $ \u{1b}[1mmise where node@20\u{1b}[22m\n    /home/jdx/.local/share/mise/installs/node/20.0.0\n\n    # Show the install directory of the currently active node\n    # Errors if node is not requested by any config file\n    $ \u{1b}[1mmise where node\u{1b}[22m\n    /home/jdx/.local/share/mise/installs/node/20.0.0\n"
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Show the latest installed node 20.x\n    # Errors if no matching version is installed\n    $ \u{1b}[1mmise where node@20\u{1b}[22m\n    /home/jdx/.local/share/mise/installs/node/20.0.0\n\n    # Show the install directory of the active node, or of the latest\n    # installed version if no config requests node\n    # Errors if no matching version is installed\n    $ \u{1b}[1mmise where node\u{1b}[22m\n    /home/jdx/.local/share/mise/installs/node/20.0.0\n"
     flag "-h --help" help="Print help" action=help builtin=#true
     arg <TOOL@VERSION> help=#"""
 Tool to look up

--- a/src/cli/activate.rs
+++ b/src/cli/activate.rs
@@ -11,10 +11,10 @@ use crate::toolset::env_cache::CachedEnv;
 use crate::{dirs, env};
 use eyre::Result;
 
-/// Initializes mise in the current shell session
+/// Initialize mise in the current shell session
 ///
-/// This should go into your shell's rc file or login shell.
-/// Otherwise, it will only take effect in the current session.
+/// Add this to your shell's rc or profile file so it runs in every new shell.
+/// Otherwise, it only takes effect in the current session.
 /// (e.g. ~/.zshrc, ~/.zprofile, ~/.zshenv, ~/.bashrc, ~/.bash_profile, ~/.profile, ~/.config/fish/config.fish, or $PROFILE for powershell)
 ///
 /// Typically, this can be added with something like the following:
@@ -52,6 +52,7 @@ pub(crate) struct Activate {
     no_hook_env: bool,
 
     /// Use shims instead of modifying PATH
+    ///
     /// Effectively the same as:
     ///
     ///     PATH="$HOME/.local/share/mise/shims:$PATH"

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -793,6 +793,7 @@ enum BootstrapPluginsCommands {
     Status(BootstrapPluginsStatus),
 }
 
+/// Install package manager plugins declared in `[bootstrap.plugins]`
 #[derive(Debug, usage_rs::Args)]
 struct BootstrapPluginsApply {
     /// Print what would happen without installing plugins
@@ -800,6 +801,7 @@ struct BootstrapPluginsApply {
     dry_run: bool,
 }
 
+/// Show whether declared package manager plugins are installed
 #[derive(Debug, usage_rs::Args)]
 struct BootstrapPluginsStatus {
     /// Exit with code 1 if a declared plugin is missing
@@ -836,6 +838,7 @@ enum BootstrapReposCommands {
     Update(BootstrapReposUpdate),
 }
 
+/// Clone and converge git repos from `[bootstrap.repos]`
 #[derive(Debug, usage_rs::Args)]
 struct BootstrapReposApply {
     /// Print the commands that would run without running them
@@ -851,6 +854,7 @@ struct BootstrapReposApply {
     skip_dirty: bool,
 }
 
+/// Pull the latest changes into configured git repos
 #[derive(Debug, usage_rs::Args)]
 struct BootstrapReposUpdate {
     /// Update only matching configured or expanded paths
@@ -870,6 +874,7 @@ struct BootstrapReposUpdate {
     skip_dirty: bool,
 }
 
+/// Run a command in each configured git repo
 #[derive(Debug, usage_rs::Args)]
 struct BootstrapReposExec {
     /// Run only in matching configured or expanded paths
@@ -889,6 +894,7 @@ struct BootstrapReposExec {
     command: Vec<String>,
 }
 
+/// Show the state of git repos from `[bootstrap.repos]`
 #[derive(Debug, usage_rs::Args)]
 struct BootstrapReposStatus {
     /// Output in JSON format
@@ -943,6 +949,7 @@ enum BootstrapMacosDefaultsCommands {
     Status(BootstrapMacosDefaultsStatus),
 }
 
+/// Write macOS defaults from `[bootstrap.macos.defaults]`
 #[derive(Debug, usage_rs::Args)]
 struct BootstrapMacosDefaultsApply {
     /// Print the commands that would run without running them
@@ -954,6 +961,7 @@ struct BootstrapMacosDefaultsApply {
     yes: bool,
 }
 
+/// Show whether macOS defaults match `[bootstrap.macos.defaults]`
 #[derive(Debug, usage_rs::Args)]
 struct BootstrapMacosDefaultsStatus {
     /// Output in JSON format
@@ -979,6 +987,7 @@ enum BootstrapLaunchdCommands {
     Status(BootstrapLaunchdStatus),
 }
 
+/// Install and load LaunchAgents from `[bootstrap.macos.launchd.agents]`
 #[derive(Debug, usage_rs::Args)]
 struct BootstrapLaunchdApply {
     /// Print the commands that would run without running them
@@ -990,6 +999,7 @@ struct BootstrapLaunchdApply {
     yes: bool,
 }
 
+/// Show the state of LaunchAgents from `[bootstrap.macos.launchd.agents]`
 #[derive(Debug, usage_rs::Args)]
 struct BootstrapLaunchdStatus {
     /// Output in JSON format
@@ -1015,6 +1025,7 @@ enum BootstrapSystemdCommands {
     Status(BootstrapSystemdStatus),
 }
 
+/// Install and start systemd user services from `[bootstrap.linux.systemd.units]`
 #[derive(Debug, usage_rs::Args)]
 struct BootstrapSystemdApply {
     /// Print the commands that would run without running them
@@ -1026,6 +1037,7 @@ struct BootstrapSystemdApply {
     yes: bool,
 }
 
+/// Show the state of systemd user services from `[bootstrap.linux.systemd.units]`
 #[derive(Debug, usage_rs::Args)]
 struct BootstrapSystemdStatus {
     /// Output in JSON format
@@ -1051,6 +1063,7 @@ enum BootstrapShellCommands {
     Status(BootstrapShellStatus),
 }
 
+/// Configure shell activation from `[bootstrap.mise_shell_activate]`
 #[derive(Debug, usage_rs::Args)]
 struct BootstrapShellApply {
     /// Print the actions that would run without writing anything
@@ -1062,6 +1075,7 @@ struct BootstrapShellApply {
     yes: bool,
 }
 
+/// Show whether shell activation matches `[bootstrap.mise_shell_activate]`
 #[derive(Debug, usage_rs::Args)]
 struct BootstrapShellStatus {
     /// Output in JSON format
@@ -1087,6 +1101,7 @@ enum BootstrapUserCommands {
     Status(BootstrapUserStatus),
 }
 
+/// Apply current-user settings from `[bootstrap.user]`
 #[derive(Debug, usage_rs::Args)]
 struct BootstrapUserApply {
     /// Print the commands that would run without running them
@@ -1098,6 +1113,7 @@ struct BootstrapUserApply {
     yes: bool,
 }
 
+/// Show whether current-user settings match `[bootstrap.user]`
 #[derive(Debug, usage_rs::Args)]
 struct BootstrapUserStatus {
     /// Output in JSON format

--- a/src/cli/cache/clear.rs
+++ b/src/cli/cache/clear.rs
@@ -8,7 +8,7 @@ use heck::ToKebabCase;
 use itertools::Itertools;
 use walkdir::WalkDir;
 
-/// Deletes all cache files in mise
+/// Delete all cache files
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, visible_alias = "c", alias = "clean")]
 pub(super) struct CacheClear {

--- a/src/cli/cache/prune.rs
+++ b/src/cli/cache/prune.rs
@@ -8,7 +8,7 @@ use eyre::Result;
 use heck::ToKebabCase;
 use std::time::Duration;
 
-/// Removes stale mise cache files
+/// Remove stale cache files
 ///
 /// By default, this command will remove files that have not been accessed in 30 days.
 /// Change this with the MISE_CACHE_PRUNE_AGE environment variable.
@@ -23,7 +23,7 @@ pub(super) struct CachePrune {
     #[usage(long, short, action = usage_rs::ArgAction::Count)]
     verbose: u8,
 
-    /// Just show what would be pruned
+    /// Show what would be pruned without deleting anything
     #[usage(long)]
     dry_run: bool,
 }

--- a/src/cli/config/get.rs
+++ b/src/cli/config/get.rs
@@ -5,11 +5,11 @@ use crate::file::display_path;
 use eyre::bail;
 use std::path::PathBuf;
 
-/// Display the value of a setting in a mise.toml file
+/// Display a value from a mise.toml file
 #[derive(Debug, usage_rs::Args)]
 #[usage(after_long_help = AFTER_LONG_HELP, verbatim_doc_comment)]
 pub(super) struct ConfigGet {
-    /// The path of the config to display
+    /// Dotted key path to display, e.g. `tools.python`; omit to print the whole file
     pub key: Option<String>,
 
     /// The path to the mise.toml file to read

--- a/src/cli/config/set.rs
+++ b/src/cli/config/set.rs
@@ -8,11 +8,11 @@ use crate::toml::dedup_toml_array;
 use eyre::bail;
 use std::path::PathBuf;
 
-/// Set the value of a setting in a mise.toml file
+/// Set a value in a mise.toml file
 #[derive(Debug, usage_rs::Args)]
 #[usage(after_long_help = AFTER_LONG_HELP, verbatim_doc_comment)]
 pub(super) struct ConfigSet {
-    /// The path of the config to display
+    /// Dotted key path to set, e.g. `tools.python`
     pub key: String,
 
     /// The value to set the key to (optional if provided as KEY=VALUE)
@@ -42,6 +42,7 @@ pub(super) struct ConfigSet {
     #[usage(long, conflicts = "append")]
     pub remove: bool,
 
+    /// TOML type to store the value as; inferred from the value by default
     #[usage(value_enum, short, long, default = "infer")]
     pub type_: TomlValueTypes,
 }

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -39,6 +39,7 @@ pub(crate) struct Doctor {
     errors: Vec<String>,
     #[usage(skip)]
     warnings: Vec<String>,
+    /// Output in JSON format
     #[usage(long, short = 'J')]
     json: bool,
 }

--- a/src/cli/en.rs
+++ b/src/cli/en.rs
@@ -3,11 +3,11 @@ use std::path::PathBuf;
 
 use crate::env;
 
-/// Starts a new shell with the mise environment built from the current configuration
+/// Start a new shell with the mise environment built from the current configuration
 ///
-/// This is an alternative to `mise activate` that allows you to explicitly start a mise session.
-/// It will have the tools and environment variables in the configs loaded.
-/// Note that changing directories will not update the mise environment.
+/// This is an alternative to `mise activate` for starting a mise session explicitly.
+/// The new shell has the tools and environment variables from the config loaded.
+/// Unlike an activated shell, changing directories does not update the environment.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(crate) struct En {

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -9,14 +9,14 @@ use crate::toolset::{InstallOptions, Toolset, ToolsetBuilder};
 use crate::wildcard::wildcard_match;
 use indexmap::IndexSet;
 
-/// Exports env vars to activate mise a single time
+/// Export env vars to activate mise a single time
 ///
-/// Use this if you don't want to permanently install mise. It's not necessary to
-/// use this if you have `mise activate` in your shell rc file.
+/// Use this to load the environment into one shell without adding `mise activate` to
+/// your shell rc file. It is not needed in shells where mise is already activated.
 #[derive(Debug, usage_rs::Args)]
 #[usage(visible_alias = "e", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(crate) struct Env {
-    /// Tool(s) to use
+    /// Tool(s) to include in addition to those in config, e.g. node@20
     #[usage(value_name = "TOOL@VERSION")]
     tool: Vec<ToolArg>,
 

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -21,17 +21,18 @@ use crate::toolset::{InstallOptions, ResolveOptions, Toolset, ToolsetBuilder};
 
 /// Execute a command with tool(s) set
 ///
-/// use this to avoid modifying the shell session or running ad-hoc commands with mise tools set.
+/// Use this to run a command with mise's tools and environment without modifying the shell
+/// session, or to run ad-hoc commands with tools that are not in the config.
 ///
-/// Tools will be loaded from mise.toml, though they can be overridden with <RUNTIME> args
-/// Note that only the plugin specified will be overridden, so if a `mise.toml` file
-/// includes "node 20" but you run `mise exec python@3.11`; it will still load node@20.
+/// Tools are loaded from mise.toml and can be overridden with <TOOL@VERSION> args. Only the
+/// tools you name are overridden: if `mise.toml` includes `node = "20"` and you run
+/// `mise exec python@3.11`, node@20 is still loaded.
 ///
-/// The "--" separates runtimes from the commands to pass along to the subprocess.
+/// The "--" separates tools from the command to pass along to the subprocess.
 #[derive(Debug, usage_rs::Args)]
 #[usage(visible_alias = "x", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(crate) struct Exec {
-    /// Tool(s) to start
+    /// Tool(s) to load
     /// e.g.: node@20 python@3.10
     #[usage(value_name = "TOOL@VERSION")]
     pub tool: Vec<ToolArg>,
@@ -46,7 +47,7 @@ pub(crate) struct Exec {
 
     /// Number of jobs to run in parallel
     /// Values below 1 are treated as 1
-    /// [default: 4]
+    /// Defaults to the `jobs` setting
     #[usage(long, short, env = "MISE_JOBS", verbatim_doc_comment)]
     pub jobs: Option<usize>,
 
@@ -96,8 +97,8 @@ pub(crate) struct Exec {
     #[usage(long)]
     pub no_deps: bool,
 
-    /// Connect backend install command stdin/stdout/stderr directly to the terminal
-    /// Implies --jobs=1
+    /// Connect backend install command stdin/stdout/stderr directly to the terminal.
+    /// Implies `--jobs=1`
     #[usage(long, overrides = "jobs")]
     pub raw: bool,
 }

--- a/src/cli/fmt.rs
+++ b/src/cli/fmt.rs
@@ -5,17 +5,17 @@ use eyre::bail;
 use std::io::{self, Read, Write};
 use taplo::formatter::Options;
 
-/// Formats mise.toml
+/// Format mise.toml
 ///
 /// Sorts keys and cleans up whitespace in mise.toml
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(crate) struct Fmt {
-    /// Format all files from the current directory
+    /// Format every config file mise currently loads, not just those in the current directory
     #[usage(short, long)]
     pub all: bool,
 
-    /// Check if the configs are formatted, no formatting is done
+    /// Check whether the configs are formatted without rewriting them; exits 1 if any are not
     #[usage(short, long)]
     pub check: bool,
 

--- a/src/cli/generate/devcontainer.rs
+++ b/src/cli/generate/devcontainer.rs
@@ -23,7 +23,7 @@ pub(super) struct Devcontainer {
     #[usage(long, short, verbatim_doc_comment)]
     name: Option<String>,
 
-    /// write to .devcontainer/devcontainer.json
+    /// Write to .devcontainer/devcontainer.json
     #[usage(long, short)]
     write: bool,
 }

--- a/src/cli/generate/git_pre_commit.rs
+++ b/src/cli/generate/git_pre_commit.rs
@@ -18,7 +18,7 @@ pub(super) struct GitPreCommit {
     /// The task to run when the pre-commit hook is triggered
     #[usage(long, short, default = "pre-commit")]
     task: String,
-    /// write to .git/hooks/pre-commit and make it executable
+    /// Write to .git/hooks/pre-commit and make it executable
     #[usage(long, short)]
     write: bool,
     /// Which hook to generate (saves to .git/hooks/$hook)

--- a/src/cli/generate/github_action.rs
+++ b/src/cli/generate/github_action.rs
@@ -13,10 +13,10 @@ pub(super) struct GithubAction {
     /// The task to run when the workflow is triggered
     #[usage(long, short, default = "ci")]
     task: String,
-    /// write to .github/workflows/$name.yml
+    /// Write to .github/workflows/$name.yml
     #[usage(long, short)]
     write: bool,
-    /// the name of the workflow to generate
+    /// The name of the workflow to generate
     #[usage(long, default = "ci")]
     name: String,
 }

--- a/src/cli/generate/install_script.rs
+++ b/src/cli/generate/install_script.rs
@@ -15,7 +15,7 @@ use xx::regex;
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(super) struct InstallScript {
-    /// Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project
+    /// Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a project-local directory (`.mise` by default, set with `--localized-dir`)
     ///
     /// This is necessary if users may use a different version of mise outside the project.
     #[usage(long, short, verbatim_doc_comment)]

--- a/src/cli/generate/install_script.rs
+++ b/src/cli/generate/install_script.rs
@@ -15,7 +15,7 @@ use xx::regex;
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(super) struct InstallScript {
-    /// Sandboxes mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project
+    /// Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project
     ///
     /// This is necessary if users may use a different version of mise outside the project.
     #[usage(long, short, verbatim_doc_comment)]
@@ -23,7 +23,7 @@ pub(super) struct InstallScript {
     /// Specify mise version to fetch
     #[usage(long, short = 'V', verbatim_doc_comment)]
     version: Option<String>,
-    /// instead of outputting the script to stdout, write to a file and make it executable
+    /// Write the script to a file and make it executable instead of printing it to stdout
     #[usage(long, short, verbatim_doc_comment, num_args=0..=1, default_missing = "./bin/mise")]
     write: Option<PathBuf>,
     /// Directory to put localized data into

--- a/src/cli/generate/task_docs.rs
+++ b/src/cli/generate/task_docs.rs
@@ -10,7 +10,7 @@ const TASK_PLACEHOLDER_END: &str = "<!-- /mise-tasks -->";
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(super) struct TaskDocs {
-    /// inserts the documentation into an existing file
+    /// Insert the documentation into an existing file
     ///
     /// This will look for a special comment, `<!-- mise-tasks -->`, and replace it with the generated documentation.
     /// It will replace everything between the comment and the next comment, `<!-- /mise-tasks -->` so it can be
@@ -18,18 +18,19 @@ pub(super) struct TaskDocs {
     /// The file must already contain both comments; mise errors instead of modifying the file if they are missing.
     #[usage(long, short, verbatim_doc_comment)]
     inject: bool,
-    /// write only an index of tasks, intended for use with `--multi`
+    /// Write only an index of tasks, intended for use with `--multi`
     #[usage(long, short = 'I', verbatim_doc_comment)]
     index: bool,
-    /// render each task as a separate document, requires `--output` to be a directory
+    /// Render each task as a separate document; requires `--output` to be a directory
     #[usage(long, short, verbatim_doc_comment)]
     multi: bool,
-    /// writes the generated docs to a file/directory
+    /// Write the generated docs to a file or directory
     #[usage(long, short, verbatim_doc_comment)]
     output: Option<PathBuf>,
-    /// root directory to search for tasks
+    /// Root directory to search for tasks
     #[usage(long, short, verbatim_doc_comment, value_hint = usage_rs::ValueHint::DirPath)]
     root: Option<PathBuf>,
+    /// Documentation style: `simple` lists tasks, `detailed` documents each task's usage
     #[usage(long, short, verbatim_doc_comment, value_enum, default = "simple")]
     style: TaskDocsStyle,
 }

--- a/src/cli/generate/task_stubs.rs
+++ b/src/cli/generate/task_stubs.rs
@@ -11,7 +11,7 @@ use std::fs;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
-/// Generates shims to run mise tasks
+/// Generate shims to run mise tasks
 ///
 /// By default, this will build shims like ./bin/<task>. These can be paired with `mise generate install-script`
 /// so contributors to a project can execute mise tasks without installing mise into their system.

--- a/src/cli/implode.rs
+++ b/src/cli/implode.rs
@@ -8,9 +8,9 @@ use crate::ui::prompt;
 use crate::{dirs, env, file};
 use std::collections::BTreeSet;
 
-/// Removes mise CLI and all related data
+/// Remove the mise CLI and all related data
 ///
-/// Skips config directory by default.
+/// The config directory is kept unless `--config` is passed.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment)]
 pub(crate) struct Implode {

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -24,13 +24,13 @@ use std::path::PathBuf;
 
 /// Install a tool version
 ///
-/// Installs a tool version to `~/.local/share/mise/installs/<TOOL>/<VERSION>`
-/// Installing alone will not activate the tools so they won't be in PATH.
-/// To install and/or activate in one command, use `mise use` which will create a `mise.toml` file
-/// in the current directory to activate this tool when inside the directory.
-/// Alternatively, run `mise exec <TOOL>@<VERSION> -- <COMMAND>` to execute a tool without creating config files.
+/// Installs a tool version to `~/.local/share/mise/installs/<TOOL>/<VERSION>`.
+/// Installing alone does not activate the tool, so it will not be on PATH.
+/// To install and activate in one command, use `mise use`, which also writes the version to
+/// `mise.toml` in the current directory so the tool is active inside it.
+/// To run a tool once without touching any config, use `mise exec <TOOL>@<VERSION> -- <COMMAND>`.
 ///
-/// Tools will be installed in parallel. To disable, set `--jobs=1` or `MISE_JOBS=1`
+/// Tools are installed in parallel. To disable, set `--jobs=1` or `MISE_JOBS=1`.
 #[derive(Debug, Default, usage_rs::Args)]
 #[usage(visible_alias = "i", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(crate) struct Install {
@@ -46,7 +46,7 @@ pub(crate) struct Install {
 
     /// Number of jobs to run in parallel
     /// Values below 1 are treated as 1
-    /// [default: 4]
+    /// Defaults to the `jobs` setting
     #[usage(long, short, env = "MISE_JOBS", verbatim_doc_comment)]
     jobs: Option<usize>,
 
@@ -92,8 +92,8 @@ pub(crate) struct Install {
     #[usage(long, env = "MISE_MONOREPO", verbatim_doc_comment)]
     monorepo: bool,
 
-    /// Connect backend install command stdin/stdout/stderr directly to the terminal
-    /// Implies --jobs=1
+    /// Connect backend install command stdin/stdout/stderr directly to the terminal.
+    /// Implies `--jobs=1`
     #[usage(long, overrides = "jobs")]
     raw: bool,
 
@@ -704,10 +704,10 @@ fn extend_toolset(toolset: &mut Toolset, additional: &[ToolRequest]) {
 static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
 
-    $ <bold>mise install node@20.0.0</bold>  # install specific node version
-    $ <bold>mise install node@20</bold>      # install fuzzy node version
-    $ <bold>mise install node</bold>         # install version specified in mise.toml
-    $ <bold>mise install</bold>              # installs everything specified in mise.toml
+    $ <bold>mise install node@20.0.0</bold>  # install a specific node version
+    $ <bold>mise install node@20</bold>      # install the latest node 20.x
+    $ <bold>mise install node</bold>         # install the version specified in mise.toml
+    $ <bold>mise install</bold>              # install everything specified in mise.toml
     $ <bold>mise install --include-lazy</bold> # also install tools configured for lazy installation
     $ <bold>mise install --include-task-tools</bold> # also install tools required by tasks
 "#

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -24,8 +24,10 @@ use std::path::PathBuf;
 
 /// Install a tool version
 ///
-/// Installs a tool version to `~/.local/share/mise/installs/<TOOL>/<VERSION>`.
-/// Installing alone does not activate the tool, so it will not be on PATH.
+/// Installs a tool version under the mise data directory, by default
+/// `~/.local/share/mise/installs/<TOOL>/<VERSION>`.
+/// Installing alone does not add the tool to your config, so a tool that is not
+/// already configured will not be on PATH.
 /// To install and activate in one command, use `mise use`, which also writes the version to
 /// `mise.toml` in the current directory so the tool is active inside it.
 /// To run a tool once without touching any config, use `mise exec <TOOL>@<VERSION> -- <COMMAND>`.

--- a/src/cli/latest.rs
+++ b/src/cli/latest.rs
@@ -7,7 +7,7 @@ use crate::install_before::resolve_cli_minimum_release_age;
 use crate::toolset::{ToolRequest, resolve_sub_base};
 use crate::ui::multi_progress_report::MultiProgressReport;
 
-/// Gets the latest available version for a plugin
+/// Get the latest available version of a tool
 ///
 /// Supports prefixes such as `node@20` to get the latest version of node 20.
 #[derive(Debug, usage_rs::Args)]

--- a/src/cli/link.rs
+++ b/src/cli/link.rs
@@ -10,9 +10,9 @@ use crate::toolset::{ToolRequest, ToolVersion, install_state};
 use crate::{backend, config, file};
 use crate::{cli::args::ToolArg, config::Config};
 
-/// Symlinks a tool version into mise
+/// Symlink a tool version into mise
 ///
-/// Use this for adding installs either custom compiled outside mise or built with a different tool.
+/// Use this to register an install that was compiled by hand or built with another tool.
 #[derive(Debug, usage_rs::Args)]
 #[usage(visible_alias = "ln", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(crate) struct Link {

--- a/src/cli/ls.rs
+++ b/src/cli/ls.rs
@@ -23,11 +23,8 @@ use crate::ui::table::MiseTable;
 
 /// List installed and active tool versions
 ///
-/// This command lists tools that mise "knows about".
-/// These may be tools that are currently installed, or those
-/// that are in a config file (active) but may or may not be installed.
-///
-/// It's a useful command to get the current state of your tools.
+/// Lists the tools mise knows about: versions that are installed, and versions requested
+/// by a config file (active) whether or not they are installed.
 #[derive(Debug, usage_rs::Args)]
 #[usage(visible_alias = "list", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(crate) struct Ls {

--- a/src/cli/ls_remote.rs
+++ b/src/cli/ls_remote.rs
@@ -25,9 +25,9 @@ struct VersionOutputAll {
     prerelease: Option<bool>,
 }
 
-/// List runtime versions available for install.
+/// List tool versions available to install
 ///
-/// Note that the results may be cached, run `mise cache clean` to clear the cache and get fresh results.
+/// Results may be cached; run `mise cache clear` to fetch fresh results.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP, aliases = ["list-all", "list-remote"]
 )]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -153,7 +153,7 @@ Shorthand for `mise tasks run <TASK>`."#
     /// Answer yes to all confirmation prompts
     #[usage(short = 'y', long, global = true)]
     pub yes: bool,
-    /// Sets log level to debug
+    /// Set the log level to debug
     #[usage(long, global = true, hide = true, overrides = &["quiet", "trace", "verbose", "silent", "log_level"])]
     pub debug: bool,
     #[usage(long, global = true, hide = true, value_name = "LEVEL", value_enum, overrides = &["quiet", "trace", "verbose", "silent", "debug"])]
@@ -173,12 +173,13 @@ Shorthand for `mise tasks run <TASK>`."#
     /// Can also use `MISE_NO_HOOKS=1`
     #[usage(long)]
     pub no_hooks: bool,
-    /// Hides elapsed time after each task completes
+    /// Hide the elapsed time printed after each task completes
     ///
-    /// Default to always hide with `MISE_TASK_TIMINGS=0`
+    /// Set `MISE_TASK_TIMINGS=0` to hide it by default
     #[usage(long, alias = "no-timing", hide = true, verbatim_doc_comment)]
     pub no_timings: bool,
-    #[usage(long)]
+    /// How task output is displayed when running a task (same as `mise run --output`)
+    #[usage(long, hide = true)]
     pub output: Option<TaskOutput>,
     /// Read/write directly to stdin/stdout/stderr instead of by line
     #[usage(long, global = true)]
@@ -193,12 +194,12 @@ Shorthand for `mise tasks run <TASK>`."#
     /// Suppress all task output and mise non-error messages
     #[usage(long, global = true, overrides = &["quiet", "trace", "verbose", "debug", "log_level"])]
     pub silent: bool,
-    /// Shows elapsed time after each task completes
+    /// Show the elapsed time after each task completes
     ///
-    /// Default to always show with `MISE_TASK_TIMINGS=1`
+    /// Set `MISE_TASK_TIMINGS=1` to show it by default
     #[usage(long, alias = "timing", verbatim_doc_comment, hide = true)]
     pub timings: bool,
-    /// Sets log level to trace
+    /// Set the log level to trace
     #[usage(long, global = true, hide = true, overrides = &["quiet", "silent", "verbose", "debug", "log_level"])]
     pub trace: bool,
 }
@@ -1076,7 +1077,9 @@ fn usage_error(argv: &[&std::ffi::OsStr], err: usage_rs::Error<'_, '_>) -> Repor
     }
 }
 
-const LONG_ABOUT: &str = "mise prepares your development environment before each command runs. https://github.com/jdx/mise";
+const LONG_ABOUT: &str = "mise installs the dev tools your projects need, sets their environment variables, and runs their tasks.
+
+Tools, env vars, and tasks are declared in mise.toml. `mise use <TOOL>` adds a tool to the project in the current directory, `mise install` installs everything the config asks for, and `mise run <TASK>` runs a task. Docs: https://mise.jdx.dev";
 
 static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>

--- a/src/cli/outdated.rs
+++ b/src/cli/outdated.rs
@@ -10,7 +10,7 @@ use indexmap::IndexMap;
 use tabled::settings::Remove;
 use tabled::settings::location::ByColumnName;
 
-/// Shows outdated tool versions
+/// Show outdated tool versions
 ///
 /// See `mise upgrade` to upgrade these versions.
 #[derive(Debug, usage_rs::Args)]
@@ -22,12 +22,10 @@ pub(crate) struct Outdated {
     #[usage(value_name = "TOOL@VERSION", verbatim_doc_comment)]
     pub tool: Vec<ToolArg>,
 
-    /// Compares against the latest versions available, not what matches the current config
+    /// Compare against the latest versions available, not just those matching the current config
     ///
-    /// For example, if you have `node = "20"` in your config by default `mise outdated` will only
-    /// show other 20.x versions, not 21.x or 22.x versions.
-    ///
-    /// Using this flag, if there are 21.x or newer versions it will display those instead of 20.x.
+    /// For example, with `node = "20"` in your config, `mise outdated` normally only reports newer
+    /// 20.x versions. With this flag it reports the newest version overall, such as 22.x.
     #[usage(long, short = 'b', verbatim_doc_comment)]
     pub bump: bool,
 

--- a/src/cli/plugins/install.rs
+++ b/src/cli/plugins/install.rs
@@ -20,10 +20,9 @@ use super::{PluginTaskNames, PluginTaskResult, join_plugin_tasks, spawn_plugin_t
 
 /// Install a plugin
 ///
-/// note that mise can automatically install plugins when you install a tool
-/// e.g.: `mise install cmake@3.30` will autoinstall the cmake plugin
-///
-/// This behavior can be modified in ~/.config/mise/config.toml
+/// Note that mise installs plugins automatically when you install a tool that needs one,
+/// e.g.: `mise install cmake@3.30` installs the cmake plugin first. This command is only
+/// needed to install a plugin ahead of time or from a custom git URL.
 #[derive(Debug, usage_rs::Args)]
 #[usage(visible_aliases = ["i", "a", "add"], verbatim_doc_comment, after_long_help = AFTER_LONG_HELP
 )]

--- a/src/cli/plugins/link.rs
+++ b/src/cli/plugins/link.rs
@@ -8,7 +8,7 @@ use crate::backend::unalias_backend;
 use crate::file::{make_symlink, remove_all};
 use crate::{dirs, file};
 
-/// Symlinks a plugin into mise
+/// Symlink a plugin into mise
 ///
 /// This is used for developing a plugin.
 #[derive(Debug, usage_rs::Args)]

--- a/src/cli/plugins/ls.rs
+++ b/src/cli/plugins/ls.rs
@@ -21,8 +21,8 @@ pub(super) struct PluginsLs {
     #[usage(short, long, hide = true, verbatim_doc_comment)]
     pub all: bool,
 
-    /// The built-in plugins only
-    /// Normally these are not shown
+    /// Only show built-in (core) plugins
+    /// These are hidden by default
     #[usage(short, long, verbatim_doc_comment, conflicts = "all", hide = true)]
     pub core: bool,
 

--- a/src/cli/plugins/ls_remote.rs
+++ b/src/cli/plugins/ls_remote.rs
@@ -7,15 +7,13 @@ use crate::toolset::install_state;
 
 /// List all available remote plugins
 #[derive(Debug, usage_rs::Args)]
-#[usage(visible_aliases = ["list-remote", "list-all"], long_about = LONG_ABOUT, verbatim_doc_comment)]
+#[usage(visible_aliases = ["list-remote", "list-all"], long_about = LONG_ABOUT, after_long_help = AFTER_LONG_HELP, verbatim_doc_comment)]
 pub(super) struct PluginsLsRemote {
-    /// Show the git url for each plugin
-    /// e.g.: https://github.com/mise-plugins/mise-poetry.git
+    /// Show the git url for each plugin, e.g. https://github.com/mise-plugins/mise-poetry.git
     #[usage(short, long)]
     pub urls: bool,
 
-    /// Only show the name of each plugin
-    /// by default it will show a "*" next to installed plugins
+    /// Only show the name of each plugin, without the "*" marking installed plugins
     #[usage(long)]
     pub only_names: bool,
 }
@@ -53,12 +51,13 @@ impl PluginsLsRemote {
     }
 }
 
-const LONG_ABOUT: &str = r#"
-List all available remote plugins
+const LONG_ABOUT: &str = r#"List all available remote plugins
 
-The full list is here: https://github.com/jdx/mise/blob/main/registry/
+These are the shorthand names from the registry: https://github.com/jdx/mise/blob/main/registry/"#;
 
-Examples:
+static AFTER_LONG_HELP: &str = color_print::cstr!(
+    r#"<bold><underline>Examples:</underline></bold>
 
-    $ mise plugins ls-remote
-"#;
+    $ <bold>mise plugins ls-remote</bold>
+"#
+);

--- a/src/cli/plugins/mod.rs
+++ b/src/cli/plugins/mod.rs
@@ -87,14 +87,14 @@ pub(crate) struct Plugins {
     #[usage(subcommand)]
     command: Option<Commands>,
 
-    /// list all available remote plugins
+    /// List all available remote plugins
     ///
-    /// same as `mise plugins ls-remote`
+    /// Same as `mise plugins ls-remote`
     #[usage(short, long, hide = true)]
     pub all: bool,
 
-    /// The built-in plugins only
-    /// Normally these are not shown
+    /// Only show built-in (core) plugins
+    /// These are hidden by default
     #[usage(short, long, verbatim_doc_comment, conflicts = "all")]
     pub core: bool,
 

--- a/src/cli/plugins/uninstall.rs
+++ b/src/cli/plugins/uninstall.rs
@@ -6,7 +6,7 @@ use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::style;
 use crate::{backend, plugins};
 
-/// Removes a plugin
+/// Remove a plugin
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, visible_aliases = ["remove", "rm"], after_long_help = AFTER_LONG_HELP)]
 pub(super) struct PluginsUninstall {

--- a/src/cli/plugins/update.rs
+++ b/src/cli/plugins/update.rs
@@ -11,9 +11,9 @@ use crate::ui::multi_progress_report::MultiProgressReport;
 
 use super::{PluginTaskNames, PluginTaskResult, join_plugin_tasks, spawn_plugin_task};
 
-/// Updates a plugin to the latest version
+/// Update a plugin to the latest version
 ///
-/// note: this updates the plugin itself, not the runtime versions
+/// Note: this updates the plugin itself, not the tool versions it manages
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, visible_aliases = ["up", "upgrade"], after_long_help = AFTER_LONG_HELP)]
 pub(super) struct Update {
@@ -23,7 +23,7 @@ pub(super) struct Update {
 
     /// Number of jobs to run in parallel
     /// Values below 1 are treated as 1
-    /// Default: 4
+    /// Defaults to the `jobs` setting
     #[usage(long, short, verbatim_doc_comment)]
     jobs: Option<usize>,
 }

--- a/src/cli/registry.rs
+++ b/src/cli/registry.rs
@@ -37,7 +37,7 @@ pub(crate) struct Registry {
     #[usage(long, short = 'J')]
     json: bool,
 
-    /// Include security features for each tool's backends in JSON output.
+    /// Include security features for each tool's backends in JSON output
     ///
     /// Requires --json. Security info is de-duplicated across
     /// all of a tool's backends. This can add noticeable time for large

--- a/src/cli/reshim.rs
+++ b/src/cli/reshim.rs
@@ -4,13 +4,12 @@ use crate::config::Config;
 use crate::shims;
 use crate::toolset::ToolsetBuilder;
 
-/// Creates new shims based on bin paths from currently installed tools.
+/// Create shims for the executables of currently installed tools
 ///
-/// This creates new shims in the configured user shim directory for CLIs that have been added.
-/// With `--system`, it rebuilds the configured system shim farm instead.
-/// mise will try to do this automatically for commands like `npm i -g` but there are
-/// other ways to install things (like using yarn or pnpm for node) that mise does
-/// not know about and so it will be necessary to call this explicitly.
+/// This creates shims in the user shim directory for executables that have been added since
+/// the last reshim. With `--system`, it rebuilds the system shim farm instead.
+/// mise runs this automatically after commands like `npm i -g`, but other ways of installing
+/// executables (such as yarn or pnpm for node) are not detected, so call this explicitly then.
 ///
 /// If you think mise should automatically call this for a particular command, please
 /// open an issue on the mise repo. You can also set up a shell function to reshim
@@ -31,7 +30,7 @@ pub(crate) struct Reshim {
     #[usage(hide = true)]
     pub version: Option<String>,
 
-    /// Rebuilds all mise-owned shims
+    /// Rebuild all mise-owned shims
     #[usage(long, short)]
     pub force: bool,
 

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1487,7 +1487,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     # Run the "lint" task, defined either in mise.toml or as a standalone script.
     $ <bold>mise run lint</bold>
 
-    # Force the "build" task to run even if its sources are up-to-date.
+    # Force the "build" task to run even if its sources are up to date.
     $ <bold>mise run --force build</bold>
 
     # Run "test" with stdin/stdout/stderr all connected to the current terminal.

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -32,10 +32,9 @@ use tokio::sync::Mutex;
 
 /// Run task(s)
 ///
-/// This command will run a task, or multiple tasks in parallel.
-/// Tasks may have dependencies on other tasks or on source files.
-/// If source is configured on a task, it will only run if the source
-/// files have changed.
+/// Runs one task, or several tasks in parallel.
+/// Tasks may depend on other tasks and on source files.
+/// If a task has `sources` configured, it only runs when those files have changed.
 ///
 /// Tasks can be defined in mise.toml or as standalone scripts.
 /// In mise.toml, tasks take this form:
@@ -48,7 +47,7 @@ use tokio::sync::Mutex;
 /// Alternatively, tasks can be defined as standalone scripts.
 /// These must be located in `mise-tasks`, `.mise-tasks`, `.mise/tasks`, `mise/tasks` or
 /// `.config/mise/tasks`.
-/// The name of the script will be the name of the tasks.
+/// The name of the script becomes the name of the task.
 ///
 ///     $ cat .mise/tasks/build<<EOF
 ///     #!/usr/bin/env bash
@@ -129,8 +128,7 @@ pub(crate) struct Run {
 
     /// Number of tasks to run in parallel
     /// Values below 1 are treated as 1
-    /// [default: 4]
-    /// Configure with `jobs` config or `MISE_JOBS` env var
+    /// Defaults to the `jobs` setting or the `MISE_JOBS` env var
     #[usage(long, short, env = "MISE_JOBS", verbatim_doc_comment)]
     pub jobs: Option<usize>,
 
@@ -138,7 +136,7 @@ pub(crate) struct Run {
     #[usage(long, short = 'n', verbatim_doc_comment)]
     pub dry_run: bool,
 
-    /// Change how tasks information is output when running tasks
+    /// How task output is displayed
     ///
     /// - `prefix` - Print stdout/stderr by line, prefixed with the task's label
     /// - `interleave` - Print directly to stdout/stderr instead of by line
@@ -229,9 +227,9 @@ pub(crate) struct Run {
     #[usage(long)]
     pub no_deps: bool,
 
-    /// Hides elapsed time after each task completes
+    /// Hide the elapsed time printed after each task completes
     ///
-    /// Default to always hide with `MISE_TASK_TIMINGS=0`
+    /// Set `MISE_TASK_TIMINGS=0` to hide it by default
     #[usage(long, alias = "no-timing", verbatim_doc_comment)]
     pub no_timings: bool,
 
@@ -284,9 +282,9 @@ pub(crate) struct Run {
     #[usage(long, verbatim_doc_comment)]
     pub timeout: Option<String>,
 
-    /// Shows elapsed time after each task completes
+    /// Show the elapsed time after each task completes
     ///
-    /// Default to always show with `MISE_TASK_TIMINGS=1`
+    /// Set `MISE_TASK_TIMINGS=1` to show it by default
     #[usage(long, alias = "timing", verbatim_doc_comment, hide = true)]
     pub timings: bool,
 
@@ -1486,21 +1484,20 @@ fn render_usage_help(spec: &usage::Spec, args: &[String]) -> String {
 static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
 
-    # Runs the "lint" tasks. This needs to either be defined in mise.toml
-    # or as a standalone script. See the project README for more information.
+    # Run the "lint" task, defined either in mise.toml or as a standalone script.
     $ <bold>mise run lint</bold>
 
-    # Forces the "build" tasks to run even if its sources are up-to-date.
+    # Force the "build" task to run even if its sources are up-to-date.
     $ <bold>mise run --force build</bold>
 
     # Run "test" with stdin/stdout/stderr all connected to the current terminal.
     # This forces `--jobs=1` to prevent interleaving of output.
     $ <bold>mise run --raw test</bold>
 
-    # Runs the "lint", "test", and "check" tasks in parallel.
+    # Run the "lint", "test", and "check" tasks in parallel.
     $ <bold>mise run lint ::: test ::: check</bold>
 
-    # Execute multiple tasks each with their own arguments.
+    # Run multiple tasks, each with its own arguments.
     $ <bold>mise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2</bold>
 "#
 );

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -33,7 +33,7 @@ pub(crate) struct Search {
     /// The tool to search for
     name: Option<String>,
 
-    /// Pick a tool from an interactive search menu
+    /// Show an interactive search menu
     #[usage(long, short, conflicts = &["match_type", "no_header"])]
     interactive: bool,
 

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -23,7 +23,7 @@ pub(crate) enum MatchType {
 
 /// Search for tools in the registry
 ///
-/// This command searches a tool in the registry.
+/// Searches the registry for tools matching NAME.
 ///
 /// By default, it will show all tools that fuzzy match the search term. For
 /// non-fuzzy matches, use the `--match-type` flag.
@@ -33,7 +33,7 @@ pub(crate) struct Search {
     /// The tool to search for
     name: Option<String>,
 
-    /// Show interactive search
+    /// Pick a tool from an interactive search menu
     #[usage(long, short, conflicts = &["match_type", "no_header"])]
     interactive: bool,
 

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -220,7 +220,7 @@ fn reexec(args: &[String], original_cwd: Option<&std::path::Path>) -> Result<()>
     Err(crate::request_exit(status.code().unwrap_or(1)))
 }
 
-/// Updates mise itself.
+/// Update mise itself
 ///
 /// Uses the GitHub Releases API to find the latest release and binary.
 /// By default, this will also update any installed plugins.

--- a/src/cli/settings/add.rs
+++ b/src/cli/settings/add.rs
@@ -2,10 +2,10 @@ use eyre::{Result, eyre};
 
 use crate::cli::settings::set::set;
 
-/// Adds a setting to the configuration file
+/// Append a value to an array setting
 ///
-/// Used with an array setting, this will append the value to the array.
-/// This modifies the contents of ~/.config/mise/config.toml
+/// Adds the value to an array setting such as `disable_hints`, keeping existing entries.
+/// This modifies ~/.config/mise/config.toml by default, or the local config with `--local`.
 #[derive(Debug, usage_rs::Args)]
 #[usage(after_long_help = AFTER_LONG_HELP, verbatim_doc_comment)]
 pub(super) struct SettingsAdd {

--- a/src/cli/settings/unset.rs
+++ b/src/cli/settings/unset.rs
@@ -4,9 +4,9 @@ use toml_edit::DocumentMut;
 use crate::config::settings::SettingsFile;
 use crate::{config, file};
 
-/// Clears a setting
+/// Clear a setting
 ///
-/// This modifies the contents of ~/.config/mise/config.toml
+/// This modifies ~/.config/mise/config.toml by default, or the local config with `--local`.
 #[derive(Debug, usage_rs::Args)]
 #[usage(visible_aliases = ["rm", "remove", "delete", "del"], after_long_help = AFTER_LONG_HELP, verbatim_doc_comment)]
 pub(super) struct SettingsUnset {

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -8,7 +8,7 @@ use crate::env;
 use crate::shell::{EXAMPLE_SHELL, require_shell};
 use crate::toolset::{InstallOptions, ToolSource, ToolsetBuilder, tool_env_var_name};
 
-/// Sets a tool version for the current session.
+/// Set a tool version for the current shell session
 ///
 /// Only works in a session where mise is already activated.
 ///
@@ -23,16 +23,16 @@ pub(crate) struct Shell {
 
     /// Number of jobs to run in parallel
     /// Values below 1 are treated as 1
-    /// [default: 4]
+    /// Defaults to the `jobs` setting
     #[usage(long, short, env = "MISE_JOBS", verbatim_doc_comment)]
     jobs: Option<usize>,
 
-    /// Removes a previously set version
+    /// Remove a previously set version
     #[usage(long, short)]
     unset: bool,
 
-    /// Connect backend install command stdin/stdout/stderr directly to the terminal
-    /// Implies --jobs=1
+    /// Connect backend install command stdin/stdout/stderr directly to the terminal.
+    /// Implies `--jobs=1`
     #[usage(long, overrides = "jobs")]
     raw: bool,
 }

--- a/src/cli/shell_alias/mod.rs
+++ b/src/cli/shell_alias/mod.rs
@@ -6,7 +6,7 @@ mod set;
 mod unset;
 
 #[derive(Debug, usage_rs::Args)]
-#[usage(name = "shell-alias", about = "Manage shell aliases.")]
+#[usage(name = "shell-alias", about = "Manage shell aliases")]
 pub(crate) struct ShellAlias {
     #[usage(subcommand)]
     command: Option<Commands>,

--- a/src/cli/shell_alias/unset.rs
+++ b/src/cli/shell_alias/unset.rs
@@ -3,7 +3,7 @@ use eyre::Result;
 use crate::config::Config;
 use crate::config::config_file::ConfigFile;
 
-/// Removes a shell alias
+/// Remove a shell alias
 ///
 /// This modifies the contents of ~/.config/mise/config.toml
 #[derive(Debug, usage_rs::Args)]

--- a/src/cli/sync/node.rs
+++ b/src/cli/sync/node.rs
@@ -8,9 +8,9 @@ use crate::{config::Config, config::Settings};
 
 use super::reconcile;
 
-/// Symlinks all tool versions from an external tool into mise
+/// Symlink node versions installed by nvm, nodenv, or Homebrew into mise
 ///
-/// For example, use this to import all Homebrew node installs into mise
+/// Use this to make versions installed by another version manager available to mise.
 ///
 /// This won't overwrite managed installs, runtime aliases, or links from other providers.
 #[derive(Debug, usage_rs::Args)]

--- a/src/cli/sync/python.rs
+++ b/src/cli/sync/python.rs
@@ -7,9 +7,9 @@ use crate::{config::Config, env::PYENV_ROOT};
 
 use super::reconcile;
 
-/// Symlinks all tool versions from an external tool into mise
+/// Symlink python versions installed by pyenv or uv into mise
 ///
-/// For example, use this to import all pyenv installs into mise
+/// Use this to make versions installed by another version manager available to mise.
 ///
 /// This won't overwrite managed installs, runtime aliases, or links from other providers.
 #[derive(Debug, usage_rs::Args)]

--- a/src/cli/sync/ruby.rs
+++ b/src/cli/sync/ruby.rs
@@ -11,7 +11,7 @@ use crate::{
 
 use super::reconcile;
 
-/// Symlinks all ruby tool versions from an external tool into mise
+/// Symlink ruby versions installed by Homebrew into mise
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(super) struct SyncRuby {

--- a/src/cli/tasks/add.rs
+++ b/src/cli/tasks/add.rs
@@ -12,10 +12,11 @@ use toml_edit::Item;
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(super) struct TasksAdd {
-    /// Tasks name to add
+    /// Name of the task to add
     #[usage()]
     task: String,
 
+    /// Command to run, given after `--`
     #[usage(double_dash = "required")]
     run: Vec<String>,
 
@@ -43,7 +44,7 @@ pub(super) struct TasksAdd {
     /// Glob patterns of files this task uses as input
     #[usage(long, short)]
     sources: Vec<String>,
-    /// Wait for these tasks to complete if they are to run
+    /// Wait for these tasks to finish if they are also being run
     #[usage(long, short)]
     wait_for: Vec<String>,
 
@@ -53,10 +54,10 @@ pub(super) struct TasksAdd {
     /// Description of the task
     #[usage(long)]
     description: Option<String>,
-    /// Glob patterns of files this task creates, to skip if they are not modified
+    /// Glob patterns of files this task creates, used to skip it when they are up to date
     #[usage(long)]
     outputs: Vec<String>,
-    /// Command to run on windows
+    /// Command to run on Windows
     #[usage(long)]
     run_windows: Option<String>,
     /// Run the task in a specific shell

--- a/src/cli/tasks/ls.rs
+++ b/src/cli/tasks/ls.rs
@@ -13,9 +13,10 @@ use eyre::{Result, bail};
 use itertools::Itertools;
 use serde_json::json;
 
-/// List available tasks to execute
-/// These may be included from the config file or from the project's .mise/tasks directory
-/// mise will merge all tasks from all parent directories into this list.
+/// List available tasks
+///
+/// Tasks come from config files and from task directories such as `.mise/tasks`.
+/// Tasks from all parent directories are merged into this list.
 ///
 /// So if you have global tasks in `~/.config/mise/tasks/*` and project-specific tasks in
 /// ~/myproject/.mise/tasks/*, then they'll both be available but the project-specific

--- a/src/cli/tasks/mod.rs
+++ b/src/cli/tasks/mod.rs
@@ -17,7 +17,7 @@ pub(crate) struct Tasks {
     #[usage(subcommand)]
     command: Option<Commands>,
 
-    /// Task name to get info of
+    /// Task name to show info for
     task: Option<String>,
 
     #[usage(flatten)]

--- a/src/cli/test_tool.rs
+++ b/src/cli/test_tool.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 use std::{collections::BTreeSet, sync::Arc};
 use tokio::task::JoinSet;
 
-/// Test a tool installs and executes
+/// Test that a tool installs and runs
 #[derive(Debug, Clone, usage_rs::Args)]
 #[usage(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(crate) struct TestTool {
@@ -31,11 +31,11 @@ pub(crate) struct TestTool {
     /// Test all tools specified in config files
     #[usage(long, conflicts = "tools", conflicts = "all")]
     pub all_config: bool,
-    /// Also test tools not defined in registry/, guessing how to test it
+    /// Also test tools not defined in registry/, guessing how to test them
     #[usage(long)]
     pub include_non_defined: bool,
-    /// Connect backend install command stdin/stdout/stderr directly to the terminal
-    /// Implies --jobs=1
+    /// Connect backend install command stdin/stdout/stderr directly to the terminal.
+    /// Implies `--jobs=1`
     #[usage(long, overrides = "jobs")]
     pub raw: bool,
 }

--- a/src/cli/token/mod.rs
+++ b/src/cli/token/mod.rs
@@ -12,11 +12,11 @@ pub(crate) struct Token {
 
 #[derive(Debug, usage_rs::Subcommands)]
 enum Commands {
-    /// Forgejo token
+    /// Show the Forgejo token mise will use
     Forgejo(forgejo::Forgejo),
-    /// GitHub token
+    /// Show the GitHub token mise will use
     Github(github::Github),
-    /// GitLab token
+    /// Show the GitLab token mise will use
     Gitlab(gitlab::Gitlab),
 }
 

--- a/src/cli/tool.rs
+++ b/src/cli/tool.rs
@@ -9,7 +9,7 @@ use crate::config::Config;
 use crate::toolset::{ToolSource, ToolVersionOptions, ToolsetBuilder};
 use crate::ui::table;
 
-/// Gets information about a tool
+/// Show information about a tool
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(crate) struct Tool {

--- a/src/cli/tool_alias/ls.rs
+++ b/src/cli/tool_alias/ls.rs
@@ -7,10 +7,10 @@ use crate::config::Config;
 use crate::ui::table;
 
 /// List tool version aliases
-/// Shows the aliases that can be specified.
-/// These can come from user config or from plugins in `bin/list-aliases`.
 ///
-/// For user config, aliases are defined like the following in `~/.config/mise/config.toml`:
+/// Aliases can be defined in user config or provided by plugins via `bin/list-aliases`.
+///
+/// In user config, aliases are defined like the following in `~/.config/mise/config.toml`:
 ///
 ///     [tool_alias.node.versions]
 ///     lts = "22.0.0"

--- a/src/cli/tool_alias/mod.rs
+++ b/src/cli/tool_alias/mod.rs
@@ -10,7 +10,7 @@ mod unset;
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     name = "tool-alias",
-    about = "Manage tool version aliases.",
+    about = "Manage tool version aliases",
     alias = "alias",
     alias = "aliases"
 )]

--- a/src/cli/tool_alias/unset.rs
+++ b/src/cli/tool_alias/unset.rs
@@ -4,7 +4,7 @@ use crate::cli::args::BackendArg;
 use crate::config::Config;
 use crate::config::config_file::ConfigFile;
 
-/// Clears an alias for a tool/backend
+/// Clear an alias for a tool/backend
 ///
 /// This modifies the contents of ~/.config/mise/config.toml
 #[derive(Debug, usage_rs::Args)]

--- a/src/cli/tool_stub.rs
+++ b/src/cli/tool_stub.rs
@@ -656,7 +656,11 @@ async fn execute_with_tool_request(
 ///
 /// For more information, see: https://mise.jdx.dev/dev-tools/tool-stubs.html
 #[derive(Debug, usage_rs::Args)]
-#[usage(disable_help_flag = true, disable_version_flag = true)]
+#[usage(
+    disable_help_flag = true,
+    disable_version_flag = true,
+    verbatim_doc_comment
+)]
 pub(crate) struct ToolStub {
     /// Path to the TOML tool stub file to execute
     ///

--- a/src/cli/trust.rs
+++ b/src/cli/trust.rs
@@ -11,7 +11,7 @@ use crate::{config, dirs, env, file};
 use eyre::{Result, bail};
 use itertools::Itertools;
 
-/// Marks a config file as trusted
+/// Mark a config file as trusted
 ///
 /// This means mise is allowed to parse the file when it needs to read config
 /// that may execute code or affect the environment. Without trust, mise may

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -11,9 +11,10 @@ use crate::toolset::{ToolRequest, ToolSource, ToolVersion, ToolsetBuilder};
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::{config, dirs, exit, file};
 
-/// Removes installed tool versions
+/// Remove installed tool versions
 ///
-/// This only removes the installed version, it does not modify mise.toml.
+/// This only removes the installed version; it does not modify mise.toml.
+/// Use `mise unuse` to remove a tool from mise.toml and uninstall it.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(crate) struct Uninstall {
@@ -180,13 +181,13 @@ impl Uninstall {
 static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
 
-    # will uninstall specific version
+    # uninstall a specific version
     $ <bold>mise uninstall node@18.0.0</bold>
 
-    # will uninstall the current node version (if only one version is installed)
+    # uninstall the current node version (if only one version is installed)
     $ <bold>mise uninstall node</bold>
 
-    # will uninstall all installed versions of node
-    $ <bold>mise uninstall --all node@18.0.0</bold> # will uninstall all node versions
+    # uninstall every installed version of node
+    $ <bold>mise uninstall --all node</bold>
 "#
 );

--- a/src/cli/unset.rs
+++ b/src/cli/unset.rs
@@ -6,7 +6,7 @@ use crate::config::config_file::ConfigFile;
 use crate::config::config_file::mise_toml::MiseToml;
 use crate::config::{ConfigPathOptions, resolve_target_config_path};
 
-/// Remove environment variable(s) from the config file.
+/// Remove environment variable(s) from the config file
 ///
 /// By default, this command modifies `mise.toml` in the current directory.
 #[derive(Debug, usage_rs::Args)]

--- a/src/cli/unuse.rs
+++ b/src/cli/unuse.rs
@@ -10,7 +10,7 @@ use eyre::Result;
 use itertools::Itertools;
 use path_absolutize::Absolutize;
 
-/// Removes installed tool versions from mise.toml
+/// Remove tool versions from mise.toml and uninstall them
 ///
 /// By default, this will use the `mise.toml` file that has the tool defined.
 /// If multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),
@@ -22,12 +22,12 @@ use path_absolutize::Absolutize;
 ///   - If `--path` is set, it will use the config file at the given path.
 ///   - If `--env` is set, it will use `mise.<env>.toml`.
 ///   - If [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) is set, it will use that instead.
-///   - If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will the first from that list.
+///   - If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will use the first from that list.
 ///   - Otherwise just "mise.toml" or global config if cwd is home directory.
 ///
 /// Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
 ///
-/// Will also prune the installed version if no other configurations are using it.
+/// The installed version is also removed unless another config still uses it or `--no-prune` is passed.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, visible_aliases = ["rm", "remove"], after_long_help = AFTER_LONG_HELP)]
 pub(crate) struct Unuse {
@@ -188,16 +188,16 @@ impl Unuse {
 static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
 
-    # will uninstall specific version
+    # remove node@18.0.0 from mise.toml and uninstall it
     $ <bold>mise unuse node@18.0.0</bold>
 
-    # will uninstall specific version from global config
+    # remove it from the global config instead
     $ <bold>mise unuse -g node@18.0.0</bold>
 
-    # will uninstall specific version from .mise.local.toml
+    # remove node@20 from .mise.local.toml
     $ <bold>mise unuse --env local node@20</bold>
 
-    # will uninstall specific version from .mise.staging.toml
+    # remove node@20 from .mise.staging.toml
     $ <bold>mise unuse --env staging node@20</bold>
 "#
 );

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -31,13 +31,13 @@ use jiff::{Span, Timestamp, civil::date};
 
 const MAX_OUT_OF_RANGE_UPDATES: usize = 5;
 
-/// Upgrades outdated tools
+/// Upgrade outdated tools
 ///
-/// By default, this keeps the range specified in mise.toml. So if you have node@20 set, it will
-/// upgrade to the latest 20.x.x version available. See the `--bump` flag to use the latest version
-/// and bump the version in mise.toml.
+/// By default, this keeps the range specified in mise.toml: with node@20 set, it upgrades to
+/// the latest 20.x.x available. Use `--bump` to upgrade to the latest version overall and
+/// rewrite the version in mise.toml.
 ///
-/// This will update mise.lock if it is enabled, see https://mise.jdx.dev/configuration/settings.html#lockfile
+/// This also updates mise.lock if lockfiles are enabled, see https://mise.jdx.dev/configuration/settings.html#lockfile
 #[derive(Debug, usage_rs::Args)]
 #[usage(visible_alias = "up", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(crate) struct Upgrade {
@@ -47,7 +47,7 @@ pub(crate) struct Upgrade {
     #[usage(value_name = "INSTALLED_TOOL@VERSION", verbatim_doc_comment)]
     tool: Vec<ToolArg>,
 
-    /// Upgrades to the latest version available, bumping the version in mise.toml
+    /// Upgrade to the latest version available, bumping the version in mise.toml
     ///
     /// For example, if you have `node = "20.0.0"` in your mise.toml but 22.1.0 is the latest available,
     /// this will install 22.1.0 and set `node = "22.1.0"` in your config.
@@ -57,13 +57,13 @@ pub(crate) struct Upgrade {
     #[usage(long, short = 'b', verbatim_doc_comment)]
     bump: bool,
 
-    /// Display multiselect menu to choose which tools to upgrade
+    /// Choose which tools to upgrade from a multiselect menu
     #[usage(long, short, verbatim_doc_comment, conflicts = "tool")]
     interactive: bool,
 
     /// Number of jobs to run in parallel
     /// Values below 1 are treated as 1
-    /// [default: 4]
+    /// Defaults to the `jobs` setting
     #[usage(long, short, env = "MISE_JOBS", verbatim_doc_comment)]
     jobs: Option<usize>,
 
@@ -71,7 +71,7 @@ pub(crate) struct Upgrade {
     #[usage(short = 'l', hide = true)]
     legacy_bump: bool,
 
-    /// Just print what would be done, don't actually do it
+    /// Print what would be done without doing it
     #[usage(long, short = 'n', verbatim_doc_comment)]
     dry_run: bool,
 
@@ -127,8 +127,8 @@ pub(crate) struct Upgrade {
     #[usage(long, verbatim_doc_comment, overrides = "no_prune")]
     prune: bool,
 
-    /// Connect backend install command stdin/stdout/stderr directly to the terminal
-    /// Implies --jobs=1
+    /// Connect backend install command stdin/stdout/stderr directly to the terminal.
+    /// Implies `--jobs=1`
     #[usage(long, overrides = "jobs")]
     raw: bool,
 }

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -21,10 +21,10 @@ use crate::toolset::{
 use crate::ui::ctrlc;
 use crate::{config, env, exit, file};
 
-/// Installs a tool and adds the version to mise.toml.
+/// Install a tool and add it to mise.toml
 ///
-/// This will install the tool version if it is not already installed.
-/// By default, this will use a `mise.toml` file in the current directory.
+/// Installs the tool version if it is not already installed, then writes it to a config file.
+/// By default, this is `mise.toml` in the current directory.
 /// If multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),
 /// the lowest precedence file (`mise.toml`) will be used.
 /// See https://mise.jdx.dev/configuration.html#target-file-for-write-operations
@@ -34,12 +34,10 @@ use crate::{config, env, exit, file};
 ///   - If `--path` is set, it will use the config file at the given path.
 ///   - If `--env` is set, it will use `mise.<env>.toml`.
 ///   - If [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) is set, it will use that instead.
-///   - If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will the first from that list.
+///   - If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will use the first from that list.
 ///   - Otherwise just "mise.toml" or global config if cwd is home directory.
 ///
 /// Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
-///
-/// Use the `--global` flag to use the global config file instead.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     verbatim_doc_comment,
@@ -65,7 +63,7 @@ pub(crate) struct Use {
 
     /// Number of jobs to run in parallel
     /// Values below 1 are treated as 1
-    /// [default: 4]
+    /// Defaults to the `jobs` setting
     #[usage(long, short, env = "MISE_JOBS", verbatim_doc_comment)]
     jobs: Option<usize>,
 
@@ -91,8 +89,8 @@ pub(crate) struct Use {
 
     /// Save fuzzy version to config file
     ///
-    /// e.g.: `mise use --fuzzy node@20` will save 20 as the version
-    /// this is the default behavior unless `MISE_PIN=1`
+    /// e.g.: `mise use --fuzzy node@20` will save `20` as the version.
+    /// This is the default behavior unless `MISE_PIN=1`
     #[usage(long, verbatim_doc_comment, overrides = "pin")]
     fuzzy: bool,
 
@@ -114,7 +112,7 @@ pub(crate) struct Use {
     #[usage(long, verbatim_doc_comment, overrides = "fuzzy")]
     pin: bool,
 
-    /// Connect backend install command stdin/stdout/stderr directly to the terminal
+    /// Connect backend install command stdin/stdout/stderr directly to the terminal.
     /// Implies `--jobs=1`
     #[usage(long, overrides = "jobs")]
     raw: bool,
@@ -132,12 +130,12 @@ struct UseTool {
 
     /// Tool to add to config file
     ///
-    /// e.g.: node@20, cargo:ripgrep@latest npm:prettier@3
-    /// If no version is specified, it will default to @latest
+    /// e.g.: node@20, cargo:ripgrep@latest, npm:prettier@3
+    /// If no version is specified, it defaults to @latest
     ///
     /// Tool options can be set with this syntax:
     ///
-    ///     mise use ubi:BurntSushi/ripgrep[exe=rg]
+    ///     mise use "cargo:ripgrep[features=pcre2]"
     #[usage(value_name = "TOOL@VERSION", verbatim_doc_comment)]
     tool: ToolArg,
 }

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -532,7 +532,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     Runs the "build" task and reruns it whenever one of its sources changes.
     The task's "sources" determine which files are watched.
 
-    $ <bold>mise watch build --glob src/**/*.rs</bold>
+    $ <bold>mise watch build --glob 'src/**/*.rs'</bold>
     Runs the "build" task, watching the files matched by the glob instead of
     the task's "sources".
 

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -15,10 +15,10 @@ use std::cmp::PartialEq;
 use std::iter::once;
 use std::path::{Path, PathBuf};
 
-/// Run task(s) and watch for changes to rerun it
+/// Run task(s) and rerun them when files change
 ///
-/// This command uses the `watchexec` tool to watch for changes to files and rerun the specified task(s).
-/// It must be installed for this command to work, but you can install it with `mise use -g watchexec@latest`.
+/// Uses `watchexec` to watch for file changes and rerun the given task(s).
+/// watchexec must be installed; `mise use -g watchexec@latest` installs it.
 ///
 /// For more advanced process management (daemon management, auto-restart, readiness checks,
 /// cron scheduling), see mise's sister project: https://pitchfork.jdx.dev
@@ -32,7 +32,7 @@ use std::path::{Path, PathBuf};
 pub(crate) struct Watch {
     /// Tasks to run
     /// Can specify multiple tasks by separating with `:::`
-    /// e.g.: `mise run task1 arg1 arg2 ::: task2 arg1 arg2`
+    /// e.g.: `mise watch task1 arg1 arg2 ::: task2 arg1 arg2`
     /// Defaults to `default`
     #[usage(verbatim_doc_comment)]
     task: Option<String>,
@@ -529,18 +529,18 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
 
     $ <bold>mise watch build</bold>
-    Runs the "build" tasks. Will re-run the tasks when any of its sources change.
-    Uses "sources" from the tasks definition to determine which files to watch.
+    Runs the "build" task and reruns it whenever one of its sources changes.
+    The task's "sources" determine which files are watched.
 
     $ <bold>mise watch build --glob src/**/*.rs</bold>
-    Runs the "build" tasks but specify the files to watch with a glob pattern.
-    This overrides the "sources" from the tasks definition.
+    Runs the "build" task, watching the files matched by the glob instead of
+    the task's "sources".
 
     $ <bold>mise watch build --clear</bold>
     Extra arguments are passed to watchexec. See `watchexec --help` for details.
 
     $ <bold>mise watch serve --watch src --exts rs --restart</bold>
-    Starts an api server, watching for changes to "*.rs" files in "./src" and kills/restarts the server when they change.
+    Starts an API server, watching "*.rs" files in "./src", and restarts the server when they change.
 "#
 );
 

--- a/src/cli/where.rs
+++ b/src/cli/where.rs
@@ -68,8 +68,9 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     $ <bold>mise where node@20</bold>
     /home/jdx/.local/share/mise/installs/node/20.0.0
 
-    # Show the install directory of the currently active node
-    # Errors if node is not requested by any config file
+    # Show the install directory of the active node, or of the latest
+    # installed version if no config requests node
+    # Errors if no matching version is installed
     $ <bold>mise where node</bold>
     /home/jdx/.local/share/mise/installs/node/20.0.0
 "#

--- a/src/cli/where.rs
+++ b/src/cli/where.rs
@@ -11,11 +11,10 @@ use crate::toolset::ToolsetBuilder;
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(crate) struct Where {
-    /// Tool(s) to look up
+    /// Tool to look up
     /// e.g.: ruby@3
-    /// if "@<PREFIX>" is specified, it will show the latest installed version
-    /// that matches the prefix
-    /// otherwise, it will show the current, active installed version
+    /// With "@<PREFIX>", shows the latest installed version matching the prefix.
+    /// Otherwise, shows the current, active installed version.
     #[usage(value_name = "TOOL@VERSION", verbatim_doc_comment)]
     tool: ToolArg,
 
@@ -64,13 +63,13 @@ impl Where {
 static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
 
-    # Show the latest installed version of node
-    # If it is is not installed, errors
+    # Show the latest installed node 20.x
+    # Errors if no matching version is installed
     $ <bold>mise where node@20</bold>
     /home/jdx/.local/share/mise/installs/node/20.0.0
 
-    # Show the current, active install directory of node
-    # Errors if node is not referenced in any .tool-version file
+    # Show the install directory of the currently active node
+    # Errors if node is not requested by any config file
     $ <bold>mise where node</bold>
     /home/jdx/.local/share/mise/installs/node/20.0.0
 "#

--- a/src/cli/which.rs
+++ b/src/cli/which.rs
@@ -8,13 +8,13 @@ use crate::toolset::{Toolset, ToolsetBuilder};
 use eyre::{Result, bail};
 use itertools::Itertools;
 
-/// Shows the path that a tool's bin points to.
+/// Show the path a tool's executable resolves to
 ///
 /// Use this to figure out what version of a tool is currently active.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(crate) struct Which {
-    /// The bin to look up
+    /// The executable to look up
     #[usage(required_unless = "complete")]
     pub bin_name: Option<String>,
 


### PR DESCRIPTION
Sweeps the CLI help text for prose and content problems, then regenerates everything derived from it. No behavior changes beyond help output.

## Consistency

About 30 commands described themselves in the third person ("Installs a tool…", "Removes…", "Symlinks…", "Formats…") while the rest used the imperative. They now all use the imperative, and one-line summaries no longer end in a period.

## Missing help

These had no description at all, so their docs pages rendered empty:

- 16 `mise bootstrap` subcommands: `repos apply|update|exec|status`, `plugins apply|status`, `user apply|status`, `mise-shell-activate apply|status`, `macos defaults apply|status`, `macos launchd-agents apply|status`, `linux systemd-units apply|status`
- `mise doctor -J`, `mise config set -t/--type`, `mise generate task-docs -s/--style`, and the `-- RUN` argument of `mise tasks add`

## Wrong or stale content

- The top-level `--output` flag was listed in help and docs with no description. It is the passthrough for the default `run` subcommand, and every sibling passthrough (`-c`, `-f`, `-n`, `-t`, `--timings`, `--no-timings`) is already hidden, so it is now described and hidden to match. **This is the one user-visible removal from `mise --help`; happy to drop it if you would rather keep the flag listed.**
- `-j/--jobs` help claimed `[default: 4]` in seven commands, but the `jobs` setting defaults to 8. It now points at the setting instead of hardcoding a number.
- `mise exec` still described its tool arguments as `<RUNTIME>` args and talked about "plugins" being overridden.
- `mise use` documented tool options with `mise use ubi:BurntSushi/ripgrep[exe=rg]`, using the deprecated `ubi:` backend. Now uses a cargo example.
- `mise latest` said "plugin" where it meant tool.
- `mise ls-remote` told readers to run `mise cache clean`. That still works as a hidden alias, but the help now names the real command, `mise cache clear`.
- Grammar: `mise use` and `mise unuse` both had "it will the first from that list" (missing verb); `mise where` had "If it is is not installed".
- Several flags rendered as run-on sentences where clap joined two doc lines, e.g. "…directly to the terminal Implies --jobs=1".

## Rendering

- `mise tool-stub --help` collapsed its bullet list into a single paragraph; it now keeps the list (`verbatim_doc_comment`).
- `mise activate --shims` short help ended on a dangling "Effectively the same as:" with the example only in long help.
- `mise plugins ls-remote` had an `Examples:` block hand-written inside `long_about`, so it rendered unstyled and in the wrong position. It now uses `after_long_help` like every other command.

## Prose

Rewrote the top-level long description and the multi-paragraph help for `activate`, `env`, `exec`, `install`, `ls`, `reshim`, `run`, `sync node|python|ruby`, `tasks ls`, `unuse`, `upgrade`, `use`, `watch`, `where`, and the `plugins` family. Tidied the example blocks for `install`, `run`, `uninstall`, `unuse`, `watch`, and `where`. `mise uninstall`'s last example was `mise uninstall --all node@18.0.0` with a comment saying it uninstalls all node versions, which reads as though the version is significant; it is now `mise uninstall --all node`.

## Generated files

`mise.usage.kdl`, `docs/cli/**` (84 pages), `man/man1/mise.1`, and `docs/public/llms.txt`. Completions and README had no derived changes.

## Verification

- `cargo fmt --check` clean, `mise run lint` clean
- 270 `cli::` unit tests pass
- e2e files that assert on help text pass: `cli/test_help_without_tasks`, `cli/test_mcp`, `cli/test_exit_status`, `cli/test_upgrade`, `cli/test_tool_stub_basic`, `env/test_env_cache_fresh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded and clarified CLI help for bootstrap, configuration, environment, task, plugin, installation, and synchronization commands.
  * Updated examples, option descriptions, job-default guidance, and task-output controls to reflect current usage.
  * Improved man-page and public CLI reference consistency with clearer imperative wording.
  * Clarified shell activation, repository management, cache pruning, tool syncing, and configuration key paths.
  * Removed the global `--output` option from the CLI reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and help text only; no install, auth, or task execution logic changes beyond how flags appear in help.
> 
> **Overview**
> **Documentation-only sweep** of CLI help and the generated reference (`docs/cli/**`, `mise.usage.kdl`, man pages, `docs/public/llms.txt`). Runtime behavior is unchanged except what users see in `--help`.
> 
> **Voice and structure:** One-line command summaries now use imperative wording (e.g. “Install…” instead of “Installs…”) and match across commands. Long help for `activate`, `install`, `exec`, `run`, `use`, `watch`, bootstrap subcommands, and others is tightened; example blocks and flag lines are clarified (including fixing run-on sentences like “terminal Implies --jobs=1”).
> 
> **Gaps filled:** Empty bootstrap `apply`/`status` pages and several flags/args (`doctor -J`, `config set -t`, `generate task-docs -s`, `tasks add -- RUN`) get real descriptions. Bootstrap entries tie commands to config keys such as `[bootstrap.repos]` and `[bootstrap.macos.launchd.agents]`.
> 
> **Corrections:** `-j/--jobs` no longer claims `[default: 4]`; it references the `jobs` setting. `mise exec`/`use` wording fixes (tools vs runtimes/plugins; cargo example instead of deprecated `ubi:`). `ls-remote` points at `mise cache clear`. Grammar fixes (`unuse`/`use`, `where`). `mise tool-stub` and `plugins ls-remote` help rendering fixes. Top-level **`--output` is described and hidden** on the root CLI (removed from the generated CLI index) so it aligns with other hidden `run` passthrough flags—**the only intentional change to `mise --help` layout** called out in the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b318bba7b7efaf949388a67ca830389eb23e4f84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->