### PR TITLE
feat(brew): evaluate ordinary third-party taps

### DIFF
--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -20,15 +20,22 @@ bottle. Formulae without a usable bottle are built from source, also without
 Homebrew (see [Source formulae](#source-formulae)). mise never shells out to
 `brew` for homebrew/core formulae.
 
-Third-party taps are supported directly when the tap publishes Homebrew API
-metadata (`api/formula/<name>.json` or `api/cask/<token>.json`). Use the same
-fully-qualified name you would pass to Homebrew:
+Third-party taps are supported with the same fully-qualified name you would
+pass to Homebrew:
 
 ```toml
 [bootstrap.packages]
-"brew:railwaycat/emacsmacport/emacs-mac" = "latest"
+"brew:owner/tap/formula" = "latest"
 "brew-cask:owner/tap/app" = "latest"
 ```
+
+mise first looks for published Homebrew API metadata at
+`api/formula/<name>.json` or `api/cask/<token>.json`. When a tap does not
+publish it, mise fetches the Ruby definition at a pinned tap commit and
+evaluates its metadata with mise's own Formula or Cask DSL shim. Formulae
+resolved this way are built from source. mise does not invoke or install
+Homebrew. The shims support the commonly used DSL and report an error when a
+definition cannot be evaluated or installed safely.
 
 For taps whose GitHub URL cannot be inferred, add a tap source. This mirrors
 `[plugins]`: the key is the tap name and the value is the GitHub git URL.
@@ -45,7 +52,7 @@ For taps whose GitHub URL cannot be inferred, add a tap source. This mirrors
 `mise bootstrap packages brew tap` and `mise bootstrap packages brew untap`
 manage `[bootstrap.brew.taps]` in `mise.toml`; they do not mutate a Homebrew
 installation. Non-GitHub taps are not currently supported because mise needs
-direct raw access to the generated API metadata.
+direct raw access to tap metadata and Ruby definitions.
 
 ```sh
 mise bootstrap packages brew tap railwaycat/emacsmacport

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -339,7 +339,6 @@ impl Exec {
                 deny_temp_write: false,
                 allow_read: self.allow_read,
                 allow_write: self.allow_write,
-                allow_exec: vec![],
                 allow_net: self.allow_net,
                 allow_env: self.allow_env,
                 pass_through_env: vec![],

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -339,6 +339,7 @@ impl Exec {
                 deny_temp_write: false,
                 allow_read: self.allow_read,
                 allow_write: self.allow_write,
+                allow_exec: vec![],
                 allow_net: self.allow_net,
                 allow_env: self.allow_env,
                 pass_through_env: vec![],

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -335,6 +335,8 @@ impl Exec {
                 deny_write: self.deny_write,
                 deny_net: self.deny_net,
                 deny_env: self.deny_env,
+                deny_process: false,
+                deny_temp_write: false,
                 allow_read: self.allow_read,
                 allow_write: self.allow_write,
                 allow_net: self.allow_net,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1267,6 +1267,8 @@ impl Run {
                     deny_write: self.deny_write,
                     deny_net: self.deny_net,
                     deny_env: self.deny_env,
+                    deny_process: false,
+                    deny_temp_write: false,
                     allow_read: self.allow_read.clone(),
                     allow_write: self.allow_write.clone(),
                     allow_net: self.allow_net.clone(),

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1271,6 +1271,7 @@ impl Run {
                     deny_temp_write: false,
                     allow_read: self.allow_read.clone(),
                     allow_write: self.allow_write.clone(),
+                    allow_exec: vec![],
                     allow_net: self.allow_net.clone(),
                     allow_env: self.allow_env.clone(),
                     pass_through_env: vec![],

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1271,7 +1271,6 @@ impl Run {
                     deny_temp_write: false,
                     allow_read: self.allow_read.clone(),
                     allow_write: self.allow_write.clone(),
-                    allow_exec: vec![],
                     allow_net: self.allow_net.clone(),
                     allow_env: self.allow_env.clone(),
                     pass_through_env: vec![],

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -24,7 +24,9 @@ use signal_hook::consts::{SIGHUP, SIGINT, SIGQUIT, SIGTERM, SIGUSR1, SIGUSR2};
 #[cfg(not(any(test, target_os = "windows")))]
 use signal_hook::iterator::Signals;
 use std::sync::LazyLock as Lazy;
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader as TokioBufReader};
+use tokio::io::{
+    AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader as TokioBufReader,
+};
 use tokio::process::Command;
 
 use crate::config::Settings;
@@ -519,6 +521,25 @@ enum HashedProcessOutput {
     Stdout(Vec<u8>),
     Stderr(Vec<u8>),
     ReadError(&'static str, std::io::Error),
+}
+
+async fn read_capped<R: AsyncRead + Unpin>(
+    mut reader: R,
+    max_bytes: usize,
+) -> std::io::Result<(Vec<u8>, usize)> {
+    let mut kept = Vec::new();
+    let mut total = 0usize;
+    let mut buffer = [0; 8192];
+    loop {
+        let len = reader.read(&mut buffer).await?;
+        if len == 0 {
+            break;
+        }
+        total = total.saturating_add(len);
+        let remaining = max_bytes.saturating_sub(kept.len());
+        kept.extend_from_slice(&buffer[..len.min(remaining)]);
+    }
+    Ok((kept, total))
 }
 
 impl<'a> CmdLineRunner<'a> {
@@ -1443,6 +1464,74 @@ impl<'a> CmdLineRunner<'a> {
         Ok(stdout.trim_end().to_string())
     }
 
+    pub(crate) async fn read_bounded(mut self, max_output_bytes: usize) -> Result<String> {
+        let _read_lock = RAW_LOCK.read().await;
+        debug!("$ {self}");
+        self.cmd.kill_on_drop(true);
+        #[cfg(unix)]
+        if should_use_pgroup() {
+            self.cmd.env(TASK_PGID_MANAGED_ENV, "1");
+            unsafe {
+                self.cmd.as_std_mut().pre_exec(|| {
+                    let _ = nix::unistd::setpgid(
+                        nix::unistd::Pid::from_raw(0),
+                        nix::unistd::Pid::from_raw(0),
+                    );
+                    Ok(())
+                });
+            }
+        }
+        let mut cp = self
+            .spawn_async_with_etxtbsy_retry()
+            .await
+            .wrap_err_with(|| format!("failed to execute command: {self}"))?;
+        let id = cp.id().unwrap_or_default();
+        let _running_pid = RunningPidGuard::new(cp.id());
+        if let Some(text) = self.stdin.take()
+            && let Some(mut stdin) = cp.stdin.take()
+        {
+            tokio::spawn(async move {
+                let _ = stdin.write_all(text.as_bytes()).await;
+            });
+        }
+        let stdout = cp.stdout.take().expect("stdout must be piped");
+        let stderr = cp.stderr.take().expect("stderr must be piped");
+        let stdout_task = tokio::spawn(read_capped(stdout, max_output_bytes));
+        let stderr_task = tokio::spawn(read_capped(stderr, max_output_bytes));
+        let status = match self.timeout {
+            Some(timeout) => match tokio::time::timeout(timeout, cp.wait()).await {
+                Ok(status) => status?,
+                Err(_) => {
+                    #[cfg(unix)]
+                    signal_process_tree(id, nix::sys::signal::Signal::SIGKILL);
+                    #[cfg(windows)]
+                    kill_process_tree(id);
+                    let _ = cp.wait().await;
+                    bail!("timed out after {timeout:?}");
+                }
+            },
+            None => cp.wait().await?,
+        };
+        let (stdout, stdout_len) = stdout_task.await??;
+        let (stderr, stderr_len) = stderr_task.await??;
+        if stdout_len.saturating_add(stderr_len) > max_output_bytes {
+            bail!("command output exceeded {max_output_bytes} bytes");
+        }
+        if !status.success() {
+            let output = std::process::Output {
+                status,
+                stdout: stdout.clone(),
+                stderr,
+            };
+            let combined_output = captured_output_lines(&self, &output);
+            self.replay_captured_stderr(&combined_output);
+            self.on_error(combined_output, output.status)?;
+        }
+        let stdout = String::from_utf8(stdout)
+            .wrap_err_with(|| format!("{} produced invalid UTF-8 output", self.get_program()))?;
+        Ok(stdout.trim_end().to_string())
+    }
+
     fn execute_raw(mut self) -> Result<()> {
         // In raw mode, inherit stdio so the child can interact with the terminal
         // directly. Piped stdout/stderr would deadlock if the child produces >64KB
@@ -2092,6 +2181,27 @@ mod tests {
         assert_eq!(stderr.lock().unwrap().as_slice(), ["err"]);
         assert_eq!(observed_stdout.lock().unwrap().as_slice(), ["out"]);
         assert_eq!(observed_stderr.lock().unwrap().as_slice(), ["err"]);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_cmd_line_runner_read_bounded() {
+        let output = super::CmdLineRunner::new("sh")
+            .args(["-c", "cat"])
+            .stdin_string("bounded input")
+            .with_timeout(std::time::Duration::from_secs(1))
+            .read_bounded(1024)
+            .await
+            .unwrap();
+        assert_eq!(output, "bounded input");
+
+        let err = super::CmdLineRunner::new("sh")
+            .args(["-c", "printf 12345"])
+            .with_timeout(std::time::Duration::from_secs(1))
+            .read_bounded(4)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("output exceeded 4 bytes"));
     }
 
     #[tokio::test]

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1607,7 +1607,9 @@ impl<'a> CmdLineRunner<'a> {
                 .get_args()
                 .map(|a| a.to_string_lossy().into_owned())
                 .collect();
-            let profile = crate::sandbox::macos_generate_profile(&sandbox).await;
+            let profile =
+                crate::sandbox::macos_generate_profile(&sandbox, std::path::Path::new(&program))
+                    .await;
 
             let mut new_cmd = Command::new("sandbox-exec");
             new_cmd.arg("-p").arg(&profile).arg("--").arg(&program);

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -24,9 +24,9 @@ use signal_hook::consts::{SIGHUP, SIGINT, SIGQUIT, SIGTERM, SIGUSR1, SIGUSR2};
 #[cfg(not(any(test, target_os = "windows")))]
 use signal_hook::iterator::Signals;
 use std::sync::LazyLock as Lazy;
-use tokio::io::{
-    AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader as TokioBufReader,
-};
+#[cfg(unix)]
+use tokio::io::AsyncRead;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader as TokioBufReader};
 use tokio::process::Command;
 
 use crate::config::Settings;
@@ -523,6 +523,7 @@ enum HashedProcessOutput {
     ReadError(&'static str, std::io::Error),
 }
 
+#[cfg(unix)]
 async fn read_capped<R: AsyncRead + Unpin>(
     mut reader: R,
     max_bytes: usize,
@@ -1464,6 +1465,7 @@ impl<'a> CmdLineRunner<'a> {
         Ok(stdout.trim_end().to_string())
     }
 
+    #[cfg(unix)]
     pub(crate) async fn read_bounded(mut self, max_output_bytes: usize) -> Result<String> {
         let _read_lock = RAW_LOCK.read().await;
         debug!("$ {self}");

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1554,6 +1554,7 @@ impl<'a> CmdLineRunner<'a> {
 
         #[cfg(target_os = "linux")]
         {
+            let initial_program = std::path::PathBuf::from(self.cmd.as_std().get_program());
             // On Linux, clear inherited env before pre_exec so child only sees filtered vars.
             // env_clear() also wipes envs explicitly set via .envs(), so save and restore them.
             if sandbox.effective_deny_env() {
@@ -1579,8 +1580,11 @@ impl<'a> CmdLineRunner<'a> {
             let sandbox = sandbox.clone();
             unsafe {
                 self.cmd.as_std_mut().pre_exec(move || {
-                    if sandbox.effective_deny_read() || sandbox.effective_deny_write() {
-                        crate::sandbox::landlock_apply(&sandbox)
+                    if sandbox.effective_deny_read()
+                        || sandbox.effective_deny_write()
+                        || sandbox.deny_process
+                    {
+                        crate::sandbox::landlock_apply(&sandbox, &initial_program)
                             .map_err(|e| std::io::Error::other(e.to_string()))?;
                     }
                     if sandbox.effective_deny_net() || sandbox.deny_process {

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1622,7 +1622,11 @@ impl<'a> CmdLineRunner<'a> {
             }
             // Match CmdLineRunner::new() defaults for stdio.
             // execute() reads from piped stdout/stderr; execute_raw() overrides to inherit.
-            new_cmd.stdin(Stdio::null());
+            if self.stdin.is_some() {
+                new_cmd.stdin(Stdio::piped());
+            } else {
+                new_cmd.stdin(Stdio::null());
+            }
             new_cmd.stdout(Stdio::piped());
             new_cmd.stderr(Stdio::piped());
             if let Some(dir) = self.cmd.as_std().get_current_dir() {
@@ -2287,6 +2291,21 @@ mod tests {
             env.iter()
                 .any(|(key, value)| *key == OsStr::new("DROP") && value.is_none())
         );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn test_macos_sandbox_preserves_piped_stdin() {
+        let mut runner = super::CmdLineRunner::new("/bin/cat")
+            .stdin_string("sandboxed stdin")
+            .with_sandbox(crate::sandbox::SandboxConfig {
+                deny_process: true,
+                ..Default::default()
+            });
+
+        runner.apply_sandbox().await.unwrap();
+
+        assert_eq!(runner.read().await.unwrap(), "sandboxed stdin");
     }
 
     #[test]

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1583,9 +1583,12 @@ impl<'a> CmdLineRunner<'a> {
                         crate::sandbox::landlock_apply(&sandbox)
                             .map_err(|e| std::io::Error::other(e.to_string()))?;
                     }
-                    if sandbox.effective_deny_net() {
-                        crate::sandbox::seccomp_apply()
-                            .map_err(|e| std::io::Error::other(e.to_string()))?;
+                    if sandbox.effective_deny_net() || sandbox.deny_process {
+                        crate::sandbox::seccomp_apply(
+                            sandbox.effective_deny_net(),
+                            sandbox.deny_process,
+                        )
+                        .map_err(|e| std::io::Error::other(e.to_string()))?;
                     }
                     Ok(())
                 });

--- a/src/sandbox/landlock.rs
+++ b/src/sandbox/landlock.rs
@@ -74,13 +74,17 @@ fn add_path_rule(
     }
 }
 
-/// Apply Landlock filesystem restrictions.
-pub(super) fn apply_landlock(config: &SandboxConfig) -> Result<()> {
+/// Apply Landlock filesystem and executable restrictions.
+pub(super) fn apply_landlock(
+    config: &SandboxConfig,
+    initial_program: Option<&std::path::Path>,
+) -> Result<()> {
     let abi = ABI::V5;
 
     let read_access = AccessFs::from_read(abi);
     let write_access = AccessFs::from_write(abi);
     let full_access = read_access | write_access;
+    let execute_access: BitFlags<AccessFs> = AccessFs::Execute.into();
 
     let deny_read = config.effective_deny_read();
     let deny_write = config.effective_deny_write();
@@ -88,12 +92,18 @@ pub(super) fn apply_landlock(config: &SandboxConfig) -> Result<()> {
     // Only handle the access types we're actually restricting.
     // If we handle_access(full_access) but only add read rules,
     // writes to un-ruled paths get blocked too (Landlock denies by default).
-    let handled_access = match (deny_read, deny_write) {
+    let mut handled_access = match (deny_read, deny_write) {
         (true, true) => full_access,
         (true, false) => read_access,
         (false, true) => full_access, // need full to add read+write rules for allowed paths
-        (false, false) => return Ok(()), // nothing to restrict
+        (false, false) => BitFlags::empty(),
     };
+    if config.deny_process {
+        handled_access |= execute_access;
+    }
+    if handled_access.is_empty() {
+        return Ok(());
+    }
 
     let mut ruleset = Ruleset::default()
         .handle_access(handled_access)
@@ -170,6 +180,15 @@ pub(super) fn apply_landlock(config: &SandboxConfig) -> Result<()> {
         for path in &config.allow_write {
             ruleset = add_path_rule(ruleset, path, full_access)?;
         }
+    }
+
+    // The ruleset is installed before the target's initial exec. Permit that
+    // exact executable while denying later execve/execveat calls for every
+    // other file (including Kernel.exec from evaluated tap Ruby).
+    if config.deny_process
+        && let Some(program) = initial_program
+    {
+        ruleset = add_path_rule(ruleset, program, execute_access)?;
     }
 
     let status = ruleset

--- a/src/sandbox/landlock.rs
+++ b/src/sandbox/landlock.rs
@@ -110,7 +110,15 @@ pub(super) fn apply_landlock(config: &SandboxConfig) -> Result<()> {
         for path in SYSTEM_READ_FILES {
             ruleset = add_read_rule(ruleset, path, read_access)?;
         }
-        ruleset = add_read_rule(ruleset, "/tmp", full_access)?;
+        ruleset = add_read_rule(
+            ruleset,
+            "/tmp",
+            if config.deny_temp_write {
+                read_access
+            } else {
+                full_access
+            },
+        )?;
         ruleset = add_read_rule(ruleset, "/dev", full_access)?;
         let installs_dir: &std::path::Path = &crate::dirs::INSTALLS;
         if installs_dir.exists() {
@@ -149,7 +157,15 @@ pub(super) fn apply_landlock(config: &SandboxConfig) -> Result<()> {
     } else if deny_write {
         // Only writes restricted — allow read everywhere, deny write except allowed paths
         ruleset = add_read_rule(ruleset, "/", read_access)?;
-        ruleset = add_read_rule(ruleset, "/tmp", full_access)?;
+        ruleset = add_read_rule(
+            ruleset,
+            "/tmp",
+            if config.deny_temp_write {
+                read_access
+            } else {
+                full_access
+            },
+        )?;
         ruleset = add_read_rule(ruleset, "/dev", full_access)?;
         for path in &config.allow_write {
             ruleset = add_path_rule(ruleset, path, full_access)?;

--- a/src/sandbox/landlock.rs
+++ b/src/sandbox/landlock.rs
@@ -81,13 +81,15 @@ pub(super) fn apply_landlock(
 ) -> Result<()> {
     let abi = ABI::V5;
 
-    let read_access = AccessFs::from_read(abi);
-    let write_access = AccessFs::from_write(abi);
-    let full_access = read_access | write_access;
-    let execute_access: BitFlags<AccessFs> = AccessFs::Execute.into();
-
     let deny_read = config.effective_deny_read();
     let deny_write = config.effective_deny_write();
+    let execute_access: BitFlags<AccessFs> = AccessFs::Execute.into();
+    let mut read_access = AccessFs::from_read(abi);
+    if config.deny_process {
+        read_access.remove(execute_access);
+    }
+    let write_access = AccessFs::from_write(abi);
+    let full_access = read_access | write_access;
 
     // Only handle the access types we're actually restricting.
     // If we handle_access(full_access) but only add read rules,

--- a/src/sandbox/macos.rs
+++ b/src/sandbox/macos.rs
@@ -33,8 +33,10 @@ pub(crate) async fn generate_seatbelt_profile(config: &SandboxConfig) -> String 
     // Filesystem write restrictions
     if config.effective_deny_write() {
         rules.push("(deny file-write*)".to_string());
-        rules.push("(allow file-write* (subpath \"/tmp\"))".to_string());
-        rules.push("(allow file-write* (subpath \"/private/tmp\"))".to_string());
+        if !config.deny_temp_write {
+            rules.push("(allow file-write* (subpath \"/tmp\"))".to_string());
+            rules.push("(allow file-write* (subpath \"/private/tmp\"))".to_string());
+        }
         rules.push("(allow file-write* (subpath \"/dev\"))".to_string());
         for path in &config.allow_write {
             let path_str = sbpl_escape(&path.to_string_lossy());
@@ -107,6 +109,10 @@ pub(crate) async fn generate_seatbelt_profile(config: &SandboxConfig) -> String 
                 }
             }
         }
+    }
+
+    if config.deny_process {
+        rules.push("(deny process-fork)".to_string());
     }
 
     rules.join("\n")

--- a/src/sandbox/macos.rs
+++ b/src/sandbox/macos.rs
@@ -130,6 +130,12 @@ pub(crate) async fn generate_seatbelt_profile(
         for path in &config.allow_exec {
             let path_str = sbpl_escape(&path.to_string_lossy());
             rules.push(format!("(allow process-exec (literal \"{path_str}\"))"));
+            if let Ok(canonical) = path.canonicalize()
+                && canonical != *path
+            {
+                let canonical = sbpl_escape(&canonical.to_string_lossy());
+                rules.push(format!("(allow process-exec (literal \"{canonical}\"))"));
+            }
         }
     }
 

--- a/src/sandbox/macos.rs
+++ b/src/sandbox/macos.rs
@@ -120,6 +120,12 @@ pub(crate) async fn generate_seatbelt_profile(
         if let Some(path) = initial_program {
             let path_str = sbpl_escape(&path.to_string_lossy());
             rules.push(format!("(allow process-exec (literal \"{path_str}\"))"));
+            if let Ok(canonical) = path.canonicalize()
+                && canonical != path
+            {
+                let canonical = sbpl_escape(&canonical.to_string_lossy());
+                rules.push(format!("(allow process-exec (literal \"{canonical}\"))"));
+            }
         }
     }
 

--- a/src/sandbox/macos.rs
+++ b/src/sandbox/macos.rs
@@ -127,6 +127,10 @@ pub(crate) async fn generate_seatbelt_profile(
                 rules.push(format!("(allow process-exec (literal \"{canonical}\"))"));
             }
         }
+        for path in &config.allow_exec {
+            let path_str = sbpl_escape(&path.to_string_lossy());
+            rules.push(format!("(allow process-exec (literal \"{path_str}\"))"));
+        }
     }
 
     rules.join("\n")
@@ -268,5 +272,49 @@ mod tests {
         assert!(profile.contains("(deny process-fork)"));
         assert!(profile.contains("(deny process-exec)"));
         assert!(profile.contains("(allow process-exec (literal \"/usr/bin/ruby\"))"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn test_deny_process_at_runtime() {
+        let config = SandboxConfig {
+            deny_process: true,
+            ..Default::default()
+        };
+        let profile = generate_seatbelt_profile(&config, Some(Path::new("/usr/bin/ruby"))).await;
+        let script = r#"
+puts "ruby started"
+begin
+  fork { exit! }
+  abort "fork escaped sandbox"
+rescue SystemCallError
+end
+begin
+  exec "/usr/bin/true"
+rescue SystemCallError
+end
+puts "child processes blocked"
+"#;
+        let output = Command::new("sandbox-exec")
+            .args([
+                "-p",
+                &profile,
+                "--",
+                "/usr/bin/ruby",
+                "--disable-gems",
+                "-e",
+                script,
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "sandboxed Ruby failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            "ruby started\nchild processes blocked\n"
+        );
     }
 }

--- a/src/sandbox/macos.rs
+++ b/src/sandbox/macos.rs
@@ -118,7 +118,6 @@ pub(crate) async fn generate_seatbelt_profile(
         rules.push("(deny process-fork)".to_string());
         rules.push("(deny process-exec)".to_string());
         if let Some(path) = initial_program {
-            let path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
             let path_str = sbpl_escape(&path.to_string_lossy());
             rules.push(format!("(allow process-exec (literal \"{path_str}\"))"));
         }

--- a/src/sandbox/macos.rs
+++ b/src/sandbox/macos.rs
@@ -25,7 +25,10 @@ const SYSTEM_READ_PATHS: &[&str] = &[
 ];
 
 /// Generate a Seatbelt (SBPL) profile string from sandbox config.
-pub(crate) async fn generate_seatbelt_profile(config: &SandboxConfig) -> String {
+pub(crate) async fn generate_seatbelt_profile(
+    config: &SandboxConfig,
+    initial_program: Option<&std::path::Path>,
+) -> String {
     let mut rules = Vec::new();
     rules.push("(version 1)".to_string());
     rules.push("(allow default)".to_string());
@@ -113,6 +116,12 @@ pub(crate) async fn generate_seatbelt_profile(config: &SandboxConfig) -> String 
 
     if config.deny_process {
         rules.push("(deny process-fork)".to_string());
+        rules.push("(deny process-exec)".to_string());
+        if let Some(path) = initial_program {
+            let path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+            let path_str = sbpl_escape(&path.to_string_lossy());
+            rules.push(format!("(allow process-exec (literal \"{path_str}\"))"));
+        }
     }
 
     rules.join("\n")
@@ -121,7 +130,11 @@ pub(crate) async fn generate_seatbelt_profile(config: &SandboxConfig) -> String 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{fs, path::PathBuf, process::Command};
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        process::Command,
+    };
 
     #[tokio::test]
     async fn test_deny_write_profile() {
@@ -129,7 +142,7 @@ mod tests {
             deny_write: true,
             ..Default::default()
         };
-        let profile = generate_seatbelt_profile(&config).await;
+        let profile = generate_seatbelt_profile(&config, None).await;
         assert!(profile.contains("(deny file-write*)"));
         assert!(profile.contains("(allow file-write* (subpath \"/tmp\"))"));
         assert!(!profile.contains("(deny file-read*)"));
@@ -142,7 +155,7 @@ mod tests {
             deny_net: true,
             ..Default::default()
         };
-        let profile = generate_seatbelt_profile(&config).await;
+        let profile = generate_seatbelt_profile(&config, None).await;
         assert!(profile.contains("(deny network*)"));
         assert!(!profile.contains("(deny file-write*)"));
     }
@@ -153,7 +166,7 @@ mod tests {
             allow_write: vec![PathBuf::from("/tmp/mydir")],
             ..Default::default()
         };
-        let profile = generate_seatbelt_profile(&config).await;
+        let profile = generate_seatbelt_profile(&config, None).await;
         assert!(profile.contains("(deny file-write*)"));
         assert!(profile.contains("(allow file-write* (subpath \"/tmp/mydir\"))"));
     }
@@ -165,7 +178,7 @@ mod tests {
             allow_net: vec!["1.2.3.4".to_string()],
             ..Default::default()
         };
-        let profile = generate_seatbelt_profile(&config).await;
+        let profile = generate_seatbelt_profile(&config, None).await;
         assert!(profile.contains("(deny network*)"));
         assert!(profile.contains("(allow network* (remote ip \"1.2.3.4:*\"))"));
         // mDNSResponder rule should appear exactly once
@@ -182,7 +195,7 @@ mod tests {
             deny_read: true,
             ..Default::default()
         };
-        let profile = generate_seatbelt_profile(&config).await;
+        let profile = generate_seatbelt_profile(&config, None).await;
         assert!(profile.contains("(deny file-read*)"));
         assert!(profile.contains("(allow file-read* (subpath \"/usr\"))"));
         assert!(profile.contains("(allow file-read* (subpath \"/System\"))"));
@@ -206,7 +219,7 @@ mod tests {
             ..Default::default()
         };
         config.resolve_paths();
-        let profile = generate_seatbelt_profile(&config).await;
+        let profile = generate_seatbelt_profile(&config, Some(Path::new("/bin/sh"))).await;
         let read = |path: &std::path::Path| {
             Command::new("sandbox-exec")
                 .current_dir("/")
@@ -234,9 +247,21 @@ mod tests {
             deny_env: true,
             ..Default::default()
         };
-        let profile = generate_seatbelt_profile(&config).await;
+        let profile = generate_seatbelt_profile(&config, None).await;
         assert!(profile.contains("(deny file-read*)"));
         assert!(profile.contains("(deny file-write*)"));
         assert!(profile.contains("(deny network*)"));
+    }
+
+    #[tokio::test]
+    async fn test_deny_process_allows_only_initial_executable() {
+        let config = SandboxConfig {
+            deny_process: true,
+            ..Default::default()
+        };
+        let profile = generate_seatbelt_profile(&config, Some(Path::new("/usr/bin/ruby"))).await;
+        assert!(profile.contains("(deny process-fork)"));
+        assert!(profile.contains("(deny process-exec)"));
+        assert!(profile.contains("(allow process-exec (literal \"/usr/bin/ruby\"))"));
     }
 }

--- a/src/sandbox/macos.rs
+++ b/src/sandbox/macos.rs
@@ -44,6 +44,7 @@ pub(crate) async fn generate_seatbelt_profile(
         for path in &config.allow_write {
             let path_str = sbpl_escape(&path.to_string_lossy());
             rules.push(format!("(allow file-write* (subpath \"{path_str}\"))"));
+            rules.push(format!("(allow file-write* (literal \"{path_str}\"))"));
         }
     }
 
@@ -62,11 +63,13 @@ pub(crate) async fn generate_seatbelt_profile(
         for path in &config.allow_read {
             let path_str = sbpl_escape(&path.to_string_lossy());
             rules.push(format!("(allow file-read* (subpath \"{path_str}\"))"));
+            rules.push(format!("(allow file-read* (literal \"{path_str}\"))"));
         }
         // allow_write paths are implicitly readable — emit AFTER deny-read
         for path in &config.allow_write {
             let path_str = sbpl_escape(&path.to_string_lossy());
             rules.push(format!("(allow file-read* (subpath \"{path_str}\"))"));
+            rules.push(format!("(allow file-read* (literal \"{path_str}\"))"));
         }
     }
 
@@ -220,7 +223,7 @@ mod tests {
 
         let mut config = SandboxConfig {
             deny_read: true,
-            allow_read: vec![allowed_dir],
+            allow_read: vec![allowed_file.clone()],
             ..Default::default()
         };
         config.resolve_paths();

--- a/src/sandbox/macos.rs
+++ b/src/sandbox/macos.rs
@@ -127,16 +127,6 @@ pub(crate) async fn generate_seatbelt_profile(
                 rules.push(format!("(allow process-exec (literal \"{canonical}\"))"));
             }
         }
-        for path in &config.allow_exec {
-            let path_str = sbpl_escape(&path.to_string_lossy());
-            rules.push(format!("(allow process-exec (literal \"{path_str}\"))"));
-            if let Ok(canonical) = path.canonicalize()
-                && canonical != *path
-            {
-                let canonical = sbpl_escape(&canonical.to_string_lossy());
-                rules.push(format!("(allow process-exec (literal \"{canonical}\"))"));
-            }
-        }
     }
 
     rules.join("\n")

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -26,6 +26,8 @@ pub(crate) struct SandboxConfig {
     pub deny_temp_write: bool,
     pub allow_read: Vec<PathBuf>,
     pub allow_write: Vec<PathBuf>,
+    /// Ruby source files that macOS must treat as executable interpreter input.
+    pub(crate) allow_exec: Vec<PathBuf>,
     pub allow_net: Vec<String>,
     pub allow_env: Vec<String>,
     /// Environment patterns that survive an active env sandbox without enabling it themselves.
@@ -141,6 +143,7 @@ impl SandboxConfig {
         };
         resolve(&mut self.allow_read);
         resolve(&mut self.allow_write);
+        resolve(&mut self.allow_exec);
     }
 
     /// Compute effective deny flags, accounting for allow_* implying deny_*.

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -20,6 +20,10 @@ pub(crate) struct SandboxConfig {
     pub deny_write: bool,
     pub deny_net: bool,
     pub deny_env: bool,
+    /// Block child-process creation. Internal-only: task/CLI sandboxes leave this disabled.
+    pub deny_process: bool,
+    /// Do not apply the normal writable-temp-directory exception.
+    pub deny_temp_write: bool,
     pub allow_read: Vec<PathBuf>,
     pub allow_write: Vec<PathBuf>,
     pub allow_net: Vec<String>,
@@ -111,6 +115,8 @@ impl SandboxConfig {
             || self.deny_write
             || self.deny_net
             || self.deny_env
+            || self.deny_process
+            || self.deny_temp_write
             || !self.allow_read.is_empty()
             || !self.allow_write.is_empty()
             || !self.allow_net.is_empty()
@@ -305,14 +311,14 @@ impl SandboxConfig {
         if self.effective_deny_read() || self.effective_deny_write() {
             landlock::apply_landlock(self)?;
         }
-        if self.effective_deny_net() {
+        if self.effective_deny_net() || self.deny_process {
             if !self.allow_net.is_empty() {
                 eyre::bail!(
                     "per-host network filtering (--allow-net=<host>) is not supported on Linux. \
                      Use --deny-net to block all network, or remove --allow-net."
                 );
             }
-            seccomp::apply_seccomp_net_filter()?;
+            seccomp::apply_seccomp_filter(self.effective_deny_net(), self.deny_process)?;
         }
         Ok(())
     }
@@ -355,10 +361,10 @@ pub(crate) fn landlock_apply(config: &SandboxConfig) -> eyre::Result<()> {
     landlock::apply_landlock(config)
 }
 
-/// Apply seccomp network filter (Linux only).
+/// Apply seccomp network/process filter (Linux only).
 #[cfg(target_os = "linux")]
-pub(crate) fn seccomp_apply() -> eyre::Result<()> {
-    seccomp::apply_seccomp_net_filter()
+pub(crate) fn seccomp_apply(deny_net: bool, deny_process: bool) -> eyre::Result<()> {
+    seccomp::apply_seccomp_filter(deny_net, deny_process)
 }
 
 /// Generate a macOS Seatbelt profile string (macOS only).

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -143,7 +143,13 @@ impl SandboxConfig {
         };
         resolve(&mut self.allow_read);
         resolve(&mut self.allow_write);
-        resolve(&mut self.allow_exec);
+        self.allow_exec.retain(|p| !p.as_os_str().is_empty());
+        for path in &mut self.allow_exec {
+            *path = replace_path(&*path);
+            if path.is_relative() {
+                *path = cwd.join(&*path);
+            }
+        }
     }
 
     /// Compute effective deny flags, accounting for allow_* implying deny_*.

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -290,7 +290,7 @@ impl SandboxConfig {
         #[cfg(target_os = "linux")]
         {
             self.warn_missing_allow_paths();
-            self.apply_linux()?;
+            self.apply_linux(program)?;
             Ok(None)
         }
 
@@ -307,9 +307,9 @@ impl SandboxConfig {
     }
 
     #[cfg(all(not(test), target_os = "linux"))]
-    fn apply_linux(&self) -> eyre::Result<()> {
-        if self.effective_deny_read() || self.effective_deny_write() {
-            landlock::apply_landlock(self)?;
+    fn apply_linux(&self, program: &str) -> eyre::Result<()> {
+        if self.effective_deny_read() || self.effective_deny_write() || self.deny_process {
+            landlock::apply_landlock(self, Some(std::path::Path::new(program)))?;
         }
         if self.effective_deny_net() || self.deny_process {
             if !self.allow_net.is_empty() {
@@ -358,8 +358,11 @@ pub(crate) struct SandboxedCommand {
 
 /// Apply Landlock filesystem restrictions (Linux only).
 #[cfg(target_os = "linux")]
-pub(crate) fn landlock_apply(config: &SandboxConfig) -> eyre::Result<()> {
-    landlock::apply_landlock(config)
+pub(crate) fn landlock_apply(
+    config: &SandboxConfig,
+    initial_program: &std::path::Path,
+) -> eyre::Result<()> {
+    landlock::apply_landlock(config, Some(initial_program))
 }
 
 /// Apply seccomp network/process filter (Linux only).

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -26,8 +26,6 @@ pub(crate) struct SandboxConfig {
     pub deny_temp_write: bool,
     pub allow_read: Vec<PathBuf>,
     pub allow_write: Vec<PathBuf>,
-    /// Ruby source files that macOS must treat as executable interpreter input.
-    pub(crate) allow_exec: Vec<PathBuf>,
     pub allow_net: Vec<String>,
     pub allow_env: Vec<String>,
     /// Environment patterns that survive an active env sandbox without enabling it themselves.
@@ -143,13 +141,6 @@ impl SandboxConfig {
         };
         resolve(&mut self.allow_read);
         resolve(&mut self.allow_write);
-        self.allow_exec.retain(|p| !p.as_os_str().is_empty());
-        for path in &mut self.allow_exec {
-            *path = replace_path(&*path);
-            if path.is_relative() {
-                *path = cwd.join(&*path);
-            }
-        }
     }
 
     /// Compute effective deny flags, accounting for allow_* implying deny_*.

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -329,7 +329,8 @@ impl SandboxConfig {
         program: &str,
         args: &[String],
     ) -> eyre::Result<Option<SandboxedCommand>> {
-        let profile = macos::generate_seatbelt_profile(self).await;
+        let profile =
+            macos::generate_seatbelt_profile(self, Some(std::path::Path::new(program))).await;
         let mut sandbox_args = vec![
             "-p".to_string(),
             profile,
@@ -369,8 +370,11 @@ pub(crate) fn seccomp_apply(deny_net: bool, deny_process: bool) -> eyre::Result<
 
 /// Generate a macOS Seatbelt profile string (macOS only).
 #[cfg(target_os = "macos")]
-pub(crate) async fn macos_generate_profile(config: &SandboxConfig) -> String {
-    macos::generate_seatbelt_profile(config).await
+pub(crate) async fn macos_generate_profile(
+    config: &SandboxConfig,
+    program: &std::path::Path,
+) -> String {
+    macos::generate_seatbelt_profile(config, Some(program)).await
 }
 
 #[cfg(test)]

--- a/src/sandbox/seccomp.rs
+++ b/src/sandbox/seccomp.rs
@@ -10,11 +10,11 @@ fn syscall_number<T: Into<i64>>(number: T) -> i64 {
     number.into()
 }
 
-/// Apply a seccomp-bpf filter that blocks network syscalls.
+/// Apply a seccomp-bpf filter that blocks network and/or process syscalls.
 ///
 /// Blocks AF_INET and AF_INET6 sockets while allowing AF_UNIX (needed by many tools).
 /// Based on the syscall list from OpenAI's codex-linux-sandbox.
-pub(super) fn apply_seccomp_net_filter() -> Result<()> {
+pub(super) fn apply_seccomp_filter(deny_net: bool, deny_process: bool) -> Result<()> {
     // Must set PR_SET_NO_NEW_PRIVS before installing seccomp filter
     let ret = unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) };
     if ret != 0 {
@@ -49,16 +49,36 @@ pub(super) fn apply_seccomp_net_filter() -> Result<()> {
 
     let mut rules: BTreeMap<i64, Vec<SeccompRule>> = BTreeMap::new();
 
-    // Block socket() and socketpair() for inet families
-    // This is sufficient — if you can't create an inet socket, you can't do networking
-    for syscall in [
-        syscall_number(libc::SYS_socket),
-        syscall_number(libc::SYS_socketpair),
-    ] {
-        rules.insert(
-            syscall,
-            vec![socket_rule_inet.clone(), socket_rule_inet6.clone()],
-        );
+    if deny_net {
+        // Block socket() and socketpair() for inet families. Without an inet
+        // socket the process cannot initiate network traffic.
+        for syscall in [
+            syscall_number(libc::SYS_socket),
+            syscall_number(libc::SYS_socketpair),
+        ] {
+            rules.insert(
+                syscall,
+                vec![socket_rule_inet.clone(), socket_rule_inet6.clone()],
+            );
+        }
+    }
+
+    if deny_process {
+        // An empty rule chain means the syscall number alone triggers the
+        // filter's match action.
+        let deny = Vec::<SeccompRule>::new();
+        for syscall in [
+            syscall_number(libc::SYS_clone),
+            syscall_number(libc::SYS_clone3),
+            syscall_number(libc::SYS_fork),
+            syscall_number(libc::SYS_vfork),
+            syscall_number(libc::SYS_kill),
+            syscall_number(libc::SYS_tkill),
+            syscall_number(libc::SYS_tgkill),
+            syscall_number(libc::SYS_ptrace),
+        ] {
+            rules.insert(syscall, deny.clone());
+        }
     }
 
     let filter: BpfProgram = SeccompFilter::new(

--- a/src/system/packages/brew/api.rs
+++ b/src/system/packages/brew/api.rs
@@ -149,6 +149,7 @@ pub(super) async fn formula_with_tap_name(
     name: &str,
     tap_name: Option<&str>,
     tap_url: Option<&str>,
+    provision_ruby: bool,
 ) -> Result<Formula> {
     let Some((owner, tap, formula_name)) = split_tap_name(name).or_else(|| {
         let (owner, tap) = split_tap(tap_name?)?;
@@ -165,18 +166,20 @@ pub(super) async fn formula_with_tap_name(
              so mise can fetch metadata directly without the brew CLI"
         );
     };
-    HTTP_FETCH
-        .json_cached::<Formula, _>(url)
-        .await
-        .wrap_err_with(|| {
-            format!(
-                "failed to fetch Homebrew tap formula '{name}' directly. \
-                 mise needs API metadata at api/formula/{formula_name}.json on the \
-                 tap's default branch, which most taps do not publish; mise will not \
-                 proxy to the brew CLI. Install it with `brew`, or see \
-                 https://mise.jdx.dev/bootstrap/packages/brew.html#third-party-taps"
-            )
-        })
+    match HTTP_FETCH.json_cached::<Formula, _>(url).await {
+        Ok(formula) => Ok(formula),
+        Err(api_err) => {
+            super::tap::formula_from_ruby(owner, tap, formula_name, tap_url, provision_ruby)
+                .await
+                .wrap_err_with(|| {
+                    format!(
+                        "failed to resolve Homebrew tap formula '{name}'; published API metadata \
+                     was unavailable ({api_err}) and mise could not evaluate \
+                     Formula/{formula_name}.rb"
+                    )
+                })
+        }
+    }
 }
 
 pub(super) fn tap_name(name: &str) -> Option<String> {

--- a/src/system/packages/brew/cask/fetch.rs
+++ b/src/system/packages/brew/cask/fetch.rs
@@ -48,10 +48,10 @@ pub(super) async fn fetch_cask(req: &PackageRequest, provision_ruby: bool) -> Re
     match fetch_cask_url(requested_token, &url, raw_base.clone(), official_api).await {
         Ok(cask) => Ok(cask),
         Err(api_err) => {
-            let Some((owner, tap, _)) =
-                tap_name.filter(|(owner, tap, _)| !(*owner == "homebrew" && *tap == "cask"))
-            else {
-                return Err(api_err);
+            let (owner, tap) = match tap_name {
+                Some((owner, tap, _)) if owner != "homebrew" || tap != "cask" => (owner, tap),
+                None if req.tap_url.is_some() => ("", ""),
+                _ => return Err(api_err),
             };
             let mut cask = super::super::tap::cask_from_ruby(
                 owner,
@@ -67,6 +67,7 @@ pub(super) async fn fetch_cask(req: &PackageRequest, provision_ruby: bool) -> Re
                 )
             })?;
             cask.raw_base = raw_base;
+            validate_cask_identity(&cask, requested_token, false)?;
             Ok(cask)
         }
     }

--- a/src/system/packages/brew/cask/fetch.rs
+++ b/src/system/packages/brew/cask/fetch.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(super) async fn fetch_cask(req: &PackageRequest) -> Result<Cask> {
+pub(super) async fn fetch_cask(req: &PackageRequest, provision_ruby: bool) -> Result<Cask> {
     let name = &req.name;
     let tap_name = split_tap_name(name);
     let (requested_token, official_api) = match tap_name {
@@ -45,7 +45,31 @@ pub(super) async fn fetch_cask(req: &PackageRequest) -> Result<Cask> {
             Some(HOMEBREW_CASK_RAW.to_string()),
         ),
     };
-    fetch_cask_url(requested_token, &url, raw_base, official_api).await
+    match fetch_cask_url(requested_token, &url, raw_base.clone(), official_api).await {
+        Ok(cask) => Ok(cask),
+        Err(api_err) => {
+            let Some((owner, tap, _)) =
+                tap_name.filter(|(owner, tap, _)| !(*owner == "homebrew" && *tap == "cask"))
+            else {
+                return Err(api_err);
+            };
+            let mut cask = super::super::tap::cask_from_ruby(
+                owner,
+                tap,
+                requested_token,
+                req.tap_url.as_deref(),
+                provision_ruby,
+            )
+            .await
+            .wrap_err_with(|| {
+                format!(
+                    "published cask metadata was unavailable ({api_err}) and mise could not evaluate Casks/{requested_token}.rb"
+                )
+            })?;
+            cask.raw_base = raw_base;
+            Ok(cask)
+        }
+    }
 }
 
 pub(super) fn normalize_cask_raw_base(mut raw_base: String) -> String {
@@ -415,20 +439,13 @@ pub(super) async fn execute_lifecycle_hook(
 }
 
 pub(super) async fn cask_ruby_bin() -> Result<PathBuf> {
-    if let Some(brew) = file::which("brew")
-        && let Ok(output) = tokio::process::Command::new(brew)
-            .args(["ruby", "-e", "print RbConfig.ruby"])
-            .output()
+    if let Some(ruby) = file::which("ruby")
+        && tokio::process::Command::new(&ruby)
+            .args(["-e", "exit 0"])
+            .status()
             .await
-        && output.status.success()
-        && let Ok(path) = String::from_utf8(output.stdout)
+            .is_ok_and(|status| status.success())
     {
-        let path = PathBuf::from(path.trim());
-        if path.is_file() {
-            return Ok(path);
-        }
-    }
-    if let Some(ruby) = file::which("ruby") {
         return Ok(ruby);
     }
     source::ruby_bin().await

--- a/src/system/packages/brew/cask/fetch.rs
+++ b/src/system/packages/brew/cask/fetch.rs
@@ -66,7 +66,12 @@ pub(super) async fn fetch_cask(req: &PackageRequest, provision_ruby: bool) -> Re
                     "published cask metadata was unavailable ({api_err}) and mise could not evaluate Casks/{requested_token}.rb"
                 )
             })?;
-            cask.raw_base = raw_base;
+            cask.raw_base = req
+                .tap_url
+                .as_deref()
+                .and_then(super::super::api::github_raw_base)
+                .map(normalize_cask_raw_base)
+                .or(raw_base);
             validate_cask_identity(&cask, requested_token, false)?;
             Ok(cask)
         }

--- a/src/system/packages/brew/cask/mod.rs
+++ b/src/system/packages/brew/cask/mod.rs
@@ -41,7 +41,7 @@ mod state;
 use artifacts::*;
 use fetch::*;
 use flight::*;
-use model::Cask;
+pub(super) use model::Cask;
 use paths::*;
 use state::*;
 pub(crate) use state::{apply_cask_prune_plan, cask_formula_dependencies, cask_prune_plan};
@@ -480,7 +480,7 @@ impl BrewCaskManager {
         ancestors: &BTreeSet<String>,
         manager_options: &ManagerPackageOptions,
     ) -> Result<String> {
-        let cask = fetch_cask(req).await?;
+        let cask = fetch_cask(req, !opts.dry_run).await?;
         if ancestors.contains(&cask.token) {
             bail!("brew-cask:{}: dependency cycle detected", cask.token);
         }
@@ -867,7 +867,7 @@ impl SystemPackageManager for BrewCaskManager {
     async fn installed(&self, pkgs: &[PackageRequest]) -> Result<Vec<PackageStatus>> {
         let mut statuses = Vec::with_capacity(pkgs.len());
         for req in pkgs {
-            let cask = fetch_cask(req).await?;
+            let cask = fetch_cask(req, false).await?;
             statuses.push(PackageStatus {
                 request: req.clone(),
                 state: package_state(req, &cask)?,

--- a/src/system/packages/brew/cask/model.rs
+++ b/src/system/packages/brew/cask/model.rs
@@ -12,7 +12,7 @@ pub(super) struct CaskUrlSpecs {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub(super) struct Cask {
+pub(in crate::system::packages::brew) struct Cask {
     pub(super) token: String,
     #[serde(default)]
     pub(super) aliases: Vec<String>,

--- a/src/system/packages/brew/cask/state.rs
+++ b/src/system/packages/brew/cask/state.rs
@@ -610,7 +610,7 @@ pub(super) async fn resolve_cask_dependency_closure(
         if closure.casks.contains_key(&cask_dependency_key(&request)) {
             continue;
         }
-        let cask = fetch_cask(&request).await?;
+        let cask = fetch_cask(&request, false).await?;
         extend_cask_dependency_closure(&mut closure, &mut pending, &request, cask);
     }
     Ok(closure)

--- a/src/system/packages/brew/maintenance.rs
+++ b/src/system/packages/brew/maintenance.rs
@@ -165,7 +165,7 @@ async fn configured_package_closure(configured: &[PackageRequest]) -> Result<Has
     if configured.is_empty() {
         return Ok(HashSet::new());
     }
-    Ok(resolve::resolve_closure_with_taps(configured)
+    Ok(resolve::resolve_closure_with_taps(configured, false)
         .await?
         .into_iter()
         .map(|rf| formula_package_name(&rf.formula))

--- a/src/system/packages/brew/mod.rs
+++ b/src/system/packages/brew/mod.rs
@@ -14,8 +14,8 @@
 //!
 //! Scope: formulae only. Casks are implemented by the sibling `brew-cask`
 //! manager. Services are not implemented. homebrew/core formulae use mise's
-//! direct pour path; fully-qualified third-party tap formulae use direct tap
-//! metadata when the tap publishes it. mise never shells out to `brew`.
+//! direct pour path; fully-qualified third-party tap formulae use published
+//! metadata or mise's metadata-only Ruby shim. mise never shells out to `brew`.
 
 use async_trait::async_trait;
 use eyre::bail;
@@ -40,6 +40,7 @@ mod relocate;
 mod resolve;
 mod source;
 mod tag;
+mod tap;
 
 pub(crate) struct BrewManager {}
 pub(crate) use cask::{
@@ -90,7 +91,7 @@ impl BrewManager {
             );
         }
         let roots: Vec<String> = pkgs.iter().map(|p| p.name.clone()).collect();
-        let closure = resolve::resolve_closure_with_taps(pkgs).await?;
+        let closure = resolve::resolve_closure_with_taps(pkgs, !opts.dry_run).await?;
         for rf in &closure {
             if rf.on_request
                 && !roots.contains(&rf.formula.name)

--- a/src/system/packages/brew/resolve.rs
+++ b/src/system/packages/brew/resolve.rs
@@ -60,6 +60,7 @@ fn install_deps<'a>(formula: &'a Formula, tag: &str) -> Vec<&'a String> {
 
 pub(super) async fn resolve_closure_with_taps(
     roots: &[PackageRequest],
+    provision_ruby: bool,
 ) -> Result<Vec<ResolvedFormula>> {
     let roots = roots
         .iter()
@@ -72,7 +73,7 @@ pub(super) async fn resolve_closure_with_taps(
             )
         })
         .collect::<Vec<_>>();
-    resolve_closure_pairs(&roots).await
+    resolve_closure_pairs(&roots, provision_ruby).await
 }
 
 /// Resolve the runtime closure of `roots` into install order (dependencies
@@ -80,6 +81,7 @@ pub(super) async fn resolve_closure_with_taps(
 /// their canonical formula.
 async fn resolve_closure_pairs(
     roots: &[(String, Option<String>, Option<String>)],
+    provision_ruby: bool,
 ) -> Result<Vec<ResolvedFormula>> {
     let host_tag = tag::host_tag();
     let mut formulae: HashMap<FormulaKey, Formula> = HashMap::new();
@@ -103,7 +105,9 @@ async fn resolve_closure_pairs(
             Some(c) => c,
             None => {
                 let (formula, effective_tap_name, effective_tap_url) = match fetch_formula(
-                    &key, requested,
+                    &key,
+                    requested,
+                    provision_ruby,
                 )
                 .await
                 {
@@ -235,7 +239,7 @@ async fn resolve_closure_pairs(
     Ok(sorted)
 }
 
-async fn fetch_formula(key: &FormulaKey, requested: bool) -> Result<Formula> {
+async fn fetch_formula(key: &FormulaKey, requested: bool, provision_ruby: bool) -> Result<Formula> {
     if !requested && key.tap_name.is_some() && api::split_tap_name(&key.name).is_none() {
         match api::formula(&key.name).await {
             Ok(formula) => return Ok(formula),
@@ -247,7 +251,13 @@ async fn fetch_formula(key: &FormulaKey, requested: bool) -> Result<Formula> {
             }
         }
     }
-    api::formula_with_tap_name(&key.name, key.tap_name.as_deref(), key.tap_url.as_deref()).await
+    api::formula_with_tap_name(
+        &key.name,
+        key.tap_name.as_deref(),
+        key.tap_url.as_deref(),
+        provision_ruby,
+    )
+    .await
 }
 
 fn tap_raw_base(key: &FormulaKey) -> Option<String> {

--- a/src/system/packages/brew/shim.rb
+++ b/src/system/packages/brew/shim.rb
@@ -157,6 +157,13 @@ class MacOSVersion
 
   def to_s = @version
   def major = @version.split(".").first.to_i
+  def same_release?(other)
+    other = self.class.from_symbol(other) if other.is_a?(Symbol)
+    other = self.class.new(other.to_s) unless other.is_a?(MacOSVersion)
+    mine = @version.split(".").map(&:to_i)
+    theirs = other.to_s.split(".").map(&:to_i)
+    mine[0] == theirs[0] && (mine[0] >= 11 || mine[1] == theirs[1])
+  end
   def requires_nehalem_cpu? = false
 end
 
@@ -616,9 +623,9 @@ class Formula
       host = MacOSVersion.host
       target = MacOSVersion.from_symbol(base.to_sym)
       case comparator
-      when :or_older then host <= target
+      when :or_older then host <= target || host.same_release?(target)
       when :or_newer then host >= target
-      else host.major == target.major
+      else host.same_release?(target)
       end
     end
     private :macos_condition_matches?
@@ -630,9 +637,9 @@ class Formula
         host = MacOSVersion.host
         target = MacOSVersion.from_symbol(sym)
         run = case comparator
-              when :or_older then host <= target
+              when :or_older then host <= target || host.same_release?(target)
               when :or_newer then host >= target
-              else host.major == target.major
+              else host.same_release?(target)
               end
         class_exec(&block) if run
       end

--- a/src/system/packages/brew/source.rs
+++ b/src/system/packages/brew/source.rs
@@ -11,8 +11,9 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
-use eyre::{WrapErr, bail};
+use eyre::{WrapErr, bail, eyre};
 
 use super::api::Formula;
 use super::pour;
@@ -197,18 +198,38 @@ pub(crate) async fn ruby_bin() -> Result<PathBuf> {
         },
     )
     .await?;
+    find_ruby_bin(&config, &ts).await?.ok_or_else(|| {
+        eyre!("failed to provision ruby for building from source (try `mise install ruby`)")
+    })
+}
+
+pub(crate) async fn installed_ruby_bin() -> Result<Option<PathBuf>> {
+    let config = Config::get().await?;
+    let tool: crate::cli::args::ToolArg = "ruby".parse()?;
+    let ts = ToolsetBuilder::new()
+        .with_args(&[tool])
+        .with_default_to_latest(true)
+        .build(&config)
+        .await?;
+    find_ruby_bin(&config, &ts).await
+}
+
+async fn find_ruby_bin(
+    config: &Arc<Config>,
+    ts: &crate::toolset::Toolset,
+) -> Result<Option<PathBuf>> {
     for (backend, tv) in ts.list_current_versions() {
         if tv.ba().short != "ruby" {
             continue;
         }
-        for bin_dir in backend.list_bin_paths(&config, &tv).await? {
+        for bin_dir in backend.list_bin_paths(config, &tv).await? {
             let ruby = bin_dir.join("ruby");
             if ruby.is_file() {
-                return Ok(ruby);
+                return Ok(Some(ruby));
             }
         }
     }
-    bail!("failed to provision ruby for building from source (try `mise install ruby`)");
+    Ok(None)
 }
 
 /// Download the formula's .rb from homebrew/core, pinned to the commit the

--- a/src/system/packages/brew/tap.rs
+++ b/src/system/packages/brew/tap.rs
@@ -141,6 +141,8 @@ pub(super) async fn cask_from_ruby(
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 fn metadata_sandbox(source: &Path, output: &Path) -> Result<SandboxConfig> {
+    let source_alias = source.to_path_buf();
+    let output_alias = output.to_path_buf();
     let mut sandbox = SandboxConfig {
         deny_read: true,
         deny_write: true,
@@ -153,6 +155,12 @@ fn metadata_sandbox(source: &Path, output: &Path) -> Result<SandboxConfig> {
         ..Default::default()
     };
     sandbox.resolve_paths();
+    if !sandbox.allow_read.contains(&source_alias) {
+        sandbox.allow_read.push(source_alias);
+    }
+    if !sandbox.allow_write.contains(&output_alias) {
+        sandbox.allow_write.push(output_alias);
+    }
     Ok(sandbox)
 }
 
@@ -451,8 +459,16 @@ end
         assert!(config.deny_write);
         assert!(config.deny_net);
         assert!(config.deny_env);
-        assert_eq!(config.allow_read.len(), 1);
-        assert_eq!(config.allow_write.len(), 1);
+        assert!(
+            config
+                .allow_read
+                .contains(&PathBuf::from("/tmp/formula.rb"))
+        );
+        assert!(
+            config
+                .allow_write
+                .contains(&PathBuf::from("/tmp/metadata.json"))
+        );
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/src/system/packages/brew/tap.rs
+++ b/src/system/packages/brew/tap.rs
@@ -152,7 +152,7 @@ fn metadata_sandbox(source: &Path, shim: &Path, output: &Path) -> Result<Sandbox
         deny_temp_write: true,
         allow_read: vec![source.to_path_buf(), shim.to_path_buf()],
         allow_write: vec![output.to_path_buf()],
-        allow_exec: vec![source.to_path_buf(), shim.to_path_buf()],
+        allow_exec: vec![shim.to_path_buf()],
         ..Default::default()
     };
     sandbox.resolve_paths();

--- a/src/system/packages/brew/tap.rs
+++ b/src/system/packages/brew/tap.rs
@@ -331,7 +331,7 @@ mod tests {
 class Widget < Formula
   desc "example"
   version "1.2.3"
-  url "https://example.com/widget-#{version}.tar.gz"
+  url "https://example.com/café/widget-#{version}.tar.gz"
   sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   depends_on "libfoo"
   depends_on "cmake" => :build
@@ -368,7 +368,7 @@ end
         assert_eq!(formula.versions.stable.as_deref(), Some("1.2.3"));
         assert_eq!(
             formula.urls["stable"].url,
-            "https://example.com/widget-1.2.3.tar.gz"
+            "https://example.com/café/widget-1.2.3.tar.gz"
         );
         assert_eq!(
             formula.dependencies,
@@ -395,7 +395,7 @@ end
 cask "widget" do
   version "1.2.3"
   sha256 :no_check
-  url "https://example.com/widget-#{version}.zip"
+  url "https://example.com/café/widget-#{version}.zip"
   depends_on formula: "libfoo"
   on_sonoma do
     url "https://example.com/wrong-platform.zip"
@@ -431,7 +431,7 @@ end
         assert_eq!(metadata["token"], "widget");
         assert_eq!(metadata["version"], "1.2.3");
         assert_eq!(metadata["sha256"], "no_check");
-        assert_eq!(metadata["url"], "https://example.com/widget-1.2.3.zip");
+        assert_eq!(metadata["url"], "https://example.com/café/widget-1.2.3.zip");
         assert_eq!(metadata["depends_on"]["formula"][0], "libfoo");
         assert_eq!(metadata["artifacts"].as_array().unwrap().len(), 2);
         Ok(())

--- a/src/system/packages/brew/tap.rs
+++ b/src/system/packages/brew/tap.rs
@@ -321,6 +321,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[tokio::test]
     async fn extracts_formula_metadata_without_homebrew() -> Result<()> {
         let Some(ruby) = test_ruby().await? else {
@@ -372,6 +373,7 @@ end
         Ok(())
     }
 
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[tokio::test]
     async fn extracts_cask_metadata_without_homebrew() -> Result<()> {
         let Some(ruby) = test_ruby().await? else {
@@ -409,7 +411,7 @@ end
             .env("MISE_BREW_SOURCE_PATH", "Casks/widget.rb")
             .env("MISE_BREW_SOURCE_CHECKSUM", "bbbb")
             .env("MISE_BREW_TAP_COMMIT", "deadbeef")
-            .env("MISE_BREW_MACOS_VERSION", macos_version())
+            .env("MISE_BREW_MACOS_VERSION", "0")
             .with_sandbox(metadata_sandbox(&cask_file, &shim, &output)?);
         runner.apply_sandbox().await?;
         runner.execute_async().await?;

--- a/src/system/packages/brew/tap.rs
+++ b/src/system/packages/brew/tap.rs
@@ -471,6 +471,10 @@ rescue SystemCallError
   false
 end
 raise "child process escaped sandbox" if ran
+begin
+  exec("false")
+rescue SystemCallError
+end
 "#,
         )?;
         crate::file::write(&output, "")?;

--- a/src/system/packages/brew/tap.rs
+++ b/src/system/packages/brew/tap.rs
@@ -70,6 +70,7 @@ pub(super) async fn formula_from_ruby(
             ("MISE_BREW_SOURCE_PATH", source_path),
             ("MISE_BREW_SOURCE_CHECKSUM", checksum),
             ("MISE_BREW_TAP_COMMIT", tap_source.commit),
+            ("MISE_BREW_MACOS_VERSION", macos_version()),
         ])
         .with_sandbox(metadata_sandbox(&formula_path, &shim_path, &output_path)?);
     runner.apply_sandbox().await?;
@@ -121,6 +122,7 @@ pub(super) async fn cask_from_ruby(
             ("MISE_BREW_SOURCE_PATH", source_path),
             ("MISE_BREW_SOURCE_CHECKSUM", checksum),
             ("MISE_BREW_TAP_COMMIT", tap_source.commit),
+            ("MISE_BREW_MACOS_VERSION", macos_version()),
         ])
         .with_sandbox(metadata_sandbox(&cask_path, &shim_path, &output_path)?);
     runner.apply_sandbox().await?;
@@ -155,6 +157,17 @@ fn metadata_sandbox(_source: &Path, _shim: &Path, _output: &Path) -> Result<Sand
     bail!(
         "evaluating third-party tap definitions is only supported inside the Linux or macOS process sandbox"
     )
+}
+
+fn macos_version() -> String {
+    if cfg!(target_os = "macos") {
+        crate::cmd::cmd("sw_vers", ["-productVersion"])
+            .read()
+            .map(|version| version.trim().to_string())
+            .unwrap_or_default()
+    } else {
+        "0".to_string()
+    }
 }
 
 async fn resolve_tap_source(owner: &str, tap: &str, tap_url: Option<&str>) -> Result<TapSource> {
@@ -275,7 +288,6 @@ fn validate_name(name: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::process::Command;
 
     async fn test_ruby() -> Result<Option<PathBuf>> {
         if let Some(ruby) = usable_system_ruby().await {
@@ -333,8 +345,8 @@ end
 "#,
         )?;
         crate::file::write(&shim, METADATA_SHIM_RB)?;
-        let status = Command::new(ruby)
-            .arg(shim)
+        let mut runner = CmdLineRunner::new(ruby)
+            .arg(&shim)
             .env("MISE_BREW_FORMULA_FILE", &formula)
             .env("MISE_BREW_METADATA_OUTPUT", &output)
             .env("MISE_BREW_NAME", "widget")
@@ -342,8 +354,10 @@ end
             .env("MISE_BREW_SOURCE_PATH", "Formula/widget.rb")
             .env("MISE_BREW_SOURCE_CHECKSUM", "bbbb")
             .env("MISE_BREW_TAP_COMMIT", "deadbeef")
-            .status()?;
-        assert!(status.success());
+            .env("MISE_BREW_MACOS_VERSION", macos_version())
+            .with_sandbox(metadata_sandbox(&formula, &shim, &output)?);
+        runner.apply_sandbox().await?;
+        runner.execute_async().await?;
         let formula: Formula = serde_json::from_str(&crate::file::read_to_string(output)?)?;
         assert_eq!(formula.name, "widget");
         assert_eq!(formula.versions.stable.as_deref(), Some("1.2.3"));
@@ -387,16 +401,18 @@ end
 "#,
         )?;
         crate::file::write(&shim, CASK_METADATA_SHIM_RB)?;
-        let status = Command::new(ruby)
-            .arg(shim)
+        let mut runner = CmdLineRunner::new(ruby)
+            .arg(&shim)
             .env("MISE_BREW_CASK_FILE", &cask_file)
             .env("MISE_BREW_METADATA_OUTPUT", &output)
             .env("MISE_BREW_TOKEN", "widget")
             .env("MISE_BREW_SOURCE_PATH", "Casks/widget.rb")
             .env("MISE_BREW_SOURCE_CHECKSUM", "bbbb")
             .env("MISE_BREW_TAP_COMMIT", "deadbeef")
-            .status()?;
-        assert!(status.success());
+            .env("MISE_BREW_MACOS_VERSION", macos_version())
+            .with_sandbox(metadata_sandbox(&cask_file, &shim, &output)?);
+        runner.apply_sandbox().await?;
+        runner.execute_async().await?;
         let json = crate::file::read_to_string(output)?;
         let _: Cask = serde_json::from_str(&json)?;
         let metadata: serde_json::Value = serde_json::from_str(&json)?;

--- a/src/system/packages/brew/tap.rs
+++ b/src/system/packages/brew/tap.rs
@@ -47,10 +47,6 @@ pub(super) async fn formula_from_ruby(
     let tap_source = resolve_tap_source(owner, tap, tap_url).await?;
     let (source, source_path) = fetch_ruby_source(&tap_source.raw_base, "Formula", name).await?;
     let checksum = crate::hash::hash_sha256_to_str(&source);
-    let cache_dir = crate::dirs::CACHE.join("system-brew").join("formula");
-    crate::file::create_dir_all(&cache_dir)?;
-    let output_path = cache_dir.join(format!("{name}-{}.json", &checksum[..12]));
-    crate::file::write(&output_path, "")?;
     let ruby = ruby_for_metadata(name, provision_ruby).await?;
     let mut runner = CmdLineRunner::new(&ruby)
         .arg("--disable-gems")
@@ -58,10 +54,6 @@ pub(super) async fn formula_from_ruby(
         .arg(METADATA_SHIM_RB)
         .stdin_string(source)
         .envs([
-            (
-                "MISE_BREW_METADATA_OUTPUT",
-                output_path.display().to_string(),
-            ),
             ("MISE_BREW_NAME", name.to_string()),
             ("MISE_BREW_TAP", format!("{owner}/{tap}")),
             ("MISE_BREW_SOURCE_PATH", source_path),
@@ -71,14 +63,14 @@ pub(super) async fn formula_from_ruby(
             ("MISE_BREW_OS", std::env::consts::OS.to_string()),
             ("MISE_BREW_ARCH", std::env::consts::ARCH.to_string()),
         ])
-        .with_sandbox(metadata_sandbox(&output_path)?);
+        .with_sandbox(metadata_sandbox()?);
     runner.apply_sandbox().await?;
-    runner
-        .execute_async()
+    let output = runner
+        .read()
         .await
         .wrap_err_with(|| format!("failed to evaluate Formula/{name}.rb"))?;
 
-    let formula: Formula = serde_json::from_str(&crate::file::read_to_string(&output_path)?)
+    let formula: Formula = serde_json::from_str(&output)
         .wrap_err_with(|| format!("invalid metadata extracted from Formula/{name}.rb"))?;
     if formula.name != name {
         bail!(
@@ -100,10 +92,6 @@ pub(super) async fn cask_from_ruby(
     let tap_source = resolve_tap_source(owner, tap, tap_url).await?;
     let (source, source_path) = fetch_ruby_source(&tap_source.raw_base, "Casks", token).await?;
     let checksum = crate::hash::hash_sha256_to_str(&source);
-    let cache_dir = crate::dirs::CACHE.join("system-brew").join("cask-source");
-    crate::file::create_dir_all(&cache_dir)?;
-    let output_path = cache_dir.join(format!("{token}-{}.json", &checksum[..12]));
-    crate::file::write(&output_path, "")?;
     let ruby = ruby_for_metadata(token, provision_ruby).await?;
     let mut runner = CmdLineRunner::new(&ruby)
         .arg("--disable-gems")
@@ -111,10 +99,6 @@ pub(super) async fn cask_from_ruby(
         .arg(CASK_METADATA_SHIM_RB)
         .stdin_string(source)
         .envs([
-            (
-                "MISE_BREW_METADATA_OUTPUT",
-                output_path.display().to_string(),
-            ),
             ("MISE_BREW_TOKEN", token.to_string()),
             ("MISE_BREW_SOURCE_PATH", source_path),
             ("MISE_BREW_SOURCE_CHECKSUM", checksum),
@@ -123,39 +107,32 @@ pub(super) async fn cask_from_ruby(
             ("MISE_BREW_OS", std::env::consts::OS.to_string()),
             ("MISE_BREW_ARCH", std::env::consts::ARCH.to_string()),
         ])
-        .with_sandbox(metadata_sandbox(&output_path)?);
+        .with_sandbox(metadata_sandbox()?);
     runner.apply_sandbox().await?;
-    runner
-        .execute_async()
+    let output = runner
+        .read()
         .await
         .wrap_err_with(|| format!("failed to evaluate Casks/{token}.rb"))?;
-    let cask: Cask = serde_json::from_str(&crate::file::read_to_string(&output_path)?)
+    let cask: Cask = serde_json::from_str(&output)
         .wrap_err_with(|| format!("invalid metadata extracted from Casks/{token}.rb"))?;
     Ok(cask)
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
-fn metadata_sandbox(output: &Path) -> Result<SandboxConfig> {
-    let output_alias = output.to_path_buf();
-    let mut sandbox = SandboxConfig {
+fn metadata_sandbox() -> Result<SandboxConfig> {
+    Ok(SandboxConfig {
         deny_read: true,
         deny_write: true,
         deny_net: true,
         deny_env: true,
         deny_process: true,
         deny_temp_write: true,
-        allow_write: vec![output.to_path_buf()],
         ..Default::default()
-    };
-    sandbox.resolve_paths();
-    if !sandbox.allow_write.contains(&output_alias) {
-        sandbox.allow_write.push(output_alias);
-    }
-    Ok(sandbox)
+    })
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-fn metadata_sandbox(_output: &Path) -> Result<SandboxConfig> {
+fn metadata_sandbox() -> Result<SandboxConfig> {
     bail!(
         "evaluating third-party tap definitions is only supported inside the Linux or macOS process sandbox"
     )
@@ -324,7 +301,6 @@ mod tests {
         };
         let dir = tempfile::tempdir()?;
         let formula = dir.path().join("widget.rb");
-        let output = dir.path().join("widget.json");
         crate::file::write(
             &formula,
             r#"
@@ -351,7 +327,6 @@ end
             .arg("-e")
             .arg(METADATA_SHIM_RB)
             .stdin_string(crate::file::read_to_string(&formula)?)
-            .env("MISE_BREW_METADATA_OUTPUT", &output)
             .env("MISE_BREW_NAME", "widget")
             .env("MISE_BREW_TAP", "acme/tools")
             .env("MISE_BREW_SOURCE_PATH", "Formula/widget.rb")
@@ -360,10 +335,10 @@ end
             .env("MISE_BREW_MACOS_VERSION", "15.3")
             .env("MISE_BREW_OS", "macos")
             .env("MISE_BREW_ARCH", std::env::consts::ARCH)
-            .with_sandbox(metadata_sandbox(&output)?);
+            .with_sandbox(metadata_sandbox()?);
         runner.apply_sandbox().await?;
-        runner.execute_async().await?;
-        let formula: Formula = serde_json::from_str(&crate::file::read_to_string(output)?)?;
+        let output = runner.read().await?;
+        let formula: Formula = serde_json::from_str(&output)?;
         assert_eq!(formula.name, "widget");
         assert_eq!(formula.versions.stable.as_deref(), Some("1.2.3"));
         assert_eq!(
@@ -388,7 +363,6 @@ end
         };
         let dir = tempfile::tempdir()?;
         let cask_file = dir.path().join("widget.rb");
-        let output = dir.path().join("widget.json");
         crate::file::write(
             &cask_file,
             r#"
@@ -414,7 +388,6 @@ end
             .arg("-e")
             .arg(CASK_METADATA_SHIM_RB)
             .stdin_string(crate::file::read_to_string(&cask_file)?)
-            .env("MISE_BREW_METADATA_OUTPUT", &output)
             .env("MISE_BREW_TOKEN", "widget")
             .env("MISE_BREW_SOURCE_PATH", "Casks/widget.rb")
             .env("MISE_BREW_SOURCE_CHECKSUM", "bbbb")
@@ -422,10 +395,9 @@ end
             .env("MISE_BREW_MACOS_VERSION", "0")
             .env("MISE_BREW_OS", std::env::consts::OS)
             .env("MISE_BREW_ARCH", std::env::consts::ARCH)
-            .with_sandbox(metadata_sandbox(&output)?);
+            .with_sandbox(metadata_sandbox()?);
         runner.apply_sandbox().await?;
-        runner.execute_async().await?;
-        let json = crate::file::read_to_string(output)?;
+        let json = runner.read().await?;
         let _: Cask = serde_json::from_str(&json)?;
         let metadata: serde_json::Value = serde_json::from_str(&json)?;
         assert_eq!(metadata["token"], "widget");
@@ -440,17 +412,13 @@ end
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
     fn metadata_evaluation_is_fully_sandboxed() {
-        let config = metadata_sandbox(Path::new("/tmp/metadata.json")).unwrap();
+        let config = metadata_sandbox().unwrap();
         assert!(config.deny_read);
         assert!(config.deny_write);
         assert!(config.deny_net);
         assert!(config.deny_env);
         assert!(config.allow_read.is_empty());
-        assert!(
-            config
-                .allow_write
-                .contains(&PathBuf::from("/tmp/metadata.json"))
-        );
+        assert!(config.allow_write.is_empty());
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -464,7 +432,6 @@ end
             .prefix(".mise-tap-sandbox-")
             .tempdir_in(&*crate::env::HOME)?;
         let source = dir.path().join("malicious.rb");
-        let output = dir.path().join("metadata.json");
         let temp_dir = tempfile::tempdir()?;
         let denied = temp_dir.path().join("denied");
         let script = r#"
@@ -484,14 +451,13 @@ rescue SystemCallError
 end
 "#;
         crate::file::write(&source, "tap source")?;
-        crate::file::write(&output, "")?;
         let mut runner = CmdLineRunner::new(ruby)
             .with_on_stderr(|line| eprintln!("{line}"))
             .arg("--disable-gems")
             .arg("-e")
             .arg(script)
             .arg(&denied)
-            .with_sandbox(metadata_sandbox(&output)?);
+            .with_sandbox(metadata_sandbox()?);
         runner.apply_sandbox().await?;
         runner.execute_async().await?;
         assert!(!denied.exists());

--- a/src/system/packages/brew/tap.rs
+++ b/src/system/packages/brew/tap.rs
@@ -1,0 +1,346 @@
+//! Metadata extraction for ordinary third-party taps.
+//!
+//! Homebrew does not publish JSON API metadata for most taps. For those taps,
+//! fetch the formula definition and evaluate only its metadata DSL with mise's
+//! own Ruby shim. The resulting formula deliberately has no bottles: source
+//! installation is the portable fallback and avoids duplicating Homebrew's
+//! bottle URL construction rules.
+
+use std::path::{Path, PathBuf};
+
+use eyre::{WrapErr, bail};
+use serde::Deserialize;
+
+use super::api::{self, Formula};
+use super::cask::Cask;
+use crate::cmd::CmdLineRunner;
+use crate::http::HTTP_FETCH;
+use crate::result::Result;
+
+const METADATA_SHIM_RB: &str = include_str!("tap_formula_metadata.rb");
+const CASK_METADATA_SHIM_RB: &str = include_str!("tap_cask_metadata.rb");
+
+#[derive(Deserialize)]
+struct GithubCommit {
+    sha: String,
+}
+
+#[derive(Deserialize)]
+struct GithubRepository {
+    default_branch: String,
+}
+
+struct TapSource {
+    raw_base: String,
+    commit: String,
+}
+
+pub(super) async fn formula_from_ruby(
+    owner: &str,
+    tap: &str,
+    name: &str,
+    tap_url: Option<&str>,
+    provision_ruby: bool,
+) -> Result<Formula> {
+    validate_name(name)?;
+    let tap_source = resolve_tap_source(owner, tap, tap_url).await?;
+    let (source, source_path) = fetch_ruby_source(&tap_source.raw_base, "Formula", name).await?;
+    let checksum = crate::hash::hash_sha256_to_str(&source);
+    let cache_dir = crate::dirs::CACHE.join("system-brew").join("formula");
+    crate::file::create_dir_all(&cache_dir)?;
+    let formula_path = cache_dir.join(format!("{name}-{}.rb", &checksum[..12]));
+    crate::file::write(&formula_path, source)?;
+
+    let shim_path = cache_dir.join("mise-brew-tap-metadata.rb");
+    ensure_shim(&shim_path, METADATA_SHIM_RB)?;
+    let output_path = cache_dir.join(format!("{name}-{}.json", &checksum[..12]));
+    let ruby = ruby_for_metadata(name, provision_ruby).await?;
+    CmdLineRunner::new(&ruby)
+        .arg(&shim_path)
+        .envs([
+            ("MISE_BREW_FORMULA_FILE", formula_path.display().to_string()),
+            (
+                "MISE_BREW_METADATA_OUTPUT",
+                output_path.display().to_string(),
+            ),
+            ("MISE_BREW_NAME", name.to_string()),
+            ("MISE_BREW_TAP", format!("{owner}/{tap}")),
+            ("MISE_BREW_SOURCE_PATH", source_path),
+            ("MISE_BREW_SOURCE_CHECKSUM", checksum),
+            ("MISE_BREW_TAP_COMMIT", tap_source.commit),
+        ])
+        .execute_async()
+        .await
+        .wrap_err_with(|| format!("failed to evaluate Formula/{name}.rb"))?;
+
+    let formula: Formula = serde_json::from_str(&crate::file::read_to_string(&output_path)?)
+        .wrap_err_with(|| format!("invalid metadata extracted from Formula/{name}.rb"))?;
+    if formula.name != name {
+        bail!(
+            "tap formula name mismatch: requested '{name}', extracted '{}'",
+            formula.name
+        );
+    }
+    Ok(formula)
+}
+
+pub(super) async fn cask_from_ruby(
+    owner: &str,
+    tap: &str,
+    token: &str,
+    tap_url: Option<&str>,
+    provision_ruby: bool,
+) -> Result<Cask> {
+    validate_name(token)?;
+    let tap_source = resolve_tap_source(owner, tap, tap_url).await?;
+    let (source, source_path) = fetch_ruby_source(&tap_source.raw_base, "Casks", token).await?;
+    let checksum = crate::hash::hash_sha256_to_str(&source);
+    let cache_dir = crate::dirs::CACHE.join("system-brew").join("cask-source");
+    crate::file::create_dir_all(&cache_dir)?;
+    let cask_path = cache_dir.join(format!("{token}-{}.rb", &checksum[..12]));
+    crate::file::write(&cask_path, source)?;
+    let shim_path = cache_dir.join("mise-brew-tap-cask-metadata.rb");
+    ensure_shim(&shim_path, CASK_METADATA_SHIM_RB)?;
+    let output_path = cache_dir.join(format!("{token}-{}.json", &checksum[..12]));
+    let ruby = ruby_for_metadata(token, provision_ruby).await?;
+    CmdLineRunner::new(&ruby)
+        .arg(&shim_path)
+        .envs([
+            ("MISE_BREW_CASK_FILE", cask_path.display().to_string()),
+            (
+                "MISE_BREW_METADATA_OUTPUT",
+                output_path.display().to_string(),
+            ),
+            ("MISE_BREW_TOKEN", token.to_string()),
+            ("MISE_BREW_SOURCE_PATH", source_path),
+            ("MISE_BREW_SOURCE_CHECKSUM", checksum),
+            ("MISE_BREW_TAP_COMMIT", tap_source.commit),
+        ])
+        .execute_async()
+        .await
+        .wrap_err_with(|| format!("failed to evaluate Casks/{token}.rb"))?;
+    let cask: Cask = serde_json::from_str(&crate::file::read_to_string(&output_path)?)
+        .wrap_err_with(|| format!("invalid metadata extracted from Casks/{token}.rb"))?;
+    Ok(cask)
+}
+
+async fn resolve_tap_source(owner: &str, tap: &str, tap_url: Option<&str>) -> Result<TapSource> {
+    let raw_base = api::tap_raw_base(owner, tap, tap_url)
+        .ok_or_else(|| eyre::eyre!("only GitHub tap URLs can be fetched directly"))?;
+    let (repo_owner, repo) = github_repository(owner, tap, tap_url)?;
+    let repository: GithubRepository = HTTP_FETCH
+        .json_cached(format!("https://api.github.com/repos/{repo_owner}/{repo}"))
+        .await
+        .wrap_err("failed to resolve tap repository")?;
+    let commit: GithubCommit = HTTP_FETCH
+        .json_cached(format!(
+            "https://api.github.com/repos/{repo_owner}/{repo}/commits/{}",
+            urlencoding::encode(&repository.default_branch)
+        ))
+        .await
+        .wrap_err("failed to resolve tap default branch")?;
+    Ok(TapSource {
+        raw_base: raw_base.trim_end_matches("/HEAD").to_string() + "/" + &commit.sha,
+        commit: commit.sha,
+    })
+}
+
+async fn usable_system_ruby() -> Option<PathBuf> {
+    let ruby = crate::file::which("ruby")?;
+    tokio::process::Command::new(&ruby)
+        .args(["-e", "exit 0"])
+        .output()
+        .await
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|_| ruby)
+}
+
+async fn ruby_for_metadata(name: &str, provision_ruby: bool) -> Result<PathBuf> {
+    match usable_system_ruby().await {
+        Some(ruby) => Ok(ruby),
+        None if provision_ruby => super::source::ruby_bin().await,
+        None => super::source::installed_ruby_bin().await?.ok_or_else(|| {
+            eyre::eyre!(
+                "evaluating the tap definition for {name} requires Ruby; install Ruby or run the apply command"
+            )
+        }),
+    }
+}
+
+fn github_repository<'a>(
+    owner: &'a str,
+    tap: &'a str,
+    tap_url: Option<&'a str>,
+) -> Result<(&'a str, String)> {
+    let Some(url) = tap_url else {
+        return Ok((owner, format!("homebrew-{tap}")));
+    };
+    let normalized = url.trim_end_matches('/').trim_end_matches(".git");
+    let rest = normalized
+        .strip_prefix("https://github.com/")
+        .ok_or_else(|| eyre::eyre!("only GitHub tap URLs can be fetched directly"))?;
+    let mut parts = rest.split('/');
+    match (parts.next(), parts.next(), parts.next()) {
+        (Some(repo_owner), Some(repo), None) if !repo_owner.is_empty() && !repo.is_empty() => {
+            Ok((repo_owner, repo.to_string()))
+        }
+        _ => bail!("invalid GitHub tap URL '{url}'"),
+    }
+}
+
+async fn fetch_ruby_source(
+    raw_base: &str,
+    directory: &str,
+    name: &str,
+) -> Result<(String, String)> {
+    let paths = [
+        format!("{directory}/{name}.rb"),
+        format!("{directory}/{}/{name}.rb", &name[..1]),
+    ];
+    let mut last_error = None;
+    for path in paths {
+        match HTTP_FETCH.get_text(format!("{raw_base}/{path}")).await {
+            Ok(source) => return Ok((source, path)),
+            Err(err) => last_error = Some(err),
+        }
+    }
+    Err(last_error.unwrap()).wrap_err_with(|| format!("tap has no {directory}/{name}.rb"))
+}
+
+fn ensure_shim(path: &Path, contents: &str) -> Result<()> {
+    if crate::file::read_to_string(path).is_ok_and(|current| current == contents) {
+        return Ok(());
+    }
+    crate::file::write(path, contents)
+}
+
+fn validate_name(name: &str) -> Result<()> {
+    if name.is_empty()
+        || name.contains(['/', '\\', '\0'])
+        || name == "."
+        || name == ".."
+        || PathBuf::from(name).components().count() != 1
+    {
+        bail!("invalid tap formula name '{name}'");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    #[test]
+    fn rejects_unsafe_formula_names() {
+        for name in ["", ".", "..", "../oops", "a/b", "a\\b"] {
+            assert!(validate_name(name).is_err(), "accepted {name:?}");
+        }
+        assert!(validate_name("foo@2").is_ok());
+    }
+
+    #[test]
+    fn resolves_default_and_explicit_github_repositories() -> Result<()> {
+        assert_eq!(
+            github_repository("acme", "tools", None)?,
+            ("acme", "homebrew-tools".to_string())
+        );
+        assert_eq!(
+            github_repository(
+                "acme",
+                "tools",
+                Some("https://github.com/example/custom.git")
+            )?,
+            ("example", "custom".to_string())
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn extracts_formula_metadata_without_homebrew() -> Result<()> {
+        let Some(ruby) = usable_system_ruby().await else {
+            return Ok(());
+        };
+        let dir = tempfile::tempdir()?;
+        let formula = dir.path().join("widget.rb");
+        let output = dir.path().join("widget.json");
+        let shim = dir.path().join("shim.rb");
+        crate::file::write(
+            &formula,
+            r#"
+class Widget < Formula
+  desc "example"
+  url "https://example.com/widget-1.2.3.tar.gz"
+  sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  depends_on "libfoo"
+  depends_on "cmake" => :build
+  keg_only :versioned_formula
+end
+"#,
+        )?;
+        crate::file::write(&shim, METADATA_SHIM_RB)?;
+        let status = Command::new(ruby)
+            .arg(shim)
+            .env("MISE_BREW_FORMULA_FILE", &formula)
+            .env("MISE_BREW_METADATA_OUTPUT", &output)
+            .env("MISE_BREW_NAME", "widget")
+            .env("MISE_BREW_TAP", "acme/tools")
+            .env("MISE_BREW_SOURCE_PATH", "Formula/widget.rb")
+            .env("MISE_BREW_SOURCE_CHECKSUM", "bbbb")
+            .env("MISE_BREW_TAP_COMMIT", "deadbeef")
+            .status()?;
+        assert!(status.success());
+        let formula: Formula = serde_json::from_str(&crate::file::read_to_string(output)?)?;
+        assert_eq!(formula.name, "widget");
+        assert_eq!(formula.versions.stable.as_deref(), Some("1.2.3"));
+        assert_eq!(formula.dependencies, ["libfoo"]);
+        assert_eq!(formula.build_dependencies, ["cmake"]);
+        assert!(formula.keg_only);
+        assert!(formula.bottle.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn extracts_cask_metadata_without_homebrew() -> Result<()> {
+        let Some(ruby) = usable_system_ruby().await else {
+            return Ok(());
+        };
+        let dir = tempfile::tempdir()?;
+        let cask_file = dir.path().join("widget.rb");
+        let output = dir.path().join("widget.json");
+        let shim = dir.path().join("shim.rb");
+        crate::file::write(
+            &cask_file,
+            r#"
+cask "widget" do
+  version "1.2.3"
+  sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  url "https://example.com/widget-#{version}.zip"
+  depends_on formula: "libfoo"
+  app "Widget.app"
+  binary "Widget.app/Contents/MacOS/widget", target: "widget"
+end
+"#,
+        )?;
+        crate::file::write(&shim, CASK_METADATA_SHIM_RB)?;
+        let status = Command::new(ruby)
+            .arg(shim)
+            .env("MISE_BREW_CASK_FILE", &cask_file)
+            .env("MISE_BREW_METADATA_OUTPUT", &output)
+            .env("MISE_BREW_TOKEN", "widget")
+            .env("MISE_BREW_SOURCE_PATH", "Casks/widget.rb")
+            .env("MISE_BREW_SOURCE_CHECKSUM", "bbbb")
+            .env("MISE_BREW_TAP_COMMIT", "deadbeef")
+            .status()?;
+        assert!(status.success());
+        let json = crate::file::read_to_string(output)?;
+        let _: Cask = serde_json::from_str(&json)?;
+        let metadata: serde_json::Value = serde_json::from_str(&json)?;
+        assert_eq!(metadata["token"], "widget");
+        assert_eq!(metadata["version"], "1.2.3");
+        assert_eq!(metadata["depends_on"]["formula"][0], "libfoo");
+        assert_eq!(metadata["artifacts"].as_array().unwrap().len(), 2);
+        Ok(())
+    }
+}

--- a/src/system/packages/brew/tap.rs
+++ b/src/system/packages/brew/tap.rs
@@ -176,7 +176,7 @@ async fn usable_system_ruby() -> Option<PathBuf> {
 }
 
 async fn ruby_is_compatible(ruby: &Path) -> bool {
-    tokio::process::Command::new(&ruby)
+    tokio::process::Command::new(ruby)
         .args(["-e", "exit RUBY_VERSION.split('.').first.to_i >= 3 ? 0 : 1"])
         .output()
         .await

--- a/src/system/packages/brew/tap.rs
+++ b/src/system/packages/brew/tap.rs
@@ -58,6 +58,7 @@ pub(super) async fn formula_from_ruby(
     crate::file::write(&output_path, "")?;
     let ruby = ruby_for_metadata(name, provision_ruby).await?;
     let mut runner = CmdLineRunner::new(&ruby)
+        .arg("--disable-gems")
         .arg(&shim_path)
         .envs([
             ("MISE_BREW_FORMULA_FILE", formula_path.display().to_string()),
@@ -71,6 +72,8 @@ pub(super) async fn formula_from_ruby(
             ("MISE_BREW_SOURCE_CHECKSUM", checksum),
             ("MISE_BREW_TAP_COMMIT", tap_source.commit),
             ("MISE_BREW_MACOS_VERSION", macos_version()),
+            ("MISE_BREW_OS", std::env::consts::OS.to_string()),
+            ("MISE_BREW_ARCH", std::env::consts::ARCH.to_string()),
         ])
         .with_sandbox(metadata_sandbox(&formula_path, &shim_path, &output_path)?);
     runner.apply_sandbox().await?;
@@ -111,6 +114,7 @@ pub(super) async fn cask_from_ruby(
     crate::file::write(&output_path, "")?;
     let ruby = ruby_for_metadata(token, provision_ruby).await?;
     let mut runner = CmdLineRunner::new(&ruby)
+        .arg("--disable-gems")
         .arg(&shim_path)
         .envs([
             ("MISE_BREW_CASK_FILE", cask_path.display().to_string()),
@@ -123,6 +127,8 @@ pub(super) async fn cask_from_ruby(
             ("MISE_BREW_SOURCE_CHECKSUM", checksum),
             ("MISE_BREW_TAP_COMMIT", tap_source.commit),
             ("MISE_BREW_MACOS_VERSION", macos_version()),
+            ("MISE_BREW_OS", std::env::consts::OS.to_string()),
+            ("MISE_BREW_ARCH", std::env::consts::ARCH.to_string()),
         ])
         .with_sandbox(metadata_sandbox(&cask_path, &shim_path, &output_path)?);
     runner.apply_sandbox().await?;
@@ -146,6 +152,7 @@ fn metadata_sandbox(source: &Path, shim: &Path, output: &Path) -> Result<Sandbox
         deny_temp_write: true,
         allow_read: vec![source.to_path_buf(), shim.to_path_buf()],
         allow_write: vec![output.to_path_buf()],
+        allow_exec: vec![source.to_path_buf(), shim.to_path_buf()],
         ..Default::default()
     };
     sandbox.resolve_paths();
@@ -341,6 +348,12 @@ class Widget < Formula
   sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   depends_on "libfoo"
   depends_on "cmake" => :build
+  on_sequoia :or_older do
+    depends_on "release-boundary"
+  end
+  on_system macos: :sequoia_or_older do
+    depends_on "system-release-boundary"
+  end
   keg_only :versioned_formula
 end
 "#,
@@ -348,6 +361,7 @@ end
         crate::file::write(&shim, METADATA_SHIM_RB)?;
         let mut runner = CmdLineRunner::new(ruby)
             .with_on_stderr(|line| eprintln!("{line}"))
+            .arg("--disable-gems")
             .arg(&shim)
             .env("MISE_BREW_FORMULA_FILE", &formula)
             .env("MISE_BREW_METADATA_OUTPUT", &output)
@@ -356,7 +370,9 @@ end
             .env("MISE_BREW_SOURCE_PATH", "Formula/widget.rb")
             .env("MISE_BREW_SOURCE_CHECKSUM", "bbbb")
             .env("MISE_BREW_TAP_COMMIT", "deadbeef")
-            .env("MISE_BREW_MACOS_VERSION", macos_version())
+            .env("MISE_BREW_MACOS_VERSION", "15.3")
+            .env("MISE_BREW_OS", "macos")
+            .env("MISE_BREW_ARCH", std::env::consts::ARCH)
             .with_sandbox(metadata_sandbox(&formula, &shim, &output)?);
         runner.apply_sandbox().await?;
         runner.execute_async().await?;
@@ -367,7 +383,10 @@ end
             formula.urls["stable"].url,
             "https://example.com/widget-1.2.3.tar.gz"
         );
-        assert_eq!(formula.dependencies, ["libfoo"]);
+        assert_eq!(
+            formula.dependencies,
+            ["libfoo", "release-boundary", "system-release-boundary"]
+        );
         assert_eq!(formula.build_dependencies, ["cmake"]);
         assert!(formula.keg_only);
         assert!(formula.bottle.is_empty());
@@ -406,6 +425,7 @@ end
         crate::file::write(&shim, CASK_METADATA_SHIM_RB)?;
         let mut runner = CmdLineRunner::new(ruby)
             .with_on_stderr(|line| eprintln!("{line}"))
+            .arg("--disable-gems")
             .arg(&shim)
             .env("MISE_BREW_CASK_FILE", &cask_file)
             .env("MISE_BREW_METADATA_OUTPUT", &output)
@@ -414,6 +434,8 @@ end
             .env("MISE_BREW_SOURCE_CHECKSUM", "bbbb")
             .env("MISE_BREW_TAP_COMMIT", "deadbeef")
             .env("MISE_BREW_MACOS_VERSION", "0")
+            .env("MISE_BREW_OS", std::env::consts::OS)
+            .env("MISE_BREW_ARCH", std::env::consts::ARCH)
             .with_sandbox(metadata_sandbox(&cask_file, &shim, &output)?);
         runner.apply_sandbox().await?;
         runner.execute_async().await?;
@@ -474,7 +496,7 @@ rescue SystemCallError
 end
 raise "child process escaped sandbox" if ran
 begin
-  exec("false")
+  exec("/usr/bin/false")
 rescue SystemCallError
 end
 "#,
@@ -482,6 +504,7 @@ end
         crate::file::write(&output, "")?;
         let mut runner = CmdLineRunner::new(ruby)
             .with_on_stderr(|line| eprintln!("{line}"))
+            .arg("--disable-gems")
             .arg(&source)
             .arg(&denied)
             .with_sandbox(metadata_sandbox(&source, &source, &output)?);

--- a/src/system/packages/brew/tap.rs
+++ b/src/system/packages/brew/tap.rs
@@ -347,6 +347,7 @@ end
         )?;
         crate::file::write(&shim, METADATA_SHIM_RB)?;
         let mut runner = CmdLineRunner::new(ruby)
+            .with_on_stderr(|line| eprintln!("{line}"))
             .arg(&shim)
             .env("MISE_BREW_FORMULA_FILE", &formula)
             .env("MISE_BREW_METADATA_OUTPUT", &output)
@@ -404,6 +405,7 @@ end
         )?;
         crate::file::write(&shim, CASK_METADATA_SHIM_RB)?;
         let mut runner = CmdLineRunner::new(ruby)
+            .with_on_stderr(|line| eprintln!("{line}"))
             .arg(&shim)
             .env("MISE_BREW_CASK_FILE", &cask_file)
             .env("MISE_BREW_METADATA_OUTPUT", &output)
@@ -479,6 +481,7 @@ end
         )?;
         crate::file::write(&output, "")?;
         let mut runner = CmdLineRunner::new(ruby)
+            .with_on_stderr(|line| eprintln!("{line}"))
             .arg(&source)
             .arg(&denied)
             .with_sandbox(metadata_sandbox(&source, &source, &output)?);

--- a/src/system/packages/brew/tap.rs
+++ b/src/system/packages/brew/tap.rs
@@ -140,6 +140,8 @@ fn metadata_sandbox(source: &Path, shim: &Path, output: &Path) -> Result<Sandbox
         deny_write: true,
         deny_net: true,
         deny_env: true,
+        deny_process: true,
+        deny_temp_write: true,
         allow_read: vec![source.to_path_buf(), shim.to_path_buf()],
         allow_write: vec![output.to_path_buf()],
         ..Default::default()
@@ -426,7 +428,7 @@ end
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[tokio::test]
-    async fn metadata_sandbox_blocks_tap_writes() -> Result<()> {
+    async fn metadata_sandbox_blocks_tap_processes_and_temp_writes() -> Result<()> {
         let Some(ruby) = test_ruby().await? else {
             return Ok(());
         };
@@ -436,15 +438,30 @@ end
             .tempdir_in(&*crate::env::HOME)?;
         let source = dir.path().join("malicious.rb");
         let output = dir.path().join("metadata.json");
-        let denied = dir.path().join("denied");
-        crate::file::write(&source, "File.write(ARGV.fetch(0), 'escaped')")?;
+        let temp_dir = tempfile::tempdir()?;
+        let denied = temp_dir.path().join("denied");
+        crate::file::write(
+            &source,
+            r#"
+begin
+  File.write(ARGV.fetch(0), "escaped")
+rescue SystemCallError
+end
+ran = begin
+  system("true")
+rescue SystemCallError
+  false
+end
+raise "child process escaped sandbox" if ran
+"#,
+        )?;
         crate::file::write(&output, "")?;
         let mut runner = CmdLineRunner::new(ruby)
             .arg(&source)
             .arg(&denied)
             .with_sandbox(metadata_sandbox(&source, &source, &output)?);
         runner.apply_sandbox().await?;
-        assert!(runner.execute_async().await.is_err());
+        runner.execute_async().await?;
         assert!(!denied.exists());
         Ok(())
     }

--- a/src/system/packages/brew/tap.rs
+++ b/src/system/packages/brew/tap.rs
@@ -7,6 +7,7 @@
 //! bottle URL construction rules.
 
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use eyre::{WrapErr, bail};
 use serde::Deserialize;
@@ -20,6 +21,8 @@ use crate::sandbox::SandboxConfig;
 
 const METADATA_SHIM_RB: &str = include_str!("tap_formula_metadata.rb");
 const CASK_METADATA_SHIM_RB: &str = include_str!("tap_cask_metadata.rb");
+const METADATA_TIMEOUT: Duration = Duration::from_secs(10);
+const METADATA_MAX_OUTPUT_BYTES: usize = 1024 * 1024;
 
 #[derive(Deserialize)]
 struct GithubCommit {
@@ -63,10 +66,11 @@ pub(super) async fn formula_from_ruby(
             ("MISE_BREW_OS", std::env::consts::OS.to_string()),
             ("MISE_BREW_ARCH", std::env::consts::ARCH.to_string()),
         ])
+        .with_timeout(METADATA_TIMEOUT)
         .with_sandbox(metadata_sandbox()?);
     runner.apply_sandbox().await?;
     let output = runner
-        .read()
+        .read_bounded(METADATA_MAX_OUTPUT_BYTES)
         .await
         .wrap_err_with(|| format!("failed to evaluate Formula/{name}.rb"))?;
 
@@ -107,10 +111,11 @@ pub(super) async fn cask_from_ruby(
             ("MISE_BREW_OS", std::env::consts::OS.to_string()),
             ("MISE_BREW_ARCH", std::env::consts::ARCH.to_string()),
         ])
+        .with_timeout(METADATA_TIMEOUT)
         .with_sandbox(metadata_sandbox()?);
     runner.apply_sandbox().await?;
     let output = runner
-        .read()
+        .read_bounded(METADATA_MAX_OUTPUT_BYTES)
         .await
         .wrap_err_with(|| format!("failed to evaluate Casks/{token}.rb"))?;
     let cask: Cask = serde_json::from_str(&output)

--- a/src/system/packages/brew/tap.rs
+++ b/src/system/packages/brew/tap.rs
@@ -52,14 +52,13 @@ pub(super) async fn formula_from_ruby(
     let formula_path = cache_dir.join(format!("{name}-{}.rb", &checksum[..12]));
     crate::file::write(&formula_path, source)?;
 
-    let shim_path = cache_dir.join("mise-brew-tap-metadata.rb");
-    ensure_shim(&shim_path, METADATA_SHIM_RB)?;
     let output_path = cache_dir.join(format!("{name}-{}.json", &checksum[..12]));
     crate::file::write(&output_path, "")?;
     let ruby = ruby_for_metadata(name, provision_ruby).await?;
     let mut runner = CmdLineRunner::new(&ruby)
         .arg("--disable-gems")
-        .arg(&shim_path)
+        .arg("-e")
+        .arg(METADATA_SHIM_RB)
         .envs([
             ("MISE_BREW_FORMULA_FILE", formula_path.display().to_string()),
             (
@@ -75,7 +74,7 @@ pub(super) async fn formula_from_ruby(
             ("MISE_BREW_OS", std::env::consts::OS.to_string()),
             ("MISE_BREW_ARCH", std::env::consts::ARCH.to_string()),
         ])
-        .with_sandbox(metadata_sandbox(&formula_path, &shim_path, &output_path)?);
+        .with_sandbox(metadata_sandbox(&formula_path, &output_path)?);
     runner.apply_sandbox().await?;
     runner
         .execute_async()
@@ -108,14 +107,13 @@ pub(super) async fn cask_from_ruby(
     crate::file::create_dir_all(&cache_dir)?;
     let cask_path = cache_dir.join(format!("{token}-{}.rb", &checksum[..12]));
     crate::file::write(&cask_path, source)?;
-    let shim_path = cache_dir.join("mise-brew-tap-cask-metadata.rb");
-    ensure_shim(&shim_path, CASK_METADATA_SHIM_RB)?;
     let output_path = cache_dir.join(format!("{token}-{}.json", &checksum[..12]));
     crate::file::write(&output_path, "")?;
     let ruby = ruby_for_metadata(token, provision_ruby).await?;
     let mut runner = CmdLineRunner::new(&ruby)
         .arg("--disable-gems")
-        .arg(&shim_path)
+        .arg("-e")
+        .arg(CASK_METADATA_SHIM_RB)
         .envs([
             ("MISE_BREW_CASK_FILE", cask_path.display().to_string()),
             (
@@ -130,7 +128,7 @@ pub(super) async fn cask_from_ruby(
             ("MISE_BREW_OS", std::env::consts::OS.to_string()),
             ("MISE_BREW_ARCH", std::env::consts::ARCH.to_string()),
         ])
-        .with_sandbox(metadata_sandbox(&cask_path, &shim_path, &output_path)?);
+        .with_sandbox(metadata_sandbox(&cask_path, &output_path)?);
     runner.apply_sandbox().await?;
     runner
         .execute_async()
@@ -142,7 +140,7 @@ pub(super) async fn cask_from_ruby(
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
-fn metadata_sandbox(source: &Path, shim: &Path, output: &Path) -> Result<SandboxConfig> {
+fn metadata_sandbox(source: &Path, output: &Path) -> Result<SandboxConfig> {
     let mut sandbox = SandboxConfig {
         deny_read: true,
         deny_write: true,
@@ -150,9 +148,8 @@ fn metadata_sandbox(source: &Path, shim: &Path, output: &Path) -> Result<Sandbox
         deny_env: true,
         deny_process: true,
         deny_temp_write: true,
-        allow_read: vec![source.to_path_buf(), shim.to_path_buf()],
+        allow_read: vec![source.to_path_buf()],
         allow_write: vec![output.to_path_buf()],
-        allow_exec: vec![shim.to_path_buf()],
         ..Default::default()
     };
     sandbox.resolve_paths();
@@ -160,7 +157,7 @@ fn metadata_sandbox(source: &Path, shim: &Path, output: &Path) -> Result<Sandbox
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-fn metadata_sandbox(_source: &Path, _shim: &Path, _output: &Path) -> Result<SandboxConfig> {
+fn metadata_sandbox(_source: &Path, _output: &Path) -> Result<SandboxConfig> {
     bail!(
         "evaluating third-party tap definitions is only supported inside the Linux or macOS process sandbox"
     )
@@ -273,13 +270,6 @@ async fn fetch_ruby_source(
     Err(last_error.unwrap()).wrap_err_with(|| format!("tap has no {directory}/{name}.rb"))
 }
 
-fn ensure_shim(path: &Path, contents: &str) -> Result<()> {
-    if crate::file::read_to_string(path).is_ok_and(|current| current == contents) {
-        return Ok(());
-    }
-    crate::file::write(path, contents)
-}
-
 fn validate_name(name: &str) -> Result<()> {
     if name.is_empty()
         || name.contains(['/', '\\', '\0'])
@@ -337,7 +327,6 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let formula = dir.path().join("widget.rb");
         let output = dir.path().join("widget.json");
-        let shim = dir.path().join("shim.rb");
         crate::file::write(
             &formula,
             r#"
@@ -358,11 +347,11 @@ class Widget < Formula
 end
 "#,
         )?;
-        crate::file::write(&shim, METADATA_SHIM_RB)?;
         let mut runner = CmdLineRunner::new(ruby)
             .with_on_stderr(|line| eprintln!("{line}"))
             .arg("--disable-gems")
-            .arg(&shim)
+            .arg("-e")
+            .arg(METADATA_SHIM_RB)
             .env("MISE_BREW_FORMULA_FILE", &formula)
             .env("MISE_BREW_METADATA_OUTPUT", &output)
             .env("MISE_BREW_NAME", "widget")
@@ -373,7 +362,7 @@ end
             .env("MISE_BREW_MACOS_VERSION", "15.3")
             .env("MISE_BREW_OS", "macos")
             .env("MISE_BREW_ARCH", std::env::consts::ARCH)
-            .with_sandbox(metadata_sandbox(&formula, &shim, &output)?);
+            .with_sandbox(metadata_sandbox(&formula, &output)?);
         runner.apply_sandbox().await?;
         runner.execute_async().await?;
         let formula: Formula = serde_json::from_str(&crate::file::read_to_string(output)?)?;
@@ -402,7 +391,6 @@ end
         let dir = tempfile::tempdir()?;
         let cask_file = dir.path().join("widget.rb");
         let output = dir.path().join("widget.json");
-        let shim = dir.path().join("shim.rb");
         crate::file::write(
             &cask_file,
             r#"
@@ -422,11 +410,11 @@ cask "widget" do
 end
 "#,
         )?;
-        crate::file::write(&shim, CASK_METADATA_SHIM_RB)?;
         let mut runner = CmdLineRunner::new(ruby)
             .with_on_stderr(|line| eprintln!("{line}"))
             .arg("--disable-gems")
-            .arg(&shim)
+            .arg("-e")
+            .arg(CASK_METADATA_SHIM_RB)
             .env("MISE_BREW_CASK_FILE", &cask_file)
             .env("MISE_BREW_METADATA_OUTPUT", &output)
             .env("MISE_BREW_TOKEN", "widget")
@@ -436,7 +424,7 @@ end
             .env("MISE_BREW_MACOS_VERSION", "0")
             .env("MISE_BREW_OS", std::env::consts::OS)
             .env("MISE_BREW_ARCH", std::env::consts::ARCH)
-            .with_sandbox(metadata_sandbox(&cask_file, &shim, &output)?);
+            .with_sandbox(metadata_sandbox(&cask_file, &output)?);
         runner.apply_sandbox().await?;
         runner.execute_async().await?;
         let json = crate::file::read_to_string(output)?;
@@ -456,7 +444,6 @@ end
     fn metadata_evaluation_is_fully_sandboxed() {
         let config = metadata_sandbox(
             Path::new("/tmp/formula.rb"),
-            Path::new("/tmp/shim.rb"),
             Path::new("/tmp/metadata.json"),
         )
         .unwrap();
@@ -464,7 +451,7 @@ end
         assert!(config.deny_write);
         assert!(config.deny_net);
         assert!(config.deny_env);
-        assert_eq!(config.allow_read.len(), 2);
+        assert_eq!(config.allow_read.len(), 1);
         assert_eq!(config.allow_write.len(), 1);
     }
 
@@ -482,9 +469,7 @@ end
         let output = dir.path().join("metadata.json");
         let temp_dir = tempfile::tempdir()?;
         let denied = temp_dir.path().join("denied");
-        crate::file::write(
-            &source,
-            r#"
+        let script = r#"
 begin
   File.write(ARGV.fetch(0), "escaped")
 rescue SystemCallError
@@ -499,15 +484,16 @@ begin
   exec("/usr/bin/false")
 rescue SystemCallError
 end
-"#,
-        )?;
+"#;
+        crate::file::write(&source, "tap source")?;
         crate::file::write(&output, "")?;
         let mut runner = CmdLineRunner::new(ruby)
             .with_on_stderr(|line| eprintln!("{line}"))
             .arg("--disable-gems")
-            .arg(&source)
+            .arg("-e")
+            .arg(script)
             .arg(&denied)
-            .with_sandbox(metadata_sandbox(&source, &source, &output)?);
+            .with_sandbox(metadata_sandbox(&source, &output)?);
         runner.apply_sandbox().await?;
         runner.execute_async().await?;
         assert!(!denied.exists());

--- a/src/system/packages/brew/tap.rs
+++ b/src/system/packages/brew/tap.rs
@@ -16,6 +16,7 @@ use super::cask::Cask;
 use crate::cmd::CmdLineRunner;
 use crate::http::HTTP_FETCH;
 use crate::result::Result;
+use crate::sandbox::SandboxConfig;
 
 const METADATA_SHIM_RB: &str = include_str!("tap_formula_metadata.rb");
 const CASK_METADATA_SHIM_RB: &str = include_str!("tap_cask_metadata.rb");
@@ -54,8 +55,9 @@ pub(super) async fn formula_from_ruby(
     let shim_path = cache_dir.join("mise-brew-tap-metadata.rb");
     ensure_shim(&shim_path, METADATA_SHIM_RB)?;
     let output_path = cache_dir.join(format!("{name}-{}.json", &checksum[..12]));
+    crate::file::write(&output_path, "")?;
     let ruby = ruby_for_metadata(name, provision_ruby).await?;
-    CmdLineRunner::new(&ruby)
+    let mut runner = CmdLineRunner::new(&ruby)
         .arg(&shim_path)
         .envs([
             ("MISE_BREW_FORMULA_FILE", formula_path.display().to_string()),
@@ -69,6 +71,9 @@ pub(super) async fn formula_from_ruby(
             ("MISE_BREW_SOURCE_CHECKSUM", checksum),
             ("MISE_BREW_TAP_COMMIT", tap_source.commit),
         ])
+        .with_sandbox(metadata_sandbox(&formula_path, &shim_path, &output_path));
+    runner.apply_sandbox().await?;
+    runner
         .execute_async()
         .await
         .wrap_err_with(|| format!("failed to evaluate Formula/{name}.rb"))?;
@@ -102,8 +107,9 @@ pub(super) async fn cask_from_ruby(
     let shim_path = cache_dir.join("mise-brew-tap-cask-metadata.rb");
     ensure_shim(&shim_path, CASK_METADATA_SHIM_RB)?;
     let output_path = cache_dir.join(format!("{token}-{}.json", &checksum[..12]));
+    crate::file::write(&output_path, "")?;
     let ruby = ruby_for_metadata(token, provision_ruby).await?;
-    CmdLineRunner::new(&ruby)
+    let mut runner = CmdLineRunner::new(&ruby)
         .arg(&shim_path)
         .envs([
             ("MISE_BREW_CASK_FILE", cask_path.display().to_string()),
@@ -116,12 +122,29 @@ pub(super) async fn cask_from_ruby(
             ("MISE_BREW_SOURCE_CHECKSUM", checksum),
             ("MISE_BREW_TAP_COMMIT", tap_source.commit),
         ])
+        .with_sandbox(metadata_sandbox(&cask_path, &shim_path, &output_path));
+    runner.apply_sandbox().await?;
+    runner
         .execute_async()
         .await
         .wrap_err_with(|| format!("failed to evaluate Casks/{token}.rb"))?;
     let cask: Cask = serde_json::from_str(&crate::file::read_to_string(&output_path)?)
         .wrap_err_with(|| format!("invalid metadata extracted from Casks/{token}.rb"))?;
     Ok(cask)
+}
+
+fn metadata_sandbox(source: &Path, shim: &Path, output: &Path) -> SandboxConfig {
+    let mut sandbox = SandboxConfig {
+        deny_read: true,
+        deny_write: true,
+        deny_net: true,
+        deny_env: true,
+        allow_read: vec![source.to_path_buf(), shim.to_path_buf()],
+        allow_write: vec![output.to_path_buf()],
+        ..Default::default()
+    };
+    sandbox.resolve_paths();
+    sandbox
 }
 
 async fn resolve_tap_source(owner: &str, tap: &str, tap_url: Option<&str>) -> Result<TapSource> {
@@ -232,6 +255,13 @@ mod tests {
     use super::*;
     use std::process::Command;
 
+    async fn test_ruby() -> Result<Option<PathBuf>> {
+        if let Some(ruby) = usable_system_ruby().await {
+            return Ok(Some(ruby));
+        }
+        super::super::source::installed_ruby_bin().await
+    }
+
     #[test]
     fn rejects_unsafe_formula_names() {
         for name in ["", ".", "..", "../oops", "a/b", "a\\b"] {
@@ -259,7 +289,7 @@ mod tests {
 
     #[tokio::test]
     async fn extracts_formula_metadata_without_homebrew() -> Result<()> {
-        let Some(ruby) = usable_system_ruby().await else {
+        let Some(ruby) = test_ruby().await? else {
             return Ok(());
         };
         let dir = tempfile::tempdir()?;
@@ -303,7 +333,7 @@ end
 
     #[tokio::test]
     async fn extracts_cask_metadata_without_homebrew() -> Result<()> {
-        let Some(ruby) = usable_system_ruby().await else {
+        let Some(ruby) = test_ruby().await? else {
             return Ok(());
         };
         let dir = tempfile::tempdir()?;
@@ -315,9 +345,12 @@ end
             r#"
 cask "widget" do
   version "1.2.3"
-  sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  sha256 :no_check
   url "https://example.com/widget-#{version}.zip"
   depends_on formula: "libfoo"
+  on_sonoma do
+    url "https://example.com/wrong-platform.zip"
+  end
   app "Widget.app"
   binary "Widget.app/Contents/MacOS/widget", target: "widget"
 end
@@ -339,8 +372,25 @@ end
         let metadata: serde_json::Value = serde_json::from_str(&json)?;
         assert_eq!(metadata["token"], "widget");
         assert_eq!(metadata["version"], "1.2.3");
+        assert_eq!(metadata["sha256"], "no_check");
+        assert_eq!(metadata["url"], "https://example.com/widget-1.2.3.zip");
         assert_eq!(metadata["depends_on"]["formula"][0], "libfoo");
         assert_eq!(metadata["artifacts"].as_array().unwrap().len(), 2);
         Ok(())
+    }
+
+    #[test]
+    fn metadata_evaluation_is_fully_sandboxed() {
+        let config = metadata_sandbox(
+            Path::new("/tmp/formula.rb"),
+            Path::new("/tmp/shim.rb"),
+            Path::new("/tmp/metadata.json"),
+        );
+        assert!(config.deny_read);
+        assert!(config.deny_write);
+        assert!(config.deny_net);
+        assert!(config.deny_env);
+        assert_eq!(config.allow_read.len(), 2);
+        assert_eq!(config.allow_write.len(), 1);
     }
 }

--- a/src/system/packages/brew/tap.rs
+++ b/src/system/packages/brew/tap.rs
@@ -71,7 +71,7 @@ pub(super) async fn formula_from_ruby(
             ("MISE_BREW_SOURCE_CHECKSUM", checksum),
             ("MISE_BREW_TAP_COMMIT", tap_source.commit),
         ])
-        .with_sandbox(metadata_sandbox(&formula_path, &shim_path, &output_path));
+        .with_sandbox(metadata_sandbox(&formula_path, &shim_path, &output_path)?);
     runner.apply_sandbox().await?;
     runner
         .execute_async()
@@ -122,7 +122,7 @@ pub(super) async fn cask_from_ruby(
             ("MISE_BREW_SOURCE_CHECKSUM", checksum),
             ("MISE_BREW_TAP_COMMIT", tap_source.commit),
         ])
-        .with_sandbox(metadata_sandbox(&cask_path, &shim_path, &output_path));
+        .with_sandbox(metadata_sandbox(&cask_path, &shim_path, &output_path)?);
     runner.apply_sandbox().await?;
     runner
         .execute_async()
@@ -133,7 +133,8 @@ pub(super) async fn cask_from_ruby(
     Ok(cask)
 }
 
-fn metadata_sandbox(source: &Path, shim: &Path, output: &Path) -> SandboxConfig {
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn metadata_sandbox(source: &Path, shim: &Path, output: &Path) -> Result<SandboxConfig> {
     let mut sandbox = SandboxConfig {
         deny_read: true,
         deny_write: true,
@@ -144,7 +145,14 @@ fn metadata_sandbox(source: &Path, shim: &Path, output: &Path) -> SandboxConfig 
         ..Default::default()
     };
     sandbox.resolve_paths();
-    sandbox
+    Ok(sandbox)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn metadata_sandbox(_source: &Path, _shim: &Path, _output: &Path) -> Result<SandboxConfig> {
+    bail!(
+        "evaluating third-party tap definitions is only supported inside the Linux or macOS process sandbox"
+    )
 }
 
 async fn resolve_tap_source(owner: &str, tap: &str, tap_url: Option<&str>) -> Result<TapSource> {
@@ -170,25 +178,37 @@ async fn resolve_tap_source(owner: &str, tap: &str, tap_url: Option<&str>) -> Re
 
 async fn usable_system_ruby() -> Option<PathBuf> {
     let ruby = crate::file::which("ruby")?;
+    ruby_is_compatible(&ruby).await.then_some(ruby)
+}
+
+async fn ruby_is_compatible(ruby: &Path) -> bool {
     tokio::process::Command::new(&ruby)
-        .args(["-e", "exit 0"])
+        .args(["-e", "exit RUBY_VERSION.split('.').first.to_i >= 3 ? 0 : 1"])
         .output()
         .await
         .ok()
         .filter(|output| output.status.success())
-        .map(|_| ruby)
+        .is_some()
 }
 
 async fn ruby_for_metadata(name: &str, provision_ruby: bool) -> Result<PathBuf> {
-    match usable_system_ruby().await {
-        Some(ruby) => Ok(ruby),
-        None if provision_ruby => super::source::ruby_bin().await,
-        None => super::source::installed_ruby_bin().await?.ok_or_else(|| {
-            eyre::eyre!(
-                "evaluating the tap definition for {name} requires Ruby; install Ruby or run the apply command"
-            )
-        }),
+    if let Some(ruby) = usable_system_ruby().await {
+        return Ok(ruby);
     }
+    if let Some(ruby) = super::source::installed_ruby_bin().await?
+        && ruby_is_compatible(&ruby).await
+    {
+        return Ok(ruby);
+    }
+    if provision_ruby {
+        let ruby = super::source::ruby_bin().await?;
+        if ruby_is_compatible(&ruby).await {
+            return Ok(ruby);
+        }
+    }
+    bail!(
+        "evaluating the tap definition for {name} requires Ruby 3 or newer; install a compatible Ruby or run the apply command"
+    )
 }
 
 fn github_repository<'a>(
@@ -301,7 +321,8 @@ mod tests {
             r#"
 class Widget < Formula
   desc "example"
-  url "https://example.com/widget-1.2.3.tar.gz"
+  version "1.2.3"
+  url "https://example.com/widget-#{version}.tar.gz"
   sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   depends_on "libfoo"
   depends_on "cmake" => :build
@@ -324,6 +345,10 @@ end
         let formula: Formula = serde_json::from_str(&crate::file::read_to_string(output)?)?;
         assert_eq!(formula.name, "widget");
         assert_eq!(formula.versions.stable.as_deref(), Some("1.2.3"));
+        assert_eq!(
+            formula.urls["stable"].url,
+            "https://example.com/widget-1.2.3.tar.gz"
+        );
         assert_eq!(formula.dependencies, ["libfoo"]);
         assert_eq!(formula.build_dependencies, ["cmake"]);
         assert!(formula.keg_only);
@@ -350,6 +375,9 @@ cask "widget" do
   depends_on formula: "libfoo"
   on_sonoma do
     url "https://example.com/wrong-platform.zip"
+  end
+  on_system macos: :ventura_or_newer do
+    url "https://example.com/also-wrong-platform.zip"
   end
   app "Widget.app"
   binary "Widget.app/Contents/MacOS/widget", target: "widget"
@@ -379,18 +407,45 @@ end
         Ok(())
     }
 
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
     fn metadata_evaluation_is_fully_sandboxed() {
         let config = metadata_sandbox(
             Path::new("/tmp/formula.rb"),
             Path::new("/tmp/shim.rb"),
             Path::new("/tmp/metadata.json"),
-        );
+        )
+        .unwrap();
         assert!(config.deny_read);
         assert!(config.deny_write);
         assert!(config.deny_net);
         assert!(config.deny_env);
         assert_eq!(config.allow_read.len(), 2);
         assert_eq!(config.allow_write.len(), 1);
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[tokio::test]
+    async fn metadata_sandbox_blocks_tap_writes() -> Result<()> {
+        let Some(ruby) = test_ruby().await? else {
+            return Ok(());
+        };
+        crate::file::create_dir_all(&*crate::env::HOME)?;
+        let dir = tempfile::Builder::new()
+            .prefix(".mise-tap-sandbox-")
+            .tempdir_in(&*crate::env::HOME)?;
+        let source = dir.path().join("malicious.rb");
+        let output = dir.path().join("metadata.json");
+        let denied = dir.path().join("denied");
+        crate::file::write(&source, "File.write(ARGV.fetch(0), 'escaped')")?;
+        crate::file::write(&output, "")?;
+        let mut runner = CmdLineRunner::new(ruby)
+            .arg(&source)
+            .arg(&denied)
+            .with_sandbox(metadata_sandbox(&source, &source, &output)?);
+        runner.apply_sandbox().await?;
+        assert!(runner.execute_async().await.is_err());
+        assert!(!denied.exists());
+        Ok(())
     }
 }

--- a/src/system/packages/brew/tap.rs
+++ b/src/system/packages/brew/tap.rs
@@ -49,9 +49,6 @@ pub(super) async fn formula_from_ruby(
     let checksum = crate::hash::hash_sha256_to_str(&source);
     let cache_dir = crate::dirs::CACHE.join("system-brew").join("formula");
     crate::file::create_dir_all(&cache_dir)?;
-    let formula_path = cache_dir.join(format!("{name}-{}.rb", &checksum[..12]));
-    crate::file::write(&formula_path, source)?;
-
     let output_path = cache_dir.join(format!("{name}-{}.json", &checksum[..12]));
     crate::file::write(&output_path, "")?;
     let ruby = ruby_for_metadata(name, provision_ruby).await?;
@@ -59,8 +56,8 @@ pub(super) async fn formula_from_ruby(
         .arg("--disable-gems")
         .arg("-e")
         .arg(METADATA_SHIM_RB)
+        .stdin_string(source)
         .envs([
-            ("MISE_BREW_FORMULA_FILE", formula_path.display().to_string()),
             (
                 "MISE_BREW_METADATA_OUTPUT",
                 output_path.display().to_string(),
@@ -74,7 +71,7 @@ pub(super) async fn formula_from_ruby(
             ("MISE_BREW_OS", std::env::consts::OS.to_string()),
             ("MISE_BREW_ARCH", std::env::consts::ARCH.to_string()),
         ])
-        .with_sandbox(metadata_sandbox(&formula_path, &output_path)?);
+        .with_sandbox(metadata_sandbox(&output_path)?);
     runner.apply_sandbox().await?;
     runner
         .execute_async()
@@ -105,8 +102,6 @@ pub(super) async fn cask_from_ruby(
     let checksum = crate::hash::hash_sha256_to_str(&source);
     let cache_dir = crate::dirs::CACHE.join("system-brew").join("cask-source");
     crate::file::create_dir_all(&cache_dir)?;
-    let cask_path = cache_dir.join(format!("{token}-{}.rb", &checksum[..12]));
-    crate::file::write(&cask_path, source)?;
     let output_path = cache_dir.join(format!("{token}-{}.json", &checksum[..12]));
     crate::file::write(&output_path, "")?;
     let ruby = ruby_for_metadata(token, provision_ruby).await?;
@@ -114,8 +109,8 @@ pub(super) async fn cask_from_ruby(
         .arg("--disable-gems")
         .arg("-e")
         .arg(CASK_METADATA_SHIM_RB)
+        .stdin_string(source)
         .envs([
-            ("MISE_BREW_CASK_FILE", cask_path.display().to_string()),
             (
                 "MISE_BREW_METADATA_OUTPUT",
                 output_path.display().to_string(),
@@ -128,7 +123,7 @@ pub(super) async fn cask_from_ruby(
             ("MISE_BREW_OS", std::env::consts::OS.to_string()),
             ("MISE_BREW_ARCH", std::env::consts::ARCH.to_string()),
         ])
-        .with_sandbox(metadata_sandbox(&cask_path, &output_path)?);
+        .with_sandbox(metadata_sandbox(&output_path)?);
     runner.apply_sandbox().await?;
     runner
         .execute_async()
@@ -140,8 +135,7 @@ pub(super) async fn cask_from_ruby(
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
-fn metadata_sandbox(source: &Path, output: &Path) -> Result<SandboxConfig> {
-    let source_alias = source.to_path_buf();
+fn metadata_sandbox(output: &Path) -> Result<SandboxConfig> {
     let output_alias = output.to_path_buf();
     let mut sandbox = SandboxConfig {
         deny_read: true,
@@ -150,14 +144,10 @@ fn metadata_sandbox(source: &Path, output: &Path) -> Result<SandboxConfig> {
         deny_env: true,
         deny_process: true,
         deny_temp_write: true,
-        allow_read: vec![source.to_path_buf()],
         allow_write: vec![output.to_path_buf()],
         ..Default::default()
     };
     sandbox.resolve_paths();
-    if !sandbox.allow_read.contains(&source_alias) {
-        sandbox.allow_read.push(source_alias);
-    }
     if !sandbox.allow_write.contains(&output_alias) {
         sandbox.allow_write.push(output_alias);
     }
@@ -165,7 +155,7 @@ fn metadata_sandbox(source: &Path, output: &Path) -> Result<SandboxConfig> {
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-fn metadata_sandbox(_source: &Path, _output: &Path) -> Result<SandboxConfig> {
+fn metadata_sandbox(_output: &Path) -> Result<SandboxConfig> {
     bail!(
         "evaluating third-party tap definitions is only supported inside the Linux or macOS process sandbox"
     )
@@ -360,7 +350,7 @@ end
             .arg("--disable-gems")
             .arg("-e")
             .arg(METADATA_SHIM_RB)
-            .env("MISE_BREW_FORMULA_FILE", &formula)
+            .stdin_string(crate::file::read_to_string(&formula)?)
             .env("MISE_BREW_METADATA_OUTPUT", &output)
             .env("MISE_BREW_NAME", "widget")
             .env("MISE_BREW_TAP", "acme/tools")
@@ -370,7 +360,7 @@ end
             .env("MISE_BREW_MACOS_VERSION", "15.3")
             .env("MISE_BREW_OS", "macos")
             .env("MISE_BREW_ARCH", std::env::consts::ARCH)
-            .with_sandbox(metadata_sandbox(&formula, &output)?);
+            .with_sandbox(metadata_sandbox(&output)?);
         runner.apply_sandbox().await?;
         runner.execute_async().await?;
         let formula: Formula = serde_json::from_str(&crate::file::read_to_string(output)?)?;
@@ -423,7 +413,7 @@ end
             .arg("--disable-gems")
             .arg("-e")
             .arg(CASK_METADATA_SHIM_RB)
-            .env("MISE_BREW_CASK_FILE", &cask_file)
+            .stdin_string(crate::file::read_to_string(&cask_file)?)
             .env("MISE_BREW_METADATA_OUTPUT", &output)
             .env("MISE_BREW_TOKEN", "widget")
             .env("MISE_BREW_SOURCE_PATH", "Casks/widget.rb")
@@ -432,7 +422,7 @@ end
             .env("MISE_BREW_MACOS_VERSION", "0")
             .env("MISE_BREW_OS", std::env::consts::OS)
             .env("MISE_BREW_ARCH", std::env::consts::ARCH)
-            .with_sandbox(metadata_sandbox(&cask_file, &output)?);
+            .with_sandbox(metadata_sandbox(&output)?);
         runner.apply_sandbox().await?;
         runner.execute_async().await?;
         let json = crate::file::read_to_string(output)?;
@@ -450,20 +440,12 @@ end
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
     fn metadata_evaluation_is_fully_sandboxed() {
-        let config = metadata_sandbox(
-            Path::new("/tmp/formula.rb"),
-            Path::new("/tmp/metadata.json"),
-        )
-        .unwrap();
+        let config = metadata_sandbox(Path::new("/tmp/metadata.json")).unwrap();
         assert!(config.deny_read);
         assert!(config.deny_write);
         assert!(config.deny_net);
         assert!(config.deny_env);
-        assert!(
-            config
-                .allow_read
-                .contains(&PathBuf::from("/tmp/formula.rb"))
-        );
+        assert!(config.allow_read.is_empty());
         assert!(
             config
                 .allow_write
@@ -509,7 +491,7 @@ end
             .arg("-e")
             .arg(script)
             .arg(&denied)
-            .with_sandbox(metadata_sandbox(&source, &output)?);
+            .with_sandbox(metadata_sandbox(&output)?);
         runner.apply_sandbox().await?;
         runner.execute_async().await?;
         assert!(!denied.exists());

--- a/src/system/packages/brew/tap.rs
+++ b/src/system/packages/brew/tap.rs
@@ -311,6 +311,7 @@ class Widget < Formula
   sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   depends_on "libfoo"
   depends_on "cmake" => :build
+  depends_on(**{"ninja" => :build})
   on_sequoia :or_older do
     depends_on "release-boundary"
   end
@@ -349,7 +350,7 @@ end
             formula.dependencies,
             ["libfoo", "release-boundary", "system-release-boundary"]
         );
-        assert_eq!(formula.build_dependencies, ["cmake"]);
+        assert_eq!(formula.build_dependencies, ["cmake", "ninja"]);
         assert!(formula.keg_only);
         assert!(formula.bottle.is_empty());
         Ok(())

--- a/src/system/packages/brew/tap_cask_metadata.rb
+++ b/src/system/packages/brew/tap_cask_metadata.rb
@@ -288,7 +288,7 @@ def cask(token, &block)
   $mise_cask_metadata.instance_eval(&block)
 end
 
-eval(STDIN.read, TOPLEVEL_BINDING, CASK_FILE, 1)
+eval(STDIN.read.force_encoding("UTF-8"), TOPLEVEL_BINDING, CASK_FILE, 1)
 metadata = $mise_cask_metadata
 raise "no cask block found" if metadata.nil?
 expected = ENV.fetch("MISE_BREW_TOKEN")

--- a/src/system/packages/brew/tap_cask_metadata.rb
+++ b/src/system/packages/brew/tap_cask_metadata.rb
@@ -2,16 +2,42 @@
 
 # Extract Homebrew Cask metadata used by mise without loading Homebrew.
 
-require "json"
-require "rbconfig"
-require "rubygems/version"
+module JSON
+  def self.generate(value)
+    case value
+    when Hash
+      "{#{value.map { |key, item| "#{generate(key.to_s)}:#{generate(item)}" }.join(",")}}"
+    when Array
+      "[#{value.map { |item| generate(item) }.join(",")}]"
+    when String
+      '"' + value.each_codepoint.map { |codepoint|
+        case codepoint
+        when 0x08 then "\\b"
+        when 0x09 then "\\t"
+        when 0x0a then "\\n"
+        when 0x0c then "\\f"
+        when 0x0d then "\\r"
+        when 0x22 then '\\"'
+        when 0x5c then "\\\\"
+        when 0...0x20 then format("\\u%04x", codepoint)
+        else codepoint.chr(Encoding::UTF_8)
+        end
+      }.join + '"'
+    when Numeric then value.to_s
+    when true then "true"
+    when false then "false"
+    when nil then "null"
+    else raise TypeError, "cannot encode #{value.class} as JSON"
+    end
+  end
+end
 
 CASK_FILE = ENV.fetch("MISE_BREW_CASK_FILE")
 OUTPUT_FILE = ENV.fetch("MISE_BREW_METADATA_OUTPUT")
 
 module OS
-  def self.mac? = RbConfig::CONFIG["host_os"].include?("darwin")
-  def self.linux? = RbConfig::CONFIG["host_os"].include?("linux")
+  def self.mac? = ENV.fetch("MISE_BREW_OS") == "macos"
+  def self.linux? = ENV.fetch("MISE_BREW_OS") == "linux"
 end
 
 class MacOSVersion
@@ -33,8 +59,12 @@ class MacOSVersion
   def <=>(other)
     other = self.class.from_symbol(other) if other.is_a?(Symbol)
     other = self.class.new(other.to_s) unless other.is_a?(MacOSVersion)
-    Gem::Version.new(@version) <=> Gem::Version.new(other.to_s)
+    version_parts <=> other.version_parts
   end
+
+  protected
+
+  def version_parts = @version.split(".").map(&:to_i)
 
   def same_release?(other)
     other = self.class.from_symbol(other) if other.is_a?(Symbol)
@@ -49,7 +79,7 @@ end
 
 module Hardware
   module CPU
-    def self.arm? = RbConfig::CONFIG["host_cpu"].match?(/arm|aarch64/)
+    def self.arm? = ENV.fetch("MISE_BREW_ARCH").match?(/arm|aarch64/)
     def self.intel? = !arm?
     def self.arch = arm? ? :arm64 : :x86_64
   end

--- a/src/system/packages/brew/tap_cask_metadata.rb
+++ b/src/system/packages/brew/tap_cask_metadata.rb
@@ -24,7 +24,7 @@ class MacOSVersion
   }.freeze
 
   def self.host
-    @host ||= new(OS.mac? ? `sw_vers -productVersion`.strip : "0")
+    @host ||= new(ENV.fetch("MISE_BREW_MACOS_VERSION"))
   end
 
   def self.from_symbol(symbol) = new(SYMBOLS.fetch(symbol.to_sym))

--- a/src/system/packages/brew/tap_cask_metadata.rb
+++ b/src/system/packages/brew/tap_cask_metadata.rb
@@ -1,0 +1,204 @@
+# frozen_string_literal: true
+
+# Extract Homebrew Cask metadata used by mise without loading Homebrew.
+
+require "json"
+require "rbconfig"
+
+CASK_FILE = ENV.fetch("MISE_BREW_CASK_FILE")
+OUTPUT_FILE = ENV.fetch("MISE_BREW_METADATA_OUTPUT")
+
+module OS
+  def self.mac? = RbConfig::CONFIG["host_os"].include?("darwin")
+  def self.linux? = RbConfig::CONFIG["host_os"].include?("linux")
+end
+
+module Hardware
+  module CPU
+    def self.arm? = RbConfig::CONFIG["host_cpu"].match?(/arm|aarch64/)
+    def self.intel? = !arm?
+    def self.arch = arm? ? :arm64 : :x86_64
+  end
+end
+
+class Version
+  def initialize(value) = @value = value.to_s
+  def to_s = @value
+  def to_str = @value
+  def csv = @value.split(",").map { |part| self.class.new(part) }
+  def before_comma = self.class.new(@value.split(",", 2).first)
+  def dots_to_underscores = @value.tr(".", "_")
+  def major = token(0)
+  def minor = token(1)
+  def patch = token(2)
+  def major_minor = self.class.new(@value.split(".")[0, 2].join("."))
+  def major_minor_patch = self.class.new(@value.split(".")[0, 3].join("."))
+
+  private
+
+  def token(index) = self.class.new(@value.split(".")[index].to_s)
+end
+
+class CaskMetadata
+  attr_reader :token, :artifacts, :formula_dependencies, :cask_dependencies,
+              :conflicting_casks
+
+  def initialize(token)
+    @token = token
+    @artifacts = []
+    @formula_dependencies = []
+    @cask_dependencies = []
+    @conflicting_casks = []
+    @auto_updates = false
+    @languages = {}
+  end
+
+  def version(value = nil)
+    @version = Version.new(value) unless value.nil?
+    @version
+  end
+
+  def arch(mapping = nil, **values)
+    mapping = values if mapping.nil? && values.any?
+    return @arch || Hardware::CPU.arch.to_s if mapping.nil?
+    @arch = Hardware::CPU.arm? ? mapping[:arm] || mapping["arm"] : mapping[:intel] || mapping["intel"]
+  end
+
+  def on_arch_conditional(values)
+    Hardware::CPU.arm? ? values[:arm] || values["arm"] : values[:intel] || values["intel"]
+  end
+
+  def sha256(value = nil, **values)
+    value = Hardware::CPU.arm? ? values[:arm] : values[:intel] if value.nil? && values.any?
+    @sha256 = value.to_s unless value.nil? || value == :no_check
+  end
+
+  def url(value = nil, **) = (@url = value.to_s unless value.nil?)
+  def auto_updates(value = nil) = (@auto_updates = value unless value.nil?)
+
+  def depends_on(values = nil, **kwargs)
+    values = kwargs if values.nil?
+    return unless values.is_a?(Hash)
+    @formula_dependencies.concat(Array(values[:formula] || values["formula"]).map(&:to_s))
+    @cask_dependencies.concat(Array(values[:cask] || values["cask"]).map(&:to_s))
+  end
+
+  def conflicts_with(values = nil, **kwargs)
+    values = kwargs if values.nil?
+    return unless values.is_a?(Hash)
+    @conflicting_casks.concat(Array(values[:cask] || values["cask"]).map(&:to_s))
+  end
+
+  def app(source, target: nil) = add_artifact("app", source, target)
+  def binary(source, target: nil) = add_artifact("binary", source, target)
+  def pkg(source, **) = add_artifact("pkg", source, nil)
+  def font(source, target: nil) = add_artifact("font", source, target)
+  def manpage(source, target: nil) = add_artifact("manpage", source, target)
+  def bash_completion(source, target: nil) = add_artifact("bash_completion", source, target)
+  def zsh_completion(source, target: nil) = add_artifact("zsh_completion", source, target)
+  def fish_completion(source, target: nil) = add_artifact("fish_completion", source, target)
+
+  def installer(**values) = @artifacts << { "installer" => values }
+  def artifact(source, target: nil) = add_artifact("artifact", source, target)
+  def uninstall(**values) = @artifacts << { "uninstall" => values }
+  def zap(**values) = @artifacts << { "zap" => values }
+  def preflight(*) = @artifacts << { "preflight" => nil }
+  def postflight(*) = @artifacts << { "postflight" => nil }
+  def uninstall_preflight(*) = @artifacts << { "uninstall_preflight" => nil }
+  def uninstall_postflight(*) = @artifacts << { "uninstall_postflight" => nil }
+
+  def language(code = nil, default: false, &block)
+    if code
+      @languages[code.to_s] = instance_eval(&block)
+      @default_language = code.to_s if default
+      return
+    end
+    @languages[@default_language] || @languages.values.first
+  end
+
+  def on_system_conditional(values)
+    values[OS.mac? ? :macos : :linux] || values[OS.mac? ? "macos" : "linux"]
+  end
+
+  def on_arm(&block)
+    instance_eval(&block) if Hardware::CPU.arm?
+  end
+
+  def on_intel(&block)
+    instance_eval(&block) if Hardware::CPU.intel?
+  end
+
+  def on_macos(&block)
+    instance_eval(&block) if OS.mac?
+  end
+
+  def on_linux(&block)
+    instance_eval(&block) if OS.linux?
+  end
+
+  %i[catalina big_sur monterey ventura sonoma sequoia tahoe].each do |release|
+    define_method(:"on_#{release}") do |comparison = nil, &block|
+      # Metadata is generated for the current host. Exact macOS release
+      # comparisons are handled by the install-time cask shim when hooks run.
+      instance_eval(&block) if OS.mac? && block && comparison != :or_older
+    end
+  end
+
+  def name(*) = nil
+  def desc(*) = nil
+  def homepage(*) = nil
+  def livecheck(*) = nil
+  def caveats(*) = nil
+  def container(*) = nil
+  def deprecate!(**) = nil
+  def disable!(**) = nil
+  def no_autobump!(*) = nil
+
+  def to_h
+    raise "cask has no version" if @version.nil?
+    raise "cask has no URL" if @url.to_s.empty?
+    {
+      "token" => @token,
+      "version" => @version.to_s,
+      "auto_updates" => @auto_updates,
+      "url" => @url,
+      "sha256" => @sha256,
+      "artifacts" => @artifacts,
+      "depends_on" => {
+        "formula" => @formula_dependencies,
+        "cask" => @cask_dependencies
+      },
+      "conflicts_with" => { "cask" => @conflicting_casks },
+      "ruby_source_path" => ENV.fetch("MISE_BREW_SOURCE_PATH"),
+      "ruby_source_checksum" => { "sha256" => ENV.fetch("MISE_BREW_SOURCE_CHECKSUM") },
+      "tap_git_head" => ENV.fetch("MISE_BREW_TAP_COMMIT")
+    }
+  end
+
+  def method_missing(name, *, &block)
+    return instance_eval(&block) if block && name.to_s.start_with?("on_")
+    raise "unsupported cask metadata DSL `#{name}`"
+  end
+
+  def respond_to_missing?(*) = true
+
+  private
+
+  def add_artifact(kind, source, target)
+    value = [source.to_s]
+    value << { "target" => target.to_s } unless target.nil?
+    @artifacts << { kind => value }
+  end
+end
+
+def cask(token, &block)
+  $mise_cask_metadata = CaskMetadata.new(token)
+  $mise_cask_metadata.instance_eval(&block)
+end
+
+load CASK_FILE
+metadata = $mise_cask_metadata
+raise "no cask block found" if metadata.nil?
+expected = ENV.fetch("MISE_BREW_TOKEN")
+raise "expected cask #{expected}, got #{metadata.token}" if metadata.token != expected
+File.write(OUTPUT_FILE, JSON.generate(metadata.to_h))

--- a/src/system/packages/brew/tap_cask_metadata.rb
+++ b/src/system/packages/brew/tap_cask_metadata.rb
@@ -4,6 +4,7 @@
 
 require "json"
 require "rbconfig"
+require "rubygems/version"
 
 CASK_FILE = ENV.fetch("MISE_BREW_CASK_FILE")
 OUTPUT_FILE = ENV.fetch("MISE_BREW_METADATA_OUTPUT")
@@ -11,6 +12,39 @@ OUTPUT_FILE = ENV.fetch("MISE_BREW_METADATA_OUTPUT")
 module OS
   def self.mac? = RbConfig::CONFIG["host_os"].include?("darwin")
   def self.linux? = RbConfig::CONFIG["host_os"].include?("linux")
+end
+
+class MacOSVersion
+  include Comparable
+
+  SYMBOLS = {
+    tahoe: "26", sequoia: "15", sonoma: "14", ventura: "13",
+    monterey: "12", big_sur: "11", catalina: "10.15", mojave: "10.14",
+    high_sierra: "10.13", sierra: "10.12", el_capitan: "10.11"
+  }.freeze
+
+  def self.host
+    @host ||= new(OS.mac? ? `sw_vers -productVersion`.strip : "0")
+  end
+
+  def self.from_symbol(symbol) = new(SYMBOLS.fetch(symbol.to_sym))
+  def initialize(version) = (@version = version.to_s)
+
+  def <=>(other)
+    other = self.class.from_symbol(other) if other.is_a?(Symbol)
+    other = self.class.new(other.to_s) unless other.is_a?(MacOSVersion)
+    Gem::Version.new(@version) <=> Gem::Version.new(other.to_s)
+  end
+
+  def same_release?(other)
+    other = self.class.from_symbol(other) if other.is_a?(Symbol)
+    other = self.class.new(other.to_s) unless other.is_a?(MacOSVersion)
+    mine = @version.split(".").map(&:to_i)
+    theirs = other.to_s.split(".").map(&:to_i)
+    mine[0] == theirs[0] && (mine[0] >= 11 || mine[1] == theirs[1])
+  end
+
+  def to_s = @version
 end
 
 module Hardware
@@ -70,7 +104,7 @@ class CaskMetadata
 
   def sha256(value = nil, **values)
     value = Hardware::CPU.arm? ? values[:arm] : values[:intel] if value.nil? && values.any?
-    @sha256 = value.to_s unless value.nil? || value == :no_check
+    @sha256 = value.to_s unless value.nil?
   end
 
   def url(value = nil, **) = (@url = value.to_s unless value.nil?)
@@ -136,11 +170,17 @@ class CaskMetadata
     instance_eval(&block) if OS.linux?
   end
 
-  %i[catalina big_sur monterey ventura sonoma sequoia tahoe].each do |release|
+  MacOSVersion::SYMBOLS.each_key do |release|
     define_method(:"on_#{release}") do |comparison = nil, &block|
-      # Metadata is generated for the current host. Exact macOS release
-      # comparisons are handled by the install-time cask shim when hooks run.
-      instance_eval(&block) if OS.mac? && block && comparison != :or_older
+      next unless OS.mac? && block
+      host = MacOSVersion.host
+      target = MacOSVersion.from_symbol(release)
+      matches = case comparison
+                when :or_older then host <= target
+                when :or_newer then host >= target
+                else host.same_release?(target)
+                end
+      instance_eval(&block) if matches
     end
   end
 

--- a/src/system/packages/brew/tap_cask_metadata.rb
+++ b/src/system/packages/brew/tap_cask_metadata.rb
@@ -33,7 +33,6 @@ module JSON
 end
 
 CASK_FILE = ENV.fetch("MISE_BREW_SOURCE_PATH")
-OUTPUT_FILE = ENV.fetch("MISE_BREW_METADATA_OUTPUT")
 
 module OS
   def self.mac? = ENV.fetch("MISE_BREW_OS") == "macos"
@@ -293,4 +292,4 @@ metadata = $mise_cask_metadata
 raise "no cask block found" if metadata.nil?
 expected = ENV.fetch("MISE_BREW_TOKEN")
 raise "expected cask #{expected}, got #{metadata.token}" if metadata.token != expected
-File.write(OUTPUT_FILE, JSON.generate(metadata.to_h))
+puts JSON.generate(metadata.to_h)

--- a/src/system/packages/brew/tap_cask_metadata.rb
+++ b/src/system/packages/brew/tap_cask_metadata.rb
@@ -20,7 +20,7 @@ module JSON
         when 0x22 then '\\"'
         when 0x5c then "\\\\"
         when 0...0x20 then format("\\u%04x", codepoint)
-        else codepoint.chr(Encoding::UTF_8)
+        else codepoint.chr("UTF-8")
         end
       }.join + '"'
     when Numeric then value.to_s

--- a/src/system/packages/brew/tap_cask_metadata.rb
+++ b/src/system/packages/brew/tap_cask_metadata.rb
@@ -62,8 +62,6 @@ class MacOSVersion
     version_parts <=> other.version_parts
   end
 
-  protected
-
   def version_parts = @version.split(".").map(&:to_i)
 
   def same_release?(other)

--- a/src/system/packages/brew/tap_cask_metadata.rb
+++ b/src/system/packages/brew/tap_cask_metadata.rb
@@ -182,7 +182,7 @@ class CaskMetadata
       host = MacOSVersion.host
       target = MacOSVersion.from_symbol(release)
       matches = case comparison
-                when :or_older then host <= target
+                when :or_older then host <= target || host.same_release?(target)
                 when :or_newer then host >= target
                 else host.same_release?(target)
                 end
@@ -202,7 +202,7 @@ class CaskMetadata
     host = MacOSVersion.host
     target = MacOSVersion.from_symbol(base)
     case comparison
-    when :or_older then host <= target
+    when :or_older then host <= target || host.same_release?(target)
     when :or_newer then host >= target
     else host.same_release?(target)
     end

--- a/src/system/packages/brew/tap_cask_metadata.rb
+++ b/src/system/packages/brew/tap_cask_metadata.rb
@@ -32,7 +32,7 @@ module JSON
   end
 end
 
-CASK_FILE = ENV.fetch("MISE_BREW_CASK_FILE")
+CASK_FILE = ENV.fetch("MISE_BREW_SOURCE_PATH")
 OUTPUT_FILE = ENV.fetch("MISE_BREW_METADATA_OUTPUT")
 
 module OS
@@ -288,7 +288,7 @@ def cask(token, &block)
   $mise_cask_metadata.instance_eval(&block)
 end
 
-eval(File.read(CASK_FILE), TOPLEVEL_BINDING, CASK_FILE, 1)
+eval(STDIN.read, TOPLEVEL_BINDING, CASK_FILE, 1)
 metadata = $mise_cask_metadata
 raise "no cask block found" if metadata.nil?
 expected = ENV.fetch("MISE_BREW_TOKEN")

--- a/src/system/packages/brew/tap_cask_metadata.rb
+++ b/src/system/packages/brew/tap_cask_metadata.rb
@@ -170,6 +170,12 @@ class CaskMetadata
     instance_eval(&block) if OS.linux?
   end
 
+  def on_system(*systems, macos: nil, &block)
+    run = systems.include?(:linux) && OS.linux?
+    run ||= OS.mac? && macos && macos_condition_matches?(macos)
+    instance_eval(&block) if run && block
+  end
+
   MacOSVersion::SYMBOLS.each_key do |release|
     define_method(:"on_#{release}") do |comparison = nil, &block|
       next unless OS.mac? && block
@@ -183,6 +189,25 @@ class CaskMetadata
       instance_eval(&block) if matches
     end
   end
+
+  def macos_condition_matches?(condition)
+    value = condition.to_s
+    base, comparison = if value.end_with?("_or_older")
+      [value.delete_suffix("_or_older"), :or_older]
+    elsif value.end_with?("_or_newer")
+      [value.delete_suffix("_or_newer"), :or_newer]
+    else
+      [value, :==]
+    end
+    host = MacOSVersion.host
+    target = MacOSVersion.from_symbol(base)
+    case comparison
+    when :or_older then host <= target
+    when :or_newer then host >= target
+    else host.same_release?(target)
+    end
+  end
+  private :macos_condition_matches?
 
   def name(*) = nil
   def desc(*) = nil
@@ -216,7 +241,6 @@ class CaskMetadata
   end
 
   def method_missing(name, *, &block)
-    return instance_eval(&block) if block && name.to_s.start_with?("on_")
     raise "unsupported cask metadata DSL `#{name}`"
   end
 

--- a/src/system/packages/brew/tap_cask_metadata.rb
+++ b/src/system/packages/brew/tap_cask_metadata.rb
@@ -290,7 +290,7 @@ def cask(token, &block)
   $mise_cask_metadata.instance_eval(&block)
 end
 
-load CASK_FILE
+eval(File.read(CASK_FILE), TOPLEVEL_BINDING, CASK_FILE, 1)
 metadata = $mise_cask_metadata
 raise "no cask block found" if metadata.nil?
 expected = ENV.fetch("MISE_BREW_TOKEN")

--- a/src/system/packages/brew/tap_formula_metadata.rb
+++ b/src/system/packages/brew/tap_formula_metadata.rb
@@ -26,7 +26,7 @@ class MacOSVersion
   }.freeze
 
   def self.host
