### PR TITLE
chore(ci): use namespace for trusted windows builds

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -19,7 +19,7 @@ self-hosted-runner:
     # with perf-pr.yml, which builds pull-request code.
     - namespace-profile-endev-linux-amd64-large;overrides.cache-tag=mise-perf-main
     - namespace-profile-endev-linux-amd64-large;overrides.cache-tag=mise-release-rust-linux
-    - namespace-profile-endev-windows-amd64
+    - namespace-profile-endev-windows-amd64;overrides.cache-tag=cache
     - buildjet-32vcpu-ubuntu-2204-arm
     - buildjet-16vcpu-ubuntu-2204-arm
     - buildjet-8vcpu-ubuntu-2204-arm

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -19,6 +19,7 @@ self-hosted-runner:
     # with perf-pr.yml, which builds pull-request code.
     - namespace-profile-endev-linux-amd64-large;overrides.cache-tag=mise-perf-main
     - namespace-profile-endev-linux-amd64-large;overrides.cache-tag=mise-release-rust-linux
+    - namespace-profile-endev-windows-amd64
     - buildjet-32vcpu-ubuntu-2204-arm
     - buildjet-16vcpu-ubuntu-2204-arm
     - buildjet-8vcpu-ubuntu-2204-arm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,7 +223,7 @@ jobs:
   build-tarball-windows:
     if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
     name: build-tarball-windows-${{matrix.arch}}
-    runs-on: namespace-profile-endev-windows-amd64
+    runs-on: namespace-profile-endev-windows-amd64;overrides.cache-tag=cache
     defaults:
       run:
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,7 +223,10 @@ jobs:
   build-tarball-windows:
     if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
     name: build-tarball-windows-${{matrix.arch}}
-    runs-on: windows-latest
+    runs-on: namespace-profile-endev-windows-amd64
+    defaults:
+      run:
+        shell: pwsh
     # Matches the Linux tarball job. 60 was sized for a non-LTO build; the fat-LTO
     # link this job now does is the long pole and its cost varies a lot with
     # available memory — locally the same relink took ~20 minutes with RAM to spare

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -104,7 +104,10 @@ jobs:
         if: always()
 
   build-windows:
-    runs-on: windows-latest
+    runs-on: ${{ !inputs.trusted && 'windows-latest' || 'namespace-profile-endev-windows-amd64' }}
+    defaults:
+      run:
+        shell: pwsh
     timeout-minutes: 60
     needs: [classify-changes]
     if: needs.classify-changes.outputs.full-ci == 'true'
@@ -399,7 +402,10 @@ jobs:
         run: scripts/test-bootstrap-linux-host.sh target/debug/mise
 
   windows-unit:
-    runs-on: windows-latest
+    runs-on: ${{ !inputs.trusted && 'windows-latest' || 'namespace-profile-endev-windows-amd64' }}
+    defaults:
+      run:
+        shell: pwsh
     timeout-minutes: 40
     needs: [classify-changes]
     if: needs.classify-changes.outputs.full-ci == 'true'
@@ -432,7 +438,10 @@ jobs:
   windows-e2e:
     permissions:
       contents: read
-    runs-on: windows-latest
+    runs-on: ${{ !inputs.trusted && 'windows-latest' || 'namespace-profile-endev-windows-amd64' }}
+    defaults:
+      run:
+        shell: pwsh
     timeout-minutes: 100
     needs: [build-windows, classify-changes]
     if: needs.classify-changes.outputs.full-ci == 'true'

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -104,7 +104,7 @@ jobs:
         if: always()
 
   build-windows:
-    runs-on: ${{ !inputs.trusted && 'windows-latest' || 'namespace-profile-endev-windows-amd64' }}
+    runs-on: ${{ !inputs.trusted && 'windows-latest' || 'namespace-profile-endev-windows-amd64;overrides.cache-tag=cache' }}
     defaults:
       run:
         shell: pwsh
@@ -402,7 +402,7 @@ jobs:
         run: scripts/test-bootstrap-linux-host.sh target/debug/mise
 
   windows-unit:
-    runs-on: ${{ !inputs.trusted && 'windows-latest' || 'namespace-profile-endev-windows-amd64' }}
+    runs-on: ${{ !inputs.trusted && 'windows-latest' || 'namespace-profile-endev-windows-amd64;overrides.cache-tag=cache' }}
     defaults:
       run:
         shell: pwsh
@@ -438,7 +438,7 @@ jobs:
   windows-e2e:
     permissions:
       contents: read
-    runs-on: ${{ !inputs.trusted && 'windows-latest' || 'namespace-profile-endev-windows-amd64' }}
+    runs-on: ${{ !inputs.trusted && 'windows-latest' || 'namespace-profile-endev-windows-amd64;overrides.cache-tag=cache' }}
     defaults:
       run:
         shell: pwsh


### PR DESCRIPTION
## Summary
- run trusted Windows build, unit, and e2e jobs on the Namespace Windows profile
- keep untrusted fork PR jobs on GitHub-hosted Windows runners
- run both Windows release artifact builds on Namespace
- share the Namespace cache volume with PR #12705 via `overrides.cache-tag=cache` while keeping mbx local
- declare PowerShell explicitly for jobs whose runner is selected dynamically

## Deployment
- create a Namespace Windows profile named `endev-windows-amd64` before merging and enable its cache volume; the current Windows checks remain queued until that profile exists

## Testing
- `actionlint` on the changed workflows
- `git diff --check`
- attempted `mise run lint-fix`; nested Cargo checks selected the outdated global mise 2026.6.13 instead of the repository binary, but the changed workflows pass targeted actionlint

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI runner selection only; trusted fork PRs stay on GitHub-hosted Windows, but release Windows artifacts now require the Namespace profile to exist before merges.
> 
> **Overview**
> **Trusted Windows CI and release builds** now run on the Namespace profile `namespace-profile-endev-windows-amd64;overrides.cache-tag=cache` instead of GitHub-hosted `windows-latest`. Untrusted workflows still use `windows-latest`, matching the existing Linux/macOS `inputs.trusted` split in `test-impl.yml`.
> 
> `build-windows`, `windows-unit`, and `windows-e2e` pick the runner with `!inputs.trusted ? windows-latest : Namespace`. Release `build-tarball-windows` always uses Namespace. Jobs with a dynamic `runs-on` set **`defaults.run.shell: pwsh`** so steps behave consistently on either runner.
> 
> **actionlint** adds the new Namespace Windows label to the allowed self-hosted runner list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 253b3b46a6d8726d9937c0c73d173b0011448059. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->