### PR TITLE
fix(schema): model bootstrap services

### DIFF
--- a/schema/mise.json
+++ b/schema/mise.json
@@ -5057,6 +5057,61 @@
             }
           },
           "additionalProperties": false
+        },
+        "services": {
+          "type": "object",
+          "description": "Linux systemd system unit lifecycles managed with `mise bootstrap services apply`, keyed by unit name (`.service` is appended only when the name contains no `.` at all)",
+          "propertyNames": {
+            "pattern": "^[A-Za-z0-9_.@:][A-Za-z0-9_.@:-]{0,254}$",
+            "description": "systemd unit name: at most 255 ASCII letters, digits, '.', '_', '@', ':' or '-', not starting with '-'"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": ["running", "stopped"],
+                "default": "running",
+                "description": "desired service state"
+              },
+              "enabled": {
+                "type": "boolean",
+                "default": true,
+                "description": "whether the unit starts at boot"
+              },
+              "masked": {
+                "type": "boolean",
+                "default": false,
+                "description": "whether systemd must prevent the unit from starting"
+              },
+              "on_change": {
+                "type": "string",
+                "enum": ["reload", "restart", "reload_or_restart", "none"],
+                "default": "reload_or_restart",
+                "description": "action to take when a changed managed file or directory notifies the service"
+              }
+            },
+            "if": {
+              "properties": {
+                "masked": {
+                  "const": true
+                }
+              },
+              "required": ["masked"]
+            },
+            "then": {
+              "title": "masked service (state and enabled default to conflicting values, so both must be set explicitly)",
+              "properties": {
+                "state": {
+                  "const": "stopped"
+                },
+                "enabled": {
+                  "const": false
+                }
+              },
+              "required": ["state", "enabled"]
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary

- model bootstrap system service declarations
- mirror unit-name, state, enabled, and masked constraints from runtime
- keep service management separate from Compose project configuration

## Validation

- `mise run render:schema`
- schema formatting and JSON validation

Split from #12529. This PR is independent and can be reviewed or merged in any order with the sibling bootstrap schema PRs.

## Related split

All scopes are independent and target `main`; no merge order is required:

- Linux accounts: #12529
- secrets: #12789
- system services: #12790
- Compose projects: #12791
- managed files and directories: #12792

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration support for managing Linux systemd services.
  - Services can now be configured for running or stopped states, enabled or disabled startup behavior, masking, and actions triggered by configuration changes.
  - Service names are validated, and masked services must explicitly be stopped and disabled to ensure consistent configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->