-    @host ||= new(OS.mac? ? `sw_vers -productVersion`.strip : "0")
+    @host ||= new(ENV.fetch("MISE_BREW_MACOS_VERSION"))
   end
 
   def self.from_symbol(symbol) = new(SYMBOLS.fetch(symbol.to_sym))

--- a/src/system/packages/brew/tap_formula_metadata.rb
+++ b/src/system/packages/brew/tap_formula_metadata.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+# Extract the subset of Homebrew Formula metadata mise needs to build a
+# third-party formula from source. This does not load or invoke Homebrew.
+
+require "json"
+
+FORMULA_FILE = ENV.fetch("MISE_BREW_FORMULA_FILE")
+OUTPUT_FILE = ENV.fetch("MISE_BREW_METADATA_OUTPUT")
+FORMULA_NAME = ENV.fetch("MISE_BREW_NAME")
+
+module OS
+  def self.mac? = RUBY_PLATFORM.include?("darwin")
+  def self.linux? = RUBY_PLATFORM.include?("linux")
+end
+
+module Hardware
+  module CPU
+    def self.arm? = RUBY_PLATFORM.match?(/arm|aarch64/)
+    def self.intel? = !arm?
+    def self.arch = arm? ? :arm64 : :x86_64
+  end
+end
+
+class MetadataVersion
+  def initialize(value) = @value = value.to_s
+  def to_s = @value
+  def to_str = @value
+  def csv = @value.split(",").map { |part| self.class.new(part) }
+  def before_comma = self.class.new(@value.split(",", 2).first)
+  def dots_to_underscores = @value.tr(".", "_")
+  def major = self.class.new(@value.split(".")[0])
+  def minor = self.class.new(@value.split(".")[1])
+  def patch = self.class.new(@value.split(".")[2])
+  def major_minor = self.class.new(@value.split(".")[0, 2].join("."))
+  def major_minor_patch = self.class.new(@value.split(".")[0, 3].join("."))
+end
+
+class Formula
+  class << self
+    attr_reader :source_url, :source_sha256, :explicit_version, :revision_value,
+                :runtime_dependencies, :build_dependencies, :keg_only_value
+
+    def inherited(subclass)
+      Formula.instance_variable_set(:@subclass, subclass)
+      subclass.instance_variable_set(:@runtime_dependencies, [])
+      subclass.instance_variable_set(:@build_dependencies, [])
+      subclass.instance_variable_set(:@revision_value, 0)
+      subclass.instance_variable_set(:@keg_only_value, false)
+    end
+
+    def url(value = nil, **) = (@source_url = value unless value.nil?)
+    def mirror(*) = nil
+    def sha256(value = nil, **) = (@source_sha256 = value if value.is_a?(String))
+    def version(value = nil) = (@explicit_version = value.to_s unless value.nil?)
+    def revision(value = nil) = (@revision_value = value.to_i unless value.nil?)
+    def keg_only(*) = (@keg_only_value = true)
+
+    def depends_on(spec = nil, **)
+      name, kind = spec.is_a?(Hash) ? spec.first : [spec, nil]
+      return if name.nil?
+      return if kind == :test || Array(kind).all? { |value| value == :test }
+      target = kind == :build || Array(kind).include?(:build) ? @build_dependencies : @runtime_dependencies
+      target << name.to_s
+    end
+
+    def uses_from_macos(spec = nil, **)
+      depends_on(spec) if OS.linux?
+    end
+
+    def stable(&block)
+      class_exec(&block) if block
+    end
+
+    def on_macos(&block)
+      class_exec(&block) if OS.mac? && block
+    end
+
+    def on_linux(&block)
+      class_exec(&block) if OS.linux? && block
+    end
+
+    def on_arm(&block)
+      class_exec(&block) if Hardware::CPU.arm? && block
+    end
+
+    def on_intel(&block)
+      class_exec(&block) if Hardware::CPU.intel? && block
+    end
+    def on_system(*systems, macos: nil, &block)
+      class_exec(&block) if block && (systems.include?(:linux) && OS.linux? || macos && OS.mac?)
+    end
+
+    def resource(*) = nil
+    def patch(*) = nil
+    def bottle(*) = nil
+    def head(*) = nil
+    def livecheck(*) = nil
+    def service(*) = nil
+    def test(*) = nil
+    def method_missing(*) = nil
+    def respond_to_missing?(*) = true
+  end
+end
+
+def inferred_version(url)
+  basename = File.basename(url.to_s).sub(/\.(tar\.(gz|xz|bz2|zst)|tgz|txz|zip|gz)\z/i, "")
+  match = basename.match(/(?:^|[-_v])([0-9]+(?:\.[0-9A-Za-z]+)+(?:[-_.][0-9A-Za-z]+)*)/)
+  match && match[1]
+end
+
+load FORMULA_FILE
+klass = Formula.instance_variable_get(:@subclass)
+raise "no Formula subclass found" unless klass
+raise "formula has no stable URL" if klass.source_url.to_s.empty?
+raise "formula has no stable sha256" if klass.source_sha256.to_s.empty?
+version = klass.explicit_version || inferred_version(klass.source_url)
+raise "could not infer formula version; add an explicit version declaration" if version.to_s.empty?
+
+metadata = {
+  "name" => FORMULA_NAME,
+  "tap" => ENV.fetch("MISE_BREW_TAP"),
+  "versions" => { "stable" => version },
+  "revision" => klass.revision_value || 0,
+  "keg_only" => klass.keg_only_value || false,
+  "dependencies" => klass.runtime_dependencies || [],
+  "build_dependencies" => klass.build_dependencies || [],
+  "bottle" => {},
+  "urls" => { "stable" => { "url" => klass.source_url, "checksum" => klass.source_sha256 } },
+  "ruby_source_path" => ENV.fetch("MISE_BREW_SOURCE_PATH"),
+  "ruby_source_checksum" => { "sha256" => ENV.fetch("MISE_BREW_SOURCE_CHECKSUM") },
+  "tap_git_head" => ENV.fetch("MISE_BREW_TAP_COMMIT")
+}
+File.write(OUTPUT_FILE, JSON.generate(metadata))

