### PR TITLE
fix(schema): allow disabling automatic task outputs

### DIFF
--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -175,8 +175,7 @@
               "unevaluatedProperties": false,
               "properties": {
                 "auto": {
-                  "description": "automatically touch an internal tracked file instead of specifying outputs",
-                  "enum": [true],
+                  "description": "automatically touch an internal tracked file instead of specifying outputs (false disables auto tracking)",
                   "type": "boolean"
                 }
               },

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -3275,8 +3275,7 @@
               "unevaluatedProperties": false,
               "properties": {
                 "auto": {
-                  "description": "automatically touch an internal tracked file instead of specifying outputs",
-                  "enum": [true],
+                  "description": "automatically touch an internal tracked file instead of specifying outputs (false disables auto tracking)",
                   "type": "boolean"
                 }
               },


### PR DESCRIPTION
Splits the task-output compatibility fix from #12521 into an independently reviewable schema change.

## Change

The parser accepts `outputs = { auto = false }` and treats it as disabled automatic output tracking. The schema previously allowed only `true`; this models the full boolean contract and documents what `false` means.

## Scope

- Schema-only; no runtime behavior changes.
- Independent of the other #12521 split PRs and based directly on `main`.

## Related split PRs

- #12521 — task dependency shapes
- #12796 — structured task-array entries
- #12795 — ignored Rust-cache verification

No merge order is required.

## Validation

- `mise run render:schema`
- Schema and Prettier checks scoped to `schema/mise.json` and `schema/mise-task.json`
- The original combined change passed `mise run test:e2e e2e/config/test_schema_tombi` and `mise run lint-fix` before splitting.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*
