### PR TITLE
fix(rust): recover missing complete profile metadata

### DIFF
--- a/docs/lang/rust.md
+++ b/docs/lang/rust.md
@@ -141,7 +141,11 @@ If not set, it defaults to the profile configured in `rustup`. You can check you
 ```
 
 If the Rust toolchain is already installed, `mise install` restores missing components implied by
-the `minimal` or `default` profile.
+the `minimal`, `default`, or `complete` profile. Complete-profile membership comes from the
+installed toolchain's rustup manifest because it can vary between Rust releases.
+
+Rustup supports only those three named profiles and discourages using `complete`. To customize a
+profile, use the `components` and `targets` options with `minimal` or `default`.
 
 ### `targets`
 

--- a/docs/lang/rust.md
+++ b/docs/lang/rust.md
@@ -140,6 +140,9 @@ If not set, it defaults to the profile configured in `rustup`. You can check you
 "rust" = { version = "1.83.0", profile = "minimal" }
 ```
 
+If the Rust toolchain is already installed, `mise install` restores missing components implied by
+the `minimal` or `default` profile.
+
 ### `targets`
 
 The `targets` option specifies platforms to install for cross-compilation. Multiple targets can

--- a/e2e/core/test_rust_components_reconcile
+++ b/e2e/core/test_rust_components_reconcile
@@ -65,7 +65,7 @@ case "$1 $2" in
 					;;
 			esac
 			done
-		if ! $toolchain_exists && [[ -z "$profile" || "$profile" == "default" ]]; then
+		if ! $toolchain_exists && [[ -z "$profile" || "$profile" == "default" || "$profile" == "d" ]]; then
 			printf '%s\n' clippy rust-docs rustfmt >>"$MISE_CARGO_HOME/components"
 		fi
 		sort -u "$MISE_CARGO_HOME/components" -o "$MISE_CARGO_HOME/components" 2>/dev/null || true
@@ -125,17 +125,28 @@ assert_contains "cat '$MISE_CARGO_HOME/components'" "rustfmt"
 
 cat >mise.toml <<EOF
 [tools]
+rust = { version = "1.81.0", profile = "d" }
+EOF
+
+sed -i '/^rustfmt$/d' "$MISE_CARGO_HOME/components"
+assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
+mise install
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "5"
+assert_contains "cat '$MISE_CARGO_HOME/components'" "rustfmt"
+
+cat >mise.toml <<EOF
+[tools]
 rust = { version = "1.81.0", components = ["rustfmt", "rust-src"], targets = ["wasm32-unknown-unknown"] }
 EOF
 
 assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
 
 mise exec -- rustc -V
-assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "5"
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "6"
 assert_contains "cat '$MISE_CARGO_HOME/components'" "rustfmt"
 assert_contains "cat '$MISE_CARGO_HOME/components'" "rust-src"
 assert_contains "cat '$MISE_CARGO_HOME/targets'" "wasm32-unknown-unknown"
 
 mise install
-assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "5"
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "6"
 assert_contains "mise install rust --dry-run-code 2>&1" "already installed"

--- a/e2e/core/test_rust_components_reconcile
+++ b/e2e/core/test_rust_components_reconcile
@@ -52,7 +52,67 @@ case "$1 $2" in
 		toolchain="$toolchain-$host"
 		toolchain_exists=false
 		[[ -d "$MISE_RUSTUP_HOME/toolchains/$toolchain" ]] && toolchain_exists=true