--- a/src/system/packages/brew/tap_formula_metadata.rb
+++ b/src/system/packages/brew/tap_formula_metadata.rb
@@ -121,7 +121,8 @@ class Formula
     def revision(value = nil) = (@revision_value = value.to_i unless value.nil?)
     def keg_only(*) = (@keg_only_value = true)
 
-    def depends_on(spec = nil, **)
+    def depends_on(spec = nil, **options)
+      spec = options if spec.nil? && !options.empty?
       name, kind = spec.is_a?(Hash) ? spec.first : [spec, nil]
       return if name.nil?
       kinds = Array(kind)

--- a/src/system/packages/brew/tap_formula_metadata.rb
+++ b/src/system/packages/brew/tap_formula_metadata.rb
@@ -34,7 +34,6 @@ module JSON
 end
 
 FORMULA_FILE = ENV.fetch("MISE_BREW_SOURCE_PATH")
-OUTPUT_FILE = ENV.fetch("MISE_BREW_METADATA_OUTPUT")
 FORMULA_NAME = ENV.fetch("MISE_BREW_NAME")
 
 module OS
@@ -233,4 +232,4 @@ metadata = {
   "ruby_source_checksum" => { "sha256" => ENV.fetch("MISE_BREW_SOURCE_CHECKSUM") },
   "tap_git_head" => ENV.fetch("MISE_BREW_TAP_COMMIT")
 }
