### PR TITLE
fix(rust): reconcile incomplete rustup toolchains

### DIFF
--- a/e2e/core/test_rust_components_reconcile
+++ b/e2e/core/test_rust_components_reconcile
@@ -25,17 +25,27 @@ set -euo pipefail
 echo "$*" >>"$MISE_CARGO_HOME/rustup.log"
 
 case "$1 $2" in
+	"show profile")
+		echo default
+		;;
 	"component list")
+		toolchain="${*: -1}"
+		[[ -d "$MISE_RUSTUP_HOME/toolchains/$toolchain" ]] || exit 1
 		cat "$MISE_CARGO_HOME/components" 2>/dev/null || true
 		;;
 	"target list")
+		toolchain="${*: -1}"
+		[[ -d "$MISE_RUSTUP_HOME/toolchains/$toolchain" ]] || exit 1
 		cat "$MISE_CARGO_HOME/targets" 2>/dev/null || true
 		;;
 	"toolchain install")
 		shift 2
 		toolchain="$1"
 		shift
+		toolchain_exists=false
+		[[ -d "$MISE_RUSTUP_HOME/toolchains/$toolchain" ]] && toolchain_exists=true
 		mkdir -p "$MISE_RUSTUP_HOME/toolchains/$toolchain"
+		profile=""
 		while [[ $# -gt 0 ]]; do
 			case "$1" in
 				--component)
@@ -47,13 +57,17 @@ case "$1 $2" in
 					shift 2
 					;;
 				--profile)
+					profile="$2"
 					shift 2
 					;;
 				*)
 					shift
 					;;
 			esac
-		done
+			done
+		if ! $toolchain_exists && [[ -z "$profile" || "$profile" == "default" ]]; then
+			printf '%s\n' clippy rust-docs rustfmt >>"$MISE_CARGO_HOME/components"
+		fi
 		sort -u "$MISE_CARGO_HOME/components" -o "$MISE_CARGO_HOME/components" 2>/dev/null || true
 		sort -u "$MISE_CARGO_HOME/targets" -o "$MISE_CARGO_HOME/targets" 2>/dev/null || true
 		;;
@@ -68,6 +82,13 @@ EOF
 
 chmod +x "$MISE_CARGO_HOME/bin/cargo" "$MISE_CARGO_HOME/bin/rustc" "$MISE_CARGO_HOME/bin/rustup"
 
+assert_hook_env_does_not_call_rustup() {
+  cp "$MISE_CARGO_HOME/rustup.log" "$MISE_CARGO_HOME/rustup.log.before-hook"
+  mise hook-env -s bash --force >/dev/null
+  cmp -s "$MISE_CARGO_HOME/rustup.log.before-hook" "$MISE_CARGO_HOME/rustup.log" ||
+    fail "hook-env unexpectedly invoked rustup"
+}
+
 cat >mise.toml <<EOF
 [tools]
 rust = "1.81.0"
@@ -75,6 +96,32 @@ EOF
 
 mise install
 assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "1"
+
+sed -i '/^rust-docs$/d' "$MISE_CARGO_HOME/components"
+assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
+mise install
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "2"
+assert_contains "cat '$MISE_CARGO_HOME/components'" "rust-docs"
+
+rm -rf "$MISE_RUSTUP_HOME/toolchains/1.81.0"
+assert_hook_env_does_not_call_rustup
+assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
+mise install
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "3"
+
+cat >mise.toml <<EOF
+[tools]
+rust = { version = "1.81.0", profile = "default" }
+EOF
+
+sed -i '/^rustfmt$/d' "$MISE_CARGO_HOME/components"
+assert_hook_env_does_not_call_rustup
+assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
+mise install
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "4"
+assert_contains "cat '$MISE_CARGO_HOME/components'" "clippy"
+assert_contains "cat '$MISE_CARGO_HOME/components'" "rust-docs"
+assert_contains "cat '$MISE_CARGO_HOME/components'" "rustfmt"
 
 cat >mise.toml <<EOF
 [tools]
@@ -84,11 +131,11 @@ EOF
 assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
 
 mise exec -- rustc -V
-assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "2"
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "5"
 assert_contains "cat '$MISE_CARGO_HOME/components'" "rustfmt"
 assert_contains "cat '$MISE_CARGO_HOME/components'" "rust-src"
 assert_contains "cat '$MISE_CARGO_HOME/targets'" "wasm32-unknown-unknown"
 
 mise install
-assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "2"
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "5"
 assert_contains "mise install rust --dry-run-code 2>&1" "already installed"

