### PR TITLE
registry: pin packslip release and index workflows

### DIFF
--- a/docs/dev-tools/backends/packslip.md
+++ b/docs/dev-tools/backends/packslip.md
@@ -16,7 +16,7 @@ young, and its own version is what says what a manifest may contain.
 With [mise activated](/getting-started.html), install packslip itself:
 
 ```sh
-mise use -g packslip:github.com/jdx/packslip
+mise use -g 'packslip:packslip.dev[issuer=https://token.actions.githubusercontent.com,identity_prefix=https://github.com/jdx/packslip/.github/workflows/release.yml@,list_identity_prefix=https://github.com/jdx/packslip/.github/workflows/packslip-releases.yml@]'
 packslip version
 ```
 
@@ -24,11 +24,23 @@ Omit `-g` to manage the tool in the current project's `mise.toml` instead.
 For a project configuration:
 
 ```toml
-[tools]
-"packslip:github.com/jdx/packslip" = "latest"
+[tools."packslip:packslip.dev"]
+version = "latest"
+issuer = "https://token.actions.githubusercontent.com"
+identity_prefix = "https://github.com/jdx/packslip/.github/workflows/release.yml@"
+list_identity_prefix = "https://github.com/jdx/packslip/.github/workflows/packslip-releases.yml@"
 ```
 
 ### Project names and discovery
+
+New packslip releases identify their project as `packslip.dev`. The explicit
+issuer and workflow prefixes above trust `release.yml` for release bundles and
+`packslip-releases.yml` for the signed release list. The trailing `@` pins the
+whole workflow filename while allowing its Git refs to vary. A repository-wide
+prefix would also trust non-release workflows such as `ci.yml`. Historical
+releases such as
+`packslip:github.com/jdx/packslip@0.2.0` retain their original GitHub identity;
+the two project names are not interchangeable.
 
 A project name is a host followed by an optional path, without `https://`.
 `packslip:owner/repo` is shorthand for `packslip:github.com/owner/repo`.
@@ -62,7 +74,7 @@ GitHub has a release-API integration; other hosts need the signed-list location.
 List the project's available versions with:
 
 ```sh
-mise ls-remote packslip:github.com/jdx/packslip
+mise ls-remote packslip:packslip.dev
 ```
 
 Packslip versions use semver, including compatible date versions such as
@@ -284,6 +296,18 @@ its `.pub` file. The vendor list and release bundles must verify against it.
 Pin a keyless signer using an exact certificate identity or an identity prefix,
 plus its OIDC issuer. These options can replace the policy derived from a forge
 name. Keep the trailing slash when pinning a repository prefix.
+
+### `list_identity_prefix`
+
+When a different workflow signs the vendor's release list, pin its certificate
+identity prefix separately. It replaces `identity` and `identity_prefix` only
+for the vendor's list; release bundles still require their original signer.
+The OIDC `issuer` is shared (including an issuer derived from a forge project).
+Without this option, the list uses the same policy as release bundles.
+
+The value must be a non-empty string and requires an issuer. It cannot be
+combined with `pubkey`. It does not affect configured stampers, whose lists
+use their own pins.
 
 ### `allow_unlogged`
 

--- a/docs/dev-tools/backends/packslip.md
+++ b/docs/dev-tools/backends/packslip.md
@@ -16,7 +16,7 @@ young, and its own version is what says what a manifest may contain.
 With [mise activated](/getting-started.html), install packslip itself:
 
 ```sh
-mise use -g 'packslip:packslip.dev[issuer=https://token.actions.githubusercontent.com,identity_prefix=https://github.com/jdx/packslip/.github/workflows/release.yml@,list_identity_prefix=https://github.com/jdx/packslip/.github/workflows/packslip-releases.yml@]'
+mise use -g packslip
 packslip version
 ```
 
