### PR TITLE
fix(schema): model dotfiles manifests

### DIFF
--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -74,8 +74,6 @@ e2e_args = { default = "--headless", redact = true }
 
 [dotfiles]
 "~/.gitconfig" = { source = "dotfiles/gitconfig", mode = "symlink" }
-"~/.zshrc" = "dotfiles/zshrc"
-"~/.bin" = { source = "bin", mode = "symlink-each", exclude = ["*.md"] }
 "~/.zshrc/activate" = { block = "eval \"$(mise activate zsh)\"", comment = "#" }
 "~/.inline" = { content = "literal content" }
 "~/.manifest" = { source = "dotfiles/config", mode = "copy", manifest = "git" }
@@ -324,14 +322,12 @@ TOML
 
 assert_fail "$TOMBI_LINT mise-bad-dotfiles-manifest.toml"
 
-for bad_mode in symlink template; do
-  cat >"$HOME/workdir/mise-bad-dotfiles-manifest.toml" <<TOML
+cat >"$HOME/workdir/mise-bad-dotfiles-manifest.toml" <<'TOML'
 [dotfiles]
-"~/.invalid" = { manifest = "git", mode = "$bad_mode" }
+"~/.invalid" = { manifest = "git", mode = "symlink" }
 TOML
 
-  assert_fail "$TOMBI_LINT mise-bad-dotfiles-manifest.toml"
-done
+assert_fail "$TOMBI_LINT mise-bad-dotfiles-manifest.toml"
 
 for incompatible_field in \
   'content = "literal content"' \

--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -73,7 +73,14 @@ description = "Lint the project"
 e2e_args = { default = "--headless", redact = true }
 
 [dotfiles]
+"~/.gitconfig" = { source = "dotfiles/gitconfig", mode = "symlink" }
+"~/.zshrc" = "dotfiles/zshrc"
+"~/.bin" = { source = "bin", mode = "symlink-each", exclude = ["*.md"] }
+"~/.zshrc/activate" = { block = "eval \"$(mise activate zsh)\"", comment = "#" }
 "~/.inline" = { content = "literal content" }
+"~/.manifest" = { source = "dotfiles/config", mode = "copy", manifest = "git" }
+"~/.manifest-default-mode" = { source = "dotfiles/default", manifest = "git" }
+"~/.manifest-implied-source" = { mode = "symlink-each", manifest = "git" }
 
 [tool_alias.java.versions]
 "11.0" = "temurin-11"
@@ -229,7 +236,7 @@ strict = true
 
 [[schemas]]
 path = "file://$SCHEMA_PATH"
-include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-dotfiles.toml", "mise-bad-dotfiles-position.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-env-float.toml", "mise-bad-install-env-float.toml", "mise-bad-minimum-release-age-array.toml", "mise-bad-minimum-release-age-table.toml", "mise-bad-package-state.toml", "mise-bad-postinstall.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-launchd-queue.toml", "mise-bad-launchd-throttle.toml", "mise-bad-systemd.toml", "mise-bad-oci-copy.toml", "mise-bad-shell-activate.toml"]
+include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-dotfiles.toml", "mise-bad-dotfiles-manifest.toml", "mise-bad-dotfiles-position.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-env-float.toml", "mise-bad-install-env-float.toml", "mise-bad-minimum-release-age-array.toml", "mise-bad-minimum-release-age-table.toml", "mise-bad-package-state.toml", "mise-bad-postinstall.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-launchd-queue.toml", "mise-bad-launchd-throttle.toml", "mise-bad-systemd.toml", "mise-bad-oci-copy.toml", "mise-bad-shell-activate.toml"]
 
 [[schemas]]
 path = "file://$TASK_SCHEMA_PATH"
@@ -306,6 +313,32 @@ cat >"$HOME/workdir/mise-bad-dotfiles-position.toml" <<'TOML'
 TOML
 
 assert_fail "$TOMBI_LINT mise-bad-dotfiles-position.toml"
