### PR TITLE
chore(ci): attest release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -521,14 +521,15 @@ jobs:
     steps:
       - name: Download draft release assets
         run: |
-          mkdir -p "releases/${{ github.ref_name }}"
-          gh release download "${{ github.ref_name }}" --dir "releases/${{ github.ref_name }}"
+          mkdir -p release-assets
+          gh release download "$RELEASE_TAG" --dir release-assets
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
       - name: Attest release artifacts
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
-          subject-checksums: releases/${{ github.ref_name }}/SHASUMS256.txt
+          subject-checksums: release-assets/SHASUMS256.txt
 
   publish-release:
     needs:
@@ -541,6 +542,7 @@ jobs:
     steps:
       - name: Publish GitHub Release
         run: |
-          gh release edit "${{ github.ref_name }}" --draft=false
+          gh release edit "$RELEASE_TAG" --draft=false
         env:
           GH_TOKEN: ${{ secrets.MISE_GH_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -508,14 +508,14 @@ jobs:
             gh release upload "$VERSION" --clobber "releases/$VERSION"/*
             RELEASE_ID="$EXISTING_RELEASE_ID"
           else
-            gh release create "$VERSION" \
+            RELEASE_URL="$(gh release create "$VERSION" \
               --title "$RELEASE_TITLE" \
               --notes-file /tmp/release-notes.txt \
               --verify-tag \
               --draft \
-              "releases/$VERSION"/*
-            RELEASE_ID="$(gh api --paginate "repos/${{ github.repository }}/releases?per_page=100" |
-              jq -s -r --arg version "$VERSION" '[.[][] | select(.tag_name == $version and .draft)][0].id // empty')"
+              "releases/$VERSION"/*)"
+            RELEASE_TAG="${RELEASE_URL##*/}"
+            RELEASE_ID="$(gh api "repos/${{ github.repository }}/releases/tags/$RELEASE_TAG" --jq '.id')"
           fi
           test -n "$RELEASE_ID"
           echo "created=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,11 +345,10 @@ jobs:
   release:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    outputs:
+      created: ${{ steps.create-release.outputs.created }}
     permissions:
-      attestations: write
-      artifact-metadata: write
       contents: write
-      id-token: write
     needs:
       - rpm
       - deb
@@ -455,11 +454,6 @@ jobs:
         if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
       - run: mise x -- scripts/release.sh
         if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
-      - name: Attest release artifacts
-        if: startsWith(github.ref, 'refs/tags/v') && steps.check-release.outputs.exists != 'true'
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
-        with:
-          subject-checksums: releases/${{ github.ref_name }}/SHASUMS256.txt
       - name: Generate release notes
         if: startsWith(github.ref, 'refs/tags/v') && steps.check-release.outputs.exists != 'true'
         run: |
@@ -495,6 +489,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       - name: Create Draft GitHub Release
+        id: create-release
         if: startsWith(github.ref, 'refs/tags/v') && steps.check-release.outputs.exists != 'true'
         run: |
           VERSION="$(./scripts/get-version.sh)"
@@ -504,6 +499,7 @@ jobs:
             --verify-tag \
             --draft \
             "releases/$VERSION"/*
+          echo "created=true" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.MISE_GH_TOKEN }}
       - name: Publish Release Assets to CDN
@@ -513,10 +509,38 @@ jobs:
           CLOUDFLARE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
           CLOUDFLARE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
-      - name: Publish GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v') && steps.check-release.outputs.exists != 'true'
+
+  attest-release:
+    needs: release
+    if: needs.release.outputs.created == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+    steps:
+      - name: Download draft release assets
         run: |
-          VERSION="$(./scripts/get-version.sh)"
-          gh release edit "$VERSION" --draft=false
+          mkdir -p "releases/${{ github.ref_name }}"
+          gh release download "${{ github.ref_name }}" --dir "releases/${{ github.ref_name }}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Attest release artifacts
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-checksums: releases/${{ github.ref_name }}/SHASUMS256.txt
+
+  publish-release:
+    needs:
+      - release
+      - attest-release
+    if: needs.release.outputs.created == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Publish GitHub Release
+        run: |
+          gh release edit "${{ github.ref_name }}" --draft=false
         env:
           GH_TOKEN: ${{ secrets.MISE_GH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -394,7 +394,7 @@ jobs:
           VERSION="$(./scripts/get-version.sh)"
           RELEASE="$(gh api --paginate "repos/${{ github.repository }}/releases?per_page=100" |
             jq -s -c --arg version "$VERSION" '[.[][] | select(.tag_name == $version)][0] // {}')"
-          DRAFT="$(jq -r '.draft // empty' <<< "$RELEASE")"
+          DRAFT="$(jq -r 'if has("draft") then .draft else empty end' <<< "$RELEASE")"
           if [[ "$DRAFT" == "false" ]]; then
             echo "::warning::Release $VERSION already exists and is published — skipping publish steps"
             echo "exists=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -514,8 +514,8 @@ jobs:
               --verify-tag \
               --draft \
               "releases/$VERSION"/*)"
-            RELEASE_TAG="${RELEASE_URL##*/}"
-            RELEASE_ID="$(gh api "repos/${{ github.repository }}/releases/tags/$RELEASE_TAG" --jq '.id')"
+            RELEASE_ID="$(gh api --paginate "repos/${{ github.repository }}/releases?per_page=100" |
+              jq -s -r --arg url "$RELEASE_URL" '[.[][] | select(.html_url == $url)][0].id // empty')"
           fi
           test -n "$RELEASE_ID"
           echo "created=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -454,6 +454,14 @@ jobs:
         if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
       - run: mise x -- scripts/release.sh
         if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