-		mkdir -p "$MISE_RUSTUP_HOME/toolchains/$toolchain"
+		mkdir -p "$MISE_RUSTUP_HOME/toolchains/$toolchain/lib/rustlib"
+		cat >"$MISE_RUSTUP_HOME/toolchains/$toolchain/lib/rustlib/multirust-channel-manifest.toml" <<'MANIFEST'
+[renames.clippy]
+to = "clippy-preview"
+
+[renames.miri]
+to = "miri-preview"
+
+[renames.rust-analyzer]
+to = "rust-analyzer-preview"
+
+[renames.rustfmt]
+to = "rustfmt-preview"
+
+[profiles]
+minimal = ["rustc", "cargo", "rust-std"]
+default = ["rustc", "cargo", "rust-std", "rust-docs", "rustfmt-preview", "clippy-preview"]
+complete = ["rustc", "cargo", "rust-std", "rust-docs", "rustfmt-preview", "clippy-preview", "rust-analyzer-preview", "rust-src", "miri-preview"]
+
+[pkg.rust.target.x86_64-unknown-linux-gnu]
+
+[[pkg.rust.target.x86_64-unknown-linux-gnu.components]]
+pkg = "rustc"
+target = "x86_64-unknown-linux-gnu"
+
+[[pkg.rust.target.x86_64-unknown-linux-gnu.components]]
+pkg = "cargo"
+target = "x86_64-unknown-linux-gnu"
+
+[[pkg.rust.target.x86_64-unknown-linux-gnu.components]]
+pkg = "rust-std"
+target = "x86_64-unknown-linux-gnu"
+
+[[pkg.rust.target.x86_64-unknown-linux-gnu.components]]
+pkg = "rust-docs"
+target = "x86_64-unknown-linux-gnu"
+
+[[pkg.rust.target.x86_64-unknown-linux-gnu.extensions]]
+pkg = "rust-std"
+target = "wasm32-unknown-unknown"
+
+[[pkg.rust.target.x86_64-unknown-linux-gnu.extensions]]
+pkg = "rustfmt-preview"
+target = "x86_64-unknown-linux-gnu"
+
+[[pkg.rust.target.x86_64-unknown-linux-gnu.extensions]]
+pkg = "clippy-preview"
+target = "x86_64-unknown-linux-gnu"
+
+[[pkg.rust.target.x86_64-unknown-linux-gnu.extensions]]
+pkg = "rust-analyzer-preview"
+target = "x86_64-unknown-linux-gnu"
+
+[[pkg.rust.target.x86_64-unknown-linux-gnu.extensions]]
+pkg = "rust-src"
+target = "*"
+
+[[pkg.rust.target.x86_64-unknown-linux-gnu.extensions]]
+pkg = "miri-preview"
+target = "x86_64-unknown-linux-gnu"
+MANIFEST
 		profile=""
 		while [[ $# -gt 0 ]]; do
 			case "$1" in
@@ -166,17 +226,45 @@ assert_contains "cat '$MISE_CARGO_HOME/components'" "rust-std-x86_64-unknown-lin
 
 cat >mise.toml <<EOF
 [tools]
+rust = { version = "1.81.0", profile = "complete" }
+EOF
+
+printf '%s\n' \
+  cargo-x86_64-unknown-linux-gnu \
+  clippy-x86_64-unknown-linux-gnu \
+  miri-x86_64-unknown-linux-gnu \
+  rust-analyzer-x86_64-unknown-linux-gnu \
+  rust-docs-x86_64-unknown-linux-gnu \
+  rust-src \
+  rust-std-x86_64-unknown-linux-gnu \
+  rustc-x86_64-unknown-linux-gnu \
+  rustfmt-x86_64-unknown-linux-gnu >"$MISE_CARGO_HOME/components"
+sed -i '/^miri-/d' "$MISE_CARGO_HOME/components"
+assert_hook_env_does_not_call_rustup
+assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
+mise install
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "7"
+assert_contains "cat '$MISE_CARGO_HOME/components'" "miri-x86_64-unknown-linux-gnu"
+
+manifest="$MISE_RUSTUP_HOME/toolchains/1.81.0-x86_64-unknown-linux-gnu/lib/rustlib/multirust-channel-manifest.toml"
+cp "$manifest" "$manifest.valid"
+echo 'not valid toml = [' >"$manifest"
+assert_fail_contains "mise install rust --dry-run-code 2>&1" "installed manifest is unusable"
+mv "$manifest.valid" "$manifest"
+
+cat >mise.toml <<EOF
+[tools]
 rust = { version = "1.81.0", components = ["rustfmt", "rust-src"], targets = ["wasm32-unknown-unknown"] }
 EOF
 
 assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
 
 mise exec -- rustc -V
-assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "7"
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "8"
 assert_contains "cat '$MISE_CARGO_HOME/components'" "rustfmt"
 assert_contains "cat '$MISE_CARGO_HOME/components'" "rust-src"
 assert_contains "cat '$MISE_CARGO_HOME/targets'" "wasm32-unknown-unknown"
 
 mise install
-assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "7"
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "8"
 assert_contains "mise install rust --dry-run-code 2>&1" "already installed"

--- a/e2e/core/test_rust_components_reconcile
+++ b/e2e/core/test_rust_components_reconcile
@@ -252,11 +252,19 @@ assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "7"
 assert_contains "cat '$MISE_CARGO_HOME/components'" "miri-x86_64-unknown-linux-gnu"
 
 manifest="$MISE_RUSTUP_HOME/toolchains/1.81.0-x86_64-unknown-linux-gnu/lib/rustlib/multirust-channel-manifest.toml"
-cp "$manifest" "$manifest.valid"
+mkdir -p "$PWD/rust-dist/dist"
+cp "$manifest" "$PWD/rust-dist/dist/channel-rust-1.81.0.toml"
+cat >mise.toml <<EOF
+[tools]
+rust = { version = "1.81.0", profile = "c", install_env = { RUSTUP_DIST_SERVER = "file://$PWD/rust-dist" } }
+EOF
+
 echo 'not valid toml = [' >"$manifest"
+sed -i.bak '/^rust-analyzer-/d' "$MISE_CARGO_HOME/components"
 assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
-assert_fail_contains "mise install rust 2>&1" "installed manifest is unusable"
-mv "$manifest.valid" "$manifest"
+mise install
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "8"
+assert_contains "cat '$MISE_CARGO_HOME/components'" "rust-analyzer-x86_64-unknown-linux-gnu"
 
 cat >mise.toml <<EOF
 [tools]
@@ -266,11 +274,11 @@ EOF
 assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
 
 mise exec -- rustc -V
-assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "8"
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "9"
 assert_contains "cat '$MISE_CARGO_HOME/components'" "rustfmt"
 assert_contains "cat '$MISE_CARGO_HOME/components'" "rust-src"
 assert_contains "cat '$MISE_CARGO_HOME/targets'" "wasm32-unknown-unknown"
 
 mise install
-assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "8"
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "9"
 assert_contains "mise install rust --dry-run-code 2>&1" "already installed"

--- a/e2e/core/test_rust_components_reconcile
+++ b/e2e/core/test_rust_components_reconcile
@@ -31,6 +31,7 @@ case "$1 $2" in
 		echo default
 		;;
 	"show active-toolchain")
+		[[ ! -f "$MISE_CARGO_HOME/fail-active-toolchain" ]] || exit 1
 		toolchain="${RUSTUP_TOOLCHAIN:-}"
 		[[ -d "$MISE_RUSTUP_HOME/toolchains/$toolchain-$host" ]] || exit 1
 		echo "$toolchain-$host (environment override by RUSTUP_TOOLCHAIN)"
@@ -172,7 +173,7 @@ EOF
 mise install
 assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "1"
 
-sed -i '/^rust-docs-/d' "$MISE_CARGO_HOME/components"
+sed -i.bak '/^rust-docs-/d' "$MISE_CARGO_HOME/components"
 assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
 mise install
 assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "2"
@@ -189,7 +190,7 @@ cat >mise.toml <<EOF
 rust = { version = "1.81.0", profile = "default" }
 EOF
 
-sed -i '/^rustfmt-/d' "$MISE_CARGO_HOME/components"
+sed -i.bak '/^rustfmt-/d' "$MISE_CARGO_HOME/components"
 assert_hook_env_does_not_call_rustup
 assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
 mise install
@@ -203,7 +204,7 @@ cat >mise.toml <<EOF
 rust = { version = "1.81.0", profile = "d" }
 EOF
 
-sed -i '/^rustfmt-/d' "$MISE_CARGO_HOME/components"
+sed -i.bak '/^rustfmt-/d' "$MISE_CARGO_HOME/components"
 assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
 mise install
 assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "5"
@@ -215,7 +216,7 @@ rust = { version = "1.81.0", profile = "minimal" }
 EOF
 
 printf '%s\n' rust-std-wasm32-unknown-unknown >>"$MISE_CARGO_HOME/components"
-sed -i '/^cargo-x86_64-unknown-linux-gnu$/d; /^rustc-x86_64-unknown-linux-gnu$/d; /^rust-std-x86_64-unknown-linux-gnu$/d' \
+sed -i.bak '/^cargo-x86_64-unknown-linux-gnu$/d; /^rustc-x86_64-unknown-linux-gnu$/d; /^rust-std-x86_64-unknown-linux-gnu$/d' \
   "$MISE_CARGO_HOME/components"
 assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
 mise install
@@ -239,7 +240,11 @@ printf '%s\n' \
   rust-std-x86_64-unknown-linux-gnu \
   rustc-x86_64-unknown-linux-gnu \
   rustfmt-x86_64-unknown-linux-gnu >"$MISE_CARGO_HOME/components"
-sed -i '/^miri-/d' "$MISE_CARGO_HOME/components"
+sed -i.bak '/^miri-/d' "$MISE_CARGO_HOME/components"
+touch "$MISE_CARGO_HOME/fail-active-toolchain"
+assert_fail_contains "mise install rust 2>&1" "active toolchain could not be determined"
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "6"
+mv "$MISE_CARGO_HOME/fail-active-toolchain" "$MISE_CARGO_HOME/active-toolchain-recovered"
 assert_hook_env_does_not_call_rustup
 assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
 mise install
@@ -249,7 +254,8 @@ assert_contains "cat '$MISE_CARGO_HOME/components'" "miri-x86_64-unknown-linux-g
 manifest="$MISE_RUSTUP_HOME/toolchains/1.81.0-x86_64-unknown-linux-gnu/lib/rustlib/multirust-channel-manifest.toml"
 cp "$manifest" "$manifest.valid"
 echo 'not valid toml = [' >"$manifest"
-assert_fail_contains "mise install rust --dry-run-code 2>&1" "installed manifest is unusable"
+assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
+assert_fail_contains "mise install rust 2>&1" "installed manifest is unusable"
 mv "$manifest.valid" "$manifest"
 
 cat >mise.toml <<EOF

--- a/e2e/core/test_rust_components_reconcile
+++ b/e2e/core/test_rust_components_reconcile
@@ -22,26 +22,34 @@ cat >"$MISE_CARGO_HOME/bin/rustup" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
+host=x86_64-unknown-linux-gnu
+
 echo "$*" >>"$MISE_CARGO_HOME/rustup.log"
 
 case "$1 $2" in
 	"show profile")
 		echo default
 		;;
+	"show active-toolchain")
+		toolchain="${RUSTUP_TOOLCHAIN:-}"
+		[[ -d "$MISE_RUSTUP_HOME/toolchains/$toolchain-$host" ]] || exit 1
+		echo "$toolchain-$host (environment override by RUSTUP_TOOLCHAIN)"
+		;;
 	"component list")
 		toolchain="${*: -1}"
