### PR TITLE
fix(bootstrap): render tera templates in hooks

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -141,7 +141,9 @@ before installing packages (apk: `--update-cache`, apt: `apt-get update`).
 Hook phases can also run before and after the built-in steps:
 `pre-packages`, `post-packages`, `pre-repos`, `post-repos`, `pre-dotfiles`,
 `post-dotfiles`, `pre-defaults`, `post-defaults`, `pre-user`, `post-user`,
-`pre-tools`, and `post-tools`.
+`pre-tools`, and `post-tools`. Hook commands support [Tera templates](/templates.html)
+using the declaring config's context, including values such as
+`{{ config_root }}`, `{{ xdg_config_home }}`, and `{{ vars.name }}`.
 
 The declarative steps converge: if a package is already installed, a repo is
 already at the requested ref, a dotfile already matches, or a default is already

--- a/docs/bootstrap/packages/aur.md
+++ b/docs/bootstrap/packages/aur.md
@@ -3,6 +3,14 @@
 The `aur` manager installs packages from the
 [Arch User Repository](https://aur.archlinux.org/) with `yay` or `paru`:
 
+::: warning Review AUR packages before installing
+AUR packages are user-submitted build recipes, not packages vetted or supported
+by Arch Linux. A compromised or malicious PKGBUILD can execute code as your user
+during the build. Review the PKGBUILD and related sources before declaring a
+package, and review upstream changes before applying upgrades. mise delegates to
+your AUR helper and does not add an independent trust or verification layer.
+:::
+
 ```toml
 [bootstrap.packages]
 "aur:google-chrome" = "latest"

--- a/docs/bootstrap/packages/aur.md
+++ b/docs/bootstrap/packages/aur.md
@@ -6,7 +6,7 @@ The `aur` manager installs packages from the
 ::: warning Review AUR packages before installing
 AUR packages are user-submitted build recipes, not packages vetted or supported
 by Arch Linux. A compromised or malicious PKGBUILD can execute code as your user
-during the build. Review the PKGBUILD and related sources before declaring a
+during the build. Review the PKGBUILD and related sources before installing a
 package, and review upstream changes before applying upgrades. mise delegates to
 your AUR helper and does not add an independent trust or verification layer.
 :::

--- a/e2e/cli/test_bootstrap
+++ b/e2e/cli/test_bootstrap
@@ -342,6 +342,7 @@ mkdir -p dotfiles/mise bootstrap-root ~/.config/mise
 cat <<'EOF' >bootstrap-root/mise.toml
 [vars]
 bootstrap_root_marker = "root"
+new_bootstrap_root_marker = "stale-root"
 EOF
 cat <<'EOF' >dotfiles/mise/bootstrap-root.local.toml
 [vars]

--- a/e2e/cli/test_bootstrap
+++ b/e2e/cli/test_bootstrap
@@ -202,6 +202,15 @@ assert_succeed "mise bootstrap --yes --only packages"
 assert "test -f '$MISE_CONFIG_DIR/bootstrap-hook-rendered'"
 assert "test -f '$PWD/bootstrap-hook-root-rendered'"
 
+# dry-run renders hooks without allowing effectful template functions
+rm -f bootstrap-hook-template-effect
+cat <<'EOF' >mise.toml
+[bootstrap.hooks.post-packages]
+run = "{{ exec(command='touch bootstrap-hook-template-effect') }}"
+EOF
+assert_fail "mise bootstrap --dry-run --only packages" "exec() is disabled during dry run"
+assert_fail "test -e bootstrap-hook-template-effect"
+
 # macOS LaunchAgents in shared configs are inert when launchd is unavailable
 cat <<EOF >mise.toml
 [bootstrap.macos.launchd.agents.my-sync]
@@ -329,7 +338,15 @@ assert_fail "test -e ~/.declined-bootstrap-edit"
 assert_fail "test -e post_declined_hook_ran"
 
 # dotfiles can add config that contributes hooks to later phases in the same run
-mkdir -p dotfiles/mise
+mkdir -p dotfiles/mise bootstrap-root ~/.config/mise
+cat <<'EOF' >bootstrap-root/mise.toml
+[vars]
+bootstrap_root_marker = "root"
+EOF
+cat <<'EOF' >~/.config/mise/config.toml
+[vars]
+post_dotfiles_message = "stale-post-dotfiles"
+EOF
 cat <<'EOF' >dotfiles/mise/dry-run-source.sh
 touch dry_run_config_source_ran
 EOF
@@ -342,12 +359,18 @@ dry_run_dynamic = "{{ exec(command='touch dry_run_config_exec_ran') }}"
 _.source = "$PWD/dotfiles/mise/dry-run-source.sh"
 
 [bootstrap.hooks.post-dotfiles]
-run = "echo {{ vars.post_dotfiles_message }} > post_dotfiles_hook_ran"
+run = "echo {{ vars.layered_post_dotfiles_message }} > post_dotfiles_hook_ran"
 
 [bootstrap.hooks.final]
 run = "echo final > final_hook_ran"
 EOF
 cat <<EOF >mise.toml
+[bootstrap]
+config_roots = ["bootstrap-root"]
+
+[vars]
+layered_post_dotfiles_message = "{{ vars.post_dotfiles_message | default(value='missing-post-dotfiles') }}"
+
 [dotfiles]
 "~/.config/mise/config.toml" = "dotfiles/mise/config.toml"
 
@@ -355,23 +378,35 @@ cat <<EOF >mise.toml
 run = "echo pre-dotfiles > pre_dotfiles_hook_ran"
 EOF
 rm -f pre_dotfiles_hook_ran post_dotfiles_hook_ran final_hook_ran dry_run_config_source_ran dry_run_config_exec_ran
-assert_contains "mise bootstrap dotfiles apply --dry-run" "echo pre-dotfiles > pre_dotfiles_hook_ran"
-assert_contains "mise bootstrap dotfiles apply --dry-run" "echo rendered-post-dotfiles > post_dotfiles_hook_ran"
+assert_contains "mise bootstrap dotfiles apply --dry-run --force" "echo pre-dotfiles > pre_dotfiles_hook_ran"
+assert_contains "mise bootstrap dotfiles apply --dry-run --force" "echo rendered-post-dotfiles > post_dotfiles_hook_ran"
 assert_fail "cat pre_dotfiles_hook_ran"
 assert_fail "cat post_dotfiles_hook_ran"
 assert_fail "test -e dry_run_config_source_ran"
 assert_fail "test -e dry_run_config_exec_ran"
-assert_succeed "mise bootstrap dotfiles apply --yes"
+assert_contains "mise bootstrap --dry-run --force-dotfiles" "echo rendered-post-dotfiles > post_dotfiles_hook_ran"
+
+# Continue the apply coverage without scoped roots, whose independent config context is
+# exercised by the dry-run assertions above.
+sed -i 's/vars.layered_post_dotfiles_message/vars.post_dotfiles_message/' dotfiles/mise/config.toml
+cat <<EOF >mise.toml
+[dotfiles]
+"~/.config/mise/config.toml" = "dotfiles/mise/config.toml"
+
+[bootstrap.hooks.pre-dotfiles]
+run = "echo pre-dotfiles > pre_dotfiles_hook_ran"
+EOF
+assert_succeed "mise bootstrap dotfiles apply --yes --force"
 assert "cat pre_dotfiles_hook_ran" "pre-dotfiles"
 assert "cat post_dotfiles_hook_ran" "rendered-post-dotfiles"
 assert_fail "cat final_hook_ran"
 rm -f pre_dotfiles_hook_ran post_dotfiles_hook_ran dry_run_config_source_ran dry_run_config_exec_ran ~/.config/mise/config.toml
-assert_succeed "mise --no-hooks bootstrap dotfiles apply --yes"
+assert_succeed "mise --no-hooks bootstrap dotfiles apply --yes --force"
 assert_fail "cat pre_dotfiles_hook_ran"
 assert_fail "cat post_dotfiles_hook_ran"
 rm -f pre_dotfiles_hook_ran post_dotfiles_hook_ran dry_run_config_source_ran dry_run_config_exec_ran
-assert_contains "mise bootstrap --dry-run" "echo rendered-post-dotfiles > post_dotfiles_hook_ran"
-assert_contains "mise bootstrap --dry-run" "echo final > final_hook_ran"
+assert_contains "mise bootstrap --dry-run --force-dotfiles" "echo rendered-post-dotfiles > post_dotfiles_hook_ran"
+assert_contains "mise bootstrap --dry-run --force-dotfiles" "echo final > final_hook_ran"
 assert_fail "cat post_dotfiles_hook_ran"
 assert_fail "cat final_hook_ran"
 assert_fail "test -e dry_run_config_source_ran"

--- a/e2e/cli/test_bootstrap
+++ b/e2e/cli/test_bootstrap
@@ -330,9 +330,16 @@ assert_fail "test -e post_declined_hook_ran"
 
 # dotfiles can add config that contributes hooks to later phases in the same run
 mkdir -p dotfiles/mise
-cat <<'EOF' >dotfiles/mise/config.toml
+cat <<'EOF' >dotfiles/mise/dry-run-source.sh
+touch dry_run_config_source_ran
+EOF
+cat <<EOF >dotfiles/mise/config.toml
 [vars]
 post_dotfiles_message = "rendered-post-dotfiles"
+dry_run_dynamic = "{{ exec(command='touch dry_run_config_exec_ran') }}"
+
+[env]
+_.source = "$PWD/dotfiles/mise/dry-run-source.sh"
 
 [bootstrap.hooks.post-dotfiles]
 run = "echo {{ vars.post_dotfiles_message }} > post_dotfiles_hook_ran"
@@ -347,24 +354,28 @@ cat <<EOF >mise.toml
 [bootstrap.hooks.pre-dotfiles]
 run = "echo pre-dotfiles > pre_dotfiles_hook_ran"
 EOF
-rm -f pre_dotfiles_hook_ran post_dotfiles_hook_ran final_hook_ran
+rm -f pre_dotfiles_hook_ran post_dotfiles_hook_ran final_hook_ran dry_run_config_source_ran dry_run_config_exec_ran
 assert_contains "mise bootstrap dotfiles apply --dry-run" "echo pre-dotfiles > pre_dotfiles_hook_ran"
 assert_contains "mise bootstrap dotfiles apply --dry-run" "echo rendered-post-dotfiles > post_dotfiles_hook_ran"
 assert_fail "cat pre_dotfiles_hook_ran"
 assert_fail "cat post_dotfiles_hook_ran"
+assert_fail "test -e dry_run_config_source_ran"
+assert_fail "test -e dry_run_config_exec_ran"
 assert_succeed "mise bootstrap dotfiles apply --yes"
 assert "cat pre_dotfiles_hook_ran" "pre-dotfiles"
 assert "cat post_dotfiles_hook_ran" "rendered-post-dotfiles"
 assert_fail "cat final_hook_ran"
-rm -f pre_dotfiles_hook_ran post_dotfiles_hook_ran ~/.config/mise/config.toml
+rm -f pre_dotfiles_hook_ran post_dotfiles_hook_ran dry_run_config_source_ran dry_run_config_exec_ran ~/.config/mise/config.toml
 assert_succeed "mise --no-hooks bootstrap dotfiles apply --yes"
 assert_fail "cat pre_dotfiles_hook_ran"
 assert_fail "cat post_dotfiles_hook_ran"
-rm -f pre_dotfiles_hook_ran post_dotfiles_hook_ran
+rm -f pre_dotfiles_hook_ran post_dotfiles_hook_ran dry_run_config_source_ran dry_run_config_exec_ran
 assert_contains "mise bootstrap --dry-run" "echo rendered-post-dotfiles > post_dotfiles_hook_ran"
 assert_contains "mise bootstrap --dry-run" "echo final > final_hook_ran"
 assert_fail "cat post_dotfiles_hook_ran"
 assert_fail "cat final_hook_ran"
+assert_fail "test -e dry_run_config_source_ran"
+assert_fail "test -e dry_run_config_exec_ran"
 assert_succeed "mise bootstrap --yes"
 assert "cat post_dotfiles_hook_ran" "rendered-post-dotfiles"
 assert "cat final_hook_ran" "final"

--- a/e2e/cli/test_bootstrap
+++ b/e2e/cli/test_bootstrap
@@ -193,13 +193,14 @@ assert_fail "test -f post_tools_hook"
 assert_fail "test -f final_hook"
 
 # bootstrap hook commands render with the declaring config's Tera context
-rm -f "$MISE_CONFIG_DIR/bootstrap-hook-rendered"
+rm -f "$MISE_CONFIG_DIR/bootstrap-hook-rendered" bootstrap-hook-root-rendered
 cat <<'EOF' >mise.toml
 [bootstrap.hooks.post-packages]
-run = 'touch "{{ xdg_config_home }}/mise/bootstrap-hook-rendered"'
+run = 'touch "{{ xdg_config_home }}/mise/bootstrap-hook-rendered" "{{ config_root }}/bootstrap-hook-root-rendered"'
 EOF
 assert_succeed "mise bootstrap --yes --only packages"
 assert "test -f '$MISE_CONFIG_DIR/bootstrap-hook-rendered'"
+assert "test -f '$PWD/bootstrap-hook-root-rendered'"
 
 # macOS LaunchAgents in shared configs are inert when launchd is unavailable
 cat <<EOF >mise.toml
@@ -330,8 +331,11 @@ assert_fail "test -e post_declined_hook_ran"
 # dotfiles can add config that contributes hooks to later phases in the same run
 mkdir -p dotfiles/mise
 cat <<'EOF' >dotfiles/mise/config.toml
+[vars]
+post_dotfiles_message = "rendered-post-dotfiles"
+
 [bootstrap.hooks.post-dotfiles]
-run = "echo post-dotfiles > post_dotfiles_hook_ran"
+run = "echo {{ vars.post_dotfiles_message }} > post_dotfiles_hook_ran"
 
 [bootstrap.hooks.final]
 run = "echo final > final_hook_ran"
@@ -345,24 +349,24 @@ run = "echo pre-dotfiles > pre_dotfiles_hook_ran"
 EOF
 rm -f pre_dotfiles_hook_ran post_dotfiles_hook_ran final_hook_ran
 assert_contains "mise bootstrap dotfiles apply --dry-run" "echo pre-dotfiles > pre_dotfiles_hook_ran"
-assert_contains "mise bootstrap dotfiles apply --dry-run" "echo post-dotfiles > post_dotfiles_hook_ran"
+assert_contains "mise bootstrap dotfiles apply --dry-run" "echo rendered-post-dotfiles > post_dotfiles_hook_ran"
 assert_fail "cat pre_dotfiles_hook_ran"
 assert_fail "cat post_dotfiles_hook_ran"
 assert_succeed "mise bootstrap dotfiles apply --yes"
 assert "cat pre_dotfiles_hook_ran" "pre-dotfiles"
-assert "cat post_dotfiles_hook_ran" "post-dotfiles"
+assert "cat post_dotfiles_hook_ran" "rendered-post-dotfiles"
 assert_fail "cat final_hook_ran"
 rm -f pre_dotfiles_hook_ran post_dotfiles_hook_ran ~/.config/mise/config.toml
 assert_succeed "mise --no-hooks bootstrap dotfiles apply --yes"
 assert_fail "cat pre_dotfiles_hook_ran"
 assert_fail "cat post_dotfiles_hook_ran"
 rm -f pre_dotfiles_hook_ran post_dotfiles_hook_ran
-assert_contains "mise bootstrap --dry-run" "echo post-dotfiles > post_dotfiles_hook_ran"
+assert_contains "mise bootstrap --dry-run" "echo rendered-post-dotfiles > post_dotfiles_hook_ran"
 assert_contains "mise bootstrap --dry-run" "echo final > final_hook_ran"
 assert_fail "cat post_dotfiles_hook_ran"
 assert_fail "cat final_hook_ran"
 assert_succeed "mise bootstrap --yes"
-assert "cat post_dotfiles_hook_ran" "post-dotfiles"
+assert "cat post_dotfiles_hook_ran" "rendered-post-dotfiles"
 assert "cat final_hook_ran" "final"
 
 # bootstrap refuses dotfile conflicts unless scoped force is requested

--- a/e2e/cli/test_bootstrap
+++ b/e2e/cli/test_bootstrap
@@ -192,6 +192,15 @@ assert_fail "test -f pre_tools_hook"
 assert_fail "test -f post_tools_hook"
 assert_fail "test -f final_hook"
 
+# bootstrap hook commands render with the declaring config's Tera context
+rm -f "$MISE_CONFIG_DIR/bootstrap-hook-rendered"
+cat <<'EOF' >mise.toml
+[bootstrap.hooks.post-packages]
+run = 'touch "{{ xdg_config_home }}/mise/bootstrap-hook-rendered"'
+EOF
+assert_succeed "mise bootstrap --yes --only packages"
+assert "test -f '$MISE_CONFIG_DIR/bootstrap-hook-rendered'"
+
 # macOS LaunchAgents in shared configs are inert when launchd is unavailable
 cat <<EOF >mise.toml
 [bootstrap.macos.launchd.agents.my-sync]

--- a/e2e/cli/test_bootstrap
+++ b/e2e/cli/test_bootstrap
@@ -343,6 +343,13 @@ cat <<'EOF' >bootstrap-root/mise.toml
 [vars]
 bootstrap_root_marker = "root"
 EOF
+cat <<'EOF' >dotfiles/mise/bootstrap-root.local.toml
+[vars]
+new_bootstrap_root_marker = "new-root"
+
+[bootstrap.hooks.post-dotfiles]
+run = "echo {{ vars.bootstrap_root_marker }}-{{ vars.new_bootstrap_root_marker }} > bootstrap_root_hook_ran"
+EOF
 cat <<'EOF' >~/.config/mise/config.toml
 [vars]
 post_dotfiles_message = "stale-post-dotfiles"
@@ -373,22 +380,25 @@ layered_post_dotfiles_message = "{{ vars.post_dotfiles_message | default(value='
 
 [dotfiles]
 "~/.config/mise/config.toml" = "dotfiles/mise/config.toml"
+"$PWD/bootstrap-root/mise.local.toml" = "dotfiles/mise/bootstrap-root.local.toml"
 
 [bootstrap.hooks.pre-dotfiles]
 run = "echo pre-dotfiles > pre_dotfiles_hook_ran"
 EOF
-rm -f pre_dotfiles_hook_ran post_dotfiles_hook_ran final_hook_ran dry_run_config_source_ran dry_run_config_exec_ran
+rm -f pre_dotfiles_hook_ran post_dotfiles_hook_ran bootstrap_root_hook_ran final_hook_ran dry_run_config_source_ran dry_run_config_exec_ran
 assert_contains "mise bootstrap dotfiles apply --dry-run --force" "echo pre-dotfiles > pre_dotfiles_hook_ran"
 assert_contains "mise bootstrap dotfiles apply --dry-run --force" "echo rendered-post-dotfiles > post_dotfiles_hook_ran"
+assert_contains "mise bootstrap dotfiles apply --dry-run --force" "echo root-new-root > bootstrap_root_hook_ran"
 assert_fail "cat pre_dotfiles_hook_ran"
 assert_fail "cat post_dotfiles_hook_ran"
+assert_fail "cat bootstrap_root_hook_ran"
 assert_fail "test -e dry_run_config_source_ran"
 assert_fail "test -e dry_run_config_exec_ran"
 assert_contains "mise bootstrap --dry-run --force-dotfiles" "echo rendered-post-dotfiles > post_dotfiles_hook_ran"
 
 # Continue the apply coverage without scoped roots, whose independent config context is
 # exercised by the dry-run assertions above.
-sed -i 's/vars.layered_post_dotfiles_message/vars.post_dotfiles_message/' dotfiles/mise/config.toml
+sed -i.bak 's/vars.layered_post_dotfiles_message/vars.post_dotfiles_message/' dotfiles/mise/config.toml
 cat <<EOF >mise.toml
 [dotfiles]
 "~/.config/mise/config.toml" = "dotfiles/mise/config.toml"

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -1288,7 +1288,7 @@ impl Bootstrap {
         if skip.contains(&BootstrapPart::Packages) {
             debug!("bootstrap: system packages skipped");
         } else {
-            self.run_hooks(&hooks, BootstrapHookPhase::PrePackages)
+            self.run_hooks(&config, &hooks, BootstrapHookPhase::PrePackages)
                 .await?;
             let all_mgrs = system::packages_from_config(&config);
             let has_plugin_packages = all_mgrs
@@ -1316,7 +1316,7 @@ impl Bootstrap {
                 driver::run(mgrs, Action::Install, &opts).await?;
             }
             if !has_plugin_packages {
-                self.run_hooks(&hooks, BootstrapHookPhase::PostPackages)
+                self.run_hooks(&config, &hooks, BootstrapHookPhase::PostPackages)
                     .await?;
                 post_packages_ran = true;
             }
@@ -1393,7 +1393,8 @@ impl Bootstrap {
         if skip.contains(&BootstrapPart::Repos) {
             debug!("bootstrap: repos skipped");
         } else {
-            self.run_hooks(&hooks, BootstrapHookPhase::PreRepos).await?;
+            self.run_hooks(&config, &hooks, BootstrapHookPhase::PreRepos)
+                .await?;
             let repos = system::repos_from_config(&config);
             if repos.is_empty() {
                 debug!("bootstrap: no [bootstrap.repos] configured, skipping");
@@ -1405,7 +1406,7 @@ impl Bootstrap {
                     install::apply_repos(repos, self.dry_run, self.yes, self.skip_dirty).await?;
                 }
             }
-            self.run_hooks(&hooks, BootstrapHookPhase::PostRepos)
+            self.run_hooks(&config, &hooks, BootstrapHookPhase::PostRepos)
                 .await?;
         }
 
@@ -1416,7 +1417,7 @@ impl Bootstrap {
                 hooks = system::hooks_from_config(&config);
             }
         } else {
-            self.run_hooks(&hooks, BootstrapHookPhase::PreDotfiles)
+            self.run_hooks(&config, &hooks, BootstrapHookPhase::PreDotfiles)
                 .await?;
             let files = system::files::files_from_config(&config)?;
             if files.is_empty() {
@@ -1457,7 +1458,7 @@ impl Bootstrap {
                 config = Config::reset().await?;
                 hooks = system::hooks_from_config(&config);
             }
-            self.run_hooks(&hooks, BootstrapHookPhase::PostDotfiles)
+            self.run_hooks(&config, &hooks, BootstrapHookPhase::PostDotfiles)
                 .await?;
         }
 
@@ -1479,7 +1480,7 @@ impl Bootstrap {
         if skip.contains(&BootstrapPart::Defaults) {
             debug!("bootstrap: system defaults skipped");
         } else {
-            self.run_hooks(&hooks, BootstrapHookPhase::PreDefaults)
+            self.run_hooks(&config, &hooks, BootstrapHookPhase::PreDefaults)
                 .await?;
             let defaults = system::defaults_from_config(&config);
             if defaults.is_empty() {
@@ -1499,7 +1500,7 @@ impl Bootstrap {
                     ));
                 }
             }
-            self.run_hooks(&hooks, BootstrapHookPhase::PostDefaults)
+            self.run_hooks(&config, &hooks, BootstrapHookPhase::PostDefaults)
                 .await?;
         }
 
@@ -1542,7 +1543,8 @@ impl Bootstrap {
         if skip.contains(&BootstrapPart::User) {
             debug!("bootstrap: login shell skipped");
         } else {
-            self.run_hooks(&hooks, BootstrapHookPhase::PreUser).await?;
+            self.run_hooks(&config, &hooks, BootstrapHookPhase::PreUser)
+                .await?;
             let login_shell = system::login_shell_from_config(&config);
             if login_shell.is_none() {
                 debug!("bootstrap: no [bootstrap.user].login_shell configured, skipping");
@@ -1566,20 +1568,22 @@ impl Bootstrap {
                     follow_up.add_skipped(format!("login shell {shell}: skipped ({reason})"));
                 }
             }
-            self.run_hooks(&hooks, BootstrapHookPhase::PostUser).await?;
+            self.run_hooks(&config, &hooks, BootstrapHookPhase::PostUser)
+                .await?;
         }
 
         if skip.contains(&BootstrapPart::Tools) {
             debug!("bootstrap: tools skipped");
         } else {
-            self.run_hooks(&hooks, BootstrapHookPhase::PreTools).await?;
+            self.run_hooks(&config, &hooks, BootstrapHookPhase::PreTools)
+                .await?;
             info!("bootstrap: tools");
             Install::new_bare(self.dry_run, self.yes).run().await?;
             if !self.dry_run {
                 config = Config::reset().await?;
                 hooks = system::hooks_from_config(&config);
             }
-            self.run_hooks(&hooks, BootstrapHookPhase::PostTools)
+            self.run_hooks(&config, &hooks, BootstrapHookPhase::PostTools)
                 .await?;
         }
 
@@ -1616,7 +1620,7 @@ impl Bootstrap {
                 }
             }
             if !post_packages_ran {
-                self.run_hooks(&hooks, BootstrapHookPhase::PostPackages)
+                self.run_hooks(&config, &hooks, BootstrapHookPhase::PostPackages)
                     .await?;
             }
         }
@@ -1636,7 +1640,8 @@ impl Bootstrap {
         if skip.contains(&BootstrapPart::FinalHook) {
             debug!("bootstrap: final hook skipped");
         } else {
-            self.run_hooks(&hooks, BootstrapHookPhase::Final).await?;
+            self.run_hooks(&config, &hooks, BootstrapHookPhase::Final)
+                .await?;
         }
         follow_up.print()?;
         Ok(())
@@ -1724,10 +1729,11 @@ impl Bootstrap {
 
     async fn run_hooks(
         &self,
+        config: &Config,
         hooks: &[hooks::BootstrapHook],
         phase: BootstrapHookPhase,
     ) -> Result<()> {
-        run_bootstrap_hooks(hooks, phase, self.dry_run).await
+        run_bootstrap_hooks(config, hooks, phase, self.dry_run).await
     }
 
     fn skip_parts(&self) -> HashSet<BootstrapPart> {
@@ -3564,11 +3570,11 @@ impl BootstrapDotfiles {
 
 impl BootstrapDotfilesApply {
     async fn run(self) -> Result<()> {
-        let config = Config::get().await?;
+        let mut config = Config::get().await?;
         let (files, edits) = self.cmd.requests(&config)?;
         let dry_run = self.cmd.dry_run();
         let hooks = system::hooks_from_config(&config);
-        run_bootstrap_hooks(&hooks, BootstrapHookPhase::PreDotfiles, dry_run).await?;
+        run_bootstrap_hooks(&config, &hooks, BootstrapHookPhase::PreDotfiles, dry_run).await?;
         if !self.cmd.run().await? {
             return Ok(());
         }
@@ -3576,14 +3582,15 @@ impl BootstrapDotfilesApply {
             let config_files = config_files_after_dotfiles_dry_run(&config, &files, &edits)?;
             system::hooks_from_config_files(&config_files)
         } else {
-            let config = Config::reset().await?;
+            config = Config::reset().await?;
             system::hooks_from_config(&config)
         };
-        run_bootstrap_hooks(&hooks, BootstrapHookPhase::PostDotfiles, dry_run).await
+        run_bootstrap_hooks(&config, &hooks, BootstrapHookPhase::PostDotfiles, dry_run).await
     }
 }
 
 async fn run_bootstrap_hooks(
+    config: &Config,
     hooks: &[hooks::BootstrapHook],
     phase: BootstrapHookPhase,
     dry_run: bool,
@@ -3595,7 +3602,7 @@ async fn run_bootstrap_hooks(
         debug!("bootstrap: {phase} hooks disabled");
         return Ok(());
     }
-    hooks::run_phase(hooks, phase, dry_run).await
+    hooks::run_phase(config, hooks, phase, dry_run).await
 }
 
 impl BootstrapDotfilesStatus {

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -1452,7 +1452,7 @@ impl Bootstrap {
             }
             if self.dry_run {
                 let config_files = config_files_after_dotfiles_dry_run(&config, &files, &edits)?;
-                config = Config::load_from_config_files(config_files.clone(), false).await?;
+                config = config.with_bootstrap_dry_run_config_files(config_files.clone())?;
                 hooks = system::hooks_from_config(&config);
                 dry_run_config_files = Some(config_files);
             } else {
@@ -3581,7 +3581,7 @@ impl BootstrapDotfilesApply {
         }
         let hooks = if dry_run {
             let config_files = config_files_after_dotfiles_dry_run(&config, &files, &edits)?;
-            config = Config::load_from_config_files(config_files, false).await?;
+            config = config.with_bootstrap_dry_run_config_files(config_files)?;
             system::hooks_from_config(&config)
         } else {
             config = Config::reset().await?;

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -1452,7 +1452,8 @@ impl Bootstrap {
             }
             if self.dry_run {
                 let config_files = config_files_after_dotfiles_dry_run(&config, &files, &edits)?;
-                hooks = system::hooks_from_config_files(&config_files);
+                config = Config::load_from_config_files(config_files.clone(), false).await?;
+                hooks = system::hooks_from_config(&config);
                 dry_run_config_files = Some(config_files);
             } else {
                 config = Config::reset().await?;
@@ -3580,7 +3581,8 @@ impl BootstrapDotfilesApply {
         }
         let hooks = if dry_run {
             let config_files = config_files_after_dotfiles_dry_run(&config, &files, &edits)?;
-            system::hooks_from_config_files(&config_files)
+            config = Config::load_from_config_files(config_files, false).await?;
+            system::hooks_from_config(&config)
         } else {
             config = Config::reset().await?;
             system::hooks_from_config(&config)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -327,7 +327,7 @@ impl Config {
         Ok(config)
     }
 
-    async fn load_from_config_files(
+    pub(crate) async fn load_from_config_files(
         config_files: ConfigMap,
         global_only: bool,
     ) -> Result<Arc<Self>> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -134,7 +134,8 @@ fn extend_monorepo_tool_request_set(union: &mut ToolRequestSet, requests: &ToolR
 struct BootstrapConfigMap {
     config_files: ConfigMap,
     tera_ctx: tera::Context,
-    inherits_main_vars: bool,
+    config_root: Option<PathBuf>,
+    vars_results: EnvResults,
 }
 
 pub(crate) struct Config {
@@ -465,10 +466,18 @@ impl Config {
         config_files: ConfigMap,
     ) -> Result<Arc<Self>> {
         let mut config = self.with_config_files(config_files);
+        let bootstrap_roots = self
+            .bootstrap_config_maps
+            .iter()
+            .filter_map(|map| map.config_root.as_deref())
+            .collect_vec();
+        let mut main_config_files = config.config_files.clone();
+        main_config_files
+            .retain(|path, _| !bootstrap_roots.iter().any(|root| path.starts_with(root)));
         let vars = bootstrap_dry_run_vars(
             Some(&self.config_files),
             self.vars_results_cached(),
-            &config.config_files,
+            &main_config_files,
             IndexMap::new(),
             false,
         )?;
@@ -477,29 +486,29 @@ impl Config {
         config_mut.vars = vars.clone();
         config_mut.tera_ctx.insert("vars", &vars);
         for map in &mut config_mut.bootstrap_config_maps {
-            let mut map_changed = false;
+            let original_config_files = map.config_files.clone();
             for (path, simulated) in &config_mut.config_files {
-                if let Some(existing) = map.config_files.get(path)
-                    && !Arc::ptr_eq(existing, simulated)
-                {
+                let belongs_to_map = match &map.config_root {
+                    Some(root) => path.starts_with(root),
+                    None => !bootstrap_roots.iter().any(|root| path.starts_with(root)),
+                };
+                if belongs_to_map {
                     map.config_files.insert(path.clone(), simulated.clone());
-                    map_changed = true;
                 }
             }
-            if map_changed || (map.inherits_main_vars && main_vars_changed) {
-                let initial = if map.inherits_main_vars {
-                    vars.clone()
-                } else {
-                    IndexMap::new()
-                };
+            if map.config_root.is_some() {
                 let map_vars = bootstrap_dry_run_vars(
-                    None,
-                    None,
+                    Some(&original_config_files),
+                    Some(&map.vars_results),
                     &map.config_files,
-                    initial,
-                    map.inherits_main_vars && main_vars_changed,
+                    vars.clone(),
+                    main_vars_changed,
                 )?;
                 map.tera_ctx.insert("vars", &map_vars);
+            } else {
+                // The base map's context is the main config context. Re-folding its files
+                // would lose cached dynamic vars that the normal loader already resolved.
+                map.tera_ctx.insert("vars", &vars);
             }
         }
         Ok(config)
@@ -1698,7 +1707,8 @@ async fn load_bootstrap_config_maps(config: &Config) -> Result<Vec<BootstrapConf
     let mut maps = vec![BootstrapConfigMap {
         config_files: base,
         tera_ctx: config.tera_ctx.clone(),
-        inherits_main_vars: false,
+        config_root: None,
+        vars_results: config.vars_results_cached().cloned().unwrap_or_default(),
     }];
     let idiomatic_filenames = BTreeMap::new();
     for root in roots {
@@ -1719,7 +1729,8 @@ async fn load_bootstrap_config_maps(config: &Config) -> Result<Vec<BootstrapConf
         maps.push(BootstrapConfigMap {
             config_files,
             tera_ctx,
-            inherits_main_vars: true,
+            config_root: Some(root),
+            vars_results,
         });
     }
     Ok(maps)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -134,6 +134,7 @@ fn extend_monorepo_tool_request_set(union: &mut ToolRequestSet, requests: &ToolR
 struct BootstrapConfigMap {
     config_files: ConfigMap,
     tera_ctx: tera::Context,
+    inherits_main_vars: bool,
 }
 
 pub(crate) struct Config {
@@ -464,10 +465,43 @@ impl Config {
         config_files: ConfigMap,
     ) -> Result<Arc<Self>> {
         let mut config = self.with_config_files(config_files);
-        let vars = bootstrap_dry_run_vars(self, &config.config_files)?;
+        let vars = bootstrap_dry_run_vars(
+            Some(&self.config_files),
+            self.vars_results_cached(),
+            &config.config_files,
+            IndexMap::new(),
+            false,
+        )?;
+        let main_vars_changed = vars != self.vars;
         let config_mut = Arc::get_mut(&mut config).expect("new config Arc is uniquely owned");
         config_mut.vars = vars.clone();
         config_mut.tera_ctx.insert("vars", &vars);
+        for map in &mut config_mut.bootstrap_config_maps {
+            let mut map_changed = false;
+            for (path, simulated) in &config_mut.config_files {
+                if let Some(existing) = map.config_files.get(path)
+                    && !Arc::ptr_eq(existing, simulated)
+                {
+                    map.config_files.insert(path.clone(), simulated.clone());
+                    map_changed = true;
+                }
+            }
+            if map_changed || (map.inherits_main_vars && main_vars_changed) {
+                let initial = if map.inherits_main_vars {
+                    vars.clone()
+                } else {
+                    IndexMap::new()
+                };
+                let map_vars = bootstrap_dry_run_vars(
+                    None,
+                    None,
+                    &map.config_files,
+                    initial,
+                    map.inherits_main_vars && main_vars_changed,
+                )?;
+                map.tera_ctx.insert("vars", &map_vars);
+            }
+        }
         Ok(config)
     }
     pub(crate) fn env_maybe(&self) -> Option<IndexMap<String, String>> {
@@ -1664,6 +1698,7 @@ async fn load_bootstrap_config_maps(config: &Config) -> Result<Vec<BootstrapConf
     let mut maps = vec![BootstrapConfigMap {
         config_files: base,
         tera_ctx: config.tera_ctx.clone(),
+        inherits_main_vars: false,
     }];
     let idiomatic_filenames = BTreeMap::new();
     for root in roots {
@@ -1684,6 +1719,7 @@ async fn load_bootstrap_config_maps(config: &Config) -> Result<Vec<BootstrapConf
         maps.push(BootstrapConfigMap {
             config_files,
             tera_ctx,
+            inherits_main_vars: true,
         });
     }
     Ok(maps)
@@ -3082,29 +3118,30 @@ pub(crate) async fn resolve_vars_from_config_files(
 }
 
 fn bootstrap_dry_run_vars(
-    config: &Config,
+    original_config_files: Option<&ConfigMap>,
+    existing_results: Option<&EnvResults>,
     config_files: &ConfigMap,
+    mut vars: IndexMap<String, String>,
+    mut preceding_layer_changed: bool,
 ) -> Result<IndexMap<String, String>> {
-    let mut vars = IndexMap::new();
     for (source, config_file) in config_files.iter().rev() {
-        let unchanged = config
-            .config_files
-            .get(source)
+        let unchanged = original_config_files
+            .and_then(|files| files.get(source))
             .is_some_and(|original| Arc::ptr_eq(original, config_file));
         for directive in config_file.vars_entries()? {
             if directive.options().tools {
                 continue;
             }
             let existing = |key: &str| {
-                unchanged
-                    .then(|| config.vars_results_cached()?.vars.get(key))
+                (unchanged && !preceding_layer_changed)
+                    .then(|| existing_results?.vars.get(key))
                     .flatten()
                     .filter(|(_, existing_source)| existing_source == source)
                     .map(|(value, _)| value.clone())
             };
             match directive {
                 EnvDirective::Val(key, value, _) => {
-                    if !contains_template_syntax(&value) {
+                    if let Some(value) = bootstrap_dry_run_var(source, &value, &vars) {
                         vars.insert(key, value);
                     } else if let Some(value) = existing(&key) {
                         vars.insert(key, value);
@@ -3121,7 +3158,7 @@ fn bootstrap_dry_run_vars(
                         .filter(|value| !value.is_empty())
                     {
                         vars.insert(key, value.clone());
-                    } else if !contains_template_syntax(&value) {
+                    } else if let Some(value) = bootstrap_dry_run_var(source, &value, &vars) {
                         vars.insert(key, value);
                     } else if let Some(value) = existing(&key) {
                         vars.insert(key, value);
@@ -3145,8 +3182,40 @@ fn bootstrap_dry_run_vars(
                 | EnvDirective::Module(..) => {}
             }
         }
+        preceding_layer_changed |= !unchanged;
     }
     Ok(vars)
+}
+
+fn bootstrap_dry_run_var(
+    source: &Path,
+    value: &str,
+    vars: &IndexMap<String, String>,
+) -> Option<String> {
+    if !contains_template_syntax(value) {
+        return Some(value.to_string());
+    }
+    let mut context = BASE_CONTEXT.clone();
+    context.insert("vars", vars);
+    context.insert(
+        "config_root",
+        &config_file::config_root::config_root(source),
+    );
+    context.insert(
+        "config_source",
+        &config_file::config_root::config_source(source),
+    );
+    let mut tera = crate::tera::get_tera_for_dry_run(source.parent());
+    match render_str(&mut tera, value, &context) {
+        Ok(value) => Some(value),
+        Err(err) => {
+            debug!(
+                "bootstrap: var template from {} omitted from dry-run context: {err}",
+                source.display()
+            );
+            None
+        }
+    }
 }
 
 async fn load_vars(config: &Arc<Config>) -> Result<EnvResults> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -493,7 +493,11 @@ impl Config {
                     None => !bootstrap_roots.iter().any(|root| path.starts_with(root)),
                 };
                 if belongs_to_map {
-                    map.config_files.insert(path.clone(), simulated.clone());
+                    insert_bootstrap_dry_run_config_file(
+                        &mut map.config_files,
+                        path.clone(),
+                        simulated.clone(),
+                    );
                 }
             }
             if map.config_root.is_some() {
@@ -1612,6 +1616,47 @@ impl Config {
     pub(crate) fn redact(&self, input: &str) -> String {
         _REDACTOR.lock().unwrap().redact(input)
     }
+}
+
+/// Insert a simulated config alongside configs from the same directory while preserving the
+/// highest-precedence-first order produced by `config_paths_in_dir_with_filenames`.
+fn insert_bootstrap_dry_run_config_file(
+    config_files: &mut ConfigMap,
+    path: PathBuf,
+    config_file: Arc<dyn ConfigFile>,
+) {
+    if config_files.contains_key(&path) {
+        config_files.insert(path, config_file);
+        return;
+    }
+
+    let precedence = bootstrap_config_filename_precedence(&path);
+    let sibling_indices = config_files
+        .keys()
+        .enumerate()
+        .filter(|(_, existing)| existing.parent() == path.parent())
+        .map(|(index, _)| index)
+        .collect_vec();
+    let index = sibling_indices
+        .iter()
+        .copied()
+        .find(|index| {
+            bootstrap_config_filename_precedence(
+                config_files
+                    .get_index(*index)
+                    .expect("config index exists")
+                    .0,
+            ) < precedence
+        })
+        .or_else(|| sibling_indices.last().map(|index| index + 1))
+        .unwrap_or(config_files.len());
+    config_files.shift_insert(index, path, config_file);
+}
+
+fn bootstrap_config_filename_precedence(path: &Path) -> Option<usize> {
+    DEFAULT_CONFIG_FILENAMES.iter().position(|candidate| {
+        !is_glob_pattern(candidate) && Path::new(candidate).file_name() == path.file_name()
+    })
 }
 
 fn configs_at_root<'a>(dir: &Path, config_files: &'a ConfigMap) -> Vec<&'a Arc<dyn ConfigFile>> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -24,7 +24,7 @@ use crate::config::config_file::mise_toml::{MiseToml, Tasks};
 use crate::config::config_file::{
     ConfigFile, TaskConfig, config_trust_root, is_path_trusted, trust_check,
 };
-use crate::config::env_directive::{EnvResolveOptions, EnvResults, ToolsFilter};
+use crate::config::env_directive::{EnvDirective, EnvResolveOptions, EnvResults, ToolsFilter};
 use crate::config::tracking::Tracker;
 use crate::env::{MISE_DEFAULT_CONFIG_FILENAME, MISE_DEFAULT_TOOL_VERSIONS_FILENAME};
 use crate::file::display_path;
@@ -327,7 +327,7 @@ impl Config {
         Ok(config)
     }
 
-    pub(crate) async fn load_from_config_files(
+    async fn load_from_config_files(
         config_files: ConfigMap,
         global_only: bool,
     ) -> Result<Arc<Self>> {
@@ -450,6 +450,24 @@ impl Config {
 
         let config = Arc::new(config);
         config.env_results().await?;
+        Ok(config)
+    }
+
+    /// Build the config view used to preview hooks introduced by dotfiles.
+    ///
+    /// This deliberately avoids the normal config loader: resolving vars or env can execute
+    /// templates, source scripts, or modules, which a dry-run must not do. Literal vars are
+    /// folded with normal config precedence; already-resolved dynamic vars are retained only
+    /// when their declaring config file is unchanged.
+    pub(crate) fn with_bootstrap_dry_run_config_files(
+        &self,
+        config_files: ConfigMap,
+    ) -> Result<Arc<Self>> {
+        let mut config = self.with_config_files(config_files);
+        let vars = bootstrap_dry_run_vars(self, &config.config_files)?;
+        let config_mut = Arc::get_mut(&mut config).expect("new config Arc is uniquely owned");
+        config_mut.vars = vars.clone();
+        config_mut.tera_ctx.insert("vars", &vars);
         Ok(config)
     }
     pub(crate) fn env_maybe(&self) -> Option<IndexMap<String, String>> {
@@ -3061,6 +3079,74 @@ pub(crate) async fn resolve_vars_from_config_files(
         },
     )
     .await
+}
+
+fn bootstrap_dry_run_vars(
+    config: &Config,
+    config_files: &ConfigMap,
+) -> Result<IndexMap<String, String>> {
+    let mut vars = IndexMap::new();
+    for (source, config_file) in config_files.iter().rev() {
+        let unchanged = config
+            .config_files
+            .get(source)
+            .is_some_and(|original| Arc::ptr_eq(original, config_file));
+        for directive in config_file.vars_entries()? {
+            if directive.options().tools {
+                continue;
+            }
+            let existing = |key: &str| {
+                unchanged
+                    .then(|| config.vars_results_cached()?.vars.get(key))
+                    .flatten()
+                    .filter(|(_, existing_source)| existing_source == source)
+                    .map(|(value, _)| value.clone())
+            };
+            match directive {
+                EnvDirective::Val(key, value, _) => {
+                    if !contains_template_syntax(&value) {
+                        vars.insert(key, value);
+                    } else if let Some(value) = existing(&key) {
+                        vars.insert(key, value);
+                    } else {
+                        vars.shift_remove(&key);
+                    }
+                }
+                EnvDirective::Default(key, value, _) => {
+                    if vars.get(&key).is_some_and(|value| !value.is_empty()) {
+                        continue;
+                    }
+                    if let Some(value) = env::PRISTINE_ENV
+                        .get(&key)
+                        .filter(|value| !value.is_empty())
+                    {
+                        vars.insert(key, value.clone());
+                    } else if !contains_template_syntax(&value) {
+                        vars.insert(key, value);
+                    } else if let Some(value) = existing(&key) {
+                        vars.insert(key, value);
+                    }
+                }
+                EnvDirective::Rm(key, _) => {
+                    vars.shift_remove(&key);
+                }
+                EnvDirective::Age { key, .. } => {
+                    if let Some(value) = existing(&key) {
+                        vars.insert(key, value);
+                    } else {
+                        vars.shift_remove(&key);
+                    }
+                }
+                EnvDirective::Required(..)
+                | EnvDirective::File(..)
+                | EnvDirective::Path(..)
+                | EnvDirective::Source(..)
+                | EnvDirective::PythonVenv { .. }
+                | EnvDirective::Module(..) => {}
+            }
+        }
+    }
+    Ok(vars)
 }
 
 async fn load_vars(config: &Arc<Config>) -> Result<EnvResults> {

--- a/src/system/hooks.rs
+++ b/src/system/hooks.rs
@@ -145,7 +145,11 @@ pub(crate) async fn run_phase(
     };
     for hook in phase_hooks {
         let run = if crate::tera::contains_template_syntax(&hook.run) {
-            let mut tera = crate::tera::get_tera(hook.config_path.parent());
+            let mut tera = if dry_run {
+                crate::tera::get_tera_for_dry_run(hook.config_path.parent())
+            } else {
+                crate::tera::get_tera(hook.config_path.parent())
+            };
             let mut context = config.bootstrap_tera_ctx(&hook.config_path).clone();
             if context.get("config_root").is_none() {
                 let config_root =

--- a/src/system/hooks.rs
+++ b/src/system/hooks.rs
@@ -146,12 +146,13 @@ pub(crate) async fn run_phase(
     for hook in phase_hooks {
         let run = if crate::tera::contains_template_syntax(&hook.run) {
             let mut tera = crate::tera::get_tera(hook.config_path.parent());
-            crate::tera::render_str(
-                &mut tera,
-                &hook.run,
-                config.bootstrap_tera_ctx(&hook.config_path),
-            )
-            .map_err(|err| {
+            let mut context = config.bootstrap_tera_ctx(&hook.config_path).clone();
+            if context.get("config_root").is_none() {
+                let config_root =
+                    crate::config::config_file::config_root::config_root(&hook.config_path);
+                context.insert("config_root", &config_root);
+            }
+            crate::tera::render_str(&mut tera, &hook.run, &context).map_err(|err| {
                 eyre::eyre!(
                     "[bootstrap.hooks.{phase}] in {}: failed to render template: {err}",
                     hook.config_path.display()

--- a/src/system/hooks.rs
+++ b/src/system/hooks.rs
@@ -5,12 +5,13 @@
 //! part of `mise install` or shell activation.
 
 use std::fmt;
+use std::path::PathBuf;
 
 use eyre::{Result, bail};
 use serde::Serialize;
 use strum::{EnumIter, IntoEnumIterator};
 
-use crate::config::Settings;
+use crate::config::{Config, Settings};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumIter, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -65,10 +66,15 @@ impl fmt::Display for BootstrapHookPhase {
 pub(crate) struct BootstrapHook {
     pub phase: BootstrapHookPhase,
     pub run: String,
+    pub config_path: PathBuf,
 }
 
 impl BootstrapHook {
-    pub(crate) fn from_toml(phase_raw: &str, value: toml::Value) -> Result<Vec<Self>> {
+    pub(crate) fn from_toml(
+        phase_raw: &str,
+        value: toml::Value,
+        config_path: PathBuf,
+    ) -> Result<Vec<Self>> {
         let Some(phase) = BootstrapHookPhase::parse(phase_raw) else {
             let valid = BootstrapHookPhase::iter()
                 .map(|phase| phase.as_str())
@@ -99,7 +105,11 @@ impl BootstrapHook {
                     warn!("[bootstrap.hooks.{phase}]: empty command, ignoring entry");
                     None
                 } else {
-                    Some(Self { phase, run })
+                    Some(Self {
+                        phase,
+                        run,
+                        config_path: config_path.clone(),
+                    })
                 }
             })
             .collect();
@@ -119,6 +129,7 @@ fn string_array(values: Vec<toml::Value>, message: &str) -> Result<Vec<String>> 
 }
 
 pub(crate) async fn run_phase(
+    config: &Config,
     hooks: &[BootstrapHook],
     phase: BootstrapHookPhase,
     dry_run: bool,
@@ -133,13 +144,29 @@ pub(crate) async fn run_phase(
         bail!("default inline shell args must not be empty");
     };
     for hook in phase_hooks {
+        let run = if crate::tera::contains_template_syntax(&hook.run) {
+            let mut tera = crate::tera::get_tera(hook.config_path.parent());
+            crate::tera::render_str(
+                &mut tera,
+                &hook.run,
+                config.bootstrap_tera_ctx(&hook.config_path),
+            )
+            .map_err(|err| {
+                eyre::eyre!(
+                    "[bootstrap.hooks.{phase}] in {}: failed to render template: {err}",
+                    hook.config_path.display()
+                )
+            })?
+        } else {
+            hook.run.clone()
+        };
         if dry_run {
-            miseprintln!("{} {}", shell.join(" "), shell_words::quote(&hook.run));
+            miseprintln!("{} {}", shell.join(" "), shell_words::quote(&run));
             continue;
         }
-        info!("$ {}", hook.run);
+        info!("$ {run}");
         crate::cmd::CmdLineRunner::new(program)
-            .cmd_body_args(shell_args, &hook.run)
+            .cmd_body_args(shell_args, &run)
             .raw(true)
             .execute_async()
             .await?;
@@ -166,8 +193,12 @@ mod tests {
 
     #[test]
     fn unknown_phase_error_lists_valid_phases() {
-        let err = BootstrapHook::from_toml("pre-things", toml::Value::String("echo nope".into()))
-            .unwrap_err();
+        let err = BootstrapHook::from_toml(
+            "pre-things",
+            toml::Value::String("echo nope".into()),
+            "mise.toml".into(),
+        )
+        .unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("pre-things"));
         assert!(msg.contains("pre-packages"));
@@ -176,14 +207,18 @@ mod tests {
 
     #[test]
     fn parses_hook_values() {
-        let hooks =
-            BootstrapHook::from_toml("pre-packages", toml::Value::String("echo preparing".into()))
-                .unwrap();
+        let hooks = BootstrapHook::from_toml(
+            "pre-packages",
+            toml::Value::String("echo preparing".into()),
+            "mise.toml".into(),
+        )
+        .unwrap();
         assert_eq!(
             hooks,
             vec![BootstrapHook {
                 phase: BootstrapHookPhase::PrePackages,
                 run: "echo preparing".into(),
+                config_path: "mise.toml".into(),
             }]
         );
 
@@ -195,7 +230,9 @@ mod tests {
                 toml::Value::String("echo two".into()),
             ]),
         );
-        let hooks = BootstrapHook::from_toml("final", toml::Value::Table(table)).unwrap();
+        let hooks =
+            BootstrapHook::from_toml("final", toml::Value::Table(table), "mise.toml".into())
+                .unwrap();
         assert_eq!(hooks.len(), 2);
         assert_eq!(hooks[1].run, "echo two");
     }

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -1488,7 +1488,7 @@ pub(crate) fn hooks_from_config_files(config_files: &ConfigMap) -> Vec<hooks::Bo
     for cf in config_files.values().rev() {
         if let Some(sys) = cf.bootstrap_config() {
             for (phase, value) in sys.hooks {
-                match hooks::BootstrapHook::from_toml(&phase, value) {
+                match hooks::BootstrapHook::from_toml(&phase, value, cf.get_path().to_path_buf()) {
                     Ok(hooks) => out.extend(hooks),
                     Err(err) => warn!("[bootstrap.hooks.{phase}]: {err}"),
                 }

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -1298,6 +1298,33 @@ pub(crate) fn get_tera(dir: Option<&Path>) -> TeraEngine {
     }
 }
 
+/// Returns the normal mise renderer with command execution disabled.
+pub(crate) fn get_tera_for_dry_run(dir: Option<&Path>) -> TeraEngine {
+    if use_tera_v1() {
+        let mut tera = get_tera_v1(dir);
+        tera.register_function("exec", dry_run_disabled_fn_v1("exec"));
+        TeraEngine::V1(Box::new(tera))
+    } else {
+        let mut tera = get_tera_v2(dir);
+        tera.register_function("exec", dry_run_disabled_fn("exec"));
+        TeraEngine::V2(Box::new(tera))
+    }
+}
+
+fn dry_run_disabled_fn(name: &'static str) -> impl Fn(Kwargs, &State) -> TeraResult<Value> {
+    move |_args: Kwargs, _: &State| -> TeraResult<Value> {
+        Err(tera_err(format!("{name}() is disabled during dry run")))
+    }
+}
+
+fn dry_run_disabled_fn_v1(
+    name: &'static str,
+) -> impl Fn(&HashMap<String, JsonValue>) -> tera1::Result<JsonValue> {
+    move |_args: &HashMap<String, JsonValue>| -> tera1::Result<JsonValue> {
+        Err(tera1_err(format!("{name}() is disabled during dry run")))
+    }
+}
+
 /// Like [`get_tera`] but with `os()` and `arch()` bound to an explicit target
 /// platform instead of the current host. Used by cross-platform `mise lock` to
 /// render URL/checksum templates for platforms other than the one mise runs on.


### PR DESCRIPTION
## Summary
- render bootstrap hook commands with the Tera context of the config that declared them
- preserve the declaring config path across layered config reloads and dotfile application
- document hook templating and add an AUR supply-chain warning based on discussion #12709 feedback

## Testing
- `cargo test --locked --bin mise system::hooks::tests`
- `mise run test:e2e e2e/cli/test_bootstrap` (target test passed; selector also matched sibling bootstrap tests, which were stopped afterward)
- scoped `hk run check --safe --format json --files0-from -`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bootstrap hook execution and dry-run config simulation; mistakes could run wrong commands or leak unsafe preview behavior, but scope is limited to bootstrap hooks and dry-run paths.
> 
> **Overview**
> **Bootstrap hook `run` commands are now rendered as Tera templates** using the context of the config file that declared them (`config_root`, `xdg_config_home`, `vars`, and related values). Hooks keep their declaring path through layered reloads, including hooks introduced when dotfiles apply mid-bootstrap.
> 
> **Dry-run previews stay non-effectful:** hook and var rendering use a restricted Tera engine that rejects `exec()`, and dotfile dry-run builds a simulated config view without sourcing env scripts or re-running full var resolution—while still folding literal vars and safe templates so post-dotfiles hooks preview correctly (including scoped `bootstrap.config_roots`).
> 
> Docs note hook templating in `bootstrap.md` and add an AUR supply-chain warning before `aur:` package installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edfc74d2c145ea955638bf8150da205d6955f065. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Bootstrap hook commands support Tera templates using configuration context, including `config_root`, `xdg_config_home`, and custom variables.
  - Hooks can use configuration values loaded or updated during bootstrap phases.

- **Bug Fixes**
  - Dry-run bootstrap no longer executes dynamic commands or sourced environment files.
  - Dry-run template rendering now blocks effectful functions such as `exec()` and reports the restriction clearly.

- **Documentation**
  - Added guidance to review AUR packages, PKGBUILDs, related sources, and upstream changes before installation or upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->