### PR TITLE
fix(schema): model ignored rust cache verify

### DIFF
--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -230,6 +230,12 @@
                 "enabled": {
                   "type": "boolean",
                   "default": true
+                },
+                "verify": {
+                  "deprecated": true,
+                  "description": "accepted for compatibility but ignored because rust_cache is deprecated and no longer used",
+                  "type": "boolean",
+                  "default": false
                 }
               }
             }

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2505,6 +2505,12 @@
                 "enabled": {
                   "type": "boolean",
                   "default": true
+                },
+                "verify": {
+                  "deprecated": true,
+                  "description": "accepted for compatibility but ignored because rust_cache is deprecated and no longer used",
+                  "type": "boolean",
+                  "default": false
                 }
               }
             }
@@ -3330,6 +3336,12 @@
                 "enabled": {
                   "type": "boolean",
                   "default": true
+                },
+                "verify": {
+                  "deprecated": true,
+                  "description": "accepted for compatibility but ignored because rust_cache is deprecated and no longer used",
+                  "type": "boolean",
+                  "default": false
                 }
               }
             }


### PR DESCRIPTION
Splits the Rust-cache compatibility field from #12521 into an independently reviewable schema change.

## Change

The task parser still accepts `rust_cache.verify` for compatibility. Because `rust_cache` is deprecated and unused, the schema marks `verify` as deprecated and accurately describes it as ignored in both task-property contexts.

## Scope

- Schema-only; no runtime behavior changes.
- Independent of the other #12521 split PRs and based directly on `main`.

## Related split PRs

- #12521 — task dependency shapes
- #12796 — structured task-array entries
- #12797 — disabled automatic outputs

No merge order is required.

## Validation

- `mise run render:schema`
- Schema and Prettier checks scoped to `schema/mise.json` and `schema/mise-task.json`
- The original combined change passed `mise run test:e2e e2e/config/test_schema_tombi` and `mise run lint-fix` before splitting.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility**
  - Configuration schemas now accept the deprecated `rust_cache.verify` option for compatibility.
  - The option defaults to `false` and is ignored because `rust_cache` is no longer used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->