--- a/e2e/core/test_rust_config_env_homes
+++ b/e2e/core/test_rust_config_env_homes
@@ -27,6 +27,9 @@ set -euo pipefail
 echo "$*" >>"$CARGO_HOME/rustup.log"
 
 case "$1 $2" in
+	"show profile")
+		echo minimal
+		;;
 	"component list")
 		echo rustfmt
 		;;

--- a/e2e/core/test_rust_external_provider
+++ b/e2e/core/test_rust_external_provider
@@ -25,6 +25,9 @@ mkdir -p "$STATE"
 			"--version ")
 				echo "rustup 1.0.0 (external provider)"
 				;;
+			"show profile")
+				echo minimal
+				;;
 			"toolchain install")
 				version=$3
 				mkdir -p "$STATE/toolchains/$version"

--- a/e2e/core/test_rust_nightly_lock
+++ b/e2e/core/test_rust_nightly_lock
@@ -29,6 +29,9 @@ set -euo pipefail
 
 echo "$*" >>"$CARGO_HOME/rustup.log"
 case "${1:-} ${2:-}" in
+	"show profile")
+		echo minimal
+		;;
 	"toolchain install")
 		mkdir -p "$RUSTUP_HOME/toolchains/$3"
 		;;

--- a/e2e/core/test_rust_parallel_install
+++ b/e2e/core/test_rust_parallel_install
@@ -24,6 +24,9 @@ cat >"$CARGO_HOME/bin/rustup" <<'RUSTUP'
 set -euo pipefail
 
 case "${1:-} ${2:-}" in
