### PR TITLE
fix(aqua): handle repository transfers in attestations

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -1563,8 +1563,9 @@ impl AquaBackend {
             .map(unescape_regex_literal);
         let repo = format!("{}/{}", pkg.repo_owner, pkg.repo_name);
         let predicate_type = attestations.predicate_type.as_deref();
+        let mut verified_repo = repo.clone();
 
-        match crate::github::sigstore::verify_attestation_with_predicate_type(
+        let mut result = crate::github::sigstore::verify_attestation_with_predicate_type(
             artifact_path,
             &pkg.repo_owner,
             &pkg.repo_name,
@@ -1573,13 +1574,40 @@ impl AquaBackend {
             None,
             self.use_versions_host_for_github_metadata(&repo),
         )
-        .await
+        .await;
+
+        // GitHub keeps release URLs working after a repository transfer, but the
+        // certificate identity uses the canonical repository name. Verification
+        // errors may aggregate a workflow mismatch with failures from unrelated
+        // attestations, so resolve a confirmed transfer through GitHub and retry
+        // with the same workflow policy rebased to the canonical repository.
+        if result.is_err()
+            && let Ok(canonical_repo) = github::canonical_repo(&repo).await
+            && !canonical_repo.eq_ignore_ascii_case(&repo)
+            && let Some((canonical_owner, canonical_name)) = canonical_repo.split_once('/')
         {
+            let canonical_workflow = signer_workflow
+                .as_deref()
+                .map(|workflow| rebase_github_signer_workflow(workflow, &repo, &canonical_repo));
+            debug!(
+                "retrying GitHub attestation verification for transferred repository {repo} as {canonical_repo}"
+            );
+            verified_repo.clone_from(&canonical_repo);
+            result = crate::github::sigstore::verify_attestation_with_predicate_type(
+                artifact_path,
+                canonical_owner,
+                canonical_name,
+                canonical_workflow.as_deref(),
+                predicate_type,
+                None,
+                self.use_versions_host_for_github_metadata(&canonical_repo),
+            )
+            .await;
+        }
+
+        match result {
             Ok(true) => {
-                debug!(
-                    "GitHub attestations verified for {}/{}",
-                    pkg.repo_owner, pkg.repo_name
-                );
+                debug!("GitHub attestations verified for {verified_repo}");
                 Ok(GithubAttestationStatus::Verified)
             }
             Ok(false) => Err(eyre!(
@@ -3378,6 +3406,16 @@ fn unescape_regex_literal(pattern: &str) -> Cow<'_, str> {
     Cow::Owned(out)
 }
 
+fn rebase_github_signer_workflow(workflow: &str, old_repo: &str, canonical_repo: &str) -> String {
+    workflow
+        .strip_prefix(old_repo)
+        .filter(|suffix| suffix.starts_with('/'))
+        .map_or_else(
+            || workflow.to_string(),
+            |suffix| format!("{canonical_repo}{suffix}"),
+        )
+}
+
 fn toml_value_to_string(value: &toml::Value) -> Option<String> {
     match value {
         toml::Value::String(s) => Some(s.clone()),
@@ -4828,6 +4866,30 @@ packages:
         let result = unescape_regex_literal("");
         assert!(matches!(result, std::borrow::Cow::Borrowed(_)));
         assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_rebase_github_signer_workflow_after_repo_transfer() {
+        assert_eq!(
+            rebase_github_signer_workflow(
+                "jdx/aube/.github/workflows/release.yml",
+                "jdx/aube",
+                "aubepkg/aube",
+            ),
+            "aubepkg/aube/.github/workflows/release.yml"
+        );
+    }
+
+    #[test]
+    fn test_rebase_github_signer_workflow_preserves_reusable_workflow_repo() {
+        assert_eq!(
+            rebase_github_signer_workflow(
+                "aquaproj/aqua-registry/.github/workflows/release.yml",
+                "jdx/aube",
+                "aubepkg/aube",
+            ),
+            "aquaproj/aqua-registry/.github/workflows/release.yml"
+        );
     }
 
     #[test]

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -1581,7 +1581,7 @@ impl AquaBackend {
         // errors may aggregate a workflow mismatch with failures from unrelated
         // attestations, so resolve a confirmed transfer through GitHub and retry
         // with the same workflow policy rebased to the canonical repository.
-        if result.is_err()
+        if attestation_needs_transfer_retry(&result)
             && let Ok(canonical_repo) = github::canonical_repo(&repo).await
             && !canonical_repo.eq_ignore_ascii_case(&repo)
             && let Some((canonical_owner, canonical_name)) = canonical_repo.split_once('/')
@@ -3416,6 +3416,14 @@ fn rebase_github_signer_workflow(workflow: &str, old_repo: &str, canonical_repo:
         )
 }
 
+/// A failed verification may become valid after resolving a repository transfer.
+/// Only a verified attestation can skip the canonical-repository lookup.
+fn attestation_needs_transfer_retry(
+    result: &std::result::Result<bool, crate::github::sigstore::AttestationError>,
+) -> bool {
+    !matches!(result, Ok(true))
+}
+
 fn toml_value_to_string(value: &toml::Value) -> Option<String> {
     match value {
         toml::Value::String(s) => Some(s.clone()),
@@ -4890,6 +4898,17 @@ packages:
             ),
             "aquaproj/aqua-registry/.github/workflows/release.yml"
         );
+    }
+
+    #[test]
+    fn test_attestation_transfer_retry_result_handling() {
+        use crate::github::sigstore::AttestationError;
+
+        assert!(!attestation_needs_transfer_retry(&Ok(true)));
+        assert!(attestation_needs_transfer_retry(&Ok(false)));
+        assert!(attestation_needs_transfer_retry(&Err(
+            AttestationError::NoAttestations
+        )));
     }
 
     #[test]

--- a/src/github.rs
+++ b/src/github.rs
@@ -85,6 +85,11 @@ pub(crate) struct GithubAsset {
     pub digest: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct GithubRepository {
+    full_name: String,
+}
+
 type CacheGroup<T> = HashMap<String, CacheManager<T>>;
 
 static RELEASES_CACHE: Lazy<RwLock<CacheGroup<Vec<GithubRelease>>>> = Lazy::new(Default::default);
@@ -325,6 +330,17 @@ async fn list_tags_with_dates_(api_url: &str, repo: &str) -> Result<Vec<GithubTa
 
 pub(crate) async fn get_release(repo: &str, tag: &str) -> Result<GithubRelease> {
     get_release_with_versions_host(repo, tag, true).await
+}
+
+/// Resolve a repository name through GitHub so callers can follow repository
+/// transfers without weakening identity checks to the former owner/name.
+pub(crate) async fn canonical_repo(repo: &str) -> Result<String> {
+    let url = format!("{API_URL}/repos/{repo}");
+    let headers = get_headers(&url)?;
+    let repository: GithubRepository = crate::http::HTTP_FETCH
+        .json_with_headers(url, &headers)
+        .await?;
+    Ok(repository.full_name)
 }
 
 pub(crate) async fn get_release_with_versions_host(


### PR DESCRIPTION
## Summary
- retry GitHub artifact attestation verification against a repository’s canonical name after GitHub confirms a transfer
- preserve the configured signer workflow while rebasing only its former repository prefix
- keep ordinary verification failures fatal when GitHub does not confirm a repository transfer

## Testing
- mise run lint-fix
- mise run build
- cargo test --locked --bin mise backend::aqua::tests::test_rebase_github_signer_workflow
- live install of aqua:jdx/aube@2.2.9 through the stale upstream aqua registry, including successful attestation verification and aube --version

Fixes the failure reported in https://github.com/aubepkg/aube/discussions/852#discussioncomment-18282461.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install-time cryptographic verification and adds a GitHub API dependency on attestation failure; behavior is gated on confirmed canonical repo mismatch, but retries broaden when lookup runs (any non-`Ok(true)` outcome).
> 
> **Overview**
> Fixes aqua installs where the registry still points at a **pre-transfer** `owner/repo` but Sigstore certificates identify the **canonical** repository after a GitHub transfer.
> 
> **GitHub artifact attestation flow** (`run_github_attestation_check`): after the first `verify_attestation_with_predicate_type` call, any non-success result can trigger a lookup via new **`github::canonical_repo`** (`GET /repos/{repo}` → `full_name`). If the canonical name differs, verification runs again with the canonical owner/name, the same predicate policy, and **`rebase_github_signer_workflow`** so only workflow strings prefixed with the stale repo (e.g. `jdx/aube/.github/...`) are rewritten; reusable workflows under another org are left unchanged. Success logging uses the repo that actually verified.
> 
> **Helpers and tests**: `attestation_needs_transfer_retry` (skip lookup only on `Ok(true)`), `rebase_github_signer_workflow`, and unit tests for rebase and retry gating. Existing error handling (unavailable attestations, non-fatal API failures) is unchanged when retry does not apply or canonical name matches the registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a103224aff7b780baea88a6e2316f20ec1f755dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub attestation checks now continue working when repositories have been transferred or renamed.
  * Verification automatically retries against the repository’s canonical name when needed.
  * Workflow references are correctly updated during retry, including reusable workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->