### PR TITLE
fix(schema): align vars shapes with the parser

### DIFF
--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -161,16 +161,19 @@ cat >"$HOME/workdir/mise-vars.toml" <<'TOML'
 STRING = "value"
 INTEGER = 123
 TRUE_BOOL = true
+FALSE_BOOL = false
 VALUE_STRING = { value = "value", redact = true }
 VALUE_INTEGER = { value = 123 }
 VALUE_TRUE = { value = true }
+VALUE_FALSE = { value = false, redact = true, tools = false }
 VALUE_DEFAULT = { default = 123, redact = true }
 REQUIRED_TRUE = { required = true, redact = true }
 REQUIRED_HELP = { required = "set REQUIRED_HELP in mise.local.toml" }
 SECRET_SIMPLE = { age = "AGE-SECRET", redact = false }
 SECRET_COMPLEX = { age = { value = "AGE-SECRET", format = "raw", redact = true } }
-_.file = ".env"
+_.file = { path = ".env", redact = true, required = true, expand = true }
 _.source = ["env.sh"]
+_.path = "./bin"
 TOML
 
 cat >"$HOME/workdir/mise-os.toml" <<'TOML'
@@ -229,7 +232,7 @@ strict = true
 
 [[schemas]]
 path = "file://$SCHEMA_PATH"
-include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-dotfiles.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-env-float.toml", "mise-bad-install-env-float.toml", "mise-bad-minimum-release-age-array.toml", "mise-bad-minimum-release-age-table.toml", "mise-bad-package-state.toml", "mise-bad-postinstall.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-launchd-queue.toml", "mise-bad-launchd-throttle.toml", "mise-bad-systemd.toml", "mise-bad-oci-copy.toml", "mise-bad-shell-activate.toml"]
+include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-dotfiles.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-env-float.toml", "mise-bad-install-env-float.toml", "mise-bad-minimum-release-age-array.toml", "mise-bad-minimum-release-age-table.toml", "mise-bad-package-state.toml", "mise-bad-postinstall.toml", "mise-bad-vars.toml", "mise-bad-vars-mise.toml", "mise-bad-vars-tools.toml", "mise-bad-vars-directive-tools.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-launchd-queue.toml", "mise-bad-launchd-throttle.toml", "mise-bad-systemd.toml", "mise-bad-oci-copy.toml", "mise-bad-shell-activate.toml"]
 
 [[schemas]]
 path = "file://$TASK_SCHEMA_PATH"
@@ -353,15 +356,41 @@ done
 
 cat >"$HOME/workdir/mise-bad-vars.toml" <<'TOML'
 [vars]
-FALSE_BOOL = false
-VALUE_FALSE = { value = false }
 REQUIRED_FALSE = { required = false }
 FLOAT = 1.23
 VALUE_FLOAT = { value = 1.23 }
-TOOLS_FILTERED = { value = "not actually resolved as a var", tools = true }
 TOML
 
 assert_fail "$TOMBI_LINT mise-bad-vars.toml"
+
+cat >"$HOME/workdir/mise-bad-vars-mise.toml" <<'TOML'
+[vars.mise]
+path = "./bin"
+TOML
+
+assert_fail "$TOMBI_LINT mise-bad-vars-mise.toml"
+
+# Vars are always resolved with the non-tools filter, so `tools = true` entries
+# are dropped rather than resolved. Exercise both regular and encrypted shapes.
+for entry in \
+  '{ value = "x", tools = true }' \
+  '{ age = "AGE-SECRET", tools = true }'; do
+  cat >"$HOME/workdir/mise-bad-vars-tools.toml" <<TOML
+[vars]
+TOOLS_FILTERED = $entry
+TOML
+  assert_fail "$TOMBI_LINT mise-bad-vars-tools.toml"
+done
+
+for directive in \
+  '_.file = { path = ".env", tools = true }' \
+  '_.path = { paths = ["./bin"], tools = true }'; do
+  cat >"$HOME/workdir/mise-bad-vars-directive-tools.toml" <<TOML
+[vars]
+$directive
+TOML
+  assert_fail "$TOMBI_LINT mise-bad-vars-directive-tools.toml"
+done
 
 # Verify that extends is rejected on task_templates (not supported at runtime)
 cat >"$HOME/workdir/mise-bad-tmpl.toml" <<'TOML'

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -701,73 +701,42 @@
           "additionalProperties": true,
           "properties": {
             "file": {
-              "oneOf": [
-                {
-                  "description": "environment file to load (dotenv, json, yaml, or toml)",
-                  "type": "string"
-                },
-                {
-                  "description": "environment files to load (dotenv, json, yaml, or toml)",
-                  "items": {
-                    "description": "environment file to load (dotenv, json, yaml, or toml)",
-                    "type": "string"
-                  },
-                  "type": "array"
-                }
-              ]
+              "$ref": "#/$defs/vars_file_directive"
+            },
+            "path": {
+              "$ref": "#/$defs/vars_path_directive"
             },
             "source": {
-              "oneOf": [
-                {
-                  "description": "bash script to load",
-                  "type": "string"
-                },
-                {
-                  "description": "bash scripts to load",
-                  "items": {
-                    "description": "bash script to load",
-                    "type": "string"
-                  },
-                  "type": "array"
-                }
-              ]
+              "$ref": "#/$defs/vars_path_directive"
             }
           },
           "type": "object"
