### PR TITLE
test(packslip): use canonical identity for latest smoke test

### DIFF
--- a/docs/dev-tools/backends/packslip.md
+++ b/docs/dev-tools/backends/packslip.md
@@ -16,7 +16,7 @@ young, and its own version is what says what a manifest may contain.
 With [mise activated](/getting-started.html), install packslip itself:
 
 ```sh
-mise use -g packslip:github.com/jdx/packslip
+mise use -g 'packslip:packslip.dev[issuer=https://token.actions.githubusercontent.com,identity_prefix=https://github.com/jdx/packslip/.github/workflows/]'
 packslip version
 ```
 
@@ -25,10 +25,16 @@ For a project configuration:
 
 ```toml
 [tools]
-"packslip:github.com/jdx/packslip" = "latest"
+"packslip:packslip.dev" = { version = "latest", issuer = "https://token.actions.githubusercontent.com", identity_prefix = "https://github.com/jdx/packslip/.github/workflows/" }
 ```
 
 ### Project names and discovery
+
+New packslip releases identify their project as `packslip.dev`. The explicit
+issuer and identity prefix above trust its GitHub publishing workflows for both
+the signed release list and release bundles. Historical releases such as
+`packslip:github.com/jdx/packslip@0.2.0` retain their original GitHub identity;
+the two project names are not interchangeable.
 
 A project name is a host followed by an optional path, without `https://`.
 `packslip:owner/repo` is shorthand for `packslip:github.com/owner/repo`.
@@ -62,7 +68,7 @@ GitHub has a release-API integration; other hosts need the signed-list location.
 List the project's available versions with:
 
 ```sh
-mise ls-remote packslip:github.com/jdx/packslip
+mise ls-remote packslip:packslip.dev
 ```
 
 Packslip versions use semver, including compatible date versions such as

--- a/e2e/backend/test_packslip
+++ b/e2e/backend/test_packslip
@@ -11,10 +11,20 @@ export MISE_MINIMUM_RELEASE_AGE=0
 # The backend needs no setting turned on to be used.
 assert_contains "env -u MISE_EXPERIMENTAL mise ls-remote packslip:github.com/jdx/packslip" "0.2.0"
 
+# New releases use the canonical domain identity. Pin the publishing repository's
+# workflows explicitly: the signed list and release bundles use different workflows.
+mkdir canonical
+pushd canonical >/dev/null
+cat >mise.toml <<'EOF'
+[tools]
+"packslip:packslip.dev" = { version = "latest", issuer = "https://token.actions.githubusercontent.com", identity_prefix = "https://github.com/jdx/packslip/.github/workflows/" }
+EOF
 # Latest resolves and verifies the vendor recommendation without installing it.
-latest=$(mise latest packslip:github.com/jdx/packslip) || exit 1
+latest=$(mise latest packslip:packslip.dev) || exit 1
 [[ -n $latest ]] || exit 1
-assert_contains "mise ls-remote packslip:github.com/jdx/packslip" "$latest"
+assert_contains "mise ls-remote packslip:packslip.dev" "$latest"
+mise packslip forget packslip.dev
+popd >/dev/null
 
 # A warm accepted-version cache must not hide changed stamper policy.
 mkdir stamp-policy

--- a/src/backend/packslip.rs
+++ b/src/backend/packslip.rs
@@ -826,11 +826,7 @@ impl PackslipBackend {
             }
         }
         let verified = verify_bundle(&text, pin, !opts.allow_unlogged(), &[])?;
-        if verified.project != project || verified.version != version {
-            bail!(
-                "packslip:{project}@{version}: verified manifest project/version differs from discovery"
-            );
-        }
+        validate_discovered_identity(project, version, &verified.project, &verified.version)?;
         let scheme = verified.scheme.to_string();
         let attested_by = verified.attested_by.to_string();
         packslip_pins::check(
@@ -1461,10 +1457,49 @@ impl Backend for PackslipBackend {
     }
 }
 
