### PR TITLE
security(self-update): require secure release sources

### DIFF
--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -35,7 +35,7 @@ updating plugins, and re-runs the original command with the new binary. Configur
 Organizations can direct manual and automatic self-updates to a curated GitHub release mirror by
 setting [`self_update.repository`](/configuration/settings.html#self_updaterepository). Private
 repositories and GitHub Enterprise use mise's existing GitHub token resolution. Mirrored archives
-must retain the official file names and embedded mise signatures:
+must retain the official file names and embedded mise signatures. The API URL must use HTTPS:
 
 ```toml
 [settings.self_update]

--- a/settings.toml
+++ b/settings.toml
@@ -2599,7 +2599,7 @@ type = "Bool"
 default = "https://api.github.com"
 description = "GitHub API base URL used by `mise self-update`."
 docs = """
-The API base URL for the GitHub repository that supplies mise releases. For GitHub Enterprise,
+The HTTPS API base URL for the GitHub repository that supplies mise releases. For GitHub Enterprise,
 include the API path, such as `https://github.example.com/api/v3`.
 
 This setting is global-only so a project configuration cannot redirect updates of the mise binary.

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -552,6 +552,7 @@ impl SelfUpdate {
 
     fn http_client() -> Result<self_update::reqwest::blocking::Client> {
         Ok(self_update::reqwest::blocking::Client::builder()
+            .https_only(true)
             .redirect(Self::redirect_policy())
             .build()?)
     }
@@ -628,6 +629,7 @@ impl SelfUpdate {
         let headers = crate::github::get_headers(&url)?;
         let archive = reqwest::Client::builder()
             .user_agent(format!("mise/{}", cargo_crate_version!()))
+            .https_only(true)
             .redirect(Self::redirect_policy())
             .build()?
             .get(&url)

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -479,8 +479,10 @@ impl SelfUpdate {
             .as_ref()
             .map(|settings| SelfUpdateSource::from_settings(settings))
             .unwrap_or_default();
+        source.validate()?;
         let (repo_owner, repo_name) = source.repository_parts()?;
         let mut update = Update::configure();
+        update.reqwest_client(Self::http_client()?);
         if let Some(token) = crate::github::resolve_token_for_api_url(&source.api_url) {
             update.auth_token(&token);
         }
@@ -548,6 +550,28 @@ impl SelfUpdate {
         Ok(status)
     }
 
+    fn http_client() -> Result<self_update::reqwest::blocking::Client> {
+        use self_update::reqwest::redirect::Policy;
+
+        let redirect_policy = Policy::custom(|attempt| {
+            let is_https_downgrade = attempt
+                .previous()
+                .last()
+                .is_some_and(|previous| previous.scheme() == "https")
+                && attempt.url().scheme() != "https";
+            if is_https_downgrade {
+                attempt.error(std::io::Error::other(
+                    "refusing to redirect a self-update request from HTTPS to an insecure URL",
+                ))
+            } else {
+                Policy::default().redirect(attempt)
+            }
+        });
+        Ok(self_update::reqwest::blocking::Client::builder()
+            .redirect(redirect_policy)
+            .build()?)
+    }
+
     // Rebuild the Windows shim copies in-process instead of shelling out to
     // `mise reshim --force`. Mirrors `cli::reshim::Reshim::run`.
     #[cfg(windows)]
@@ -571,6 +595,7 @@ impl SelfUpdate {
         use crate::http::HTTP;
         use std::io::Read;
 
+        source.validate()?;
         let version = version.strip_prefix('v').unwrap_or(version);
         let archive_name = format!("mise-v{version}-{}-{}.zip", *OS, *ARCH);
         let release = crate::github::get_release_for_url_with_versions_host(

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -551,9 +551,15 @@ impl SelfUpdate {
     }
 
     fn http_client() -> Result<self_update::reqwest::blocking::Client> {
-        use self_update::reqwest::redirect::Policy;
+        Ok(self_update::reqwest::blocking::Client::builder()
+            .redirect(Self::redirect_policy())
+            .build()?)
+    }
 
-        let redirect_policy = Policy::custom(|attempt| {
+    fn redirect_policy() -> reqwest::redirect::Policy {
+        use reqwest::redirect::Policy;
+
+        Policy::custom(|attempt| {
             let is_https_downgrade = attempt
                 .previous()
                 .last()
@@ -566,10 +572,7 @@ impl SelfUpdate {
             } else {
                 Policy::default().redirect(attempt)
             }
-        });
-        Ok(self_update::reqwest::blocking::Client::builder()
-            .redirect(redirect_policy)
-            .build()?)
+        })
     }
 
     // Rebuild the Windows shim copies in-process instead of shelling out to
@@ -592,7 +595,6 @@ impl SelfUpdate {
 
     #[cfg(windows)]
     async fn update_mise_shim(source: &SelfUpdateSource, version: &str) -> Result<()> {
-        use crate::http::HTTP;
         use std::io::Read;
 
         source.validate()?;
@@ -622,7 +624,19 @@ impl SelfUpdate {
         let temp_dir = tempfile::tempdir()?;
         // Use the real archive name so zipsign context matches the release signature
         let zip_path = temp_dir.path().join(&archive_name);
-        HTTP.download_file(&url, &zip_path, None).await?;
+        let headers = crate::github::get_headers(&url)?;
+        let archive = reqwest::Client::builder()
+            .user_agent(format!("mise/{}", cargo_crate_version!()))
+            .redirect(Self::redirect_policy())
+            .build()?
+            .get(&url)
+            .headers(headers)
+            .send()
+            .await?
+            .error_for_status()?
+            .bytes()
+            .await?;
+        fs::write(&zip_path, archive)?;
 
         // Verify the archive signature using the same key as the main update
         Self::verify_zip_signature(&zip_path)?;

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -561,12 +561,7 @@ impl SelfUpdate {
         use reqwest::redirect::Policy;
 
         Policy::custom(|attempt| {
-            let is_https_downgrade = attempt
-                .previous()
-                .last()
-                .is_some_and(|previous| previous.scheme() == "https")
-                && attempt.url().scheme() != "https";
-            if is_https_downgrade {
+            if crate::http::is_https_downgrade(attempt.previous(), attempt.url()) {
                 attempt.error(std::io::Error::other(
                     "refusing to redirect a self-update request from HTTPS to an insecure URL",
                 ))
@@ -627,10 +622,15 @@ impl SelfUpdate {
         // Use the real archive name so zipsign context matches the release signature
         let zip_path = temp_dir.path().join(&archive_name);
         let headers = crate::github::get_headers(&url)?;
+        let settings = Settings::get();
+        let request_timeout = settings.http_timeout();
         let archive = reqwest::Client::builder()
             .user_agent(format!("mise/{}", cargo_crate_version!()))
             .https_only(true)
             .redirect(Self::redirect_policy())
+            .connect_timeout(request_timeout)
+            .read_timeout(request_timeout)
+            .timeout(settings.http_download_timeout())
             .build()?
             .get(&url)
             .headers(headers)

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -617,8 +617,9 @@ impl SelfUpdate {
                     source.repository
                 )
             })?;
-        let url =
-            crate::github::pick_reachable_asset_url(&asset.browser_download_url, &asset.url).await;
+        // Use the API asset endpoint directly so every redirect is governed by
+        // the downgrade-rejecting client below. This also supports private releases.
+        let url = asset.url.clone();
         debug!("Downloading mise-shim.exe from {url}");
 
         let temp_dir = tempfile::tempdir()?;

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -77,6 +77,16 @@ impl SelfUpdateSource {
         );
         Ok((owner, repo))
     }
+
+    pub(crate) fn validate(&self) -> Result<()> {
+        let api_url = url::Url::parse(&self.api_url)?;
+        eyre::ensure!(
+            api_url.scheme() == "https",
+            "self_update.api_url must use HTTPS, got {:?}",
+            self.api_url
+        );
+        Ok(())
+    }
 }
 
 /// Display the version of mise
@@ -357,6 +367,10 @@ fn cached_latest_version(path: &Path, duration: Duration) -> Cached {
 
 async fn get_latest_version(duration: Duration) -> Option<String> {
     let source = SelfUpdateSource::current();
+    if let Err(err) = source.validate() {
+        debug!("invalid self-update source: {err:#}");
+        return None;
+    }
     let version_file_path = source.cache_path();
     if let Cached::Fresh(version) = cached_latest_version(&version_file_path, duration) {
         return version;
@@ -556,6 +570,25 @@ mod tests {
         assert!(source("mise").repository_parts().is_err());
         assert!(source("acme/mise/releases").repository_parts().is_err());
         assert!(source("/mise").repository_parts().is_err());
+    }
+
+    #[test]
+    fn self_update_api_url_requires_https() {
+        let source = |api_url: &str| SelfUpdateSource {
+            api_url: api_url.to_string(),
+            ..SelfUpdateSource::default()
+        };
+
+        assert!(
+            source("https://github.example.com/api/v3")
+                .validate()
+                .is_ok()
+        );
+        assert!(
+            source("http://github.example.com/api/v3")
+                .validate()
+                .is_err()
+        );
     }
 
     #[tokio::test]

--- a/src/http.rs
+++ b/src/http.rs
@@ -505,7 +505,7 @@ fn fetch_redirect_policy() -> reqwest::redirect::Policy {
     })
 }
 
-fn is_https_downgrade(previous: &[Url], next: &Url) -> bool {
+pub(crate) fn is_https_downgrade(previous: &[Url], next: &Url) -> bool {
     previous
         .last()
         .is_some_and(|url| url.scheme() == "https" && next.scheme() != "https")

--- a/src/http.rs
+++ b/src/http.rs
@@ -491,6 +491,26 @@ fn parse_content_range(value: &str) -> Option<ParsedContentRange> {
     Some(ParsedContentRange::Bytes { start, end, total })
 }
 
+fn fetch_redirect_policy() -> reqwest::redirect::Policy {
+    use reqwest::redirect::Policy;
+
+    Policy::custom(|attempt| {
+        if is_https_downgrade(attempt.previous(), attempt.url()) {
+            attempt.error(std::io::Error::other(
+                "refusing to redirect a remote version request from HTTPS to HTTP",
+            ))
+        } else {
+            Policy::default().redirect(attempt)
+        }
+    })
+}
+
+fn is_https_downgrade(previous: &[Url], next: &Url) -> bool {
+    previous
+        .last()
+        .is_some_and(|url| url.scheme() == "https" && next.scheme() != "https")
+}
+
 #[derive(Debug)]
 pub(crate) struct Client {
     reqwest: Result<reqwest::Client, String>,
@@ -508,7 +528,7 @@ impl Client {
     #[cfg(test)]
     fn new(timeout: Duration, kind: ClientKind) -> Result<Self> {
         Ok(Self {
-            reqwest: Ok(Self::build(timeout)?),
+            reqwest: Ok(Self::build(timeout, kind)?),
             timeout,
             kind,
         })
@@ -516,17 +536,19 @@ impl Client {
 
     fn new_shared(timeout: Duration, kind: ClientKind) -> Self {
         Self {
-            reqwest: Self::build(timeout).map_err(|err| format!("{err:#}")),
+            reqwest: Self::build(timeout, kind).map_err(|err| format!("{err:#}")),
             timeout,
             kind,
         }
     }
 
-    fn build(timeout: Duration) -> Result<reqwest::Client> {
-        Ok(Self::_new()
-            .read_timeout(timeout)
-            .connect_timeout(timeout)
-            .build()?)
+    fn build(timeout: Duration, kind: ClientKind) -> Result<reqwest::Client> {
+        let builder = Self::_new().read_timeout(timeout).connect_timeout(timeout);
+        let builder = match kind {
+            ClientKind::Http => builder,
+            ClientKind::Fetch => builder.redirect(fetch_redirect_policy()),
+        };
+        Ok(builder.build()?)
     }
 
     #[cfg(test)]
@@ -3060,6 +3082,20 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         let _guard = set_test_prefer_offline(3);
 
         assert_eq!(client.request_timeout(), Duration::from_secs(3));
+    }
+
+    #[test]
+    fn test_fetch_redirect_policy_rejects_https_to_http_downgrades() {
+        let https = Url::parse("https://example.com/versions").unwrap();
+        let other_https = Url::parse("https://cdn.example.com/versions").unwrap();
+        let http = Url::parse("http://cdn.example.com/versions").unwrap();
+
+        assert!(is_https_downgrade(std::slice::from_ref(&https), &http));
+        assert!(!is_https_downgrade(
+            std::slice::from_ref(&https),
+            &other_https
+        ));
+        assert!(!is_https_downgrade(&[http], &other_https));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- reject self-update API URLs that do not use HTTPS before version lookup or token resolution
- prevent the blocking updater from following HTTPS-to-HTTP redirects
- document and test the HTTPS requirement

Follow-up to the security review on #12735.

## Testing
- `mise run test:unit -- cli::version`
- `mise run lint`
- `mise exec -- cargo check --no-default-features --features native-tls,vfox/vendored-lua`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication and download paths for the running mise binary (self-update and Windows shim refresh); misconfigured mirrors or unusual redirect chains could break updates until fixed.
> 
> **Overview**
> Hardens **mise self-update** so release metadata and binaries cannot be pulled over insecure channels or via redirects that drop TLS.
> 
> **`self_update.api_url` must be HTTPS** — `SelfUpdateSource::validate()` rejects `http://` before any update or latest-version lookup (invalid config is skipped quietly for version checks). Docs and `settings.toml` now state this explicitly for mirrors and GitHub Enterprise.
> 
> **Update HTTP clients** use `https_only` and a shared **HTTPS→HTTP redirect block** (`is_https_downgrade` in `http.rs`). The blocking `self_update` crate client and the Windows **mise-shim** download path get this policy; shim downloads now hit the GitHub **API asset URL** with auth headers instead of the generic downloader and browser download URL.
> 
> **Remote version fetch** (`ClientKind::Fetch`) applies the same redirect rule so version/tag enumeration cannot be redirected to plain HTTP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a96f41deb9397df9ed05399a004ca12a32f3c04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Self-updates now require an HTTPS API URL.
  * Update downloads, including Windows shim updates, no longer follow redirects that downgrade from HTTPS to an insecure connection.
  * Invalid update sources are rejected before downloads begin.
* **Documentation**
  * Clarified that mirrored release archives must use HTTPS, retain official filenames, and preserve embedded signatures.
  * Updated configuration guidance to identify the API URL as HTTPS-only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->