### PR TITLE
fix(go): use loong64 artifact architecture

### DIFF
--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -363,6 +363,7 @@ impl Backend for GoPlugin {
             "x64" => "amd64",
             "arm64" => "arm64",
             "arm" => "armv6l",
+            "loongarch64" => "loong64",
             "riscv64" => "riscv64",
             other => other,
         };
@@ -486,8 +487,27 @@ fn parse_gomod(body: &str, ignore_minimums: bool) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::Platform;
+    use crate::toolset::ToolSource;
     use indoc::indoc;
     use pretty_assertions::assert_eq;
+
+    #[tokio::test]
+    async fn test_loongarch64_tarball_uses_go_arch_name() {
+        let backend = GoPlugin::new();
+        let request = ToolRequest::new(backend.ba().clone(), "1.26.8", ToolSource::Unknown)
+            .expect("valid go request");
+        let tv = ToolVersion::new(request, "1.26.8".to_string());
+        let target = PlatformTarget::new(Platform::parse("linux-loongarch64").unwrap());
+
+        let url = backend
+            .get_tarball_url(&tv, &target)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(url.ends_with("/go1.26.8.linux-loong64.tar.gz"));
+    }
 
     #[test]
     fn test_parse_gomod() {


### PR DESCRIPTION
## Summary
- map the canonical mise `loongarch64` platform name to the `loong64` name used by Go release artifacts
- add a regression test for Linux loong64 tarball URL generation

## Testing
- `mise run test:unit plugins::core::go::tests::test_loongarch64_tarball_uses_go_arch_name`
- `mise run lint-fix`
- `mise run lint`

Related to discussion #12762.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single arch alias in Go tarball URL construction with a regression test; no auth, data, or broad behavior changes.
> 
> **Overview**
> Fixes Go installs on **linux-loongarch64** by mapping mise’s `loongarch64` arch to **`loong64`**, the segment Go uses in official tarball names (same idea as `x64` → `amd64`).
> 
> Adds an async unit test that **`get_tarball_url`** for `linux-loongarch64` ends with `/go1.26.8.linux-loong64.tar.gz`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94d959f11b96d9a63fcf9c8e00eeeb216cbee984. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for downloading Go distributions on Linux loongarch64 systems by using the correct architecture naming in download URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->