### PR TITLE
docs(bootstrap): prevent blank guide page

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitepress";
 import { sidebar } from "./sidebar";
@@ -28,6 +28,35 @@ const publicSchemas = [
   "mise-settings.json",
   "mise-registry-tool.json",
 ];
+
+function assertNoEmptyDocPages(outDir: string) {
+  const emptyPages: string[] = [];
+
+  function visit(dir: string) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        visit(path);
+      } else if (entry.name.endsWith(".html")) {
+        const html = readFileSync(path, "utf8");
+        if (
+          /<div\b(?=[^>]*\bclass="[^"]*\bvp-doc\b[^"]*")[^>]*>\s*<\/div>/.test(
+            html,
+          )
+        ) {
+          emptyPages.push(relative(outDir, path));
+        }
+      }
+    }
+  }
+
+  visit(outDir);
+  if (emptyPages.length > 0) {
+    throw new Error(
+      `generated empty documentation pages:\n${emptyPages.map((page) => `- ${page}`).join("\n")}`,
+    );
+  }
+}
 
 // https://vitepress.dev/reference/site-config
 export default withMermaid(
@@ -303,6 +332,9 @@ export default withMermaid(
         /<script id="check-dark-mode">/,
         '<script id="check-dark-mode" data-cfasync="false">',
       );
+    },
+    buildEnd(siteConfig) {
+      assertNoEmptyDocPages(siteConfig.outDir);
     },
   }),
 );

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -29,9 +29,28 @@ const publicSchemas = [
   "mise-registry-tool.json",
 ];
 
+/** Return whether VitePress emitted a documentation container with no content. */
+function hasEmptyDocContainer(html: string) {
+  const divPattern = /<div\b[^>]*\sclass="([^"]*)"[^>]*>/g;
+  for (const match of html.matchAll(divPattern)) {
+    if (!match[1].split(/\s+/).includes("vp-doc")) continue;
+
+    let content = html.slice((match.index ?? 0) + match[0].length).trimStart();
+    while (content.startsWith("<!--")) {
+      const commentEnd = content.indexOf("-->");
+      if (commentEnd === -1) return false;
+      content = content.slice(commentEnd + 3).trimStart();
+    }
+    return content.startsWith("</div>");
+  }
+  return false;
+}
+
+/** Fail the build when server-side rendering leaves a documentation page empty. */
 function assertNoEmptyDocPages(outDir: string) {
   const emptyPages: string[] = [];
 
+  /** Recursively inspect generated HTML files beneath the output directory. */
   function visit(dir: string) {
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
       const path = join(dir, entry.name);
@@ -39,11 +58,7 @@ function assertNoEmptyDocPages(outDir: string) {
         visit(path);
       } else if (entry.name.endsWith(".html")) {
         const html = readFileSync(path, "utf8");
-        if (
-          /<div\b(?=[^>]*\bclass="[^"]*\bvp-doc\b[^"]*")[^>]*>\s*<\/div>/.test(
-            html,
-          )
-        ) {
+        if (hasEmptyDocContainer(html)) {
           emptyPages.push(relative(outDir, path));
         }
       }

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -143,7 +143,8 @@ Hook phases can also run before and after the built-in steps:
 `post-dotfiles`, `pre-defaults`, `post-defaults`, `pre-user`, `post-user`,
 `pre-tools`, and `post-tools`. Hook commands support [Tera templates](/templates.html)
 using the declaring config's context, including values such as
-`{{ config_root }}`, `{{ xdg_config_home }}`, and `{{ vars.name }}`.
+<code v-pre>{{ config_root }}</code>, <code v-pre>{{ xdg_config_home }}</code>,
+and <code v-pre>{{ vars.name }}</code>.
 
 The declarative steps converge: if a package is already installed, a repo is
 already at the requested ref, a dotfile already matches, or a default is already


### PR DESCRIPTION
## Summary
- mark inline Tera examples with v-pre so Vue does not evaluate them
- restore server-rendered content for the Bootstrap guide
- fail docs builds when VitePress emits an empty documentation page after an SSR error

## Testing
- mise run docs:build
- hk run check --safe --format json docs/.vitepress/config.ts docs/bootstrap.md
- regression: restored the unsafe interpolation and verified the build exits 1 while identifying bootstrap.html, then restored the fix

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only content fix and a docs build-time check; no runtime product or security impact.
> 
> **Overview**
> Fixes the Bootstrap guide rendering as a **blank page** after SSR by wrapping inline Tera examples (`{{ config_root }}`, `{{ xdg_config_home }}`, `{{ vars.name }}`) in `<code v-pre>…</code>` so Vue does not compile them as templates.
> 
> Adds a **post-build guard** in VitePress config: after `buildEnd`, it walks generated HTML and throws if any page has an empty `.vp-doc` container (listing paths such as `bootstrap.html`), so similar SSR regressions fail `docs:build` instead of shipping silent empty pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0bc1dbf971bacbbaed1140ba60ee52327b5a355. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated hook template examples to display Tera expressions correctly using code formatting.
  - Added validation during documentation builds to detect and report empty documentation pages, helping ensure published content renders correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->