+        },
+        "mise": {
+          "allOf": [false],
+          "description": "`vars.mise` is not supported; use `vars._` instead"
         }
       },
       "additionalProperties": {
         "oneOf": [
           {
-            "description": "value of variable",
-            "type": "string"
-          },
-          {
-            "description": "value of variable",
-            "type": "integer"
-          },
-          {
-            "description": "value of variable",
-            "const": true
+            "$ref": "#/$defs/env_value"
           },
           {
             "type": "object",
             "properties": {
               "value": {
-                "oneOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "integer"
-                  },
-                  {
-                    "const": true
-                  }
-                ]
+                "$ref": "#/$defs/env_value"
               },
               "redact": {
                 "$ref": "#/$defs/env_redact"
+              },
+              "tools": {
+                "$ref": "#/$defs/vars_tools"
+              },
+              "required": {
+                "const": false,
+                "description": "cannot be required when a value is provided; only `required = false` is accepted"
               }
             },
             "required": ["value"],
@@ -781,6 +750,9 @@
               },
               "redact": {
                 "$ref": "#/$defs/env_redact"
+              },
+              "tools": {
+                "$ref": "#/$defs/vars_tools"
               }
             },
             "required": ["default"],
@@ -791,6 +763,9 @@
             "properties": {
               "redact": {
                 "$ref": "#/$defs/env_redact"
+              },
+              "tools": {
+                "$ref": "#/$defs/vars_tools"
               },
               "required": {
                 "oneOf": [
@@ -814,6 +789,12 @@
               },
               "redact": {
                 "$ref": "#/$defs/env_redact"
+              },
+              "tools": {
+                "$ref": "#/$defs/vars_tools"
+              },
+              "required": {
+                "$ref": "#/$defs/env_required"
               }
             },
             "required": ["age"],
@@ -834,6 +815,12 @@
                   },
                   "redact": {
                     "$ref": "#/$defs/env_redact"
+                  },
+                  "tools": {
+                    "$ref": "#/$defs/vars_tools"
+                  },
+                  "required": {
+                    "$ref": "#/$defs/env_required"
                   }
                 },
                 "required": ["value"],
@@ -1041,6 +1028,52 @@
         }
       ]
     },
+    "vars_file_directive": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/vars_directive"
+        },
+        {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/vars_directive"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "vars_path_directive": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/vars_directive_no_expand"
+        },
+        {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/vars_directive_no_expand"
+              }
+            ]
+          }
+        }
+      ]
+    },
     "env_tools": {
       "type": "boolean",
       "description": "load tools before resolving"
@@ -1078,6 +1111,10 @@
     "env_age": {
       "type": "string",
       "description": "[experimental] age-encrypted value (simplified format)"
+    },
+    "vars_tools": {
+      "const": false,
+      "description": "`tools = true` is not supported in `[vars]`: vars are always resolved before tools, so the entry would be dropped instead of resolved. Use `[env]` for values that need tools."
     },
     "tool_options": {
       "properties": {
@@ -1181,6 +1218,33 @@
       "type": "string",
       "enum": ["raw", "zstd"],
       "description": "[experimental] compression format for the encrypted value"
+    },
+    "vars_directive": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/env_directive"
+        }
+      ],
+      "properties": {
+        "tools": {
+          "$ref": "#/$defs/vars_tools"
+        }
+      }
+    },
+    "vars_directive_no_expand": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/vars_directive"
+        }
+      ],
+      "properties": {
+        "expand": {
+          "const": false,
+          "description": "`expand` is only read for `_.file`; it does nothing on `_.path` or `_.source`"
+        }
+      }
     },
     "env_path": {
       "oneOf": [

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2287,6 +2287,83 @@
         }
       ]
     },
