### PR TITLE
fix(schema): add missing built-in deps providers

### DIFF
--- a/e2e/config/test_schema_deps_provider_arrays
+++ b/e2e/config/test_schema_deps_provider_arrays
@@ -9,6 +9,12 @@ TOMBI="mise x tombi@$TOMBI_VERSION -- tombi"
 TOMBI_LINT="$TOMBI lint --offline --no-cache --error-on-warnings --quiet"
 assert_contains "$TOMBI --version" "tombi $TOMBI_VERSION"
 
+for provider in aube deno git-submodule; do
+  jq -e --arg provider "$provider" \
+    '.properties.deps.properties[$provider]."$ref" == "#/$defs/deps_provider"' \
+    "$SCHEMA_PATH" >/dev/null || fail "missing schema entry for deps provider: $provider"
+done
+
 cat >"$HOME/tombi.toml" <<EOF
 toml-version = "v1.0.0"
 

--- a/e2e/config/test_schema_deps_provider_arrays
+++ b/e2e/config/test_schema_deps_provider_arrays
@@ -9,12 +9,6 @@ TOMBI="mise x tombi@$TOMBI_VERSION -- tombi"
 TOMBI_LINT="$TOMBI lint --offline --no-cache --error-on-warnings --quiet"
 assert_contains "$TOMBI --version" "tombi $TOMBI_VERSION"
 
-for provider in aube deno git-submodule; do
-  jq -e --arg provider "$provider" \
-    '.properties.deps.properties[$provider]."$ref" == "#/$defs/deps_provider"' \
-    "$SCHEMA_PATH" >/dev/null || fail "missing schema entry for deps provider: $provider"
-done
-
 cat >"$HOME/tombi.toml" <<EOF
 toml-version = "v1.0.0"
 

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -3836,6 +3836,12 @@
         "bun": {
           "$ref": "#/$defs/deps_provider"
         },
+        "aube": {
+          "$ref": "#/$defs/deps_provider"
+        },
+        "deno": {
+          "$ref": "#/$defs/deps_provider"
+        },
         "go": {
           "$ref": "#/$defs/deps_provider"
         },
@@ -3858,6 +3864,9 @@
           "$ref": "#/$defs/deps_provider"
         },
         "flutter": {
+          "$ref": "#/$defs/deps_provider"
+        },
+        "git-submodule": {
           "$ref": "#/$defs/deps_provider"
         }
       },


### PR DESCRIPTION
## Summary

- add named schema entries for the built-in `aube`, `deno`, and `git-submodule` dependency providers
- keep each entry aligned with the shared `deps_provider` definition

This is split out of #12528 so the dependency-provider schema gap can be reviewed independently. Custom dependency providers remain supported through `additionalProperties`; these named entries restore editor discovery and completion for built-in providers.

## Gap provenance

- `git-submodule` was introduced by #8407, merged 2026-03-02, without adding its named schema entry.
- `aube` was introduced by #9452, merged 2026-04-28, without adding its named schema entry.
- `deno` was introduced by #10291, merged 2026-06-11, without adding its named schema entry.

## Validation

- `mise run render:schema`
- `mise run test:e2e e2e/config/test_schema_tombi e2e/config/test_schema_deps_provider_arrays`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added schema support for the `aube`, `deno`, and `git-submodule` dependency providers.
  * Added a `state` option for bootstrap packages, supporting `present` or `absent` values with `present` as the default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*
