### PR TITLE
docs: redesign landing page around one config file

### DIFF
--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -7,59 +7,34 @@
           <img class="chef-logo chef-logo-dark" src="/logo-dark.svg" alt="" />
           <span class="lockup-word">mise-en-place</span>
         </div>
-        <h1>Your dev environment, prepped and ready</h1>
-        <p>One tool that manages dev tools, env vars, and tasks per project.</p>
+        <h1>
+          Every tool, env var, and task your project needs,
+          <em>in one file.</em>
+        </h1>
+        <p class="hero-lede">
+          mise reads a <code>mise.toml</code> checked into your repo, installs
+          the right versions of your dev tools, loads the project's environment,
+          and runs its tasks. Point it at a fresh machine and
+          <code>mise bootstrap</code> sets up the rest: packages, dotfiles,
+          services.
+        </p>
         <div class="hero-actions">
-          <a class="action-btn action-btn-brand" href="/getting-started"
-            >Getting Started</a
-          >
-          <a class="action-btn action-btn-alt" href="/demo">Demo</a>
-        </div>
-      </div>
-    </template>
-
-    <template #home-hero-info-after>
-      <div class="hero-right">
-        <div class="hero-terminal" aria-label="mise terminal example">
-          <div class="terminal-bar">
-            <span></span>
-            <span></span>
-            <span></span>
-            <strong>~/projects/orders · zsh</strong>
-          </div>
-          <div class="terminal-body">
-            <div>
-              <span class="prompt">$</span> mise use node@24 python@3.13
-            </div>
-            <div>
-              <span class="dim">mise</span> node@24.18.0
-              <span class="ok">✓ installed</span>
-            </div>
-            <div>
-              <span class="dim">mise</span> python@3.13.14
-              <span class="ok">✓ installed</span>
-            </div>
-            <div>
-              <span class="dim">mise</span> ./mise.toml tools: node@24.18.0,
-              python@3.13.14
-            </div>
-            <div><span class="prompt">$</span> node --version</div>
-            <div>v24.18.0</div>
-            <div><span class="prompt">$</span> mise run build</div>
-            <div><span class="key">[build]</span> $ tsc</div>
-          </div>
-        </div>
-        <div class="hero-install">
           <button class="install-command" type="button" @click="copyInstall">
             <code>curl https://mise.run | sh</code>
             <span class="install-copy" :class="{ copied }">{{
               copied ? "copied" : "copy"
             }}</span>
           </button>
-          <a class="install-alt" href="/installing-mise"
-            >More install methods</a
+          <a class="action-btn action-btn-brand" href="/getting-started"
+            >Getting started</a
           >
+          <a class="action-btn action-btn-alt" href="/demo">Watch the demo</a>
         </div>
+        <p class="hero-meta">
+          <span>Open source, MIT</span>
+          <span>macOS, Linux, Windows</span>
+          <span>One static binary, no dependencies</span>
+        </p>
       </div>
     </template>
 
