### PR TITLE
fix(schema): model bootstrap secrets

### DIFF
--- a/schema/mise.json
+++ b/schema/mise.json
@@ -5057,6 +5057,43 @@
             }
           },
           "additionalProperties": false
+        },
+        "secrets": {
+          "type": "object",
+          "description": "sensitive bootstrap inputs resolved from environment variables, keyed by logical secret name",
+          "propertyNames": {
+            "pattern": "^[A-Za-z0-9_.-]+$",
+            "description": "secret name using ASCII letters, digits, '.', '_' or '-'"
+          },
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "string",
+                "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+                "description": "environment variable that provides this secret's value"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "env": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+                    "description": "environment variable that provides this secret's value"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "human-readable description shown in status output and prompts"
+                  },
+                  "allow_empty": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "accept an empty value; empty values are rejected by default"
+                  }
+                },
+                "required": ["env"]
+              }
+            ]
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary

- model bootstrap secret declarations accepted by `BootstrapTomlConfig`
- mirror secret-name and environment-variable validation from runtime
- keep the change independent from the other bootstrap schema scopes

## Validation

- `mise run render:schema`
- schema formatting and JSON validation

Split from #12529. This PR is independent and can be reviewed or merged in any order with the sibling bootstrap schema PRs.

## Related split

All scopes are independent and target `main`; no merge order is required:

- Linux accounts: #12529
- secrets: #12789
- system services: #12790
- Compose projects: #12791
- managed files and directories: #12792

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added schema support for declaring sensitive bootstrap inputs sourced from environment variables.
  * Secret entries can now include descriptions and specify whether empty values are allowed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->