### PR TITLE
chore(render): run markdown-magic non-interactively

### DIFF
--- a/tasks.toml
+++ b/tasks.toml
@@ -106,7 +106,7 @@ sources = ["mise"]
 outputs = ["README.md"]
 run = [
   "mise render-help",
-  "mise run show-output-on-failure -- mise x node@latest -- npx markdown-magic",
+  "mise run show-output-on-failure -- mise x node@latest -- npx --yes markdown-magic",
 ]
 
 ["render:llms"]

--- a/tasks.toml
+++ b/tasks.toml
@@ -106,7 +106,7 @@ sources = ["mise"]
 outputs = ["README.md"]
 run = [
   "mise render-help",
-  "mise run show-output-on-failure -- mise x node@latest -- npx --yes markdown-magic",
+  "mise run show-output-on-failure -- mise x node npm:markdown-magic -- md-magic",
 ]
 
 ["render:llms"]


### PR DESCRIPTION
## Summary

Run `markdown-magic` via mise's `npm:` backend instead of `npx`.

Without `--yes`, npx prompts "Need to install the following packages: markdown-magic … Ok to proceed? (y)" whenever `markdown-magic` is not already in `node_modules`. The `show-output-on-failure` wrapper captures stdout/stderr, so the prompt is invisible and a local `mise run render:help` (and therefore `mise run render`) sits blocked on stdin with no output — it looks like a mise hang. CI is unaffected because `CI=true` makes npm non-interactive; this only bites local runs.

Rather than paper over the prompt with `--yes`, this switches to `mise x node npm:markdown-magic -- md-magic`, matching how the repo already manages other npm CLI tools (`npm:markdownlint-cli`, `npm:ajv-cli` in `mise.toml`). mise's `npm:` backend installs via its embedded aube installer, which never prompts, so there's no interactive install to suppress in the first place. It also resolves `node` from the project's pinned `mise.toml` version rather than `node@latest`.

Verified the new invocation produces an identical (no-op) result to the current `npx markdown-magic` run against this repo's README.md.

Found while rendering docs for #12819.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-sonnet-5; version: unavailable.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the help documentation generation process to use a more consistent tool execution method.
  * No changes were made to the resulting help documentation or other end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->