### PR TITLE
fix(schema): model inline dotfile content

### DIFF
--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -264,9 +264,10 @@ TOML
 assert_fail "$TOMBI_LINT mise-bad-age.toml"
 
 # Inline content is a complete whole-file entry and cannot be combined with
-# source-backed fields or file edit fields.
+# source-backed fields, manifests, or file edit fields.
 for other_field in \
   'source = "dotfiles/config"' \
+  'manifest = "git"' \
   'mode = "copy"' \
   'exclude = ["*.tmp"]' \
   'block = "managed block"' \

--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -269,7 +269,6 @@ for other_field in \
   'source = "dotfiles/config"' \
   'mode = "copy"' \
   'exclude = ["*.tmp"]' \
-  'manifest = "git"' \
   'block = "managed block"' \
   'line = "managed line"' \
   'template = "tera"' \

--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -269,6 +269,7 @@ for other_field in \
   'source = "dotfiles/config"' \
   'mode = "copy"' \
   'exclude = ["*.tmp"]' \
+  'manifest = "git"' \
   'block = "managed block"' \
   'line = "managed line"' \
   'template = "tera"' \

--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -72,6 +72,9 @@ description = "Lint the project"
 [vars]
 e2e_args = { default = "--headless", redact = true }
 
+[dotfiles]
+"~/.inline" = { content = "literal content" }
+
 [tool_alias.java.versions]
 "11.0" = "temurin-11"
 
@@ -226,7 +229,7 @@ strict = true
 
 [[schemas]]
 path = "file://$SCHEMA_PATH"
-include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-env-float.toml", "mise-bad-install-env-float.toml", "mise-bad-minimum-release-age-array.toml", "mise-bad-minimum-release-age-table.toml", "mise-bad-package-state.toml", "mise-bad-postinstall.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-launchd-queue.toml", "mise-bad-launchd-throttle.toml", "mise-bad-systemd.toml", "mise-bad-oci-copy.toml", "mise-bad-shell-activate.toml"]
+include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-dotfiles.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-env-float.toml", "mise-bad-install-env-float.toml", "mise-bad-minimum-release-age-array.toml", "mise-bad-minimum-release-age-table.toml", "mise-bad-package-state.toml", "mise-bad-postinstall.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-launchd-queue.toml", "mise-bad-launchd-throttle.toml", "mise-bad-systemd.toml", "mise-bad-oci-copy.toml", "mise-bad-shell-activate.toml"]
 
 [[schemas]]
 path = "file://$TASK_SCHEMA_PATH"
@@ -259,6 +262,25 @@ SECRET_FORMAT = { age = { value = "AGE-SECRET", format = "zip" } }
 TOML
 
 assert_fail "$TOMBI_LINT mise-bad-age.toml"
+
+# Inline content is a complete whole-file entry and cannot be combined with
+# source-backed fields or file edit fields.
+for other_field in \
+  'source = "dotfiles/config"' \
+  'mode = "copy"' \
+  'exclude = ["*.tmp"]' \
+  'manifest = "git"' \
+  'block = "managed block"' \
+  'line = "managed line"' \
+  'template = "tera"' \
+  'comment = "#"'; do
+  cat >"$HOME/workdir/mise-bad-dotfiles.toml" <<TOML
+[dotfiles]
+"~/.invalid" = { content = "literal content", $other_field }
+TOML
+
+  assert_fail "$TOMBI_LINT mise-bad-dotfiles.toml"
+done
 
 cat >"$HOME/workdir/mise-bad-env-default.toml" <<'TOML'
 [env]

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -4034,7 +4034,6 @@
                   "source": false,
                   "mode": false,
                   "exclude": false,
-                  "manifest": false,
                   "block": false,
                   "line": false,
                   "template": false,

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -4034,6 +4034,7 @@
                   "source": false,
                   "mode": false,
                   "exclude": false,
+                  "manifest": false,
                   "block": false,
                   "line": false,
                   "template": false,

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -3979,6 +3979,10 @@
                 "type": "string",
                 "description": "source file or directory"
               },
+              "content": {
+                "type": "string",
+                "description": "literal inline file content; alternative to source"
+              },
               "mode": {
                 "type": "string",
                 "description": "how to apply a whole-file source to the target; omitted uses dotfiles.default_mode",
@@ -4022,7 +4026,27 @@
                 "type": "string",
                 "description": "comment prefix for edit marker lines; inferred from the file extension when omitted"
               }
-            }
+            },
+            "oneOf": [
+              {
+                "required": ["content"],
+                "properties": {
+                  "source": false,
+                  "mode": false,
+                  "exclude": false,
+                  "manifest": false,
+                  "block": false,
+                  "line": false,
+                  "template": false,
+                  "comment": false
+                }
+              },
+              {
+                "properties": {
+                  "content": false
+                }
+              }
+            ]
           }
         ]
       }

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -4032,6 +4032,7 @@
                 "required": ["content"],
                 "properties": {
                   "source": false,
+                  "manifest": false,
                   "mode": false,
                   "exclude": false,
                   "block": false,


### PR DESCRIPTION
## Summary

- model inline `content` dotfile entries in the JSON schema
- make inline content exclusive with source-backed fields (`source`, `mode`, `exclude`, `manifest`) and file-edit fields (`block`, `line`, `template`, `comment`)
- add focused Tombi coverage for valid content and representative invalid content combinations

## Inline content exclusivity vs. runtime

Runtime validation lives in `merge_file_entry` (`src/system/files.rs`). It warns and skips an entry when:

- `source` and `content` are both set
- `content` is combined with `mode`, `exclude`, or `manifest`

`manifest` is included in that list since #12523 tightened it, so the schema's content branch denies `manifest` as well. (An earlier revision of this PR omitted `"manifest": false`, which let the schema accept a `{ content, manifest }` entry that runtime rejects.)

The schema is deliberately **stricter** than runtime for `content` combined with `block`, `line`, `template`, or `comment`. Runtime currently *accepts* those: `edit_entry_from_toml` (`src/system/edits.rs`) routes a table containing an edit field to the file-edit path, and `EditTomlTable` has no `#[serde(deny_unknown_fields)]`, so the `content` key is silently ignored and the entry is applied as a plain block/line edit. Silently dropping `content` is a runtime bug, not a supported combination — the config is meaningless either way — so the schema rejects it rather than mirroring the silent-ignore. Flagged here so the divergence is a deliberate choice rather than an accident; happy to relax it if you'd rather keep the schema exactly in step with today's runtime behavior.

## Gap provenance

- #11983, merged 2026-08-14, introduced inline whole-file content and the schema gap for `content`

## Validation

- `mise run render:schema`
- `mise run test:e2e e2e/config/test_schema_tombi`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dotfile configurations now support specifying literal inline content as an alternative to a source.
  * Inline-content entries must be used independently and cannot be combined with source, mode, exclusion, manifest, or file-editing options.

* **Tests**
  * Added schema coverage for valid inline-content configurations.
  * Added validation tests confirming that unsupported combinations of inline content and other dotfile options are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*