+    "vars_tools": {
+      "const": false,
+      "description": "`tools = true` is not supported in `[vars]`: vars are always resolved before tools, so the entry would be dropped instead of resolved. Use `[env]` for values that need tools."
+    },
+    "vars_directive": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/env_directive"
+        }
+      ],
+      "properties": {
+        "tools": {
+          "$ref": "#/$defs/vars_tools"
+        }
+      }
+    },
+    "vars_directive_no_expand": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/vars_directive"
+        }
+      ],
+      "properties": {
+        "expand": {
+          "const": false,
+          "description": "`expand` is only read for `_.file`; it does nothing on `_.path` or `_.source`"
+        }
+      }
+    },
+    "vars_file_directive": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/vars_directive"
+        },
+        {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/vars_directive"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "vars_path_directive": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/vars_directive_no_expand"
+        },
+        {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/vars_directive_no_expand"
+              }
+            ]
+          }
+        }
+      ]
+    },
     "vars": {
       "description": "variables to set",
       "type": "object",
@@ -2296,73 +2373,42 @@
           "additionalProperties": true,
           "properties": {
             "file": {
-              "oneOf": [
-                {
-                  "description": "environment file to load (dotenv, json, yaml, or toml)",
-                  "type": "string"
-                },
-                {
-                  "description": "environment files to load (dotenv, json, yaml, or toml)",
-                  "items": {
-                    "description": "environment file to load (dotenv, json, yaml, or toml)",
-                    "type": "string"
-                  },
-                  "type": "array"
-                }
-              ]
+              "$ref": "#/$defs/vars_file_directive"
+            },
+            "path": {
+              "$ref": "#/$defs/vars_path_directive"
             },
             "source": {
-              "oneOf": [
-                {
-                  "description": "bash script to load",
-                  "type": "string"
-                },
-                {
-                  "description": "bash scripts to load",
-                  "items": {
-                    "description": "bash script to load",
-                    "type": "string"
-                  },
-                  "type": "array"
-                }
-              ]
+              "$ref": "#/$defs/vars_path_directive"
             }
           },
           "type": "object"
+        },
+        "mise": {
+          "allOf": [false],
+          "description": "`vars.mise` is not supported; use `vars._` instead"
         }
       },
       "additionalProperties": {
         "oneOf": [
           {
-            "description": "value of variable",
-            "type": "string"
-          },
-          {
-            "description": "value of variable",
-            "type": "integer"
-          },
-          {
-            "description": "value of variable",
-            "const": true
+            "$ref": "#/$defs/env_value"
           },
           {
             "type": "object",
             "properties": {
               "value": {
-                "oneOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "integer"
-                  },
-                  {
-                    "const": true
-                  }
-                ]
+                "$ref": "#/$defs/env_value"
               },
               "redact": {
                 "$ref": "#/$defs/env_redact"
+              },
+              "tools": {
+                "$ref": "#/$defs/vars_tools"
+              },
+              "required": {
+                "const": false,
+                "description": "cannot be required when a value is provided; only `required = false` is accepted"
               }
             },
             "required": ["value"],
@@ -2376,6 +2422,9 @@
               },
               "redact": {
                 "$ref": "#/$defs/env_redact"
+              },
+              "tools": {
+                "$ref": "#/$defs/vars_tools"
               }
             },
             "required": ["default"],
@@ -2386,6 +2435,9 @@
             "properties": {
               "redact": {
                 "$ref": "#/$defs/env_redact"
+              },
+              "tools": {
+                "$ref": "#/$defs/vars_tools"
               },
               "required": {
                 "oneOf": [
@@ -2409,6 +2461,12 @@
               },
               "redact": {
                 "$ref": "#/$defs/env_redact"
+              },
+              "tools": {
+                "$ref": "#/$defs/vars_tools"
+              },
+              "required": {
+                "$ref": "#/$defs/env_required"
               }
             },
             "required": ["age"],
@@ -2429,6 +2487,12 @@
                   },
                   "redact": {
                     "$ref": "#/$defs/env_redact"
+                  },
+                  "tools": {
+                    "$ref": "#/$defs/vars_tools"
+                  },
+                  "required": {
+                    "$ref": "#/$defs/env_required"
                   }
                 },
                 "required": ["value"],


### PR DESCRIPTION
## Summary

- accept false-removal values and parser-supported option tables in `[vars]`
- model object and array forms for `vars._.file`, `vars._.path`, and `vars._.source`
- reject `tools = true`, which the non-tools vars resolver silently drops
- reject the unsupported `[vars.mise]` alias and no-op path/source expansion

This is one scope split from #12531. It is independent and based directly on `main`; #12793 separately covers the corresponding environment-directive aliases and options.

## Validation

- `mise run render:schema`
- `mise run test:e2e e2e/config/test_schema_tombi`

Schema-only change; runtime behavior is unchanged.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*