-File.write(OUTPUT_FILE, JSON.generate(metadata))
+puts JSON.generate(metadata)

--- a/src/system/packages/brew/tap_formula_metadata.rb
+++ b/src/system/packages/brew/tap_formula_metadata.rb
@@ -3,17 +3,43 @@
 # Extract the subset of Homebrew Formula metadata mise needs to build a
 # third-party formula from source. This does not load or invoke Homebrew.
 
-require "json"
-require "rbconfig"
-require "rubygems/version"
+module JSON
+  def self.generate(value)
+    case value
+    when Hash
+      "{#{value.map { |key, item| "#{generate(key.to_s)}:#{generate(item)}" }.join(",")}}"
+    when Array
+      "[#{value.map { |item| generate(item) }.join(",")}]"
+    when String
+      '"' + value.each_codepoint.map { |codepoint|
+        case codepoint
+        when 0x08 then "\\b"
+        when 0x09 then "\\t"
+        when 0x0a then "\\n"
+        when 0x0c then "\\f"
+        when 0x0d then "\\r"
+        when 0x22 then '\\"'
+        when 0x5c then "\\\\"
+        when 0...0x20 then format("\\u%04x", codepoint)
+        else codepoint.chr(Encoding::UTF_8)
+        end
+      }.join + '"'
+    when Numeric then value.to_s
+    when true then "true"
+    when false then "false"
+    when nil then "null"
+    else raise TypeError, "cannot encode #{value.class} as JSON"
+    end
+  end
+end
 
 FORMULA_FILE = ENV.fetch("MISE_BREW_FORMULA_FILE")
 OUTPUT_FILE = ENV.fetch("MISE_BREW_METADATA_OUTPUT")
 FORMULA_NAME = ENV.fetch("MISE_BREW_NAME")
 
 module OS
