### PR TITLE
docs: clarify onboarding and improve website guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,159 +51,120 @@
 
 </div>
 
-> [!TIP]
-> Rust builds filling every checkout's `target/`? [Mr Boxington](https://mr-boxington.jdx.dev/) gives Cargo one shared, self-pruning cache across worktrees, local builds, and CI.
+## What is mise?
 
-## What is it?
+mise manages your development tools, environment variables, and project tasks.
+Declare them in `mise.toml`, commit the file, and use the same setup in your shell,
+your editor, and CI.
 
-`mise` prepares your development environment before each command runs. It keeps
-project tools, environment variables, and tasks in one `mise.toml` file so new
-shells, checkouts, and CI jobs all start from the same setup.
+- **[Tools](https://mise.jdx.dev/dev-tools/):** install Node.js, Python, Go, and [hundreds more](https://mise.jdx.dev/registry.html), with different versions for each project.
+- **[Environments](https://mise.jdx.dev/environments/):** set project environment variables and load `.env` files.
+- **[Tasks](https://mise.jdx.dev/tasks/):** run build, test, and other commands with the tools and environment they need.
+- **[Bootstrap](https://mise.jdx.dev/bootstrap.html):** declare machine setup, including system packages, dotfiles, and services.
 
-- Install and switch between [dev tools](https://mise.jdx.dev/dev-tools/) like node, python, cmake, terraform, and [hundreds more](https://mise.jdx.dev/registry.html).
-- Load [environment variables](https://mise.jdx.dev/environments/) per project directory, including values from `.env` files and other sources.
-- Define and run [tasks](https://mise.jdx.dev/tasks/) for building, testing, linting, and deploying projects.
-
-## Demo
-
-The following demo shows how to install and use `mise` to manage multiple versions of `node` on the same system.
-Note that calling `which node` gives us a real path to node, not a shim.
-
-It also shows that you can use `mise` to install and many other tools such as `jq`, `terraform`, or `go`.
-
-[![demo](./docs/tapes/demo.gif)](https://mise.jdx.dev/demo.html)
-
-See [demo transcript](https://mise.jdx.dev/demo.html).
+Use the parts you need. Start with one tool or task and add more to the same config.
 
 ## Quickstart
 
-### Install mise
+### 1. Install mise
 
-See [Getting started](https://mise.jdx.dev/getting-started.html) for more options.
+On macOS or Linux:
 
-```sh-session
-$ curl https://mise.run | sh
-$ ~/.local/bin/mise --version
-              _                                        __
-   ____ ___  (_)_______        ___  ____        ____  / /___ _________
-  / __ `__ \/ / ___/ _ \______/ _ \/ __ \______/ __ \/ / __ `/ ___/ _ \
- / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
-/_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
-                                            /_/                 by @jdx
-2026.9.1 macos-arm64 (2026-09-02)
+```sh
+curl https://mise.run | sh
+~/.local/bin/mise --version
 ```
 
-Hook mise into your shell (pick the right one for your shell):
+On Windows, install with `winget install jdx.mise`. See the
+[installation guide](https://mise.jdx.dev/installing-mise.html) for package managers
+and other installation methods.
 
-```sh-session
-# note this assumes mise is located at ~/.local/bin/mise
-# which is what https://mise.run does by default
-echo 'eval "$(~/.local/bin/mise activate bash)"' >> ~/.bashrc
-echo 'eval "$(~/.local/bin/mise activate zsh)"' >> ~/.zshrc
-echo '~/.local/bin/mise activate fish | source' >> ~/.config/fish/config.fish
-echo '~/.local/bin/mise activate pwsh | Out-String | Invoke-Expression' >> ~/.config/powershell/Microsoft.PowerShell_profile.ps1
+The examples below use `mise`. If it isn't on your `PATH` yet, use
+`~/.local/bin/mise` instead on macOS or Linux.
+
+### 2. Try a tool
+
+```sh
+mise exec node@24 -- node --version
 ```
 
-### Execute commands with specific tools
+This installs Node.js if needed and runs it for this command, without changing
+your project configuration. No shell activation is required.
 
-```sh-session
-$ mise exec node@26 -- node -v
-mise node@26.x.x ✓ installed
-v26.x.x
-```
+### 3. Give a project its own environment
 
-### Install tools
-
-```sh-session
-$ mise use --global node@26 go@1
-$ node -v
-v26.x.x
-$ go version
-go version go1.x.x macos/arm64
-```
-
-See [dev tools](https://mise.jdx.dev/dev-tools/) for more examples.
-
-### Manage environment variables
+In a project directory, create `mise.toml`:
 
 ```toml
-# mise.toml
-[env]
-SOME_VAR = "foo"
-```
-
-```sh-session
-$ mise set SOME_VAR=bar
-$ echo $SOME_VAR
-bar
-```
-
-Note that `mise` can also [load `.env` files](https://mise.jdx.dev/environments/#env-directives).
-
-### Run tasks
-
-```toml
-# mise.toml
-[tasks.build]
-description = "build the project"
-run = "echo building..."
-```
-
-```sh-session
-$ mise run build
-building...
-```
-
-See [tasks](https://mise.jdx.dev/tasks/) for more information.
-
-### Example mise project
-
-Here is a combined example to give you an idea of how you can use mise to manage your a project's tools, environment, and tasks.
-
-```toml
-# mise.toml
 [tools]
-terraform = "1"
-aws-cli = "2"
+node = "24"
 
 [env]
-TF_WORKSPACE = "development"
-AWS_REGION = "us-west-2"
-AWS_PROFILE = "dev"
+NODE_ENV = "development"
 
-[tasks.plan]
-description = "Run terraform plan with configured workspace"
-run = """
-terraform init
-terraform workspace select $TF_WORKSPACE
-terraform plan
-"""
-
-[tasks.validate]
-description = "Validate AWS credentials and terraform config"
-run = """
-aws sts get-caller-identity
-terraform validate
-"""
-
-[tasks.deploy]
-description = "Deploy infrastructure after validation"
-depends = ["validate", "plan"]
-run = "terraform apply -auto-approve"
+[tasks.hello]
+description = "Print the project's Node.js version and environment"
+run = "node -e \"console.log(process.version, process.env.NODE_ENV)\""
 ```
 
-Run it with:
+Run the task:
 
-```sh-session
-mise install # install tools specified in mise.toml
-mise run deploy
+```sh
+mise run hello
 ```
 
-Find more examples in the [mise cookbook](https://mise.jdx.dev/mise-cookbook/).
+mise installs the configured tool if needed, loads `NODE_ENV`, and runs the task.
+The output includes the Node.js version and `development`. Commit `mise.toml` so
+teammates and CI can run the same command.
 
-## Full Documentation
+To add tools later, run `mise use python@3.13` from the project directory.
+Use `mise use --global` to set personal defaults. Version requests such as `"24"`
+select a release in that series; use [exact pins or a lockfile](https://mise.jdx.dev/dev-tools/mise-lock.html)
+when you need everyone to use the same resolved version.
 
-See [mise.jdx.dev](https://mise.jdx.dev)
+### 4. Activate your shell (optional)
+
+Activation makes project tools and environment variables available directly when
+you enter a directory. For an installation from `mise.run`, add **one** of these
+lines to the corresponding shell config:
+
+```bash
+# ~/.bashrc
+eval "$(~/.local/bin/mise activate bash)"
+```
+
+```zsh
+# ~/.zshrc
+eval "$(~/.local/bin/mise activate zsh)"
+```
+
+```fish
+# ~/.config/fish/config.fish
+~/.local/bin/mise activate fish | source
+```
+
+Restart your shell, then run `node --version` inside the project. For PowerShell
+and other installation methods, follow the
+[shell setup guide](https://mise.jdx.dev/getting-started.html#activate-mise).
+
+## Where to go next
+
+| I want to…                             | Read                                                                                                                                      |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Set up mise for the first time         | [Getting started](https://mise.jdx.dev/getting-started.html)                                                                              |
+| Add mise to an existing project        | [Walkthrough](https://mise.jdx.dev/walkthrough.html)                                                                                      |
+| Understand configuration and overrides | [Configuration](https://mise.jdx.dev/configuration.html)                                                                                  |
+| Use mise in an editor or CI            | [IDE integration](https://mise.jdx.dev/ide-integration.html) · [Continuous integration](https://mise.jdx.dev/continuous-integration.html) |
+| Find a command or solve a problem      | [CLI reference](https://mise.jdx.dev/cli/) · [Troubleshooting](https://mise.jdx.dev/troubleshooting.html)                                 |
+| Contribute to mise                     | [Contributing](CONTRIBUTING.md) · [Writing docs](docs/README.md)                                                                          |
+
+## Demo
+
+Watch mise install tools and switch Node.js versions as you change directories.
+
+[![Demo of mise managing tools](./docs/tapes/demo.gif)](https://mise.jdx.dev/demo.html)
+
+A [text transcript](https://mise.jdx.dev/demo.html) is also available.
 
 ## GitHub Issues & Discussions
 

--- a/docs/.vitepress/sidebar.ts
+++ b/docs/.vitepress/sidebar.ts
@@ -11,10 +11,10 @@ export type SidebarItem = {
 
 export const sidebar: SidebarItem[] = [
   {
-    text: "Guides",
+    text: "Start Here",
     items: [
-      { text: "Demo", link: "/demo" },
       { text: "Getting Started", link: "/getting-started" },
+      { text: "Demo", link: "/demo" },
       { text: "Walkthrough", link: "/walkthrough" },
       { text: "Installing mise", link: "/installing-mise" },
       { text: "IDE Integration", link: "/ide-integration" },

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -8,15 +8,14 @@
           <span class="lockup-word">mise-en-place</span>
         </div>
         <h1>
-          Every tool, env var, and task your project needs,
+          Your development tools, environment, and tasks,
           <em>in one file.</em>
         </h1>
         <p class="hero-lede">
-          mise reads a <code>mise.toml</code> checked into your repo, installs
-          the right versions of your dev tools, loads the project's environment,
-          and runs its tasks. Point it at a fresh machine and
-          <code>mise bootstrap</code> sets up the rest: packages, dotfiles,
-          services.
+          Declare your tool versions, environment variables, and commands in
+          <code>mise.toml</code>. Use them in your shell, editor, and CI. Add
+          machine setup with <code>mise bootstrap</code> when you need system
+          packages, dotfiles, or services.
         </p>
         <div class="hero-actions">
           <button class="install-command" type="button" @click="copyInstall">
@@ -33,7 +32,7 @@
         <p class="hero-meta">
           <span>Open source, MIT</span>
           <span>macOS, Linux, Windows</span>
-          <span>One static binary, no dependencies</span>
+          <span>Single CLI</span>
         </p>
       </div>
     </template>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,69 @@
-# mise-docs
+# Working on the mise docs
 
-This repository contains the documentation website for the runtime executor [mise](https://github.com/jdx/mise). The website is powered by [VitePress](https://vitepress.dev/).
+This directory contains the [mise documentation website](https://mise.jdx.dev/),
+built with VitePress. Run the commands below from the repository root.
+
+## Preview and build
+
+Install the repository's development tools with `mise install`, then start the site:
+
+```sh
+mise run docs
+```
+
+Open the local URL printed by VitePress. Edits reload automatically.
+
+Before submitting a change, build the production site:
+
+```sh
+mise run docs:build
+```
+
+The task installs JavaScript dependencies, runs the social image tests, builds the
+site, and checks generated social images. VitePress also checks internal page links.
+Use `mise run docs:preview` to serve the production build locally.
+
+## Choose the right page
+
+| Content                                           | Location                                                                        |
+| ------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Project introduction and a short runnable example | Root `README.md`                                                                |
+| Website overview and entry points                 | `docs/index.md` and the hero in `docs/.vitepress/theme/Layout.vue`              |
+| First successful tool, environment, and task      | `docs/getting-started.md`                                                       |
+| Daily use, configuration choices, and upgrades    | `docs/walkthrough.md`                                                           |
+| Concepts and feature guides                       | `docs/dev-tools/`, `docs/environments/`, `docs/tasks/`, and `docs/bootstrap.md` |
+| Configuration reference                           | `docs/configuration.md` and `docs/configuration/`                               |
+| Site navigation                                   | `docs/.vitepress/sidebar.ts`                                                    |
+| Generated command reference                       | `docs/cli/`                                                                     |
+
+Put detailed behavior in the relevant feature guide and link to it from onboarding
+pages. Keep the README short enough for someone deciding whether to try mise.
+
+## Write examples readers can run
+
+- State prerequisites, the working directory, and whether shell activation is required.
+- Include every file, tool, and dependency needed for a runnable example. Label excerpts and illustrations.
+- Explain what a command changes: installing a tool, saving a version request, or running a process.
+- Use a small observable result, such as printing an environment variable. Avoid live deployment as a first example.
+- Distinguish version requests from exact pins and lockfile resolutions. Avoid output that becomes stale with each release.
+- Keep platform-specific commands in labeled code groups. Use `mise exec` or `mise run` when activation is unnecessary.
+
+Use descriptive headings and link text. Preserve existing heading anchors when
+reorganizing a page, using explicit IDs such as `{#activate-mise}` where needed.
+Internal website links start at the docs root, for example
+`/dev-tools/backends/github.html`.
+
+## Generated content
+
+Check for a generated-file comment before editing reference pages. For CLI changes,
+edit the command documentation in `src/cli/`, then run `mise run render:usage`.
+For settings, edit `settings.toml` and run `mise run render:schema` as described in
+[AGENTS.md](https://github.com/jdx/mise/blob/main/AGENTS.md). Review generated diffs and keep unrelated changes out of
+the patch.
+
+## Review a documentation change
+
+Check formatting with the repository's lint tools, build the site, and inspect
+changed pages in the browser. Check narrow and wide layouts when changing the
+homepage or theme. Follow the new-reader path and verify that commands, filenames,
+and expected results agree across the README and website.

--- a/docs/dev-tools/index.md
+++ b/docs/dev-tools/index.md
@@ -1,102 +1,85 @@
 # Dev Tools
 
-> _Install and switch between dev tools like node, python, cmake, terraform,
-> and [hundreds more](/registry.html), all from the same project config._
+mise installs development tools and selects their versions for each project.
+Keep multiple versions of Node.js, Python, Ruby, Go, and other tools on the same
+machine, then declare which ones a project uses in `mise.toml`.
 
-`mise` manages installations of programming language runtimes and other tools for local development. For example, it can manage multiple versions of Node.js, Python, Ruby, and Go on the same machine.
+## Add a tool to a project
 
-Once [activated](/getting-started.html#activate-mise), mise can automatically switch between different versions of tools based on the directory you're in.
-This means that if you have a project that requires Node.js 18 and another that requires Node.js 22, mise automatically switches between them as you move between the two projects. See the tools available for mise in the [registry](/registry).
+From the project directory:
 
-To determine which tool version to use, mise typically looks for a `mise.toml` file in the current directory and its parents. Here is an example of a [mise.toml](/configuration.html) file showing how tools are specified:
+```sh
+mise use node@24 python@3.13
+```
+
+This installs the tools and records the version requests in your configuration:
 
 ```toml [mise.toml]
 [tools]
-node = '24'
-python = '3'
-ruby = 'latest'
+node = "24"
+python = "3.13"
 ```
 
-mise is also compatible
-with asdf `.tool-versions` files and with [idiomatic version files](/configuration#idiomatic-version-files) like `.node-version` and
-`.ruby-version`. See [configuration](/configuration) for more details.
+Run a command with those tools:
 
-When specifying tool versions and tool options, you can also refer to environment variables or
-[`vars`](/configuration/vars) defined in your config hierarchy, including values
-produced by directives like `_.source`, `_.file`, or env modules. These are resolved before tool
-version and option templates are rendered.
-
-::: info
-mise is compatible with asdf `.tool-versions` files and can still use asdf
-plugins when needed. If you're migrating from asdf, see the
-[comparison guide](./comparison-to-asdf).
-:::
-
-## How it works
-
-mise manages development tools through a sophisticated but user-friendly system that automatically handles tool installation, version management, and environment setup.
-
-### Tool Resolution Flow
-
-When you enter a directory or run a command, mise follows this process:
-
-1. **Configuration Discovery**: mise walks up the directory tree looking for configuration files (`mise.toml`, `.tool-versions`, etc.) and merges them hierarchically
-2. **Tool Resolution**: mise resolves version specifications (like `node@latest` or `python@3`) to specific versions using registries and version lists
-3. **Backend Selection**: mise chooses the appropriate [backend](/dev-tools/backend_architecture) to handle each tool (core, asdf, aqua, etc.)
-4. **Installation Check**: mise checks whether the required tool versions are installed and automatically installs missing ones
-5. **Environment Setup**: mise configures your `PATH` and environment variables to use the resolved tool versions
-
-### Environment Integration
-
-mise provides several ways to integrate with your development environment:
-
-**Automatic Activation**: With `mise activate`, mise hooks into your shell prompt and automatically updates your environment when you change directories:
-
-```bash
-eval "$(mise activate zsh)"  # In your ~/.zshrc
-cd my-project               # Automatically loads mise.toml tools
+```sh
+mise exec -- node --version
 ```
 
-**On-Demand Execution**: Use `mise exec` to run commands with mise's environment without permanent activation:
+With [shell activation](/getting-started.html#activate-mise), you can run
+`node --version` directly. mise updates your shell environment as you move between
+projects. Activation selects installed tools; use `mise install` to install tools
+after cloning a repository or editing its configuration.
 
-```bash
-mise exec -- node my-script.js  # Runs with tools from mise.toml
-```
+## Choose the right command
 
-**Shims**: mise can create lightweight wrapper scripts that automatically use the correct tool versions:
+| Goal                                             | Command                               |
+| ------------------------------------------------ | ------------------------------------- |
+| Add or change a project's tool version           | `mise use node@24`                    |
+| Set a personal default                           | `mise use --global node@24`           |
+| Install tools declared by a project              | `mise install`                        |
+| Try a version without saving it                  | `mise exec node@24 -- node --version` |
+| Show tools selected by the current configuration | `mise ls --current`                   |
+| Upgrade within the configured version request    | `mise upgrade node`                   |
 
-```bash
-mise activate --shims  # Creates shims instead of modifying PATH
-```
+A version request such as `"24"` selects a release in that series. An exact pin
+selects a specific release. See [mise.lock](/dev-tools/mise-lock.html) for recording
+resolved versions without replacing the version requests in `mise.toml`.
 
-### Path Management
+## How tools are selected
 
-mise modifies your `PATH` environment variable to prioritize the correct tool versions:
+1. mise discovers configuration in the current directory and its parents, along
+   with global configuration. More specific configuration can override defaults.
+2. Each tool's [backend](/dev-tools/backends/) resolves its version request and
+   handles installation. The [registry](/registry.html) maps short tool names to
+   backends, so you usually don't need to choose one yourself.
+3. mise adds the selected tools to the command's `PATH`. By default, `mise exec`
+   and `mise run` install missing tools before executing the command or task.
 
-```bash
-# Before mise
-echo $PATH
-/usr/local/bin:/usr/bin:/bin
+Use `mise config ls` to inspect active configuration files. See
+[configuration](/configuration.html) for the full precedence rules.
 
-# After mise activation in a project with node@20
-echo $PATH
-/home/user/.local/share/mise/installs/node/20.11.0/bin:/usr/local/bin:/usr/bin:/bin
-```
+### Shells, editors, and scripts
 
-This ensures that when you run `node`, you get the version specified in your project configuration, not a system-wide installation.
+- **Interactive shells:** [activate mise](/getting-started.html#activate-mise) to
+  update `PATH` and project environment variables at each prompt.
+- **Editors:** use [IDE integration](/ide-integration.html), including
+  [shims](/dev-tools/shims.html) where a program needs a stable executable path.
+- **Scripts and CI:** use `mise exec -- <command>` or `mise run <task>` to load the
+  project environment without relying on shell startup files.
 
-### Configuration Hierarchy
+### Existing version files
 
-mise supports nested configuration that cascades from broad to specific settings:
+mise also reads asdf `.tool-versions` files. Tool-specific files such as `.nvmrc`
+and `.python-version` require enabling
+[idiomatic version files](/configuration.html#idiomatic-version-files).
+For migration guidance, see [comparison to asdf](./comparison-to-asdf).
 
-```bash
-~/.config/mise/config.toml      # Global defaults
-~/work/mise.toml                # Work-specific tools
-~/work/project/mise.toml        # Project-specific overrides
-~/work/project/.tool-versions   # Legacy asdf compatibility
-```
+### Templates in tool configuration
 
-Each level can override or extend the previous ones, giving you fine-grained control over tool versions across different contexts.
+Tool versions and options can reference environment variables and
+[`vars`](/configuration/vars.html), including values from `_.source`, `_.file`,
+and environment modules. Those values are resolved before tool templates render.
 
 ## Tool Options
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,21 +1,24 @@
-<!-- markdownlint-disable MD034 -->
+# Getting started
 
-# Getting Started
+By the end of this guide, you'll have a project with a managed tool, an environment
+variable, and a task you can run. Shell activation is optional: the first examples
+work without changing your shell configuration.
 
-Get up and running with mise in minutes.
+Already installed mise for an existing project? Review its `mise.toml`, then run
+`mise install` from the project directory. Use `mise tasks ls` to see its tasks.
 
 ## 1. Install `mise` CLI {#installing-mise-cli}
 
-See [installing mise](/installing-mise.html) for other ways to install mise (`macport`, `apt`, `yum`, `nix`, etc.).
+See [installing mise](/installing-mise.html) for other ways to install mise (Homebrew, MacPorts, apt, Nix, and more).
 
-:::tabs key:installing-mise
+::::tabs key:installing-mise
 == Linux/macOS
 
 ```shell
 curl https://mise.run | sh
 ```
 
-By default, mise installs to `~/.local/bin`, but it can go anywhere.
+The installer places the mise executable in `~/.local/bin`.
 
 Verify the installation:
 
@@ -41,6 +44,8 @@ winget install jdx.mise
 ```shell [chocolatey]
 choco install mise
 ```
+
+:::
 
 == Debian/Ubuntu (apt)
 
@@ -68,66 +73,125 @@ sudo snap install mise --classic
 
 See the [snapcraft.io page](https://snapcraft.io/mise) for more information.
 
-:::
+::::
 
-`mise` respects [`MISE_DATA_DIR`](/configuration) and [`XDG_DATA_HOME`](/configuration) if you'd like
-to change these locations.
+To customize where mise stores downloaded tools and other data, see
+[directories](/directories.html).
 
-## 2. mise `exec` and `run` {#mise-exec-run}
+## 2. Run your first tool {#mise-exec-run}
 
-Once installed, you can start using mise right away to install and run [tools](/dev-tools/), launch [tasks](/tasks/), and manage [environment variables](/environments/).
-
-The quickest way to run a tool at a specific version is [`mise x|exec`](/cli/exec.html). For example, to launch a Python 3 REPL:
-
-::: tip
-If `mise` isn't on `PATH` yet, use `~/.local/bin/mise` instead.
-:::
+Use [`mise exec`](/cli/exec.html) to run a command with a specific tool version:
 
 ```sh
-mise exec python@3 -- python
-# this will download and install Python if it is not already installed
-# Python 3.15.0
-# >>> ...
+mise exec node@24 -- node --version
 ```
 
-Or run node 26:
-
-```sh
-mise exec node@26 -- node -v
-# v26.x.x
-```
-
-To install a tool permanently, use [`mise u|use`](/cli/use.html):
-
-```shell
-mise use --global node@26 # install node 26 and set it as the global default
-mise exec -- node my-script.js
-# run my-script.js with node 26...
-```
-
-[`mise r|run`](/cli/run.html) lets you run [tasks](/tasks/) or scripts with the full mise context (tools + env vars) loaded.
+By default, mise downloads the tool if needed, then runs the command after `--`.
+This does not add Node.js to your project configuration or change your current
+shell's environment. The output starts with `v24.`; the patch version may vary.
 
 ::: tip
-You can set a shell alias in your shell's rc file like `alias x="mise x --"` to save some keystrokes.
+If `mise` isn't on `PATH` yet, use `~/.local/bin/mise` instead on macOS or Linux.
+Activation in [step 4](#activate-mise) adds mise to your shell's `PATH`.
 :::
 
-## 3. Activate `mise` <Badge text="optional" /> {#activate-mise}
+## 3. Set up a project {#set-up-a-project}
+
+Create a directory for this example, or use an existing project directory:
+
+```sh
+mkdir mise-example
+cd mise-example
+mise use node@24
+```
+
+[`mise use`](/cli/use.html) installs the tool and writes its version request to
+`mise.toml`. Unlike `mise install`, it also changes your configuration.
+
+### Set an environment variable {#environment-variables}
+
+Edit the generated `mise.toml` to contain:
+
+```toml [mise.toml]
+[tools]
+node = "24"
+
+[env]
+NODE_ENV = "development"
+```
+
+Run a command with both the configured tool and environment:
+
+```sh
+mise exec -- node -p process.env.NODE_ENV
+# development
+```
+
+You can also [load variables from a `.env` file](/environments/#env-directives).
+
+### Run a task {#run-a-task}
+
+Add this section to the same `mise.toml`:
+
+```toml [mise.toml]
+[tasks.hello]
+description = "Print the project's Node.js version and environment"
+run = "node -e \"console.log(process.version, process.env.NODE_ENV)\""
+```
+
+```sh
+mise run hello
+```
+
+The output includes a Node.js version starting with `v24.` and `development`.
+Tasks get the project's tools and environment automatically. By default,
+`mise run` installs missing configured tools before running the task.
+
+Commit `mise.toml` so teammates and CI can use the same configuration. The version
+request `"24"` selects a release in the Node.js 24 series; it is not an exact pin.
+See [lockfiles](/dev-tools/mise-lock.html) to share resolved versions across machines.
+
+### Project configuration or global defaults?
+
+| Command                       | What it does                                                                                              |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `mise use node@24`            | Installs Node.js and saves the version request in the project config. Run it from your project directory. |
+| `mise use --global node@24`   | Installs Node.js and saves a personal default in the global config.                                       |
+| `mise install`                | Installs tools already declared in your configuration.                                                    |
+| `mise exec -- node --version` | Runs one command with the project's tools and environment.                                                |
+| `mise run hello`              | Runs a named task with the project's tools and environment.                                               |
+
+Project configuration can override global defaults. Use `mise config ls` to see
+which files are active and `mise ls --current` to inspect the selected tools.
+
+### Trusting config files {#trust}
+
+Review configuration from other people before running it: tasks, hooks, and some
+environment directives can execute code. Use `mise trust` to explicitly trust a
+config you've reviewed.
+
+In normal mode, commands that execute project behavior, including `mise install`,
+`mise exec`, and `mise run`, automatically trust the active config. With
+[paranoid mode](/paranoid.html), non-global configs require explicit trust.
+See [`mise trust`](/cli/trust.html) for details.
+
+## 4. Activate `mise` <Badge text="optional" /> {#activate-mise}
 
 `mise exec` works great for one-off commands, but for interactive shells you'll probably want to activate mise so tools and environment variables are loaded automatically.
 
 There are two approaches:
 
 - [`mise activate`](/cli/activate) — updates your `PATH` and environment every time your prompt runs. Recommended for interactive shells.
-- [Shims](dev-tools/shims.md) — symlinks that intercept commands and load the right environment. Better for CI/CD, IDEs, and scripts. [Shims don't support all features of `mise activate`](/dev-tools/shims.html#shims-vs-path).
+- [Shims](/dev-tools/shims.html) — command entry points that select tool versions. Useful for editors and other programs that do not load your shell config. [Shims don't support all features of `mise activate`](/dev-tools/shims.html#shims-vs-path).
 
-You can also skip both and call `mise exec` or `mise run` directly.
-See [this guide](dev-tools/shims.md) for more information.
+You can skip both and use `mise exec` or `mise run` to load the project environment
+explicitly, including in CI and scripts.
 
 Here is how to activate mise for your shell:
 
-:::tabs key:installing-mise
+::::tabs key:activating-mise
 
-== https://mise.run
+== mise.run installer
 
 ::: code-group
 
@@ -142,6 +206,8 @@ echo 'eval "$(~/.local/bin/mise activate zsh)"' >> ~/.zshrc
 ```sh [fish]
 echo '~/.local/bin/mise activate fish | source' >> ~/.config/fish/config.fish
 ```
+
+:::
 
 == Brew
 
@@ -159,6 +225,8 @@ echo 'eval "$(mise activate zsh)"' >> ~/.zshrc
 # do nothing! mise is automatically activated when using brew and fish
 # you can disable this behavior with `set -Ux MISE_FISH_AUTO_ACTIVATE 0`
 ```
+
+:::
 
 == Windows
 
@@ -197,22 +265,67 @@ echo 'mise activate fish | source' >> ~/.config/fish/config.fish
 
 :::
 
+::::
+
 Restart your shell session after modifying your rc file. Run [`mise dr|doctor`](/cli/doctor.html) to verify everything is set up correctly.
 
 With mise activated, tools are available directly on `PATH`:
 
 ```sh
-mise use --global node@26
+mise use --global node@24
 node -v
-# v26.x.x
+# v24.x.x
 ```
 
-When you ran `mise use --global node@26`, mise updated your global config:
+When you ran `mise use --global node@24`, mise updated your global config:
 
 ```toml [~/.config/mise/config.toml]
 [tools]
-node = "26"
+node = "24"
 ```
+
+## 5. Find more tools {#tool-backends}
+
+Use the [registry](/registry.html) to find tool names such as `node`, `python`,
+`jq`, and `ripgrep`. Most of the time, the name is all you need:
+
+```sh
+mise use ripgrep
+mise exec -- rg --version
+```
+
+A **backend** tells mise where to get a tool and how to install it. You can choose
+one explicitly, including for tools without a registry shorthand:
+
+```sh
+mise exec github:BurntSushi/ripgrep -- rg --version
+```
+
+Some backends require another runtime or package manager. Check the
+[backend guide](/dev-tools/backends/) before using a new ecosystem.
+
+## 6. Next steps {#next-steps}
+
+- **Keep working in a project:** follow the [walkthrough](/walkthrough.html) for configuration overrides, upgrades, and daily commands.
+- **Write build and test commands:** see [tasks](/tasks/).
+- **Use mise outside a terminal:** set up your [editor](/ide-integration.html) or [CI pipeline](/continuous-integration.html).
+- **Set up a machine:** use [bootstrap](/bootstrap.html) for declared system packages, dotfiles, and services.
+
+### Set up autocompletion {#autocompletion}
+
+Enable [shell completions](/installing-mise.html#autocompletion) to complete tools,
+versions, and task names.
+
+### If something doesn't work
+
+Run `mise doctor` to check your setup. If a tool works through `mise exec` but not
+as a plain command, check [shell activation](#activate-mise) and restart your shell.
+See [troubleshooting](/troubleshooting.html) for other common problems.
+
+#### GitHub API rate limiting {#github-api-rate-limiting}
+
+If an error reports GitHub API rate limiting, configure a
+[GitHub token](/dev-tools/github-tokens.html).
 
 ### Shell Feature Compatibility {#shell-feature-compatibility}
 
@@ -224,172 +337,3 @@ Not all shells support every mise feature:
 | `mise shell`                    | Yes  | Yes | Yes  | Yes     | Yes    | Yes   | Yes        |
 | Shell aliases (`[shell_alias]`) | Yes  | Yes | Yes  | No      | No     | Yes   | No         |
 | `chpwd` hook                    | Yes  | Yes | Yes  | Yes     | Yes    | Yes   | Yes        |
-
-## 4. Use tools from backends (npm, pipx, core, aqua, github) {#tool-backends}
-
-```mermaid
-flowchart LR
-  subgraph Backends
-    core
-    aqua
-    github
-    npm
-    pipx
-  end
-
-  core --> node["core:node"]
-  core --> python["core:python"]
-  aqua -->gh["aqua:cli/cli"]
-  github -->ripgrep["github:BurntSushi/ripgrep"]
-  github -->ruff["github:astral-sh/ruff"]
-  npm --> prettier["npm:prettier"]
-  npm --> claude_code["npm:@anthropic-ai/claude-code"]
-  pipx -->black["pipx:black"]
-  pipx -->pycowsay["pipx:pycowsay"]
-  aqua -->terraform["aqua:hashicorp/terraform"]
-
-  subgraph Tools
-    node
-    python
-    gh
-    ripgrep
-    ruff
-    prettier
-    claude_code
-    black
-    pycowsay
-    terraform
-  end
-```
-
-Backends are the package ecosystems that mise pulls tools from. With `mise use`, you can install from any of them.
-
-Install [claude-code](https://www.npmjs.com/package/@anthropic-ai/claude-code) from npm:
-
-```sh
-# one-off
-mise exec npm:@anthropic-ai/claude-code -- claude --version
-
-# or install globally
-mise use --global npm:@anthropic-ai/claude-code
-claude --version
-```
-
-Install [black](https://github.com/psf/black) from PyPI via pipx:
-
-```sh
-# one-off
-mise exec pipx:black -- black --version
-
-# or install globally
-mise use --global pipx:black
-black --version
-```
-
-Install [ripgrep](https://github.com/BurntSushi/ripgrep) directly from GitHub releases:
-
-```sh
-# one-off
-mise exec github:BurntSushi/ripgrep -- rg --version
-
-# or install globally
-mise use --global github:BurntSushi/ripgrep
-rg --version
-```
-
-Each `mise use` command above updates your config file. For example, after running all three globally, your `~/.config/mise/config.toml` would contain:
-
-```toml [~/.config/mise/config.toml]
-[tools]
-"npm:@anthropic-ai/claude-code" = "latest"
-"pipx:black" = "latest"
-"github:BurntSushi/ripgrep" = "latest"
-```
-
-You can also edit `mise.toml` directly instead of using `mise use` — the effect is the same. Run `mise install` after editing to install the tools.
-
-See [Backends](/dev-tools/backends/) for more ecosystems and details.
-
-## Trusting config files {#trust}
-
-When you or a teammate adds a `mise.toml` to a project, mise may prompt you to trust it before it runs env directives or hooks:
-
-```
-mise ~/my-project/mise.toml is not trusted. Trust it? [y/n]
-```
-
-This is a security measure — config files can execute arbitrary code via `[env]` directives, hooks, and tasks. To trust a file, run:
-
-```sh
-mise trust
-```
-
-In normal mode, `mise run`, naked task invocations such as `mise <TASK>`, `mise install`,
-`mise exec`, and `mise watch` automatically trust the active config because those commands
-explicitly execute project-defined behavior. Paranoid mode requires `mise trust` for all
-non-global configs, including configs that are safe in normal mode.
-
-To disable trust prompts for a path, configure:
-
-```sh
-mise settings trusted_config_paths=["/"]
-```
-
-Or set the environment variable `MISE_TRUSTED_CONFIG_PATHS=/`.
-
-::: tip
-`mise use` automatically trusts the file it creates.
-:::
-
-See [`mise trust`](/cli/trust) for more details.
-
-## 5. Setting environment variables {#environment-variables}
-
-Define environment variables in `mise.toml` — they're loaded whenever mise is activated or when you use `mise exec`:
-
-```toml [mise.toml]
-[env]
-NODE_ENV = "production"
-```
-
-```sh
-mise exec -- node --eval 'console.log(process.env.NODE_ENV)'
-
-# or if mise is activated in your shell
-echo "node env: $NODE_ENV"
-# node env: production
-```
-
-## 6. Run a task {#run-a-task}
-
-Define tasks in `mise.toml` and run them with `mise run`:
-
-```toml [mise.toml]
-[tasks]
-hello = "echo hello from mise"
-```
-
-```sh
-mise run hello
-# hello from mise
-```
-
-:::tip
-mise automatically installs all tools from `mise.toml` before running a task.
-:::
-
-See [tasks](/tasks/) for more on defining and running tasks.
-
-## 7. Next steps {#next-steps}
-
-Follow the [walkthrough](/walkthrough) for more examples of how to use mise.
-
-### Set up autocompletion {#autocompletion}
-
-See [autocompletion](/installing-mise.html#autocompletion) to learn how to set up autocompletion for your shell.
-
-### GitHub API rate limiting {#github-api-rate-limiting}
-
-::: warning
-Many tools in mise use the GitHub API. Unauthenticated requests are often rate limited — if you see 4xx errors, see [GitHub Tokens](/dev-tools/github-tokens.html) to configure authentication.
-:::

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ hero:
 <section class="landing-page" aria-label="mise overview">
   <div class="hero-card" aria-label="One mise.toml drives tools, env vars, and tasks">
     <div class="card-file">
-      <div class="card-bar"><strong>mise.toml</strong><span>checked into your repo</span></div>
+      <div class="card-bar"><strong>mise.toml</strong><span>illustrative project configuration</span></div>
       <div class="card-toml" aria-label="Example mise.toml">
         <div class="row row-tools"><span class="tk-section">[tools]</span></div>
         <div class="row row-tools"><span class="tk-key">node</span><span class="tk-op"> = </span><span class="tk-str">"24"</span></div>
@@ -24,9 +24,11 @@ hero:
         <div class="row row-env"><span class="tk-key">DATABASE_URL</span><span class="tk-op"> = </span><span class="tk-str">"postgres://localhost/orders"</span></div>
         <div class="row row-env"><span class="tk-key">_.file</span><span class="tk-op"> = </span><span class="tk-str">".env.local"</span></div>
         <div class="row row-blank"></div>
+        <div class="row row-tasks"><span class="tk-section">[tasks.build]</span></div>
+        <div class="row row-tasks"><span class="tk-key">run</span><span class="tk-op"> = </span><span class="tk-str">"node --check app.js"</span></div>
         <div class="row row-tasks"><span class="tk-section">[tasks.test]</span></div>
         <div class="row row-tasks"><span class="tk-key">depends</span><span class="tk-op"> = [</span><span class="tk-str">"build"</span><span class="tk-op">]</span></div>
-        <div class="row row-tasks"><span class="tk-key">run</span><span class="tk-op"> = </span><span class="tk-str">"pytest"</span></div>
+        <div class="row row-tasks"><span class="tk-key">run</span><span class="tk-op"> = </span><span class="tk-str">"node --test"</span></div>
         <div class="row row-blank"></div>
         <div class="row row-boot"><span class="tk-section">[bootstrap.packages]</span></div>
         <div class="row row-boot"><span class="tk-key">"brew:postgresql@17"</span><span class="tk-op"> = </span><span class="tk-str">"latest"</span></div>
@@ -55,9 +57,9 @@ hero:
       <div class="card-output pillar-tasks">
         <div class="card-output-head"><span class="pillar-dot"></span><span>Tasks</span><code>$ mise run test</code></div>
         <div class="terminal-lines">
-          <div><span class="key">[build]</span> $ npm run build</div>
-          <div><span class="key">[test]</span> $ pytest</div>
-          <div><span class="ok">42 passed</span> in 1.02s</div>
+          <div><span class="key">[build]</span> $ node --check app.js</div>
+          <div><span class="key">[test]</span> $ node --test</div>
+          <div><span class="ok">tests passed</span></div>
         </div>
       </div>
       <div class="card-output pillar-boot">
@@ -66,7 +68,7 @@ hero:
           <div><span class="dim">mise bootstrap:</span> system packages</div>
           <div>brew:postgresql@17 <span class="ok">✓ installed</span></div>
           <div><span class="dim">mise bootstrap:</span> dotfiles</div>
-          <div>~/.zshrc <span class="ok">✓ symlinked</span></div>
+          <div>~/.config/mise/config.toml <span class="ok">✓ symlinked</span></div>
         </div>
       </div>
     </div>
@@ -76,13 +78,12 @@ hero:
     <p class="landing-kicker"><span>01</span> Why mise</p>
     <div class="landing-why-grid">
       <div>
-        <h2>Clear the counter.</h2>
+        <h2>Keep project setup with the project.</h2>
         <p class="landing-lede">
-          Most projects carry a drawer of version managers, dotfiles, and a
-          README full of setup steps. Every new machine adds a Brewfile, a
-          dotfiles manager, and a playbook. mise replaces them with one file
-          that's checked in, so a fresh laptop is <code>git clone</code> and
-          <code>mise bootstrap</code>.
+          A project needs more than a list of tools: it needs their versions,
+          environment variables, and commands for everyday work. Keep those
+          choices in <code>mise.toml</code> so teammates can install the declared
+          tools and run the project's tasks from a fresh checkout.
         </p>
         <p class="landing-note">
           Coming from asdf? mise reads <code>.tool-versions</code> as-is. Files
@@ -90,21 +91,20 @@ hero:
           <a href="/configuration.html#idiomatic-version-files">enable them</a>.
         </p>
       </div>
-      <div class="landing-ledger" aria-label="Before and after mise">
+      <div class="landing-ledger" aria-label="Project setup in mise.toml">
         <div class="ledger-col ledger-before">
-          <p class="ledger-head">Before</p>
+          <p class="ledger-head">What you declare</p>
           <ul>
-            <li>nvm, pyenv, rbenv <span>.nvmrc, .python-version</span></li>
-            <li>direnv <span>.envrc</span></li>
-            <li>make, just <span>Makefile</span></li>
-            <li>Homebrew <span>Brewfile</span></li>
-            <li>chezmoi <span>dotfiles repo</span></li>
-            <li>Ansible <span>playbook.yml</span></li>
-            <li>README <span>"Setup", 14 steps</span></li>
+            <li>Tool versions <span>Node.js, Python, Go</span></li>
+            <li>Environment <span>variables, .env files</span></li>
+            <li>Tasks <span>build, test, lint</span></li>
+            <li>System packages <span>via OS package managers</span></li>
+            <li>Dotfiles <span>links and templates</span></li>
+            <li>Services <span>machine setup</span></li>
           </ul>
         </div>
         <div class="ledger-col ledger-after">
-          <p class="ledger-head">After</p>
+          <p class="ledger-head">Where it lives</p>
           <ul>
             <li><strong>mise</strong> <span>mise.toml</span></li>
           </ul>
@@ -121,13 +121,13 @@ hero:
 
   <div class="landing-section landing-stations">
     <p class="landing-kicker"><span>02</span> What it does</p>
-    <h2>Four stations, one line.</h2>
+    <h2>Start with tools. Add what you need.</h2>
     <div class="stations-grid">
       <a class="station pillar-tools" href="/dev-tools/">
         <p class="station-cmd">$ mise use node@24</p>
         <h3>Dev tools</h3>
         <p>
-          Install any of 1000+ tools, pin versions per project, and switch
+          Install hundreds of tools, select versions per project, and switch
           automatically as you move between directories.
         </p>
         <span class="card-link">Dev tools</span>
@@ -154,8 +154,8 @@ hero:
         <p class="station-cmd">$ mise bootstrap</p>
         <h3>Bootstrap</h3>
         <p>
-          Set up a whole machine from the same config: OS packages, dotfiles,
-          repos, services, macOS defaults, then your tools.
+          Apply the machine setup you declare: OS packages, dotfiles,
+          repos, services, macOS defaults, and development tools.
         </p>
         <span class="card-link">Bootstrap</span>
       </a>
@@ -169,8 +169,9 @@ hero:
         <h2>Change directory. <em>Everything follows.</em></h2>
         <p class="landing-lede">
           Activate mise in your shell once. From then on, entering a project
-          puts its tool versions on your <code>PATH</code> and its env vars in
-          your shell. Leaving takes them away again.
+          puts its installed tool versions on your <code>PATH</code> and loads
+          its environment variables. Leave the project and mise restores the
+          environment for your new directory.
         </p>
         <ul class="landing-checklist">
           <li>Shell hooks for bash, zsh, fish, nushell, PowerShell, and more</li>
@@ -227,13 +228,11 @@ hero:
       <div>
         <h2>One config for the <em>whole machine.</em></h2>
         <p class="landing-lede">
-          <code>mise bootstrap</code> sets up a new computer from the same
-          file: OS packages, git repos, dotfiles, shell activation, macOS
-          defaults, and services, then your tools. Run it again and mise skips
-          anything that's already set up. mise has its own Homebrew
-          implementation, so it installs formulae and casks without requiring
-          Homebrew. It replaces what you'd otherwise assemble from a Brewfile,
-          chezmoi, and an Ansible playbook.
+          Declare the packages, repositories, dotfiles, and services your
+          machine needs, then apply them with <code>mise bootstrap</code>.
+          Preview declarative resource changes with
+          <code>mise bootstrap plan</code>. Add shell activation and
+          platform-specific settings to keep machine setup alongside your tools.
         </p>
         <ul class="landing-checklist">
           <li>Packages through brew, apt, dnf, pacman, apk, and mas</li>
@@ -305,56 +304,53 @@ hero:
 
   <div class="landing-section landing-recipe">
     <p class="landing-kicker"><span>05</span> Quickstart</p>
-    <h2>Set up in four steps.</h2>
+    <h2>Run your first project task.</h2>
     <ol class="recipe">
       <li class="recipe-row">
         <div class="recipe-text">
           <span class="recipe-num">Step 1</span>
           <h3>Install mise</h3>
-          <p>One command, one static binary. <a href="/installing-mise">Homebrew, apt, cargo, and more</a> also work.</p>
+          <p>On macOS or Linux, use the installer below. See <a href="/installing-mise">Windows and package manager instructions</a> for other options.</p>
         </div>
         <div class="recipe-code terminal-lines">
           <div><span class="prompt">$</span> curl https://mise.run | sh</div>
-          <div><span class="prompt">$</span> mise --version</div>
-          <div>2026.9.1 linux-x64</div>
+          <div><span class="prompt">$</span> ~/.local/bin/mise --version</div>
         </div>
       </li>
       <li class="recipe-row">
         <div class="recipe-text">
           <span class="recipe-num">Step 2</span>
-          <h3>Hook into your shell</h3>
-          <p>Optional, but this is what makes tools and env vars switch as you <code>cd</code>. <a href="/installing-mise#shells">Other shells</a> are one line too.</p>
+          <h3>Activate your shell</h3>
+          <p>For zsh, add this line and restart your shell. Follow the <a href="/getting-started#activate-mise">activation guide</a> for other shells. You can also skip activation and use <code>~/.local/bin/mise exec</code> or <code>~/.local/bin/mise run</code>.</p>
         </div>
         <div class="recipe-code terminal-lines">
-          <div><span class="prompt">$</span> echo 'eval "$(mise activate zsh)"' &gt;&gt; ~/.zshrc</div>
-          <div><span class="dim"># bash: ~/.bashrc · fish: config.fish · pwsh: $PROFILE</span></div>
+          <div><span class="prompt">$</span> echo 'eval "$(~/.local/bin/mise activate zsh)"' &gt;&gt; ~/.zshrc</div>
+          <div><span class="dim"># Restart your shell before continuing.</span></div>
         </div>
       </li>
       <li class="recipe-row">
         <div class="recipe-text">
           <span class="recipe-num">Step 3</span>
           <h3>Add tools</h3>
-          <p><code>mise use</code> installs the tool and pins it in <code>mise.toml</code> in one go. Commit the file.</p>
+          <p>From your project directory, <code>mise use</code> installs a tool and saves its version request in <code>mise.toml</code>.</p>
         </div>
         <div class="recipe-code terminal-lines">
-          <div><span class="prompt">$</span> mise use node@24 python@3.13</div>
-          <div><span class="dim">mise</span> node@24.18.0 <span class="ok">✓ installed</span></div>
-          <div><span class="dim">mise</span> python@3.13.14 <span class="ok">✓ installed</span></div>
-          <div><span class="dim">mise</span> ./mise.toml tools: node@24.18.0, python@3.13.14</div>
+          <div><span class="prompt">$</span> mkdir mise-example</div>
+          <div><span class="prompt">$</span> cd mise-example</div>
+          <div><span class="prompt">$</span> mise use node@24</div>
         </div>
       </li>
       <li class="recipe-row">
         <div class="recipe-text">
           <span class="recipe-num">Step 4</span>
           <h3>Add env vars and tasks</h3>
-          <p>They live in the same file, next to the tools they depend on. Teammates run <code>mise install</code>; a new laptop runs <code>mise bootstrap</code>.</p>
+          <p>Save a task alongside its environment, then run it. Commit <code>mise.toml</code> to share the setup. See <a href="/getting-started#set-up-a-project">the complete example</a> to print both the tool version and environment.</p>
         </div>
         <div class="recipe-code terminal-lines">
-          <div><span class="prompt">$</span> mise set DATABASE_URL=postgres://localhost/orders</div>
-          <div><span class="prompt">$</span> mise tasks add test -- pytest</div>
-          <div><span class="prompt">$</span> mise run test</div>
-          <div><span class="key">[test]</span> $ pytest</div>
-          <div><span class="ok">42 passed</span> in 1.02s</div>
+          <div><span class="prompt">$</span> mise set NODE_ENV=development</div>
+          <div><span class="prompt">$</span> mise tasks add hello -- node -p process.env.NODE_ENV</div>
+          <div><span class="prompt">$</span> mise run hello</div>
+          <div>development</div>
         </div>
       </li>
     </ol>
@@ -366,7 +362,7 @@ hero:
     <div class="landing-mini-install"><code>curl https://mise.run | sh</code></div>
     <div class="landing-links">
       <a href="/getting-started">Getting started</a>
-      <a href="/demo">Run the demo</a>
+      <a href="/demo">Watch the demo</a>
       <a href="https://github.com/jdx/mise">GitHub</a>
     </div>
   </div>

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -1,19 +1,23 @@
 # Walkthrough
 
-Once you've completed the [Getting Started](/getting-started) guide, you're ready to start using mise.
-This document offers a quick overview of some things you may want to try first.
+Use this guide to add mise to an existing project and maintain its configuration:
+select tools, share defaults, upgrade versions, and run everyday commands.
+Complete [getting started](/getting-started.html) first if you haven't installed mise.
+
+The examples that run tools directly assume [shell activation](/getting-started.html#activate-mise).
+Without activation, prefix a tool command with `mise exec --`, for example
+`mise exec -- node --version`.
 
 ## Installing Dev Tools
 
 The main command for working with tools in mise is [`mise u|use`](/cli/use). It does two things:
 
 - Installs the tool (if not already installed)
-- Adds the tool to the `mise.toml` config file—in mise, I say a tool is "active" if it's in `mise.toml`
+- Saves its version request in the project configuration
 
-:::warning
-Both steps are required to use a tool. If you only install a tool with `mise install`, it won't be available in your shell.
-It must also be added to `mise.toml`—which is why I recommend `mise use`, since it does both.
-:::
+`mise install node@24` downloads a tool without selecting it for your project.
+Use `mise use` to save that selection, or `mise exec node@24 -- node --version`
+to use it for one command.
 
 Use it like so (`mise` must be [activated](/getting-started.html#activate-mise) for this example to work):
 
@@ -32,7 +36,7 @@ node = "26"
 ```
 
 - If this file is in the root of a project, `node` will be installed whenever someone runs [`mise install|i`](/cli/install).
-- `mise install` is the command to run when you first clone a project or when you want to update installed tools.
+- `mise install` installs the configured tools after you clone a project. Use `mise upgrade` to update them.
 
 ## `mise.toml` Configuration
 
@@ -58,9 +62,10 @@ For tools or settings you want to keep private, use [`mise.local.toml`](/configu
 Use [`mise config ls`](/cli/config/ls) to see the configuration files currently used by `mise`.
 :::
 
-In general, prefer loose versions like `node@26` so that other people working
-on a project don't have to worry about the exact version of a tool you're using. If you'd like to
-enforce a specific version, use `mise use --pin` or the [`lockfile`](/configuration/settings#lockfile) setting.
+Choose version precision to match the project. A request such as `node@26` allows
+releases within that series. Use `mise use --pin` to save an exact version, or a
+[lockfile](/dev-tools/mise-lock.html) to share resolved versions while keeping
+broader requests in `mise.toml`.
 
 If you leave out the version, mise defaults to `node@latest`.
 


### PR DESCRIPTION
The README and getting-started guide previously introduced disconnected examples and backend details before showing a complete project. The README's combined example deployed infrastructure, while the homepage quickstart assumed mise was already on PATH and used an undeclared test dependency.

Reorganize onboarding around a small Node.js project with an environment variable and a runnable task. Clarify installation versus activation, project configuration versus global defaults, and version requests versus exact pins and lockfiles. Tighten the homepage copy and examples, put Getting Started first in navigation, repair nested installation/activation tabs, and expand the docs contributor guide.

## Validation

- `mise run docs:build` passed, including social image tests and checks for 333 documentation pages.
- Changed-file `hk run check --safe --format json --files0-from …` passed (Prettier and Markdown lint).
- README and homepage examples ran successfully in an isolated project configuration.
- Reviewed the production site at desktop and mobile widths; verified installation tabs render without exposed markup.
- `git diff --check` passed.

The required `mise run lint-fix` was attempted but failed at Cargo: the active rustc is 1.93.0, while this checkout requires 1.95. The development server also encountered a dependency-optimizer error; browser validation used the successful production build.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and VitePress theme/markdown only; no changes to mise runtime behavior or configuration handling.
> 
> **Overview**
> **Reframes onboarding** around one runnable **Node.js** project (`mise.toml` with tools, `NODE_ENV`, and a `hello` task) across the root **README**, **getting-started**, homepage hero/quickstart, and related pages—replacing scattered examples (Terraform deploy, pytest) and assumptions that `mise` is already on `PATH`.
> 
> **Clarifies concepts** readers hit early: install vs shell activation, `mise exec`/`mise run` without activation, project vs `--global` config, `mise use` vs `mise install`, and version requests vs pins/lockfiles. **Getting started** is reordered (tool → project → optional activate), backend deep-dives are trimmed, installation/activation **tabs are fixed** (`::::tabs`), and a **trust** section is integrated into the project flow.
> 
> **Site navigation and contributor docs**: sidebar **“Start Here”** puts **Getting Started** before Demo; **docs/README.md** documents where to put content and how to write runnable examples; **dev-tools** overview and **walkthrough** are tightened to match; homepage/hero copy is softened (less “replace everything” framing) with aligned illustrative examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 279771bf16ba3cc40b1ed74d2fb33717cf85e3b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the README and getting-started materials into a clearer, numbered quickstart covering installation, tools, project environments, shell activation, and next steps.
  * Updated homepage messaging and examples to highlight tools, environment variables, tasks, and machine setup.
  * Added Windows installation guidance and expanded platform-specific instructions.
  * Reworked Dev Tools and walkthrough content with practical setup, versioning, configuration, and lockfile guidance.
  * Updated documentation navigation and added contributor guidance for building, previewing, and reviewing docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->