@@ -24,12 +24,11 @@ Omit `-g` to manage the tool in the current project's `mise.toml` instead.
 For a project configuration:
 
 ```toml
-[tools."packslip:packslip.dev"]
-version = "latest"
-issuer = "https://token.actions.githubusercontent.com"
-identity_prefix = "https://github.com/jdx/packslip/.github/workflows/release.yml@"
-list_identity_prefix = "https://github.com/jdx/packslip/.github/workflows/packslip-releases.yml@"
+[tools]
+packslip = "latest"
 ```
+
+The registry entry supplies Packslip's signer policy.
 
 ### Project names and discovery
 
@@ -65,7 +64,7 @@ GitHub has a release-API integration; other hosts need the signed-list location.
 List the project's available versions with:
 
 ```sh
-mise ls-remote packslip:packslip.dev
+mise ls-remote packslip
 ```
 
 Packslip versions use semver, including compatible date versions such as

--- a/docs/dev-tools/backends/packslip.md
+++ b/docs/dev-tools/backends/packslip.md
@@ -33,15 +33,6 @@ list_identity_prefix = "https://github.com/jdx/packslip/.github/workflows/packsl
 
 ### Project names and discovery
 
-New packslip releases identify their project as `packslip.dev`. The explicit
-issuer and workflow prefixes above trust `release.yml` for release bundles and
-`packslip-releases.yml` for the signed release list. The trailing `@` pins the
-whole workflow filename while allowing its Git refs to vary. A repository-wide
-prefix would also trust non-release workflows such as `ci.yml`. Historical
-releases such as
-`packslip:github.com/jdx/packslip@0.2.0` retain their original GitHub identity;
-the two project names are not interchangeable.
-
 A project name is a host followed by an optional path, without `https://`.
 `packslip:owner/repo` is shorthand for `packslip:github.com/owner/repo`.
 

--- a/e2e/backend/test_packslip
+++ b/e2e/backend/test_packslip
@@ -11,10 +11,25 @@ export MISE_MINIMUM_RELEASE_AGE=0
 # The backend needs no setting turned on to be used.
 assert_contains "env -u MISE_EXPERIMENTAL mise ls-remote packslip:github.com/jdx/packslip" "0.2.0"
 
+# New releases use the canonical domain identity. Pin each publishing workflow
+# separately so CI signing jobs cannot authorize either bundles or the index.
+mkdir canonical
+pushd canonical >/dev/null
+cat >mise.toml <<'EOF'
+[tools]
+"packslip:packslip.dev" = { version = "latest", issuer = "https://token.actions.githubusercontent.com", identity_prefix = "https://github.com/jdx/packslip/.github/workflows/release.yml@", list_identity_prefix = "https://github.com/jdx/packslip/.github/workflows/packslip-releases.yml@" }
+EOF
 # Latest resolves and verifies the vendor recommendation without installing it.
-latest=$(mise latest packslip:github.com/jdx/packslip) || exit 1
+latest=$(mise latest packslip:packslip.dev) || exit 1
 [[ -n $latest ]] || exit 1
-assert_contains "mise ls-remote packslip:github.com/jdx/packslip" "$latest"
+assert_contains "mise ls-remote packslip:packslip.dev" "$latest"
+# Changing a list policy must not reuse the accepted versions from the warm cache.
+assert_fail_contains "mise ls-remote 'packslip:packslip.dev[list_identity_prefix=https://github.com/jdx/packslip/.github/workflows/ci.yml@]'" "verifying the release list"
+# A trusted index does not authorize its signer (or CI) to sign release bundles.
+assert_fail_contains "mise latest 'packslip:packslip.dev[identity_prefix=https://github.com/jdx/packslip/.github/workflows/packslip-releases.yml@]'" "expected an identity starting with"
+assert_fail_contains "mise latest 'packslip:packslip.dev[identity_prefix=https://github.com/jdx/packslip/.github/workflows/ci.yml@]'" "expected an identity starting with"
+mise packslip forget packslip.dev
+popd >/dev/null
 
 # A warm accepted-version cache must not hide changed stamper policy.
 mkdir stamp-policy

