### PR TITLE
docs(packslip): reorganize backend and resource guides

### DIFF
--- a/docs/.vitepress/sidebar.ts
+++ b/docs/.vitepress/sidebar.ts
@@ -48,6 +48,10 @@ export const sidebar: SidebarItem[] = [
       { text: "GitHub Tokens", link: "/dev-tools/github-tokens" },
       { text: "mise.lock Lockfile", link: "/dev-tools/mise-lock" },
       { text: "Security", link: "/security" },
+      {
+        text: "Packslip Completions and Skills",
+        link: "/dev-tools/packslip-resources",
+      },
       { text: "OCI Images (experimental)", link: "/dev-tools/mise-oci" },
       { text: "Deps", link: "/dev-tools/deps" },
       {

--- a/docs/dev-tools/backends/packslip.md
+++ b/docs/dev-tools/backends/packslip.md
@@ -1,84 +1,262 @@
 # packslip Backend <Badge type="warning" text="experimental" />
 
-The `packslip` backend installs a release from the vendor's own signed release manifest, a [packslip](https://packslip.dev). One file per release, `packslip.sigstore.json`, says what shipped and how to verify it: checksums, platforms, executables, and provenance links, in a standard sigstore bundle. mise verifies it against the identity the project name implies and installs exactly what it lists, so nothing is guessed from file names and no registry entry is needed.
-
-The code for this is inside of the mise repository at [`./src/backend/packslip.rs`](https://github.com/jdx/mise/blob/main/src/backend/packslip.rs).
+The `packslip` backend installs tools from a vendor's signed release manifest.
+The manifest names the release files, their digests, supported platforms, and
+executable paths. mise verifies the signer and downloaded bytes, then installs
+the artifact that fits your host.
 
 ::: warning
-packslip is a work-in-progress proposal and this backend is experimental: enable it with `mise settings experimental=true`. The format still changes between releases, and few projects publish one yet.
+The backend and the [packslip format](https://packslip.dev) are experimental.
+Enable `experimental` to use the backend. A project must publish packslips for
+its releases; this backend cannot install arbitrary GitHub release assets.
 :::
-
-## Why publish one
-
-The backends most people use today work from the outside of a release:
-
-- `github:owner/repo` picks an asset by scoring file names against the host (OS, arch, libc, format). That holds until a project renames its assets, ships two builds for one platform, or puts the executable somewhere unexpected; then every user needs `asset_pattern` or `bin` in their config. Nothing ties the file to the project unless the project also publishes checksums or provenance in a form mise recognises.
-- `aqua:owner/repo` reads a registry entry that volunteers maintain for the project, with checksums and, for some packages, cosign or SLSA checks. When a project changes its asset names the entry is wrong until someone sends a fix ([pnpm v11](https://github.com/aquaproj/aqua-registry/pull/52822), [doggo v1.2.0](https://github.com/aquaproj/aqua-registry/pull/55890), [go-jsonnet v0.22.0](https://github.com/aquaproj/aqua-registry/pull/50942), [wrkflw v0.8.0](https://github.com/aquaproj/aqua-registry/pull/59777)), and the snapshot built into mise picks it up a release later.
-- `packslip:owner/repo` reads what the project itself published with the release, signed by the project. Nothing to guess, nobody to wait for.
-
-For a vendor:
-
-- **A direct line to your users.** You say which file is for which platform, which executables it holds and what they are called on PATH, and what the host needs. Your users get that with the release itself, not after someone updates a registry, and when you change a layout or a naming scheme the next packslip says so and no install breaks.
-- **You ship more than binaries.** Shell completions, man pages, a [usage](https://usage.jdx.dev) spec of the CLI, and [agent skills](https://packslip.dev/release/v1/#resources), each declared once and installed in the version the user actually has.
-- **On GitHub, one step in the release job.** `uses: jdx/packslip@v1` with the artifact glob signs the manifest keylessly with the workflow's own identity, attests build provenance, and uploads it. There is no key to create, store, or rotate. On another forge, or a plain web server, `packslip create` signs with a key you hold and you publish a signed release list at a well-known URL on your domain; users pin the key in their config.
-- **Nothing between you and the user can swap the bytes.** A mirror, a proxy, or a compromised download host cannot pass off other bytes as your release, because the signer is your workflow or your key.
-
-For a user asking a vendor for one:
-
-- **The name says who may sign, the way `~/.ssh/known_hosts` says which key a host must present.** `packslip:github.com/owner/repo` accepts only a packslip signed by that repository's release workflow through GitHub's issuer; the signature, its transparency log entry, the statement, and the artifact's digest and size are all checked before anything is unpacked. mise then remembers the signer it accepted, as [Pinned signers](#pinned-signers) describes, and refuses a later release from anyone else.
-- **The right artifact, with no registry to update first.** musl and gnu, universal binaries, a `fips` or `baseline` variant, the executable's path inside the archive: all from the manifest the vendor wrote when it cut the release, so nobody plays catch-up after a rename.
-- **Completions and skills that match the version in use**, from the vendor, with no per-tool setup in mise or in your shell config.
-- **Upgrades are checked the way first installs are.** A checksum in `mise.lock` proves one download is the same file it was the first time. A packslip proves the next version came from the same signer as well, so an upgrade on a teammate's machine or in CI is checked against the project's identity rather than against a hash nobody could verify when it was first recorded. `mise.lock` records that signer next to the URL and digest, so a machine with the lockfile refuses a release signed by anyone else even on its first install.
-
-The specification and the `packslip` CLI are at [packslip.dev](https://packslip.dev).
 
 ## Usage
 
-A project is named the way Go names a module: a host, then a path. On github.com the name is also the pin: the packslip must be signed by a workflow of that repository, through GitHub's OIDC issuer.
+With [mise activated](/getting-started.html), enable the backend and install
+packslip itself:
 
 ```sh
-$ mise use -g packslip:github.com/jdx/packslip
-$ packslip version
-packslip 0.2.0
+mise settings experimental=true
+mise use -g packslip:github.com/jdx/packslip
+packslip version
 ```
 
-`packslip:owner/repo` means the same as `packslip:github.com/owner/repo`. A tool in a monorepo adds its subpath, `packslip:github.com/oxc-project/oxc/oxlint`, and mise reads that tool's own `packslip.oxlint.sigstore.json` from the shared release.
+Omit `-g` to manage the tool in the current project's `mise.toml` instead.
+For a project configuration:
 
-A project on its own domain publishes a signed release list at `https://<host>/.well-known/packslip/<path>.json`. Nothing implies its signer, so pin it yourself:
+```toml
+[settings]
+experimental = true
+
+[tools]
+"packslip:github.com/jdx/packslip" = "latest"
+```
+
+### Project names and discovery
+
+A project name is a host followed by an optional path, without `https://`.
+`packslip:owner/repo` is shorthand for `packslip:github.com/owner/repo`.
+
+| Project form                         | Where mise looks                                                             |
+| ------------------------------------ | ---------------------------------------------------------------------------- |
+| `github.com/owner/repo`              | GitHub releases carrying `packslip.sigstore.json`.                           |
+| `github.com/owner/repo/tools/mytool` | The same repository's releases, using `packslip.tools-mytool.sigstore.json`. |
+| `tool.example.com`                   | `https://tool.example.com/.well-known/packslip.json`.                        |
+| `example.com/tools/mytool`           | `https://example.com/.well-known/packslip/tools/mytool.json`.                |
+
+A GitHub monorepo subpath identifies one tool, but the signing identity is
+still pinned to the repository. The signed project and version must match
+the requested tool and release, regardless of the bundle's filename.
+
+For a domain project, obtain the vendor's public key through a trusted channel
+and configure it explicitly. This example assumes the key file already exists:
 
 ```toml
 [tools]
-"packslip:tool.example.com" = { version = "latest", pubkey = "RWQ..." }
+"packslip:tool.example.com" = { version = "latest", pubkey = "/path/to/vendor.pub" }
 ```
+
+The domain's signed list points to release bundles; their artifacts can live
+on a different download host. A domain project without a signed list cannot
+be installed. Recognizing a forge's signing issuer does not provide discovery:
+GitHub has a release-API integration; other hosts need the signed-list location.
+
+## Versions
+
+List the project's available versions with:
+
+```sh
+mise ls-remote packslip:github.com/jdx/packslip
+```
+
+Packslip versions use semver, including compatible date versions such as
+`2026.9.1`. mise uses that version to order releases and identify prereleases;
+GitHub's release order and editable prerelease flag do not decide either.
+Prereleases are excluded unless the `prerelease` tool option is enabled.
+
+For GitHub discovery, mise reads versions from tags such as `v1.2.3`,
+`mytool-v1.2.3`, or `v4.1` (normalized to `4.1.0`). Tags that do not map to a
+version need an explicit mapping in a signed list. At installation, the
+manifest's version must agree with the tag or list entry.
+
+### Signed release lists
+
+A GitHub repository can publish a supplementary signed list on its default
+branch at `.well-known/packslip.json`, or `.well-known/packslip/<tool>.json`
+for a monorepo tool. The list can withdraw a version, supply a bundle URL and
+digest, or add a version that the release API does not expose.
+
+Omitted versions can still come from GitHub releases: omission does not withdraw
+them. For a domain project, the signed list supplies the entire release index.
+A vendor withdrawal excludes a version even if a trusted stamper approved it.
+
+### Release-list continuity and minimum age
+
+mise rejects expired signed lists and sequences below the highest it has
+accepted for the project. Once it has accepted a supplementary GitHub list,
+that list disappearing is an error. A missing list cannot silently undo a
+withdrawal. This continuity state is stored alongside the [signer pin](#pinned-signers).
+
+If a [minimum release age](/configuration/settings.html#minimum_release_age)
+is configured, discovery timestamps help filter candidates. Before downloading
+an artifact, mise checks the verified transparency-log timestamp against the
+effective cutoff. Only an explicitly allowed unlogged bundle uses the signed
+publication timestamp instead.
+
+## Latest
+
+An unconstrained `latest` request considers recommendations in this order:
+
+1. The vendor's `latest` pointer in an accepted signed release list.
+2. GitHub's latest release, if there is no signed pointer.
+3. The highest eligible semver, if there is no eligible recommendation.
+
+The vendor can recommend an older supported release while a newer major
+version exists. Prefix and channel requests keep their normal matching rules;
+the recommendation does not reorder them.
+
+A recommendation must still pass signature, identity, digest, release-age,
+stamping, and host checks. A policy exclusion warns and tries another candidate.
+An ineligible signed recommendation falls directly back to semver selection,
+without consulting GitHub's pointer. Signature or digest failures and invalid,
+expired, rolled-back, or unexpectedly missing lists stop resolution.
+
+Version listing and `latest` resolution perform online policy checks and bypass
+mise's remote-version cache so withdrawals and trust changes take effect.
 
 ## What is verified
 
-1. The bundle's signature, certificate chain, and transparency log entry, as sigstore defines them, against the pinned identity or key.
-2. The statement's structure, and that it is for the project you asked for at the version you asked for.
-3. The digest and size of the one artifact selected for this host, from the signed statement, before it is unpacked.
+Before unpacking a release, mise checks:
 
-Only after that does mise unpack the artifact and put the executables the packslip names on PATH. The verified statement is kept in the install directory as `.mise-packslip.json`.
+1. The bundle's signature and applicable certificate and transparency-log
+   evidence against the expected repository identity or configured key.
+2. The statement's structure, requested project and version, and any bundle
+   digest recorded by a vendor list or trusted stamper.
+3. Signer continuity, lockfile commitments, and applicable release-age policy.
+4. The selected artifact's digest and size, plus any existing lockfile checksum.
 
-The artifact is chosen as the specification's consumer rules say. An artifact fits when each of its `os`, `arch`, and `libc` is absent or equal to the host's, so a universal macOS binary, a jar, or a script fits everywhere; among those that fit, the one naming the most of those three wins, so a build for the host beats a portable one; then mise's format preference decides, archives first (`tar.xz`, `tar.zst`, `tar.gz`, `tar.bz2`, `tar`, `zip`, `7z`), then a single compressed executable (`xz`, `zst`, `gz`, `bz2`), then a bare one. Installer formats such as `deb`, `dmg`, and `msi` are never chosen. When two artifacts still tie, mise refuses to guess; set `variant` to say which one you mean. A glibc host with no gnu build takes a musl build, which is static, and says so in the debug log.
+The verified statement is retained as `.mise-packslip.json` in the install
+directory. It supplies executable paths and metadata for resources.
+
+Verification authenticates the signer's statement and the downloaded bytes.
+It does not establish that the software is safe. A provenance link in the
+manifest is separate evidence: this backend records its presence for continuity
+checks but does not fetch and verify the linked build provenance.
+
+### Artifact selection
+
+mise uses signed metadata to select one artifact:
+
+1. Match OS, architecture, and libc. An absent field leaves only that dimension
+   unrestricted: a universal macOS build still requires macOS.
+2. With a `variant`, consider only that variant. Without one, consider only
+   artifacts that have no variant.
+3. Keep formats mise can install, preferring the most specific platform match,
+   then its archive/compression format preference over a bare executable.
+4. Refuse an unresolved tie rather than guessing between builds.
+
+Installer formats such as `deb`, `dmg`, and `msi` are not selected. A glibc host
+with no matching GNU artifact may use a musl artifact; mise reports that
+fallback in the debug log. The vendor must distinguish alternative builds with
+variants; a client-side option cannot repair two identically described artifacts.
+
+## Host requirements
+
+After selecting an artifact, mise checks its declared requirements before
+downloading it. Requirements do not break a selection tie or select another build.
+
+| Requirement result                                                        | mise behavior                                      |
+| ------------------------------------------------------------------------- | -------------------------------------------------- |
+| Confirmed missing library, insufficient glibc, or insufficient OS version | Refuse installation.                               |
+| Missing or outdated required command                                      | Warn and continue.                                 |
+| A check cannot be completed                                               | Warn instead of assuming the host is incompatible. |
+
+Command checks prefer active mise tools over ambient PATH. Library detection is
+platform-dependent; for example, an absent macOS library file may still exist
+in the dyld shared cache, so mise reports that absence as unknown.
+
+`ignore_requirements = true` allows a tool to install despite confirmed failures.
+It does not supply the missing libraries or make an incompatible executable run.
 
 ## Pinned signers
 
-mise remembers which signer it accepted a project's packslips from, the way SSH remembers hosts, in `packslip/pins.toml` under its state directory: the scheme, the workflow path (without its ref, since a new tag of the same workflow is the same signer) or key id, who attested, whether every artifact linked provenance, and the highest release-list sequence seen. A later release that comes from another signer, is a repackager's where the vendor's own was accepted before, or drops the provenance every artifact linked before is refused, as the specification's no-downgrade rule says; anything that got stronger is remembered as the new floor.
+mise preserves trust in two places:
+
+| State                                                                                | What it protects                                                                                                                                |
+| ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packslip/pins.toml` under the [state directory](/directories.html#local-state-mise) | Previously accepted signers, signing scheme, vendor versus repackager status, provenance-link presence, and release-list continuity.            |
+| `mise.lock`                                                                          | The project's signer and attestor commitment alongside each platform's artifact URL and checksum, including on another machine's first install. |
+
+For a keyless signer, continuity compares the workflow path without its tag or
+branch ref. A new release tag of the same workflow is the same signer. A new
+workflow path or key requires an explicit trust decision. A signing-scheme change,
+a vendor-to-repackager change, or lost provenance links can also be refused.
+
+Inspect the local pins before investigating a trust failure:
 
 ```sh
-mise packslip pins                     # what is pinned, and from what
-mise packslip forget github.com/o/r    # the vendor rotated a key: let the next release set the pin
+mise packslip pins
+mise packslip pins --json
 ```
 
-A lockfile carries the project's commitment as well: each platform entry records the `signer` (as `scheme:signer`) and, for a repackager's document, `attested_by = "repackager"`, next to the URL and digest. A release signed by anyone else is refused on every machine that has the lockfile, whether or not that machine has seen the project before; removing the entry from `mise.lock` accepts the change for the project.
+After confirming a vendor's announced signer change, reset its local pin:
+
+```sh
+mise packslip forget github.com/owner/repo
+```
+
+This also resets remembered vendor-list continuity. It does not change an
+explicit `pubkey` or identity option, erase stamper-list state, or remove the
+signer commitment in `mise.lock`. Review those separately when accepting a
+rotation. A conflicting lockfile entry must be removed and regenerated after
+the new policy is configured; commit the reviewed change for other machines.
+
+## Stamps
+
+A stamper is a registry, mirror, or review service that publishes a signed list
+of releases it admits. Configure the hosts you trust and the key or identity
+allowed to sign each host's lists:
+
+```toml
+[settings.packslip]
+stampers = [
+  "stamps.example.com=/path/to/stamper.pub",
+  "reviews.example.com=https://github.com/example/reviews/",
+]
+```
+
+Each entry is `host=PIN`. The pin may be a minisign-format public key line,
+a public-key file path, or a GitHub identity prefix. The example hosts and key
+path are placeholders; replace them with a service and pin you trust.
+
+A host publishes one list per project at
+`https://<host>/.well-known/packslip/<project>.json`. With stampers configured:
+
+- A version needs a non-yanked approval from at least one trusted host to be
+  listed or installed. One host's withdrawal does not veto another's approval.
+- A vendor withdrawal still excludes the release, regardless of stamps.
+- mise checks the stamped bundle digest and the vendor-list digest, when present,
+  then verifies the vendor signature. A stamp never replaces that signature.
+- Expired, rolled-back, invalid, or previously accepted but now missing stamper
+  lists cause errors. Silently ignoring one would weaken the configured policy.
+
+A stamper can mirror the exact vendor-signed bundle. Re-signed repackager
+bundles requiring a separate identity policy are not supported here.
+
+No stamps are required when the setting is unset. To exempt one tool from
+configured stampers, set `trust = "vendor"` as described below.
 
 ## Tool Options
 
-The following [tool-options](/dev-tools/#tool-options) are available for the `packslip` backend—these go in `[tools]` in `mise.toml`.
+These [tool options](/dev-tools/#tool-options) go in `[tools]` in `mise.toml`.
+They apply to one tool; `packslip.exec`, `packslip.stampers`, and `skills.*`
+are settings and belong under `[settings]`.
 
 ### `variant`
 
-Selects one of several builds the vendor publishes for one platform, such as `fips` or `baseline`. Without it, only artifacts with no variant are considered.
+Choose a vendor-declared alternative build, such as `fips` or `baseline`.
+Without this option, only unvarianted builds are considered.
 
 ```toml
 [tools]
@@ -87,118 +265,92 @@ Selects one of several builds the vendor publishes for one platform, such as `fi
 
 ### `pubkey`
 
-For a project on its own domain: the vendor's public key, as the minisign-format line from its `.pub` file or the path of that file. The release list and every packslip must be signed with it.
+Pin a key-signed release using the minisign-format public-key line or a path to
+its `.pub` file. The vendor list and release bundles must verify against it.
 
 ### `identity`, `identity_prefix`, `issuer`
 
-For a project on its own domain signed keylessly, or to override the identity a forge name implies: the exact certificate identity, or a prefix it must start with, and the OIDC issuer.
+Pin a keyless signer using an exact certificate identity or an identity prefix,
+plus its OIDC issuer. These options can replace the policy derived from a forge
+name. Keep the trailing slash when pinning a repository prefix.
 
 ### `allow_unlogged`
 
-Accept a key-signed bundle that carries no transparency log entry, which a vendor produces for an air-gapped release. Off by default; turn it on only for a vendor you have agreed to accept that from.
+Defaults to `false`. Set to `true` only when your policy accepts a vendor's
+key-signed bundles without transparency-log evidence. This does not bypass
+signature or artifact verification.
 
 ### `trust`
 
-`trust = "vendor"` takes the vendor's own manifest under the vendor's pin, with no stamp from the hosts [`packslip.stampers`](/configuration/settings#packslip-stampers) names. See Stamps below. The choice is recorded in the lockfile, so an install from the lock does not quietly relax it later.
+`trust = "vendor"` exempts the tool from configured stampers while retaining
+vendor signature verification. The choice is recorded in lockfile options.
 
 ```toml
 [tools]
-"packslip:github.com/jdx/mise" = { version = "latest", trust = "vendor" }
+"packslip:github.com/jdx/packslip" = { version = "latest", trust = "vendor" }
 ```
 
-## Stamps
+### `prerelease`
 
-A vendor's packslip proves what the vendor shipped. It does not say whether anyone else looked at it. A stamping host, a registry, a mirror, or a scanning service, publishes its own signed release list per vendor project at `https://<host>/.well-known/packslip/<project>.json`, naming the versions it checked, pinning the digest of each packslip it looked at, and saying what it checked. The [`packslip.stampers`](/configuration/settings#packslip-stampers) setting names the hosts you trust, each with its pin:
+Set to `true` to include prerelease versions in selection.
 
-```toml
-[settings.packslip]
-stampers = ["registry.mise.jdx.dev=RWQ..."]
-```
+### `ignore_requirements`
 
-With hosts named, mise offers and installs a packslip tool only at versions one of them lists. A version no trusted host stamped is not shown by `mise ls-remote` and is refused by `mise install`, however valid the vendor's own manifest is; a host withdrawing its stamp does not veto another host’s non-yanked approval. Any one host’s non-yanked stamp suffices; vendor withdrawals still veto every stamp. The stamp points at the manifest it admitted, so mise fetches that exact file, checks it against the digest the host recorded, and then verifies it against the vendor's pin as always: the stamp never stands in for the vendor's signature. A stamp that records no digest is refused — the digest is what ties the host's review to a file, and without one the entry admits a URL rather than a manifest.
-
-Each host's list carries an expiry and a sequence number. mise refuses a list that has expired, and remembers the highest sequence it accepted per host and project so a replayed older list is refused as a rollback.
-
-A stamper may mirror the exact vendor-signed manifest. Mise checks both the stamper digest and any digest in the vendor’s list. Because the stamp already names the manifest, mise asks the vendor only for what the vendor decides — a withdrawal, and the digest they pinned — so a release asset deleted from GitHub does not veto a mirror of a release that was never withdrawn. Re-signed repackager manifests need a separate identity policy and are not supported by this backend yet.
-
-Unset, no stamps are required and every version the vendor published is offered. mise's own registry host will become the default once it publishes stamps.
+Set to `true` to override confirmed [host requirement](#host-requirements)
+failures for this tool. Other verification checks still apply.
 
 ## Completions
 
-A packslip may list what the release ships besides its executables: shell completions, a spec of the CLI, an agent skill. mise reads those `resources` for tools it installed this way.
-
-```sh
-mise completion zsh --tool rg           # print the script
-mise completion zsh --tool rg --install # put a stub where zsh looks
-```
-
-The script comes from whichever version of the tool is active in the current directory. A vendor whose layouts differ by platform scopes an entry with `os`, `arch`, or `libc`; mise keeps the entries that apply to the artifact it installed and, of those, the most specific. It then takes the most verifiable source the vendor offered, in the order the specification gives: a file inside the artifact or a separate signed asset, a file from the source repository at the release's commit, a script derived from the tool's [usage](https://usage.jdx.dev) spec with the `usage` command, and only then a command of the tool's own. That last kind is how cobra, clap, and oclif tools ship completions, so mise runs it: the stub calls mise the first time your shell completes the command, which is when you were going to run the tool anyway, and mise caches the script beside the install so the command runs once per version rather than at every tab. No setting is needed. The [`packslip.exec`](/configuration/settings#packslip-exec) setting governs only exec resources mise would run at install time and write to disk, such as an agent skill.
-
-`--install` writes a stub, not the script. Completions are global shell state while the active version depends on the directory, so the stub asks mise for the script when the shell completes the tool. In zsh and bash the vendor's script takes over for one completion and the stub is put back afterwards, so a version switch in another directory is followed on the next tab. fish reads the script in a child shell of its own, and PowerShell puts mise's completer back after handing one completion to the vendor's, for the same reason: neither keeps the registrations of a version that is no longer active. The file goes where the shell loads completions by name, the same place `mise completion zsh --install` puts mise's own, and the command prints any one-time line your shell still needs.
-
-Files the vendor keeps outside the artifact (a separate release asset, or a path in the repository) are fetched at install time. An asset must match the digest the packslip signed; a repository file is pinned by the release's commit. Completions derived from a usage spec call `usage complete-word` at shell runtime, so install `usage` alongside such tools (`mise use -g usage`).
+For a command installed through this backend, `mise completion zsh --tool mytool
+--install` installs a shell stub that follows the active version. See
+[tool completions](/dev-tools/packslip-resources.html#completions) for shell
+support, setup, and generated-script behavior.
 
 ## Skills
 
-A packslip may also declare an agent skill: a directory holding `SKILL.md` and whatever it references, in the Agent Skills format. mise fetches it at install time, from inside the artifact, from a separate signed asset, or from the source repository at the release's commit, so every installed version carries its own copy.
-
-```sh
-mise skills ls              # the skills of the tools active here
-mise skills sync            # link them into .claude/skills
-mise skills sync --prune    # and drop links for versions no longer active
-```
-
-Since a project pins its tool versions in `mise.toml`, mise knows exactly which version of each skill an agent working in that project should see. `mise skills sync` writes one symlink per skill into the project's `.claude/skills` (or `--dir` for another agent's location, `--global` for `~/.claude/skills`), pointing at the installed version's directory. Run it again after `mise use` changes a version and the links follow. Only links mise made are ever replaced or pruned; a directory or link of your own at a skill's name is left alone and reported.
-
-Four settings shape this:
-
-- [`skills.dir`](/configuration/settings#skills-dir) is where the links go, relative to the project root (or the home directory with `--global`): `.claude/skills` by default, `.agents/skills` for agents that look there.
-- [`skills.auto_sync`](/configuration/settings#skills-auto-sync) runs the sync after every `mise install` and `mise use`, so the links never lag the versions in `mise.toml`.
-- [`skills.prune`](/configuration/settings#skills-prune) makes removing links for versions no longer active the default, for the command and for auto sync.
-- [`skills.fetch`](/configuration/settings#skills-fetch) turned off installs tools without their skills.
-
-A skill the packslip offers only as a command of the tool's own (`tool skill`, printing `SKILL.md`) is generated at install time only when [`packslip.exec`](/configuration/settings#packslip-exec) is on, for the same reason as completions.
-
-Several sources for one skill are alternatives, not a set to collect: mise takes the most verifiable one that is on disk and does not fetch or run the ones below it, so a skill the release ships never runs the tool. A directory is that skill only once it holds `SKILL.md`; what an interrupted fetch or unpack left behind is not a skill, and the source below it is still tried.
-
-## Versions
-
-A packslip version is semver, so mise ranks a project's versions by semver precedence whatever order GitHub lists its releases in, and treats a version with a prerelease part (`1.3.0-rc.1`, `1.4.0-nightly.20260904`) as a prerelease whatever the GitHub release's own flag says. Prereleases are skipped unless the `prerelease` tool option is set.
-
-For a project on github.com, the versions are the repository's releases that carry a packslip, named by their tags as the specification reads them: the version itself, optionally after a `v`, and optionally after the tool's subpath, its last segment, or the repository name plus a separator (`v1.2.3`, `jq-1.7.1`, `oxlint_v1.0.0`), with loose spellings such as `v4.1` normalized to `4.1.0`. A tag that names no version is skipped. At install time mise checks that the packslip inside the release agrees with the version the tag named and refuses the release if it does not.
-
-The repository may also keep a signed list at `.well-known/packslip.json` (or `.well-known/packslip/<tool>.json` for a monorepo tool) on its default branch, signed by the same identity as its packslips. When it does, a version the list marks withdrawn is dropped, a version it names has its packslip fetched from the URL the list gives and checked against the digest it signed, and a version it lists that the releases endpoint lacks is added.
-
-For a project on its own domain, the versions are the entries of its signed release list, minus any the vendor has withdrawn. For either kind of list mise refuses one that has expired, and refuses one whose sequence is below the highest it has accepted for the project, which it remembers under its state directory.
-
-Lockfiles record the artifact URL and its sha256 from the signed statement.
+`mise skills ls` lists skills provided by active installed tools; `mise skills
+sync` links them into an agent's skill directory. See
+[agent skills](/dev-tools/packslip-resources.html#skills) for project setup,
+automatic synchronization, and pruning.
 
 ### Resource selection and command execution
 
-Resources may name one exact `artifact` when layouts differ between archive formats or variants. Completions are selected for the command being completed; when a release has several executables, pass its command name to `--tool`. Generated scripts are cached separately for each installed version, executable, and shell.
+See [resource selection](/dev-tools/packslip-resources.html#resource-selection-and-command-execution)
+for source priority, caching, and when mise runs a vendor executable.
 
-Exec resources receive the manifest’s environment variables, with `{shell}` expanded for completions. They run in a temporary directory with the installed executables on PATH, no stdin, discarded stderr, and a five-second timeout. The same execution rules apply to skills when `packslip.exec` permits generating them.
+## Troubleshooting
 
-A script that comes back empty is a failed source, not a completion: mise moves on to the next source and caches nothing. Shells completing the same command at once take turns, so the tool runs once between them rather than once each, and no shell reads a half-written entry. Only generation takes turns: a completion the release ships is read straight out of the install, so a read-only system or shared install still completes. A CLI spec generated for one shell, as `{shell}` in the command allows, is kept under that shell's name and written whole.
+| Symptom                                      | What to check                                                                                                                    |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Experimental backend refused                 | Enable `experimental` in settings.                                                                                               |
+| No release or bundle found                   | Confirm that the project publishes packslips, the subpath is correct, and the tag maps to a version or appears in a signed list. |
+| Nothing pins the signer                      | Supply `pubkey`, or a certificate identity/prefix and issuer, for a domain project.                                              |
+| Signer or trust downgrade refused            | Inspect `mise packslip pins`, explicit tool options, and `mise.lock`; confirm the publisher's change before resetting trust.     |
+| No eligible artifact or ambiguous artifacts  | Check the host and requested variant against the signed manifest. The publisher must fix an unresolved metadata tie.             |
+| Signed list expired, rolled back, or missing | Obtain a current valid list from its publisher; removing an accepted list does not remove its policy.                            |
+| Version excluded by stamp policy             | Check trusted hosts' non-yanked approvals and any vendor withdrawal.                                                             |
+| Digest or size mismatch                      | Confirm the release and downloaded file; the bytes must match the signed statement.                                              |
 
-Static `cli-spec` entries are ranked like a shipped script's: the release's own archive, then a signed asset, then the source repository, with the order they are written in breaking ties.
+Use `MISE_DEBUG=1` for selection and verification details. For resource-specific
+failures, see [completions and skills troubleshooting](/dev-tools/packslip-resources.html#troubleshooting).
 
-### Release-list continuity and minimum age
+## Why publish one
 
-Once mise has accepted a supplementary signed list, a missing list is an error: a 404 cannot silently restore releases the vendor withdrew. `mise packslip forget <project>` explicitly resets that remembered policy along with the signer pin.
+A packslip lets a vendor describe each release's platforms and executable paths
+with the release itself. Users can install through `packslip:` without a new
+registry shorthand or a separate filename-matching recipe. It can also supply
+versioned completions, CLI specifications, and agent skills.
 
-The release API or list timestamp helps select candidates. Before downloading an artifact, mise checks the verified transparency-log timestamp against the effective `minimum_release_age` cutoff. Only a permitted unlogged bundle uses its signed publication timestamp instead.
+The `github:` backend remains useful for releases without packslips, while
+`aqua:` uses curated registry metadata. Publishing a packslip adds a signed
+vendor description; it does not require replacing an existing release layout.
 
-## Latest
+For GitHub releases, the `jdx/packslip@v0` action can sign and upload a bundle
+after your workflow has built and uploaded the final artifacts. Follow the
+[Packslip publishing guide](https://packslip.dev/docs/publishing/) for permissions,
+inputs, version pinning, and monorepo setup. For domain hosting, also publish a
+[signed release list](https://packslip.dev/docs/release-lists/).
 
-An unconstrained `latest` request uses the vendor’s signed release-list `latest` pointer first. On GitHub, absent a signed pointer, mise consults GitHub’s latest release. Without an eligible recommendation it falls back to highest eligible semver. Prefix and channel requests keep their existing matching rules and never use the default pointer.
-
-Mise verifies each candidate manifest before accepting it, including its identity and digest pins, reaching for the vendor exactly as installation does: a stamped candidate is fetched from the stamp's URL and the vendor is asked only for a withdrawal and a digest, so resolution accepts every version installation would. Minimum release age uses the verified log time (or signed publication time for explicitly allowed unlogged bundles), and stamping and host requirements still apply. A policy exclusion warns and tries the next candidate; a signature, digest, identity, or list freshness failure stops resolution. A signed pointer that is ineligible falls straight back to semver, not to GitHub’s pointer. Resolution and version listing read policy afresh rather than trusting mise’s remote-version cache, so changed stamper trust, withdrawals, expired lists, or missing accepted lists take effect; what they read is written back to that cache. Offline, there is no policy to consult and no network to consult it over, so both serve that cache like every other backend, or nothing when it is empty; installing still rechecks.
-
-## Host requirements
-
-After selecting the artifact, mise checks its declared minimum OS/glibc and host libraries before downloading it. Confirmed failures refuse installation; `ignore_requirements = true` overrides this for one tool. Missing or old commands warn, and unknown checks warn instead of refusing. Active mise command paths take precedence over ambient PATH; either way mise picks a path the OS can start, so a Windows `git.exe` or `node.cmd` counts and a shebang-only script does not. Requirements never break an artifact-selection tie or select a different build.
-
-On Linux the OS version is the kernel release from `uname -r`, read up to the distribution's suffix: `6.8.0-31-generic` is compared as `6.8.0`. OS and glibc probes and command version probes have bounded execution and output. Linux library checks use `LD_LIBRARY_PATH`, standard directories, and `ldconfig -p`; Windows uses PATH and the system directory. macOS checks common library directories but reports unknown absence because the dyld shared cache can contain libraries with no filesystem entry.
-
-Resource generators have a five-second deadline including inherited output pipes and a 4 MiB output limit. Their child processes are cleaned up on completion, failure, timeout, and cancellation.
+The [Packslip specification](https://packslip.dev/release/v1/) defines the format.
+The mise implementation is in
+[`src/backend/packslip.rs`](https://github.com/jdx/mise/blob/main/src/backend/packslip.rs).

--- a/docs/dev-tools/backends/packslip.md
+++ b/docs/dev-tools/backends/packslip.md
@@ -122,8 +122,15 @@ An ineligible signed recommendation falls directly back to semver selection,
 without consulting GitHub's pointer. Signature or digest failures and invalid,
 expired, rolled-back, or unexpectedly missing lists stop resolution.
 
-Version listing and `latest` resolution perform online policy checks and bypass
-mise's remote-version cache so withdrawals and trust changes take effect.
+Resolution reaches for the vendor exactly as installation does: a stamped
+candidate is fetched from the stamp's URL, and the vendor is asked only for a
+withdrawal and a digest, so `latest` accepts every version `install` would.
+
+Version listing and `latest` resolution read policy afresh rather than trusting
+mise's remote-version cache, so withdrawals and trust changes take effect; what
+they read is written back to that cache. Offline there is no policy to consult
+and no network to consult it over, so both serve that cache like every other
+backend, or nothing when it is empty; installing still rechecks.
 
 ## What is verified
 
@@ -172,9 +179,13 @@ downloading it. Requirements do not break a selection tie or select another buil
 | Missing or outdated required command                                      | Warn and continue.                                 |
 | A check cannot be completed                                               | Warn instead of assuming the host is incompatible. |
 
-Command checks prefer active mise tools over ambient PATH. Library detection is
+Command checks prefer active mise tools over ambient PATH, and either way mise
+picks a path the OS can start, so a Windows `git.exe` or `node.cmd` counts and a
+shebang-only script does not. Library detection is
 platform-dependent; for example, an absent macOS library file may still exist
-in the dyld shared cache, so mise reports that absence as unknown.
+in the dyld shared cache, so mise reports that absence as unknown. On Linux the
+OS version is the kernel release from `uname -r`, read up to the distribution's
+suffix: `6.8.0-31-generic` is compared as `6.8.0`.
 
 `ignore_requirements = true` allows a tool to install despite confirmed failures.
 It does not supply the missing libraries or make an incompatible executable run.
@@ -238,11 +249,16 @@ A host publishes one list per project at
 - A vendor withdrawal still excludes the release, regardless of stamps.
 - mise checks the stamped bundle digest and the vendor-list digest, when present,
   then verifies the vendor signature. A stamp never replaces that signature.
+- A stamp that records no digest is refused. The digest is what ties the host's
+  review to a file; without one the entry admits a URL, not a bundle.
 - Expired, rolled-back, invalid, or previously accepted but now missing stamper
   lists cause errors. Silently ignoring one would weaken the configured policy.
 
-A stamper can mirror the exact vendor-signed bundle. Re-signed repackager
-bundles requiring a separate identity policy are not supported here.
+A stamper can mirror the exact vendor-signed bundle. Because the stamp already
+names the bundle, mise asks the vendor only for what the vendor decides — a
+withdrawal, and the digest they pinned — so a release asset deleted from GitHub
+does not veto a mirror of a release that was never withdrawn. Re-signed
+repackager bundles requiring a separate identity policy are not supported here.
 
 No stamps are required when the setting is unset. To exempt one tool from
 configured stampers, set `trust = "vendor"` as described below.

--- a/docs/dev-tools/packslip-resources.md
+++ b/docs/dev-tools/packslip-resources.md
@@ -1,0 +1,200 @@
+# Packslip Completions and Skills <Badge type="warning" text="experimental" />
+
+Tools installed with the [packslip backend](/dev-tools/backends/packslip.html)
+can provide completions and agent skills for the version active in your project.
+The vendor declares these resources in its release manifest; mise fetches them
+with the tool and exposes them to your shell or agent.
+
+A tool installed through another backend does not acquire these resources just
+because its publisher also ships a packslip. The installed version must have
+Packslip metadata, and that manifest must declare the resource you want.
+
+The examples below use `mytool` for an installed executable that declares
+completions or skills. Replace it with your command's name.
+
+## Completions
+
+First, print the completion script to check that the active tool provides one:
+
+```sh
+mise completion zsh --tool mytool
+```
+
+Then install a stub for the command:
+
+```sh
+mise completion zsh --tool mytool --install
+```
+
+`--install` takes the executable name as typed, such as `mytool`, rather than
+a backend identifier containing slashes. For a release with several commands,
+choose the command you want to complete. Without `--tool`, `mise completion`
+generates completions for mise itself.
+
+The command writes a completion file but does not edit your shell configuration.
+Follow any one-time setup line it prints, then load the completion file or start
+a new shell. It preserves an existing file that mise did not create unless you
+explicitly pass `--force`.
+
+### Follow the active version
+
+The installed stub asks mise for the script when you complete the command.
+It does not generate a completion by running the vendor tool at shell startup.
+After you change directories or select another version with `mise use`, the
+next completion uses that directory's active version.
+
+| Shell      | How the installed stub follows version changes                                                               |
+| ---------- | ------------------------------------------------------------------------------------------------------------ |
+| zsh        | Temporarily hands a completion to the vendor script, then restores mise's stub.                              |
+| bash       | Hands completion to the vendor registration and restores the stub at the next prompt.                        |
+| fish       | Loads the vendor script in a child shell for each completion, keeping registrations out of the parent shell. |
+| PowerShell | Hands a completion to the vendor completer, then restores mise's completer.                                  |
+
+These four shells support `--tool ... --install`. For shells that load
+completions eagerly, such as nushell or elvish, generate the script without
+`--install` and load it yourself. Regenerate it when the active version changes.
+
+### Static files, usage specs, and generated scripts
+
+mise prefers a completion file supplied by the vendor, then a script derived
+from a static [usage](https://usage.jdx.dev) CLI spec, then a vendor command
+that generates a completion or CLI spec. Selection is scoped to the installed
+artifact, executable, and shell.
+
+Usage-derived completions require the `usage` command both to generate the
+script and at shell runtime:
+
+```sh
+mise use -g usage
+```
+
+If the only usable source runs the vendor executable, mise runs it on demand
+and caches successful output per installed version, executable, and shell.
+Concurrent requests share that work. Empty output, a failure, or a timeout
+does not become a cached script; mise tries the next source.
+
+Calling `mise completion ... --tool` directly can also trigger generation.
+The [`packslip.exec`](/configuration/settings.html#packslip.exec) setting does
+not gate on-demand completion generation. It controls resource commands run
+during installation, such as generated skills.
+
+## Skills
+
+A skill is a directory containing `SKILL.md` and any supporting files. mise
+fetches declared skills during tool installation by default, so different tool
+versions can carry different skill content.
+
+Inspect the installed skills of tools active in the current directory:
+
+```sh
+mise skills ls
+mise skills ls --json
+```
+
+Link them where your agent reads skills:
+
+```sh
+mise skills sync --dir .agents/skills
+```
+
+By default, `mise skills sync` uses `.claude/skills` under the nearest mise
+project root. `--dir` selects a directory for that invocation.
+`--global` instead resolves the configured skill directory under your home
+folder. With the default setting, that is `~/.claude/skills`.
+
+Each link points into the active tool version's install directory. Run sync
+after a version change to update those links. Only mise-owned links are replaced;
+a user-created directory or unrelated link at the same name is preserved and
+reported as skipped.
+
+### Keep project links up to date
+
+Configure your agent's directory and enable synchronization after `mise install`
+and `mise use`:
+
+```toml
+[settings.skills]
+dir = ".agents/skills"
+auto_sync = true
+prune = true
+```
+
+`prune = true` also removes mise-owned links for skills no longer active. Without
+it, stale links remain. To prune on one manual run:
+
+```sh
+mise skills sync --dir .agents/skills --prune
+```
+
+Automatic sync requires a mise project root. It does not run merely because
+you change directories, and it does not change an already running agent's
+skill-loading behavior. Reload skills as your agent requires.
+
+### Choose whether to fetch or generate skills
+
+| Setting                                                             | Default          | Effect                                                                      |
+| ------------------------------------------------------------------- | ---------------- | --------------------------------------------------------------------------- |
+| [`skills.fetch`](/configuration/settings.html#skills.fetch)         | `true`           | Fetch declared skills while installing tools.                               |
+| [`skills.dir`](/configuration/settings.html#skills.dir)             | `.claude/skills` | Choose the directory used by sync.                                          |
+| [`skills.auto_sync`](/configuration/settings.html#skills.auto_sync) | `false`          | Sync after install and use within a mise project.                           |
+| [`skills.prune`](/configuration/settings.html#skills.prune)         | `false`          | Remove stale mise-owned links during sync.                                  |
+| [`packslip.exec`](/configuration/settings.html#packslip.exec)       | `false`          | Allow running the installed tool to produce a resource during installation. |
+
+A skill can be fetched from the artifact, a separate signed asset, or the source
+repository at the release commit. A skill offered only as an `exec` command is
+generated during installation only when `packslip.exec` is enabled. That command
+runs the newly installed vendor executable and must print `SKILL.md` content.
+Fetched skills do not require executing the tool.
+
+Turning off `skills.fetch` affects skill fetching during installation; it does
+not delete previously fetched files or existing links. Run sync with pruning
+when you want to remove links to inactive skills.
+
+## Resource selection and command execution
+
+Resources can target an exact artifact filename or a platform. mise selects
+resources for the artifact it installed, preferring exact artifact scope and
+then the most specific platform scope. Different executables, shells, and skill
+names identify separate resources.
+
+Within an identity, equally scoped sources are alternatives. mise prefers an
+archive file, then a signed asset, then a source-repository file. Static CLI specs
+follow the same ordering. Declaration order breaks ties within a source type.
+A usable higher-priority skill source prevents fetching or running lower ones.
+A directory counts as a skill only when `SKILL.md` is present.
+
+Separate resource assets must match their signed digests; repository resources
+are pinned to the release's source commit. A missing optional resource can leave
+the tool installed without it. A digest mismatch is a verification failure,
+not permission to choose an unverified alternative.
+
+When mise runs a resource generator, it:
+
+- Adds the installed executables to PATH and applies the manifest's environment
+  variables, expanding `{shell}` for completion resources.
+- Uses a temporary working directory, no stdin, and discarded stderr.
+- Enforces a five-second deadline and a 4 MiB output limit, and cleans up child
+  processes after completion, failure, timeout, or cancellation.
+
+These limits bound generation; they do not make vendor code a sandboxed program.
+The [backend trust checks](/dev-tools/backends/packslip.html#what-is-verified)
+establish which publisher's executable is being used.
+
+## Troubleshooting
+
+| Symptom                                        | What to check                                                                                                                                                                 |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Tool was not installed from a packslip         | Check the active tool's backend and version with `mise ls`.                                                                                                                   |
+| No completion declared                         | Check whether the release declares a matching shell, command, or usage spec. For multiple executables, pass the command name.                                                 |
+| `--install` rejects a tool identifier          | Use the executable name, not `packslip:host/owner/repo`.                                                                                                                      |
+| A completion file already exists               | Inspect its source before choosing whether to replace it with `--force`.                                                                                                      |
+| Script prints but tab completion does not work | Follow the shell setup printed by `--install`; check that the stub is loaded and `usage` is on PATH if required.                                                              |
+| Completion generation fails                    | Check whether the vendor command emits nonempty output within the time and size limits.                                                                                       |
+| No skills listed                               | Check the active installed version, its declared resources, `skills.fetch`, and whether `SKILL.md` is present. An exec-only skill also needs `packslip.exec` at installation. |
+| A skill link is skipped                        | A user-owned file or directory may occupy its name; mise leaves it intact.                                                                                                    |
+| Links still point to an old version            | Run `mise skills sync` after changing versions, or enable automatic sync.                                                                                                     |
+
+For exact flags, see [`mise completion`](/cli/completion.html),
+[`mise skills ls`](/cli/skills/ls.html), and [`mise skills sync`](/cli/skills/sync.html).
+Publishers can follow the [Packslip resources guide](https://packslip.dev/docs/resources/)
+to add these declarations to their releases.

--- a/docs/dev-tools/packslip-resources.md
+++ b/docs/dev-tools/packslip-resources.md
@@ -50,9 +50,9 @@ next completion uses that directory's active version.
 | fish       | Loads the vendor script in a child shell for each completion, keeping registrations out of the parent shell. |
 | PowerShell | Hands a completion to the vendor completer, then restores mise's completer.                                  |
 
-These four shells support `--tool ... --install`. For shells that load
-completions eagerly, such as nushell or elvish, generate the script without
-`--install` and load it yourself. Regenerate it when the active version changes.
+These four are the shells `mise completion` knows, for `--tool` with and
+without `--install`. A tool's packslip completions are not available in any
+other shell.
 
 ### Static files, usage specs, and generated scripts
 
@@ -72,6 +72,10 @@ If the only usable source runs the vendor executable, mise runs it on demand
 and caches successful output per installed version, executable, and shell.
 Concurrent requests share that work. Empty output, a failure, or a timeout
 does not become a cached script; mise tries the next source.
+
+Only generation takes turns, and only generation writes: a completion the
+release ships is read straight out of the install, so a read-only system or
+shared install still completes.
 
 Calling `mise completion ... --tool` directly can also trigger generation.
 The [`packslip.exec`](/configuration/settings.html#packslip.exec) setting does

--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -495,6 +495,9 @@ Some installation methods automatically install autocompletion scripts.
 :::
 
 The [`mise completion`](/cli/completion.html) command can generate autocompletion scripts for your shell.
+
+The instructions below complete mise itself. For commands installed through the
+packslip backend, see [tool completions and skills](/dev-tools/packslip-resources.html).
 The generated scripts are self-contained and do not require the separate `usage` CLI.
 
 The simplest way to install the completion script is:

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -29,6 +29,7 @@
 - [GitHub Tokens](https://mise.jdx.dev/dev-tools/github-tokens.html): Many tools in mise are hosted on GitHub. For public releases, mise uses mise-versions by default as a shared cache for version lists, release metadata, and GitHub artifact attestations.
 - [mise.lock Lockfile](https://mise.jdx.dev/dev-tools/mise-lock.html): mise.lock is a lockfile that pins exact versions and checksums of tools for reproducible environments.
 - [Security](https://mise.jdx.dev/security.html): mise includes several supply-chain controls for installing and managing tools. These controls have different coverage depending on the backend and the metadata available from upstream.
+- [Packslip Completions and Skills](https://mise.jdx.dev/dev-tools/packslip-resources.html): Tools installed with the packslip backend can provide completions and agent skills for the version active in your project.
 - [OCI Images (experimental)](https://mise.jdx.dev/dev-tools/mise-oci.html): mise oci build turns a mise.toml into a container image, with one OCI layer per installed tool.
 - [Deps](https://mise.jdx.dev/dev-tools/deps.html): The mise deps command manages project dependencies by hashing source files (e.g., package-lock.json) and running install commands when changes are detected.
 - [Backend Architecture](https://mise.jdx.dev/dev-tools/backend_architecture.html): Understanding how mise's backend system works can help you choose the right backend for your tools and troubleshoot issues when they arise.
@@ -58,7 +59,7 @@
 - [go](https://mise.jdx.dev/dev-tools/backends/go.html): You can install packages directly via go install even if there isn't an asdf plugin for them.
 - [http](https://mise.jdx.dev/dev-tools/backends/http.html): You may install tools directly from HTTP URLs using the http backend. This backend downloads files from any HTTP/HTTPS URL and is ideal for tools that distribute pre-built binaries or archives through…
 - [npm](https://mise.jdx.dev/dev-tools/backends/npm.html): You can install packages directly from npmjs.org even if there isn't an asdf plugin for them.
-- [packslip](https://mise.jdx.dev/dev-tools/backends/packslip.html): The packslip backend installs a release from the vendor's own signed release manifest, a packslip. One file per release, packslip.sigstore.json, says what shipped and how to verify it: checksums,…
+- [packslip](https://mise.jdx.dev/dev-tools/backends/packslip.html): The packslip backend installs tools from a vendor's signed release manifest. The manifest names the release files, their digests, supported platforms, and executable paths.
 - [pipx](https://mise.jdx.dev/dev-tools/backends/pipx.html): pipx is a tool for running Python CLIs in isolated virtualenvs. This isolation helps prevent dependency conflicts between CLIs, or between a CLI and your Python projects.
 - [pkgx](https://mise.jdx.dev/dev-tools/backends/pkgx.html): The pkgx backend installs packages from the pkgx pantry without shelling out to the pkgx CLI. mise resolves pantry metadata, downloads pkgx bottles from dist.pkgx.dev, verifies bottle checksums when…
 - [spm](https://mise.jdx.dev/dev-tools/backends/spm.html): You may install executables managed by Swift Package Manager directly from GitHub or GitLab releases.

--- a/settings.toml
+++ b/settings.toml
@@ -2117,13 +2117,17 @@ type = "ListString"
 default = false
 description = "Run a tool's own command at install time to produce a resource its packslip offers only as an exec entry, such as an agent skill."
 docs = """
-A packslip may say that a resource is produced by running the tool itself,
-such as an agent skill printed by `tool skill`. That runs a freshly
-installed binary at install time, before you have run the tool yourself,
-and writes the result to disk, so mise does it only when this is on.
-Shell completions are the exception and need no setting: mise runs an exec
-completion when your shell first asks for one, which is when you were going
-to run the tool anyway, and caches the script beside the install.
+Allow resource generation that runs the installed vendor executable during
+installation, such as a command that prints an agent skill's `SKILL.md`.
+Fetched files do not need this setting.
+
+On-demand shell completions are separate: mise may run a declared completion
+command when the shell requests it, or when you run `mise completion --tool`,
+and caches successful output per version, executable, and shell. Disabling
+this setting does not disable on-demand completion generation.
+
+See [completions and skills](/dev-tools/packslip-resources.html) for setup,
+source selection, and execution limits.
 """
 env = "MISE_PACKSLIP_EXEC"
 type = "Bool"
@@ -2137,8 +2141,10 @@ signed release list per vendor project at
 checked and what it checked. When this setting names hosts, mise installs a
 packslip tool only at a version one of them lists: a version no trusted host
 stamped is not offered and not installed, however valid the vendor's own
-manifest is, and a version a host withdrew is refused. Any one host's stamp
-suffices.
+manifest is. Any one host's non-yanked approval suffices: one host withdrawing
+its approval does not veto another's. A vendor withdrawal still excludes the
+version regardless of stamps. Each accepted list must remain available,
+unexpired, and at or above its highest previously accepted sequence.
 
 Each entry is `host=PIN`, where the pin is the minisign-format public key the
 host signs with, the path of that `.pub` file, or, for a host that signs
@@ -2148,7 +2154,7 @@ keylessly from GitHub, an identity prefix such as
 ```toml
 [settings.packslip]
 stampers = [
-  "registry.mise.jdx.dev=RWQ...",
+  "registry.example.com=/path/to/stamper.pub",
   "stamps.example.com=https://github.com/example/stamps/",
 ]
 ```
@@ -2161,8 +2167,9 @@ under the vendor's pin, with no stamp:
 "packslip:github.com/jdx/mise" = { version = "latest", trust = "vendor" }
 ```
 
-Unset, no stamps are required. mise's own registry host will become the
-default once it publishes stamps.
+Unset, no stamps are required. The example hosts and key path are placeholders;
+configure a real service and a pin you trust. A stamp never replaces verification
+of the vendor signature. See [stamps](/dev-tools/backends/packslip.html#stamps).
 """
 env = "MISE_PACKSLIP_STAMPERS"
 optional = true
@@ -2760,10 +2767,10 @@ description = "Link the active tools' agent skills into the project after `mise 
 docs = """
 When on, mise runs the equivalent of `mise skills sync` after every install
 and after `mise use` changes a version, so the links under
-[`skills.dir`](#skills-dir) always point at the versions that are active in
+[`skills.dir`](#skills.dir) always point at the versions that are active in
 the project. Only projects with a mise config get links; nothing is written
 outside a project root. Links mise made are the only ones it touches, and
-stale ones are removed only when [`skills.prune`](#skills-prune) is on.
+stale ones are removed only when [`skills.prune`](#skills.prune) is on.
 """
 env = "MISE_SKILLS_AUTO_SYNC"
 type = "Bool"
@@ -2786,8 +2793,10 @@ description = "Fetch the agent skills a tool's packslip declares when installing
 docs = """
 A packslip may declare agent skills beside the tool's executables. mise
 fetches them at install time so every installed version carries its own
-copy. Turn this off to install tools without their skills; `mise skills ls`
-then lists nothing for them.
+copy. Turn this off to skip fetching skills during installation. This does not
+delete previously fetched skills or existing links. See
+[agent skills](/dev-tools/packslip-resources.html#skills) for synchronization
+and pruning.
 """
 env = "MISE_SKILLS_FETCH"
 type = "Bool"
@@ -2798,7 +2807,7 @@ description = "Remove links mise made for skills that are no longer active when 
 docs = """
 `mise skills sync` leaves links for skills of versions that are no longer
 active unless told to prune them. This makes pruning the default, for the
-command and for [`skills.auto_sync`](#skills-auto-sync). Only links mise
+command and for [`skills.auto_sync`](#skills.auto_sync). Only links mise
 made, recorded beside them and pointing into its installs directory, are
 ever removed.
 """


### PR DESCRIPTION
The Packslip backend page accumulated installation, trust policy, publisher guidance, and resource implementation details as the stack grew. Reorganize it around installing a tool, finding a version, verifying the release, and managing trust; move completion and skill setup into a dedicated guide linked from the sidebar and mise installation docs.

Clarify domain discovery URLs, platform selection, latest recommendations, host requirements, signer resets versus lockfile commitments, and stamper withdrawals. Add command and configuration examples and troubleshooting tables. Correct the action reference to `jdx/packslip@v0`, explain the four shells' completion lifecycle at the stack tip, and align settings prose and anchors with actual behavior. Preserve the existing backend section anchors and regenerate the docs index.

Stacked on #12808 (`codex/packslip-resource-lifecycle`), the current top of the mise Packslip support stack. This PR changes documentation and navigation only.

## Validation

- `mise run docs:build` passes; inspected both Packslip pages in the browser.
- Scoped hk fixes and `hk run check --safe --files0-from … --format json` pass (Prettier, markdownlint, Taplo).
- All 609 local links and anchors on the two Packslip pages resolve; all six TOML examples parse.
- `mise run render:schema` leaves schemas unchanged; regenerated `docs/public/llms.txt`.
- `git diff --check` passes.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes with no code or configuration defaults altered; risk is limited to possible doc inaccuracies or broken links.
> 
> **Overview**
> This PR is **documentation and navigation only**—no runtime behavior changes.
> 
> The **packslip backend** page is restructured around install → discovery → versions/`latest` → verification → trust (pins, lockfile, stampers) → tool options, with new tables for project discovery URLs, host requirements, and troubleshooting. Long completion/skill walkthroughs are **removed from the backend page** and replaced with links to a dedicated guide.
> 
> A new **`packslip-resources`** page covers version-following completion stubs (including per-shell behavior), skills fetch/sync/prune, resource selection limits, and its own troubleshooting table. The **Dev Tools sidebar**, **Installing mise** autocompletion section, **`llms.txt`**, and **`settings.toml` docs** (`packslip.exec`, `packslip.stampers`, `skills.*`) are updated to match— notably clarifying that **`packslip.exec` gates install-time generation, not on-demand `--tool` completions**, fixing internal anchor links, and correcting the GitHub Action reference to **`jdx/packslip@v0`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 979f5caa97b0ac0653ab35f334a728ebcdc0f38a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for Packslip-provided shell completions and agent skills.
  - Expanded Packslip backend documentation with setup, release selection, verification, resources, configuration, troubleshooting, and publishing details.
  - Added a Dev Tools navigation link for the Packslip resources guide.
  - Clarified the distinction between mise completions and completions for tools installed through Packslip.
  - Updated documentation indexes and configuration references for Packslip resources, stampers, and skills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->