### PR TITLE
chore(release): only run the release PR dry run once auto-merge is enabled

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     tags: ["v[0-9]*"]
   pull_request:
     branches: ["main"]
+    # auto_merge_enabled arms the dry run on the release PR; see the gate job.
+    types: [opened, synchronize, reopened, auto_merge_enabled]
   workflow_dispatch:
     inputs:
       force:
@@ -14,6 +16,9 @@ on:
 
 concurrency:
   group: release-${{ github.ref_name }}
+  # A dry run for a superseded release PR head can never satisfy auto-merge,
+  # so stop it as soon as the next one starts. Tag runs are never cancelled.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -24,8 +29,37 @@ env:
   GH_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
 
 jobs:
+  gate:
+    # Decides what this run does. Tag pushes and manual dispatches always
+    # build and publish. Pull requests only matter when they come from the
+    # `release` branch of this repository, and even then the tarballs are only
+    # built once auto-merge has been enabled on the release PR: every merge to
+    # main force-pushes `release`, and building eight PGO tarballs for each of
+    # those was the bulk of the Namespace bill. The `release` job below still
+    # runs for an unarmed release PR so that the required check fails instead
+    # of being skipped (GitHub treats a skipped required check as passed).
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    outputs:
+      release-run: ${{ steps.gate.outputs.release-run }}
+      build: ${{ steps.gate.outputs.build }}
+    steps:
+      - id: gate
+        env:
+          RELEASE_RUN: ${{ github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository) }}
+          ARMED: ${{ github.event_name != 'pull_request' || github.event.pull_request.auto_merge != null }}
+        run: |
+          build=false
+          if [ "$RELEASE_RUN" = true ] && [ "$ARMED" = true ]; then
+            build=true
+          fi
+          echo "release-run=$RELEASE_RUN" >> "$GITHUB_OUTPUT"
+          echo "build=$build" >> "$GITHUB_OUTPUT"
+          echo "release-run=$RELEASE_RUN armed=$ARMED build=$build"
   build-tarball-linux:
-    if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
+    needs: [gate]
+    if: needs.gate.outputs.build == 'true'
     name: build-tarball-${{matrix.name}}
     runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || (github.event.pull_request.user.login != 'jdx' && github.event.pull_request.user.login != 'mise-en-dev')) && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64-xlarge' }}
     # PGO and cross-built release tarballs can exceed 90 minutes on
@@ -92,7 +126,8 @@ jobs:
             dist/mise-*.tar.zst
           if-no-files-found: error
   build-tarball-macos:
-    if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
+    needs: [gate]
+    if: needs.gate.outputs.build == 'true'
     name: build-tarball-${{matrix.name}}
     runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || (github.event.pull_request.user.login != 'jdx' && github.event.pull_request.user.login != 'mise-en-dev')) && 'macos-14' || 'namespace-profile-endev-macos-arm64' }}
     timeout-minutes: 300
@@ -221,7 +256,8 @@ jobs:
             dist/mise-*.tar.zst
           if-no-files-found: error
   build-tarball-windows:
-    if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
+    needs: [gate]
+    if: needs.gate.outputs.build == 'true'
     name: build-tarball-windows-${{matrix.arch}}
     runs-on: windows-latest
     # Matches the Linux tarball job. 60 was sized for a non-LTO build; the fat-LTO
