### PR TITLE
feat(packslip): install only what a trusted stamper lists

### DIFF
--- a/docs/dev-tools/backends/packslip.md
+++ b/docs/dev-tools/backends/packslip.md
@@ -86,6 +86,32 @@ For a project on its own domain signed keylessly, or to override the identity a 
 
 Accept a key-signed bundle that carries no transparency log entry, which a vendor produces for an air-gapped release. Off by default; turn it on only for a vendor you have agreed to accept that from.
 
+### `trust`
+
+`trust = "vendor"` takes the vendor's own manifest under the vendor's pin, with no stamp from the hosts [`packslip.stampers`](/configuration/settings#packslip-stampers) names. See Stamps below. The choice is recorded in the lockfile, so an install from the lock does not quietly relax it later.
+
+```toml
+[tools]
+"packslip:github.com/jdx/mise" = { version = "latest", trust = "vendor" }
+```
+
+## Stamps
+
+A vendor's packslip proves what the vendor shipped. It does not say whether anyone else looked at it. A stamping host, a registry, a mirror, or a scanning service, publishes its own signed release list per vendor project at `https://<host>/.well-known/packslip/<project>.json`, naming the versions it checked, pinning the digest of each packslip it looked at, and saying what it checked. The [`packslip.stampers`](/configuration/settings#packslip-stampers) setting names the hosts you trust, each with its pin:
+
+```toml
+[settings.packslip]
+stampers = ["registry.mise.jdx.dev=RWQ..."]
+```
+
+With hosts named, mise offers and installs a packslip tool only at versions one of them lists. A version no trusted host stamped is not shown by `mise ls-remote` and is refused by `mise install`, however valid the vendor's own manifest is; a version a host withdrew is refused with the host's reason. Any one host's stamp suffices. The stamp points at the manifest it admitted, so mise fetches that exact file, checks it against the digest the host recorded, and then verifies it against the vendor's pin as always: the stamp never stands in for the vendor's signature.
+
+Each host's list carries an expiry and a sequence number. mise refuses a list that has expired, and remembers the highest sequence it accepted per host and project so a replayed older list is refused as a rollback.
+
+A mirror is a stamping host whose entries point at manifests it signed itself, carrying the vendor's digests with the mirror's own download URLs. Name it as the only stamper and you get its curated versions and its bytes.
+
+Unset, no stamps are required and every version the vendor published is offered. mise's own registry host will become the default once it publishes stamps.
+
 ## Completions
 
 A packslip may list what the release ships besides its executables: shell completions, a spec of the CLI, an agent skill. mise reads those `resources` for tools it installed this way.

--- a/docs/dev-tools/backends/packslip.md
+++ b/docs/dev-tools/backends/packslip.md
@@ -104,7 +104,7 @@ A vendor's packslip proves what the vendor shipped. It does not say whether anyo
 stampers = ["registry.mise.jdx.dev=RWQ..."]
 ```
 
-With hosts named, mise offers and installs a packslip tool only at versions one of them lists. A version no trusted host stamped is not shown by `mise ls-remote` and is refused by `mise install`, however valid the vendor's own manifest is; a version a host withdrew is refused with the host's reason. Any one host's stamp suffices. The stamp points at the manifest it admitted, so mise fetches that exact file, checks it against the digest the host recorded, and then verifies it against the vendor's pin as always: the stamp never stands in for the vendor's signature.
+With hosts named, mise offers and installs a packslip tool only at versions one of them lists. A version no trusted host stamped is not shown by `mise ls-remote` and is refused by `mise install`, however valid the vendor's own manifest is; a version a host withdrew is refused with the host's reason. Any one host's stamp suffices. The stamp points at the manifest it admitted, so mise fetches that exact file, checks it against the digest the host recorded, and then verifies it against the vendor's pin as always: the stamp never stands in for the vendor's signature. A stamp that records no digest is refused — the digest is what ties the host's review to a file, and without one the entry admits a URL rather than a manifest.
 
 Each host's list carries an expiry and a sequence number. mise refuses a list that has expired, and remembers the highest sequence it accepted per host and project so a replayed older list is refused as a rollback.
 

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1441,6 +1441,13 @@
               "default": false,
               "description": "Run a tool's own command at install time to produce a resource its packslip offers only as an exec entry, such as an agent skill.",
               "type": "boolean"
+            },
+            "stampers": {
+              "description": "Hosts whose signed stamp lists say which packslip releases may be installed, each with its pin.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         },

--- a/settings.toml
+++ b/settings.toml
@@ -2128,6 +2128,48 @@ to run the tool anyway, and caches the script beside the install.
 env = "MISE_PACKSLIP_EXEC"
 type = "Bool"
 
+[packslip.stampers]
+description = "Hosts whose signed stamp lists say which packslip releases may be installed, each with its pin."
+docs = """
+A stamping host, a registry, a mirror, or a scanning service, publishes a
+signed release list per vendor project at
+`https://<host>/.well-known/packslip/<project>.json`, naming the versions it
+checked and what it checked. When this setting names hosts, mise installs a
+packslip tool only at a version one of them lists: a version no trusted host
+stamped is not offered and not installed, however valid the vendor's own
+manifest is, and a version a host withdrew is refused. Any one host's stamp
+suffices.
+
+Each entry is `host=PIN`, where the pin is the minisign-format public key the
+host signs with, the path of that `.pub` file, or, for a host that signs
+keylessly from GitHub, an identity prefix such as
+`https://github.com/org/registry/`:
+
+```toml
+[settings.packslip]
+stampers = [
+  "registry.mise.jdx.dev=RWQ...",
+  "stamps.example.com=https://github.com/example/stamps/",
+]
+```
+
+A tool whose options say `trust = "vendor"` takes the vendor's own manifest
+under the vendor's pin, with no stamp:
+
+```toml
+[tools]
+"packslip:github.com/jdx/mise" = { version = "latest", trust = "vendor" }
+```
+
+Unset, no stamps are required. mise's own registry host will become the
+default once it publishes stamps.
+"""
+env = "MISE_PACKSLIP_STAMPERS"
+optional = true
+parse_env = "list_by_comma"
+rust_type = "Vec<String>"
+type = "ListString"
+
 [paranoid]
 description = "Enables extra-secure behavior."
 docs = """

--- a/src/backend/packslip.rs
+++ b/src/backend/packslip.rs
@@ -825,10 +825,23 @@ impl Backend for PackslipBackend {
                     stamp.host,
                     stamp.entry.packslip
                 );
+                // A stamp says a host reviewed this manifest, and the digest is
+                // the whole of what ties the claim to a file. Without one the
+                // stamp admits a URL, and any later manifest the vendor signs
+                // for this version can stand at it in place of the reviewed
+                // one — so refuse rather than call that a review.
+                let Some(digest) = stamp.digest.clone() else {
+                    bail!(
+                        "the stamp for packslip:{project}@{} from {} records no sha256 for {}, so nothing says the manifest is the one that host reviewed",
+                        tv.version,
+                        stamp.host,
+                        stamp.entry.packslip
+                    );
+                };
                 Located {
                     headers: headers_for(&stamp.entry.packslip)?,
                     url: stamp.entry.packslip.clone(),
-                    digest: stamp.digest.clone(),
+                    digest: Some(digest),
                 }
             }
             None => self.locate_bundle(&project, &tv, &pin, &opts).await?,

