### PR TITLE
fix(packslip): enforce signed list continuity and verified release age

### DIFF
--- a/docs/dev-tools/backends/packslip.md
+++ b/docs/dev-tools/backends/packslip.md
@@ -176,3 +176,9 @@ Lockfiles record the artifact URL and its sha256 from the signed statement.
 Resources may name one exact `artifact` when layouts differ between archive formats or variants. Completions are selected for the command being completed; when a release has several executables, pass its command name to `--tool`. Generated scripts are cached separately for each installed version, executable, and shell.
 
 Exec resources receive the manifest’s environment variables, with `{shell}` expanded for completions. They run in a temporary directory with the installed executables on PATH, no stdin, discarded stderr, and a five-second timeout. Failed or empty output is not cached. The same execution rules apply to skills when `packslip.exec` permits generating them.
+
+### Release-list continuity and minimum age
+
+Once mise has accepted a supplementary signed list, a missing list is an error: a 404 cannot silently restore releases the vendor withdrew. `mise packslip forget <project>` explicitly resets that remembered policy along with the signer pin.
+
+The release API or list timestamp helps select candidates. Before downloading an artifact, mise checks the verified transparency-log timestamp against the effective `minimum_release_age` cutoff. Only a permitted unlogged bundle uses its signed publication timestamp instead.

--- a/src/backend/packslip.rs
+++ b/src/backend/packslip.rs
@@ -425,6 +425,31 @@ pub(crate) fn verify_release_list(
 }
 
 /// The headers a download from GitHub needs; nothing for anywhere else.
