### PR TITLE
docs(config): clarify environments and repair secret setup guides

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,33 @@
 # Configuration
 
-Learn how to configure mise for your project with `mise.toml` files, environment variables, and various configuration options to manage your development environment.
+A project's `mise.toml` declares tools, environment variables, and tasks. Global
+configuration supplies personal defaults; project and local files override them.
+
+Start with one file in the project root:
+
+```toml [mise.toml]
+[tools]
+node = "24"
+
+[env]
+NODE_ENV = "development"
+
+[tasks.hello]
+run = "node --eval 'console.log(process.env.NODE_ENV)'"
+```
+
+Run `mise run hello` to install the declared tool if needed and print
+`development`. Use `mise config` to see the active config files and
+`mise ls --current` to see the selected tool versions.
+
+| Configure                                  | Reference                                               |
+| ------------------------------------------ | ------------------------------------------------------- |
+| Tool versions and installation options     | [Dev tools](/dev-tools/)                                |
+| Variables passed to commands               | [Environments](/environments/)                          |
+| Reusable values inside templates           | [Variables](/configuration/vars.html)                   |
+| Development, test, and production overlays | [Config Environments](/configuration/environments.html) |
+| Commands and dependencies                  | [Tasks](/tasks/)                                        |
+| mise's own behavior                        | [Settings](/configuration/settings.html)                |
 
 ## `mise.toml`
 
@@ -41,10 +68,16 @@ what is defined there overrides anything set in
 
 When mise needs configuration, it follows this process:
 
-1. **Walks up the directory tree** from your current location to the root (or `MISE_CEILING_PATHS`)
-2. **Collects all config files** it finds along the way
-3. **Merges them in order** with more specific (closer to your current directory) settings overriding broader ones
-4. **Applies environment-specific configs** like `mise.dev.toml` if `MISE_ENV` is set
+1. Reads early configuration, including the selected config environments.
+2. Discovers system and global config, then searches the current directory and its
+   parents up to the root or `MISE_CEILING_PATHS`.
+3. Includes matching environment-specific files at each level of that hierarchy.
+4. Merges the files with child directories taking precedence over parents, and
+   same-directory variants following the order above.
+
+An environment-specific parent file does not override an ordinary child file
+just because it names an environment. Environment selection is part of file
+discovery, not a final override applied after the hierarchy.
 
 ### Visual Configuration Hierarchy
 
@@ -106,13 +139,17 @@ locked = true
 # Result: NODE_ENV=production, API_URL=localhost
 ```
 
-**Tasks** (`[tasks]`): Completely replaced per task
+**Tasks** (`[tasks]`): A more specific command definition replaces the earlier command
 
 ```toml
 # Global: [tasks.test] = "npm test"
 # Project: [tasks.test] = "yarn test"
-# Result: "yarn test" (completely replaces global)
+# Result: "yarn test"
 ```
+
+Metadata-only task definitions can overlay an existing task without replacing its
+command. Included task files and file tasks have additional merge rules; see
+[`task_config.includes`](/tasks/task-configuration.html#task_config.includes).
 
 **Settings** (`[settings]`): Additive with overrides
 
@@ -146,47 +183,6 @@ $ mise set NODE_ENV=production  # writes to mise.toml
 ```
 
 :::
-
-Here is what a typical `mise.toml` looks like:
-
-```toml
-[tools]
-node = '24'
-python = '3.12'
-
-[env]
-NODE_ENV = 'development'
-
-[tasks.dev]
-run = 'npm run dev'
-
-[tasks.test]
-run = 'pytest'
-```
-
-`mise.toml` files are hierarchical. The configuration in a file in the current directory
-overrides conflicting configuration in parent directories. For example, if `~/src/myproj/mise.toml`
-defines the following:
-
-```toml
-[tools]
-node = '20'
-python = '3.10'
-```
-
-And `~/src/myproj/backend/mise.toml` defines:
-
-```toml
-[tools]
-node = '18'
-ruby = '3.1'
-```
-
-Then, inside `~/src/myproj/backend`, `node` will be `18`, `python` will be `3.10`, and `ruby`
-will be `3.1`. You can check the active versions with `mise ls --current`.
-
-You can also have environment-specific config files like `.mise.production.toml`; see
-[Configuration Environments](/configuration/environments) for details.
 
 ### `[tools]` - Dev tools
 
@@ -286,11 +282,6 @@ The old `[alias]` key still works but is deprecated.
 
 The following makes `mise install node@my_custom_node` install node-20.x.
 Aliases can also be specified in a [plugin](/dev-tools/aliases.md).
-Adding an alias also adds a symlink, in this case:
-
-```sh
-~/.local/share/mise/installs/node/20 -> ./20.x.x
-```
 
 ```toml
 [tool_alias.node.versions]
@@ -318,22 +309,24 @@ Specify the minimum mise version required by the configuration file.
 You can set a hard minimum (errors if unmet) or a soft minimum (warns and continues):
 
 ```toml
-# (equivalent to hard)
+# Require this version or newer
 min_version = '2024.11.1'
+```
 
-# new object form
-min_version = { hard = '2024.11.1' }
+Or specify a hard minimum and a newer recommended version:
 
-# soft recommendation
-min_version = { soft = '2024.11.1' }
-
-# both
-min_version = { hard = '2024.11.1', soft = '2024.9.0' }
+```toml
+min_version = { hard = '2024.11.1', soft = '2026.1.0' }
 ```
 
 When a soft minimum is not met, mise prints a warning and, if available, self-update instructions. When a hard minimum is not met, mise errors and shows self-update instructions.
 
-Use `min_version` to communicate the oldest mise version your project supports. In general, users should keep mise up to date because mise integrates with external registries and backends that change over time. Projects and organizations should prefer a minimum version requirement over locking users to a specific mise executable, which is generally discouraged. Pinning users back is like preventing `apt update` or `brew update` from refreshing package metadata: it can hide deprecation warnings and let upstream integrations drift out of date.
+Use a hard minimum for syntax or behavior the project requires. A soft minimum
+recommends an upgrade while allowing older clients to continue. A soft-only
+requirement is also valid: `min_version = { soft = '2026.1.0' }`.
+
+Keep mise current so backend integrations and deprecation notices stay up to date.
+A minimum version lets teammates upgrade without changing the project's requirement.
 
 ### Monorepo root
 
@@ -341,15 +334,19 @@ Mark a configuration file as a monorepo root to enable target path syntax for ta
 
 ```toml
 monorepo_root = true
+
+[monorepo]
+config_roots = ["projects/frontend", "projects/api"]
 ```
 
-When enabled:
+`monorepo_root` enables task addressing; `config_roots` identifies the projects to
+load. When enabled:
 
 - Tasks in subdirectories are available with namespaced paths (e.g., `//projects/frontend:build`)
 - Subdirectory tasks use tools from parent configs
 - Tasks are only loaded when needed (e.g., when running them, or with `mise tasks ls --all`)
-- All descendant config files are **implicitly trusted** when the root is trusted
-- Each subdirectory's configuration no longer needs to be trusted individually
+- Trusting a monorepo root allows descendant configs to share that trust; review
+  the repository before trusting it (see [trust behavior](/cli/trust.html))
 
 See [Monorepo Tasks](/tasks/monorepo) for detailed usage and examples.
 
@@ -567,12 +564,8 @@ There is a small performance cost to discovering and parsing these files. Regist
 in-process; plugin-provided files may invoke the plugin's parser. Results are [cached](/cache-behavior),
 so this is generally not noticeable.
 
-::: info
-asdf called these "legacy version files". I think this was a bad name since it implies
-that they shouldn't be used—which is definitely not the case IMO. I prefer the term "idiomatic"
-version files since they are version files not specific to asdf/mise and can be used by other tools.
-(`.nvmrc` being a notable exception, which is tied to a specific tool.)
-:::
+asdf calls these "legacy version files". mise uses "idiomatic version files" to
+distinguish language and ecosystem conventions from mise's own configuration.
 
 ## Settings
 

