### PR TITLE
ci: enforce conventional commits

### DIFF
--- a/.cursor/rules/conventional_commits.mdc
+++ b/.cursor/rules/conventional_commits.mdc
@@ -5,11 +5,12 @@ description: how to write commit and PR titles
 
 ## Conventional Commits (REQUIRED)
 
-All commit messages and PR titles MUST follow conventional commit format:
+PR titles MUST follow conventional commit format. Intermediate commit subjects
+SHOULD use the same format:
 
 ### Format
 ```
-<type>(<scope>): <description>
+<type>[optional scope][optional !]: <description>
 ```
 
 ### Types
@@ -21,6 +22,8 @@ All commit messages and PR titles MUST follow conventional commit format:
 - `perf:` - Performance improvements
 - `test:` - Testing changes
 - `chore:` - Maintenance tasks, releases, dependency updates, CI/infrastructure
+- `ci:` - CI and automation changes
+- `revert:` - Revert a previous change
 - `security:` - Security-related changes
 - `registry:` - Any changes to `registry/` (no extra scope)
 
@@ -43,4 +46,4 @@ Command names (`install`, `activate`, `use`, `exec`, …) or subsystems:
 Use `task` (not `run`) for task-related changes, even if the code lives in
 `src/cli/run.rs` or `src/cmd.rs`.
 
-Description: lowercase after the colon, imperative mood, concise.
+Description: start with a lowercase character, use imperative mood, and keep it concise.

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,27 @@
+name: conventional-commits
+
+on: # zizmor: ignore[dangerous-triggers] reads only the PR title and executes no untrusted code
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check pull request title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^(chore|ci|docs|feat|fix|perf|refactor|registry|revert|security|style|test)(\([[:alnum:]][[:alnum:]./_-]*(, ?[[:alnum:]][[:alnum:]./_-]*)*\))?!?: [[:lower:]](.*[[:graph:]])?$'
+          if [[ ! "$PR_TITLE" =~ $pattern || "$PR_TITLE" =~ ^registry\( ]]; then
+            echo "::error title=Invalid pull request title::The title does not match the required format."
+            printf 'Received title: %q\n' "$PR_TITLE"
+            echo "Use: <type>[optional scope][optional !]: <description starting lowercase>"
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,9 +171,10 @@ Mise is a Rust CLI tool that manages development environments, tools, tasks, and
 ## Development Guidelines
 
 ### Conventional Commits (REQUIRED)
-All commit messages and PR titles MUST follow conventional commit format:
+PR titles MUST follow conventional commit format. Intermediate commit subjects
+SHOULD use the same format:
 
-**Format:** `<type>(<scope>): <description>`
+**Format:** `<type>[optional scope][optional !]: <description>`
 
 **Types:**
 - `feat:` - New features
@@ -185,7 +186,9 @@ All commit messages and PR titles MUST follow conventional commit format:
 - `test:` - Testing changes
 - `chore:` - Maintenance tasks, releases, dependency updates, CI/infrastructure changes
 - `security:` - Security-related changes
-- `registry:` - Any changes to `registry/` (no scope needed, use for both new tools and fixes)
+- `registry:` - Any changes to `registry/` (do not add a scope)
+- `ci:` - CI and automation changes
+- `revert:` - Reverting a previous change
 
 **Scopes:**
 - For command-specific changes, use the command name: `install`, `activate`, `use`, `exec`, etc.
@@ -193,7 +196,7 @@ All commit messages and PR titles MUST follow conventional commit format:
 - Use `task` (not `run`) for task-related changes, even if the code lives in `src/cli/run.rs` or `src/cmd.rs`
 
 **Description Style:**
-- Use lowercase after the colon
+- Start the description with a lowercase character
 - Use imperative mood ("add feature" not "added feature")
 - Keep it concise but descriptive
 
@@ -206,6 +209,11 @@ All commit messages and PR titles MUST follow conventional commit format:
 - `chore: release 2026.1.6`
 - `chore(ci): add FORGEJO_TOKEN for API authentication`
 - `registry: add miller`
+
+CI validates the pull request title and re-runs when it is edited. Intermediate
+commit subjects are not checked because pull requests are squash-merged. CI
+mechanically checks the allowed type, syntax, and lowercase-leading description;
+imperative mood and breaking-change details remain review rules.
 
 ### Pre-commit Process
 1. Run `mise run lint-fix` and `git add` any lint fixes before committing


### PR DESCRIPTION
## Summary

- document or connect the repository’s Conventional Commits policy for pull request titles
- validate the title on creation and every edit with the repository’s allowed types
- use a permissionless `pull_request_target` workflow with no checkout, so pull request code cannot bypass the check
- intentionally ignore intermediate commit subjects because pull requests are squash-merged using their titles

## Testing

- `actionlint .github/workflows/conventional-commits.yml`
- exercised valid, breaking-change, invalid-type, uppercase-description, and trailing-space title cases locally

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated validation to ensure pull request titles follow the project’s Conventional Commits format.
  - Validation runs when pull requests are opened, edited, reopened, or updated, with errors reported for invalid titles.
  - Scoped `registry` pull request titles are rejected.

- **Documentation**
  - Updated contribution guidance with the supported `ci` and `revert` commit types.
  - Clarified title and commit-subject rules, lowercase descriptions, and review expectations for imperative wording and breaking changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI title validation and contributor docs; no application runtime or auth logic is modified.
> 
> **Overview**
> Adds a **permissionless GitHub Actions workflow** that validates every pull request title against the repo’s Conventional Commits rules on open, edit, reopen, and sync. The job uses `pull_request_target` with **no checkout**—it only regex-checks the title for allowed types, optional scope/breaking `!`, and a **lowercase-leading description**, and it **rejects scoped `registry(...)` titles**.
> 
> **Documentation** in `AGENTS.md` and `.cursor/rules/conventional_commits.mdc` is aligned with that enforcement: PR titles are required to match the format; squash-merge means **intermediate commit subjects are not checked**; new types **`ci:`** and **`revert:`** are listed; **`registry:`** is documented as **no scope**; and the format line now includes optional scope and breaking-change `!`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c37f6af48873a5f37ccaa2fd5f81a33b7fac44d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->