### PR TITLE
fix(packslip): preserve vendor policy across trusted stamps

### DIFF
--- a/docs/dev-tools/backends/packslip.md
+++ b/docs/dev-tools/backends/packslip.md
@@ -115,11 +115,11 @@ A vendor's packslip proves what the vendor shipped. It does not say whether anyo
 stampers = ["registry.mise.jdx.dev=RWQ..."]
 ```
 
-With hosts named, mise offers and installs a packslip tool only at versions one of them lists. A version no trusted host stamped is not shown by `mise ls-remote` and is refused by `mise install`, however valid the vendor's own manifest is; a version a host withdrew is refused with the host's reason. Any one host's stamp suffices. The stamp points at the manifest it admitted, so mise fetches that exact file, checks it against the digest the host recorded, and then verifies it against the vendor's pin as always: the stamp never stands in for the vendor's signature. A stamp that records no digest is refused — the digest is what ties the host's review to a file, and without one the entry admits a URL rather than a manifest.
+With hosts named, mise offers and installs a packslip tool only at versions one of them lists. A version no trusted host stamped is not shown by `mise ls-remote` and is refused by `mise install`, however valid the vendor's own manifest is; a host withdrawing its stamp does not veto another host’s non-yanked approval. Any one host’s non-yanked stamp suffices; vendor withdrawals still veto every stamp. The stamp points at the manifest it admitted, so mise fetches that exact file, checks it against the digest the host recorded, and then verifies it against the vendor's pin as always: the stamp never stands in for the vendor's signature. A stamp that records no digest is refused — the digest is what ties the host's review to a file, and without one the entry admits a URL rather than a manifest.
 
 Each host's list carries an expiry and a sequence number. mise refuses a list that has expired, and remembers the highest sequence it accepted per host and project so a replayed older list is refused as a rollback.
 
-A mirror is a stamping host whose entries point at manifests it signed itself, carrying the vendor's digests with the mirror's own download URLs. Name it as the only stamper and you get its curated versions and its bytes.
+A stamper may mirror the exact vendor-signed manifest. Mise checks both the stamper digest and any digest in the vendor’s list. Re-signed repackager manifests need a separate identity policy and are not supported by this backend yet.
 
 Unset, no stamps are required and every version the vendor published is offered. mise's own registry host will become the default once it publishes stamps.
 

--- a/docs/dev-tools/backends/packslip.md
+++ b/docs/dev-tools/backends/packslip.md
@@ -119,7 +119,7 @@ With hosts named, mise offers and installs a packslip tool only at versions one 
 
 Each host's list carries an expiry and a sequence number. mise refuses a list that has expired, and remembers the highest sequence it accepted per host and project so a replayed older list is refused as a rollback.
 
-A stamper may mirror the exact vendor-signed manifest. Mise checks both the stamper digest and any digest in the vendor’s list. Re-signed repackager manifests need a separate identity policy and are not supported by this backend yet.
+A stamper may mirror the exact vendor-signed manifest. Mise checks both the stamper digest and any digest in the vendor’s list. Because the stamp already names the manifest, mise asks the vendor only for what the vendor decides — a withdrawal, and the digest they pinned — so a release asset deleted from GitHub does not veto a mirror of a release that was never withdrawn. Re-signed repackager manifests need a separate identity policy and are not supported by this backend yet.
 
 Unset, no stamps are required and every version the vendor published is offered. mise's own registry host will become the default once it publishes stamps.
 

--- a/src/backend/packslip.rs
+++ b/src/backend/packslip.rs
@@ -812,6 +812,9 @@ impl Backend for PackslipBackend {
             ),
             None => None,
         };
+        // Vendor discovery is always authoritative for withdrawals and digest
+        // pins, even when a stamper supplies a mirror URL.
+        let vendor = self.locate_bundle(&project, &tv, &pin, &opts).await?;
         let located = match &stamp {
             Some(stamp) => {
                 debug!(
@@ -839,7 +842,11 @@ impl Backend for PackslipBackend {
                     digest: Some(digest),
                 }
             }
-            None => self.locate_bundle(&project, &tv, &pin, &opts).await?,
+            None => Located {
+                url: vendor.url.clone(),
+                headers: vendor.headers.clone(),
+                digest: vendor.digest.clone(),
+            },
         };
         let bundle_path = tv.download_path().join(bundle_name(&project));
         file::create_dir_all(tv.download_path())?;
@@ -851,7 +858,7 @@ impl Backend for PackslipBackend {
             Some(ctx.pr.as_ref()),
         )
         .await?;
-        if let Some(expected) = &located.digest {
+        for expected in located.digest.iter().chain(vendor.digest.iter()) {
             let (actual, _) = packslip::digest_file(&bundle_path)?;
             if &actual != expected {
                 bail!(

--- a/src/backend/packslip.rs
+++ b/src/backend/packslip.rs
@@ -18,8 +18,8 @@ use async_trait::async_trait;
 use eyre::{Result, WrapErr, bail, eyre};
 use itertools::Itertools;
 use packslip::model::{
-    Artifact, Host, ReleaseListStatement, Selection, Statement, is_bare_format, repository,
-    repository_subpath, tag_version,
+    Artifact, Host, ReleaseListStatement, ReleaseRef, Selection, Statement, is_bare_format,
+    repository, repository_subpath, tag_version,
 };
 use packslip::sigstore::{Policy, Trust};
 use reqwest::header::HeaderMap;
@@ -450,6 +450,22 @@ fn check_verified_age(
     Ok(())
 }
 
+/// A withdrawal in the vendor's signed list is the end of the matter: no
+/// stamp, mirror, or cached manifest reinstates the version.
+fn refuse_if_withdrawn(project: &str, version: &str, entry: &ReleaseRef) -> Result<()> {
+    if entry.is_yanked() {
+        bail!(
+            "packslip:{project}@{version} was withdrawn by the vendor{}",
+            entry
+                .status_reason
+                .as_deref()
+                .map(|r| format!(": {r}"))
+                .unwrap_or_default()
+        );
+    }
+    Ok(())
+}
+
 fn headers_for(url: &str) -> Result<HeaderMap> {
     if url.starts_with("https://github.com/") || url.starts_with("https://api.github.com/") {
         github::get_headers(url)
@@ -559,58 +575,36 @@ impl PackslipBackend {
         Ok(Some(list))
     }
 
-    async fn locate_bundle(
+    /// What the vendor themselves say about a version, from the release
+    /// list they sign: a withdrawal refuses it outright, and the entry pins
+    /// the manifest's digest. `None` only when no signed list covers the
+    /// version, which a project served from a GitHub repository is allowed
+    /// to do and any other project is not.
+    async fn vendor_entry(
         &self,
         project: &str,
         tv: &ToolVersion,
         pin: &Pin,
         opts: &PackslipOptions<'_>,
-    ) -> Result<Located> {
-        let asset_name = bundle_name(project);
+    ) -> Result<Option<Located>> {
         if let Some(repo) = Self::repo(project) {
-            // A signed list the repository keeps decides first: it can
-            // withdraw a release and it pins the bundle's digest.
-            if let Some(list) = self.github_list(project, &repo, pin, opts).await?
-                && let Some(entry) = list
-                    .predicate
-                    .releases
-                    .iter()
-                    .find(|r| r.version == tv.version)
-            {
-                if entry.is_yanked() {
-                    bail!(
-                        "packslip:{project}@{} was withdrawn by the vendor{}",
-                        tv.version,
-                        entry
-                            .status_reason
-                            .as_deref()
-                            .map(|r| format!(": {r}"))
-                            .unwrap_or_default()
-                    );
-                }
-                return Ok(Located {
-                    headers: headers_for(&entry.packslip)?,
-                    url: entry.packslip.clone(),
-                    digest: list.digest_of(&entry.packslip).map(str::to_string),
-                });
-            }
-            let releases = github::list_releases_including_prereleases(&repo).await?;
-            let found = releases.iter().find_map(|r| {
-                let asset = r.assets.iter().find(|a| a.name == asset_name)?;
-                (tag_version(&r.tag_name, project).as_deref() == Some(tv.version.as_str()))
-                    .then_some(asset)
-            });
-            let Some(asset) = found else {
-                bail!(
-                    "github.com/{repo} has no release {} carrying {asset_name}; mise installs from a packslip and does not guess at release assets",
-                    tv.version
-                );
+            let Some(list) = self.github_list(project, &repo, pin, opts).await? else {
+                return Ok(None);
             };
-            return Ok(Located {
-                headers: github::get_headers(&asset.browser_download_url)?,
-                url: asset.browser_download_url.clone(),
-                digest: None,
-            });
+            let Some(entry) = list
+                .predicate
+                .releases
+                .iter()
+                .find(|r| r.version == tv.version)
+            else {
+                return Ok(None);
+            };
+            refuse_if_withdrawn(project, &tv.version, entry)?;
+            return Ok(Some(Located {
+                headers: headers_for(&entry.packslip)?,
+                url: entry.packslip.clone(),
+                digest: list.digest_of(&entry.packslip).map(str::to_string),
+            }));
         }
         let list = self.release_list(project, pin, opts).await?;
         let Some(entry) = list
@@ -624,21 +618,45 @@ impl PackslipBackend {
                 tv.version
             );
         };
-        if entry.is_yanked() {
-            bail!(
-                "packslip:{project}@{} was withdrawn by the vendor{}",
-                tv.version,
-                entry
-                    .status_reason
-                    .as_deref()
-                    .map(|r| format!(": {r}"))
-                    .unwrap_or_default()
-            );
-        }
-        Ok(Located {
+        refuse_if_withdrawn(project, &tv.version, entry)?;
+        Ok(Some(Located {
             url: entry.packslip.clone(),
             headers: HeaderMap::new(),
             digest: list.digest_of(&entry.packslip).map(str::to_string),
+        }))
+    }
+
+    async fn locate_bundle(
+        &self,
+        project: &str,
+        tv: &ToolVersion,
+        pin: &Pin,
+        opts: &PackslipOptions<'_>,
+    ) -> Result<Located> {
+        if let Some(located) = self.vendor_entry(project, tv, pin, opts).await? {
+            return Ok(located);
+        }
+        // No signed list names the manifest, so the release asset is the
+        // only place left to find it. Only a GitHub project gets here.
+        let asset_name = bundle_name(project);
+        let repo = Self::repo(project)
+            .ok_or_else(|| eyre!("packslip:{project} publishes no signed release list"))?;
+        let releases = github::list_releases_including_prereleases(&repo).await?;
+        let found = releases.iter().find_map(|r| {
+            let asset = r.assets.iter().find(|a| a.name == asset_name)?;
+            (tag_version(&r.tag_name, project).as_deref() == Some(tv.version.as_str()))
+                .then_some(asset)
+        });
+        let Some(asset) = found else {
+            bail!(
+                "github.com/{repo} has no release {} carrying {asset_name}; mise installs from a packslip and does not guess at release assets",
+                tv.version
+            );
+        };
+        Ok(Located {
+            headers: github::get_headers(&asset.browser_download_url)?,
+            url: asset.browser_download_url.clone(),
+            digest: None,
         })
     }
 
@@ -812,10 +830,13 @@ impl Backend for PackslipBackend {
             ),
             None => None,
         };
-        // Vendor discovery is always authoritative for withdrawals and digest
-        // pins, even when a stamper supplies a mirror URL.
-        let vendor = self.locate_bundle(&project, &tv, &pin, &opts).await?;
-        let located = match &stamp {
+        // The vendor stays authoritative for withdrawals and digest pins even
+        // when a stamper supplies a mirror URL. What the vendor's list cannot
+        // speak to is whether the original release asset is still on GitHub,
+        // and a stamp already names the manifest and its digest — so mise asks
+        // the signed list here rather than `locate_bundle`, and a deleted asset
+        // does not veto a release the vendor never withdrew.
+        let (located, vendor_digest) = match &stamp {
             Some(stamp) => {
                 debug!(
                     "{}: stamped by {}, manifest at {}",
@@ -836,17 +857,19 @@ impl Backend for PackslipBackend {
                         stamp.entry.packslip
                     );
                 };
-                Located {
-                    headers: headers_for(&stamp.entry.packslip)?,
-                    url: stamp.entry.packslip.clone(),
-                    digest: Some(digest),
-                }
+                let vendor = self.vendor_entry(&project, &tv, &pin, &opts).await?;
+                (
+                    Located {
+                        headers: headers_for(&stamp.entry.packslip)?,
+                        url: stamp.entry.packslip.clone(),
+                        digest: Some(digest),
+                    },
+                    vendor.and_then(|v| v.digest),
+                )
             }
-            None => Located {
-                url: vendor.url.clone(),
-                headers: vendor.headers.clone(),
-                digest: vendor.digest.clone(),
-            },
+            // Without a stamp the located bundle is the vendor's own, so its
+            // digest is already the one checked below.
+            None => (self.locate_bundle(&project, &tv, &pin, &opts).await?, None),
         };
         let bundle_path = tv.download_path().join(bundle_name(&project));
         file::create_dir_all(tv.download_path())?;
@@ -858,13 +881,16 @@ impl Backend for PackslipBackend {
             Some(ctx.pr.as_ref()),
         )
         .await?;
-        for expected in located.digest.iter().chain(vendor.digest.iter()) {
+        let pinned: Vec<&String> = located.digest.iter().chain(vendor_digest.iter()).collect();
+        if !pinned.is_empty() {
             let (actual, _) = packslip::digest_file(&bundle_path)?;
-            if &actual != expected {
-                bail!(
-                    "the packslip at {} is not the one the signed release list points at (sha256 {actual}, list says {expected})",
-                    located.url
-                );
+            for expected in pinned {
+                if &actual != expected {
+                    bail!(
+                        "the packslip at {} is not the one the signed release list points at (sha256 {actual}, list says {expected})",
+                        located.url
+                    );
+                }
             }
         }
         let bundle = file::read_to_string(&bundle_path)?;

--- a/src/packslip_stamps.rs
+++ b/src/packslip_stamps.rs
@@ -28,7 +28,6 @@ use crate::config::Settings;
 use crate::dirs;
 use crate::file;
 use crate::http::HTTP_FETCH;
-use crate::lock_file::LockFile;
 use crate::toolset::ToolVersionOptions;
 
 /// GitHub's OIDC issuer, for a stamper pinned by a workflow identity.
@@ -203,9 +202,20 @@ fn write_state(dir: &Path, host: &str, state: &HostState) -> Result<()> {
     file::write_atomic(state_path(dir, host), serde_json::to_vec_pretty(state)?)
 }
 
-/// One mise at a time reads and rewrites a host's state.
+/// One mise at a time reads and rewrites a host's state. The lock sits
+/// beside that state, not under the cache: two mise processes can share a
+/// state directory and disagree about their cache, and a lock they do not
+/// share is no lock at all — the loser's write would drop an accepted
+/// sequence and reopen the rollback this state exists to refuse.
 fn locked(dir: &Path, host: &str) -> Result<fslock::LockFile> {
-    LockFile::new(&state_path(dir, host)).lock()
+    file::create_dir_all(dir)?;
+    let path = state_path(dir, host).with_extension("lock");
+    let mut lock = fslock::LockFile::open(&path)?;
+    if !lock.try_lock()? {
+        debug!("waiting for lock on {}", path.display());
+        lock.lock()?;
+    }
+    Ok(lock)
 }
 
 /// Refuse a list whose sequence is below the last one accepted from this
@@ -485,6 +495,19 @@ mod tests {
         std::fs::write(d.join("seq.example.com.json"), b"{not json").unwrap();
         let err = check_sequence_in(d, host, project, &list(project, 9, &entries)).unwrap_err();
         assert!(err.to_string().contains("remove it"), "{err}");
+    }
+
+    #[test]
+    fn the_sequence_lock_sits_beside_the_state_it_guards() {
+        let dir = tempfile::tempdir().unwrap();
+        let d = dir.path().join("stampers");
+        let host = "lock.example.com";
+        drop(locked(&d, host).unwrap());
+        assert!(
+            d.join("lock.example.com.lock").is_file(),
+            "processes sharing a state directory must share the lock, so it \
+             cannot live under a cache directory they may not share"
+        );
     }
 
     #[test]

--- a/src/packslip_stamps.rs
+++ b/src/packslip_stamps.rs
@@ -121,7 +121,7 @@ pub(crate) struct Stamps {
 
 impl Stamps {
     /// Fold in one host's verified list. The first host to stamp a version
-    /// is the one followed; a yank from any host excludes it.
+    /// is the one followed; a yank withdraws only that host's approval.
     fn add(&mut self, host: &str, list: &ReleaseListStatement) {
         self.hosts.push(host.to_string());
         for entry in &list.predicate.releases {
@@ -145,11 +145,8 @@ impl Stamps {
         }
     }
 
-    /// The stamp that admits a version, if one does and no host withdrew it.
+    /// The first non-yanked stamp that admits a version.
     pub(crate) fn stamp(&self, version: &str) -> Option<&Stamp> {
-        if self.yanked.contains_key(version) {
-            return None;
-        }
         self.stamps.get(version)
     }
 
@@ -304,10 +301,7 @@ pub(crate) async fn fetch(project: &str, opts: &ToolVersionOptions) -> Result<Op
 }
 
 fn is_not_found(err: &eyre::Report) -> bool {
-    err.downcast_ref::<reqwest::Error>()
-        .and_then(|e| e.status())
-        .is_some_and(|s| s == reqwest::StatusCode::NOT_FOUND)
-        || err.to_string().contains("404")
+    crate::http::error_code(err) == Some(404)
 }
 
 #[cfg(test)]
@@ -386,7 +380,7 @@ mod tests {
     }
 
     #[test]
-    fn any_stamp_admits_and_any_yank_excludes() {
+    fn any_non_yanked_stamp_admits() {
         let mut stamps = Stamps::default();
         stamps.add(
             "a.example.com",
@@ -412,7 +406,7 @@ mod tests {
         );
         assert!(stamps.allows("1.0.0"));
         assert!(stamps.allows("1.2.0"));
-        assert!(!stamps.allows("1.1.0"), "b withdrew it");
+        assert!(stamps.allows("1.1.0"), "a still approves it");
         assert!(!stamps.allows("2.0.0"), "nobody stamped it");
         let first = stamps.stamp("1.0.0").unwrap();
         assert_eq!(first.host, "a.example.com");
@@ -421,11 +415,25 @@ mod tests {
             first.entry.packslip,
             "https://x/1.0.0/packslip.sigstore.json"
         );
-        let why = stamps.refusal("github.com/o/r", "1.1.0").to_string();
-        assert!(
-            why.contains("withdrawn by b.example.com: bad build"),
-            "{why}"
+        let mut reversed = Stamps::default();
+        reversed.add(
+            "b.example.com",
+            &list(
+                "github.com/o/r",
+                1,
+                &[("1.1.0", "https://y/1.1.0/p.json", true)],
+            ),
         );
+        assert!(!reversed.allows("1.1.0"));
+        reversed.add(
+            "a.example.com",
+            &list(
+                "github.com/o/r",
+                1,
+                &[("1.1.0", "https://x/1.1.0/p.json", false)],
+            ),
+        );
+        assert!(reversed.allows("1.1.0"));
         let why = stamps.refusal("github.com/o/r", "2.0.0").to_string();
         assert!(
             why.contains("no stamp from a.example.com, b.example.com")


### PR DESCRIPTION
Integrate stamp admission with signer pins and vendor release-list policy. Any trusted host’s non-yanked stamp admits a version; one host withdrawing approval no longer vetoes another. Installation still consults the vendor list and checks its digest, so a stamp or mirror cannot bypass vendor withdrawals or substitute a different pinned manifest.

Builds on the stamping implementation from #12782, now below pins in the same stack, including locked atomic sequence state and refusal of unexpectedly missing lists. Clarifies that mirrored manifests must still satisfy the vendor identity policy; re-signed repackager manifests are not supported yet.

Validation at the combined stack tip: 34 Packslip-focused tests and 2 process-cleanup tests passed; clippy with warnings denied and scoped formatting/TOML/Markdown/shell checks passed. The final live backend E2E test passed with the rebuilt binary, including latest resolution, warm-cache stamper-policy changes, signer pinning/reset, and lockfile reinstall.

*AI-assisted — Tool: Codex; model: OpenAI/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes packslip install trust, multi-stamper admission, and digest checks—security-sensitive supply-chain behavior—with concurrent stamper sequence updates.
> 
> **Overview**
> Packslip **stamping** no longer treats one trusted host’s yank as a global veto: any **non-yanked** stamp from another configured host can still admit a version, while **vendor** withdrawals in the signed release list remain authoritative for every install path.
> 
> **Install flow** splits vendor policy from bundle location: new `vendor_entry` enforces vendor yanks and digest pins even when the manifest URL comes from a stamper mirror; stamped installs verify **both** the stamper’s digest and the vendor list’s digest when present, so mirrors cannot bypass vendor pins or withdrawals. A missing GitHub release asset no longer blocks a stamped mirror if the vendor never withdrew the release.
> 
> **Stamper state** locking moves to a `*.lock` file beside per-host sequence state (not a separate cache lock), with a test ensuring concurrent processes share it. Docs describe per-host yanks, mirrored vendor manifests, and that re-signed repackager manifests are still unsupported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95cae442bb9744422306338f795963eab86ddcb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Vendor-signed release lists now take precedence when validating and locating release assets.
  - Installations verify both the discovered and vendor-published manifest digests.
  - A yanked release now withdraws only the affected host’s stamp; another valid host’s stamp can still be used.
  - Vendor withdrawals continue to block all stamps.

- **Documentation**
  - Updated packslip documentation to describe vendor manifest mirroring and revised stamp-withdrawal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->