### PR TITLE
fix(schema): restrict absent packages to pacman

### DIFF
--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -129,6 +129,9 @@ zshrc = true
 
 [bootstrap.packages]
 "pacman:libreoffice-fresh" = { state = "absent" }
+"apt:curl" = { state = "present" }
+"apt:git" = "latest"
+"apt:jq" = { version = "latest" }
 
 [[oci.copy]]
 host = "dist/my-app"
@@ -229,7 +232,7 @@ strict = true
 
 [[schemas]]
 path = "file://$SCHEMA_PATH"
-include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-dotfiles.toml", "mise-bad-dotfiles-position.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-env-float.toml", "mise-bad-install-env-float.toml", "mise-bad-minimum-release-age-array.toml", "mise-bad-minimum-release-age-table.toml", "mise-bad-package-state.toml", "mise-bad-postinstall.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-launchd-queue.toml", "mise-bad-launchd-throttle.toml", "mise-bad-systemd.toml", "mise-bad-oci-copy.toml", "mise-bad-shell-activate.toml"]
+include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-dotfiles.toml", "mise-bad-dotfiles-position.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-env-float.toml", "mise-bad-install-env-float.toml", "mise-bad-minimum-release-age-array.toml", "mise-bad-minimum-release-age-table.toml", "mise-bad-package-state.toml", "mise-bad-package-absent.toml", "mise-bad-postinstall.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-launchd-queue.toml", "mise-bad-launchd-throttle.toml", "mise-bad-systemd.toml", "mise-bad-oci-copy.toml", "mise-bad-shell-activate.toml"]
 
 [[schemas]]
 path = "file://$TASK_SCHEMA_PATH"
@@ -253,6 +256,14 @@ cat >"$HOME/workdir/mise-bad-package-state.toml" <<'TOML'
 TOML
 
 assert_fail "$TOMBI_LINT mise-bad-package-state.toml"
+
+# Verify that package removal is limited to managers that support it
+cat >"$HOME/workdir/mise-bad-package-absent.toml" <<'TOML'
+[bootstrap.packages]
+"apt:curl" = { state = "absent" }
+TOML
+
+assert_fail "$TOMBI_LINT mise-bad-package-absent.toml"
 
 # Verify that options for complex age values must be nested inside age
 cat >"$HOME/workdir/mise-bad-age.toml" <<'TOML'

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -4477,6 +4477,28 @@
           "propertyNames": {
             "pattern": "^[A-Za-z0-9_-]+:.+$"
           },
+          "allOf": [
+            {
+              "patternProperties": {
+                "^pacman:": true
+              },
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "state": {
+                        "const": "present"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ],
           "additionalProperties": {
             "oneOf": [
               {


### PR DESCRIPTION
The schema currently accepts `"apt:curl" = { state = "absent" }`, although only pacman implements declarative package removal. Restrict `absent` to `pacman:` entries while preserving string versions, omitted state, and explicit `present` for other managers. Keep the shared package-option schema intact.

Adds a non-pacman invalid fixture and verifies ordinary apt entries alongside the existing valid pacman removal fixture. Runtime behavior is unchanged.

Follow-up to #12785; addresses the outside-diff finding in #12741. Based directly on `main`.

Validation: `mise run render:schema`, `mise run lint-fix` (including strict schema compilation and Cargo check), and `mise run --skip-deps test:e2e e2e/config/test_schema_tombi` passed. The e2e harness used the existing binary because the change only affects schema and fixtures.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Pacman package declarations now support explicitly specifying `state = "present"` alongside existing version formats.

- **Bug Fixes**
  - Schema validation now rejects package-removal declarations for package managers that do not support removal states.
  - Valid package declarations for supported formats are now covered by automated checks, including Apt’s `present` and `latest` formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->