-		[[ -d "$MISE_RUSTUP_HOME/toolchains/$toolchain" ]] || exit 1
+		[[ -d "$MISE_RUSTUP_HOME/toolchains/$toolchain-$host" ]] || exit 1
 		cat "$MISE_CARGO_HOME/components" 2>/dev/null || true
 		;;
 	"target list")
 		toolchain="${*: -1}"
-		[[ -d "$MISE_RUSTUP_HOME/toolchains/$toolchain" ]] || exit 1
+		[[ -d "$MISE_RUSTUP_HOME/toolchains/$toolchain-$host" ]] || exit 1
 		cat "$MISE_CARGO_HOME/targets" 2>/dev/null || true
 		;;
 	"toolchain install")
 		shift 2
 		toolchain="$1"
 		shift
+		toolchain="$toolchain-$host"
 		toolchain_exists=false
 		[[ -d "$MISE_RUSTUP_HOME/toolchains/$toolchain" ]] && toolchain_exists=true
 		mkdir -p "$MISE_RUSTUP_HOME/toolchains/$toolchain"
@@ -49,7 +57,11 @@ case "$1 $2" in
 		while [[ $# -gt 0 ]]; do
 			case "$1" in
 				--component)
-					echo "$2" >>"$MISE_CARGO_HOME/components"
+					if [[ "$2" == "rust-src" ]]; then
+						echo "$2" >>"$MISE_CARGO_HOME/components"
+					else
+						echo "$2-$host" >>"$MISE_CARGO_HOME/components"
+					fi
 					shift 2
 					;;
 				--target)
@@ -65,8 +77,11 @@ case "$1 $2" in
 					;;
 			esac
 			done
-		if ! $toolchain_exists && [[ -z "$profile" || "$profile" == "default" || "$profile" == "d" ]]; then
-			printf '%s\n' clippy rust-docs rustfmt >>"$MISE_CARGO_HOME/components"
+		if ! $toolchain_exists; then
+			printf '%s\n' "cargo-$host" "rust-std-$host" "rustc-$host" >>"$MISE_CARGO_HOME/components"
+			if [[ -z "$profile" || "$profile" == "default" || "$profile" == "d" ]]; then
+				printf '%s\n' "clippy-$host" "rust-docs-$host" "rustfmt-$host" >>"$MISE_CARGO_HOME/components"
+			fi
 		fi
 		sort -u "$MISE_CARGO_HOME/components" -o "$MISE_CARGO_HOME/components" 2>/dev/null || true
 		sort -u "$MISE_CARGO_HOME/targets" -o "$MISE_CARGO_HOME/targets" 2>/dev/null || true
@@ -97,13 +112,13 @@ EOF
 mise install
 assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "1"
 
-sed -i '/^rust-docs$/d' "$MISE_CARGO_HOME/components"
+sed -i '/^rust-docs-/d' "$MISE_CARGO_HOME/components"
 assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
 mise install
 assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "2"
 assert_contains "cat '$MISE_CARGO_HOME/components'" "rust-docs"
 
-rm -rf "$MISE_RUSTUP_HOME/toolchains/1.81.0"
+rm -rf "$MISE_RUSTUP_HOME/toolchains/1.81.0-x86_64-unknown-linux-gnu"
 assert_hook_env_does_not_call_rustup
 assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
 mise install
@@ -114,7 +129,7 @@ cat >mise.toml <<EOF
 rust = { version = "1.81.0", profile = "default" }
 EOF
 
-sed -i '/^rustfmt$/d' "$MISE_CARGO_HOME/components"
+sed -i '/^rustfmt-/d' "$MISE_CARGO_HOME/components"
 assert_hook_env_does_not_call_rustup
 assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
 mise install
@@ -128,11 +143,26 @@ cat >mise.toml <<EOF
 rust = { version = "1.81.0", profile = "d" }
 EOF
 
-sed -i '/^rustfmt$/d' "$MISE_CARGO_HOME/components"
+sed -i '/^rustfmt-/d' "$MISE_CARGO_HOME/components"
 assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
 mise install
 assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "5"
 assert_contains "cat '$MISE_CARGO_HOME/components'" "rustfmt"
+
+cat >mise.toml <<EOF
+[tools]
+rust = { version = "1.81.0", profile = "minimal" }
+EOF
+
+printf '%s\n' rust-std-wasm32-unknown-unknown >>"$MISE_CARGO_HOME/components"
+sed -i '/^cargo-x86_64-unknown-linux-gnu$/d; /^rustc-x86_64-unknown-linux-gnu$/d; /^rust-std-x86_64-unknown-linux-gnu$/d' \
+  "$MISE_CARGO_HOME/components"
+assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
+mise install
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "6"
+assert_contains "cat '$MISE_CARGO_HOME/components'" "cargo-x86_64-unknown-linux-gnu"
+assert_contains "cat '$MISE_CARGO_HOME/components'" "rustc-x86_64-unknown-linux-gnu"
+assert_contains "cat '$MISE_CARGO_HOME/components'" "rust-std-x86_64-unknown-linux-gnu"
 
 cat >mise.toml <<EOF
 [tools]
@@ -142,11 +172,11 @@ EOF
 assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
 
 mise exec -- rustc -V
-assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "6"
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "7"
 assert_contains "cat '$MISE_CARGO_HOME/components'" "rustfmt"
 assert_contains "cat '$MISE_CARGO_HOME/components'" "rust-src"
 assert_contains "cat '$MISE_CARGO_HOME/targets'" "wasm32-unknown-unknown"
 
 mise install
-assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "6"
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "7"
 assert_contains "mise install rust --dry-run-code 2>&1" "already installed"

--- a/e2e/core/test_rust_config_env_homes
+++ b/e2e/core/test_rust_config_env_homes
@@ -31,7 +31,7 @@ case "$1 $2" in
 		echo minimal
 		;;
 	"component list")
-		echo rustfmt
+		printf '%s\n' cargo rust-std rustc rustfmt
 		;;
 	"toolchain install")
 		mkdir -p "$RUSTUP_HOME/toolchains/$3"

--- a/e2e/core/test_rust_external_provider
+++ b/e2e/core/test_rust_external_provider
@@ -28,6 +28,9 @@ mkdir -p "$STATE"
 			"show profile")
 				echo minimal
 				;;
+			"show active-toolchain")
+				echo "$RUSTUP_TOOLCHAIN-x86_64-unknown-linux-gnu (environment override)"
+				;;
 			"toolchain install")
 				version=$3
 				mkdir -p "$STATE/toolchains/$version"
@@ -55,6 +58,10 @@ mkdir -p "$STATE"
 				rm -rf "$STATE/toolchains/$3"
 				;;
 			"component list")
+				printf '%s\n' \
+					cargo-x86_64-unknown-linux-gnu \
+					rust-std-x86_64-unknown-linux-gnu \
+					rustc-x86_64-unknown-linux-gnu
 				cat "$STATE/components" 2>/dev/null || true
 				;;
 			"target list")

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -388,6 +388,8 @@ impl Backend for RustPlugin {
             None => self.rustup_default_profile(tv, &runtime)?,
         };
         let effective_profile = normalize_rustup_profile(&effective_profile)?;
+        let active_toolchain = self.rustup_active_toolchain(tv, &runtime)?;
+        let host = active_toolchain.as_deref().and_then(rustup_toolchain_host);
 
         // Query components even when none were explicitly requested. This
         // verifies that rustup still has the toolchain represented by mise's
