### PR TITLE
fix(vfox): preserve tool name from legacy lockfiles

### DIFF
--- a/e2e/backend/test_vfox_backend_npm
+++ b/e2e/backend/test_vfox_backend_npm
@@ -28,6 +28,14 @@ backend = "vfox-npm:prettier"
 EOF
 assert "mise install --locked --dry-run"
 
+# Legacy lockfiles stored only the backend plugin name. Keep the tool name from
+# the plugin:tool request when restoring that backend during installation.
+assert "mise uninstall vfox-npm:prettier@$latest_version"
+assert_directory_not_exists "$MISE_DATA_DIR/installs/vfox-npm/prettier/$latest_version"
+sed -i.bak 's/backend = "vfox-npm:prettier"/backend = "vfox-npm"/' mise.lock
+mise install --locked
+assert_contains "mise exec -- prettier --version" "$latest_version"
+
 # Test uninstall functionality
 assert "mise uninstall vfox-npm:prettier@$latest_version"
 assert_directory_not_exists "$MISE_DATA_DIR/installs/vfox-npm/prettier/$latest_version"

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -623,9 +623,17 @@ impl VfoxBackend {
         plugin.full = Some(ba.full());
         let plugin = Arc::new(plugin);
 
-        // Extract the tool name from the resolved backend so aliases from a bare
-        // name to a backend plugin still provide the plugin:tool identifier.
-        let tool_name = backend_plugin_name.as_ref().map(|_| ba.tool_name());
+        // Prefer an explicit plugin:tool short name over the resolved backend.
+        // Legacy lockfiles can store only the plugin name as the backend, which
+        // must not replace the tool portion of the original request. Bare aliases
+        // still need the tool name from their resolved backend.
+        let tool_name = backend_plugin_name.as_ref().map(|plugin_name| {
+            ba.short
+                .split_once(':')
+                .filter(|(plugin, _)| plugin == plugin_name)
+                .map(|(_, tool)| tool.to_string())
+                .unwrap_or_else(|| ba.tool_name())
+        });
 
         Self {
             metadata_snapshot_cache: OnceLock::new(),
@@ -885,6 +893,28 @@ mod test {
             backend.plugin.full,
             Some("vfox:version-fox/vfox-golang".to_string())
         );
+    }
+
+    #[test]
+    fn test_backend_plugin_tool_name_preserves_explicit_short() {
+        let ba = BackendArg::new(
+            "toolshed:get-skills".to_string(),
+            Some("toolshed".to_string()),
+        );
+        let backend = VfoxBackend::from_arg(ba, Some("toolshed".to_string()));
+
+        assert_eq!(backend.tool_name.as_deref(), Some("get-skills"));
+    }
+
+    #[test]
+    fn test_backend_plugin_tool_name_resolves_bare_alias() {
+        let ba = BackendArg::new(
+            "skills".to_string(),
+            Some("toolshed:get-skills".to_string()),
+        );
+        let backend = VfoxBackend::from_arg(ba, Some("toolshed".to_string()));
+
+        assert_eq!(backend.tool_name.as_deref(), Some("get-skills"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- preserve the explicit `plugin:tool` request name when a legacy lockfile stores only the custom backend plugin name
- retain resolved backend tool names for bare aliases
- cover legacy custom-backend lockfiles with unit and end-to-end regression tests

## Cause
Lockfile restoration rebuilt `toolshed:get-skills` with the stored backend `toolshed`. The custom vfox backend then derived `ctx.tool` from that backend value, producing `toolshed` instead of `get-skills`.

## Testing
- `MBX_DISABLE=1 cargo +1.95.0 test --all-features backend::vfox::test`
- `MISE_CARGO_BUILD_COMMAND="MBX_DISABLE=1 /Users/jdx/.cargo/bin/cargo +1.95.0 build" target/debug/mise run test:e2e e2e/backend/test_vfox_backend_npm`
- scoped hk fix/check for the two changed files (cargo fmt, cargo check, shellcheck, shfmt)

Related to discussion #12744.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to vfox backend plugin tool-name resolution during lockfile restore, with regression tests and no auth or data-handling impact.
> 
> **Overview**
> Fixes **vfox custom backend** installs when `mise.lock` only records the plugin name (e.g. `backend = "vfox-npm"`) instead of the full `plugin:tool` backend string.
> 
> `VfoxBackend::from_arg` now derives `tool_name` from an explicit `plugin:tool` in `ba.short` when it matches the stored backend plugin, and still uses the resolved backend’s tool segment for bare aliases. That keeps `ctx.tool` correct during `mise install --locked` instead of treating the plugin name as the tool.
> 
> Adds unit tests for explicit `toolshed:get-skills` and alias `skills`, plus an e2e case that mutates the lockfile to the legacy backend form and verifies `prettier` still installs and runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 772faebf1252afffd6f1a8a6ce08d13c0c91ccfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed restoration of tools from legacy lockfiles that store only the plugin name.
  * Tool names are now preserved correctly when installing from explicit `plugin:tool` requests.
  * Bare plugin aliases continue to resolve to the appropriate tool name.

* **Tests**
  * Added coverage for legacy lockfile restoration and both supported backend naming formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->