### PR TITLE
registry: add buildprof

### DIFF
--- a/registry/buildprof.toml
+++ b/registry/buildprof.toml
@@ -1,0 +1,6 @@
+backends = ["github:LalitMaganti/buildprof"]
+bins = ["buildprof"]
+description = "Profiler for software builds that records every process and file access and shows the build on an interactive timeline"
+os = ["linux", "macos"]
+test = { cmd = "buildprof --version", expected = "buildprof {{version}}" }
+version_order = "semver"


### PR DESCRIPTION
Adds [buildprof](https://github.com/LalitMaganti/buildprof), a profiler for software builds, via the GitHub backend.

Releases ship `buildprof-<target>.tar.xz` for x86_64/aarch64 Linux (glibc and musl) and macOS, with `sha256.sum` and provenance attestations; the backend's platform scoring picks the glibc build on Linux.

Verified locally:

```
$ mise install github:LalitMaganti/buildprof@0.2.1
mise github:LalitMaganti/buildprof@0.2.1 ✓ installed
$ mise exec github:LalitMaganti/buildprof@0.2.1 -- buildprof --version
buildprof 0.2.1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing and managing the `buildprof` tool on Linux and macOS.
  * Added version verification and semantic version ordering for `buildprof`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->