### PR TITLE
docs: preserve code spans when flattening markdown for llms.txt

### DIFF
--- a/docs/.vitepress/llms.ts
+++ b/docs/.vitepress/llms.ts
@@ -35,15 +35,24 @@ function pageUrl(link: string): string {
 
 /** Strip the markdown that would only add noise for a reader of this index. */
 function plain(md: string): string {
+  // Code spans are set aside before the emphasis and tag passes and restored
+  // afterwards, so an identifier inside one keeps its punctuation:
+  // `[bootstrap.mise_shell_activate]` would otherwise be read as emphasis and
+  // come out as [bootstrap.miseshellactivate].
+  const spans: string[] = [];
   return (
     md
       .replace(/!\[[^\]]*\]\([^)]*\)/g, "") // images
       // links -> text. The label may itself contain brackets, as it does for
       // links to TOML sections: [`[bootstrap.packages]`](/bootstrap/packages/)
       .replace(/\[((?:[^[\]]|\[[^[\]]*\])*)\]\([^)]*\)/g, "$1")
-      .replace(/`([^`]*)`/g, "$1")
-      .replace(/[*_]{1,3}([^*_]+)[*_]{1,3}/g, "$1")
+      .replace(/`([^`]*)`/g, (_, span: string) => `\0${spans.push(span) - 1}\0`)
+      .replace(/\*{1,3}([^*]+)\*{1,3}/g, "$1")
+      // Unlike `*`, `_` only opens emphasis at a word boundary, so snake_case
+      // outside a code span survives too.
+      .replace(/(^|[^\w])_{1,3}([^_]+)_{1,3}(?!\w)/g, "$1$2")
       .replace(/<[^>]+>/g, "")
+      .replace(/\0(\d+)\0/g, (_, i: string) => spans[Number(i)])
       .replace(/\s+/g, " ")
       .trim()
   );

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -23,7 +23,7 @@
 - [Dev Tools Overview](https://mise.jdx.dev/dev-tools/): Install and switch between dev tools like node, python, cmake, terraform, and hundreds more, all from the same project config.
 - [Comparison to asdf](https://mise.jdx.dev/dev-tools/comparison-to-asdf.html): mise can be used as a drop-in replacement for asdf. It supports the same .tool-versions files that you may have used with asdf and can use asdf plugins through the asdf backend.
 - [Shims](https://mise.jdx.dev/dev-tools/shims.html): There are several ways to load the mise context (dev tools, environment variables) into your shell.
-- [Tool Aliases](https://mise.jdx.dev/dev-tools/aliases.html): [alias] has been renamed to [toolalias] to distinguish it from [shellalias]. The old [alias] key still works but is deprecated.
+- [Tool Aliases](https://mise.jdx.dev/dev-tools/aliases.html): [alias] has been renamed to [tool_alias] to distinguish it from [shell_alias]. The old [alias] key still works but is deprecated.
 - [Tool Stubs](https://mise.jdx.dev/dev-tools/tool-stubs.html): Tool stubs let you create executable files with embedded TOML configuration for tool execution. They provide a convenient way to define tool versions, backends, and execution parameters directly…
 - [Registry](https://mise.jdx.dev/registry.html): List of all tools aliased by default in mise.
 - [GitHub Tokens](https://mise.jdx.dev/dev-tools/github-tokens.html): Many tools in mise are hosted on GitHub. For public releases, mise uses mise-versions by default as a shared cache for version lists, release metadata, and GitHub artifact attestations.
@@ -83,7 +83,7 @@
 - [Secret Inputs](https://mise.jdx.dev/bootstrap/secrets.html): [bootstrap.secrets] declares the sensitive inputs a bootstrap configuration needs without storing their values in mise configuration.
 - [Repos](https://mise.jdx.dev/bootstrap/repos.html): mise can declare git repositories in [bootstrap.repos] and apply them with mise bootstrap repos apply or as part of mise bootstrap.
 - [Dotfiles](https://mise.jdx.dev/dotfiles.html): [!WARNING] The top-level mise dotfiles command is deprecated and hidden from help. It will begin warning in mise 2027.2.0 and be removed in mise 2028.2.0. Use mise bootstrap dotfiles instead.
-- [Shell Activation](https://mise.jdx.dev/bootstrap/shell.html): mise can declaratively add shell activation snippets for bash, zsh, and fish with [bootstrap.miseshellactivate], applied by mise bootstrap mise-shell-activate apply or as part of mise bootstrap.
+- [Shell Activation](https://mise.jdx.dev/bootstrap/shell.html): mise can declaratively add shell activation snippets for bash, zsh, and fish with [bootstrap.mise_shell_activate], applied by mise bootstrap mise-shell-activate apply or as part of mise bootstrap.
 - [macOS Defaults](https://mise.jdx.dev/bootstrap/macos-defaults.html): mise can declare macOS user defaults (preferences) in the [bootstrap.macos.defaults] section of mise.toml and apply them with mise bootstrap macos defaults apply or as part of mise bootstrap.
 - [launchd](https://mise.jdx.dev/bootstrap/launchd.html): mise can declare macOS user LaunchAgents in [bootstrap.macos.launchd.agents] and apply them with mise bootstrap macos launchd-agents apply or as part of mise bootstrap.
 - [systemd](https://mise.jdx.dev/bootstrap/systemd.html): mise can declare Linux systemd user services and timers in [bootstrap.linux.systemd.units] and apply them with mise bootstrap linux systemd-units apply or as part of mise bootstrap.
@@ -159,7 +159,7 @@
 
 ## CLI Reference
 
-- [CLI Overview](https://mise.jdx.dev/cli/): Usage: mise [FLAGS] [TASK]
+- [CLI Overview](https://mise.jdx.dev/cli/): Usage: mise [FLAGS] [TASK] <SUBCOMMAND>
 - [mise activate](https://mise.jdx.dev/cli/activate.html): Initialize mise in the current shell session
 - [mise backends](https://mise.jdx.dev/cli/backends.html): Manage backends
 - [mise backends ls](https://mise.jdx.dev/cli/backends/ls.html): List built-in backends
@@ -172,7 +172,7 @@
 - [mise bootstrap firewall](https://mise.jdx.dev/cli/bootstrap/firewall.html): Manage the Linux host firewall from [bootstrap.linux.firewall]
 - [mise bootstrap linux](https://mise.jdx.dev/cli/bootstrap/linux.html): Manage Linux bootstrap config from [bootstrap.linux]
 - [mise bootstrap macos](https://mise.jdx.dev/cli/bootstrap/macos.html): Manage macOS bootstrap config from [bootstrap.macos]
-- [mise bootstrap mise-shell-activate](https://mise.jdx.dev/cli/bootstrap/mise-shell-activate.html): Manage mise shell activation from [bootstrap.miseshellactivate]
+- [mise bootstrap mise-shell-activate](https://mise.jdx.dev/cli/bootstrap/mise-shell-activate.html): Manage mise shell activation from [bootstrap.mise_shell_activate]
 - [mise bootstrap packages](https://mise.jdx.dev/cli/bootstrap/packages.html): Manage bootstrap system packages from [bootstrap.packages]
 - [mise bootstrap plan](https://mise.jdx.dev/cli/bootstrap/plan.html): Show the changes declarative bootstrap resources would make
 - [mise bootstrap plugins](https://mise.jdx.dev/cli/bootstrap/plugins.html): Manage package manager plugins declared in [bootstrap.plugins]


### PR DESCRIPTION
TOML table names containing underscores were emitted into `docs/public/llms.txt` with the underscores stripped — `[bootstrap.mise_shell_activate]` came out as `[bootstrap.miseshellactivate]`.

## Cause

`plain()` in `docs/.vitepress/llms.ts` unwrapped code spans first, so the identifier inside one reached the emphasis pass as bare text and `/[*_]{1,3}([^*_]+)[*_]{1,3}/` ate the paired `_shell_`. A second pass had the same shape of bug: `<SUBCOMMAND>` inside a code span was stripped as an HTML tag.

## Fix

Code spans are set aside as placeholders before the emphasis and tag passes and restored afterwards. The emphasis rule is also split in two so `_` only opens emphasis at a word boundary, which protects `snake_case` appearing outside a code span — the old rule would have mangled that just as happily. HTML tags outside code spans are still stripped.

## Result

Four lines change in `docs/public/llms.txt`, all fixes:

- `[bootstrap.miseshellactivate]` → `[bootstrap.mise_shell_activate]`, from `docs/bootstrap/shell.md`
- the same, from the `mise bootstrap mise-shell-activate` command description
- `[toolalias]` / `[shellalias]` → `[tool_alias]` / `[shell_alias]` on the Tool Aliases page
- `Usage: mise [FLAGS] [TASK]` → `Usage: mise [FLAGS] [TASK] <SUBCOMMAND>`

## Verification

Two sweeps for remaining damage, both clean:

1. Diffed the output against a variant with the emphasis and tag passes disabled entirely. Every remaining difference is genuine `**bold**` / `_italic_` markup being stripped as intended.
2. Collected every `snake_case` token across `docs/**/*.md` and searched `llms.txt` for its de-underscored form. The only hits were `preinstall` / `postinstall`, which are genuinely spelled that way in `docs/hooks.md`.

`plain()` was also exercised against edge cases directly: nested code spans, triple emphasis, links wrapping code, images, and real HTML tags.

Noticed while reviewing #12700, but unrelated to that PR's CLI help changes, so it was left out of scope there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change to the VitePress `llms.txt` generator and its committed output; no runtime or CLI behavior.
> 
> **Overview**
> Fixes **incorrect `llms.txt` blurbs** where TOML keys and CLI usage inside backticks were mangled during markdown flattening (underscores dropped, angle-bracket placeholders removed).
> 
> In `plain()` (`docs/.vitepress/llms.ts`), **inline code is stashed as placeholders** before emphasis and HTML-tag stripping, then restored so identifiers like `` `[bootstrap.mise_shell_activate]` `` and `` `<SUBCOMMAND>` `` stay intact. **Underscore emphasis** is handled separately from asterisks, with `_` only treated as emphasis at word boundaries so `snake_case` outside code spans is preserved.
> 
> Regenerated **`docs/public/llms.txt`** reflects four description fixes: `[bootstrap.mise_shell_activate]`, `[tool_alias]` / `[shell_alias]`, and the CLI overview usage line including `<SUBCOMMAND>`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3760a35e8b6853e6ab791ade4961ae48f570a72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected configuration key names in the Tool Aliases and Shell Activation documentation.
  * Updated the CLI overview to show the required subcommand argument.
  * Improved generated documentation formatting so code identifiers retain punctuation and snake_case text remains readable.
  * Preserved inline code formatting when converting documentation to plain text, making technical references easier to scan and interpret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->