### PR TITLE
feat(bootstrap): support absent pacman packages

### DIFF
--- a/docs/bootstrap/packages/index.md
+++ b/docs/bootstrap/packages/index.md
@@ -33,7 +33,13 @@ aliases as `[tools]` (`linux`, `macos`, `windows`, `linux/x64`,
 "brew:coreutils" = "latest"
 "brew-cask:1password" = { os = "macos" }
 "brew-cask:font-jetbrains-mono" = { os = ["linux", "macos"] }
+"pacman:libreoffice-fresh" = { state = "absent" }
 ```
+
+`pacman` entries may set `state = "absent"` to declaratively remove a package.
+`mise bootstrap packages status --missing` treats an installed package with
+that declaration as drift, and `mise bootstrap packages apply` removes it.
+Other built-in managers currently support only the default `state = "present"`.
 
 `brew-cask` entries additionally accept `adopt = true` to adopt an identical
 app already installed at the cask destination. Set `bootstrap.brew.adopt = true`
@@ -84,7 +90,8 @@ declarative sections work the same way:
 - **Declarative and additive by default** — entries merge across the
   [config hierarchy](/configuration.html) (global → project) as a union of
   keys. A project can add packages on top of the global list (and override a
-  global entry's version pin) but not remove them. Pruning is an explicit,
+  global entry's version pin). A more local config can override a pacman entry
+  with `state = "absent"`. Pruning is an explicit,
   manager-scoped destructive operation: `mise bootstrap packages prune`
   defaults to Homebrew, while plugin-owned packages require
   `mise bootstrap packages prune --manager <plugin>`. It removes only packages

--- a/docs/bootstrap/packages/pacman.md
+++ b/docs/bootstrap/packages/pacman.md
@@ -6,6 +6,7 @@ System packages for Arch-family Linux (Arch, Manjaro, EndeavourOS, ...).
 [bootstrap.packages]
 "pacman:openssl" = "latest"
 "pacman:base-devel" = "latest"
+"pacman:libreoffice-fresh" = { state = "absent" }
 ```
 
 ## Behavior
@@ -17,6 +18,11 @@ System packages for Arch-family Linux (Arch, Manjaro, EndeavourOS, ...).
   elevated with sudo when necessary (see
   [sudo](/bootstrap/packages/#sudo)). `--needed` makes installs
   idempotent.
+- Packages declared with `state = "absent"` are removed with
+  `pacman -R --noconfirm`. Removal is based on pacman's installed package
+  database, so it works the same for official Arch packages and packages from
+  configured third-party repositories such as the Omarchy Package Repository.
+  mise does not cascade to dependents or remove orphaned dependencies.
 - If `/var/lib/pacman/sync` contains no databases (fresh containers), mise
   runs `pacman -Sy` automatically before installing. Force a refresh with
   `mise bootstrap packages apply --update`.

--- a/docs/cli/bootstrap/packages/apply.md
+++ b/docs/cli/bootstrap/packages/apply.md
@@ -3,7 +3,7 @@
 
 - **Usage:** `mise bootstrap packages apply [FLAGS] [PACKAGE]…`
 - **Aliases:** `i`, `install`
-- **Effect:** modifies state
+- **Effect:** destructive — may delete or irreversibly overwrite
 - **Source code:** [`src/cli/system/install.rs`](https://github.com/jdx/mise/blob/main/src/cli/system/install.rs)
 
 Apply system packages from `[bootstrap.packages]`

--- a/e2e/cli/test_system_status
+++ b/e2e/cli/test_system_status
@@ -3,7 +3,7 @@
 cat <<EOF >mise.toml
 [bootstrap.packages]
 "apt:bc" = "latest"
-"apk:bc" = "latest"
+"apk:bc" = { state = "absent" }
 "brew:jq" = "latest"
 "dnf:bc" = "latest"
 "mas:497799835" = "latest"
@@ -17,6 +17,7 @@ assert_contains "mise bootstrap packages status" "bc"
 assert_contains "mise bootstrap packages status" "497799835"
 assert_contains "mise bootstrap packages status --json" '"apt"'
 assert_contains "mise bootstrap packages status --json" '"apk"'
+assert_contains "mise bootstrap packages status --json" '"desired_state": "absent"'
 assert_contains "mise bootstrap packages status --json" '"mas"'
 if ! command -v apk >/dev/null; then
   assert_fail_contains "mise bootstrap packages apply --manager apk --dry-run --yes" "apk is not available"

--- a/e2e/cli/test_system_status
+++ b/e2e/cli/test_system_status
@@ -17,9 +17,14 @@ assert_contains "mise bootstrap packages status" "bc"
 assert_contains "mise bootstrap packages status" "497799835"
 assert_contains "mise bootstrap packages status --json" '"apt"'
 assert_contains "mise bootstrap packages status --json" '"apk"'
-assert_contains "mise bootstrap packages status --json" '"desired_state": "absent"'
+assert \
+  "mise bootstrap packages status --json | jq -r '.apk.packages[] | select(.package == \"bc\") | [.package, .desired_state] | @tsv'" \
+  $'bc\tabsent'
 assert_contains "mise bootstrap packages status --json" '"mas"'
 if ! command -v apk >/dev/null; then
+  assert \
+    "mise bootstrap packages status --json | jq -r '.apk.packages[] | select(.package == \"bc\") | .state'" \
+    "skipped"
   assert_fail_contains "mise bootstrap packages apply --manager apk --dry-run --yes" "apk is not available"
 fi
 if [[ "$(uname)" == "Darwin" ]] && command -v mas >/dev/null; then

--- a/mise.lock
+++ b/mise.lock
@@ -159,9 +159,8 @@ provenance = "github-attestations"
 
 [tools.aube."platforms.macos-arm64"]
 checksum = "sha256:702de7f549cef800a1f35900e638ea4fbe07bce854f234cef869cd5442484c90"
-url = "https://github.com/jdx/aube/releases/download/v2.2.0/aube-v2.2.0-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/529761660"
-provenance = "github-attestations"
+url = "https://github.com/aubepkg/aube/releases/download/v2.2.0/aube-v2.2.0-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/529761660"
 
 [tools.aube."platforms.windows-x64"]
 checksum = "sha256:2d68e3e995c336486647034eb8b99c3cfa68894e385a44200af2bc14bc4064cf"

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -769,7 +769,7 @@ edits require `--force`.
     }
     cmd packages subcommand_required=#true help="Manage bootstrap system packages from `[bootstrap.packages]`" effect=read {
         flag "-h --help" help="Print help" action=help builtin=#true
-        cmd apply help="Apply system packages from `[bootstrap.packages]`" effect=write {
+        cmd apply help="Apply system packages from `[bootstrap.packages]`" effect=destructive {
             alias i install
             long_help #"""
 Apply system packages from `[bootstrap.packages]`

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -25,7 +25,7 @@ use crate::system::files::{FileMode, FileRequest, FileState};
 use crate::system::hooks::{self, BootstrapHookPhase};
 use crate::system::launchd::LaunchdState;
 use crate::system::login_shell::LoginShellState;
-use crate::system::packages::PackageState;
+use crate::system::packages::{PackageDesiredState, PackageState};
 use crate::system::repos::RepoState;
 use crate::system::resources::{ResourceAction, ResourceId};
 use crate::system::systemd::SystemdState;
@@ -2937,23 +2937,36 @@ impl BootstrapStatus {
             let mut json_pkgs = vec![];
             for s in statuses {
                 let auto_updates = s.state.auto_updates();
-                let (installed_version, state, reason, missing) = match &s.state {
-                    PackageState::Installed { version } => {
+                let desired_absent = s.request.desired == PackageDesiredState::Absent;
+                let (installed_version, state, reason, missing) = match (&s.state, desired_absent) {
+                    (PackageState::Missing, true) => {
+                        ("".to_string(), "absent", None::<&str>, false)
+                    }
+                    (PackageState::Installed { version }, true)
+                    | (PackageState::NeedsRepair { installed: version }, true)
+                    | (PackageState::VersionMismatch { installed: version }, true) => {
+                        (version.clone(), "unexpectedly installed", None, true)
+                    }
+                    #[cfg(unix)]
+                    (PackageState::InstalledAutoUpdates { version }, true) => {
+                        (version.clone(), "unexpectedly installed", None, true)
+                    }
+                    (PackageState::Installed { version }, false) => {
                         (version.clone(), "installed", None::<&str>, false)
                     }
                     #[cfg(unix)]
-                    PackageState::InstalledAutoUpdates { version } => {
+                    (PackageState::InstalledAutoUpdates { version }, false) => {
                         (version.clone(), "installed", None::<&str>, false)
                     }
-                    PackageState::Missing => ("".to_string(), "missing", None, true),
-                    PackageState::NeedsRepair { installed } => {
+                    (PackageState::Missing, false) => ("".to_string(), "missing", None, true),
+                    (PackageState::NeedsRepair { installed }, false) => {
                         (installed.clone(), "needs repair", None, true)
                     }
-                    PackageState::VersionMismatch { installed } => {
+                    (PackageState::VersionMismatch { installed }, false) => {
                         (installed.clone(), "version mismatch", None, true)
                     }
                     #[cfg(unix)]
-                    PackageState::Unavailable { reason } => {
+                    (PackageState::Unavailable { reason }, _) => {
                         ("".to_string(), "skipped", Some(reason.as_str()), false)
                     }
                 };
@@ -2974,6 +2987,7 @@ impl BootstrapStatus {
                 let mut package = json!({
                     "package": s.request.name,
                     "requested_version": s.request.version.clone().unwrap_or_else(|| "latest".to_string()),
+                    "desired_state": if desired_absent { "absent" } else { "present" },
                     "state": state.replace(' ', "_"),
                     "installed_version": installed_version,
                 });

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -2926,6 +2926,10 @@ impl BootstrapStatus {
                             json!({
                                 "package": req.name,
                                 "requested_version": req.version.clone().unwrap_or_else(|| "latest".to_string()),
+                                "desired_state": match req.desired {
+                                    PackageDesiredState::Present => "present",
+                                    PackageDesiredState::Absent => "absent",
+                                },
                                 "state": "skipped",
                             })
                         }).collect::<Vec<_>>(),

--- a/src/cli/command_effects.rs
+++ b/src/cli/command_effects.rs
@@ -97,7 +97,7 @@ pub(super) const EFFECTS: &[(&str, SpecCommandEffect)] = &[
     ("bootstrap mise-shell-activate apply", Write),
     ("bootstrap mise-shell-activate status", Read),
     ("bootstrap packages", Read),
-    ("bootstrap packages apply", Write),
+    ("bootstrap packages apply", Destructive),
     ("bootstrap packages import", Write),
     // Uninstalls system packages that are no longer declared.
     ("bootstrap packages prune", Destructive),
@@ -380,6 +380,10 @@ mod tests {
         // Nested commands are reached too.
         assert_eq!(
             cmd("plugins").subcommands["uninstall"].effect,
+            Some(Destructive)
+        );
+        assert_eq!(
+            cmd("bootstrap").subcommands["packages"].subcommands["apply"].effect,
             Some(Destructive)
         );
         // Anything in UNCLASSIFIED must be left unset, not defaulted.

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -530,7 +530,12 @@ impl Doctor {
                 Ok(statuses) => {
                     let missing = statuses
                         .iter()
-                        .filter(|s| !s.state.is_installed() && !s.state.is_unavailable())
+                        .filter(|s| {
+                            s.request.desired
+                                == crate::system::packages::PackageDesiredState::Present
+                                && !s.state.is_installed()
+                                && !s.state.is_unavailable()
+                        })
                         .count();
                     total_missing += missing;
                     map.insert(
@@ -756,7 +761,12 @@ impl Doctor {
                 Ok(statuses) => {
                     let missing = statuses
                         .iter()
-                        .filter(|s| !s.state.is_installed() && !s.state.is_unavailable())
+                        .filter(|s| {
+                            s.request.desired
+                                == crate::system::packages::PackageDesiredState::Present
+                                && !s.state.is_installed()
+                                && !s.state.is_unavailable()
+                        })
                         .count();
                     lines.push(format!(
                         "{name}: {} requested, {missing} missing",

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -225,7 +225,12 @@ impl Install {
                 Ok(statuses) => {
                     missing += statuses
                         .iter()
-                        .filter(|s| !s.state.is_installed() && !s.state.is_unavailable())
+                        .filter(|s| {
+                            s.request.desired
+                                == crate::system::packages::PackageDesiredState::Present
+                                && !s.state.is_installed()
+                                && !s.state.is_unavailable()
+                        })
                         .count();
                 }
                 // a transient query failure must not start the 24h throttle

--- a/src/cli/system/driver.rs
+++ b/src/cli/system/driver.rs
@@ -6,7 +6,7 @@ use eyre::{Result, bail};
 
 use crate::config::Settings;
 use crate::system::ManagerPackages;
-use crate::system::packages::{InstallOpts, PackageState, PackageStatus};
+use crate::system::packages::{InstallOpts, PackageDesiredState, PackageState, PackageStatus};
 use crate::ui::prompt;
 
 #[derive(Clone, Copy, PartialEq)]
@@ -110,8 +110,21 @@ pub(crate) async fn run(mgrs: Vec<ManagerPackages>, action: Action, d: &DriverOp
         if let Some(reason) = unavailable_package_reason(d, &statuses) {
             bail!("{reason}");
         }
+        let remove_targets = if action == Action::Install {
+            statuses
+                .iter()
+                .filter(|status| {
+                    status.request.desired == PackageDesiredState::Absent
+                        && !matches!(status.state, PackageState::Missing)
+                        && !status.state.is_unavailable()
+                })
+                .collect::<Vec<_>>()
+        } else {
+            vec![]
+        };
         let mut targets: Vec<_> = statuses
             .iter()
+            .filter(|status| status.request.desired == PackageDesiredState::Present)
             .filter(|s| match action {
                 Action::Install => !s.state.is_installed() && !s.state.is_unavailable(),
                 // upgrade acts on whatever is present (the manager no-ops
@@ -124,6 +137,7 @@ pub(crate) async fn run(mgrs: Vec<ManagerPackages>, action: Action, d: &DriverOp
             .collect();
         let missing = statuses
             .iter()
+            .filter(|status| status.request.desired == PackageDesiredState::Present)
             .filter(|status| matches!(status.state, PackageState::Missing))
             .count();
         if action == Action::Upgrade && missing > 0 {
@@ -151,10 +165,46 @@ pub(crate) async fn run(mgrs: Vec<ManagerPackages>, action: Action, d: &DriverOp
         }
         let installed = statuses
             .iter()
+            .filter(|status| status.request.desired == PackageDesiredState::Present)
             .filter(|status| status.state.is_installed())
             .count();
         if action == Action::Install && installed > 0 {
             info!("{name}: {installed} package(s) already installed");
+        }
+        let already_absent = statuses
+            .iter()
+            .filter(|status| status.request.desired == PackageDesiredState::Absent)
+            .filter(|status| matches!(status.state, PackageState::Missing))
+            .count();
+        if action == Action::Install && already_absent > 0 {
+            info!("{name}: {already_absent} package(s) already absent");
+        }
+        if !remove_targets.is_empty() {
+            if !mp.manager.supports_remove() {
+                bail!("{name} does not support declarative package removal");
+            }
+            let remove = remove_targets
+                .iter()
+                .map(|status| status.request.clone())
+                .collect::<Vec<_>>();
+            let list = remove
+                .iter()
+                .map(|request| request.to_string())
+                .collect::<Vec<_>>();
+            if !d.dry_run && !d.yes && console::user_attended_stderr() {
+                let msg = format!("{name}: remove {}?", list.join(", "));
+                if !prompt::confirm(msg)?.is_yes() {
+                    info!("{name}: removal skipped");
+                } else {
+                    mp.manager.remove(&remove, &opts).await?;
+                    info!("{name}: removed {}", list.join(", "));
+                }
+            } else {
+                mp.manager.remove(&remove, &opts).await?;
+                if !d.dry_run {
+                    info!("{name}: removed {}", list.join(", "));
+                }
+            }
         }
         if targets.is_empty() {
             continue;
@@ -256,6 +306,7 @@ mod tests {
                 name: "example".to_string(),
                 version: None,
                 tap_url: None,
+                desired: PackageDesiredState::Present,
             },
             state: PackageState::Unavailable {
                 reason: "unsupported on this platform".to_string(),

--- a/src/cli/system/import.rs
+++ b/src/cli/system/import.rs
@@ -264,6 +264,7 @@ mod tests {
             version: "1.0.0".to_string(),
             os: vec!["macos".to_string()],
             adopt: None,
+            state: crate::system::PackageDesiredStateTomlConfig::Present,
         });
         assert_eq!(
             imported_package_value(None, Some(&inherited)).to_string(),
@@ -274,6 +275,7 @@ mod tests {
             version: "1.0.0".to_string(),
             os: vec![],
             adopt: Some(true),
+            state: crate::system::PackageDesiredStateTomlConfig::Present,
         });
         assert_eq!(
             imported_package_value(None, Some(&adopted)).to_string(),

--- a/src/cli/system/status.rs
+++ b/src/cli/system/status.rs
@@ -3,7 +3,7 @@ use serde_json::json;
 
 use crate::config::Config;
 use crate::system;
-use crate::system::packages::PackageState;
+use crate::system::packages::{PackageDesiredState, PackageState};
 use crate::ui::table::MiseTable;
 
 /// Show the status of system packages from `[bootstrap.packages]`
@@ -55,28 +55,41 @@ impl SystemStatus {
             let mut json_pkgs = vec![];
             for s in statuses {
                 let auto_updates = s.state.auto_updates();
-                let (installed_version, state, reason) = match &s.state {
-                    PackageState::Installed { version } => {
+                let desired_absent = s.request.desired == PackageDesiredState::Absent;
+                let (installed_version, state, reason) = match (&s.state, desired_absent) {
+                    (PackageState::Missing, true) => ("".to_string(), "absent", None::<&str>),
+                    (PackageState::Installed { version }, true)
+                    | (PackageState::NeedsRepair { installed: version }, true)
+                    | (PackageState::VersionMismatch { installed: version }, true) => {
+                        any_missing = true;
+                        (version.clone(), "unexpectedly installed", None)
+                    }
+                    #[cfg(unix)]
+                    (PackageState::InstalledAutoUpdates { version }, true) => {
+                        any_missing = true;
+                        (version.clone(), "unexpectedly installed", None)
+                    }
+                    (PackageState::Installed { version }, false) => {
                         (version.clone(), "installed", None::<&str>)
                     }
                     #[cfg(unix)]
-                    PackageState::InstalledAutoUpdates { version } => {
+                    (PackageState::InstalledAutoUpdates { version }, false) => {
                         (version.clone(), "installed", None::<&str>)
                     }
-                    PackageState::Missing => {
+                    (PackageState::Missing, false) => {
                         any_missing = true;
                         ("".to_string(), "missing", None)
                     }
-                    PackageState::NeedsRepair { installed } => {
+                    (PackageState::NeedsRepair { installed }, false) => {
                         any_missing = true;
                         (installed.clone(), "needs repair", None)
                     }
-                    PackageState::VersionMismatch { installed } => {
+                    (PackageState::VersionMismatch { installed }, false) => {
                         any_missing = true;
                         (installed.clone(), "version mismatch", None)
                     }
                     #[cfg(unix)]
-                    PackageState::Unavailable { reason } => {
+                    (PackageState::Unavailable { reason }, _) => {
                         ("".to_string(), "skipped", Some(reason.as_str()))
                     }
                 };
@@ -84,6 +97,7 @@ impl SystemStatus {
                     let mut package = json!({
                         "package": s.request.name,
                         "requested_version": s.request.version.clone().unwrap_or_else(|| "latest".to_string()),
+                        "desired_state": if desired_absent { "absent" } else { "present" },
                         "state": state.replace(' ', "_"),
                         "installed_version": installed_version,
                     });

--- a/src/cli/system/status.rs
+++ b/src/cli/system/status.rs
@@ -37,7 +37,22 @@ impl SystemStatus {
                 if self.json {
                     json_out.insert(
                         name.to_string(),
-                        json!({ "available": false, "reason": reason }),
+                        json!({
+                            "available": false,
+                            "reason": reason,
+                            "packages": mp.requests.iter().map(|req| {
+                                json!({
+                                    "package": req.name,
+                                    "requested_version": req.version.clone().unwrap_or_else(|| "latest".to_string()),
+                                    "desired_state": match req.desired {
+                                        PackageDesiredState::Present => "present",
+                                        PackageDesiredState::Absent => "absent",
+                                    },
+                                    "state": "skipped",
+                                    "installed_version": "",
+                                })
+                            }).collect::<Vec<_>>(),
+                        }),
                     );
                 } else {
                     for req in &mp.requests {

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -832,17 +832,20 @@ impl MiseToml {
         version: &str,
     ) -> eyre::Result<()> {
         let packages = &mut self.bootstrap.get_or_insert_with(Default::default).packages;
-        let preserve_options = match packages.get_mut(spec) {
+        let (preserve_options, reset_absent) = match packages.get_mut(spec) {
             Some(PackageTomlConfig::Options(options)) => {
                 options.version = version.to_string();
-                true
+                let reset_absent =
+                    options.state == crate::system::PackageDesiredStateTomlConfig::Absent;
+                options.state = crate::system::PackageDesiredStateTomlConfig::Present;
+                (true, reset_absent)
             }
             _ => {
                 packages.insert(
                     spec.to_string(),
                     PackageTomlConfig::Version(version.to_string()),
                 );
-                false
+                (false, false)
             }
         };
         let mut doc = self.doc_mut()?;
@@ -863,10 +866,16 @@ impl MiseToml {
         if preserve_options && let Some(item) = packages.get_mut(spec) {
             if let Some(options) = item.as_value_mut().and_then(Value::as_inline_table_mut) {
                 options.insert("version", Value::from(version));
+                if reset_absent {
+                    options.insert("state", Value::from("present"));
+                }
                 return Ok(());
             }
             if item.as_table().is_some() {
                 insert_preserving_decor(item, "version", value(version));
+                if reset_absent {
+                    insert_preserving_decor(item, "state", value("present"));
+                }
                 return Ok(());
             }
         }
@@ -896,6 +905,7 @@ impl MiseToml {
         {
             let mut options = options.clone();
             options.version = version.to_string();
+            options.state = crate::system::PackageDesiredStateTomlConfig::Present;
             self.bootstrap
                 .get_or_insert_with(Default::default)
                 .packages
@@ -3660,6 +3670,7 @@ mod tests {
             [bootstrap.packages]
             "brew:ripgrep" = {{ version = "14.0.0", os = ["macos"] }} # keep me
             "apt:curl" = "8.5.0"
+            "pacman:libreoffice-fresh" = {{ state = "absent" }}
 
             [bootstrap.packages."brew:fd"]
             version = "10.0.0" # keep version comment
@@ -3671,6 +3682,8 @@ mod tests {
         cf.update_bootstrap_package("brew:ripgrep", "latest")
             .unwrap();
         cf.update_bootstrap_package("brew:fd", "latest").unwrap();
+        cf.update_bootstrap_package("pacman:libreoffice-fresh", "latest")
+            .unwrap();
         #[cfg(unix)]
         {
             let inherited = cf
@@ -3689,6 +3702,7 @@ mod tests {
                         version: "1.0.0".to_string(),
                         os: vec![],
                         adopt: None,
+                        state: crate::system::PackageDesiredStateTomlConfig::Present,
                     });
                 cf.update_bootstrap_package_with_fallback(
                     "brew:tree",
@@ -3711,6 +3725,12 @@ mod tests {
         assert!(
             dump.contains(r#"os = ["macos"] # keep selector comment"#),
             "nested package selectors should survive: {dump}"
+        );
+        assert!(
+            dump.contains(
+                r#""pacman:libreoffice-fresh" = { state = "present", version = "latest" }"#
+            ),
+            "using an absent package should make it present: {dump}"
         );
         #[cfg(unix)]
         assert!(

--- a/src/oci/packages.rs
+++ b/src/oci/packages.rs
@@ -818,6 +818,7 @@ mod tests {
             name: name.to_string(),
             version: version.map(str::to_string),
             tap_url: None,
+            desired: crate::system::packages::PackageDesiredState::Present,
         }
     }
 

--- a/src/system/deps.rs
+++ b/src/system/deps.rs
@@ -570,6 +570,7 @@ pub(crate) async fn build_requests(
                         name: pkg,
                         version: None,
                         tap_url: None,
+                        desired: crate::system::packages::PackageDesiredState::Present,
                     });
                 }
             }

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -154,6 +154,16 @@ pub(crate) struct PackageOptionsTomlConfig {
     /// Adopt an identical existing cask artifact instead of replacing it.
     #[serde(default)]
     pub adopt: Option<bool>,
+    #[serde(default)]
+    pub state: PackageDesiredStateTomlConfig,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum PackageDesiredStateTomlConfig {
+    #[default]
+    Present,
+    Absent,
 }
 
 impl PackageTomlConfig {
@@ -168,6 +178,16 @@ impl PackageTomlConfig {
         match self {
             Self::Options(options) => options.adopt,
             Self::Version(_) => None,
+        }
+    }
+
+    fn desired(&self) -> packages::PackageDesiredState {
+        match self {
+            Self::Version(_) => packages::PackageDesiredState::Present,
+            Self::Options(options) => match options.state {
+                PackageDesiredStateTomlConfig::Present => packages::PackageDesiredState::Present,
+                PackageDesiredStateTomlConfig::Absent => packages::PackageDesiredState::Absent,
+            },
         }
     }
 
@@ -358,6 +378,7 @@ pub(crate) fn parse_use_spec(spec: &str) -> eyre::Result<(String, PackageRequest
                 name: rest.to_string(),
                 version: None,
                 tap_url: None,
+                desired: packages::PackageDesiredState::Present,
             },
         ));
     }
@@ -368,6 +389,7 @@ pub(crate) fn parse_use_spec(spec: &str) -> eyre::Result<(String, PackageRequest
                 name: name.to_string(),
                 version: (version != "latest").then(|| version.to_string()),
                 tap_url: None,
+                desired: packages::PackageDesiredState::Present,
             },
         )),
         Some(_) => {
@@ -379,6 +401,7 @@ pub(crate) fn parse_use_spec(spec: &str) -> eyre::Result<(String, PackageRequest
                 name: rest.to_string(),
                 version: None,
                 tap_url: None,
+                desired: packages::PackageDesiredState::Present,
             },
         )),
     }
@@ -632,6 +655,7 @@ fn package_requests_from_config_files(
                     name,
                     version,
                     tap_url,
+                    desired: package.desired(),
                 });
             }
             Err(err) => warn!("[bootstrap.packages]: {err}"),
@@ -1498,6 +1522,7 @@ pub(crate) fn packages_from_specs_with_config(
             name,
             version: None,
             tap_url,
+            desired: packages::PackageDesiredState::Present,
         };
         if !requests.contains(&request) {
             requests.push(request);
@@ -1705,6 +1730,30 @@ mod tests {
                 ("ffmpeg", None),
             ]
         );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn package_table_form_parses_absent_state() -> Result<()> {
+        let (_dir, config_files) = config_map_from_toml(&[(
+            "mise.toml",
+            r#"
+                [bootstrap.packages]
+                "pacman:libreoffice-fresh" = { state = "absent" }
+            "#,
+        )])?;
+        let pacman = packages_from_config_files(&config_files)
+            .into_iter()
+            .find(|packages| packages.manager.name() == "pacman")
+            .unwrap();
+
+        assert_eq!(pacman.requests.len(), 1);
+        assert_eq!(
+            pacman.requests[0].desired,
+            packages::PackageDesiredState::Absent
+        );
+        assert_eq!(pacman.requests[0].version, None);
         Ok(())
     }
 

--- a/src/system/packages/apk.rs
+++ b/src/system/packages/apk.rs
@@ -134,6 +134,7 @@ mod tests {
             name: name.to_string(),
             version: version.map(str::to_string),
             tap_url: None,
+            desired: crate::system::packages::PackageDesiredState::Present,
         }
     }
 

--- a/src/system/packages/apt.rs
+++ b/src/system/packages/apt.rs
@@ -282,6 +282,7 @@ mod tests {
             name: name.to_string(),
             version: version.map(str::to_string),
             tap_url: None,
+            desired: crate::system::packages::PackageDesiredState::Present,
         }
     }
 

--- a/src/system/packages/brew/cask/mod.rs
+++ b/src/system/packages/brew/cask/mod.rs
@@ -520,6 +520,7 @@ impl BrewCaskManager {
                     name: name.clone(),
                     version: None,
                     tap_url: None,
+                    desired: super::super::PackageDesiredState::Present,
                 })
                 .collect::<Vec<_>>();
             super::BrewManager::new()
@@ -531,6 +532,7 @@ impl BrewCaskManager {
                 name: dependency.clone(),
                 version: None,
                 tap_url: None,
+                desired: super::super::PackageDesiredState::Present,
             };
             Box::pin(self.install_one_with_ancestors(
                 &request,

--- a/src/system/packages/brew/cask/state.rs
+++ b/src/system/packages/brew/cask/state.rs
@@ -656,6 +656,7 @@ pub(super) fn extend_cask_dependency_closure(
             tap_url: dependency_tap_url(request, &name),
             name,
             version: None,
+            desired: super::super::super::PackageDesiredState::Present,
         };
         closure
             .formulae
@@ -666,6 +667,7 @@ pub(super) fn extend_cask_dependency_closure(
         tap_url: dependency_tap_url(request, &name),
         name,
         version: None,
+        desired: super::super::super::PackageDesiredState::Present,
     }));
 }
 

--- a/src/system/packages/brew/cask/tests.rs
+++ b/src/system/packages/brew/cask/tests.rs
@@ -111,6 +111,7 @@ fn cask_dependency_closure_collects_formulae_and_transitive_casks() {
         name: "acme/tools/root".to_string(),
         version: None,
         tap_url: Some("https://github.com/acme/custom-tools.git".to_string()),
+        desired: crate::system::packages::PackageDesiredState::Present,
     };
     extend_cask_dependency_closure(&mut closure, &mut pending, &root_request, root.clone());
     assert_eq!(pending.len(), 1);
@@ -139,6 +140,7 @@ fn cask_dependency_closure_collects_formulae_and_transitive_casks() {
     );
     let standard_tap_request = PackageRequest {
         tap_url: None,
+        desired: crate::system::packages::PackageDesiredState::Present,
         ..root_request
     };
     assert_eq!(
@@ -173,6 +175,7 @@ fn cask_dependency_closure_keeps_duplicate_names_from_each_tap() {
             name: format!("{owner}/tools/shared"),
             version: None,
             tap_url: Some(tap_url.to_string()),
+            desired: crate::system::packages::PackageDesiredState::Present,
         };
         extend_cask_dependency_closure(&mut closure, &mut pending, &request, root);
     }
@@ -404,6 +407,7 @@ fn externally_managed_version_precedes_artifact_parsing() -> Result<()> {
         name: cask.token.clone(),
         version: None,
         tap_url: None,
+        desired: crate::system::packages::PackageDesiredState::Present,
     };
 
     assert_eq!(
@@ -432,6 +436,7 @@ fn both_receipt_types_satisfy_installed_state_without_mutation() -> Result<()> {
         name: cask.token.clone(),
         version: None,
         tap_url: None,
+        desired: crate::system::packages::PackageDesiredState::Present,
     };
 
     assert_eq!(
@@ -465,6 +470,7 @@ fn mise_owned_state_validates_artifacts_before_receipt() -> Result<()> {
         name: cask.token.clone(),
         version: None,
         tap_url: None,
+        desired: crate::system::packages::PackageDesiredState::Present,
     };
 
     let error = package_state(&request, &cask).unwrap_err();
@@ -487,6 +493,7 @@ fn mise_owned_state_validates_platform_before_receipt() -> Result<()> {
         name: cask.token.clone(),
         version: None,
         tap_url: None,
+        desired: crate::system::packages::PackageDesiredState::Present,
     };
 
     assert!(matches!(

--- a/src/system/packages/brew/pour.rs
+++ b/src/system/packages/brew/pour.rs
@@ -1003,6 +1003,7 @@ mod tests {
             name: "foo".to_string(),
             version: None,
             tap_url: None,
+            desired: crate::system::packages::PackageDesiredState::Present,
         };
         let keg_inode = keg.metadata()?.ino();
         let receipt_modified = keg.join("INSTALL_RECEIPT.json").metadata()?.modified()?;

--- a/src/system/packages/dnf.rs
+++ b/src/system/packages/dnf.rs
@@ -166,6 +166,7 @@ mod tests {
             name: name.to_string(),
             version: version.map(str::to_string),
             tap_url: None,
+            desired: crate::system::packages::PackageDesiredState::Present,
         }
     }
 

--- a/src/system/packages/flatpak.rs
+++ b/src/system/packages/flatpak.rs
@@ -190,6 +190,7 @@ mod tests {
             name: name.to_string(),
             version: version.map(str::to_string),
             tap_url: None,
+            desired: crate::system::packages::PackageDesiredState::Present,
         }
     }
 

--- a/src/system/packages/mas.rs
+++ b/src/system/packages/mas.rs
@@ -315,6 +315,7 @@ mod tests {
             name: name.to_string(),
             version: version.map(str::to_string),
             tap_url: None,
+            desired: crate::system::packages::PackageDesiredState::Present,
         }
     }
 

--- a/src/system/packages/mod.rs
+++ b/src/system/packages/mod.rs
@@ -35,6 +35,16 @@ pub(crate) struct PackageRequest {
     /// and casks: `[bootstrap.brew.taps]` can attach a git URL to
     /// `owner/tap/name`.
     pub tap_url: Option<String>,
+    /// Desired declarative state. Explicit CLI package requests are always
+    /// present; table-form config entries may request removal.
+    pub desired: PackageDesiredState,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub(crate) enum PackageDesiredState {
+    #[default]
+    Present,
+    Absent,
 }
 
 impl std::fmt::Display for PackageRequest {
@@ -178,6 +188,18 @@ pub(crate) trait SystemPackageManager: Send + Sync {
 
     /// Install the given packages (already filtered to missing, mismatched, or repairable).
     async fn install(&self, pkgs: &[PackageRequest], opts: &InstallOpts) -> Result<()>;
+
+    /// Remove packages declared with `state = "absent"`.
+    async fn remove(&self, _pkgs: &[PackageRequest], _opts: &InstallOpts) -> Result<()> {
+        eyre::bail!(
+            "{} does not support declarative package removal",
+            self.name()
+        )
+    }
+
+    fn supports_remove(&self) -> bool {
+        false
+    }
 
     /// Install with manager-specific declarative options. Managers without
     /// additional package options use the ordinary install path unchanged.

--- a/src/system/packages/pacman.rs
+++ b/src/system/packages/pacman.rs
@@ -76,11 +76,17 @@ fn package_state(req: &PackageRequest, version: &str) -> PackageState {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct PacmanProvide {
+    name: String,
+    version: Option<String>,
+}
+
 #[derive(Debug, PartialEq, Eq)]
 struct PacmanPackageMetadata {
     name: String,
     version: String,
-    provides: HashSet<String>,
+    provides: HashSet<PacmanProvide>,
 }
 
 fn parse_pacman_info(output: &str) -> Vec<PacmanPackageMetadata> {
@@ -119,31 +125,74 @@ fn parse_pacman_info(output: &str) -> Vec<PacmanPackageMetadata> {
     packages
 }
 
-fn parse_provides(value: &str) -> impl Iterator<Item = String> + '_ {
+fn parse_provides(value: &str) -> impl Iterator<Item = PacmanProvide> + '_ {
     value
         .split_whitespace()
         .filter(|provide| *provide != "None")
         .map(|provide| {
-            provide
-                .split(['<', '=', '>'])
-                .next()
-                .unwrap_or(provide)
-                .to_string()
+            let (name, version) = provide
+                .split_once('=')
+                .map(|(name, version)| (name, Some(version.to_string())))
+                .unwrap_or_else(|| (provide.split(['<', '>']).next().unwrap_or(provide), None));
+            PacmanProvide {
+                name: name.to_string(),
+                version,
+            }
         })
 }
 
 fn find_provider<'a>(
     packages: &'a [PacmanPackageMetadata],
-    requested: &str,
+    request: &PackageRequest,
+    constraint_satisfied: bool,
+    eligible: impl Fn(&PacmanPackageMetadata) -> bool,
 ) -> Option<&'a PacmanPackageMetadata> {
     packages
         .iter()
-        .find(|package| package.name == requested)
+        .filter(|package| eligible(package))
+        .find(|package| {
+            package.name == request.name
+                && (!constraint_satisfied
+                    || request
+                        .version
+                        .as_ref()
+                        .is_none_or(|version| version_matches(version, &package.version)))
+        })
         .or_else(|| {
             packages
                 .iter()
-                .find(|package| package.provides.contains(requested))
+                .filter(|package| eligible(package))
+                .find(|package| {
+                    package.provides.iter().any(|provide| {
+                        provide.name == request.name
+                            && (!constraint_satisfied
+                                || request.version.as_ref().is_none_or(|version| {
+                                    provide
+                                        .version
+                                        .as_ref()
+                                        .is_some_and(|provided| version_matches(version, provided))
+                                }))
+                    })
+                })
         })
+}
+
+fn matching_provider_names(packages: &[PacmanPackageMetadata], requested: &str) -> Vec<String> {
+    packages
+        .iter()
+        .filter(|package| {
+            package.name == requested
+                || package
+                    .provides
+                    .iter()
+                    .any(|provide| provide.name == requested)
+        })
+        .map(|package| package.name.clone())
+        .collect()
+}
+
+fn version_matches(requested: &str, installed: &str) -> bool {
+    installed == requested || installed.starts_with(&format!("{requested}-"))
 }
 
 fn parse_pacman_deptest(output: &str) -> HashSet<&str> {
@@ -174,16 +223,19 @@ fn remove_args(names: &[String]) -> Vec<String> {
 async fn concrete_remove_names(pkgs: &[PackageRequest]) -> Result<Vec<String>> {
     let info = pacman_info().await?;
     let packages = parse_pacman_info(&info);
-    let mut names = Vec::with_capacity(pkgs.len());
+    let mut names = Vec::new();
     for pkg in pkgs {
-        let provider = find_provider(&packages, &pkg.name).ok_or_else(|| {
-            eyre::eyre!(
+        let providers = matching_provider_names(&packages, &pkg.name);
+        if providers.is_empty() {
+            return Err(eyre::eyre!(
                 "pacman -Qi returned no provider for satisfied requirement '{}'",
                 pkg.name
-            )
-        })?;
-        if !names.iter().any(|existing| existing == &provider.name) {
-            names.push(provider.name.clone());
+            ));
+        }
+        for provider in providers {
+            if !names.contains(&provider) {
+                names.push(provider);
+            }
         }
     }
     Ok(names)
@@ -194,12 +246,13 @@ fn apply_provider_query<'a>(
     packages: &'a [PacmanPackageMetadata],
     constraint_satisfied: bool,
 ) -> Result<&'a PacmanPackageMetadata> {
-    let provider = find_provider(packages, &status.request.name).ok_or_else(|| {
-        eyre::eyre!(
-            "pacman -Qi returned no provider for satisfied requirement '{}'",
-            status.request.name
-        )
-    })?;
+    let provider = find_provider(packages, &status.request, constraint_satisfied, |_| true)
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "pacman -Qi returned no provider for satisfied requirement '{}'",
+                status.request.name
+            )
+        })?;
     // The provider's package version is display metadata; pacman -T evaluates
     // the requested version against the version declared in Provides.
     status.state = if constraint_satisfied {
@@ -517,8 +570,18 @@ mod tests {
         let provider = apply_provider_query(&mut status, &packages, true).unwrap();
 
         assert_eq!(provider.name, "percona-server-clients");
-        assert!(provider.provides.contains("mariadb-clients"));
-        assert!(provider.provides.contains("mysql-clients"));
+        assert!(
+            provider
+                .provides
+                .iter()
+                .any(|provide| provide.name == "mariadb-clients")
+        );
+        assert!(
+            provider
+                .provides
+                .iter()
+                .any(|provide| provide.name == "mysql-clients")
+        );
         assert_eq!(
             status.state,
             PackageState::Installed {
@@ -539,7 +602,30 @@ mod tests {
              Provides        : None\n",
         );
 
-        assert_eq!(find_provider(&packages, "foo").unwrap().name, "foo");
+        assert_eq!(
+            find_provider(&packages, &req("foo", None), true, |_| true)
+                .unwrap()
+                .name,
+            "foo"
+        );
+    }
+
+    #[test]
+    fn test_matching_provider_names_returns_every_provider() {
+        let packages = parse_pacman_info(
+            "Name            : foo-one\n\
+             Version         : 1.0-1\n\
+             Provides        : foo\n\
+             \n\
+             Name            : foo-two\n\
+             Version         : 2.0-1\n\
+             Provides        : foo\n",
+        );
+
+        assert_eq!(
+            matching_provider_names(&packages, "foo"),
+            ["foo-one", "foo-two"]
+        );
     }
 
     #[test]

--- a/src/system/packages/pacman.rs
+++ b/src/system/packages/pacman.rs
@@ -156,7 +156,7 @@ fn find_provider<'a>(
                     || request
                         .version
                         .as_ref()
-                        .is_none_or(|version| version_matches(version, &package.version)))
+                        .is_none_or(|version| pacman_version_matches(version, &package.version)))
         })
         .or_else(|| {
             packages
@@ -167,10 +167,9 @@ fn find_provider<'a>(
                         provide.name == request.name
                             && (!constraint_satisfied
                                 || request.version.as_ref().is_none_or(|version| {
-                                    provide
-                                        .version
-                                        .as_ref()
-                                        .is_some_and(|provided| version_matches(version, provided))
+                                    provide.version.as_ref().is_some_and(|provided| {
+                                        pacman_version_matches(version, provided)
+                                    })
                                 }))
                     })
                 })
@@ -191,8 +190,22 @@ fn matching_provider_names(packages: &[PacmanPackageMetadata], requested: &str) 
         .collect()
 }
 
-fn version_matches(requested: &str, installed: &str) -> bool {
-    installed == requested || installed.starts_with(&format!("{requested}-"))
+fn pacman_version_matches(requested: &str, provided: &str) -> bool {
+    // vercmp ships with pacman and uses the same libalpm version ordering as
+    // dependency resolution. It intentionally considers e.g. 2.0 and
+    // 2.0-13 equal, which a textual comparison cannot model correctly.
+    match std::process::Command::new("vercmp")
+        .args([provided, requested])
+        .stdin(Stdio::null())
+        .output()
+    {
+        Ok(output) if output.status.success() => {
+            String::from_utf8_lossy(&output.stdout).trim() == "0"
+        }
+        // Unit tests and non-Arch development hosts do not necessarily have
+        // vercmp. A real pacman installation always supplies it.
+        _ => provided == requested || provided.starts_with(&format!("{requested}-")),
+    }
 }
 
 fn parse_pacman_deptest(output: &str) -> HashSet<&str> {

--- a/src/system/packages/pacman.rs
+++ b/src/system/packages/pacman.rs
@@ -76,8 +76,69 @@ fn package_state(req: &PackageRequest, version: &str) -> PackageState {
     }
 }
 
-fn parse_pacman_package(output: &str) -> Option<(&str, &str)> {
-    output.lines().find_map(|line| line.split_once(' '))
+#[derive(Debug, PartialEq, Eq)]
+struct PacmanPackageMetadata {
+    name: String,
+    version: String,
+    provides: HashSet<String>,
+}
+
+fn parse_pacman_info(output: &str) -> Vec<PacmanPackageMetadata> {
+    let mut packages = Vec::new();
+    let mut name = None;
+    let mut version = None;
+    let mut provides = HashSet::new();
+    let mut reading_provides = false;
+    for line in output.lines().chain(std::iter::once("")) {
+        if line.trim().is_empty() {
+            if let (Some(name), Some(version)) = (name.take(), version.take()) {
+                packages.push(PacmanPackageMetadata {
+                    name,
+                    version,
+                    provides: std::mem::take(&mut provides),
+                });
+            }
+            reading_provides = false;
+            continue;
+        }
+        if let Some((key, value)) = line.split_once(':') {
+            reading_provides = false;
+            match key.trim() {
+                "Name" => name = Some(value.trim().to_string()),
+                "Version" => version = Some(value.trim().to_string()),
+                "Provides" => {
+                    reading_provides = true;
+                    provides.extend(parse_provides(value));
+                }
+                _ => {}
+            }
+        } else if reading_provides {
+            provides.extend(parse_provides(line));
+        }
+    }
+    packages
+}
+
+fn parse_provides(value: &str) -> impl Iterator<Item = String> + '_ {
+    value
+        .split_whitespace()
+        .filter(|provide| *provide != "None")
+        .map(|provide| {
+            provide
+                .split(['<', '=', '>'])
+                .next()
+                .unwrap_or(provide)
+                .to_string()
+        })
+}
+
+fn find_provider<'a>(
+    packages: &'a [PacmanPackageMetadata],
+    requested: &str,
+) -> Option<&'a PacmanPackageMetadata> {
+    packages
+        .iter()
+        .find(|package| package.name == requested || package.provides.contains(requested))
 }
 
 fn parse_pacman_deptest(output: &str) -> HashSet<&str> {
@@ -106,14 +167,18 @@ fn remove_args(names: &[String]) -> Vec<String> {
 }
 
 async fn concrete_remove_names(pkgs: &[PackageRequest]) -> Result<Vec<String>> {
+    let info = pacman_info().await?;
+    let packages = parse_pacman_info(&info);
     let mut names = Vec::with_capacity(pkgs.len());
     for pkg in pkgs {
-        let output = pacman_query(std::slice::from_ref(&pkg.name)).await?;
-        let Some((name, _)) = parse_pacman_package(&output) else {
-            bail!("pacman -Q returned no installed package for '{}'", pkg.name);
-        };
-        if !names.iter().any(|existing| existing == name) {
-            names.push(name.to_string());
+        let provider = find_provider(&packages, &pkg.name).ok_or_else(|| {
+            eyre::eyre!(
+                "pacman -Qi returned no provider for satisfied requirement '{}'",
+                pkg.name
+            )
+        })?;
+        if !names.iter().any(|existing| existing == &provider.name) {
+            names.push(provider.name.clone());
         }
     }
     Ok(names)
@@ -121,27 +186,47 @@ async fn concrete_remove_names(pkgs: &[PackageRequest]) -> Result<Vec<String>> {
 
 fn apply_provider_query<'a>(
     status: &mut PackageStatus,
-    output: &'a str,
+    packages: &'a [PacmanPackageMetadata],
     constraint_satisfied: bool,
-) -> Result<&'a str> {
-    let Some((provider, version)) = parse_pacman_package(output) else {
-        bail!(
-            "pacman -Q returned no package for satisfied requirement '{}'",
+) -> Result<&'a PacmanPackageMetadata> {
+    let provider = find_provider(packages, &status.request.name).ok_or_else(|| {
+        eyre::eyre!(
+            "pacman -Qi returned no provider for satisfied requirement '{}'",
             status.request.name
-        );
-    };
+        )
+    })?;
     // The provider's package version is display metadata; pacman -T evaluates
     // the requested version against the version declared in Provides.
     status.state = if constraint_satisfied {
         PackageState::Installed {
-            version: version.to_string(),
+            version: provider.version.clone(),
         }
     } else {
         PackageState::VersionMismatch {
-            installed: version.to_string(),
+            installed: provider.version.clone(),
         }
     };
     Ok(provider)
+}
+
+async fn pacman_info() -> Result<String> {
+    let args = ["-Qi"];
+    debug!("$ pacman {}", args.join(" "));
+    let output = tokio::process::Command::new("pacman")
+        .args(args)
+        .env("LC_ALL", "C")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await?;
+    if !output.status.success() {
+        bail!(
+            "pacman -Qi failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
 async fn pacman_query(names: &[String]) -> Result<String> {
@@ -233,10 +318,9 @@ impl SystemPackageManager for PacmanManager {
             return Ok(statuses);
         }
 
-        // A bare query may answer a virtual package target under the installed
-        // provider's real name. Deptest tells us which apparent misses are
-        // genuinely unsatisfied; query the provider-satisfied names one at a
-        // time so their returned versions can be associated positionally.
+        // Deptest tells us which apparent misses are genuinely unsatisfied.
+        // Package metadata below maps satisfied virtual names back to their
+        // concrete installed providers.
         let deptest = pacman_deptest(&apparent_missing).await?;
         let unsatisfied = parse_pacman_deptest(&deptest);
         // A failed version constraint can still have a provider for the bare
@@ -251,6 +335,8 @@ impl SystemPackageManager for PacmanManager {
             .collect::<Vec<_>>();
         let bare_deptest = pacman_deptest(&versioned_unsatisfied).await?;
         let bare_missing = parse_pacman_deptest(&bare_deptest);
+        let info = pacman_info().await?;
+        let packages = parse_pacman_info(&info);
         for status in statuses
             .iter_mut()
             .filter(|status| matches!(status.state, PackageState::Missing))
@@ -263,11 +349,10 @@ impl SystemPackageManager for PacmanManager {
             {
                 continue;
             }
-            let output = pacman_query(std::slice::from_ref(&status.request.name)).await?;
-            let provider = apply_provider_query(status, &output, constraint_satisfied)?;
+            let provider = apply_provider_query(status, &packages, constraint_satisfied)?;
             debug!(
-                "pacman: {} is satisfied by installed provider {provider}",
-                status.request.name
+                "pacman: {} is satisfied by installed provider {}",
+                status.request.name, provider.name,
             );
         }
         Ok(statuses)
@@ -417,10 +502,18 @@ mod tests {
 
         // pacman -T validated the version declared by Provides even though the
         // provider package has a different version of its own.
-        let provider =
-            apply_provider_query(&mut status, "percona-server-clients 9.7.1_1-1\n", true).unwrap();
+        let packages = parse_pacman_info(
+            "Name            : percona-server-clients\n\
+             Version         : 9.7.1_1-1\n\
+             Provides        : mariadb-clients=12.3.2\n\
+                               mysql-clients\n\
+             Description     : database clients\n",
+        );
+        let provider = apply_provider_query(&mut status, &packages, true).unwrap();
 
-        assert_eq!(provider, "percona-server-clients");
+        assert_eq!(provider.name, "percona-server-clients");
+        assert!(provider.provides.contains("mariadb-clients"));
+        assert!(provider.provides.contains("mysql-clients"));
         assert_eq!(
             status.state,
             PackageState::Installed {
@@ -444,7 +537,12 @@ mod tests {
             state: PackageState::Missing,
         };
 
-        apply_provider_query(&mut status, "provider-package 2.0-1\n", false).unwrap();
+        let packages = parse_pacman_info(
+            "Name            : provider-package\n\
+             Version         : 2.0-1\n\
+             Provides        : virtual-package=1.0\n",
+        );
+        apply_provider_query(&mut status, &packages, false).unwrap();
 
         assert_eq!(
             status.state,

--- a/src/system/packages/pacman.rs
+++ b/src/system/packages/pacman.rs
@@ -95,14 +95,28 @@ fn deptest_requirement(req: &PackageRequest) -> String {
     }
 }
 
-fn remove_args(pkgs: &[PackageRequest]) -> Vec<String> {
+fn remove_args(names: &[String]) -> Vec<String> {
     let mut args = vec![
         "-R".to_string(),
         "--noconfirm".to_string(),
         "--".to_string(),
     ];
-    args.extend(pkgs.iter().map(|p| p.name.clone()));
+    args.extend(names.iter().cloned());
     args
+}
+
+async fn concrete_remove_names(pkgs: &[PackageRequest]) -> Result<Vec<String>> {
+    let mut names = Vec::with_capacity(pkgs.len());
+    for pkg in pkgs {
+        let output = pacman_query(std::slice::from_ref(&pkg.name)).await?;
+        let Some((name, _)) = parse_pacman_package(&output) else {
+            bail!("pacman -Q returned no installed package for '{}'", pkg.name);
+        };
+        if !names.iter().any(|existing| existing == name) {
+            names.push(name.to_string());
+        }
+    }
+    Ok(names)
 }
 
 fn apply_provider_query<'a>(
@@ -296,7 +310,11 @@ impl SystemPackageManager for PacmanManager {
     }
 
     async fn remove(&self, pkgs: &[PackageRequest], opts: &InstallOpts) -> Result<()> {
-        let args = remove_args(pkgs);
+        // A request may name a virtual capability satisfied through Provides.
+        // Resolve each target through the local database immediately before
+        // removal so pacman receives the concrete installed package identity.
+        let names = concrete_remove_names(pkgs).await?;
+        let args = remove_args(&names);
         if opts.dry_run {
             miseprintln!("{}", sudo::argv("pacman", &args).join(" "));
             return Ok(());
@@ -414,7 +432,7 @@ mod tests {
     #[test]
     fn test_remove_args_remove_exact_packages_without_cascading() {
         assert_eq!(
-            remove_args(&[req("omarchy", None), req("omarchy-settings", None)]),
+            remove_args(&["omarchy".to_string(), "omarchy-settings".to_string()]),
             ["-R", "--noconfirm", "--", "omarchy", "omarchy-settings"]
         );
     }

--- a/src/system/packages/pacman.rs
+++ b/src/system/packages/pacman.rs
@@ -138,7 +138,12 @@ fn find_provider<'a>(
 ) -> Option<&'a PacmanPackageMetadata> {
     packages
         .iter()
-        .find(|package| package.name == requested || package.provides.contains(requested))
+        .find(|package| package.name == requested)
+        .or_else(|| {
+            packages
+                .iter()
+                .find(|package| package.provides.contains(requested))
+        })
 }
 
 fn parse_pacman_deptest(output: &str) -> HashSet<&str> {
@@ -520,6 +525,21 @@ mod tests {
                 version: "9.7.1_1-1".to_string()
             }
         );
+    }
+
+    #[test]
+    fn test_find_provider_prefers_exact_package_name() {
+        let packages = parse_pacman_info(
+            "Name            : alternate-foo\n\
+             Version         : 2.0-1\n\
+             Provides        : foo\n\
+             \n\
+             Name            : foo\n\
+             Version         : 1.0-1\n\
+             Provides        : None\n",
+        );
+
+        assert_eq!(find_provider(&packages, "foo").unwrap().name, "foo");
     }
 
     #[test]

--- a/src/system/packages/pacman.rs
+++ b/src/system/packages/pacman.rs
@@ -95,6 +95,16 @@ fn deptest_requirement(req: &PackageRequest) -> String {
     }
 }
 
+fn remove_args(pkgs: &[PackageRequest]) -> Vec<String> {
+    let mut args = vec![
+        "-R".to_string(),
+        "--noconfirm".to_string(),
+        "--".to_string(),
+    ];
+    args.extend(pkgs.iter().map(|p| p.name.clone()));
+    args
+}
+
 fn apply_provider_query<'a>(
     status: &mut PackageStatus,
     output: &'a str,
@@ -281,6 +291,19 @@ impl SystemPackageManager for PacmanManager {
         sudo::run("pacman", &args, &[])
     }
 
+    fn supports_remove(&self) -> bool {
+        true
+    }
+
+    async fn remove(&self, pkgs: &[PackageRequest], opts: &InstallOpts) -> Result<()> {
+        let args = remove_args(pkgs);
+        if opts.dry_run {
+            miseprintln!("{}", sudo::argv("pacman", &args).join(" "));
+            return Ok(());
+        }
+        sudo::run("pacman", &args, &[])
+    }
+
     async fn upgrade(&self, pkgs: &[PackageRequest], opts: &InstallOpts) -> Result<()> {
         let names = pkgs.iter().map(|pkg| pkg.name.clone()).collect::<Vec<_>>();
         let stdout = pacman_query(&names).await?;
@@ -330,6 +353,7 @@ mod tests {
             name: name.to_string(),
             version: version.map(str::to_string),
             tap_url: None,
+            desired: crate::system::packages::PackageDesiredState::Present,
         }
     }
 
@@ -384,6 +408,14 @@ mod tests {
             PackageState::Installed {
                 version: "9.7.1_1-1".to_string()
             }
+        );
+    }
+
+    #[test]
+    fn test_remove_args_remove_exact_packages_without_cascading() {
+        assert_eq!(
+            remove_args(&[req("omarchy", None), req("omarchy-settings", None)]),
+            ["-R", "--noconfirm", "--", "omarchy", "omarchy-settings"]
         );
     }
 

--- a/src/system/packages/plugin.rs
+++ b/src/system/packages/plugin.rs
@@ -60,6 +60,7 @@ impl PackagePluginState {
                 name: name.clone(),
                 version: owned.version.clone(),
                 tap_url: None,
+                desired: crate::system::packages::PackageDesiredState::Present,
             })
             .collect()
     }
@@ -375,6 +376,7 @@ impl PackagePluginManager {
                     name: status.request.name,
                     version: Some(version),
                     tap_url: None,
+                    desired: crate::system::packages::PackageDesiredState::Present,
                 }),
                 None if matches!(status.state, PackageState::Missing) => {
                     stale.push(status.request.name);
@@ -403,6 +405,7 @@ impl PackagePluginManager {
                     name: name.clone(),
                     version: owned.version.clone(),
                     tap_url: None,
+                    desired: crate::system::packages::PackageDesiredState::Present,
                 })
             })
             .collect::<Vec<_>>();
@@ -428,6 +431,7 @@ impl PackagePluginManager {
                     name: status.request.name.clone(),
                     version: Some(version),
                     tap_url: None,
+                    desired: crate::system::packages::PackageDesiredState::Present,
                 })
             })
             .collect::<Vec<_>>();
@@ -718,6 +722,7 @@ mod tests {
             name: "keep".to_string(),
             version: Some("a-different-pin".to_string()),
             tap_url: None,
+            desired: crate::system::packages::PackageDesiredState::Present,
         }];
         assert_eq!(
             state("fake").prune_requests(&configured),
@@ -725,6 +730,7 @@ mod tests {
                 name: "remove".to_string(),
                 version: Some("release:edge".to_string()),
                 tap_url: None,
+                desired: crate::system::packages::PackageDesiredState::Present,
             }]
         );
     }
@@ -737,17 +743,20 @@ mod tests {
                 name: "remove".to_string(),
                 version: Some("release:edge".to_string()),
                 tap_url: None,
+                desired: crate::system::packages::PackageDesiredState::Present,
             },
             PackageRequest {
                 name: "not-owned".to_string(),
                 version: None,
                 tap_url: None,
+                desired: crate::system::packages::PackageDesiredState::Present,
             },
         ];
         let configured = vec![PackageRequest {
             name: "remove".to_string(),
             version: Some("newly-declared".to_string()),
             tap_url: None,
+            desired: crate::system::packages::PackageDesiredState::Present,
         }];
 
         assert_eq!(
@@ -770,6 +779,7 @@ mod tests {
                     name: "keep".to_string(),
                     version: Some("nightly-2026.08".to_string()),
                     tap_url: None,
+                    desired: crate::system::packages::PackageDesiredState::Present,
                 },
                 state: PackageState::Installed {
                     version: "nightly-2026.08".to_string(),
@@ -780,6 +790,7 @@ mod tests {
                     name: "manual".to_string(),
                     version: None,
                     tap_url: None,
+                    desired: crate::system::packages::PackageDesiredState::Present,
                 },
                 state: PackageState::Installed {
                     version: "release:edge".to_string(),
@@ -806,6 +817,7 @@ mod tests {
                     name: "keep".to_string(),
                     version: Some("nightly-2026.07".to_string()),
                     tap_url: None,
+                    desired: crate::system::packages::PackageDesiredState::Present,
                 },
                 state: PackageState::Installed {
                     version: "nightly-2026.07".to_string(),
@@ -816,6 +828,7 @@ mod tests {
                     name: "remove".to_string(),
                     version: Some("release:edge".to_string()),
                     tap_url: None,
+                    desired: crate::system::packages::PackageDesiredState::Present,
                 },
                 state: PackageState::Missing,
             },

--- a/src/system/resources.rs
+++ b/src/system/resources.rs
@@ -373,11 +373,16 @@ pub(crate) async fn plan(
         }
 
         let supports_version_pins = manager.supports_version_pins();
+        let supports_remove = manager.supports_remove();
         for status in manager.installed(&manager_packages.requests).await? {
             let id = ResourceId::new("package", format!("{manager_name}:{}", status.request.name));
             let desired = desired_package(&status.request);
-            let (current, action) =
-                package_resource_state(status.state, &status.request, supports_version_pins);
+            let (current, action) = package_resource_state(
+                status.state,
+                &status.request,
+                supports_version_pins,
+                supports_remove,
+            );
             plan.insert(ResourcePlan::new(id, current, desired, action))?;
         }
     }
@@ -648,6 +653,9 @@ fn add_account_dependencies(
 }
 
 fn desired_package(request: &super::packages::PackageRequest) -> String {
+    if request.desired == super::packages::PackageDesiredState::Absent {
+        return "absent".to_string();
+    }
     request
         .version
         .as_ref()
@@ -659,7 +667,36 @@ fn package_resource_state(
     state: PackageState,
     request: &PackageRequest,
     supports_version_pins: bool,
+    supports_remove: bool,
 ) -> (String, ResourceAction) {
+    if request.desired == super::packages::PackageDesiredState::Absent {
+        return match state {
+            PackageState::Missing => ("absent".to_string(), ResourceAction::Noop),
+            #[cfg(unix)]
+            PackageState::Unavailable { reason } => {
+                (format!("skipped ({reason})"), ResourceAction::Unknown)
+            }
+            PackageState::Installed { version }
+            | PackageState::NeedsRepair { installed: version }
+            | PackageState::VersionMismatch { installed: version } => (
+                format!("installed ({version})"),
+                if supports_remove {
+                    ResourceAction::Remove
+                } else {
+                    ResourceAction::Unknown
+                },
+            ),
+            #[cfg(unix)]
+            PackageState::InstalledAutoUpdates { version } => (
+                format!("installed ({version})"),
+                if supports_remove {
+                    ResourceAction::Remove
+                } else {
+                    ResourceAction::Unknown
+                },
+            ),
+        };
+    }
     let unsupported_pin = request.version.is_some() && !supports_version_pins;
     match state {
         PackageState::Installed { version } => {
@@ -739,6 +776,7 @@ mod tests {
             name: "example".to_string(),
             version: version.map(str::to_string),
             tap_url: None,
+            desired: crate::system::packages::PackageDesiredState::Present,
         }
     }
 
@@ -828,7 +866,7 @@ mod tests {
                 installed: "1.0.0".to_string(),
             },
         ] {
-            let (current, action) = package_resource_state(state, &request, false);
+            let (current, action) = package_resource_state(state, &request, false, false);
             assert_eq!(action, ResourceAction::Unknown);
             assert!(current.contains("cannot install pinned versions"));
         }
@@ -843,6 +881,7 @@ mod tests {
             },
             &request,
             false,
+            false,
         );
 
         assert_eq!(action, ResourceAction::Update);
@@ -851,16 +890,46 @@ mod tests {
     #[test]
     fn managers_with_pin_support_plan_missing_and_mismatched_packages() {
         let request = package_request(Some("1.2.3"));
-        let (_, missing_action) = package_resource_state(PackageState::Missing, &request, true);
+        let (_, missing_action) =
+            package_resource_state(PackageState::Missing, &request, true, false);
         let (_, mismatch_action) = package_resource_state(
             PackageState::VersionMismatch {
                 installed: "1.0.0".to_string(),
             },
             &request,
             true,
+            false,
         );
 
         assert_eq!(missing_action, ResourceAction::Create);
         assert_eq!(mismatch_action, ResourceAction::Update);
+    }
+
+    #[test]
+    fn absent_package_plans_removal_only_when_supported() {
+        let mut request = package_request(None);
+        request.desired = crate::system::packages::PackageDesiredState::Absent;
+        let (_, absent_action) =
+            package_resource_state(PackageState::Missing, &request, false, true);
+        let (_, remove_action) = package_resource_state(
+            PackageState::Installed {
+                version: "1.0.0".to_string(),
+            },
+            &request,
+            false,
+            true,
+        );
+        let (_, unsupported_action) = package_resource_state(
+            PackageState::Installed {
+                version: "1.0.0".to_string(),
+            },
+            &request,
+            false,
+            false,
+        );
+
+        assert_eq!(absent_action, ResourceAction::Noop);
+        assert_eq!(remove_action, ResourceAction::Remove);
+        assert_eq!(unsupported_action, ResourceAction::Unknown);
     }
 }


### PR DESCRIPTION
## Summary

- add `state = "absent"` to declarative bootstrap package entries
- plan, report, and apply exact non-cascading removals through pacman
- keep `mise packages use` intuitive by changing an absent entry back to present
- document compatibility with packages installed from configured third-party pacman repositories, including OPR

## Testing

- `mise run lint-fix`
- `mise run build`
- `MBX_DISABLE=1 mise exec -- cargo test --all-features --no-run`
- `MBX_DISABLE=1 mise exec -- cargo test --all-features absent`
- `MBX_DISABLE=1 mise exec -- cargo test --all-features test_remove_args_remove_exact_packages_without_cascading`
- `MBX_DISABLE=1 mise exec -- cargo test --all-features test_update_bootstrap_package_preserves_options`
- manually exercised status, plan, and dry-run apply against a fake pacman executable

## Notes

OPR packages require no special removal path: once installed, pacman exposes them through the same local package database as official repository packages.

The Cargo test compile passed with `MBX_DISABLE=1` after the transparent wrapper encountered missing cache blobs; the ordinary wrapped project build and lint checks passed.

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Apply can uninstall system packages via pacman (sudo), and status/doctor semantics changed for absent entries; scope is limited to pacman removal support today.
> 
> **Overview**
> Adds **`state = "absent"`** on `[bootstrap.packages]` table entries so a more local config can override a global pacman package and request removal. **`mise bootstrap packages apply`** now uninstalls those packages (with prompts/dry-run) via **`pacman -R --noconfirm`**, without cascading to dependents; other built-in managers still only support **`present`** and error if removal is requested.
> 
> Status, bootstrap plan JSON, and **`--missing`** treat **`desired_state`**: absent-and-not-installed is converged, but still-installed packages are drift (**`unexpectedly installed`**). Doctor, install throttling, and missing counts ignore absent entries. **`mise bootstrap packages use`** flips an absent entry back to **`present`** when you pin a version.
> 
> Pacman status/removal resolves virtual **`Provides`** using parsed **`pacman -Qi`** metadata (replacing per-name **`pacman -Q`** for providers). **`bootstrap packages apply`** is classified **destructive** in usage/docs because it can remove packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1178e8abf1039f2025c5bfc166cddea76bc33402. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pacman package declarations now support `state = "absent"` to remove installed packages.
  * Status and JSON reports show desired package states and flag unexpectedly installed packages.
  * Removal plans support dry runs and confirmation prompts without cascading to dependencies.

* **Bug Fixes**
  * Intentionally absent packages are no longer reported as missing.
  * Install and doctor checks count only packages requested to be present.

* **Documentation**
  * Added configuration examples and behavior details for declarative pacman package removal.
  * Package removal actions are now classified as destructive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->