### PR TITLE
chore(ci): bump packslip to v1.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -634,7 +634,7 @@ jobs:
       # writing it under packslip/, and an artifact holding files at two
       # depths keeps the directory, which the flat `sha256sum ./*` below
       # would then choke on.
-      - uses: jdx/packslip@5c1cced7cfa661140dbc972a0de55b2b6bd81522 # v1.0.2
+      - uses: jdx/packslip@a0d434ad57571c62dbd0ab5095b4eff607a71fd3 # v1.1.1
         with:
           artifacts: release-assets/mise-*
           bin: mise


### PR DESCRIPTION
Update the release workflow to use packslip v1.1.1 at its immutable commit SHA. This release pins the nested provenance action, so repositories enforcing full-length action SHAs can load the composite action.

Validation: `git diff --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pin on the release packslip step; no application or release-script logic changes.
> 
> **Overview**
> Updates the **release** workflow’s `packslip` job to use **`jdx/packslip` v1.1.1** (pinned at commit `a0d434a…`) instead of v1.0.2. The step’s inputs (`artifacts`, `bin`, `resources`, `attest`, `out`, `token`) are unchanged.
> 
> The bump mainly brings in **packslip v1.1.1**, which pins its nested provenance action at a full-length SHA so the composite action loads under policies that require immutable action references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6437c77eca6735c407c02698419a0b75f24d1067. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release packaging workflow to use a newer version of the packaging action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->