### PR TITLE
fix(github): silence oauth refresh warnings during env export

### DIFF
--- a/e2e/cli/test_token_github
+++ b/e2e/cli/test_token_github
@@ -139,6 +139,24 @@ assert_contains "$OAUTH_ENV mise env --shell bash" "export GITHUB_TOKEN=user-set
 assert_not_contains "$OAUTH_ENV mise env --shell bash" "ghu-native-oauth-token"
 rm mise.toml
 
+# Test 9f: rejected refreshes are quiet during env export, but still warn
+# when credentials are explicitly requested.
+python3 - <<'PYTHON'
+import os
+import re
+from pathlib import Path
+
+cache = Path(os.environ["MISE_STATE_DIR"]) / "github-oauth-tokens.toml"
+contents = cache.read_text()
+contents = re.sub(r'^expires_at = .*$', 'expires_at = "2000-01-01T00:00:00Z"', contents, flags=re.M)
+contents = re.sub(r'^refresh_token = .*$', 'refresh_token = "ghr-rejected"', contents, flags=re.M)
+cache.write_text(contents)
+PYTHON
+assert_not_contains "$OAUTH_ENV mise env --shell bash 2>&1" "GitHub OAuth refresh was rejected"
+assert_not_contains "$OAUTH_ENV mise env --shell bash" "ghu-native-oauth-token"
+assert_not_contains "$OAUTH_ENV mise exec -- true 2>&1" "GitHub OAuth refresh was rejected"
+assert_contains "$OAUTH_ENV mise token github 127.0.0.1 2>&1" "GitHub OAuth refresh was rejected"
+
 kill "$MOCK_PID"
 
 # Test 10: git credential fill

--- a/e2e/fixtures/mock-github-oauth.py
+++ b/e2e/fixtures/mock-github-oauth.py
@@ -61,6 +61,11 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 "scope": "",
             }
         if grant_type == "refresh_token":
+            if form.get("refresh_token", [""])[0] == "ghr-rejected":
+                return {
+                    "error": "incorrect_client_credentials",
+                    "error_description": "The client credentials are incorrect.",
+                }
             return {
                 "access_token": REFRESHED_TOKEN,
                 "expires_in": 28800,

--- a/src/cli/token/github.rs
+++ b/src/cli/token/github.rs
@@ -42,6 +42,7 @@ impl Github {
                     host: self.host.clone(),
                     allow_device_flow: true,
                     force_refresh: self.refresh,
+                    ..Default::default()
                 })?,
                 github::TokenSource::GithubOauth,
             ))

--- a/src/github/oauth.rs
+++ b/src/github/oauth.rs
@@ -28,6 +28,8 @@ pub(crate) struct TokenRequest {
     /// permissions granted afterwards (e.g. the app was installed on a repo
     /// after authorizing) until it expires hours later.
     pub force_refresh: bool,
+    /// Report refresh failures when credentials are needed, rather than merely exported.
+    pub warn_on_refresh_failure: bool,
 }
 
 impl Default for TokenRequest {
@@ -36,6 +38,7 @@ impl Default for TokenRequest {
             host: "github.com".to_string(),
             allow_device_flow: false,
             force_refresh: false,
+            warn_on_refresh_failure: true,
         }
     }
 }
@@ -100,6 +103,7 @@ pub(crate) fn resolve_token(host: &str) -> Option<String> {
         host: host.to_string(),
         allow_device_flow: false,
         force_refresh: false,
+        ..Default::default()
     })
     .ok()
 }
@@ -140,7 +144,11 @@ pub(crate) fn inject_token_env(env: &mut EnvMap) {
     if env.contains_key(var_name) {
         return;
     }
-    if let Some(token) = resolve_token(&host) {
+    if let Ok(token) = token(TokenRequest {
+        host,
+        warn_on_refresh_failure: false,
+        ..Default::default()
+    }) {
         env.insert(var_name.to_string(), token);
     }
 }
@@ -255,7 +263,11 @@ async fn token_async(req: TokenRequest) -> Result<String> {
             Ok(Some(token)) => return Ok(token),
             Ok(None) => {}
             Err(err) => {
-                log_refresh_error(&err);
+                if req.warn_on_refresh_failure {
+                    log_refresh_error(&err);
+                } else {
+                    debug!("failed to refresh GitHub OAuth token for environment export: {err:#}");
+                }
             }
         }
         if !req.force_refresh && cached.expires_at > chrono::Utc::now() {
@@ -900,6 +912,7 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
             host: "github.com".to_string(),
             allow_device_flow: false,
             force_refresh: false,
+            ..Default::default()
         })
         .await
         .unwrap();
@@ -911,6 +924,7 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
             host: "github.com".to_string(),
             allow_device_flow: false,
             force_refresh: true,
+            ..Default::default()
         })
         .await
         .unwrap();


### PR DESCRIPTION
When an expired GitHub OAuth token cannot be refreshed, automatic environment export currently warns on local commands such as `mise env` and `mise exec -- true`.

Log refresh failures at debug level when resolving a token for environment export. Keep the existing warning for credential resolution and explicit token requests, and preserve successful refresh and export behavior.

Validation:
- `RUSTUP_TOOLCHAIN=1.98.0 mise run test:e2e e2e/cli/test_token_github` passed, including rejected-refresh cases for env export, exec, and credential requests.
- Verified the built binary runs `mise exec -- true` silently with the locally expired OAuth credentials.
- `RUSTUP_TOOLCHAIN=1.98.0 mise run lint-fix`.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to warning visibility on env-export paths; explicit token/credential requests still surface refresh failures.
> 
> **Overview**
> When cached GitHub OAuth tokens are expired and refresh fails, **`mise env`**, **`mise exec`**, and other automatic env injection paths no longer print **"GitHub OAuth refresh was rejected"** to stderr. Those failures are logged at **debug** instead, and **`GITHUB_TOKEN` is not exported** when refresh cannot succeed.
> 
> **`TokenRequest`** gains **`warn_on_refresh_failure`** (default **true**). **`inject_token_env`** passes **`warn_on_refresh_failure: false`**; explicit flows such as **`mise token github`** (including OAuth resolution) keep the existing user-facing warning.
> 
> E2E coverage adds a rejected-refresh scenario via the mock OAuth server and **test 9f**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd76a2d7fd9492e4ae9d78e8b0948882ff66d7ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub OAuth refresh failures are now handled quietly during environment and command execution.
  * A warning is still shown when explicitly requesting a GitHub token, making credential issues visible when relevant.
  * Improved handling of default options for GitHub token requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->