### PR TITLE
fix(env): create bootstrap shims for lazy tools when printing the env

### DIFF
--- a/e2e/cli/test_lazy_tools_env
+++ b/e2e/cli/test_lazy_tools_env
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC2016
+
+export MISE_SHIMS_DIR="$HOME/.local/share/mise/user-shims"
+
+# The environment `mise env` prints places the shim farms on PATH for lazy
+# declarations, and the eval'd shell that consumes it has no command-not-found
+# handler to fall back on (discussion #12678). Evaluating the printed env must
+# therefore leave working bootstrap shims behind, exactly like the env mise
+# builds for tasks and `mise x`.
+case ":$PATH:" in
+  *":$MISE_SHIMS_DIR:"*) fail "expected user shims to be absent from PATH: $PATH" ;;
+esac
+cat >mise.toml <<'EOF'
+[tools]
+dummy = { version = "1.0.0", lazy = true, lazy_bins = ["dummy"] }
+EOF
+assert_fail "test -e '$MISE_SHIMS_DIR/dummy'"
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
+
+mise_path="$(MISE_NOT_FOUND_AUTO_INSTALL=0 mise env -s bash | sed -n 's/^export PATH=//p' | tr -d "'\"")"
+case "$mise_path" in
+  *"$MISE_SHIMS_DIR:"*) ;;
+  *) fail "expected the shim farm in the printed PATH: $mise_path" ;;
+esac
+# printing the env must not install lazy tools eagerly; the install must
+# happen only when the evaluated shell actually runs one of their commands
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
+
+# Evaluating the printed env installs the lazy tool the first time one of its
+# commands runs, the same way it does in a task or `mise x` child.
+assert_contains 'eval "$(MISE_NOT_FOUND_AUTO_INSTALL=0 mise env -s bash)" && dummy --version' "This is Dummy 1.0.0"
+assert_succeed "test -e '$MISE_SHIMS_DIR/dummy'"
+assert_directory_exists "$MISE_DATA_DIR/installs/dummy/1.0.0"

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -55,6 +55,15 @@ impl Env {
         let (_, missing) = ts
             .install_missing_versions(&mut config, &InstallOptions::default())
             .await?;
+        // The printed environment places the shim farms on PATH for lazy
+        // declarations, so evaluating it must leave working bootstrap shims
+        // behind: an eval'd shell has no command-not-found handler to fall
+        // back on (discussion #12678).
+        if ts.has_lazy_declarations()
+            && let Err(err) = crate::shims::ensure_lazy_shims(&missing)
+        {
+            warn!("failed to create shims for lazy tools: {err:#}");
+        }
         ts.notify_missing_versions(missing);
 
         // Pre-compute final_env when needed by --redacted or --dotenv to


### PR DESCRIPTION
## Summary

follow-up to #12687: a tool declared `lazy = true` installs on first use through its bootstrap shim, and the env mise builds for `mise run`, `mise x` and `mise env` puts the shim farms on PATH so that works everywhere
the docs added by that PR also promise "any missing bootstrap shims are created first", but only `mise run` and `mise x` reconcile the farm, `mise env` kept the PATH half of the promise and dropped the shim half

both reproduce with a hand-edited lazy declaration and no `mise reshim`:

```
$ eval "$(mise env -s bash)"
$ dummy --version
bash: dummy: command not found
```

while `mise x -- dummy --version` in the same directory installs and runs it
an eval'd `mise env` shell is exactly the case a task shell is in, no command-not-found handler to fall back on (discussion #12678)

## Fix

- `mise env` now materializes missing bootstrap shims for lazy declarations the same way `exec.rs` and `run.rs` already do: guarded by `has_lazy_declarations()`, so toolsets without a lazy declaration see no difference, and a failure is a warning, not an abort
- in the common case this is a few file existence checks
- new e2e fixture `e2e/cli/test_lazy_tools_env` covers the eval'd env flow: no shim after a hand-edited declaration, farm present in the printed PATH, first invocation installs and runs, shim and install dir left behind

## Testing

- pre-change probe: eval'd env + `dummy --version` = command not found, `mise x -- dummy --version` = works, and after `mise x` the eval'd env works too (isolated env, dummy test plugin)
- `e2e/cli/test_lazy_tools_env` fails without the change, passes with it
- lazy siblings `test_lazy_tools_task` and `test_lazy_tools_system` unchanged and green
- `cargo fmt --check` clean, `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean
- `cargo test --all-features --ignore-rust-version`: 3417 passed, the 2 `system::firewall` failures are pre-existing on upstream main in this environment, verified by running the same filtered suite on b8bf2b0 without this commit

*AI-assisted — Tool: dsh; model: z-ai/glm-5.3-flash; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed shell environments generated by `mise env` so lazy tools are discovered and automatically installed when first run.
  - Evaluating the generated environment now enables lazy tool commands, even without a command-not-found handler.
  - Lazy tool commands remain available through the generated shell environment after initialization.

- **Tests**
  - Added end-to-end coverage confirming that lazy tools install on demand and produce the expected command output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->