--- a/e2e/backend/test_packslip
+++ b/e2e/backend/test_packslip
@@ -11,23 +11,29 @@ export MISE_MINIMUM_RELEASE_AGE=0
 # The backend needs no setting turned on to be used.
 assert_contains "env -u MISE_EXPERIMENTAL mise ls-remote packslip:github.com/jdx/packslip" "0.2.0"
 
-# New releases use the canonical domain identity. Pin each publishing workflow
+# The registry supplies the canonical project and pins each publishing workflow
 # separately so CI signing jobs cannot authorize either bundles or the index.
 mkdir canonical
 pushd canonical >/dev/null
 cat >mise.toml <<'EOF'
 [tools]
-"packslip:packslip.dev" = { version = "latest", issuer = "https://token.actions.githubusercontent.com", identity_prefix = "https://github.com/jdx/packslip/.github/workflows/release.yml@", list_identity_prefix = "https://github.com/jdx/packslip/.github/workflows/packslip-releases.yml@" }
+packslip = "latest"
 EOF
 # Latest resolves and verifies the vendor recommendation without installing it.
-latest=$(mise latest packslip:packslip.dev) || exit 1
+latest=$(mise latest packslip) || exit 1
 [[ -n $latest ]] || exit 1
-assert_contains "mise ls-remote packslip:packslip.dev" "$latest"
+assert_contains "mise ls-remote packslip" "$latest"
+# The quickstart works with no explicit signer options in the user's config.
+MISE_GLOBAL_CONFIG_FILE="$PWD/global.toml" mise use -g packslip
+assert_contains "cat global.toml" 'packslip ='
+assert_contains "mise exec -- packslip version" "packslip $latest"
+canonical_install_path="$(mise where packslip)"
+assert_contains "cat $canonical_install_path/.mise-packslip.json" '"project": "packslip.dev"'
 # Changing a list policy must not reuse the accepted versions from the warm cache.
-assert_fail_contains "mise ls-remote 'packslip:packslip.dev[list_identity_prefix=https://github.com/jdx/packslip/.github/workflows/ci.yml@]'" "verifying the release list"
+assert_fail_contains "mise ls-remote 'packslip[list_identity_prefix=https://github.com/jdx/packslip/.github/workflows/ci.yml@]'" "verifying the release list"
 # A trusted index does not authorize its signer (or CI) to sign release bundles.
-assert_fail_contains "mise latest 'packslip:packslip.dev[identity_prefix=https://github.com/jdx/packslip/.github/workflows/packslip-releases.yml@]'" "expected an identity starting with"
-assert_fail_contains "mise latest 'packslip:packslip.dev[identity_prefix=https://github.com/jdx/packslip/.github/workflows/ci.yml@]'" "expected an identity starting with"
+assert_fail_contains "mise latest 'packslip[identity_prefix=https://github.com/jdx/packslip/.github/workflows/packslip-releases.yml@]'" "expected an identity starting with"
+assert_fail_contains "mise latest 'packslip[identity_prefix=https://github.com/jdx/packslip/.github/workflows/ci.yml@]'" "expected an identity starting with"
 mise packslip forget packslip.dev
 popd >/dev/null
 

--- a/registry/packslip.toml
+++ b/registry/packslip.toml
@@ -1,9 +1,18 @@
-backends = [
-  "packslip:github.com/jdx/packslip",
-  "github:jdx/packslip",
-  "cargo:packslip",
-]
 bins = ["packslip"]
 description = "A signed release manifest for vendor binaries"
 test = { cmd = "packslip --version", expected = "packslip {{version}}" }
 version_order = "semver"
+
+[[backends]]
+full = "packslip:packslip.dev"
+
+[backends.options]
+identity_prefix = "https://github.com/jdx/packslip/.github/workflows/release.yml@"
+issuer = "https://token.actions.githubusercontent.com"
+list_identity_prefix = "https://github.com/jdx/packslip/.github/workflows/packslip-releases.yml@"
+
+[[backends]]
+full = "github:jdx/packslip"
+
+[[backends]]
+full = "cargo:packslip"

