### PR TITLE
feat(bootstrap): journal dotfiles and edits

### DIFF
--- a/docs/bootstrap/generations.md
+++ b/docs/bootstrap/generations.md
@@ -22,14 +22,14 @@ content snapshot, when git is available.
 
 ## What is recorded
 
-| Field      | Contents                                                                                           |
-| ---------- | -------------------------------------------------------------------------------------------------- |
-| `command`  | The mise command line that ran, such as `bootstrap dotfiles apply --yes`                           |
-| `snapshot` | Content snapshots of the config directory and `dotfiles.root` before and after the run             |
-| `lockfile` | The global `mise.lock` (its hash, and its bytes inside the snapshot)                               |
-| `journal`  | Entries describing what changed. Hook commands and the `bootstrap` task are noted as not journaled |
-| `summary`  | The bootstrap parts the run covered                                                                |
-| `status`   | `completed`, `failed`, or `pending` when the run did not finish                                    |
+| Field      | Contents                                                                                   |
+| ---------- | ------------------------------------------------------------------------------------------ |
+| `command`  | The mise command line that ran, such as `bootstrap dotfiles apply --yes`                   |
+| `snapshot` | Content snapshots of the config directory and `dotfiles.root` before and after the run     |
+| `lockfile` | The global `mise.lock` (its hash, and its bytes inside the snapshot)                       |
+| `journal`  | Every path the run touched, with what was there before and what it left behind (see below) |
+| `summary`  | The bootstrap parts the run covered                                                        |
+| `status`   | `completed`, `failed`, or `pending` when the run did not finish                            |
 
 The snapshot covers two roots:
 
@@ -52,6 +52,21 @@ with more than 100,000 files or 1 GiB is skipped with a warning. A git
 repository nested inside a root (a plugin checkout, say) is recorded as a
 reference to its commit, not by content.
 
+## The journal
+
+Before a dotfile apply, unapply, `add`, or edit touches a path, the run
+records a `path_changed` entry holding the path's prior state: its content
+and mode for a file, its destination for a symlink, its files for a directory
+replaced with `--force`, or `missing`. After the mutation a `committed` entry
+records the state it left behind. Prior content up to 64 KiB is embedded in
+the record; larger content goes to `$MISE_STATE_DIR/bootstrap/blobs/` by
+hash; files over 8 MiB and directories over 256 MiB are noted as not
+captured. `symlink-each` entries journal every link they create or remove
+plus their ownership state file. An entry without a matching `committed`
+means the run died mid-change. Hook commands and the `bootstrap` task are
+noted as not journaled. `mise bootstrap generations show` renders each
+entry as `part: item: path <before> -> <after>`.
+
 A run that changes nothing and records nothing in its journal leaves no
 generation behind, so a daily `mise bootstrap` on a converged machine does not
 accumulate entries. Dry runs never record.
