### PR TITLE
feat(self-update): allow curated github release sources

### DIFF
--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -31,6 +31,20 @@ mise settings set auto_update true
 mise then periodically checks before eligible interactive commands, installs a newer release without
 updating plugins, and re-runs the original command with the new binary. Configure the interval with
 [`auto_update_check_duration`](/configuration/settings.html#auto_update_check_duration).
+
+Organizations can direct manual and automatic self-updates to a curated GitHub release mirror by
+setting [`self_update.repository`](/configuration/settings.html#self_updaterepository). Private
+repositories and GitHub Enterprise use mise's existing GitHub token resolution. Mirrored archives
+must retain the official file names and embedded mise signatures:
+
+```toml
+[settings.self_update]
+repository = "myorg/mise-mirror"
+api_url = "https://api.github.com"
+```
+
+These settings are global-only: set them in the user-global or system configuration, not a project
+configuration.
 :::
 
 ::: tip Keep mise up to date

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1692,6 +1692,22 @@
             }
           }
         },
+        "self_update": {
+          "type": "object",
+          "unevaluatedProperties": false,
+          "properties": {
+            "api_url": {
+              "default": "https://api.github.com",
+              "description": "GitHub API base URL used by `mise self-update`.",
+              "type": "string"
+            },
+            "repository": {
+              "default": "jdx/mise",
+              "description": "GitHub repository used by `mise self-update`.",
+              "type": "string"
+            }
+          }
+        },
         "shared_install_dirs": {
           "description": "Additional read-only directories to search for installed tool versions.",
           "type": "array",

--- a/settings.toml
+++ b/settings.toml
@@ -2595,6 +2595,34 @@ description = "Deny filesystem writes by default for `mise run` and `mise exec`.
 env = "MISE_SANDBOX_DENY_WRITE"
 type = "Bool"
 
+[self_update.api_url]
+default = "https://api.github.com"
+description = "GitHub API base URL used by `mise self-update`."
+docs = """
+The API base URL for the GitHub repository that supplies mise releases. For GitHub Enterprise,
+include the API path, such as `https://github.example.com/api/v3`.
+
+This setting is global-only so a project configuration cannot redirect updates of the mise binary.
+"""
+env = "MISE_SELF_UPDATE_API_URL"
+global_only = true
+type = "Url"
+
+[self_update.repository]
+default = "jdx/mise"
+description = "GitHub repository used by `mise self-update`."
+docs = """
+The repository must contain official mise release archives with their original names and embedded
+signatures. This can be set to a private repository that mirrors only releases approved by an
+organization. Authentication uses mise's existing GitHub token resolution settings.
+
+The configured repository is also used for version notifications and automatic updates. This
+setting is global-only so a project configuration cannot redirect updates of the mise binary.
+"""
+env = "MISE_SELF_UPDATE_REPOSITORY"
+global_only = true
+type = "String"
+
 [shared_install_dirs]
 description = "Additional read-only directories to search for installed tool versions."
 docs = """

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -416,7 +416,7 @@ impl SelfUpdate {
             // in the `.version` marker, masking the staleness from future
             // (non-forced) reshims. Best-effort. See discussion #10022.
             #[cfg(windows)]
-            match Self::update_mise_shim(&version).await {
+            match Self::update_mise_shim(&SelfUpdateSource::current(), &version).await {
                 Ok(()) => {
                     if let Err(e) = Self::reshim_after_update().await {
                         warn!("Failed to reshim after self-update: {e}");
@@ -567,14 +567,31 @@ impl SelfUpdate {
     }
 
     #[cfg(windows)]
-    async fn update_mise_shim(version: &str) -> Result<()> {
+    async fn update_mise_shim(source: &SelfUpdateSource, version: &str) -> Result<()> {
         use crate::http::HTTP;
         use std::io::Read;
 
         let version = version.strip_prefix('v').unwrap_or(version);
         let archive_name = format!("mise-v{version}-{}-{}.zip", *OS, *ARCH);
+        let release = crate::github::get_release_for_url_with_versions_host(
+            &source.api_url,
+            &source.repository,
+            &format!("v{version}"),
+            false,
+        )
+        .await?;
+        let asset = release
+            .assets
+            .iter()
+            .find(|asset| asset.name == archive_name)
+            .ok_or_else(|| {
+                color_eyre::eyre::eyre!(
+                    "release v{version} for {} has no asset named {archive_name}",
+                    source.repository
+                )
+            })?;
         let url =
-            format!("https://github.com/jdx/mise/releases/download/v{version}/{archive_name}",);
+            crate::github::pick_reachable_asset_url(&asset.browser_download_url, &asset.url).await;
         debug!("Downloading mise-shim.exe from {url}");
 
         let temp_dir = tempfile::tempdir()?;

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -6,7 +6,7 @@ use indoc::formatdoc;
 use self_update::backends::github::Update;
 use self_update::{VersionStatus, cargo_crate_version};
 
-use crate::cli::version::{ARCH, OS};
+use crate::cli::version::{ARCH, OS, SelfUpdateSource};
 use crate::config::Settings;
 use crate::env;
 #[cfg(windows)]
@@ -474,8 +474,14 @@ impl SelfUpdate {
     }
 
     fn do_update_blocking(&self) -> Result<VersionStatus> {
+        let settings = Settings::try_get();
+        let source = settings
+            .as_ref()
+            .map(|settings| SelfUpdateSource::from_settings(settings))
+            .unwrap_or_default();
+        let (repo_owner, repo_name) = source.repository_parts()?;
         let mut update = Update::configure();
-        if let Some((token, _)) = crate::github::resolve_token("github.com") {
+        if let Some(token) = crate::github::resolve_token_for_api_url(&source.api_url) {
             update.auth_token(&token);
         }
         #[cfg(windows)]
@@ -483,13 +489,13 @@ impl SelfUpdate {
         #[cfg(not(windows))]
         let bin_path_in_archive = "mise/bin/mise";
         update
-            .repo_owner("jdx")
-            .repo_name("mise")
+            .repo_owner(repo_owner)
+            .repo_name(repo_name)
+            .api_base_url(&source.api_url)
             .bin_name("mise")
             .current_version(cargo_crate_version!())
             .bin_path_in_archive(bin_path_in_archive);
 
-        let settings = Settings::try_get();
         let v = self
             .version
             .clone()
@@ -499,7 +505,9 @@ impl SelfUpdate {
                         .build()?
                         .get_latest_release()?
                         .latest()
-                        .ok_or_else(|| eyre::eyre!("no GitHub releases found for jdx/mise"))?
+                        .ok_or_else(|| {
+                            eyre::eyre!("no GitHub releases found for {}", source.repository)
+                        })?
                         .version()
                         .to_string())
                 },

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -13,6 +13,72 @@ use crate::file::modified_duration;
 use crate::ui::style;
 use crate::{dirs, duration, env, file};
 
+const DEFAULT_SELF_UPDATE_API_URL: &str = "https://api.github.com";
+const DEFAULT_SELF_UPDATE_REPOSITORY: &str = "jdx/mise";
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct SelfUpdateSource {
+    pub(crate) api_url: String,
+    pub(crate) repository: String,
+}
+
+impl Default for SelfUpdateSource {
+    fn default() -> Self {
+        Self {
+            api_url: DEFAULT_SELF_UPDATE_API_URL.to_string(),
+            repository: DEFAULT_SELF_UPDATE_REPOSITORY.to_string(),
+        }
+    }
+}
+
+impl SelfUpdateSource {
+    pub(crate) fn from_settings(settings: &Settings) -> Self {
+        Self {
+            api_url: settings
+                .self_update
+                .api_url
+                .trim_end_matches('/')
+                .to_string(),
+            repository: settings.self_update.repository.clone(),
+        }
+    }
+
+    fn current() -> Self {
+        Settings::try_get()
+            .map(|settings| Self::from_settings(&settings))
+            .unwrap_or_default()
+    }
+
+    fn is_default(&self) -> bool {
+        self.api_url == DEFAULT_SELF_UPDATE_API_URL
+            && self.repository == DEFAULT_SELF_UPDATE_REPOSITORY
+    }
+
+    fn cache_path(&self) -> std::path::PathBuf {
+        if self.is_default() {
+            dirs::CACHE.join("latest-version")
+        } else {
+            dirs::CACHE.join(format!("latest-version-{}", crate::hash::hash_to_str(self)))
+        }
+    }
+
+    #[cfg(feature = "self_update")]
+    pub(crate) fn repository_parts(&self) -> Result<(&str, &str)> {
+        let (owner, repo) = self.repository.split_once('/').ok_or_else(|| {
+            eyre::eyre!(
+                "self_update.repository must be in owner/repository format, got {:?}",
+                self.repository
+            )
+        })?;
+        eyre::ensure!(
+            !owner.is_empty() && !repo.is_empty() && !repo.contains('/'),
+            "self_update.repository must be in owner/repository format, got {:?}",
+            self.repository
+        );
+        Ok((owner, repo))
+    }
+}
+
 /// Display the version of mise
 ///
 /// Displays the version, os, architecture, and the date of the build.
@@ -290,12 +356,13 @@ fn cached_latest_version(path: &Path, duration: Duration) -> Cached {
 }
 
 async fn get_latest_version(duration: Duration) -> Option<String> {
-    let version_file_path = dirs::CACHE.join("latest-version");
+    let source = SelfUpdateSource::current();
+    let version_file_path = source.cache_path();
     if let Cached::Fresh(version) = cached_latest_version(&version_file_path, duration) {
         return version;
     }
     let _ = file::create_dir_all(*dirs::CACHE);
-    let version = get_latest_version_call().await;
+    let version = get_latest_version_call(&source).await;
     // Written even on failure, so its mtime acts as a negative cache and a
     // machine that cannot reach the network stops retrying once per invocation.
     let _ = file::write(version_file_path, version.clone().unwrap_or_default());
@@ -303,13 +370,17 @@ async fn get_latest_version(duration: Duration) -> Option<String> {
 }
 
 #[cfg(test)]
-async fn get_latest_version_call() -> Option<String> {
+async fn get_latest_version_call(_source: &SelfUpdateSource) -> Option<String> {
     Some("0.0.0".to_string())
 }
 
 #[cfg(not(test))]
-async fn get_latest_version_call() -> Option<String> {
-    fetch_latest_version(&crate::http::HTTP).await
+async fn get_latest_version_call(source: &SelfUpdateSource) -> Option<String> {
+    if source.is_default() {
+        fetch_latest_version(&crate::http::HTTP).await
+    } else {
+        fetch_latest_github_version(source).await
+    }
 }
 
 async fn fetch_latest_version(client: &crate::http::Client) -> Option<String> {
@@ -322,6 +393,34 @@ async fn fetch_latest_version(client: &crate::http::Client) -> Option<String> {
         }
         Err(err) => {
             debug!("failed to check for version: {:#?}", err);
+            None
+        }
+    }
+}
+
+#[cfg(not(test))]
+async fn fetch_latest_github_version(source: &SelfUpdateSource) -> Option<String> {
+    debug!(
+        "checking mise version from {}/{}",
+        source.api_url, source.repository
+    );
+    match crate::github::get_release_for_url_with_versions_host(
+        &source.api_url,
+        &source.repository,
+        "latest",
+        false,
+    )
+    .await
+    {
+        Ok(release) => Some(
+            release
+                .tag_name
+                .strip_prefix('v')
+                .unwrap_or(&release.tag_name)
+                .to_string(),
+        ),
+        Err(err) => {
+            debug!("failed to check for version: {err:#?}");
             None
         }
     }
@@ -420,6 +519,43 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let p = write(dir.path(), "2030.1.2\n");
         assert_eq!(cached_latest_version(&p, Duration::ZERO), Cached::Stale);
+    }
+
+    #[test]
+    fn custom_self_update_sources_use_separate_version_caches() {
+        let default = SelfUpdateSource::default();
+        let custom = SelfUpdateSource {
+            api_url: "https://github.example.com/api/v3".to_string(),
+            repository: "acme/mise".to_string(),
+        };
+
+        assert_eq!(default.cache_path(), dirs::CACHE.join("latest-version"));
+        assert_ne!(custom.cache_path(), default.cache_path());
+        assert!(
+            custom
+                .cache_path()
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .starts_with("latest-version-")
+        );
+    }
+
+    #[cfg(feature = "self_update")]
+    #[test]
+    fn self_update_repository_requires_exactly_owner_and_repository() {
+        let source = |repository: &str| SelfUpdateSource {
+            repository: repository.to_string(),
+            ..SelfUpdateSource::default()
+        };
+
+        assert_eq!(
+            source("acme/mise").repository_parts().unwrap(),
+            ("acme", "mise")
+        );
+        assert!(source("mise").repository_parts().is_err());
+        assert!(source("acme/mise/releases").repository_parts().is_err());
+        assert!(source("/mise").repository_parts().is_err());
     }
 
     #[tokio::test]

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -43,7 +43,7 @@ impl SelfUpdateSource {
         }
     }
 
-    fn current() -> Self {
+    pub(crate) fn current() -> Self {
         Settings::try_get()
             .map(|settings| Self::from_settings(&settings))
             .unwrap_or_default()

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -2365,6 +2365,26 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_settings_file_strips_local_self_update_sources() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mise.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [settings.self_update]
+            api_url = "https://github.example.com/api/v3"
+            repository = "acme/mise"
+            "#,
+        )
+        .unwrap();
+
+        let partial = Settings::parse_settings_file(&path).unwrap();
+
+        assert_eq!(partial.self_update.api_url, None);
+        assert_eq!(partial.self_update.repository, None);
+    }
+
+    #[test]
     fn test_global_config_preserves_credential_commands() {
         let path = Path::new("/tmp/global-config.toml");
         let mut settings = credential_command_settings_table();


### PR DESCRIPTION
## Summary
- add global-only `self_update.repository` and `self_update.api_url` settings
- use the configured GitHub source for manual updates, version notifications, and automatic updates
- isolate latest-version caches by source while retaining the lightweight default VERSION endpoint
- reuse host-aware GitHub credentials for private repositories and GitHub Enterprise
- retain verification against the embedded official mise signing key

## Security
Project configuration cannot redirect self-updates because both settings are global-only. Alternate repositories can curate official mise archives, but replacement artifacts still fail the existing embedded-signature verification.

## Tests
- `mise run test:unit -- cli::version`
- `mise run test:unit -- config::settings::tests`
- `mise run test:e2e e2e/cli/test_version_update_hint`
- `mise run lint`
- `mise exec -- cargo check --no-default-features --features native-tls,vfox/vendored-lua`

Context: https://github.com/jdx/mise/discussions/12734

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where the running binary is downloaded from and how version checks resolve, but project configs cannot redirect updates and signature verification on release artifacts is unchanged.
> 
> **Overview**
> Adds **global-only** `settings.self_update.repository` and `settings.self_update.api_url` so organizations can point manual `mise self-update`, out-of-date hints, and automatic updates at a curated GitHub (or GitHub Enterprise) release mirror instead of hard-coded `jdx/mise`.
> 
> A new `SelfUpdateSource` drives the self-update backend (repo, API base URL, host-aware token resolution) and Windows `mise-shim` downloads from the same release assets. **Default behavior is unchanged**: the lightweight `mise.jdx.dev/VERSION` check still applies for the official source; alternate sources use the GitHub releases API and get **separate** `latest-version` cache files. Project `mise.toml` cannot set these keys (they are stripped like other global-only settings). Archives must keep official names and still pass existing embedded signature verification.
> 
> Documentation and JSON schema/env vars (`MISE_SELF_UPDATE_*`) describe mirror setup and requirements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d5ba480c4414ea283fef7791398767e19ec528f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring a custom release mirror for `mise self-update`.
  - Custom sources can specify a GitHub-compatible API URL and repository.
  - Custom update sources use separate cached version data.
  - Added environment variable configuration for global self-update settings.

- **Bug Fixes**
  - Prevented project-level configuration from redirecting `mise` binary updates.

- **Documentation**
  - Documented custom self-update source configuration, including official filenames and embedded signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->