+/// A trusted signer does not make a different project or version interchangeable.
+fn validate_discovered_identity(
+    project: &str,
+    version: &str,
+    signed_project: &str,
+    signed_version: &str,
+) -> Result<()> {
+    if signed_project != project || signed_version != version {
+        bail!(
+            "packslip:{project}@{version}: verified manifest project/version differs from discovery"
+        );
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use packslip::model::Bin;
+
+    #[test]
+    fn discovery_requires_exact_signed_project_and_version() {
+        assert!(
+            validate_discovered_identity("packslip.dev", "1.1.1", "packslip.dev", "1.1.1").is_ok()
+        );
+        for (signed_project, signed_version) in [
+            ("packslip.dev", "1.1.1"),
+            ("github.com/jdx/packslip", "1.1.0"),
+            ("packslip.dev", "1.1.0"),
+        ] {
+            assert!(
+                validate_discovered_identity(
+                    "github.com/jdx/packslip",
+                    "1.1.1",
+                    signed_project,
+                    signed_version
+                )
+                .unwrap_err()
+                .to_string()
+                .contains("project/version differs from discovery")
+            );
+        }
+    }
 
     fn artifact(name: &str, os: &str, arch: &str, libc: Option<&str>, format: &str) -> Artifact {
         Artifact {


### PR DESCRIPTION
## Summary

- Resolve the live packslip `latest` smoke test through the canonical `packslip.dev` signed index, explicitly pinning the GitHub Actions issuer and jdx/packslip publishing workflow path.
- Preserve historical `github.com/jdx/packslip@0.2.0` installation, signer, lockfile, and shorthand coverage.
- Update install examples and explain the identity migration.
- Extract the existing exact project/version comparison without changing behavior and add deterministic mismatch regression coverage. No signature, transparency-log, or identity checks are relaxed.

## Why

Current packslip releases sign project `packslip.dev`. The test on main asks `mise latest packslip:github.com/jdx/packslip`, which correctly rejects v1.1.1 because its signed project differs. This is the remaining unrelated CI failure on #12830. The signed release list and release bundles use different publishing workflows in the same repository; both are covered by the explicitly configured repository workflow prefix.

## Validation

- 10 packslip backend unit tests passed, including exact signed project/version regression.
- Both `e2e/backend/test_packslip` and `test_packslip_resources` passed via the mise e2e task.
- Live canonical latest resolved and verified 1.1.1; historical 0.2.0 installs verified successfully.
- Rust formatting, shellcheck, shfmt, markdownlint, and Prettier passed.
- Used the documented MBX_DISABLE Cargo fallback for the local wrapper mismatch; no permanent wrapper changes.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and test alignment plus a no-behavior-change refactor with added regression tests; packslip verification rules are not relaxed.
> 
> **Overview**
> Aligns packslip install docs and live e2e coverage with **canonical `packslip.dev` releases**, which sign a different project id than legacy **`github.com/jdx/packslip`** (e.g. 0.2.0). Examples and the **`latest` / `ls-remote` smoke test** now use `packslip:packslip.dev` with explicit **`issuer`** and **`identity_prefix`** so both the signed index and release bundles from jdx/packslip workflows verify. Historical GitHub-path installs and other e2e checks stay unchanged.
> 
> Refactors the **`latest` candidate** manifest check into **`validate_discovered_identity`** (same strict project/version match) and adds a unit test that **`packslip.dev` and `github.com/jdx/packslip` are not interchangeable** even when the signer is trusted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4100534d2b91e207e0466f72a528c25f9dcae454. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Packslip setup examples to use the canonical `packslip.dev` domain.
  - Added guidance for configuring explicit OIDC issuer and identity settings.
  - Clarified how current and historical Packslip releases are identified and that their project names are not interchangeable.

- **Bug Fixes**
  - Improved validation of signed manifests and release bundles to ensure they match the requested project and version exactly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->