### PR TITLE
fix(lockfile): drop deferred provenance baseline once auto-lock verifies the upgrade

### DIFF
--- a/e2e/lockfile/test_lockfile_provenance_already_installed_upgrade
+++ b/e2e/lockfile/test_lockfile_provenance_already_installed_upgrade
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+export MISE_LOCKFILE=1
+
+detect_platform
+PLATFORM="$MISE_PLATFORM"
+
+# Regression test: upgrading a github backend tool to a version that is already
+# installed on disk left both versions in the lockfile.
+#
+# The already-installed upgrade skips the download, so the provenance regression
+# check is deferred to the auto-lock pass and the old provenance-bearing entry is
+# kept as a baseline for it. Once auto-lock verifies the new version, that
+# baseline must be dropped rather than shipped as a second version of the tool.
+#
+# NOTE: This test depends on github:jdx/mr-boxington releases 1.5.0 and 1.8.1
+# existing and carrying GitHub attestations.
+
+cat <<TOML >mise.toml
+[tools]
+"github:jdx/mr-boxington" = "1.5.0"
+TOML
+
+# Lock the old version for this platform only; lock-time verification records
+# its provenance without installing it.
+mise lock --platform "$PLATFORM"
+assert_contains "cat mise.lock" 'version = "1.5.0"'
+assert_contains "cat mise.lock" 'provenance = "github-attestations"'
+
+# Get 1.8.1 onto disk without touching the lockfile so the upgrade below finds
+# it already installed and skips the download.
+MISE_LOCKFILE=0 mise install "github:jdx/mr-boxington@1.8.1"
+assert_not_contains "cat mise.lock" 'version = "1.8.1"'
+
+mise use "github:jdx/mr-boxington@1.8.1"
+assert_contains "cat mise.lock" 'version = "1.8.1"'
+assert_contains "cat mise.lock" 'provenance = "github-attestations"'
+assert_not_contains "cat mise.lock" 'version = "1.5.0"'
+# mr-boxington is the only tool, so exactly one entry should remain.
+assert "grep -c '^version = ' mise.lock" "1"

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -2395,8 +2395,9 @@ fn reinsert_deferred_baselines(
 /// some later command rewrites it. Only entries no request still resolves to are
 /// removed, and only when they are exactly the baseline the verified version would have
 /// been checked against. Detection-only provenance (for example an entry another
-/// platform's `mise lock` populated for this one) does not count. Returns the pruned
-/// versions.
+/// platform's `mise lock` populated for this one) does not count, and a baseline that
+/// another requested entry (say a second option variant of the same version) is still
+/// waiting on stays until that entry verifies too. Returns the pruned versions.
 fn prune_verified_provenance_baselines(
     tools: &mut Vec<LockfileTool>,
     requested_versions: &BTreeSet<String>,
@@ -2404,25 +2405,35 @@ fn prune_verified_provenance_baselines(
 ) -> Vec<String> {
     let mut pruned = Vec::new();
     loop {
-        let stale = tools
+        let verified_here = |tool: &LockfileTool| {
+            tool.platforms
+                .get(platform_key)
+                .is_some_and(|info| info.provenance.is_some() && info.provenance_verified)
+        };
+        // The baseline the deferred regression check for `tool` compares against, as
+        // `check_provenance_regression` computes it for a not-yet-verified entry.
+        let baseline_of = |tool: &LockfileTool| {
+            find_provenance_regression_baseline(
+                Some(tools.as_slice()),
+                &tool.version,
+                tool.backend.as_deref().unwrap_or(""),
+                platform_key,
+                None,
+            )
+            .map(|baseline| (baseline.version.clone(), baseline.options.clone()))
+        };
+        let requested = tools
             .iter()
-            .filter(|tool| requested_versions.contains(&tool.version))
-            .filter(|tool| {
-                tool.platforms
-                    .get(platform_key)
-                    .is_some_and(|info| info.provenance.is_some() && info.provenance_verified)
-            })
-            .filter_map(|tool| {
-                find_provenance_regression_baseline(
-                    Some(tools.as_slice()),
-                    &tool.version,
-                    tool.backend.as_deref().unwrap_or(""),
-                    platform_key,
-                    None,
-                )
-            })
-            .find(|baseline| !requested_versions.contains(&baseline.version))
-            .map(|baseline| (baseline.version.clone(), baseline.options.clone()));
+            .filter(|tool| requested_versions.contains(&tool.version));
+        let still_needed: HashSet<LockfileToolKey> = requested
+            .clone()
+            .filter(|tool| !verified_here(tool))
+            .filter_map(baseline_of)
+            .collect();
+        let stale = requested
+            .filter(|tool| verified_here(tool))
+            .filter_map(baseline_of)
+            .find(|key| !requested_versions.contains(&key.0) && !still_needed.contains(key));
         let Some((version, options)) = stale else {
             return pruned;
         };
@@ -5052,6 +5063,39 @@ options = { exe = "rg" }
         let mut tools = vec![detected_only, verified_github_tool("0.11.0", &platform)];
         assert!(prune_verified_provenance_baselines(&mut tools, &requested, &platform).is_empty());
         assert_eq!(lockfile_tool_versions(&tools), vec!["0.12.0", "0.11.0"]);
+
+        // Two option variants of the requested version, only one verified: the other
+        // still relies on the baseline for its deferred check.
+        let mut musl_variant = basic_tool("0.12.0", "github:owner/repo");
+        musl_variant
+            .options
+            .insert("flavor".to_string(), "musl".to_string());
+        let mut tools = vec![
+            verified_github_tool("0.12.0", &platform),
+            musl_variant,
+            verified_github_tool("0.11.0", &platform),
+        ];
+        assert!(prune_verified_provenance_baselines(&mut tools, &requested, &platform).is_empty());
+        assert_eq!(
+            lockfile_tool_versions(&tools),
+            vec!["0.12.0", "0.12.0", "0.11.0"]
+        );
+
+        // Once that variant verifies as well, the baseline has served both and goes.
+        let mut musl_variant = verified_github_tool("0.12.0", &platform);
+        musl_variant
+            .options
+            .insert("flavor".to_string(), "musl".to_string());
+        let mut tools = vec![
+            verified_github_tool("0.12.0", &platform),
+            musl_variant,
+            verified_github_tool("0.11.0", &platform),
+        ];
+        assert_eq!(
+            prune_verified_provenance_baselines(&mut tools, &requested, &platform),
+            vec!["0.11.0".to_string()]
+        );
+        assert_eq!(lockfile_tool_versions(&tools), vec!["0.12.0", "0.12.0"]);
 
         // Both versions are requested (multi-version config): neither is a baseline.
         let both: BTreeSet<String> = ["0.11.0".to_string(), "0.12.0".to_string()].into();

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -2384,6 +2384,50 @@ fn reinsert_deferred_baselines(
     }
 }
 
+/// Drop prior-version entries that survived the merge only as deferred provenance
+/// baselines once the upgrade they guarded has verified provenance on `platform_key`.
+///
+/// `reinsert_deferred_baselines` keeps the prior provenance-bearing version alive when
+/// an already-installed upgrade skipped its download, so the auto-lock pass can compare
+/// the two. Once that pass records provenance for the new version the baseline has done
+/// its job; leaving it behind ships a lockfile listing two versions of the tool until
+/// some later command rewrites it. Only entries no request still resolves to are
+/// removed, and only when they are exactly the baseline the verified version would have
+/// been checked against. Returns the pruned versions.
+fn prune_verified_provenance_baselines(
+    tools: &mut Vec<LockfileTool>,
+    requested_versions: &BTreeSet<String>,
+    platform_key: &str,
+) -> Vec<String> {
+    let mut pruned = Vec::new();
+    loop {
+        let stale = tools
+            .iter()
+            .filter(|tool| requested_versions.contains(&tool.version))
+            .filter(|tool| {
+                tool.platforms
+                    .get(platform_key)
+                    .is_some_and(|info| info.provenance.is_some())
+            })
+            .filter_map(|tool| {
+                find_provenance_regression_baseline(
+                    Some(tools.as_slice()),
+                    &tool.version,
+                    tool.backend.as_deref().unwrap_or(""),
+                    platform_key,
+                    None,
+                )
+            })
+            .find(|baseline| !requested_versions.contains(&baseline.version))
+            .map(|baseline| (baseline.version.clone(), baseline.options.clone()));
+        let Some((version, options)) = stale else {
+            return pruned;
+        };
+        tools.retain(|tool| tool.version != version || tool.options != options);
+        pruned.push(version);
+    }
+}
+
 /// Check if any github backend tool is losing provenance when upgrading versions.
 ///
 /// Only checks the current platform because new `LockfileTool` entries (from
@@ -2687,6 +2731,26 @@ pub(crate) async fn auto_lock_new_versions(
     let deferred_retry_only = new_versions.is_empty();
     let mut all_provenance_errors: Vec<String> = Vec::new();
 
+    // Versions each lockfile's requests resolve to, mirroring what `update_lockfiles`
+    // writes. Anything else left in a lockfile is either a monorepo sibling's entry or
+    // a deferred provenance baseline; the latter is pruned once its upgrade verifies.
+    let mut requested_versions_by_lockfile: HashMap<PathBuf, HashMap<String, BTreeSet<String>>> =
+        HashMap::new();
+    for (source, tools) in tools_by_source_for_update(ts, new_versions) {
+        let Some((lockfile_path, _)) = lockfile_path_for_tool_source(config, &source) else {
+            continue;
+        };
+        let requested = requested_versions_by_lockfile
+            .entry(lockfile_path)
+            .or_default();
+        for (short, versions) in tools {
+            requested
+                .entry(short)
+                .or_default()
+                .extend(versions.into_iter().map(|tv| tv.version));
+        }
+    }
+
     let empty_keys: BTreeSet<String> = BTreeSet::new();
     let mut candidate_versions_by_lockfile: HashMap<PathBuf, Vec<ToolVersion>> = HashMap::new();
     let mut seen_candidates: HashMap<PathBuf, HashSet<(String, String, String, ToolSource)>> =
@@ -2854,6 +2918,33 @@ pub(crate) async fn auto_lock_new_versions(
                 }
                 Err(e) => {
                     debug!("auto-lock task failed: {}", e);
+                }
+            }
+        }
+
+        // Monorepo root lockfiles hold sibling projects' entries that this run cannot
+        // see, so an absent version there is not necessarily a baseline. Fail closed
+        // and leave them alone, as `update_lockfiles` does.
+        let is_monorepo_root_lockfile = config
+            .monorepo_lockfile_root()
+            .is_some_and(|root| lockfile_path.parent() == Some(root.as_path()));
+        if provenance_errors.is_empty() && !is_monorepo_root_lockfile {
+            let current_platform = Platform::current().to_key();
+            let empty = BTreeSet::new();
+            let requested = requested_versions_by_lockfile.get(&lockfile_path);
+            for (short, tools) in lockfile.tools.iter_mut() {
+                let requested_versions = requested
+                    .and_then(|requested| requested.get(short))
+                    .unwrap_or(&empty);
+                for version in prune_verified_provenance_baselines(
+                    tools,
+                    requested_versions,
+                    &current_platform,
+                ) {
+                    debug!(
+                        "auto-lock: pruned {short}@{version} from {}: provenance baseline no longer needed",
+                        display_path(&lockfile_path)
+                    );
                 }
             }
         }
@@ -4878,6 +4969,109 @@ options = { exe = "rg" }
         );
     }
 
