### PR TITLE
fix(packslip): ask for a completion at the tab, not at shell startup

### DIFF
--- a/docs/cli/completion.md
+++ b/docs/cli/completion.md
@@ -31,10 +31,10 @@ Generate shell completions
 
   NAME is a tool installed with the `packslip:` backend, or one of its executables. The
   script comes from whichever version is active here, from the most verifiable source its
-  packslip offers: a file the vendor shipped, a script derived from its CLI spec, or, only
-  with `packslip.exec` enabled, a command of the tool's own. With --install, what is written
-  is a small stub that asks mise for the script when the shell first completes the tool, so
-  it follows version switches without being rewritten.
+  packslip offers: a file the vendor shipped, a script derived from its CLI spec, or a
+  command of the tool's own. With --install, what is written is a small stub that asks mise
+  for the script each time the shell completes the tool, so it follows version switches
+  without being rewritten.
 - **`-h --help`** — Print help
 
 Examples:

--- a/docs/dev-tools/backends/packslip.md
+++ b/docs/dev-tools/backends/packslip.md
@@ -134,7 +134,7 @@ mise completion zsh --tool rg --install # put a stub where zsh looks
 
 The script comes from whichever version of the tool is active in the current directory. A vendor whose layouts differ by platform scopes an entry with `os`, `arch`, or `libc`; mise keeps the entries that apply to the artifact it installed and, of those, the most specific. It then takes the most verifiable source the vendor offered, in the order the specification gives: a file inside the artifact or a separate signed asset, a file from the source repository at the release's commit, a script derived from the tool's [usage](https://usage.jdx.dev) spec with the `usage` command, and only then a command of the tool's own. That last kind is how cobra, clap, and oclif tools ship completions, so mise runs it: the stub calls mise the first time your shell completes the command, which is when you were going to run the tool anyway, and mise caches the script beside the install so the command runs once per version rather than at every tab. No setting is needed. The [`packslip.exec`](/configuration/settings#packslip-exec) setting governs only exec resources mise would run at install time and write to disk, such as an agent skill.
 
-`--install` writes a stub, not the script. Completions are global shell state while the active version depends on the directory, so the stub asks mise for the script when the shell completes the tool. In zsh and bash the vendor's script takes over for one completion and the stub is put back afterwards, so a version switch in another directory is followed on the next tab; fish and PowerShell load the script once per shell session. The file goes where the shell loads completions by name, the same place `mise completion zsh --install` puts mise's own, and the command prints any one-time line your shell still needs.
+`--install` writes a stub, not the script. Completions are global shell state while the active version depends on the directory, so the stub asks mise for the script when the shell completes the tool. In zsh and bash the vendor's script takes over for one completion and the stub is put back afterwards, so a version switch in another directory is followed on the next tab. fish reads the script in a child shell of its own, and PowerShell puts mise's completer back after handing one completion to the vendor's, for the same reason: neither keeps the registrations of a version that is no longer active. The file goes where the shell loads completions by name, the same place `mise completion zsh --install` puts mise's own, and the command prints any one-time line your shell still needs.
 
 Files the vendor keeps outside the artifact (a separate release asset, or a path in the repository) are fetched at install time. An asset must match the digest the packslip signed; a repository file is pinned by the release's commit. Completions derived from a usage spec call `usage complete-word` at shell runtime, so install `usage` alongside such tools (`mise use -g usage`).
 
@@ -159,6 +159,8 @@ Four settings shape this:
 
 A skill the packslip offers only as a command of the tool's own (`tool skill`, printing `SKILL.md`) is generated at install time only when [`packslip.exec`](/configuration/settings#packslip-exec) is on, for the same reason as completions.
 
+Several sources for one skill are alternatives, not a set to collect: mise takes the most verifiable one that is on disk and does not fetch or run the ones below it, so a skill the release ships never runs the tool. A directory is that skill only once it holds `SKILL.md`; what an interrupted fetch or unpack left behind is not a skill, and the source below it is still tried.
+
 ## Versions
 
 A packslip version is semver, so mise ranks a project's versions by semver precedence whatever order GitHub lists its releases in, and treats a version with a prerelease part (`1.3.0-rc.1`, `1.4.0-nightly.20260904`) as a prerelease whatever the GitHub release's own flag says. Prereleases are skipped unless the `prerelease` tool option is set.
@@ -175,7 +177,11 @@ Lockfiles record the artifact URL and its sha256 from the signed statement.
 
 Resources may name one exact `artifact` when layouts differ between archive formats or variants. Completions are selected for the command being completed; when a release has several executables, pass its command name to `--tool`. Generated scripts are cached separately for each installed version, executable, and shell.
 
-Exec resources receive the manifest’s environment variables, with `{shell}` expanded for completions. They run in a temporary directory with the installed executables on PATH, no stdin, discarded stderr, and a five-second timeout. Failed or empty output is not cached. The same execution rules apply to skills when `packslip.exec` permits generating them.
+Exec resources receive the manifest’s environment variables, with `{shell}` expanded for completions. They run in a temporary directory with the installed executables on PATH, no stdin, discarded stderr, and a five-second timeout. The same execution rules apply to skills when `packslip.exec` permits generating them.
+
+A script that comes back empty is a failed source, not a completion: mise moves on to the next source and caches nothing. Shells completing the same command at once take turns, so the tool runs once between them rather than once each, and no shell reads a half-written entry. A CLI spec generated for one shell, as `{shell}` in the command allows, is kept under that shell's name and written whole.
+
+Static `cli-spec` entries are ranked like a shipped script's: the release's own archive, then a signed asset, then the source repository, with the order they are written in breaking ties.
 
 ### Release-list continuity and minimum age
 

--- a/docs/dev-tools/backends/packslip.md
+++ b/docs/dev-tools/backends/packslip.md
@@ -179,7 +179,7 @@ Resources may name one exact `artifact` when layouts differ between archive form
 
 Exec resources receive the manifest’s environment variables, with `{shell}` expanded for completions. They run in a temporary directory with the installed executables on PATH, no stdin, discarded stderr, and a five-second timeout. The same execution rules apply to skills when `packslip.exec` permits generating them.
 
-A script that comes back empty is a failed source, not a completion: mise moves on to the next source and caches nothing. Shells completing the same command at once take turns, so the tool runs once between them rather than once each, and no shell reads a half-written entry. A CLI spec generated for one shell, as `{shell}` in the command allows, is kept under that shell's name and written whole.
+A script that comes back empty is a failed source, not a completion: mise moves on to the next source and caches nothing. Shells completing the same command at once take turns, so the tool runs once between them rather than once each, and no shell reads a half-written entry. Only generation takes turns: a completion the release ships is read straight out of the install, so a read-only system or shared install still completes. A CLI spec generated for one shell, as `{shell}` in the command allows, is kept under that shell's name and written whole.
 
 Static `cli-spec` entries are ranked like a shipped script's: the release's own archive, then a signed asset, then the source repository, with the order they are written in breaking ties.
 

--- a/e2e/backend/test_packslip_resources
+++ b/e2e/backend/test_packslip_resources
@@ -75,9 +75,40 @@ for version in ("1.0.0", "2.0.0"):
         },
     }
     (root / ".mise-packslip.json").write_text(json.dumps(statement))
