### PR TITLE
feat(packslip): check declared host requirements before install

### DIFF
--- a/docs/dev-tools/backends/packslip.md
+++ b/docs/dev-tools/backends/packslip.md
@@ -182,3 +182,11 @@ Exec resources receive the manifest’s environment variables, with `{shell}` ex
 Once mise has accepted a supplementary signed list, a missing list is an error: a 404 cannot silently restore releases the vendor withdrew. `mise packslip forget <project>` explicitly resets that remembered policy along with the signer pin.
 
 The release API or list timestamp helps select candidates. Before downloading an artifact, mise checks the verified transparency-log timestamp against the effective `minimum_release_age` cutoff. Only a permitted unlogged bundle uses its signed publication timestamp instead.
+
+## Host requirements
+
+After selecting the artifact, mise checks its declared minimum OS/glibc and host libraries before downloading it. Confirmed failures refuse installation; `ignore_requirements = true` overrides this for one tool. Missing or old commands warn, and unknown checks warn instead of refusing. Active mise command paths take precedence over ambient PATH. Requirements never break an artifact-selection tie or select a different build.
+
+OS and glibc probes and command version probes have bounded execution and output. Linux library checks use `LD_LIBRARY_PATH`, standard directories, and `ldconfig -p`; Windows uses PATH and the system directory. macOS checks common library directories but reports unknown absence because the dyld shared cache can contain libraries with no filesystem entry.
+
+Resource generators have a five-second deadline including inherited output pipes and a 4 MiB output limit. Their child processes are cleaned up on completion, failure, timeout, and cancellation.

--- a/docs/dev-tools/backends/packslip.md
+++ b/docs/dev-tools/backends/packslip.md
@@ -187,6 +187,6 @@ The release API or list timestamp helps select candidates. Before downloading an
 
 After selecting the artifact, mise checks its declared minimum OS/glibc and host libraries before downloading it. Confirmed failures refuse installation; `ignore_requirements = true` overrides this for one tool. Missing or old commands warn, and unknown checks warn instead of refusing. Active mise command paths take precedence over ambient PATH. Requirements never break an artifact-selection tie or select a different build.
 
-OS and glibc probes and command version probes have bounded execution and output. Linux library checks use `LD_LIBRARY_PATH`, standard directories, and `ldconfig -p`; Windows uses PATH and the system directory. macOS checks common library directories but reports unknown absence because the dyld shared cache can contain libraries with no filesystem entry.
+On Linux the OS version is the kernel release from `uname -r`, read up to the distribution's suffix: `6.8.0-31-generic` is compared as `6.8.0`. OS and glibc probes and command version probes have bounded execution and output. Linux library checks use `LD_LIBRARY_PATH`, standard directories, and `ldconfig -p`; Windows uses PATH and the system directory. macOS checks common library directories but reports unknown absence because the dyld shared cache can contain libraries with no filesystem entry.
 
 Resource generators have a five-second deadline including inherited output pipes and a 4 MiB output limit. Their child processes are cleaned up on completion, failure, timeout, and cancellation.

--- a/docs/dev-tools/backends/packslip.md
+++ b/docs/dev-tools/backends/packslip.md
@@ -185,7 +185,7 @@ The release API or list timestamp helps select candidates. Before downloading an
 
 ## Host requirements
 
-After selecting the artifact, mise checks its declared minimum OS/glibc and host libraries before downloading it. Confirmed failures refuse installation; `ignore_requirements = true` overrides this for one tool. Missing or old commands warn, and unknown checks warn instead of refusing. Active mise command paths take precedence over ambient PATH. Requirements never break an artifact-selection tie or select a different build.
+After selecting the artifact, mise checks its declared minimum OS/glibc and host libraries before downloading it. Confirmed failures refuse installation; `ignore_requirements = true` overrides this for one tool. Missing or old commands warn, and unknown checks warn instead of refusing. Active mise command paths take precedence over ambient PATH; either way mise picks a path the OS can start, so a Windows `git.exe` or `node.cmd` counts and a shebang-only script does not. Requirements never break an artifact-selection tie or select a different build.
 
 On Linux the OS version is the kernel release from `uname -r`, read up to the distribution's suffix: `6.8.0-31-generic` is compared as `6.8.0`. OS and glibc probes and command version probes have bounded execution and output. Linux library checks use `LD_LIBRARY_PATH`, standard directories, and `ldconfig -p`; Windows uses PATH and the system directory. macOS checks common library directories but reports unknown absence because the dyld shared cache can contain libraries with no filesystem entry.
 