-  def self.mac? = RbConfig::CONFIG["host_os"].include?("darwin")
-  def self.linux? = RbConfig::CONFIG["host_os"].include?("linux")
+  def self.mac? = ENV.fetch("MISE_BREW_OS") == "macos"
+  def self.linux? = ENV.fetch("MISE_BREW_OS") == "linux"
 end
 
 class MacOSVersion
@@ -35,8 +61,12 @@ class MacOSVersion
   def <=>(other)
     other = self.class.from_symbol(other) if other.is_a?(Symbol)
     other = self.class.new(other.to_s) unless other.is_a?(MacOSVersion)
-    Gem::Version.new(@version) <=> Gem::Version.new(other.to_s)
+    version_parts <=> other.version_parts
   end
+
+  protected
+
+  def version_parts = @version.split(".").map(&:to_i)
 
   def same_release?(other)
     other = self.class.from_symbol(other) if other.is_a?(Symbol)
@@ -144,7 +174,7 @@ class Formula
       target = MacOSVersion.from_symbol(base)
       host = MacOSVersion.host
       case comparison
-      when :or_older then host <= target
+      when :or_older then host <= target || host.same_release?(target)
       when :or_newer then host >= target
       else host.same_release?(target)
       end
@@ -157,7 +187,7 @@ class Formula
         host = MacOSVersion.host
         target = MacOSVersion.from_symbol(release)
         matches = case comparison
