### PR TITLE
fix(config): terminate every newly added .tool-versions line

### DIFF
--- a/src/config/config_file/tool_versions.rs
+++ b/src/config/config_file/tool_versions.rs
@@ -233,7 +233,7 @@ fn get_or_create_plugin<'a>(
         .or_insert_with(|| ToolVersionPlugin {
             orig_name: fa.short.to_string(),
             versions: vec![],
-            post: "".into(),
+            post: "\n".into(),
         })
 }
 
@@ -246,5 +246,46 @@ impl Clone for ToolVersions {
             plugins: Mutex::new(self.plugins.lock().unwrap().clone()),
             tools: Mutex::new(self.tools.lock().unwrap().clone()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `dump` relies on `post` to terminate each line, and `trim_end` only ever
+    /// fixes up the last one. A tool that is not already present in the file is
+    /// created by `get_or_create_plugin`, so its `post` has to carry the newline
+    /// too, otherwise two freshly added tools share a physical line and
+    /// `parse_plugins` reads them back as a single tool.
+    #[test]
+    fn newly_added_tools_each_get_their_own_line() {
+        let tv = ToolVersions::init(Path::new("/tmp/.tool-versions"));
+        {
+            let mut plugins = tv.plugins.lock().unwrap();
+            for (tool, version) in [("node", "20.0.0"), ("java", "21.0.0")] {
+                let ba: BackendArg = tool.into();
+                get_or_create_plugin(&mut plugins, &ba)
+                    .versions
+                    .push(version.to_string());
+            }
+        }
+
+        let dumped = tv.dump().unwrap();
+        assert_eq!(dumped.lines().count(), 2, "dumped: {dumped:?}");
+
+        let reparsed = ToolVersions::parse_plugins(&dumped);
+        let round_tripped: Vec<(String, Vec<String>)> = reparsed
+            .values()
+            .map(|p| (p.orig_name.clone(), p.versions.clone()))
+            .collect();
+        assert_eq!(
+            round_tripped,
+            vec![
+                ("nodejs".to_string(), vec!["20.0.0".to_string()]),
+                ("java".to_string(), vec!["21.0.0".to_string()]),
+            ],
+            "dumped: {dumped:?}"
+        );
     }
 }


### PR DESCRIPTION
`dump` relies on `ToolVersionPlugin.post` to terminate each line, and `s.trim_end() + "\n"` only repairs the last one.

`parse_plugins` always builds `post` ending in `"\n"`. `get_or_create_plugin` -- the constructor for a tool *not* already in the file -- defaults it to `""`. Adding two or more new tools in one command runs them onto one physical line, and `split_whitespace` reads that back as a single tool with a garbage version, silently dropping the rest.

Debug build, isolated `env -i` HOME, starting from `ruby system`:

```
$ mise use node@system java@system
$ cat .tool-versions
ruby system
nodejs systemjava system     <- 2 lines, not 3
$ mise ls --current
node  systemjava (missing)   <- java is gone
```

Controls: one new tool is correct (`trim_end` masks it); both tools already present is correct (the reader supplied `post`). Only newly created entries corrupt; three new tools loses two.

No fence -- the `""` default arrived incidentally in #699 (2023-07-19), while the masking `trim_end` predates it in the initial commit. The file had no test module at all, which is why this round trip was never covered; the added test fails with exactly `"nodejs 20.0.0java 21.0.0\n"` if the fix is reverted.

`cargo test --bin mise`: 3370 passed / 12 failed, identical to pristine `main` here (the failures are `brew::cask` tests refusing to run under a temp dir).

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed formatting when adding multiple tools to an existing version configuration file.
  - Newly added tools now appear on separate lines, preserving consistent formatting and ensuring configurations can be read back correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->