### PR TITLE
fix(npm): support pnpm 12 global installs

### DIFF
--- a/e2e/backend/test_npm_package_manager
+++ b/e2e/backend/test_npm_package_manager
@@ -18,11 +18,9 @@ if ! command -v bun >/dev/null 2>&1; then
   assert_succeed "mise use bun@latest"
 fi
 
-# Ensure pnpm is available
-if ! command -v pnpm >/dev/null 2>&1; then
-  echo "pnpm not available in test environment, installing..."
-  assert_succeed "mise use pnpm@10.16.0"
-fi
+# Always exercise pnpm 12's environment-based global directory configuration.
+# pnpm 11 and earlier accept the CLI flags that mise continues to use for them.
+assert_succeed "mise use pnpm@12.0.0"
 
 # Test 1: npm.package_manager = "npm". Pin explicitly rather than relying
 # on the `auto` default, which uses mise's embedded aube.
@@ -92,6 +90,7 @@ fi
 assert_contains "cat '$PNPM_DEBUG_LOG'" "--config.minimumReleaseAge="
 assert_contains "cat '$PNPM_DEBUG_LOG'" "--loglevel=warn"
 assert_contains "cat '$PNPM_DEBUG_LOG'" "--allow-build=tiny"
+assert_succeed "mise exec -- tiny --help >/dev/null"
 echo "✓ npm backend successfully installs package using pnpm (package_manager=pnpm)"
 mise uninstall npm:tiny@latest >/dev/null 2>&1 || true
 

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -41,6 +41,7 @@ const AUBE_PROGRAM: &str = if cfg!(windows) { "aube.exe" } else { "aube" };
 const BUN_MIN_RELEASE_AGE_VERSION: &str = "1.3.0";
 const NPM_IGNORE_SCRIPTS_ARG: &str = "--ignore-scripts=true";
 const PNPM_MIN_RELEASE_AGE_VERSION: &str = "10.16.0";
+const PNPM_GLOBAL_DIR_ENV_VERSION: &str = "12.0.0";
 
 #[derive(Debug)]
 pub(crate) struct NPMBackend {
@@ -477,16 +478,20 @@ impl Backend for NPMBackend {
             NpmPackageManager::Pnpm => {
                 let bin_dir = tv.install_path().join("bin");
                 crate::file::create_dir_all(&bin_dir)?;
+                let pnpm_version = crate::backend::semver_version_from_toolsets_or_path(
+                    self,
+                    &ctx.config,
+                    &ctx.ts,
+                    "pnpm",
+                )
+                .await;
+                let use_global_dir_env = Self::pnpm_uses_global_dir_env(pnpm_version.as_deref());
                 let mut cmd = CmdLineRunner::new(
                     self.spawn_program(&ctx.config, Some(&ctx.ts), "pnpm").await,
                 )
                 .arg("add")
                 .arg("--global")
                 .arg(&package)
-                .arg("--global-dir")
-                .arg(tv.install_path())
-                .arg("--global-bin-dir")
-                .arg(&bin_dir)
                 .args(install_before_args)
                 .with_pr(ctx.pr.as_ref())
                 .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
@@ -500,7 +505,20 @@ impl Backend for NPMBackend {
                 )?
                 // required to avoid pnpm error "global bin dir isn't in PATH"
                 // https://github.com/pnpm/pnpm/issues/9333
-                .prepend_path(vec![bin_dir])?;
+                .prepend_path(vec![bin_dir.clone()])?;
+                if use_global_dir_env {
+                    // pnpm 12's replacement Rust CLI does not accept both path settings
+                    // as flags, but reads them from PNPM_CONFIG_* environment variables.
+                    cmd = cmd
+                        .env("PNPM_CONFIG_GLOBAL_DIR", tv.install_path())
+                        .env("PNPM_CONFIG_GLOBAL_BIN_DIR", &bin_dir);
+                } else {
+                    cmd = cmd
+                        .arg("--global-dir")
+                        .arg(tv.install_path())
+                        .arg("--global-bin-dir")
+                        .arg(&bin_dir);
+                }
                 if let Some(args) = options.pnpm_args() {
                     cmd = cmd.args(shell_words::split(args)?);
                 }
@@ -720,6 +738,12 @@ impl NPMBackend {
     fn build_pnpm_release_age_args(seconds: u64) -> Vec<OsString> {
         let minutes = seconds.div_ceil(60);
         vec![format!("--config.minimumReleaseAge={minutes}").into()]
+    }
+
+    fn pnpm_uses_global_dir_env(version: Option<&str>) -> bool {
+        version.is_some_and(|version| {
+            semver_is_at_least(version, PNPM_GLOBAL_DIR_ENV_VERSION).unwrap_or(false)
+        })
     }
 
     async fn warn_if_package_manager_may_not_support_release_age(
@@ -1948,6 +1972,14 @@ mod tests {
     fn test_build_pnpm_release_age_args_rounds_up_to_minutes() {
         let args = NPMBackend::build_pnpm_release_age_args(1);
         assert_eq!(args, vec![OsString::from("--config.minimumReleaseAge=1")]);
+    }
+
+    #[test]
+    fn test_pnpm_global_dir_transport_version_boundary() {
+        assert!(!NPMBackend::pnpm_uses_global_dir_env(Some("11.25.0")));
+        assert!(NPMBackend::pnpm_uses_global_dir_env(Some("12.0.0-rc.1")));
+        assert!(NPMBackend::pnpm_uses_global_dir_env(Some("12.0.0")));
+        assert!(!NPMBackend::pnpm_uses_global_dir_env(None));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- detect the selected pnpm version before configuring global install paths
- use `PNPM_CONFIG_GLOBAL_DIR` and `PNPM_CONFIG_GLOBAL_BIN_DIR` with pnpm 12+
- retain the existing CLI flags for pnpm 11 and earlier
- exercise pnpm 12 in the npm package-manager e2e and verify the installed executable

Reported in https://github.com/jdx/mise/discussions/12590

## Testing
- `mise run lint-fix`
- `mise exec -- cargo test --bin mise test_pnpm_global_dir_transport_version_boundary`
- `mise run test:e2e e2e/backend/test_npm_package_manager`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how global npm-tool installs invoke pnpm based on version detection; wrong version or env handling could break pnpm installs, but behavior for pnpm ≤11 is unchanged and coverage targets pnpm 12.
> 
> **Overview**
> Fixes **pnpm 12** global installs for the npm backend when `npm.package_manager=pnpm`. pnpm 12’s CLI no longer accepts `--global-dir` and `--global-bin-dir` together, so mise now **resolves the active pnpm version** and, for **12.0.0+**, sets `PNPM_CONFIG_GLOBAL_DIR` and `PNPM_CONFIG_GLOBAL_BIN_DIR` instead of those flags. **pnpm 11 and earlier** still get the existing flag-based layout.
> 
> Adds a version gate (`pnpm_uses_global_dir_env`) with unit tests at the 11→12 boundary. The **e2e** npm package-manager script always provisions **pnpm@12.0.0** and asserts `mise exec -- tiny --help` after a pnpm install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73e1a3c7759f00b199fcb46e6e41bce2540d6040. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pnpm compatibility by applying global directory settings according to the installed pnpm version.
  * Added support for pnpm 12 and preserved configuration behavior for older versions.
  * Added validation that installed command-line tools run successfully through the execution environment.

* **Tests**
  * Expanded coverage for supported, pre-release, legacy, and unavailable pnpm versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->