-                  when :or_older then host <= target
+                  when :or_older then host <= target || host.same_release?(target)
                   when :or_newer then host >= target
                   else host.same_release?(target)
                   end

--- a/src/system/packages/brew/tap_formula_metadata.rb
+++ b/src/system/packages/brew/tap_formula_metadata.rb
@@ -64,8 +64,6 @@ class MacOSVersion
     version_parts <=> other.version_parts
   end
 
-  protected
-
   def version_parts = @version.split(".").map(&:to_i)
 
   def same_release?(other)
@@ -218,7 +216,7 @@ klass = Formula.instance_variable_get(:@subclass)
 raise "no Formula subclass found" unless klass
 raise "formula has no stable URL" if klass.source_url.to_s.empty?
 raise "formula has no stable sha256" if klass.source_sha256.to_s.empty?
-version = klass.explicit_version || inferred_version(klass.source_url)
+version = (klass.explicit_version || inferred_version(klass.source_url)).to_s
 raise "could not infer formula version; add an explicit version declaration" if version.to_s.empty?
 
 metadata = {

--- a/src/system/packages/brew/tap_formula_metadata.rb
+++ b/src/system/packages/brew/tap_formula_metadata.rb
@@ -122,7 +122,7 @@ class Formula
     def keg_only(*) = (@keg_only_value = true)
 
     def depends_on(spec = nil, **options)
-      spec = options if spec.nil? && !options.empty?
+      spec = options if spec.nil? && options.keys.any? { |key| key.is_a?(String) }
       name, kind = spec.is_a?(Hash) ? spec.first : [spec, nil]
       return if name.nil?
       kinds = Array(kind)

--- a/src/system/packages/brew/tap_formula_metadata.rb
+++ b/src/system/packages/brew/tap_formula_metadata.rb
@@ -21,7 +21,7 @@ module JSON
         when 0x22 then '\\"'
         when 0x5c then "\\\\"
         when 0...0x20 then format("\\u%04x", codepoint)
-        else codepoint.chr(Encoding::UTF_8)
+        else codepoint.chr("UTF-8")
         end
       }.join + '"'
     when Numeric then value.to_s

