### PR TITLE
registry: add packslip

### DIFF
--- a/registry/packslip.toml
+++ b/registry/packslip.toml
@@ -1,0 +1,9 @@
+backends = [
+  "packslip:github.com/jdx/packslip",
+  "github:jdx/packslip",
+  "cargo:packslip",
+]
+bins = ["packslip"]
+description = "A signed release manifest for vendor binaries"
+test = { cmd = "packslip --version", expected = "packslip {{version}}" }
+version_order = "semver"


### PR DESCRIPTION
`mise use packslip` for the tool whose signed release manifest the `packslip:` backend reads.

`packslip:` leads, so installing packslip is itself checked against the manifest jdx/packslip signs for each release — verified locally: `mise use -g packslip@0.3.0` with `MISE_EXPERIMENTAL` unset installs through that backend and leaves the verified statement in the install. `github:` and `cargo:` follow it for a host the manifest names no artifact for.

Stacked on #12811, which is what lets `packslip:` lead: the registry filters out experimental backend types, so before that change mise silently fell through to `github:`.

## Popularity

- GitHub: 9 stars, 0 forks, three releases (v0.1.0 and v0.2.0 on 2026-09-03, v0.3.0 on 2026-09-05)
- crates.io: 8 downloads
- Used by: mise's own `packslip:` backend

This is nowhere near the bar the contributing guide sets — thousands of stars, real third-party usage — and I would tell any other contributor the PR would be closed. It is here because it is your own tool and you asked for it; the numbers are above so the decision rests on them rather than on my summary.

If you would rather not carry a registry entry yet, `mise use packslip:github.com/jdx/packslip` works without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*AI-assisted — Tool: Claude Code; model: Anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only addition with no runtime or security logic changes.
> 
> **Overview**
> Adds a **registry manifest** for **packslip** so `mise use packslip` resolves without a full backend specifier.
> 
> The manifest lists **`packslip:github.com/jdx/packslip`** first, then **`github:jdx/packslip`** and **`cargo:packslip`** as fallbacks, with semver ordering and a version smoke test (`packslip --version`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6addaaf37c0be76f18c4c7fd75126fc578082d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a registry manifest for the Packslip command-line tool.
  - Enables package metadata, version detection, and semantic version ordering across supported sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->