### PR TITLE
fix(task): prevent symlink loops in task globs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6369,6 +6369,7 @@ dependencies = [
  "gix",
  "glob",
  "globset",
+ "globwalk",
  "heck",
  "hex",
  "homedir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ mise-cache-core = { path = "crates/mise-cache-core", version = "0.1", default-fe
 fslock = "0.2"
 gix = { version = "<1", features = ["worktree-mutation"] }
 glob = "0.3"
+globwalk = "0.9"
 globset = "0.4"
 ignore = { version = "0.4", features = [] }
 heck = "0.5"

--- a/e2e/tasks/test_task_source_symlink_loop
+++ b/e2e/tasks/test_task_source_symlink_loop
@@ -82,7 +82,8 @@ assert "mise run -q missing-output" "generated output"
 assert "mise run -q missing-output" "generated output"
 assert "wc -l < missing-output-runs.txt | tr -d ' '" "1"
 
-# A dangling symlink created by the task must not make artifact-cache storage
-# fail after the task completes.
+# A dangling symlink created by the task must be stored in the artifact cache
+# so the second invocation does not execute the task body again.
+assert "mise run -q created-dangling-output" "dangling output"
 assert "mise run -q created-dangling-output" "dangling output"
 assert "wc -l < dangling-output-runs.txt | tr -d ' '" "1"

--- a/e2e/tasks/test_task_source_symlink_loop
+++ b/e2e/tasks/test_task_source_symlink_loop
@@ -2,6 +2,7 @@
 
 mkdir tree
 printf 'input\n' >tree/input.txt
+printf 'cache input\n' >cache-input.txt
 ln -s . tree/a
 ln -s . tree/b
 
@@ -18,9 +19,19 @@ cache = { enabled = true }
 [tasks.render-sources]
 run = "echo {{ task_source_files() | join(sep=' ') }}"
 sources = ["tree/**/*"]
+
+[tasks.cached-output]
+run = "echo cached output"
+sources = ["cache-input.txt"]
+outputs = ["tree/**/*"]
+cache = { enabled = true }
 EOF
 
 # Recursive source expansion must skip ancestor symlink loops while retaining
 # ordinary files, both for artifact-cache inputs and task_source_files().
 assert "mise run -q cached" "cached"
 assert_contains "mise run -q render-sources" "tree/input.txt"
+
+# Artifact-cache output enumeration must likewise prune loops without aborting
+# task preparation.
+assert "mise run -q cached-output" "cached output"

--- a/e2e/tasks/test_task_source_symlink_loop
+++ b/e2e/tasks/test_task_source_symlink_loop
@@ -40,6 +40,12 @@ outputs = ["tree/**/*"]
 run = "touch tree/input.txt && echo mtime output"
 sources = ["mtime-input.txt"]
 outputs = ["tree/**/*"]
+
+[tasks.missing-output]
+run = "mkdir -p generated && touch generated/output.txt && echo generated output"
+sources = ["cache-input.txt"]
+outputs = ["generated/**/*"]
+cache = { enabled = true }
 EOF
 
 # Recursive source expansion must skip ancestor symlink loops while retaining
@@ -61,3 +67,7 @@ assert_empty "mise run -q hash-output"
 printf 'changed\n' >mtime-input.txt
 assert "MISE_TASK_SOURCE_FRESHNESS_HASH_CONTENTS=false mise run -q mtime-output" "mtime output"
 assert_empty "MISE_TASK_SOURCE_FRESHNESS_HASH_CONTENTS=false mise run -q mtime-output"
+
+# A not-yet-created literal output prefix is zero matches during cache
+# preparation, not a traversal failure.
+assert "mise run -q missing-output" "generated output"

--- a/e2e/tasks/test_task_source_symlink_loop
+++ b/e2e/tasks/test_task_source_symlink_loop
@@ -8,6 +8,7 @@ printf 'mtime input\n' >mtime-input.txt
 ln -s . tree/a
 ln -s . tree/b
 ln -s missing tree/dangling
+ln -s self tree/self
 
 cat <<'EOF' >mise.toml
 [settings]

--- a/e2e/tasks/test_task_source_symlink_loop
+++ b/e2e/tasks/test_task_source_symlink_loop
@@ -44,9 +44,15 @@ sources = ["mtime-input.txt"]
 outputs = ["tree/**/*"]
 
 [tasks.missing-output]
-run = "mkdir -p generated && touch generated/output.txt && echo generated output"
+run = "mkdir -p generated && touch generated/output.txt && echo ran >> missing-output-runs.txt && echo generated output"
 sources = ["cache-input.txt"]
 outputs = ["generated/**/*"]
+cache = { enabled = true }
+
+[tasks.created-dangling-output]
+run = "mkdir -p links && ln -sfn missing links/broken && echo ran >> dangling-output-runs.txt && echo dangling output"
+sources = ["cache-input.txt"]
+outputs = ["links/**/*"]
 cache = { enabled = true }
 EOF
 
@@ -73,3 +79,10 @@ assert_empty "MISE_TASK_SOURCE_FRESHNESS_HASH_CONTENTS=false mise run -q mtime-o
 # A not-yet-created literal output prefix is zero matches during cache
 # preparation, not a traversal failure.
 assert "mise run -q missing-output" "generated output"
+assert "mise run -q missing-output" "generated output"
+assert "wc -l < missing-output-runs.txt | tr -d ' '" "1"
+
+# A dangling symlink created by the task must not make artifact-cache storage
+# fail after the task completes.
+assert "mise run -q created-dangling-output" "dangling output"
+assert "wc -l < dangling-output-runs.txt | tr -d ' '" "1"

--- a/e2e/tasks/test_task_source_symlink_loop
+++ b/e2e/tasks/test_task_source_symlink_loop
@@ -7,6 +7,7 @@ printf 'hash input\n' >hash-input.txt
 printf 'mtime input\n' >mtime-input.txt
 ln -s . tree/a
 ln -s . tree/b
+ln -s missing tree/dangling
 
 cat <<'EOF' >mise.toml
 [settings]

--- a/e2e/tasks/test_task_source_symlink_loop
+++ b/e2e/tasks/test_task_source_symlink_loop
@@ -3,12 +3,17 @@
 mkdir tree
 printf 'input\n' >tree/input.txt
 printf 'cache input\n' >cache-input.txt
+printf 'hash input\n' >hash-input.txt
+printf 'mtime input\n' >mtime-input.txt
 ln -s . tree/a
 ln -s . tree/b
 
 cat <<'EOF' >mise.toml
 [settings]
 experimental = true
+
+[settings.task]
+source_freshness_hash_contents = true
 
 [tasks.cached]
 run = "echo cached"
@@ -25,6 +30,16 @@ run = "echo cached output"
 sources = ["cache-input.txt"]
 outputs = ["tree/**/*"]
 cache = { enabled = true }
+
+[tasks.hash-output]
+run = "touch tree/input.txt && echo hash output"
+sources = ["hash-input.txt"]
+outputs = ["tree/**/*"]
+
+[tasks.mtime-output]
+run = "touch tree/input.txt && echo mtime output"
+sources = ["mtime-input.txt"]
+outputs = ["tree/**/*"]
 EOF
 
 # Recursive source expansion must skip ancestor symlink loops while retaining
@@ -35,3 +50,14 @@ assert "mise run -q render-sources" "tree/input.txt"
 # Artifact-cache output enumeration must likewise prune loops without aborting
 # task preparation.
 assert "mise run -q cached-output" "cached output"
+
+# Content-based output hashing must prune loop errors and retain a usable
+# freshness baseline.
+assert "mise run -q hash-output" "hash output"
+assert_empty "mise run -q hash-output"
+
+# Mtime-based freshness uses a separate traversal path and must also prune the
+# same loops.
+printf 'changed\n' >mtime-input.txt
+assert "MISE_TASK_SOURCE_FRESHNESS_HASH_CONTENTS=false mise run -q mtime-output" "mtime output"
+assert_empty "MISE_TASK_SOURCE_FRESHNESS_HASH_CONTENTS=false mise run -q mtime-output"

--- a/e2e/tasks/test_task_source_symlink_loop
+++ b/e2e/tasks/test_task_source_symlink_loop
@@ -30,7 +30,7 @@ EOF
 # Recursive source expansion must skip ancestor symlink loops while retaining
 # ordinary files, both for artifact-cache inputs and task_source_files().
 assert "mise run -q cached" "cached"
-assert_contains "mise run -q render-sources" "tree/input.txt"
+assert "mise run -q render-sources" "tree/input.txt"
 
 # Artifact-cache output enumeration must likewise prune loops without aborting
 # task preparation.

--- a/e2e/tasks/test_task_source_symlink_loop
+++ b/e2e/tasks/test_task_source_symlink_loop
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+mkdir tree
+printf 'input\n' >tree/input.txt
+ln -s . tree/a
+ln -s . tree/b
+
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[tasks.cached]
+run = "echo cached"
+sources = ["tree/**/*"]
+outputs = []
+cache = { enabled = true }
+
+[tasks.render-sources]
+run = "echo {{ task_source_files() | join(sep=' ') }}"
+sources = ["tree/**/*"]
+EOF
+
+# Recursive source expansion must skip ancestor symlink loops while retaining
+# ordinary files, both for artifact-cache inputs and task_source_files().
+assert "mise run -q cached" "cached"
+assert_contains "mise run -q render-sources" "tree/input.txt"

--- a/mise.lock
+++ b/mise.lock
@@ -161,19 +161,16 @@ provenance = "github-attestations"
 checksum = "sha256:702de7f549cef800a1f35900e638ea4fbe07bce854f234cef869cd5442484c90"
 url = "https://github.com/jdx/aube/releases/download/v2.2.0/aube-v2.2.0-aarch64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/jdx/aube/releases/assets/529761660"
-provenance = "github-attestations"
 
 [tools.aube."platforms.windows-x64"]
 checksum = "sha256:2d68e3e995c336486647034eb8b99c3cfa68894e385a44200af2bc14bc4064cf"
 url = "https://github.com/jdx/aube/releases/download/v2.2.0/aube-v2.2.0-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/jdx/aube/releases/assets/529724125"
-provenance = "github-attestations"
 
 [tools.aube."platforms.windows-x64-baseline"]
 checksum = "sha256:2d68e3e995c336486647034eb8b99c3cfa68894e385a44200af2bc14bc4064cf"
 url = "https://github.com/jdx/aube/releases/download/v2.2.0/aube-v2.2.0-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/jdx/aube/releases/assets/529724125"
-provenance = "github-attestations"
 
 [[tools.bun]]
 version = "1.4.0"

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -9,7 +9,7 @@ use crate::task::task_cache_store::{
 };
 use crate::task::task_source_checker::{
     TaskCacheInputs, build_output_matcher, expand_enumeration_patterns, glob_walk, is_output,
-    output_glob_patterns, task_cache_inputs, task_cwd,
+    output_glob_patterns, prune_symlink_loop, task_cache_inputs, task_cwd,
 };
 use crate::task::{RunEntry, Task};
 use crate::toolset::Toolset;
@@ -1277,11 +1277,10 @@ fn resolve_output_roots(task: &Task, root: &Path, require_matches: bool) -> Resu
             for expanded in expand_enumeration_patterns(&output)? {
                 ensure_safe_relative(Path::new(&expanded))?;
                 for entry in glob_walk(&root.join(expanded), false)? {
-                    let path = match entry {
-                        Ok(entry) => entry.into_path(),
-                        Err(err) if err.loop_ancestor().is_some() => continue,
-                        Err(err) => return Err(err.into()),
+                    let Some(entry) = prune_symlink_loop(entry)? else {
+                        continue;
                     };
+                    let path = entry.into_path();
                     glob_matched = true;
                     let rel = path.strip_prefix(root)?.to_path_buf();
                     ensure_safe_relative(&rel)?;

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -9,7 +9,7 @@ use crate::task::task_cache_store::{
 };
 use crate::task::task_source_checker::{
     TaskCacheInputs, build_output_matcher, expand_enumeration_patterns, glob_walk, is_output,
-    output_glob_patterns, prune_symlink_walk_error, task_cache_inputs, task_cwd,
+    output_glob_patterns, symlink_walk_error_path, task_cache_inputs, task_cwd,
 };
 use crate::task::{RunEntry, Task};
 use crate::toolset::Toolset;
@@ -1277,10 +1277,13 @@ fn resolve_output_roots(task: &Task, root: &Path, require_matches: bool) -> Resu
             for expanded in expand_enumeration_patterns(&output)? {
                 ensure_safe_relative(Path::new(&expanded))?;
                 for entry in glob_walk(&root.join(expanded), false)? {
-                    let Some(entry) = prune_symlink_walk_error(entry)? else {
-                        continue;
+                    let path = match entry {
+                        Ok(entry) => entry.into_path(),
+                        Err(err) => match symlink_walk_error_path(&err) {
+                            Some(path) => path.to_path_buf(),
+                            None => return Err(err.into()),
+                        },
                     };
-                    let path = entry.into_path();
                     glob_matched = true;
                     let rel = path.strip_prefix(root)?.to_path_buf();
                     ensure_safe_relative(&rel)?;
@@ -1419,6 +1422,19 @@ fn copy_excluded_outputs(
     let mut directories = Vec::new();
     for root in roots {
         let backup_root = backup.join(root);
+        let root_metadata = fs::symlink_metadata(&backup_root)?;
+        if root_metadata.file_type().is_symlink() {
+            if !is_output(matcher, &matcher.path().join(root), false) {
+                let to = staging.join(root);
+                if let Some(parent) = to.parent() {
+                    file::create_dir_all(parent)?;
+                }
+                if fs::symlink_metadata(&to).is_err() {
+                    file::make_symlink(&fs::read_link(&backup_root)?, &to)?;
+                }
+            }
+            continue;
+        }
         for entry in WalkDir::new(&backup_root).follow_links(false) {
             let entry = entry?;
             let from = entry.path();
@@ -1534,6 +1550,13 @@ fn write_archive(
     let mut entries = BTreeMap::<PathBuf, PathBuf>::new();
     for rel_root in roots {
         let abs_root = root.join(rel_root);
+        let root_metadata = fs::symlink_metadata(&abs_root)?;
+        if root_metadata.file_type().is_symlink() {
+            if is_output(output_matcher, &abs_root, false) {
+                entries.insert(rel_root.clone(), abs_root);
+            }
+            continue;
+        }
         for entry in WalkDir::new(&abs_root).follow_links(false) {
             let entry = entry?;
             let abs = entry.path().to_path_buf();
@@ -1930,6 +1953,25 @@ mod tests {
                 PathBuf::from("dist/client/app.js"),
                 PathBuf::from("dist/server/app.js"),
             ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn output_roots_include_dangling_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        fs::create_dir(root.path().join("links")).unwrap();
+        symlink("missing", root.path().join("links/broken")).unwrap();
+        let task = Task {
+            outputs: crate::task::task_sources::TaskOutputs::Files(vec!["links/**/*".to_string()]),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            resolve_output_roots(&task, root.path(), true).unwrap(),
+            [PathBuf::from("links/broken")]
         );
     }
 

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -9,7 +9,7 @@ use crate::task::task_cache_store::{
 };
 use crate::task::task_source_checker::{
     TaskCacheInputs, build_output_matcher, expand_enumeration_patterns, glob_walk, is_output,
-    output_glob_patterns, prune_symlink_loop, task_cache_inputs, task_cwd,
+    output_glob_patterns, prune_symlink_walk_error, task_cache_inputs, task_cwd,
 };
 use crate::task::{RunEntry, Task};
 use crate::toolset::Toolset;
@@ -1277,7 +1277,7 @@ fn resolve_output_roots(task: &Task, root: &Path, require_matches: bool) -> Resu
             for expanded in expand_enumeration_patterns(&output)? {
                 ensure_safe_relative(Path::new(&expanded))?;
                 for entry in glob_walk(&root.join(expanded), false)? {
-                    let Some(entry) = prune_symlink_loop(entry)? else {
+                    let Some(entry) = prune_symlink_walk_error(entry)? else {
                         continue;
                     };
                     let path = entry.into_path();

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -1277,7 +1277,11 @@ fn resolve_output_roots(task: &Task, root: &Path, require_matches: bool) -> Resu
             for expanded in expand_enumeration_patterns(&output)? {
                 ensure_safe_relative(Path::new(&expanded))?;
                 for entry in glob_walk(&root.join(expanded), false)? {
-                    let path = entry?.into_path();
+                    let path = match entry {
+                        Ok(entry) => entry.into_path(),
+                        Err(err) if err.loop_ancestor().is_some() => continue,
+                        Err(err) => return Err(err.into()),
+                    };
                     glob_matched = true;
                     let rel = path.strip_prefix(root)?.to_path_buf();
                     ensure_safe_relative(&rel)?;

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -8,14 +8,13 @@ use crate::task::task_cache_store::{
     compose_task_cache_stores,
 };
 use crate::task::task_source_checker::{
-    TaskCacheInputs, build_output_matcher, expand_enumeration_patterns, is_output,
+    TaskCacheInputs, build_output_matcher, expand_enumeration_patterns, glob_walk, is_output,
     output_glob_patterns, task_cache_inputs, task_cwd,
 };
 use crate::task::{RunEntry, Task};
 use crate::toolset::Toolset;
 use bytesize::ByteSize;
 use eyre::{Context, Report, Result, bail, eyre};
-use glob::glob;
 use ignore::overrides::Override;
 use jdx_tar::{Builder, EntryType, Header};
 use mise_cache_core::RemoteCacheConfig;
@@ -1277,8 +1276,8 @@ fn resolve_output_roots(task: &Task, root: &Path, require_matches: bool) -> Resu
             let mut glob_matched = false;
             for expanded in expand_enumeration_patterns(&output)? {
                 ensure_safe_relative(Path::new(&expanded))?;
-                for entry in glob(root.join(expanded).to_str().unwrap_or_default())? {
-                    let path = entry?;
+                for entry in glob_walk(&root.join(expanded), false)? {
+                    let path = entry?.into_path();
                     glob_matched = true;
                     let rel = path.strip_prefix(root)?.to_path_buf();
                     ensure_safe_relative(&rel)?;

--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -277,13 +277,9 @@ impl TaskScriptParser {
                                 } else {
                                     expanded_pattern
                                 };
-                                let expanded = match glob::glob_with(
-                                    &rooted_pattern,
-                                    glob::MatchOptions {
-                                        case_sensitive: false,
-                                        require_literal_separator: false,
-                                        require_literal_leading_dot: false,
-                                    },
+                                let expanded = match crate::task::task_source_checker::glob_walk(
+                                    Path::new(&rooted_pattern),
+                                    true,
                                 ) {
                                     Ok(expanded) => expanded,
                                     Err(error) => {
@@ -301,7 +297,8 @@ impl TaskScriptParser {
                                 for path in expanded {
                                     source_found = true;
                                     match path {
-                                        Ok(path) => {
+                                        Ok(entry) => {
+                                            let path = entry.into_path();
                                             if !crate::task::task_source_checker::is_source(
                                                 &matcher, &path,
                                             ) {
@@ -334,10 +331,12 @@ impl TaskScriptParser {
                                             resolved.push(source);
                                         }
                                         Err(error) => {
-                                            let source = error.path().display();
+                                            let source = error
+                                                .path()
+                                                .map(|path| path.display().to_string())
+                                                .unwrap_or_else(|| "<unknown>".to_string());
                                             warn!(
-                                                "tera::render::resolve_task_sources omitting '{source}' from resolved task sources due to: {:#?}",
-                                                error.error()
+                                                "tera::render::resolve_task_sources omitting '{source}' from resolved task sources due to: {error:#?}"
                                             );
                                         }
                                     }

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -542,14 +542,25 @@ pub(crate) fn glob_walk(pattern: &Path, case_insensitive: bool) -> Result<GlobWa
     Ok(builder.build()?)
 }
 
-/// Return a successful walk entry, pruning the expected error emitted when a
-/// followed directory symlink points back to one of its ancestors.
-pub(crate) fn prune_symlink_loop(
+/// Return a successful walk entry, pruning expected errors from following
+/// symlinks that either loop to an ancestor or point to a missing target.
+pub(crate) fn prune_symlink_walk_error(
     entry: std::result::Result<DirEntry, WalkError>,
 ) -> Result<Option<DirEntry>> {
     match entry {
         Ok(entry) => Ok(Some(entry)),
         Err(err) if err.loop_ancestor().is_some() => Ok(None),
+        Err(err)
+            if err
+                .io_error()
+                .is_some_and(|error| error.kind() == std::io::ErrorKind::NotFound)
+                && err.path().is_some_and(|path| {
+                    fs::symlink_metadata(path)
+                        .is_ok_and(|metadata| metadata.file_type().is_symlink())
+                }) =>
+        {
+            Ok(None)
+        }
         Err(err) => Err(err.into()),
     }
 }
@@ -1093,7 +1104,7 @@ fn compute_output_hash(task: &Task, root: &Path) -> Result<Option<String>> {
     ) -> Result<bool> {
         let mut found_any = false;
         for entry in WalkDir::new(dir).follow_links(true).into_iter() {
-            let Some(entry) = prune_symlink_loop(entry)? else {
+            let Some(entry) = prune_symlink_walk_error(entry)? else {
                 continue;
             };
             let path = entry.path();
@@ -1160,7 +1171,7 @@ fn compute_output_hash(task: &Task, root: &Path) -> Result<Option<String>> {
                 // Propagate glob resolution errors (OS errors during directory
                 // reads) rather than silently skipping them — a partial result
                 // could produce the same hash as a complete one.
-                let Some(entry) = prune_symlink_loop(entry)? else {
+                let Some(entry) = prune_symlink_walk_error(entry)? else {
                     continue;
                 };
                 let path = entry.into_path();
@@ -1385,7 +1396,7 @@ fn get_last_modified(root: &Path, patterns_or_paths: &[String]) -> Result<Option
             for expanded in expand_enumeration_patterns(&pattern)? {
                 let expanded = resolve_task_path(root, expanded);
                 for entry in glob_walk(&expanded, false)? {
-                    if let Some(entry) = prune_symlink_loop(entry)? {
+                    if let Some(entry) = prune_symlink_walk_error(entry)? {
                         candidates.push(entry.into_path());
                     }
                 }
@@ -1401,7 +1412,7 @@ fn get_last_modified(root: &Path, patterns_or_paths: &[String]) -> Result<Option
             }
             found_candidate = true;
             for entry in WalkDir::new(candidate).follow_links(true) {
-                let Some(entry) = prune_symlink_loop(entry)? else {
+                let Some(entry) = prune_symlink_walk_error(entry)? else {
                     continue;
                 };
                 let metadata = entry.metadata()?;
@@ -1465,6 +1476,26 @@ mod tests {
             entries.len() < 10,
             "loop expansion was not bounded: {entries:?}"
         );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn glob_walk_skips_dangling_symlinks() -> Result<()> {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir()?;
+        let tree = temp.path().join("tree");
+        fs::create_dir(&tree)?;
+        fs::write(tree.join("input.txt"), "input")?;
+        symlink("missing", tree.join("dangling"))?;
+
+        let paths = glob_walk(&tree.join("**/*"), false)?
+            .filter_map(|entry| prune_symlink_walk_error(entry).transpose())
+            .map(|entry| entry.map(|entry| entry.into_path()))
+            .collect::<Result<Vec<_>>>()?;
+
+        assert_eq!(paths, [tree.join("input.txt")]);
         Ok(())
     }
 

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -543,7 +543,7 @@ pub(crate) fn glob_walk(pattern: &Path, case_insensitive: bool) -> Result<GlobWa
 }
 
 /// Return a successful walk entry, pruning expected errors from following
-/// symlinks that either loop to an ancestor or point to a missing target.
+/// symlinks that loop or point to a missing target.
 pub(crate) fn prune_symlink_walk_error(
     entry: std::result::Result<DirEntry, WalkError>,
 ) -> Result<Option<DirEntry>> {
@@ -551,18 +551,30 @@ pub(crate) fn prune_symlink_walk_error(
         Ok(entry) => Ok(Some(entry)),
         Err(err) if err.loop_ancestor().is_some() => Ok(None),
         Err(err)
-            if err
-                .io_error()
-                .is_some_and(|error| error.kind() == std::io::ErrorKind::NotFound)
-                && err.path().is_some_and(|path| {
-                    fs::symlink_metadata(path)
-                        .is_ok_and(|metadata| metadata.file_type().is_symlink())
-                }) =>
+            if err.io_error().is_some_and(|error| {
+                error.kind() == std::io::ErrorKind::NotFound || is_filesystem_loop_error(error)
+            }) && err.path().is_some_and(|path| {
+                fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink())
+            }) =>
         {
             Ok(None)
         }
         Err(err) => Err(err.into()),
     }
+}
+
+#[cfg(unix)]
+fn is_filesystem_loop_error(error: &std::io::Error) -> bool {
+    error.raw_os_error() == Some(nix::errno::Errno::ELOOP as i32)
+}
+
+#[cfg(windows)]
+fn is_filesystem_loop_error(error: &std::io::Error) -> bool {
+    use windows_sys::Win32::Foundation::{ERROR_CANT_RESOLVE_FILENAME, ERROR_CIRCULAR_DEPENDENCY};
+
+    error.raw_os_error().is_some_and(|code| {
+        code == ERROR_CANT_RESOLVE_FILENAME as i32 || code == ERROR_CIRCULAR_DEPENDENCY as i32
+    })
 }
 
 /// Build an ordered matcher for task output patterns.
@@ -1481,7 +1493,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn glob_walk_skips_dangling_symlinks() -> Result<()> {
+    fn glob_walk_skips_broken_symlinks() -> Result<()> {
         use std::os::unix::fs::symlink;
 
         let temp = tempfile::tempdir()?;
@@ -1489,6 +1501,7 @@ mod tests {
         fs::create_dir(&tree)?;
         fs::write(tree.join("input.txt"), "input")?;
         symlink("missing", tree.join("dangling"))?;
+        symlink("self", tree.join("self"))?;
 
         let paths = glob_walk(&tree.join("**/*"), false)?
             .filter_map(|entry| prune_symlink_walk_error(entry).transpose())

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -549,18 +549,27 @@ pub(crate) fn prune_symlink_walk_error(
 ) -> Result<Option<DirEntry>> {
     match entry {
         Ok(entry) => Ok(Some(entry)),
-        Err(err) if err.loop_ancestor().is_some() => Ok(None),
-        Err(err)
-            if err.io_error().is_some_and(|error| {
-                error.kind() == std::io::ErrorKind::NotFound || is_filesystem_loop_error(error)
-            }) && err.path().is_some_and(|path| {
-                fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink())
-            }) =>
-        {
-            Ok(None)
-        }
+        Err(err) if symlink_walk_error_path(&err).is_some() => Ok(None),
         Err(err) => Err(err.into()),
     }
+}
+
+/// Return the symlink path attached to an expected loop or missing-target
+/// traversal error. Callers that only enumerate reachable files prune it;
+/// artifact caching retains the symlink itself as an output root.
+pub(crate) fn symlink_walk_error_path(err: &WalkError) -> Option<&Path> {
+    let path = err.path()?;
+    let is_symlink =
+        || fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink());
+    if err.loop_ancestor().is_some() && is_symlink() {
+        return Some(path);
+    }
+    err.io_error()
+        .is_some_and(|error| {
+            error.kind() == std::io::ErrorKind::NotFound || is_filesystem_loop_error(error)
+        })
+        .then_some(path)
+        .filter(|_| is_symlink())
 }
 
 #[cfg(unix)]
@@ -945,7 +954,12 @@ pub(crate) async fn save_checksum(task: &Task, config: &Arc<Config>) -> Result<(
                         patterns.into_iter().any(|pattern| {
                             let pattern = resolve_task_path(&root, pattern);
                             glob_walk(&pattern, false)
-                                .map(|paths| paths.flatten().next().is_some())
+                                .map(|mut paths| {
+                                    paths.any(|entry| match entry {
+                                        Ok(_) => true,
+                                        Err(err) => symlink_walk_error_path(&err).is_some(),
+                                    })
+                                })
                                 .unwrap_or(false)
                         })
                     })
@@ -957,7 +971,7 @@ pub(crate) async fn save_checksum(task: &Task, config: &Arc<Config>) -> Result<(
                 } else {
                     path.to_path_buf()
                 };
-                full_path.exists()
+                fs::symlink_metadata(full_path).is_ok()
             };
             if !output_exists {
                 warn!(

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -19,7 +19,7 @@ use std::io::{Read, Write};
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
-use walkdir::WalkDir;
+use walkdir::{DirEntry, Error as WalkError, WalkDir};
 
 /// Remove mise's automatic output before rerunning a task so an earlier
 /// success cannot make a failed attempt look fresh.
@@ -527,6 +527,18 @@ pub(crate) fn glob_walk(pattern: &Path, case_insensitive: bool) -> Result<GlobWa
         builder = builder.max_depth(pattern_depth);
     }
     Ok(builder.build()?)
+}
+
+/// Return a successful walk entry, pruning the expected error emitted when a
+/// followed directory symlink points back to one of its ancestors.
+pub(crate) fn prune_symlink_loop(
+    entry: std::result::Result<DirEntry, WalkError>,
+) -> Result<Option<DirEntry>> {
+    match entry {
+        Ok(entry) => Ok(Some(entry)),
+        Err(err) if err.loop_ancestor().is_some() => Ok(None),
+        Err(err) => Err(err.into()),
+    }
 }
 
 /// Build an ordered matcher for task output patterns.
@@ -1068,7 +1080,9 @@ fn compute_output_hash(task: &Task, root: &Path) -> Result<Option<String>> {
     ) -> Result<bool> {
         let mut found_any = false;
         for entry in WalkDir::new(dir).follow_links(true).into_iter() {
-            let entry = entry?;
+            let Some(entry) = prune_symlink_loop(entry)? else {
+                continue;
+            };
             let path = entry.path();
             if path == dir {
                 continue; // skip the root directory itself
@@ -1133,7 +1147,10 @@ fn compute_output_hash(task: &Task, root: &Path) -> Result<Option<String>> {
                 // Propagate glob resolution errors (OS errors during directory
                 // reads) rather than silently skipping them — a partial result
                 // could produce the same hash as a complete one.
-                let path = entry?.into_path();
+                let Some(entry) = prune_symlink_loop(entry)? else {
+                    continue;
+                };
+                let path = entry.into_path();
                 glob_matched = true;
                 let metadata = match path.metadata() {
                     Ok(metadata) => metadata,
@@ -1354,11 +1371,11 @@ fn get_last_modified(root: &Path, patterns_or_paths: &[String]) -> Result<Option
             let mut candidates = Vec::new();
             for expanded in expand_enumeration_patterns(&pattern)? {
                 let expanded = resolve_task_path(root, expanded);
-                candidates.extend(
-                    glob_walk(&expanded, false)?
-                        .map(|entry| entry.map(|entry| entry.into_path()))
-                        .collect::<Result<Vec<_>, _>>()?,
-                );
+                for entry in glob_walk(&expanded, false)? {
+                    if let Some(entry) = prune_symlink_loop(entry)? {
+                        candidates.push(entry.into_path());
+                    }
+                }
             }
             candidates
         } else {
@@ -1371,7 +1388,9 @@ fn get_last_modified(root: &Path, patterns_or_paths: &[String]) -> Result<Option
             }
             found_candidate = true;
             for entry in WalkDir::new(candidate).follow_links(true) {
-                let entry = entry?;
+                let Some(entry) = prune_symlink_loop(entry)? else {
+                    continue;
+                };
                 let metadata = entry.metadata()?;
                 if is_output(&matcher, entry.path(), metadata.is_dir()) {
                     if metadata.is_dir() {

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -467,7 +467,9 @@ pub(crate) fn source_glob_patterns(sources: &[String]) -> Vec<String> {
 ///
 /// `globwalk` recursively searches its base directory, so non-globstar
 /// patterns are capped at their component depth to preserve `glob`'s
-/// component-by-component expansion semantics.
+/// component-by-component expansion semantics. Literal prefixes that do not
+/// exist yet are moved into the pattern so they produce zero matches instead
+/// of a traversal error.
 pub(crate) fn glob_walk(pattern: &Path, case_insensitive: bool) -> Result<GlobWalker> {
     fn has_metacharacters(component: &str) -> bool {
         let mut escaped = false;
@@ -510,6 +512,17 @@ pub(crate) fn glob_walk(pattern: &Path, case_insensitive: bool) -> Result<GlobWa
         base.pop();
         glob_pattern.push(file_name);
         pattern_depth = 1;
+    }
+
+    while !base.as_os_str().is_empty() && !base.exists() {
+        let Some(file_name) = base.file_name().map(|name| name.to_os_string()) else {
+            break;
+        };
+        base.pop();
+        let mut prefixed_pattern = PathBuf::from(file_name);
+        prefixed_pattern.push(glob_pattern);
+        glob_pattern = prefixed_pattern;
+        pattern_depth += 1;
     }
 
     let Some(mut glob_pattern) = pattern_from_path(&glob_pattern) else {
@@ -1490,6 +1503,15 @@ mod tests {
             .collect::<Result<Vec<_>, _>>()?;
 
         assert_eq!(paths, [tree.join("a.txt"), tree.join("b.txt")]);
+        Ok(())
+    }
+
+    #[test]
+    fn glob_walk_treats_missing_literal_prefix_as_no_matches() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let entries = glob_walk(&temp.path().join("missing/**/*.txt"), false)?.collect_vec();
+
+        assert!(entries.is_empty());
         Ok(())
     }
 

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -8,7 +8,7 @@ use eyre::{Result, bail};
 use flate2::Compression;
 use flate2::read::ZlibDecoder;
 use flate2::write::ZlibEncoder;
-use glob::glob;
+use globwalk::{GlobWalker, GlobWalkerBuilder};
 use ignore::overrides::{Override, OverrideBuilder};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -462,6 +462,73 @@ pub(crate) fn source_glob_patterns(sources: &[String]) -> Vec<String> {
         .collect()
 }
 
+/// Build a glob iterator that follows valid directory symlinks but detects
+/// ancestor loops instead of recursively expanding them forever.
+///
+/// `globwalk` recursively searches its base directory, so non-globstar
+/// patterns are capped at their component depth to preserve `glob`'s
+/// component-by-component expansion semantics.
+pub(crate) fn glob_walk(pattern: &Path, case_insensitive: bool) -> Result<GlobWalker> {
+    fn has_metacharacters(component: &str) -> bool {
+        let mut escaped = false;
+        for ch in component.chars() {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' && !cfg!(windows) {
+                escaped = true;
+            } else if matches!(ch, '*' | '?' | '[') {
+                return true;
+            }
+        }
+        false
+    }
+
+    let mut base = PathBuf::new();
+    let mut glob_pattern = PathBuf::new();
+    let mut globbing = false;
+    let mut recursive = false;
+    let mut pattern_depth = 0;
+
+    for component in pattern.components() {
+        let text = component.as_os_str().to_string_lossy();
+        if !globbing && has_metacharacters(&text) {
+            globbing = true;
+        }
+        if globbing {
+            recursive |= text == "**";
+            pattern_depth += 1;
+            glob_pattern.push(component);
+        } else {
+            base.push(component);
+        }
+    }
+
+    // `task_source_files` also resolves statically named sources through this
+    // helper. Walk the parent in that case because globwalk intentionally does
+    // not yield its traversal root.
+    if !globbing && let Some(file_name) = base.file_name().map(|name| name.to_os_string()) {
+        base.pop();
+        glob_pattern.push(file_name);
+        pattern_depth = 1;
+    }
+
+    let Some(mut glob_pattern) = pattern_from_path(&glob_pattern) else {
+        bail!("glob pattern is not valid UTF-8: {}", pattern.display());
+    };
+    if glob_pattern.starts_with('!') {
+        glob_pattern.insert(0, '\\');
+    }
+
+    let mut builder = GlobWalkerBuilder::new(&base, glob_pattern)
+        .follow_links(true)
+        .sort_by(|a, b| a.file_name().cmp(b.file_name()))
+        .case_insensitive(case_insensitive);
+    if !recursive {
+        builder = builder.max_depth(pattern_depth);
+    }
+    Ok(builder.build()?)
+}
+
 /// Build an ordered matcher for task output patterns.
 ///
 /// Output entries use the same syntax as sources: `!` excludes, `\!` escapes
@@ -829,7 +896,7 @@ pub(crate) async fn save_checksum(task: &Task, config: &Arc<Config>) -> Result<(
                     .map(|patterns| {
                         patterns.into_iter().any(|pattern| {
                             let pattern = resolve_task_path(&root, pattern);
-                            glob(pattern.to_str().unwrap_or_default())
+                            glob_walk(&pattern, false)
                                 .map(|paths| paths.flatten().next().is_some())
                                 .unwrap_or(false)
                         })
@@ -1062,11 +1129,11 @@ fn compute_output_hash(task: &Task, root: &Path) -> Result<Option<String>> {
         let mut glob_matched = false;
         for expanded in expand_enumeration_patterns(pattern_str)? {
             let full = resolve_task_path(root, expanded);
-            for entry in glob(full.to_str().unwrap_or_default())? {
+            for entry in glob_walk(&full, false)? {
                 // Propagate glob resolution errors (OS errors during directory
                 // reads) rather than silently skipping them — a partial result
                 // could produce the same hash as a complete one.
-                let path = entry?;
+                let path = entry?.into_path();
                 glob_matched = true;
                 let metadata = match path.metadata() {
                     Ok(metadata) => metadata,
@@ -1123,8 +1190,8 @@ fn get_file_metadatas(
     for pattern in patterns {
         for expanded in expand_enumeration_patterns(pattern)? {
             let pattern = resolve_task_path(root, expanded);
-            let files = glob(pattern.to_str().unwrap())?;
-            for file in files.flatten() {
+            let files = glob_walk(&pattern, false)?;
+            for file in files.flatten().map(|entry| entry.into_path()) {
                 if let Ok(metadata) = file.metadata() {
                     metadatas.insert(file, metadata);
                 }
@@ -1288,7 +1355,9 @@ fn get_last_modified(root: &Path, patterns_or_paths: &[String]) -> Result<Option
             for expanded in expand_enumeration_patterns(&pattern)? {
                 let expanded = resolve_task_path(root, expanded);
                 candidates.extend(
-                    glob(expanded.to_str().unwrap_or_default())?.collect::<Result<Vec<_>, _>>()?,
+                    glob_walk(&expanded, false)?
+                        .map(|entry| entry.map(|entry| entry.into_path()))
+                        .collect::<Result<Vec<_>, _>>()?,
                 );
             }
             candidates
@@ -1337,6 +1406,73 @@ fn get_last_modified(root: &Path, patterns_or_paths: &[String]) -> Result<Option
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn glob_walk_skips_symlink_loops() -> Result<()> {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir()?;
+        let tree = temp.path().join("tree");
+        fs::create_dir(&tree)?;
+        fs::write(tree.join("input.txt"), "input")?;
+        symlink(".", tree.join("a"))?;
+        symlink(".", tree.join("b"))?;
+
+        let pattern = tree.join("**/*");
+        let entries = glob_walk(&pattern, false)?.collect_vec();
+        let paths = entries
+            .iter()
+            .filter_map(|entry| entry.as_ref().ok())
+            .map(|entry| entry.path())
+            .collect_vec();
+
+        assert!(paths.contains(&tree.join("input.txt").as_path()));
+        assert_eq!(entries.iter().filter(|entry| entry.is_err()).count(), 2);
+        assert!(
+            entries.len() < 10,
+            "loop expansion was not bounded: {entries:?}"
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn glob_walk_follows_non_looping_directory_symlinks() -> Result<()> {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir()?;
+        let tree = temp.path().join("tree");
+        let actual = temp.path().join("actual");
+        fs::create_dir(&tree)?;
+        fs::create_dir(&actual)?;
+        fs::write(actual.join("input.txt"), "input")?;
+        symlink("../actual", tree.join("linked"))?;
+
+        let paths = glob_walk(&tree.join("**/*"), false)?
+            .map(|entry| entry.map(|entry| entry.into_path()))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        assert!(paths.contains(&tree.join("linked/input.txt")));
+        Ok(())
+    }
+
+    #[test]
+    fn glob_walk_preserves_non_recursive_depth_and_order() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let tree = temp.path().join("tree");
+        fs::create_dir_all(tree.join("nested"))?;
+        fs::write(tree.join("b.txt"), "b")?;
+        fs::write(tree.join("a.txt"), "a")?;
+        fs::write(tree.join("nested/deep.txt"), "deep")?;
+
+        let paths = glob_walk(&tree.join("*.txt"), false)?
+            .map(|entry| entry.map(|entry| entry.into_path()))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        assert_eq!(paths, [tree.join("a.txt"), tree.join("b.txt")]);
+        Ok(())
+    }
 
     fn matches(sources: &[&str], path: &str) -> bool {
         let sources: Vec<String> = sources.iter().map(|s| s.to_string()).collect();


### PR DESCRIPTION
## Summary
- replace recursive task glob expansion with a cycle-aware walker
- continue traversing valid directory symlinks while pruning ancestor loops
- preserve component depth, deterministic ordering, brace expansion, and case behavior
- use the shared walker for sources, outputs, artifact caching, and task_source_files

Related: https://github.com/jdx/mise/discussions/12710

## Testing
- mise run lint
- mise exec -- cargo test --locked --all-features --bin mise task::task_source_checker::tests
- mise run test:e2e e2e/tasks/test_task_source_symlink_loop e2e/tasks/test_task_run_sources
- mise run test:e2e e2e/tasks/test_task_artifact_cache e2e/tasks/test_task_source_symlink_loop

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Centralizes filesystem traversal for task caching and freshness; incorrect pruning could skip files or change cache keys, though behavior is heavily tested.
> 
> **Overview**
> Fixes task runs that hang or fail when **sources** or **outputs** use recursive globs over trees with symlink loops, dangling links, or missing path prefixes.
> 
> Task file discovery now goes through a shared **`glob_walk`** helper (backed by **`globwalk`**) instead of the old **`glob`** crate. The walker follows normal directory symlinks but **prunes ancestor loops** and broken/self-referential links via **`prune_symlink_walk_error`** / **`symlink_walk_error_path`**, while keeping prior behavior for depth limits, ordering, brace expansion, and case sensitivity. **Missing literal prefixes** yield zero matches instead of traversal errors.
> 
> The same logic is wired into **artifact cache** output resolution, archive restore/store (including **dangling symlink outputs**), **content- and mtime-based freshness**, and **`task_source_files()`** in templates. A new **e2e** script covers loops, cache hits, and generated broken symlinks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c48c747dcea77b224b2c58dbd6f0e0d29b1a2a8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recursive file discovery for task sources and outputs.
  - Symlink loops and dangling symlinks are now skipped safely.
  - Directory symlinks can be followed without interrupting file matching.
  - Artifact output enumeration and freshness checks handle recursive symlink trees reliably.
  - Missing literal output paths resolve cleanly with no matches.
  - Recursive and non-recursive patterns provide more consistent results.
  - Improved error reporting for invalid paths and filesystem issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->