### PR TITLE
fix(oci): preserve paths for reused tool layers

### DIFF
--- a/e2e/oci/test_oci_push_layer_reuse
+++ b/e2e/oci/test_oci_push_layer_reuse
@@ -46,6 +46,8 @@ assert_contains "cat push1.log" "pushed sha256:"
 assert_not_contains "cat push1.log" "reused from previous image"
 jq_digest_v1="$(mise x crane@latest -- crane manifest --insecure "$REGISTRY/e2e/devenv:v1" |
   jq -r '.layers[] | select(.annotations."dev.mise.tool.short" == "jq") | .digest')"
+jq_path_v1="$(mise x crane@latest -- crane config --insecure "$REGISTRY/e2e/devenv:v1" |
+  jq -r '.config.Env[] | select(startswith("PATH="))')"
 
 # --- 2. Uninstall the tool entirely; re-push to the same tag must reuse
 # the layer from the registry without rebuilding or reinstalling ---
@@ -63,7 +65,10 @@ assert_contains "mise oci push --from scratch --no-mise --cache-from $REGISTRY/e
 # validates end-to-end (all blobs actually present in the repo).
 jq_digest_v2="$(mise x crane@latest -- crane manifest --insecure "$REGISTRY/e2e/devenv:v2" |
   jq -r '.layers[] | select(.annotations."dev.mise.tool.short" == "jq") | .digest')"
+jq_path_v2="$(mise x crane@latest -- crane config --insecure "$REGISTRY/e2e/devenv:v2" |
+  jq -r '.config.Env[] | select(startswith("PATH="))')"
 assert "echo $jq_digest_v2" "$jq_digest_v1"
+assert "echo $jq_path_v2" "$jq_path_v1"
 assert_succeed "mise x crane@latest -- crane validate --insecure --remote $REGISTRY/e2e/devenv:v2"
 
 # --- 4. --cache-from must be in the destination repository ---

--- a/e2e/oci/test_oci_push_layer_reuse
+++ b/e2e/oci/test_oci_push_layer_reuse
@@ -68,6 +68,7 @@ jq_digest_v2="$(mise x crane@latest -- crane manifest --insecure "$REGISTRY/e2e/
 jq_path_v2="$(mise x crane@latest -- crane config --insecure "$REGISTRY/e2e/devenv:v2" |
   jq -r '.config.Env[] | select(startswith("PATH="))')"
 assert "echo $jq_digest_v2" "$jq_digest_v1"
+assert_succeed "test -n '$jq_path_v1'"
 assert "echo $jq_path_v2" "$jq_path_v1"
 assert_succeed "mise x crane@latest -- crane validate --insecure --remote $REGISTRY/e2e/devenv:v2"
 

