### PR TITLE
feat(packslip): the backend is no longer experimental

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,7 +1475,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2368,21 +2368,6 @@ checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "crc"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc-fast"
@@ -4854,17 +4839,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "goblin"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17582616a7718cca54cec18e534a76c7c4aec11a8b9a85695712f262fd15a4c8"
-dependencies = [
- "log",
- "plain",
- "scroll",
-]
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5386,7 +5360,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6181,16 +6155,6 @@ checksum = "869665372263eb337b14f480cfb864b89f12eade4eb42cb415f71517b4a67572"
 dependencies = [
  "cc",
  "which",
-]
-
-[[package]]
-name = "lzma-rs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
-dependencies = [
- "byteorder",
- "crc",
 ]
 
 [[package]]
@@ -7045,39 +7009,25 @@ dependencies = [
 
 [[package]]
 name = "packslip"
-version = "0.2.0"
-source = "git+https://github.com/jdx/packslip?rev=89a9487#89a94872302c1addf561d6715d3ab98f4204de01"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "546adbfe64f11e2565379a1205f104f8eda98eaa69dd9ecb7a8bc33d101b2b62"
 dependencies = [
  "base64 0.22.1",
  "blake2 0.10.6",
- "bzip2",
- "color-eyre",
  "ed25519-dalek",
- "eyre",
- "flate2",
- "getrandom 0.3.4",
- "goblin",
  "jiff",
- "lzma-rs",
- "ruzstd",
- "schemars 1.2.2",
  "semver",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "sigstore-bundle",
- "sigstore-oidc",
  "sigstore-rekor",
- "sigstore-sign",
  "sigstore-trust-root",
  "sigstore-types",
  "sigstore-verify",
- "tar",
  "thiserror 2.0.20",
  "tokio",
- "toml 1.1.4+spec-1.1.0",
- "usage-rs",
- "zip 8.6.0",
 ]
 
 [[package]]
@@ -7515,12 +7465,6 @@ name = "pkg-config"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "platforms"
@@ -8957,15 +8901,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ruzstd"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a252f5e20f038fe7b4ea53e073e65398d652c864cc162fc77c56c2f13717b888"
-dependencies = [
- "twox-hash",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9053,26 +8988,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "scroll"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1257cd4248b4132760d6524d6dda4e053bc648c9070b960929bf50cfb1e7add"
-dependencies = [
- "scroll_derive",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1a36a382ed65dbcc0ab47fd5e9a94112417ccd34560a392ef3b7b0f0ec39148"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.4",
-]
 
 [[package]]
 name = "scrypt"
@@ -9632,7 +9547,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.3.14",
+ "errno 0.2.8",
  "libc",
 ]
 
@@ -9686,23 +9601,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sigstore-fulcio"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823d3f43c29500feb1ccacec68552f8e2bcecd62ec99c5284570a623bcf0c921"
-dependencies = [
- "base64 0.22.1",
- "reqwest",
- "serde",
- "serde_json",
- "sigstore-crypto",
- "sigstore-oidc",
- "sigstore-types",
- "thiserror 2.0.20",
- "url",
-]
-
-[[package]]
 name = "sigstore-merkle"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9713,25 +9611,6 @@ dependencies = [
  "sigstore-crypto",
  "sigstore-types",
  "thiserror 2.0.20",
-]
-
-[[package]]
-name = "sigstore-oidc"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdb57c6e3af8a17d535a06084353d8e0bd32bb70f4807262f51b6cd009c9b4f"
-dependencies = [
- "ambient-id",
- "base64 0.22.1",
- "rand 0.9.5",
- "reqwest",
- "serde",
- "serde_json",
- "sigstore-crypto",
- "sigstore-types",
- "thiserror 2.0.20",
- "tokio",
- "url",
 ]
 
 [[package]]
@@ -9750,26 +9629,6 @@ dependencies = [
  "sigstore-types",
  "thiserror 2.0.20",
  "url",
-]
-
-[[package]]
-name = "sigstore-sign"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33672126088b7fa9d5827e79fe0cd87eda607efa0d28c1366e61bbb47f423a"
-dependencies = [
- "base64 0.22.1",
- "serde_json",
- "sigstore-bundle",
- "sigstore-crypto",
- "sigstore-fulcio",
- "sigstore-oidc",
- "sigstore-rekor",
- "sigstore-trust-root",
- "sigstore-tsa",
- "sigstore-types",
- "thiserror 2.0.20",
- "x509-cert 0.2.5",
 ]
 
 [[package]]
@@ -10943,12 +10802,6 @@ checksum = "a78e83a30223c757c3947cd144a31014ff04298d8719ae10d03c31c0448c8013"
 dependencies = [
  "cipher 0.4.4",
 ]
-
-[[package]]
-name = "twox-hash"
-version = "2.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5283634e518fe9e82c7b20520bb4bc209009fd16c82077c802f8111ecbb0117a"
 
 [[package]]
 name = "type-map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ nodejs-semver = "5"
 nucleo-matcher = "0.3"
 num_cpus = "1"
 once_cell = "1"
-packslip = { git = "https://github.com/jdx/packslip", rev = "89a9487" }
+packslip = { version = "0.3", default-features = false }
 openssl = { version = "0.10", optional = true }
 path-absolutize = "4"
 petgraph = "0.8"

--- a/docs/dev-tools/backends/packslip.md
+++ b/docs/dev-tools/backends/packslip.md
@@ -1,4 +1,4 @@
-# packslip Backend <Badge type="warning" text="experimental" />
+# packslip Backend
 
 The `packslip` backend installs tools from a vendor's signed release manifest.
 The manifest names the release files, their digests, supported platforms, and
@@ -6,18 +6,16 @@ executable paths. mise verifies the signer and downloaded bytes, then installs
 the artifact that fits your host.
 
 ::: warning
-The backend and the [packslip format](https://packslip.dev) are experimental.
-Enable `experimental` to use the backend. A project must publish packslips for
-its releases; this backend cannot install arbitrary GitHub release assets.
+A project must publish packslips for its releases; this backend cannot install
+arbitrary GitHub release assets. The [packslip format](https://packslip.dev) is
+young, and its own version is what says what a manifest may contain.
 :::
 
 ## Usage
 
-With [mise activated](/getting-started.html), enable the backend and install
-packslip itself:
+With [mise activated](/getting-started.html), install packslip itself:
 
 ```sh
-mise settings experimental=true
 mise use -g packslip:github.com/jdx/packslip
 packslip version
 ```
@@ -26,9 +24,6 @@ Omit `-g` to manage the tool in the current project's `mise.toml` instead.
 For a project configuration:
 
 ```toml
-[settings]
-experimental = true
-
 [tools]
 "packslip:github.com/jdx/packslip" = "latest"
 ```
@@ -338,7 +333,6 @@ for source priority, caching, and when mise runs a vendor executable.
 
 | Symptom                                      | What to check                                                                                                                    |
 | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| Experimental backend refused                 | Enable `experimental` in settings.                                                                                               |
 | No release or bundle found                   | Confirm that the project publishes packslips, the subpath is correct, and the tag maps to a version or appears in a signed list. |
 | Nothing pins the signer                      | Supply `pubkey`, or a certificate identity/prefix and issuer, for a domain project.                                              |
 | Signer or trust downgrade refused            | Inspect `mise packslip pins`, explicit tool options, and `mise.lock`; confirm the publisher's change before resetting trust.     |

--- a/docs/dev-tools/packslip-resources.md
+++ b/docs/dev-tools/packslip-resources.md
@@ -1,4 +1,4 @@
-# Packslip Completions and Skills <Badge type="warning" text="experimental" />
+# Packslip Completions and Skills
 
 Tools installed with the [packslip backend](/dev-tools/backends/packslip.html)
 can provide completions and agent skills for the version active in your project.

--- a/e2e/backend/test_packslip
+++ b/e2e/backend/test_packslip
@@ -5,14 +5,11 @@
 # release workflow, which is the identity the project name pins.
 
 # Every release carrying a packslip is recent; do not let the default
-# minimum release age hide them all. The backend is experimental.
+# minimum release age hide them all.
 export MISE_MINIMUM_RELEASE_AGE=0
-export MISE_EXPERIMENTAL=1
 
-# Without the experimental setting the backend refuses to do anything.
-assert_fail_contains "env -u MISE_EXPERIMENTAL mise ls-remote packslip:github.com/jdx/packslip" "experimental"
-
-assert_contains "mise ls-remote packslip:github.com/jdx/packslip" "0.2.0"
+# The backend needs no setting turned on to be used.
+assert_contains "env -u MISE_EXPERIMENTAL mise ls-remote packslip:github.com/jdx/packslip" "0.2.0"
 
 # Latest resolves and verifies the vendor recommendation without installing it.
 latest=$(mise latest packslip:github.com/jdx/packslip) || exit 1
@@ -61,7 +58,6 @@ assert_directory_not_exists agents
 
 # A lockfile records who signed, so the project commits to that signer.
 export MISE_LOCKFILE=1
-export MISE_EXPERIMENTAL=1
 mkdir -p locked && cd locked
 touch mise.lock
 cat <<EOF >mise.toml

--- a/e2e/backend/test_packslip_resources
+++ b/e2e/backend/test_packslip_resources
@@ -5,7 +5,6 @@
 # these fixtures start after verification, with the statement and the
 # resources already in the install.
 
-export MISE_EXPERIMENTAL=1
 # These installs are linked, not downloaded, and the project they name has no
 # releases to discover: discovery and verification are test_packslip's. Offline
 # keeps resolution to what is installed here.

--- a/schema/mise-registry-tool.json
+++ b/schema/mise-registry-tool.json
@@ -7,7 +7,7 @@
   "$defs": {
     "backendFull": {
       "type": "string",
-      "pattern": "^(aqua|asdf|cargo|conda|core|dotnet|forgejo|gem|github|gitlab|go|http|npm|pipx|pkgx|s3|spm|ubi|vfox):([^\\[\\]]|\\[[^\\]=]*\\])+$"
+      "pattern": "^(aqua|asdf|cargo|conda|core|dotnet|forgejo|gem|github|gitlab|go|http|npm|packslip|pipx|pkgx|s3|spm|ubi|vfox):([^\\[\\]]|\\[[^\\]=]*\\])+$"
     },
     "optionValue": {
       "description": "Backend option value.",

--- a/src/backend/packslip.rs
+++ b/src/backend/packslip.rs
@@ -41,9 +41,9 @@ use crate::packslip_pins::{self, Observed};
 use crate::platform::Platform;
 use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions};
 
-/// The format is a draft and few projects publish one yet, so the backend
-/// is behind the experimental setting until both settle.
-pub(crate) const EXPERIMENTAL: bool = true;
+/// The backend installs only from a signed manifest, which is a property of
+/// the format rather than a rough edge, so nothing is held back by a setting.
+pub(crate) const EXPERIMENTAL: bool = false;
 
 /// The verified statement, kept beside the install so the rest of mise can
 /// read what the release declared without verifying it again.
@@ -581,10 +581,6 @@ impl PackslipBackend {
         Self { ba: Arc::new(ba) }
     }
 
-    fn ensure_experimental(&self) -> Result<()> {
-        Settings::get().ensure_experimental("packslip backend")
-    }
-
     fn project(&self) -> Result<String> {
         project_name(&self.ba.tool_name())
     }
@@ -928,7 +924,6 @@ impl PackslipBackend {
 
     /// Every version the vendor published, before stamps are applied.
     async fn vendor_versions(&self, raw_opts: &ToolVersionOptions) -> Result<Vec<VersionInfo>> {
-        self.ensure_experimental()?;
         let project = self.project()?;
         let opts = PackslipOptions::new(raw_opts);
         let pin = pin(&project, &opts)?;
@@ -1071,7 +1066,6 @@ impl Backend for PackslipBackend {
         before_date: Option<jiff::Timestamp>,
         refresh: bool,
     ) -> Result<Option<String>> {
-        self.ensure_experimental()?;
         let before =
             crate::backend::effective_latest_before_date(self, selection_opts, before_date)?;
         let query = query.as_deref().unwrap_or("latest");
@@ -1155,7 +1149,6 @@ impl Backend for PackslipBackend {
         ctx: &InstallContext,
         mut tv: ToolVersion,
     ) -> Result<ToolVersion> {
-        self.ensure_experimental()?;
         let project = self.project()?;
         let raw_opts = tv.request.options();
         let opts = PackslipOptions::new(&raw_opts);


### PR DESCRIPTION
The `packslip:` backend no longer needs `experimental`.

The gate was there because the backend was new and the format was moving. Neither is the reason it was still there: the layers below this one added signed release lists, stamper admission, signer pins, host requirements, verified release age, and resource handling, and packslip itself has reached a published 0.3.0 on crates.io.

- Drops `ensure_experimental` from the backend.
- Clears `EXPERIMENTAL`, which is what `RegistryTool::backends()` consults when deciding whether a tool's backends are usable — without this, `packslip:` is filtered out of any registry entry that lists it and mise silently falls through to the next backend.
- Teaches the hand-maintained registry schema the `packslip:` prefix, which it had never been told about.
- Removes the experimental badge and the `experimental = true` lines from the documented usage.

The warning that the backend installs only from a signed manifest stays: that is a property of the format, not of its maturity.

The e2e test previously asserted the backend *refuses* without the setting; it now asserts it works with the setting explicitly unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*AI-assisted — Tool: Claude Code; model: Anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install-path behavior for packslip tools and bumps the packslip crate, but verification, pinning, and stamp policy are unchanged; main risk is users who relied on the experimental gate or the older git dependency graph.
> 
> **Overview**
> The **`packslip:`** backend is now stable: **`EXPERIMENTAL`** is **`false`**, all **`ensure_experimental`** checks are removed, and **`packslip`** is pulled from **crates.io 0.3** (with **`default-features = false`**) instead of a git revision—trimming transitive deps in **`Cargo.lock`**.
> 
> Registry tooling now treats **`packslip:`** as a first-class backend: **`mise-registry-tool.json`** allows the prefix so registry entries listing it are not filtered out. Docs drop the experimental badge and **`experimental = true`** setup; e2e tests assert **`ls-remote`** works with **`MISE_EXPERIMENTAL`** unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d14fa51ea6eb78f84254e19fcb0e3bf36ad9a2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Packslip is now available without enabling experimental settings.
  * Packslip backends are recognized as valid registry tool configurations.
  * Packslip uses the stable crates.io release.

* **Documentation**
  * Updated Packslip documentation to present the backend as generally available.
  * Removed experimental setup instructions and related troubleshooting guidance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->