### PR TITLE
docs(bootstrap): clarify landing page examples

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -184,6 +184,7 @@ action = "allow"
 "~/src/dotfiles" = { url = "git@github.com:jdx/dotfiles.git", ref = "main" }
 
 [dotfiles]
+"~/.config/mise/config.toml" = { source = "config.toml", mode = "symlink" }
 "~/.gitconfig" = { mode = "symlink" }
 "~/.config/nvim" = { mode = "symlink" }
 

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -15,7 +15,8 @@ dotfiles.root = "~/.dotfiles"
 dotfiles.default_mode = "symlink"
 
 [dotfiles]
-"~/.zshrc" = {}                                                       # ~/.dotfiles/.zshrc
+"~/.config/mise/config.toml" = { source = "config.toml", mode = "symlink" }
+"~/.zshrc" = { mode = "symlink" }                                     # ~/.dotfiles/.zshrc
 "~/.gitconfig" = "dotfiles/gitconfig"                                # explicit source
 "~/.config/alacritty.toml" = { mode = "copy" }                       # ~/.dotfiles/.config/alacritty.toml
 "~/.config/starship.toml" = { source = "dotfiles/starship.toml", mode = "copy" }
@@ -51,7 +52,7 @@ with `--mode`:
 
 ```toml
 [dotfiles]
-"~/.zshrc" = {}
+"~/.zshrc" = { mode = "symlink" }
 "~/.ssh/config" = { source = "ssh/config", mode = "copy" }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ hero:
         <div class="row row-boot"><span class="tk-key">"apt:build-essential"</span><span class="tk-op"> = </span><span class="tk-str">"latest"</span></div>
         <div class="row row-blank"></div>
         <div class="row row-boot"><span class="tk-section">[dotfiles]</span></div>
-        <div class="row row-boot"><span class="tk-key">"~/.zshrc"</span><span class="tk-op"> = {}</span></div>
+        <div class="row row-boot"><span class="tk-key">"~/.zshrc"</span><span class="tk-op"> = { </span><span class="tk-key">source</span><span class="tk-op"> = </span><span class="tk-str">"dotfiles/zshrc"</span><span class="tk-op"> }</span></div>
       </div>
     </div>
     <div class="card-outputs">
@@ -210,8 +210,8 @@ hero:
           <div class="row row-boot"><span class="tk-key">"~/src/notes"</span><span class="tk-op"> = { </span><span class="tk-key">url</span><span class="tk-op"> = </span><span class="tk-str">"git@github.com:me/notes.git"</span><span class="tk-op"> }</span></div>
           <div class="row row-blank"></div>
           <div class="row row-boot"><span class="tk-section">[dotfiles]</span></div>
-          <div class="row row-boot"><span class="tk-key">"~/.gitconfig"</span><span class="tk-op"> = {}</span></div>
-          <div class="row row-boot"><span class="tk-key">"~/.config/nvim"</span><span class="tk-op"> = {}</span></div>
+          <div class="row row-boot"><span class="tk-key">"~/.gitconfig"</span><span class="tk-op"> = { </span><span class="tk-key">source</span><span class="tk-op"> = </span><span class="tk-str">"dotfiles/gitconfig"</span><span class="tk-op">, </span><span class="tk-key">mode</span><span class="tk-op"> = </span><span class="tk-str">"template"</span><span class="tk-op"> }</span></div>
+          <div class="row row-boot"><span class="tk-key">"~/.config/nvim"</span><span class="tk-op"> = { </span><span class="tk-key">source</span><span class="tk-op"> = </span><span class="tk-str">"dotfiles/nvim"</span><span class="tk-op">, </span><span class="tk-key">mode</span><span class="tk-op"> = </span><span class="tk-str">"symlink"</span><span class="tk-op"> }</span></div>
           <div class="row row-blank"></div>
           <div class="row row-boot"><span class="tk-section">[bootstrap.macos.dock]</span></div>
           <div class="row row-boot"><span class="tk-key">autohide</span><span class="tk-op"> = </span><span class="tk-str">true</span></div>
@@ -225,9 +225,11 @@ hero:
         <p class="landing-lede">
           <code>mise bootstrap</code> sets up a new computer from the same
           file: OS packages, git repos, dotfiles, shell activation, macOS
-          defaults, and services, then your tools. It converges, so running it
-          again only does what's missing. It's what you'd otherwise assemble
-          from a Brewfile, chezmoi, and an Ansible playbook.
+          defaults, and services, then your tools. Run it again and mise skips
+          anything that's already set up. mise has its own Homebrew
+          implementation, so it installs formulae and casks without requiring
+          Homebrew. It replaces what you'd otherwise assemble from a Brewfile,
+          chezmoi, and an Ansible playbook.
         </p>
         <ul class="landing-checklist">
           <li>Packages through brew, apt, dnf, pacman, apk, and mas</li>

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ hero:
         <div class="row row-boot"><span class="tk-key">"apt:build-essential"</span><span class="tk-op"> = </span><span class="tk-str">"latest"</span></div>
         <div class="row row-blank"></div>
         <div class="row row-boot"><span class="tk-section">[dotfiles]</span></div>
-        <div class="row row-boot"><span class="tk-key">"~/.zshrc"</span><span class="tk-op"> = { </span><span class="tk-key">source</span><span class="tk-op"> = </span><span class="tk-str">"dotfiles/zshrc"</span><span class="tk-op"> }</span></div>
+        <div class="row row-boot"><span class="tk-key">"~/.config/mise/config.toml"</span><span class="tk-op"> = { </span><span class="tk-key">source</span><span class="tk-op"> = </span><span class="tk-str">"config.toml"</span><span class="tk-op">, </span><span class="tk-key">mode</span><span class="tk-op"> = </span><span class="tk-str">"symlink"</span><span class="tk-op"> }</span></div>
       </div>
     </div>
     <div class="card-outputs">
@@ -210,6 +210,7 @@ hero:
           <div class="row row-boot"><span class="tk-key">"~/src/notes"</span><span class="tk-op"> = { </span><span class="tk-key">url</span><span class="tk-op"> = </span><span class="tk-str">"git@github.com:me/notes.git"</span><span class="tk-op"> }</span></div>
           <div class="row row-blank"></div>
           <div class="row row-boot"><span class="tk-section">[dotfiles]</span></div>
+          <div class="row row-boot"><span class="tk-key">"~/.config/mise/config.toml"</span><span class="tk-op"> = { </span><span class="tk-key">source</span><span class="tk-op"> = </span><span class="tk-str">"config.toml"</span><span class="tk-op">, </span><span class="tk-key">mode</span><span class="tk-op"> = </span><span class="tk-str">"symlink"</span><span class="tk-op"> }</span></div>
           <div class="row row-boot"><span class="tk-key">"~/.gitconfig"</span><span class="tk-op"> = { </span><span class="tk-key">source</span><span class="tk-op"> = </span><span class="tk-str">"dotfiles/gitconfig"</span><span class="tk-op">, </span><span class="tk-key">mode</span><span class="tk-op"> = </span><span class="tk-str">"template"</span><span class="tk-op"> }</span></div>
           <div class="row row-boot"><span class="tk-key">"~/.config/nvim"</span><span class="tk-op"> = { </span><span class="tk-key">source</span><span class="tk-op"> = </span><span class="tk-str">"dotfiles/nvim"</span><span class="tk-op">, </span><span class="tk-key">mode</span><span class="tk-op"> = </span><span class="tk-str">"symlink"</span><span class="tk-op"> }</span></div>
           <div class="row row-blank"></div>

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -103,6 +103,7 @@ one:
 "~/src/dotfiles" = { url = "git@github.com:jdx/dotfiles.git", ref = "main" }
 
 [dotfiles]                             # dotfiles: symlink/copy/template
+"~/.config/mise/config.toml" = { source = "config.toml", mode = "symlink" }
 "~/.gitconfig" = { mode = "symlink" }
 "~/.config/nvim" = { mode = "symlink" }
 

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -7,7 +7,8 @@
 //!
 //! ```toml
 //! [dotfiles]