+
+# An install whose only completion is a file it ships, for the read-only
+# system and shared installs mise is expected to serve completions from.
+static = Path("3.0.0")
+(static / "bin").mkdir(parents=True)
+(static / "_probe.bash").write_text("complete -W 'shipped' probe\n")
+# Nothing should run it: the completion this install ships is a file.
+program = static / "bin/probe"
+program.write_text("#!/usr/bin/env sh\nexit 1\n")
+program.chmod(0o755)
+(static / ".mise-packslip.json").write_text(json.dumps({
+    "_type": "https://in-toto.io/Statement/v1",
+    "subject": [{"name": "probe.tar.gz", "digest": {"sha256": "a" * 64}}],
+    "predicateType": "https://packslip.dev/release/v1",
+    "predicate": {
+        "project": "github.com/test/probe",
+        "version": "3.0.0",
+        "published_at": "2026-09-01T00:00:00Z",
+        "artifacts": [{
+            "name": "probe.tar.gz", "size": 1, "format": "tar.gz", "bin": ["bin/probe"],
+        }],
+        "resources": [
+            {"kind": "completion", "bin": "probe", "shell": "bash", "archive": "_probe.bash"},
+        ],
+        "identity": {
+            "scheme": "sigstore-oidc",
+            "key_id": "https://github.com/test/probe/.github/workflows/release.yml@refs/tags/v3.0.0",
+            "issuer": "https://token.actions.githubusercontent.com",
+        },
+    },
+}))
 PY
 
-for version in 1.0.0 2.0.0; do
+for version in 1.0.0 2.0.0 3.0.0; do
   mise link "packslip:test/probe@$version" "$PWD/$version"
   mkdir "project-$version"
   printf '[tools]\n"packslip:test/probe" = "%s"\n' "$version" >"project-$version/mise.toml"
@@ -167,3 +198,15 @@ assert_contains "cat ../skills/probe/SKILL.md" "# probe 2.0.0"
 cd ../project-1.0.0
 mise skills sync --dir ../skills
 assert_contains "cat ../skills/probe/SKILL.md" "# probe 1.0.0"
+
+# A completion the release ships is read, not generated, so it asks nothing
+# of the install: no lock, no directory, and no write. That is what lets a
+# system or shared install, which is read-only, complete at all.
+cd ../project-3.0.0
+assert_contains "mise completion bash --tool probe" "complete -W 'shipped' probe"
+assert "test ! -e ../3.0.0/.mise-packslip/completions && echo clean" "clean"
+if [ "$(id -u)" != 0 ]; then
+  chmod -R a-w ../3.0.0
+  assert_contains "mise completion bash --tool probe" "complete -W 'shipped' probe"
+  chmod -R u+w ../3.0.0
+fi

