### PR TITLE
fix(brew-cask): drop stale brew advice from the cask metadata error

### DIFF
--- a/src/system/packages/brew/cask/fetch.rs
+++ b/src/system/packages/brew/cask/fetch.rs
@@ -94,16 +94,12 @@ pub(super) async fn fetch_cask_url(
     let mut cask = HTTP_FETCH
         .json_cached::<Cask, _>(url)
         .await
-        .wrap_err_with(|| {
-            format!(
-                "failed to fetch Homebrew cask '{requested_token}' directly. \
-                 mise needs API metadata at api/cask/{requested_token}.json; for a \
-                 third-party tap that means a JSON file on the tap's default branch, \
-                 which most taps do not publish. mise will not proxy to the brew CLI; \
-                 install it with `brew`, or see \
-                 https://mise.jdx.dev/bootstrap/packages/brew.html#third-party-taps"
-            )
-        })?;
+        // Context only. What to do about it depends on which caller failed, and
+        // each of them already says: the parent-tap probe logs and moves on, the
+        // tap path reports that the Ruby definition could not be evaluated
+        // either, and an official cask has no tap story to tell. Mirrors
+        // `api::formula`.
+        .wrap_err_with(|| format!("failed to fetch Homebrew cask '{requested_token}'"))?;
     cask.raw_base = raw_base;
     validate_cask_identity(&cask, requested_token, official_api)?;
     Ok(cask)


### PR DESCRIPTION
Follow-up to #12645, which I got merged and which has been overtaken by the tap Ruby fallback. Not in a release yet — #12645 merged 2026-09-04, the newest release is v2026.9.1 — so the broken state can be fixed before it ships.

## What went stale

#12645 rewrote two brew error messages to say that taps mostly do not publish API metadata and that the user should install with `brew`. Direct tap support then landed, and `docs/bootstrap/packages/brew.md` now documents the opposite:

> mise first looks for published Homebrew API metadata … **When a tap does not publish it, mise fetches the Ruby definition at a pinned tap commit and evaluates its metadata with mise's own Formula or Cask DSL shim.**

The formula side was reorganized at the same time and my message there was removed. `api.rs` now reads:

```rust
// inner: short context only
.wrap_err_with(|| format!("failed to fetch Homebrew formula '{name}'"))

// outer: what to do when both halves failed
"failed to resolve Homebrew tap formula '{name}'; published API metadata was unavailable \
 ({api_err}) and mise could not evaluate Formula/{formula_name}.rb"
```

The cask side was not. `fetch_cask_url` still carries the long message, and `fetch_cask` wraps it with the equivalent Ruby-fallback explanation — so the inner text tells the user mise will not proxy to `brew` from inside the very attempt that goes on to evaluate `Casks/<token>.rb`.

## The broken link

The message ends with `https://mise.jdx.dev/bootstrap/packages/brew.html#third-party-taps`. That anchor does not exist. `brew.md` on `main` has: Casks, Supported platforms, The prefix, Coexistence with a real Homebrew, Importing and pruning, How pouring works, Source formulae, Upgrades, Limitations.

@coderabbitai flagged this on #12645 and **I was wrong to push back on it.** My argument was that #12644 would add the section and would merge first. #12644 is being closed — the tap fallback replaced its premise — so the anchor is never going to appear. It was the only reference to it in the repository; after this change there are none.

## Change

One `wrap_err_with`, matching `api::formula`:

```rust
.wrap_err_with(|| format!("failed to fetch Homebrew cask '{requested_token}'"))
```

`fetch_cask_url` has three callers, and the shorter text reads correctly for each:

| caller | after |
| --- | --- |
| parent-tap probe (logged at `debug!`) | `brew-cask: x unavailable in parent tap metadata (failed to fetch Homebrew cask 'x': …)` |
| tap path, as `{api_err}` | `published cask metadata was unavailable (failed to fetch Homebrew cask 'x': …) and mise could not evaluate Casks/x.rb` |
| official cask, `_ => return Err(api_err)` | `failed to fetch Homebrew cask 'x': <http error>` |

The third one matters beyond tidiness. `fetch_cask_url` is shared, so a mistyped official token — `brew-cask:firefx` — was answered with advice about third-party taps. That is the defect #12645 set out to fix, and it fixes more cleanly by having the shared function say less rather than by scoping its explanation.

## No test

Saying so rather than leaving it to be noticed:

- Nothing pins this text. Searching `src/` and `e2e/` for `most taps do not publish`, `will not proxy` and `failed to fetch Homebrew cask` hits only the implementation line itself.
- There is no HTTP test scaffolding under `src/system/packages/brew/` — no `mockito`, no `#[tokio::test]`; `cask/tests.rs` is 7400 lines of synchronous tests over pure functions. Introducing the first one to assert a message string seemed disproportionate for text that is expected to keep changing.
- The change removes wording; it adds no behavior.

I cannot build locally, so CI is the first execution.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.236.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the error message shown when fetching a package fails.
  * Fetching and validation behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->