--- a/src/backend/packslip.rs
+++ b/src/backend/packslip.rs
@@ -96,6 +96,12 @@ impl<'a> PackslipOptions<'a> {
     fn allow_unlogged(&self) -> bool {
         matches!(self.raw.get("allow_unlogged"), Some("true"))
     }
+
+    /// `vendor` takes the vendor's own manifest with no stamp from the
+    /// hosts `packslip.stampers` names.
+    fn trust(&self) -> Option<String> {
+        self.raw.get_string("trust")
+    }
 }
 
 pub(crate) fn install_time_option_keys() -> Vec<String> {
@@ -106,6 +112,7 @@ pub(crate) fn install_time_option_keys() -> Vec<String> {
         "identity_prefix",
         "issuer",
         "allow_unlogged",
+        "trust",
     ]
     .iter()
     .map(|s| s.to_string())
@@ -335,7 +342,7 @@ fn locate_entry(install_path: &Path, rel: &str, wanted: fn(&Path) -> bool) -> Op
 
 /// What the consumer pinned: the forge identity a name implies, or the key
 /// or identity given in the tool options.
-enum Pin {
+pub(crate) enum Pin {
     Identity(Policy),
     Key(packslip::minisign::PublicKey),
 }
@@ -394,7 +401,11 @@ fn verify_bundle(
     })
 }
 
