### PR TITLE
ci(release): publish a signed packslip with each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -571,6 +571,13 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    # The workflow-level env puts the publishing token in every step. This job
+    # runs the binary it just built, so it takes the token back out and hands
+    # it only to the two steps that publish with it.
+    env:
+      GH_TOKEN: ""
+      GITHUB_TOKEN: ""
+      GITHUB_API_TOKEN: ""
     steps:
       - name: Download release assets
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -580,8 +587,9 @@ jobs:
       # From this a consumer generates completions, a man page, and
       # documentation with its own copy of usage, so nothing of mise's has to
       # run on the machine it is being installed on. Generating it and
-      # uploading it are separate steps so that the release token is not in
-      # the environment of the binary that was just built.
+      # uploading it are separate steps so that the release token is only in
+      # the environment of the step that publishes, not of the binary that was
+      # just built.
       - name: Generate the CLI specification
         run: |
           mkdir -p bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -551,10 +551,89 @@ jobs:
         with:
           subject-checksums: release-assets/SHASUMS256.txt
 
+  # The packslip is this release's signed inventory: every artifact's digest,
+  # the executable inside it, the man page beside that, the shared objects it
+  # needs from the host, and the workflow identity that signed for all of it.
+  # SHASUMS and the minisign and GPG signatures say the bytes did not change;
+  # this says which platform each file is for and what is in it, so an
+  # installer can pick and check one against the identity github.com/jdx/mise.
+  # See https://packslip.dev.
+  #
+  # attest: false -- attest-release above already attests every artifact
+  # through SHASUMS256.txt, and attesting again here would only add a second
+  # statement about the same digests.
+  packslip:
+    needs:
+      - release
+      - attest-release
+    if: needs.release.outputs.created == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Download release assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: release-assets
+          path: release-assets
+      # From this a consumer generates completions, a man page, and
+      # documentation with its own copy of usage, so nothing of mise's has to
+      # run on the machine it is being installed on.
+      - name: Publish the CLI specification
+        env:
+          GH_TOKEN: ${{ secrets.MISE_GH_TOKEN }}
+        run: |
+          mkdir -p bin
+          tar -xzf "release-assets/mise-$GITHUB_REF_NAME-linux-x64.tar.gz" -C bin
+          bin/mise/bin/mise usage > mise.usage.kdl
+          gh release upload "$GITHUB_REF_NAME" mise.usage.kdl --clobber
+      # Two things the file names cannot say. A bare executable named for a
+      # dotted version has no extension to read a format from. And the man
+      # page is inside the Unix archives only -- the Windows zip carries none,
+      # and a bare executable is not an archive to look inside -- so each
+      # entry names the artifact it is really in.
+      - name: Describe what the file names cannot
+        run: |
+          {
+            for f in "release-assets/mise-$GITHUB_REF_NAME"-*; do
+              case "${f##*/}" in
+                *.tar.gz | *.tar.xz | *.tar.zst | *.zip | *.exe) continue ;;
+              esac
+              printf '[[artifact]]\npath = "%s"\nformat = "raw"\n\n' "$f"
+            done
+            for f in "release-assets/mise-$GITHUB_REF_NAME"-*.tar.*; do
+              name="${f##*/}"
+              case "$name" in *windows*) continue ;; esac
+              printf '[[resource]]\nkind = "man"\nartifact = "%s"\narchive = "mise/man/man1/mise.1"\n\n' "$name"
+            done
+          } > packslip.toml
+          cat packslip.toml
+      - uses: jdx/packslip@433c0c0f033e64c22f12433471768c255ef2bd93 # v0.3.0
+        with:
+          artifacts: release-assets/mise-*
+          manifest: packslip.toml
+          bin: mise
+          resources: cli-spec/usage=asset:mise.usage.kdl
+          attest: "false"
+          token: ${{ secrets.MISE_GH_TOKEN }}
+      # publish-release compares the draft's assets against what this workflow
+      # built, so the two files added here have to reach it or the diff fails.
+      - name: Stage the packslip for the asset check
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-extras
+          path: |
+            mise.usage.kdl
+            packslip/packslip.sigstore.json
+          if-no-files-found: error
+          retention-days: 1
+
   publish-release:
     needs:
       - release
       - attest-release
