### PR TITLE
feat(backend): apply install_env when resolving and downloading tools

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -194,7 +194,7 @@ See [Tools](/dev-tools/). In addition to specifying versions, each tool entry ca
 
 - `os`: Restrict installation to certain operating systems
 - `depends`: Install order relative to other tools in this config only; vfox plugin hook dependencies belong in plugin `metadata.lua` (see [Tool Dependencies](/dev-tools/#tool-dependencies))
-- `install_env`: Environment vars used during install and tool-level `postinstall`
+- `install_env`: Environment vars used during download, install, and tool-level `postinstall`
 - `postinstall`: Command to run after installation completes for that specific tool
 
 Examples:

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3406,7 +3406,10 @@ pub(crate) trait Backend: Debug + Send + Sync {
         self.create_install_dirs(&tv)?;
 
         let old_tv = tv.clone();
-        let tv = match self.install_version_(&ctx, tv).await {
+        let install_env = tv.install_env();
+        let tv = match crate::env::with_install_env(install_env, self.install_version_(&ctx, tv))
+            .await
+        {
             Ok(tv) => tv,
             Err(e) => {
                 self.cleanup_install_dirs_on_error(&old_tv);

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,4 +1,5 @@
 use crate::Result;
+use crate::config::env_directive::EnvValue;
 use crate::config::miserc;
 use crate::env_diff::{EnvDiff, EnvMap};
 use crate::file::replace_path;
@@ -19,6 +20,30 @@ use std::{
 };
 use std::{path::Path, string::ToString};
 use std::{path::PathBuf, sync::atomic::AtomicBool};
+
+tokio::task_local! {
+    static INSTALL_ENV: IndexMap<String, EnvValue>;
+}
+
+/// Overlays a tool's `install_env` on the process env for the duration of `future`,
+/// so anything it does reads that tool's values through [`scoped_var`].
+pub(crate) async fn with_install_env<T>(
+    env: IndexMap<String, EnvValue>,
+    future: impl std::future::Future<Output = T>,
+) -> T {
+    INSTALL_ENV.scope(env, future).await
+}
+
+/// Reads an env var through the active [`with_install_env`] overlay, falling back to the
+/// process env. Blank reads as unset, as does an `install_env` entry set to `false`.
+pub(crate) fn scoped_var(key: &str) -> Option<String> {
+    match INSTALL_ENV.try_with(|env| env.get(key).cloned()) {
+        Ok(Some(value)) => value.into_string(),
+        _ => std::env::var(key).ok(),
+    }
+    .map(|value| value.trim().to_string())
+    .filter(|value| !value.is_empty())
+}
 
 pub(crate) static ARGS: RwLock<Vec<String>> = RwLock::new(vec![]);
 pub(crate) static TOOL_ARGS: RwLock<Vec<ToolArg>> = RwLock::new(vec![]);
@@ -811,8 +836,6 @@ pub(crate) static GITLAB_TOKEN: Lazy<Option<String>> =
     Lazy::new(|| get_token(&["MISE_GITLAB_TOKEN", "GITLAB_TOKEN"]));
 pub(crate) static MISE_GITLAB_ENTERPRISE_TOKEN: Lazy<Option<String>> =
     Lazy::new(|| get_token(&["MISE_GITLAB_ENTERPRISE_TOKEN"]));
-pub(crate) static MISE_FORGEJO_ENTERPRISE_TOKEN: Lazy<Option<String>> =
-    Lazy::new(|| get_token(&["MISE_FORGEJO_ENTERPRISE_TOKEN"]));
 
 pub(crate) static TEST_TRANCHE: Lazy<usize> = Lazy::new(|| var_u8("TEST_TRANCHE") as usize);
 pub(crate) static TEST_TRANCHE_COUNT: Lazy<usize> =

--- a/src/forgejo.rs
+++ b/src/forgejo.rs
@@ -250,20 +250,13 @@ pub(crate) fn resolve_token(host: &str) -> Option<(String, TokenSource)> {
     let is_codeberg = host == "codeberg.org";
 
     // 1. Enterprise token (non-codeberg.org only)
-    if !is_codeberg && let Some(token) = env::MISE_FORGEJO_ENTERPRISE_TOKEN.as_deref() {
-        return Some((
-            token.to_string(),
-            TokenSource::EnvVar("MISE_FORGEJO_ENTERPRISE_TOKEN"),
-        ));
+    if !is_codeberg && let Some(token) = env::scoped_var("MISE_FORGEJO_ENTERPRISE_TOKEN") {
+        return Some((token, TokenSource::EnvVar("MISE_FORGEJO_ENTERPRISE_TOKEN")));
     }
 
     // 2. Standard env vars
     for var_name in &["MISE_FORGEJO_TOKEN", "FORGEJO_TOKEN"] {
-        if let Some(tok) = std::env::var(var_name)
-            .ok()
-            .map(|t| t.trim().to_string())
-            .filter(|t| !t.is_empty())
-        {
+        if let Some(tok) = env::scoped_var(var_name) {
             return Some((tok, TokenSource::EnvVar(var_name)));
         }
     }

--- a/src/github.rs
+++ b/src/github.rs
@@ -686,20 +686,13 @@ pub(crate) fn resolve_token(host: &str) -> Option<(String, TokenSource)> {
     let lookup_hosts = token_lookup_hosts(host);
 
     // 1. Enterprise token (non-github.com only)
-    if !is_ghcom && let Some(token) = env::MISE_GITHUB_ENTERPRISE_TOKEN.as_deref() {
-        return Some((
-            token.to_string(),
-            TokenSource::EnvVar("MISE_GITHUB_ENTERPRISE_TOKEN"),
-        ));
+    if !is_ghcom && let Some(token) = env::scoped_var("MISE_GITHUB_ENTERPRISE_TOKEN") {
+        return Some((token, TokenSource::EnvVar("MISE_GITHUB_ENTERPRISE_TOKEN")));
     }
 
     // 2. Standard env vars (checked individually for correct precedence and source reporting)
     for var_name in GITHUB_TOKEN_ENV_VARS {
-        if let Some(token) = std::env::var(var_name)
-            .ok()
-            .map(|t| t.trim().to_string())
-            .filter(|t| !t.is_empty())
-        {
+        if let Some(token) = env::scoped_var(var_name) {
             return Some((token, TokenSource::EnvVar(var_name)));
         }
     }
@@ -1289,6 +1282,42 @@ something_else = "value"
             published_at: None,
             assets: vec![],
         }
+    }
+
+    #[tokio::test]
+    async fn test_download_uses_scoped_install_env() {
+        let _token = GithubTokenGuard::new();
+        let _config = crate::config::Config::get().await.unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let api_url = ghes_api_url(&server.url());
+        let install_env = [(
+            "GITHUB_TOKEN".to_string(),
+            crate::config::env_directive::EnvValue::from(false),
+        )]
+        .into_iter()
+        .collect();
+        let mock = server
+            .mock("GET", format!("{API_PATH}/download").as_str())
+            .match_header("authorization", mockito::Matcher::Missing)
+            .with_status(200)
+            .with_body("download")
+            .expect(1)
+            .create_async()
+            .await;
+        let tempdir = tempfile::tempdir().unwrap();
+
+        crate::env::with_install_env(install_env, async {
+            crate::http::HTTP
+                .download_file(
+                    format!("{api_url}/download"),
+                    &tempdir.path().join("file"),
+                    None,
+                )
+                .await
+        })
+        .await
+        .unwrap();
+        mock.assert_async().await;
     }
 
     #[test]

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -356,20 +356,13 @@ pub(crate) fn resolve_token(host: &str) -> Option<(String, TokenSource)> {
     let is_gitlab_com = host == "gitlab.com";
 
     // 1. Enterprise token (non-gitlab.com only)
-    if !is_gitlab_com && let Some(token) = env::MISE_GITLAB_ENTERPRISE_TOKEN.as_deref() {
-        return Some((
-            token.to_string(),
-            TokenSource::EnvVar("MISE_GITLAB_ENTERPRISE_TOKEN"),
-        ));
+    if !is_gitlab_com && let Some(token) = env::scoped_var("MISE_GITLAB_ENTERPRISE_TOKEN") {
+        return Some((token, TokenSource::EnvVar("MISE_GITLAB_ENTERPRISE_TOKEN")));
     }
 
     // 2. Standard env vars
     for var_name in &["MISE_GITLAB_TOKEN", "GITLAB_TOKEN"] {
-        if let Some(token) = std::env::var(var_name)
-            .ok()
-            .map(|t| t.trim().to_string())
-            .filter(|t| !t.is_empty())
-        {
+        if let Some(token) = env::scoped_var(var_name) {
             return Some((token, TokenSource::EnvVar(var_name)));
         }
     }

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -2854,7 +2854,12 @@ pub(crate) async fn resolve_tool_lock_info(
                 );
             }
         };
-        match backend.resolve_lock_info(&tv, &target).await {
+        match crate::env::with_install_env(
+            tv.install_env(),
+            backend.resolve_lock_info(&tv, &target),
+        )
+        .await
+        {
             Ok(info) => {
                 let conda_packages = if backend.get_type() == BackendType::Conda {
                     let conda_backend = CondaBackend::from_arg(ba.clone());

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -98,6 +98,15 @@ impl ToolVersion {
         request: ToolRequest,
         opts: &ResolveOptions,
     ) -> Result<Self> {
+        let install_env = request.options().core.install_env;
+        crate::env::with_install_env(install_env, Self::resolve_(config, request, opts)).await
+    }
+
+    async fn resolve_(
+        config: &Arc<Config>,
+        request: ToolRequest,
+        opts: &ResolveOptions,
+    ) -> Result<Self> {
         let minimum_release_age = request.options().minimum_release_age().map(str::to_string);
         let mut opts = opts.clone();
         opts.apply_before_date_for_tool(request.ba(), minimum_release_age.as_deref())?;


### PR DESCRIPTION
`install_env` reached install commands and tool-level `postinstall` hooks, but not the
API calls and downloads mise makes on a tool's behalf. An inherited `GITHUB_TOKEN` still
authenticated those, which breaks a GitHub Enterprise install when the instance rejects
the token:

```toml
[tools]
"github:acme/internal-tool" = { version = "v1.2.3", api_url = "https://github.acme.test/api/v3", install_env = { GITHUB_TOKEN = false } }
```

A tool's `install_env` is now overlaid on the process env for the whole version
resolution, install, and lock path, and GitHub/GitLab/Forgejo token resolution reads
through that overlay — so a tool can drop or replace inherited credentials. The overlay
is a `tokio` task-local, so it applies per tool and works with parallel installs.

Verified against a real GitHub Enterprise instance with a bogus `GITHUB_TOKEN` exported
and `install_env = { GITHUB_TOKEN = false }` on the tool: `main` fails with `401 Bad
credentials` while listing releases; this branch resolves, downloads, verifies the
checksum and SLSA provenance, and installs.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-sonnet-5; version: 2.1.260.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tool-specific `install_env` variables now apply consistently during tool resolution, downloads, installation, lockfile checks, and tool-level postinstall steps.
  - GitHub, GitLab, and Forgejo authentication now respects these scoped installation environments.
  - Environment variable values are trimmed, and blank or disabled values are ignored.

- **Documentation**
  - Clarified that `install_env` variables are used during downloads, installation, and tool-level postinstall steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->