### PR TITLE
fix(completions): include installed plugins in plugin completion

### DIFF
--- a/e2e/cli/test_completion_dynamic
+++ b/e2e/cli/test_completion_dynamic
@@ -24,9 +24,12 @@ zsh_tasks="$(mise __complete_word__ --shell zsh --line 'mise run ')"
 assert_contains_text "$zsh_tasks" $'test\tRun the test task\ttest'
 assert_not_contains_text "$zsh_tasks" $'\001files'
 
+ln -s "$ROOT/test/data/plugins/dummy" "$MISE_DATA_DIR/plugins/node"
 zsh_plugins="$(mise __complete_word__ --shell zsh --line 'mise plugins uninstall ')"
 assert_contains_text "$zsh_plugins" $'dummy\t\tdummy'
 assert_contains_text "$zsh_plugins" $'node\t\tnode'
+node_candidates="$(awk -F $'\t' '$1 == "node" { count++ } END { print count + 0 }' <<<"$zsh_plugins")"
+[[ $node_candidates == 1 ]] || fail "node appeared $node_candidates times in plugin completion"
 
 naked_tasks="$(mise __complete_word__ --shell fish --line 'mise te')"
 assert_contains_text "$naked_tasks" $'test\tRun the test task'

--- a/e2e/cli/test_completion_dynamic
+++ b/e2e/cli/test_completion_dynamic
@@ -24,6 +24,10 @@ zsh_tasks="$(mise __complete_word__ --shell zsh --line 'mise run ')"
 assert_contains_text "$zsh_tasks" $'test\tRun the test task\ttest'
 assert_not_contains_text "$zsh_tasks" $'\001files'
 
+zsh_plugins="$(mise __complete_word__ --shell zsh --line 'mise plugins uninstall ')"
+assert_contains_text "$zsh_plugins" $'dummy\t\tdummy'
+assert_contains_text "$zsh_plugins" $'node\t\tnode'
+
 naked_tasks="$(mise __complete_word__ --shell fish --line 'mise te')"
 assert_contains_text "$naked_tasks" $'test\tRun the test task'
 

--- a/src/cli/plugins/ls.rs
+++ b/src/cli/plugins/ls.rs
@@ -57,7 +57,9 @@ impl PluginsLs {
             for p in CORE_PLUGINS.keys() {
                 miseprintln!("{p}");
             }
-            return Ok(());
+            if !self.user {
+                return Ok(());
+            }
         }
 
         if self.all {

--- a/src/cli/plugins/ls.rs
+++ b/src/cli/plugins/ls.rs
@@ -56,6 +56,7 @@ impl PluginsLs {
         if self.core {
             for p in CORE_PLUGINS.keys() {
                 miseprintln!("{p}");
+                plugins.remove(p);
             }
             if !self.user {
                 return Ok(());


### PR DESCRIPTION
## Summary
- restore the documented combined behavior of --core --user
- include installed user plugins in plugin argument completion
- add Zsh completion regression coverage for core and user plugins

Discussion: https://github.com/jdx/mise/discussions/12719

## Testing
- mise run test:e2e e2e/cli/test_completion_dynamic
- mise run lint-fix

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to plugin listing flags and completion-related output; no auth or data-path changes.
> 
> **Overview**
> **Plugin shell completion** (`mise plugins uninstall`, etc.) is driven by `mise plugins --core --user`. **`plugins ls`** no longer exits after printing core names when **`--user`** is also set: it still prints core plugins, drops those keys from the installed set (so names like `node` are not listed twice), then continues with user-installed plugins.
> 
> **E2E coverage** symlinks a dummy plugin as `node` and asserts Zsh completion for `mise plugins uninstall` includes both `dummy` and `node`, with **`node` appearing exactly once**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58e92c15d3defb67d27b286be130e3589c806501. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate entries when combining core and user-installed plugin listings with `mise plugins ls --core --user`.
  * Improved consistency when combining plugin listing filters.

* **Tests**
  * Added coverage for zsh completion of `mise plugins uninstall`, including `dummy` and `node` plugin entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->