-//! "~/.zshrc" = {}                                        # implied source
+//! "~/.config/mise/config.toml" = { source = "config.toml", mode = "symlink" }
+//! "~/.zshrc" = { mode = "symlink" }                      # implied source
 //! "~/.gitconfig" = "dotfiles/gitconfig"                  # explicit source
 //! "~/.config/foo.toml" = { mode = "copy" }               # implied source
 //! "~/.ssh/config" = { source = "ssh.tmpl", mode = "template" }


### PR DESCRIPTION
## Summary
- replace empty dotfile objects with concrete source and mode examples
- show `~/.config/mise/config.toml` as a self-managed symlink across the landing page and primary bootstrap/dotfiles examples
- describe reruns in plain language instead of using “converges”
- explain that mise’s built-in Homebrew implementation installs formulae and casks without requiring Homebrew

## Testing
- `mise run docs:build`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and comment-only changes with no runtime behavior impact.
> 
> **Overview**
> Updates **docs and landing-page examples** so `[dotfiles]` entries show explicit `source` and `mode` (including self-managing `~/.config/mise/config.toml`) instead of empty `{}` tables.
> 
> On the home page **bootstrap section**, rewrites the lede to say reruns skip work that is already done (instead of “converges”) and notes that **mise can install brew formulae and casks without a separate Homebrew install**.
> 
> The same example refresh is applied in `bootstrap.md`, `dotfiles.md`, `tips-and-tricks.md`, and the `[dotfiles]` module doc comment in `files.rs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b3fca38416094a723bcaabd8960bb2a14efcf7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded dotfile configuration examples to show explicit sources and symlink modes.
  * Added examples for managing `~/.config/mise/config.toml`.
  * Clarified bootstrap behavior when rerun and documented mise’s Homebrew installation support.
  * Updated examples to make implied dotfile sources and configuration modes clearer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->