+      - name: Stage release assets for attestation
+        if: startsWith(github.ref, 'refs/tags/v') && steps.check-release.outputs.exists != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-assets
+          path: releases/${{ github.ref_name }}
+          if-no-files-found: error
+          retention-days: 1
       - name: Generate release notes
         if: startsWith(github.ref, 'refs/tags/v') && steps.check-release.outputs.exists != 'true'
         run: |
@@ -519,13 +527,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Download draft release assets
-        run: |
-          mkdir -p release-assets
-          gh release download "$RELEASE_TAG" --dir release-assets
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.ref_name }}
+      - name: Download release assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: release-assets
+          path: release-assets
       - name: Attest release artifacts
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,7 +346,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
+      attestations: write
+      artifact-metadata: write
       contents: write
+      id-token: write
     needs:
       - rpm
       - deb
@@ -452,6 +455,11 @@ jobs:
         if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
       - run: mise x -- scripts/release.sh
         if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
+      - name: Attest release artifacts
+        if: startsWith(github.ref, 'refs/tags/v') && steps.check-release.outputs.exists != 'true'
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-checksums: releases/${{ github.ref_name }}/SHASUMS256.txt
       - name: Generate release notes
         if: startsWith(github.ref, 'refs/tags/v') && steps.check-release.outputs.exists != 'true'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,6 +347,7 @@ jobs:
     timeout-minutes: 30
     outputs:
       created: ${{ steps.create-release.outputs.created }}
+      release-id: ${{ steps.create-release.outputs.release-id }}
     permissions:
       contents: write
     needs:
@@ -391,15 +392,17 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v') && inputs.force != true
         run: |
           VERSION="$(./scripts/get-version.sh)"
-          if gh api "repos/${{ github.repository }}/releases/tags/$VERSION" --jq '.draft' 2>/dev/null; then
-            DRAFT="$(gh api "repos/${{ github.repository }}/releases/tags/$VERSION" --jq '.draft')"
-            if [[ "$DRAFT" == "false" ]]; then
-              echo "::warning::Release $VERSION already exists and is published — skipping publish steps"
-              echo "exists=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "Draft release $VERSION exists — will continue publishing"
-              echo "exists=false" >> "$GITHUB_OUTPUT"
-            fi
+          RELEASE="$(gh api --paginate "repos/${{ github.repository }}/releases?per_page=100" |
+            jq -s -c --arg version "$VERSION" '[.[][] | select(.tag_name == $version)][0] // {}')"
+          DRAFT="$(jq -r '.draft // empty' <<< "$RELEASE")"
+          if [[ "$DRAFT" == "false" ]]; then
+            echo "::warning::Release $VERSION already exists and is published — skipping publish steps"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$DRAFT" == "true" ]]; then
+            echo "Draft release $VERSION exists — will refresh its assets and continue publishing"
+            echo "draft=true" >> "$GITHUB_OUTPUT"
+            echo "release-id=$(jq -r '.id' <<< "$RELEASE")" >> "$GITHUB_OUTPUT"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           else
             echo "No release found for $VERSION"
             echo "exists=false" >> "$GITHUB_OUTPUT"