@@ -398,13 +400,11 @@ impl Backend for RustPlugin {
         };
 
         let mut required_components = components.unwrap_or_default();
-        required_components.extend(fallback_rustup_profile_components(effective_profile));
+        required_components.extend(fallback_rustup_profile_components(effective_profile, host));
         required_components.sort();
         required_components.dedup();
 
         if !required_components.is_empty() {
-            let active_toolchain = self.rustup_active_toolchain(tv, &runtime)?;
-            let host = active_toolchain.as_deref().and_then(rustup_toolchain_host);
             let missing =
                 self.missing_components(&required_components, &installed_components, host);
             if !missing.is_empty() {
@@ -562,8 +562,10 @@ impl Backend for RustPlugin {
             None => self.rustup_default_profile(&tv, &runtime)?,
         };
         let effective_profile = normalize_rustup_profile(&effective_profile)?;
+        let active_toolchain = self.rustup_active_toolchain(&tv, &runtime)?;
+        let host = active_toolchain.as_deref().and_then(rustup_toolchain_host);
         let mut components = components.unwrap_or_default();
-        components.extend(fallback_rustup_profile_components(effective_profile));
+        components.extend(fallback_rustup_profile_components(effective_profile, host));
         components.sort();
         components.dedup();
 
@@ -1132,7 +1134,7 @@ fn normalize_rustup_profile(profile: &str) -> Result<&'static str> {
     }
 }
 
