### PR TITLE
fix(schema): support absent bootstrap packages

### DIFF
--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -124,6 +124,9 @@ zshenv = { enabled = false }
 zprofile = { enabled = true, mode = "shims" }
 zshrc = true
 
+[bootstrap.packages]
+"pacman:libreoffice-fresh" = { state = "absent" }
+
 [[oci.copy]]
 host = "dist/my-app"
 image = "/usr/local/bin/my-app"
@@ -223,7 +226,7 @@ strict = true
 
 [[schemas]]
 path = "file://$SCHEMA_PATH"
-include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-env-float.toml", "mise-bad-install-env-float.toml", "mise-bad-minimum-release-age-array.toml", "mise-bad-minimum-release-age-table.toml", "mise-bad-postinstall.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-launchd-queue.toml", "mise-bad-launchd-throttle.toml", "mise-bad-systemd.toml", "mise-bad-oci-copy.toml", "mise-bad-shell-activate.toml"]
+include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-env-float.toml", "mise-bad-install-env-float.toml", "mise-bad-minimum-release-age-array.toml", "mise-bad-minimum-release-age-table.toml", "mise-bad-package-state.toml", "mise-bad-postinstall.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-launchd-queue.toml", "mise-bad-launchd-throttle.toml", "mise-bad-systemd.toml", "mise-bad-oci-copy.toml", "mise-bad-shell-activate.toml"]
 
 [[schemas]]
 path = "file://$TASK_SCHEMA_PATH"
@@ -239,6 +242,14 @@ include = ["mise-bad-tool-alias.toml"]
 EOF
 
 assert_fail "$TOMBI_LINT mise-bad.toml"
+
+# Verify that package state matches runtime validation
+cat >"$HOME/workdir/mise-bad-package-state.toml" <<'TOML'
+[bootstrap.packages]
+"pacman:libreoffice-fresh" = { state = "removed" }
+TOML
+
+assert_fail "$TOMBI_LINT mise-bad-package-state.toml"
 
 # Verify that options for complex age values must be nested inside age
 cat >"$HOME/workdir/mise-bad-age.toml" <<'TOML'

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -4212,6 +4212,12 @@
                   "adopt": {
                     "type": "boolean",
                     "description": "adopt an existing identical brew-cask app artifact instead of replacing it"
+                  },
+                  "state": {
+                    "type": "string",
+                    "description": "desired package state; only pacman currently supports absent",
+                    "enum": ["present", "absent"],
+                    "default": "present"
                   }
                 },
                 "additionalProperties": false


### PR DESCRIPTION
## Summary

- allow `state` in bootstrap package table entries in the JSON schema
- cover accepted `absent` and reject unsupported values in the Tombi schema test

## Context

`state = "absent"` was added in #12716, but the JSON schema still rejects it, so editors and Tombi report valid package configuration as invalid.

## Testing

- strict AJV schema compilation
- Prettier 3.9.6
- ShellCheck 0.11.0
- Tombi 0.9.22: accepted `absent` and rejected an invalid state
- `git diff --check`

The full mise E2E and lint suites were not run locally because Rust is not installed; CI will provide full coverage.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying whether bootstrap packages should be `present` or `absent`.
  - Package state defaults to `present`; `absent` is currently supported for pacman-managed packages.

- **Bug Fixes**
  - Improved configuration validation to reject unsupported package states, such as `removed`, with a clear schema error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->