### PR TITLE
fix(rust): normalize rustup profile aliases

### DIFF
--- a/e2e/core/test_rust_components_reconcile
+++ b/e2e/core/test_rust_components_reconcile
@@ -65,7 +65,7 @@ case "$1 $2" in
 					;;
 			esac
 			done
-		if ! $toolchain_exists && [[ -z "$profile" || "$profile" == "default" ]]; then
+		if ! $toolchain_exists && [[ -z "$profile" || "$profile" == "default" || "$profile" == "d" ]]; then
 			printf '%s\n' clippy rust-docs rustfmt >>"$MISE_CARGO_HOME/components"
 		fi
 		sort -u "$MISE_CARGO_HOME/components" -o "$MISE_CARGO_HOME/components" 2>/dev/null || true
@@ -125,17 +125,28 @@ assert_contains "cat '$MISE_CARGO_HOME/components'" "rustfmt"
 
 cat >mise.toml <<EOF
 [tools]
+rust = { version = "1.81.0", profile = "d" }
+EOF
+
+sed -i '/^rustfmt$/d' "$MISE_CARGO_HOME/components"
+assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
+mise install
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "5"
+assert_contains "cat '$MISE_CARGO_HOME/components'" "rustfmt"
+
+cat >mise.toml <<EOF
+[tools]
 rust = { version = "1.81.0", components = ["rustfmt", "rust-src"], targets = ["wasm32-unknown-unknown"] }
 EOF
 
 assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
 
 mise exec -- rustc -V
-assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "5"
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "6"
 assert_contains "cat '$MISE_CARGO_HOME/components'" "rustfmt"
 assert_contains "cat '$MISE_CARGO_HOME/components'" "rust-src"
 assert_contains "cat '$MISE_CARGO_HOME/targets'" "wasm32-unknown-unknown"
 
 mise install
-assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "5"
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "6"
 assert_contains "mise install rust --dry-run-code 2>&1" "already installed"

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -347,6 +347,7 @@ impl Backend for RustPlugin {
             Some(profile) => profile,
             None => self.rustup_default_profile(tv, &runtime)?,
         };
+        let effective_profile = normalize_rustup_profile(&effective_profile)?;
 
         // Query components even when none were explicitly requested. This
         // verifies that rustup still has the toolchain represented by mise's
@@ -523,6 +524,7 @@ impl Backend for RustPlugin {
             Some(profile) => profile.to_string(),
             None => self.rustup_default_profile(&tv, &runtime)?,
         };
+        let effective_profile = normalize_rustup_profile(&effective_profile)?;
         let mut components = components.unwrap_or_default();
         if effective_profile == "default" {
             components.extend(
@@ -1088,6 +1090,17 @@ fn rustup_path_env(runtime: &RustRuntime) -> Result<OsString> {
     )?)
 }
 
+fn normalize_rustup_profile(profile: &str) -> Result<&'static str> {
+    match profile {
+        "minimal" | "m" => Ok("minimal"),
+        "default" | "d" | "" => Ok("default"),
+        "complete" | "c" => Ok("complete"),
+        _ => bail!(
+            "unknown rustup profile name: {profile}; valid profile names are: minimal, default, complete"
+        ),
+    }
+}
+
 fn rustup_component_installed(installed: &BTreeSet<String>, component: &str) -> bool {
     installed.iter().any(|item| {
         item == component
@@ -1287,6 +1300,18 @@ mod tests {
         assert!(!rustup_component_installed(&installed, "rustfmt"));
         assert!(!rustup_component_installed(&installed, "rust"));
         assert!(!rustup_component_installed(&installed, "llvm"));
+    }
+
+    #[test]
+    fn profile_aliases_match_rustup() {
+        assert_eq!(normalize_rustup_profile("minimal").unwrap(), "minimal");
+        assert_eq!(normalize_rustup_profile("m").unwrap(), "minimal");
+        assert_eq!(normalize_rustup_profile("default").unwrap(), "default");
+        assert_eq!(normalize_rustup_profile("d").unwrap(), "default");
+        assert_eq!(normalize_rustup_profile("").unwrap(), "default");
+        assert_eq!(normalize_rustup_profile("complete").unwrap(), "complete");
+        assert_eq!(normalize_rustup_profile("c").unwrap(), "complete");
+        assert!(normalize_rustup_profile("custom").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- accept rustup profile aliases `m`, `d`, and `c` when mise evaluates an installed toolchain
- normalize only mise’s internal comparisons while preserving the configured value passed to rustup and stored in lock metadata
- cover default-profile alias reconciliation end to end

## Validation
- `mise run lint-fix`
- `mise run test:unit -- plugins::core::rust::tests::`
- `mise run test:e2e e2e/core/test_rust_components_reconcile`

## Rustup source validation
Rustup’s profile parser accepts the full names, the one-letter aliases, and an empty value as `default`; this PR mirrors that parser behavior.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Rust toolchain installations now correctly recognize abbreviated rustup profiles, including `d`, `m`, and `c`.
  - Missing default components such as rustfmt, clippy, and Rust documentation are restored when using supported profile aliases.
  - Repeated installation checks now avoid reinstalling an already-correctly configured toolchain.
- **Tests**
  - Added coverage for profile alias handling and component restoration during Rust toolchain installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->