-fn fallback_rustup_profile_components(profile: &str) -> Vec<String> {
+fn fallback_rustup_profile_components(profile: &str, host: Option<&str>) -> Vec<String> {
     let mut components = match profile {
         "minimal" | "default" => RUST_MINIMAL_PROFILE_COMPONENTS
             .iter()
@@ -1147,6 +1149,9 @@ fn fallback_rustup_profile_components(profile: &str) -> Vec<String> {
                 .iter()
                 .map(|component| (*component).to_string()),
         );
+    }
+    if host.is_some_and(|host| host.ends_with("-pc-windows-gnu")) {
+        components.push("rust-mingw".to_string());
     }
     components
 }
@@ -1374,11 +1379,11 @@ mod tests {
     #[test]
     fn required_profile_components_match_rustup() {
         assert_eq!(
-            fallback_rustup_profile_components("minimal"),
+            fallback_rustup_profile_components("minimal", Some("x86_64-unknown-linux-gnu")),
             ["cargo", "rust-std", "rustc"]
         );
         assert_eq!(
-            fallback_rustup_profile_components("default"),
+            fallback_rustup_profile_components("default", Some("x86_64-unknown-linux-gnu")),
             [
                 "cargo",
                 "rust-std",
@@ -1388,7 +1393,11 @@ mod tests {
                 "rustfmt"
             ]
         );
-        assert!(fallback_rustup_profile_components("complete").is_empty());
+        assert_eq!(
+            fallback_rustup_profile_components("minimal", Some("x86_64-pc-windows-gnu")),
+            ["cargo", "rust-std", "rustc", "rust-mingw"]
+        );
+        assert!(fallback_rustup_profile_components("complete", None).is_empty());
     }
 
     #[test]

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -28,6 +28,7 @@ pub(super) struct RustPlugin {
 
 const RUST_NIGHTLY_MANIFEST_URL: &str =
     "https://static.rust-lang.org/dist/channel-rust-nightly.toml";
+const RUST_DIST_ROOT: &str = "https://static.rust-lang.org/dist";
 const RUST_MINIMAL_PROFILE_COMPONENTS: &[&str] = &["cargo", "rust-std", "rustc"];
 const RUST_DEFAULT_PROFILE_COMPONENTS: &[&str] = &["clippy", "rust-docs", "rustfmt"];
 
@@ -424,7 +425,7 @@ impl RustPlugin {
         }))
     }
 
-    fn rustup_complete_profile_components(
+    async fn rustup_complete_profile_components(
         &self,
         tv: &ToolVersion,
         runtime: &RustRuntime,
@@ -450,10 +451,25 @@ impl RustPlugin {
                 ),
             }
         }
-        bail!(
-            "cannot reconcile the rustup complete profile for {} because its installed manifest is unusable",
-            tv.style()
-        )
+        let url = rustup_channel_manifest_url(
+            &tv.version,
+            rustup_dist_var(tv, "RUSTUP_DIST_SERVER"),
+            rustup_dist_var(tv, "RUSTUP_DIST_ROOT"),
+        );
+        let manifest = read_rustup_channel_manifest(&url).await.wrap_err_with(|| {
+            format!(
+                "cannot reconcile the rustup complete profile for {} because its installed manifest is unusable and {url} could not be fetched",
+                tv.style()
+            )
+        })?;
+        parse_rustup_profile_components(&manifest, &installed.toolchain, "complete")
+            .map(Some)
+            .wrap_err_with(|| {
+                format!(
+                    "cannot reconcile the rustup complete profile for {} from {url}",
+                    tv.style()
+                )
+            })
     }
 
     fn missing_components(
@@ -536,7 +552,9 @@ impl Backend for RustPlugin {
 
         let mut required_components = components.unwrap_or_default();
         let manifest_host = if effective_profile == "complete" {
-            let Some(profile_components) = self.rustup_complete_profile_components(tv, &runtime)?
+            let Some(profile_components) = self
+                .rustup_complete_profile_components(tv, &runtime)
+                .await?
             else {
                 return Ok(false);
             };
@@ -716,8 +734,9 @@ impl Backend for RustPlugin {
         let host = active_toolchain.as_deref().and_then(rustup_toolchain_host);
         let mut components = components.unwrap_or_default();
         if effective_profile == "complete" {
-            if let Some(profile_components) =
-                self.rustup_complete_profile_components(&tv, &runtime)?
+            if let Some(profile_components) = self
+                .rustup_complete_profile_components(&tv, &runtime)
+                .await?
             {
                 components.extend(profile_components.components);
             }
@@ -1292,6 +1311,52 @@ fn normalize_rustup_profile(profile: &str) -> Result<&'static str> {
     }
 }
 
+fn rustup_dist_var(tv: &ToolVersion, key: &str) -> Option<String> {
+    match tv.install_env().shift_remove(key) {
+        Some(value) => value.into_string(),
+        None => env::var(key).ok(),
+    }
+    .map(|value| value.trim().to_string())
+    .filter(|value| !value.is_empty())
+}
+
+fn rustup_channel_manifest_url(
+    version: &str,
+    dist_server: Option<String>,
+    legacy_dist_root: Option<String>,
+) -> String {
+    let dist_root = if let Some(server) = dist_server {
+        format!("{}/dist", server.trim_end_matches('/'))
+    } else if let Some(root) = legacy_dist_root {
+        let root = root.trim_end_matches('/');
+        format!("{}/dist", root.strip_suffix("/dist").unwrap_or(root))
+    } else {
+        RUST_DIST_ROOT.to_string()
+    };
+    if let Some(date) = version
+        .strip_prefix("nightly-")
+        .filter(|date| date.parse::<jiff::civil::Date>().is_ok())
+    {
+        format!("{dist_root}/{date}/channel-rust-nightly.toml")
+    } else {
+        format!("{dist_root}/channel-rust-{version}.toml")
+    }
+}
+
+async fn read_rustup_channel_manifest(url: &str) -> Result<String> {
+    if let Ok(url) = url::Url::parse(url)
+        && url.scheme() == "file"
+    {
+        let path = url
+            .to_file_path()
+            .map_err(|_| eyre::eyre!("invalid rustup file URL: {url}"))?;
+        return file::read_to_string(&path).wrap_err_with(|| {
+            format!("failed to read Rust channel manifest at {}", path.display())
+        });
+    }
+    HTTP_FETCH.get_text_cached(url).await
+}
+
 fn fallback_rustup_profile_components(profile: &str, host: Option<&str>) -> Vec<String> {
     let mut components = match profile {
         "minimal" | "default" => RUST_MINIMAL_PROFILE_COMPONENTS
@@ -1746,6 +1811,47 @@ target = "x86_64-unknown-linux-gnu"
             .unwrap()
             .components,
             vec!["cargo", "rustc"]
+        );
+    }
+
+    #[test]
+    fn builds_rustup_channel_manifest_urls() {
+        assert_eq!(
+            rustup_channel_manifest_url("1.81.0", None, None),
+            "https://static.rust-lang.org/dist/channel-rust-1.81.0.toml"
+        );
+        assert_eq!(
+            rustup_channel_manifest_url("nightly-2026-08-12", None, None),
+            "https://static.rust-lang.org/dist/2026-08-12/channel-rust-nightly.toml"
+        );
+        assert_eq!(
+            rustup_channel_manifest_url(
+                "1.81.0",
+                Some("https://mirror.example.com/".to_string()),
+                Some("https://ignored.example.com/dist".to_string())
+            ),
+            "https://mirror.example.com/dist/channel-rust-1.81.0.toml"
+        );
+        assert_eq!(
+            rustup_channel_manifest_url(
+                "1.81.0",
+                None,
+                Some("https://legacy.example.com/dist".to_string())
+            ),
+            "https://legacy.example.com/dist/channel-rust-1.81.0.toml"
+        );
+    }
+
+    #[tokio::test]
+    async fn reads_rustup_channel_manifest_from_file_server() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("channel-rust-1.81.0.toml");
+        std::fs::write(&path, "manifest-version = '2'").unwrap();
+        let url = url::Url::from_file_path(path).unwrap();
+
+        assert_eq!(
+            read_rustup_channel_manifest(url.as_str()).await.unwrap(),
+            "manifest-version = '2'"
         );
     }
 

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -28,6 +28,7 @@ pub(super) struct RustPlugin {
 
 const RUST_NIGHTLY_MANIFEST_URL: &str =
     "https://static.rust-lang.org/dist/channel-rust-nightly.toml";
+const RUST_MINIMAL_PROFILE_COMPONENTS: &[&str] = &["cargo", "rust-std", "rustc"];
 const RUST_DEFAULT_PROFILE_COMPONENTS: &[&str] = &["clippy", "rust-docs", "rustfmt"];
 
 fn parse_nightly_manifest(manifest: &str) -> Result<String> {
@@ -286,14 +287,53 @@ impl RustPlugin {
         Ok(profile)
     }
 
+    fn rustup_active_toolchain(
+        &self,
+        tv: &ToolVersion,
+        runtime: &RustRuntime,
+    ) -> Result<Option<String>> {
+        let args = vec!["show".to_string(), "active-toolchain".to_string()];
+        let mut cmd = cmd(runtime.bin_dir.join(RUSTUP_BIN), args)
+            .env("PATH", rustup_path_env(runtime)?)
+            .stdout_capture()
+            .stderr_capture()
+            .unchecked();
+        for (key, value) in rustup_env(&runtime.homes, &tv.version) {
+            cmd = cmd.env(key, value);
+        }
+        let output = match cmd.run() {
+            Ok(output) if output.status.success() => output,
+            Ok(output) => {
+                debug!(
+                    "rustup show active-toolchain failed for {}: {}",
+                    tv.style(),
+                    String::from_utf8_lossy(&output.stderr).trim()
+                );
+                return Ok(None);
+            }
+            Err(err) => {
+                debug!(
+                    "rustup show active-toolchain failed for {}: {err:#}",
+                    tv.style()
+                );
+                return Ok(None);
+            }
+        };
+        Ok(String::from_utf8_lossy(&output.stdout)
+            .split_whitespace()
+            .next()
+            .map(String::from))
+    }
+
     fn missing_components(
         &self,
         requested: &[String],
         installed: &BTreeSet<String>,
+        host: Option<&str>,
     ) -> Vec<String> {
         requested
             .iter()
-            .filter(|component| !rustup_component_installed(installed, component))
+            .filter(|component| !rustup_component_installed(installed, component, host))
             .cloned()
             .collect()
     }
@@ -358,18 +398,15 @@ impl Backend for RustPlugin {
         };
 
         let mut required_components = components.unwrap_or_default();
-        if effective_profile == "default" {
-            required_components.extend(
-                RUST_DEFAULT_PROFILE_COMPONENTS
-                    .iter()
-                    .map(|component| (*component).to_string()),
-            );
-        }
+        required_components.extend(fallback_rustup_profile_components(effective_profile));
         required_components.sort();
         required_components.dedup();
 
         if !required_components.is_empty() {
-            let missing = self.missing_components(&required_components, &installed_components);
+            let active_toolchain = self.rustup_active_toolchain(tv, &runtime)?;
+            let host = active_toolchain.as_deref().and_then(rustup_toolchain_host);
+            let missing =
+                self.missing_components(&required_components, &installed_components, host);
             if !missing.is_empty() {
                 debug!(
                     "{} missing rustup component(s): {}",
@@ -526,15 +563,9 @@ impl Backend for RustPlugin {
         };
         let effective_profile = normalize_rustup_profile(&effective_profile)?;
         let mut components = components.unwrap_or_default();
-        if effective_profile == "default" {
-            components.extend(
-                RUST_DEFAULT_PROFILE_COMPONENTS
-                    .iter()
-                    .map(|component| (*component).to_string()),
-            );
-            components.sort();
-            components.dedup();
-        }
+        components.extend(fallback_rustup_profile_components(effective_profile));
+        components.sort();
+        components.dedup();
 
         let mut cmd = CmdLineRunner::new(runtime.bin_dir.join(RUSTUP_BIN))
             .with_pr(ctx.pr.as_ref())
@@ -1101,13 +1132,47 @@ fn normalize_rustup_profile(profile: &str) -> Result<&'static str> {
     }
 }
 
-fn rustup_component_installed(installed: &BTreeSet<String>, component: &str) -> bool {
+fn fallback_rustup_profile_components(profile: &str) -> Vec<String> {
+    let mut components = match profile {
+        "minimal" | "default" => RUST_MINIMAL_PROFILE_COMPONENTS
+            .iter()
+            .map(|component| (*component).to_string())
+            .collect::<Vec<_>>(),
+        "complete" => Vec::new(),
+        _ => unreachable!("profile was normalized"),
+    };
+    if profile == "default" {
+        components.extend(
+            RUST_DEFAULT_PROFILE_COMPONENTS
+                .iter()
+                .map(|component| (*component).to_string()),
+        );
+    }
+    components
+}
+
+fn rustup_toolchain_host(toolchain: &str) -> Option<&str> {
+    if rustup_component_suffix_is_host_triple(toolchain) {
+        return Some(toolchain);
+    }
+    toolchain.match_indices('-').find_map(|(index, _)| {
+        let suffix = &toolchain[index + 1..];
+        rustup_component_suffix_is_host_triple(suffix).then_some(suffix)
+    })
+}
+
+fn rustup_component_installed(
+    installed: &BTreeSet<String>,
+    component: &str,
+    host: Option<&str>,
+) -> bool {
     installed.iter().any(|item| {
         item == component
-            || item
-                .strip_prefix(component)
-                .and_then(|suffix| suffix.strip_prefix('-'))
-                .is_some_and(rustup_component_suffix_is_host_triple)
+            || host.is_some_and(|host| {
+                item.strip_prefix(component)
+                    .and_then(|suffix| suffix.strip_prefix('-'))
+                    == Some(host)
+            })
     })
 }
 
@@ -1289,17 +1354,41 @@ mod tests {
     }
 
     #[test]
-    fn rustup_component_matching_allows_host_suffixes() {
-        let installed = BTreeSet::from([
+    fn rustup_component_matching_requires_the_selected_host() {
+        let mut installed = BTreeSet::from([
             "rust-src".to_string(),
             "llvm-tools-x86_64-unknown-linux-gnu".to_string(),
+            "rust-std-wasm32-unknown-unknown".to_string(),
         ]);
+        let host = rustup_toolchain_host("1.81.0-x86_64-unknown-linux-gnu");
 
-        assert!(rustup_component_installed(&installed, "rust-src"));
-        assert!(rustup_component_installed(&installed, "llvm-tools"));
-        assert!(!rustup_component_installed(&installed, "rustfmt"));
-        assert!(!rustup_component_installed(&installed, "rust"));
-        assert!(!rustup_component_installed(&installed, "llvm"));
+        assert_eq!(host, Some("x86_64-unknown-linux-gnu"));
+        assert!(rustup_component_installed(&installed, "rust-src", host));
+        assert!(rustup_component_installed(&installed, "llvm-tools", host));
+        assert!(!rustup_component_installed(&installed, "rust-std", host));
+        assert!(!rustup_component_installed(&installed, "rustfmt", host));
+        installed.insert("rust-std-x86_64-unknown-linux-gnu".to_string());
+        assert!(rustup_component_installed(&installed, "rust-std", host));
+    }
+
+    #[test]
+    fn required_profile_components_match_rustup() {
+        assert_eq!(
+            fallback_rustup_profile_components("minimal"),
+            ["cargo", "rust-std", "rustc"]
+        );
+        assert_eq!(
+            fallback_rustup_profile_components("default"),
+            [
+                "cargo",
+                "rust-std",
+                "rustc",
+                "clippy",
+                "rust-docs",
+                "rustfmt"
+            ]
+        );
+        assert!(fallback_rustup_profile_components("complete").is_empty());
     }
 
     #[test]

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -31,6 +31,56 @@ const RUST_NIGHTLY_MANIFEST_URL: &str =
 const RUST_MINIMAL_PROFILE_COMPONENTS: &[&str] = &["cargo", "rust-std", "rustc"];
 const RUST_DEFAULT_PROFILE_COMPONENTS: &[&str] = &["clippy", "rust-docs", "rustfmt"];
 
+#[derive(Debug, serde::Deserialize)]
+struct RustupManifest {
+    #[serde(default)]
+    profiles: BTreeMap<String, Vec<String>>,
+    #[serde(default)]
+    renames: BTreeMap<String, RustupManifestRename>,
+    pkg: RustupManifestPackages,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct RustupManifestRename {
+    to: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct RustupManifestPackages {
+    rust: RustupManifestPackage,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct RustupManifestPackage {
+    target: BTreeMap<String, RustupManifestTarget>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct RustupManifestTarget {
+    #[serde(default)]
+    components: Vec<RustupManifestComponent>,
+    #[serde(default)]
+    extensions: Vec<RustupManifestComponent>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct RustupManifestComponent {
+    pkg: String,
+    target: Option<String>,
+}
+
+#[derive(Debug, PartialEq)]
+struct RustupProfileComponents {
+    components: Vec<String>,
+    host: String,
+}
+
+#[derive(Debug)]
+struct InstalledRustupManifest {
+    toolchain: String,
+    contents: Option<String>,
+}
+
 fn parse_nightly_manifest(manifest: &str) -> Result<String> {
     let manifest: toml::Value =
         toml::from_str(manifest).wrap_err("failed to parse the Rust nightly channel manifest")?;
@@ -319,10 +369,82 @@ impl RustPlugin {
                 return Ok(None);
             }
         };
-        Ok(String::from_utf8_lossy(&output.stdout)
-            .split_whitespace()
-            .next()
-            .map(String::from))
+        let output = String::from_utf8_lossy(&output.stdout);
+        let Some(toolchain) = output.split_whitespace().next() else {
+            debug!(
+                "rustup show active-toolchain returned no toolchain for {}",
+                tv.style()
+            );
+            return Ok(None);
+        };
+        Ok(Some(toolchain.to_string()))
+    }
+
+    fn rustup_toolchain_manifest(
+        &self,
+        tv: &ToolVersion,
+        runtime: &RustRuntime,
+    ) -> Result<Option<InstalledRustupManifest>> {
+        let Some(toolchain) = self.rustup_active_toolchain(tv, runtime)? else {
+            return Ok(None);
+        };
+        let manifest = runtime
+            .homes
+            .rustup
+            .join("toolchains")
+            .join(&toolchain)
+            .join("lib")
+            .join("rustlib")
+            .join("multirust-channel-manifest.toml");
+        if !manifest.is_file() {
+            debug!(
+                "rustup manifest missing for {} at {}",
+                tv.style(),
+                manifest.display()
+            );
+            return Ok(Some(InstalledRustupManifest {
+                toolchain,
+                contents: None,
+            }));
+        }
+        let contents = match file::read_to_string(&manifest) {
+            Ok(contents) => Some(contents),
+            Err(err) => {
+                debug!(
+                    "failed to read rustup manifest for {} at {}: {err:#}",
+                    tv.style(),
+                    manifest.display()
+                );
+                None
+            }
+        };
+        Ok(Some(InstalledRustupManifest {
+            toolchain,
+            contents,
+        }))
+    }
+
+    fn rustup_complete_profile_components(
+        &self,
+        tv: &ToolVersion,
+        runtime: &RustRuntime,
+    ) -> Result<Option<RustupProfileComponents>> {
+        let Some(installed) = self.rustup_toolchain_manifest(tv, runtime)? else {
+            return Ok(None);
+        };
+        if let Some(manifest) = installed.contents {
+            match parse_rustup_profile_components(&manifest, &installed.toolchain, "complete") {
+                Ok(components) => return Ok(Some(components)),
+                Err(err) => debug!(
+                    "failed to resolve the rustup complete profile for {} from its installed manifest: {err:#}",
+                    tv.style()
+                ),
+            }
+        }
+        bail!(
+            "cannot reconcile the rustup complete profile for {} because its installed manifest is unusable",
+            tv.style()
+        )
     }
 
     fn missing_components(
@@ -388,7 +510,11 @@ impl Backend for RustPlugin {
             None => self.rustup_default_profile(tv, &runtime)?,
         };
         let effective_profile = normalize_rustup_profile(&effective_profile)?;
-        let active_toolchain = self.rustup_active_toolchain(tv, &runtime)?;
+        let active_toolchain = if effective_profile == "complete" {
+            None
+        } else {
+            self.rustup_active_toolchain(tv, &runtime)?
+        };
         let host = active_toolchain.as_deref().and_then(rustup_toolchain_host);
 
         // Query components even when none were explicitly requested. This
@@ -400,7 +526,19 @@ impl Backend for RustPlugin {
         };
 
         let mut required_components = components.unwrap_or_default();
-        required_components.extend(fallback_rustup_profile_components(effective_profile, host));
+        let manifest_host = if effective_profile == "complete" {
+            let Some(profile_components) =
+                self.rustup_complete_profile_components(tv, &runtime)?
+            else {
+                return Ok(false);
+            };
+            required_components.extend(profile_components.components);
+            Some(profile_components.host)
+        } else {
+            required_components.extend(fallback_rustup_profile_components(effective_profile, host));
+            None
+        };
+        let host = manifest_host.as_deref().or(host);
         required_components.sort();
         required_components.dedup();
 
@@ -562,10 +700,22 @@ impl Backend for RustPlugin {
             None => self.rustup_default_profile(&tv, &runtime)?,
         };
         let effective_profile = normalize_rustup_profile(&effective_profile)?;
-        let active_toolchain = self.rustup_active_toolchain(&tv, &runtime)?;
+        let active_toolchain = if effective_profile == "complete" {
+            None
+        } else {
+            self.rustup_active_toolchain(&tv, &runtime)?
+        };
         let host = active_toolchain.as_deref().and_then(rustup_toolchain_host);
         let mut components = components.unwrap_or_default();
-        components.extend(fallback_rustup_profile_components(effective_profile, host));
+        if effective_profile == "complete" {
+            if let Some(profile_components) =
+                self.rustup_complete_profile_components(&tv, &runtime)?
+            {
+                components.extend(profile_components.components);
+            }
+        } else {
+            components.extend(fallback_rustup_profile_components(effective_profile, host));
+        }
         components.sort();
         components.dedup();
 
@@ -1140,7 +1290,7 @@ fn fallback_rustup_profile_components(profile: &str, host: Option<&str>) -> Vec<
             .iter()
             .map(|component| (*component).to_string())
             .collect::<Vec<_>>(),
-        "complete" => Vec::new(),
+        "complete" => return Vec::new(),
         _ => unreachable!("profile was normalized"),
     };
     if profile == "default" {
@@ -1164,6 +1314,70 @@ fn rustup_toolchain_host(toolchain: &str) -> Option<&str> {
         let suffix = &toolchain[index + 1..];
         rustup_component_suffix_is_host_triple(suffix).then_some(suffix)
     })
+}
+
+fn parse_rustup_profile_components(
+    manifest: &str,
+    toolchain: &str,
+    profile: &str,
+) -> Result<RustupProfileComponents> {
+    let manifest: RustupManifest =
+        toml::from_str(manifest).wrap_err("failed to parse the installed rustup manifest")?;
+    let host = manifest
+        .pkg
+        .rust
+        .target
+        .keys()
+        .filter(|target| {
+            target.as_str() != "*"
+                && (toolchain == target.as_str()
+                    || toolchain
+                        .strip_suffix(target.as_str())
+                        .is_some_and(|prefix| prefix.ends_with('-')))
+        })
+        .max_by_key(|target| target.len())
+        .cloned()
+        .ok_or_else(|| eyre::eyre!("unable to determine the host for toolchain {toolchain}"))?;
+    let target = manifest
+        .pkg
+        .rust
+        .target
+        .get(&host)
+        .ok_or_else(|| eyre::eyre!("rustup manifest is missing host target {host}"))?;
+    let all_components = || target.components.iter().chain(&target.extensions);
+    let selected: Vec<&RustupManifestComponent> = if manifest.profiles.is_empty() {
+        target.components.iter().collect()
+    } else {
+        manifest
+            .profiles
+            .get(profile)
+            .ok_or_else(|| eyre::eyre!("rustup manifest is missing the {profile} profile"))?
+            .iter()
+            .filter_map(|name| {
+                all_components().find(|component| {
+                    component.pkg == *name
+                        && component
+                            .target
+                            .as_deref()
+                            .is_none_or(|target| target == "*" || target == host)
+                })
+            })
+            .collect()
+    };
+    let mut components = selected
+        .into_iter()
+        .map(|component| {
+            manifest
+                .renames
+                .iter()
+                .rev()
+                .find_map(|(name, rename)| (rename.to == component.pkg).then(|| name.clone()))
+                .unwrap_or_else(|| component.pkg.clone())
+        })
+        .collect::<Vec<_>>();
+    components.sort();
+    components.dedup();
+    Ok(RustupProfileComponents { components, host })
 }
 
 fn rustup_component_installed(
@@ -1366,6 +1580,7 @@ mod tests {
             "rust-src".to_string(),
             "llvm-tools-x86_64-unknown-linux-gnu".to_string(),
             "rust-std-wasm32-unknown-unknown".to_string(),
+            "rustc-x86_64-unknown-linux-gnu".to_string(),
         ]);
         let host = rustup_toolchain_host("1.81.0-x86_64-unknown-linux-gnu");
 
@@ -1426,6 +1641,103 @@ mod tests {
         assert!(
             fallback_rustup_profile_components("complete", Some("x86_64-pc-windows-gnu"))
                 .is_empty()
+        );
+    }
+
+    #[test]
+    fn parses_profile_components_for_the_selected_host() {
+        let manifest = r#"
+[renames.a-clippy]
+to = "clippy-preview"
+
+[renames.clippy]
+to = "clippy-preview"
+
+[renames.rust-analyzer]
+to = "rust-analyzer-preview"
+
+[profiles]
+minimal = ["rustc", "cargo", "rust-std", "rust-mingw"]
+default = ["rustc", "cargo", "rust-std", "rust-mingw", "clippy-preview"]
+complete = ["rustc", "rust-mingw", "clippy-preview", "rust-analyzer-preview", "rust-src"]
+
+[pkg.rust.target.x86_64-unknown-linux-gnu]
+
+[[pkg.rust.target.x86_64-unknown-linux-gnu.components]]
+pkg = "rustc"
+target = "x86_64-unknown-linux-gnu"
+
+[[pkg.rust.target.x86_64-unknown-linux-gnu.components]]
+pkg = "cargo"
+target = "x86_64-unknown-linux-gnu"
+
+[[pkg.rust.target.x86_64-unknown-linux-gnu.components]]
+pkg = "rust-std"
+target = "x86_64-unknown-linux-gnu"
+
+[[pkg.rust.target.x86_64-unknown-linux-gnu.extensions]]
+pkg = "rust-std"
+target = "wasm32-unknown-unknown"
+
+[[pkg.rust.target.x86_64-unknown-linux-gnu.extensions]]
+pkg = "clippy-preview"
+target = "x86_64-unknown-linux-gnu"
+
+[[pkg.rust.target.x86_64-unknown-linux-gnu.extensions]]
+pkg = "rust-analyzer-preview"
+target = "x86_64-unknown-linux-gnu"
+
+[[pkg.rust.target.x86_64-unknown-linux-gnu.extensions]]
+pkg = "rust-src"
+target = "*"
+"#;
+
+        assert_eq!(
+            parse_rustup_profile_components(
+                manifest,
+                "1.81.0-x86_64-unknown-linux-gnu",
+                "complete"
+            )
+            .unwrap(),
+            RustupProfileComponents {
+                components: vec![
+                    "clippy".to_string(),
+                    "rust-analyzer".to_string(),
+                    "rust-src".to_string(),
+                    "rustc".to_string()
+                ],
+                host: "x86_64-unknown-linux-gnu".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn profileless_manifests_use_legacy_components() {
+        let manifest = r#"
+[pkg.rust.target.x86_64-unknown-linux-gnu]
+
+[[pkg.rust.target.x86_64-unknown-linux-gnu.components]]
+pkg = "rustc"
+target = "x86_64-unknown-linux-gnu"
+
+[[pkg.rust.target.x86_64-unknown-linux-gnu.components]]
+pkg = "cargo"
+target = "x86_64-unknown-linux-gnu"
+
+[[pkg.rust.target.x86_64-unknown-linux-gnu.extensions]]
+pkg = "clippy-preview"
+target = "x86_64-unknown-linux-gnu"
+"#;
+
+        assert_eq!(
+            parse_rustup_profile_components(
+                manifest,
+                "1.19.0-x86_64-unknown-linux-gnu",
+                "complete"
+            )
+            .unwrap()
+            .components,
+            vec!["cargo", "rustc"]
         );
     }
 

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -1312,7 +1312,7 @@ fn normalize_rustup_profile(profile: &str) -> Result<&'static str> {
 }
 
 fn rustup_dist_var(tv: &ToolVersion, key: &str) -> Option<String> {
-    match tv.install_env().shift_remove(key) {
+    match tv.install_env().get(key).cloned() {
         Some(value) => value.into_string(),
         None => env::var(key).ok(),
     }

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -430,6 +430,15 @@ impl RustPlugin {
         runtime: &RustRuntime,
     ) -> Result<Option<RustupProfileComponents>> {
         let Some(installed) = self.rustup_toolchain_manifest(tv, runtime)? else {
+            if self
+                .rustup_installed_items(tv, "component", runtime)?
+                .is_some()
+            {
+                bail!(
+                    "cannot reconcile the rustup complete profile for {} because its active toolchain could not be determined",
+                    tv.style()
+                );
+            }
             return Ok(None);
         };
         if let Some(manifest) = installed.contents {
@@ -527,8 +536,7 @@ impl Backend for RustPlugin {
 
         let mut required_components = components.unwrap_or_default();
         let manifest_host = if effective_profile == "complete" {
-            let Some(profile_components) =
-                self.rustup_complete_profile_components(tv, &runtime)?
+            let Some(profile_components) = self.rustup_complete_profile_components(tv, &runtime)?
             else {
                 return Ok(false);
             };

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -1150,7 +1150,7 @@ fn fallback_rustup_profile_components(profile: &str, host: Option<&str>) -> Vec<
                 .map(|component| (*component).to_string()),
         );
     }
-    if host.is_some_and(|host| host.ends_with("-pc-windows-gnu")) {
+    if profile != "complete" && host.is_some_and(|host| host.ends_with("-pc-windows-gnu")) {
         components.push("rust-mingw".to_string());
     }
     components
@@ -1398,6 +1398,10 @@ mod tests {
             ["cargo", "rust-std", "rustc", "rust-mingw"]
         );
         assert!(fallback_rustup_profile_components("complete", None).is_empty());
+        assert!(
+            fallback_rustup_profile_components("complete", Some("x86_64-pc-windows-gnu"))
+                .is_empty()
+        );
     }
 
     #[test]

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -347,6 +347,7 @@ impl Backend for RustPlugin {
             Some(profile) => profile,
             None => self.rustup_default_profile(tv, &runtime)?,
         };
+        let effective_profile = normalize_rustup_profile(&effective_profile)?;
 
         // Query components even when none were explicitly requested. This
         // verifies that rustup still has the toolchain represented by mise's
@@ -523,6 +524,7 @@ impl Backend for RustPlugin {
             Some(profile) => profile.to_string(),
             None => self.rustup_default_profile(&tv, &runtime)?,
         };
+        let effective_profile = normalize_rustup_profile(&effective_profile)?;
         let mut components = components.unwrap_or_default();
         if effective_profile == "default" {
             components.extend(
@@ -1088,6 +1090,17 @@ fn rustup_path_env(runtime: &RustRuntime) -> Result<OsString> {
     )?)
 }
 
+fn normalize_rustup_profile(profile: &str) -> Result<&'static str> {
+    match profile {
+        "minimal" | "m" => Ok("minimal"),
+        "default" | "d" | "" => Ok("default"),
+        "complete" | "c" => Ok("complete"),
+        _ => bail!(
+            "unknown rustup profile name: {profile}; valid profile names are: minimal, default, complete"
+        ),
+    }
+}
+
 fn rustup_component_installed(installed: &BTreeSet<String>, component: &str) -> bool {
     installed.iter().any(|item| {
         item == component
@@ -1287,6 +1300,18 @@ mod tests {
         assert!(!rustup_component_installed(&installed, "rustfmt"));
         assert!(!rustup_component_installed(&installed, "rust"));
         assert!(!rustup_component_installed(&installed, "llvm"));
+    }
+
+    #[test]
+    fn profile_aliases_match_rustup() {
+        assert_eq!(normalize_rustup_profile("minimal").unwrap(), "minimal");
+        assert_eq!(normalize_rustup_profile("m").unwrap(), "minimal");
+        assert_eq!(normalize_rustup_profile("default").unwrap(), "default");
+        assert_eq!(normalize_rustup_profile("d").unwrap(), "default");
+        assert_eq!(normalize_rustup_profile("").unwrap(), "default");
+        assert_eq!(normalize_rustup_profile("complete").unwrap(), "complete");
+        assert_eq!(normalize_rustup_profile("c").unwrap(), "complete");
+        assert!(normalize_rustup_profile("custom").is_err());
     }
 
     #[test]

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -1221,6 +1221,8 @@ const RUST_TARGET_ARCHES: &[&str] = &[
     "powerpc64le",
     "riscv32",
     "riscv64",
+    "riscv64a23",
+    "riscv64gc",
     "s390x",
     "sparc",
     "sparc64",
@@ -1374,6 +1376,29 @@ mod tests {
         assert!(!rustup_component_installed(&installed, "rustfmt", host));
         installed.insert("rust-std-x86_64-unknown-linux-gnu".to_string());
         assert!(rustup_component_installed(&installed, "rust-std", host));
+    }
+
+    #[test]
+    fn rustup_required_components_recognize_riscv_hosts() {
+        let plugin = RustPlugin::new();
+        for host in [
+            "riscv64gc-unknown-linux-gnu",
+            "riscv64a23-unknown-linux-gnu",
+        ] {
+            let toolchain = format!("nightly-2026-09-01-{host}");
+            let selected_host = rustup_toolchain_host(&toolchain);
+            assert_eq!(selected_host, Some(host));
+            let required = fallback_rustup_profile_components("minimal", selected_host);
+            let installed = required
+                .iter()
+                .map(|component| format!("{component}-{host}"))
+                .collect();
+            assert!(
+                plugin
+                    .missing_components(&required, &installed, selected_host)
+                    .is_empty()
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Missing or malformed installed rustup manifests prevent complete-profile reconciliation. This change recovers the exact release manifest from the configured distribution source, including file mirrors, and uses it to restore the selected host's profile components. If authoritative metadata remains unavailable, installation reports a clear error.

Depends on #12817, which depends on #12816 and #12814. This PR targets main, so its GitHub diff includes those prerequisites. [Review this layer only](https://github.com/risu729/mise/compare/fix/rust-complete-profile-components...fix/rust-complete-profile-reconcile). Merge after the prerequisite PRs and rebase to remove their cumulative changes.

Distribution selection honors tool-scoped install environment values, RUSTUP_DIST_SERVER precedence over legacy RUSTUP_DIST_ROOT, and stable/beta/nightly or dated-nightly manifest paths. The behavior was checked against [rustup source](https://github.com/rust-lang/rustup/blob/60e495a99dc409c13c52dff1889217f5f9a1ae61/src/config.rs#L1126-L1140).

Validation at 6de0c4cbc: lint, 32 Rust-plugin unit tests, and the reconciliation/custom-home/external-provider E2E tests passed. Independent subagent review found no remaining issues. CodeRabbit and Greptile findings were addressed; both checks are green and review threads are resolved.

*AI-assisted — Tool: Codex; model: openai/gpt-6; version: unavailable.*