--- a/e2e/backend/test_packslip_resources
+++ b/e2e/backend/test_packslip_resources
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+
+# What a consumer does with the resources a packslip declares, against two
+# linked installs. Signing, discovery, and downloading are test_packslip's;
+# these fixtures start after verification, with the statement and the
+# resources already in the install.
+
+export MISE_EXPERIMENTAL=1
+# These installs are linked, not downloaded, and the project they name has no
+# releases to discover: discovery and verification are test_packslip's. Offline
+# keeps resolution to what is installed here.
+export MISE_OFFLINE=1
+
+python3 <<'PY'
+import json
+from pathlib import Path
+
+PROBE = '''#!/usr/bin/env python3
+import pathlib, sys, time
+root = pathlib.Path(__file__).resolve().parent.parent
+shell = sys.argv[1]
+with (root / ("calls-" + shell)).open("a") as log:
+    log.write("call\\n")
+# Long enough that shells completing at once overlap on the lock below.
+time.sleep(0.2)
+if shell == "fish":
+    print("complete -c probe -f -a 'version" + root.name + "'")
+elif shell == "powershell":
+    print("Register-ArgumentCompleter -Native -CommandName probe -ScriptBlock {")
+    print("  param($wordToComplete, $commandAst, $cursorPosition)")
+    text = "version" + root.name
+    print("  [System.Management.Automation.CompletionResult]::new('%s', '%s', 'ParameterValue', '%s')" % (text, text, text))
+    print("}")
+else:
+    print('name "probe"')
+    print("# " + shell + " " + root.name)
+'''
+
+RESOURCES = [
+    {"kind": "skill", "name": "probe", "archive": "skill"},
+    # An empty shipped script is no completion, and the sources below it
+    # are still there to be tried.
+    {"kind": "completion", "bin": "probe", "shell": "fish", "archive": "empty.fish"},
+    {"kind": "completion", "bin": "probe", "shells": ["fish", "powershell"], "exec": ["probe", "{shell}"]},
+    {"kind": "cli-spec", "bin": "probe", "format": "usage", "exec": ["probe", "{shell}"]},
+]
+
+for version in ("1.0.0", "2.0.0"):
+    root = Path(version)
+    (root / "bin").mkdir(parents=True)
+    (root / "skill").mkdir()
+    (root / "skill/SKILL.md").write_text("# probe %s\n" % version)
+    (root / "empty.fish").write_text("  \n")
+    program = root / "bin/probe"
+    program.write_text(PROBE)
+    program.chmod(0o755)
+    statement = {
+        "_type": "https://in-toto.io/Statement/v1",
+        "subject": [{"name": "probe.tar.gz", "digest": {"sha256": "a" * 64}}],
+        "predicateType": "https://packslip.dev/release/v1",
+        "predicate": {
+            "project": "github.com/test/probe",
+            "version": version,
+            "published_at": "2026-09-01T00:00:00Z",
+            "artifacts": [{
+                "name": "probe.tar.gz", "size": 1, "format": "tar.gz",
+                "bin": ["bin/probe"],
+            }],
+            "resources": RESOURCES,
+            "identity": {
+                "scheme": "sigstore-oidc",
+                "key_id": "https://github.com/test/probe/.github/workflows/release.yml@refs/tags/v" + version,
+                "issuer": "https://token.actions.githubusercontent.com",
+            },
+        },
+    }
+    (root / ".mise-packslip.json").write_text(json.dumps(statement))
+PY
+
+for version in 1.0.0 2.0.0; do
+  mise link "packslip:test/probe@$version" "$PWD/$version"
+  mkdir "project-$version"
+  printf '[tools]\n"packslip:test/probe" = "%s"\n' "$version" >"project-$version/mise.toml"
+done
+
+# A stand-in for the usage command, which turns a CLI spec into a script.
+# It says which spec file it read, so the assertions can name it.
+cat >"$HOME/bin/usage" <<'EOF'
+#!/usr/bin/env sh
+printf '# spec: %s\n' "$6"
+cat "$6"
+EOF
+chmod +x "$HOME/bin/usage"
+
+cd project-1.0.0
+
+# What an interrupted generation leaves is not a completion, and the shells
+# asking at once run the tool once between them rather than once each.
+cache="../1.0.0/.mise-packslip/completions/probe"
+mkdir -p "$cache"
+printf ' \n' >"$cache/fish.completion"
+for i in 1 2 3 4; do
+  mise completion fish --tool probe >"completion-$i" &
+done
+wait
+for i in 1 2 3 4; do
+  assert_contains "cat completion-$i" "version1.0.0"
+done
+assert "wc -l <../1.0.0/calls-fish | tr -d ' '" "1"
+
+# A spec generated for one shell is not the spec for another, and neither
+# generation reads the other's half-written file.
+mise completion bash --tool probe >bash.completion &
+mise completion zsh --tool probe >zsh.completion
+wait
+assert_contains "cat bash.completion" "specs/bash/probe.usage"
+assert_contains "cat zsh.completion" "specs/zsh/probe.usage"
+assert_contains "cat ../1.0.0/.mise-packslip/specs/bash/probe.usage" "# bash 1.0.0"
+assert_contains "cat ../1.0.0/.mise-packslip/specs/zsh/probe.usage" "# zsh 1.0.0"
+
+# The skill the release ships is the skill, and the link follows the
+# version that is active here.
+assert_contains "mise skills ls" "probe"
+assert_contains "mise skills ls --json" "1.0.0"
+mise skills sync --dir ../skills
+assert_contains "cat ../skills/probe/SKILL.md" "# probe 1.0.0"
+
+if command -v fish >/dev/null; then
+  mise completion fish --tool probe --install
+  stub="$HOME/.config/fish/completions/probe.fish"
+  assert_contains "cat $stub" "complete -c 'probe'"
+  rm -f ../2.0.0/calls-fish
+  # One shell, one sourced stub, two directories: the stub is loaded once
+  # and each completion follows the version that is active where it happens.
+  fish --no-config -c "
+    source $stub
+    test ! -e ../2.0.0/calls-fish; or exit 1
+    complete -C 'probe '
+    cd ../project-2.0.0
+    complete -C 'probe '
+  " >fish.completions
+  assert_contains "cat fish.completions" "version1.0.0"
+  assert_contains "cat fish.completions" "version2.0.0"
+fi
+
+if command -v pwsh >/dev/null; then
+  mise completion powershell --tool probe --install 2>pwsh.install
+  stub="$(sed -n 's/^installing to //p' pwsh.install)"
+  rm -f ../2.0.0/calls-powershell
+  # shellcheck disable=SC2016 # the $ names below are PowerShell's, not bash's
+  PACKSLIP_STUB="$stub" pwsh -NoProfile -NonInteractive -Command '
+    . $env:PACKSLIP_STUB
+    if (Test-Path ../2.0.0/calls-powershell) { throw "the stub ran the tool when it was loaded" }
+    (TabExpansion2 "probe " 6).CompletionMatches.CompletionText
+    Set-Location ../project-2.0.0
+    (TabExpansion2 "probe " 6).CompletionMatches.CompletionText
+  ' >pwsh.completions
+  assert_contains "cat pwsh.completions" "version1.0.0"
+  assert_contains "cat pwsh.completions" "version2.0.0"
+fi
+
+# A version switch is a different install, with its own cache and skill.
+cd ../project-2.0.0
+assert_contains "mise completion fish --tool probe" "version2.0.0"
+mise skills sync --dir ../skills
+assert_contains "cat ../skills/probe/SKILL.md" "# probe 2.0.0"
+cd ../project-1.0.0
+mise skills sync --dir ../skills
+assert_contains "cat ../skills/probe/SKILL.md" "# probe 1.0.0"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2453,10 +2453,10 @@ A tool's completion instead of mise's own, from the packslip it was installed fr
 
 NAME is a tool installed with the `packslip:` backend, or one of its executables. The
 script comes from whichever version is active here, from the most verifiable source its
