### PR TITLE
docs: link packslip announcement from backend guide

### DIFF
--- a/docs/dev-tools/backends/packslip.md
+++ b/docs/dev-tools/backends/packslip.md
@@ -10,6 +10,9 @@ whose publishers provide these manifests. For other tools, use
 [aqua](/dev-tools/backends/aqua.html), [github](/dev-tools/backends/github.html),
 or another supported backend. You do not need to install the Packslip CLI.
 
+For the background and examples of version-matched completions and agent skills,
+read [Introducing packslip](https://jdx.dev/posts/2026-09-05-introducing-packslip/).
+
 ## Quick start {#usage}
 
 With [mise activated](/getting-started.html), install [hk](https://hk.jdx.dev),


### PR DESCRIPTION
Link the published “Introducing packslip” announcement near the top of the Packslip backend documentation, before quick start. Readers can find the background and examples of version-matched completions and agent skills alongside the setup guide.

Validation: confirmed the link returns HTTP 200 with the expected page title; scoped Markdownlint and Prettier checks pass; `git diff --check` passes. The repository-wide lint-fix task failed because the local Rust 1.93 toolchain is older than the required Rust 1.95. Only the documentation link is changed.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link addition with no runtime or configuration behavior changes.
> 
> **Overview**
> Adds a short pointer near the top of the Packslip backend docs (before **Quick start**) to the [Introducing packslip](https://jdx.dev/posts/2026-09-05-introducing-packslip/) post for background and examples of version-matched completions and agent skills.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dd4ada8fa0e67b56a2c9429fba250c28360b7b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a link to an external “Introducing Packslip” post, providing additional background and examples for version-matched completions and agent skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->