### PR TITLE
fix(deps): bump self_update to 1.3 to clear quick-xml advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,15 +348,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
-]
-
-[[package]]
 name = "arc-swap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2835,17 +2826,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -6464,7 +6444,7 @@ dependencies = [
  "xx",
  "xz2",
  "zip 8.6.0",
- "zipsign-api 0.2.1",
+ "zipsign-api",
  "zstd",
 ]
 
@@ -7450,7 +7430,7 @@ checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.1",
- "quick-xml 0.41.0",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -7692,15 +7672,6 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quick-xml"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "quick-xml"
@@ -8066,7 +8037,7 @@ dependencies = [
  "known-folders",
  "once_cell",
  "plist",
- "quick-xml 0.41.0",
+ "quick-xml",
  "rattler_conda_types",
  "rattler_shell",
  "regex",
@@ -9063,16 +9034,14 @@ checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 
 [[package]]
 name = "self_update"
-version = "0.44.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e79722b5a505d4ddc77527455a97244e9e8c4c07533ff44cf4421cce7bb6d17"
+checksum = "1c39da82b90ac89d099e21109c81c91b70bd85a582d8e382a5e88aa007f5310b"
 dependencies = [
- "either",
  "flate2",
  "http 1.5.0",
  "indicatif",
  "log",
- "quick-xml 0.38.4",
  "regex",
  "reqwest",
  "self-replace",
@@ -9083,8 +9052,8 @@ dependencies = [
  "tempfile",
  "ureq",
  "urlencoding",
- "zip 6.0.0",
- "zipsign-api 0.1.5",
+ "zip 8.6.0",
+ "zipsign-api",
 ]
 
 [[package]]
@@ -12206,21 +12175,6 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
-dependencies = [
- "arbitrary",
- "crc32fast",
- "flate2",
- "indexmap 2.14.1",
- "memchr",
- "time",
- "zopfli",
-]
-
-[[package]]
-name = "zip"
 version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
@@ -12256,17 +12210,6 @@ dependencies = [
  "zeroize",
  "zopfli",
  "zstd",
-]
-
-[[package]]
-name = "zipsign-api"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba6063ff82cdbd9a765add16d369abe81e520f836054e997c2db217ceca40c0"
-dependencies = [
- "base64 0.22.1",
- "ed25519-dalek",
- "thiserror 2.0.20",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -252,11 +252,13 @@ zstd = "0.13"
 [target.'cfg(unix)'.dependencies]
 exec = "0.3"
 nix = { version = "0.31", features = ["dir", "fs", "signal", "term", "user"] }
-self_update = { version = "0.44", optional = true, default-features = false, features = [
+self_update = { version = "1", optional = true, default-features = false, features = [
   "archive-tar",
-  "compression-flate2",
+  "compression-tar-gz",
   "signatures",
   "reqwest",
+  "github",
+  "progress-bar",
 ] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -264,11 +266,13 @@ landlock = "0.4"
 seccompiler = "0.5"
 
 [target.'cfg(windows)'.dependencies]
-self_update = { version = "0.44", optional = true, default-features = false, features = [
+self_update = { version = "1", optional = true, default-features = false, features = [
   "archive-zip",
   "compression-zip-deflate",
   "signatures",
   "reqwest",
+  "github",
+  "progress-bar",
 ] }
 zipsign-api = "0.2"
 winapi = { version = "0.3", features = ["consoleapi", "minwindef"] }
@@ -312,7 +316,7 @@ native-tls = [
   "ubi/native-tls",
   "vfox/native-tls",
   "xx/native-tls",
-  "self_update?/default-tls",
+  "self_update?/native-tls",
 ]
 rustls = [
   "gix/blocking-http-transport-reqwest-rust-tls",

--- a/deny.toml
+++ b/deny.toml
@@ -72,8 +72,6 @@ feature-depth = 1
 ignore = [
   { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 unmaintained - transitive via age/mlua/tabled/rops, no safe upgrade available" },
   { id = "RUSTSEC-2023-0071", reason = "rsa crate Marvin attack vulnerability from sigstore crate - no safe upgrade available" },
-  { id = "RUSTSEC-2026-0194", reason = "quick-xml transitive via plist/self_update/rattler_menuinst; no published upstream release supports quick-xml >=0.41 yet" },
-  { id = "RUSTSEC-2026-0195", reason = "quick-xml transitive via plist/self_update/rattler_menuinst; no published upstream release supports quick-xml >=0.41 yet" },
   #"RUSTSEC-0000-0000",
   #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
   #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -4,7 +4,7 @@ use console::style;
 #[cfg(windows)]
 use indoc::formatdoc;
 use self_update::backends::github::Update;
-use self_update::{Status, cargo_crate_version};
+use self_update::{VersionStatus, cargo_crate_version};
 
 use crate::cli::version::{ARCH, OS};
 use crate::config::Settings;
@@ -405,7 +405,7 @@ impl SelfUpdate {
         Self::ensure_temp_dir_can_replace_binary()?;
         let status = self.do_update()?;
 
-        if status.updated() {
+        if status.is_updated() {
             let version = status.version().to_string();
             let styled_version = style(&version).bright().yellow();
             miseprintln!("Updated mise to {styled_version}");
@@ -467,13 +467,13 @@ impl SelfUpdate {
         bail!("{msg}");
     }
 
-    fn do_update(&self) -> Result<Status> {
+    fn do_update(&self) -> Result<VersionStatus> {
         // Use block_in_place to allow self_update's blocking HTTP calls
         // to work within mise's async runtime
         tokio::task::block_in_place(|| self.do_update_blocking())
     }
 
-    fn do_update_blocking(&self) -> Result<Status> {
+    fn do_update_blocking(&self) -> Result<VersionStatus> {
         let mut update = Update::configure();
         if let Some((token, _)) = crate::github::resolve_token("github.com") {
             update.auth_token(&token);
@@ -494,7 +494,15 @@ impl SelfUpdate {
             .version
             .clone()
             .map_or_else(
-                || -> Result<String> { Ok(update.build()?.get_latest_release()?.version) },
+                || -> Result<String> {
+                    Ok(update
+                        .build()?
+                        .get_latest_release()?
+                        .latest()
+                        .ok_or_else(|| eyre::eyre!("no GitHub releases found for jdx/mise"))?
+                        .version()
+                        .to_string())
+                },
                 Ok,
             )
             .map(|v| format!("v{v}"))?;
@@ -502,15 +510,15 @@ impl SelfUpdate {
         // Check if already up to date (unless --force is specified)
         let current_version = format!("v{}", cargo_crate_version!());
         if !self.force && v == current_version {
-            return Ok(Status::UpToDate(current_version));
+            return Ok(VersionStatus::UpToDate(current_version));
         }
 
         let target = format!("{}-{}", *OS, *ARCH);
         #[cfg(target_env = "musl")]
         let target = format!("{target}-musl");
-        // Always set target_version_tag to ensure we download the correct release
+        // Always set release_tag to ensure we download the correct release
         // (fixes semver mismatch across year boundaries, e.g. 2025.x -> 2026.x)
-        update.target_version_tag(&v);
+        update.release_tag(&v);
         #[cfg(windows)]
         let target = format!("mise-{v}-{target}.zip");
         #[cfg(not(windows))]
@@ -525,7 +533,7 @@ impl SelfUpdate {
 
         // Verify macOS binary signature after update
         #[cfg(target_os = "macos")]
-        if status.updated() {
+        if status.is_updated() {
             Self::verify_macos_signature(&env::MISE_BIN)?;
         }
 


### PR DESCRIPTION
Automated dependency bump to address disclosed CVEs in a transitive dependency of `self_update`.

- **CVE / Advisory:** [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194), [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195)
- **Severity:** high (CVSS 7.5, availability DoS)
- **Package:** `self_update` `0.44.0` → `1.3.0` (drops transitive `quick-xml` `0.38.4`; remaining `quick-xml` usage is only `0.41.0` via `plist` / `rattler_menuinst`)

### Why this works
`self_update` 1.x gates `quick-xml` behind the optional `s3` feature. mise only uses the GitHub backend, so enabling `github` + the existing archive/signature features leaves the vulnerable `0.38` line out of the default graph. The July `deny.toml` ignores (#10717) can therefore be removed.

### Verification
- Reproduced locally: yes
- Command: `cargo tree -i quick-xml@0.38.4` (fails: package not present) / `cargo tree -i quick-xml@0.41.0` / `cargo check`
- Before: `self_update 0.44.0` → `quick-xml 0.38.4` (RUSTSEC-2026-0194/0195)
- After: no `quick-xml 0.38.4`; only `quick-xml 0.41.0`
- Environment: rustc 1.98.0, `cargo check` clean on linux amd64

Detected by [osv-scanner](https://google.github.io/osv-scanner/). Call-site edits follow the upstream [0.x → 1.0 migration guide](https://github.com/jaemk/self_update/blob/master/docs/migrations/0.x-to-1.0-human.md) (`VersionStatus`, `release_tag`, `is_updated`, `Releases::latest`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the self-update process by adopting the latest update workflow.
  - Added support for GitHub releases and progress indicators during updates.
  - Updated release version handling for more reliable update checks.
  - Removed previously ignored security advisories from dependency auditing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->