@@ -150,54 +125,48 @@ async function copyText(text: string) {
 
 <style>
 /* ═══════════════════════════════════════════
-   INSTALL COMMAND
+   INSTALL COMMAND (hero)
    ═══════════════════════════════════════════ */
-.hero-install {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  margin-top: 0;
-}
-
 .install-command {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 12px;
-  padding: 14px 20px;
+  gap: 16px;
+  height: 48px;
+  padding: 0 18px;
   background: var(--vp-c-bg-soft);
   border: 1px solid var(--vp-c-divider);
-  border-radius: 10px;
+  border-radius: 8px;
   cursor: pointer;
-  transition: all 0.25s ease;
-  position: relative;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .install-command:hover {
   border-color: var(--vp-c-brand-1);
-  box-shadow: 0 4px 20px rgba(139, 34, 82, 0.1);
-  transform: translateY(-1px);
-}
-
-.dark .install-command:hover {
-  box-shadow: 0 4px 20px rgba(199, 91, 122, 0.1);
+  box-shadow: 0 8px 24px -16px rgba(139, 34, 82, 0.35);
 }
 
 .install-command code {
-  font-family: "JetBrains Mono", var(--vp-font-family-mono);
-  font-size: 0.95rem;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.9rem;
   color: var(--vp-c-text-1);
   background: none;
   padding: 0;
   letter-spacing: -0.01em;
+  white-space: nowrap;
 }
 
 .install-copy {
-  font-size: 1.1rem;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
   color: var(--vp-c-text-3);
-  transition: all 0.2s ease;
+  transition: color 0.2s ease;
   user-select: none;
-  min-width: 1.2em;
-  text-align: center;
+  min-width: 4.5em;
+  text-align: right;
 }
 
 .install-copy.copied {
@@ -208,25 +177,14 @@ async function copyText(text: string) {
   color: var(--vp-c-brand-1);
 }
 
-.install-alt {
-  margin-top: 10px;
-  font-size: 0.85rem;
-  font-family: "Roc Grotesk", sans-serif;
-  color: var(--vp-c-text-3);
-  text-decoration: none;
-  transition: color 0.2s ease;
-}
+@media (max-width: 640px) {
+  .install-command {
+    width: 100%;
+    justify-content: space-between;
+  }
 
-.install-alt:hover {
-  color: var(--vp-c-brand-1);
-}
-
-/* ═══════════════════════════════════════════
-   RESPONSIVE
-   ═══════════════════════════════════════════ */
-@media (max-width: 768px) {
   .install-command code {
-    font-size: 0.85rem;
+    font-size: 0.82rem;
   }
 }
 </style>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -507,126 +507,6 @@ h1, h2, h3, h4, h5, h6,
   letter-spacing: 0.03em;
 }
 
-/* ═══ Hero section — "The Chef's Counter" ═══ */
-/* VitePress pulls the hero up under the nav with a negative margin
-   (nav height + layout-top banner), so padding-top must include that
-   offset or the hero content hides behind the navbar. */
-.VPHero {
-  padding-top: calc(
-    var(--vp-nav-height) + var(--vp-layout-top-height, 0px) + 76px
-  ) !important;
-  padding-bottom: 64px !important;
-  position: relative;
-  z-index: 1;
-  /* single static tint for depth — deliberately no animation/orbs/grain */
-  background: radial-gradient(
-    1000px 500px at 68% 12%,
-    rgba(139, 34, 82, 0.08),
-    transparent 70%
-  );
-}
-
-.dark .VPHero {
-  background: radial-gradient(
-    1000px 500px at 68% 12%,
-    rgba(199, 91, 122, 0.07),
-    transparent 70%
-  );
-}
-
-/* Two-column hero layout */
-.VPHero .container {
-  max-width: 1040px !important;
-  margin: 0 auto !important;
-}
-
-.VPHero .main {
-  display: grid !important;
-  grid-template-columns: 1fr 1fr;
-  align-items: center;
-  gap: 0 60px;
-}
-
-/* Hide the default VitePress hero name and actions */
-.VPHero .name {
-  display: none !important;
-}
-
-.VPHero .actions {
-  display: none !important;
-}
-
-.VPHero .tagline {
-  grid-column: 1;
-  grid-row: 2;
-  font-family: "Cormorant Garamond", Georgia, serif !important;
-  font-size: 1.75rem !important;
-  font-weight: 500;
-  font-style: italic;
-  letter-spacing: 0.01em;
-  color: var(--vp-c-text-2);
-  margin-top: -4px !important;
-  text-align: center;
-}
-
-/* Right column wrapper */
-.hero-right {
-  grid-column: 2;
-  grid-row: 1 / 3;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 28px;
-}
-
-/* Custom action buttons in right column */
-.hero-actions {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-  margin-top: 12px;
-}
-
-.action-btn {
-  font-family: "Roc Grotesk", sans-serif;
-  font-weight: 500;
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  padding: 10px 24px;
-  border-radius: 6px;
-  text-decoration: none;
-  transition: all 0.25s ease;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  height: 40px;
-  line-height: 1;
-}
-
-.action-btn-brand {
-  background: var(--vp-c-brand-1);
-  color: #fff;
-}
-
-.action-btn-brand:hover {
-  background: var(--vp-c-brand-2);
-  transform: translateY(-2px);
-  box-shadow: 0 4px 16px rgba(139, 34, 82, 0.25);
-}
-
-.action-btn-alt {
-  background: var(--vp-c-bg-soft);
-  color: var(--vp-c-text-1);
-  border: 1px solid var(--vp-c-divider);
-}
-
-.action-btn-alt:hover {
-  border-color: var(--vp-c-brand-1);
-  color: var(--vp-c-brand-1);
-  transform: translateY(-2px);
-}
-
 /* Landing page feature card text */
 .VPFeature .details {
   font-size: 1rem;
@@ -1052,38 +932,6 @@ div[class*="language-"] .copy:hover {
   letter-spacing: 0.25rem;
 }
 
-/* Responsive improvements */
-@media (max-width: 768px) {
-  .VPHero .main {
-    grid-template-columns: 1fr !important;
-  }
-
-  .VPHero .tagline {
-    grid-column: 1;
-    grid-row: auto;
-    text-align: center;
-    font-size: 1.15rem !important;
-  }
-
-  .hero-right {
-    grid-column: 1;
-    grid-row: auto;
-    align-items: center;
-    margin-top: 24px;
-  }
-
-  .hero-actions {
-    justify-content: center;
-  }
-
-  .VPHero {
-    padding-top: calc(
-      var(--vp-nav-height) + var(--vp-layout-top-height, 0px) + 48px
-    ) !important;
-    padding-bottom: 40px !important;
-  }
-}
-
 /* Loading animation for async content */
 @keyframes pulse {
   0%,
@@ -1129,7 +977,43 @@ div[class*="language-"] .copy:hover {
   border: 1px solid var(--vp-c-danger-2);
 }
 
-/* ═══ Landing page ═══ */
+
+/* ═══ Landing page ═══
+   A centered editorial hero, then a "card" showing one mise.toml driving
+   three outputs. The three pillars — tools, env, tasks — each carry one
+   accent (burgundy, gold, sage) that repeats down the page. Flat surfaces,
+   hairline rules, no motion beyond hover. */
+
+:root {
+  --pillar-tools: var(--vp-c-brand-1);
+  --pillar-env: #9a7245;
+  --pillar-tasks: #6b7f4e;
+  --pillar-boot: #a8503d;
+}
+
+.dark {
+  --pillar-env: #d4a76a;
+  --pillar-tasks: #8fa86e;
+  --pillar-boot: #d4826c;
+}
+
+.pillar-tools {
+  --pillar: var(--pillar-tools);
+}
+
+.pillar-env {
+  --pillar: var(--pillar-env);
+}
+
+.pillar-tasks {
+  --pillar: var(--pillar-tasks);
+}
+
+.pillar-boot {
+  --pillar: var(--pillar-boot);
+}
+
+/* ─── Hero ─── */
 /* .heading wraps .name; hide it too or it occupies an empty grid row */
 .VPHero .heading,
 .VPHero .name,
@@ -1138,15 +1022,25 @@ div[class*="language-"] .copy:hover {
   display: none !important;
 }
 
+/* VitePress pulls the hero up under the nav with a negative margin
+   (nav height + layout-top banner), so padding-top must include that
+   offset or the hero content hides behind the navbar. */
+.VPHero {
+  position: relative;
+  z-index: 1;
+  padding-top: calc(
+    var(--vp-nav-height) + var(--vp-layout-top-height, 0px) + 72px
+  ) !important;
+  padding-bottom: 56px !important;
+}
+
 .VPHero .container {
   max-width: 1120px !important;
+  margin: 0 auto !important;
 }
 
 .VPHero .main {
-  display: grid !important;
-  grid-template-columns: minmax(0, 0.95fr) minmax(360px, 1.05fr);
-  gap: 56px;
-  align-items: center;
+  display: block !important;
 }
 
 .VPHero .text {
@@ -1159,33 +1053,12 @@ div[class*="language-"] .copy:hover {
 }
 
 .hero-copy {
-  position: relative;
-  z-index: 1;
-  min-width: 0;
-}
-
-.landing-kicker {
-  font-family: var(--vp-font-family-mono);
-  font-size: 0.72rem !important;
-  line-height: 1.3 !important;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--vp-c-text-3);
-}
-
-.landing-kicker::before {
-  content: "";
-  display: inline-block;
-  width: 24px;
-  height: 1px;
-  margin-right: 10px;
-  vertical-align: middle;
-  background: currentColor;
-}
-
-/* centered CTA — no leading dash */
-.landing-cta .landing-kicker::before {
-  display: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 860px;
+  margin: 0 auto;
+  text-align: center;
 }
 
 /* Big brand lockup — same composition as the navbar brand, scaled up.
@@ -1193,18 +1066,17 @@ div[class*="language-"] .copy:hover {
 .hero-lockup {
   display: flex;
   align-items: center;
-  gap: 18px;
+  gap: 16px;
 }
 
 .hero-lockup .chef-logo {
   width: auto;
-  height: clamp(64px, 9vw, 96px);
-  filter: drop-shadow(0 12px 34px rgba(139, 34, 82, 0.16));
+  height: clamp(56px, 8vw, 80px);
 }
 
 .lockup-word {
   font-family: "Roc Grotesk", sans-serif;
-  font-size: clamp(1.8rem, 3.2vw, 2.5rem);
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
   font-weight: 400;
   letter-spacing: -0.02em;
   color: var(--vp-c-text-1);
@@ -1224,131 +1096,110 @@ div[class*="language-"] .copy:hover {
 }
 
 .hero-copy h1 {
-  margin: 22px 0 0;
+  margin: 36px 0 0;
   font-family: "Cormorant Garamond", Georgia, serif;
-  font-size: clamp(2.9rem, 5vw, 4rem);
-  font-style: italic;
+  font-size: clamp(2.9rem, 6.2vw, 5rem);
   font-weight: 300;
-  line-height: 1.05;
-  letter-spacing: 0;
-  color: var(--vp-c-brand-1);
+  font-style: normal;
+  line-height: 1;
+  letter-spacing: -0.01em;
+  color: var(--vp-c-text-1);
   text-wrap: balance;
 }
 
-.hero-copy p {
-  max-width: min(42ch, 100%);
-  margin: 22px 0 0;
-  color: var(--vp-c-text-2);
-  font-size: 1.1rem;
-  line-height: 1.65;
-  overflow-wrap: break-word;
-}
-
-.hero-right {
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-  min-width: 0;
-}
-
-.hero-terminal {
-  width: 100%;
-  max-width: 100%;
-  overflow: hidden;
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 8px;
-  background: var(--vp-c-bg-soft);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.04),
-    0 22px 48px -28px rgba(0, 0, 0, 0.5);
-  font-family: var(--vp-font-family-mono);
-  font-size: 0.82rem;
-}
-
-.terminal-bar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 11px 14px;
-  border-bottom: 1px solid var(--vp-c-divider);
-  background: var(--vp-c-bg-mute);
-}
-
-.terminal-bar span {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-}
-
-.terminal-bar span:nth-child(1) {
-  background: var(--vp-c-danger-1);
-}
-
-.terminal-bar span:nth-child(2) {
-  background: var(--vp-c-warning-1);
-}
-
-.terminal-bar span:nth-child(3) {
-  background: var(--vp-c-success-1);
-}
-
-.terminal-bar strong {
-  margin-left: auto;
-  margin-right: auto;
-  color: var(--vp-c-text-3);
-  font-size: 0.68rem;
-  font-weight: 400;
-  letter-spacing: 0.08em;
-}
-
-.terminal-body {
-  padding: 18px 20px;
-  color: var(--vp-c-text-1);
-  line-height: 1.75;
-  white-space: nowrap;
-  overflow: auto;
-}
-
-.terminal-body .prompt {
+.hero-copy h1 em {
+  font-style: italic;
   color: var(--vp-c-brand-1);
 }
 
-.terminal-body .ok {
-  color: var(--vp-c-success-1);
+.hero-lede {
+  max-width: 58ch;
+  margin: 26px 0 0;
+  font-size: 1.15rem;
+  line-height: 1.6;
+  color: var(--vp-c-text-2);
+  text-wrap: pretty;
 }
 
-.terminal-body .key {
-  color: var(--vp-c-warning-1);
+.hero-lede code {
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-1);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.88em;
 }
 
-.terminal-body .dim {
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 34px;
+}
+
+.action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 48px;
+  padding: 0 22px;
+  border-radius: 8px;
+  font-family: "Roc Grotesk", sans-serif;
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-decoration: none;
+  line-height: 1;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.action-btn-brand {
+  background: var(--vp-c-brand-1);
+  color: #fff;
+}
+
+.action-btn-brand:hover {
+  background: var(--vp-c-brand-2);
+}
+
+.action-btn-alt {
+  border: 1px solid var(--vp-c-divider);
+  background: transparent;
+  color: var(--vp-c-text-1);
+}
+
+.action-btn-alt:hover {
+  border-color: var(--vp-c-brand-1);
+  color: var(--vp-c-brand-1);
+}
+
+.hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin: 26px 0 0;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
   color: var(--vp-c-text-3);
 }
 
-.hero-install {
-  align-items: stretch;
+.hero-meta span + span::before {
+  content: "·";
+  margin: 0 12px;
 }
 
-.hero-install .install-command {
-  width: 100%;
-  justify-content: space-between;
-  border-radius: 8px;
-  font-size: 0.88rem;
-}
-
-.hero-install .install-copy {
-  font-size: 0.74rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.hero-install .install-alt {
-  align-self: flex-start;
-}
-
+/* ─── Page frame ─── */
 .VPHome .vp-doc {
   max-width: none;
-  padding: 0 24px 80px;
+  padding: 0 24px;
 }
 
 .landing-page {
@@ -1356,177 +1207,418 @@ div[class*="language-"] .copy:hover {
   margin: 0 auto;
 }
 
-.landing-section {
-  margin-top: 76px;
+/* vp-doc list/link/heading defaults don't fit a composed page */
+.landing-page ul,
+.landing-page ol {
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
-.landing-metaphor {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.9fr);
-  gap: 64px;
-  align-items: center;
-  padding-top: 72px;
-  border-top: 1px solid var(--vp-c-divider);
+.landing-page li + li {
+  margin-top: 0;
 }
 
-.landing-section h2 {
-  margin: 12px 0 0;
-  /* reset vp-doc h2 defaults (top border + padding) on landing headings */
-  border-top: 0;
-  padding-top: 0;
-  font-family: "Cormorant Garamond", Georgia, serif;
-  font-size: clamp(2.5rem, 5vw, 4rem);
-  font-style: italic;
-  font-weight: 300;
-  line-height: 1;
-  letter-spacing: 0;
+.landing-page h2,
+.landing-page h3 {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.landing-page a::after {
+  content: none !important;
+}
+
+.landing-page p a {
   color: var(--vp-c-brand-1);
-  text-wrap: balance;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--vp-c-brand-1) 40%, transparent);
+  text-underline-offset: 3px;
 }
 
-.landing-special h2,
-.landing-cta h2 {
-  text-wrap: balance;
+.landing-page p a:hover {
+  text-decoration-color: var(--vp-c-brand-1);
 }
 
-.landing-section p {
-  color: var(--vp-c-text-2);
-}
-
-.landing-definition {
-  margin-top: 24px;
-  padding: 22px;
-  border-left: 2px solid var(--vp-c-brand-1);
-  border-radius: 0 8px 8px 0;
-  background: var(--vp-c-bg-soft);
-}
-
-.definition-word {
-  font-family: "Cormorant Garamond", Georgia, serif;
-  font-size: 1.7rem;
-  font-style: italic;
-  color: var(--vp-c-text-1);
-}
-
-.definition-word span {
-  margin-left: 8px;
+/* ─── Terminal transcript (shared) ─── */
+.terminal-lines {
   font-family: var(--vp-font-family-mono);
-  font-size: 0.8rem;
+  font-size: 0.84rem;
+  line-height: 1.8;
+  color: var(--vp-c-text-1);
+  white-space: nowrap;
+  overflow: auto;
+}
+
+.terminal-lines .prompt {
+  color: var(--vp-c-brand-1);
+}
+
+.terminal-lines .ok {
+  color: var(--vp-c-success-1);
+}
+
+.terminal-lines .key {
+  color: var(--vp-c-warning-1);
+}
+
+.terminal-lines .dim {
   color: var(--vp-c-text-3);
 }
 
-/* Syntax-highlighted mise.toml example — wrap the VitePress code block
-   in the brand-accent panel and let Shiki color the tokens. */
-.landing-config .language-toml {
-  margin: 0;
-  border: 1px solid var(--vp-c-divider);
-  border-left: 2px solid var(--vp-c-brand-1);
-  border-radius: 0 8px 8px 0;
-  background: var(--vp-c-bg-soft);
-}
-
-.landing-config .language-toml pre {
-  margin: 0;
-  padding: 22px;
-  overflow: auto;
-  background: transparent;
-}
-
-.landing-config .language-toml code {
-  padding: 0;
-  font-family: var(--vp-font-family-mono);
-  font-size: 0.88rem;
-  line-height: 1.8;
-}
-
-/* The lang label just repeats "toml"; the copy button is enough */
-.landing-config .language-toml > .lang {
-  display: none;
-}
-
-.landing-section-heading {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 24px;
-  margin-bottom: 34px;
-}
-
-.landing-small-button,
-.landing-links a {
-  display: inline-flex;
-  align-items: center;
-  min-height: 38px;
-  padding: 0 16px;
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 6px;
-  color: var(--vp-c-text-1);
-  font-family: var(--vp-font-family-mono);
-  font-size: 0.72rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  text-decoration: none;
-}
-
-.landing-feature-grid {
+/* ─── The card: mise.toml → three outputs ─── */
+.hero-card {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 18px;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  overflow: hidden;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 10px;
+  background: var(--vp-c-bg-soft);
+  box-shadow: 0 32px 64px -48px rgba(0, 0, 0, 0.45);
 }
 
-.landing-feature-card {
+.card-file {
   display: flex;
   flex-direction: column;
   min-width: 0;
-  padding: 28px;
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 8px;
-  background: var(--vp-c-bg-soft);
-  color: var(--vp-c-text-1);
-  text-decoration: none !important;
-  transition:
-    border-color 0.2s ease,
-    transform 0.2s ease,
-    box-shadow 0.2s ease;
+  border-right: 1px solid var(--vp-c-divider);
 }
 
-.card-cmd {
-  margin: 0 0 14px;
+.card-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--vp-c-divider);
+  background: var(--vp-c-bg-mute);
   font-family: var(--vp-font-family-mono);
-  font-size: 0.72rem;
-  letter-spacing: 0.06em;
+  font-size: 0.68rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
   color: var(--vp-c-text-3);
 }
 
-.landing-feature-card:hover {
-  border-color: var(--vp-c-brand-1);
-  transform: translateY(-2px);
-  box-shadow: 0 18px 44px -32px rgba(139, 34, 82, 0.45);
-}
-
-.landing-feature-card h3 {
-  margin: 0 0 10px;
-  font-family: "Roc Grotesk", sans-serif;
-  font-size: 2rem;
+.card-bar strong {
   font-weight: 500;
-  line-height: 1.05;
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: 0.78rem;
+  color: var(--vp-c-text-1);
 }
 
-.landing-feature-card p {
+.card-toml {
+  flex: 1;
+  padding: 20px 0;
+  overflow: auto;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.86rem;
+  line-height: 1.9;
+  white-space: pre;
+  color: var(--vp-c-text-2);
+}
+
+.card-toml .row {
+  padding: 0 20px 0 18px;
+  border-left: 2px solid transparent;
+}
+
+.card-toml .row-blank {
+  height: 0.9em;
+}
+
+.card-toml .row-tools {
+  border-left-color: var(--pillar-tools);
+}
+
+.card-toml .row-env {
+  border-left-color: var(--pillar-env);
+}
+
+.card-toml .row-tasks {
+  border-left-color: var(--pillar-tasks);
+}
+
+.card-toml .row-boot {
+  border-left-color: var(--pillar-boot);
+}
+
+.card-toml .tk-section {
+  font-weight: 600;
+}
+
+.card-toml .row-tools .tk-section {
+  color: var(--pillar-tools);
+}
+
+.card-toml .row-env .tk-section {
+  color: var(--pillar-env);
+}
+
+.card-toml .row-tasks .tk-section {
+  color: var(--pillar-tasks);
+}
+
+.card-toml .row-boot .tk-section {
+  color: var(--pillar-boot);
+}
+
+.card-toml .tk-key {
+  color: var(--vp-c-text-1);
+}
+
+.card-toml .tk-str {
+  color: var(--vp-c-text-2);
+}
+
+.card-outputs {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.card-output {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 0;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--vp-c-divider);
+}
+
+.card-output:last-child {
+  border-bottom: 0;
+}
+
+.card-output-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vp-c-text-3);
+}
+
+.pillar-dot {
+  flex: none;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--pillar);
+}
+
+.landing-page .card-output-head code {
+  margin-left: auto;
+  padding: 0 !important;
+  background: transparent;
+  font-size: 0.78rem !important;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--vp-c-text-1);
+}
+
+.card-output .terminal-lines {
+  margin-top: 8px;
+  font-size: 0.82rem;
+}
+
+/* ─── Sections ─── */
+.landing-section {
+  margin-top: 96px;
+  padding-top: 28px;
+  border-top: 1px solid var(--vp-c-divider);
+}
+
+.landing-page .landing-kicker {
+  display: flex;
+  align-items: center;
+  gap: 12px;
   margin: 0;
-  font-size: 0.95rem;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.68rem;
+  line-height: 1.3;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vp-c-text-3);
+}
+
+.landing-kicker span {
+  color: var(--vp-c-brand-1);
+}
+
+.landing-page .landing-section h2,
+.landing-page .landing-cta h2 {
+  margin: 18px 0 0;
+  font-family: "Cormorant Garamond", Georgia, serif;
+  font-size: clamp(2.4rem, 4.6vw, 3.6rem);
+  font-weight: 300;
+  line-height: 1.02;
+  letter-spacing: -0.01em;
+  color: var(--vp-c-text-1);
+  text-wrap: balance;
+}
+
+.landing-page h2 em {
+  font-style: italic;
+  color: var(--vp-c-brand-1);
+}
+
+.landing-page .landing-lede {
+  margin: 22px 0 0;
+  font-size: 1.1rem;
+  line-height: 1.65;
+  color: var(--vp-c-text-2);
+  text-wrap: pretty;
+}
+
+.landing-page .landing-note {
+  margin: 16px 0 0;
+  font-size: 0.92rem;
   line-height: 1.6;
+  color: var(--vp-c-text-3);
+}
+
+/* 01 · Why: before/after ledger */
+.landing-why-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.95fr);
+  gap: 48px;
+  align-items: start;
+}
+
+.landing-ledger {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  margin-top: 26px;
+  overflow: hidden;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 10px;
+  background: var(--vp-c-bg-soft);
+}
+
+.ledger-col {
+  min-width: 0;
+  padding: 20px 22px 22px;
+}
+
+.ledger-before {
+  border-right: 1px solid var(--vp-c-divider);
+}
+
+.landing-page .ledger-head {
+  margin: 0 0 6px;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.66rem;
+  line-height: 1.3;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vp-c-text-3);
+}
+
+.landing-page .ledger-col li {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 9px 0;
+  border-top: 1px solid var(--vp-c-divider);
+  font-family: "Roc Grotesk", sans-serif;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  color: var(--vp-c-text-2);
+}
+
+.ledger-col li span {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.72rem;
+  text-align: right;
+  color: var(--vp-c-text-3);
+}
+
+.landing-page .ledger-after li {
+  color: var(--vp-c-text-1);
+}
+
+.ledger-after li strong {
+  font-weight: 500;
+}
+
+.ledger-pillars {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 16px;
+}
+
+.ledger-pillars span {
+  padding: 3px 9px;
+  border: 1px solid color-mix(in srgb, var(--pillar) 45%, transparent);
+  border-radius: 999px;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--pillar);
+}
+
+/* 02 · Stations: three ruled columns */
+.stations-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0 32px;
+  margin-top: 40px;
+}
+
+.station {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding-top: 20px;
+  border-top: 2px solid var(--pillar);
+  color: var(--vp-c-text-1);
+  text-decoration: none !important;
+}
+
+.landing-page .station-cmd {
+  margin: 0;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.74rem;
+  line-height: 1.4;
+  color: var(--pillar);
+}
+
+.landing-page .station h3 {
+  margin: 12px 0 8px;
+  font-size: 1.9rem;
+  line-height: 1.1;
+  color: var(--vp-c-text-1);
+  transition: color 0.2s ease;
+}
+
+.station:hover h3 {
+  color: var(--pillar);
+}
+
+.landing-page .station p:not(.station-cmd) {
+  margin: 0;
+  font-size: 0.97rem;
+  line-height: 1.6;
+  color: var(--vp-c-text-2);
 }
 
 .card-link {
   display: inline-block;
-  /* push to the card bottom so links align across the grid */
   margin-top: auto;
   padding-top: 20px;
   font-family: var(--vp-font-family-mono);
-  font-size: 0.72rem;
+  font-size: 0.7rem;
   letter-spacing: 0.1em;
-  color: var(--vp-c-brand-1);
+  text-transform: uppercase;
+  color: var(--pillar, var(--vp-c-brand-1));
 }
 
 .card-link::after {
@@ -1536,123 +1628,338 @@ div[class*="language-"] .copy:hover {
   transition: transform 0.2s ease;
 }
 
-.landing-feature-card:hover .card-link::after {
+a:hover > .card-link::after,
+a:hover > div + .card-link::after {
   transform: translateX(3px);
 }
 
-.landing-tools {
+/* 03 · Day to day */
+.landing-switch-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(360px, 1.1fr);
+  gap: 56px;
+  align-items: center;
+}
+
+.landing-page .landing-checklist {
+  margin-top: 26px;
+}
+
+.landing-page .landing-checklist li {
+  display: flex;
+  gap: 14px;
+  padding: 11px 0;
+  border-top: 1px solid var(--vp-c-divider);
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--vp-c-text-1);
+}
+
+.landing-checklist li::before {
+  content: "";
+  flex: none;
+  width: 6px;
+  height: 6px;
+  margin-top: 0.55em;
+  border-radius: 50%;
+  background: var(--vp-c-brand-1);
+}
+
+.landing-terminal {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 10px;
+  background: var(--vp-c-bg-soft);
+  box-shadow: 0 32px 64px -48px rgba(0, 0, 0, 0.45);
+}
+
+.terminal-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--vp-c-divider);
+  background: var(--vp-c-bg-mute);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vp-c-text-3);
+}
+
+.landing-terminal .terminal-lines {
+  padding: 18px 20px;
+}
+
+/* 04 · New machine: bootstrap config beside the pitch */
+.landing-machine-grid {
+  display: grid;
+  grid-template-columns: minmax(360px, 1.1fr) minmax(0, 0.9fr);
+  gap: 56px;
+  align-items: center;
+}
+
+.landing-config-card {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 10px;
+  background: var(--vp-c-bg-soft);
+  box-shadow: 0 32px 64px -48px rgba(0, 0, 0, 0.45);
+}
+
+.landing-config-card .card-toml {
+  padding: 18px 0;
+}
+
+.landing-inline-cmd {
+  margin-top: 24px;
+  padding: 12px 16px;
+  overflow: auto;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  background: var(--vp-c-bg-soft);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.84rem;
+  white-space: nowrap;
+  color: var(--vp-c-text-1);
+}
+
+.landing-page .landing-inline-cmd code {
+  padding: 0 !important;
+  background: transparent;
+  color: inherit;
+  font-size: inherit !important;
+}
+
+/* The pantry: full-bleed strip */
+.landing-pantry {
   width: 100vw;
-  margin: 76px calc(50% - 50vw) 0;
-  padding: 28px 24px;
+  margin: 96px calc(50% - 50vw) 0;
+  padding: 44px 24px;
   border-top: 1px solid var(--vp-c-divider);
   border-bottom: 1px solid var(--vp-c-divider);
   background: var(--vp-c-bg-soft);
 }
 
-.landing-tools p {
-  margin: 0 0 14px;
-  text-align: center;
-  font-family: var(--vp-font-family-mono);
-  font-size: 0.68rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--vp-c-text-3);
+.landing-pantry-inner {
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr);
+  gap: 28px 56px;
+  align-items: start;
+  max-width: 1120px;
+  margin: 0 auto;
+}
+
+.landing-page .pantry-stat {
+  margin: 12px 0 0;
+  font-family: "Cormorant Garamond", Georgia, serif;
+  font-size: 3.4rem;
+  font-weight: 300;
+  line-height: 1;
+  color: var(--vp-c-text-1);
+}
+
+.pantry-stat small {
+  display: block;
+  margin-top: 8px;
+  font-family: "Roc Grotesk", sans-serif;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--vp-c-text-2);
 }
 
 .landing-tools-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px 32px;