--- a/docs/configuration/environments.md
+++ b/docs/configuration/environments.md
@@ -170,12 +170,10 @@ that would be newly loaded. To control the behavior explicitly:
 
 ```toml
 # .miserc.toml
-auto_env = true # adopt the new behavior now
-# or
-# auto_env = false # keep the old behavior and silence the warning
+auto_env = false # keep the old behavior and silence the warning
 ```
 
-Alternatively, set `MISE_AUTO_ENV=true` / `MISE_AUTO_ENV=false`. Like `MISE_ENV`, this is an early-init
-setting: it must be set in `.miserc.toml` or via the environment variable — setting it in
-`mise.toml` has no effect because config file discovery has already happened by the time
-`mise.toml` is read.
+Set `auto_env = true` instead to adopt the new behavior now. Alternatively, set
+`MISE_AUTO_ENV=true` / `MISE_AUTO_ENV=false`. Like `MISE_ENV`, this is an early-init setting: it must
+be set in `.miserc.toml` or via the environment variable — setting it in `mise.toml` has no effect
+because config file discovery has already happened by the time `mise.toml` is read.

--- a/docs/configuration/environments.md
+++ b/docs/configuration/environments.md
@@ -1,15 +1,46 @@
 # Config Environments
 
-It's possible to have separate `mise.toml` files in the same directory for different
-environments like `development` and `production`. To enable this, set `MISE_ENV` to an
-environment name using one of these methods:
+Config environments select additional files such as `mise.development.toml` and
+`mise.production.toml`. The base `mise.toml` still loads, and the selected file
+overrides values at the same directory level.
+
+For variables passed to your application, use [`[env]`](/environments/). Selecting
+a mise config environment does not set application variables such as `NODE_ENV`
+unless you define them.
+
+## Try an environment
+
+```toml [mise.toml]
+[env]
+APP_MODE = "development"
+```
+
+```toml [mise.production.toml]
+[env]
+APP_MODE = "production"
+```
+
+```sh
+mise exec -- sh -c 'echo "$APP_MODE"'                # development
+mise -E production exec -- sh -c 'echo "$APP_MODE"'  # production
+mise -E production config                          # inspect loaded files
+```
+
+## Select environments
+
+Select an environment using one of these methods:
 
 - CLI flag: `-E development` or `--env development`
 - Environment variable: `MISE_ENV=development`
 - `.miserc.toml` file: `env = ["development"]`
 
-mise then looks for a `mise.{MISE_ENV}.toml` file in the current directory,
-parent directories, and the `MISE_CONFIG_DIR` directory.
+mise looks for matching files throughout the configuration hierarchy. Project
+files use names such as `mise.production.toml`; the global config uses
+`config.production.toml` in `MISE_CONFIG_DIR`.
+
+Multiple environments can be specified, for example `mise -E ci,test run build`.
+Within the same directory, the last environment takes precedence. Use
+`mise -E ci,test config` to inspect the combined selection.
 
 ## Setting MISE_ENV in .miserc.toml
 
@@ -52,6 +83,8 @@ File locations searched (in order of precedence):
 
 `MISE_ENV` cannot be set in `mise.toml` because it determines which config
 files are loaded in the first place.
+
+## Local overrides
 
 mise also looks for "local" files like `mise.local.toml` and `mise.{MISE_ENV}.local.toml`
 in the current directory and parent directories.
@@ -105,8 +138,6 @@ Use `mise config` to see which files are being used.
 The rules for which file is written to are different, because one file ultimately has to be chosen. See
 the docs for [`mise use`](/cli/use.html) for more information.
 