@@ -501,14 +504,25 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v') && steps.check-release.outputs.exists != 'true'
         run: |
           VERSION="$(./scripts/get-version.sh)"
-          gh release create "$VERSION" \
-            --title "$RELEASE_TITLE" \
-            --notes-file /tmp/release-notes.txt \
-            --verify-tag \
-            --draft \
-            "releases/$VERSION"/*
+          if [[ "$EXISTING_DRAFT" == "true" ]]; then
+            gh release upload "$VERSION" --clobber "releases/$VERSION"/*
+            RELEASE_ID="$EXISTING_RELEASE_ID"
+          else
+            gh release create "$VERSION" \
+              --title "$RELEASE_TITLE" \
+              --notes-file /tmp/release-notes.txt \
+              --verify-tag \
+              --draft \
+              "releases/$VERSION"/*
+            RELEASE_ID="$(gh api --paginate "repos/${{ github.repository }}/releases?per_page=100" |
+              jq -s -r --arg version "$VERSION" '[.[][] | select(.tag_name == $version and .draft)][0].id // empty')"
+          fi
+          test -n "$RELEASE_ID"
           echo "created=true" >> "$GITHUB_OUTPUT"
+          echo "release-id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
         env:
+          EXISTING_DRAFT: ${{ steps.check-release.outputs.draft }}
+          EXISTING_RELEASE_ID: ${{ steps.check-release.outputs.release-id }}
           GH_TOKEN: ${{ secrets.MISE_GH_TOKEN }}
       - name: Publish Release Assets to CDN
         if: startsWith(github.ref, 'refs/tags/v') && steps.check-release.outputs.exists != 'true'
@@ -546,9 +560,19 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Publish GitHub Release
+      - name: Download release assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: release-assets
+          path: release-assets
+      - name: Verify and publish GitHub Release
         run: |
-          gh release edit "$RELEASE_TAG" --draft=false
+          (cd release-assets && sha256sum ./* | sort) > /tmp/expected-assets
+          gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+            --jq '.assets[] | select(.digest | startswith("sha256:")) | "\(.digest[7:])  ./\(.name)"' \
+            | sort > /tmp/draft-assets
+          diff -u /tmp/expected-assets /tmp/draft-assets
+          gh api --method PATCH "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" -F draft=false
         env:
           GH_TOKEN: ${{ secrets.MISE_GH_TOKEN }}
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_ID: ${{ needs.release.outputs.release-id }}


### PR DESCRIPTION
## Summary
- create a draft GitHub release before attestation
- generate SLSA provenance for its artifacts in a dedicated least-privilege job using the existing SHA-256 manifest
- publish the draft only after attestation succeeds
- pin `actions/attest` to v4.2.2 by commit SHA

## Testing
- focused `hk run check --safe` for `.github/workflows/release.yml`
  - prettier passed
  - actionlint passed
- `mise x zizmor -- zizmor --persona=regular --min-severity=high .github/workflows/release.yml`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the production release gate and timing of when artifacts become public; a misconfigured verify/diff step could block or delay releases.
> 
> **Overview**
> Release publishing is split so **draft GitHub releases stay unpublished until attestation succeeds**. The `release` job now exposes `created` and `release-id`, stages `releases/<tag>` (including `SHASUMS256.txt`) as a short-lived `release-assets` artifact, and creates or refreshes a **draft** release (re-upload with `--clobber` when a draft already exists) instead of flipping `draft=false` in the same job.
> 
> A new **`attest-release`** job (least-privilege: `attestations: write`) downloads those assets and runs pinned **`actions/attest`** against `SHASUMS256.txt`. **`publish-release`** runs only after attestation, **diffs** local SHA-256 sums against GitHub release asset digests, then PATCHes the release to non-draft.
> 
> **Existing-release detection** now paginates the releases API and records draft `release-id`, fixing unreliable “already published” checks from the per-tag endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f70238d642c7f5274fabf8fdfdb493a0ab9a3c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected release detection so existing published releases are recognized reliably.
  * Improved handling of release status checks, preventing published releases from being incorrectly treated as unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->