### PR TITLE
fix(bootstrap): expand tilde in managed file sources

### DIFF
--- a/docs/bootstrap/files.md
+++ b/docs/bootstrap/files.md
@@ -18,7 +18,8 @@ mode = "0644"
 ```
 
 File content may come from `source` or inline `content`. Relative source paths
-are resolved from the configuration file that declares them. Present files
+are resolved from the configuration file that declares them, and source paths
+beginning with `~/` are resolved from the user's home directory. Present files
 must declare exactly one content source. Targets must be absolute paths, and
 mise refuses to manage `/` itself.
 

--- a/e2e/cli/test_bootstrap_system_files_no_sudo
+++ b/e2e/cli/test_bootstrap_system_files_no_sudo
@@ -23,6 +23,18 @@ assert "cat '$managed_file'" "first"
 assert "stat -c %a '$managed_dir'" "750"
 assert "stat -c %a '$managed_file'" "640"
 
+# A bare tilde remains a config-relative filename.
+echo "from bare tilde source" >"~"
+cat <<EOF >mise.toml
+[bootstrap.files."$managed_file"]
+source = "~"
+mode = "0600"
+EOF
+
+assert_succeed "MISE_SYSTEM_PACKAGES_SUDO=0 mise bootstrap files status --json | jq -e '.[0].origin.source == \"$PWD/~\"'"
+assert_succeed "MISE_SYSTEM_PACKAGES_SUDO=0 mise bootstrap files apply --yes"
+assert "cat '$managed_file'" "from bare tilde source"
+
 echo "from tilde source" >"$HOME/bootstrap-source"
 cat <<EOF >mise.toml
 [bootstrap.files."$managed_file"]

--- a/e2e/cli/test_bootstrap_system_files_no_sudo
+++ b/e2e/cli/test_bootstrap_system_files_no_sudo
@@ -23,6 +23,18 @@ assert "cat '$managed_file'" "first"
 assert "stat -c %a '$managed_dir'" "750"
 assert "stat -c %a '$managed_file'" "640"
 
+echo "from tilde source" >"$HOME/bootstrap-source"
+cat <<EOF >mise.toml
+[bootstrap.files."$managed_file"]
+source = "~/bootstrap-source"
+mode = "0600"
+EOF
+
+assert_succeed "MISE_SYSTEM_PACKAGES_SUDO=0 mise bootstrap files status --json | jq -e '.[0].origin.source == \"$HOME/bootstrap-source\"'"
+assert_succeed "MISE_SYSTEM_PACKAGES_SUDO=0 mise bootstrap files apply --yes"
+assert "cat '$managed_file'" "from tilde source"
+assert "stat -c %a '$managed_file'" "600"
+
 cat <<EOF >mise.toml
 [bootstrap.files."$managed_file"]
 content = "second"

--- a/src/system/managed_files.rs
+++ b/src/system/managed_files.rs
@@ -620,7 +620,11 @@ impl ManagedFileRequest {
 }
 
 fn resolve_source_path(base: &Path, source: &str) -> PathBuf {
-    let source = crate::file::replace_path(source);
+    let source = if source.starts_with("~/") {
+        crate::file::replace_path(source)
+    } else {
+        PathBuf::from(source)
+    };
     if source.is_absolute() {
         source
     } else {

--- a/src/system/managed_files.rs
+++ b/src/system/managed_files.rs
@@ -620,9 +620,9 @@ impl ManagedFileRequest {
 }
 
 fn resolve_source_path(base: &Path, source: &str) -> PathBuf {
-    let source = Path::new(source);
+    let source = crate::file::replace_path(source);
     if source.is_absolute() {
-        source.to_path_buf()
+        source
     } else {
         base.join(source)
     }


### PR DESCRIPTION
## Summary
- expand leading `~/` in `[bootstrap.files].source` using the same path helper as `[dotfiles].source`
- preserve config-relative resolution for other source paths
- document the behavior and cover resolved provenance plus file application

Addresses https://github.com/jdx/mise/discussions/12763.

## Tests
- `mise run test:e2e e2e/cli/test_bootstrap_system_files_no_sudo`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow path-resolution change for bootstrap file sources; only affects configs using `~/…` sources, with no auth or privileged-behavior changes beyond reading the expanded file path.
> 
> **Overview**
> Bootstrap **`[bootstrap.files].source`** paths that start with **`~/`** now resolve from the user’s home directory via the same **`replace_path`** helper used for dotfiles, instead of being treated as config-relative paths.
> 
> **Relative** sources and a bare **`~`** filename (without **`/`**) still resolve next to the declaring config file. Docs describe the rules, and e2e coverage checks **`status --json`** provenance plus **`apply`** for both tilde cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c901d598700b021996557fdeb5e679eae8940617. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Bootstrap file sources beginning with `~/` now resolve from the user’s home directory.
  - Other source paths are used as configured, while relative paths continue to resolve from the declaring configuration file.

- **Documentation**
  - Updated bootstrap file documentation to clarify relative-path and home-directory path resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->