### PR TITLE
fix(rust): reconcile required profile components

### DIFF
--- a/docs/lang/rust.md
+++ b/docs/lang/rust.md
@@ -140,6 +140,9 @@ If not set, it defaults to the profile configured in `rustup`. You can check you
 "rust" = { version = "1.83.0", profile = "minimal" }
 ```
 
+If the Rust toolchain is already installed, `mise install` restores missing components implied by
+the `minimal` or `default` profile.
+
 ### `targets`
 
 The `targets` option specifies platforms to install for cross-compilation. Multiple targets can

--- a/e2e/core/test_rust_components_reconcile
+++ b/e2e/core/test_rust_components_reconcile
@@ -65,7 +65,7 @@ case "$1 $2" in
 					;;
 			esac
 			done
-		if ! $toolchain_exists && [[ -z "$profile" || "$profile" == "default" ]]; then
+		if ! $toolchain_exists && [[ -z "$profile" || "$profile" == "default" || "$profile" == "d" ]]; then
 			printf '%s\n' clippy rust-docs rustfmt >>"$MISE_CARGO_HOME/components"
 		fi
 		sort -u "$MISE_CARGO_HOME/components" -o "$MISE_CARGO_HOME/components" 2>/dev/null || true
@@ -125,17 +125,28 @@ assert_contains "cat '$MISE_CARGO_HOME/components'" "rustfmt"
 
 cat >mise.toml <<EOF
 [tools]
+rust = { version = "1.81.0", profile = "d" }
+EOF
+
+sed -i '/^rustfmt$/d' "$MISE_CARGO_HOME/components"
+assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
+mise install
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "5"
+assert_contains "cat '$MISE_CARGO_HOME/components'" "rustfmt"
+
+cat >mise.toml <<EOF
+[tools]
 rust = { version = "1.81.0", components = ["rustfmt", "rust-src"], targets = ["wasm32-unknown-unknown"] }
 EOF
 
 assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
 
 mise exec -- rustc -V
-assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "5"
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "6"
 assert_contains "cat '$MISE_CARGO_HOME/components'" "rustfmt"
 assert_contains "cat '$MISE_CARGO_HOME/components'" "rust-src"
 assert_contains "cat '$MISE_CARGO_HOME/targets'" "wasm32-unknown-unknown"
 
 mise install
-assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "5"
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "6"
 assert_contains "mise install rust --dry-run-code 2>&1" "already installed"

--- a/e2e/core/test_rust_components_reconcile
+++ b/e2e/core/test_rust_components_reconcile
@@ -22,26 +22,34 @@ cat >"$MISE_CARGO_HOME/bin/rustup" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
+host=x86_64-unknown-linux-gnu
+
 echo "$*" >>"$MISE_CARGO_HOME/rustup.log"
 
 case "$1 $2" in
 	"show profile")
 		echo default
 		;;
+	"show active-toolchain")
+		toolchain="${RUSTUP_TOOLCHAIN:-}"
+		[[ -d "$MISE_RUSTUP_HOME/toolchains/$toolchain-$host" ]] || exit 1
+		echo "$toolchain-$host (environment override by RUSTUP_TOOLCHAIN)"
+		;;
 	"component list")
 		toolchain="${*: -1}"
-		[[ -d "$MISE_RUSTUP_HOME/toolchains/$toolchain" ]] || exit 1
+		[[ -d "$MISE_RUSTUP_HOME/toolchains/$toolchain-$host" ]] || exit 1
 		cat "$MISE_CARGO_HOME/components" 2>/dev/null || true
 		;;
 	"target list")
 		toolchain="${*: -1}"
-		[[ -d "$MISE_RUSTUP_HOME/toolchains/$toolchain" ]] || exit 1
+		[[ -d "$MISE_RUSTUP_HOME/toolchains/$toolchain-$host" ]] || exit 1
 		cat "$MISE_CARGO_HOME/targets" 2>/dev/null || true
 		;;
 	"toolchain install")
 		shift 2
 		toolchain="$1"
 		shift
+		toolchain="$toolchain-$host"
 		toolchain_exists=false
 		[[ -d "$MISE_RUSTUP_HOME/toolchains/$toolchain" ]] && toolchain_exists=true
 		mkdir -p "$MISE_RUSTUP_HOME/toolchains/$toolchain"
@@ -49,7 +57,11 @@ case "$1 $2" in
 		while [[ $# -gt 0 ]]; do
 			case "$1" in
 				--component)
-					echo "$2" >>"$MISE_CARGO_HOME/components"
+					if [[ "$2" == "rust-src" ]]; then
+						echo "$2" >>"$MISE_CARGO_HOME/components"
+					else
+						echo "$2-$host" >>"$MISE_CARGO_HOME/components"
+					fi
 					shift 2
 					;;
 				--target)
@@ -65,8 +77,11 @@ case "$1 $2" in
 					;;
 			esac
 			done
-		if ! $toolchain_exists && [[ -z "$profile" || "$profile" == "default" || "$profile" == "d" ]]; then
-			printf '%s\n' clippy rust-docs rustfmt >>"$MISE_CARGO_HOME/components"
+		if ! $toolchain_exists; then
+			printf '%s\n' "cargo-$host" "rust-std-$host" "rustc-$host" >>"$MISE_CARGO_HOME/components"
+			if [[ -z "$profile" || "$profile" == "default" || "$profile" == "d" ]]; then
+				printf '%s\n' "clippy-$host" "rust-docs-$host" "rustfmt-$host" >>"$MISE_CARGO_HOME/components"
+			fi
 		fi
 		sort -u "$MISE_CARGO_HOME/components" -o "$MISE_CARGO_HOME/components" 2>/dev/null || true
 		sort -u "$MISE_CARGO_HOME/targets" -o "$MISE_CARGO_HOME/targets" 2>/dev/null || true
@@ -97,13 +112,13 @@ EOF
 mise install
 assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "1"
 
-sed -i '/^rust-docs$/d' "$MISE_CARGO_HOME/components"
+sed -i '/^rust-docs-/d' "$MISE_CARGO_HOME/components"
 assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
 mise install
 assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "2"
 assert_contains "cat '$MISE_CARGO_HOME/components'" "rust-docs"
 
-rm -rf "$MISE_RUSTUP_HOME/toolchains/1.81.0"
+rm -rf "$MISE_RUSTUP_HOME/toolchains/1.81.0-x86_64-unknown-linux-gnu"
 assert_hook_env_does_not_call_rustup
 assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
 mise install
@@ -114,7 +129,7 @@ cat >mise.toml <<EOF
 rust = { version = "1.81.0", profile = "default" }
 EOF
 
-sed -i '/^rustfmt$/d' "$MISE_CARGO_HOME/components"
+sed -i '/^rustfmt-/d' "$MISE_CARGO_HOME/components"
 assert_hook_env_does_not_call_rustup
 assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
 mise install
@@ -128,11 +143,26 @@ cat >mise.toml <<EOF
 rust = { version = "1.81.0", profile = "d" }
 EOF
 
-sed -i '/^rustfmt$/d' "$MISE_CARGO_HOME/components"
+sed -i '/^rustfmt-/d' "$MISE_CARGO_HOME/components"
 assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
 mise install
 assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "5"
 assert_contains "cat '$MISE_CARGO_HOME/components'" "rustfmt"
+
+cat >mise.toml <<EOF
+[tools]
+rust = { version = "1.81.0", profile = "minimal" }
+EOF
+
+printf '%s\n' rust-std-wasm32-unknown-unknown >>"$MISE_CARGO_HOME/components"
+sed -i '/^cargo-x86_64-unknown-linux-gnu$/d; /^rustc-x86_64-unknown-linux-gnu$/d; /^rust-std-x86_64-unknown-linux-gnu$/d' \
+  "$MISE_CARGO_HOME/components"
+assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
+mise install
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "6"
+assert_contains "cat '$MISE_CARGO_HOME/components'" "cargo-x86_64-unknown-linux-gnu"
+assert_contains "cat '$MISE_CARGO_HOME/components'" "rustc-x86_64-unknown-linux-gnu"
+assert_contains "cat '$MISE_CARGO_HOME/components'" "rust-std-x86_64-unknown-linux-gnu"
 
 cat >mise.toml <<EOF
 [tools]
@@ -142,11 +172,11 @@ EOF
 assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
 
 mise exec -- rustc -V
-assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "6"
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "7"
 assert_contains "cat '$MISE_CARGO_HOME/components'" "rustfmt"
 assert_contains "cat '$MISE_CARGO_HOME/components'" "rust-src"
 assert_contains "cat '$MISE_CARGO_HOME/targets'" "wasm32-unknown-unknown"
 
 mise install
-assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "6"
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "7"
 assert_contains "mise install rust --dry-run-code 2>&1" "already installed"

--- a/e2e/core/test_rust_config_env_homes
+++ b/e2e/core/test_rust_config_env_homes
@@ -31,7 +31,7 @@ case "$1 $2" in
 		echo minimal
 		;;
 	"component list")
-		echo rustfmt
+		printf '%s\n' cargo rust-std rustc rustfmt
 		;;
 	"toolchain install")
 		mkdir -p "$RUSTUP_HOME/toolchains/$3"

--- a/e2e/core/test_rust_external_provider
+++ b/e2e/core/test_rust_external_provider
@@ -28,6 +28,9 @@ mkdir -p "$STATE"
 			"show profile")
 				echo minimal
 				;;
+			"show active-toolchain")
+				echo "$RUSTUP_TOOLCHAIN-x86_64-unknown-linux-gnu (environment override)"
+				;;
 			"toolchain install")
 				version=$3
 				mkdir -p "$STATE/toolchains/$version"
@@ -55,6 +58,10 @@ mkdir -p "$STATE"
 				rm -rf "$STATE/toolchains/$3"
 				;;
 			"component list")
+				printf '%s\n' \
+					cargo-x86_64-unknown-linux-gnu \
+					rust-std-x86_64-unknown-linux-gnu \
+					rustc-x86_64-unknown-linux-gnu
 				cat "$STATE/components" 2>/dev/null || true
 				;;
 			"target list")

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -388,6 +388,8 @@ impl Backend for RustPlugin {
             None => self.rustup_default_profile(tv, &runtime)?,
         };
         let effective_profile = normalize_rustup_profile(&effective_profile)?;
+        let active_toolchain = self.rustup_active_toolchain(tv, &runtime)?;
+        let host = active_toolchain.as_deref().and_then(rustup_toolchain_host);
 
         // Query components even when none were explicitly requested. This
         // verifies that rustup still has the toolchain represented by mise's
@@ -398,13 +400,11 @@ impl Backend for RustPlugin {
         };
 
         let mut required_components = components.unwrap_or_default();
-        required_components.extend(fallback_rustup_profile_components(effective_profile));
+        required_components.extend(fallback_rustup_profile_components(effective_profile, host));
         required_components.sort();
         required_components.dedup();
 
         if !required_components.is_empty() {
-            let active_toolchain = self.rustup_active_toolchain(tv, &runtime)?;
-            let host = active_toolchain.as_deref().and_then(rustup_toolchain_host);
             let missing =
                 self.missing_components(&required_components, &installed_components, host);
             if !missing.is_empty() {
@@ -562,8 +562,10 @@ impl Backend for RustPlugin {
             None => self.rustup_default_profile(&tv, &runtime)?,
         };
         let effective_profile = normalize_rustup_profile(&effective_profile)?;
+        let active_toolchain = self.rustup_active_toolchain(&tv, &runtime)?;
+        let host = active_toolchain.as_deref().and_then(rustup_toolchain_host);
         let mut components = components.unwrap_or_default();
-        components.extend(fallback_rustup_profile_components(effective_profile));
+        components.extend(fallback_rustup_profile_components(effective_profile, host));
         components.sort();
         components.dedup();
 
@@ -1132,7 +1134,7 @@ fn normalize_rustup_profile(profile: &str) -> Result<&'static str> {
     }
 }
 
-fn fallback_rustup_profile_components(profile: &str) -> Vec<String> {
+fn fallback_rustup_profile_components(profile: &str, host: Option<&str>) -> Vec<String> {
     let mut components = match profile {
         "minimal" | "default" => RUST_MINIMAL_PROFILE_COMPONENTS
             .iter()
@@ -1147,6 +1149,9 @@ fn fallback_rustup_profile_components(profile: &str) -> Vec<String> {
                 .iter()
                 .map(|component| (*component).to_string()),
         );
+    }
+    if host.is_some_and(|host| host.ends_with("-pc-windows-gnu")) {
+        components.push("rust-mingw".to_string());
     }
     components
 }
@@ -1374,11 +1379,11 @@ mod tests {
     #[test]
     fn required_profile_components_match_rustup() {
         assert_eq!(
-            fallback_rustup_profile_components("minimal"),
+            fallback_rustup_profile_components("minimal", Some("x86_64-unknown-linux-gnu")),
             ["cargo", "rust-std", "rustc"]
         );
         assert_eq!(
-            fallback_rustup_profile_components("default"),
+            fallback_rustup_profile_components("default", Some("x86_64-unknown-linux-gnu")),
             [
                 "cargo",
                 "rust-std",
@@ -1388,7 +1393,11 @@ mod tests {
                 "rustfmt"
             ]
         );
-        assert!(fallback_rustup_profile_components("complete").is_empty());
+        assert_eq!(
+            fallback_rustup_profile_components("minimal", Some("x86_64-pc-windows-gnu")),
+            ["cargo", "rust-std", "rustc", "rust-mingw"]
+        );
+        assert!(fallback_rustup_profile_components("complete", None).is_empty());
     }
 
     #[test]

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -28,6 +28,7 @@ pub(super) struct RustPlugin {
 
 const RUST_NIGHTLY_MANIFEST_URL: &str =
     "https://static.rust-lang.org/dist/channel-rust-nightly.toml";
+const RUST_MINIMAL_PROFILE_COMPONENTS: &[&str] = &["cargo", "rust-std", "rustc"];
 const RUST_DEFAULT_PROFILE_COMPONENTS: &[&str] = &["clippy", "rust-docs", "rustfmt"];
 
 fn parse_nightly_manifest(manifest: &str) -> Result<String> {
@@ -286,14 +287,53 @@ impl RustPlugin {
         Ok(profile)
     }
 
+    fn rustup_active_toolchain(
+        &self,
+        tv: &ToolVersion,
+        runtime: &RustRuntime,
+    ) -> Result<Option<String>> {
+        let args = vec!["show".to_string(), "active-toolchain".to_string()];
+        let mut cmd = cmd(runtime.bin_dir.join(RUSTUP_BIN), args)
+            .env("PATH", rustup_path_env(runtime)?)
+            .stdout_capture()
+            .stderr_capture()
+            .unchecked();
+        for (key, value) in rustup_env(&runtime.homes, &tv.version) {
+            cmd = cmd.env(key, value);
+        }
+        let output = match cmd.run() {
+            Ok(output) if output.status.success() => output,
+            Ok(output) => {
+                debug!(
+                    "rustup show active-toolchain failed for {}: {}",
+                    tv.style(),
+                    String::from_utf8_lossy(&output.stderr).trim()
+                );
+                return Ok(None);
+            }
+            Err(err) => {
+                debug!(
+                    "rustup show active-toolchain failed for {}: {err:#}",
+                    tv.style()
+                );
+                return Ok(None);
+            }
+        };
+        Ok(String::from_utf8_lossy(&output.stdout)
+            .split_whitespace()
+            .next()
+            .map(String::from))
+    }
+
     fn missing_components(
         &self,
         requested: &[String],
         installed: &BTreeSet<String>,
+        host: Option<&str>,
     ) -> Vec<String> {
         requested
             .iter()
-            .filter(|component| !rustup_component_installed(installed, component))
+            .filter(|component| !rustup_component_installed(installed, component, host))
             .cloned()
             .collect()
     }
@@ -358,18 +398,15 @@ impl Backend for RustPlugin {
         };
 
         let mut required_components = components.unwrap_or_default();
-        if effective_profile == "default" {
-            required_components.extend(
-                RUST_DEFAULT_PROFILE_COMPONENTS
-                    .iter()
-                    .map(|component| (*component).to_string()),
-            );
-        }
+        required_components.extend(fallback_rustup_profile_components(effective_profile));
         required_components.sort();
         required_components.dedup();
 
         if !required_components.is_empty() {
-            let missing = self.missing_components(&required_components, &installed_components);
+            let active_toolchain = self.rustup_active_toolchain(tv, &runtime)?;
+            let host = active_toolchain.as_deref().and_then(rustup_toolchain_host);
+            let missing =
+                self.missing_components(&required_components, &installed_components, host);
             if !missing.is_empty() {
                 debug!(
                     "{} missing rustup component(s): {}",
@@ -526,15 +563,9 @@ impl Backend for RustPlugin {
         };
         let effective_profile = normalize_rustup_profile(&effective_profile)?;
         let mut components = components.unwrap_or_default();
-        if effective_profile == "default" {
-            components.extend(
-                RUST_DEFAULT_PROFILE_COMPONENTS
-                    .iter()
-                    .map(|component| (*component).to_string()),
-            );
-            components.sort();
-            components.dedup();
-        }
+        components.extend(fallback_rustup_profile_components(effective_profile));
+        components.sort();
+        components.dedup();
 
         let mut cmd = CmdLineRunner::new(runtime.bin_dir.join(RUSTUP_BIN))
             .with_pr(ctx.pr.as_ref())
@@ -1101,13 +1132,47 @@ fn normalize_rustup_profile(profile: &str) -> Result<&'static str> {
     }
 }
 
-fn rustup_component_installed(installed: &BTreeSet<String>, component: &str) -> bool {
+fn fallback_rustup_profile_components(profile: &str) -> Vec<String> {
+    let mut components = match profile {
+        "minimal" | "default" => RUST_MINIMAL_PROFILE_COMPONENTS
+            .iter()
+            .map(|component| (*component).to_string())
+            .collect::<Vec<_>>(),
+        "complete" => Vec::new(),
+        _ => unreachable!("profile was normalized"),
+    };
+    if profile == "default" {
+        components.extend(
+            RUST_DEFAULT_PROFILE_COMPONENTS
+                .iter()
+                .map(|component| (*component).to_string()),
+        );
+    }
+    components
+}
+
+fn rustup_toolchain_host(toolchain: &str) -> Option<&str> {
+    if rustup_component_suffix_is_host_triple(toolchain) {
+        return Some(toolchain);
+    }
+    toolchain.match_indices('-').find_map(|(index, _)| {
+        let suffix = &toolchain[index + 1..];
+        rustup_component_suffix_is_host_triple(suffix).then_some(suffix)
+    })
+}
+
+fn rustup_component_installed(
+    installed: &BTreeSet<String>,
+    component: &str,
+    host: Option<&str>,
+) -> bool {
     installed.iter().any(|item| {
         item == component
-            || item
-                .strip_prefix(component)
-                .and_then(|suffix| suffix.strip_prefix('-'))
-                .is_some_and(rustup_component_suffix_is_host_triple)
+            || host.is_some_and(|host| {
+                item.strip_prefix(component)
+                    .and_then(|suffix| suffix.strip_prefix('-'))
+                    == Some(host)
+            })
     })
 }
 
@@ -1289,17 +1354,41 @@ mod tests {
     }
 
     #[test]
-    fn rustup_component_matching_allows_host_suffixes() {
-        let installed = BTreeSet::from([
+    fn rustup_component_matching_requires_the_selected_host() {
+        let mut installed = BTreeSet::from([
             "rust-src".to_string(),
             "llvm-tools-x86_64-unknown-linux-gnu".to_string(),
+            "rust-std-wasm32-unknown-unknown".to_string(),
         ]);
+        let host = rustup_toolchain_host("1.81.0-x86_64-unknown-linux-gnu");
 
-        assert!(rustup_component_installed(&installed, "rust-src"));
-        assert!(rustup_component_installed(&installed, "llvm-tools"));
-        assert!(!rustup_component_installed(&installed, "rustfmt"));
-        assert!(!rustup_component_installed(&installed, "rust"));
-        assert!(!rustup_component_installed(&installed, "llvm"));
+        assert_eq!(host, Some("x86_64-unknown-linux-gnu"));
+        assert!(rustup_component_installed(&installed, "rust-src", host));
+        assert!(rustup_component_installed(&installed, "llvm-tools", host));
+        assert!(!rustup_component_installed(&installed, "rust-std", host));
+        assert!(!rustup_component_installed(&installed, "rustfmt", host));
+        installed.insert("rust-std-x86_64-unknown-linux-gnu".to_string());
+        assert!(rustup_component_installed(&installed, "rust-std", host));
+    }
+
+    #[test]
+    fn required_profile_components_match_rustup() {
+        assert_eq!(
+            fallback_rustup_profile_components("minimal"),
+            ["cargo", "rust-std", "rustc"]
+        );
+        assert_eq!(
+            fallback_rustup_profile_components("default"),
+            [
+                "cargo",
+                "rust-std",
+                "rustc",
+                "clippy",
+                "rust-docs",
+                "rustfmt"
+            ]
+        );
+        assert!(fallback_rustup_profile_components("complete").is_empty());
     }
 
     #[test]

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -1150,7 +1150,7 @@ fn fallback_rustup_profile_components(profile: &str, host: Option<&str>) -> Vec<
                 .map(|component| (*component).to_string()),
         );
     }
-    if host.is_some_and(|host| host.ends_with("-pc-windows-gnu")) {
+    if profile != "complete" && host.is_some_and(|host| host.ends_with("-pc-windows-gnu")) {
         components.push("rust-mingw".to_string());
     }
     components
@@ -1398,6 +1398,10 @@ mod tests {
             ["cargo", "rust-std", "rustc", "rust-mingw"]
         );
         assert!(fallback_rustup_profile_components("complete", None).is_empty());
+        assert!(
+            fallback_rustup_profile_components("complete", Some("x86_64-pc-windows-gnu"))
+                .is_empty()
+        );
     }
 
     #[test]

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -347,6 +347,7 @@ impl Backend for RustPlugin {
             Some(profile) => profile,
             None => self.rustup_default_profile(tv, &runtime)?,
         };
+        let effective_profile = normalize_rustup_profile(&effective_profile)?;
 
         // Query components even when none were explicitly requested. This
         // verifies that rustup still has the toolchain represented by mise's
@@ -523,6 +524,7 @@ impl Backend for RustPlugin {
             Some(profile) => profile.to_string(),
             None => self.rustup_default_profile(&tv, &runtime)?,
         };
+        let effective_profile = normalize_rustup_profile(&effective_profile)?;
         let mut components = components.unwrap_or_default();
         if effective_profile == "default" {
             components.extend(
@@ -1088,6 +1090,17 @@ fn rustup_path_env(runtime: &RustRuntime) -> Result<OsString> {
     )?)
 }
 
+fn normalize_rustup_profile(profile: &str) -> Result<&'static str> {
+    match profile {
+        "minimal" | "m" => Ok("minimal"),
+        "default" | "d" | "" => Ok("default"),
+        "complete" | "c" => Ok("complete"),
+        _ => bail!(
+            "unknown rustup profile name: {profile}; valid profile names are: minimal, default, complete"
+        ),
+    }
+}
+
 fn rustup_component_installed(installed: &BTreeSet<String>, component: &str) -> bool {
     installed.iter().any(|item| {
         item == component
@@ -1287,6 +1300,18 @@ mod tests {
         assert!(!rustup_component_installed(&installed, "rustfmt"));
         assert!(!rustup_component_installed(&installed, "rust"));
         assert!(!rustup_component_installed(&installed, "llvm"));
+    }
+
+    #[test]
+    fn profile_aliases_match_rustup() {
+        assert_eq!(normalize_rustup_profile("minimal").unwrap(), "minimal");
+        assert_eq!(normalize_rustup_profile("m").unwrap(), "minimal");
+        assert_eq!(normalize_rustup_profile("default").unwrap(), "default");
+        assert_eq!(normalize_rustup_profile("d").unwrap(), "default");
+        assert_eq!(normalize_rustup_profile("").unwrap(), "default");
+        assert_eq!(normalize_rustup_profile("complete").unwrap(), "complete");
+        assert_eq!(normalize_rustup_profile("c").unwrap(), "complete");
+        assert!(normalize_rustup_profile("custom").is_err());
     }
 
     #[test]

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -1221,6 +1221,8 @@ const RUST_TARGET_ARCHES: &[&str] = &[
     "powerpc64le",
     "riscv32",
     "riscv64",
+    "riscv64a23",
+    "riscv64gc",
     "s390x",
     "sparc",
     "sparc64",
@@ -1374,6 +1376,29 @@ mod tests {
         assert!(!rustup_component_installed(&installed, "rustfmt", host));
         installed.insert("rust-std-x86_64-unknown-linux-gnu".to_string());
         assert!(rustup_component_installed(&installed, "rust-std", host));
+    }
+
+    #[test]
+    fn rustup_required_components_recognize_riscv_hosts() {
+        let plugin = RustPlugin::new();
+        for host in [
+            "riscv64gc-unknown-linux-gnu",
+            "riscv64a23-unknown-linux-gnu",
+        ] {
+            let toolchain = format!("nightly-2026-09-01-{host}");
+            let selected_host = rustup_toolchain_host(&toolchain);
+            assert_eq!(selected_host, Some(host));
+            let required = fallback_rustup_profile_components("minimal", selected_host);
+            let installed = required
+                .iter()
+                .map(|component| format!("{component}-{host}"))
+                .collect();
+            assert!(
+                plugin
+                    .missing_components(&required, &installed, selected_host)
+                    .is_empty()
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Existing rustup toolchains can lose required components such as cargo, rustc, or the host standard library. Reapplying a profile alone does not restore those components. This change explicitly reconciles minimal/default profile requirements, including rust-mingw on GNU Windows, and prevents cross-target components from satisfying host requirements.

Depends on #12814. This PR targets main, so its GitHub diff includes that prerequisite. [Review this layer only](https://github.com/risu729/mise/compare/fix/rust-profile-aliases...fix/rust-required-profile-components).

Validation: independent subagent review; focused Rust unit and reconciliation/custom-home/external-provider E2E coverage passed on the combined stack. The profile requirements and selected-host behavior were checked against rustup source.

*AI-assisted — Tool: Codex; model: openai/gpt-6; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Rust toolchain installation now restores missing components from an existing toolchain.
  - Component detection now accounts for the active host platform and supported RISC-V targets.
  - Rust profiles recognize `minimal`, `default`, and `complete` aliases consistently.
  - Minimal and default profiles install the appropriate standard components, while Windows GNU targets receive required components.

- **Documentation**
  - Clarified when `mise install` restores components implied by the selected Rust profile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->