+/// Listing timestamps only filter candidates. The authenticated log time
+/// decides whether a selected release is old enough to install.
+fn check_verified_age(
+    logged_at: Option<&str>,
+    published_at: &str,
+    before: Option<jiff::Timestamp>,
+) -> Result<()> {
+    let Some(before) = before else {
+        return Ok(());
+    };
+    let (time, source) = match logged_at {
+        Some(time) => (time, "transparency log"),
+        None => (published_at, "unlogged manifest"),
+    };
+    let time: jiff::Timestamp = time
+        .parse()
+        .wrap_err("invalid verified packslip timestamp")?;
+    if time > before {
+        bail!(
+            "packslip release was recorded by the {source} at {time}, after the allowed cutoff {before}; refusing to bypass minimum_release_age"
+        );
+    }
+    Ok(())
+}
+
 fn headers_for(url: &str) -> Result<HeaderMap> {
     if url.starts_with("https://github.com/") || url.starts_with("https://api.github.com/") {
         github::get_headers(url)
@@ -513,7 +538,10 @@ impl PackslipBackend {
             .await
         {
             Ok(text) => text,
-            Err(err) if crate::http::error_code(&err) == Some(404) => return Ok(None),
+            Err(err) if crate::http::error_code(&err) == Some(404) => {
+                packslip_pins::check_missing_list(project)?;
+                return Ok(None);
+            }
             Err(err) => {
                 return Err(err)
                     .wrap_err_with(|| format!("fetching the release list of packslip:{project}"));
@@ -859,6 +887,17 @@ impl Backend for PackslipBackend {
                 .map(|t| format!(", logged {t}"))
                 .unwrap_or_default()
         );
+        let before = crate::install_before::resolve_before_date_for_tool(
+            &self.ba,
+            tv.before_date.or(ctx.before_date),
+            raw_opts.minimum_release_age(),
+        )?;
+        check_verified_age(
+            verified.logged_at.as_deref(),
+            &verified.published_at,
+            before,
+        )?;
+
         // Who signed, against what this machine accepted before, and then
         // against what the project committed to in its lockfile.
         let scheme = verified.scheme.to_string();
@@ -1066,6 +1105,20 @@ mod tests {
             arch: "x86_64".into(),
             libc: Some("gnu".into()),
         }
+    }
+
+    #[test]
+    fn age_is_checked_against_the_authenticated_log_time() {
+        let before = Some("2026-09-03T00:00:00Z".parse().unwrap());
+        let old = "2026-09-01T00:00:00Z";
+        let new = "2026-09-04T00:00:00Z";
+        assert!(check_verified_age(Some(new), old, before).is_err());
+        assert!(check_verified_age(Some(old), new, before).is_ok());
+        assert!(check_verified_age(None, old, before).is_ok());
+        assert!(check_verified_age(None, new, before).is_err());
+        assert!(check_verified_age(Some(new), old, None).is_ok());
+        assert!(check_verified_age(Some("invalid"), old, before).is_err());
+        assert!(check_verified_age(Some("2026-09-03T00:00:00Z"), old, before).is_ok());
     }
 
     #[test]

--- a/src/packslip_pins.rs
+++ b/src/packslip_pins.rs
@@ -221,6 +221,22 @@ pub(crate) fn check_sequence_at(path: &Path, project: &str, sequence: u64) -> Re
     Ok(())
 }
 
+/// An absent supplementary list is allowed only before this machine has
+/// accepted one. Its disappearance must not undo signed withdrawals.
+pub(crate) fn check_missing_list(project: &str) -> Result<()> {
+    check_missing_list_at(&pins_file(), project)
+}
+
+fn check_missing_list_at(path: &Path, project: &str) -> Result<()> {
+    let _lock = locked(path)?;
+    if load(path)?.sequences.contains_key(project) {
+        bail!(
+            "the signed release list of packslip:{project} disappeared; restore the list or explicitly forget this project's packslip pin"
+        );
+    }
+    Ok(())
+}
+
 /// Every pin, by project.
 pub(crate) fn list() -> Result<BTreeMap<String, Pin>> {
     Ok(load(&pins_file())?.pins)
@@ -261,6 +277,18 @@ mod tests {
             provenance: false,
             logged: true,
         }
+    }
+
+    #[test]
+    fn an_accepted_list_cannot_disappear_until_forgotten() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pins.toml");
+        check_missing_list_at(&path, "github.com/o/r").unwrap();
+        check_sequence_at(&path, "github.com/o/r", 0).unwrap();
+        assert!(check_missing_list_at(&path, "github.com/o/r").is_err());
+        check_missing_list_at(&path, "github.com/o/other").unwrap();
+        assert!(forget_at(&path, "github.com/o/r").unwrap());
+        check_missing_list_at(&path, "github.com/o/r").unwrap();
     }
 
     #[test]


### PR DESCRIPTION
A supplementary Packslip release list could disappear after mise accepted it, and installation did not apply the configured release-age cutoff to authenticated manifest timestamps. Refuse a missing list after recording any sequence (including zero), until the project pin is explicitly forgotten.

Check the verified transparency-log timestamp against the effective tool/install age cutoff before accepting pins or downloading artifacts; explicitly allowed unlogged manifests use the signed publication timestamp.

Regression coverage includes first use, other projects, sequence zero, explicit reset, timestamp boundaries, invalid timestamps, and logged versus unlogged manifests.

Validation: scoped formatting, Cargo check, and Markdown checks passed. At the final stack tip, all 26 Packslip-focused Rust tests, full clippy with warnings denied, and the live Packslip backend E2E test passed. The local Cargo wrapper selected an older mise; validation used its documented MBX_DISABLE bypass and the rebuilt mise binary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes packslip install acceptance and version discovery when supplementary lists vanish or releases are younger than configured age cutoffs, which can break installs that previously succeeded until pins are forgotten or releases age out.
> 
> **Overview**
> Packslip installs now treat two policy gaps as hard failures instead of silent bypasses.
> 
> **Signed release-list continuity:** After mise has accepted a GitHub supplementary `.well-known` release list (including sequence **0**), a **404** on that list is an error so a vendor cannot remove the file and undo withdrawals. Operators reset that state with **`mise packslip forget`**, which clears the remembered sequence as well as the signer pin.
> 
> **Minimum release age:** Before pins are recorded and artifacts download, installs compare the verified bundle against the effective **`minimum_release_age`** cutoff via **`check_verified_age`**: logged bundles use the **transparency-log** timestamp; explicitly permitted **unlogged** bundles use the signed **publication** timestamp. Listing/API timestamps still only help pick candidates, not satisfy the age gate.
> 
> Docs add a **Release-list continuity and minimum age** subsection; regression tests cover missing-list behavior and logged vs unlogged age boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acc12a79703028f83797f567da52c3786271db5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enforced minimum release age using verified transparency-log timestamps when available.
  * Unlogged releases now use their signed publication timestamp for age eligibility.
  * Missing signed release lists are rejected after a project’s release sequence has been accepted, unless the project is explicitly forgotten.

* **Bug Fixes**
  * Invalid timestamps and releases newer than the configured minimum age are now rejected.
  * Added handling for missing release lists to prevent previously withdrawn releases from becoming eligible again.

* **Documentation**
  * Documented release-list continuity and minimum release age behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->