### PR TITLE
fix(task): preserve task status when cache audit tracer fails

### DIFF
--- a/e2e/tasks/test_task_artifact_cache_audit
+++ b/e2e/tasks/test_task_artifact_cache_audit
@@ -22,7 +22,12 @@ done
 if [[ -z $trace ]]; then
   exec "$@"
 fi
-cat <<TRACE >"$trace"
+if [[ $trace == \|* ]]; then
+  sink=${trace#|}
+else
+  sink="cat > '$trace'"
+fi
+cat <<TRACE | sh -c "$sink"
 123 openat(AT_FDCWD<$PWD>, "input.txt", O_RDONLY) = 3
 123 openat(AT_FDCWD<$PWD>, "../shared.txt", O_RDONLY) = 3
 123 openat(AT_FDCWD<$PWD>, "secret.txt", O_RDONLY) = 3

--- a/e2e/tasks/test_task_artifact_cache_audit
+++ b/e2e/tasks/test_task_artifact_cache_audit
@@ -22,18 +22,24 @@ done
 if [[ -z $trace ]]; then
   exec "$@"
 fi
-if [[ $trace == \|* ]]; then
-  sink=${trace#|}
-else
-  sink="cat > '$trace'"
-fi
-cat <<TRACE | sh -c "$sink"
+emit_trace() {
+  if [[ $trace != \|* ]]; then
+    printf '123 execve("%s", ["%s"], 0x0) = 0\n' "$1" "$1"
+    return
+  fi
+  cat <<TRACE
 123 openat(AT_FDCWD<$PWD>, "input.txt", O_RDONLY) = 3
 123 openat(AT_FDCWD<$PWD>, "../shared.txt", O_RDONLY) = 3
 123 openat(AT_FDCWD<$PWD>, "secret.txt", O_RDONLY) = 3
 123 openat(AT_FDCWD<$PWD>, "dist/result.txt", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 3
 123 openat(AT_FDCWD<$PWD>, "leak.txt", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 3
 TRACE
+}
+if [[ $trace == \|* ]]; then
+  emit_trace "$1" | sh -c "${trace#|}"
+else
+  emit_trace "$1" >"$trace"
+fi
 exec "$@"
 EOF
 chmod +x bin/strace

--- a/e2e/tasks/test_task_artifact_cache_audit_anchoring
+++ b/e2e/tasks/test_task_artifact_cache_audit_anchoring
@@ -22,7 +22,12 @@ done
 if [[ -z $trace ]]; then
   exec "$@"
 fi
-cat <<TRACE >"$trace"
+if [[ $trace == \|* ]]; then
+  sink=${trace#|}
+else
+  sink="cat > '$trace'"
+fi
+cat <<TRACE | sh -c "$sink"
 123 openat(AT_FDCWD<$PWD>, "node_modules/dep.js", O_RDONLY) = 3
 123 openat(AT_FDCWD<$PWD>, "../node_modules/dep.js", O_RDONLY) = 3
 123 openat(AT_FDCWD<$PWD>, "dist/result.txt", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 3

--- a/e2e/tasks/test_task_artifact_cache_audit_anchoring
+++ b/e2e/tasks/test_task_artifact_cache_audit_anchoring
@@ -22,16 +22,22 @@ done
 if [[ -z $trace ]]; then
   exec "$@"
 fi
-if [[ $trace == \|* ]]; then
-  sink=${trace#|}
-else
-  sink="cat > '$trace'"
-fi
-cat <<TRACE | sh -c "$sink"
+emit_trace() {
+  if [[ $trace != \|* ]]; then
+    printf '123 execve("%s", ["%s"], 0x0) = 0\n' "$1" "$1"
+    return
+  fi
+  cat <<TRACE
 123 openat(AT_FDCWD<$PWD>, "node_modules/dep.js", O_RDONLY) = 3
 123 openat(AT_FDCWD<$PWD>, "../node_modules/dep.js", O_RDONLY) = 3
 123 openat(AT_FDCWD<$PWD>, "dist/result.txt", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 3
 TRACE
+}
+if [[ $trace == \|* ]]; then
+  emit_trace "$1" | sh -c "${trace#|}"
+else
+  emit_trace "$1" >"$trace"
+fi
 exec "$@"
 EOF
 chmod +x bin/strace

--- a/e2e/tasks/test_task_artifact_cache_audit_report
+++ b/e2e/tasks/test_task_artifact_cache_audit_report
@@ -25,11 +25,17 @@ done
 if [[ -z $trace ]]; then
   exec "$@"
 fi
-: >"$trace"
-for i in $(seq 1 25); do
-  echo "123 openat(AT_FDCWD<$PWD>, \"undeclared$i.txt\", O_RDONLY) = 3" >>"$trace"
-done
-echo "123 openat(AT_FDCWD<$PWD>, \"generated.txt\", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 3" >>"$trace"
+if [[ $trace == \|* ]]; then
+  sink=${trace#|}
+else
+  sink="cat > '$trace'"
+fi
+{
+  for i in $(seq 1 25); do
+    echo "123 openat(AT_FDCWD<$PWD>, \"undeclared$i.txt\", O_RDONLY) = 3"
+  done
+  echo "123 openat(AT_FDCWD<$PWD>, \"generated.txt\", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 3"
+} | sh -c "$sink"
 exec "$@"
 EOF
 chmod +x bin/strace

--- a/e2e/tasks/test_task_artifact_cache_audit_report
+++ b/e2e/tasks/test_task_artifact_cache_audit_report
@@ -25,17 +25,21 @@ done
 if [[ -z $trace ]]; then
   exec "$@"
 fi
-if [[ $trace == \|* ]]; then
-  sink=${trace#|}
-else
-  sink="cat > '$trace'"
-fi
-{
+emit_trace() {
+  if [[ $trace != \|* ]]; then
+    printf '123 execve("%s", ["%s"], 0x0) = 0\n' "$1" "$1"
+    return
+  fi
   for i in $(seq 1 25); do
     echo "123 openat(AT_FDCWD<$PWD>, \"undeclared$i.txt\", O_RDONLY) = 3"
   done
   echo "123 openat(AT_FDCWD<$PWD>, \"generated.txt\", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 3"
-} | sh -c "$sink"
+}
+if [[ $trace == \|* ]]; then
+  emit_trace "$1" | sh -c "${trace#|}"
+else
+  emit_trace "$1" >"$trace"
+fi
 exec "$@"
 EOF
 chmod +x bin/strace

--- a/e2e/tasks/test_task_artifact_cache_audit_symlinked_dir
+++ b/e2e/tasks/test_task_artifact_cache_audit_symlinked_dir
@@ -29,15 +29,21 @@ fi
 # `pwd -P` rather than $PWD: real strace annotates the dirfd with the path the
 # kernel resolved, which is the symlink's target.
 cwd=$(pwd -P)
-if [[ $trace == \|* ]]; then
-  sink=${trace#|}
-else
-  sink="cat > '$trace'"
-fi
-cat <<TRACE | sh -c "$sink"
+emit_trace() {
+  if [[ $trace != \|* ]]; then
+    printf '123 execve("%s", ["%s"], 0x0) = 0\n' "$1" "$1"
+    return
+  fi
+  cat <<TRACE
 123 openat(AT_FDCWD<$cwd>, "input.txt", O_RDONLY) = 3
 123 openat(AT_FDCWD<$cwd>, "secret.txt", O_RDONLY) = 3
 TRACE
+}
+if [[ $trace == \|* ]]; then
+  emit_trace "$1" | sh -c "${trace#|}"
+else
+  emit_trace "$1" >"$trace"
+fi
 exec "$@"
 EOF
 chmod +x bin/strace

--- a/e2e/tasks/test_task_artifact_cache_audit_symlinked_dir
+++ b/e2e/tasks/test_task_artifact_cache_audit_symlinked_dir
@@ -29,7 +29,12 @@ fi
 # `pwd -P` rather than $PWD: real strace annotates the dirfd with the path the
 # kernel resolved, which is the symlink's target.
 cwd=$(pwd -P)
-cat <<TRACE >"$trace"
+if [[ $trace == \|* ]]; then
+  sink=${trace#|}
+else
+  sink="cat > '$trace'"
+fi
+cat <<TRACE | sh -c "$sink"
 123 openat(AT_FDCWD<$cwd>, "input.txt", O_RDONLY) = 3
 123 openat(AT_FDCWD<$cwd>, "secret.txt", O_RDONLY) = 3
 TRACE

--- a/e2e/tasks/test_task_artifact_cache_audit_tracer_failure
+++ b/e2e/tasks/test_task_artifact_cache_audit_tracer_failure
@@ -40,9 +40,18 @@ if $daemonize; then
   # a grandchild whose internal failure cannot replace the task's exit status.
   (
     sleep 0.05
-    cat <<TRACE | sh -c "${trace#|}"
-123 openat(AT_FDCWD<$PWD>, "secret.txt", O_RDONLY) = 3
-TRACE
+    if [[ ${FAKE_PROBE_FAILURE:-0} == 1 && $trace != \|* ]]; then
+      echo 'strace: ptrace(PTRACE_TRACEME): Operation not permitted' >&2
+      exit 1
+    fi
+    if [[ $trace == \|* ]]; then
+      sink=${trace#|}
+      record="123 openat(AT_FDCWD<$PWD>, \"secret.txt\", O_RDONLY) = 3"
+    else
+      sink="cat > '$trace'"
+      record="123 execve(\"$1\", [\"$1\"], 0x0) = 0"
+    fi
+    printf '%s\n' "$record" | sh -c "$sink"
     echo 'strace: ptrace(PTRACE_LISTEN,pid:123,sig:0): Input/output error' >&2
     exit 1
   ) &
@@ -87,13 +96,21 @@ EOF
 export PATH="$PWD/bin:$PATH"
 
 # A failure in the advisory tracer must not replace a successful task status.
-output=$(mise run --force success 2>&1)
+status=0
+output=$(mise run --force success 2>&1) || status=$?
+assert "test $status -eq 0"
 assert_contains_text "$output" "ptrace(PTRACE_LISTEN"
 assert_contains_text "$output" "cache audit detected undeclared read: secret.txt"
 
 # Daemonizing the tracer must not mask a real task failure either.
-assert_fail "mise run --force failure"
+status=0
+output=$(mise run --force failure 2>&1) || status=$?
+assert "test $status -eq 42"
 
 # An unresponsive tracer remains advisory and its incomplete report is ignored.
 output=$(mise run --force incomplete 2>&1)
 assert_contains_text "$output" "cache audit tracer did not finish; skipping its incomplete report"
+
+# A daemonized capability probe must still detect a tracer startup failure.
+output=$(FAKE_PROBE_FAILURE=1 mise run --force success 2>&1)
+assert_contains_text "$output" "cache audit could not start strace; running without filesystem auditing"

--- a/e2e/tasks/test_task_artifact_cache_audit_tracer_failure
+++ b/e2e/tasks/test_task_artifact_cache_audit_tracer_failure
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+mkdir -p bin
+cat <<'EOF' >bin/strace
+#!/usr/bin/env bash
+set -euo pipefail
+
+daemonize=false
+trace=
+while (($#)); do
+  case $1 in
+  -D)
+    daemonize=true
+    shift
+    ;;
+  -o)
+    trace=$2
+    shift 2
+    ;;
+  --)
+    shift
+    break
+    ;;
+  *) shift ;;
+  esac
+done
+
+# The capability probe has no output file. Requiring -D here also verifies that
+# mise does not enable an incompatible strace and fail later during the task.
+if [[ -z $trace ]]; then
+  $daemonize || exit 1
+  exec "$@"
+fi
+
+cat <<TRACE >"$trace"
+123 openat(AT_FDCWD<$PWD>, "input.txt", O_RDONLY) = 3
+TRACE
+
+if $daemonize; then
+  # Model strace -D: the original process becomes the task while the tracer is
+  # a grandchild whose internal failure cannot replace the task's exit status.
+  (
+    echo 'strace: ptrace(PTRACE_LISTEN,pid:123,sig:0): Input/output error' >&2
+    exit 1
+  ) &
+  exec "$@"
+fi
+
+# Without -D, strace is the process mise waits for and its internal status wins.
+"$@"
+exit 1
+EOF
+chmod +x bin/strace
+
+printf 'input\n' >input.txt
+
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[tasks.success]
+run = "true"
+sources = ["input.txt"]
+outputs = []
+cache = { enabled = true, audit = true }
+
+[tasks.failure]
+run = "exit 42"
+sources = ["input.txt"]
+outputs = []
+cache = { enabled = true, audit = true }
+EOF
+
+export PATH="$PWD/bin:$PATH"
+
+# A failure in the advisory tracer must not replace a successful task status.
+output=$(mise run --force success 2>&1)
+assert_contains_text "$output" "ptrace(PTRACE_LISTEN"
+
+# Daemonizing the tracer must not mask a real task failure either.
+assert_fail "mise run --force failure"

--- a/e2e/tasks/test_task_artifact_cache_audit_tracer_failure
+++ b/e2e/tasks/test_task_artifact_cache_audit_tracer_failure
@@ -33,6 +33,11 @@ if [[ -z $trace ]]; then
 fi
 
 if $daemonize; then
+  if [[ ${FAKE_PROBE_FAILURE:-0} == 1 ]]; then
+    sh -c "${trace#|}" </dev/null
+    echo 'strace: ptrace(PTRACE_TRACEME): Operation not permitted' >&2
+    exec "$@"
+  fi
   if [[ ${FAKE_INCOMPLETE:-0} == 1 ]]; then
     { sleep 10 | sh -c "${trace#|}"; } >/dev/null 2>&1 &
     exec "$@"
@@ -41,10 +46,6 @@ if $daemonize; then
   # a grandchild whose internal failure cannot replace the task's exit status.
   (
     sleep 0.05
-    if [[ ${FAKE_PROBE_FAILURE:-0} == 1 && $trace != \|* ]]; then
-      echo 'strace: ptrace(PTRACE_TRACEME): Operation not permitted' >&2
-      exit 1
-    fi
     if [[ $trace == \|* ]]; then
       sink=${trace#|}
       record="123 openat(AT_FDCWD<$PWD>, \"secret.txt\", O_RDONLY) = 3"

--- a/e2e/tasks/test_task_artifact_cache_audit_tracer_failure
+++ b/e2e/tasks/test_task_artifact_cache_audit_tracer_failure
@@ -32,14 +32,17 @@ if [[ -z $trace ]]; then
   exec "$@"
 fi
 
-cat <<TRACE >"$trace"
-123 openat(AT_FDCWD<$PWD>, "input.txt", O_RDONLY) = 3
-TRACE
-
 if $daemonize; then
+  if [[ ${FAKE_INCOMPLETE:-0} == 1 ]]; then
+    exec "$@"
+  fi
   # Model strace -D: the original process becomes the task while the tracer is
   # a grandchild whose internal failure cannot replace the task's exit status.
   (
+    sleep 0.05
+    cat <<TRACE | sh -c "${trace#|}"
+123 openat(AT_FDCWD<$PWD>, "secret.txt", O_RDONLY) = 3
+TRACE
     echo 'strace: ptrace(PTRACE_LISTEN,pid:123,sig:0): Input/output error' >&2
     exit 1
   ) &
@@ -47,6 +50,9 @@ if $daemonize; then
 fi
 
 # Without -D, strace is the process mise waits for and its internal status wins.
+cat <<TRACE >"$trace"
+123 openat(AT_FDCWD<$PWD>, "secret.txt", O_RDONLY) = 3
+TRACE
 "$@"
 exit 1
 EOF
@@ -69,6 +75,13 @@ run = "exit 42"
 sources = ["input.txt"]
 outputs = []
 cache = { enabled = true, audit = true }
+
+[tasks.incomplete]
+run = "true"
+sources = ["input.txt"]
+outputs = []
+cache = { enabled = true, audit = true }
+env = { FAKE_INCOMPLETE = "1" }
 EOF
 
 export PATH="$PWD/bin:$PATH"
@@ -76,6 +89,11 @@ export PATH="$PWD/bin:$PATH"
 # A failure in the advisory tracer must not replace a successful task status.
 output=$(mise run --force success 2>&1)
 assert_contains_text "$output" "ptrace(PTRACE_LISTEN"
+assert_contains_text "$output" "cache audit detected undeclared read: secret.txt"
 
 # Daemonizing the tracer must not mask a real task failure either.
 assert_fail "mise run --force failure"
+
+# An unresponsive tracer remains advisory and its incomplete report is ignored.
+output=$(mise run --force incomplete 2>&1)
+assert_contains_text "$output" "cache audit tracer did not finish; skipping its incomplete report"

--- a/e2e/tasks/test_task_artifact_cache_audit_tracer_failure
+++ b/e2e/tasks/test_task_artifact_cache_audit_tracer_failure
@@ -33,6 +33,10 @@ if [[ -z $trace ]]; then
 fi
 
 if $daemonize; then
+  if [[ ${FAKE_INCOMPLETE:-0} == 1 ]]; then
+    { sleep 10 | sh -c "${trace#|}"; } >/dev/null 2>&1 &
+    exec "$@"
+  fi
   # Model strace -D: the original process becomes the task while the tracer is
   # a grandchild whose internal failure cannot replace the task's exit status.
   (
@@ -44,11 +48,11 @@ if $daemonize; then
     if [[ $trace == \|* ]]; then
       sink=${trace#|}
       record="123 openat(AT_FDCWD<$PWD>, \"secret.txt\", O_RDONLY) = 3"
+      printf '%s\n' "$record" | sh -c "$sink"
     else
-      sink="cat > '$trace'"
       record="123 execve(\"$1\", [\"$1\"], 0x0) = 0"
+      printf '%s\n' "$record" >"$trace"
     fi
-    printf '%s\n' "$record" | sh -c "$sink"
     echo 'strace: ptrace(PTRACE_LISTEN,pid:123,sig:0): Input/output error' >&2
     exit 1
   ) &
@@ -82,6 +86,13 @@ sources = ["input.txt"]
 outputs = []
 cache = { enabled = true, audit = true }
 
+[tasks.incomplete]
+run = "true"
+sources = ["input.txt"]
+outputs = []
+cache = { enabled = true, audit = true }
+env = { FAKE_INCOMPLETE = "1" }
+
 EOF
 
 export PATH="$PWD/bin:$PATH"
@@ -97,6 +108,10 @@ assert_contains_text "$output" "cache audit detected undeclared read: secret.txt
 status=0
 output=$(mise run --force failure 2>&1) || status=$?
 assert "test $status -eq 42"
+
+# A long-lived traced descendant must not hang the completed task indefinitely.
+output=$(mise run --force incomplete 2>&1)
+assert_contains_text "$output" "cache audit tracer did not finish; skipping its incomplete report"
 
 # A daemonized capability probe must still detect a tracer startup failure.
 output=$(FAKE_PROBE_FAILURE=1 mise run --force success 2>&1)

--- a/e2e/tasks/test_task_artifact_cache_audit_tracer_failure
+++ b/e2e/tasks/test_task_artifact_cache_audit_tracer_failure
@@ -33,9 +33,6 @@ if [[ -z $trace ]]; then
 fi
 
 if $daemonize; then
-  if [[ ${FAKE_INCOMPLETE:-0} == 1 ]]; then
-    exec "$@"
-  fi
   # Model strace -D: the original process becomes the task while the tracer is
   # a grandchild whose internal failure cannot replace the task's exit status.
   (
@@ -85,12 +82,6 @@ sources = ["input.txt"]
 outputs = []
 cache = { enabled = true, audit = true }
 
-[tasks.incomplete]
-run = "true"
-sources = ["input.txt"]
-outputs = []
-cache = { enabled = true, audit = true }
-env = { FAKE_INCOMPLETE = "1" }
 EOF
 
 export PATH="$PWD/bin:$PATH"
@@ -106,10 +97,6 @@ assert_contains_text "$output" "cache audit detected undeclared read: secret.txt
 status=0
 output=$(mise run --force failure 2>&1) || status=$?
 assert "test $status -eq 42"
-
-# An unresponsive tracer remains advisory and its incomplete report is ignored.
-output=$(mise run --force incomplete 2>&1)
-assert_contains_text "$output" "cache audit tracer did not finish; skipping its incomplete report"
 
 # A daemonized capability probe must still detect a tracer startup failure.
 output=$(FAKE_PROBE_FAILURE=1 mise run --force success 2>&1)

--- a/e2e/tasks/test_task_artifact_cache_audit_tracer_failure
+++ b/e2e/tasks/test_task_artifact_cache_audit_tracer_failure
@@ -112,7 +112,7 @@ assert "test $status -eq 42"
 
 # A long-lived traced descendant must not hang the completed task indefinitely.
 output=$(mise run --force incomplete 2>&1)
-assert_contains_text "$output" "cache audit tracer did not finish; skipping its incomplete report"
+assert_contains_text "$output" "cache audit tracer exceeded its drain grace; report may be incomplete"
 
 # A daemonized capability probe must still detect a tracer startup failure.
 output=$(FAKE_PROBE_FAILURE=1 mise run --force success 2>&1)

--- a/src/task/task_cache_audit.rs
+++ b/src/task/task_cache_audit.rs
@@ -24,7 +24,7 @@ use tempfile::NamedTempFile;
 use tokio::sync::OnceCell;
 
 const MAX_REPORTED_PATHS: usize = 20;
-const TRACE_COMPLETION_TIMEOUT: Duration = Duration::from_secs(1);
+const TRACE_START_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[cfg(target_os = "linux")]
 static STRACE: OnceCell<Option<PathBuf>> = OnceCell::const_new();
@@ -135,7 +135,7 @@ impl TaskCacheAudit {
         let trace_complete = shell_escape::escape(self.trace_complete.path().to_string_lossy());
         // Piping the trace through a small sink gives mise a completion signal from the detached
         // tracer. strace closes the pipe only after it has finished following every tracee.
-        let output = format!("|cat > {trace} && printf 1 > {trace_complete}");
+        let output = format!("|cat > {trace}; printf 1 > {trace_complete}");
         let mut wrapped = vec![
             // Keep the task as mise's direct child so a failure in the advisory tracer does not
             // replace the task's exit status. The tracer runs as the task's grandchild instead.
@@ -162,13 +162,7 @@ impl TaskCacheAudit {
     }
 
     pub(crate) async fn report(&self, task: &Task) {
-        if !wait_for_file(self.trace_complete.path()).await {
-            warn!(
-                "task {} cache audit tracer did not finish; skipping its incomplete report",
-                task.name
-            );
-            return;
-        }
+        wait_for_file(self.trace_complete.path()).await;
         let trace = match fs::read_to_string(self.trace.path()) {
             Ok(trace) => trace,
             Err(err) => {
@@ -327,21 +321,17 @@ async fn usable_strace() -> Option<PathBuf> {
         .clone()
 }
 
-async fn wait_for_file(path: &Path) -> bool {
-    tokio::time::timeout(TRACE_COMPLETION_TIMEOUT, async {
-        loop {
-            if fs::metadata(path).is_ok_and(|meta| meta.len() > 0) {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
+async fn wait_for_file(path: &Path) {
+    loop {
+        if fs::metadata(path).is_ok_and(|meta| meta.len() > 0) {
+            break;
         }
-    })
-    .await
-    .is_ok()
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
 }
 
 async fn wait_for_trace_record(path: &Path) -> bool {
-    tokio::time::timeout(TRACE_COMPLETION_TIMEOUT, async {
+    tokio::time::timeout(TRACE_START_TIMEOUT, async {
         loop {
             if fs::read_to_string(path).is_ok_and(|trace| trace.contains("execve(")) {
                 break;

--- a/src/task/task_cache_audit.rs
+++ b/src/task/task_cache_audit.rs
@@ -24,6 +24,7 @@ use tempfile::NamedTempFile;
 use tokio::sync::OnceCell;
 
 const MAX_REPORTED_PATHS: usize = 20;
+const TRACE_COMPLETION_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[cfg(target_os = "linux")]
 static STRACE: OnceCell<Option<PathBuf>> = OnceCell::const_new();
@@ -161,17 +162,7 @@ impl TaskCacheAudit {
     }
 
     pub(crate) async fn report(&self, task: &Task) {
-        if tokio::time::timeout(Duration::from_secs(1), async {
-            loop {
-                if fs::metadata(self.trace_complete.path()).is_ok_and(|meta| meta.len() > 0) {
-                    break;
-                }
-                tokio::time::sleep(Duration::from_millis(10)).await;
-            }
-        })
-        .await
-        .is_err()
-        {
+        if !wait_for_file(self.trace_complete.path()).await {
             warn!(
                 "task {} cache audit tracer did not finish; skipping its incomplete report",
                 task.name
@@ -310,14 +301,21 @@ async fn usable_strace() -> Option<PathBuf> {
                 warn_once!("task cache audit requires strace; running without filesystem auditing");
                 return None;
             };
+            let trace = NamedTempFile::new().ok()?;
             let status = tokio::process::Command::new(&strace)
-                .args(["-D", "-qq", "-yy", "-e", "trace=none", "--", "true"])
+                .args(["-D", "-qq", "-e", "trace=execve", "-o"])
+                .arg(trace.path())
+                .args(["--", "true"])
                 .stdin(Stdio::null())
                 .stdout(Stdio::null())
                 .stderr(Stdio::null())
                 .status()
                 .await;
-            if !status.is_ok_and(|status| status.success()) {
+            // With -D, the status belongs to `true`, not the detached tracer. Requiring its
+            // execve record catches startup failures such as ptrace being blocked by seccomp.
+            if !status.is_ok_and(|status| status.success())
+                || !wait_for_trace_record(trace.path()).await
+            {
                 warn_once!(
                     "task cache audit could not start strace; running without filesystem auditing"
                 );
@@ -327,6 +325,32 @@ async fn usable_strace() -> Option<PathBuf> {
         })
         .await
         .clone()
+}
+
+async fn wait_for_file(path: &Path) -> bool {
+    tokio::time::timeout(TRACE_COMPLETION_TIMEOUT, async {
+        loop {
+            if fs::metadata(path).is_ok_and(|meta| meta.len() > 0) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .is_ok()
+}
+
+async fn wait_for_trace_record(path: &Path) -> bool {
+    tokio::time::timeout(TRACE_COMPLETION_TIMEOUT, async {
+        loop {
+            if fs::read_to_string(path).is_ok_and(|trace| trace.contains("execve(")) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .is_ok()
 }
 
 fn matches_override(matcher: &Override, path: &Path) -> bool {

--- a/src/task/task_cache_audit.rs
+++ b/src/task/task_cache_audit.rs
@@ -25,6 +25,7 @@ use tokio::sync::OnceCell;
 
 const MAX_REPORTED_PATHS: usize = 20;
 const TRACE_START_TIMEOUT: Duration = Duration::from_secs(1);
+const TRACE_SINK_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[cfg(target_os = "linux")]
 static STRACE: OnceCell<Option<PathBuf>> = OnceCell::const_new();
@@ -68,6 +69,8 @@ pub(crate) struct TaskCacheAudit {
     strace: PathBuf,
     trace: NamedTempFile,
     trace_complete: NamedTempFile,
+    trace_task_complete: NamedTempFile,
+    trace_timed_out: NamedTempFile,
     root: PathBuf,
     source_root: PathBuf,
     sources: Override,
@@ -120,6 +123,8 @@ impl TaskCacheAudit {
                 strace,
                 trace: NamedTempFile::new()?,
                 trace_complete: NamedTempFile::new()?,
+                trace_task_complete: NamedTempFile::new()?,
+                trace_timed_out: NamedTempFile::new()?,
                 root,
                 source_root,
                 sources,
@@ -133,9 +138,18 @@ impl TaskCacheAudit {
     pub(crate) fn wrap(&self, program: OsString, args: &[String]) -> (OsString, Vec<String>) {
         let trace = shell_escape::escape(self.trace.path().to_string_lossy());
         let trace_complete = shell_escape::escape(self.trace_complete.path().to_string_lossy());
+        let trace_task_complete =
+            shell_escape::escape(self.trace_task_complete.path().to_string_lossy());
+        let trace_timed_out = shell_escape::escape(self.trace_timed_out.path().to_string_lossy());
         // Piping the trace through a small sink gives mise a completion signal from the detached
         // tracer. strace closes the pipe only after it has finished following every tracee.
-        let output = format!("|cat > {trace}; printf 1 > {trace_complete}");
+        let output = format!(
+            "|exec 3<&0; cat <&3 > {trace} & child=$!; \
+             (while test ! -s {trace_task_complete}; do sleep 0.01; done; sleep 1; \
+             printf 1 > {trace_timed_out}; kill \"$child\" 2>/dev/null) & watchdog=$!; \
+             wait \"$child\"; kill \"$watchdog\" 2>/dev/null; wait \"$watchdog\" 2>/dev/null; \
+             printf 1 > {trace_complete}"
+        );
         let mut wrapped = vec![
             // Keep the task as mise's direct child so a failure in the advisory tracer does not
             // replace the task's exit status. The tracer runs as the task's grandchild instead.
@@ -162,7 +176,22 @@ impl TaskCacheAudit {
     }
 
     pub(crate) async fn report(&self, task: &Task) {
-        wait_for_file(self.trace_complete.path()).await;
+        if let Err(err) = fs::write(self.trace_task_complete.path(), b"1") {
+            warn!(
+                "task {} cache audit could not signal its tracer: {err}",
+                task.name
+            );
+            return;
+        }
+        if !wait_for_file(self.trace_complete.path(), TRACE_SINK_TIMEOUT).await
+            || fs::metadata(self.trace_timed_out.path()).is_ok_and(|meta| meta.len() > 0)
+        {
+            warn!(
+                "task {} cache audit tracer did not finish; skipping its incomplete report",
+                task.name
+            );
+            return;
+        }
         let trace = match fs::read_to_string(self.trace.path()) {
             Ok(trace) => trace,
             Err(err) => {
@@ -321,13 +350,17 @@ async fn usable_strace() -> Option<PathBuf> {
         .clone()
 }
 
-async fn wait_for_file(path: &Path) {
-    loop {
-        if fs::metadata(path).is_ok_and(|meta| meta.len() > 0) {
-            break;
+async fn wait_for_file(path: &Path, timeout: Duration) -> bool {
+    tokio::time::timeout(timeout, async {
+        loop {
+            if fs::metadata(path).is_ok_and(|meta| meta.len() > 0) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
         }
-        tokio::time::sleep(Duration::from_millis(10)).await;
-    }
+    })
+    .await
+    .is_ok()
 }
 
 async fn wait_for_trace_record(path: &Path) -> bool {

--- a/src/task/task_cache_audit.rs
+++ b/src/task/task_cache_audit.rs
@@ -183,14 +183,18 @@ impl TaskCacheAudit {
             );
             return;
         }
-        if !wait_for_file(self.trace_complete.path(), TRACE_SINK_TIMEOUT).await
-            || fs::metadata(self.trace_timed_out.path()).is_ok_and(|meta| meta.len() > 0)
-        {
+        if !wait_for_file(self.trace_complete.path(), TRACE_SINK_TIMEOUT).await {
             warn!(
                 "task {} cache audit tracer did not finish; skipping its incomplete report",
                 task.name
             );
             return;
+        }
+        if fs::metadata(self.trace_timed_out.path()).is_ok_and(|meta| meta.len() > 0) {
+            warn!(
+                "task {} cache audit tracer exceeded its drain grace; report may be incomplete",
+                task.name
+            );
         }
         let trace = match fs::read_to_string(self.trace.path()) {
             Ok(trace) => trace,

--- a/src/task/task_cache_audit.rs
+++ b/src/task/task_cache_audit.rs
@@ -18,6 +18,7 @@ use std::path::{Path, PathBuf};
 #[cfg(target_os = "linux")]
 use std::process::Stdio;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use tempfile::NamedTempFile;
 #[cfg(target_os = "linux")]
 use tokio::sync::OnceCell;
@@ -65,6 +66,7 @@ pub(crate) struct TaskCacheAudit {
     #[cfg(target_os = "linux")]
     strace: PathBuf,
     trace: NamedTempFile,
+    trace_complete: NamedTempFile,
     root: PathBuf,
     source_root: PathBuf,
     sources: Override,
@@ -116,6 +118,7 @@ impl TaskCacheAudit {
             Ok(Some(Self {
                 strace,
                 trace: NamedTempFile::new()?,
+                trace_complete: NamedTempFile::new()?,
                 root,
                 source_root,
                 sources,
@@ -127,6 +130,11 @@ impl TaskCacheAudit {
 
     #[cfg(target_os = "linux")]
     pub(crate) fn wrap(&self, program: OsString, args: &[String]) -> (OsString, Vec<String>) {
+        let trace = shell_escape::escape(self.trace.path().to_string_lossy());
+        let trace_complete = shell_escape::escape(self.trace_complete.path().to_string_lossy());
+        // Piping the trace through a small sink gives mise a completion signal from the detached
+        // tracer. strace closes the pipe only after it has finished following every tracee.
+        let output = format!("|cat > {trace} && printf 1 > {trace_complete}");
         let mut wrapped = vec![
             // Keep the task as mise's direct child so a failure in the advisory tracer does not
             // replace the task's exit status. The tracer runs as the task's grandchild instead.
@@ -139,7 +147,7 @@ impl TaskCacheAudit {
             "-s".to_string(),
             "4096".to_string(),
             "-o".to_string(),
-            self.trace.path().to_string_lossy().into_owned(),
+            output,
             "--".to_string(),
             program.to_string_lossy().into_owned(),
         ];
@@ -152,7 +160,24 @@ impl TaskCacheAudit {
         (program, args.to_vec())
     }
 
-    pub(crate) fn report(&self, task: &Task) {
+    pub(crate) async fn report(&self, task: &Task) {
+        if tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if fs::metadata(self.trace_complete.path()).is_ok_and(|meta| meta.len() > 0) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .is_err()
+        {
+            warn!(
+                "task {} cache audit tracer did not finish; skipping its incomplete report",
+                task.name
+            );
+            return;
+        }
         let trace = match fs::read_to_string(self.trace.path()) {
             Ok(trace) => trace,
             Err(err) => {

--- a/src/task/task_cache_audit.rs
+++ b/src/task/task_cache_audit.rs
@@ -325,19 +325,25 @@ async fn usable_strace() -> Option<PathBuf> {
                 return None;
             };
             let trace = NamedTempFile::new().ok()?;
+            let trace_complete = NamedTempFile::new().ok()?;
+            let trace_path = shell_escape::escape(trace.path().to_string_lossy());
+            let trace_complete_path = shell_escape::escape(trace_complete.path().to_string_lossy());
+            let output = format!("|cat > {trace_path}; printf 1 > {trace_complete_path}");
             let status = tokio::process::Command::new(&strace)
                 .args(["-D", "-qq", "-e", "trace=execve", "-o"])
-                .arg(trace.path())
+                .arg(output)
                 .args(["--", "true"])
                 .stdin(Stdio::null())
                 .stdout(Stdio::null())
                 .stderr(Stdio::null())
                 .status()
                 .await;
-            // With -D, the status belongs to `true`, not the detached tracer. Requiring its
-            // execve record catches startup failures such as ptrace being blocked by seccomp.
+            // With -D, the status belongs to `true`, not the detached tracer. Requiring the same
+            // output-pipe handshake and a trace record catches unsupported strace syntax and
+            // startup failures such as ptrace being blocked by seccomp.
             if !status.is_ok_and(|status| status.success())
-                || !wait_for_trace_record(trace.path()).await
+                || !wait_for_file(trace_complete.path(), TRACE_START_TIMEOUT).await
+                || !fs::metadata(trace.path()).is_ok_and(|meta| meta.len() > 0)
             {
                 warn_once!(
                     "task cache audit could not start strace; running without filesystem auditing"
@@ -354,19 +360,6 @@ async fn wait_for_file(path: &Path, timeout: Duration) -> bool {
     tokio::time::timeout(timeout, async {
         loop {
             if fs::metadata(path).is_ok_and(|meta| meta.len() > 0) {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-    })
-    .await
-    .is_ok()
-}
-
-async fn wait_for_trace_record(path: &Path) -> bool {
-    tokio::time::timeout(TRACE_START_TIMEOUT, async {
-        loop {
-            if fs::read_to_string(path).is_ok_and(|trace| trace.contains("execve(")) {
                 break;
             }
             tokio::time::sleep(Duration::from_millis(10)).await;

--- a/src/task/task_cache_audit.rs
+++ b/src/task/task_cache_audit.rs
@@ -24,6 +24,7 @@ use tempfile::NamedTempFile;
 use tokio::sync::OnceCell;
 
 const MAX_REPORTED_PATHS: usize = 20;
+#[cfg(target_os = "linux")]
 const TRACE_START_TIMEOUT: Duration = Duration::from_secs(1);
 const TRACE_SINK_TIMEOUT: Duration = Duration::from_secs(2);
 

--- a/src/task/task_cache_audit.rs
+++ b/src/task/task_cache_audit.rs
@@ -128,6 +128,9 @@ impl TaskCacheAudit {
     #[cfg(target_os = "linux")]
     pub(crate) fn wrap(&self, program: OsString, args: &[String]) -> (OsString, Vec<String>) {
         let mut wrapped = vec![
+            // Keep the task as mise's direct child so a failure in the advisory tracer does not
+            // replace the task's exit status. The tracer runs as the task's grandchild instead.
+            "-D".to_string(),
             "-f".to_string(),
             "-qq".to_string(),
             "-yy".to_string(),
@@ -283,7 +286,7 @@ async fn usable_strace() -> Option<PathBuf> {
                 return None;
             };
             let status = tokio::process::Command::new(&strace)
-                .args(["-qq", "-yy", "-e", "trace=none", "--", "true"])
+                .args(["-D", "-qq", "-yy", "-e", "trace=none", "--", "true"])
                 .stdin(Stdio::null())
                 .stdout(Stdio::null())
                 .stderr(Stdio::null())

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -1834,7 +1834,7 @@ impl TaskExecutor {
             })
             .await;
         if let Some(audit) = audit {
-            audit.report(task);
+            audit.report(task).await;
         }
         result?;
         trace!("{prefix} exited successfully");


### PR DESCRIPTION
## Summary
- run the task-cache audit tracer as a grandchild so mise observes the task exit status directly
- wait for a trace-sink completion marker before reporting, then close the sink after a bounded post-task grace period so long-lived descendants cannot hang the scheduler
- preserve and analyze the captured trace prefix on timeout while warning that the report may be incomplete
- require the daemonized capability probe to produce a trace record through the same `-o |command` output path, detecting ptrace failures and unsupported pipe syntax
- cover delayed and stalled tracers, exact task statuses, capability-probe failure, and shell-safe fixture paths

Addresses https://github.com/jdx/mise/discussions/12761

## Tests
- `mise run lint-fix`
- `mise run test:e2e e2e/tasks/test_task_artifact_cache_audit_tracer_failure e2e/tasks/test_task_artifact_cache_audit e2e/tasks/test_task_artifact_cache_audit_report e2e/tasks/test_task_artifact_cache_audit_anchoring e2e/tasks/test_task_artifact_cache_audit_symlinked_dir`
- `cargo fmt --all -- --check`
- focused `shellcheck` for the five cache-audit fixtures

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Linux-only task execution wrapping and shell-invoked strace pipelines; incorrect timeout or signal handling could drop audit reports or leave stray processes, but task exit semantics are the intended fix.
> 
> **Overview**
> **Task cache audit** no longer wraps the task as strace’s direct child. It runs strace with **`-D`** and routes trace output through a **shell pipe sink** so mise waits on the real task process and advisory tracer failures cannot override exit codes.
> 
> After the task finishes, **`report` is async**: it signals the tracer, waits (with timeouts) for a completion marker, and warns or skips when the sink never finishes. A short **post-task grace period** can force-close a stuck trace drain so long-lived descendants do not hang the run, while still analyzing any trace captured so far.
> 
> The **strace capability probe** uses the same daemonized **`-o |…`** handshake and requires a non-empty trace, so blocked **ptrace** or unsupported pipe syntax disables auditing up front instead of failing mid-task.
> 
> E2E **fake strace** fixtures were updated for pipe mode, and a new test covers tracer errors, masked task failures, incomplete drains, and probe startup failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e6f48346b7fa01b6d6c3b6101706ca7b50d4d12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->