+    fn verified_github_tool(version: &str, platform: &str) -> LockfileTool {
+        let mut tool = basic_tool(version, "github:owner/repo");
+        tool.platforms.insert(
+            platform.to_string(),
+            PlatformInfo {
+                url: Some(format!("https://example.com/repo-{version}.tar.gz")),
+                provenance: Some(ProvenanceType::GithubAttestations),
+                ..Default::default()
+            },
+        );
+        tool
+    }
+
+    fn lockfile_tool_versions(tools: &[LockfileTool]) -> Vec<&str> {
+        tools.iter().map(|tool| tool.version.as_str()).collect()
+    }
+
+    #[test]
+    fn test_prune_verified_provenance_baselines_drops_resolved_baseline() {
+        // `mise use repo@0.12.0` with 0.12.0 already installed skips the download, so
+        // update_lockfiles keeps 0.11.0 as a provenance baseline. Once auto-lock has
+        // verified 0.12.0 the baseline is just a stale duplicate and must go.
+        let platform = Platform::current().to_key();
+        let requested: BTreeSet<String> = ["0.12.0".to_string()].into();
+
+        let mut tools = vec![
+            verified_github_tool("0.12.0", &platform),
+            verified_github_tool("0.11.0", &platform),
+        ];
+        let pruned = prune_verified_provenance_baselines(&mut tools, &requested, &platform);
+        assert_eq!(pruned, vec!["0.11.0".to_string()]);
+        assert_eq!(lockfile_tool_versions(&tools), vec!["0.12.0"]);
+
+        // Repeated unresolved upgrades can stack several baselines; all of them go.
+        let mut tools = vec![
+            verified_github_tool("0.12.0", &platform),
+            verified_github_tool("0.10.0", &platform),
+            verified_github_tool("0.11.0", &platform),
+        ];
+        let pruned = prune_verified_provenance_baselines(&mut tools, &requested, &platform);
+        assert_eq!(pruned, vec!["0.11.0".to_string(), "0.10.0".to_string()]);
+        assert_eq!(lockfile_tool_versions(&tools), vec!["0.12.0"]);
+    }
+
+    #[test]
+    fn test_prune_verified_provenance_baselines_keeps_entries_still_needed() {
+        let platform = Platform::current().to_key();
+        let requested: BTreeSet<String> = ["0.12.0".to_string()].into();
+
+        // The upgrade is still unverified on this platform: the baseline is what the
+        // deferred regression check compares against, so it must stay.
+        let mut tools = vec![
+            basic_tool("0.12.0", "github:owner/repo"),
+            verified_github_tool("0.11.0", &platform),
+        ];
+        assert!(prune_verified_provenance_baselines(&mut tools, &requested, &platform).is_empty());
+        assert_eq!(lockfile_tool_versions(&tools), vec!["0.12.0", "0.11.0"]);
+
+        // Verified on another platform only: this platform's check is still pending.
+        let mut tools = vec![
+            verified_github_tool("0.12.0", "other-platform"),
+            verified_github_tool("0.11.0", &platform),
+        ];
+        assert!(prune_verified_provenance_baselines(&mut tools, &requested, &platform).is_empty());
+        assert_eq!(lockfile_tool_versions(&tools), vec!["0.12.0", "0.11.0"]);
+
+        // Both versions are requested (multi-version config): neither is a baseline.
+        let both: BTreeSet<String> = ["0.11.0".to_string(), "0.12.0".to_string()].into();
+        let mut tools = vec![
+            verified_github_tool("0.12.0", &platform),
+            verified_github_tool("0.11.0", &platform),
+        ];
+        assert!(prune_verified_provenance_baselines(&mut tools, &both, &platform).is_empty());
+        assert_eq!(lockfile_tool_versions(&tools), vec!["0.12.0", "0.11.0"]);
+
+        // A downgrade never has a baseline: the newer, unrequested entry is not ours to drop.
+        let downgrade: BTreeSet<String> = ["0.11.0".to_string()].into();
+        let mut tools = vec![
+            verified_github_tool("0.12.0", &platform),
+            verified_github_tool("0.11.0", &platform),
+        ];
+        assert!(prune_verified_provenance_baselines(&mut tools, &downgrade, &platform).is_empty());
+        assert_eq!(lockfile_tool_versions(&tools), vec!["0.12.0", "0.11.0"]);
+
+        // A prior version without provenance was never a baseline.
+        let mut tools = vec![
+            verified_github_tool("0.12.0", &platform),
+            basic_tool("0.11.0", "github:owner/repo"),
+        ];
+        assert!(prune_verified_provenance_baselines(&mut tools, &requested, &platform).is_empty());
+        assert_eq!(lockfile_tool_versions(&tools), vec!["0.12.0", "0.11.0"]);
+
+        // Provenance baselines only exist for github backends.
+        let mut tools = vec![
+            verified_github_tool("0.12.0", &platform),
+            verified_github_tool("0.11.0", &platform),
+        ];
+        for tool in &mut tools {
+            tool.backend = Some("aqua:owner/repo".to_string());
+        }
+        assert!(prune_verified_provenance_baselines(&mut tools, &requested, &platform).is_empty());
+        assert_eq!(lockfile_tool_versions(&tools), vec!["0.12.0", "0.11.0"]);
+    }
     #[test]
     fn test_preserve_absent_does_not_resurrect_rekeyed_empty_options_entry() {
         // #10564: after merge_tool_entries rekeys an empty-options entry into a

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -2385,7 +2385,8 @@ fn reinsert_deferred_baselines(
 }
 
 /// Drop prior-version entries that survived the merge only as deferred provenance
-/// baselines once the upgrade they guarded has verified provenance on `platform_key`.
+/// baselines once the upgrade they guarded has cryptographically verified provenance
+/// on `platform_key`.
 ///
 /// `reinsert_deferred_baselines` keeps the prior provenance-bearing version alive when
 /// an already-installed upgrade skipped its download, so the auto-lock pass can compare
@@ -2393,7 +2394,9 @@ fn reinsert_deferred_baselines(
 /// its job; leaving it behind ships a lockfile listing two versions of the tool until
 /// some later command rewrites it. Only entries no request still resolves to are
 /// removed, and only when they are exactly the baseline the verified version would have
-/// been checked against. Returns the pruned versions.
+/// been checked against. Detection-only provenance (for example an entry another
+/// platform's `mise lock` populated for this one) does not count. Returns the pruned
+/// versions.
 fn prune_verified_provenance_baselines(
     tools: &mut Vec<LockfileTool>,
     requested_versions: &BTreeSet<String>,
@@ -2407,7 +2410,7 @@ fn prune_verified_provenance_baselines(
             .filter(|tool| {
                 tool.platforms
                     .get(platform_key)
-                    .is_some_and(|info| info.provenance.is_some())
+                    .is_some_and(|info| info.provenance.is_some() && info.provenance_verified)
             })
             .filter_map(|tool| {
                 find_provenance_regression_baseline(
@@ -4969,6 +4972,7 @@ options = { exe = "rg" }
         );
     }
 
+    /// A github tool entry whose provenance was cryptographically verified on `platform`.
     fn verified_github_tool(version: &str, platform: &str) -> LockfileTool {
         let mut tool = basic_tool(version, "github:owner/repo");
         tool.platforms.insert(
@@ -4976,12 +4980,14 @@ options = { exe = "rg" }
             PlatformInfo {
                 url: Some(format!("https://example.com/repo-{version}.tar.gz")),
                 provenance: Some(ProvenanceType::GithubAttestations),
+                provenance_verified: true,
                 ..Default::default()
             },
         );
         tool
     }
 
+    /// The versions of `tools` in lockfile order.
     fn lockfile_tool_versions(tools: &[LockfileTool]) -> Vec<&str> {
         tools.iter().map(|tool| tool.version.as_str()).collect()
     }
@@ -5032,6 +5038,18 @@ options = { exe = "rg" }
             verified_github_tool("0.12.0", "other-platform"),
             verified_github_tool("0.11.0", &platform),
         ];
+        assert!(prune_verified_provenance_baselines(&mut tools, &requested, &platform).is_empty());
+        assert_eq!(lockfile_tool_versions(&tools), vec!["0.12.0", "0.11.0"]);
+
+        // Provenance detected but never cryptographically verified on this platform, as
+        // when another platform's `mise lock` populated the entry: not good enough.
+        let mut detected_only = verified_github_tool("0.12.0", &platform);
+        detected_only
+            .platforms
+            .get_mut(&platform)
+            .unwrap()
+            .provenance_verified = false;
+        let mut tools = vec![detected_only, verified_github_tool("0.11.0", &platform)];
         assert!(prune_verified_provenance_baselines(&mut tools, &requested, &platform).is_empty());
         assert_eq!(lockfile_tool_versions(&tools), vec!["0.12.0", "0.11.0"]);
 


### PR DESCRIPTION
## Summary

Upgrading a `github:` tool to a version that is **already installed on disk** left both the old and new versions in `mise.lock`. Seen in the wild in [jdx/tak#93](https://github.com/jdx/tak/pull/93), where `mise use mr-boxington@1.8.1` on a machine that already had 1.8.1 produced a lockfile with both 1.8.1 and 1.5.0 entries.

## Why it happened

- An already-installed upgrade skips the download, so the new entry has no `url` for the current platform when `update_lockfiles` runs.
- `check_provenance_regression` treats that as "unverified, not regressed" (#11230, the fix for #11225) and reinserts the prior provenance-bearing entry as a deferred baseline so the auto-lock pass can compare against it.
- `auto_lock_new_versions` then downloads the artifact, verifies provenance, records it on the new entry, and saves. It never re-runs the merge, so the baseline survives until some later lockfile-writing command drops it. The code comment even says it "self-heals on the next update".

Running one `mise use` against tak's base `mise.toml`/`mise.lock` reproduces the PR's lockfile byte-for-byte.

## Fix

After auto-lock applies its results, prune entries that are exactly the baseline a requested version would have been checked against, once that version has cryptographically verified provenance on the current platform (`provenance_verified`, not merely detected provenance) and no request still resolves to them. The requested-version set comes from `tools_by_source_for_update`, the same source `update_lockfiles` writes from, so multi-version configs keep both entries. Nothing is pruned if any provenance error was raised for the lockfile, and monorepo root lockfiles are skipped because absent versions there may belong to sibling projects (matching `update_lockfiles`' fail-closed behaviour).

## Tests

- Unit tests for the prune helper: resolved baseline dropped, stacked baselines dropped, and kept when the upgrade is still unverified (on this or another platform), when its provenance was only detected rather than verified, when both versions are requested, on downgrades, when the prior entry had no provenance, and for non-github backends.
- New e2e `test_lockfile_provenance_already_installed_upgrade` reproducing the tak scenario with `github:jdx/mr-boxington`. Verified it fails on a build without the fix and passes with it.
- `test_lockfile_provenance`, `test_lockfile_provenance_upgrade`, `test_lockfile_install`, `test_lockfile_monorepo`, the `lockfile::` unit module, and clippy with `-D warnings` all pass.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5-1; version: unavailable.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lockfile merge/prune behavior around GitHub provenance verification; logic is conservative (verified-only, fail-closed on errors and monorepo roots) but incorrect pruning could drop needed entries or leave stale ones.
> 
> **Overview**
> Fixes a lockfile bug where **`mise use`** to a **GitHub-backed version already on disk** could leave **two tool versions** in `mise.lock` (e.g. both 1.5.0 and 1.8.1) after auto-lock finished.
> 
> Skipped downloads defer provenance checks and **`reinsert_deferred_baselines`** keeps the old provenance-bearing row for comparison. Auto-lock then verifies the new version but never merged again, so the baseline stuck around until some later rewrite.
> 
> After auto-lock succeeds on a lockfile, the change **prunes** rows that are only that deferred baseline: the new version must have **cryptographically verified** provenance on the **current platform**, the pruned version must **not** still be requested (from the same resolution set as **`update_lockfiles`**), and pruning is **skipped** if provenance failed or the path is a **monorepo root** lockfile. New helper **`prune_verified_provenance_baselines`** plus unit cases and e2e **`test_lockfile_provenance_already_installed_upgrade`** cover the tak-style upgrade path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 566497190ab0d626ce57894941ae5d52d1fa08ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented stale provenance baselines from being removed until the requested tool version’s provenance is cryptographically verified.
  - Preserved detected—but not independently verified—provenance and retained baselines until all version options are verified.
  - Improved lockfile accuracy when upgrading an already-installed GitHub-backed tool.

- **Tests**
  - Added coverage for upgrades that record the new version and verified provenance while removing the outdated lockfile entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->