### PR TITLE
docs: make cookbook recipes complete and reproducible

### DIFF
--- a/docs/mise-cookbook/cpp.md
+++ b/docs/mise-cookbook/cpp.md
@@ -1,47 +1,58 @@
-# Mise + C++ Cookbook
+# C++ Cookbook
 
-Here are some tips on managing C++ projects with mise.
+Use mise to install build tools and define the configure/build cycle. A C or C++
+compiler must already be available, for example through your operating system's
+development tools. Installing CMake does not install a compiler.
 
 ## A C++ Project with CMake
 
+This recipe expects a `CMakeLists.txt` at the project root. It uses CMake's build
+interface so the task does not depend on a specific Make or Ninja generator:
+
 ```toml [mise.toml]
-min_version = "2024.9.5"
-
-[env]
-# Project information
-PROJECT_NAME = "{{ config_root | basename }}"
-
-# Build directory
-BUILD_DIR = "{{ config_root }}/build"
-
 [tools]
-# Install CMake and make
 cmake = "latest"
-make = "latest"
 
 [tasks.configure]
-description = "Configure the project"
-run = "mkdir -p $BUILD_DIR && cd $BUILD_DIR && cmake .."
+description = "Configure the CMake build"
+run = 'cmake -S . -B build'
 
 [tasks.build]
 description = "Build the project"
 alias = "b"
-run = "cd $BUILD_DIR && make"
+depends = ["configure"]
+run = 'cmake --build build'
 
 [tasks.clean]
-description = "Clean the build directory"
+description = "Clean compiled targets while keeping CMake configuration"
 alias = "c"
-run = "rm -rf $BUILD_DIR"
-
-[tasks.run]
-alias = "r"
-description = "Run the application"
-run = "$BUILD_DIR/bin/$PROJECT_NAME"
-
-[tasks.info]
-description = "Print project information"
-run = '''
-echo "Project: $PROJECT_NAME"
-echo "Build Directory: $BUILD_DIR"
-'''
+run = 'cmake --build build --target clean'
 ```
