### PR TITLE
chore(deps): bump aube to 2.2.9

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,7 +231,7 @@ All commit messages and PR titles MUST follow conventional commit format:
 
 - Update `aube` and `aube-registry` together and refresh all aube workspace crates in `Cargo.lock`.
 - Review the upstream changes for embedder API or behavior changes and make any required mise integration changes.
-- Do not update the standalone `aube` tool entry in `mise.lock` unless the development tool is also intentionally being updated.
+- Update the standalone `aube` development tool entry in `mise.lock` to the same version so local and CI workflows exercise the version mise embeds.
 - Run these focused checks:
   - `cargo check --locked`
   - `cargo test --locked --bin mise aube`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,9 +554,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "2.2.4"
+version = "2.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7c0cbbdeb22323f0c5447fa53d81cff4714d179560b119be2ef9dde9943243"
+checksum = "280d3a4aa13d7892930c7d4aacea22ade744843b00f1f08804d0b33121f1c352"
 dependencies = [
  "aube-codes",
  "aube-linker",
@@ -610,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "2.2.4"
+version = "2.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3224f21cae2844ac34a0eb189c500525e1cfd40f6a7a914fab222e399056ec9c"
+checksum = "c1dd70a9cb7e0531569adb802bb4349d824d205e5d5f22b9bf7d6e7a020600dd"
 dependencies = [
  "serde",
  "serde_json",
@@ -620,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "2.2.4"
+version = "2.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba1221a16a85a078335bcc2f9a31c3fde7d263bb325e31230bd3bbe8f770826"
+checksum = "9e87709cec0333536dceb18265a7fb7b9e0ca6ef777ad5b9e04dda24fd7b394c"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "2.2.4"
+version = "2.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c986b6cae006a67e0b23546235880bd63d033f4bc3f2a43c77dd698f8c0d46e3"
+checksum = "128285d7c001f9392f974b389d978a48cf7215111a7b507f1a8ee11dbe67dba8"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -675,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "2.2.4"
+version = "2.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c972004c3d3c1ace55c58eadb746461e0158dcd76ef40af08557ae394257901"
+checksum = "2418411224dbe7e20efd934509700fe36a6f14896c2a527eb947b957600a8067"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -718,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "2.2.4"
+version = "2.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3553cc3e7a2fa121297461548c0a23ec5d2851c079f2abc41c2b2f3f14252585"
+checksum = "9f4407ddca1d4641ac55f2ef68807baa05bd506665d0ad2475fd5315f0c160de"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -748,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "aube-runtime"
-version = "2.2.4"
+version = "2.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac05125536a3b55bbd50ccf37210c005576ee6969bacdcc263ddd939d67e2509"
+checksum = "b51551e99effd1e1ebabff0a893155028d92d079d99f14fa9f1ce4c104aa6fad"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -773,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "2.2.4"
+version = "2.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767c6e3fc27a056aa6718e83a03f5e505d7d7089982947af6c1bf0566c036c69"
+checksum = "c43231c89f36fe68121fcc95132da9ae81f06cd5a46e023dd68604f685cd7448"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -793,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "2.2.4"
+version = "2.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f38a9a5547a39c50a2b9d594f1b66ef2680998b5996cfa4071a0c0050ea4ead"
+checksum = "362ab904eb7bd8cb73d509f5e20110866c661f7e88d5c7e15b6e67baa027c89b"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -807,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "2.2.4"
+version = "2.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b36160d63de4425a9bdf518c7c81da8f0f0d04218014cac655b99d59daa888de"
+checksum = "4649ae8904af9001492820b1ed84324fba6a2f8174aaab57edd139b23335692c"
 dependencies = [
  "aube-util",
  "base64 0.23.1",
@@ -834,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "2.2.4"
+version = "2.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc7fd0e85447f421f6f8195c10bb37975120ce2d5b220fd866bd0d152b25c35"
+checksum = "b1081ae5c401c1b0e623487d0a8ebd30d666929ba5784f6e40fe087da17645a0"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -856,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "2.2.4"
+version = "2.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dafdd27480bedff7bcb528a625c2f8bc402fbf88f5e0ff721917860def2d12a"
+checksum = "37c569ed06b68c624c7113aa9b29f93615b719b61fb4ebd210823d4078a297f5"
 dependencies = [
  "aube-codes",
  "aube-manifest",

--- a/mise.lock
+++ b/mise.lock
@@ -117,53 +117,63 @@ url_api = "https://api.github.com/repos/FiloSottile/age/releases/assets/53554193
 provenance = "github-attestations"
 
 [[tools.aube]]
-version = "2.2.0"
+version = "2.2.9"
 backend = "github:endevco/aube"
 
 [tools.aube."platforms.linux-arm64"]
-checksum = "sha256:cbfb10e58297f6b352b7722af7d069a10a991a2ec6589f2b7a9c017d14d9926e"
-url = "https://github.com/aubepkg/aube/releases/download/v2.2.0/aube-v2.2.0-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/529737048"
+checksum = "sha256:4fa6d439992097a91fc96a481c67c0cfbf9ecd8d43a36c70ca4ae65c09d8e8f9"
+url = "https://github.com/aubepkg/aube/releases/download/v2.2.9/aube-v2.2.9-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/543704857"
+provenance = "github-attestations"
 
 [tools.aube."platforms.linux-arm64-musl"]
-checksum = "sha256:115adfa9ba0b138f7d54c10ea8a9741d1cd1854c07306320796406d5a83375c1"
-url = "https://github.com/aubepkg/aube/releases/download/v2.2.0/aube-v2.2.0-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/529705095"
+checksum = "sha256:619156760f3727d39ad2157a6efcab28f16124ff769264c4ae1ba14d6c948d6f"
+url = "https://github.com/aubepkg/aube/releases/download/v2.2.9/aube-v2.2.9-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/543696849"
+provenance = "github-attestations"
 
 [tools.aube."platforms.linux-x64"]
-checksum = "sha256:5d8b91f772712e6f971a2e15a52dcc392acbb21782fbb532124588deb647656b"
-url = "https://github.com/aubepkg/aube/releases/download/v2.2.0/aube-v2.2.0-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/529716822"
+checksum = "sha256:02dd762b6f1e0ed99e8be2d94f577d9050856319a58f02f6c64740199294f1e8"
+url = "https://github.com/aubepkg/aube/releases/download/v2.2.9/aube-v2.2.9-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/543692591"
+provenance = "github-attestations"
+provenance_verified = true
 
 [tools.aube."platforms.linux-x64-baseline"]
-checksum = "sha256:5d8b91f772712e6f971a2e15a52dcc392acbb21782fbb532124588deb647656b"
-url = "https://github.com/aubepkg/aube/releases/download/v2.2.0/aube-v2.2.0-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/529716822"
+checksum = "sha256:02dd762b6f1e0ed99e8be2d94f577d9050856319a58f02f6c64740199294f1e8"
+url = "https://github.com/aubepkg/aube/releases/download/v2.2.9/aube-v2.2.9-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/543692591"
+provenance = "github-attestations"
 
 [tools.aube."platforms.linux-x64-musl"]
-checksum = "sha256:3f01b75136705709cda862ae29c059dedf52341b2bb95359f61c2b72b03f9fc8"
-url = "https://github.com/aubepkg/aube/releases/download/v2.2.0/aube-v2.2.0-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/529714460"
+checksum = "sha256:2a241ea622a9b86f2da02e3396a138c43e32d59dbf51f2b5b61d4d37ab9fe667"
+url = "https://github.com/aubepkg/aube/releases/download/v2.2.9/aube-v2.2.9-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/543692371"
+provenance = "github-attestations"
 
 [tools.aube."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:3f01b75136705709cda862ae29c059dedf52341b2bb95359f61c2b72b03f9fc8"
-url = "https://github.com/aubepkg/aube/releases/download/v2.2.0/aube-v2.2.0-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/529714460"
+checksum = "sha256:2a241ea622a9b86f2da02e3396a138c43e32d59dbf51f2b5b61d4d37ab9fe667"
+url = "https://github.com/aubepkg/aube/releases/download/v2.2.9/aube-v2.2.9-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/543692371"
+provenance = "github-attestations"
 
 [tools.aube."platforms.macos-arm64"]
-checksum = "sha256:702de7f549cef800a1f35900e638ea4fbe07bce854f234cef869cd5442484c90"
-url = "https://github.com/aubepkg/aube/releases/download/v2.2.0/aube-v2.2.0-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/529761660"
+checksum = "sha256:b94c1e5a1b6a8049f785e99c8c03b1f922c25ce3efa8ec31c0c8ff84237eb3e4"
+url = "https://github.com/aubepkg/aube/releases/download/v2.2.9/aube-v2.2.9-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/543705939"
+provenance = "github-attestations"
 
 [tools.aube."platforms.windows-x64"]
-checksum = "sha256:2d68e3e995c336486647034eb8b99c3cfa68894e385a44200af2bc14bc4064cf"
-url = "https://github.com/aubepkg/aube/releases/download/v2.2.0/aube-v2.2.0-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/529724125"
+checksum = "sha256:5961d57c3f1b0571c203c817e497a64bc1d6a67d765733895994825edeeeb1c5"
+url = "https://github.com/aubepkg/aube/releases/download/v2.2.9/aube-v2.2.9-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/543704068"
+provenance = "github-attestations"
 
 [tools.aube."platforms.windows-x64-baseline"]
-checksum = "sha256:2d68e3e995c336486647034eb8b99c3cfa68894e385a44200af2bc14bc4064cf"
-url = "https://github.com/aubepkg/aube/releases/download/v2.2.0/aube-v2.2.0-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/529724125"
+checksum = "sha256:5961d57c3f1b0571c203c817e497a64bc1d6a67d765733895994825edeeeb1c5"
+url = "https://github.com/aubepkg/aube/releases/download/v2.2.9/aube-v2.2.9-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/543704068"
+provenance = "github-attestations"
 
 [[tools.bun]]
 version = "1.4.0"


### PR DESCRIPTION
## Summary
- bump the embedded aube workspace crates from 2.2.4 to 2.2.9
- keep aube-registry aligned at 2.2.9
- bump the standalone aube development tool lock from 2.2.0 to 2.2.9
- update contributor instructions so future embedded bumps keep the standalone development tool aligned

## Upstream review
- reviewed aubepkg/aube changes from v2.2.4 through v2.2.9
- relevant behavior changes include faster CAS writes and rejection of unsupported pre-v9 pnpm lockfiles
- no mise embedder integration changes were required

## Testing
- `cargo check --locked`
- `cargo test --locked --bin mise aube`
- `cargo test --locked --bin mise task::workspace::node::tests`
- `mise run test:e2e e2e/backend/test_npm_aube`
- locked standalone aube install and `aube --version` (2.2.9)
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*