### PR TITLE
fix(schema): model bootstrap managed paths

### DIFF
--- a/schema/mise.json
+++ b/schema/mise.json
@@ -5057,6 +5057,189 @@
             }
           },
           "additionalProperties": false
+        },
+        "files": {
+          "type": "object",
+          "description": "system files managed with `mise bootstrap files apply`, keyed by absolute target path",
+          "propertyNames": {
+            "pattern": "^(/|~/)"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string",
+                "description": "file providing the content; relative paths resolve from the declaring config file"
+              },
+              "content": {
+                "type": "string",
+                "description": "inline file content"
+              },
+              "owner": {
+                "type": "string",
+                "pattern": ".*\\S.*",
+                "description": "owning user name"
+              },
+              "group": {
+                "type": "string",
+                "pattern": ".*\\S.*",
+                "description": "owning group name"
+              },
+              "mode": {
+                "type": "string",
+                "pattern": "^(0o)?0*[0-7]{1,4}$",
+                "description": "octal permission mode (e.g. \"0644\"); defaults to 0644"
+              },
+              "template": {
+                "type": "boolean",
+                "default": false,
+                "description": "render the content with mise's template engine"
+              },
+              "state": {
+                "type": "string",
+                "enum": ["present", "absent"],
+                "default": "present",
+                "description": "desired file state"
+              },
+              "replace": {
+                "type": "boolean",
+                "default": false,
+                "description": "replace a target of the wrong node type instead of refusing to destroy it"
+              },
+              "notify": {
+                "type": "array",
+                "description": "configured `[bootstrap.services]` names to notify after the file changes",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "oneOf": [
+              {
+                "title": "present file from a source path",
+                "required": ["source"],
+                "not": {
+                  "anyOf": [
+                    {
+                      "required": ["content"]
+                    },
+                    {
+                      "properties": {
+                        "state": {
+                          "const": "absent"
+                        }
+                      },
+                      "required": ["state"]
+                    }
+                  ]
+                }
+              },
+              {
+                "title": "present file with inline content",
+                "required": ["content"],
+                "not": {
+                  "anyOf": [
+                    {
+                      "required": ["source"]
+                    },
+                    {
+                      "properties": {
+                        "state": {
+                          "const": "absent"
+                        }
+                      },
+                      "required": ["state"]
+                    }
+                  ]
+                }
+              },
+              {
+                "title": "absent file",
+                "properties": {
+                  "state": {
+                    "const": "absent"
+                  }
+                },
+                "required": ["state"],
+                "not": {
+                  "anyOf": [
+                    {
+                      "required": ["source"]
+                    },
+                    {
+                      "required": ["content"]
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "directories": {
+          "type": "object",
+          "description": "system directories managed with `mise bootstrap files apply`, keyed by absolute target path",
+          "propertyNames": {
+            "pattern": "^(/|~/)"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "owner": {
+                "type": "string",
+                "pattern": ".*\\S.*",
+                "description": "owning user name"
+              },
+              "group": {
+                "type": "string",
+                "pattern": ".*\\S.*",
+                "description": "owning group name"
+              },
+              "mode": {
+                "type": "string",
+                "pattern": "^(0o)?0*[0-7]{1,4}$",
+                "description": "octal permission mode (e.g. \"0755\"); defaults to 0755"
+              },
+              "state": {
+                "type": "string",
+                "enum": ["present", "absent"],
+                "default": "present",
+                "description": "desired directory state"
+              },
+              "recursive": {
+                "type": "boolean",
+                "default": false,
+                "description": "recursively delete the directory's contents when removing it"
+              },
+              "replace": {
+                "type": "boolean",
+                "default": false,
+                "description": "replace a target of the wrong node type instead of refusing to destroy it"
+              },
+              "notify": {
+                "type": "array",
+                "description": "configured `[bootstrap.services]` names to notify after the directory changes",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "if": {
+              "properties": {
+                "recursive": {
+                  "const": true
+                }
+              },
+              "required": ["recursive"]
+            },
+            "then": {
+              "properties": {
+                "state": {
+                  "const": "absent"
+                }
+              },
+              "required": ["state"]
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary

- model bootstrap managed files and directories
- mirror absolute-path, content-source, ownership, mode, templating, lifecycle, and recursive-removal constraints from runtime
- keep managed paths separate from accounts, services, and Compose

## Validation

- `mise run render:schema`
- schema formatting and JSON validation

Split from #12529. This PR is independent and can be reviewed or merged in any order with the sibling bootstrap schema PRs.

## Related split

All scopes are independent and target `main`; no merge order is required:

- Linux accounts: #12529
- secrets: #12789
- system services: #12790
- Compose projects: #12791
- managed files and directories: #12792

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added schema support for managing system files through bootstrap configuration, including sources or inline content, permissions, ownership, templating, replacement, and notifications.
  * Added schema support for managing directories, including permissions, ownership, recursive handling, replacement, and notifications.
  * Added validation for supported file and directory states and configuration variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->