### PR TITLE
fix(nushell): preserve PATH list type in activation prelude

### DIFF
--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -3,7 +3,10 @@ use std::fmt::Display;
 
 use indoc::formatdoc;
 
-use crate::shell::{self, ActivateOptions, ActivatePrelude, Shell};
+use crate::{
+    env,
+    shell::{self, ActivateOptions, ActivatePrelude, Shell},
+};
 use itertools::Itertools;
 
 #[derive(Default)]
@@ -36,6 +39,9 @@ impl Nushell {
         prelude
             .iter()
             .map(|p| match p {
+                ActivatePrelude::Set(k, v) if env::is_path_key(k) => {
+                    format!("$env.{k} = (r#'{v}'# | split row (char esep))\n")
+                }
                 ActivatePrelude::Set(k, v) => format!("$env.{k} = r#'{v}'#\n"),
                 ActivatePrelude::Prepend(k, v) | ActivatePrelude::MovePrepend(k, v) => {
                     self.prepend_env(k, v)
@@ -184,6 +190,21 @@ mod tests {
     #[test]
     fn test_set_env() {
         assert_snapshot!(Nushell::default().set_env("FOO", "1"));
+    }
+
+    #[test]
+    fn test_format_activate_prelude_path() {
+        let nushell = Nushell::default();
+        let path_key = if cfg!(windows) { "Path" } else { "PATH" };
+        let prelude = vec![ActivatePrelude::Set(
+            path_key.to_string(),
+            "/one:/two".to_string(),
+        )];
+
+        assert_eq!(
+            nushell.format_activate_prelude_inline(&prelude),
+            format!("$env.{path_key} = (r#'/one:/two'# | split row (char esep))\n")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- keep Nushell's `PATH`/Windows `Path` value as `list<string>` when an activation prelude replaces it
- cover the generated prelude on Unix and the Windows-specific key spelling with a regression test

## Root cause

The direct `ActivatePrelude::Set` path added for shim positioning bypassed Nushell's existing PATH conversion in `update-env`. On Windows this emitted `$env.Path` as a scalar string, which violates Nushell's native PATH type.

The fix keeps the generic prelude operation unchanged and performs the PATH conversion in the Nushell formatter that owns the emitted syntax.

## Testing

- `cargo fmt --check`
- `cargo test --all-features shell::nushell::tests`
- `cargo clippy --all-features --all-targets -- -D warnings -A clippy::collapsible-match`

The Clippy exception is limited to two pre-existing `collapsible_match` warnings in `src/backend/cargo.rs` and `src/task/task_source_checker.rs` on current `main` with Rust 1.95.

Discussion: #12750

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment activation in Nushell by correctly handling path-based variables, including platform-specific path separators.
* **Tests**
  * Added coverage to verify path-based environment variables are activated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->