+	"show profile")
+		echo minimal
+		;;
 	"toolchain install")
 		version="$3"
 		if ! mkdir "$RUSTUP_HOME/install-in-progress" 2>/dev/null; then

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -231,7 +231,7 @@ impl Exec {
             // The original list was computed before the command's lazy provider
             // was installed. Refresh it so a successful install is not reported
             // as missing below.
-            missing = ts.list_missing_versions(&config).await;
+            missing = ts.list_missing_versions_for_install(&config).await;
         }
         if ts.has_lazy_declarations()
             && !opts.dry_run

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -553,7 +553,7 @@ impl Install {
             if self.force {
                 install_candidates
             } else {
-                trs.missing_tools(&install_config)
+                trs.missing_tools_for_install(&install_config)
                     .await
                     .into_iter()
                     .cloned()

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -17,7 +17,7 @@ use crate::toolset::{ResolveOptions, ToolRequest, ToolVersion, ToolVersionOption
 use crate::ui::progress_report::SingleReport;
 use crate::{dirs, env, file, github, plugins};
 use async_trait::async_trait;
-use eyre::{Context, Result};
+use eyre::{Context, Result, bail};
 use indexmap::IndexMap;
 use xx::regex;
 
@@ -28,6 +28,7 @@ pub(super) struct RustPlugin {
 
 const RUST_NIGHTLY_MANIFEST_URL: &str =
     "https://static.rust-lang.org/dist/channel-rust-nightly.toml";
+const RUST_DEFAULT_PROFILE_COMPONENTS: &[&str] = &["clippy", "rust-docs", "rustfmt"];
 
 fn parse_nightly_manifest(manifest: &str) -> Result<String> {
     let manifest: toml::Value =
@@ -256,6 +257,35 @@ impl RustPlugin {
         ))
     }
 
+    /// Returns the profile rustup applies when an install omits `--profile`.
+    fn rustup_default_profile(&self, tv: &ToolVersion, runtime: &RustRuntime) -> Result<String> {
+        let args = vec!["show".to_string(), "profile".to_string()];
+        let mut cmd = cmd(runtime.bin_dir.join(RUSTUP_BIN), args)
+            .env("PATH", rustup_path_env(runtime)?)
+            .stdout_capture()
+            .stderr_capture()
+            .unchecked();
+        for (key, value) in rustup_env(&runtime.homes, &tv.version) {
+            cmd = cmd.env(key, value);
+        }
+        let output = cmd.run()?;
+        if !output.status.success() {
+            bail!(
+                "rustup show profile failed for {}: {}",
+                tv.style(),
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        let profile = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if profile.is_empty() {
+            bail!(
+                "rustup show profile returned an empty profile for {}",
+                tv.style()
+            );
+        }
+        Ok(profile)
+    }
+
     fn missing_components(
         &self,
         requested: &[String],
@@ -289,9 +319,9 @@ impl Backend for RustPlugin {
         false
     }
 
-    /// Rust toolchains can be installed while requested components/targets are
-    /// still absent because rustup owns that mutable state outside mise's
-    /// install directory.
+    /// Rust toolchains can be absent or missing requested components/targets
+    /// while mise's install symlink still exists because rustup owns that
+    /// mutable state outside mise's install directory.
     async fn is_install_satisfied(
         &self,
         config: &Arc<Config>,
@@ -312,15 +342,33 @@ impl Backend for RustPlugin {
         }
 
         let raw_opts = tv.request.options();
-        let (_, components, targets) = RustOptions::new(&raw_opts).install_args();
+        let (profile, components, targets) = RustOptions::new(&raw_opts).install_args();
+        let effective_profile = match profile {
+            Some(profile) => profile,
+            None => self.rustup_default_profile(tv, &runtime)?,
+        };
 
-        if let Some(components) = components
-            && !components.is_empty()
-        {
-            let Some(installed) = self.rustup_installed_items(tv, "component", &runtime)? else {
-                return Ok(false);
-            };
-            let missing = self.missing_components(&components, &installed);
+        // Query components even when none were explicitly requested. This
+        // verifies that rustup still has the toolchain represented by mise's
+        // install symlink after restoring only mise's data directory.
+        let Some(installed_components) = self.rustup_installed_items(tv, "component", &runtime)?
+        else {
+            return Ok(false);
+        };
+
+        let mut required_components = components.unwrap_or_default();
+        if effective_profile == "default" {
+            required_components.extend(
+                RUST_DEFAULT_PROFILE_COMPONENTS
+                    .iter()
+                    .map(|component| (*component).to_string()),
+            );
+        }
+        required_components.sort();
+        required_components.dedup();
+
+        if !required_components.is_empty() {
+            let missing = self.missing_components(&required_components, &installed_components);
             if !missing.is_empty() {
                 debug!(
                     "{} missing rustup component(s): {}",
@@ -471,13 +519,27 @@ impl Backend for RustPlugin {
 
         let raw_opts = tv.request.options();
         let (profile, components, targets) = RustOptions::new(&raw_opts).install_args();
+        let effective_profile = match profile.as_deref() {
+            Some(profile) => profile.to_string(),
+            None => self.rustup_default_profile(&tv, &runtime)?,
+        };
+        let mut components = components.unwrap_or_default();
+        if effective_profile == "default" {
+            components.extend(
+                RUST_DEFAULT_PROFILE_COMPONENTS
+                    .iter()
+                    .map(|component| (*component).to_string()),
+            );
+            components.sort();
+            components.dedup();
+        }
 
         let mut cmd = CmdLineRunner::new(runtime.bin_dir.join(RUSTUP_BIN))
             .with_pr(ctx.pr.as_ref())
             .arg("toolchain")
             .arg("install")
             .arg(&tv.version)
-            .opt_args("--component", components)
+            .opt_args("--component", Some(components))
             .opt_args("--target", targets)
             .prepend_path(vec![runtime.bin_dir.clone()])?
             .env_values(tv.install_env())

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -172,9 +172,26 @@ impl Toolset {
             .collect()
     }
 
+    /// Lists missing install markers without invoking backend-specific checks.
     pub(crate) async fn list_missing_versions(&self, config: &Arc<Config>) -> Vec<ToolVersion> {
         trace!("list_missing_versions");
         measure!("toolset::list_missing_versions", {
+            self.list_current_versions()
+                .into_iter()
+                .filter_map(|(backend, tv)| {
+                    (!backend.is_version_installed(config, &tv, true)).then_some(tv)
+                })
+                .collect()
+        })
+    }
+
+    /// Lists versions whose complete backend-managed install state is unsatisfied.
+    pub(crate) async fn list_missing_versions_for_install(
+        &self,
+        config: &Arc<Config>,
+    ) -> Vec<ToolVersion> {
+        trace!("list_missing_versions_for_install");
+        measure!("toolset::list_missing_versions_for_install", {
             let versions = self.list_current_versions().into_iter().collect::<Vec<_>>();
             let parallel_versions = versions
                 .clone()

--- a/src/toolset/tool_request_set.rs
+++ b/src/toolset/tool_request_set.rs
@@ -47,7 +47,11 @@ impl ToolRequestSet {
     //         .collect()
     // }
 
-    pub(crate) async fn missing_tools(&self, config: &Arc<Config>) -> Vec<&ToolRequest> {
+    /// Lists requests whose complete backend-managed install state is unsatisfied.
+    pub(crate) async fn missing_tools_for_install(
+        &self,
+        config: &Arc<Config>,
+    ) -> Vec<&ToolRequest> {
         let mut tools = vec![];
         for tr in self.tools.values().flatten() {
             if tr.is_os_supported() && !tr.is_install_satisfied(config).await {

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -33,7 +33,7 @@ impl Toolset {
         bin_name: &str,
     ) -> Result<Option<ToolVersion>> {
         let mut providers = self
-            .list_missing_versions(config)
+            .list_missing_versions_for_install(config)
             .await
             .into_iter()
             .filter_map(|tv| {
@@ -174,7 +174,7 @@ impl Toolset {
         config: &mut Arc<Config>,
         opts: &InstallOptions,
     ) -> Result<(Vec<ToolVersion>, Vec<ToolVersion>)> {
-        let missing = self.list_missing_versions(config).await;
+        let missing = self.list_missing_versions_for_install(config).await;
 
         // If auto-install is explicitly disabled, skip installation but return what's missing
         if opts.skip_auto_install {
@@ -217,7 +217,7 @@ impl Toolset {
             )
             .await?;
             // Re-check what's still missing after installation
-            let still_missing = self.list_missing_versions(config).await;
+            let still_missing = self.list_missing_versions_for_install(config).await;
             return Ok((installed, still_missing));
         }
         // Nothing was installed, the missing list is unchanged
@@ -701,7 +701,7 @@ impl Toolset {
         // before falling back to executable discovery from existing installs.
         let mut plugins = IndexSet::new();
         let mut registry_providers = self
-            .list_missing_versions(config)
+            .list_missing_versions_for_install(config)
             .await
             .into_iter()
             .filter(|tv| {
@@ -752,7 +752,7 @@ impl Toolset {
         // Install missing versions for backends that provide this bin
         for plugin in plugins {
             let versions = self
-                .list_missing_versions(config)
+                .list_missing_versions_for_install(config)
                 .await
                 .into_iter()
                 .filter(|tv| tv.ba() == &**plugin.ba())


### PR DESCRIPTION
## Summary
- keep prompt-time and other interactive missing-tool checks on the cheap install-marker path
- reserve backend-specific satisfaction checks for install, auto-install, lazy-install, and dry-run decisions
- verify rustup still has the selected toolchain before treating a mise install request as satisfied
- reconcile the clippy, rust-docs, and rustfmt components implicit in the effective default profile
- assert that hook-env never invokes rustup, including for incomplete toolchains and explicit profiles

## Why
mise-action caches MISE_DATA_DIR, while rustup state normally lives elsewhere. A restored mise install symlink can therefore outlive the corresponding rustup toolchain. This lets mise repair that state during mise install without adding selective cache-path controls to mise-action.

Backend satisfaction may require subprocesses or deeper state validation, so it must not run from hook-env. Interactive missing-tool notifications continue to use the existing cheap install-marker check.

Addresses jdx/mise-action#612.

## Testing
- mise run lint-fix
- mise run lint
- mise run test:e2e e2e/core/test_rust_components_reconcile

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install satisfaction semantics for Rust and splits missing-tool detection across code paths; incorrect splitting could cause missed repairs or unexpected rustup calls outside install flows.
> 
> **Overview**
> **Rust installs are no longer treated as complete when only mise’s install symlink exists.** Satisfaction checks now validate rustup toolchain presence, installed components/targets, and—when the effective profile is `default`—the implicit `clippy`, `rust-docs`, and `rustfmt` components. Installs apply the same default-profile component set and resolve the active profile via `rustup show profile` when none is configured.
> 
> **Install and auto-install decisions use deeper backend checks; interactive paths stay cheap.** `list_missing_versions` only looks at install markers (e.g. shell notifications), while new `list_missing_versions_for_install` and `missing_tools_for_install` drive `mise install`, lazy bin install, and post-install refresh in `mise exec`—so `hook-env` does not invoke rustup.
> 
> **E2E coverage** expands reconciliation scenarios (missing components, deleted toolchains, explicit `profile = "default"`) and updates rustup mocks to support `show profile`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3942985b71929476f73276c9eca984ff1daa3f00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Rust installations using the default profile now include `clippy`, `rust-docs`, and `rustfmt`.
  - Rust toolchain checks now verify that requested toolchains exist before evaluating installed components or targets.

- **Bug Fixes**
  - Improved detection of incomplete or unavailable Rust installations, including missing rustup-managed state.
  - Improved missing-tool detection during installation and lazy tool setup, while preventing duplicate component requirements.

- **Tests**
  - Added coverage for reinstall behavior, dry runs, default-profile components, and explicit component or target installation counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