+      - packslip
     if: needs.release.outputs.created == 'true'
     runs-on: ubuntu-24.04
     permissions:
@@ -564,6 +643,11 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: release-assets
+          path: release-assets
+      - name: Download the packslip
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: release-extras
           path: release-assets
       - name: Verify and publish GitHub Release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -579,15 +579,18 @@ jobs:
           path: release-assets
       # From this a consumer generates completions, a man page, and
       # documentation with its own copy of usage, so nothing of mise's has to
-      # run on the machine it is being installed on.
-      - name: Publish the CLI specification
-        env:
-          GH_TOKEN: ${{ secrets.MISE_GH_TOKEN }}
+      # run on the machine it is being installed on. Generating it and
+      # uploading it are separate steps so that the release token is not in
+      # the environment of the binary that was just built.
+      - name: Generate the CLI specification
         run: |
           mkdir -p bin
           tar -xzf "release-assets/mise-$GITHUB_REF_NAME-linux-x64.tar.gz" -C bin
           bin/mise/bin/mise usage > mise.usage.kdl
-          gh release upload "$GITHUB_REF_NAME" mise.usage.kdl --clobber
+      - name: Publish the CLI specification
+        env:
+          GH_TOKEN: ${{ secrets.MISE_GH_TOKEN }}
+        run: gh release upload "$GITHUB_REF_NAME" mise.usage.kdl --clobber
       # Two things the file names cannot say. A bare executable named for a
       # dotted version has no extension to read a format from. And the man
       # page is inside the Unix archives only -- the Windows zip carries none,
@@ -609,6 +612,10 @@ jobs:
             done
           } > packslip.toml
           cat packslip.toml
+      # `out: .` keeps the bundle beside mise.usage.kdl. The action defaults to
+      # writing it under packslip/, and an artifact holding files at two
+      # depths keeps the directory, which the flat `sha256sum ./*` below
+      # would then choke on.
       - uses: jdx/packslip@433c0c0f033e64c22f12433471768c255ef2bd93 # v0.3.0
         with:
           artifacts: release-assets/mise-*
@@ -616,6 +623,7 @@ jobs:
           bin: mise
           resources: cli-spec/usage=asset:mise.usage.kdl
           attest: "false"
+          out: "."
           token: ${{ secrets.MISE_GH_TOKEN }}
       # publish-release compares the draft's assets against what this workflow
       # built, so the two files added here have to reach it or the diff fails.
@@ -625,7 +633,7 @@ jobs:
           name: release-extras
           path: |
             mise.usage.kdl
-            packslip/packslip.sigstore.json
+            packslip.sigstore.json
           if-no-files-found: error
           retention-days: 1
 