-packslip offers: a file the vendor shipped, a script derived from its CLI spec, or, only
-with `packslip.exec` enabled, a command of the tool's own. With \-\-install, what is written
-is a small stub that asks mise for the script when the shell first completes the tool, so
-it follows version switches without being rewritten.
+packslip offers: a file the vendor shipped, a script derived from its CLI spec, or a
+command of the tool's own. With \-\-install, what is written is a small stub that asks mise
+for the script each time the shell completes the tool, so it follows version switches
+without being rewritten.
 .TP
 \fB\-h, \-\-help\fR
 Print help

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1256,10 +1256,10 @@ A tool's completion instead of mise's own, from the packslip it was installed fr
 
 NAME is a tool installed with the `packslip:` backend, or one of its executables. The
 script comes from whichever version is active here, from the most verifiable source its
-packslip offers: a file the vendor shipped, a script derived from its CLI spec, or, only
-with `packslip.exec` enabled, a command of the tool's own. With --install, what is written
-is a small stub that asks mise for the script when the shell first completes the tool, so
-it follows version switches without being rewritten.
+packslip offers: a file the vendor shipped, a script derived from its CLI spec, or a
+command of the tool's own. With --install, what is written is a small stub that asks mise
+for the script each time the shell completes the tool, so it follows version switches
+without being rewritten.
 """#
         arg <TOOL>
     }

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -90,10 +90,10 @@ pub(crate) struct Completion {
     ///
     /// NAME is a tool installed with the `packslip:` backend, or one of its executables. The
     /// script comes from whichever version is active here, from the most verifiable source its
-    /// packslip offers: a file the vendor shipped, a script derived from its CLI spec, or, only
-    /// with `packslip.exec` enabled, a command of the tool's own. With --install, what is written
-    /// is a small stub that asks mise for the script when the shell first completes the tool, so
-    /// it follows version switches without being rewritten.
+    /// packslip offers: a file the vendor shipped, a script derived from its CLI spec, or a
+    /// command of the tool's own. With --install, what is written is a small stub that asks mise
+    /// for the script each time the shell completes the tool, so it follows version switches
+    /// without being rewritten.
     #[usage(long, verbatim_doc_comment)]
     tool: Option<String>,
 }

--- a/src/packslip.rs
+++ b/src/packslip.rs
@@ -1195,34 +1195,29 @@ pub(crate) async fn completion_script(
         )
     })?;
     let cache = completion_cache_path(&install_path, bin, shell)?;
-    // Deriving a script runs the tool. Several shells can complete the same
-    // command at once, so they take turns here: the first generates and the
-    // rest read what it cached, and no shell reads a half-written entry.
-    // The lock lives beside the cache, shared by every process that shares
-    // the install, and is taken off the runtime's threads.
-    let lock_path = cache.with_extension("lock");
-    let _lock = tokio::task::spawn_blocking(move || -> Result<fslock::LockFile> {
-        if let Some(dir) = lock_path.parent() {
-            file::create_dir_all(dir)?;
-        }
-        let mut lock = fslock::LockFile::open(&lock_path)?;
-        lock.lock()?;
-        Ok(lock)
-    })
-    .await??;
-    // An empty entry is what an interrupted generation leaves behind, not a
-    // completion; reading it back would hide every source the vendor offers.
-    if let Ok(cached) = file::read_to_string(&cache)
-        && !cached.trim().is_empty()
-    {
-        return Ok(cached);
-    }
+    // Nothing below happens until a source that runs the tool comes up. A
+    // system or shared install is read-only, and a completion that is simply
+    // a file in it has to stay readable there: taking the lock first would
+    // ask to write to the install before reading anything from it.
+    // `None` until the first source that runs the tool, and `Some(None)`
+    // where the install cannot be written to and so cannot be locked.
+    let mut generating: Option<Option<fslock::LockFile>> = None;
     let mut skipped = Vec::new();
     for source in sources {
         let ran_tool = matches!(
             source,
             CompletionSource::Exec(..) | CompletionSource::SpecExec { .. }
         );
+        if ran_tool && generating.is_none() {
+            generating = Some(lock_generation(&cache).await);
+            // An empty entry is what an interrupted generation leaves behind,
+            // not a completion; reading it back would hide every source below.
+            if let Ok(cached) = file::read_to_string(&cache)
+                && !cached.trim().is_empty()
+            {
+                return Ok(cached);
+            }
+        }
         let attempt = match source {
             CompletionSource::File(path) => file::read_to_string(&path),
             CompletionSource::Spec { format, bin, path } => {
@@ -1279,6 +1274,38 @@ pub(crate) async fn completion_script(
         tv.style(),
         skipped.join("; ")
     )
+}
+
+/// Take turns generating, so that of the shells completing one command at
+/// once the first runs the tool and the rest read what it cached. The lock
+/// lives beside the cache, shared by every process that shares the install,
+/// and is taken off the runtime's threads.
+///
+/// A read-only install cannot be locked and does not need to be: nothing
+/// will be cached there either, so each shell generates its own script
+/// rather than being refused a completion.
+async fn lock_generation(cache: &Path) -> Option<fslock::LockFile> {
+    let lock_path = cache.with_extension("lock");
+    let taken = tokio::task::spawn_blocking(move || -> Result<fslock::LockFile> {
+        if let Some(dir) = lock_path.parent() {
+            file::create_dir_all(dir)?;
+        }
+        let mut lock = fslock::LockFile::open(&lock_path)?;
+        lock.lock()?;
+        Ok(lock)
+    })
+    .await;
+    match taken {
+        Ok(Ok(lock)) => Some(lock),
+        Ok(Err(err)) => {
+            debug!("generating a completion without a lock: {err}");
+            None
+        }
+        Err(err) => {
+            debug!("generating a completion without a lock: {err}");
+            None
+        }
+    }
 }
 
 /// A stub the shell loads by name, which asks mise for the real script at
@@ -1821,6 +1848,48 @@ mod tests {
             bins(Some("github.com/o/r")),
             Vec::<String>::new(),
             "an ambiguous tool id must not complete an arbitrary executable"
+        );
+    }
+
+    #[test]
+    fn a_shipped_skill_never_shadows_a_scoped_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        // The unscoped source is the one on disk, so it would win a race the
+        // fetch loop's "a higher source already has it" skip could start.
+        let shipped = root.join("share/skills/t");
+        std::fs::create_dir_all(&shipped).unwrap();
+        std::fs::write(shipped.join("SKILL.md"), "# shipped").unwrap();
+        let s = statement_with(
+            r#"[
+            {"kind":"skill","name":"t","archive":"top/share/skills/t"},
+            {"kind":"skill","name":"t","os":"linux","asset":"t-skill.tar.gz"}
+        ]"#,
+        );
+        let linux = s.predicate.artifacts[0].clone();
+        // Fetching and reading agree because both narrow to the most specific
+        // entry per skill name first: the unscoped entry is not a "higher
+        // source" for the scoped one, it is a different platform's answer to
+        // the same question and is gone before either looks.
+        let selected: Vec<_> = selected_resources(&s, Some(&linux))
+            .into_iter()
+            .map(|r| r.asset.as_deref().or(r.archive.as_deref()))
+            .collect();
+        assert_eq!(selected, [Some("t-skill.tar.gz")]);
+        assert!(
+            skills_of(&s, root, "tool", "1", Some(&linux)).is_empty(),
+            "the scoped skill is the skill, and it is not on disk yet"
+        );
+        // With nothing scoped fitting, the shipped one applies as it always did.
+        let mut windows = linux.clone();
+        windows.os = Some("windows".into());
+        windows.libc = None;
+        assert_eq!(
+            skills_of(&s, root, "tool", "1", Some(&windows))
+                .iter()
+                .map(|s| s.path.clone())
+                .collect::<Vec<_>>(),
+            [shipped]
         );
     }
 

--- a/src/packslip.rs
+++ b/src/packslip.rs
@@ -87,13 +87,17 @@ pub(crate) fn resource_dir(install_path: &Path, resource: &Resource) -> Option<P
     let fetched = |sub: &str, rel: &str| {
         Some(install_path.join(RESOURCES_DIR).join(sub).join(rel)).filter(|p| p.is_dir())
     };
-    match resource.source()? {
+    let dir = match resource.source()? {
         ResourceSource::Archive => {
             locate_dir_in_install(install_path, resource.archive.as_deref()?)
         }
         ResourceSource::Asset | ResourceSource::Exec => fetched("skills", skill_name(resource)?),
         ResourceSource::Repo => fetched("repo", repo_path(resource)?),
-    }
+    }?;
+    // A directory without SKILL.md is not a skill. Fetching already treats
+    // one as unfinished, and a directory an interrupted attempt left behind
+    // must not pass for the skill and hide the sources below it.
+    dir.join("SKILL.md").is_file().then_some(dir)
 }
 
 /// The `owner/repo` of a release built from a github.com repository.
@@ -176,7 +180,19 @@ pub(crate) async fn fetch_files(
         Some(ResourceSource::Exec) => 3,
         None => 4,
     });
-    for resource in resources {
+    for (index, resource) in resources.iter().copied().enumerate() {
+        // Sources are alternatives, not a set to collect: once a higher
+        // source has the skill on disk, the ones below it are not fetched
+        // and, in particular, a shipped skill never runs the tool.
+        if resource.kind == "skill"
+            && resources[..index].iter().any(|higher| {
+                higher.kind == "skill"
+                    && skill_name(higher) == skill_name(resource)
+                    && resource_dir(&tv.install_path(), higher).is_some()
+            })
+        {
+            continue;
+        }
         // An entry scoped to another platform is not for this install.
         if let Some(artifact) = artifact
             && !resource_fits(resource, artifact)
@@ -936,12 +952,21 @@ pub(crate) fn completion_sources(
         }),
         artifact,
     );
-    let spec_entries: Vec<_> = selected
+    let mut spec_entries: Vec<_> = selected
         .iter()
         .copied()
         .filter(describes)
         .filter(|r| r.kind == "cli-spec")
         .collect();
+    // The specification ranks the static sources of a spec as it ranks a
+    // shipped script's: the archive the release signed, then a signed asset,
+    // then the source repository. Document order breaks ties within a rank.
+    spec_entries.sort_by_key(|r| match r.source() {
+        Some(ResourceSource::Archive) => 0,
+        Some(ResourceSource::Asset) => 1,
+        Some(ResourceSource::Repo) => 2,
+        _ => 3,
+    });
     let completions = || completion_entries.iter().copied();
     let for_shell =
         |r: &Resource| r.shell.as_deref() == Some(shell) || r.shells.iter().any(|s| s == shell);
@@ -1170,7 +1195,26 @@ pub(crate) async fn completion_script(
         )
     })?;
     let cache = completion_cache_path(&install_path, bin, shell)?;
-    if let Ok(cached) = file::read_to_string(&cache) {
+    // Deriving a script runs the tool. Several shells can complete the same
+    // command at once, so they take turns here: the first generates and the
+    // rest read what it cached, and no shell reads a half-written entry.
+    // The lock lives beside the cache, shared by every process that shares
+    // the install, and is taken off the runtime's threads.
+    let lock_path = cache.with_extension("lock");
+    let _lock = tokio::task::spawn_blocking(move || -> Result<fslock::LockFile> {
+        if let Some(dir) = lock_path.parent() {
+            file::create_dir_all(dir)?;
+        }
+        let mut lock = fslock::LockFile::open(&lock_path)?;
+        lock.lock()?;
+        Ok(lock)
+    })
+    .await??;
+    // An empty entry is what an interrupted generation leaves behind, not a
+    // completion; reading it back would hide every source the vendor offers.
+    if let Ok(cached) = file::read_to_string(&cache)
+        && !cached.trim().is_empty()
+    {
         return Ok(cached);
     }
     let mut skipped = Vec::new();
@@ -1200,16 +1244,24 @@ pub(crate) async fn completion_script(
                         bail!("cli-spec entry names {bin:?} in format {format:?}");
                     }
                     let spec = run_tool(config, &backend, &tv, &argv, &env).await?;
-                    let dir = install_path.join(RESOURCES_DIR).join("specs");
+                    // A spec generated for one shell, as `{shell}` in the
+                    // command allows, is not the spec for another, and two
+                    // shells generating at once must not read each other's
+                    // half-written file. `shell` is a plain file name: the
+                    // cache path above refuses anything else.
+                    let dir = install_path.join(RESOURCES_DIR).join("specs").join(shell);
                     file::create_dir_all(&dir)?;
                     let path = dir.join(format!("{bin}.{format}"));
-                    file::write(&path, &spec)?;
+                    file::write_atomic(&path, &spec)?;
                     derive_from_spec(config, ts, &format, &bin, &path, shell).await
                 }
                 .await
             }
         };
         match attempt {
+            Ok(script) if script.trim().is_empty() => {
+                skipped.push("nothing was printed".to_string())
+            }
             Ok(script) => {
                 if ran_tool
                     && let Some(dir) = cache.parent()
@@ -1237,7 +1289,9 @@ pub(crate) async fn completion_script(
 /// In zsh and bash the vendor's script replaces the stub while it completes
 /// and the stub is put back afterwards, so the next completion asks mise
 /// again and a version switch in another directory is followed on the next
-/// tab. fish and PowerShell load the script once per shell session.
+/// tab. fish reads the script in a child shell of its own, and PowerShell
+/// puts this completer back after delegating, for the same reason: neither
+/// keeps the registrations of a version that is no longer the active one.
 pub(crate) fn stub(tool: &str, shell: usage_rs::complete::Shell) -> Result<String> {
     use usage_rs::complete::Shell;
     let note = format!("mise completes {tool} from the packslip of whichever version is active");
@@ -1326,10 +1380,51 @@ complete -F {func} '{tool}'
             )
         }
         Shell::Fish => format!(
-            "# {note}.\n# {by}\ncommand mise completion fish --tool '{tool}' 2>/dev/null | source\n"
+            r#"# {note}.
+# {by}
+# The vendor's script is read in a child shell, once per completion, so its
+# registrations and helper functions never outlive the version they came
+# from and a version switch in another directory is followed at the next tab.
+function {loader}
+    set -l __mise_fish (status fish-path)
+    set -l __mise_line (commandline --current-process --cut-at-cursor | string collect --allow-empty)
+    # An empty completion path keeps the child from autoloading this stub.
+    $__mise_fish --no-config -c '
+        set fish_complete_path
+        command mise completion fish --tool $argv[1] 2>/dev/null | source
+        complete --do-complete "$argv[2]"
+    ' -- '{tool}' $__mise_line
+end
+complete -c '{tool}' -f -a '({loader})'
+"#
         ),
         Shell::PowerShell => format!(
-            "# {note}.\n# {by}\n$__mise_script = @(& mise completion powershell --tool '{tool}' 2>$null) -join \"`n\"\nif ($__mise_script) {{ Invoke-Expression $__mise_script }}\n"
+            r#"# {note}.
+# {by}
+# The vendor's script registers its own completer, which handles this
+# completion; this one is put back afterwards, so the next completion asks
+# mise again and a version switch in another directory is followed.
+function global:{loader} {{
+    param($wordToComplete, $commandAst, $cursorPosition)
+    # A script that registers nothing for this command would otherwise reach
+    # this completer again through TabExpansion2, without end.
+    if ($global:{loader}_busy) {{ return }}
+    $global:{loader}_busy = $true
+    try {{
+        $__mise_script = @(& mise completion powershell --tool '{tool}' 2>$null) -join "`n"
+        if ($__mise_script) {{
+            Invoke-Expression $__mise_script
+            $__mise_cursor = $cursorPosition - $commandAst.Extent.StartOffset
+            $__mise_line = $commandAst.Extent.Text.PadRight([Math]::Max($commandAst.Extent.Text.Length, $__mise_cursor))
+            (TabExpansion2 -inputScript $__mise_line -cursorColumn $__mise_cursor).CompletionMatches
+        }}
+    }} finally {{
+        Register-ArgumentCompleter -Native -CommandName '{tool}' -ScriptBlock $function:{loader}
+        $global:{loader}_busy = $false
+    }}
+}}
+Register-ArgumentCompleter -Native -CommandName '{tool}' -ScriptBlock $function:{loader}
+"#
         ),
         _ => bail!(
             "{} loads completions eagerly, so mise cannot leave it a stub; redirect `mise completion {} --tool {tool}` yourself",
@@ -1538,6 +1633,49 @@ mod tests {
     }
 
     #[test]
+    fn static_specs_follow_source_priority_then_document_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        for rel in [
+            "first.kdl",
+            "second.kdl",
+            &format!("{RESOURCES_DIR}/repo/t.kdl"),
+            &format!("{RESOURCES_DIR}/assets/t-skill.tar.gz"),
+        ] {
+            let path = root.join(rel);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, "name t").unwrap();
+        }
+        let s = statement_with(
+            r#"[
+            {"kind":"cli-spec","bin":"t","format":"usage","repo":"t.kdl"},
+            {"kind":"cli-spec","bin":"t","format":"usage","asset":"t-skill.tar.gz"},
+            {"kind":"cli-spec","bin":"t","format":"usage","archive":"first.kdl"},
+            {"kind":"cli-spec","bin":"t","format":"usage","archive":"second.kdl"}
+        ]"#,
+        );
+        let paths: Vec<_> =
+            completion_sources(&s, root, "fish", Some(&s.predicate.artifacts[0]), Some("t"))
+                .into_iter()
+                .map(|source| match source {
+                    CompletionSource::Spec { path, .. } => path,
+                    other => panic!("unexpected source {other:?}"),
+                })
+                .collect();
+        assert_eq!(
+            paths,
+            [
+                "first.kdl",
+                "second.kdl",
+                &format!("{RESOURCES_DIR}/assets/t-skill.tar.gz"),
+                &format!("{RESOURCES_DIR}/repo/t.kdl"),
+            ]
+            .map(|rel| root.join(rel)),
+            "the release's own archive first, the source repository last"
+        );
+    }
+
+    #[test]
     fn a_declared_completion_is_not_an_absent_one() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
@@ -1560,6 +1698,31 @@ mod tests {
         assert!(!declares_completion(&s, "fish"));
         let none = statement_with(r#"[{"kind":"skill","name":"t","asset":"t-skill.tar.gz"}]"#);
         assert!(!declares_completion(&none, "zsh"));
+    }
+
+    #[test]
+    fn an_unfinished_skill_directory_does_not_hide_the_source_below_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let s = statement_with(
+            r#"[
+            {"kind":"skill","name":"t","archive":"empty"},
+            {"kind":"skill","name":"t","repo":"skills/t"},
+            {"kind":"skill","name":"other","asset":"t-skill.tar.gz"}
+        ]"#,
+        );
+        // What an interrupted unpack leaves: the directory, and no SKILL.md.
+        std::fs::create_dir_all(root.join("empty")).unwrap();
+        let fallback = root.join(RESOURCES_DIR).join("repo/skills/t");
+        std::fs::create_dir_all(&fallback).unwrap();
+        assert!(
+            skills_of(&s, root, "tool", "1", Some(&s.predicate.artifacts[0])).is_empty(),
+            "neither directory holds a skill yet"
+        );
+        std::fs::write(fallback.join("SKILL.md"), "# t").unwrap();
+        let skills = skills_of(&s, root, "tool", "1", Some(&s.predicate.artifacts[0]));
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].path, fallback);
     }
 
     #[test]
@@ -1743,11 +1906,16 @@ mod tests {
     fn skills_are_found_where_the_install_holds_them() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
-        std::fs::create_dir_all(root.join("share/skills/t")).unwrap();
-        std::fs::create_dir_all(root.join("share/skills/here")).unwrap();
-        std::fs::create_dir_all(root.join("share/skills/elsewhere")).unwrap();
-        std::fs::create_dir_all(root.join(RESOURCES_DIR).join("skills/packed")).unwrap();
-        std::fs::create_dir_all(root.join(RESOURCES_DIR).join("repo/skills/fromrepo")).unwrap();
+        for rel in [
+            "share/skills/t",
+            "share/skills/here",
+            "share/skills/elsewhere",
+            &format!("{RESOURCES_DIR}/skills/packed"),
+            &format!("{RESOURCES_DIR}/repo/skills/fromrepo"),
+        ] {
+            std::fs::create_dir_all(root.join(rel)).unwrap();
+            std::fs::write(root.join(rel).join("SKILL.md"), "# skill").unwrap();
+        }
         let s = statement_with(
             r#"[
             {"kind":"skill","name":"t","archive":"top/share/skills/t"},
@@ -1963,9 +2131,10 @@ mod tests {
             let stub = stub("rg", shell).unwrap();
             assert!(stub.contains("@generated by usage"), "{stub}");
             assert!(
-                stub.contains(&format!("mise completion {} --tool 'rg'", shell.as_str())),
+                stub.contains(&format!("mise completion {} --tool", shell.as_str())),
                 "{stub}"
             );
+            assert!(stub.contains("'rg'"), "the stub names the tool: {stub}");
         }
         let zsh = stub("rg", Shell::Zsh).unwrap();
         assert!(zsh.starts_with("#compdef rg\n"), "{zsh}");
@@ -1975,6 +2144,25 @@ mod tests {
         );
         let pwsh = stub("rg", Shell::PowerShell).unwrap();
         assert!(pwsh.contains("if ($__mise_script)"), "{pwsh}");
+        assert!(
+            pwsh.contains("if ($global:__mise_load_rg_busy) { return }"),
+            "a script registering nothing must not recurse: {pwsh}"
+        );
+        assert!(
+            pwsh.matches("Register-ArgumentCompleter -Native -CommandName 'rg'")
+                .count()
+                == 2,
+            "registered once, and put back after delegating: {pwsh}"
+        );
+        let fish = stub("rg", Shell::Fish).unwrap();
+        assert!(
+            fish.contains("complete -c 'rg' -f -a '(__mise_load_rg)'"),
+            "asked for at completion time, not sourced at load: {fish}"
+        );
+        assert!(
+            fish.contains("set fish_complete_path"),
+            "the child cannot autoload this stub: {fish}"
+        );
         assert!(
             zsh.contains("compstate[nmatches]"),
             "a script that completes on its own is not called again: {zsh}"


### PR DESCRIPTION
Completions are global shell state while the active version depends on the directory. zsh and bash already put mise's stub back after one completion; fish sourced the vendor's script at shell startup and PowerShell evaluated it at load, so both kept the registrations of whichever version happened to be active then, and a version switch in another directory was never followed.

fish now reads the script in a child shell of its own for each completion, with an empty `fish_complete_path` so the child cannot autoload the stub back into itself. PowerShell registers a completer that fetches and evaluates the vendor's script, hands that one completion to it through `TabExpansion2`, and re-registers itself afterwards, with a reentrancy guard for a script that registers nothing for the command.

Several sources for one resource are alternatives, not a set to collect:

- A skill already on disk from a higher source is not fetched or generated again, so a shipped skill never runs the tool.
- A directory is a skill only once it holds `SKILL.md`; what an interrupted fetch or unpack left behind no longer passes for one and hides the source below it.
- Static `cli-spec` entries rank archive, asset, repository like a shipped script's, with document order breaking ties, instead of following declaration order.

Deriving a script runs the tool, so generation is serialized on a lock beside the cache: shells completing at once run it once between them and none reads a half-written entry. An empty result is a failed source rather than a completion, an empty cache entry is not read back, and a spec generated for one shell (`{shell}` in the command) is kept under that shell's name and written whole.

`e2e/backend/test_packslip_resources` exercises this against two linked installs: concurrent generation running the tool once, an empty seeded cache falling through, per-shell spec files, skills listing and syncing across a version switch, and real fish and PowerShell sessions where one sourced stub completes 1.0.0 in one directory and 2.0.0 in the next.

Validation: 36 packslip-focused Rust tests, clippy with warnings denied, `mise run render`, scoped hk checks, and the new e2e test with fish 4.9.1 and PowerShell 7.6.5 present (20 assertions, all passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shell integration and concurrent completion caching beside installs; behavior changes for fish/PowerShell users and packslip resource resolution, though scoped to experimental packslip and covered by new e2e and unit tests.
> 
> **Overview**
> **Packslip tool completions** now stay aligned with the active version in each directory. **fish** and **PowerShell** `--install` stubs no longer source or evaluate the vendor script at load time; they call `mise completion` on each tab (fish via a child shell with an empty completion path; PowerShell via a delegating completer that re-registers itself, with a reentrancy guard). Help and docs drop the implication that tool-run completion sources require `packslip.exec`, and describe stubs as refreshing on every completion, not only the first.
> 
> **Completion generation** defers cache reads and locking until an exec/cli-spec source is needed, so shipped files still work on read-only installs. Empty scripts and stale cache entries fall through to the next source; concurrent tabs share a generation lock; per-shell CLI specs live under `specs/{shell}/` with atomic writes. Static `cli-spec` sources are ordered like shipped files (archive → asset → repo).
> 
> **Skills** treat a directory as valid only when it contains `SKILL.md`, skip fetch/exec for lower-priority skill sources when a higher one is already present, and avoid letting interrupted unpacks block fallbacks.
> 
> Adds **`e2e/backend/test_packslip_resources`** and expanded **`packslip.rs`** unit tests for the above.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 099ecefda3af97fd503dc770b717e92110003c02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Completion scripts support vendor files, CLI specifications, and tool-provided commands.
  - Completion generation prioritizes sources consistently and supports shell-specific results.
  - Skills require `SKILL.md`, with improved selection among alternative sources.

- **Bug Fixes**
  - Installed completion stubs now refresh scripts for each completion, including improved fish and PowerShell behavior.
  - Improved concurrent generation, interrupted or empty cache handling, and support for shipped completions on read-only systems.

- **Documentation**
  - Updated CLI help, man pages, and developer documentation to reflect completion and skill behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->