### PR TITLE
test: fix unit-macos link and packslip e2e under the release workflow

### DIFF
--- a/e2e/backend/test_packslip_resources
+++ b/e2e/backend/test_packslip_resources
@@ -121,6 +121,9 @@ printf '# spec: %s\n' "$6"
 cat "$6"
 EOF
 chmod +x "$HOME/bin/usage"
+# The release workflow installs the real usage into cargo's bin, which the
+# harness puts ahead of this stub.
+export PATH="$HOME/bin:$PATH"
 
 cd project-1.0.0
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -8,7 +8,17 @@ use indoc::indoc;
 
 use crate::{env, file};
 
-#[ctor::ctor(unsafe)]
+// ctor puts the constructor body in `__TEXT,__text_startup` on Apple targets, a
+// section laid out after `__text`. The debug test binary's `__text` is past the
+// 128MB reach of an arm64 direct branch, and ld only inserts branch islands
+// inside `__text`, so a call from that section into the front of `__text` fails
+// to link with "B/BL out of range". Keeping the body in `__text` lets the
+// linker island the call like any other.
+#[cfg_attr(
+    target_vendor = "apple",
+    ctor::ctor(unsafe, body(link_section = "__TEXT,__text,regular,pure_instructions"))
+)]
+#[cfg_attr(not(target_vendor = "apple"), ctor::ctor(unsafe))]
 fn init() {
     if env::var("RUST_LOG").is_err() {
         env::set_var("RUST_LOG", "debug")


### PR DESCRIPTION
Fixes the two CI failures blocking the 2026.9.2 release PR (#12692). Neither is caused by the release diff itself.

## `untrusted / unit-macos`: `ld: B/BL out of range`

`ctor` 1.x places the constructor body in `__TEXT,__text_startup` on Apple targets, a section laid out *after* `__text`. The debug test binary's `__text` is now ~137MB, past the 128MB reach of an arm64 direct branch, and ld only inserts branch islands inside `__text`. So the `bl` from `mise::test::init`'s ctor wrapper into `PathBuf::deref` near the front of `__text` fails to link:

```
ld: B/BL out of range -134899900 (max +/-128MB) from 0x10833AE20 ('mise::test::init::___ctor_private_inner'+224 …) to 0x100294564 ('<PathBuf as Deref>::deref' …)
```

The same error hit `untrusted / unit-macos` on four PRs today (this one, #12692 twice, `fix/schema-dotfiles-manifest`, `brew-cask-stale-tap-advice`, `fix/schema-package-absent-managers`) on the same `macos-14` image, while other cold builds passed minutes apart: the binary is right at the boundary. The trusted Namespace runners build incrementally from a warm cache and have not hit it.

This keeps the constructor body in `__TEXT,__text` via ctor's `body(link_section = …)` option, so the linker can island the call like any other. Verified by compiling the attribute for `aarch64-apple-darwin` and checking the emitted IR: both the ctor wrapper and `init` land in `__TEXT,__text,regular,pure_instructions` (previously `__text_startup`); other targets are unchanged (`.text.startup` on Linux). I do not have a macOS machine to link the full test binary on, so the CI run on this PR is the end-to-end check.

## `e2e-linux-4` (release workflow): `backend/test_packslip_resources`

The test writes a fake `usage` into `$HOME/bin`, but `release.yml`'s e2e job installs the real `usage-cli` into `~/.cargo/bin` via `taiki-e/install-action`, and `e2e/run_test` puts `$CARGO_HOME/bin` ahead of `$TEST_HOME/bin` on PATH. mise then runs the real `usage` against the test's fake spec (`# bash 1.0.0` is not KDL) and fails with exit 181. `test.yml`'s e2e jobs never install `usage-cli`, so the test passed on #12808 and only broke once the release workflow ran it.

The test now prepends `$HOME/bin` to PATH, the same as the other tests that stub a host tool (`test_pipx_*`, `test_go_*`, `test_cargo_*`). Reproduced locally with a `CARGO_HOME` whose `bin/usage` is the real usage 6.6.1: the test fails before this change and passes after.


*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5-1; version: unavailable.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect test initialization and an e2e harness PATH tweak, with no production runtime or security-sensitive behavior.
> 
> **Overview**
> Fixes two CI-only failures: **macOS unit test linking** and **packslip e2e** when the release workflow installs real host tools.
> 
> On **Apple arm64**, the test harness `init` ctor now links its body into `__TEXT,__text` (via `ctor`'s `body(link_section = …)`) instead of `__text_startup`. That avoids `ld: B/BL out of range` when the debug test binary's `__text` grows past the 128MB branch limit and the ctor calls into code near the start of `__text`. Non-Apple targets keep the plain `#[ctor::ctor(unsafe)]` attribute.
> 
> In **`test_packslip_resources`**, the fake `usage` stub is prepended to `PATH` (`$HOME/bin` first), matching other e2e tests that override cargo-installed binaries. Release e2e puts `~/.cargo/bin` ahead of the test home, so mise was invoking real `usage` against fixture specs and failing; the stub is used again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 909bb4301183645e794a37838005eadd49877608. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Apple arm64 builds that could fail during linking due to constructor placement.
  - Updated test setup so the installed `usage` command is selected when available, while retaining the fixture stub as a fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->