-  justify-content: center;
-  max-width: 1120px;
-  margin: 0 auto;
+  gap: 8px;
 }
 
 .landing-tools-list a {
-  white-space: nowrap;
-  font-family: "Cormorant Garamond", Georgia, serif;
-  font-style: italic;
-  font-size: 1.75rem;
-  font-weight: 300;
-  color: var(--vp-c-text-2);
-  text-decoration: none;
-}
-
-.landing-tools-list a:hover {
-  color: var(--vp-c-brand-1);
-}
-
-.landing-special {
-  display: block;
-  margin: 48px auto 0;
-  padding: 28px;
-  border: 1px solid rgba(107, 127, 78, 0.35);
-  border-radius: 8px;
-  background:
-    linear-gradient(135deg, rgba(107, 127, 78, 0.12), transparent 44%),
-    var(--vp-c-bg-soft);
-  color: var(--vp-c-text-1);
-  text-decoration: none !important;
-  transition:
-    border-color 0.2s ease,
-    box-shadow 0.2s ease,
-    transform 0.2s ease;
-}
-
-.landing-special:hover {
-  border-color: var(--vp-c-brand-1);
-  transform: translateY(-2px);
-  box-shadow: 0 18px 44px -32px rgba(107, 127, 78, 0.55);
-}
-
-.dark .landing-special {
-  background:
-    linear-gradient(135deg, rgba(143, 168, 110, 0.14), transparent 48%),
-    var(--vp-c-bg-soft);
-  border-color: rgba(143, 168, 110, 0.35);
-}
-
-.landing-special h2 {
-  margin: 12px 0 0;
-  /* reset vp-doc h2 defaults (top border + padding) inside the card */
-  border-top: 0;
-  padding-top: 0;
-  font-family: "Cormorant Garamond", Georgia, serif;
-  font-size: clamp(2.2rem, 4vw, 3.4rem);
-  font-style: italic;
-  font-weight: 300;
-  line-height: 1;
-  letter-spacing: 0;
-  color: var(--vp-c-brand-1);
-}
-
-.landing-special p:not(.landing-kicker) {
-  max-width: 58ch;
-  margin: 16px 0 0;
-  color: var(--vp-c-text-2);
-}
-
-.landing-recipe-grid {
-  display: grid;
-  position: relative;
-  grid-template-columns: 260px minmax(0, 1fr);
-  overflow: hidden;
+  padding: 6px 12px;
   border: 1px solid var(--vp-c-divider);
-  border-radius: 8px;
-}
-
-.landing-mini-install {
-  display: flex;
-  align-items: center;
-  min-height: 48px;
-  padding: 0 16px;
-  overflow: auto;
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 8px;
+  border-radius: 999px;
   background: var(--vp-c-bg);
   color: var(--vp-c-text-1);
   font-family: var(--vp-font-family-mono);
-  font-size: 0.88rem;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  text-decoration: none;
+  transition:
+    border-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.landing-tools-list a:hover {
+  border-color: var(--vp-c-brand-1);
+  color: var(--vp-c-brand-1);
+}
+
+.landing-tools-list a.more {
+  border-style: dashed;
+  background: transparent;
+  color: var(--vp-c-text-2);
+}
+
+.landing-page .pantry-backends {
+  grid-column: 2;
+  margin: 0;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.74rem;
+  line-height: 1.8;
+  letter-spacing: 0.04em;
+  color: var(--vp-c-text-3);
+}
+
+.landing-page .pantry-backends a {
+  color: var(--vp-c-text-2);
+  text-decoration: underline;
+  text-decoration-color: var(--vp-c-divider);
+  text-underline-offset: 3px;
+}
+
+.landing-page .pantry-backends a:hover {
+  color: var(--vp-c-brand-1);
+  text-decoration-color: currentColor;
+}
+
+/* Chef's special: promo strip */
+.landing-special {
+  --pillar: var(--pillar-tasks);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 32px;
+  margin-top: 56px;
+  padding: 24px 28px;
+  border: 1px solid color-mix(in srgb, var(--pillar-tasks) 40%, transparent);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--pillar-tasks) 7%, var(--vp-c-bg-soft));
+  color: var(--vp-c-text-1);
+  text-decoration: none !important;
+  transition: border-color 0.2s ease;
+}
+
+.landing-special:hover {
+  border-color: var(--pillar-tasks);
+}
+
+.landing-special .landing-kicker span {
+  color: var(--pillar-tasks);
+}
+
+.landing-page .landing-special h2 {
+  margin: 8px 0 0;
+  font-family: "Cormorant Garamond", Georgia, serif;
+  font-size: clamp(1.6rem, 2.8vw, 2.2rem);
+  font-weight: 400;
+  font-style: italic;
+  line-height: 1.1;
+  color: var(--vp-c-text-1);
+  text-wrap: balance;
+}
+
+.landing-page .landing-special p:not(.landing-kicker) {
+  margin: 8px 0 0;
+  font-size: 0.95rem;
+  color: var(--vp-c-text-2);
+}
+
+.landing-special .card-link {
+  flex: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* 04 · Quickstart: a ruled recipe */
+.landing-page .recipe {
+  margin-top: 40px;
+  border-top: 1px solid var(--vp-c-divider);
+}
+
+.recipe-row {
+  display: grid;
+  grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr);
+  gap: 24px 56px;
+  align-items: center;
+  padding: 30px 0;
+  border-bottom: 1px solid var(--vp-c-divider);
+}
+
+.recipe-num {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vp-c-brand-1);
+}
+
+.landing-page .recipe-text h3 {
+  margin: 8px 0 6px;
+  font-size: 1.6rem;
+  line-height: 1.2;
+  color: var(--vp-c-text-1);
+}
+
+.landing-page .recipe-text p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: var(--vp-c-text-2);
+}
+
+.recipe-code {
+  min-width: 0;
+  padding: 16px 20px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  background: var(--vp-c-bg-soft);
+}
+
+/* CTA band */
+.landing-cta {
+  width: 100vw;
+  margin: 96px calc(50% - 50vw) 0;
+  padding: 88px 24px 96px;
+  background: #4e1626;
+  color: #fff;
+  text-align: center;
+}
+
+.dark .landing-cta {
+  background: #2f1019;
+}
+
+.landing-page .landing-cta .landing-kicker {
+  justify-content: center;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.landing-cta .landing-kicker span,
+.landing-page .landing-cta h2 em {
+  color: var(--mise-accent-gold);
+}
+
+.landing-page .landing-cta h2 {
+  font-size: clamp(2.6rem, 5.5vw, 4.4rem);
+  color: #fff;
+}
+
+.landing-mini-install {
+  display: inline-flex;
+  align-items: center;
+  min-height: 52px;
+  max-width: 100%;
+  margin-top: 32px;
+  padding: 0 22px;
+  overflow: auto;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.25);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.92rem;
+  color: #fff;
 }
 
 /* strip VitePress's inline-code pill so it doesn't box-in-a-box
@@ -1665,153 +1972,84 @@ div[class*="language-"] .copy:hover {
   font-size: inherit !important;
 }
 
-.landing-quickstart {
-  display: grid;
-  grid-template-columns: 260px minmax(0, 1fr);
-  gap: 48px;
-}
-
-.recipe-steps {
-  /* distribute the four labels over the full panel height */
-  display: flex;
-  flex-direction: column;
-  padding: 0;
-  border-right: 1px solid var(--vp-c-divider);
-  background: var(--vp-c-bg-soft);
-}
-
-.recipe-tab-input {
-  position: absolute;
-  opacity: 0;
-  pointer-events: none;
-}
-
-.recipe-step {
-  display: flex;
-  flex: 1;
-  gap: 12px;
-  align-items: center;
-  margin: 0;
-  padding: 14px 18px;
-  border-left: 2px solid transparent;
-  color: var(--vp-c-text-2);
-  cursor: pointer;
-  transition:
-    background-color 0.2s ease,
-    color 0.2s ease;
-}
-
-.recipe-step:hover {
-  background: color-mix(in srgb, var(--vp-c-brand-1) 8%, transparent);
-  color: var(--vp-c-text-1);
-}
-
-#recipe-tab-1:checked ~ .recipe-steps .recipe-step-1,
-#recipe-tab-2:checked ~ .recipe-steps .recipe-step-2,
-#recipe-tab-3:checked ~ .recipe-steps .recipe-step-3,
-#recipe-tab-4:checked ~ .recipe-steps .recipe-step-4 {
-  border-left: 2px solid var(--vp-c-brand-1);
-  background: var(--vp-c-bg);
-  color: var(--vp-c-text-1);
-}
-
-.recipe-steps span {
-  font-family: var(--vp-font-family-mono);
-  font-size: 0.72rem;
-  color: var(--vp-c-text-3);
-}
-
-.recipe-panel {
-  display: none;
-  height: 100%;
-}
-
-#recipe-tab-1:checked ~ .landing-code .recipe-panel-1,
-#recipe-tab-2:checked ~ .landing-code .recipe-panel-2,
-#recipe-tab-3:checked ~ .landing-code .recipe-panel-3,
-#recipe-tab-4:checked ~ .landing-code .recipe-panel-4 {
-  display: block;
-}
-
-/* Quickstart transcripts reuse the hero terminal's palette
-   (.terminal-body .prompt/.dim/.ok/.key) for one coherent look. */
-.landing-code .terminal-body {
-  box-sizing: border-box;
-  height: 100%;
-  min-height: 280px;
-  padding: 24px;
-  background: var(--vp-code-block-bg);
-  font-family: var(--vp-font-family-mono);
-  font-size: 0.88rem;
-  line-height: 1.8;
-}
-
-.landing-cta {
-  padding: 64px 28px;
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 8px;
-  background:
-    radial-gradient(600px 260px at 50% 0%, rgba(139, 34, 82, 0.14), transparent),
-    var(--vp-c-bg-soft);
-  text-align: center;
-}
-
-.landing-cta h2 {
-  color: var(--vp-c-text-1);
-  font-family: "Roc Grotesk", sans-serif;
-  font-style: normal;
-  /* reset vp-doc h2 defaults (top border + margin) inside the card */
-  margin: 12px 0 24px;
-  border-top: 0;
-  padding-top: 0;
-}
-
-.landing-cta h2 em {
-  color: var(--vp-c-brand-1);
-}
-
-.landing-cta .landing-mini-install {
-  max-width: 460px;
-  margin: 0 auto;
-  justify-content: center;
-}
-
 .landing-links {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
   justify-content: center;
-  margin-top: 22px;
+  margin-top: 20px;
 }
 
