### PR TITLE
docs(bootstrap): make toml examples valid standalone configs

### DIFF
--- a/docs/bootstrap/launchd.md
+++ b/docs/bootstrap/launchd.md
@@ -51,6 +51,8 @@ launchd calendar keys. For multiple independent calendar schedules, use an
 array of inline tables:
 
 ```toml
+[bootstrap.macos.launchd.agents.my-sync]
+program = "~/.local/bin/my-sync"
 start_calendar_interval = [{ hour = 3 }, { hour = 12, weekday = 1 }]
 ```
 

--- a/docs/bootstrap/secrets.md
+++ b/docs/bootstrap/secrets.md
@@ -8,10 +8,7 @@ provider boundary rather than adding provider-specific credentials to mise.
 ```toml
 [bootstrap.secrets]
 cache_token = "MISE_CACHE_TOKEN"
-database_password = {
-  env = "PRODUCTION_DATABASE_PASSWORD",
-  description = "Production database password",
-}
+database_password = { env = "PRODUCTION_DATABASE_PASSWORD", description = "Production database password" }
 
 [bootstrap.files."/etc/example/service.env"]
 content = '''


### PR DESCRIPTION
Two TOML examples under `docs/bootstrap/` do not validate as standalone `mise.toml` files.

- `docs/bootstrap/launchd.md` — the "array of inline tables" example for `start_calendar_interval` was a bare fragment with no table header, so it does not validate against `schema/mise.json` (top-level `start_calendar_interval` is not a valid key). It now carries the same `[bootstrap.macos.launchd.agents.my-sync]` header as the first example in the file plus the required `program` key, and stays focused on the calendar array.
- `docs/bootstrap/secrets.md` — the `database_password` inline table was written across multiple lines with a trailing comma. mise's own parser accepts this (it uses the `toml` 1.x crate with TOML 1.1 support), but both are invalid in TOML 1.0, so `taplo` (the TOML linter this repo uses) and most editors and parsers reject the block (`newline is not allowed in an inline table`). It is now a single-line inline table with no trailing comma so the example is copy-pasteable everywhere.

No prose changes; every other TOML block in these files already validated.

## Validation

Extracted every fenced `toml` block in `docs/bootstrap/**/*.md` and `docs/dotfiles.md`, parsed each with Python `tomllib`, and validated the result against `schema/mise.json`:

```
mise x npm:ajv-cli@5 -- ajv validate --spec=draft2020 -s schema/mise.json -d <block>.json
```

Before: 1 block failed to parse (`secrets.md`; `tomllib` is a TOML 1.0 parser, which is why it flags a block mise itself accepts) and 1 failed schema validation (`launchd.md`). After: both pass.

## Unrelated finding (not changed here)

`docs/bootstrap/packages/pacman.md` and `docs/bootstrap/packages/index.md` both document `"pacman:libreoffice-fresh" = { state = "absent" }`, which is implemented in `src/system/packages/`, but `schema/mise.json` does not list `state` under `bootstrap.packages` entries and sets `additionalProperties: false`, so those examples are flagged as invalid by schema-aware editors. That looks like a schema gap rather than a docs bug, so I left it for a separate change.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a launchd configuration example showing multiple independent calendar schedules.
  - Reformatted the bootstrap secret configuration example for improved readability, with no change to its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