-Multiple environments can be specified, e.g. `MISE_ENV=ci,test`, with the last one taking precedence.
-
 ## Platform environments
 
 With the [`auto_env` setting](/configuration/settings.html#auto_env) enabled, mise automatically
@@ -141,7 +172,7 @@ that would be newly loaded. To control the behavior explicitly:
 # .miserc.toml
 auto_env = true # adopt the new behavior now
 # or
-auto_env = false # keep the old behavior and silence the warning
+# auto_env = false # keep the old behavior and silence the warning
 ```
 
 Alternatively, set `MISE_AUTO_ENV=true` / `MISE_AUTO_ENV=false`. Like `MISE_ENV`, this is an early-init

--- a/docs/configuration/settings.md
+++ b/docs/configuration/settings.md
@@ -4,10 +4,40 @@
 import Settings from '/components/settings.vue';
 </script>
 
-The following is a list of all of mise's settings. These can be set via `mise settings key=value`,
-by directly modifying the [global config file](/configuration.html#mise_global_config_file)
-(`~/.config/mise/config.toml`) or local config, or via environment variables.
+Settings control mise itself, such as installation concurrency and task output.
+Application environment variables belong in [`[env]`](/environments/).
 
-Some of them also can be set via global CLI flags.
+## Change a setting
+
+The settings command writes to the global config by default. Use `--local` to
+write to the project's selected config file:
+
+```sh
+mise settings set jobs 4          # personal default
+mise settings set --local jobs 2  # project setting
+mise settings unset --local jobs  # remove the project override
+```
+
+The equivalent TOML is:
+
+```toml
+[settings]
+jobs = 4
+```
+
+Use `mise settings ls --all` to inspect effective settings, including defaults.
+`mise settings ls --json-extended` includes source information for configured
+values. A setting's reference below lists its type, default, and environment
+variable when available. Some settings also have global CLI flags.
+
+## Early initialization
+
+Some settings control config discovery and are read before `mise.toml`. These
+must be set through their environment variable or, where supported, a
+[`.miserc.toml` file](/configuration/environments.html#setting-mise-env-in-miserc-toml).
+Follow the individual setting's instructions; putting an early setting under
+`[settings]` can be too late to affect discovery.
+
+## Reference
 
 <Settings :level="2" />

--- a/docs/configuration/vars.md
+++ b/docs/configuration/vars.md
@@ -13,8 +13,12 @@ test_mode = "headless"
 node = "{{ vars.node_version }}"
 
 [tasks.test]
-run = "./scripts/test-e2e.sh --{{ vars.test_mode }}"
+run = "echo {{ vars.test_mode | quote }}"
 ```
+
+Run `mise run test` to print `headless`. `test_mode` is available through the
+`vars` template map, but it is not exported as `$test_mode`. The `quote` filter in
+this example targets POSIX shells; see [template quoting](/templates.html#string-manipulation).
 
 Vars are available to Tera-rendered configuration such as tool versions and options, task
 definitions, hooks, task includes, watch configuration, and dotfile templates. See
@@ -72,7 +76,9 @@ test_mode = "headless"
 
 [tasks.test]
 vars = { test_mode = "headed" }
-run = "./scripts/test-e2e.sh --{{ vars.test_mode }}"
+run = "echo {{ vars.test_mode | quote }}"
 ```
 
-See [Task Configuration](/tasks/task-configuration.html#task-vars) for task-local vars.
+Here, `mise run test` prints `headed`; other tasks still see `headless` unless
+they define their own override. See [Task Configuration](/tasks/task-configuration.html#task-vars)
+for task-local vars.

--- a/docs/direnv.md
+++ b/docs/direnv.md
@@ -1,74 +1,74 @@
 # direnv <Badge type="warning" text="deprecated" />
 
-[direnv](https://direnv.net) and mise both manage environment variables based on directory. Because
-they both analyze
-the current environment variables before and after their respective "hook" commands are run, they
-can sometimes conflict with each other.
+[direnv](https://direnv.net) and mise both change the environment when you enter a
+directory. Their shell hooks can disagree about which `PATH` entries to add,
+restore, or remove.
 
-::: warning
-The official stance is you should not use direnv with mise. Issues arising
-from incompatibilities are not considered bugs and PRs to improve direnv
-compatibility will not be accepted.
-While that's the official stance, the reality is mise and direnv can
-coexist for simple cases like setting unrelated environment variables.
-Anything involving PATH — which is most of what people use both tools
-for — is where problems arise.
+::: warning Unsupported integration
+Using direnv with mise is unsupported. Compatibility issues are not considered
+mise bugs, and PRs for direnv compatibility are not accepted. The `use mise`
+integration is deprecated.
 :::
 
-If you have an issue, it's likely to do with the ordering of PATH. This is really only a problem
-if you are trying to manage the same tool with both direnv and mise. For example, you may use
-`layout python` in an `.envrc` while also maintaining a `.tool-versions` file with python in it.
+## Do you need direnv? {#do-you-need-direnv}
 
-A more typical use of direnv is to set arbitrary environment variables or add unrelated
-binaries to PATH. In these cases, mise does not interfere with direnv.
+For a project that uses direnv to set variables, load dotenv files, or activate a
+Python environment, mise has corresponding configuration:
+
+| Existing `.envrc` behavior       | mise configuration                                                                   |
+| -------------------------------- | ------------------------------------------------------------------------------------ |
+| `export NODE_ENV=development`    | `[env]` with `NODE_ENV = "development"`                                              |
+| Load a dotenv file               | [`env._.file`](/environments/#env-file)                                              |
+| Add `bin` to `PATH`              | [`env._.path`](/environments/#env-path)                                              |
+| Export values from a Bash script | [`env._.source`](/environments/#env-source)                                          |
+| Activate a Python virtualenv     | [Python virtualenv configuration](/lang/python.html#automatic-virtualenv-activation) |
+
+For example:
+
+```toml [mise.toml]
+[env]
+NODE_ENV = "development"
+_.file = ".env"
+_.path = "bin"
+```
+
+This example assumes the project has a `.env` file. Remove that directive if it
+does not. See [Environments](/environments/) for defaults, unsetting values, and
+sourcing scripts.
+
+After moving the required behavior into `mise.toml`, remove the project's direnv
+integration, [activate mise](/getting-started.html#activate-mise), and open a fresh
+shell to verify the environment. `mise exec -- <command>` can check project
+commands without depending on the interactive shell's current state.
 
 ## mise inside of direnv (`use mise` in `.envrc`)
 
-::: warning
-`use mise` is deprecated and no longer supported.
-:::
+The following describes the deprecated setup for people maintaining or removing
+an existing integration. It gives direnv control of the exported environment and
+does not provide mise's full activation behavior.
 
-If you encounter issues with `mise activate`, or want to use direnv in a different way,
-this is a simpler setup that's less likely to cause issues—at the cost of functionality.
-
-This may be required if you want to use direnv's `layout python` with mise. Otherwise, there are
-situations where mise overrides direnv's PATH. `use mise` ensures that direnv always has
-control.
-
-To do this, first use `mise` to build a `use_mise` function that you can use in `.envrc` files:
+The integration generates a direnv library function:
 
 ```sh
+mkdir -p ~/.config/direnv/lib
 mise direnv activate > ~/.config/direnv/lib/use_mise.sh
 ```
 
-Now add the following to your `.envrc` file:
+An `.envrc` then calls it as:
 
 ```sh
 use mise
 ```
 
-direnv now calls mise to export its environment variables. Make sure to add `use_mise`
-to all projects that use mise (or use direnv's `source_up` to load it from a subdirectory). You can
-also add `use mise` to `~/.config/direnv/direnvrc`.
+Keep the distinction between the shell function `use_mise` and direnv's
+`use mise` syntax. Existing projects may also load it from a parent `.envrc` with
+`source_up`, or from `~/.config/direnv/direnvrc`.
 
-With this method, direnv typically won't know to refresh `.tool-versions` files
-unless they're at the same level as an `.envrc` file, so you'll likely always want
-an `.envrc` file next to your `.tool-versions`. To make this easier to manage,
-I encourage _not_ using `.tool-versions` at all, and instead
-setting environment variables entirely in `.envrc`:
+If retaining this integration, avoid having both tools manage the same runtime
+or virtualenv. A common conflict is direnv's `layout python` alongside a Python
+version selected by mise. Changes to a `.tool-versions` file outside the `.envrc`
+directory may also fail to trigger a direnv refresh.
 
-```sh
-export MISE_NODE_VERSION=20.0.0
-export MISE_PYTHON_VERSION=3.11
-```
-
-Of course, if you use `mise activate`, these steps aren't necessary and you can use
-mise as if direnv were not in use.
-
-If you continue to struggle, you can also try using the [shims method](dev-tools/shims.md).
-
-### Do you need direnv?
-
-mise can replace direnv for most use cases. This is why mise includes support for
-managing env vars and [virtualenv](lang/python.md#automatic-virtualenv-activation)
-for python using `mise.toml`.
+[Shims](/dev-tools/shims.html) provide another way to run mise-managed tools, but
+they do not reproduce all the features of `mise activate` or make mixed shell
+hooks a supported setup.

--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -1,15 +1,24 @@
 # Environments
 
-> Load the right _environment variables_ automatically for each project
-> directory.
+Define project environment variables in `[env]`. mise supplies them to commands
+run with `mise exec`, tasks, and activated interactive shells.
 
-Use mise to specify environment variables used for different projects.
+For separate development, test, or production config files, see
+[Config Environments](/configuration/environments.html). For reusable values that
+should stay inside mise templates, use [`[vars]`](/configuration/vars.html).
 
-To get started, create a `mise.toml` file in the root of your project directory:
+Create a `mise.toml` file in the root of your project directory:
 
 ```toml [mise.toml]
 [env]
 NODE_ENV = 'production'
+```
+
+Check the value in a child process without changing your shell:
+
+```sh
+mise exec -- sh -c 'printf "%s\n" "$NODE_ENV"'
+# production
 ```
 
 To clear an env var, set it to `false`:
@@ -114,7 +123,7 @@ run = "echo $MY_VAR"
 env = { _.file = '/path/to/file.env', "MY_VAR" = "my variable" }
 ```
 
-## Lazy eval
+## Resolve values after tools {#lazy-eval}
 
 Environment variables typically are resolved before tools—that way you can configure tool installation
 subprocesses with environment variables. This does not apply to variables that configure mise itself,
@@ -133,7 +142,9 @@ NODE_VERSION = { value = "{{ tools.node.version }}", tools = true }
 
 ## Redactions
 
-Variables can be redacted from the output by setting `redact = true`:
+Mark values as sensitive with `redact = true` so mise can mask them in captured
+task output. This does not encrypt the config file or prevent a child process
+from reading the value:
 
 ```toml
 [env]
@@ -175,7 +186,9 @@ The same applies to a `default` whose fallback the caller overrides.
 
 ### Viewing Redacted Environment Variables
 
-The `mise env` command provides flags to work with redacted variables:
+`mise env` exports actual values, including secrets. `--redacted` filters the
+output to sensitive variables; it does **not** hide their values. Use these flags
+when deliberately exporting secrets to another program:
 
 ```bash
 # Show only redacted environment variables
@@ -209,21 +222,25 @@ task.output = "prefix"
 
 :::
 
-::: danger
-Because mise may output sensitive values that could show up in CI logs, you'll need to tell your CI setup
-which values are sensitive.
+### CI masking
 
-For example, when using GitHub Actions, you should use `::add-mask::` to prevent secrets from appearing in logs:
+[mise-action](https://github.com/jdx/mise-action) registers masks for values marked
+with `redact = true` or matching the `redactions` array. When resolving secrets
+outside that action, register masks before running commands that might print them.
+
+For a custom GitHub Actions step with Bash and `jq` available, export JSON to
+preserve whitespace and escape workflow-command data before emitting masks:
 
 ```bash
-# In a GitHub Actions workflow
-for value in $(mise env --redacted --values); do
-  echo "::add-mask::$value"
-done
+set -o pipefail
+mise env --redacted --json | jq -r '
+  .[] | select(length > 0) |
+  "::add-mask::" + (gsub("%"; "%25") | gsub("\r"; "%0D") | gsub("\n"; "%0A"))
+'
 ```
 
-If you're using [mise-action](https://github.com/jdx/mise-action), it automatically redacts values marked with `redact = true` or matching patterns in the `redactions` array.
-:::
+This uses the [workflow-command escaping applied by the Actions toolkit](https://github.com/actions/toolkit/blob/main/packages/core/src/command.ts).
+Do not use a whitespace-splitting loop such as `for value in $(...)` for secrets.
 
 ## Required Variables
 
@@ -242,16 +259,14 @@ caller passed in.
 You can also provide help text to guide users on how to set the variable:
 
 ```toml
-[env]
-DATABASE_URL = {
-  required = "Set DATABASE_URL to your PostgreSQL connection string (e.g., postgres://user:pass@localhost/dbname)",
-}
-API_KEY = {
-  required = "Get your API key from https://example.com/api-keys",
-}
-AWS_REGION = {
-  required = "Set to your AWS region (e.g., us-east-1, eu-west-1)",
-}
+[env.DATABASE_URL]
+required = "Set DATABASE_URL to your PostgreSQL connection string"
+
+[env.API_KEY]
+required = "Get your API key from https://example.com/api-keys"
+
+[env.AWS_REGION]
+required = "Set to your AWS region (e.g., us-east-1, eu-west-1)"
 ```
 
 When a required variable is missing, mise shows the help text in the error message.
@@ -318,7 +333,7 @@ ENABLE_BETA_FEATURES = { required = true }
 `config_root` is the canonical project root directory that mise uses when resolving relative paths inside config files. Generally, relative paths in mise refer to this directory.
 
 - When your config lives at nested paths like `.config/mise/config.toml` or `.mise/config.toml`, `config_root` points to the project directory that contains those files (for example, `/path/to/project`).
-- When your config lives at the project root (for example, `mise.toml`), `config_root` is the current directory.
+- When your config lives at the project root (for example, `mise.toml`), `config_root` is the directory containing that file, even when you invoke mise from a subdirectory.
 - Relative paths in environment directives are resolved against `config_root` so they behave consistently regardless of where the config file itself lives.
 
 Here are some example config files and their `config_root`:
@@ -420,11 +435,11 @@ for dotenv files, `expand = true` additionally enables references to previously 
 ```toml
 [env]
 _.file = [
-    # Load env from the json file relative to this config file
+    # Load env from the JSON file relative to the config root
     '.env.json',
     # Load env from the dotenv file at an absolute path
-    '/User/bob/.env',
-    # Load env from the yaml file relative to this config file and redact the values
+    '/Users/bob/.env',
+    # Load env from the YAML file relative to the config root and redact the values
     { path = ".secrets.yaml", redact = true }
 ]
 ```
@@ -432,7 +447,7 @@ _.file = [
 To automatically load dotenv files from the current directory and parent directories, set
 [`MISE_ENV_FILE=.env`](/configuration#mise-env-file) or `env_file = ".env"` under `[settings]`
 in `~/.config/mise/config.toml`. This is different from `env._.file`, which resolves paths
-relative to the config file that declares it.
+relative to the config root of the file that declares it.
 
 See [secrets](/environments/secrets/) for ways to read encrypted files with `env._.file`.
 
@@ -543,7 +558,7 @@ _.source = [
     # Sources the file relative to the config root
     './scripts/base.sh',
     # Sources a file at an absolute path
-    '/User/bob/env.sh',
+    '/Users/bob/env.sh',
     # Sources the file relative to the config root and redacts the values
     { path = ".secrets.sh", redact = true }
 ]
@@ -559,6 +574,9 @@ Plugins can provide their own `env._` directives that dynamically set environmen
 - Providing team-wide environment standardization
 
 ### Basic Usage
+
+These are illustrative plugin names. Install a plugin that implements `MiseEnv`
+before using its directive; naming a directive does not create or install a plugin.
 
 Simple plugin activation:
 
@@ -588,12 +606,9 @@ The configuration options you provide (the TOML table after `=`) are passed to t
 ### Example: Secret Management Plugin
 
 ```toml
-[env]
-# Fetch secrets from a vault
-_.vault-secrets = {
-  vault_url = "https://vault.example.com",
-  secrets_path = "secret/myapp"
-}
+[env._.vault-secrets]
+vault_url = "https://vault.example.com"
+secrets_path = "secret/myapp"
 ```
 
 The plugin could then fetch secrets from HashiCorp Vault and expose them as environment variables.
@@ -630,7 +645,7 @@ Environment variable values can be templates; see [Templates](/templates) for de
 
 ```toml
 [env]
-LD_LIBRARY_PATH = "/some/path:{{env.LD_LIBRARY_PATH}}"
+PROJECT_CACHE = "{{config_root}}/.cache"
 ```
 
 ## Using env vars in other env vars
@@ -652,7 +667,7 @@ As a simpler alternative to Tera templates for referencing env vars, you can use
 ```toml
 [env]
 MY_PROJ_LIB = "{{config_root}}/lib"
-LD_LIBRARY_PATH = "$MY_PROJ_LIB:$LD_LIBRARY_PATH"
+LD_LIBRARY_PATH = "$MY_PROJ_LIB:${LD_LIBRARY_PATH:-}"
 ```
 
 Supported syntax:

--- a/docs/environments/secrets/age.md
+++ b/docs/environments/secrets/age.md
@@ -1,6 +1,6 @@
 # Direct age Encryption <Badge type="warning" text="experimental" />
 
-Encrypt individual environment variable values directly in `mise.toml` using [age](https://github.com/FiloSottile/age) encryption. The age tool is not required—support is built into mise.
+Encrypt individual environment variable values directly in `mise.toml` using [age](https://github.com/FiloSottile/age) encryption. Encryption and decryption are built into mise. The optional `age-keygen` command below comes from the separate age CLI.
 
 This is a simple way to store encrypted environment variables directly in `mise.toml`. Run `mise set --age-encrypt <key>=<value>` to use it. By default, mise uses your SSH key (`~/.ssh/id_ed25519` or `~/.ssh/id_rsa`) if one exists.
 
@@ -16,12 +16,19 @@ This is a simple way to store encrypted environment variables directly in `mise.
 mise settings set experimental=true
 ```
 
-2. (Optional) Generate an age key if you don't want to use your SSH key:
+2. Use an existing SSH identity, or install age and generate a dedicated identity.
+   Skip key generation if `age.txt` already contains an identity you want to keep:
 
 ```bash
-age-keygen -o ~/.config/mise/age.txt
-# Note the public key output for encryption
+mise use -g age
+mkdir -p ~/.config/mise
+mise exec -- age-keygen -o ~/.config/mise/age.txt
+# Public key: age1...
 ```
+
+The public key is a **recipient**: share it with people who need to encrypt for
+you. `age.txt` contains the private **identity** needed to decrypt; keep it outside
+the repository.
 
 3. Encrypt a value:
 
@@ -31,7 +38,7 @@ mise set --age-encrypt --prompt DB_PASSWORD
 ```
 
 ::: warning
-Use `--prompt` to avoid accidentally exposing the value in your shell history. It is optional, though: you can also run `mise set --age-encrypt DB_PASSWORD="password123"`.
+Use `--prompt` so the plaintext does not become part of the command or shell history.
 :::
 
 4. Values are stored encrypted in `mise.toml` as an age directive:
@@ -41,11 +48,15 @@ Use `--prompt` to avoid accidentally exposing the value in your shell history. I
 DB_PASSWORD = { age = { value = "<base64>" } }
 ```
 
-5. Decryption happens automatically:
+5. Run a command or task that needs the value. mise decrypts it before starting the process:
 
 ```bash
-mise env  # Variables are decrypted automatically
+# Bash example: checks availability without printing the password
+mise exec -- bash -c 'test -n "$DB_PASSWORD" && echo "DB_PASSWORD is available"'
 ```
+
+`mise env` and `mise set DB_PASSWORD` print the decrypted value. Use them only when
+that plaintext output is intended; see [redaction](/environments/#redactions).
 
 ## CLI flags
 
@@ -59,7 +70,8 @@ If no recipients are provided explicitly, mise tries the defaults (see below).
 
 ## Storage format
 
-Encrypted values are stored as base64 along with a `format` field:
+The stored payload is base64-encoded ciphertext, not an encoded plaintext secret.
+The `format` field identifies the payload representation:
 
 - `format = "raw"` — uncompressed ciphertext (typically for small values)
 - `format = "zstd"` — zstd-compressed ciphertext (used when ciphertext > 1KB)

--- a/docs/environments/secrets/index.md
+++ b/docs/environments/secrets/index.md
@@ -1,7 +1,39 @@
 # Secrets
 
-Use mise to manage sensitive environment variables securely. There are multiple supported approaches:
+Choose how to supply secret values to the project. mise passes resolved values to
+commands as environment variables; the secret provider or encryption key controls
+who can resolve them.
 
-- **[fnox](https://github.com/jdx/fnox)** <Badge type="tip" text="recommended" /> — Full-featured secret manager with remote secret storage (e.g. 1Password, AWS Secrets Manager) and remote encryption (e.g. AWS KMS). Use `fnox exec -- mise ...` to populate mise's environment. [Bootstrap secret inputs](/bootstrap/secrets.html) give provisioning templates stable logical names while fnox remains responsible for providers and authentication.
-- [sops](/environments/secrets/sops) <Badge type="warning" text="experimental" /> — Encrypt entire files and load them via `env._.file`
-- [Direct age encryption](/environments/secrets/age) <Badge type="warning" text="experimental" /> — Encrypt individual env vars inline in `mise.toml`
+| Approach                                           | Store in the repository                               | Required at runtime                                                            |
+| -------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------ |
+| [fnox](https://github.com/jdx/fnox) (recommended)  | Secret references or encrypted values managed by fnox | fnox and access to its configured providers                                    |
+| [sops](./sops.html) (experimental)                 | An encrypted JSON, YAML, or TOML file                 | A decryption identity; the SOPS CLI for providers outside built-in age support |
+| [Direct age encryption](./age.html) (experimental) | Individual encrypted values inside `mise.toml`        | An age or SSH decryption identity                                              |
+
+## Use a secret manager
+
+With fnox configured for the project and authenticated to its providers, run:
+
+```sh
+fnox exec -- mise run deploy
+```
+
+Replace `deploy` with your task. fnox resolves secrets before starting mise, so
+mise templates and tasks can read them from the inherited environment. fnox
+supports remote secret storage, such as 1Password and AWS Secrets Manager, and
+remote encryption, such as AWS KMS. See the [fnox documentation](https://github.com/jdx/fnox)
+for provider setup.
+
+[Bootstrap secret inputs](/bootstrap/secrets.html) give provisioning templates
+stable names while fnox handles providers and authentication.
+
+## Encrypt repository files or values
+
+Use [sops](./sops.html) when secrets belong in a separate file, or [direct age
+values](./age.html) when a few encrypted variables should live beside the rest of
+`mise.toml`. Commit the ciphertext and distribute decryption identities separately.
+
+Encryption protects stored values. [Redaction](/environments/#redactions) masks
+captured task output, and [CI masking](/environments/#ci-masking) protects logs
+outside mise's output capture. `mise env` intentionally exports plaintext values,
+including those marked as redacted.

--- a/docs/environments/secrets/sops.md
+++ b/docs/environments/secrets/sops.md
@@ -5,53 +5,66 @@ mise reads encrypted secret files and makes values available as environment vari
 - **Formats**: `.env.json`, `.env.yaml`, `.env.toml`
 - **Encryption**: [sops](https://getsops.io), using the built-in age support or the external `sops` CLI
 
-## Example
+<span id="example"></span>
 
-```json
-{
-  "AWS_ACCESS_KEY_ID": "AKIAIOSFODNN7EXAMPLE",
-  "AWS_SECRET_ACCESS_KEY": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-}
-```
+## Choose a decryption method
 
-```toml [mise.toml]
-[env]
-_.file = ".env.json"
-```
-
-mise automatically decrypts the file if it is sops-encrypted.
+The default built-in implementation handles age-encrypted files. To use AWS KMS,
+GCP KMS, Azure Key Vault, Vault, or PGP, install the SOPS CLI, authenticate to the
+provider, and set `sops.rops = false` as described below.
 
 ## Encrypt with sops
 
-:::: info
+::: info
 The default `sops.rops = true` implementation supports age-encrypted files. Set
 `sops.rops = false` to use the external `sops` CLI for other key services and
 methods supported by SOPS, such as AWS KMS, GCP KMS, Azure Key Vault, Vault,
 and PGP.
-::::
+:::
 
-:::: warning
+::: warning
 The external `sops` CLI does not currently support TOML input/output. mise can decrypt SOPS-encrypted `.env.toml` files only with the default `sops.rops = true` setting. If you set `sops.rops = false`, mise shells out to the `sops` CLI and encrypted TOML env files fail with a configuration error. Use `.env.json` or `.env.yaml` when you need the external CLI path.
-::::
+:::
 
-1. Install tools: `mise use -g sops age`
-
-2. Generate an age key and note the public key:
+1. Install tools and enable experimental features:
 
 ```sh
-age-keygen -o ~/.config/mise/age.txt
+mise use -g sops age
+mise settings set experimental=true
+```
+
+2. Reuse an existing age identity, or create one if the file does not exist:
+
+```sh
+mkdir -p ~/.config/mise
+mise exec -- age-keygen -o ~/.config/mise/age.txt
 # Public key: <public key>
 ```
 
-3. Encrypt the file:
+3. Create `.env.json` with your values. This example uses a placeholder:
 
-```sh
-sops encrypt -i --age "<public key>" .env.json
+```json [.env.json]
+{
+  "API_TOKEN": "replace-with-your-token"
+}
 ```
 
-:::: tip
-The `-i` flag overwrites the file. The encrypted file is safe to commit. Set `SOPS_AGE_KEY_FILE=~/.config/mise/age.txt` or `MISE_SOPS_AGE_KEY_FILE=~/.config/mise/age.txt` to decrypt/edit with sops.
-::::
+Encrypt it with the public key printed by `age-keygen`:
+
+```sh
+mise exec -- sops encrypt -i --age "<public key>" .env.json
+```
+
+::: tip
+The `-i` flag replaces the plaintext file with ciphertext. Commit the encrypted
+file, and keep `age.txt` outside the repository. The external SOPS CLI reads
+`SOPS_AGE_KEY_FILE`; `MISE_SOPS_AGE_KEY_FILE` configures mise only. To edit the file:
+
+```sh
+SOPS_AGE_KEY_FILE="$HOME/.config/mise/age.txt" mise exec -- sops .env.json
+```
+
+:::
 
 Age key files use the standard SOPS/age format: put one identity on each line.
 Blank lines and lines beginning with `#` are ignored, and all identities are
@@ -61,10 +74,11 @@ tried when decrypting.
 
 ```toml
 [env]
-_.file = ".env.json"
+_.file = { path = ".env.json", redact = true }
 ```
 
-Now `mise env` exposes the values.
+mise now decrypts the file for `mise exec`, tasks, and shell activation.
+`mise env` prints the plaintext values; `redact = true` does not hide that export.
 
 ## Environment Variables
 
@@ -99,27 +113,14 @@ Mark secrets from files as sensitive:
 _.file = { path = ".env.json", redact = true }
 ```
 
-Work with redacted values:
-
-```bash
-mise env --redacted
-mise env --redacted --values
-```
+Redaction applies to captured task output. `mise env --redacted` deliberately
+exports the matching secrets; it does not mask them. See [redactions](/environments/#redactions)
+for output-mode limitations.
 
 ### CI masking (GitHub Actions)
 
-```yaml
-- name: Mask secrets
-  run: |
-    for value in $(mise env --redacted --values); do
-      echo "::add-mask::$value"
-    done
-- name: Use secrets safely
-  run: |
-    mise exec -- ./deploy.sh
-```
-
-If you use [mise-action](https://github.com/jdx/mise-action), values marked `redact = true` are masked automatically.
+See [CI masking](/environments/#ci-masking) for mise-action integration and a
+manual masking example that preserves whitespace and multiline values.
 
 ## Settings
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -4,6 +4,17 @@ mise can automatically execute scripts during a `mise activate` session. Except 
 and `postinstall` hooks, these require the `mise activate` shell hook to be installed in your shell.
 Hooks are configured in `mise.toml`.
 
+| Event                        | Runs when                                             | Requires shell activation |
+| ---------------------------- | ----------------------------------------------------- | ------------------------- |
+| `cd`                         | The working directory changes                         | Yes                       |
+| `enter` / `leave`            | The shell enters or leaves a project's directory tree | Yes                       |
+| `preinstall` / `postinstall` | mise installs the selected tools                      | No                        |
+| `watch_files`                | Activation detects a change to a matching file        | Yes                       |
+
+Use [tasks](/tasks/) for commands you want to invoke explicitly. Use
+[`mise watch`](/cli/watch.html) for a running file watcher; `watch_files` hooks
+are checked by shell activation, rather than by a background watcher.
+
 When the same hook type is defined in multiple loaded config files, mise runs every matching hook
 rather than overriding hooks from lower-precedence files. Hooks run from the highest-precedence
 config file to the lowest-precedence config file. Within a single config file, hooks defined as an
@@ -63,7 +74,7 @@ platforms, a hook with only `run_windows` is skipped.
 
 ```toml
 [hooks]
-postinstall = { run = "echo installed", run_windows = "Write-Output installed" }
+postinstall = { run = "pwd", run_windows = "cd" }
 ```
 
 For `preinstall` and `postinstall`, `script = ...` and `scripts = ...` are legacy aliases for `run = ...`. If a `shell` is also set on a `script`/`scripts` hook, mise warns that the shell is ignored and still runs the script with the default inline shell. Use `run = ...` with `shell = "bash -c"` to choose the inline shell command. The `script` and `scripts` aliases for install hooks are deprecated.
@@ -82,12 +93,15 @@ echo "Installed: $MISE_INSTALLED_TOOLS"
 
 ## Tool-level postinstall
 
-Individual tools can define their own postinstall scripts using the `postinstall` option. These run immediately after each tool is installed (before other tools in the same session are installed):
+Use a tool's `postinstall` option for work specific to that installation. It runs
+after that tool installs; independent tool installations can still run in
+parallel. Use the project-level `postinstall` hook for work that needs the whole
+selected toolset:
 
 ```toml
 [tools]
-node = { version = "20", postinstall = "npm install -g pnpm" }
-python = { version = "3.12", postinstall = "pip install pipx" }
+node = { version = "24", postinstall = "node --version" }
+python = { version = "3.12", postinstall = "python --version" }
 ```
 
 Tool-level postinstall scripts receive the following environment variables:
@@ -107,6 +121,9 @@ via `mise run`, so it reuses the full task system including dependencies, enviro
 and file-based task definitions.
 
 ```toml
+[tasks.install-deps]
+run = "echo 'install project dependencies here'"
+
 [tasks.setup]
 run = "echo 'setting up project'"
 depends = ["install-deps"]
@@ -249,9 +266,9 @@ Use `run` when the hook should execute as an inline command in a subprocess. `pr
 if `shell` is set with `script`/`scripts` on those hooks, it is ignored.
 
 ::: warning
-Shell code runs only when entering the directory. Leaving the directory does not clean up
-its changes the way `[env]` in `mise.toml` does. Hooks execute shell code that mise does not
-track or undo.
+mise does not track or undo changes made by shell scripts. For example, an
+`enter` script that exports a variable needs a corresponding `leave` script to
+unset it. Prefer `[env]` when you want mise to manage the value's lifetime.
 
 :::
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -2,25 +2,25 @@
 
 > Dev tools, env vars, and tasks in one CLI
 
-## Guides
+## Start Here
 
+- [Getting Started](https://mise.jdx.dev/getting-started.html): By the end of this guide, you'll have a project with a managed tool, an environment variable, and a task you can run.
 - [Demo](https://mise.jdx.dev/demo.html): The following demo shows.
-- [Getting Started](https://mise.jdx.dev/getting-started.html): Get up and running with mise in minutes.
-- [Walkthrough](https://mise.jdx.dev/walkthrough.html): Once you've completed the Getting Started guide, you're ready to start using mise. This document offers a quick overview of some things you may want to try first.
+- [Walkthrough](https://mise.jdx.dev/walkthrough.html): Use this guide to add mise to an existing project and maintain its configuration: select tools, share defaults, upgrade versions, and run everyday commands.
 - [Installing mise](https://mise.jdx.dev/installing-mise.html): If you are new to mise, follow the Getting Started guide first.
 - [IDE Integration](https://mise.jdx.dev/ide-integration.html): Code editors and IDEs work differently from interactive shells.
 - [Continuous Integration](https://mise.jdx.dev/continuous-integration.html): You can use mise in continuous integration (CI) environments to provision the tools your project needs. We recommend pinning tools to specific versions so the environment is reproducible.
 
 ## Configuration
 
-- [mise.toml](https://mise.jdx.dev/configuration.html): Learn how to configure mise for your project with mise.toml files, environment variables, and various configuration options to manage your development environment.
+- [mise.toml](https://mise.jdx.dev/configuration.html): A project's mise.toml declares tools, environment variables, and tasks. Global configuration supplies personal defaults; project and local files override them.
 - [Variables](https://mise.jdx.dev/configuration/vars.html): [vars] defines values that can be reused in mise configuration templates. Vars are similar to environment variables, but mise does not export them to child processes.
-- [Settings](https://mise.jdx.dev/configuration/settings.html): The following is a list of all of mise's settings. These can be set via mise settings key=value, by directly modifying the global config file (~/.config/mise/config.toml) or local config, or via…
-- [Configuration Environments](https://mise.jdx.dev/configuration/environments.html): It's possible to have separate mise.toml files in the same directory for different environments like development and production.
+- [Settings](https://mise.jdx.dev/configuration/settings.html): Settings control mise itself, such as installation concurrency and task output. Application environment variables belong in [env].
+- [Configuration Environments](https://mise.jdx.dev/configuration/environments.html): Config environments select additional files such as mise.development.toml and mise.production.toml. The base mise.toml still loads, and the selected file overrides values at the same directory level.
 
 ## Dev Tools
 
-- [Dev Tools Overview](https://mise.jdx.dev/dev-tools/): Install and switch between dev tools like node, python, cmake, terraform, and hundreds more, all from the same project config.
+- [Dev Tools Overview](https://mise.jdx.dev/dev-tools/): mise installs development tools and selects their versions for each project. Keep multiple versions of Node.js, Python, Ruby, Go, and other tools on the same machine, then declare which ones a project…
 - [Comparison to asdf](https://mise.jdx.dev/dev-tools/comparison-to-asdf.html): mise can be used as a drop-in replacement for asdf. It supports the same .tool-versions files that you may have used with asdf and can use asdf plugins through the asdf backend.
 - [Shims](https://mise.jdx.dev/dev-tools/shims.html): There are several ways to load the mise context (dev tools, environment variables) into your shell.
 - [Tool Aliases](https://mise.jdx.dev/dev-tools/aliases.html): [alias] has been renamed to [tool_alias] to distinguish it from [shell_alias]. The old [alias] key still works but is deprecated.
@@ -95,13 +95,13 @@
 
 ## Environments
 
-- [Environment Variables](https://mise.jdx.dev/environments/): Load the right environment variables automatically for each project directory.
-- [Shell Aliases](https://mise.jdx.dev/shell-aliases.html): mise can manage shell aliases that are set dynamically when you enter a directory and unset when you leave, similar to how environment variables work.
-- [Secrets](https://mise.jdx.dev/environments/secrets/): Use mise to manage sensitive environment variables securely. There are multiple supported approaches.
+- [Environment Variables](https://mise.jdx.dev/environments/): Define project environment variables in [env]. mise supplies them to commands run with mise exec, tasks, and activated interactive shells.
+- [Shell Aliases](https://mise.jdx.dev/shell-aliases.html): Define project shortcuts for an interactive Bash, Zsh, or Fish shell with mise activate. mise sets the aliases as you enter a directory and removes them when they are no longer configured.
+- [Secrets](https://mise.jdx.dev/environments/secrets/): Choose how to supply secret values to the project. mise passes resolved values to commands as environment variables; the secret provider or encryption key controls who can resolve them.
 - [sops](https://mise.jdx.dev/environments/secrets/sops.html): mise reads encrypted secret files and makes values available as environment variables via env._.file.
-- [age](https://mise.jdx.dev/environments/secrets/age.html): Encrypt individual environment variable values directly in mise.toml using age encryption. The age tool is not required—support is built into mise.
+- [age](https://mise.jdx.dev/environments/secrets/age.html): Encrypt individual environment variable values directly in mise.toml using age encryption. Encryption and decryption are built into mise.
 - [Hooks](https://mise.jdx.dev/hooks.html): mise can automatically execute scripts during a mise activate session. Except for the preinstall and postinstall hooks, these require the mise activate shell hook to be installed in your shell.
-- [direnv](https://mise.jdx.dev/direnv.html): direnv and mise both manage environment variables based on directory. Because they both analyze the current environment variables before and after their respective "hook" commands are run, they can…
+- [direnv](https://mise.jdx.dev/direnv.html): direnv and mise both change the environment when you enter a directory. Their shell hooks can disagree about which PATH entries to add, restore, or remove.
 
 ## Tasks
 
@@ -155,7 +155,7 @@
 
 - [Architecture](https://mise.jdx.dev/architecture.html): This document gives an overview of mise's architecture. It is aimed at contributors and anyone interested in how mise works internally.
 - [Paranoid](https://mise.jdx.dev/paranoid.html): Paranoid mode is an optional behavior that locks mise down further to make it harder for a bad actor to compromise your system.
-- [Templates](https://mise.jdx.dev/templates.html): Templates in mise provide a powerful way to configure different aspects of your environment and project settings.
+- [Templates](https://mise.jdx.dev/templates.html): Use Tera expressions to derive configuration values from the project directory, environment, or [vars]. mise renders those expressions when it resolves configuration or prepares a task.
 - [URL Replacements](https://mise.jdx.dev/url-replacements.html): mise does not include a built-in registry for downloading artifacts. Instead, it retrieves remote registry manifests, which specify the URLs for downloading tools.
 - [Model Context Protocol](https://mise.jdx.dev/mcp.html): The Model Context Protocol (MCP) is a standard protocol that enables AI assistants to interact with development tools and access project context.
 - [Directory Structure](https://mise.jdx.dev/directories.html): mise uses the following directories.

--- a/docs/shell-aliases.md
+++ b/docs/shell-aliases.md
@@ -1,6 +1,11 @@
 # Shell Aliases
 
-mise can manage shell aliases that are set dynamically when you enter a directory and unset when you leave, similar to how environment variables work.
+Define project shortcuts for an interactive Bash, Zsh, or Fish shell with
+[`mise activate`](/getting-started.html#activate-mise). mise sets the aliases as
+you enter a directory and removes them when they are no longer configured.
+
+For commands that also need to work in scripts and CI, define [tasks](/tasks/).
+Shell aliases are not available inside tasks or through `mise exec`.
 
 ## Configuration
 
@@ -49,24 +54,25 @@ $ cd ~
 
 Like other mise config, shell aliases from parent directories are available in child directories. A child directory can override a parent's alias:
 
-```toml
-# ~/projects/mise.toml
+```toml [~/projects/mise.toml]
 [shell_alias]
 build = "make build"
+```
 
-# ~/projects/myapp/mise.toml
+```toml [~/projects/myapp/mise.toml]
 [shell_alias]
 build = "npm run build"  # Overrides parent
 ```
 
 ## Templates
 
-Alias values support [templates](/templates), allowing dynamic values:
+Alias values support [templates](/templates). This Bash/Zsh example quotes the
+project path for the shell and runs `node --version` when you invoke the alias:
 
 ```toml
 [shell_alias]
-proj = "cd {{config_root}}"
-node_version = "echo {{exec(command='node --version')}}"
+proj = "cd {{config_root | quote}}"
+node_version = "node --version"
 ```
 
 ## Use Cases
@@ -95,11 +101,13 @@ terraform = "terraform -chdir=./infrastructure"
 
 ### Quick Navigation
 
+Quote project paths so directories containing spaces work in Bash and Zsh:
+
 ```toml
 [shell_alias]
-src = "cd {{config_root}}/src"
-tests = "cd {{config_root}}/tests"
-docs = "cd {{config_root}}/docs"
+src = "cd {{config_root | quote}}/src"
+tests = "cd {{config_root | quote}}/tests"
+docs = "cd {{config_root | quote}}/docs"
 ```
 
 ## Limitations
@@ -111,9 +119,9 @@ docs = "cd {{config_root}}/docs"
 
 mise has two alias features that serve different purposes:
 
-| Feature           | Purpose                                                | Config Key      |
-| ----------------- | ------------------------------------------------------ | --------------- |
-| **Shell Aliases** | Define shell command shortcuts (`alias ll='ls -la'`)   | `[shell_alias]` |
-| **Tool Aliases**  | Define version aliases for tools (`node@lts` → `20.x`) | `[tool_alias]`  |
+| Feature           | Purpose                                                     | Config Key      |
+| ----------------- | ----------------------------------------------------------- | --------------- |
+| **Shell Aliases** | Define shell command shortcuts (`alias ll='ls -la'`)        | `[shell_alias]` |
+| **Tool Aliases**  | Define version aliases for tools (`node@my-version` → `24`) | `[tool_alias]`  |
 
 See [Tool Aliases](/dev-tools/aliases) for documentation on aliasing tool versions.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,10 +1,11 @@
 # Templates
 
-Templates in mise provide a powerful way to configure different aspects of
-your environment and project settings.
+Use Tera expressions to derive configuration values from the project directory,
+environment, or [`[vars]`](/configuration/vars.html). mise renders those expressions
+when it resolves configuration or prepares a task.
 
-A template is a string that contains variables, expressions, and control structures.
-When rendered, the template engine (`tera`) replaces the variables with their values.
+This page covers string templates. For reusable task definitions with `extends`,
+see [Task Templates](/tasks/templates.html).
 
 You can define and use templates in the following locations:
 
@@ -19,7 +20,7 @@ Here is an example of a `mise.toml` file that uses templates:
 
 ```toml
 [env]
-PROJECT_NAME = "{{ cwd | basename }}"
+PROJECT_NAME = "{{ config_root | basename }}"
 TERRAFORM_VERSION = "1.0.0"
 
 [tools]
@@ -29,7 +30,9 @@ terraform = "{{ env.TERRAFORM_VERSION }}"
 node = "{{ get_env(name='NODE_VERSION', default='20') }}"
 ```
 
-You will find more examples in the [cookbook](./mise-cookbook/index.md).
+`config_root` stays at the project root when you run mise from a subdirectory;
+`cwd` follows the invocation directory. Use the former for project-relative paths.
+See the [cookbook](./mise-cookbook/index.md) for recipes.
 
 ## Template Rendering
 
@@ -226,7 +229,10 @@ specification (see [Task Arguments](/tasks/task-arguments#usage-field)):
 
 The keys are the argument/flag names as written in the usage spec. If the name
 contains `-`, use bracket access, e.g. <span v-pre>`{{ usage["dry-run"] }}`</span>.
-Examples:
+For a POSIX shell, quote string values before inserting them into a command.
+Double quotes around an unescaped template expression do not prevent its value
+from becoming shell syntax. This example uses `quote` and converts booleans to
+strings explicitly:
 
 ```mise-toml
 [tasks.deploy]
@@ -236,11 +242,11 @@ flag "-v --verbose" help="Enable verbose output"
 arg "[tags]" var=#true
 '''
 run = '''
-echo "env={{ usage.environment }}"
-echo "verbose={{ usage.verbose }}"
-echo "tag count={{ usage.tags | length }}"
+printf 'env=%s\n' {{ usage.environment | quote }}
+printf 'verbose=%s\n' {{ usage.verbose | str | quote }}
+printf 'tag count=%s\n' {{ usage.tags | length | str | quote }}
 {% for tag in usage.tags %}
-  echo "tag={{ tag }}"
+  printf 'tag=%s\n' {{ tag | quote }}
 {% endfor %}
 '''
 ```
@@ -282,9 +288,10 @@ mise offers many useful functions in addition to tera's built-ins.
 
 ##### General Functions
 
-These functions are available in all tasks and always behave the same way regardless
-of the task definition they are used in. In other words, their return values are consistent
-across task definitions.
+These helpers are available in regular configuration and task templates. Their
+results depend on the rendering context: `exec()` observes the process environment
+and working directory, and `read_file()` observes the file's current contents.
+See the [early-init limitations](#miserc-template-support) for `.miserc.toml`.
 
 - `exec(command) -> String` – Runs a shell command and returns its output as a string.
 - `get_env(name, [default]) -> String` – Returns the original process environment
@@ -312,10 +319,7 @@ template functions. Keep commands passed to `exec()` free of side effects.
 
 ##### Task-Specific Functions
 
-These functions are task-specific and behave differently depending on the task they are used
-in. In other words, their return values **_may_** (but are not guaranteed to) be consistent
-across executions of a given _task_, and should be expected to differ across
-task definitions.
+These helpers use the current task's configuration and execution state.
 
 For example, `task_source_files()` returns a different set of file paths depending on the [`sources`](https://mise.jdx.dev/tasks/task-configuration.html#sources) of the task it's called from.
 
@@ -340,7 +344,7 @@ For example, `task_source_files()` returns a different set of file paths dependi
 
 ```toml
 # Using exec to get command output
-[alias.node.versions]
+[tool_alias.node.versions]
 current = "{{ exec(command='node --version') }}"
 
 # Using read_file to include content from a file
@@ -352,7 +356,7 @@ VERSION = "{{ read_file(path='VERSION') | trim }}"
 sources = ["src/**/*.ts", "package.json"]
 run = '''
 {% for file in task_source_files() %}
-  echo "Processing: {{ file }}"
+  printf 'Processing: %s\n' {{ file | quote }}
 {% endfor %}
 '''
 
@@ -397,9 +401,9 @@ Some filters:
 - `str | trim_start -> String` – Removes leading whitespace.
 - `str | trim_end -> String` – Removes trailing whitespace.
 - `str | truncate -> String` – Truncates a string to the indicated length.
-- `str | first -> String` – Returns the first element in an array or string.
-- `str | last -> String` – Returns the last element in an array or string.
-- `str | join(sep) -> String` – Joins an array of strings with a separator,
+- `array | first -> Value` – Returns the first element in an array.
+- `array | last -> Value` – Returns the last element in an array.
+- `array | join(sep) -> String` – Joins an array of strings with a separator,
   such as <span v-pre>`{{ ["a", "b", "c"] | join(sep=", ") }}`</span>
   to produce `a, b, c`.
 - `str | length -> usize` – Returns the length of a string or array.
@@ -533,7 +537,7 @@ only information available at the OS level can be used.
 - `config_root: PathBuf` – Directory containing the `.miserc.toml` file
 - `cwd: PathBuf` – Current working directory
 - `xdg_cache_home`, `xdg_config_home`, `xdg_data_home`, `xdg_state_home` – XDG base directories
-- All [functions](#functions): `arch()`, `os()`, `os_family()`, `num_cpus()`, `choice()`, etc.
+- Context-independent [functions](#functions), including `arch()`, `os()`, `os_family()`, `num_cpus()`, and `choice()`; exclusions are listed below.
 - All [filters](#filters): `absolute`, `dirname`, `basename`, `hash`, etc.
 
 ### Not available


### PR DESCRIPTION
Configuration and environment guides mixed up config selection, application variables, and mise settings. Secret setup examples omitted prerequisites and suggested whitespace-splitting loops for CI masking. Clarify these workflows across twelve pages, with runnable introductory examples and complete age/SOPS setup steps.

Correct hierarchy and task-merge explanations, invalid TOML, template shell quoting, and hook execution details. Explain that `mise env --redacted` exports plaintext secrets, preserve multiline values in GitHub Actions masking, and provide migration guidance for the deprecated direnv integration.

Validation:
- Production documentation build passes, including social-image tests and metadata checks for 333 pages.
- All ordinary TOML examples in the changed pages parse. The whole-file miserc template is checked through mise.
- Isolated smoke checks pass for environment overlays, settings writes, vars, template quoting, CI mask escaping, age encryption, and SOPS decryption.
- Scoped hk checks and `git diff --check` pass.
- Full `mise run lint-fix` was attempted; Cargo checks are blocked by installed Rust 1.93 versus the repository's Rust 1.95 requirement. Documentation formatting and checks pass independently.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or config behavior modifications; risk is limited to possible doc inaccuracies rather than product regressions.
> 
> **Overview**
> This PR **reworks a dozen documentation pages** so readers can follow mise configuration, environments, secrets, and shell integration without mixing concepts or unsafe examples.
> 
> **Configuration and environments** get a shorter getting-started path on the main config page, a corrected resolution/merge story (including when env-specific files apply), and clearer separation between **config environments** (`-E` / `MISE_ENV`), **`[env]`** application variables, and **`[settings]`**. Config environments and settings pages add runnable snippets and notes on early-init via `.miserc.toml`.
> 
> **Environments, templates, and aliases** emphasize **`config_root`**, valid TOML for required env vars, and **`quote`** in shell-facing templates. Redaction docs now state that **`mise env --redacted` still exports plaintext**; GitHub Actions masking uses **JSON + `jq`** instead of whitespace-splitting loops.
> 
> **Secrets (fnox, SOPS, age)** gain comparison tables, full install/encrypt flows, and warnings about when decrypted values appear on the CLI.
> 
> **Hooks, direnv, and `llms.txt`** are updated for hook vs task behavior, **unsupported/deprecated direnv** with migration to `[env]`, and refreshed index blurbs for LLM consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41693ee0d528b853223a93b2f14f0fde63c90f2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated configuration, environment, settings, variables, templates, hooks, aliases, and secret-management guidance with clearer examples, commands, and precedence details.
  - Added guidance for local overrides, early initialization, task overlays, config roots, runtime secret requirements, CI masking, and hook behavior.
  - Clarified template quoting, path resolution, environment-variable handling, and encryption workflows.
  - Deprecated and marked the `use mise` direnv integration as unsupported, with maintenance and migration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->