--- a/src/backend/packslip.rs
+++ b/src/backend/packslip.rs
@@ -110,6 +110,7 @@ pub(crate) fn install_time_option_keys() -> Vec<String> {
         "pubkey",
         "identity",
         "identity_prefix",
+        "list_identity_prefix",
         "issuer",
         "allow_unlogged",
         "ignore_requirements",
@@ -417,6 +418,7 @@ fn locate_entry(install_path: &Path, rel: &str, wanted: fn(&Path) -> bool) -> Op
 
 /// What the consumer pinned: the forge identity a name implies, or the key
 /// or identity given in the tool options.
+#[derive(Clone)]
 pub(crate) enum Pin {
     Identity(Policy),
     Key(packslip::minisign::PublicKey),
@@ -450,6 +452,28 @@ fn pin(project: &str, opts: &PackslipOptions<'_>) -> Result<Pin> {
 }
 
 impl Pin {
+    /// A vendor may publish its index from a different workflow than its bundles.
+    /// The override replaces only the list's subject constraint, retaining the issuer.
+    fn for_release_list(&self, opts: &PackslipOptions<'_>) -> Result<Self> {
+        let Some(value) = opts.raw.opts.get("list_identity_prefix") else {
+            return Ok(self.clone());
+        };
+        let Some(prefix) = value.as_str().filter(|prefix| !prefix.trim().is_empty()) else {
+            bail!("packslip: list_identity_prefix must be a non-empty string");
+        };
+        let Self::Identity(policy) = self else {
+            bail!("packslip: list_identity_prefix cannot be combined with pubkey");
+        };
+        if policy.issuer.as_deref().is_none_or(str::is_empty) {
+            bail!("packslip: list_identity_prefix requires an issuer");
+        }
+        Ok(Self::Identity(Policy {
+            issuer: policy.issuer.clone(),
+            identity: None,
+            identity_prefix: Some(prefix.to_string()),
+        }))
+    }
+
     fn trust(&self) -> Trust<'_> {
         match self {
             Pin::Identity(policy) => Trust::Identity(policy),
@@ -596,11 +620,12 @@ impl PackslipBackend {
         pin: &Pin,
         opts: &PackslipOptions<'_>,
     ) -> Result<ReleaseListStatement> {
+        let pin = pin.for_release_list(opts)?;
         let url = well_known_url(project);
         let text = HTTP_FETCH.get_text(&url).await.wrap_err_with(|| {
             format!("fetching the release list of packslip:{project} from {url}")
         })?;
-        let list = verify_release_list(&text, pin, !opts.allow_unlogged())
+        let list = verify_release_list(&text, &pin, !opts.allow_unlogged())
             .wrap_err_with(|| format!("verifying the release list of packslip:{project}"))?;
         if list.predicate.project != project {
             bail!(
@@ -613,10 +638,10 @@ impl PackslipBackend {
     }
 
     /// The signed list a github.com repository may keep at `.well-known`
-    /// on its default branch, verified against the same identity as its
-    /// packslips. `None` when the repository has none, which is the usual
-    /// case: a vendor writes one only to withdraw a release, flag a
-    /// security fix, or list a release whose tag names no version.
+    /// on its default branch, verified against its list signer (by default,
+    /// the same identity as its packslips). `None` when the repository has
+    /// none, which is the usual case: a vendor writes one only to withdraw
+    /// a release, flag a security fix, or list a release whose tag names no version.
     async fn github_list(
         &self,
         project: &str,
@@ -624,6 +649,7 @@ impl PackslipBackend {
         pin: &Pin,
         opts: &PackslipOptions<'_>,
     ) -> Result<Option<ReleaseListStatement>> {
+        let pin = pin.for_release_list(opts)?;
         let path = match repository_subpath(project) {
             Some(sub) => format!(".well-known/packslip/{sub}.json"),
             None => ".well-known/packslip.json".to_string(),
@@ -646,7 +672,7 @@ impl PackslipBackend {
                     .wrap_err_with(|| format!("fetching the release list of packslip:{project}"));
             }
         };
-        let list = verify_release_list(&text, pin, !opts.allow_unlogged())
+        let list = verify_release_list(&text, &pin, !opts.allow_unlogged())
             .wrap_err_with(|| format!("verifying the release list of packslip:{project}"))?;
         if list.predicate.project != project {
             bail!(
@@ -1006,6 +1032,7 @@ impl Backend for PackslipBackend {
             "pubkey",
             "identity",
             "identity_prefix",
+            "list_identity_prefix",
             "issuer",
             "allow_unlogged",
             "trust",
@@ -1465,6 +1492,86 @@ impl Backend for PackslipBackend {
 mod tests {
     use super::*;
     use packslip::model::Bin;
+
+    #[test]
+    fn release_list_policy_keeps_bundle_and_index_signers_separate() {
+        let raw: ToolVersionOptions = toml::from_str(
+            r#"
+issuer = "https://token.actions.githubusercontent.com"
+identity = "https://github.com/jdx/packslip/.github/workflows/release.yml@refs/tags/v1.1.1"
+identity_prefix = "https://github.com/jdx/packslip/.github/workflows/release.yml@"
+list_identity_prefix = "https://github.com/jdx/packslip/.github/workflows/packslip-releases.yml@"
+"#,
+        )
+        .unwrap();
+        let opts = PackslipOptions::new(&raw);
+        let bundle_pin = pin("packslip.dev", &opts).unwrap();
+        let list_pin = bundle_pin.for_release_list(&opts).unwrap();
+        let (Pin::Identity(bundle), Pin::Identity(list)) = (&bundle_pin, list_pin) else {
+            panic!("expected keyless policies");
+        };
+        assert_eq!(bundle.identity, opts.identity());
+        assert_eq!(bundle.identity_prefix, opts.identity_prefix());
+        assert_eq!(list.issuer, bundle.issuer);
+        assert_eq!(list.identity, None);
+        assert_eq!(list.identity_prefix, raw.get_string("list_identity_prefix"));
+
+        let mut raw = raw.clone();
+        raw.opts.shift_remove("list_identity_prefix");
+        let Pin::Identity(list) = bundle_pin
+            .for_release_list(&PackslipOptions::new(&raw))
+            .unwrap()
+        else {
+            panic!("expected keyless policy");
+        };
+        assert_eq!(&list, bundle);
+    }
+
+    #[test]
+    fn release_list_policy_rejects_invalid_overrides() {
+        let bundle = Pin::Identity(Policy::for_project("github.com/jdx/packslip").unwrap());
+        for value in ["\"\"", "\"  \"", "true", "[]"] {
+            let raw: ToolVersionOptions =
+                toml::from_str(&format!("list_identity_prefix = {value}")).unwrap();
+            assert!(
+                bundle
+                    .for_release_list(&PackslipOptions::new(&raw))
+                    .err()
+                    .unwrap()
+                    .to_string()
+                    .contains("must be a non-empty string")
+            );
+        }
+        let raw: ToolVersionOptions = toml::from_str(
+            r#"list_identity_prefix = "https://github.com/jdx/packslip/.github/workflows/packslip-releases.yml@""#,
+        )
+        .unwrap();
+        let opts = PackslipOptions::new(&raw);
+        let Pin::Identity(list) = bundle.for_release_list(&opts).unwrap() else {
+            panic!("expected keyless policy");
+        };
+        assert_eq!(
+            list.issuer.as_deref(),
+            Some("https://token.actions.githubusercontent.com")
+        );
+        let unpinned = Pin::Identity(Policy::default());
+        assert!(
+            unpinned
+                .for_release_list(&opts)
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("requires an issuer")
+        );
+        let key = Pin::Key(packslip::minisign::SecretKey::from_seed([7; 32]).public_key());
+        assert!(
+            key.for_release_list(&opts)
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("cannot be combined with pubkey")
+        );
+    }
 
     fn artifact(name: &str, os: &str, arch: &str, libc: Option<&str>, format: &str) -> Artifact {
         Artifact {

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -114,8 +114,18 @@ pub(crate) fn split_bracketed_opts(s: &str) -> Option<(&str, &str)> {
     if !s.ends_with(']') {
         return None;
     }
+    let (name, opts, suffix) = split_bracketed_opts_with_suffix(s)?;
+    suffix.is_empty().then_some((name, opts))
+}
 
+/// Split inline options while preserving a following version, even when option
+/// values contain '@', quoted brackets, or nested arrays.
+pub(crate) fn split_bracketed_opts_with_suffix(s: &str) -> Option<(&str, &str, &str)> {
+    if !s.contains('[') {
+        return None;
+    }
     let mut bracket_start = None;
+    let mut depth = 0;
     let mut in_single_quotes = false;
     let mut in_double_quotes = false;
     let mut escaped = false;
@@ -124,14 +134,16 @@ pub(crate) fn split_bracketed_opts(s: &str) -> Option<(&str, &str)> {
         match ch {
             '\'' if !in_double_quotes => in_single_quotes = !in_single_quotes,
             '"' if !in_single_quotes && !escaped => in_double_quotes = !in_double_quotes,
-            '[' if !in_single_quotes && !in_double_quotes && bracket_start.is_none() => {
-                bracket_start = Some(index);
+            '[' if !in_single_quotes && !in_double_quotes => {
+                bracket_start.get_or_insert(index);
+                depth += 1;
             }
-            ']' if !in_single_quotes && !in_double_quotes && index == s.len() - 1 => {
-                if let Some(start) = bracket_start {
-                    return Some((&s[..start], &s[start + 1..index]));
+            ']' if !in_single_quotes && !in_double_quotes => {
+                let start = bracket_start?;
+                depth -= 1;
+                if depth == 0 {
+                    return Some((&s[..start], &s[start + 1..index], &s[index + 1..]));
                 }
-                return None;
             }
             _ => {}
         }

--- a/src/cli/args/tool_arg.rs
+++ b/src/cli/args/tool_arg.rs
@@ -151,6 +151,23 @@ impl Display for ToolArg {
 }
 
 fn parse_input(s: &str) -> (&str, Option<&str>) {
+    // An identity or URL in inline options may contain '@'. Only a separator
+    // after the closing bracket starts a version; scoped package names still
+    // follow the ordinary rules below.
+    if let Some((name, _, suffix)) = super::backend_arg::split_bracketed_opts_with_suffix(s)
+        && parse_input(name) == (name, None)
+    {
+        if suffix.is_empty() {
+            return (s, None);
+        }
+        if let Some(version) = suffix.strip_prefix('@') {
+            return (
+                &s[..s.len() - suffix.len()],
+                (!version.is_empty()).then_some(version),
+            );
+        }
+    }
+
     let Some((left, right)) = s.split_once('@') else {
         return (s, None);
     };
@@ -258,7 +275,7 @@ mod tests {
     #[tokio::test]
     async fn test_tool_arg_parse_input() {
         let _config = Config::get().await.unwrap();
-        let t = |input, f, v| {
+        let t = |input: &str, f: &str, v: Option<&str>| {
             let (backend, version) = parse_input(input);
             assert_eq!(backend, f);
             assert_eq!(version, v);
@@ -298,5 +315,26 @@ mod tests {
         t("@biomejs/biome@latest", "@biomejs/biome", Some("latest"));
         t("@biomejs/biome@1.0.0", "@biomejs/biome", Some("1.0.0"));
         t("@biomejs/biome@", "@biomejs/biome", None);
+        for backend in [
+            "packslip:packslip.dev[identity_prefix=https://github.com/jdx/packslip/.github/workflows/release.yml@,list_identity_prefix=https://github.com/jdx/packslip/.github/workflows/packslip-releases.yml@]",
+            "npm:@scope/tool[registry=https://user@example.com]",
+            "@scope/tool[registry=https://user@example.com]",
+            "http:tool[url='https://example.com/a]@b']",
+            r#"http:tool[values=["a@b", "c[d]"]]"#,
+        ] {
+            t(backend, backend, None);
+            t(&format!("{backend}@"), backend, None);
+            t(&format!("{backend}@1.0.0"), backend, Some("1.0.0"));
+            t(
+                &format!("{backend}@path:/tmp/[tool]"),
+                backend,
+                Some("path:/tmp/[tool]"),
+            );
+            t(
+                &format!("{backend}@ref:branch@name"),
+                backend,
+                Some("ref:branch@name"),
+            );
+        }
     }
 }


### PR DESCRIPTION
Configure the existing Packslip registry entry with `packslip.dev` and separate pins for release bundles (`release.yml@`) and the signed index (`packslip-releases.yml@`). Users can install with `mise use -g packslip` or `[tools] packslip = "latest"` without supplying signer options. This restricts the broad workflow trust reported on #12839, excluding CI signing jobs.

Add `list_identity_prefix` to select the vendor index signer separately while retaining the bundle policy's OIDC issuer. Include the option in listing cache keys and persisted installation options, reject invalid combinations, and update the CLI example, TOML configuration, documentation, and registry-shorthand smoke test. Configured stampers keep their own policies.

Workflow identities contain `@`, so also fix CLI argument parsing to distinguish that character inside backend options from the version separator. Regression cases cover scoped package names, quoted brackets, nested arrays, and version paths containing brackets.

Validation:

- 11 Packslip unit tests and 20 CLI argument tests passed.
- `mise run test:e2e 'e2e/backend/test_packslip$' 'e2e/backend/test_packslip_resources$'` passed, including live `1.1.1` resolution and installation with `mise use -g packslip`, `0.2.0` installation/lockfile fixture checks, rejection of CI signer pins, and rejection of the index signer for release bundles.
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` passed.
- Scoped hk checks passed: Rust formatting, shellcheck, shfmt, Taplo, Markdown lint, and Prettier. Documentation TOML examples parse successfully.

Local mbx 1.5.0 emitted target-path cache mapping warnings; equivalent Cargo validation passed after resetting generated CMake state from a compiler-wrapper switch. No repository build configuration changes.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes Packslip signer verification and registry trust policy; a parsing or policy bug could reject valid installs or weaken which workflows are accepted.
> 
> **Overview**
> Tightens Packslip trust so **release bundles** and the **signed release index** can use different GitHub Actions workflow identities, closing the gap where a CI job could satisfy the same pin as release publishing.
> 
> Adds **`list_identity_prefix`**, applied only when verifying vendor release lists (well-known and GitHub `.well-known` lists) while bundle verification keeps `identity` / `identity_prefix`. The option is wired into install/listing cache keys, validated (non-empty, requires issuer, incompatible with `pubkey`), and documented.
> 
> The **`packslip` registry entry** now resolves via `packslip:packslip.dev` with registry-supplied pins: `release.yml@` for bundles and `packslip-releases.yml@` for the index, so users can run `mise use -g packslip` without hand-configuring signers. Docs and e2e cover the canonical quickstart and that wrong pins fail even with a warm version cache.
> 
> **CLI parsing** is updated so `@` inside bracketed backend options (common in workflow URLs) is not treated as a version separator; nested brackets and quoted values are handled when splitting options from an optional `@version` suffix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69110732cbad8674832f123302b2de926af13b8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring a separate signing identity prefix for verified release lists.
  - Packslip registry entries now use the canonical project name and support signer and issuer verification policies.
  - Verification rejects invalid or conflicting signing-policy combinations.

- **Bug Fixes**
  - Improved parsing of tool references with bracketed options, URLs, scoped names, nested brackets, and `@` characters.

- **Documentation**
  - Updated Packslip installation and version-listing examples.
  - Documented release-list signing identity configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->