@@ -61,6 +76,7 @@ accumulate entries. Dry runs never record.
 ```text
 $MISE_STATE_DIR/bootstrap/
 ├── generations.git/          bare git repository holding every snapshot
+├── blobs/                    prior file content over 64 KiB, by sha256
 └── generations/
     ├── 000041.json
     └── 000042.json

--- a/e2e/cli/test_bootstrap_generations
+++ b/e2e/cli/test_bootstrap_generations
@@ -188,7 +188,7 @@ assert "mise bootstrap generations --json | jq -r '[.[0].journal[] | select(.kin
 mkdir -p ~/.local/other
 echo hi >~/.local/other/file
 echo eleven >"$MISE_CONFIG_DIR/dotfiles/copied"
-assert_succeed "MISE_DOTFILES_ROOT=$HOME/.local mise bootstrap dotfiles apply --yes"
+assert_succeed "MISE_DOTFILES_ROOT=$HOME/.local mise bootstrap dotfiles apply --yes ~/.copied"
 tree="$(mise bootstrap generations --json | jq -r '.[0].snapshot.after.roots[] | select(.label == "dotfiles") | .tree')"
 assert_contains "git --git-dir='$shadow' ls-tree -r --name-only '$tree'" "other/file"
 assert_not_contains "git --git-dir='$shadow' ls-tree -r --name-only '$tree'" "state/mise"

--- a/e2e/cli/test_bootstrap_generations
+++ b/e2e/cli/test_bootstrap_generations
@@ -41,7 +41,10 @@ assert "mise bootstrap generations --json | jq -r '.[0].snapshot.after.roots[] |
 assert "mise bootstrap generations --json | jq -r '.[0].snapshot.after.roots[] | select(.label == \"dotfiles\") | .skipped'" "missing"
 # targets live outside the snapshot roots, so the first apply changes nothing inside them
 assert "mise bootstrap generations --json | jq -r '.[0].snapshot.unchanged'" "true"
-assert "mise bootstrap generations --json | jq -r '.[0].journal[0].message'" "dotfiles: applied ~/.zshrc, ~/.copied"
+# the journal records every path the run touched: prior state before, resulting state after
+assert "mise bootstrap generations --json | jq -r '[.[0].journal[] | select(.kind == \"path_changed\") | .path] | join(\" \")'" "$HOME/.zshrc $HOME/.copied"
+assert "mise bootstrap generations --json | jq -r '.[0].journal[0].prior.state, .[0].journal[1].after.state, .[0].journal[3].after.state'" $'missing\nsymlink\nfile'
+assert_contains "mise bootstrap generations show 1" "dotfiles: ~/.zshrc: ~/.zshrc missing -> a symlink to"
 tree="$(mise bootstrap generations --json | jq -r '.[0].snapshot.after.roots[0].tree')"
 assert_contains "git --git-dir='$shadow' ls-tree -r --name-only '$tree'" "dotfiles/zshrc"
 assert_contains "git --git-dir='$shadow' ls-tree -r --name-only '$tree'" "config.toml"
@@ -74,8 +77,8 @@ assert "mise bootstrap generations show latest~1 --json | jq -r .id" "1"
 assert_contains "mise bootstrap generations diff 1 2" "config/dotfiles/copied"
 assert_contains "mise bootstrap generations diff 1 2 --patch" "+two"
 assert_contains "mise bootstrap generations diff 1 2 --root config/dotfiles/copied --patch" "-one"
-assert_contains "mise bootstrap generations diff 1 2 2>&1" "dotfiles: applied ~/.copied"
-assert_not_contains "mise bootstrap generations diff 1 2 --no-journal 2>&1" "dotfiles: applied"
+assert_contains "mise bootstrap generations diff 1 2 2>&1" "dotfiles: ~/.copied: ~/.copied a file (4 bytes) -> a file"
+assert_not_contains "mise bootstrap generations diff 1 2 --no-journal 2>&1" "dotfiles: ~/.copied"
 assert_contains "mise bootstrap generations diff 2 2>&1" "no differences"
 assert_fail "mise bootstrap generations diff 1 2 --exit-code"
 assert_succeed "mise bootstrap generations diff 2 --exit-code"
@@ -148,6 +151,38 @@ assert "git -C '$MISE_CONFIG_DIR' rev-parse HEAD" "$head"
 assert "git -C '$MISE_CONFIG_DIR' status --porcelain" " M dotfiles/copied"
 assert "mise bootstrap generations --json | jq -r '.[0].snapshot.after.roots[0].vcs.head'" "$head"
 assert "mise bootstrap generations --json | jq -r '.[0].snapshot.after.roots[0].vcs.branch'" "main"
+
+# edits, unapply, and add journal the files they touch, with the prior content kept
+cat <<'EOF' >>"$MISE_CONFIG_DIR/config.toml"
+"~/.bashrc/activate" = { block = 'eval "$(mise activate bash)"' }
+EOF
+echo 'export PS1=x' >~/.bashrc
+assert_succeed "mise bootstrap dotfiles apply --yes"
+assert "mise bootstrap generations --json | jq -r '[.[0].journal[] | select(.kind == \"path_changed\") | .path] | join(\" \")'" "$HOME/.bashrc"
+assert "mise bootstrap generations --json | jq -r '.[0].journal[0].prior.state, .[0].journal[0].prior.content.size, .[0].journal[1].after.state'" $'file\n13\nfile'
+assert "mise bootstrap generations --json | jq -r '.[0].journal[0].prior.content.inline' | base64 -d" "export PS1=x"
+assert_contains "mise bootstrap generations show latest" "dotfiles: ~/.bashrc: ~/.bashrc a file (13 bytes) -> a file"
+
+assert_succeed "mise bootstrap dotfiles unapply --yes ~/.bashrc"
+assert "cat ~/.bashrc" "export PS1=x"
+assert "mise bootstrap generations --json | jq -r '.[0].journal[0].kind, .[0].journal[0].path, .[0].journal[1].after.state'" $'path_changed\n'"$HOME/.bashrc"$'\nfile'
+
+echo 'real file' >~/.newrc
+assert_succeed "mise bootstrap dotfiles add --yes ~/.newrc"
+assert "readlink ~/.newrc" "$HOME/.dotfiles/.newrc"
+assert "mise bootstrap generations --json | jq -r '[.[0].journal[] | select(.kind == \"path_changed\") | .prior.state] | .[0:2] | join(\" \")'" "file missing"
+assert "mise bootstrap generations --json | jq -r '.[0].journal[0].prior.content.inline' | base64 -d" "real file"
+assert "mise bootstrap generations --json | jq -r '.[0].snapshot.after.roots[] | select(.label == \"dotfiles\") | .tree | length'" "40"
+
+# a symlink-each entry journals every link and its ownership state file
+mkdir -p "$MISE_CONFIG_DIR/dotfiles/bin"
+echo one >"$MISE_CONFIG_DIR/dotfiles/bin/one"
+cat <<'EOF' >>"$MISE_CONFIG_DIR/config.toml"
+"~/.local/mybin" = { source = "dotfiles/bin", mode = "symlink-each" }
+EOF
+assert_succeed "mise bootstrap dotfiles apply --yes"
+assert "readlink ~/.local/mybin/one" "$MISE_CONFIG_DIR/dotfiles/bin/one"
+assert "mise bootstrap generations --json | jq -r '[.[0].journal[] | select(.kind == \"path_changed\") | .path | select(endswith(\"/one\") or endswith(\".toml\") or endswith(\"/mybin\"))] | length'" "3"
 
 # mise's own state, cache, and data directories under a root are never captured
 mkdir -p ~/.local/other

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -1519,6 +1519,7 @@ impl Bootstrap {
             } else {
                 info!("bootstrap: dotfile edits");
                 let opts = system::edits::ApplyOpts {
+                    part: "dotfiles",
                     dry_run: self.dry_run,
                     verbose: false,
                     yes: self.yes,

--- a/src/cli/bootstrap/generations.rs
+++ b/src/cli/bootstrap/generations.rs
@@ -2,6 +2,7 @@ use eyre::{Result, bail};
 
 use crate::dirs;
 use crate::file::display_path;
+use crate::system::generations::journal;
 use crate::system::generations::shadow::{DiffOpts, ShadowRepo};
 use crate::system::generations::store::{self, Generation, GenerationStatus, Snapshot};
 use crate::ui::table::MiseTable;
@@ -274,8 +275,8 @@ impl BootstrapGenerationsShow {
         if !g.journal.is_empty() {
             miseprintln!("");
             miseprintln!("Journal:");
-            for entry in &g.journal {
-                miseprintln!("  - {}", entry.describe());
+            for line in journal::render(&g.journal) {
+                miseprintln!("  - {line}");
             }
         }
 
@@ -382,8 +383,8 @@ impl BootstrapGenerationsDiff {
         if !self.no_journal {
             for generation in covered.iter().filter(|g| !g.journal.is_empty()) {
                 miseprintln!("Journal (generation {}):", generation.id);
-                for entry in &generation.journal {
-                    miseprintln!("  - {}", entry.describe());
+                for line in journal::render(&generation.journal) {
+                    miseprintln!("  - {line}");
                 }
             }
         }

--- a/src/cli/dotfiles/add.rs
+++ b/src/cli/dotfiles/add.rs
@@ -290,7 +290,7 @@ impl DotfilesAdd {
                             "dotfiles",
                             &item.target_raw,
                             [item.target.clone(), item.source.clone()],
-                        );
+                        )?;
                         remove_path(&item.source)?;
                         if let Some(parent) = item.source.parent() {
                             file::create_dir_all(parent)?;

--- a/src/cli/dotfiles/add.rs
+++ b/src/cli/dotfiles/add.rs
@@ -13,6 +13,7 @@ use crate::path::PathExt;
 use crate::system;
 use crate::system::files::{FileManifest, FileMode, FileRequest};
 use crate::system::generations::GenerationScope;
+use crate::system::generations::journal;
 use crate::ui::prompt;
 
 /// Add or update dotfiles in `[dotfiles]`
@@ -285,6 +286,11 @@ impl DotfilesAdd {
                     let move_before_apply = item.mode == FileMode::Symlink
                         || (item.mode == FileMode::SymlinkEach && item.already_managed.is_none());
                     if !self.no_apply && move_before_apply && !item.target.is_symlink() {
+                        let pending = journal::begin_changes(
+                            "dotfiles",
+                            &item.target_raw,
+                            [item.target.clone(), item.source.clone()],
+                        );
                         remove_path(&item.source)?;
                         if let Some(parent) = item.source.parent() {
                             file::create_dir_all(parent)?;
@@ -326,6 +332,7 @@ impl DotfilesAdd {
                                 item.source.display_user()
                             ),
                         }
+                        journal::commit_changes(pending);
                         info!(
                             "dotfiles: moved {} to {}",
                             item.target.display_user(),

--- a/src/cli/dotfiles/apply.rs
+++ b/src/cli/dotfiles/apply.rs
@@ -78,6 +78,7 @@ impl DotfilesApply {
         }
         if !edits.is_empty() {
             let opts = system::edits::ApplyOpts {
+                part: "dotfiles",
                 dry_run: self.dry_run,
                 verbose: Settings::get().verbose,
                 yes: self.yes,

--- a/src/cli/dotfiles/edit.rs
+++ b/src/cli/dotfiles/edit.rs
@@ -185,6 +185,7 @@ async fn apply_target(target: &str) -> Result<()> {
     }
     if !edits.is_empty() {
         let opts = system::edits::ApplyOpts {
+            part: "dotfiles",
             dry_run: false,
             verbose: false,
             yes: true,

--- a/src/cli/system/install.rs
+++ b/src/cli/system/install.rs
@@ -223,6 +223,7 @@ pub(crate) fn apply_shell_activation(
         .map(|request| request.edit)
         .collect::<Vec<_>>();
     let opts = system::edits::ApplyOpts {
+        part: "mise-shell-activate",
         dry_run,
         verbose: Settings::get().verbose,
         yes,

--- a/src/system/edits.rs
+++ b/src/system/edits.rs
@@ -34,6 +34,7 @@ use crate::config::{Config, ConfigMap};
 use crate::file;
 use crate::path::PathExt;
 use crate::system::files::FileState;
+use crate::system::generations::journal;
 use crate::system::resources::ResourceOrigin;
 use crate::ui::prompt;
 
@@ -560,6 +561,8 @@ pub(crate) struct ApplyOpts {
     pub dry_run: bool,
     pub verbose: bool,
     pub yes: bool,
+    /// bootstrap part these edits belong to, for the generation journal
+    pub part: &'static str,
 }
 
 /// Apply all edits that aren't already in the desired state. Edits never
@@ -685,14 +688,15 @@ pub(crate) fn apply(config: &Config, requests: &[EditRequest], opts: &ApplyOpts)
         }
     }
     for (req, desired) in &todo {
+        let pending = journal::begin_changes(opts.part, &req.path_raw, [req.path.clone()]);
         apply_one(req, desired.as_deref())?;
+        journal::commit_changes(pending);
     }
     let applied = todo
         .iter()
         .map(|(r, _)| format!("{} ({})", r.path_raw, r.describe_op()))
         .collect::<Vec<_>>()
         .join(", ");
-    crate::system::generations::journal::note(format!("edits: applied {applied}"));
     info!("edits: applied {applied}");
     Ok(true)
 }
@@ -971,7 +975,10 @@ pub(crate) fn execute_unapply(todo: &[UnapplyPlan<'_>], opts: &UnapplyOpts) -> R
         }
     }
     for plan in todo {
+        let pending =
+            journal::begin_changes("dotfiles", &plan.req.path_raw, [plan.req.path.clone()]);
         unapply_one(plan.req)?;
+        journal::commit_changes(pending);
     }
     crate::system::generations::journal::note(format!(
         "edits: unapplied {}",

--- a/src/system/edits.rs
+++ b/src/system/edits.rs
@@ -34,7 +34,7 @@ use crate::config::{Config, ConfigMap};
 use crate::file;
 use crate::path::PathExt;
 use crate::system::files::FileState;
-use crate::system::generations::journal;
+use crate::system::generations::journal::{self, Capture};
 use crate::system::resources::ResourceOrigin;
 use crate::ui::prompt;
 
@@ -688,7 +688,7 @@ pub(crate) fn apply(config: &Config, requests: &[EditRequest], opts: &ApplyOpts)
         }
     }
     for (req, desired) in &todo {
-        let pending = journal::begin_changes(opts.part, &req.path_raw, [req.path.clone()]);
+        let pending = journal::begin_changes_with(opts.part, &req.path_raw, edit_paths(&req.path))?;
         apply_one(req, desired.as_deref())?;
         journal::commit_changes(pending);
     }
@@ -976,7 +976,7 @@ pub(crate) fn execute_unapply(todo: &[UnapplyPlan<'_>], opts: &UnapplyOpts) -> R
     }
     for plan in todo {
         let pending =
-            journal::begin_changes("dotfiles", &plan.req.path_raw, [plan.req.path.clone()]);
+            journal::begin_changes("dotfiles", &plan.req.path_raw, [plan.req.path.clone()])?;
         unapply_one(plan.req)?;
         journal::commit_changes(pending);
     }
@@ -1066,6 +1066,17 @@ pub(crate) fn apply_dry_run_to_string(
     }
     let desired = desired_content(config, req)?;
     apply_to_string(req, desired.as_deref(), text).map(Some)
+}
+
+/// The paths an edit may create or change: the file itself, captured whole,
+/// preceded by any ancestors `apply_one` will have to create.
+fn edit_paths(path: &Path) -> Vec<(PathBuf, Capture)> {
+    let mut paths: Vec<(PathBuf, Capture)> = crate::system::files::missing_ancestors(path)
+        .into_iter()
+        .map(|dir| (dir, Capture::Shallow))
+        .collect();
+    paths.push((path.to_path_buf(), Capture::Full));
+    paths
 }
 
 fn apply_one(req: &EditRequest, desired: Option<&str>) -> Result<()> {

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -35,7 +35,7 @@ use crate::dirs;
 use crate::file;
 use crate::hash::hash_to_str;
 use crate::path::PathExt;
-use crate::system::generations::journal;
+use crate::system::generations::journal::{self, Capture};
 use crate::system::resources::ResourceOrigin;
 use crate::ui::prompt;
 
@@ -1584,7 +1584,13 @@ pub(crate) fn execute_apply(plan: ApplyPlan<'_>, opts: &ApplyOpts) -> Result<boo
     if plan.todo.is_empty() && !has_reconciliation {
         if !opts.dry_run {
             for req in plan.record_symlink_each {
+                let pending = journal::begin_changes(
+                    DOTFILES_PART,
+                    &req.target_raw,
+                    [symlink_each_state_path(req)],
+                )?;
                 save_symlink_each_state(req);
+                journal::commit_changes(pending);
             }
         }
         info!("files: all files are applied");
@@ -1628,13 +1634,28 @@ pub(crate) fn execute_apply(plan: ApplyPlan<'_>, opts: &ApplyOpts) -> Result<boo
     for link in &plan.reconciliation.stale_links {
         if link_points_to(&link.source, &link.target) {
             let item = link.target.display_user().to_string();
-            let pending = journal::begin_changes(DOTFILES_PART, &item, [link.target.clone()]);
+            // parents up to the entry target may be pruned once empty
+            let root = plan
+                .reconciliation
+                .targets
+                .iter()
+                .find(|target| link.target.starts_with(target));
+            let mut paths = vec![(link.target.clone(), Capture::Full)];
+            if let Some(root) = root {
+                paths.extend(
+                    dirs_between(&link.target, root)
+                        .into_iter()
+                        .map(|dir| (dir, Capture::Shallow)),
+                );
+            }
+            let pending = journal::begin_changes_with(DOTFILES_PART, &item, paths)?;
             file::remove_file(&link.target)?;
             journal::commit_changes(pending);
         }
     }
     for (req, rendered) in &plan.todo {
-        let pending = journal::begin_changes(DOTFILES_PART, &req.target_raw, touched_paths(req)?);
+        let pending =
+            journal::begin_changes_with(DOTFILES_PART, &req.target_raw, touched_paths(req)?)?;
         apply_one(req, rendered.as_deref())?;
         if req.mode == FileMode::SymlinkEach {
             save_symlink_each_state(req);
@@ -1648,7 +1669,7 @@ pub(crate) fn execute_apply(plan: ApplyPlan<'_>, opts: &ApplyOpts) -> Result<boo
                 DOTFILES_PART,
                 &req.target_raw,
                 [symlink_each_state_path(req)],
-            );
+            )?;
             save_symlink_each_state(req);
             journal::commit_changes(pending);
         }
@@ -1958,26 +1979,32 @@ pub(crate) fn execute_unapply(plans: &[UnapplyPlan<'_>], opts: &UnapplyOpts) -> 
         }
     }
     for plan in todo {
-        let mut paths = plan.paths.clone();
+        let mut paths: Vec<(PathBuf, Capture)> = plan
+            .paths
+            .iter()
+            .map(|path| (path.clone(), Capture::Full))
+            .collect();
         if plan.clear_symlink_each_state {
-            paths.push(symlink_each_state_path(plan.req));
+            paths.push((symlink_each_state_path(plan.req), Capture::Full));
         }
         if plan.cleanup_empty_dirs {
-            paths.push(plan.req.target.clone());
+            // the upward walk removes directories that end up empty
+            for path in &plan.paths {
+                paths.extend(
+                    dirs_between(path, &plan.req.target)
+                        .into_iter()
+                        .map(|dir| (dir, Capture::Shallow)),
+                );
+            }
+            paths.push((plan.req.target.clone(), Capture::Shallow));
         }
-        let pending = journal::begin_changes(DOTFILES_PART, &plan.req.target_raw, paths);
+        let pending = journal::begin_changes_with(DOTFILES_PART, &plan.req.target_raw, paths)?;
         unapply_one(plan)?;
         if plan.clear_symlink_each_state {
             remove_symlink_each_state(plan.req)?;
         }
         journal::commit_changes(pending);
     }
-    crate::system::generations::journal::note(format!(
-        "dotfiles: unapplied {}",
-        todo.iter()
-            .map(|plan| plan.req.target_raw.clone())
-            .join(", ")
-    ));
     info!(
         "files: unapplied {}",
         todo.iter()
@@ -2539,43 +2566,76 @@ pub(crate) fn print_diffs(config: &Config, requests: &[FileRequest]) -> Result<(
 
 const DOTFILES_PART: &str = "dotfiles";
 
-/// Every path `apply_one` may create, replace, or remove for `req`, so the
-/// journal can capture their prior state first.
-fn touched_paths(req: &FileRequest) -> Result<Vec<PathBuf>> {
-    let mut paths: IndexMap<PathBuf, ()> = IndexMap::new();
+/// Every path `apply_one` may create, replace, or remove for `req`, with how
+/// deeply to capture it first: a path that gets replaced is captured whole,
+/// a directory that stays a directory only by existence.
+fn touched_paths(req: &FileRequest) -> Result<Vec<(PathBuf, Capture)>> {
+    let mut paths: IndexMap<PathBuf, Capture> = IndexMap::new();
     for dir in missing_ancestors(&req.target) {
-        paths.insert(dir, ());
+        paths.insert(dir, Capture::Shallow);
     }
+    // a directory that will keep being a directory is never walked; a file
+    // or link in the way of one is replaced and captured whole
+    let dir_capture = |dir: &Path| {
+        if dir.is_dir() {
+            Capture::Shallow
+        } else {
+            Capture::Full
+        }
+    };
     match req.mode {
         FileMode::Symlink | FileMode::Template | FileMode::Content => {
-            paths.insert(req.target.clone(), ());
+            paths.insert(req.target.clone(), Capture::Full);
         }
         FileMode::Copy => {
-            paths.insert(req.target.clone(), ());
             if req.source.is_dir() {
+                paths.insert(req.target.clone(), dir_capture(&req.target));
                 for (_, target) in walk_source_files(req)? {
-                    paths.insert(target, ());
+                    // intermediate directories the copy creates on the way
+                    // down; an existing one keeps being a directory
+                    for dir in missing_ancestors(&target) {
+                        paths.entry(dir).or_insert(Capture::Shallow);
+                    }
+                    paths.insert(target, Capture::Full);
                 }
+            } else {
+                paths.insert(req.target.clone(), Capture::Full);
             }
         }
         FileMode::SymlinkEach => {
             for dir in needed_dirs(req)? {
-                paths.insert(dir, ());
+                let capture = dir_capture(&dir);
+                paths.insert(dir, capture);
             }
             for (_, target) in walk_source_files(req)? {
-                paths.insert(target, ());
+                paths.insert(target, Capture::Full);
             }
             for stale in stale_links(req)? {
-                paths.insert(stale, ());
+                paths.insert(stale, Capture::Full);
             }
-            paths.insert(symlink_each_state_path(req), ());
+            paths.insert(symlink_each_state_path(req), Capture::Full);
         }
     }
-    Ok(paths.into_keys().collect())
+    Ok(paths.into_iter().collect())
+}
+
+/// Directories strictly between `path` and `root`, deepest first: the ones an
+/// upward cleanup may remove once they are empty.
+fn dirs_between(path: &Path, root: &Path) -> Vec<PathBuf> {
+    let mut dirs = vec![];
+    let mut dir = path.parent();
+    while let Some(d) = dir {
+        if d == root || !d.starts_with(root) {
+            break;
+        }
+        dirs.push(d.to_path_buf());
+        dir = d.parent();
+    }
+    dirs
 }
 
 /// Ancestors of `path` that do not exist yet, outermost first.
-fn missing_ancestors(path: &Path) -> Vec<PathBuf> {
+pub(crate) fn missing_ancestors(path: &Path) -> Vec<PathBuf> {
     let mut missing = vec![];
     let mut dir = path.parent();
     while let Some(d) = dir {

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -35,6 +35,7 @@ use crate::dirs;
 use crate::file;
 use crate::hash::hash_to_str;
 use crate::path::PathExt;
+use crate::system::generations::journal;
 use crate::system::resources::ResourceOrigin;
 use crate::ui::prompt;
 
@@ -1626,36 +1627,33 @@ pub(crate) fn execute_apply(plan: ApplyPlan<'_>, opts: &ApplyOpts) -> Result<boo
     }
     for link in &plan.reconciliation.stale_links {
         if link_points_to(&link.source, &link.target) {
+            let item = link.target.display_user().to_string();
+            let pending = journal::begin_changes(DOTFILES_PART, &item, [link.target.clone()]);
             file::remove_file(&link.target)?;
+            journal::commit_changes(pending);
         }
     }
     for (req, rendered) in &plan.todo {
+        let pending = journal::begin_changes(DOTFILES_PART, &req.target_raw, touched_paths(req)?);
         apply_one(req, rendered.as_deref())?;
         if req.mode == FileMode::SymlinkEach {
             save_symlink_each_state(req);
         }
+        journal::commit_changes(pending);
         info!("files: {}", describe_applied(req)?);
     }
     for req in plan.record_symlink_each {
         if !plan.todo.iter().any(|(todo, _)| std::ptr::eq(*todo, req)) {
+            let pending = journal::begin_changes(
+                DOTFILES_PART,
+                &req.target_raw,
+                [symlink_each_state_path(req)],
+            );
             save_symlink_each_state(req);
+            journal::commit_changes(pending);
         }
     }
     cleanup_reconciled_directories(&plan.reconciliation)?;
-    crate::system::generations::journal::note(format!(
-        "dotfiles: applied {}",
-        plan.todo
-            .iter()
-            .map(|(r, _)| r.target_raw.clone())
-            .chain(
-                plan.reconciliation
-                    .stale_links
-                    .iter()
-                    .map(|link| format!("removed {}", link.target.display_user()))
-            )
-            .collect::<Vec<_>>()
-            .join(", ")
-    ));
     let applied = plan
         .todo
         .iter()
@@ -1960,10 +1958,19 @@ pub(crate) fn execute_unapply(plans: &[UnapplyPlan<'_>], opts: &UnapplyOpts) -> 
         }
     }
     for plan in todo {
+        let mut paths = plan.paths.clone();
+        if plan.clear_symlink_each_state {
+            paths.push(symlink_each_state_path(plan.req));
+        }
+        if plan.cleanup_empty_dirs {
+            paths.push(plan.req.target.clone());
+        }
+        let pending = journal::begin_changes(DOTFILES_PART, &plan.req.target_raw, paths);
         unapply_one(plan)?;
         if plan.clear_symlink_each_state {
             remove_symlink_each_state(plan.req)?;
         }
+        journal::commit_changes(pending);
     }
     crate::system::generations::journal::note(format!(
         "dotfiles: unapplied {}",
@@ -2528,6 +2535,58 @@ pub(crate) fn print_diffs(config: &Config, requests: &[FileRequest]) -> Result<(
         info!("files: all files are applied");
     }
     Ok(())
+}
+
+const DOTFILES_PART: &str = "dotfiles";
+
+/// Every path `apply_one` may create, replace, or remove for `req`, so the
+/// journal can capture their prior state first.
+fn touched_paths(req: &FileRequest) -> Result<Vec<PathBuf>> {
+    let mut paths: IndexMap<PathBuf, ()> = IndexMap::new();
+    for dir in missing_ancestors(&req.target) {
+        paths.insert(dir, ());
+    }
+    match req.mode {
+        FileMode::Symlink | FileMode::Template | FileMode::Content => {
+            paths.insert(req.target.clone(), ());
+        }
+        FileMode::Copy => {
+            paths.insert(req.target.clone(), ());
+            if req.source.is_dir() {
+                for (_, target) in walk_source_files(req)? {
+                    paths.insert(target, ());
+                }
+            }
+        }
+        FileMode::SymlinkEach => {
+            for dir in needed_dirs(req)? {
+                paths.insert(dir, ());
+            }
+            for (_, target) in walk_source_files(req)? {
+                paths.insert(target, ());
+            }
+            for stale in stale_links(req)? {
+                paths.insert(stale, ());
+            }
+            paths.insert(symlink_each_state_path(req), ());
+        }
+    }
+    Ok(paths.into_keys().collect())
+}
+
+/// Ancestors of `path` that do not exist yet, outermost first.
+fn missing_ancestors(path: &Path) -> Vec<PathBuf> {
+    let mut missing = vec![];
+    let mut dir = path.parent();
+    while let Some(d) = dir {
+        if d.exists() || d.as_os_str().is_empty() {
+            break;
+        }
+        missing.push(d.to_path_buf());
+        dir = d.parent();
+    }
+    missing.reverse();
+    missing
 }
 
 fn apply_one(req: &FileRequest, rendered: Option<&str>) -> Result<()> {

--- a/src/system/generations/journal.rs
+++ b/src/system/generations/journal.rs
@@ -162,11 +162,20 @@ pub(crate) enum PathSnapshot {
     Symlink {
         dest: PathBuf,
     },
-    /// A directory replaced wholesale (`--force`). Empty subdirectories are
-    /// not preserved.
+    /// A directory that is about to be replaced wholesale (`--force`),
+    /// captured with its whole contents.
     Dir {
         files: Vec<DirFileSnapshot>,
         links: Vec<DirLinkSnapshot>,
+        /// every subdirectory, empty ones included, with its mode
+        #[serde(default)]
+        dirs: Vec<DirDirSnapshot>,
+        mode: u32,
+    },
+    /// A directory that stays a directory (something inside it changes, or
+    /// it may be pruned once empty), so only its existence and mode are
+    /// captured, never its contents.
+    Directory {
         mode: u32,
     },
     /// Existed but could not be captured.
@@ -189,10 +198,25 @@ pub(crate) struct DirLinkSnapshot {
     pub dest: PathBuf,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct DirDirSnapshot {
+    pub rel: PathBuf,
+    pub mode: u32,
+}
+
+/// How much of a path to capture before it is touched.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Capture {
+    /// Everything, including a directory's contents: the path is replaced.
+    Full,
+    /// A directory only by existence and mode: it stays a directory.
+    Shallow,
+}
+
 impl PathSnapshot {
     /// Captures `path` without following symlinks. Never fails: anything
     /// that cannot be read becomes `Unrecorded` with the reason.
-    pub(crate) fn capture_in(state_dir: &Path, path: &Path) -> Self {
+    pub(crate) fn capture_with(state_dir: &Path, path: &Path, capture: Capture) -> Self {
         let metadata = match std::fs::symlink_metadata(path) {
             Ok(metadata) => metadata,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Self::Missing,
@@ -226,10 +250,16 @@ impl PathSnapshot {
             };
         }
         if file_type.is_dir() {
+            if capture == Capture::Shallow {
+                return Self::Directory {
+                    mode: mode_of(&metadata),
+                };
+            }
             return match capture_dir(state_dir, path) {
-                Ok((files, links)) => Self::Dir {
+                Ok((files, links, dirs)) => Self::Dir {
                     files,
                     links,
+                    dirs,
                     mode: mode_of(&metadata),
                 },
                 Err(reason) => Self::Unrecorded {
@@ -252,6 +282,7 @@ impl PathSnapshot {
             Self::Dir { files, links, .. } => {
                 format!("a directory ({} files, {} links)", files.len(), links.len())
             }
+            Self::Directory { .. } => "a directory".into(),
             Self::Unrecorded { kind, reason } => format!("{kind} (not captured: {reason})"),
         }
     }
@@ -269,11 +300,16 @@ fn capture_file(state_dir: &Path, path: &Path, size: u64) -> std::result::Result
     Blob::store_in(state_dir, &bytes).map_err(|err| format!("{err:#}"))
 }
 
-type DirCapture = (Vec<DirFileSnapshot>, Vec<DirLinkSnapshot>);
+type DirCapture = (
+    Vec<DirFileSnapshot>,
+    Vec<DirLinkSnapshot>,
+    Vec<DirDirSnapshot>,
+);
 
 fn capture_dir(state_dir: &Path, dir: &Path) -> std::result::Result<DirCapture, String> {
     let mut files = vec![];
     let mut links = vec![];
+    let mut dirs = vec![];
     let mut total = 0u64;
     for entry in walkdir::WalkDir::new(dir).follow_links(false) {
         let entry = entry.map_err(|err| err.to_string())?;
@@ -301,11 +337,17 @@ fn capture_dir(state_dir: &Path, dir: &Path) -> std::result::Result<DirCapture, 
                 content,
                 mode: mode_of(&metadata),
             });
-        } else if !file_type.is_dir() {
+        } else if file_type.is_dir() {
+            let metadata = entry.metadata().map_err(|err| err.to_string())?;
+            dirs.push(DirDirSnapshot {
+                rel,
+                mode: mode_of(&metadata),
+            });
+        } else {
             return Err(format!("{} is a special file", display_path(entry.path())));
         }
     }
-    Ok((files, links))
+    Ok((files, links, dirs))
 }
 
 /// Identity of a path after a mutation, enough to tell later whether it
@@ -314,10 +356,20 @@ fn capture_dir(state_dir: &Path, dir: &Path) -> std::result::Result<DirCapture, 
 #[serde(tag = "state", rename_all = "snake_case")]
 pub(crate) enum PathState {
     Missing,
-    File { sha256: String, mode: u32 },
-    Symlink { dest: PathBuf },
-    Dir,
-    Other { kind: String },
+    File {
+        sha256: String,
+        mode: u32,
+    },
+    Symlink {
+        dest: PathBuf,
+    },
+    /// with how many entries it holds, so additions since are detectable
+    Dir {
+        entries: u64,
+    },
+    Other {
+        kind: String,
+    },
 }
 
 impl PathState {
@@ -326,7 +378,12 @@ impl PathState {
 
         let metadata = match std::fs::symlink_metadata(path) {
             Ok(metadata) => metadata,
-            Err(_) => return Self::Missing,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Self::Missing,
+            Err(err) => {
+                return Self::Other {
+                    kind: format!("unreadable: {err}"),
+                };
+            }
         };
         let file_type = metadata.file_type();
         if file_type.is_symlink() {
@@ -349,7 +406,14 @@ impl PathState {
             };
         }
         if file_type.is_dir() {
-            return Self::Dir;
+            return match std::fs::read_dir(path) {
+                Ok(entries) => Self::Dir {
+                    entries: entries.count() as u64,
+                },
+                Err(err) => Self::Other {
+                    kind: format!("unreadable directory: {err}"),
+                },
+            };
         }
         Self::Other {
             kind: "special file".into(),
@@ -359,9 +423,11 @@ impl PathState {
     pub(crate) fn describe(&self) -> String {
         match self {
             Self::Missing => "missing".into(),
-            Self::File { sha256, .. } => format!("a file ({})", &sha256[..7]),
+            Self::File { sha256, .. } => {
+                format!("a file ({})", sha256.get(..7).unwrap_or(sha256))
+            }
             Self::Symlink { dest } => format!("a symlink to {}", display_path(dest)),
-            Self::Dir => "a directory".into(),
+            Self::Dir { entries } => format!("a directory ({entries} entries)"),
             Self::Other { kind } => kind.clone(),
         }
     }
@@ -392,42 +458,72 @@ pub(crate) fn begin_changes(
     part: &str,
     item: &str,
     paths: impl IntoIterator<Item = PathBuf>,
-) -> Vec<PendingChange> {
+) -> Result<Vec<PendingChange>> {
+    begin_changes_with(
+        part,
+        item,
+        paths.into_iter().map(|path| (path, Capture::Full)),
+    )
+}
+
+/// [`begin_changes`] with a capture depth per path. Fails when an entry
+/// cannot be persisted: the mutation must not go ahead without its
+/// write-ahead record.
+pub(crate) fn begin_changes_with(
+    part: &str,
+    item: &str,
+    paths: impl IntoIterator<Item = (PathBuf, Capture)>,
+) -> Result<Vec<PendingChange>> {
     if !super::scope::is_active() {
-        return vec![];
+        return Ok(vec![]);
     }
     let mut pending = vec![];
-    for path in paths {
-        let prior = PathSnapshot::capture_in(&dirs::STATE, &path);
+    for (path, capture) in paths {
+        let prior = PathSnapshot::capture_with(&dirs::STATE, &path, capture);
         if let Some(seq) = super::scope::record(JournalEntry::PathChanged {
             part: part.to_string(),
             item: item.to_string(),
             path: path.clone(),
             prior,
-        }) {
+        })? {
             pending.push(PendingChange { seq, path });
         }
     }
-    pending
+    Ok(pending)
 }
 
 /// Records the resulting state of each pending change.
 pub(crate) fn commit_changes(pending: Vec<PendingChange>) {
     for change in pending {
-        super::scope::record(JournalEntry::Committed {
+        // the mutation already happened; a missing `committed` is handled by
+        // inspecting the path later, so this is a warning
+        if let Err(err) = super::scope::record(JournalEntry::Committed {
             seq: change.seq,
             after: PathState::observe(&change.path),
-        });
+        }) {
+            warn!("bootstrap generations: {err:#}");
+        }
+    }
+}
+
+/// Records a free-form note on the open generation.
+pub(crate) fn note(message: impl Into<String>) {
+    if let Err(err) = super::scope::record(JournalEntry::Note {
+        message: message.into(),
+    }) {
+        warn!("bootstrap generations: {err:#}");
     }
 }
 
 /// Records that `part` changed `item` in a way rollback cannot undo.
 pub(crate) fn unrecorded(part: &str, item: impl Into<String>, reason: impl Into<String>) {
-    super::scope::record(JournalEntry::Unrecorded {
+    if let Err(err) = super::scope::record(JournalEntry::Unrecorded {
         part: part.to_string(),
         item: item.into(),
         reason: reason.into(),
-    });
+    }) {
+        warn!("bootstrap generations: {err:#}");
+    }
 }
 
 #[cfg(test)]
@@ -457,10 +553,10 @@ mod tests {
         let file = tmp.path().join("file");
         std::fs::write(&file, "content").unwrap();
         assert!(matches!(
-            PathSnapshot::capture_in(&state, &tmp.path().join("nope")),
+            PathSnapshot::capture_with(&state, &tmp.path().join("nope"), Capture::Full),
             PathSnapshot::Missing
         ));
-        match PathSnapshot::capture_in(&state, &file) {
+        match PathSnapshot::capture_with(&state, &file, Capture::Full) {
             PathSnapshot::File { content, .. } => assert_eq!(content.size, 7),
             other => panic!("{other:?}"),
         }
@@ -469,32 +565,40 @@ mod tests {
             let link = tmp.path().join("link");
             std::os::unix::fs::symlink("file", &link).unwrap();
             assert!(matches!(
-                PathSnapshot::capture_in(&state, &link),
+                PathSnapshot::capture_with(&state, &link, Capture::Full),
                 PathSnapshot::Symlink { dest } if dest == Path::new("file")
             ));
             nix::unistd::mkfifo(&tmp.path().join("fifo"), nix::sys::stat::Mode::S_IRWXU).unwrap();
             assert!(matches!(
-                PathSnapshot::capture_in(&state, &tmp.path().join("fifo")),
+                PathSnapshot::capture_with(&state, &tmp.path().join("fifo"), Capture::Full),
                 PathSnapshot::Unrecorded { .. }
             ));
         }
         let dir = tmp.path().join("dir/nested");
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("a"), "a").unwrap();
-        match PathSnapshot::capture_in(&state, &tmp.path().join("dir")) {
-            PathSnapshot::Dir { files, .. } => {
+        std::fs::create_dir_all(tmp.path().join("dir/empty")).unwrap();
+        match PathSnapshot::capture_with(&state, &tmp.path().join("dir"), Capture::Full) {
+            PathSnapshot::Dir { files, dirs, .. } => {
                 assert_eq!(files.len(), 1);
                 assert_eq!(files[0].rel, Path::new("nested/a"));
+                let mut names: Vec<_> = dirs.iter().map(|d| d.rel.clone()).collect();
+                names.sort();
+                assert_eq!(names, vec![PathBuf::from("empty"), PathBuf::from("nested")]);
             }
             other => panic!("{other:?}"),
         }
+        assert!(matches!(
+            PathSnapshot::capture_with(&state, &tmp.path().join("dir"), Capture::Shallow),
+            PathSnapshot::Directory { .. }
+        ));
         let large = tmp.path().join("large");
         std::fs::File::create(&large)
             .unwrap()
             .set_len(BLOB_MAX + 1)
             .unwrap();
         assert!(matches!(
-            PathSnapshot::capture_in(&state, &large),
+            PathSnapshot::capture_with(&state, &large, Capture::Full),
             PathSnapshot::Unrecorded { kind, .. } if kind == "file"
         ));
     }
@@ -510,7 +614,15 @@ mod tests {
         assert_ne!(PathState::observe(&file), first);
         std::fs::write(&file, "one").unwrap();
         assert_eq!(PathState::observe(&file), first);
-        assert_eq!(PathState::observe(tmp.path()), PathState::Dir);
+        assert!(matches!(
+            PathState::observe(tmp.path()),
+            PathState::Dir { entries: 1 }
+        ));
+        std::fs::write(tmp.path().join("second"), "").unwrap();
+        assert!(matches!(
+            PathState::observe(tmp.path()),
+            PathState::Dir { entries: 2 }
+        ));
     }
 
     #[test]
@@ -536,9 +648,14 @@ mod tests {
         assert_eq!(lines.len(), 2);
         assert!(lines[0].contains("missing -> a symlink to"), "{}", lines[0]);
         assert_eq!(lines[1], "hi");
-        let entry: JournalEntry =
-            serde_json::from_str(r#"{"kind":"committed","seq":3,"after":{"state":"dir"}}"#)
-                .unwrap();
+        let entry: JournalEntry = serde_json::from_str(
+            r#"{"kind":"committed","seq":3,"after":{"state":"dir","entries":2}}"#,
+        )
+        .unwrap();
         assert!(matches!(entry, JournalEntry::Committed { seq: 3, .. }));
+        // a record without `dirs` (written before they were captured) still loads
+        let old: PathSnapshot =
+            serde_json::from_str(r#"{"state":"dir","files":[],"links":[],"mode":493}"#).unwrap();
+        assert!(matches!(old, PathSnapshot::Dir { .. }));
     }
 }

--- a/src/system/generations/journal.rs
+++ b/src/system/generations/journal.rs
@@ -1,11 +1,29 @@
-//! The per-generation journal: what a bootstrap run changed.
+//! The per-generation journal: what a bootstrap run changed, recorded
+//! before each mutation so a later rollback can invert it.
 //!
-//! Entries are appended to the active generation as the run proceeds and
-//! are the input a later rollback inverts. This version records only what
-//! cannot be inverted (`Unrecorded`) and free-form notes; the reversible
-//! entry kinds land with the parts that produce them.
+//! The journal is write-ahead. For every path an apply is about to touch,
+//! [`begin_changes`] captures the path's prior state as a [`PathSnapshot`]
+//! and appends a `PathChanged` entry *before* the mutation; afterwards
+//! [`commit_changes`] appends a `Committed` entry carrying the path's
+//! resulting [`PathState`]. A `PathChanged` without a matching `Committed`
+//! means the run died mid-mutation and the path's real state must be
+//! inspected before anything is undone. Both entries are tiny except for
+//! the prior content, which lives in a content-addressed [`Blob`].
 
+use std::path::{Path, PathBuf};
+
+use eyre::Result;
 use serde::{Deserialize, Serialize};
+
+use crate::dirs;
+use crate::file::{self, display_path};
+
+/// Prior content at or below this size is embedded in the record itself.
+pub(crate) const BLOB_INLINE_MAX: u64 = 64 * 1024;
+/// Prior content above this size is not captured.
+pub(crate) const BLOB_MAX: u64 = 8 * 1024 * 1024;
+/// A replaced directory holding more than this is not captured.
+pub(crate) const DIR_SNAPSHOT_MAX: u64 = 256 * 1024 * 1024;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
@@ -18,6 +36,17 @@ pub(crate) enum JournalEntry {
         item: String,
         reason: String,
     },
+    /// Written before `path` is mutated on behalf of `item` (a dotfile
+    /// target, an edit key) in bootstrap part `part`.
+    PathChanged {
+        part: String,
+        item: String,
+        path: PathBuf,
+        prior: PathSnapshot,
+    },
+    /// The mutation recorded at index `seq` finished; `after` is what the
+    /// path looks like now.
+    Committed { seq: u32, after: PathState },
     /// Written by a newer mise than this one.
     #[serde(other)]
     Unknown,
@@ -31,16 +60,365 @@ impl JournalEntry {
             Self::Unrecorded { part, item, reason } => {
                 format!("{part}: {item} — not recorded ({reason})")
             }
+            Self::PathChanged {
+                part,
+                item,
+                path,
+                prior,
+            } => format!(
+                "{part}: {item}: {} was {}",
+                display_path(path),
+                prior.describe()
+            ),
+            Self::Committed { seq, after } => format!("#{seq} now {}", after.describe()),
             Self::Unknown => "recorded by a newer mise".to_string(),
         }
     }
 }
 
-/// Records a free-form note on the open generation.
-pub(crate) fn note(message: impl Into<String>) {
-    super::scope::record(JournalEntry::Note {
-        message: message.into(),
-    });
+/// Renders a journal for humans, folding each `Committed` into the
+/// `PathChanged` it completes: `dotfiles: ~/.zshrc: missing -> symlink`.
+pub(crate) fn render(entries: &[JournalEntry]) -> Vec<String> {
+    let mut lines: Vec<(u32, String)> = vec![];
+    for (index, entry) in entries.iter().enumerate() {
+        match entry {
+            JournalEntry::PathChanged {
+                part,
+                item,
+                path,
+                prior,
+            } => lines.push((
+                index as u32,
+                format!(
+                    "{part}: {item}: {} {} -> (not finished)",
+                    display_path(path),
+                    prior.describe()
+                ),
+            )),
+            JournalEntry::Committed { seq, after } => {
+                if let Some((_, line)) = lines.iter_mut().find(|(s, _)| s == seq) {
+                    *line = line.replace("-> (not finished)", &format!("-> {}", after.describe()));
+                }
+            }
+            other => lines.push((index as u32, other.describe())),
+        }
+    }
+    lines.into_iter().map(|(_, line)| line).collect()
+}
+
+/// Content-addressed bytes. Small content is inlined into the generation
+/// record; larger content is a file under `$MISE_STATE_DIR/bootstrap/blobs/`.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct Blob {
+    pub sha256: String,
+    pub size: u64,
+    /// base64 of the bytes when they fit [`BLOB_INLINE_MAX`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inline: Option<String>,
+}
+
+pub(crate) fn blobs_dir_in(state_dir: &Path) -> PathBuf {
+    super::store::store_dir_in(state_dir).join("blobs")
+}
+
+impl Blob {
+    pub(crate) fn store_in(state_dir: &Path, bytes: &[u8]) -> Result<Self> {
+        use base64::Engine;
+        use sha2::Digest;
+
+        let sha256 = hex::encode(sha2::Sha256::digest(bytes));
+        let size = bytes.len() as u64;
+        if size <= BLOB_INLINE_MAX {
+            return Ok(Self {
+                sha256,
+                size,
+                inline: Some(base64::engine::general_purpose::STANDARD.encode(bytes)),
+            });
+        }
+        let dir = blobs_dir_in(state_dir);
+        file::create_dir_all(&dir)?;
+        let path = dir.join(&sha256);
+        if !path.exists() {
+            file::write_atomic(&path, bytes)?;
+        }
+        Ok(Self {
+            sha256,
+            size,
+            inline: None,
+        })
+    }
+}
+
+/// What was at a path before a mutation, captured completely enough to
+/// put it back.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub(crate) enum PathSnapshot {
+    Missing,
+    File {
+        content: Blob,
+        mode: u32,
+    },
+    Symlink {
+        dest: PathBuf,
+    },
+    /// A directory replaced wholesale (`--force`). Empty subdirectories are
+    /// not preserved.
+    Dir {
+        files: Vec<DirFileSnapshot>,
+        links: Vec<DirLinkSnapshot>,
+        mode: u32,
+    },
+    /// Existed but could not be captured.
+    Unrecorded {
+        kind: String,
+        reason: String,
+    },
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct DirFileSnapshot {
+    pub rel: PathBuf,
+    pub content: Blob,
+    pub mode: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct DirLinkSnapshot {
+    pub rel: PathBuf,
+    pub dest: PathBuf,
+}
+
+impl PathSnapshot {
+    /// Captures `path` without following symlinks. Never fails: anything
+    /// that cannot be read becomes `Unrecorded` with the reason.
+    pub(crate) fn capture_in(state_dir: &Path, path: &Path) -> Self {
+        let metadata = match std::fs::symlink_metadata(path) {
+            Ok(metadata) => metadata,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Self::Missing,
+            Err(err) => {
+                return Self::Unrecorded {
+                    kind: "unknown".into(),
+                    reason: err.to_string(),
+                };
+            }
+        };
+        let file_type = metadata.file_type();
+        if file_type.is_symlink() {
+            return match std::fs::read_link(path) {
+                Ok(dest) => Self::Symlink { dest },
+                Err(err) => Self::Unrecorded {
+                    kind: "symlink".into(),
+                    reason: err.to_string(),
+                },
+            };
+        }
+        if file_type.is_file() {
+            return match capture_file(state_dir, path, metadata.len()) {
+                Ok(content) => Self::File {
+                    content,
+                    mode: mode_of(&metadata),
+                },
+                Err(reason) => Self::Unrecorded {
+                    kind: "file".into(),
+                    reason,
+                },
+            };
+        }
+        if file_type.is_dir() {
+            return match capture_dir(state_dir, path) {
+                Ok((files, links)) => Self::Dir {
+                    files,
+                    links,
+                    mode: mode_of(&metadata),
+                },
+                Err(reason) => Self::Unrecorded {
+                    kind: "directory".into(),
+                    reason,
+                },
+            };
+        }
+        Self::Unrecorded {
+            kind: "special file".into(),
+            reason: "not a regular file, symlink, or directory".into(),
+        }
+    }
+
+    pub(crate) fn describe(&self) -> String {
+        match self {
+            Self::Missing => "missing".into(),
+            Self::File { content, .. } => format!("a file ({} bytes)", content.size),
+            Self::Symlink { dest } => format!("a symlink to {}", display_path(dest)),
+            Self::Dir { files, links, .. } => {
+                format!("a directory ({} files, {} links)", files.len(), links.len())
+            }
+            Self::Unrecorded { kind, reason } => format!("{kind} (not captured: {reason})"),
+        }
+    }
+}
+
+fn capture_file(state_dir: &Path, path: &Path, size: u64) -> std::result::Result<Blob, String> {
+    if size > BLOB_MAX {
+        return Err(format!(
+            "{} bytes is over the {} MiB limit",
+            size,
+            BLOB_MAX / (1024 * 1024)
+        ));
+    }
+    let bytes = std::fs::read(path).map_err(|err| err.to_string())?;
+    Blob::store_in(state_dir, &bytes).map_err(|err| format!("{err:#}"))
+}
+
+type DirCapture = (Vec<DirFileSnapshot>, Vec<DirLinkSnapshot>);
+
+fn capture_dir(state_dir: &Path, dir: &Path) -> std::result::Result<DirCapture, String> {
+    let mut files = vec![];
+    let mut links = vec![];
+    let mut total = 0u64;
+    for entry in walkdir::WalkDir::new(dir).follow_links(false) {
+        let entry = entry.map_err(|err| err.to_string())?;
+        let rel = match entry.path().strip_prefix(dir) {
+            Ok(rel) if !rel.as_os_str().is_empty() => rel.to_path_buf(),
+            _ => continue,
+        };
+        let file_type = entry.file_type();
+        if file_type.is_symlink() {
+            let dest = std::fs::read_link(entry.path()).map_err(|err| err.to_string())?;
+            links.push(DirLinkSnapshot { rel, dest });
+        } else if file_type.is_file() {
+            let metadata = entry.metadata().map_err(|err| err.to_string())?;
+            total += metadata.len();
+            if total > DIR_SNAPSHOT_MAX {
+                return Err(format!(
+                    "more than {} MiB",
+                    DIR_SNAPSHOT_MAX / (1024 * 1024)
+                ));
+            }
+            let content = capture_file(state_dir, entry.path(), metadata.len())
+                .map_err(|reason| format!("{}: {reason}", display_path(entry.path())))?;
+            files.push(DirFileSnapshot {
+                rel,
+                content,
+                mode: mode_of(&metadata),
+            });
+        } else if !file_type.is_dir() {
+            return Err(format!("{} is a special file", display_path(entry.path())));
+        }
+    }
+    Ok((files, links))
+}
+
+/// Identity of a path after a mutation, enough to tell later whether it
+/// is still in the state the run left it in.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub(crate) enum PathState {
+    Missing,
+    File { sha256: String, mode: u32 },
+    Symlink { dest: PathBuf },
+    Dir,
+    Other { kind: String },
+}
+
+impl PathState {
+    pub(crate) fn observe(path: &Path) -> Self {
+        use sha2::Digest;
+
+        let metadata = match std::fs::symlink_metadata(path) {
+            Ok(metadata) => metadata,
+            Err(_) => return Self::Missing,
+        };
+        let file_type = metadata.file_type();
+        if file_type.is_symlink() {
+            return match std::fs::read_link(path) {
+                Ok(dest) => Self::Symlink { dest },
+                Err(err) => Self::Other {
+                    kind: format!("unreadable symlink: {err}"),
+                },
+            };
+        }
+        if file_type.is_file() {
+            return match std::fs::read(path) {
+                Ok(bytes) => Self::File {
+                    sha256: hex::encode(sha2::Sha256::digest(&bytes)),
+                    mode: mode_of(&metadata),
+                },
+                Err(err) => Self::Other {
+                    kind: format!("unreadable file: {err}"),
+                },
+            };
+        }
+        if file_type.is_dir() {
+            return Self::Dir;
+        }
+        Self::Other {
+            kind: "special file".into(),
+        }
+    }
+
+    pub(crate) fn describe(&self) -> String {
+        match self {
+            Self::Missing => "missing".into(),
+            Self::File { sha256, .. } => format!("a file ({})", &sha256[..7]),
+            Self::Symlink { dest } => format!("a symlink to {}", display_path(dest)),
+            Self::Dir => "a directory".into(),
+            Self::Other { kind } => kind.clone(),
+        }
+    }
+}
+
+#[cfg(unix)]
+fn mode_of(metadata: &std::fs::Metadata) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+    metadata.permissions().mode() & 0o7777
+}
+
+#[cfg(not(unix))]
+fn mode_of(_metadata: &std::fs::Metadata) -> u32 {
+    0
+}
+
+/// A `PathChanged` entry awaiting its `Committed`.
+#[derive(Debug)]
+pub(crate) struct PendingChange {
+    seq: u32,
+    path: PathBuf,
+}
+
+/// Captures every path's prior state and records a `PathChanged` for each,
+/// before the caller mutates them. Returns nothing when no generation is
+/// open, so inactive runs pay no capture cost.
+pub(crate) fn begin_changes(
+    part: &str,
+    item: &str,
+    paths: impl IntoIterator<Item = PathBuf>,
+) -> Vec<PendingChange> {
+    if !super::scope::is_active() {
+        return vec![];
+    }
+    let mut pending = vec![];
+    for path in paths {
+        let prior = PathSnapshot::capture_in(&dirs::STATE, &path);
+        if let Some(seq) = super::scope::record(JournalEntry::PathChanged {
+            part: part.to_string(),
+            item: item.to_string(),
+            path: path.clone(),
+            prior,
+        }) {
+            pending.push(PendingChange { seq, path });
+        }
+    }
+    pending
+}
+
+/// Records the resulting state of each pending change.
+pub(crate) fn commit_changes(pending: Vec<PendingChange>) {
+    for change in pending {
+        super::scope::record(JournalEntry::Committed {
+            seq: change.seq,
+            after: PathState::observe(&change.path),
+        });
+    }
 }
 
 /// Records that `part` changed `item` in a way rollback cannot undo.
@@ -50,4 +428,117 @@ pub(crate) fn unrecorded(part: &str, item: impl Into<String>, reason: impl Into<
         item: item.into(),
         reason: reason.into(),
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blobs_inline_small_and_store_large_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let small = Blob::store_in(tmp.path(), b"hello").unwrap();
+        assert_eq!(small.size, 5);
+        assert!(small.inline.is_some());
+        let big = vec![7u8; BLOB_INLINE_MAX as usize + 1];
+        let stored = Blob::store_in(tmp.path(), &big).unwrap();
+        assert!(stored.inline.is_none());
+        let on_disk = blobs_dir_in(tmp.path()).join(&stored.sha256);
+        assert_eq!(std::fs::read(&on_disk).unwrap(), big);
+        // content-addressed: storing again is a no-op with the same id
+        let again = Blob::store_in(tmp.path(), &big).unwrap();
+        assert_eq!(again, stored);
+    }
+
+    #[test]
+    fn snapshots_capture_each_kind_of_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = tmp.path().join("state");
+        let file = tmp.path().join("file");
+        std::fs::write(&file, "content").unwrap();
+        assert!(matches!(
+            PathSnapshot::capture_in(&state, &tmp.path().join("nope")),
+            PathSnapshot::Missing
+        ));
+        match PathSnapshot::capture_in(&state, &file) {
+            PathSnapshot::File { content, .. } => assert_eq!(content.size, 7),
+            other => panic!("{other:?}"),
+        }
+        #[cfg(unix)]
+        {
+            let link = tmp.path().join("link");
+            std::os::unix::fs::symlink("file", &link).unwrap();
+            assert!(matches!(
+                PathSnapshot::capture_in(&state, &link),
+                PathSnapshot::Symlink { dest } if dest == Path::new("file")
+            ));
+            nix::unistd::mkfifo(&tmp.path().join("fifo"), nix::sys::stat::Mode::S_IRWXU).unwrap();
+            assert!(matches!(
+                PathSnapshot::capture_in(&state, &tmp.path().join("fifo")),
+                PathSnapshot::Unrecorded { .. }
+            ));
+        }
+        let dir = tmp.path().join("dir/nested");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("a"), "a").unwrap();
+        match PathSnapshot::capture_in(&state, &tmp.path().join("dir")) {
+            PathSnapshot::Dir { files, .. } => {
+                assert_eq!(files.len(), 1);
+                assert_eq!(files[0].rel, Path::new("nested/a"));
+            }
+            other => panic!("{other:?}"),
+        }
+        let large = tmp.path().join("large");
+        std::fs::File::create(&large)
+            .unwrap()
+            .set_len(BLOB_MAX + 1)
+            .unwrap();
+        assert!(matches!(
+            PathSnapshot::capture_in(&state, &large),
+            PathSnapshot::Unrecorded { kind, .. } if kind == "file"
+        ));
+    }
+
+    #[test]
+    fn path_state_tracks_identity() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("file");
+        assert_eq!(PathState::observe(&file), PathState::Missing);
+        std::fs::write(&file, "one").unwrap();
+        let first = PathState::observe(&file);
+        std::fs::write(&file, "two").unwrap();
+        assert_ne!(PathState::observe(&file), first);
+        std::fs::write(&file, "one").unwrap();
+        assert_eq!(PathState::observe(&file), first);
+        assert_eq!(PathState::observe(tmp.path()), PathState::Dir);
+    }
+
+    #[test]
+    fn render_folds_committed_into_its_change() {
+        let entries = vec![
+            JournalEntry::PathChanged {
+                part: "dotfiles".into(),
+                item: "~/.zshrc".into(),
+                path: PathBuf::from("/home/u/.zshrc"),
+                prior: PathSnapshot::Missing,
+            },
+            JournalEntry::Note {
+                message: "hi".into(),
+            },
+            JournalEntry::Committed {
+                seq: 0,
+                after: PathState::Symlink {
+                    dest: PathBuf::from("/home/u/.dotfiles/zshrc"),
+                },
+            },
+        ];
+        let lines = render(&entries);
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("missing -> a symlink to"), "{}", lines[0]);
+        assert_eq!(lines[1], "hi");
+        let entry: JournalEntry =
+            serde_json::from_str(r#"{"kind":"committed","seq":3,"after":{"state":"dir"}}"#)
+                .unwrap();
+        assert!(matches!(entry, JournalEntry::Committed { seq: 3, .. }));
+    }
 }

--- a/src/system/generations/scope.rs
+++ b/src/system/generations/scope.rs
@@ -51,10 +51,14 @@ fn lock_unpoisoned<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
 }
 
 /// Appends an entry to the open generation, if any, and persists it.
-/// Returns the entry's index in the journal.
-pub(crate) fn record(entry: JournalEntry) -> Option<u32> {
+/// Returns the entry's index in the journal, or an error when it could
+/// not be written to disk (the caller decides whether to proceed).
+pub(crate) fn record(entry: JournalEntry) -> Result<Option<u32>> {
     let shared = lock_unpoisoned(&CURRENT).clone();
-    shared.map(|shared| lock_unpoisoned(&shared).record(entry))
+    match shared {
+        Some(shared) => lock_unpoisoned(&shared).record(entry).map(Some),
+        None => Ok(None),
+    }
 }
 
 /// Whether a generation is open in this process.
@@ -216,13 +220,12 @@ impl Writer {
         Ok(writer)
     }
 
-    fn record(&mut self, entry: JournalEntry) -> u32 {
+    fn record(&mut self, entry: JournalEntry) -> Result<u32> {
         let seq = self.generation.journal.len() as u32;
         self.generation.journal.push(entry);
-        if let Err(err) = self.write() {
-            warn!("bootstrap generations: could not persist a journal entry: {err:#}");
-        }
-        seq
+        self.write()
+            .map_err(|err| eyre::eyre!("could not persist the generation journal: {err:#}"))?;
+        Ok(seq)
     }
 
     fn finish(&mut self, error: Option<String>, summary: Option<Summary>) -> Result<()> {

--- a/src/system/generations/scope.rs
+++ b/src/system/generations/scope.rs
@@ -51,11 +51,15 @@ fn lock_unpoisoned<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
 }
 
 /// Appends an entry to the open generation, if any, and persists it.
-pub(crate) fn record(entry: JournalEntry) {
+/// Returns the entry's index in the journal.
+pub(crate) fn record(entry: JournalEntry) -> Option<u32> {
     let shared = lock_unpoisoned(&CURRENT).clone();
-    if let Some(shared) = shared {
-        lock_unpoisoned(&shared).record(entry);
-    }
+    shared.map(|shared| lock_unpoisoned(&shared).record(entry))
+}
+
+/// Whether a generation is open in this process.
+pub(crate) fn is_active() -> bool {
+    lock_unpoisoned(&CURRENT).is_some()
 }
 
 /// RAII handle for the generation a command records into. Inactive scopes
@@ -212,11 +216,13 @@ impl Writer {
         Ok(writer)
     }
 
-    fn record(&mut self, entry: JournalEntry) {
+    fn record(&mut self, entry: JournalEntry) -> u32 {
+        let seq = self.generation.journal.len() as u32;
         self.generation.journal.push(entry);
         if let Err(err) = self.write() {
             warn!("bootstrap generations: could not persist a journal entry: {err:#}");
         }
+        seq
     }
 
     fn finish(&mut self, error: Option<String>, summary: Option<Summary>) -> Result<()> {


### PR DESCRIPTION
## Summary

Third PR of the bootstrap generations stack (on #12821 ← #12819). Dotfile applies, unapplies, `add`, and edits (including shell activation) now write a **write-ahead journal** into the open generation: for every path they are about to touch, a `path_changed` entry captures the path's prior state *before* the mutation, and a `committed` entry records the state it left behind afterwards. This is the data `mise bootstrap rollback` (next PR) inverts; nothing is inverted yet.

## Design

- One generic entry kind instead of one per dotfile mode. `PathSnapshot` captures a path completely enough to put it back — file content + mode, symlink destination, the files and links of a directory replaced with `--force`, or `missing` — and `PathState` is a compact identity (sha256 + mode, link destination, dir) for the "is it still what we left?" safety rule at rollback time. Prior content ≤ 64 KiB is inlined (base64) in the record; larger content is a content-addressed file under `$MISE_STATE_DIR/bootstrap/blobs/`; files > 8 MiB and directories > 256 MiB are recorded as not captured with the reason.
- The set of touched paths is computed per entry before `apply_one` runs (`touched_paths`): the target and its missing ancestors; per-file targets for directory copies; for `symlink-each` every link target, needed directory, stale link, and the ownership state file under `$MISE_STATE_DIR/dotfiles/`. Cross-profile stale-link removal and `record_symlink_each` state saves are journaled too. `unapply` journals the paths it removes (plus the state file and target dir it may clean up); `dotfiles add` journals the target it moves into the source and the source it creates.
- `edits::ApplyOpts` gains `part` so shell activation entries are attributed to `mise-shell-activate` and dotfile edits to `dotfiles`.
- A `path_changed` with no matching `committed` means the run died mid-change. `generations show`/`diff` fold the pair into one line: `dotfiles: ~/.zshrc: ~/.zshrc missing -> a symlink to ~/.config/mise/dotfiles/zshrc`.
- The interim "applied …" notes from #12819 are replaced by these entries; the no-op rule (a run covering only journaled parts with an empty journal and unchanged trees leaves no generation) is unchanged and now backed by real entries.

Capture is skipped entirely when no generation is open (dry runs, disabled, nested), so inactive runs pay nothing.

## Testing

- Unit: `journal::tests` (blob inline/external + dedup, snapshot of file/symlink/fifo/dir/oversized, `PathState` identity, `render` folding and forward-compat deserialization); existing `system::files`/`system::edits` tests unchanged.
- e2e: `e2e/cli/test_bootstrap_generations` asserts journal paths and prior/after states for symlink and copy applies, an edit block (prior content round-trips through base64), unapply, `add` (target prior content, source prior missing, dotfiles root now snapshotted), and a `symlink-each` entry (link, target dir, and state file journaled). `test_dotfiles_*`, `test_bootstrap*` pass unchanged.
- Docs: "The journal" section in `docs/bootstrap/generations.md`.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5-1; version: unavailable.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mutating dotfile/edit paths now depends on journaling and blob writes before filesystem changes; bugs could block applies or store sensitive prior file content under state dir (0700).
> 
> **Overview**
> Replaces coarse journal notes with a **write-ahead path journal** on bootstrap generations: before each dotfile apply/unapply/add, edit, or stale-link change, mise records `path_changed` with a full **prior** snapshot (`PathSnapshot`), then `committed` with the **after** identity (`PathState`). That data is meant for future rollback; this PR does not invert changes yet.
> 
> Prior file content is stored inline (≤64 KiB) or in content-addressed **`$MISE_STATE_DIR/bootstrap/blobs/`**; oversized paths are marked not captured. Dotfile flows compute touched paths per mode (including `symlink-each` links and state files); `edits::ApplyOpts` gains a **`part`** label (`dotfiles` vs `mise-shell-activate`). Journal persistence failures block mutations via `scope::record` returning `Result`; capture is skipped when no generation is open.
> 
> **`generations show`/`diff`** render folded lines like `dotfiles: ~/.zshrc: missing -> symlink`. Docs and e2e cover journal shape, prior content round-trip, and diff output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f689cfd01f37c90ad6ce82992df543cf122ba12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bootstrap generations now record detailed per-path changes, including previous and resulting states, file contents, symlink ownership, and incomplete entries.
  * Large captured file contents are preserved in generation state storage for later review.
  * Dotfile edits, additions, applications, and removals are included in the generation journal.
  * Generation diffs support comparing one or two generations, patch output, alternate roots, and exit-code checks.

* **Improvements**
  * Generation show and diff commands now display clearer, state-based change descriptions.
  * Journal output consistently identifies affected bootstrap components and changed paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> **Note (2026-09-05):** the on-disk format introduced here is finalized later in the stack, in #12833 (`feat(dotfiles): track files in place with history`), before anything merges. That PR turns the generations store into `mise history` and keeps `mise bootstrap generations` as a view over it.
