### PR TITLE
chore(release): simplify the packslip job with upstream v1.0.0 fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -603,7 +603,7 @@ jobs:
       # writing it under packslip/, and an artifact holding files at two
       # depths keeps the directory, which the flat `sha256sum ./*` below
       # would then choke on.
-      - uses: jdx/packslip@0121abf6972fe6ca13633233402439a715f4cc0e # v1.0.0
+      - uses: jdx/packslip@a6eddff2d884891faa2efbec374b48e7053df2c4 # v1.0.1
         with:
           artifacts: release-assets/mise-*
           bin: mise

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -599,37 +599,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.MISE_GH_TOKEN }}
         run: gh release upload "$GITHUB_REF_NAME" mise.usage.kdl --clobber
-      # Two things the file names cannot say. A bare executable named for a
-      # dotted version has no extension to read a format from. And the man
-      # page is inside the Unix archives only -- the Windows zip carries none,
-      # and a bare executable is not an archive to look inside -- so each
-      # entry names the artifact it is really in.
-      - name: Describe what the file names cannot
-        run: |
-          {
-            for f in "release-assets/mise-$GITHUB_REF_NAME"-*; do
-              case "${f##*/}" in
-                *.tar.gz | *.tar.xz | *.tar.zst | *.zip | *.exe) continue ;;
-              esac
-              printf '[[artifact]]\npath = "%s"\nformat = "raw"\n\n' "$f"
-            done
-            for f in "release-assets/mise-$GITHUB_REF_NAME"-*.tar.*; do
-              name="${f##*/}"
-              case "$name" in *windows*) continue ;; esac
-              printf '[[resource]]\nkind = "man"\nartifact = "%s"\narchive = "mise/man/man1/mise.1"\n\n' "$name"
-            done
-          } > packslip.toml
-          cat packslip.toml
       # `out: .` keeps the bundle beside mise.usage.kdl. The action defaults to
       # writing it under packslip/, and an artifact holding files at two
       # depths keeps the directory, which the flat `sha256sum ./*` below
       # would then choke on.
-      - uses: jdx/packslip@433c0c0f033e64c22f12433471768c255ef2bd93 # v0.3.0
+      - uses: jdx/packslip@0121abf6972fe6ca13633233402439a715f4cc0e # v1.0.0
         with:
           artifacts: release-assets/mise-*
-          manifest: packslip.toml
           bin: mise
-          resources: cli-spec/usage=asset:mise.usage.kdl
+          # A bare executable named for a dotted version (mise-v2026.9.1-linux-x64)
+          # now infers format = "raw" on its own, and the platform scope below picks
+          # the man page out of the Unix archives only -- the Windows zip carries
+          # none -- so neither needs a manifest to say what the file name can't.
+          resources: |
+            man@linux=archive:mise/man/man1/mise.1
+            man@darwin=archive:mise/man/man1/mise.1
+            cli-spec/usage=asset:mise.usage.kdl
           attest: "false"
           out: "."
           token: ${{ secrets.MISE_GH_TOKEN }}


### PR DESCRIPTION
## Summary
- Bumps the pinned `jdx/packslip` action from v0.3.0 to v1.0.0.
- Removes the hand-generated `packslip.toml` manifest and its "Describe what the file names cannot" step.
- packslip v1.0.0 infers `format = "raw"` for a bare executable ending in a dotted version (mise's own asset naming, e.g. `mise-v2026.9.1-linux-x64`), and its `resources` input now accepts a platform scope (`man@linux=...`, `man@darwin=...`), so both of the reasons the manifest existed are now handled without it.

## Test plan
- [ ] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` (done locally)
- [ ] Next tagged release runs the `packslip` job successfully and `packslip.sigstore.json` shows the man-page resource for linux/darwin artifacts and `format = "raw"` on the bare executables

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only release workflow change; risk is a failed or incorrect packslip on the next tag if upstream inference or platform scoping regresses.
> 
> **Overview**
> **Release packaging** now pins `jdx/packslip` at **v1.0.1** (was v0.3.0) and drops the shell step that generated `packslip.toml`, plus the action’s `manifest` input.
> 
> Man pages and the bare versioned executables are configured inline via the action’s `resources` block: `man@linux` / `man@darwin` pull `mise.1` from Unix archives only, and v1 is expected to infer `format = "raw"` for extensionless `mise-v*-*` assets. The `cli-spec/usage` resource is unchanged in intent (`asset:mise.usage.kdl`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5ff3aa19ed9de4afcb64c9b0182b6fb94d5aa4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release packaging workflow to use the latest packaging action.
  * Simplified packaging configuration while preserving platform-specific man page handling.
  * Improved packaging of version-named executables by automatically recognizing their format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

*AI-assisted — Tool: Claude Code; model: anthropic/claude-sonnet-5; version: unavailable.*
