### PR TITLE
fix(schema): allow structured task array entries

### DIFF
--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -15,10 +15,9 @@
           "type": "string"
         },
         {
-          "description": "script to run",
+          "description": "scripts or task references to run",
           "items": {
-            "description": "script to run",
-            "type": "string"
+            "$ref": "#/$defs/task_run_entry"
           },
           "type": "array"
         },
@@ -38,6 +37,54 @@
           ],
           "unevaluatedProperties": false,
           "type": "object"
+        }
+      ]
+    },
+    "task_run_entry": {
+      "oneOf": [
+        {
+          "description": "script to run",
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "unevaluatedProperties": false,
+          "properties": {
+            "task": {
+              "description": "single task name to run",
+              "type": "string"
+            },
+            "args": {
+              "description": "arguments to pass to the task",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "env": {
+              "description": "environment variables to set for the task",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "required": ["task"]
+        },
+        {
+          "type": "object",
+          "unevaluatedProperties": false,
+          "properties": {
+            "tasks": {
+              "description": "parallel task group to run",
+              "items": {
+                "description": "task name and args",
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": ["tasks"]
         }
       ]
     },
@@ -936,54 +983,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "task_run_entry": {
-      "oneOf": [
-        {
-          "description": "script to run",
-          "type": "string"
-        },
-        {
-          "type": "object",
-          "unevaluatedProperties": false,
-          "properties": {
-            "task": {
-              "description": "single task name to run",
-              "type": "string"
-            },
-            "args": {
-              "description": "arguments to pass to the task",
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "env": {
-              "description": "environment variables to set for the task",
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            }
-          },
-          "required": ["task"]
-        },
-        {
-          "type": "object",
-          "unevaluatedProperties": false,
-          "properties": {
-            "tasks": {
-              "description": "parallel task group to run",
-              "items": {
-                "description": "task name and args",
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          "required": ["tasks"]
         }
       ]
     },

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2261,10 +2261,9 @@
           "type": "string"
         },
         {
-          "description": "script to run",
+          "description": "scripts or task references to run",
           "items": {
-            "description": "script to run",
-            "type": "string"
+            "$ref": "#/$defs/task_run_entry"
           },
           "type": "array"
         },


### PR DESCRIPTION
Splits structured task-array entries from #12521 into an independently reviewable schema change.

## Change

The task parser accepts full `RunEntry` values inside task arrays, including task-reference tables with `task`, `args`, and `env`. The schema previously limited array items to strings. Point array items at the existing `task_run_entry` definition.

## Scope

- Schema-only; no runtime behavior changes.
- Independent of the other #12521 split PRs and based directly on `main`.

## Related split PRs

- #12521 — task dependency shapes
- #12797 — disabled automatic outputs
- #12795 — ignored Rust-cache verification

No merge order is required.

## Validation

- `mise run render:schema`
- Schema and Prettier checks scoped to `schema/mise.json` and `schema/mise-task.json`
- The original combined change passed `mise run test:e2e e2e/config/test_schema_tombi` and `mise run lint-fix` before splitting.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task lists now support both scripts and task references.
  * Task references can include optional arguments and environment settings.
  * Parallel task groups are supported within task lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->