--- a/src/system/packages/brew/tap_formula_metadata.rb
+++ b/src/system/packages/brew/tap_formula_metadata.rb
@@ -4,14 +4,49 @@
 # third-party formula from source. This does not load or invoke Homebrew.
 
 require "json"
+require "rbconfig"
+require "rubygems/version"
 
 FORMULA_FILE = ENV.fetch("MISE_BREW_FORMULA_FILE")
 OUTPUT_FILE = ENV.fetch("MISE_BREW_METADATA_OUTPUT")
 FORMULA_NAME = ENV.fetch("MISE_BREW_NAME")
 
 module OS
-  def self.mac? = RUBY_PLATFORM.include?("darwin")
-  def self.linux? = RUBY_PLATFORM.include?("linux")
+  def self.mac? = RbConfig::CONFIG["host_os"].include?("darwin")
+  def self.linux? = RbConfig::CONFIG["host_os"].include?("linux")
+end
+
+class MacOSVersion
+  include Comparable
+
+  SYMBOLS = {
+    tahoe: "26", sequoia: "15", sonoma: "14", ventura: "13",
+    monterey: "12", big_sur: "11", catalina: "10.15", mojave: "10.14",
+    high_sierra: "10.13", sierra: "10.12", el_capitan: "10.11"
+  }.freeze
+
+  def self.host
+    @host ||= new(OS.mac? ? `sw_vers -productVersion`.strip : "0")
+  end
+
+  def self.from_symbol(symbol) = new(SYMBOLS.fetch(symbol.to_sym))
+  def initialize(version) = (@version = version.to_s)
+
+  def <=>(other)
+    other = self.class.from_symbol(other) if other.is_a?(Symbol)
+    other = self.class.new(other.to_s) unless other.is_a?(MacOSVersion)
+    Gem::Version.new(@version) <=> Gem::Version.new(other.to_s)
+  end
+
+  def same_release?(other)
+    other = self.class.from_symbol(other) if other.is_a?(Symbol)
+    other = self.class.new(other.to_s) unless other.is_a?(MacOSVersion)
+    mine = @version.split(".").map(&:to_i)
+    theirs = other.to_s.split(".").map(&:to_i)
+    mine[0] == theirs[0] && (mine[0] >= 11 || mine[1] == theirs[1])
+  end
+
+  def to_s = @version
 end
 
 module Hardware
