### PR TITLE
docs: promote mr boxington and aube

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 </div>
 
 > [!TIP]
-> My latest project, [aube](https://aube.jdx.dev) just hit stable! It's the fastest Node.js package manager with strong security defaults and is compatible with npm/pnpm/yarn lockfiles!
+> Rust builds filling every checkout's `target/`? [Mr Boxington](https://mr-boxington.jdx.dev/) gives Cargo one shared, self-pruning cache across worktrees, local builds, and CI.
 
 ## What is it?
 

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1384,7 +1384,7 @@ div[class*="language-"] .copy:hover {
   text-wrap: balance;
 }
 
-.landing-aube h2,
+.landing-special h2,
 .landing-cta h2 {
   text-wrap: balance;
 }
@@ -1582,7 +1582,7 @@ div[class*="language-"] .copy:hover {
   color: var(--vp-c-brand-1);
 }
 
-.landing-aube {
+.landing-special {
   display: block;
   margin: 48px auto 0;
   padding: 28px;
@@ -1599,20 +1599,20 @@ div[class*="language-"] .copy:hover {
     transform 0.2s ease;
 }
 
-.landing-aube:hover {
+.landing-special:hover {
   border-color: var(--vp-c-brand-1);
   transform: translateY(-2px);
   box-shadow: 0 18px 44px -32px rgba(107, 127, 78, 0.55);
 }
 
-.dark .landing-aube {
+.dark .landing-special {
   background:
     linear-gradient(135deg, rgba(143, 168, 110, 0.14), transparent 48%),
     var(--vp-c-bg-soft);
   border-color: rgba(143, 168, 110, 0.35);
 }
 
-.landing-aube h2 {
+.landing-special h2 {
   margin: 12px 0 0;
   /* reset vp-doc h2 defaults (top border + padding) inside the card */
   border-top: 0;
@@ -1626,7 +1626,7 @@ div[class*="language-"] .copy:hover {
   color: var(--vp-c-brand-1);
 }
 
-.landing-aube p:not(.landing-kicker) {
+.landing-special p:not(.landing-kicker) {
   max-width: 58ch;
   margin: 16px 0 0;
   color: var(--vp-c-text-2);
@@ -1853,7 +1853,7 @@ div[class*="language-"] .copy:hover {
     margin-top: 54px;
   }
 
-  .landing-aube {
+  .landing-special {
     margin-top: 40px;
     padding: 22px;
   }

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,13 +92,13 @@ run = "pytest"
     </div>
   </div>
 
-  <a class="landing-aube" href="https://aube.jdx.dev/" aria-label="Try aube">
+  <a class="landing-special" href="https://mr-boxington.jdx.dev/" aria-label="Try Mr Boxington">
     <div>
       <p class="landing-kicker">Chef's Special</p>
-      <h2>aube: a fast Node.js package manager.</h2>
+      <h2>Mr Boxington: fix your target/.</h2>
       <p>
-        From the author of mise. aube works with your existing lockfile — no
-        migration needed.
+        Give every Cargo checkout one shared, self-pruning compilation cache —
+        locally and in CI.
       </p>
     </div>
   </a>

--- a/docs/lang/node.md
+++ b/docs/lang/node.md
@@ -20,6 +20,23 @@ mise use -g node@26
 
 See the [Node.JS Cookbook](/mise-cookbook/nodejs.html) for common tasks and examples.
 
+## Run projects with aube
+
+[aube](https://aube.jdx.dev/) is a fast Node.js package manager with strong supply-chain security defaults. It reads
+and writes existing `package-lock.json`, `pnpm-lock.yaml`, and `yarn.lock` files in place, so a project can try it
+without a lockfile migration. Its `aubr` command installs stale dependencies automatically before running a package
+script and skips the install when dependencies are already current.
+
+Install it with mise, then run an existing package script:
+
+```sh
+mise use aube
+aubr test
+```
+
+See [aube's security overview](https://aube.jdx.dev/security) for its release-cooling, trust-policy, malicious-package,
+and lifecycle-script protections.
+
 ## Tool Options
 
 The following [tool-options](/dev-tools/#tool-options) are available for the `node` backend.

--- a/docs/lang/rust.md
+++ b/docs/lang/rust.md
@@ -68,6 +68,35 @@ mise use -g rust@1.82
 cargo build
 ```
 
+## Share Cargo builds with Mr Boxington
+
+[Mr Boxington](https://mr-boxington.jdx.dev/) (`mbx`) gives every checkout on a machine one shared,
+self-pruning compilation cache. A crate compiled in one worktree can be reused in another, and concurrent Cargo
+commands share a CPU and memory budget instead of oversubscribing the machine. It can also share cached artifacts
+with teammates and CI runners through a cache server, S3, or GitHub Actions.
+
+Install `mbx` and configure mise's [`cargo` command wrapper](/dev-tools/shims.html#command-wrappers) to use it:
+
+```toml [mise.toml]
+[tools]
+rust = "latest"
+mr-boxington = "latest"
+
+[wrappers.cargo]
+command = "mbx"
+env = { MBX_CARGO_SHIM_MODE = "1" }
+```
+
+Run `mise reshim` after adding the wrapper. Existing commands and mise tasks can keep invoking `cargo` normally:
+
+```toml [mise.toml]
+[tasks.build]
+run = "cargo build"
+```
+
+Within the mise environment, the wrapper transparently routes those commands through `mbx`. This also avoids
+rewriting every task as `mbx build`, and keeps the same tasks usable if the wrapper is later removed.
+
 ## Tool Options
 
 The following [tool-options](/dev-tools/#tool-options) are available for the `rust` backend—these

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -1018,18 +1018,22 @@ deprecated no-op so existing task configurations continue to run. Enabled values
 warning; disabled values are silent.
 
 Use [mbx](https://mr-boxington.jdx.dev/getting-started) for Rust action caching instead. Install it
-globally with `mise use -g mr-boxington`, or add it to the project tools, then put `mbx` in front of
-the Cargo subcommand:
+globally with `mise use -g mr-boxington`, or add it to the project tools. To keep existing task commands unchanged,
+configure mise's [`cargo` command wrapper](/dev-tools/shims.html#command-wrappers):
 
 ```mise-toml
 [tools]
 mr-boxington = "latest"
 
+[wrappers.cargo]
+command = "mbx"
+env = { MBX_CARGO_SHIM_MODE = "1" }
+
 [tasks.build]
-run = "mbx build"
+run = "cargo build"
 ```
 
-Remove `rust_cache` after changing the command. The compatibility field is scheduled for removal in
+Run `mise reshim` after adding the wrapper, then remove `rust_cache`. The compatibility field is scheduled for removal in
 mise 2027.8.14.
 
 ### `shell`
@@ -1415,7 +1419,9 @@ command_inputs = ["node --version"]
 
 This deprecated compatibility setting no longer enables Rust action caching. An effective enabled
 value warns once while tasks continue normally. Remove it and run Rust build commands through
-[mbx](https://mr-boxington.jdx.dev/getting-started) instead.
+[mbx](https://mr-boxington.jdx.dev/getting-started) instead. The
+[`wrappers.cargo` configuration](/lang/rust.html#share-cargo-builds-with-mr-boxington) lets existing tasks keep
+invoking `cargo` without modification.
 
 ```toml
 [task_config]


### PR DESCRIPTION
## Summary
- replace the aube promotion on the landing page and README with Mr Boxington
- promote Mr Boxington in the Rust docs and document the `wrappers.cargo` integration for mise tasks
- promote aube in the Node docs
- update the deprecated Rust task-cache migration example to preserve existing `cargo` task commands

## Testing
- `target/debug/mise run docs:build`
- `target/debug/mise x "npm:markdownlint-cli" -- markdownlint README.md docs/index.md docs/lang/node.md docs/lang/rust.md docs/tasks/task-configuration.md`
- `target/debug/mise x prettier -- prettier --write README.md docs/index.md docs/lang/node.md docs/lang/rust.md docs/tasks/task-configuration.md docs/.vitepress/theme/custom.css`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CSS class renames only; no runtime or configuration behavior changes in mise itself.
> 
> **Overview**
> Swaps the featured “Chef’s Special” promo on the **README** and docs home from **aube** to **Mr Boxington**, and renames the landing card styles from `landing-aube` to **`landing-special`** so the same UI can highlight either product.
> 
> Adds language-specific guidance: a new **Node** section on installing **aube** via mise and running scripts with `aubr`, and a new **Rust** section on **Mr Boxington** with a **`[wrappers.cargo]`** setup (`mbx` + `MBX_CARGO_SHIM_MODE`) so tasks can keep using `cargo build` unchanged.
> 
> Updates **deprecated `rust_cache`** migration docs to recommend the cargo wrapper pattern instead of rewriting task `run` lines to `mbx build`, and points readers at the Rust doc anchor for the same integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1ef922c21d9fb9aca2561e80bbb9cff380d180e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README and landing-page promotional content to highlight Mr Boxington, a shared, self-pruning Cargo compilation cache.
  - Added guidance for using aube as a Node.js package manager, including installation and command examples.
  - Added Rust documentation covering Mr Boxington setup, shared build caching, and integrations with cache servers, S3, and GitHub Actions.
  - Updated Rust task configuration guidance to use a Cargo command wrapper while keeping existing Cargo commands unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->