### PR TITLE
fix(nix): skip aube node-gyp bootstrap test in checkPhase

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, rustPlatform, coreutils, bash, direnv, openssl, git }:
+{ pkgs, lib, rustPlatform, coreutils, bash, direnv, openssl, git, stdenv }:
 
 rustPlatform.buildRustPackage {
   pname = "mise";
@@ -69,7 +69,8 @@ rustPlatform.buildRustPackage {
       --skip system::packages::brew::cask::tests::staged_symlink_source_copies_reachable_internal_links \
       --skip system::packages::brew::cask::tests::staged_symlink_sources_become_caskroom_owned \
       --skip system::packages::brew::cask::tests::structured_copy_restores_external_target_without_status_tracking \
-      --skip system::packages::brew::cask::tests::structured_copy_rollback_removes_target_with_created_parent
+      --skip system::packages::brew::cask::tests::structured_copy_rollback_removes_target_with_created_parent \
+      ${lib.optionalString stdenv.isDarwin "--skip mise_binary_services_aube_node_gyp_bootstrap_trampoline"}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
### Description

When building `mise` via Nix on macOS (`nix build`), the integration test `tests/aube_node_gyp_bootstrap.rs` fails because `mise __node-gyp-bootstrap` attempts filesystem mutations inside the read-only sandbox:

```
test mise_binary_services_aube_node_gyp_bootstrap_trampoline ... FAILED
stderr=  × Read-only file system (os error 30)
```

This PR skips `mise_binary_services_aube_node_gyp_bootstrap_trampoline` in `default.nix` so the Nix check phase succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated package test configuration to skip tests that are not applicable in the current environment.
  * Added a Darwin-specific skip for a platform-dependent test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->