### PR TITLE
fix(sandbox): omit SYS_fork/SYS_vfork on aarch64

### DIFF
--- a/src/sandbox/seccomp.rs
+++ b/src/sandbox/seccomp.rs
@@ -67,10 +67,21 @@ pub(super) fn apply_seccomp_filter(deny_net: bool, deny_process: bool) -> Result
         // An empty rule chain means the syscall number alone triggers the
         // filter's match action.
         let deny = Vec::<SeccompRule>::new();
+        // Linux generic syscall ABI has no fork/vfork; aarch64 implements fork via clone.
         for syscall in [
             syscall_number(libc::SYS_clone),
             syscall_number(libc::SYS_clone3),
+            #[cfg(not(any(
+                target_arch = "aarch64",
+                target_arch = "riscv64",
+                target_arch = "loongarch64"
+            )))]
             syscall_number(libc::SYS_fork),
+            #[cfg(not(any(
+                target_arch = "aarch64",
+                target_arch = "riscv64",
+                target_arch = "loongarch64"
+            )))]
             syscall_number(libc::SYS_vfork),
             syscall_number(libc::SYS_kill),
             syscall_number(libc::SYS_tkill),


### PR DESCRIPTION
Linux aarch64 has no fork/vfork syscalls; libc does not define SYS_fork or SYS_vfork. d29f9f4 added them unconditionally to the deny_process seccomp list and broke the linux-arm64 tarball build.

This MR was 100% generated by Grok Build 4.6 after I told it about the failure blocking release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox compatibility on aarch64, riscv64, and loongarch64 platforms by correctly handling process-creation system calls.
  * Preserved process-denial protections for clone, vfork, signal, and tracing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->