@@ -59,8 +94,9 @@ class Formula
     def depends_on(spec = nil, **)
       name, kind = spec.is_a?(Hash) ? spec.first : [spec, nil]
       return if name.nil?
-      return if kind == :test || Array(kind).all? { |value| value == :test }
-      target = kind == :build || Array(kind).include?(:build) ? @build_dependencies : @runtime_dependencies
+      kinds = Array(kind)
+      return if kind == :test || (!kinds.empty? && kinds.all? { |value| value == :test })
+      target = kind == :build || kinds.include?(:build) ? @build_dependencies : @runtime_dependencies
       target << name.to_s
     end
 
@@ -88,7 +124,42 @@ class Formula
       class_exec(&block) if Hardware::CPU.intel? && block
     end
     def on_system(*systems, macos: nil, &block)
-      class_exec(&block) if block && (systems.include?(:linux) && OS.linux? || macos && OS.mac?)
+      run = systems.include?(:linux) && OS.linux?
+      run ||= OS.mac? && macos && macos_condition_matches?(macos)
+      class_exec(&block) if run && block
+    end
+
+    def macos_condition_matches?(condition)
+      value = condition.to_s
+      base, comparison = if value.end_with?("_or_older")
+        [value.delete_suffix("_or_older"), :or_older]
+      elsif value.end_with?("_or_newer")
+        [value.delete_suffix("_or_newer"), :or_newer]
+      else
+        [value, :==]
+      end
+      target = MacOSVersion.from_symbol(base)
+      host = MacOSVersion.host
+      case comparison
+      when :or_older then host <= target
+      when :or_newer then host >= target
+      else host.same_release?(target)
+      end
+    end
+    private :macos_condition_matches?
+
+    MacOSVersion::SYMBOLS.each_key do |release|
+      define_method(:"on_#{release}") do |comparison = nil, &block|
+        next unless OS.mac? && block
+        host = MacOSVersion.host
+        target = MacOSVersion.from_symbol(release)
+        matches = case comparison
+                  when :or_older then host <= target
+                  when :or_newer then host >= target
+                  else host.same_release?(target)
+                  end
+        class_exec(&block) if matches
+      end
     end
 
     def resource(*) = nil

--- a/src/system/packages/brew/tap_formula_metadata.rb
+++ b/src/system/packages/brew/tap_formula_metadata.rb
@@ -213,7 +213,7 @@ def inferred_version(url)
   match && match[1]
 end
 
-load FORMULA_FILE
+eval(File.read(FORMULA_FILE), TOPLEVEL_BINDING, FORMULA_FILE, 1)
 klass = Formula.instance_variable_get(:@subclass)
 raise "no Formula subclass found" unless klass
 raise "formula has no stable URL" if klass.source_url.to_s.empty?

--- a/src/system/packages/brew/tap_formula_metadata.rb
+++ b/src/system/packages/brew/tap_formula_metadata.rb
@@ -33,7 +33,7 @@ module JSON
   end
 end
 
-FORMULA_FILE = ENV.fetch("MISE_BREW_FORMULA_FILE")
+FORMULA_FILE = ENV.fetch("MISE_BREW_SOURCE_PATH")
 OUTPUT_FILE = ENV.fetch("MISE_BREW_METADATA_OUTPUT")
 FORMULA_NAME = ENV.fetch("MISE_BREW_NAME")
 
@@ -211,7 +211,7 @@ def inferred_version(url)
   match && match[1]
 end
 
-eval(File.read(FORMULA_FILE), TOPLEVEL_BINDING, FORMULA_FILE, 1)
+eval(STDIN.read, TOPLEVEL_BINDING, FORMULA_FILE, 1)
 klass = Formula.instance_variable_get(:@subclass)
 raise "no Formula subclass found" unless klass
 raise "formula has no stable URL" if klass.source_url.to_s.empty?

--- a/src/system/packages/brew/tap_formula_metadata.rb
+++ b/src/system/packages/brew/tap_formula_metadata.rb
@@ -87,7 +87,10 @@ class Formula
     def url(value = nil, **) = (@source_url = value unless value.nil?)
     def mirror(*) = nil
     def sha256(value = nil, **) = (@source_sha256 = value if value.is_a?(String))
-    def version(value = nil) = (@explicit_version = value.to_s unless value.nil?)
+    def version(value = nil)
+      @explicit_version = MetadataVersion.new(value) unless value.nil?
+      @explicit_version
+    end
     def revision(value = nil) = (@revision_value = value.to_i unless value.nil?)
     def keg_only(*) = (@keg_only_value = true)
 

--- a/src/system/packages/brew/tap_formula_metadata.rb
+++ b/src/system/packages/brew/tap_formula_metadata.rb
@@ -211,7 +211,7 @@ def inferred_version(url)
   match && match[1]
 end
 
-eval(STDIN.read, TOPLEVEL_BINDING, FORMULA_FILE, 1)
+eval(STDIN.read.force_encoding("UTF-8"), TOPLEVEL_BINDING, FORMULA_FILE, 1)
 klass = Formula.instance_variable_get(:@subclass)
 raise "no Formula subclass found" unless klass
 raise "formula has no stable URL" if klass.source_url.to_s.empty?

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -428,6 +428,8 @@ impl TaskExecutor {
             deny_write: task.deny_all || task.deny_write || self.sandbox.deny_write,
             deny_net: task.deny_all || task.deny_net || self.sandbox.deny_net,
             deny_env: task.deny_all || task.deny_env || self.sandbox.deny_env,
+            deny_process: false,
+            deny_temp_write: false,
             allow_read: task
                 .allow_read
                 .iter()

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -430,6 +430,7 @@ impl TaskExecutor {
             deny_env: task.deny_all || task.deny_env || self.sandbox.deny_env,
             deny_process: false,
             deny_temp_write: false,
+            allow_exec: vec![],
             allow_read: task
                 .allow_read
                 .iter()

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -430,7 +430,6 @@ impl TaskExecutor {
             deny_env: task.deny_all || task.deny_env || self.sandbox.deny_env,
             deny_process: false,
             deny_temp_write: false,
-            allow_exec: vec![],
             allow_read: task
                 .allow_read
                 .iter()


### PR DESCRIPTION
## Summary
- fall back from missing tap API JSON to commit-pinned `Formula/*.rb` and `Casks/*.rb` definitions
- extract install metadata with mise-owned Ruby DSL shims without invoking Homebrew
- build fallback formulae from source and feed fallback casks through the existing validated installer
- avoid provisioning Ruby for read-only/dry-run operations when no usable Ruby is already installed
- update the tap documentation to describe the working fallback

This addresses the practical limitation documented in #12644: ordinary taps generally publish Ruby definitions but no Homebrew API metadata. Published JSON remains the preferred fast path.

## Verification
- `mise run lint-fix`
- `MBX_DISABLE=1 mise exec -- cargo test --all-features tap::tests`
- `mise x ruby@3.4 -- ruby -c src/system/packages/brew/tap_formula_metadata.rb`
- `mise x ruby@3.4 -- ruby -c src/system/packages/brew/tap_cask_metadata.rb`
- `target/debug/mise bootstrap packages apply --dry-run brew:jdx/tap/aube` resolves the live Ruby-only tap and plans `build aube/2.2.9 from source`
- a live Ruby-only cask resolves through metadata extraction and reaches the expected Linux platform-support check

The first wrapped Cargo test attempt hit an mbx/CMake cache mismatch while building `aws-lc-sys`; rerunning the equivalent test with `MBX_DISABLE=1` passed.

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces execution of fetched tap Ruby inside new process/filesystem restrictions and changes brew/cask metadata resolution; mistakes in sandbox or DSL evaluation could break installs or weaken isolation.
> 
> **Overview**
> Adds a **fallback path for third-party Homebrew taps** when published `api/formula` / `api/cask` JSON is missing: mise pins a tap commit, downloads `Formula/*.rb` or `Casks/*.rb`, and extracts install metadata via new Ruby DSL shims (`tap.rs`, `tap_formula_metadata.rb`, `tap_cask_metadata.rb`)—still without calling `brew`. Resolution and install flows thread a `provision_ruby` flag so dry-run/status can avoid provisioning Ruby when none is already available; real applies can build formulae from source and route casks through the existing installer.
> 
> **Sandbox and command plumbing** gain internal-only `deny_process` and `deny_temp_write` so tap metadata evaluation runs under tight Linux (Landlock + seccomp) and macOS (Seatbelt) rules: block fork/exec and extra writes except the initial Ruby binary, with optional removal of the usual writable `/tmp` exception. `CmdLineRunner::read_bounded` caps stdout/stderr for that path; macOS `sandbox-exec` wrapping now preserves piped stdin when needed.
> 
> Docs in `brew.md` describe API-first resolution and the Ruby fallback. Task/`mise run`/`mise exec` sandboxes explicitly leave the new flags disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e5453834947be4760f83d67c11e4b1850ab6eed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for installing third-party Homebrew tap formulas and casks without published API metadata.
  - Tap definitions can be evaluated from pinned Ruby sources, enabling formula builds from source without invoking Homebrew.
  - Added support for using an available Ruby runtime or provisioning one when needed.
  - Added clear errors for unsupported, unsafe, or invalid tap definitions.
  - Improved sandbox controls for restricting process execution and temporary-directory writes.

- **Documentation**
  - Updated Homebrew tap documentation with resolution paths, limitations, and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->