-@media (max-width: 960px) {
-  .VPHero .main,
-  .landing-metaphor,
-  .landing-quickstart,
-  .landing-recipe-grid {
-    grid-template-columns: 1fr !important;
-  }
+.landing-links a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 40px;
+  padding: 0 16px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 6px;
+  color: #fff;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease;
+}
 
-  .landing-feature-grid {
+.landing-links a:hover {
+  border-color: #fff;
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+}
+
+/* ─── Responsive ─── */
+@media (max-width: 960px) {
+  .hero-card,
+  .landing-why-grid,
+  .landing-switch-grid,
+  .landing-pantry-inner,
+  .recipe-row {
     grid-template-columns: 1fr;
   }
 
-  .recipe-steps {
+  .card-file {
     border-right: 0;
     border-bottom: 1px solid var(--vp-c-divider);
   }
 
-  .landing-section-heading {
-    display: block;
+  .stations-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 36px 32px;
+  }
+
+  .landing-machine-grid {
+    grid-template-columns: 1fr;
+  }
+
+  /* pitch first, config second on narrow screens */
+  .landing-machine-grid > .landing-config-card {
+    order: 2;
+  }
+
+  .landing-page .pantry-backends {
+    grid-column: auto;
+  }
+
+  .landing-special {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 18px;
   }
 }
 
 @media (max-width: 640px) {
   .VPHero {
     padding-top: calc(
-      var(--vp-nav-height) + var(--vp-layout-top-height, 0px) + 42px
+      var(--vp-nav-height) + var(--vp-layout-top-height, 0px) + 40px
     ) !important;
-    padding-bottom: 48px !important;
+    padding-bottom: 40px !important;
   }
 
   .VPHero .container {
@@ -1820,45 +2058,56 @@ div[class*="language-"] .copy:hover {
   }
 
   .hero-copy h1 {
-    font-size: 2.4rem;
+    font-size: 2.5rem;
   }
 
-  .landing-section h2 {
-    font-size: 2.2rem;
-  }
-
-  .hero-lockup .chef-logo {
-    height: 52px;
-  }
-
-  .lockup-word {
-    font-size: 1.5rem;
-  }
-
-  /* panels hold 3-5 lines; don't reserve desktop height on phones */
-  .landing-code .terminal-body {
-    min-height: 180px;
-  }
-
-  .hero-copy p {
+  .hero-lede {
     font-size: 1rem;
-    max-width: 30ch;
   }
 
-  .terminal-body {
+  .hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
+  }
+
+  .hero-meta span + span::before {
+    margin: 0 8px;
+  }
+
+  .landing-section,
+  .landing-pantry,
+  .landing-cta {
+    margin-top: 64px;
+  }
+
+  .landing-page .landing-section h2 {
+    font-size: 2.1rem;
+  }
+
+  .landing-ledger,
+  .stations-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .ledger-before {
+    border-right: 0;
+    border-bottom: 1px solid var(--vp-c-divider);
+  }
+
+  .landing-pantry {
+    padding: 36px 24px;
+  }
+
+  .landing-page .pantry-stat {
+    font-size: 2.6rem;
+  }
+
+  .terminal-lines {
     font-size: 0.76rem;
   }
 
-  .landing-section {
-    margin-top: 54px;
-  }
-
-  .landing-special {
-    margin-top: 40px;
-    padding: 22px;
-  }
-
-  .landing-metaphor {
-    padding-top: 48px;
+  .landing-cta {
+    padding: 64px 24px 72px;
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,161 +8,360 @@ hero:
 ---
 
 <section class="landing-page" aria-label="mise overview">
-  <div class="landing-section landing-metaphor">
-    <div>
-      <p class="landing-kicker">The Idea</p>
-      <h2>Everything in its place, <em>before</em> you code.</h2>
-      <p>
-        It installs the tools your project needs, loads its env vars, and runs
-        its tasks — all configured in a single <code>mise.toml</code> checked
-        into your repo, so every machine gets the same setup.
-      </p>
-      <div class="landing-definition">
-        <div class="definition-word">mise en place <span>/meez ahn plahs/</span></div>
-        <p>1. the gathering and arrangement of ingredients and tools before cooking.</p>
-        <p>2. a polyglot tool that keeps your project tools, env, and tasks in one place.</p>
+  <div class="hero-card" aria-label="One mise.toml drives tools, env vars, and tasks">
+    <div class="card-file">
+      <div class="card-bar"><strong>mise.toml</strong><span>checked into your repo</span></div>
+      <div class="card-toml" aria-label="Example mise.toml">
+        <div class="row row-tools"><span class="tk-section">[tools]</span></div>
+        <div class="row row-tools"><span class="tk-key">node</span><span class="tk-op"> = </span><span class="tk-str">"24"</span></div>
+        <div class="row row-tools"><span class="tk-key">python</span><span class="tk-op"> = </span><span class="tk-str">"3.13"</span></div>
+        <div class="row row-tools"><span class="tk-key">terraform</span><span class="tk-op"> = </span><span class="tk-str">"1.13"</span></div>
+        <div class="row row-blank"></div>
+        <div class="row row-env"><span class="tk-section">[env]</span></div>
+        <div class="row row-env"><span class="tk-key">DATABASE_URL</span><span class="tk-op"> = </span><span class="tk-str">"postgres://localhost/orders"</span></div>
+        <div class="row row-env"><span class="tk-key">_.file</span><span class="tk-op"> = </span><span class="tk-str">".env.local"</span></div>
+        <div class="row row-blank"></div>
+        <div class="row row-tasks"><span class="tk-section">[tasks.test]</span></div>
+        <div class="row row-tasks"><span class="tk-key">depends</span><span class="tk-op"> = [</span><span class="tk-str">"build"</span><span class="tk-op">]</span></div>
+        <div class="row row-tasks"><span class="tk-key">run</span><span class="tk-op"> = </span><span class="tk-str">"pytest"</span></div>
+        <div class="row row-blank"></div>
+        <div class="row row-boot"><span class="tk-section">[bootstrap.packages]</span></div>
+        <div class="row row-boot"><span class="tk-key">"brew:postgresql@17"</span><span class="tk-op"> = </span><span class="tk-str">"latest"</span></div>
+        <div class="row row-boot"><span class="tk-key">"apt:build-essential"</span><span class="tk-op"> = </span><span class="tk-str">"latest"</span></div>
+        <div class="row row-blank"></div>
+        <div class="row row-boot"><span class="tk-section">[dotfiles]</span></div>
+        <div class="row row-boot"><span class="tk-key">"~/.zshrc"</span><span class="tk-op"> = {}</span></div>
       </div>
     </div>
-    <div class="landing-config" aria-label="Example mise.toml">
-
-```toml
-# mise.toml
-[tools]
-node = "24"
-python = "3.13"
-
-[env]
-_.file = ".env.local"
-
-[tasks.test]
-run = "pytest"
-```
-
-</div>
+    <div class="card-outputs">
+      <div class="card-output pillar-tools">
+        <div class="card-output-head"><span class="pillar-dot"></span><span>Dev tools</span><code>$ mise install</code></div>
+        <div class="terminal-lines">
+          <div><span class="dim">mise</span> node@24.18.0 <span class="ok">✓ installed</span></div>
+          <div><span class="dim">mise</span> python@3.13.14 <span class="ok">✓ installed</span></div>
+          <div><span class="dim">mise</span> terraform@1.13.2 <span class="ok">✓ installed</span></div>
+        </div>
+      </div>
+      <div class="card-output pillar-env">
+        <div class="card-output-head"><span class="pillar-dot"></span><span>Environments</span><code>$ mise env</code></div>
+        <div class="terminal-lines">
+          <div>export DATABASE_URL=postgres://localhost/orders</div>
+          <div>export STRIPE_KEY=sk_test_51H… <span class="dim"># from .env.local</span></div>
+        </div>
+      </div>
+      <div class="card-output pillar-tasks">
+        <div class="card-output-head"><span class="pillar-dot"></span><span>Tasks</span><code>$ mise run test</code></div>
+        <div class="terminal-lines">
+          <div><span class="key">[build]</span> $ npm run build</div>
+          <div><span class="key">[test]</span> $ pytest</div>
+          <div><span class="ok">42 passed</span> in 1.02s</div>
+        </div>
+      </div>
+      <div class="card-output pillar-boot">
+        <div class="card-output-head"><span class="pillar-dot"></span><span>Bootstrap</span><code>$ mise bootstrap</code></div>
+        <div class="terminal-lines">
+          <div><span class="dim">mise bootstrap:</span> system packages</div>
+          <div>brew:postgresql@17 <span class="ok">✓ installed</span></div>
+          <div><span class="dim">mise bootstrap:</span> dotfiles</div>
+          <div>~/.zshrc <span class="ok">✓ symlinked</span></div>
+        </div>
+      </div>
+    </div>
   </div>
 
-  <div class="landing-section landing-menu">
-    <div class="landing-section-heading">
+  <div class="landing-section landing-why">
+    <p class="landing-kicker"><span>01</span> Why mise</p>
+    <div class="landing-why-grid">
       <div>
-        <p class="landing-kicker">The Menu</p>
-        <h2>What mise does.</h2>
+        <h2>Clear the counter.</h2>
+        <p class="landing-lede">
+          Most projects carry a drawer of version managers, dotfiles, and a
+          README full of setup steps. Every new machine adds a Brewfile, a
+          dotfiles manager, and a playbook. mise replaces them with one file
+          that's checked in, so a fresh laptop is <code>git clone</code> and
+          <code>mise bootstrap</code>.
+        </p>
+        <p class="landing-note">
+          Coming from asdf? mise reads <code>.tool-versions</code> as-is. Files
+          like <code>.nvmrc</code> work too, once you
+          <a href="/configuration.html#idiomatic-version-files">enable them</a>.
+        </p>
       </div>
-      <a href="/getting-started" class="landing-small-button">All docs</a>
+      <div class="landing-ledger" aria-label="Before and after mise">
+        <div class="ledger-col ledger-before">
+          <p class="ledger-head">Before</p>
+          <ul>
+            <li>nvm, pyenv, rbenv <span>.nvmrc, .python-version</span></li>
+            <li>direnv <span>.envrc</span></li>
+            <li>make, just <span>Makefile</span></li>
+            <li>Homebrew <span>Brewfile</span></li>
+            <li>chezmoi <span>dotfiles repo</span></li>
+            <li>Ansible <span>playbook.yml</span></li>
+            <li>README <span>"Setup", 14 steps</span></li>
+          </ul>
+        </div>
+        <div class="ledger-col ledger-after">
+          <p class="ledger-head">After</p>
+          <ul>
+            <li><strong>mise</strong> <span>mise.toml</span></li>
+          </ul>
+          <div class="ledger-pillars">
+            <span class="pillar-tools">tools</span>
+            <span class="pillar-env">env</span>
+            <span class="pillar-tasks">tasks</span>
+            <span class="pillar-boot">bootstrap</span>
+          </div>
+        </div>
+      </div>
     </div>
-    <div class="landing-feature-grid">
-      <a href="/dev-tools/" class="landing-feature-card">
-        <p class="card-cmd">$ mise install</p>
-        <h3>Dev Tools</h3>
-        <p>Install project tools, pin versions, and switch automatically as you move between directories.</p>
-        <span class="card-link">Learn more</span>
+  </div>
+
+  <div class="landing-section landing-stations">
+    <p class="landing-kicker"><span>02</span> What it does</p>
+    <h2>Four stations, one line.</h2>
+    <div class="stations-grid">
+      <a class="station pillar-tools" href="/dev-tools/">
+        <p class="station-cmd">$ mise use node@24</p>
+        <h3>Dev tools</h3>
+        <p>
+          Install any of 1000+ tools, pin versions per project, and switch
+          automatically as you move between directories.
+        </p>
+        <span class="card-link">Dev tools</span>
       </a>
-      <a href="/environments/" class="landing-feature-card">
-        <p class="card-cmd">$ mise env</p>
+      <a class="station pillar-env" href="/environments/">
+        <p class="station-cmd">$ mise env</p>
         <h3>Environments</h3>
-        <p>Load project-specific environment variables from <code>mise.toml</code>, <code>.env</code> files, shell commands, and more.</p>
-        <span class="card-link">Learn more</span>
+        <p>
+          Per-project env vars from <code>mise.toml</code>, .env files,
+          secrets, and shell commands. Set when you enter, gone when you leave.
+        </p>
+        <span class="card-link">Environments</span>
       </a>
-      <a href="/tasks/" class="landing-feature-card">
-        <p class="card-cmd">$ mise run</p>
+      <a class="station pillar-tasks" href="/tasks/">
+        <p class="station-cmd">$ mise run test</p>
         <h3>Tasks</h3>
-        <p>Define build, test, lint, and deploy commands next to the tools and env vars they need.</p>
-        <span class="card-link">Learn more</span>
+        <p>
+          Build, test, lint, and deploy commands defined next to the tools and
+          env they need, with dependencies and parallel runs.
+        </p>
+        <span class="card-link">Tasks</span>
+      </a>
+      <a class="station pillar-boot" href="/bootstrap">
+        <p class="station-cmd">$ mise bootstrap</p>
+        <h3>Bootstrap</h3>
+        <p>
+          Set up a whole machine from the same config: OS packages, dotfiles,
+          repos, services, macOS defaults, then your tools.
+        </p>
+        <span class="card-link">Bootstrap</span>
       </a>
     </div>
   </div>
 
-  <div class="landing-tools" aria-label="Supported tools">
-    <p>The pantry · 1000+ tools, one config file</p>
-    <div class="landing-tools-list">
-      <a href="https://mise-versions.jdx.dev/tools/node">node</a>
-      <a href="https://mise-versions.jdx.dev/tools/python">python</a>
-      <a href="https://mise-versions.jdx.dev/tools/ruby">ruby</a>
-      <a href="https://mise-versions.jdx.dev/tools/go">go</a>
-      <a href="https://mise-versions.jdx.dev/tools/rust">rust</a>
-      <a href="https://mise-versions.jdx.dev/tools/java">java</a>
-      <a href="https://mise-versions.jdx.dev/tools/deno">deno</a>
-      <a href="https://mise-versions.jdx.dev/tools/bun">bun</a>
-      <a href="https://mise-versions.jdx.dev/tools/terraform">terraform</a>
-      <a href="https://mise-versions.jdx.dev/tools/kubectl">kubectl</a>
-      <a href="https://mise-versions.jdx.dev/tools/zig">zig</a>
-      <a href="https://mise-versions.jdx.dev/tools/swift">swift</a>
-      <a href="https://mise-versions.jdx.dev/tools/php">php</a>
-      <a href="https://mise-versions.jdx.dev/tools/elixir">elixir</a>
-      <a href="/registry">…and 1000+ more</a>
+  <div class="landing-section landing-switch">
+    <p class="landing-kicker"><span>03</span> Day to day</p>
+    <div class="landing-switch-grid">
+      <div>
+        <h2>Change directory. <em>Everything follows.</em></h2>
+        <p class="landing-lede">
+          Activate mise in your shell once. From then on, entering a project
+          puts its tool versions on your <code>PATH</code> and its env vars in
+          your shell. Leaving takes them away again.
+        </p>
+        <ul class="landing-checklist">
+          <li>Shell hooks for bash, zsh, fish, nushell, PowerShell, and more</li>
+          <li>Shims for editors and scripts that never source your shell rc</li>
+          <li><code>mise exec</code> and <code>mise-action</code> for Docker and CI</li>
+        </ul>
+      </div>
+      <div class="landing-terminal" aria-label="Switching between two projects">
+        <div class="terminal-bar"><span>~/work</span><span>zsh</span></div>
+        <div class="terminal-lines">
+          <div><span class="prompt">$</span> cd api</div>
+          <div><span class="prompt">$</span> node --version</div>
+          <div>v22.12.0</div>
+          <div><span class="prompt">$</span> echo $DATABASE_URL</div>
+          <div>postgres://localhost/api</div>
+          <div>&nbsp;</div>
+          <div><span class="prompt">$</span> cd ../dashboard</div>
+          <div><span class="prompt">$</span> node --version</div>
+          <div>v24.18.0</div>
+          <div><span class="prompt">$</span> mise ls --current</div>
+          <div><span class="dim">Tool&nbsp;&nbsp;&nbsp;Version&nbsp;&nbsp;&nbsp;Source</span></div>
+          <div>bun&nbsp;&nbsp;&nbsp;&nbsp;1.2.20&nbsp;&nbsp;&nbsp;&nbsp;~/work/dashboard/mise.toml</div>
+          <div>node&nbsp;&nbsp;&nbsp;24.18.0&nbsp;&nbsp;&nbsp;~/work/dashboard/mise.toml</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="landing-section landing-machine">
+    <p class="landing-kicker"><span>04</span> New machine</p>
+    <div class="landing-machine-grid">
+      <div class="landing-config-card" aria-label="Example bootstrap config">
+        <div class="card-bar"><strong>mise.toml</strong><span>~/.config/mise</span></div>
+        <div class="card-toml">
+          <div class="row row-boot"><span class="tk-section">[bootstrap.packages]</span></div>
+          <div class="row row-boot"><span class="tk-key">"brew:postgresql@17"</span><span class="tk-op"> = </span><span class="tk-str">"latest"</span></div>
+          <div class="row row-boot"><span class="tk-key">"apt:build-essential"</span><span class="tk-op"> = </span><span class="tk-str">"latest"</span></div>
+          <div class="row row-blank"></div>
+          <div class="row row-boot"><span class="tk-section">[bootstrap.repos]</span></div>
+          <div class="row row-boot"><span class="tk-key">"~/src/notes"</span><span class="tk-op"> = { </span><span class="tk-key">url</span><span class="tk-op"> = </span><span class="tk-str">"git@github.com:me/notes.git"</span><span class="tk-op"> }</span></div>
+          <div class="row row-blank"></div>
+          <div class="row row-boot"><span class="tk-section">[dotfiles]</span></div>
+          <div class="row row-boot"><span class="tk-key">"~/.gitconfig"</span><span class="tk-op"> = {}</span></div>
+          <div class="row row-boot"><span class="tk-key">"~/.config/nvim"</span><span class="tk-op"> = {}</span></div>
+          <div class="row row-blank"></div>
+          <div class="row row-boot"><span class="tk-section">[bootstrap.macos.dock]</span></div>
+          <div class="row row-boot"><span class="tk-key">autohide</span><span class="tk-op"> = </span><span class="tk-str">true</span></div>
+          <div class="row row-blank"></div>
+          <div class="row row-boot"><span class="tk-section">[bootstrap.mise_shell_activate]</span></div>
+          <div class="row row-boot"><span class="tk-key">zshrc</span><span class="tk-op"> = </span><span class="tk-str">"activate"</span></div>
+        </div>
+      </div>
+      <div>
+        <h2>One config for the <em>whole machine.</em></h2>
+        <p class="landing-lede">
+          <code>mise bootstrap</code> sets up a new computer from the same
+          file: OS packages, git repos, dotfiles, shell activation, macOS
+          defaults, and services, then your tools. It converges, so running it
+          again only does what's missing. It's what you'd otherwise assemble
+          from a Brewfile, chezmoi, and an Ansible playbook.
+        </p>
+        <ul class="landing-checklist">
+          <li>Packages through brew, apt, dnf, pacman, apk, and mas</li>
+          <li>Dotfiles as symlinks, copies, or templates, plus single-line edits</li>
+          <li>Remote hosts over SSH with <code>mise bootstrap remote</code></li>
+        </ul>
+        <div class="landing-inline-cmd"><code>mise bootstrap --from git@github.com:you/dotfiles.git</code></div>
+        <p class="landing-note"><a href="/bootstrap">Read the bootstrap guide</a></p>
+      </div>
+    </div>
+  </div>
+
+  <div class="landing-pantry" aria-label="Supported tools">
+    <div class="landing-pantry-inner">
+      <div class="pantry-head">
+        <p class="landing-kicker"><span>—</span> The pantry</p>
+        <p class="pantry-stat">1000+<small>tools in the registry, from node to terraform</small></p>
+      </div>
+      <div class="landing-tools-list">
+        <a href="https://mise-versions.jdx.dev/tools/node">node</a>
+        <a href="https://mise-versions.jdx.dev/tools/python">python</a>
+        <a href="https://mise-versions.jdx.dev/tools/ruby">ruby</a>
+        <a href="https://mise-versions.jdx.dev/tools/go">go</a>
+        <a href="https://mise-versions.jdx.dev/tools/rust">rust</a>
+        <a href="https://mise-versions.jdx.dev/tools/java">java</a>
+        <a href="https://mise-versions.jdx.dev/tools/deno">deno</a>
+        <a href="https://mise-versions.jdx.dev/tools/bun">bun</a>
+        <a href="https://mise-versions.jdx.dev/tools/terraform">terraform</a>
+        <a href="https://mise-versions.jdx.dev/tools/kubectl">kubectl</a>
+        <a href="https://mise-versions.jdx.dev/tools/zig">zig</a>
+        <a href="https://mise-versions.jdx.dev/tools/swift">swift</a>
+        <a href="https://mise-versions.jdx.dev/tools/php">php</a>
+        <a href="https://mise-versions.jdx.dev/tools/elixir">elixir</a>
+        <a href="https://mise-versions.jdx.dev/tools/erlang">erlang</a>
+        <a href="https://mise-versions.jdx.dev/tools/dotnet">dotnet</a>
+        <a href="https://mise-versions.jdx.dev/tools/pnpm">pnpm</a>
+        <a href="https://mise-versions.jdx.dev/tools/uv">uv</a>
+        <a href="https://mise-versions.jdx.dev/tools/awscli">awscli</a>
+        <a href="https://mise-versions.jdx.dev/tools/gh">gh</a>
+        <a href="https://mise-versions.jdx.dev/tools/jq">jq</a>
+        <a href="https://mise-versions.jdx.dev/tools/ripgrep">ripgrep</a>
+        <a class="more" href="/registry">browse the registry</a>
+      </div>
+      <p class="pantry-backends">
+        Sourced from
+        <a href="/dev-tools/backends/aqua">aqua</a>,
+        <a href="/dev-tools/backends/github">GitHub releases</a>,
+        <a href="/dev-tools/backends/cargo">cargo</a>,
+        <a href="/dev-tools/backends/npm">npm</a>,
+        <a href="/dev-tools/backends/pipx">pipx</a>,
+        <a href="/dev-tools/backends/go">go</a>,
+        <a href="/dev-tools/backends/gem">gem</a>,
+        <a href="/dev-tools/backends/http">http</a>,
+        <a href="/dev-tools/backends/asdf">asdf</a>,
+        <a href="/dev-tools/backends/vfox">vfox</a>, and
+        <a href="/dev-tools/backends/">more</a>.
+      </p>
     </div>
   </div>
 
   <a class="landing-special" href="https://mr-boxington.jdx.dev/" aria-label="Try Mr Boxington">
     <div>
-      <p class="landing-kicker">Chef's Special</p>
+      <p class="landing-kicker"><span>—</span> Chef's special</p>
       <h2>Mr Boxington: fix your target/.</h2>
-      <p>
-        Give every Cargo checkout one shared, self-pruning compilation cache —
-        locally and in CI.
-      </p>
+      <p>Give every Cargo checkout one shared, self-pruning compilation cache, locally and in CI.</p>
     </div>
+    <span class="card-link">mr-boxington.jdx.dev</span>
   </a>
 
-  <div class="landing-section landing-quickstart">
-    <div>
-      <p class="landing-kicker">The Recipe</p>
-      <h2>Get set up in four steps.</h2>
-    </div>
-    <div class="landing-recipe-grid">
-      <input class="recipe-tab-input" type="radio" name="recipe-tab" id="recipe-tab-1" checked />
-      <input class="recipe-tab-input" type="radio" name="recipe-tab" id="recipe-tab-2" />
-      <input class="recipe-tab-input" type="radio" name="recipe-tab" id="recipe-tab-3" />
-      <input class="recipe-tab-input" type="radio" name="recipe-tab" id="recipe-tab-4" />
-      <div class="recipe-steps" aria-label="Quickstart steps">
-        <label class="recipe-step recipe-step-1" for="recipe-tab-1"><span>01</span> Install mise</label>
-        <label class="recipe-step recipe-step-2" for="recipe-tab-2"><span>02</span> Add and install tools</label>
-        <label class="recipe-step recipe-step-3" for="recipe-tab-3"><span>03</span> Load env vars</label>
-        <label class="recipe-step recipe-step-4" for="recipe-tab-4"><span>04</span> Define tasks</label>
-      </div>
-      <div class="landing-code">
-        <div class="recipe-panel recipe-panel-1">
-          <div class="terminal-body">
-            <div><span class="prompt">$</span> curl https://mise.run | sh</div>
-            <div>&nbsp;</div>
-            <div><span class="prompt">$</span> mise --version</div>
-            <div>2026.7.0 linux-x64</div>
-          </div>
+  <div class="landing-section landing-recipe">
+    <p class="landing-kicker"><span>05</span> Quickstart</p>
+    <h2>Set up in four steps.</h2>
+    <ol class="recipe">
+      <li class="recipe-row">
+        <div class="recipe-text">
+          <span class="recipe-num">Step 1</span>
+          <h3>Install mise</h3>
+          <p>One command, one static binary. <a href="/installing-mise">Homebrew, apt, cargo, and more</a> also work.</p>
         </div>
-        <div class="recipe-panel recipe-panel-2">
-          <div class="terminal-body">
-            <div><span class="prompt">$</span> mise use node@24 python@3.13</div>
-            <div><span class="dim">mise</span> node@24.18.0 <span class="ok">✓ installed</span></div>
-            <div><span class="dim">mise</span> python@3.13.14 <span class="ok">✓ installed</span></div>
-            <div><span class="dim">mise</span> ./mise.toml tools: node@24.18.0, python@3.13.14</div>
-          </div>
+        <div class="recipe-code terminal-lines">
+          <div><span class="prompt">$</span> curl https://mise.run | sh</div>
+          <div><span class="prompt">$</span> mise --version</div>
+          <div>2026.9.1 linux-x64</div>
         </div>
-        <div class="recipe-panel recipe-panel-3">
-          <div class="terminal-body">
-            <div><span class="prompt">$</span> cat .env.local</div>
-            <div>DATABASE_URL=postgres://localhost/orders</div>
-            <div>&nbsp;</div>
-            <div><span class="prompt">$</span> mise env -s bash</div>
-            <div>export DATABASE_URL='postgres://localhost/orders'</div>
-          </div>
+      </li>
+      <li class="recipe-row">
+        <div class="recipe-text">
+          <span class="recipe-num">Step 2</span>
+          <h3>Hook into your shell</h3>
+          <p>Optional, but this is what makes tools and env vars switch as you <code>cd</code>. <a href="/installing-mise#shells">Other shells</a> are one line too.</p>
         </div>
-        <div class="recipe-panel recipe-panel-4">
-          <div class="terminal-body">
-            <div><span class="prompt">$</span> mise run test</div>
-            <div><span class="key">[test]</span> $ pytest</div>
-            <div><span class="ok">42 passed</span> in 1.02s</div>
-          </div>
+        <div class="recipe-code terminal-lines">
+          <div><span class="prompt">$</span> echo 'eval "$(mise activate zsh)"' &gt;&gt; ~/.zshrc</div>
+          <div><span class="dim"># bash: ~/.bashrc · fish: config.fish · pwsh: $PROFILE</span></div>
         </div>
-      </div>
-    </div>
+      </li>
+      <li class="recipe-row">
+        <div class="recipe-text">
+          <span class="recipe-num">Step 3</span>
+          <h3>Add tools</h3>
+          <p><code>mise use</code> installs the tool and pins it in <code>mise.toml</code> in one go. Commit the file.</p>
+        </div>
+        <div class="recipe-code terminal-lines">
+          <div><span class="prompt">$</span> mise use node@24 python@3.13</div>
+          <div><span class="dim">mise</span> node@24.18.0 <span class="ok">✓ installed</span></div>
+          <div><span class="dim">mise</span> python@3.13.14 <span class="ok">✓ installed</span></div>
+          <div><span class="dim">mise</span> ./mise.toml tools: node@24.18.0, python@3.13.14</div>
+        </div>
+      </li>
+      <li class="recipe-row">
+        <div class="recipe-text">
+          <span class="recipe-num">Step 4</span>
+          <h3>Add env vars and tasks</h3>
+          <p>They live in the same file, next to the tools they depend on. Teammates run <code>mise install</code>; a new laptop runs <code>mise bootstrap</code>.</p>
+        </div>
+        <div class="recipe-code terminal-lines">
+          <div><span class="prompt">$</span> mise set DATABASE_URL=postgres://localhost/orders</div>
+          <div><span class="prompt">$</span> mise tasks add test -- pytest</div>
+          <div><span class="prompt">$</span> mise run test</div>
+          <div><span class="key">[test]</span> $ pytest</div>
+          <div><span class="ok">42 passed</span> in 1.02s</div>
+        </div>
+      </li>
+    </ol>
   </div>
 
-  <div class="landing-section landing-cta">
-    <p class="landing-kicker">Ready When You Are</p>
-    <h2><em>Allez,</em> prep your station.</h2>
+  <div class="landing-cta">
+    <p class="landing-kicker"><span>—</span> Ready when you are</p>
+    <h2><em>Allez.</em> Prep your station.</h2>
     <div class="landing-mini-install"><code>curl https://mise.run | sh</code></div>
     <div class="landing-links">
       <a href="/getting-started">Getting started</a>
       <a href="/demo">Run the demo</a>
+      <a href="https://github.com/jdx/mise">GitHub</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary

A fresh design for mise.jdx.dev's home page. The old page was a two-column hero plus feature cards; the new one is built around a single idea: **one `mise.toml` drives tools, env vars, tasks, and machine bootstrap**. Each pillar gets a fixed accent (burgundy / gold / sage / terracotta) that repeats down the page.

Sections, top to bottom:

- **Hero**: centered Cormorant headline, copyable install command, two actions, mono meta line.
- **The card**: an annotated `mise.toml` with color-coded sections on the left and the four outputs it produces on the right (`mise install`, `mise env`, `mise run test`, `mise bootstrap`).
- **01 Why: "Clear the counter."** Before/after ledger: nvm/pyenv/rbenv, direnv, make, Homebrew Brewfile, chezmoi, Ansible, README setup steps vs. one `mise.toml`.
- **02 What it does: "Four stations, one line."** Dev tools, Environments, Tasks, Bootstrap as ruled columns.
- **03 Day to day: "Change directory. Everything follows."** Terminal switching between two projects, plus shells/shims/CI checklist.
- **04 New machine: "One config for the whole machine."** `mise bootstrap` pitch with a bootstrap config example (packages, repos, dotfiles, macOS dock, shell activation), `--from` one-liner, and a link to the guide.
- **The pantry**: full-bleed strip with tool pills and the backends line.
- **aube** strip (kept, restyled).
- **05 Quickstart**: vertical ruled recipe replacing the radio-button tabs, so all four steps are visible.
- **CTA**: burgundy band.

Kept intact: the `.hero-lockup` element the navbar-brand hide logic and preboot script depend on, the banner offset handling, and the sponsors/footer slots.

## Files

- `docs/.vitepress/theme/Layout.vue`: new hero (info-before slot only; the info-after terminal is gone).
- `docs/index.md`: all sections as HTML in the home layout.
- `docs/.vitepress/theme/custom.css`: old hero + landing blocks removed, one consolidated landing block appended (light/dark, responsive at 960/640).

## Verification

- `bun run docs:build` passes.
- prettier and markdownlint pass on the changed md/vue files.
- Rendered light, dark, and 390px mobile in headless Chromium and reviewed every section.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5-1; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site markup and CSS only; no changes to the mise CLI or runtime behavior. Main risk is visual/regression on the home page across breakpoints and themes.
> 
> **Overview**
> Redesigns the mise.jdx.dev home page around **one `mise.toml`** for tools, env, tasks, and bootstrap, with pillar accents (burgundy / gold / sage / terracotta) reused across sections.
> 
> **Hero (`Layout.vue` + CSS):** Switches from a two-column layout with a side terminal to a **centered** headline and lede; folds the copyable install command into the action row with “Getting started” / “Watch the demo”; adds a mono meta line; **removes** the `#home-hero-info-after` terminal block.
> 
> **Body (`index.md`):** Replaces the old metaphor + three feature cards + tabbed quickstart with a **hero card** (annotated TOML left, four command outputs right), a before/after **ledger**, **four station** columns (including Bootstrap), day-to-day and new-machine sections, an expanded **pantry** strip, a vertical **four-step quickstart**, and a full-width burgundy **CTA** (plus GitHub). Quickstart copy now includes shell activation as step 2.
> 
> **Styles (`custom.css`):** Drops the old two-column hero/grid rules and consolidates landing styles (hero card, ledger, stations, terminals, pantry, recipe rows, responsive at 960px/640px). **Unchanged behavior:** `.hero-lockup` for navbar brand hide/show, sponsors/footer slots, install copy button logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 500c33f4caea99aa987fad1904d6a3a2df0c7beb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Redesigned the landing page with updated messaging about mise and `mise bootstrap`.
  * Added a configuration example covering tools, environment variables, and tasks.
  * Added sections for workflows, machine setup, available tools, and a guided quickstart.
  * Updated hero actions to “Getting started” and “Watch the demo.”
  * Added copy-to-clipboard support for the installation command.
  * Improved responsive layouts and refreshed visual presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->