--- a/src/oci/builder.rs
+++ b/src/oci/builder.rs
@@ -607,6 +607,7 @@ impl Builder {
         let image_config = self
             .build_image_config(
                 &versions,
+                &tool_reuse,
                 &mount_point,
                 base_config_json.as_ref(),
                 all_diff_ids.clone(),
@@ -659,6 +660,7 @@ impl Builder {
     async fn build_image_config(
         &self,
         versions: &[(Arc<dyn crate::backend::Backend>, ToolVersion)],
+        tool_reuse: &[Option<ReusedLayer>],
         mount_point: &str,
         base_config_json: Option<&serde_json::Value>,
         diff_ids: Vec<String>,
@@ -780,9 +782,21 @@ impl Builder {
         // `<install>/bin` if a backend returns nothing or paths outside its
         // install dir.
         let mut path_entries: Vec<String> = Vec::new();
-        for (backend, tv) in versions {
+        for (i, (backend, tv)) in versions.iter().enumerate() {
             let install_path = crate::file::canonicalize_or_self(&tv.install_path());
             let in_image_tool_root = tool_in_image_path(mount_point, tv);
+            if tool_reuse[i].is_some() {
+                let cached_entries = self
+                    .opts
+                    .reuse_from
+                    .as_ref()
+                    .map(|remote| cached_tool_path_entries(remote, &in_image_tool_root))
+                    .unwrap_or_default();
+                if !cached_entries.is_empty() {
+                    path_entries.extend(cached_entries);
+                    continue;
+                }
+            }
             let bin_paths = backend
                 .list_bin_paths(&self.cfg, tv)
                 .await
@@ -1282,6 +1296,36 @@ fn sanitize_label(s: &str) -> String {
     s.replace([':', '/'], ".")
 }
 
+/// Recover the PATH entries that described a reused tool in the cache image.
+/// A reused tool may not be installed locally, so asking its backend for bin
+/// paths can return nothing even though the remote layer has a non-standard
+/// layout such as an executable directly in the install root.
+fn cached_tool_path_entries(remote: &registry::RemoteImage, tool_root: &str) -> Vec<String> {
+    remote
+        .config
+        .get("config")
+        .and_then(|config| config.get("Env"))
+        .and_then(|env| env.as_array())
+        .and_then(|env| {
+            env.iter()
+                .filter_map(|entry| entry.as_str())
+                .filter_map(|entry| entry.strip_prefix("PATH="))
+                .next_back()
+        })
+        .map(|path| {
+            path.split(':')
+                .filter(|entry| {
+                    *entry == tool_root
+                        || entry
+                            .strip_prefix(tool_root)
+                            .is_some_and(|suffix| suffix.starts_with('/'))
+                })
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1360,6 +1404,7 @@ mod tests {
                 annotations: Default::default(),
             },
             diff_ids: vec!["sha256:diff-a".into(), "sha256:diff-b".into()],
+            config: serde_json::json!({}),
         };
 
         let index = build_reuse_index(&remote);
@@ -1386,6 +1431,36 @@ mod tests {
                     relocation: TOOL_LAYER_RELOCATION_VERSION.into(),
                 })
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn cached_path_entries_are_scoped_to_the_reused_tool() {
+        let remote = registry::RemoteImage {
+            manifest: ImageManifest {
+                schema_version: 2,
+                media_type: manifest::MEDIA_TYPE_OCI_MANIFEST.to_string(),
+                config: layer(&[], "sha256:cfg"),
+                layers: vec![],
+                annotations: Default::default(),
+            },
+            diff_ids: vec![],
+            config: serde_json::json!({
+                "config": {
+                    "Env": [
+                        "PATH=/mise/installs/pnpm/9.15.9:/mise/installs/deno/2.0.0/bin:/usr/bin"
+                    ]
+                }
+            }),
+        };
+
+        assert_eq!(
+            cached_tool_path_entries(&remote, "/mise/installs/pnpm/9.15.9"),
+            vec!["/mise/installs/pnpm/9.15.9"]
+        );
+        assert_eq!(
+            cached_tool_path_entries(&remote, "/mise/installs/deno/2.0.0"),
+            vec!["/mise/installs/deno/2.0.0/bin"]
         );
     }
 

--- a/src/oci/builder.rs
+++ b/src/oci/builder.rs
@@ -1315,10 +1315,14 @@ fn cached_tool_path_entries(remote: &registry::RemoteImage, tool_root: &str) -> 
         .map(|path| {
             path.split(':')
                 .filter(|entry| {
-                    *entry == tool_root
-                        || entry
-                            .strip_prefix(tool_root)
-                            .is_some_and(|suffix| suffix.starts_with('/'))
+                    let has_parent = PathBuf::from(entry)
+                        .components()
+                        .any(|component| component == std::path::Component::ParentDir);
+                    !has_parent
+                        && (*entry == tool_root
+                            || entry
+                                .strip_prefix(tool_root)
+                                .is_some_and(|suffix| suffix.starts_with('/')))
                 })
                 .map(str::to_string)
                 .collect()
@@ -1448,7 +1452,7 @@ mod tests {
             config: serde_json::json!({
                 "config": {
                     "Env": [
-                        "PATH=/mise/installs/pnpm/9.15.9:/mise/installs/deno/2.0.0/bin:/usr/bin"
+                        "PATH=/mise/installs/pnpm/9.15.9:/mise/installs/deno/2.0.0/bin:/mise/installs/pnpm/9.15.9/../../other/bin:/usr/bin"
                     ]
                 }
             }),

--- a/src/oci/registry.rs
+++ b/src/oci/registry.rs
@@ -740,13 +740,14 @@ fn parse_single_manifest(body: serde_json::Value) -> Result<ImageManifest> {
     Ok(manifest)
 }
 
-/// A remote image's manifest paired with its config's `rootfs.diff_ids`
+/// A remote image's manifest and config, including `rootfs.diff_ids`
 /// (index-aligned with `manifest.layers`). Used as the layer-reuse cache for
 /// `mise oci push`.
 #[derive(Debug, Clone)]
 pub(crate) struct RemoteImage {
     pub manifest: ImageManifest,
     pub diff_ids: Vec<String>,
+    pub config: serde_json::Value,
 }
 
 /// Fetch the manifest + config diff_ids of `reference` for layer reuse.
@@ -867,7 +868,11 @@ pub(crate) async fn fetch_remote_image(reference: &str) -> Result<Option<RemoteI
         // Malformed remote image — don't reuse anything from it.
         return Ok(None);
     }
-    Ok(Some(RemoteImage { manifest, diff_ids }))
+    Ok(Some(RemoteImage {
+        manifest,
+        diff_ids,
+        config,
+    }))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- retain the fetched cache image config during OCI layer reuse
- recover each reused tool's PATH entries from that config instead of deriving them from a potentially absent local install
- verify an Aqua root-level binary keeps the same PATH across cached pushes

## Context

When `mise oci push --cache-from` reused a tool layer after that tool was uninstalled locally, `list_bin_paths` could return no paths. OCI image generation then fell back to `<install>/bin`, even when the reused layer stored its executable directly in the install root.

This uses the cache image config that originally described the reused layer, scoped to the layer's exact in-image install prefix. It works with existing cache images and leaves the existing fallback in place when cached PATH metadata is unavailable.

Fixes the PATH failure reported in https://github.com/jdx/mise/discussions/12747. Backend-specific `exec_env` derivation remains covered by the existing documented caveat and is outside this focused fix.

## Verification

- `mise run test:unit -- oci::builder::tests::cached_path_entries_are_scoped_to_the_reused_tool`
- `mise run test:e2e e2e/oci/test_oci_push_layer_reuse`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OCI image `PATH` assembly for reused layers; behavior is scoped with fallback to existing logic, but incorrect PATH scoping could break containers that rely on non-standard tool layouts.
> 
> **Overview**
> When **`mise oci push`** reuses a tool layer from a prior image (same tag or **`--cache-from`**) and the tool is no longer installed locally, image **`PATH`** was rebuilt via **`list_bin_paths`**, which often returned nothing and fell back to **`<install>/bin`** even when the cached layer used a different layout (e.g. binary in the install root).
> 
> The change **keeps the full remote image config** on **`RemoteImage`** and, for each reused tool, **pulls that tool’s PATH segments from the cache image’s `PATH=` env**, scoped to the tool’s in-image install prefix (excluding `..` paths). Local **`list_bin_paths`** still runs when reuse metadata is missing or cached PATH can’t be recovered.
> 
> E2E layer-reuse tests now assert **`PATH`** matches across **`v1`** and **`v2`** after reuse; a unit test covers scoping across multiple tools in one **`PATH`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 900f90974fb9f87e6f6c8162eb6dd02d635cc054. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - OCI image layer reuse now preserves the correct `PATH` environment value from cached images.
  - Reused tool layers can reliably recover environment settings even when the original backend is unavailable.
  - PATH entries containing parent-directory references are excluded, preventing unrelated values from carrying over.

- **Tests**
  - Added coverage confirming PATH preservation, non-empty environment values, and correct scoping during OCI layer reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->