### PR DESCRIPTION
Part of adopting [packslip](https://packslip.dev) across the jdx.dev CLIs. Independent of the packslip *backend* stack — this is mise publishing its own release manifest, not consuming anyone else's, and it branches off `main`.

`SHASUMS256.txt`, the minisign signatures, and the GPG signatures say the bytes did not change in transit. They say nothing about which platform a given file is for, which executable is inside it, where the man page lives, or what the binary needs from the host. Each release now also publishes `packslip.sigstore.json` — one signed document listing all of that, signed keylessly with this workflow's OIDC identity, so an installer picks an artifact and verifies it against the identity `github.com/jdx/mise` with no key to distribute.

`mise usage` is run against the freshly built Linux binary and uploaded as `mise.usage.kdl`, listed as a `cli-spec` resource. A consumer generates completions, a man page, and docs from it with its own copy of usage — nothing of mise's runs on the installing machine.

### Changes

- A new `packslip` job after `attest-release`. It downloads the `release-assets` artifact the `release` job already stages, generates the CLI spec, writes a small manifest, and creates the bundle.
- `publish-release` now also needs `packslip`, and downloads the two new files into `release-assets` before its asset comparison. That comparison is a strict diff of the draft's assets against what the workflow built, so the new files have to reach it rather than slip past it.

Two things the file names cannot say go into a generated `packslip.toml`:

- **Bare executables.** `mise-v2026.9.1-linux-x64` has no extension to read a format from — the dotted version leaves a tail that is not one — so each is declared `format = "raw"`.
- **The man page.** `mise/man/man1/mise.1` is inside the Unix archives only. The Windows zip carries none and a bare executable is not an archive to look inside, so each `man` entry names the artifact it is really in instead of claiming every artifact holds one.

`attest: false` on purpose: `attest-release` already attests every artifact through `SHASUMS256.txt`, and attesting again in a later job would only add a second statement about the same digests. The cost is that the packslip carries no `provenance` links; the action can only emit those when it does the attesting itself, which is worth a follow-up input on the action.

### Verification

Rehearsed end to end against real v2026.9.1 assets — the bare binaries, all three tarball formats, the Windows `.exe` and `.zip`:

```
mise-v2026.9.1-linux-x64          | linux   x86_64  gnu  raw    | mise -> mise-v2026.9.1-linux-x64
mise-v2026.9.1-macos-arm64        | darwin  aarch64  -   raw    | mise -> mise-v2026.9.1-macos-arm64
mise-v2026.9.1-linux-x64.tar.gz   | linux   x86_64  gnu  tar.gz | mise/bin/mise
mise-v2026.9.1-linux-x64.tar.xz   | linux   x86_64  gnu  tar.xz | mise/bin/mise
mise-v2026.9.1-macos-arm64.tar.gz | darwin  aarch64  -   tar.gz | mise/bin/mise
mise-v2026.9.1-windows-x64.exe    | windows x86_64   -   raw    | mise -> mise-v2026.9.1-windows-x64.exe
mise-v2026.9.1-windows-x64.zip    | windows x86_64   -   zip    | mise/bin/mise.exe
```

`mise/bin/mise-shim.exe` sitting next to `mise/bin/mise.exe` in the Windows zip does not confuse the `--bin mise` lookup. `vcruntime140.dll` is picked up as a host requirement on the Windows builds. `mise usage` ran clean from the released linux-x64 tarball (5136 lines).

`zizmor --offline` reports the same 14 medium findings on this branch as on `main` — no new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release publish gate and adds steps that must succeed for a release to ship; no application runtime code, but a failed packslip job blocks publishing.
> 
> **Overview**
> Each GitHub release now gets a **`packslip` job** after attestation that builds installer-oriented metadata on top of the existing `release-assets` bundle.
> 
> The job runs **`mise usage`** from the Linux x64 tarball, uploads **`mise.usage.kdl`** to the draft release (as a `cli-spec` resource in the packslip), and generates a small **`packslip.toml`** so bare platform binaries are marked `format = "raw"` and Unix tarball man pages are tied to the right archive. **`jdx/packslip`** then emits **`packslip.sigstore.json`** (Sigstore/OIDC identity `github.com/jdx/mise`) with **`attest: false`** to avoid duplicating the existing SHASUMS attestation. Release tokens are cleared from the job env except on publish steps because the freshly built binary runs in the same job.
> 
> **`publish-release`** now **`needs: packslip`**, pulls **`release-extras`** (`mise.usage.kdl` + `packslip.sigstore.json`) into `release-assets`, and only then runs the strict draft-vs-built SHA256 diff before undrafting the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a11c2c43ce2b54ab31ae18df0644cbfefc5eb98c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release packages now include an automatically generated CLI specification for improved tooling and command discovery.
  * Releases include a manifest describing available downloadable artifacts and manual-page resources.
  * Additional release metadata, including verification information, is uploaded alongside standard release assets and checked during publication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->