### PR TITLE
fix(env): avoid duplicate unset in hook output

### DIFF
--- a/e2e/env/test_env_unset_inherited
+++ b/e2e/env/test_env_unset_inherited
@@ -53,3 +53,24 @@ export UNSET_TOOLS_ENV=parent
 MISE_ENV_CACHE=true mise env -s bash >/dev/null
 assert_contains "MISE_ENV_CACHE=true mise env -s bash" "unset UNSET_ENV"
 assert_contains "MISE_ENV_CACHE=true mise env -s bash" "unset UNSET_TOOLS_ENV"
+
+# Clearing the old managed value and applying an explicit removal should emit
+# only one unset, even when a runtime override makes both phases remove it.
+cat >mise.toml <<'EOF'
+[env]
+UNSET_ENV = "managed"
+EOF
+unset UNSET_ENV
+unset_count=$(
+  env -u __MISE_DIFF bash --noprofile --norc <<'BASH'
+set -euo pipefail
+eval "$(mise hook-env -s bash --force)"
+export UNSET_ENV=runtime-override
+cat >mise.toml <<'EOF'
+[env]
+UNSET_ENV = false
+EOF
+mise hook-env -s bash --force | grep -c '^unset UNSET_ENV$'
+BASH
+)
+assert "printf '%s' '$unset_count'" "1"

--- a/src/cli/hook_env.rs
+++ b/src/cli/hook_env.rs
@@ -126,7 +126,15 @@ impl HookEnv {
             return Ok(());
         }
         time!("should_exit_early false");
-        miseprint!("{}", hook_env::clear_old_env(&*shell))?;
+        let old_patches = hook_env::clear_old_env_patches(&*shell);
+        let cleared_keys: BTreeSet<&str> = old_patches
+            .iter()
+            .filter_map(|patch| match patch {
+                EnvDiffOperation::Remove(key) => Some(key.as_str()),
+                _ => None,
+            })
+            .collect();
+        miseprint!("{}", hook_env::build_env_commands(&*shell, &old_patches))?;
 
         // Use env_with_path_and_split which handles caching internally
         let (mut mise_env, env_remove, user_paths, tool_paths, env_watch_files) =
@@ -144,17 +152,22 @@ impl HookEnv {
                 diff.old.insert(key, value.clone());
             }
         }
-        let mut patches = diff.to_patches();
+        let mut diff_patches = diff.to_patches();
 
         // For fish shell, filter out PATH operations from diff patches because
         // fish's PATH handling conflicts with setting PATH multiple times
         if shell.to_string() == "fish" {
-            patches.retain(|p| match p {
+            diff_patches.retain(|p| match p {
                 EnvDiffOperation::Add(k, _)
                 | EnvDiffOperation::Change(k, _)
                 | EnvDiffOperation::Remove(k) => k != &*PATH_KEY,
             });
         }
+        diff_patches.retain(|patch| match patch {
+            EnvDiffOperation::Remove(key) => !cleared_keys.contains(key.as_str()),
+            _ => true,
+        });
+        let mut patches = diff_patches;
 
         // Combine paths for __MISE_DIFF tracking (all mise-managed paths)
         let all_paths: Vec<PathBuf> = user_paths

--- a/src/hook_env.rs
+++ b/src/hook_env.rs
@@ -617,7 +617,7 @@ fn get_mise_env_vars_hashed() -> String {
     hash_to_str(&env_vars)
 }
 
-pub(crate) fn clear_old_env(shell: &dyn Shell) -> String {
+pub(crate) fn clear_old_env_patches(shell: &dyn Shell) -> EnvDiffPatches {
     let mut patches = env::__MISE_DIFF.reverse().to_patches();
 
     // For fish shell, filter out PATH operations from the reversed diff because
@@ -636,7 +636,11 @@ pub(crate) fn clear_old_env(shell: &dyn Shell) -> String {
         let new_path = compute_deactivated_path();
         patches.push(EnvDiffOperation::Change(PATH_KEY.to_string(), new_path));
     }
-    build_env_commands(shell, &patches)
+    patches
+}
+
+pub(crate) fn clear_old_env(shell: &dyn Shell) -> String {
+    build_env_commands(shell, &clear_old_env_patches(shell))
 }
 
 /// Clear all aliases from the previous session. Called only during deactivation.


### PR DESCRIPTION
## Summary
- track variables removed while clearing the previous hook environment
- suppress matching removals when applying the new environment diff
- cover an activated-shell runtime override followed by an explicit removal

Follow-up to #12664.

## Tests
- scoped `hk fix` for the three changed files with Rust 1.95 and `MBX_DISABLE=1`
- `target/debug/mise run --skip-deps test:e2e e2e/env/test_env_unset_inherited`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow deduplication in shell hook output with e2e coverage; behavior change is limited to redundant unset lines, not env semantics.
> 
> **Overview**
> **`mise hook-env`** could emit the same `unset` twice when tearing down the previous session and applying the new config both removed the same variable (e.g. a managed value cleared, then `[env] KEY = false` after a runtime override).
> 
> The hook now splits **clear previous env** into patch generation (`clear_old_env_patches`) and shell command rendering. It records keys already removed in that first phase and **drops matching `Remove` ops** from the new environment diff before printing the second batch of commands. `clear_old_env` still wraps the same patches for other callers (e.g. deactivation).
> 
> An e2e case asserts **`hook-env` prints exactly one** `unset UNSET_ENV` for the managed-value → runtime override → explicit removal sequence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4020bb2f49362cb0007eb6bfd8a77378853f8344. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->