-fn verify_release_list(bundle: &str, pin: &Pin, require_log: bool) -> Result<ReleaseListStatement> {
+pub(crate) fn verify_release_list(
+    bundle: &str,
+    pin: &Pin,
+    require_log: bool,
+) -> Result<ReleaseListStatement> {
     file::run_blocking(|| {
         let root = packslip::sigstore::trusted_root(None).map_err(|e| eyre!("{e}"))?;
         let options = packslip::Options {
@@ -668,40 +679,9 @@ impl PackslipBackend {
         }
         Ok(())
     }
-}
 
-#[async_trait]
-impl Backend for PackslipBackend {
-    fn get_type(&self) -> BackendType {
-        BackendType::Packslip
-    }
-
-    fn ba(&self) -> &Arc<BackendArg> {
-        &self.ba
-    }
-
-    async fn security_info(&self) -> Vec<SecurityFeature> {
-        vec![SecurityFeature::Packslip]
-    }
-
-    /// A packslip version is semver, and the specification ranks releases
-    /// by semver precedence, never by the order a release list gives.
-    fn version_order(&self, _opts: &ToolVersionOptions) -> Result<VersionOrder> {
-        Ok(VersionOrder::Semver)
-    }
-
-    fn remote_version_listing_tool_option_keys(&self) -> &'static [&'static str] {
-        &[
-            "pubkey",
-            "identity",
-            "identity_prefix",
-            "issuer",
-            "allow_unlogged",
-        ]
-    }
-
-    async fn _list_remote_versions(&self, config: &Arc<Config>) -> Result<Vec<VersionInfo>> {
-        self.ensure_experimental()?;
+    /// Every version the vendor published, before stamps are applied.
+    async fn vendor_versions(&self, config: &Arc<Config>) -> Result<Vec<VersionInfo>> {
         let project = self.project()?;
         let raw_opts = config.get_tool_opts_with_overrides(&self.ba).await?;
         let opts = PackslipOptions::new(&raw_opts);
@@ -758,6 +738,56 @@ impl Backend for PackslipBackend {
         versions.reverse();
         Ok(versions)
     }
+}
+
+#[async_trait]
+impl Backend for PackslipBackend {
+    fn get_type(&self) -> BackendType {
+        BackendType::Packslip
+    }
+
+    fn ba(&self) -> &Arc<BackendArg> {
+        &self.ba
+    }
+
+    async fn security_info(&self) -> Vec<SecurityFeature> {
+        vec![SecurityFeature::Packslip]
+    }
+
+    /// A packslip version is semver, and the specification ranks releases
+    /// by semver precedence, never by the order a release list gives.
+    fn version_order(&self, _opts: &ToolVersionOptions) -> Result<VersionOrder> {
+        Ok(VersionOrder::Semver)
+    }
+
+    fn remote_version_listing_tool_option_keys(&self) -> &'static [&'static str] {
+        &[
+            "pubkey",
+            "identity",
+            "identity_prefix",
+            "issuer",
+            "allow_unlogged",
+            "trust",
+        ]
+    }
+
+    async fn _list_remote_versions(&self, config: &Arc<Config>) -> Result<Vec<VersionInfo>> {
+        self.ensure_experimental()?;
+        let mut versions = self.vendor_versions(config).await?;
+        // Only what a trusted stamper lists is released, as far as mise is
+        // concerned; the rest is not offered.
+        let project = self.project()?;
+        let raw_opts = config.get_tool_opts_with_overrides(&self.ba).await?;
+        if let Some(stamps) = crate::packslip_stamps::fetch(&project, &raw_opts).await? {
+            let before = versions.len();
+            versions.retain(|v| stamps.allows(&v.version));
+            debug!(
+                "packslip:{project}: {} of {before} version(s) carry a stamp",
+                versions.len()
+            );
+        }
+        Ok(versions)
+    }
 
     async fn install_operation_count(&self, _tv: &ToolVersion, _ctx: &InstallContext) -> usize {
         4
@@ -775,8 +805,34 @@ impl Backend for PackslipBackend {
         let pin = pin(&project, &opts)?;
         let require_log = !opts.allow_unlogged();
 
-        // The manifest first: nothing else is downloaded until it verifies.
-        let located = self.locate_bundle(&project, &tv, &pin, &opts).await?;
+        // A stamp first, when the settings ask for one: it says this exact
+        // manifest is admitted, and points at it. Then the manifest: nothing
+        // else is downloaded until it verifies.
+        let stamp = match crate::packslip_stamps::fetch(&project, &raw_opts).await? {
+            Some(stamps) => Some(
+                stamps
+                    .stamp(&tv.version)
+                    .ok_or_else(|| stamps.refusal(&project, &tv.version))?
+                    .clone(),
+            ),
+            None => None,
+        };
+        let located = match &stamp {
+            Some(stamp) => {
+                debug!(
+                    "{}: stamped by {}, manifest at {}",
+                    tv.style(),
+                    stamp.host,
+                    stamp.entry.packslip
+                );
+                Located {
+                    headers: headers_for(&stamp.entry.packslip)?,
+                    url: stamp.entry.packslip.clone(),
+                    digest: stamp.digest.clone(),
+                }
+            }
+            None => self.locate_bundle(&project, &tv, &pin, &opts).await?,
+        };
         let bundle_path = tv.download_path().join(bundle_name(&project));
         file::create_dir_all(tv.download_path())?;
         ctx.pr.set_message("download packslip".into());
@@ -909,16 +965,21 @@ impl Backend for PackslipBackend {
     }
 
     /// `variant` decides which artifact is downloaded, so a lock entry for a
-    /// variant build is not the entry for the plain one.
+    /// variant build is not the entry for the plain one. `trust` is kept so
+    /// an install from the lock does not quietly relax to the vendor alone.
     fn resolve_lockfile_options(
         &self,
         request: &ToolRequest,
         _target: &PlatformTarget,
     ) -> Result<BTreeMap<String, String>> {
         let raw_opts = request.options();
+        let opts = PackslipOptions::new(&raw_opts);
         let mut options = BTreeMap::new();
-        if let Some(variant) = PackslipOptions::new(&raw_opts).variant() {
+        if let Some(variant) = opts.variant() {
             options.insert("variant".to_string(), variant);
+        }
+        if let Some(trust) = opts.trust() {
+            options.insert("trust".to_string(), trust);
         }
         Ok(options)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,7 @@ mod minisign;
 mod netrc;
 mod oci;
 mod packslip;
+mod packslip_stamps;
 pub(crate) mod parallel;
 mod path;
 mod path_env;

--- a/src/packslip_stamps.rs
+++ b/src/packslip_stamps.rs
@@ -28,6 +28,7 @@ use crate::config::Settings;
 use crate::dirs;
 use crate::file;
 use crate::http::HTTP_FETCH;
+use crate::lock_file::LockFile;
 use crate::toolset::ToolVersionOptions;
 
 /// GitHub's OIDC issuer, for a stamper pinned by a workflow identity.
@@ -180,29 +181,61 @@ fn state_dir() -> PathBuf {
     dirs::STATE.join("packslip").join("stampers")
 }
 
-fn read_state(dir: &Path, host: &str) -> HostState {
-    let path = dir.join(format!("{host}.json"));
+fn state_path(dir: &Path, host: &str) -> PathBuf {
+    dir.join(format!("{host}.json"))
+}
+
+/// The state file is what stands between a replayed list and an install,
+/// so a file that cannot be read is an error rather than an empty slate.
+fn read_state(dir: &Path, host: &str) -> Result<HostState> {
+    let path = state_path(dir, host);
     if !path.is_file() {
-        return HostState::default();
+        return Ok(HostState::default());
     }
-    file::read_to_string(&path)
-        .ok()
-        .and_then(|text| serde_json::from_str(&text).ok())
-        .unwrap_or_default()
+    let text = file::read_to_string(&path)?;
+    serde_json::from_str(&text).wrap_err_with(|| {
+        format!(
+            "{} is not the stamper state mise wrote; remove it to start over, which forgets which lists were already accepted",
+            path.display()
+        )
+    })
 }
 
 fn write_state(dir: &Path, host: &str, state: &HostState) -> Result<()> {
     file::create_dir_all(dir)?;
-    file::write(
-        dir.join(format!("{host}.json")),
-        serde_json::to_vec_pretty(state)?,
-    )
+    file::write_atomic(state_path(dir, host), serde_json::to_vec_pretty(state)?)
+}
+
+/// One mise at a time reads and rewrites a host's state.
+fn locked(dir: &Path, host: &str) -> Result<fslock::LockFile> {
+    LockFile::new(&state_path(dir, host)).lock()
 }
 
 /// Refuse a list whose sequence is below the last one accepted from this
 /// host for this project, and remember the new one.
 fn check_sequence(host: &str, project: &str, list: &ReleaseListStatement) -> Result<()> {
-    check_sequence_in(&state_dir(), host, project, list)
+    let dir = state_dir();
+    let _lock = locked(&dir, host)?;
+    check_sequence_in(&dir, host, project, list)
+}
+
+/// A host that answered 404 for a project it had a list for before is not
+/// "no list": it would drop that list's yanks and let another host's stamp
+/// stand alone. Refuse until the host publishes again.
+fn missing_list(host: &str, project: &str, url: &str) -> Result<()> {
+    let dir = state_dir();
+    let _lock = locked(&dir, host)?;
+    missing_list_in(&dir, host, project, url)
+}
+
+fn missing_list_in(dir: &Path, host: &str, project: &str, url: &str) -> Result<()> {
+    let state = read_state(dir, host)?;
+    if let Some(last) = state.sequences.get(project) {
+        bail!(
+            "{host} published a stamp list for {project} before (sequence {last}) but now answers 404 at {url}; refusing to treat that as no list, since it would drop the yanks that list carried"
+        );
+    }
+    Ok(())
 }
 
 fn check_sequence_in(
@@ -211,7 +244,7 @@ fn check_sequence_in(
     project: &str,
     list: &ReleaseListStatement,
 ) -> Result<()> {
-    let mut state = read_state(dir, host);
+    let mut state = read_state(dir, host)?;
     let sequence = list.predicate.sequence;
     if let Some(&last) = state.sequences.get(project)
         && sequence < last
@@ -246,6 +279,7 @@ pub(crate) async fn fetch(project: &str, opts: &ToolVersionOptions) -> Result<Op
         let text = match HTTP_FETCH.get_text(&url).await {
             Ok(text) => text,
             Err(err) if is_not_found(&err) => {
+                missing_list(&stamper.host, project, &url)?;
                 debug!("{}: no stamp list for {project} at {url}", stamper.host);
                 stamps.hosts.push(stamper.host.clone());
                 continue;
@@ -413,6 +447,23 @@ mod tests {
         let err = check_sequence_in(d, host, project, &list(project, 4, &entries)).unwrap_err();
         assert!(err.to_string().contains("rollback"), "{err}");
         assert!(d.join("seq.example.com.json").is_file());
+        // A host that had a list for the project may not turn into "no list".
+        let err = missing_list_in(d, host, project, "https://seq.example.com/x.json").unwrap_err();
+        assert!(err.to_string().contains("sequence 6"), "{err}");
+        missing_list_in(
+            d,
+            host,
+            "github.com/o/unseen",
+            "https://seq.example.com/y.json",
+        )
+        .unwrap();
+        missing_list_in(
+            d,
+            "new.example.com",
+            project,
+            "https://new.example.com/y.json",
+        )
+        .unwrap();
         // Another project or host starts fresh.
         check_sequence_in(
             d,
@@ -422,6 +473,10 @@ mod tests {
         )
         .unwrap();
         check_sequence_in(d, "other.example.com", project, &list(project, 1, &entries)).unwrap();
+        // A state file mise cannot read is an error, not an empty slate.
+        std::fs::write(d.join("seq.example.com.json"), b"{not json").unwrap();
+        let err = check_sequence_in(d, host, project, &list(project, 9, &entries)).unwrap_err();
+        assert!(err.to_string().contains("remove it"), "{err}");
     }
 
     #[test]

--- a/src/packslip_stamps.rs
+++ b/src/packslip_stamps.rs
@@ -1,0 +1,435 @@
+//! Stamps: which packslip releases a trusted host says may be installed.
+//!
+//! A stamping host, a registry, a mirror, or a scanning service, publishes
+//! a signed `releases/v1` list per vendor project at
+//! `https://<host>/.well-known/packslip/<project>.json`. Each entry pins
+//! the digest of the packslip the host checked and carries what it checked.
+//! When the `packslip.stampers` setting names such hosts, a version none of
+//! them lists is not released as far as mise is concerned: it is not
+//! offered and not installed, however valid the vendor's own document is.
+//! Any one trusted host's stamp suffices. A tool whose options say
+//! `trust = "vendor"` takes the vendor's document alone, with no stamp.
+//!
+//! The stamp never replaces the vendor's signature: the bundle a stamp
+//! points at is still verified against the pin the project name implies.
+//! The stamp says who selected the release and what they checked.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use eyre::{Result, WrapErr, bail, eyre};
+use itertools::Itertools;
+use packslip::model::{ReleaseListStatement, ReleaseRef};
+use packslip::sigstore::Policy;
+use serde::{Deserialize, Serialize};
+
+use crate::backend::packslip::{Pin, verify_release_list};
+use crate::config::Settings;
+use crate::dirs;
+use crate::file;
+use crate::http::HTTP_FETCH;
+use crate::toolset::ToolVersionOptions;
+
+/// GitHub's OIDC issuer, for a stamper pinned by a workflow identity.
+const GITHUB_ISSUER: &str = "https://token.actions.githubusercontent.com";
+
+/// A host whose stamps mise trusts, and how its lists are pinned.
+pub(crate) struct Stamper {
+    pub(crate) host: String,
+    pin: Pin,
+}
+
+impl Stamper {
+    /// `host=PIN`, where PIN is a minisign public key line, the path of a
+    /// `.pub` file, or an `https://` identity prefix for a keyless signer
+    /// on GitHub such as `https://github.com/org/registry/`.
+    pub(crate) fn parse(spec: &str) -> Result<Stamper> {
+        let spec = spec.trim();
+        let Some((host, pin)) = spec.split_once('=') else {
+            bail!(
+                "packslip.stampers entry {spec:?} has no pin; write host=PUBKEY, host=path/to/key.pub, or host=https://github.com/org/repo/"
+            );
+        };
+        let host = host.trim();
+        let pin = pin.trim();
+        if host.is_empty() || !host.contains('.') || host.contains('/') {
+            bail!("packslip.stampers entry {spec:?}: {host:?} is not a host name");
+        }
+        let pin = if pin.starts_with("https://") {
+            Pin::Identity(Policy {
+                issuer: Some(GITHUB_ISSUER.into()),
+                identity: None,
+                identity_prefix: Some(pin.to_string()),
+            })
+        } else {
+            let text = if std::path::Path::new(pin).is_file() {
+                file::read_to_string(pin)?
+            } else {
+                pin.to_string()
+            };
+            let key = packslip::minisign::PublicKey::parse(&text)
+                .map_err(|e| eyre!("packslip.stampers entry for {host}: pubkey: {e}"))?;
+            Pin::Key(key)
+        };
+        Ok(Stamper {
+            host: host.to_string(),
+            pin,
+        })
+    }
+
+    /// Where this host publishes its list for a vendor project.
+    pub(crate) fn url(&self, project: &str) -> String {
+        format!("https://{}/.well-known/packslip/{project}.json", self.host)
+    }
+}
+
+/// The stampers the settings name, or none when stamping is off.
+pub(crate) fn stampers() -> Result<Vec<Stamper>> {
+    Settings::get()
+        .packslip
+        .stampers
+        .iter()
+        .flatten()
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| Stamper::parse(s))
+        .collect()
+}
+
+/// Whether a tool's options take the vendor's document alone.
+pub(crate) fn trusts_vendor(opts: &ToolVersionOptions) -> bool {
+    matches!(opts.get("trust"), Some("vendor"))
+}
+
+/// One stamp: a trusted host's entry for a version.
+#[derive(Debug, Clone)]
+pub(crate) struct Stamp {
+    pub(crate) host: String,
+    pub(crate) entry: ReleaseRef,
+    /// The sha256 the host recorded for the packslip it points at.
+    pub(crate) digest: Option<String>,
+}
+
+/// Every stamp the trusted hosts gave a project, by version.
+#[derive(Debug, Default)]
+pub(crate) struct Stamps {
+    hosts: Vec<String>,
+    stamps: BTreeMap<String, Stamp>,
+    /// Versions a trusted host withdrew, with the host and reason.
+    yanked: BTreeMap<String, String>,
+}
+
+impl Stamps {
+    /// Fold in one host's verified list. The first host to stamp a version
+    /// is the one followed; a yank from any host excludes it.
+    fn add(&mut self, host: &str, list: &ReleaseListStatement) {
+        self.hosts.push(host.to_string());
+        for entry in &list.predicate.releases {
+            if entry.is_yanked() {
+                let reason = entry
+                    .status_reason
+                    .as_deref()
+                    .map(|r| format!(": {r}"))
+                    .unwrap_or_default();
+                self.yanked
+                    .insert(entry.version.clone(), format!("{host}{reason}"));
+                continue;
+            }
+            self.stamps
+                .entry(entry.version.clone())
+                .or_insert_with(|| Stamp {
+                    host: host.to_string(),
+                    entry: entry.clone(),
+                    digest: list.digest_of(&entry.packslip).map(str::to_string),
+                });
+        }
+    }
+
+    /// The stamp that admits a version, if one does and no host withdrew it.
+    pub(crate) fn stamp(&self, version: &str) -> Option<&Stamp> {
+        if self.yanked.contains_key(version) {
+            return None;
+        }
+        self.stamps.get(version)
+    }
+
+    pub(crate) fn allows(&self, version: &str) -> bool {
+        self.stamp(version).is_some()
+    }
+
+    /// Why a version is not installable.
+    pub(crate) fn refusal(&self, project: &str, version: &str) -> eyre::Report {
+        if let Some(by) = self.yanked.get(version) {
+            return eyre!("packslip:{project}@{version} was withdrawn by {by}");
+        }
+        eyre!(
+            "packslip:{project}@{version} carries no stamp from {}; mise installs only versions a trusted stamper lists. Set `trust = \"vendor\"` in the tool's options to take the vendor's own manifest instead",
+            self.hosts.iter().join(", ")
+        )
+    }
+}
+
+/// What mise remembers about a stamper between runs: the highest list
+/// sequence it accepted per project, so a replayed older list is refused.
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct HostState {
+    #[serde(default)]
+    sequences: BTreeMap<String, u64>,
+}
+
+fn state_dir() -> PathBuf {
+    dirs::STATE.join("packslip").join("stampers")
+}
+
+fn read_state(dir: &Path, host: &str) -> HostState {
+    let path = dir.join(format!("{host}.json"));
+    if !path.is_file() {
+        return HostState::default();
+    }
+    file::read_to_string(&path)
+        .ok()
+        .and_then(|text| serde_json::from_str(&text).ok())
+        .unwrap_or_default()
+}
+
+fn write_state(dir: &Path, host: &str, state: &HostState) -> Result<()> {
+    file::create_dir_all(dir)?;
+    file::write(
+        dir.join(format!("{host}.json")),
+        serde_json::to_vec_pretty(state)?,
+    )
+}
+
+/// Refuse a list whose sequence is below the last one accepted from this
+/// host for this project, and remember the new one.
+fn check_sequence(host: &str, project: &str, list: &ReleaseListStatement) -> Result<()> {
+    check_sequence_in(&state_dir(), host, project, list)
+}
+
+fn check_sequence_in(
+    dir: &Path,
+    host: &str,
+    project: &str,
+    list: &ReleaseListStatement,
+) -> Result<()> {
+    let mut state = read_state(dir, host);
+    let sequence = list.predicate.sequence;
+    if let Some(&last) = state.sequences.get(project)
+        && sequence < last
+    {
+        bail!(
+            "the stamp list from {host} for {project} has sequence {sequence}, below the {last} already accepted; refusing what may be a rollback"
+        );
+    }
+    if state.sequences.get(project) != Some(&sequence) {
+        state.sequences.insert(project.to_string(), sequence);
+        write_state(dir, host, &state)?;
+    }
+    Ok(())
+}
+
+/// Fetch and verify every trusted host's list for a project. `None` when
+/// no stampers are configured or the tool trusts its vendor alone. A host
+/// that has no list for the project stamps nothing; one whose list fails
+/// to verify is an error, since silently ignoring it would let a broken
+/// host widen what another admits.
+pub(crate) async fn fetch(project: &str, opts: &ToolVersionOptions) -> Result<Option<Stamps>> {
+    if trusts_vendor(opts) {
+        return Ok(None);
+    }
+    let stampers = stampers()?;
+    if stampers.is_empty() {
+        return Ok(None);
+    }
+    let mut stamps = Stamps::default();
+    for stamper in &stampers {
+        let url = stamper.url(project);
+        let text = match HTTP_FETCH.get_text(&url).await {
+            Ok(text) => text,
+            Err(err) if is_not_found(&err) => {
+                debug!("{}: no stamp list for {project} at {url}", stamper.host);
+                stamps.hosts.push(stamper.host.clone());
+                continue;
+            }
+            Err(err) => {
+                return Err(err)
+                    .wrap_err_with(|| format!("fetching the stamp list for {project} from {url}"));
+            }
+        };
+        let list = verify_release_list(&text, &stamper.pin, true)
+            .wrap_err_with(|| format!("verifying the stamp list from {}", stamper.host))?;
+        if list.predicate.project != project {
+            bail!(
+                "the stamp list at {url} is for {}, not {project}",
+                list.predicate.project
+            );
+        }
+        check_sequence(&stamper.host, project, &list)?;
+        stamps.add(&stamper.host, &list);
+    }
+    Ok(Some(stamps))
+}
+
+fn is_not_found(err: &eyre::Report) -> bool {
+    err.downcast_ref::<reqwest::Error>()
+        .and_then(|e| e.status())
+        .is_some_and(|s| s == reqwest::StatusCode::NOT_FOUND)
+        || err.to_string().contains("404")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use packslip::model::{
+        Digest, Identity, RELEASES_PREDICATE_TYPE, ReleaseList, ReleaseStatus, STATEMENT_TYPE,
+        Scheme, Subject,
+    };
+
+    fn list(project: &str, sequence: u64, entries: &[(&str, &str, bool)]) -> ReleaseListStatement {
+        ReleaseListStatement {
+            kind: STATEMENT_TYPE.into(),
+            subject: entries
+                .iter()
+                .map(|(_, url, _)| Subject {
+                    name: url.to_string(),
+                    digest: Digest {
+                        sha256: "a".repeat(64),
+                        sha512: None,
+                    },
+                })
+                .collect(),
+            predicate_type: RELEASES_PREDICATE_TYPE.into(),
+            predicate: ReleaseList {
+                project: project.into(),
+                generated_at: "2026-09-01T00:00:00Z".into(),
+                expires_at: "2026-10-01T00:00:00Z".into(),
+                sequence,
+                identity: Identity {
+                    scheme: Scheme::SigstoreKey,
+                    key_id: "5A0A0B8B9C6D7E1F".into(),
+                    issuer: None,
+                },
+                releases: entries
+                    .iter()
+                    .map(|(version, url, yanked)| ReleaseRef {
+                        version: version.to_string(),
+                        published_at: "2026-09-01T00:00:00Z".into(),
+                        packslip: url.to_string(),
+                        status: yanked.then_some(ReleaseStatus::Yanked),
+                        status_reason: yanked.then(|| "bad build".to_string()),
+                        ..ReleaseRef::default()
+                    })
+                    .collect(),
+                extensions: Default::default(),
+            },
+        }
+    }
+
+    #[test]
+    fn stampers_parse_with_a_pin() {
+        let key = Stamper::parse(
+            "stamps.example.com=RWTAVOFZR6bcSVX+dSDiaFuHVVytD5UMn/HtxqPp/UbQDE5MW1nPZth7",
+        )
+        .unwrap();
+        assert_eq!(key.host, "stamps.example.com");
+        assert!(matches!(key.pin, Pin::Key(_)));
+        assert_eq!(
+            key.url("github.com/jdx/mise"),
+            "https://stamps.example.com/.well-known/packslip/github.com/jdx/mise.json"
+        );
+        let identity =
+            Stamper::parse(" registry.mise.jdx.dev = https://github.com/jdx/mise-registry/ ")
+                .unwrap();
+        assert!(matches!(identity.pin, Pin::Identity(_)));
+        for bad in [
+            "stamps.example.com",
+            "=RWTAVOFZR6bcSVX+dSDiaFuHVVytD5UMn/HtxqPp/UbQDE5MW1nPZth7",
+            "nodots=https://github.com/o/r/",
+            "a.example.com/path=https://github.com/o/r/",
+            "stamps.example.com=not a key",
+        ] {
+            assert!(Stamper::parse(bad).is_err(), "{bad}");
+        }
+    }
+
+    #[test]
+    fn any_stamp_admits_and_any_yank_excludes() {
+        let mut stamps = Stamps::default();
+        stamps.add(
+            "a.example.com",
+            &list(
+                "github.com/o/r",
+                1,
+                &[
+                    ("1.0.0", "https://x/1.0.0/packslip.sigstore.json", false),
+                    ("1.1.0", "https://x/1.1.0/packslip.sigstore.json", false),
+                ],
+            ),
+        );
+        stamps.add(
+            "b.example.com",
+            &list(
+                "github.com/o/r",
+                7,
+                &[
+                    ("1.1.0", "https://y/1.1.0/packslip.sigstore.json", true),
+                    ("1.2.0", "https://y/1.2.0/packslip.sigstore.json", false),
+                ],
+            ),
+        );
+        assert!(stamps.allows("1.0.0"));
+        assert!(stamps.allows("1.2.0"));
+        assert!(!stamps.allows("1.1.0"), "b withdrew it");
+        assert!(!stamps.allows("2.0.0"), "nobody stamped it");
+        let first = stamps.stamp("1.0.0").unwrap();
+        assert_eq!(first.host, "a.example.com");
+        assert_eq!(first.digest.as_deref(), Some("a".repeat(64).as_str()));
+        assert_eq!(
+            first.entry.packslip,
+            "https://x/1.0.0/packslip.sigstore.json"
+        );
+        let why = stamps.refusal("github.com/o/r", "1.1.0").to_string();
+        assert!(
+            why.contains("withdrawn by b.example.com: bad build"),
+            "{why}"
+        );
+        let why = stamps.refusal("github.com/o/r", "2.0.0").to_string();
+        assert!(
+            why.contains("no stamp from a.example.com, b.example.com")
+                && why.contains("trust = \"vendor\""),
+            "{why}"
+        );
+    }
+
+    #[test]
+    fn sequences_only_go_up_per_host_and_project() {
+        let dir = tempfile::tempdir().unwrap();
+        let d = dir.path();
+        let host = "seq.example.com";
+        let project = "github.com/o/r";
+        let entries = [("1.0.0", "https://x/p.json", false)];
+        check_sequence_in(d, host, project, &list(project, 5, &entries)).unwrap();
+        check_sequence_in(d, host, project, &list(project, 5, &entries)).unwrap();
+        check_sequence_in(d, host, project, &list(project, 6, &entries)).unwrap();
+        let err = check_sequence_in(d, host, project, &list(project, 4, &entries)).unwrap_err();
+        assert!(err.to_string().contains("rollback"), "{err}");
+        assert!(d.join("seq.example.com.json").is_file());
+        // Another project or host starts fresh.
+        check_sequence_in(
+            d,
+            host,
+            "github.com/o/other",
+            &list("github.com/o/other", 1, &entries),
+        )
+        .unwrap();
+        check_sequence_in(d, "other.example.com", project, &list(project, 1, &entries)).unwrap();
+    }
+
+    #[test]
+    fn vendor_trust_is_a_tool_option() {
+        let mut opts = ToolVersionOptions::default();
+        assert!(!trusts_vendor(&opts));
+        opts.insert_option("trust".into(), toml::Value::String("vendor".into()))
+            .unwrap();
+        assert!(trusts_vendor(&opts));
+    }
+}


### PR DESCRIPTION
Stacked on #12780. Adds the consumer side of the stamping model from [jdx/packslip#27](https://github.com/jdx/packslip/pull/27): a version of a packslip tool is installable only when a trusted host has stamped it.

## What changed

- **`packslip.stampers` setting.** A list of hosts, each with its pin: `host=RWQ...` (a minisign public key or the path of a `.pub` file) or `host=https://github.com/org/repo/` (a keyless signer on GitHub). Unset, nothing changes and every version the vendor published is offered.
- **`src/packslip_stamps.rs`.** Fetches each trusted host's list at `https://<host>/.well-known/packslip/<project>.json`, verifies it against that host's pin, refuses an expired list, and remembers the highest `sequence` accepted per host and project under the state dir so a replayed list is refused as a rollback. Folds the lists into one view: any host's stamp admits a version, any host's yank excludes it, and the first host to stamp a version is the one followed.
- **Backend.** `mise ls-remote` keeps only stamped versions. `mise install` refuses an unstamped or withdrawn version with the host and reason, and otherwise fetches the manifest at the URL the stamp names, checks it against the digest the host recorded, and then verifies it against the vendor's pin exactly as before. The stamp never replaces the vendor's signature.
- **`trust = "vendor"` tool option.** Takes the vendor's manifest alone for that tool. Recorded in the lockfile so an install from the lock does not relax it.
- Docs on the backend page and the setting.

## Why

Users should by default wait for a release to be checked before mise offers it, be able to add other stampers such as a paid scanning service, and still trust a vendor outright per tool. The registry acting as a stamper is how tools that never adopt packslip get covered, and a mirror is a stamper whose entries point at manifests it signed itself.

## Reviewer notes

- Unstamped means refused, not warned. That was the decision; a warning would train people to ignore it and the override is one line.
- Any-of across hosts. Requiring all hosts to agree, or requiring specific evidence kinds, is left until someone asks.
- A host with no list for a project stamps nothing for it; a host whose list fails to verify is an error rather than ignored, so a broken host cannot silently widen what another admits.
- No default host is baked in yet: the registry host does not publish stamps, so a default would refuse everything. Once it does, its key goes in the binary and the setting defaults to it.
- Verified with the new unit tests, the packslip backend tests, and clippy. No e2e test yet because no stamping host exists to run against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes packslip install and version discovery with network trust policy, cryptographic verification, and persistent sequence state—mistakes could block installs or weaken rollback/yank protections.
> 
> **Overview**
> Adds **packslip stamping**: when `packslip.stampers` names trusted hosts (`host=pin`), mise only **offers and installs** packslip versions those hosts list in signed `/.well-known/packslip/<project>.json` release lists. Unconfigured behavior is unchanged (all vendor-published versions).
> 
> New **`packslip_stamps`** logic fetches each stamper’s list, verifies it against the host pin (minisign key, `.pub` path, or GitHub identity prefix), enforces expiry and **per-host/project sequence** anti-rollback state on disk, merges **any-of** admission with **any-host yank** exclusion, and errors if a host that previously published a list returns 404. Install uses the stamp’s manifest URL and **required sha256 digest**, then still verifies the bundle against the **vendor pin** as before.
> 
> Per-tool **`trust = "vendor"`** skips stampers; **`trust`** is persisted in lockfile options so lock installs don’t silently relax policy. Docs, `settings.toml`, and JSON schema document `stampers` and `MISE_PACKSLIP_STAMPERS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3861dd95ff4bd563a084f2dad8b48ac59c7fe22f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Packslip release stampers for trusted, signed release lists.
  * Packslip installations and available versions can now be limited to releases approved by configured stampers.
  * Added support for stamper pins using minisign keys, public-key files, or GitHub identity prefixes.
  * Added protection against withdrawn releases, invalid digests, expired lists, and rollback attempts.
  * Added `trust = "vendor"` to use vendor manifests without stamper approval.
  * Documented Packslip stamping and configuration options, including the `MISE_PACKSLIP_STAMPERS` environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->