+
+# Manifests support only directory-walking modes. An omitted mode stays valid
+# because `dotfiles.default_mode` may be set to `copy` or `symlink-each`, and an
+# omitted source stays valid because runtime supports implied sources.
+for bad_mode in symlink template; do
+  cat >"$HOME/workdir/mise-bad-dotfiles-manifest.toml" <<TOML
+[dotfiles]
+"~/.invalid" = { manifest = "git", mode = "$bad_mode" }
+TOML
+
+  assert_fail "$TOMBI_LINT mise-bad-dotfiles-manifest.toml"
+done
+
+for incompatible_field in \
+  'content = "literal content"' \
+  'block = "managed block"' \
+  'line = "managed line"' \
+  'template = "tera"' \
+  'comment = "#"'; do
+  cat >"$HOME/workdir/mise-bad-dotfiles-manifest.toml" <<TOML
+[dotfiles]
+"~/.invalid" = { manifest = "git", mode = "copy", $incompatible_field }
+TOML
+
+  assert_fail "$TOMBI_LINT mise-bad-dotfiles-manifest.toml"
+done
 
 cat >"$HOME/workdir/mise-bad-env-default.toml" <<'TOML'
 [env]

--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -317,6 +317,13 @@ assert_fail "$TOMBI_LINT mise-bad-dotfiles-position.toml"
 # Manifests support only directory-walking modes. An omitted mode stays valid
 # because `dotfiles.default_mode` may be set to `copy` or `symlink-each`, and an
 # omitted source stays valid because runtime supports implied sources.
