### PR TITLE
fix(bootstrap): pin relative config dir during reexec

### DIFF
--- a/e2e/cli/test_bootstrap_from
+++ b/e2e/cli/test_bootstrap_from
@@ -67,6 +67,14 @@ rm -f "$HOME/bootstrap-from-relative-global-task"
 assert_succeed "MISE_GLOBAL_CONFIG_FILE=relative-global/config.toml mise bootstrap --from-git '$relative_global_source_repo' --yes --only task"
 assert "cat ~/bootstrap-from-relative-global-task" "relative-global"
 
+# A relative MISE_CONFIG_DIR is resolved before the child changes into the
+# checkout and remains the config directory during re-execution.
+relative_config_checkout="bootstrap-relative-config-checkout"
+rm -f "$HOME/bootstrap-from-relative-global-task"
+assert_succeed "MISE_CONFIG_DIR='$relative_config_checkout' mise bootstrap --from-git '$relative_global_source_repo' --yes --only task"
+assert "git -C '$relative_config_checkout' remote get-url origin" "$relative_global_source_repo"
+assert "cat ~/bootstrap-from-relative-global-task" "relative-global"
+
 # A bare relative MISE_GLOBAL_CONFIG_FILE checks out into the current directory
 # rather than silently falling back to the default global config directory.
 mkdir "$bare_global_checkout"

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -1701,12 +1701,21 @@ impl Bootstrap {
             &checkout,
             &crate::env::ARGS.read().unwrap(),
         ));
-        if self.from_git.is_some()
-            && let Some(file_name) = crate::env::MISE_GLOBAL_CONFIG_FILE
+        if self.from_git.is_some() {
+            let config_dir = crate::env::MISE_CONFIG_DIR.as_path();
+            let config_dir = if config_dir.is_absolute() {
+                config_dir.to_path_buf()
+            } else {
+                std::env::current_dir()?.join(config_dir)
+            };
+            command.env("MISE_CONFIG_DIR", config_dir);
+
+            if let Some(file_name) = crate::env::MISE_GLOBAL_CONFIG_FILE
                 .as_deref()
                 .and_then(Path::file_name)
-        {
-            command.env("MISE_GLOBAL_CONFIG_FILE", checkout.join(file_name));
+            {
+                command.env("MISE_GLOBAL_CONFIG_FILE", checkout.join(file_name));
+            }
         }
 
         let mut trusted = std::env::split_paths(


### PR DESCRIPTION
## Summary

- preserve a relative `MISE_CONFIG_DIR` across the `bootstrap --from-git` child re-exec
- add E2E coverage proving the cloned config and bootstrap task remain discoverable
- follow up on review feedback from #12715

## Testing

- `mise run test:e2e e2e/cli/test_bootstrap_from`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow bootstrap `--from-git` re-exec env forwarding fix with E2E coverage; no auth or data-path changes beyond config directory resolution.
> 
> **Overview**
> **`bootstrap --from-git`** clones into the config directory and re-runs mise from that checkout. Without pinning, a **relative `MISE_CONFIG_DIR`** would be reinterpreted after the child changes working directory, so the clone location and config discovery could diverge from what the parent intended.
> 
> This change **resolves relative `MISE_CONFIG_DIR` against the parent’s current directory** and passes the absolute path into the child via **`MISE_CONFIG_DIR`**, mirroring the existing behavior for relative **`MISE_GLOBAL_CONFIG_FILE`**. Optional global config file forwarding stays under the same `from_git` block.
> 
> E2E coverage asserts that with a relative config dir, the repo is cloned there, **`origin`** matches, and the bootstrap task still runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62e062b809a6a112ba978ea7da8d3a2f010fa0f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `--from-git` bootstrapping when `MISE_CONFIG_DIR` is set to a relative path.
  * Configuration directories now remain correctly resolved when the bootstrap process changes into the checkout directory.
  * Preserved forwarding of the global configuration during bootstrap re-execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->