--- a/src/backend/packslip.rs
+++ b/src/backend/packslip.rs
@@ -112,6 +112,7 @@ pub(crate) fn install_time_option_keys() -> Vec<String> {
         "identity_prefix",
         "issuer",
         "allow_unlogged",
+        "ignore_requirements",
         "trust",
     ]
     .iter()
@@ -981,6 +982,17 @@ impl Backend for PackslipBackend {
             opts.variant().as_deref(),
         )?
         .clone();
+        let mut commands = BTreeMap::new();
+        if let Some(req) = &artifact.requires {
+            for bin in &req.bin {
+                if let Some(path) = ctx.ts.which_bin(&ctx.config, &bin.name).await {
+                    commands.insert(bin.name.clone(), path);
+                }
+            }
+        }
+        crate::packslip_requirements::check(&artifact, &commands)
+            .await
+            .enforce(raw_opts.get("ignore_requirements") == Some("true"))?;
         let Some(url) = artifact.url.clone() else {
             bail!("the packslip gives no download URL for {}", artifact.name);
         };

--- a/src/backend/packslip.rs
+++ b/src/backend/packslip.rs
@@ -985,7 +985,10 @@ impl Backend for PackslipBackend {
         let mut commands = BTreeMap::new();
         if let Some(req) = &artifact.requires {
             for bin in &req.bin {
-                if let Some(path) = ctx.ts.which_bin(&ctx.config, &bin.name).await {
+                // Spawnable, not merely present: the probe below runs the
+                // path with `--version`, so a shebang-only script or a `.ps1`
+                // would be chosen and then fail to start.
+                if let Some(path) = ctx.ts.which_bin_spawnable(&ctx.config, &bin.name).await {
                     commands.insert(bin.name.clone(), path);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,7 @@ mod netrc;
 mod oci;
 mod packslip;
 mod packslip_pins;
+mod packslip_requirements;
 mod packslip_stamps;
 pub(crate) mod parallel;
 mod path;

--- a/src/packslip_requirements.rs
+++ b/src/packslip_requirements.rs
@@ -223,7 +223,10 @@ pub(crate) async fn check(artifact: &Artifact, commands: &BTreeMap<String, PathB
         let path = commands
             .get(&bin.name)
             .cloned()
-            .or_else(|| file::which(&bin.name));
+            // `which` matches the bare name, so on Windows `git.exe` and
+            // `node.cmd` read as missing; `which_spawnable` applies PATHEXT
+            // and only offers a path the OS will start.
+            .or_else(|| file::which_spawnable(&bin.name));
         let Some(path) = path else {
             report.warnings.push(format!(
                 "command {}{} is missing; install it before using features that need it",

--- a/src/packslip_requirements.rs
+++ b/src/packslip_requirements.rs
@@ -1,0 +1,258 @@
+//! Host requirements describe prerequisites, not dependencies to install.
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use eyre::{Result, bail};
+use packslip::model::Artifact;
+
+use crate::cmd::CmdLineRunner;
+use crate::file;
+
+#[derive(Debug, Default)]
+pub(crate) struct Report {
+    pub(crate) failures: Vec<String>,
+    pub(crate) warnings: Vec<String>,
+}
+
+impl Report {
+    pub(crate) fn enforce(&self, ignore: bool) -> Result<()> {
+        for warning in &self.warnings {
+            warn!("packslip requirement: {warning}");
+        }
+        if self.failures.is_empty() {
+            return Ok(());
+        }
+        let failures = self.failures.join("; ");
+        if ignore {
+            warn!("overriding packslip host requirements: {failures}");
+            Ok(())
+        } else {
+            bail!(
+                "packslip host requirements not met: {failures}; set ignore_requirements=true for this tool to override"
+            )
+        }
+    }
+}
+
+/// Compare arbitrarily large numeric components without overflow or semver.
+fn numeric_cmp(actual: &str, min: &str) -> Option<Ordering> {
+    fn parts(s: &str) -> Option<Vec<&str>> {
+        s.split('.')
+            .map(|p| {
+                if p.is_empty() || !p.bytes().all(|c| c.is_ascii_digit()) {
+                    return None;
+                }
+                let p = p.trim_start_matches('0');
+                Some(if p.is_empty() { "0" } else { p })
+            })
+            .collect()
+    }
+    let a = parts(actual)?;
+    let b = parts(min)?;
+    for i in 0..a.len().max(b.len()) {
+        let a = a.get(i).copied().unwrap_or("0");
+        let b = b.get(i).copied().unwrap_or("0");
+        let cmp = a.len().cmp(&b.len()).then_with(|| a.cmp(b));
+        if cmp != Ordering::Equal {
+            return Some(cmp);
+        }
+    }
+    Some(Ordering::Equal)
+}
+
+fn version_from_output(output: &str) -> Option<String> {
+    output
+        .split_whitespace()
+        .map(|s| s.trim_matches(['"', '\'', '(', ')', '[', ']']))
+        .find(|s| numeric_cmp(s, "0").is_some())
+        .map(str::to_owned)
+}
+
+async fn probe(program: &str, args: &[&str]) -> Option<String> {
+    CmdLineRunner::new(program)
+        .args(args)
+        .read_isolated(64 * 1024)
+        .await
+        .ok()
+}
+
+async fn os_version() -> Option<String> {
+    #[cfg(target_os = "macos")]
+    let output = probe("/usr/bin/sw_vers", &["-productVersion"]).await;
+    #[cfg(windows)]
+    let output = probe("cmd.exe", &["/D", "/C", "ver"]).await;
+    #[cfg(not(any(target_os = "macos", windows)))]
+    let output = probe("uname", &["-r"]).await;
+    output.as_deref().and_then(version_from_output)
+}
+
+async fn library_present(name: &str) -> Option<bool> {
+    if !file::is_plain_file_name(name) {
+        return None;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let mut paths: Vec<PathBuf> = std::env::var_os("LD_LIBRARY_PATH")
+            .map(|p| std::env::split_paths(&p).collect())
+            .unwrap_or_default();
+        paths.extend(["/lib", "/lib64", "/usr/lib", "/usr/lib64"].map(PathBuf::from));
+        if paths.iter().any(|p| p.join(name).is_file()) {
+            return Some(true);
+        }
+        // Cache failure is unknown, not proof of absence. The cache normally
+        // covers distribution-specific multiarch directories as well.
+        let cache = probe("/sbin/ldconfig", &["-p"]).await?;
+        let arch = std::env::consts::ARCH;
+        Some(cache.lines().any(|line| {
+            line.split_whitespace().next() == Some(name)
+                && match arch {
+                    "x86_64" => line.contains("x86-64"),
+                    "aarch64" => line.contains("AArch64"),
+                    _ => true,
+                }
+                && line
+                    .split("=>")
+                    .nth(1)
+                    .is_some_and(|p| std::path::Path::new(p.trim()).is_file())
+        }))
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let mut paths: Vec<PathBuf> = std::env::var_os("DYLD_LIBRARY_PATH")
+            .map(|p| std::env::split_paths(&p).collect())
+            .unwrap_or_default();
+        paths.extend(["/usr/local/lib", "/usr/lib", "/opt/homebrew/lib"].map(PathBuf::from));
+        if paths.iter().any(|p| p.join(name).is_file()) {
+            return Some(true);
+        }
+        // The dyld shared cache can contain libraries without filesystem
+        // entries. Without querying it we cannot establish absence.
+        None
+    }
+    #[cfg(windows)]
+    {
+        let mut paths: Vec<PathBuf> =
+            std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default()).collect();
+        if let Some(root) = std::env::var_os("SystemRoot") {
+            paths.push(PathBuf::from(root).join("System32"));
+        }
+        Some(paths.iter().any(|p| p.join(name).is_file()))
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+    {
+        None
+    }
+}
+
+fn check_min(report: &mut Report, label: &str, actual: Option<&str>, min: &str, fatal: bool) {
+    match actual.and_then(|actual| numeric_cmp(actual, min)) {
+        Some(Ordering::Less) => {
+            let message = format!("{label} {} is below required {min}", actual.unwrap());
+            if fatal {
+                report.failures.push(message);
+            } else {
+                report.warnings.push(message);
+            }
+        }
+        Some(_) => {}
+        None => report.warnings.push(format!("cannot check {label}>={min}")),
+    }
+}
+
+/// `commands` contains paths resolved from the install's active mise toolset.
+/// Ambient PATH supplies commands not managed by that toolset.
+pub(crate) async fn check(artifact: &Artifact, commands: &BTreeMap<String, PathBuf>) -> Report {
+    let mut report = Report::default();
+    let Some(req) = &artifact.requires else {
+        return report;
+    };
+    if let Some(min) = &req.os_min {
+        check_min(&mut report, "OS", os_version().await.as_deref(), min, true);
+    }
+    if let Some(min) = &req.glibc_min {
+        let glibc = if cfg!(target_os = "linux") {
+            probe("getconf", &["GNU_LIBC_VERSION"])
+                .await
+                .as_deref()
+                .and_then(version_from_output)
+        } else {
+            None
+        };
+        check_min(&mut report, "glibc", glibc.as_deref(), min, true);
+    }
+    for lib in req.libs.iter().flatten() {
+        match library_present(lib).await {
+            Some(true) => {}
+            Some(false) => report.failures.push(format!(
+                "shared library {lib} was not found by the host loader search"
+            )),
+            None => report
+                .warnings
+                .push(format!("cannot check shared library {lib}")),
+        }
+    }
+    for bin in &req.bin {
+        let path = commands
+            .get(&bin.name)
+            .cloned()
+            .or_else(|| file::which(&bin.name));
+        let Some(path) = path else {
+            report.warnings.push(format!(
+                "command {}{} is missing; install it before using features that need it",
+                bin.name,
+                bin.min
+                    .as_deref()
+                    .map(|v| format!(">={v}"))
+                    .unwrap_or_default()
+            ));
+            continue;
+        };
+        if let Some(min) = &bin.min {
+            let output = CmdLineRunner::new(path)
+                .arg("--version")
+                .read_isolated(64 * 1024)
+                .await
+                .ok();
+            let version = output.as_deref().and_then(version_from_output);
+            check_min(&mut report, &bin.name, version.as_deref(), min, false);
+        }
+    }
+    report
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn lower_bounds_are_numeric_and_unknown_is_a_warning() {
+        for (a, b, order) in [
+            ("21", "17", Ordering::Greater),
+            ("2.10", "2.9", Ordering::Greater),
+            ("17", "17.0.0", Ordering::Equal),
+            ("0002.09", "2.9", Ordering::Equal),
+            ("999999999999999999999999999999", "21", Ordering::Greater),
+        ] {
+            assert_eq!(numeric_cmp(a, b), Some(order));
+        }
+        for bad in ["", "v2.0", "2.1-rc1", "2..0", "-1"] {
+            assert_eq!(numeric_cmp(bad, "1"), None);
+        }
+        let mut r = Report::default();
+        check_min(&mut r, "OS", Some("12"), "13", true);
+        check_min(&mut r, "java", Some("11"), "17", false);
+        check_min(&mut r, "glibc", None, "2.31", true);
+        assert_eq!(r.failures.len(), 1);
+        assert_eq!(r.warnings.len(), 2);
+        assert!(r.enforce(false).is_err());
+        assert!(r.enforce(true).is_ok());
+        assert_eq!(
+            version_from_output("openjdk version \"21.0.4\""),
+            Some("21.0.4".into())
+        );
+        assert_eq!(
+            version_from_output("git version 2.49.0"),
+            Some("2.49.0".into())
+        );
+    }
+}

--- a/src/packslip_requirements.rs
+++ b/src/packslip_requirements.rs
@@ -77,14 +77,41 @@ async fn probe(program: &str, args: &[&str]) -> Option<String> {
         .ok()
 }
 
+/// `uname -r` reports a release, not a version: `6.8.0-31-generic` on one
+/// distribution and `6.6.87.2-microsoft-standard-WSL2` on another. What
+/// follows the dotted numbers is the distribution's own business, and an
+/// `os_min` is a lower bound on the numbers, so read those and stop.
+///
+/// Windows reads its version from a sentence `ver` prints, so nothing there
+/// calls this and the compiler would rightly call it dead.
+#[cfg(not(windows))]
+fn release_version(output: &str) -> Option<String> {
+    let word = output.split_whitespace().next()?;
+    let end = word
+        .find(|c: char| !c.is_ascii_digit() && c != '.')
+        .unwrap_or(word.len());
+    let version = word[..end].trim_end_matches('.');
+    numeric_cmp(version, "0").map(|_| version.to_owned())
+}
+
 async fn os_version() -> Option<String> {
     #[cfg(target_os = "macos")]
-    let output = probe("/usr/bin/sw_vers", &["-productVersion"]).await;
+    let version = probe("/usr/bin/sw_vers", &["-productVersion"])
+        .await
+        .as_deref()
+        .and_then(release_version);
+    // `Microsoft Windows [Version 10.0.19045.5011]`, so read it by the word.
     #[cfg(windows)]
-    let output = probe("cmd.exe", &["/D", "/C", "ver"]).await;
+    let version = probe("cmd.exe", &["/D", "/C", "ver"])
+        .await
+        .as_deref()
+        .and_then(version_from_output);
     #[cfg(not(any(target_os = "macos", windows)))]
-    let output = probe("uname", &["-r"]).await;
-    output.as_deref().and_then(version_from_output)
+    let version = probe("uname", &["-r"])
+        .await
+        .as_deref()
+        .and_then(release_version);
+    version
 }
 
 async fn library_present(name: &str) -> Option<bool> {
@@ -254,5 +281,22 @@ mod tests {
             version_from_output("git version 2.49.0"),
             Some("2.49.0".into())
         );
+        // A kernel release carries a suffix; an `os_min` bounds the numbers.
+        #[cfg(not(windows))]
+        for (release, version) in [
+            ("6.8.0-31-generic", Some("6.8.0")),
+            ("6.6.87.2-microsoft-standard-WSL2", Some("6.6.87.2")),
+            ("5.15", Some("5.15")),
+            ("15.5", Some("15.5")),
+            ("14.3-RELEASE-p5", Some("14.3")),
+            ("-broken", None),
+            ("", None),
+        ] {
+            assert_eq!(
+                release_version(release).as_deref(),
+                version,
+                "reading {release:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
A verified artifact could install even when the declared host prerequisites prevent it from starting. Check the selected artifact before download: confirmed OS/glibc/library failures refuse installation, missing or old commands warn, and checks the host cannot answer warn. A per-tool `ignore_requirements=true` explicitly overrides hard failures.

Resolve commands from the active mise toolset before ambient PATH, use bounded probes, and compare numeric version components with zero padding. Linux library checks use the linker cache/search paths; macOS reports unknown absence when the dyld cache prevents a reliable answer. Requirements never resolve an artifact-selection tie.

Validation at the combined stack tip: 34 Packslip-focused tests and 2 process-cleanup tests passed; clippy with warnings denied and scoped formatting/TOML/Markdown/shell checks passed. The final live backend E2E test passed with the rebuilt binary, including latest resolution, warm-cache stamper-policy changes, signer pinning/reset, and lockfile reinstall.

*AI-assisted — Tool: Codex; model: OpenAI/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Install path now runs bounded host probes and can refuse downloads based on manifest requirements; incorrect probes or version parsing could block or warn wrongly, though overrides exist and artifact selection is unchanged.
> 
> **Overview**
> Packslip installs now validate the **selected artifact’s** `requires` block **after** host matching and **before** downloading the release binary.
> 
> **`packslip_requirements`** probes the machine for `os_min`, `glibc_min` (Linux), shared libraries, and optional commands (with `--version` when a minimum is set). Confirmed OS/glibc/library gaps **block** install; missing or under-version commands and checks mise cannot run **warn** only. Per-tool **`ignore_requirements = true`** turns hard failures into warnings. Command lookup prefers the active mise toolset’s spawnable paths over ambient PATH (including Windows PATHEXT). These checks do **not** change which artifact is chosen.
> 
> Docs add a **Host requirements** section describing overrides, platform-specific library probing, and probe limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a7bc340aaeddcfd4e16e6c91a5883b4392f3437. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Packslip installations now validate artifact host requirements, including operating system versions, glibc, required libraries, and command availability.
  - Installations are blocked when required checks fail unless `ignore_requirements = true` is configured.
  - Missing or outdated commands and unknown checks generate warnings without blocking installation.
  - Validation supports Linux, macOS, and Windows hosts.
  - Installations now support trusted vendor manifests, signer and attestation verification, supplemental files, and release-age checks.

- **Documentation**
  - Added guidance on host requirement checks, platform-specific behavior, overrides, and validation limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->