+
+Run `mise run build` from the project. It configures the build directory before
+compiling. After the first build, `mise run clean` removes compiled targets using
+the selected generator's clean target; it keeps the build configuration.
+
+For a runnable example, create these two files:
+
+```cmake [CMakeLists.txt]
+cmake_minimum_required(VERSION 3.20)
+project(hello LANGUAGES CXX)
+add_executable(hello main.cpp)
+```
+
+```cpp [main.cpp]
+#include <iostream>
+
+int main() {
+    std::cout << "Hello from CMake\n";
+}
+```
+
+With a single-configuration generator such as Unix Makefiles, the resulting
+program is `build/hello` on Unix. Multi-configuration generators can put it in a
+configuration subdirectory; build a specific configuration with
+`mise run build -- --config Debug` and use that generator's output path.
+
+Add `build/` to `.gitignore`. See [CMake's command-line reference](https://cmake.org/cmake/help/latest/manual/cmake.1.html)
+for generator selection and build options.

--- a/docs/mise-cookbook/docker.md
+++ b/docs/mise-cookbook/docker.md
@@ -25,7 +25,17 @@ ENV MISE_INSTALL_PATH="/usr/local/bin/mise"
 ENV PATH="/mise/shims:$PATH"
 # ENV MISE_VERSION="..."
 
-RUN curl --fail --show-error --silent --location https://mise.run | sh
+RUN curl --proto '=https' --proto-redir '=https' \
+    --fail --show-error --silent --location https://mise.run | sh
+```
+
+Before building, exclude local credentials from the build context:
+
+```gitignore [.dockerignore]
+.env
+.env.*
+*.tfvars
+*.tfvars.json
 ```
 
 Build and run the Docker image:
@@ -47,6 +57,7 @@ COPY . .
 
 Also copy `mise.lock` if the project uses a lockfile, plus any files the config
 reads. If an install hook needs application files, copy those before `mise install`.
+Keep credentials out of the build context rather than relying on later image layers to remove them.
 Use `mise exec -- <command>` or `mise run <task>` in `RUN` and `CMD` instructions;
 Docker build shells do not run interactive activation hooks.
 

--- a/docs/mise-cookbook/docker.md
+++ b/docs/mise-cookbook/docker.md
@@ -1,6 +1,8 @@
-# Mise + Docker Cookbook
+# Docker Cookbook
 
-Here are some tips on using Docker with mise.
+Install mise inside an image, use it to run project commands, or preinstall tools
+outside user home directories for shared development containers. Building these
+examples requires Docker and a running container engine.
 
 ## Docker image with mise
 
@@ -12,7 +14,7 @@ FROM debian:13-slim
 RUN apt-get update  \
     && apt-get -y --no-install-recommends install  \
         # install any other dependencies you might need
-        sudo curl git ca-certificates build-essential \
+        curl git ca-certificates build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -23,7 +25,7 @@ ENV MISE_INSTALL_PATH="/usr/local/bin/mise"
 ENV PATH="/mise/shims:$PATH"
 # ENV MISE_VERSION="..."
 
-RUN curl https://mise.run | sh
+RUN curl --fail --show-error --silent --location https://mise.run | sh
 ```
 
 Build and run the Docker image:
@@ -32,6 +34,21 @@ Build and run the Docker image:
 docker build -t debian-mise .
 docker run -it --rm debian-mise
 ```
+
+The image above installs mise itself. To install project tools as a build layer,
+copy the project config before its source files:
+
+```Dockerfile
+WORKDIR /app
+COPY mise.toml ./
+RUN mise install
+COPY . .
+```
+
+Also copy `mise.lock` if the project uses a lockfile, plus any files the config
+reads. If an install hook needs application files, copy those before `mise install`.
+Use `mise exec -- <command>` or `mise run <task>` in `RUN` and `CMD` instructions;
+Docker build shells do not run interactive activation hooks.
 
 ## Shared tools in multi-user containers
 
@@ -65,10 +82,12 @@ EOF
 RUN mise install --system node@26 python@3.15
 ```
 
-Users in the container will see these tools automatically:
+Users can inspect the shared installations with `mise ls --installed`. The
+versions below illustrate the output; patch versions depend on when the image
+was built:
 
 ```shell
-$ mise ls
+$ mise ls --installed
 node    26.0.0 (system)
 python  3.15.0 (system)
 ```
@@ -120,17 +139,17 @@ This is useful for reproducing a mise issue in a clean environment.
 
 ```toml [mise.toml]
 [tasks.docker]
+interactive = true
 run = "docker run -it --rm debian-mise"
 ```
 
 Build the image first (see above), then:
 
 ```shell
-❯ mise docker
-[docker] $ docker run -it --rm debian-mise
-root@75f179a190a1:/# eval "$(mise activate bash)"
-# overwrite configuration and prune to give us a clean state
-root@75f179a190a1:/# echo "" > /mise/config.toml
-root@75f179a190a1:/# mise prune --yes
-# ...
+mise run docker
 ```
+
+Inside the disposable container, run `mise doctor` or create a small `mise.toml`
+that reproduces the issue. Activate mise with `eval "$(mise activate bash)"` only
+when testing interactive shell behavior. Exiting the shell removes the container
+because the task uses `--rm`.

--- a/docs/mise-cookbook/index.md
+++ b/docs/mise-cookbook/index.md
@@ -1,17 +1,27 @@
 # Cookbook
 
-Here are a few mise setups that other people have found useful.
+These recipes combine tools, environment variables, and tasks for specific
+workflows. Start with the recipe closest to your project, then adapt its paths,
+versions, and application commands. Each recipe states the files or tools it
+expects to exist.
 
-- [C++](cpp.md)
-- [Docker](docker.md)
-- [Node.JS](nodejs.md)
-- [Python](python.md)
-- [Ruby](ruby.md)
-- [Terraform](terraform.md)
-- [Neovim](neovim.md)
+| Workflow                                                       | Recipe                                                  |
+| -------------------------------------------------------------- | ------------------------------------------------------- |
+| Configure and build a CMake project                            | [C++](/mise-cookbook/cpp.html)                          |
+| Install mise and share tools in containers                     | [Docker](/mise-cookbook/docker.html)                    |
+| Run npm scripts or select a package manager                    | [Node.js](/mise-cookbook/nodejs.html)                   |
+| Work with requirements files, uv projects, or inline scripts   | [Python](/mise-cookbook/python.html)                    |
+| Run Rails and Bundler commands                                 | [Ruby](/mise-cookbook/ruby.html)                        |
+| Initialize, validate, plan, and apply infrastructure changes   | [Terraform and OpenTofu](/mise-cookbook/terraform.html) |
+| Highlight task scripts and configure embedded language servers | [Neovim](/mise-cookbook/neovim.html)                    |
+| Create your own project scaffold                               | [Presets](/mise-cookbook/presets.html)                  |
+| Customize prompts and inspect shell integration                | [Shell tricks](/mise-cookbook/shell-tricks.html)        |
 
-Finally, here is how to create [presets](presets.md) and some [shell tricks](shell-tricks.md) you might find useful.
+For the underlying behavior, see [task configuration](/tasks/task-configuration.html),
+[environment variables](/environments/), and [tool configuration](/dev-tools/).
 
 ## Contributing
 
-If you would like to share your setup, post it in this [cookbook thread](https://github.com/jdx/mise/discussions/3645).
+Share a recipe in the [cookbook discussion](https://github.com/jdx/mise/discussions/3645).
+Include prerequisites, a complete config, the command to run, and the expected
+result so another reader can reproduce the workflow.

--- a/docs/mise-cookbook/neovim.md
+++ b/docs/mise-cookbook/neovim.md
@@ -82,7 +82,11 @@ For example, using [`lazy.nvim`](https://github.com/folke/lazy.nvim):
       local filepath = vim.fs.normalize(vim.api.nvim_buf_get_name(tonumber(bufnr) or 0))
       local filename = vim.fn.fnamemodify(filepath, ":t")
       return filename:match("^%.?mise.*%.toml$") ~= nil
-        or filepath:match("/%.?mise/[^/]+%.toml$") ~= nil
+        or filepath:match("/%.?mise/config%.toml$") ~= nil
+        or filepath:match("/%.?mise/config%.local%.toml$") ~= nil
+        or filepath:match("/%.?mise/config%.[^/]+%.toml$") ~= nil
+        or filepath:match("/%.config/mise/mise%.toml$") ~= nil
+        or filepath:match("/%.config/mise/mise%.local%.toml$") ~= nil
         or filepath:match("/%.?mise/conf%.d/[^/]+%.toml$") ~= nil
     end, { force = true, all = false })
   end,

--- a/docs/mise-cookbook/neovim.md
+++ b/docs/mise-cookbook/neovim.md
@@ -1,6 +1,16 @@
-# Mise + Neovim Cookbook
+# Neovim Cookbook
 
-Here are some tips for an improved mise workflow with [Neovim](https://github.com/neovim/neovim).
+Highlight scripts embedded in `mise.toml` and metadata in file tasks, then add
+language-server features with otter.nvim. These examples configure the editor;
+they do not change how mise executes tasks.
+
+Before adding the queries, install the Treesitter parsers for `toml`, `bash`, and
+any injected languages you use (`kdl` for `#USAGE`, for example). Enable Treesitter
+highlighting through your Neovim setup. Query files alone do not install parsers
+or start highlighting; see [Neovim's Treesitter documentation](https://neovim.io/doc/user/treesitter.html).
+
+Paths below are relative to `stdpath("config")`, normally `~/.config/nvim`. The Lua
+plugin specifications assume you already use lazy.nvim.
 
 ## Syntax highlighting
 
@@ -69,15 +79,25 @@ For example, using [`lazy.nvim`](https://github.com/folke/lazy.nvim):
   "nvim-treesitter/nvim-treesitter",
   init = function()
     require("vim.treesitter.query").add_predicate("is-mise?", function(_, _, bufnr, _)
-      local filepath = vim.api.nvim_buf_get_name(tonumber(bufnr) or 0)
+      local filepath = vim.fs.normalize(vim.api.nvim_buf_get_name(tonumber(bufnr) or 0))
       local filename = vim.fn.fnamemodify(filepath, ":t")
-      return string.match(filename, ".*mise.*%.toml$") ~= nil
+      return filename:match("^%.?mise.*%.toml$") ~= nil
+        or filepath:match("/%.?mise/[^/]+%.toml$") ~= nil
+        or filepath:match("/%.?mise/conf%.d/[^/]+%.toml$") ~= nil
     end, { force = true, all = false })
   end,
 },
 ```
 
-This treats any `toml` file with `mise` in its name as a mise file.
+This recognizes mise-named files and grouped config files such as
+`.config/mise/config.toml`. Adjust the predicate if your project uses a custom
+config filename.
+
+The shebang queries handle a direct interpreter path and `/usr/bin/env <name>`.
+The extracted name must match an installed Treesitter language; wrappers such as
+`env -S uv run` and versioned names such as `python3` need a custom mapping or
+query. The Bash fallback controls highlighting only; mise's actual default shell
+is described in [TOML tasks](/tasks/toml-tasks.html#shell-shebang).
 
 ### MISE and USAGE comments in file tasks
 
@@ -160,7 +180,8 @@ In your Neovim config, create an `after/queries/bash/injections.scm` file with t
 
 ```
 
-The same queries work as-is for all languages that use `#` as a comment delimiter.
+These queries can also work with other grammars that represent `#` comments as
+`comment` nodes. Use `:InspectTree` to check the node names in your parser.
 Because Treesitter injections are per language, you need to add the same queries to each language's query file.
 For example, put them in `after/queries/python/injections.scm` to enable them for `Python` in addition to `bash`.
 
@@ -220,4 +241,18 @@ Again using [`lazy.nvim`](https://github.com/folke/lazy.nvim):
 },
 ```
 
-This only works if the [TS injection queries](#run-commands) are also set up.
+This requires both the [injection queries](#run-commands) and a configured language
+server for each embedded language. otter.nvim creates the embedded buffers and
+routes requests; it does not install the language servers. See
+[otter.nvim's setup guide](https://github.com/jmbuhr/otter.nvim#how-do-i-use-otternvim).
+
+## Troubleshooting
+
+- Run `:checkhealth vim.treesitter` to check parser availability.
+- Use `:InspectTree` to confirm the TOML `run` value or file-task comment matches
+  the query's node types. These queries cover string `run` values; task arrays and
+  `run_windows` need additional patterns.
+- If a predicate is unknown, load the Lua registration before opening the file,
+  or remove `(#is-mise?)` to apply the query to all TOML files.
+- If highlighting works but LSP features do not, verify that the same language
+  server works in an ordinary file before debugging the embedded buffer.

--- a/docs/mise-cookbook/nodejs.md
+++ b/docs/mise-cookbook/nodejs.md
@@ -1,6 +1,7 @@
-# Mise + Node.js Cookbook
+# Node.js Cookbook
 
-Here are some tips on managing [Node.js](/lang/node.html) projects with mise.
+Use mise to select [Node.js](/lang/node.html) and your package manager, then run
+the scripts and dependencies declared by the project.
 
 ## Getting started with Node.js
 
@@ -28,7 +29,7 @@ mise use -g node@26
 When you install Node.js packages listed in `package.json`, you typically need `npx` or the full path to run their binaries. For example:
 
 ```shell
-npm install --save eslint
+mise exec -- npm install --save-dev eslint
 eslint --version # doesn't work
 npx eslint --version # works
 ```
@@ -43,72 +44,61 @@ _.path = ['{{config_root}}/node_modules/.bin']
 Example:
 
 ```shell
-npm install --save eslint
-eslint --version # works
+mise exec -- npm install --save-dev eslint
+mise exec -- eslint --version # works without shell activation
 ```
+
+With shell activation, `eslint --version` also works directly.
 
 ## Example Node.js Project
 
+This recipe expects a `package.json` with `start`, `lint`, `test`, and `build`
+scripts, plus a committed `package-lock.json`. Keep ESLint, TypeScript, and test
+runners in the project's `devDependencies`, so npm's lockfile controls their
+versions alongside the packages they use.
+
 ```toml [mise.toml]
-min_version = "2024.9.5"
+[tools]
+node = "24"
 
 [env]
-_.path = ['{{config_root}}/node_modules/.bin']
-
-# Use the project name derived from the current directory
-PROJECT_NAME = "{{ config_root | basename }}"
-
-# Set up the path for node module binaries
-BIN_PATH = "{{ config_root }}/node_modules/.bin"
-
-NODE_ENV = "{{ env.NODE_ENV | default(value='development') }}"
-
-[tools]
-# Install Node.js using the specified version
-node = "{{ env['NODE_VERSION'] | default(value='lts') }}"
-
-# Install some npm packages globally if needed
-"npm:typescript" = "latest"
-"npm:eslint" = "latest"
-"npm:jest" = "latest"
+NODE_ENV = { default = "development" }
 
 [tasks.install]
+description = "Install the locked npm dependency tree"
 alias = "i"
-description = "Install npm dependencies"
-run = "npm install"
+run = "npm ci"
 
 [tasks.start]
-alias = "s"
 description = "Start the development server"
+alias = "s"
 run = "npm run start"
 
 [tasks.lint]
+description = "Run the project's lint script"
 alias = "l"
-description = "Run ESLint"
-run = "eslint src/"
+run = "npm run lint"
 
 [tasks.test]
-description = "Run tests"
+description = "Run the project's tests"
 alias = "t"
-run = "jest"
+run = "npm test"
 
 [tasks.build]
 description = "Build the project"
 alias = "b"
 run = "npm run build"
-
-[tasks.info]
-description = "Print project information"
-run = '''
-echo "Project: $PROJECT_NAME"
-echo "NODE_ENV: $NODE_ENV"
-'''
 ```
+
+Run `mise run install` after cloning the repository, then `mise run test` or
+`mise run start`. npm scripts already put `node_modules/.bin` on `PATH`, so these
+tasks do not need a separate path directive. For a new project without a lockfile,
+run `mise exec -- npm install` once and commit the resulting lockfile.
 
 ## Example with `pnpm`
 
-This example uses `pnpm` as the package manager. It expects
-`devEngines.packageManager` in `package.json` to pin the pnpm version:
+This example uses `pnpm` as the package manager. Merge the following field into
+your existing `package.json`, which must also define a `dev` script:
 
 ```json [package.json]
 {
@@ -148,11 +138,15 @@ run = 'node --run dev'
 depends = ['pnpm-install']
 ```
 
-With this setup, getting started in a Node.js project is as simple as running `mise dev`:
+Run `mise run dev` to install the selected tools and prepare dependencies before
+starting the existing application:
 
 - `mise` will install the correct version of Node.js
 - `mise` will install the `pnpm` version declared in `package.json`
-- `pnpm install` will be run before `node --run dev`
+- `pnpm install` runs when its sources or outputs are stale, before `node --run dev`
+
+The timestamp check does not verify every file in `node_modules`. If dependencies
+are missing or damaged, run `mise run --force pnpm-install`.
 
 ## Replacing Corepack
 

--- a/docs/mise-cookbook/presets.md
+++ b/docs/mise-cookbook/presets.md
@@ -1,71 +1,74 @@
 # Presets
 
-You can create your own presets with [mise tasks](../tasks/index.md) to reduce boilerplate and make setting up new projects easier.
+A preset is a task you write to create a project's starting configuration. Store
+it as a [global file task](/tasks/file-tasks.html) so it is available in new
+repositories. For reuse within an existing project, [task templates](/tasks/templates.html)
+may be a better fit: they share task definitions without generating files.
 
 ## Example python preset
 
-Here is an example of a Python preset that creates a `mise.toml` file for working with `python` and `pdm`:
+This Bash task writes a Python and uv config into the directory where you invoke
+it. It refuses to replace an existing `mise.toml` and leaves project initialization
+and dependency installation as explicit next steps.
 
-```shell [~/.config/mise/tasks/preset/python]
+Create the task directory:
+
+```sh
+mkdir -p ~/.config/mise/tasks/preset
+```
+
+Then save the following as `~/.config/mise/tasks/preset/python`:
+
+```bash [~/.config/mise/tasks/preset/python]
 #!/usr/bin/env bash
+#MISE description="Create a Python and uv project config"
 #MISE dir="{{cwd}}"
+set -euo pipefail
 
-mise use pre-commit
-mise config set env._.python.venv.path .venv
-mise config set env._.python.venv.create true -t bool
-mise tasks add lint -- pre-commit run -a
-```
+if [[ -e mise.toml ]]; then
+  echo "mise.toml already exists; merge the preset manually" >&2
+  exit 1
+fi
 
-```shell [~/.config/mise/tasks/preset/pdm]
-#!/usr/bin/env bash
-#MISE dir="{{cwd}}"
-#MISE depends=["preset:python"]
-#USAGE arg "<version>"
-
-mise use python@${usage_version?}
-mise use pdm@latest
-mise config set hooks.postinstall "pdm sync"
-```
-
-Then in any directory, you can run `mise preset:pdm 3.10` to scaffold a new project with `python` and `pdm`:
-
-```shell
-cd my-project
-mise preset:pdm 3.10
-# [preset:python] $ ~/.config/mise/tasks/preset/python
-# mise WARN  No untrusted config files found.
-# mise ~/my-project/mise.toml tools: pre-commit@4.0.1
-# [preset:pdm] $ ~/.config/mise/tasks/preset/pdm 3.10
-# mise WARN  No untrusted config files found.
-# mise ~/my-project/mise.toml tools: python@3.10.15
-# mise ~/my-project/mise.toml tools: pdm@2.21.0
-# mise creating venv with uv at: ~/my-project/.venv
-# Using CPython 3.10.15 interpreter at: /Users/simon/.local/share/mise/installs/python/3.10.15/bin/python
-# Creating virtual environment at: .venv
-# Activate with: source .venv/bin/activate.fish
-
-~/my-project via 🐍 v3.10.15 (.venv)
-# we are in the virtual environment ^
-```
-
-Here is the generated `mise.toml` file:
-
-```toml [mise.toml]
+cat > mise.toml <<'TOML'
 [tools]
-pdm = "latest"
-pre-commit = "latest"
-python = "3.10"
+python = "3.12"
+uv = "latest"
 
-[hooks]
-postinstall = "pdm sync"
+[tasks.sync]
+description = "Sync the project's locked dependencies"
+run = "uv sync --locked"
 
-[env]
-[env._]
-[env._.python]
-[env._.python.venv]
-path = ".venv"
-create = true
+[tasks.test]
+description = "Run tests from the project environment"
+run = "uv run --locked pytest"
+TOML
 
-[tasks.lint]
-run = "pre-commit run -a"
+echo "Created mise.toml"
 ```
+
+Make the task executable on Unix:
+
+```sh
+chmod +x ~/.config/mise/tasks/preset/python
+```
+
+Then run it from an empty project directory:
+
+```sh
+mkdir my-project
+cd my-project
+mise run preset:python
+mise exec -- uv init --bare
+mise exec -- uv add --dev pytest
+```
+
+The preset creates `mise.toml`; uv creates the project manifest and lockfile.
+Add your application and tests, then run `mise run test`. Teammates can run
+`mise run sync` after cloning to install the locked dependencies. Commit
+`mise.toml`, `pyproject.toml`, and `uv.lock`, and ignore `.venv/`.
+
+`#MISE dir="{{cwd}}"` matters for a global task: it makes the task write into the
+invocation directory instead of the global task's config root. Adapt the script
+before using it in repositories with existing configuration or another package
+manager.

--- a/docs/mise-cookbook/python.md
+++ b/docs/mise-cookbook/python.md
@@ -1,10 +1,14 @@
-# Mise + Python Cookbook
+# Python Cookbook
 
-Here are some tips on managing [Python](/lang/python.html) projects with mise.
+Choose a recipe for an existing requirements-based project, a uv project, or a
+standalone Python script. See [Python configuration](/lang/python.html) for runtime
+installation and virtualenv settings.
 
 ## A Python Project with virtualenv
 
-Here is an example Python project with a `requirements.txt` file.
+This recipe expects `requirements.txt`, `app.py`, and a `tests/` directory. Include
+`pytest` in the requirements used for development. mise creates `.venv`; the
+install task populates it with project dependencies.
 
 ```toml [mise.toml]
 min_version = "2024.9.5"
@@ -17,7 +21,8 @@ PROJECT_NAME = "{{ config_root | basename }}"
 _.python.venv = { path = ".venv", create = true }
 
 [tools]
-python = "{{ get_env(name='PYTHON_VERSION', default='3.11') }}"
+python = "3.12"
+uv = "latest"
 ruff = "latest"
 
 [tasks.install]
@@ -31,11 +36,11 @@ run = "python app.py"
 
 [tasks.test]
 description = "Run tests"
-run = "pytest tests/"
+run = "python -m pytest tests/"
 
 [tasks.lint]
 description = "Lint the code"
-run = "ruff src/"
+run = "ruff check ."
 
 [tasks.info]
 description = "Print project information"
@@ -44,6 +49,9 @@ echo "Project: $PROJECT_NAME"
 echo "Virtual Environment: $VIRTUAL_ENV"
 '''
 ```
+
+Run `mise run install`, then `mise run test`, `mise run lint`, or `mise run run`.
+Add `.venv/` to `.gitignore`.
 
 ## mise + uv
 
@@ -65,13 +73,20 @@ cat .python-version
 
 If you run `uv run main.py` in the `uv` project, `uv` automatically creates a virtual environment for you using the Python version specified in the `.python-version` file. It also creates a `uv.lock` file.
 
-`mise` detects the Python version in `.python-version`, but by default it does not use the virtual environment created by `uv`. So `which python` shows a global Python installation from `mise`.
+Enable `.python-version` discovery if you want mise to select the same Python
+version. Declare uv as a tool as well:
 
-```shell
-mise i
-which python
-# ~/.local/share/mise/installs/python/3.12.4/bin/python
+```toml [mise.toml]
+[tools]
+uv = "latest"
+
+[settings]
+idiomatic_version_file_enable_tools = ["python"]
 ```
+
+Run `mise install`, then `mise exec -- uv sync` to create the lockfile, virtualenv,
+and project dependencies. By default, mise still selects its managed Python when
+you run `mise exec -- python`; `uv run` selects uv's project environment.
 
 To make `mise` use the virtual environment created by `uv`, set the [`python.uv_venv_auto`](/lang/python.html#python.uv_venv_auto) setting in your `mise.toml` file.
 Use `"source"` to source only an existing `.venv`, or `"create|source"` to create it if missing and then source it.
@@ -88,11 +103,12 @@ python.uv_venv_auto = "source"
 # python.uv_venv_auto = "create|source"
 ```
 
-`which python` now shows the Python version from the virtual environment created by `uv`.
+After activation refreshes, `python` resolves to the virtualenv. You can also
+check through mise directly:
 
 ```shell
-which python
-# ./uv-project/.venv/bin/python
+mise exec -- python -c 'import sys; print(sys.executable)'
+# /path/to/uv-project/.venv/bin/python
 ```
 
 Another option is to use `_.python.venv` in your `mise.toml` file to specify the path to the virtual environment created by `uv`.
@@ -104,7 +120,10 @@ _.python.venv = { path = ".venv" }
 
 ### Syncing python versions installed by mise and uv
 
-Use [mise sync python --uv](/cli/sync/python.html#uv) to sync the Python version installed by `mise` with the version specified in the `uv` project's `.python-version` file.
+Use [`mise sync python --uv`](/cli/sync/python.html#uv) to make existing Python
+installations available across mise and uv. This shares installed runtimes; it
+does not update `.python-version`, select the project version, or sync packages.
+Use `uv sync` for project dependencies.
 
 ### uv scripts
 
@@ -127,7 +146,8 @@ run = '''
 import requests
 from rich.pretty import pprint
 
-resp = requests.get("https://peps.python.org/api/peps.json")
+resp = requests.get("https://peps.python.org/api/peps.json", timeout=30)
+resp.raise_for_status()
 data = resp.json()
 pprint([(k, v["title"]) for k, v in data.items()][:10])
 '''
@@ -144,12 +164,15 @@ Or as a file task:
 import requests
 from rich.pretty import pprint
 
-resp = requests.get("https://peps.python.org/api/peps.json")
+resp = requests.get("https://peps.python.org/api/peps.json", timeout=30)
+resp.raise_for_status()
 data = resp.json()
 pprint([(k, v["title"]) for k, v in data.items()][:10])
 ```
 
-You can then run it with `mise run print_peps`:
+For the file task, make it executable on Unix with
+`chmod +x mise-tasks/print_peps.py`. Declare uv in the project as in the TOML
+example. Either form can then run with `mise run print_peps`:
 
 ```shell
 ❯ mise run print_peps

--- a/docs/mise-cookbook/ruby.md
+++ b/docs/mise-cookbook/ruby.md
@@ -1,6 +1,10 @@
-# Mise + Ruby Cookbook
+# Ruby Cookbook
 
-Here are some tips on managing Ruby projects with mise.
+Use mise to select Ruby and tasks to run the application's Bundler and Rails
+commands. This recipe assumes an existing Rails project with `Gemfile`,
+`Gemfile.lock`, and `bin/rails`. Add RuboCop to the development bundle before using
+the lint task. Install Ruby's platform dependencies as described in the
+[Ruby guide](/lang/ruby.html).
 
 ## A Ruby on Rails Project
 
@@ -22,15 +26,20 @@ run = "bundle install"
 [tasks.server]
 description = "Start the Rails server"
 alias = "s"
-run = "rails server"
+run = "bundle exec rails server"
 
 [tasks.test]
 description = "Run tests"
 alias = "t"
-run = "rails test"
+run = "bundle exec rails test"
 
 [tasks.lint]
 description = "Run lint using Rubocop"
 alias = "l"
-run = "rubocop"
+run = "bundle exec rubocop"
 ```
+
+Run `mise run bundle:install` after cloning, then `mise run test` or
+`mise run server`. `bundle exec` selects the executables from the project's bundle,
+including its locked Rails and RuboCop versions. Application setup such as database
+creation remains part of the Rails project's own instructions.

--- a/docs/mise-cookbook/shell-tricks.md
+++ b/docs/mise-cookbook/shell-tricks.md
@@ -4,36 +4,33 @@ A collection of shell utilities that build on mise.
 
 ## Prompt colouring
 
-In zsh, to change the prompt colour whenever mise updates the environment (e.g. on `cd` into a project, or after a `.mise*.toml` file is modified):
+In Zsh, add a prompt hook after your existing `mise activate zsh` setup. This
+example replaces the prompt with a blue marker when mise's environment state
+changes and a green marker otherwise. It leaves mise's activation functions intact:
 
-```shell
-# activate mise like normal
-source <(command mise activate zsh)
+```zsh
+# Put this after your existing mise activation in ~/.zshrc.
+autoload -Uz add-zsh-hook
+typeset -g _mise_prompt_diff="${__MISE_DIFF-}"
 
-typeset -i _mise_updated
-
-# replace default mise hook
-function _mise_hook {
-  local diff=${__MISE_DIFF}
-  source <(command mise hook-env -s zsh)
-  [[ ${diff} == ${__MISE_DIFF} ]]
-  _mise_updated=$?
-}
-
-_PROMPT="❱ "  # or _PROMPT=${PROMPT} to keep the default
-
-function _prompt {
-  if (( ${_mise_updated} )); then
-    PROMPT='%F{blue}${_PROMPT}%f'
+function _mise_prompt_colour {
+  local previous_status=$?
+  if [[ "${__MISE_DIFF-}" != "$_mise_prompt_diff" ]]; then
+    PROMPT='%F{blue}❱ %f'
   else
-    PROMPT='%(?.%F{green}${_PROMPT}%f.%F{red}${_PROMPT}%f)'
+    PROMPT='%F{green}❱ %f'
   fi
+  _mise_prompt_diff="${__MISE_DIFF-}"
+  return "$previous_status"
 }
 
-add-zsh-hook precmd _prompt
+add-zsh-hook -d precmd _mise_prompt_colour
+add-zsh-hook precmd _mise_prompt_colour
 ```
 
-Now, whenever mise updates the environment, the prompt turns blue.
+`__MISE_DIFF` is internal state, so treat this as a customization to maintain when
+upgrading mise. To undo it, remove `_mise_prompt_colour` with `add-zsh-hook -d precmd
+_mise_prompt_colour` and restore your usual `PROMPT` or prompt theme.
 
 ## Current configuration environment in powerline-go prompt
 
@@ -47,47 +44,53 @@ Mostly, it works as you would expect: include `shell-var` in `-modules`,
 pass `-shell-var MISE_ENV -shell-var-no-warn-empty` in the arguments,
 and make sure `MISE_ENV` is exported so `powerline-go` can see it.
 
-A gotcha as of February 2025 is that the `shell-var` module does not
-tolerate _unset_ (as opposed to empty) environment variables.
-To work around this, set `MISE_ENV` to an empty value early in the shell
-startup scripts, and avoid manually `unset`ing it.
-For example, for bash, typically in `~/.bashrc`:
+If your version of powerline-go warns when `MISE_ENV` is unset, ensure the variable
+is defined while preserving any selection made before the shell started:
 
 ```bash
-export MISE_ENV=
+export MISE_ENV="${MISE_ENV-}"
 ```
+
+This displays the exported `MISE_ENV` value. Environments chosen only for one
+command with `mise -E`, or platform environments selected by `auto_env`, are not
+persistent changes to that shell variable.
 
 ## Inspect what changed after mise hook
 
-Using record-query, you can inspect the `__MISE_DIFF` and `__MISE_SESSION` variables to see what the mise hook changes in your environment.
+For ordinary troubleshooting, start with `mise config`, `mise doctor`, or
+`MISE_DEBUG=1 mise env`. If you need to inspect shell bookkeeping itself,
+`__MISE_DIFF` and `__MISE_SESSION` currently contain base64-encoded, zlib-compressed
+MessagePack data.
 
-```toml [~/.config/mise/config.toml]
-[tools]
-"cargo:record-query" = "latest"
+The following Bash/Zsh helper requires Python and the `msgpack` package. Create an
+isolated Python environment for the decoder:
+
+```sh
+python3 -m venv ~/.cache/mise-env-inspect
+~/.cache/mise-env-inspect/bin/python -m pip install msgpack
 ```
 
-```shell
+```bash
 function mise_parse_env {
-  rq -m < <(
-    zcat -q < <(
-      printf '\x1f\x8b\x08\x00\x00\x00\x00\x00'
-      base64 -d <<< "$1"
-    )
-  )
+  printf '%s' "$1" | "$HOME/.cache/mise-env-inspect/bin/python" -c '
+import base64, pprint, sys, zlib
+import msgpack
+value = sys.stdin.read().strip()
+if not value:
+    raise SystemExit("No mise state was supplied; activate mise first")
+payload = zlib.decompress(base64.b64decode(value + "=" * (-len(value) % 4)))
+pprint.pprint(msgpack.unpackb(payload, raw=False), sort_dicts=False)
+'
 }
 ```
 
-```shell
-$ mise_parse_env "${__MISE_DIFF}"
-{
-  "new": {
-    ...
-  },
-  "old": {
-    ...
-  },
-  "path": [
-    ...
-  ]
-}
+Use it in an activated shell:
+
+```sh
+mise_parse_env "$__MISE_DIFF"
+mise_parse_env "$__MISE_SESSION"
 ```
+
+This format is an implementation detail, not an API. The decoded data can contain
+environment values, including secrets; inspect it locally and redact it before
+sharing diagnostic output.

--- a/docs/mise-cookbook/terraform.md
+++ b/docs/mise-cookbook/terraform.md
@@ -1,6 +1,8 @@
-# Mise + Terraform/Opentofu Cookbook
+# Terraform and OpenTofu Cookbook
 
-Here are some tips on managing Terraform projects with mise.
+Use tasks to keep infrastructure commands pointed at the same working directory.
+The recipe assumes a `terraform/` directory containing your configuration and any
+provider credentials already configured in the environment.
 
 ## Managing `terraform`/`opentofu` Projects
 
@@ -18,29 +20,52 @@ run = "terraform -chdir=terraform init"
 
 [tasks."terraform:plan"]
 description = "Generates an execution plan for Terraform"
+depends = ["terraform:init"]
 run = "terraform -chdir=terraform plan"
 
 [tasks."terraform:apply"]
 description = "Applies the changes required to reach the desired state of the configuration"
+depends = ["terraform:init"]
+interactive = true
 run = "terraform -chdir=terraform apply"
 
 [tasks."terraform:destroy"]
 description = "Destroy Terraform-managed infrastructure"
+depends = ["terraform:init"]
+interactive = true
 run = "terraform -chdir=terraform destroy"
 
 [tasks."terraform:validate"]
 description = "Validates the Terraform files"
+depends = ["terraform:init"]
 run = "terraform -chdir=terraform validate"
 
 [tasks."terraform:format"]
 description = "Formats the Terraform files"
 run = "terraform -chdir=terraform fmt"
 
+[tasks."terraform:format-check"]
+description = "Check formatting without changing files"
+run = "terraform -chdir=terraform fmt -check"
+
 [tasks."terraform:check"]
-description = "Checks the Terraform files"
-depends = ["terraform:format", "terraform:validate"]
-
-[env]
-_.file = ".env"
-
+description = "Check formatting and validate the configuration"
+depends = ["terraform:format-check", "terraform:validate"]
 ```
+
+Run `mise run terraform:check` for validation, then `mise run terraform:plan` to
+inspect proposed changes. `terraform:format` is the separate task that rewrites
+formatting. Initialization may download providers and update the dependency
+lockfile even when the selected task is a check.
+
+`terraform:apply` and `terraform:destroy` retain Terraform's confirmation prompts;
+`interactive = true` gives those commands access to the terminal. This recipe does
+not save a plan file, so `apply` calculates its own plan before asking for approval.
+
+For OpenTofu, replace the tool declaration with `opentofu = "1"` and the command
+name `terraform` with `tofu`. The `terraform/` directory and task names can stay
+as they are, or be renamed to match your project.
+
+If you use a local dotenv file for credentials, add
+[`env._.file`](/environments/#env-file) explicitly. Keep plaintext credential files
+out of version control; see [secrets](/environments/secrets/) for encrypted storage.

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -138,14 +138,14 @@
 - [Troubleshooting](https://mise.jdx.dev/troubleshooting.html): If you're looking for help with a specific error message, see Errors — this page is organized by symptom instead.
 - [Errors](https://mise.jdx.dev/errors.html): This page lists common error messages mise emits, what causes them, and how to fix them. It complements Troubleshooting, which is organized by symptom (wrong tool version, slow prompts, activation…
 - [Tips & Tricks](https://mise.jdx.dev/tips-and-tricks.html): An assortment of helpful tips for using mise.
-- [Cookbook](https://mise.jdx.dev/mise-cookbook/): Here are a few mise setups that other people have found useful.
-- [C++](https://mise.jdx.dev/mise-cookbook/cpp.html): Here are some tips on managing C++ projects with mise.
-- [Docker](https://mise.jdx.dev/mise-cookbook/docker.html): Here are some tips on using Docker with mise.
-- [Node](https://mise.jdx.dev/mise-cookbook/nodejs.html): Here are some tips on managing Node.js projects with mise.
-- [Ruby](https://mise.jdx.dev/mise-cookbook/ruby.html): Here are some tips on managing Ruby projects with mise.
-- [Terraform](https://mise.jdx.dev/mise-cookbook/terraform.html): Here are some tips on managing Terraform projects with mise.
-- [Python](https://mise.jdx.dev/mise-cookbook/python.html): Here are some tips on managing Python projects with mise.
-- [Presets](https://mise.jdx.dev/mise-cookbook/presets.html): You can create your own presets with mise tasks to reduce boilerplate and make setting up new projects easier.
+- [Cookbook](https://mise.jdx.dev/mise-cookbook/): These recipes combine tools, environment variables, and tasks for specific workflows. Start with the recipe closest to your project, then adapt its paths, versions, and application commands.
+- [C++](https://mise.jdx.dev/mise-cookbook/cpp.html): Use mise to install build tools and define the configure/build cycle. A C or C++ compiler must already be available, for example through your operating system's development tools.
+- [Docker](https://mise.jdx.dev/mise-cookbook/docker.html): Install mise inside an image, use it to run project commands, or preinstall tools outside user home directories for shared development containers.
+- [Node](https://mise.jdx.dev/mise-cookbook/nodejs.html): Use mise to select Node.js and your package manager, then run the scripts and dependencies declared by the project.
+- [Ruby](https://mise.jdx.dev/mise-cookbook/ruby.html): Use mise to select Ruby and tasks to run the application's Bundler and Rails commands. This recipe assumes an existing Rails project with Gemfile, Gemfile.lock, and bin/rails.
+- [Terraform](https://mise.jdx.dev/mise-cookbook/terraform.html): Use tasks to keep infrastructure commands pointed at the same working directory. The recipe assumes a terraform/ directory containing your configuration and any provider credentials already configured…
+- [Python](https://mise.jdx.dev/mise-cookbook/python.html): Choose a recipe for an existing requirements-based project, a uv project, or a standalone Python script. See Python configuration for runtime installation and virtualenv settings.
+- [Presets](https://mise.jdx.dev/mise-cookbook/presets.html): A preset is a task you write to create a project's starting configuration. Store it as a global file task so it is available in new repositories.
 - [Shell tricks](https://mise.jdx.dev/mise-cookbook/shell-tricks.html): A collection of shell utilities that build on mise.
 - [Team](https://mise.jdx.dev/team.html): Jeff Dickey is the primary developer behind mise. He does the bulk of development for the project.
 - [Contributing](https://mise.jdx.dev/contributing.html): mise has a specific scope and design taste. Unless the change is obvious, start a discussion or mention what you plan to do in Discord before opening a PR.


### PR DESCRIPTION
Several cookbook recipes could not be followed from their stated setup: Python invoked undeclared uv, Rails commands bypassed the project bundle, and the CMake build assumed an existing build directory. Review and improve all ten cookbook pages with prerequisites, working commands, and clearer outcomes.

- Add a complete CMake example, project-owned npm dependency guidance, uv setup, and Bundler-aware Rails commands.
- Separate Terraform format checks from formatting changes and initialize before validation or planning.
- Explain Docker config layers and interactive container tasks.
- Replace the incomplete preset with a runnable Python/uv scaffold that refuses to overwrite an existing config.
- Keep mise's shell hook intact in the prompt recipe, fix decoding of shell state, and document Neovim parser/LSP prerequisites and query limitations.

Validation:
- Production docs build and social-image checks pass; scoped hk checks and formatting pass.
- Cookbook TOML and Python blocks parse.
- CMake configure/build/clean succeeds in a path containing spaces. Preset creation/overwrite refusal and Zsh prompt behavior pass smoke checks.
- Neovim 0.12.5 matches all four documented run-string forms and six metadata-comment forms against real parsers; the C-style query parses.
- The decoder reads actual mise diff/session state, including binary fields.
- Full lint-fix was attempted; its Cargo check requires Rust 1.95 while this environment has 1.93. Docker images and application-specific Rails/Terraform workflows were reviewed but not executed.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to examples and prose; no runtime or application code paths are modified.
> 
> **Overview**
> **Overhauls all ten mise cookbook pages** so readers can follow each recipe from stated prerequisites through working commands, without hidden setup gaps.
> 
> The **index** becomes a workflow-oriented table and tighter contributing guidance. **Language/stack recipes** are rewritten: CMake uses the portable `cmake -S/-B` / `cmake --build` flow with a minimal `hello` example; Node favors `npm ci` and package.json scripts over global npm tools; Python declares **uv**, clarifies venv/sync behavior, and hardens inline script examples; Rails tasks use **`bundle exec`**; Terraform adds **`depends` on init**, non-mutating **`format-check`**, and **`interactive`** apply/destroy.
> 
> **Docker** adds safer install curl, **`.dockerignore`**, config-first **`mise install`** layers, and documents **`mise exec`/`mise run`** in non-interactive builds. The **Python preset** is replaced with a global file task that writes a uv-based `mise.toml` and **refuses to overwrite** existing config. **Shell tricks** preserve mise’s activation hook in the Zsh prompt recipe and swap **record-query** for a small Python **msgpack** decoder of `__MISE_DIFF`/`__MISE_SESSION`. **Neovim** expands the `is-mise?` predicate, documents parser/LSP prerequisites, and adds troubleshooting. **`docs/public/llms.txt`** blurbs are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c8afd76626646b7de80cdb53f0886678f7880a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated cookbook guidance for C++, Docker, Node.js, Python, Ruby, Terraform/OpenTofu, Neovim, shell workflows, and presets.
  * Added clearer setup, task execution, troubleshooting, environment, security, and project-structure instructions.
  * Reorganized the cookbook index with workflow-based navigation and updated links.
  * Refined examples to use current recommended commands, configuration, and development workflows.
  * Expanded public cookbook descriptions with more specific summaries of each recipe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->