### PR TITLE
registry: compile baked registry in release tests

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -26,7 +26,7 @@ use url::Url;
 // the registry is generated from registry/ in the project root
 static BAKED_REGISTRY: Registry = include!(concat!(env!("OUT_DIR"), "/registry.rs"));
 
-#[cfg(debug_assertions)]
+#[cfg(any(test, debug_assertions))]
 pub(crate) fn baked_registry() -> &'static Registry {
     &BAKED_REGISTRY
 }


### PR DESCRIPTION
`baked_registry()` is imported by the `#[cfg(test)]` registry tests, but is currently compiled only when `debug_assertions` is enabled.

This makes `cargo test --release` fail with an unresolved import, since test code is enabled while debug assertions are disabled.

Compile the helper when either tests or debug assertions are enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * The built-in registry is now available in test configurations, enabling broader validation during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->