@@ -251,9 +287,9 @@ jobs:
           path: dist/*.zip
           if-no-files-found: error
   e2e-linux:
-    if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
+    needs: [gate, build-tarball-linux]
+    if: needs.gate.outputs.build == 'true'
     name: e2e-linux-${{matrix.tranche}}
-    needs: [build-tarball-linux]
     runs-on: ubuntu-latest
     #container: ghcr.io/jdx/mise:github-actions
     timeout-minutes: 30
@@ -293,9 +329,9 @@ jobs:
           max_attempts: 3
           command: ./e2e/run_all_tests
   rpm:
-    if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
+    needs: [gate, build-tarball-linux]
+    if: needs.gate.outputs.build == 'true'
     runs-on: ubuntu-latest
-    needs: [build-tarball-linux]
     timeout-minutes: 10
     container: ghcr.io/jdx/mise:rpm@sha256:a8468e3c31eb2ec25ba1d74cda9960dfe5d309d676c251f8432c74a283704b74
     steps:
@@ -318,9 +354,9 @@ jobs:
           path: dist/rpmrepo
           if-no-files-found: error
   deb:
-    if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
+    needs: [gate, build-tarball-linux]
+    if: needs.gate.outputs.build == 'true'
     runs-on: ubuntu-latest
-    needs: [build-tarball-linux]
     container: ghcr.io/jdx/mise:deb@sha256:d952c001014be8c424c1f3b0b04e0f57a4ee4138e25a01ec383f2cb91c8cb8e1
     timeout-minutes: 10
     steps:
@@ -351,16 +387,24 @@ jobs:
     permissions:
       contents: write
     needs:
+      - gate
       - rpm
       - deb
       - e2e-linux
       - build-tarball-linux
       - build-tarball-macos
       - build-tarball-windows
-    if: ${{ !cancelled() && !failure() && (github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)) }}
+    # Run even when a build failed: this is the required `release` check on
+    # main, and a skipped required check counts as passed. The steps below
+    # turn an unarmed release PR or a failed build into an explicit failure.
+    if: ${{ !cancelled() && needs.gate.outputs.release-run == 'true' }}
     steps:
+      - name: Require auto-merge on the release PR
+        if: needs.gate.outputs.build != 'true'
+        run: |
+          echo "::error title=Release dry run not armed::Enable auto-merge on this pull request to build and test the release tarballs. The PR merges once that dry run passes."
+          exit 1
       - name: Verify all build targets succeeded
-        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
         run: |
           failed=""
           for result in \
@@ -408,17 +452,14 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
       - uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
-        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
         with:
           gpg_private_key: ${{ secrets.MISE_GPG_KEY }}
           git_user_signingkey: true
           git_commit_gpgsign: true
       - run: ./scripts/setup-zipsign.sh
-        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
         env:
           ZIPSIGN: ${{ secrets.ZIPSIGN }}
       - name: Install fd-find
-        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
         run: |
           sudo apt-get update
           sudo apt-get install fd-find minisign
@@ -426,12 +467,9 @@ jobs:
           ln -s "$(which fdfind)" "$HOME/.local/bin/fd"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
         with: { path: artifacts }
       - run: ls -R artifacts
-        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
         with:
           path: artifacts
           pattern: |
@@ -441,22 +479,15 @@ jobs:
             mise-v*.zip
           merge-multiple: true
       - run: echo "${{ secrets.MINISIGN_KEY }}" >minisign.key
-        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
       - run: ls -R artifacts
-        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
         with:
           name: tarball-x86_64-unknown-linux-gnu
           path: dist
       - run: tar -C "$HOME" -xvf "dist/mise-$(./scripts/get-version.sh)-linux-x64.tar.zst"
-        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
       - run: echo "$HOME/mise/bin" >> "$GITHUB_PATH"
-        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
       - run: which mise && mise -v && mise i
-        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
       - run: mise x -- scripts/release.sh
-        if: github.event_name != 'pull_request' || (github.head_ref == 'release' && github.event.pull_request.head.repo.full_name == github.repository)
       - name: Stage release assets for attestation
         if: startsWith(github.ref, 'refs/tags/v') && steps.check-release.outputs.exists != 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -630,8 +630,13 @@ development:
 
 - **release-plz**: Automated release management based on conventional commits
 - Automatically creates release PRs and publishes releases
-- Runs daily via scheduled workflow
+- Runs on every push to `main` and daily via scheduled workflow
 - Handles version bumping and changelog generation
+- The release PR's dry run (`release.yml`) only builds the release tarballs
+  once auto-merge is enabled on that PR. Until then its required `release`
+  check fails with a message saying so, which keeps the PR from merging
+  without a dry run while avoiding a full tarball build on every push to
+  `main`.
 
 ## Adding a new setting
 


### PR DESCRIPTION
## Problem

Every merge to `main` makes release-plz force-push the `release` branch, which synchronizes the release PR and starts a full dry run of `release.yml`: six PGO/BOLT linux tarballs on `namespace-profile-endev-linux-amd64-xlarge` (~156 runner-minutes) and two macOS tarballs on `namespace-profile-endev-macos-arm64` (~57 runner-minutes). On a busy day that is seven or more dry runs, most of them cancelled or superseded before they finish, and it is the bulk of the Namespace bill.

While checking today's failed dry runs I also found that a failed build or e2e tranche leaves the required `release` job **skipped**, and GitHub counts a skipped required check as passed. So a failed dry run did not actually block auto-merge on the release PR.

## Change

- Add a `gate` job. On the release PR the tarball, e2e, rpm and deb jobs only run while auto-merge is enabled. Tag pushes and manual dispatches behave as before.
- Trigger on `pull_request: auto_merge_enabled`, so enabling auto-merge starts the dry run on the current head. Later syncs while armed re-run it, exactly as today.
- The required `release` check now runs for every release PR event and fails explicitly when the dry run is not armed (with a message saying to enable auto-merge) or when any build or e2e job did not succeed. A release PR at rest therefore shows a red `release` check, which is what keeps it from merging without a dry run.
- `cancel-in-progress` for `pull_request` runs only. A dry run for a superseded head can never satisfy auto-merge.
- Drop the step-level `if:` copies of the job condition inside the `release` job; they were redundant with the job-level condition.
- Document the flow in `docs/contributing.md`.

## Resulting flow

1. Merges to `main` land all day. release-plz refreshes the release PR as before. `release.yml` only runs the few-second `gate` and `release` jobs (GitHub-hosted, free) and the check is red with "dry run not armed".
2. Enable auto-merge on the release PR (manually or via the nightly `auto-merge-release` workflow). The dry run builds and tests the tarballs on Namespace; when it passes, GitHub merges.
3. If something lands mid-run, the stale run is cancelled and a new one starts on the new head, same as today but only inside the release window.

Nothing else moves off Namespace; release-plz and the trusted test suite are unchanged.

## Notes for review

- The gate relies on `github.event.pull_request.auto_merge` being present in the `synchronize` payload once auto-merge is on. The `gate` job logs `release-run`, `armed` and `build` so the first real release makes this easy to confirm.
- Regular PRs are unaffected: `gate` reports `release-run=false`, everything else skips, and the `release` check stays skipped as before.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5-1; version: unavailable.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release gating and required-check behavior; incorrect gate logic could block legitimate releases or change when tarball validation runs before merge.
> 
> **Overview**
> **Release CI cost and gating:** `release.yml` adds a **`gate`** job so expensive tarball, e2e, rpm, and deb work runs only when the event is a real release path **and** (for release PRs) **auto-merge is enabled**. Tag pushes and `workflow_dispatch` still build as before; routine `main` updates that refresh the release PR no longer spin up Namespace PGO/macOS builds until someone arms the PR.
> 
> **Triggers and concurrency:** Pull request runs listen for **`auto_merge_enabled`** so enabling auto-merge starts the dry run on the current head. **`cancel-in-progress`** applies only to `pull_request` runs so superseded dry runs stop instead of racing auto-merge.
> 
> **Required `release` check:** The **`release`** job now runs for every release-PR workflow (not only when builds ran) and **fails explicitly** when the dry run is not armed or when any build/e2e job did not succeed—addressing GitHub treating a **skipped** required check as passed. Redundant per-step `if:` guards inside `release` are removed.
> 
> **Docs:** `docs/contributing.md` documents the auto-merge–gated dry run and that release-plz runs on pushes to `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 404cec678d1fbb96d0e8fbad8aa1e2b5247900b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Automation**
  * Release pull requests now wait for auto-merge to be enabled before building release artifacts.
  * Release checks clearly fail when the required dry run has not been armed.
  * Workflow runs are coordinated to reduce duplicate or outdated release builds.

* **Documentation**
  * Updated contributor guidance explains release workflow timing, scheduled runs, and dry-run requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->