### PR TITLE
ci(release): bump packslip to v1.0.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -634,7 +634,7 @@ jobs:
       # writing it under packslip/, and an artifact holding files at two
       # depths keeps the directory, which the flat `sha256sum ./*` below
       # would then choke on.
-      - uses: jdx/packslip@a6eddff2d884891faa2efbec374b48e7053df2c4 # v1.0.1
+      - uses: jdx/packslip@5c1cced7cfa661140dbc972a0de55b2b6bd81522 # v1.0.2
         with:
           artifacts: release-assets/mise-*
           bin: mise


### PR DESCRIPTION
v1.0.1 uploaded the packslip with `gh release upload "$TAG" "$BUNDLE" --clobber` and no `--repo`, so `gh` fell back to asking git which repository it was in. The job that runs it only downloads artifacts and has no checkout, so the upload failed with

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

after the packslip had already been created and verified.
The packslip job here has not run on a tag yet (it landed after v2026.9.1), so the next release would be the first to hit it. jdx/mr-boxington and jdx/tak hit exactly this today.


v1.0.2 carries jdx/packslip#71, which passes `--repo`. Pinned to the release commit `5c1cced`, which is what the `v1.0.2` tag points at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single pinned third-party action bump in CI with no application or release-script logic changes.
> 
> **Overview**
> Updates the **packslip** job in `release.yml` from **jdx/packslip v1.0.1** to **v1.0.2** (commit `5c1cced`).
> 
> v1.0.2 fixes release uploads in jobs that never run `actions/checkout`: v1.0.1’s `gh release upload` omitted `--repo`, so `gh` tried to infer the repository via git and failed with “not a git repository” after the bundle was built. The fix (packslip#71) passes `--repo` explicitly so the next tag release can publish `packslip.sigstore.json` and related assets from this workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68792802fc5d4c7320cf6973485d5351059d495b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release packaging workflow to use the latest patch version of the packaging action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->