+cat >"$HOME/workdir/mise-bad-dotfiles-manifest.toml" <<'TOML'
+[dotfiles]
+"~/.invalid" = { manifest = "unsupported", mode = "copy" }
+TOML
+
+assert_fail "$TOMBI_LINT mise-bad-dotfiles-manifest.toml"
+
 for bad_mode in symlink template; do
   cat >"$HOME/workdir/mise-bad-dotfiles-manifest.toml" <<TOML
 [dotfiles]

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -4186,14 +4186,7 @@
               "manifest": {
                 "type": "string",
                 "description": "source manifest used to select managed files from a directory",
-                "anyOf": [
-                  {
-                    "enum": ["git"]
-                  },
-                  {
-                    "type": "string"
-                  }
-                ]
+                "enum": ["git"]
               },
               "block": {
                 "type": "string",

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -4127,6 +4127,27 @@
           {
             "type": "object",
             "description": "whole-file dotfile entry or file edit entry",
+            "additionalProperties": true,
+            "oneOf": [
+              {
+                "required": ["manifest"],
+                "properties": {
+                  "content": false,
+                  "mode": {
+                    "enum": ["copy", "symlink-each"]
+                  },
+                  "block": false,
+                  "line": false,
+                  "template": false,
+                  "comment": false
+                }
+              },
+              {
+                "properties": {
+                  "manifest": false
+                }
+              }
+            ],
             "properties": {
               "encrypt": {
                 "type": "boolean",
@@ -4159,6 +4180,18 @@
                 "items": {
                   "type": "string"
                 }
+              },
+              "manifest": {
+                "type": "string",
+                "description": "source manifest used to select managed files from a directory",
+                "anyOf": [
+                  {
+                    "enum": ["git"]
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
               },
               "block": {
                 "type": "string",

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -4127,15 +4127,17 @@
           {
             "type": "object",
             "description": "whole-file dotfile entry or file edit entry",
-            "additionalProperties": true,
             "oneOf": [
               {
                 "required": ["manifest"],
                 "properties": {
+                  "source": {},
                   "content": false,
                   "mode": {
                     "enum": ["copy", "symlink-each"]
                   },
+                  "exclude": {},
+                  "manifest": {},
                   "block": false,
                   "line": false,
                   "template": false,

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -4127,29 +4127,6 @@
           {
             "type": "object",
             "description": "whole-file dotfile entry or file edit entry",
-            "oneOf": [
-              {
-                "required": ["manifest"],
-                "properties": {
-                  "source": {},
-                  "content": false,
-                  "mode": {
-                    "enum": ["copy", "symlink-each"]
-                  },
-                  "exclude": {},
-                  "manifest": {},
-                  "block": false,
-                  "line": false,
-                  "template": false,
-                  "comment": false
-                }
-              },
-              {
-                "properties": {
-                  "manifest": false
-                }
-              }
-            ],
             "properties": {
               "encrypt": {
                 "type": "boolean",
@@ -4226,39 +4203,68 @@
                 "description": "comment prefix for edit marker lines; inferred from the file extension when omitted"
               }
             },
-            "oneOf": [
+            "allOf": [
               {
-                "required": ["content"],
-                "properties": {
-                  "source": false,
-                  "manifest": false,
-                  "mode": false,
-                  "exclude": false,
-                  "block": false,
-                  "line": false,
-                  "position": false,
-                  "template": false,
-                  "comment": false
-                }
+                "oneOf": [
+                  {
+                    "required": ["manifest"],
+                    "properties": {
+                      "source": {},
+                      "content": false,
+                      "mode": {
+                        "enum": ["copy", "symlink-each"]
+                      },
+                      "exclude": {},
+                      "manifest": {},
+                      "block": false,
+                      "line": false,
+                      "template": false,
+                      "comment": false
+                    }
+                  },
+                  {
+                    "properties": {
+                      "manifest": false
+                    }
+                  }
+                ]
               },
               {
-                "required": ["line"],
-                "properties": {
-                  "content": false,
-                  "mode": false,
-                  "exclude": false,
-                  "source": false,
-                  "block": false,
-                  "template": false,
-                  "comment": false
-                }
-              },
-              {
-                "properties": {
-                  "content": false,
-                  "line": false,
-                  "position": false
-                }
+                "oneOf": [
+                  {
+                    "required": ["content"],
+                    "properties": {
+                      "source": false,
+                      "manifest": false,
+                      "mode": false,
+                      "exclude": false,
+                      "block": false,
+                      "line": false,
+                      "position": false,
+                      "template": false,
+                      "comment": false
+                    }
+                  },
+                  {
+                    "required": ["line"],
+                    "properties": {
+                      "content": false,
+                      "mode": false,
+                      "exclude": false,
+                      "source": false,
+                      "block": false,
+                      "template": false,
+                      "comment": false
+                    }
+                  },
+                  {
+                    "properties": {
+                      "content": false,
+                      "line": false,
+                      "position": false
+                    }
+                  }
+                ]
               }
             ],
             "anyOf": [


### PR DESCRIPTION
## Summary

- model Git directory `manifest` dotfile entries and reject unsupported manifest values
- restrict explicit manifest modes to `copy` or `symlink-each`
- reject manifest entries combined with inline content or file-edit fields
- combine manifest exclusivity with the inline-content rules merged in #12738
- cover valid explicit/default modes, implied sources, invalid values, and incompatible fields

An omitted `mode` remains valid because runtime settings may supply `settings.dotfiles.default_mode`. An explicit source is optional because implied sources are supported.

## Deliberate strictness

`manifest` and manifest-specific `mode` use strict enums. Unlike forward-compatible ordinary mode fields, an unsupported manifest value makes the entry unusable, so editor validation should reject it.

## Gap provenance

- #12523 introduced Git-tracked directory manifests and the schema gap.

## Validation

- `mise run render:schema` after rebasing onto current `main`
- focused Tombi E2E and full lint passed on the pre-rebase head; fresh CI is running for the rebased head

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Dotfiles configuration now supports selecting managed files from a directory using a Git-based manifest.
  - Manifest-based entries support explicit, default, and implied source configurations, along with symlink, block, and content entries.

- **Bug Fixes**
  - Validation now rejects unsupported manifest values, incompatible modes, and conflicting configuration fields.

- **Tests**
  - Expanded schema coverage with valid and invalid dotfiles configuration examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->