### PR TITLE
feat(bootstrap): add AUR package manager

### DIFF
--- a/docs/.vitepress/sidebar.ts
+++ b/docs/.vitepress/sidebar.ts
@@ -114,6 +114,7 @@ export const sidebar: SidebarItem[] = [
         items: [
           { text: "apk", link: "/bootstrap/packages/apk" },
           { text: "apt", link: "/bootstrap/packages/apt" },
+          { text: "AUR", link: "/bootstrap/packages/aur" },
           { text: "dnf", link: "/bootstrap/packages/dnf" },
           { text: "pacman", link: "/bootstrap/packages/pacman" },
           { text: "brew", link: "/bootstrap/packages/brew" },

--- a/docs/bootstrap/packages/aur.md
+++ b/docs/bootstrap/packages/aur.md
@@ -1,0 +1,33 @@
+# Arch User Repository (AUR)
+
+The `aur` manager installs packages from the
+[Arch User Repository](https://aur.archlinux.org/) with `yay` or `paru`:
+
+```toml
+[bootstrap.packages]
+"aur:google-chrome" = "latest"
+"aur:visual-studio-code-bin" = "latest"
+```
+
+mise prefers `yay` when both helpers are on `PATH`, matching Omarchy's default,
+and otherwise uses `paru`. The helper runs as the current user because AUR
+packages are built with `makepkg`; the helper requests elevation from pacman
+when it installs the finished package.
+
+Package state is checked read-only through pacman's local database. Installs use
+the helper's AUR-only mode with `--noconfirm` and `--needed`, so a repository
+package with the same name is not selected instead. `mise bootstrap packages
+apply --update` additionally asks the helper to refresh repository metadata.
+
+AUR helpers build the current PKGBUILD rather than resolving historical package
+versions, so version pins are status-only. Use `"latest"` for entries mise can
+install automatically.
+
+```sh
+mise bootstrap packages status --manager aur
+mise bootstrap packages apply --manager aur
+mise bootstrap packages upgrade --manager aur
+```
+
+`upgrade` rebuilds only the configured AUR packages. It does not upgrade every
+foreign package on the machine.

--- a/docs/bootstrap/packages/aur.md
+++ b/docs/bootstrap/packages/aur.md
@@ -14,10 +14,12 @@ and otherwise uses `paru`. The helper runs as the current user because AUR
 packages are built with `makepkg`; the helper requests elevation from pacman
 when it installs the finished package.
 
-Package state is checked read-only through pacman's local database. Installs use
-the helper's AUR-only mode with `--noconfirm` and `--needed`, so a repository
-package with the same name is not selected instead. `mise bootstrap packages
-apply --update` additionally asks the helper to refresh repository metadata.
+Package state is checked read-only through pacman's local database with its
+foreign-package filter. A same-named package from a configured repository does
+not satisfy an `aur:` declaration. Installs use the helper's AUR-only mode with
+`--noconfirm` and `--needed`, so a repository package with the same name is not
+selected instead. `mise bootstrap packages apply --update` additionally asks
+the helper to refresh repository metadata.
 
 AUR helpers build the current PKGBUILD rather than resolving historical package
 versions, so version pins are status-only. Use `"latest"` for entries mise can

--- a/docs/bootstrap/packages/aur.md
+++ b/docs/bootstrap/packages/aur.md
@@ -16,10 +16,11 @@ when it installs the finished package.
 
 Package state is checked read-only through pacman's local database with its
 foreign-package filter. A same-named package from a configured repository does
-not satisfy an `aur:` declaration. Installs use the helper's AUR-only mode with
-`--noconfirm` and `--needed`, so a repository package with the same name is not
-selected instead. `mise bootstrap packages apply --update` additionally asks
-the helper to refresh repository metadata.
+not satisfy an `aur:` declaration. Virtual package names are accepted only when
+their installed provider is also a foreign package. Installs use the helper's
+AUR-only mode with `--noconfirm` and `--needed`, so a repository package with the
+same name is not selected instead. `mise bootstrap packages apply --update`
+additionally asks the helper to refresh repository metadata.
 
 AUR helpers build the current PKGBUILD rather than resolving historical package
 versions, so version pins are status-only. Use `"latest"` for entries mise can

--- a/docs/bootstrap/packages/aur.md
+++ b/docs/bootstrap/packages/aur.md
@@ -18,8 +18,10 @@ Package state is checked read-only through pacman's local database with its
 foreign-package filter. A same-named package from a configured repository does
 not satisfy an `aur:` declaration. Virtual package names are accepted only when
 their installed provider is also a foreign package. Installs use the helper's
-AUR-only mode with `--noconfirm` and `--needed`, so a repository package with the
-same name is not selected instead. `mise bootstrap packages apply --update`
+AUR-only mode with `--noconfirm`, so a repository package with the
+same name is not selected instead. mise intentionally omits `--needed` so the
+helper can replace an installed repository package that has the requested AUR
+package's name. `mise bootstrap packages apply --update`
 additionally asks the helper to refresh repository metadata.
 
 AUR helpers build the current PKGBUILD rather than resolving historical package

--- a/docs/bootstrap/packages/index.md
+++ b/docs/bootstrap/packages/index.md
@@ -10,6 +10,7 @@ mise can ensure host packages are installed via the
 "apk:build-base" = "latest"
 "apt:libssl-dev" = "latest"
 "apt:build-essential" = "latest"
+"aur:google-chrome" = "latest"
 "brew:postgresql@17" = "latest"
 "brew:ffmpeg" = "latest"
 "brew-cask:firefox" = "latest"
@@ -70,6 +71,7 @@ declarative sections work the same way:
 | -------------- | -------------------------------------------------------------- | --------------------------------------------------- |
 | `apk`          | Alpine Linux                                                   | [apk](/bootstrap/packages/apk.html)                 |
 | `apt`          | Debian, Ubuntu                                                 | [apt](/bootstrap/packages/apt.html)                 |
+| `aur`          | Arch, Manjaro with yay or paru                                 | [AUR](/bootstrap/packages/aur.html)                 |
 | `dnf`          | Fedora, RHEL, CentOS, Rocky, Alma                              | [dnf](/bootstrap/packages/dnf.html)                 |
 | `pacman`       | Arch, Manjaro                                                  | [pacman](/bootstrap/packages/pacman.html)           |
 | `brew`         | macOS (arm64), Linux (x86_64/arm64) — **no Homebrew required** | [brew](/bootstrap/packages/brew.html)               |
@@ -190,8 +192,9 @@ ownership state.
 
 `mise bootstrap packages upgrade` refreshes package manager metadata and upgrades the
 configured packages that are already installed to the newest available
-version — apk, apt, and dnf also honor a version pinned in config (pacman, brew,
-brew-cask, flatpak, flatpak-user, and mas [can't install pins](/bootstrap/packages/pacman.html), so
+version — apk, apt, and dnf also honor a version pinned in config
+([AUR](/bootstrap/packages/aur.html), [pacman](/bootstrap/packages/pacman.html),
+brew, brew-cask, flatpak, flatpak-user, and mas can't install pins, so
 pinned entries are skipped with a warning). Packages that aren't installed
 yet are skipped — that's `mise bootstrap packages apply`'s job. For brew,
 this pours the formula's current bottle and replaces the old keg; for

--- a/docs/bootstrap/packages/pacman.md
+++ b/docs/bootstrap/packages/pacman.md
@@ -31,6 +31,6 @@ System packages for Arch-family Linux (Arch, Manjaro, EndeavourOS, ...).
 Arch repositories only carry the latest version of each package, so pacman
 entries cannot be installed at a pinned version — `mise bootstrap packages apply`
 skips pinned entries with a warning, though `mise bootstrap packages status` still
-reports a `version mismatch` for them. AUR packages are not supported (they
-require an AUR helper and building from source).
+reports a `version mismatch` for them. Declare packages that must be built from
+the Arch User Repository with the separate [`aur:` manager](./aur.md).
 :::

--- a/docs/cli/bootstrap/packages/upgrade.md
+++ b/docs/cli/bootstrap/packages/upgrade.md
@@ -9,12 +9,13 @@
 Upgrade installed bootstrap packages from `[bootstrap.packages]`
 
 Refreshes package manager metadata and upgrades the configured packages
-that are already installed: apk/apt/dnf/pacman upgrade to the newest available
-version (apk, apt, and dnf honor a version pinned in config), brew pours the
-formula's current bottle and replaces the old keg, brew-cask installs
-the current cask artifact, flatpak and flatpak-user update applications and runtimes, and mas upgrades App Store apps. Packages that
-are not installed yet are skipped — use `mise bootstrap packages apply`
-for those.
+that are already installed: apk/apt/aur/dnf/pacman upgrade to the newest
+available version (apk, apt, and dnf honor a version pinned in config), brew
+pours the formula's current bottle and replaces the old keg, brew-cask
+installs the current cask artifact, flatpak and flatpak-user update
+applications and runtimes, and mas upgrades App Store apps. Packages that
+are not installed yet are skipped — use `mise bootstrap packages apply` for
+those.
 
 Packages can also be given explicitly in `manager:package` form.
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -71,6 +71,7 @@
 - [Bootstrap Packages](https://mise.jdx.dev/bootstrap/packages/): mise can ensure host packages are installed via the [bootstrap.packages] section of mise.toml, applied by mise bootstrap packages apply or as part of mise bootstrap.
 - [apk](https://mise.jdx.dev/bootstrap/packages/apk.html): System packages for Alpine Linux.
 - [apt](https://mise.jdx.dev/bootstrap/packages/apt.html): System packages for Debian-family Linux (Debian, Ubuntu, Mint, ...).
+- [AUR](https://mise.jdx.dev/bootstrap/packages/aur.html): The aur manager installs packages from the Arch User Repository with yay or paru.
 - [dnf](https://mise.jdx.dev/bootstrap/packages/dnf.html): System packages for Red Hat-family Linux (Fedora, RHEL, CentOS Stream, Rocky, Alma, ...).
 - [pacman](https://mise.jdx.dev/bootstrap/packages/pacman.html): System packages for Arch-family Linux (Arch, Manjaro, EndeavourOS, ...).
 - [brew](https://mise.jdx.dev/bootstrap/packages/brew.html): Homebrew formulae and casks — without requiring Homebrew to be installed.

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1840,12 +1840,13 @@ Print help
 Upgrade installed bootstrap packages from `[bootstrap.packages]`
 
 Refreshes package manager metadata and upgrades the configured packages
-that are already installed: apk/apt/dnf/pacman upgrade to the newest available
-version (apk, apt, and dnf honor a version pinned in config), brew pours the
-formula's current bottle and replaces the old keg, brew\-cask installs
-the current cask artifact, flatpak and flatpak\-user update applications and runtimes, and mas upgrades App Store apps. Packages that
-are not installed yet are skipped — use `mise bootstrap packages apply`
-for those.
+that are already installed: apk/apt/aur/dnf/pacman upgrade to the newest
+available version (apk, apt, and dnf honor a version pinned in config), brew
+pours the formula's current bottle and replaces the old keg, brew\-cask
+installs the current cask artifact, flatpak and flatpak\-user update
+applications and runtimes, and mas upgrades App Store apps. Packages that
+are not installed yet are skipped — use `mise bootstrap packages apply` for
+those.
 
 Packages can also be given explicitly in `manager:package` form.
 .PP

--- a/mise.lock
+++ b/mise.lock
@@ -159,9 +159,8 @@ provenance = "github-attestations"
 
 [tools.aube."platforms.macos-arm64"]
 checksum = "sha256:702de7f549cef800a1f35900e638ea4fbe07bce854f234cef869cd5442484c90"
-url = "https://github.com/jdx/aube/releases/download/v2.2.0/aube-v2.2.0-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/529761660"
-provenance = "github-attestations"
+url = "https://github.com/aubepkg/aube/releases/download/v2.2.0/aube-v2.2.0-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/529761660"
 
 [tools.aube."platforms.windows-x64"]
 checksum = "sha256:2d68e3e995c336486647034eb8b99c3cfa68894e385a44200af2bc14bc4064cf"

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -884,12 +884,13 @@ first applied them are never claimed or removed.
 Upgrade installed bootstrap packages from `[bootstrap.packages]`
 
 Refreshes package manager metadata and upgrades the configured packages
-that are already installed: apk/apt/dnf/pacman upgrade to the newest available
-version (apk, apt, and dnf honor a version pinned in config), brew pours the
-formula's current bottle and replaces the old keg, brew-cask installs
-the current cask artifact, flatpak and flatpak-user update applications and runtimes, and mas upgrades App Store apps. Packages that
-are not installed yet are skipped — use `mise bootstrap packages apply`
-for those.
+that are already installed: apk/apt/aur/dnf/pacman upgrade to the newest
+available version (apk, apt, and dnf honor a version pinned in config), brew
+pours the formula's current bottle and replaces the old keg, brew-cask
+installs the current cask artifact, flatpak and flatpak-user update
+applications and runtimes, and mas upgrades App Store apps. Packages that
+are not installed yet are skipped — use `mise bootstrap packages apply` for
+those.
 
 Packages can also be given explicitly in `manager:package` form.
 """#

--- a/src/cli/system/upgrade.rs
+++ b/src/cli/system/upgrade.rs
@@ -7,12 +7,13 @@ use crate::system;
 /// Upgrade installed bootstrap packages from `[bootstrap.packages]`
 ///
 /// Refreshes package manager metadata and upgrades the configured packages
-/// that are already installed: apk/apt/dnf/pacman upgrade to the newest available
-/// version (apk, apt, and dnf honor a version pinned in config), brew pours the
-/// formula's current bottle and replaces the old keg, brew-cask installs
-/// the current cask artifact, flatpak and flatpak-user update applications and runtimes, and mas upgrades App Store apps. Packages that
-/// are not installed yet are skipped — use `mise bootstrap packages apply`
-/// for those.
+/// that are already installed: apk/apt/aur/dnf/pacman upgrade to the newest
+/// available version (apk, apt, and dnf honor a version pinned in config), brew
+/// pours the formula's current bottle and replaces the old keg, brew-cask
+/// installs the current cask artifact, flatpak and flatpak-user update
+/// applications and runtimes, and mas upgrades App Store apps. Packages that
+/// are not installed yet are skipped — use `mise bootstrap packages apply` for
+/// those.
 ///
 /// Packages can also be given explicitly in `manager:package` form.
 #[derive(Debug, usage_rs::Args)]

--- a/src/system/packages/aur.rs
+++ b/src/system/packages/aur.rs
@@ -142,6 +142,7 @@ impl SystemPackageManager for AurManager {
         if crate::system::sudo::is_root() {
             bail!("AUR packages cannot be built as root; run mise as a non-root user");
         }
+        crate::system::sudo::ensure_elevation_available(&shell_words::join(&command))?;
         let mut runner = CmdLineRunner::new(helper);
         for arg in &args {
             runner = runner.arg(arg);

--- a/src/system/packages/aur.rs
+++ b/src/system/packages/aur.rs
@@ -127,13 +127,14 @@ async fn foreign_packages() -> Result<String> {
         .stderr(Stdio::piped())
         .output()
         .await?;
-    if !output.status.success() {
-        bail!(
-            "pacman -Qm failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let no_foreign_packages =
+        output.status.code() == Some(1) && stdout.trim().is_empty() && stderr.trim().is_empty();
+    if !output.status.success() && !no_foreign_packages {
+        bail!("pacman -Qm failed: {}", stderr.trim());
     }
-    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    Ok(stdout.into_owned())
 }
 
 #[async_trait(?Send)]

--- a/src/system/packages/aur.rs
+++ b/src/system/packages/aur.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::process::Stdio;
 
 use async_trait::async_trait;
@@ -102,12 +102,14 @@ async fn resolve_foreign_packages(
 ) -> Result<Vec<ResolvedForeignPackage>> {
     let output = foreign_packages().await?;
     let (installed, mut resolved) = parse_foreign_packages(&output, requests);
+    let foreign_names = installed.keys().cloned().collect::<HashSet<_>>();
     for package in resolved
         .iter_mut()
         .filter(|package| matches!(package.status.state, PackageState::Missing))
     {
         let Some((provider, state)) =
-            super::pacman::resolve_installed_provider(&package.status.request).await?
+            super::pacman::resolve_installed_provider(&package.status.request, &foreign_names)
+                .await?
         else {
             continue;
         };

--- a/src/system/packages/aur.rs
+++ b/src/system/packages/aur.rs
@@ -1,0 +1,161 @@
+use async_trait::async_trait;
+use eyre::bail;
+
+use super::{InstallOpts, PackageRequest, PackageStatus, SystemPackageManager};
+use crate::cmd::CmdLineRunner;
+use crate::result::Result;
+
+/// Arch User Repository packages via yay or paru.
+pub(crate) struct AurManager {}
+
+impl AurManager {
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+
+    fn helper(&self) -> Option<&'static str> {
+        ["yay", "paru"]
+            .into_iter()
+            .find(|helper| crate::file::which(helper).is_some())
+    }
+}
+
+fn install_args(pkgs: &[PackageRequest], opts: &InstallOpts) -> Vec<String> {
+    let mut args = vec![
+        "-S".to_string(),
+        "--aur".to_string(),
+        "--noconfirm".to_string(),
+        "--needed".to_string(),
+    ];
+    if opts.update {
+        args.push("--refresh".to_string());
+    }
+    args.push("--".to_string());
+    args.extend(pkgs.iter().map(|pkg| pkg.name.clone()));
+    args
+}
+
+#[async_trait(?Send)]
+impl SystemPackageManager for AurManager {
+    fn name(&self) -> &str {
+        "aur"
+    }
+
+    fn is_available(&self) -> bool {
+        cfg!(target_os = "linux")
+            && crate::file::which("pacman").is_some()
+            && self.helper().is_some()
+    }
+
+    fn unavailable_reason(&self) -> String {
+        if !cfg!(target_os = "linux") {
+            "only available on linux".to_string()
+        } else if crate::file::which("pacman").is_none() {
+            "pacman not found".to_string()
+        } else {
+            "neither yay nor paru found".to_string()
+        }
+    }
+
+    async fn installed(&self, pkgs: &[PackageRequest]) -> Result<Vec<PackageStatus>> {
+        super::pacman::PacmanManager::new().installed(pkgs).await
+    }
+
+    fn supports_version_pins(&self) -> bool {
+        false
+    }
+
+    async fn install(&self, pkgs: &[PackageRequest], opts: &InstallOpts) -> Result<()> {
+        if let Some(pkg) = pkgs.iter().find(|pkg| pkg.version.is_some()) {
+            bail!("AUR helpers cannot install a pinned version ('{pkg}')");
+        }
+        let helper = self
+            .helper()
+            .ok_or_else(|| eyre::eyre!(self.unavailable_reason()))?;
+        let args = install_args(pkgs, opts);
+        let command = std::iter::once(helper.to_string())
+            .chain(args.iter().cloned())
+            .collect::<Vec<_>>();
+        if opts.dry_run {
+            miseprintln!("{}", shell_words::join(command));
+            return Ok(());
+        }
+        if crate::system::sudo::is_root() {
+            bail!("AUR packages cannot be built as root; run mise as a non-root user");
+        }
+        let mut runner = CmdLineRunner::new(helper);
+        for arg in &args {
+            runner = runner.arg(arg);
+        }
+        runner.raw(true).execute()
+    }
+
+    async fn upgrade(&self, pkgs: &[PackageRequest], opts: &InstallOpts) -> Result<()> {
+        self.install(
+            pkgs,
+            &InstallOpts {
+                dry_run: opts.dry_run,
+                update: true,
+            },
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req(name: &str, version: Option<&str>) -> PackageRequest {
+        PackageRequest {
+            name: name.to_string(),
+            version: version.map(str::to_string),
+            tap_url: None,
+        }
+    }
+
+    #[test]
+    fn test_install_args_force_aur_targets() {
+        let pkgs = vec![
+            req("google-chrome", None),
+            req("visual-studio-code-bin", None),
+        ];
+        let args = install_args(&pkgs, &InstallOpts::default());
+        assert_eq!(
+            args,
+            vec![
+                "-S",
+                "--aur",
+                "--noconfirm",
+                "--needed",
+                "--",
+                "google-chrome",
+                "visual-studio-code-bin"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_install_args_update_refreshes_metadata() {
+        let pkgs = vec![req("google-chrome", None)];
+        let args = install_args(
+            &pkgs,
+            &InstallOpts {
+                dry_run: false,
+                update: true,
+            },
+        );
+        assert_eq!(
+            args,
+            vec![
+                "-S",
+                "--aur",
+                "--noconfirm",
+                "--needed",
+                "--refresh",
+                "--",
+                "google-chrome"
+            ]
+        );
+    }
+}

--- a/src/system/packages/aur.rs
+++ b/src/system/packages/aur.rs
@@ -8,6 +8,11 @@ use super::{InstallOpts, PackageRequest, PackageState, PackageStatus, SystemPack
 use crate::cmd::CmdLineRunner;
 use crate::result::Result;
 
+struct ResolvedForeignPackage {
+    status: PackageStatus,
+    installed_name: Option<String>,
+}
+
 /// Arch User Repository packages via yay or paru.
 pub(crate) struct AurManager {}
 
@@ -38,18 +43,22 @@ fn install_args(pkgs: &[PackageRequest], opts: &InstallOpts) -> Vec<String> {
     args
 }
 
-fn parse_foreign_packages(output: &str, requests: &[PackageRequest]) -> Vec<PackageStatus> {
+fn parse_foreign_packages(
+    output: &str,
+    requests: &[PackageRequest],
+) -> (HashMap<String, String>, Vec<ResolvedForeignPackage>) {
     let installed = output
         .lines()
         .filter_map(|line| line.split_once(' '))
+        .map(|(name, version)| (name.to_string(), version.to_string()))
         .collect::<HashMap<_, _>>();
-    requests
+    let resolved = requests
         .iter()
         .map(|request| {
             let state = match installed.get(request.name.as_str()) {
                 Some(version) => match &request.version {
                     Some(requested)
-                        if *version != requested
+                        if version != requested
                             && !version.starts_with(&format!("{requested}-")) =>
                     {
                         PackageState::VersionMismatch {
@@ -62,12 +71,49 @@ fn parse_foreign_packages(output: &str, requests: &[PackageRequest]) -> Vec<Pack
                 },
                 None => PackageState::Missing,
             };
-            PackageStatus {
-                request: request.clone(),
-                state,
+            ResolvedForeignPackage {
+                installed_name: installed
+                    .contains_key(request.name.as_str())
+                    .then(|| request.name.clone()),
+                status: PackageStatus {
+                    request: request.clone(),
+                    state,
+                },
             }
         })
-        .collect()
+        .collect();
+    (installed, resolved)
+}
+
+fn apply_foreign_provider(
+    package: &mut ResolvedForeignPackage,
+    installed: &HashMap<String, String>,
+    provider: String,
+    state: PackageState,
+) {
+    if installed.contains_key(&provider) {
+        package.installed_name = Some(provider);
+        package.status.state = state;
+    }
+}
+
+async fn resolve_foreign_packages(
+    requests: &[PackageRequest],
+) -> Result<Vec<ResolvedForeignPackage>> {
+    let output = foreign_packages().await?;
+    let (installed, mut resolved) = parse_foreign_packages(&output, requests);
+    for package in resolved
+        .iter_mut()
+        .filter(|package| matches!(package.status.state, PackageState::Missing))
+    {
+        let Some((provider, state)) =
+            super::pacman::resolve_installed_provider(&package.status.request).await?
+        else {
+            continue;
+        };
+        apply_foreign_provider(package, &installed, provider, state);
+    }
+    Ok(resolved)
 }
 
 async fn foreign_packages() -> Result<String> {
@@ -116,8 +162,11 @@ impl SystemPackageManager for AurManager {
         if pkgs.is_empty() {
             return Ok(vec![]);
         }
-        let output = foreign_packages().await?;
-        Ok(parse_foreign_packages(&output, pkgs))
+        Ok(resolve_foreign_packages(pkgs)
+            .await?
+            .into_iter()
+            .map(|package| package.status)
+            .collect())
     }
 
     fn supports_version_pins(&self) -> bool {
@@ -151,8 +200,22 @@ impl SystemPackageManager for AurManager {
     }
 
     async fn upgrade(&self, pkgs: &[PackageRequest], opts: &InstallOpts) -> Result<()> {
+        let pkgs = resolve_foreign_packages(pkgs)
+            .await?
+            .into_iter()
+            .filter_map(|package| {
+                package.installed_name.map(|name| PackageRequest {
+                    name,
+                    version: None,
+                    tap_url: None,
+                })
+            })
+            .collect::<Vec<_>>();
+        if pkgs.is_empty() {
+            return Ok(());
+        }
         self.install(
-            pkgs,
+            &pkgs,
             &InstallOpts {
                 dry_run: opts.dry_run,
                 update: true,
@@ -224,13 +287,45 @@ mod tests {
         let requests = vec![req("aur-package", None), req("native-name-collision", None)];
         // pacman -Qm omits packages available from a configured sync database,
         // even if a same-named native package is installed.
-        let statuses = parse_foreign_packages("aur-package 1.2.3-1\n", &requests);
+        let (_, statuses) = parse_foreign_packages("aur-package 1.2.3-1\n", &requests);
         assert_eq!(
-            statuses[0].state,
+            statuses[0].status.state,
             PackageState::Installed {
                 version: "1.2.3-1".to_string()
             }
         );
-        assert_eq!(statuses[1].state, PackageState::Missing);
+        assert_eq!(statuses[1].status.state, PackageState::Missing);
+    }
+
+    #[test]
+    fn test_provider_must_itself_be_foreign() {
+        let request = req("virtual-capability", None);
+        let (installed, mut statuses) =
+            parse_foreign_packages("aur-provider 2.0-1\n", std::slice::from_ref(&request));
+        apply_foreign_provider(
+            &mut statuses[0],
+            &installed,
+            "native-provider".to_string(),
+            PackageState::Installed {
+                version: "1.0-1".to_string(),
+            },
+        );
+        assert_eq!(statuses[0].status.state, PackageState::Missing);
+
+        apply_foreign_provider(
+            &mut statuses[0],
+            &installed,
+            "aur-provider".to_string(),
+            PackageState::Installed {
+                version: "2.0-1".to_string(),
+            },
+        );
+        assert_eq!(statuses[0].installed_name.as_deref(), Some("aur-provider"));
+        assert_eq!(
+            statuses[0].status.state,
+            PackageState::Installed {
+                version: "2.0-1".to_string()
+            }
+        );
     }
 }

--- a/src/system/packages/aur.rs
+++ b/src/system/packages/aur.rs
@@ -1,7 +1,10 @@
+use std::collections::HashMap;
+use std::process::Stdio;
+
 use async_trait::async_trait;
 use eyre::bail;
 
-use super::{InstallOpts, PackageRequest, PackageStatus, SystemPackageManager};
+use super::{InstallOpts, PackageRequest, PackageState, PackageStatus, SystemPackageManager};
 use crate::cmd::CmdLineRunner;
 use crate::result::Result;
 
@@ -35,6 +38,58 @@ fn install_args(pkgs: &[PackageRequest], opts: &InstallOpts) -> Vec<String> {
     args
 }
 
+fn parse_foreign_packages(output: &str, requests: &[PackageRequest]) -> Vec<PackageStatus> {
+    let installed = output
+        .lines()
+        .filter_map(|line| line.split_once(' '))
+        .collect::<HashMap<_, _>>();
+    requests
+        .iter()
+        .map(|request| {
+            let state = match installed.get(request.name.as_str()) {
+                Some(version) => match &request.version {
+                    Some(requested)
+                        if *version != requested
+                            && !version.starts_with(&format!("{requested}-")) =>
+                    {
+                        PackageState::VersionMismatch {
+                            installed: version.to_string(),
+                        }
+                    }
+                    _ => PackageState::Installed {
+                        version: version.to_string(),
+                    },
+                },
+                None => PackageState::Missing,
+            };
+            PackageStatus {
+                request: request.clone(),
+                state,
+            }
+        })
+        .collect()
+}
+
+async fn foreign_packages() -> Result<String> {
+    let args = ["-Qm"];
+    debug!("$ pacman {}", args.join(" "));
+    let output = tokio::process::Command::new("pacman")
+        .args(args)
+        .env("LC_ALL", "C")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await?;
+    if !output.status.success() {
+        bail!(
+            "pacman -Qm failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
 #[async_trait(?Send)]
 impl SystemPackageManager for AurManager {
     fn name(&self) -> &str {
@@ -58,7 +113,11 @@ impl SystemPackageManager for AurManager {
     }
 
     async fn installed(&self, pkgs: &[PackageRequest]) -> Result<Vec<PackageStatus>> {
-        super::pacman::PacmanManager::new().installed(pkgs).await
+        if pkgs.is_empty() {
+            return Ok(vec![]);
+        }
+        let output = foreign_packages().await?;
+        Ok(parse_foreign_packages(&output, pkgs))
     }
 
     fn supports_version_pins(&self) -> bool {
@@ -157,5 +216,20 @@ mod tests {
                 "google-chrome"
             ]
         );
+    }
+
+    #[test]
+    fn test_installed_state_only_uses_foreign_query_results() {
+        let requests = vec![req("aur-package", None), req("native-name-collision", None)];
+        // pacman -Qm omits packages available from a configured sync database,
+        // even if a same-named native package is installed.
+        let statuses = parse_foreign_packages("aur-package 1.2.3-1\n", &requests);
+        assert_eq!(
+            statuses[0].state,
+            PackageState::Installed {
+                version: "1.2.3-1".to_string()
+            }
+        );
+        assert_eq!(statuses[1].state, PackageState::Missing);
     }
 }

--- a/src/system/packages/aur.rs
+++ b/src/system/packages/aur.rs
@@ -33,7 +33,6 @@ fn install_args(pkgs: &[PackageRequest], opts: &InstallOpts) -> Vec<String> {
         "-S".to_string(),
         "--aur".to_string(),
         "--noconfirm".to_string(),
-        "--needed".to_string(),
     ];
     if opts.update {
         args.push("--refresh".to_string());
@@ -255,7 +254,6 @@ mod tests {
                 "-S",
                 "--aur",
                 "--noconfirm",
-                "--needed",
                 "--",
                 "google-chrome",
                 "visual-studio-code-bin"
@@ -279,7 +277,6 @@ mod tests {
                 "-S",
                 "--aur",
                 "--noconfirm",
-                "--needed",
                 "--refresh",
                 "--",
                 "google-chrome"

--- a/src/system/packages/mod.rs
+++ b/src/system/packages/mod.rs
@@ -1,4 +1,4 @@
-//! Host package managers (apk, apt, brew, brew-cask, flatpak, flatpak-user, mas) for the `[bootstrap.packages]` config section.
+//! Host package managers (apk, apt, aur, brew, brew-cask, flatpak, flatpak-user, mas) for the `[bootstrap.packages]` config section.
 //!
 //! These are host-owned, unversioned packages — deliberately separate from
 //! the `Backend` system, which manages per-project, version-pinned dev tools.
@@ -12,6 +12,7 @@ use crate::system::ManagerPackageOptions;
 
 pub(crate) mod apk;
 pub(crate) mod apt;
+pub(crate) mod aur;
 #[cfg(unix)]
 pub(crate) mod brew;
 pub(crate) mod dnf;
@@ -218,6 +219,7 @@ pub(crate) fn builtin_managers() -> Vec<Arc<dyn SystemPackageManager>> {
     vec![
         Arc::new(apk::ApkManager::new()),
         Arc::new(apt::AptManager::new()),
+        Arc::new(aur::AurManager::new()),
         #[cfg(unix)]
         Arc::new(brew::BrewManager::new()),
         #[cfg(unix)]

--- a/src/system/packages/pacman.rs
+++ b/src/system/packages/pacman.rs
@@ -138,7 +138,12 @@ fn find_provider<'a>(
 ) -> Option<&'a PacmanPackageMetadata> {
     packages
         .iter()
-        .find(|package| package.name == requested || package.provides.contains(requested))
+        .find(|package| package.name == requested)
+        .or_else(|| {
+            packages
+                .iter()
+                .find(|package| package.provides.contains(requested))
+        })
 }
 
 fn parse_pacman_deptest(output: &str) -> HashSet<&str> {
@@ -512,6 +517,21 @@ mod tests {
                 version: "9.7.1_1-1".to_string()
             }
         );
+    }
+
+    #[test]
+    fn test_find_provider_prefers_exact_package_name() {
+        let packages = parse_pacman_info(
+            "Name            : alternate-foo\n\
+             Version         : 2.0-1\n\
+             Provides        : foo\n\
+             \n\
+             Name            : foo\n\
+             Version         : 1.0-1\n\
+             Provides        : None\n",
+        );
+
+        assert_eq!(find_provider(&packages, "foo").unwrap().name, "foo");
     }
 
     #[test]

--- a/src/system/packages/pacman.rs
+++ b/src/system/packages/pacman.rs
@@ -156,7 +156,7 @@ fn find_provider<'a>(
                     || request
                         .version
                         .as_ref()
-                        .is_none_or(|version| version_matches(version, &package.version)))
+                        .is_none_or(|version| pacman_version_matches(version, &package.version)))
         })
         .or_else(|| {
             packages
@@ -167,18 +167,31 @@ fn find_provider<'a>(
                         provide.name == request.name
                             && (!constraint_satisfied
                                 || request.version.as_ref().is_none_or(|version| {
-                                    provide
-                                        .version
-                                        .as_ref()
-                                        .is_some_and(|provided| version_matches(version, provided))
+                                    provide.version.as_ref().is_some_and(|provided| {
+                                        pacman_version_matches(version, provided)
+                                    })
                                 }))
                     })
                 })
         })
 }
 
-fn version_matches(requested: &str, installed: &str) -> bool {
-    installed == requested || installed.starts_with(&format!("{requested}-"))
+fn pacman_version_matches(requested: &str, provided: &str) -> bool {
+    // vercmp ships with pacman and uses the same libalpm version ordering as
+    // dependency resolution. It intentionally considers e.g. 2.0 and
+    // 2.0-13 equal, which a textual comparison cannot model correctly.
+    match std::process::Command::new("vercmp")
+        .args([provided, requested])
+        .stdin(Stdio::null())
+        .output()
+    {
+        Ok(output) if output.status.success() => {
+            String::from_utf8_lossy(&output.stdout).trim() == "0"
+        }
+        // Unit tests and non-Arch development hosts do not necessarily have
+        // vercmp. A real pacman installation always supplies it.
+        _ => provided == requested || provided.starts_with(&format!("{requested}-")),
+    }
 }
 
 fn parse_pacman_deptest(output: &str) -> HashSet<&str> {
@@ -594,11 +607,11 @@ mod tests {
              \n\
              Name            : foo-two\n\
              Version         : 20.0-1\n\
-             Provides        : foo=2\n",
+             Provides        : foo=2.0-13\n",
         );
 
         assert_eq!(
-            find_provider(&packages, &req("foo", Some("2")), true, |_| true)
+            find_provider(&packages, &req("foo", Some("2.0")), true, |_| true)
                 .unwrap()
                 .name,
             "foo-two"

--- a/src/system/packages/pacman.rs
+++ b/src/system/packages/pacman.rs
@@ -76,11 +76,17 @@ fn package_state(req: &PackageRequest, version: &str) -> PackageState {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct PacmanProvide {
+    name: String,
+    version: Option<String>,
+}
+
 #[derive(Debug, PartialEq, Eq)]
 struct PacmanPackageMetadata {
     name: String,
     version: String,
-    provides: HashSet<String>,
+    provides: HashSet<PacmanProvide>,
 }
 
 fn parse_pacman_info(output: &str) -> Vec<PacmanPackageMetadata> {
@@ -119,31 +125,60 @@ fn parse_pacman_info(output: &str) -> Vec<PacmanPackageMetadata> {
     packages
 }
 
-fn parse_provides(value: &str) -> impl Iterator<Item = String> + '_ {
+fn parse_provides(value: &str) -> impl Iterator<Item = PacmanProvide> + '_ {
     value
         .split_whitespace()
         .filter(|provide| *provide != "None")
         .map(|provide| {
-            provide
-                .split(['<', '=', '>'])
-                .next()
-                .unwrap_or(provide)
-                .to_string()
+            let (name, version) = provide
+                .split_once('=')
+                .map(|(name, version)| (name, Some(version.to_string())))
+                .unwrap_or_else(|| (provide.split(['<', '>']).next().unwrap_or(provide), None));
+            PacmanProvide {
+                name: name.to_string(),
+                version,
+            }
         })
 }
 
 fn find_provider<'a>(
     packages: &'a [PacmanPackageMetadata],
-    requested: &str,
+    request: &PackageRequest,
+    constraint_satisfied: bool,
+    eligible: impl Fn(&PacmanPackageMetadata) -> bool,
 ) -> Option<&'a PacmanPackageMetadata> {
     packages
         .iter()
-        .find(|package| package.name == requested)
+        .filter(|package| eligible(package))
+        .find(|package| {
+            package.name == request.name
+                && (!constraint_satisfied
+                    || request
+                        .version
+                        .as_ref()
+                        .is_none_or(|version| version_matches(version, &package.version)))
+        })
         .or_else(|| {
             packages
                 .iter()
-                .find(|package| package.provides.contains(requested))
+                .filter(|package| eligible(package))
+                .find(|package| {
+                    package.provides.iter().any(|provide| {
+                        provide.name == request.name
+                            && (!constraint_satisfied
+                                || request.version.as_ref().is_none_or(|version| {
+                                    provide
+                                        .version
+                                        .as_ref()
+                                        .is_some_and(|provided| version_matches(version, provided))
+                                }))
+                    })
+                })
         })
+}
+
+fn version_matches(requested: &str, installed: &str) -> bool {
+    installed == requested || installed.starts_with(&format!("{requested}-"))
 }
 
 fn parse_pacman_deptest(output: &str) -> HashSet<&str> {
@@ -166,12 +201,13 @@ fn apply_provider_query<'a>(
     packages: &'a [PacmanPackageMetadata],
     constraint_satisfied: bool,
 ) -> Result<&'a PacmanPackageMetadata> {
-    let provider = find_provider(packages, &status.request.name).ok_or_else(|| {
-        eyre::eyre!(
-            "pacman -Qi returned no provider for satisfied requirement '{}'",
-            status.request.name
-        )
-    })?;
+    let provider = find_provider(packages, &status.request, constraint_satisfied, |_| true)
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "pacman -Qi returned no provider for satisfied requirement '{}'",
+                status.request.name
+            )
+        })?;
     // The provider's package version is display metadata; pacman -T evaluates
     // the requested version against the version declared in Provides.
     status.state = if constraint_satisfied {
@@ -263,6 +299,7 @@ async fn pacman_deptest(names: &[String]) -> Result<String> {
 
 pub(super) async fn resolve_installed_provider(
     request: &PackageRequest,
+    eligible_names: &HashSet<String>,
 ) -> Result<Option<(String, PackageState)>> {
     let requirement = deptest_requirement(request);
     let deptest = pacman_deptest(&[requirement]).await?;
@@ -281,12 +318,11 @@ pub(super) async fn resolve_installed_provider(
 
     let info = pacman_info().await?;
     let packages = parse_pacman_info(&info);
-    let provider = find_provider(&packages, &request.name).ok_or_else(|| {
-        eyre::eyre!(
-            "pacman -Qi returned no provider for satisfied requirement '{}'",
-            request.name
-        )
-    })?;
+    let Some(provider) = find_provider(&packages, request, constraint_satisfied, |package| {
+        eligible_names.contains(&package.name)
+    }) else {
+        return Ok(None);
+    };
     let state = if constraint_satisfied {
         PackageState::Installed {
             version: provider.version.clone(),
@@ -509,8 +545,18 @@ mod tests {
         let provider = apply_provider_query(&mut status, &packages, true).unwrap();
 
         assert_eq!(provider.name, "percona-server-clients");
-        assert!(provider.provides.contains("mariadb-clients"));
-        assert!(provider.provides.contains("mysql-clients"));
+        assert!(
+            provider
+                .provides
+                .iter()
+                .any(|provide| provide.name == "mariadb-clients")
+        );
+        assert!(
+            provider
+                .provides
+                .iter()
+                .any(|provide| provide.name == "mysql-clients")
+        );
         assert_eq!(
             status.state,
             PackageState::Installed {
@@ -531,7 +577,54 @@ mod tests {
              Provides        : None\n",
         );
 
-        assert_eq!(find_provider(&packages, "foo").unwrap().name, "foo");
+        assert_eq!(
+            find_provider(&packages, &req("foo", None), true, |_| true)
+                .unwrap()
+                .name,
+            "foo"
+        );
+    }
+
+    #[test]
+    fn test_find_provider_matches_virtual_version() {
+        let packages = parse_pacman_info(
+            "Name            : foo-one\n\
+             Version         : 10.0-1\n\
+             Provides        : foo=1\n\
+             \n\
+             Name            : foo-two\n\
+             Version         : 20.0-1\n\
+             Provides        : foo=2\n",
+        );
+
+        assert_eq!(
+            find_provider(&packages, &req("foo", Some("2")), true, |_| true)
+                .unwrap()
+                .name,
+            "foo-two"
+        );
+    }
+
+    #[test]
+    fn test_find_provider_filters_ineligible_exact_match() {
+        let packages = parse_pacman_info(
+            "Name            : foo\n\
+             Version         : 1.0-1\n\
+             Provides        : None\n\
+             \n\
+             Name            : aur-foo\n\
+             Version         : 2.0-1\n\
+             Provides        : foo\n",
+        );
+
+        assert_eq!(
+            find_provider(&packages, &req("foo", None), true, |package| {
+                package.name == "aur-foo"
+            })
+            .unwrap()
+            .name,
+            "aur-foo"
+        );
     }
 
     #[test]

--- a/src/system/packages/pacman.rs
+++ b/src/system/packages/pacman.rs
@@ -175,6 +175,43 @@ async fn pacman_deptest(names: &[String]) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
+pub(super) async fn resolve_installed_provider(
+    request: &PackageRequest,
+) -> Result<Option<(String, PackageState)>> {
+    let requirement = deptest_requirement(request);
+    let deptest = pacman_deptest(&[requirement]).await?;
+    let unsatisfied = parse_pacman_deptest(&deptest);
+    let constraint_satisfied = unsatisfied.is_empty();
+    if !constraint_satisfied {
+        if request.version.is_none() {
+            return Ok(None);
+        }
+        let bare_deptest = pacman_deptest(std::slice::from_ref(&request.name)).await?;
+        let bare_missing = parse_pacman_deptest(&bare_deptest);
+        if !bare_missing.is_empty() {
+            return Ok(None);
+        }
+    }
+
+    let output = pacman_query(std::slice::from_ref(&request.name)).await?;
+    let Some((provider, version)) = parse_pacman_package(&output) else {
+        bail!(
+            "pacman -Q returned no package for satisfied requirement '{}'",
+            request.name
+        );
+    };
+    let state = if constraint_satisfied {
+        PackageState::Installed {
+            version: version.to_string(),
+        }
+    } else {
+        PackageState::VersionMismatch {
+            installed: version.to_string(),
+        }
+    };
+    Ok(Some((provider.to_string(), state)))
+}
+
 #[async_trait(?Send)]
 impl SystemPackageManager for PacmanManager {
     fn name(&self) -> &str {

--- a/src/system/packages/pacman.rs
+++ b/src/system/packages/pacman.rs
@@ -76,8 +76,69 @@ fn package_state(req: &PackageRequest, version: &str) -> PackageState {
     }
 }
 
-fn parse_pacman_package(output: &str) -> Option<(&str, &str)> {
-    output.lines().find_map(|line| line.split_once(' '))
+#[derive(Debug, PartialEq, Eq)]
+struct PacmanPackageMetadata {
+    name: String,
+    version: String,
+    provides: HashSet<String>,
+}
+
+fn parse_pacman_info(output: &str) -> Vec<PacmanPackageMetadata> {
+    let mut packages = Vec::new();
+    let mut name = None;
+    let mut version = None;
+    let mut provides = HashSet::new();
+    let mut reading_provides = false;
+    for line in output.lines().chain(std::iter::once("")) {
+        if line.trim().is_empty() {
+            if let (Some(name), Some(version)) = (name.take(), version.take()) {
+                packages.push(PacmanPackageMetadata {
+                    name,
+                    version,
+                    provides: std::mem::take(&mut provides),
+                });
+            }
+            reading_provides = false;
+            continue;
+        }
+        if let Some((key, value)) = line.split_once(':') {
+            reading_provides = false;
+            match key.trim() {
+                "Name" => name = Some(value.trim().to_string()),
+                "Version" => version = Some(value.trim().to_string()),
+                "Provides" => {
+                    reading_provides = true;
+                    provides.extend(parse_provides(value));
+                }
+                _ => {}
+            }
+        } else if reading_provides {
+            provides.extend(parse_provides(line));
+        }
+    }
+    packages
+}
+
+fn parse_provides(value: &str) -> impl Iterator<Item = String> + '_ {
+    value
+        .split_whitespace()
+        .filter(|provide| *provide != "None")
+        .map(|provide| {
+            provide
+                .split(['<', '=', '>'])
+                .next()
+                .unwrap_or(provide)
+                .to_string()
+        })
+}
+
+fn find_provider<'a>(
+    packages: &'a [PacmanPackageMetadata],
+    requested: &str,
+) -> Option<&'a PacmanPackageMetadata> {
+    packages
+        .iter()
+        .find(|package| package.name == requested || package.provides.contains(requested))
 }
 
 fn parse_pacman_deptest(output: &str) -> HashSet<&str> {
@@ -97,27 +158,47 @@ fn deptest_requirement(req: &PackageRequest) -> String {
 
 fn apply_provider_query<'a>(
     status: &mut PackageStatus,
-    output: &'a str,
+    packages: &'a [PacmanPackageMetadata],
     constraint_satisfied: bool,
-) -> Result<&'a str> {
-    let Some((provider, version)) = parse_pacman_package(output) else {
-        bail!(
-            "pacman -Q returned no package for satisfied requirement '{}'",
+) -> Result<&'a PacmanPackageMetadata> {
+    let provider = find_provider(packages, &status.request.name).ok_or_else(|| {
+        eyre::eyre!(
+            "pacman -Qi returned no provider for satisfied requirement '{}'",
             status.request.name
-        );
-    };
+        )
+    })?;
     // The provider's package version is display metadata; pacman -T evaluates
     // the requested version against the version declared in Provides.
     status.state = if constraint_satisfied {
         PackageState::Installed {
-            version: version.to_string(),
+            version: provider.version.clone(),
         }
     } else {
         PackageState::VersionMismatch {
-            installed: version.to_string(),
+            installed: provider.version.clone(),
         }
     };
     Ok(provider)
+}
+
+async fn pacman_info() -> Result<String> {
+    let args = ["-Qi"];
+    debug!("$ pacman {}", args.join(" "));
+    let output = tokio::process::Command::new("pacman")
+        .args(args)
+        .env("LC_ALL", "C")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await?;
+    if !output.status.success() {
+        bail!(
+            "pacman -Qi failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
 async fn pacman_query(names: &[String]) -> Result<String> {
@@ -193,23 +274,24 @@ pub(super) async fn resolve_installed_provider(
         }
     }
 
-    let output = pacman_query(std::slice::from_ref(&request.name)).await?;
-    let Some((provider, version)) = parse_pacman_package(&output) else {
-        bail!(
-            "pacman -Q returned no package for satisfied requirement '{}'",
+    let info = pacman_info().await?;
+    let packages = parse_pacman_info(&info);
+    let provider = find_provider(&packages, &request.name).ok_or_else(|| {
+        eyre::eyre!(
+            "pacman -Qi returned no provider for satisfied requirement '{}'",
             request.name
-        );
-    };
+        )
+    })?;
     let state = if constraint_satisfied {
         PackageState::Installed {
-            version: version.to_string(),
+            version: provider.version.clone(),
         }
     } else {
         PackageState::VersionMismatch {
-            installed: version.to_string(),
+            installed: provider.version.clone(),
         }
     };
-    Ok(Some((provider.to_string(), state)))
+    Ok(Some((provider.name.clone(), state)))
 }
 
 #[async_trait(?Send)]
@@ -246,10 +328,9 @@ impl SystemPackageManager for PacmanManager {
             return Ok(statuses);
         }
 
-        // A bare query may answer a virtual package target under the installed
-        // provider's real name. Deptest tells us which apparent misses are
-        // genuinely unsatisfied; query the provider-satisfied names one at a
-        // time so their returned versions can be associated positionally.
+        // Deptest tells us which apparent misses are genuinely unsatisfied.
+        // Package metadata below maps satisfied virtual names back to their
+        // concrete installed providers.
         let deptest = pacman_deptest(&apparent_missing).await?;
         let unsatisfied = parse_pacman_deptest(&deptest);
         // A failed version constraint can still have a provider for the bare
@@ -264,6 +345,8 @@ impl SystemPackageManager for PacmanManager {
             .collect::<Vec<_>>();
         let bare_deptest = pacman_deptest(&versioned_unsatisfied).await?;
         let bare_missing = parse_pacman_deptest(&bare_deptest);
+        let info = pacman_info().await?;
+        let packages = parse_pacman_info(&info);
         for status in statuses
             .iter_mut()
             .filter(|status| matches!(status.state, PackageState::Missing))
@@ -276,11 +359,10 @@ impl SystemPackageManager for PacmanManager {
             {
                 continue;
             }
-            let output = pacman_query(std::slice::from_ref(&status.request.name)).await?;
-            let provider = apply_provider_query(status, &output, constraint_satisfied)?;
+            let provider = apply_provider_query(status, &packages, constraint_satisfied)?;
             debug!(
-                "pacman: {} is satisfied by installed provider {provider}",
-                status.request.name
+                "pacman: {} is satisfied by installed provider {}",
+                status.request.name, provider.name,
             );
         }
         Ok(statuses)
@@ -412,10 +494,18 @@ mod tests {
 
         // pacman -T validated the version declared by Provides even though the
         // provider package has a different version of its own.
-        let provider =
-            apply_provider_query(&mut status, "percona-server-clients 9.7.1_1-1\n", true).unwrap();
+        let packages = parse_pacman_info(
+            "Name            : percona-server-clients\n\
+             Version         : 9.7.1_1-1\n\
+             Provides        : mariadb-clients=12.3.2\n\
+                               mysql-clients\n\
+             Description     : database clients\n",
+        );
+        let provider = apply_provider_query(&mut status, &packages, true).unwrap();
 
-        assert_eq!(provider, "percona-server-clients");
+        assert_eq!(provider.name, "percona-server-clients");
+        assert!(provider.provides.contains("mariadb-clients"));
+        assert!(provider.provides.contains("mysql-clients"));
         assert_eq!(
             status.state,
             PackageState::Installed {
@@ -431,7 +521,12 @@ mod tests {
             state: PackageState::Missing,
         };
 
-        apply_provider_query(&mut status, "provider-package 2.0-1\n", false).unwrap();
+        let packages = parse_pacman_info(
+            "Name            : provider-package\n\
+             Version         : 2.0-1\n\
+             Provides        : virtual-package=1.0\n",
+        );
+        apply_provider_query(&mut status, &packages, false).unwrap();
 
         assert_eq!(
             status.state,

--- a/src/system/sudo.rs
+++ b/src/system/sudo.rs
@@ -274,7 +274,9 @@ pub(crate) fn run_with_input_output(
     Ok(output.stdout)
 }
 
-fn ensure_elevation_available(manual_cmd: &str) -> Result<()> {
+/// Verify that a subprocess which performs its own sudo elevation can do so
+/// without violating mise's elevation policy or hanging without a TTY.
+pub(crate) fn ensure_elevation_available(manual_cmd: &str) -> Result<()> {
     if is_root() {
         return Ok(());
     }


### PR DESCRIPTION
## Summary

- add an `aur:` bootstrap package manager backed by `yay` or `paru`
- prefer `yay` for Omarchy compatibility and force AUR-only target resolution
- query pacman's foreign-package state so native package collisions do not satisfy AUR requests, while retaining foreign virtual providers
- install as the current user while preflighting the helper's sudo access for non-interactive runs
- document install, status, upgrade, helper selection, and version-pin behavior

## Testing

- `mise run lint-fix`
- `mise run build`
- `mise exec -- cargo test --all-features system::packages::`
- manually exercised JSON status and dry-run apply with fake `pacman` and `yay` executables, including a native-package name collision

## Compatibility

Omarchy currently installs AUR packages with `yay -S --noconfirm --needed`. This manager uses the same helper and flags, adding `--aur` so repository packages with colliding names cannot be selected. `paru` is supported as a fallback for other Arch-family systems.

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Installs execute external AUR helpers and can replace same-named repo packages; incorrect foreign/provider logic could mis-report status, but scope is limited to Arch bootstrap packages.
> 
> **Overview**
> Adds an **`aur:`** bootstrap package manager so `[bootstrap.packages]` can install from the Arch User Repository via **`yay`** (preferred) or **`paru`**.
> 
> **Status** uses `pacman -Qm` so repo packages with the same name do not satisfy an `aur:` entry; virtual names count only when the provider is foreign. **Install/upgrade** run the helper as the non-root user with `--aur --noconfirm` (and `--refresh` on update), preflight sudo via the newly public `ensure_elevation_available`, and reject version pins for installs. **Upgrade** rebuilds only configured AUR packages. Pacman gains shared **`resolve_installed_provider`** for foreign-only provider matching.
> 
> Docs, sidebar, `llms.txt`, man page, and upgrade help text are updated; pacman docs now point AUR users to the new manager.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd4f3c3bf0cb80ce508a37bd9a6f2a892d3980b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AUR package management support for Arch- and Manjaro-based systems.
  * Added AUR package status checks, installations, upgrades, and support for `yay` or `paru`.
  * Added version mismatch reporting for pinned AUR packages.
  * Improved detection of installed pacman packages and virtual package providers, including preference for exact package matches.

* **Documentation**
  * Added AUR setup guidance, configuration examples, usage instructions, and troubleshooting details.
  * Updated package manager listings and upgrade documentation to include AUR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->