### PR TITLE
fix(schema): align env directive options

### DIFF
--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -229,7 +229,7 @@ strict = true
 
 [[schemas]]
 path = "file://$SCHEMA_PATH"
-include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-dotfiles.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-env-float.toml", "mise-bad-install-env-float.toml", "mise-bad-minimum-release-age-array.toml", "mise-bad-minimum-release-age-table.toml", "mise-bad-package-state.toml", "mise-bad-postinstall.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-launchd-queue.toml", "mise-bad-launchd-throttle.toml", "mise-bad-systemd.toml", "mise-bad-oci-copy.toml", "mise-bad-shell-activate.toml"]
+include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-dotfiles.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-env-directive-expand.toml", "mise-bad-env-float.toml", "mise-bad-install-env-float.toml", "mise-bad-minimum-release-age-array.toml", "mise-bad-minimum-release-age-table.toml", "mise-bad-package-state.toml", "mise-bad-postinstall.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-launchd-queue.toml", "mise-bad-launchd-throttle.toml", "mise-bad-systemd.toml", "mise-bad-oci-copy.toml", "mise-bad-shell-activate.toml"]
 
 [[schemas]]
 path = "file://$TASK_SCHEMA_PATH"
@@ -302,6 +302,18 @@ _.file = { path = ".env", required = 123 }
 TOML
 
 assert_fail "$TOMBI_LINT mise-bad-env-directive.toml"
+
+# `expand` is only read for `_.file`; reject it on path/source directives so
+# editors do not suggest that the option has an effect there.
+for directive in \
+  '_.path = { paths = ["./bin"], expand = true }' \
+  '_.source = { path = "env.sh", expand = true }'; do
+  cat >"$HOME/workdir/mise-bad-env-directive-expand.toml" <<TOML
+[env]
+$directive
+TOML
+  assert_fail "$TOMBI_LINT mise-bad-env-directive-expand.toml"
+done
 
 cat >"$HOME/workdir/mise-bad-env-float.toml" <<'TOML'
 [env]

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -550,38 +550,7 @@
             "path": {
               "oneOf": [
                 {
-                  "type": "object",
-                  "properties": {
-                    "path": {
-                      "$ref": "#/$defs/env_path"
-                    },
-                    "paths": {
-                      "$ref": "#/$defs/env_paths"
-                    },
-                    "tools": {
-                      "$ref": "#/$defs/env_tools"
-                    }
-                  },
-                  "oneOf": [
-                    {
-                      "type": "object",
-                      "properties": {
-                        "path": {
-                          "$ref": "#/$defs/env_path"
-                        }
-                      },
-                      "required": ["path"]
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "paths": {
-                          "$ref": "#/$defs/env_paths"
-                        }
-                      },
-                      "required": ["paths"]
-                    }
-                  ]
+                  "$ref": "#/$defs/env_directive_no_expand"
                 },
                 {
                   "description": "PATH entry to add",
@@ -597,15 +566,7 @@
                         "type": "string"
                       },
                       {
-                        "type": "object",
-                        "properties": {
-                          "path": {
-                            "$ref": "#/$defs/env_path"
-                          },
-                          "tools": {
-                            "$ref": "#/$defs/env_tools"
-                          }
-                        }
+                        "$ref": "#/$defs/env_directive_no_expand"
                       }
                     ]
                   }
