### PR TITLE
fix(http): flush a failed download's partial file before giving up

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -1110,11 +1110,23 @@ impl Client {
                         pr.inc(chunk.len() as u64);
                     }
                 }
+                Ok::<_, Report>(())
+            }
+            .await;
+            // Outside the transfer, so it also runs when the transfer failed.
+            // `tokio::fs::File` buffers writes and dropping one does not flush,
+            // so a transfer that dies part way through was leaving the bytes it
+            // had already received unwritten — the resume then asked for a range
+            // starting before them and downloaded them again. Whether any of it
+            // survived depended on when the background flush happened to land.
+            let persisted = async {
                 file.shutdown().await?;
                 file.sync_all().await?;
                 Ok::<_, Report>(())
             }
             .await;
+            // Before `clear()`: flushing into a file that has just been removed
+            // would recreate it.
             if transfer.is_err()
                 && !resumable
                 && let Err(err) = partial.clear()
@@ -1122,6 +1134,7 @@ impl Client {
                 debug!("failed to remove unvalidated partial download: {err:#}");
             }
             transfer?;
+            persisted?;
 
             if let Some(total_size) = total_size {
                 let actual_size = tokio::fs::metadata(&partial.path).await?.len();
@@ -3740,6 +3753,12 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
             .download_file_with_headers_metadata(&url, &destination, &headers, None)
             .await
             .unwrap_err();
+        // The whole point of the partial: the bytes that arrived before the
+        // body was cut short have to be on disk, or the `Range: bytes=5-` at
+        // the bottom of this test is asking to resume from somewhere the file
+        // does not reach. This was intermittently empty on macOS until the
+        // download path started flushing on the failure branch too — do not
+        // relax it to a length check.
         assert_eq!(std::fs::read(&partial.path).unwrap(), b"hello");
         let state = std::fs::read_to_string(&partial.state_path).unwrap();
         assert!(!state.contains("url-secret"));


### PR DESCRIPTION
`http::tests::test_download_resumes_across_calls_without_storing_secrets` has failed twice on `unit-macos` in the last two days, on unrelated PRs, reading an empty partial file where five bytes had arrived:

```
assertion `left == right` failed
  left: []
 right: [104, 101, 108, 108, 111]     // "hello"
```

Both times it passed on other branches minutes either side, so it looked like a flake. It is not the test that is wrong.

## What actually happens

A failed download is meant to keep what it received so a later call can resume from it. The flush that puts it on disk was inside the transfer future, after the loop:

```rust
let transfer = async {
    while let Some(chunk) = resp.chunk().await? { … file.write_all(&chunk).await?; … }
    file.shutdown().await?;      // ← only reached when the loop completes
    file.sync_all().await?;
    Ok::<_, Report>(())
}.await;
```

When the body is cut short, `resp.chunk().await?` propagates and `shutdown`/`sync_all` never run. `tokio::fs::File` buffers writes and **dropping one does not flush** — the write is handed to a blocking task and the drop does not wait for it. So whether the received bytes reached disk depended on whether that background write happened to land before the assertion read the file.

The test's server sends `Content-Length: 10` with a five-byte body and closes, which is exactly this path.

## Impact outside the test

Small, and worth being precise about: the resume asks for a range starting at the file's actual length, so a short partial is re-downloaded rather than corrupted. The cost is discarded work — a large download that fails near the end can lose most of what it fetched — plus a partial whose contents are not a function of what was received.

## Change

Move the flush out of the transfer so it runs on both outcomes, and keep it **before** the `clear()` for non-resumable failures, since flushing into a file that has just been removed would recreate it. The transfer's error still wins; the flush error is only propagated when the transfer succeeded.

## Test

No new test. `test_download_resumes_across_calls_without_storing_secrets` already asserts exactly this — it was the thing catching the defect, intermittently. I added a comment there recording why the assertion is a byte comparison and asking that it not be relaxed to a length check, which is the tempting way to "fix" a flake like this.

I cannot build locally, so CI is the first execution.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.236.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Partial downloads now reliably save received data even when a transfer fails, allowing interrupted downloads to resume from the saved progress.
  - Improved resume behavior by ensuring downloaded bytes are written to disk before a failed attempt completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->