### PR TITLE
docs: complete social and search metadata

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -21,6 +21,9 @@ if (!versionMatch) {
   console.warn("Unable to find package version in Cargo.toml");
 }
 const latestVersion = versionMatch?.[1] ?? "0.0.0";
+const siteUrl = "https://mise.jdx.dev";
+const siteDescription =
+  "mise manages developer tools, environment variables, tasks, packages, and dotfiles in one project configuration for macOS, Linux, and Windows.";
 const publicSchemas = [
   "mise.json",
   "mise.plugin.json",
@@ -77,7 +80,7 @@ function assertNoEmptyDocPages(outDir: string) {
 export default withMermaid(
   defineConfig({
     title: "mise-en-place",
-    description: "mise-en-place documentation",
+    description: siteDescription,
     lang: "en-US",
     lastUpdated: true,
     appearance: true,
@@ -203,6 +206,8 @@ export default withMermaid(
         },
       ],
       ["link", { rel: "icon", href: "/favicon.svg", type: "image/svg+xml" }],
+      ["link", { rel: "manifest", href: "/site.webmanifest" }],
+      ["meta", { name: "theme-color", content: "#0d0221" }],
       // Pre-paint setup to avoid first-load pop-in (see custom.css "preboot"
       // rules; Layout.vue removes the preboot classes right after hydration):
       // - `preboot` disables navbar transitions so hydration state
@@ -310,18 +315,65 @@ export default withMermaid(
       // Open Graph
       ["meta", { property: "og:site_name", content: "mise-en-place" }],
       ["meta", { property: "og:type", content: "website" }],
+      ["meta", { property: "og:locale", content: "en_US" }],
       [
         "meta",
         { property: "og:image", content: "https://mise.jdx.dev/og.png" },
       ],
       ["meta", { property: "og:image:width", content: "1200" }],
       ["meta", { property: "og:image:height", content: "630" }],
+      [
+        "meta",
+        {
+          property: "og:image:alt",
+          content:
+            "mise — developer tools, environment variables, and tasks in one configuration",
+        },
+      ],
       ["meta", { name: "twitter:card", content: "summary_large_image" }],
+      ["meta", { name: "twitter:site", content: "@jdxcode" }],
       [
         "meta",
         { name: "twitter:image", content: "https://mise.jdx.dev/og.png" },
       ],
+      [
+        "meta",
+        {
+          name: "twitter:image:alt",
+          content:
+            "mise — developer tools, environment variables, and tasks in one configuration",
+        },
+      ],
     ],
+    transformHead({ pageData, title, description }) {
+      const url = `${siteUrl}/${pageData.relativePath}`
+        .replace(/index\.md$/, "")
+        .replace(/\.md$/, ".html");
+
+      return [
+        ["meta", { property: "og:url", content: url }],
+        ["meta", { property: "og:title", content: title }],
+        ["meta", { property: "og:description", content: description }],
+        ["meta", { name: "twitter:title", content: title }],
+        ["meta", { name: "twitter:description", content: description }],
+        [
+          "script",
+          { type: "application/ld+json" },
+          JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "WebPage",
+            name: title,
+            description,
+            url,
+            isPartOf: {
+              "@type": "WebSite",
+              name: "mise-en-place",
+              url: siteUrl,
+            },
+          }),
+        ],
+      ];
+    },
     transformPageData(pageData) {
       const canonicalUrl = `https://mise.jdx.dev/${pageData.relativePath}`
         .replace(/index\.md$/, "")

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -22,8 +22,23 @@ if (!versionMatch) {
 }
 const latestVersion = versionMatch?.[1] ?? "0.0.0";
 const siteUrl = "https://mise.jdx.dev";
+// Keep in sync with --vp-c-brand-1 in theme/custom.css and theme_color in
+// public/site.webmanifest so browser chrome matches the installed-app chrome.
+const brandColor = "#8B2252";
 const siteDescription =
   "mise manages developer tools, environment variables, tasks, packages, and dotfiles in one project configuration for macOS, Linux, and Windows.";
+
+// `foo/index.md` publishes as `foo/`, everything else as `foo/bar.html`. Anchor
+// the index match on the leading slash so `guide/myindex.md` keeps its name.
+const pageUrl = (relativePath: string) =>
+  `${siteUrl}/${relativePath}`
+    .replace(/\/index\.md$/, "/")
+    .replace(/\.md$/, ".html");
+
+// VitePress writes an `application/ld+json` body through as raw HTML, so a page
+// whose title or description contains `</script>` would otherwise break out of
+// the tag. JSON allows `\u003c` anywhere `<` is legal.
+const ldJson = (data: unknown) => JSON.stringify(data).replace(/</g, "\\u003c");
 const publicSchemas = [
   "mise.json",
   "mise.plugin.json",
@@ -207,7 +222,7 @@ export default withMermaid(
       ],
       ["link", { rel: "icon", href: "/favicon.svg", type: "image/svg+xml" }],
       ["link", { rel: "manifest", href: "/site.webmanifest" }],
-      ["meta", { name: "theme-color", content: "#0d0221" }],
+      ["meta", { name: "theme-color", content: brandColor }],
       // Pre-paint setup to avoid first-load pop-in (see custom.css "preboot"
       // rules; Layout.vue removes the preboot classes right after hydration):
       // - `preboot` disables navbar transitions so hydration state
@@ -346,9 +361,7 @@ export default withMermaid(
       ],
     ],
     transformHead({ pageData, title, description }) {
-      const url = `${siteUrl}/${pageData.relativePath}`
-        .replace(/index\.md$/, "")
-        .replace(/\.md$/, ".html");
+      const url = pageUrl(pageData.relativePath);
 
       return [
         ["meta", { property: "og:url", content: url }],
@@ -359,7 +372,7 @@ export default withMermaid(
         [
           "script",
           { type: "application/ld+json" },
-          JSON.stringify({
+          ldJson({
             "@context": "https://schema.org",
             "@type": "WebPage",
             name: title,
@@ -375,9 +388,7 @@ export default withMermaid(
       ];
     },
     transformPageData(pageData) {
-      const canonicalUrl = `https://mise.jdx.dev/${pageData.relativePath}`
-        .replace(/index\.md$/, "")
-        .replace(/\.md$/, ".html");
+      const canonicalUrl = pageUrl(pageData.relativePath);
 
       pageData.frontmatter.head ??= [];
       pageData.frontmatter.head.push([

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,6 +1,6 @@
 <template>
   <DefaultTheme.Layout>
-    <template #home-hero-info-before>
+    <template #home-hero-info>
       <div class="hero-copy">
         <div class="hero-lockup">
           <img class="chef-logo chef-logo-light" src="/logo-light.svg" alt="" />

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,9 +2,7 @@
 layout: home
 title: Home
 
-hero:
-  name: mise-en-place
-  tagline: Dev tools, env vars, and tasks in one CLI
+hero: {}
 ---
 
 <section class="landing-page" aria-label="mise overview">

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,12 @@
 layout: home
 title: Home
 
-hero: {}
+# Not rendered: Layout.vue overrides the theme's `home-hero-info` slot with the
+# custom hero, so these values never reach the page (no duplicate H1). They stay
+# here because docs/.vitepress/llms.ts reads them for the llms.txt header.
+hero:
+  name: mise-en-place
+  tagline: Dev tools, env vars, and tasks in one CLI
 ---
 
 <section class="landing-page" aria-label="mise overview">

--- a/docs/public/site.webmanifest
+++ b/docs/public/site.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "mise-en-place",
   "short_name": "mise",
-  "description": "Dev tools, env vars, and tasks in one CLI",
+  "description": "mise manages developer tools, environment variables, tasks, packages, and dotfiles in one project configuration for macOS, Linux, and Windows.",
   "icons": [
     {
       "src": "/logo.svg",


### PR DESCRIPTION
## Summary

- add per-page Open Graph, Twitter, and structured data metadata
- publish locale, image alt text, theme color, and the existing web app manifest
- improve the default description and remove the duplicate homepage H1

## Testing

- bun run docs:build
- mise run lint-fix
- verified generated homepage and nested-page metadata

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-site-only metadata and layout slot changes; no runtime product or security-sensitive application logic beyond safe JSON-LD escaping.
> 
> **Overview**
> **Expands VitePress SEO and social sharing** with a shared site description, canonical URL helper (`pageUrl`), and per-page **Open Graph / Twitter** tags via `transformHead` (title, description, URL). Adds **JSON-LD `WebPage` schema** with `\u003c` escaping so titles/descriptions cannot break out of the script tag.
> 
> **Site-wide head** now links the web app manifest, sets **theme-color** (aligned with brand CSS/manifest), and adds locale, Twitter `@jdxcode`, and OG/Twitter image alt text.
> 
> **Homepage:** custom hero moves to the `home-hero-info` slot so the theme does not emit a second H1; frontmatter `hero` stays for `llms.txt` generation (documented in `index.md`). **PWA manifest** description matches the new default site blurb.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba56a50760acc78dd6efcdb0690bafc6ee620aba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved page metadata for search engines and social sharing, including canonical URLs, localized descriptions, image alt text, Twitter details, and structured page information.
  * Added browser manifest and theme-color metadata for a more polished browsing experience.
  * Restored homepage hero content and tagline, and updated its rendering behavior.
  * Expanded the web app manifest description to better explain mise’s capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->