@@ -614,6 +575,7 @@
             },
             "python": {
               "description": "python environment",
+              "additionalProperties": false,
               "properties": {
                 "venv": {
                   "oneOf": [
@@ -623,6 +585,7 @@
                     },
                     {
                       "description": "virtualenv options",
+                      "additionalProperties": false,
                       "properties": {
                         "create": {
                           "default": false,
@@ -663,7 +626,7 @@
             "source": {
               "oneOf": [
                 {
-                  "$ref": "#/$defs/env_directive"
+                  "$ref": "#/$defs/env_directive_no_expand"
                 },
                 {
                   "description": "bash script to load",
@@ -679,7 +642,7 @@
                         "type": "string"
                       },
                       {
-                        "$ref": "#/$defs/env_directive"
+                        "$ref": "#/$defs/env_directive_no_expand"
                       }
                     ]
                   }
@@ -688,6 +651,11 @@
             }
           },
           "type": "object"
+        },
+        "mise": {
+          "$ref": "#/$defs/env/properties/_",
+          "deprecated": true,
+          "description": "deprecated alias for `_`; use `env._` instead"
         }
       },
       "type": "object"
@@ -1139,6 +1107,16 @@
         "paths": {
           "$ref": "#/$defs/env_paths"
         },
+        "value": {
+          "$ref": "#/$defs/env_path",
+          "deprecated": true,
+          "description": "deprecated alias for `path`"
+        },
+        "values": {
+          "$ref": "#/$defs/env_paths",
+          "deprecated": true,
+          "description": "deprecated alias for `paths`"
+        },
         "tools": {
           "$ref": "#/$defs/env_tools"
         },
@@ -1154,24 +1132,32 @@
       },
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "path": {
-              "$ref": "#/$defs/env_path"
-            }
-          },
           "required": ["path"]
         },
         {
-          "type": "object",
-          "properties": {
-            "paths": {
-              "$ref": "#/$defs/env_paths"
-            }
-          },
           "required": ["paths"]
+        },
+        {
+          "required": ["value"]
+        },
+        {
+          "required": ["values"]
         }
       ]
+    },
+    "env_directive_no_expand": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/env_directive"
+        }
+      ],
+      "properties": {
+        "expand": {
+          "const": false,
+          "description": "`expand` is only read for `_.file`; it does nothing on `_.path` or `_.source`"
+        }
+      }
     },
     "env_age_value": {
       "type": "string",
@@ -1181,6 +1167,21 @@
       "type": "string",
       "enum": ["raw", "zstd"],
       "description": "[experimental] compression format for the encrypted value"
+    },
+    "os_filter": {
+      "description": "operating system filters to install on",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/os_filter_item"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/os_filter_item"
+          },
+          "minItems": 1
+        }
+      ]
     },
     "env_path": {
       "oneOf": [
@@ -1201,25 +1202,10 @@
         "type": "string"
       }
     },
-    "os_filter": {
-      "description": "operating system filters to install on",
-      "oneOf": [
-        {
-          "$ref": "#/$defs/os_filter_item"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/os_filter_item"
-          },
-          "minItems": 1
-        }
-      ]
-    },
     "env_file_expand": {
       "type": "boolean",
       "default": false,
-      "description": "enable shell-style variable expansion for values loaded by env._.file"
+      "description": "enable shell-style variable expansion for values loaded by `_.file`"
     },
     "os_filter_item": {
       "description": "operating system or os/arch pair to install on",

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -138,7 +138,7 @@
     "env_file_expand": {
       "type": "boolean",
       "default": false,
-      "description": "enable shell-style variable expansion for values loaded by env._.file"
+      "description": "enable shell-style variable expansion for values loaded by `_.file`"
     },
     "env_redact": {
       "type": "boolean",
@@ -192,6 +192,16 @@
         "paths": {
           "$ref": "#/$defs/env_paths"
         },
+        "value": {
+          "$ref": "#/$defs/env_path",
+          "deprecated": true,
+          "description": "deprecated alias for `path`"
+        },
+        "values": {
+          "$ref": "#/$defs/env_paths",
+          "deprecated": true,
+          "description": "deprecated alias for `paths`"
+        },
         "tools": {
           "$ref": "#/$defs/env_tools"
         },
@@ -207,24 +217,32 @@
       },
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "path": {
-              "$ref": "#/$defs/env_path"
-            }
-          },
           "required": ["path"]
         },
         {
-          "type": "object",
-          "properties": {
-            "paths": {
-              "$ref": "#/$defs/env_paths"
-            }
-          },
           "required": ["paths"]
+        },
+        {
+          "required": ["value"]
+        },
+        {
+          "required": ["values"]
         }
       ]
