### PR TITLE
registry: use canonical Crossplane CLI package

### DIFF
--- a/registry/crossplane.toml
+++ b/registry/crossplane.toml
@@ -1,4 +1,4 @@
 aliases = ["crossplane-cli"]
-backends = ["aqua:crossplane/crossplane", "asdf:joke/asdf-crossplane-cli"]
+backends = ["aqua:crossplane/cli", "asdf:joke/asdf-crossplane-cli"]
 description = "The Crossplane CLI extends kubectl with functionality to build, push, and install Crossplane packages"
 version_order = "semver"


### PR DESCRIPTION
The Crossplane CLI moved to github.com/crossplane/cli and now has an independent release cadence. aqua-registry PR #59231 renamed its canonical package to crossplane/cli while retaining crossplane/crossplane as an alias.

Use the canonical package for mise's short crossplane tool. This preserves aqua installation of cli.crossplane.io artifacts and lets Renovate identify the CLI repository instead of looking up Crossplane core tags.

Ref: https://github.com/aquaproj/aqua-registry/pull/59231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Crossplane CLI backend reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->