+    },
+    "env_directive_no_expand": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/env_directive"
+        }
+      ],
+      "properties": {
+        "expand": {
+          "const": false,
+          "description": "`expand` is only read for `_.file`; it does nothing on `_.path` or `_.source`"
+        }
+      }
     },
     "env": {
       "additionalProperties": {
@@ -371,38 +389,7 @@
             "path": {
               "oneOf": [
                 {
-                  "type": "object",
-                  "properties": {
-                    "path": {
-                      "$ref": "#/$defs/env_path"
-                    },
-                    "paths": {
-                      "$ref": "#/$defs/env_paths"
-                    },
-                    "tools": {
-                      "$ref": "#/$defs/env_tools"
-                    }
-                  },
-                  "oneOf": [
-                    {
-                      "type": "object",
-                      "properties": {
-                        "path": {
-                          "$ref": "#/$defs/env_path"
-                        }
-                      },
-                      "required": ["path"]
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "paths": {
-                          "$ref": "#/$defs/env_paths"
-                        }
-                      },
-                      "required": ["paths"]
-                    }
-                  ]
+                  "$ref": "#/$defs/env_directive_no_expand"
                 },
                 {
                   "description": "PATH entry to add",
@@ -418,15 +405,7 @@
                         "type": "string"
                       },
                       {
-                        "type": "object",
-                        "properties": {
-                          "path": {
-                            "$ref": "#/$defs/env_path"
-                          },
-                          "tools": {
-                            "$ref": "#/$defs/env_tools"
-                          }
-                        }
+                        "$ref": "#/$defs/env_directive_no_expand"
                       }
                     ]
                   }
@@ -435,6 +414,7 @@
             },
             "python": {
               "description": "python environment",
+              "additionalProperties": false,
               "properties": {
                 "venv": {
                   "oneOf": [
@@ -444,6 +424,7 @@
                     },
                     {
                       "description": "virtualenv options",
+                      "additionalProperties": false,
                       "properties": {
                         "create": {
                           "default": false,
@@ -484,7 +465,7 @@
             "source": {
               "oneOf": [
                 {
-                  "$ref": "#/$defs/env_directive"
+                  "$ref": "#/$defs/env_directive_no_expand"
                 },
                 {
                   "description": "bash script to load",
@@ -500,7 +481,7 @@
                         "type": "string"
                       },
                       {
-                        "$ref": "#/$defs/env_directive"
+                        "$ref": "#/$defs/env_directive_no_expand"
                       }
                     ]
                   }
@@ -509,6 +490,11 @@
             }
           },
           "type": "object"
+        },
+        "mise": {
+          "$ref": "#/$defs/env/properties/_",
+          "deprecated": true,
+          "description": "deprecated alias for `_`; use `env._` instead"
         }
       },
       "type": "object"


### PR DESCRIPTION
## Summary

- model the deprecated `value` and `values` aliases for environment directives
- model the deprecated `[env.mise]` alias using the same contract as `[env._]`
- expose the full directive option shape on path and source entries while rejecting their no-op `expand = true`
- make Python virtual-environment option objects strict

This is one scope split from #12531. It is independent and based directly on `main`; #12794 separately covers vars values and directives. The three PRs can merge in any order.

## Validation

- `mise run render:schema`
- `mise run test:e2e e2e/config/test_schema_tombi`

Schema-only change; runtime behavior is unchanged.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for environment directives, preventing unsupported `expand` settings on path and source directives.
  - Python and virtual environment configurations now reject unrecognized properties.

- **Compatibility**
  - Schema validation now recognizes deprecated `value`/`values` aliases for environment paths.
  - Added support for the deprecated `env.mise` alias.

- **Tests**
  - Added coverage for invalid environment directive expansion settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->