### PR TITLE
docs: make language setup guides project focused and accurate

### DIFF
--- a/docs/lang/bun.md
+++ b/docs/lang/bun.md
@@ -2,25 +2,28 @@
 
 `mise` can be used to install and manage multiple versions of [bun](https://bun.sh/) on the same system.
 
-> The following are instructions for using the bun mise core plugin. It is used when no
-> git plugin named "bun" is installed.
-
-The code for this is inside the mise repository at
-[`./src/plugins/core/bun.rs`](https://github.com/jdx/mise/blob/main/src/plugins/core/bun.rs).
-
 ## Usage
 
-The following installs bun and makes it the global default:
+Install Bun for the current project and check the selected executable:
 
 ```sh
-mise use -g bun@0.7     # install bun 0.7.x
-mise use -g bun@latest  # install latest bun
+mise use bun@latest
+mise exec -- bun --version
 ```
+
+Use `mise use -g bun@latest` for a personal default outside projects. Commit the
+project's `mise.toml` so teammates select the same version request.
 
 See available versions with `mise ls-remote bun`.
 
 > [!NOTE]
-> Avoid upgrading bun with `bun upgrade`, since `mise` will not be aware of the change.
+> Update with `mise upgrade bun`. Running `bun upgrade` changes the installed
+> binary without updating mise's recorded version.
+
+These instructions use mise's built-in bun support. An installed external
+plugin with the same name can change the behavior; use `mise plugins ls` to
+check for overrides. See the [core implementation](https://github.com/jdx/mise/blob/main/src/plugins/core/bun.rs)
+for backend details.
 
 ## Tool Options
 

--- a/docs/lang/deno.md
+++ b/docs/lang/deno.md
@@ -2,26 +2,28 @@
 
 `mise` can be used to install and manage multiple versions of [deno](https://deno.land/) on the same system.
 
-> The following are instructions for using the deno mise core plugin. It is used when no
-> git plugin named "deno" is installed. If you want to use [asdf-deno](https://github.com/asdf-community/asdf-deno) instead,
-> run `mise plugins install deno https://github.com/asdf-community/asdf-deno`.
-
-The code for this is inside the mise repository at
-[`./src/plugins/core/deno.rs`](https://github.com/jdx/mise/blob/main/src/plugins/core/deno.rs).
-
 ## Usage
 
-The following installs deno and makes it the global default:
+Install Deno for the current project and verify the selected executable:
 
 ```sh
-mise use -g deno@1       # install deno 1.x
-mise use -g deno@latest  # install latest deno
+mise use deno@latest
+mise exec -- deno --version
 ```
+
+Use `mise use -g deno@latest` for a personal default outside projects. A specific
+version request such as `deno@2` keeps the project within that release series.
 
 See available versions with `mise ls-remote deno`.
 
 > [!NOTE]
-> Avoid upgrading with `deno upgrade`, as `mise` will not be aware of the change.
+> Update with `mise upgrade deno`. Running `deno upgrade` changes the installed
+> binary without updating mise's recorded version.
+
+These instructions use mise's built-in deno support. An installed external
+plugin with the same name can change the behavior; use `mise plugins ls` to
+check for overrides. See the [core implementation](https://github.com/jdx/mise/blob/main/src/plugins/core/deno.rs)
+for backend details.
 
 ## Tool Options
 

--- a/docs/lang/dotnet.md
+++ b/docs/lang/dotnet.md
@@ -5,8 +5,10 @@ installed side-by-side under a shared `DOTNET_ROOT` directory, matching .NET's n
 This means `dotnet --list-sdks` shows every version you've installed through mise.
 
 Unlike most tools, the SDKs don't live inside `~/.local/share/mise/installs` because they share a
-common root. mise symlinks the install path to `DOTNET_ROOT` and sets environment variables so the
-correct SDK is picked up.
+common root. mise symlinks its tracking path to `DOTNET_ROOT` and puts that shared installation
+on `PATH`. The .NET SDK resolver then chooses an SDK, using `global.json` when
+present. Without it, .NET normally uses the highest installed SDK; a mise version
+declaration alone does not isolate SDK selection in shared mode.
 
 ::: info
 This plugin manages the **.NET SDK** itself. To install .NET global tools (e.g., `dotnet-ef`),
@@ -15,46 +17,52 @@ use the [`dotnet` backend](/dev-tools/backends/dotnet.html) with `dotnet:ToolNam
 
 ## Usage
 
-Use the latest .NET SDK:
+Install the latest SDK for the current project and inspect the shared installation:
 
 ```sh
-mise use -g dotnet@latest
-dotnet --version
+mise use dotnet@latest
+mise exec -- dotnet --list-sdks
+mise exec -- dotnet --version
 ```
 
-Use a specific version:
+Use `mise use -g dotnet@latest` for a personal default. To install another SDK
+without replacing the project's version request, use `mise install`:
 
 ```sh
-mise use -g dotnet@8.0.400
-dotnet --version
+mise install dotnet@8.0.400
+mise exec -- dotnet --list-sdks
 ```
 
-Install multiple SDKs side-by-side for multi-targeting:
-
-```sh
-mise use dotnet@8
-mise use dotnet@9
-dotnet --list-sdks
-```
+For a project that must build with a particular SDK, configure `global.json` below,
+or enable [isolated mode](#isolated-mode) before installation.
 
 ## `global.json` support
 
-mise recognizes `global.json` as an idiomatic version file. If your project contains a `global.json`
-with an SDK version, mise will automatically use it:
+Enable discovery so mise installs the SDK declared by the project, preserving any
+other tools already enabled for idiomatic files:
+
+```sh
+mise settings add idiomatic_version_file_enable_tools dotnet
+```
+
+For example, this file requests an exact SDK and disables .NET's roll-forward
+behavior:
 
 ```json
 {
   "sdk": {
-    "version": "8.0.100"
+    "version": "8.0.400",
+    "rollForward": "disable"
   }
 }
 ```
 
-Enable idiomatic version file support:
-
-```sh
-mise settings set idiomatic_version_file_enable_tools=dotnet
-```
+Run `mise install`, then `mise exec -- dotnet --version` from the project.
+mise reads `sdk.version` to install the requested SDK. .NET itself interprets
+`rollForward` and other SDK selection policy; see Microsoft's
+[`global.json` reference](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json).
+Do not keep a conflicting `dotnet` version in `mise.toml` if `global.json` is the
+project's version source.
 
 ## Isolated Mode
 
@@ -67,6 +75,9 @@ isolated mode:
 ```sh
 mise settings set dotnet.isolated=true
 ```
+
+Choose this mode before installing the versions you need. Changing the setting
+alone does not move existing shared installations into isolated directories.
 
 In isolated mode each SDK version is installed under `~/.local/share/mise/installs/dotnet/<version>/`,
 just like most other mise-managed tools. `dotnet --list-sdks` will only report the currently active
@@ -83,8 +94,8 @@ version.
 By default, mise installs the full .NET SDK. If you only need to _run_ .NET applications, without building them or the overhead of the SDK, install just the runtime with the `runtime` inline option:
 
 ```sh
-mise use dotnet[runtime=dotnet]@8.0.14
-dotnet --list-runtimes
+mise use "dotnet[runtime=dotnet]@8.0.14"
+mise exec -- dotnet --list-runtimes
 ```
 
 ### Valid runtime values

--- a/docs/lang/elixir.md
+++ b/docs/lang/elixir.md
@@ -2,21 +2,28 @@
 
 `mise` can be used to manage multiple [`elixir`](https://elixir-lang.org/) versions on the same system.
 
-> The following are instructions for using the elixir mise core plugin. It is used when no
-> git plugin named "elixir" is installed.
-
-The code for this is inside the mise repository at
-[`./src/plugins/core/elixir.rs`](https://github.com/jdx/mise/blob/main/src/plugins/core/elixir.rs).
-
 ## Usage
 
-Use the latest stable version of elixir:
+Declare both Erlang and Elixir for the project:
 
 ```sh
-mise use -g erlang elixir
+mise use erlang elixir
+mise exec -- elixir --version
 ```
 
-[`erlang`](/lang/erlang.html) is required to install `elixir`.
+[Erlang/OTP](/lang/erlang.html) is required by Elixir. The version command reports
+both runtimes, which helps diagnose an incompatible pair. Use `mise ls-remote
+elixir` and `mise ls-remote erlang` to choose versions supported by your project,
+and pass both requests to `mise use`.
+
+Add `-g` to set personal defaults. In an existing Mix project, run
+`mise exec -- mix deps.get` to install application dependencies; selecting Elixir
+does not install them.
+
+These instructions use mise's built-in elixir support. An installed external
+plugin with the same name can change the behavior; use `mise plugins ls` to
+check for overrides. See the [core implementation](https://github.com/jdx/mise/blob/main/src/plugins/core/elixir.rs)
+for backend details.
 
 ## Tool Options
 

--- a/docs/lang/erlang.md
+++ b/docs/lang/erlang.md
@@ -2,26 +2,34 @@
 
 `mise` can be used to install and manage multiple versions of [erlang](https://www.erlang.org/) on the same system.
 
-> The following are instructions for using the erlang mise core plugin. It is used when no
-> git plugin named "erlang" is installed.
-
-The code for this is inside the mise repository at
-[`./src/plugins/core/erlang.rs`](https://github.com/jdx/mise/blob/main/src/plugins/core/erlang.rs).
-
 ## Usage
 
-The following installs erlang and makes it the global default:
+Install Erlang for the project, then check the OTP release without starting an
+interactive Erlang shell:
 
 ```sh
-mise use -g erlang@26
+mise use erlang@latest
+mise exec -- erl -noshell -eval 'io:format("~s~n", [erlang:system_info(otp_release)]), halt().'
 ```
+
+Use `mise use -g erlang@latest` for a personal default, or replace `latest` with
+the release series required by your application.
 
 See available versions with `mise ls-remote erlang`.
 
+These instructions use mise's built-in erlang support. An installed external
+plugin with the same name can change the behavior; use `mise plugins ls` to
+check for overrides. See the [core implementation](https://github.com/jdx/mise/blob/main/src/plugins/core/erlang.rs)
+for backend details.
+
 ## kerl
 
-The plugin uses [kerl](https://github.com/kerl/kerl) under the hood to build erlang.
-See kerl's docs for information on configuring it.
+mise tries a compatible precompiled build by default and falls back to a source
+build when needed. Source builds use [kerl](https://github.com/kerl/kerl) and
+require its platform build dependencies. Set `erlang.compile = true` to request
+a source build, or `false` to fail when a precompiled build is unavailable.
+
+See kerl's documentation for build dependencies and configuration.
 
 On GitHub Actions Linux runners, `ImageOS=ubuntu24`, `ImageOS=ubuntu22`, and
 `ImageOS=ubuntu20` map to their corresponding precompiled Erlang build targets. In the

--- a/docs/lang/go.md
+++ b/docs/lang/go.md
@@ -2,35 +2,46 @@
 
 `mise` can be used to install and manage multiple versions of [go](https://golang.org/) on the same system.
 
-> The following are instructions for using the go mise core plugin. It is used when no
-> git plugin named "go" is installed. If you want to use [asdf-golang](https://github.com/kennyp/asdf-golang) instead,
-> run `mise plugins install go GIT_URL`.
-
-The code for this is inside the mise repository at
-[`./src/plugins/core/go.rs`](https://github.com/jdx/mise/blob/main/src/plugins/core/go.rs).
-
 ## Usage
 
-The following installs the latest version of go-1.21.x (if some version of 1.21.x is not already
-installed) and makes it the global default:
+Select a Go release series for the current project:
 
 ```sh
-mise use -g go@1.21
+mise use go@1.25
+mise exec -- go version
 ```
+
+Use `mise use -g go@1.25` for a personal default. `mise ls-remote go` lists
+available versions; `mise upgrade go` updates within the configured request.
 
 Minor go versions 1.20 and below require specifying `prefix` before the version number because the
 first version of each series was released without a `.0` suffix, making 1.20 an exact version match:
 
 ```sh
-mise use -g go@prefix:1.20
+mise use go@prefix:1.20
 ```
+
+These instructions use mise's built-in go support. An installed external
+plugin with the same name can change the behavior; use `mise plugins ls` to
+check for overrides. See the [core implementation](https://github.com/jdx/mise/blob/main/src/plugins/core/go.rs)
+for backend details.
 
 ## `.go-version` file support
 
-mise uses a `mise.toml` or `.tool-versions` file for auto-switching between software versions.
-However, it can also read go-specific version files named `.go-version`.
+Enable Go's idiomatic files explicitly:
 
-See [idiomatic version files](/configuration.html#idiomatic-version-files).
+```sh
+mise settings add idiomatic_version_file_enable_tools go
+```
+
+mise can read `.go-version` or the `toolchain goX.Y.Z` declaration in `go.mod`.
+The `go` directive is a minimum compatibility requirement; reading it as a version
+request is [deprecated](/configuration.html#which-fields-mise-reads).
+
+Go also has its own [toolchain selection](https://go.dev/doc/toolchain), controlled
+by `GOTOOLCHAIN` and module/workspace declarations. It may use a different
+toolchain after mise starts it. Compare `mise exec -- go version` with
+`mise exec -- go env GOTOOLCHAIN` when investigating unexpected versions.
 
 ## Default packages
 

--- a/docs/lang/java.md
+++ b/docs/lang/java.md
@@ -2,44 +2,49 @@
 
 Like `sdkman`, `mise` can manage multiple versions of Java on the same system.
 
-> The following are instructions for using the java mise core plugin. It is used when no
-> git plugin named "java" is installed. If you want to use [asdf-java](https://github.com/halcyon/asdf-java) instead,
-> run `mise plugins install java GIT_URL`.
-
-The code for this is inside the mise repository at
-[`./src/plugins/core/java.rs`](https://github.com/jdx/mise/blob/main/src/plugins/core/java.rs).
-
 ## Usage
 
-The following installs the latest version of openjdk-21.x (if some version of openjdk-21.x is
-not already installed) and makes it the global default:
+Select a JDK vendor and release for the current project:
 
 ```sh
-mise use -g java@openjdk-21
-mise use -g java@21         # alternate shorthands for openjdk
+mise use java@temurin-21
+mise exec -- java -version
+mise exec -- javac -version
 ```
+
+Use `mise use -g java@temurin-21` for a personal default. The vendor prefix makes
+the project's distribution choice explicit.
 
 You can also install a JDK from a different vendor. To get the latest version from a vendor, use the
 vendor prefix.
 
 ```sh
-mise use -g java@temurin        # latest version from Temurin
-mise use -g java@temurin-21
-mise use -g java@zulu-21
-mise use -g java@corretto-21
+mise use java@temurin        # latest version from Temurin
+mise use java@temurin-21
+mise use java@zulu-21
+mise use java@corretto-21
 ```
 
 See available versions with `mise ls-remote java`.
 
-::: warning
-Shorthand versions (like `21` in the example) use [`OpenJDK`](https://openjdk.org/) as the default vendor. The default vendor can be changed with the setting [`java.shorthand_vendor`](../configuration/settings.md#java.shorthand_vendor). OpenJDK versions are only updated for a 6-month period; updates and security patches are not available after that. This also applies to LTS versions.
-
-For more information on which JDK to choose, see <https://whichjdk.com>.
+::: info Vendor selection
+Unqualified versions such as `java@21` use
+[`java.shorthand_vendor`](/configuration/settings.html#java.shorthand_vendor),
+which defaults to `openjdk`. Vendor distributions have different update and
+support policies. Use a vendor-qualified request when the project depends on a
+particular distribution.
 :::
+
+These instructions use mise's built-in java support. An installed external
+plugin with the same name can change the behavior; use `mise plugins ls` to
+check for overrides. See the [core implementation](https://github.com/jdx/mise/blob/main/src/plugins/core/java.rs)
+for backend details.
 
 ## JAVA_HOME
 
-mise automatically sets `JAVA_HOME` to the active Java installation. This requires [`mise activate`](/cli/activate) — shims alone do not set environment variables like `JAVA_HOME`.
+mise sets `JAVA_HOME` for commands run with `mise exec`, tasks, and activated
+shells. [Shell activation](/cli/activate.html) updates the parent shell itself;
+running a shim does not export `JAVA_HOME` back into that parent shell.
 
 If `JAVA_HOME` appears stuck on an old version after changing your `mise.toml`, try:
 
@@ -54,19 +59,38 @@ If you use an IDE that reads `JAVA_HOME` at startup, you may need to restart it 
 
 Some applications on macOS rely on `/usr/libexec/java_home` to find installed Java runtimes.
 
-To integrate an installed Java runtime with macOS, run the following commands for the appropriate
-version (e.g. openjdk-21).
+If the selected distribution includes a macOS `Contents` bundle, register it with
+macOS. First inspect the installation selected for this directory:
 
 ```sh
-sudo mkdir /Library/Java/JavaVirtualMachines/openjdk-21.jdk
-sudo ln -s ~/.local/share/mise/installs/java/openjdk-21/Contents /Library/Java/JavaVirtualMachines/openjdk-21.jdk/Contents
+mise where java
 ```
 
-> Note: Not all distributions of the Java SDK support this integration (e.g. liberica).
+Then, in a POSIX shell:
+
+```sh
+mise_java_home="$(mise where java)"
+if test -d "$mise_java_home/Contents"; then
+  sudo mkdir -p /Library/Java/JavaVirtualMachines/mise-java.jdk
+  sudo ln -s "$mise_java_home/Contents" /Library/Java/JavaVirtualMachines/mise-java.jdk/Contents
+fi
+/usr/libexec/java_home -V
+```
+
+Run the link command only when `Contents` exists and the destination is not
+already registered. Not all distributions include this bundle. The link points
+to the selected installation; it does not automatically follow future upgrades.
 
 ## `.java-version` and `.sdkmanrc` files support
 
-The Java core plugin supports the idiomatic version files `.java-version` and `.sdkmanrc`. See [idiomatic version files](/configuration.html#idiomatic-version-files).
+Enable discovery of `.java-version` and `.sdkmanrc` explicitly:
+
+```sh
+mise settings add idiomatic_version_file_enable_tools java
+```
+
+A conflicting Java declaration in `mise.toml` takes precedence. See
+[idiomatic version files](/configuration.html#idiomatic-version-files).
 
 For `.sdkmanrc` files, mise tries to map the vendor and version to the appropriate version
 string. For example, the version `20.0.2-tem` is mapped to `temurin-20.0.2`. Due to Azul's Zulu
@@ -77,33 +101,28 @@ The following vendors are NOT supported: `bsg` (Bisheng), `graal` (GraalVM), `ni
 
 ### Using unsupported versions
 
-If you need an unsupported version of Java, some manual work is required:
+For a JDK already installed by SDKMAN or another source, point mise at its home
+directory instead of creating internal cache entries or modifying the JDK:
 
-1. Download the unsupported version to a directory (e.g. `~/.sdkman/candidates/java/21.0.1-open`)
-2. Symlink the new version:
-
-```sh
-ln -s ~/.sdkman/candidates/java/21.0.1-open ~/.local/share/mise/installs/java/21.0.1-open
+```toml [mise.toml]
+[tools]
+java = { path = "/path/to/jdk-home" }
 ```
 
-3. If on Mac:
+The directory must contain `bin/java` and, for a full JDK, `bin/javac`. For a
+macOS `.jdk` bundle, this is usually its `Contents/Home` directory. Check with
+`mise exec -- java -version`.
+
+Alternatively, register a local installation under a name with
+[`mise link`](/cli/link.html), then select it with `mise use`:
 
 ```sh
-mkdir ~/.local/share/mise/installs/java/21.0.1-open/Contents
-mkdir ~/.local/share/mise/installs/java/21.0.1-open/Contents/MacOS
-
-ln -s ~/.sdkman/candidates/java/21.0.1-open ~/.local/share/mise/installs/java/21.0.1-open/Contents/Home
-cp ~/.local/share/mise/installs/java/21.0.1-open/lib/libjli.dylib ~/.local/share/mise/installs/java/21.0.1-open/Contents/MacOS/libjli.dylib
+mise link java@local /path/to/jdk-home
+mise use java@local
 ```
 
-4. Make sure the cache is blocked and valid by ensuring an **empty** directory **exists** for your version in the [mise cache](https://mise.jdx.dev/directories.html#cache-mise), for example:
-
-```sh
-$ ls -R $MISE_CACHE_DIR/java
-21.0.1-open
-
-mise/java/21.0.1-open:
-```
+mise uses this installation in place; updates remain the responsibility of the
+source that installed it.
 
 ## Tool Options
 
@@ -134,15 +153,29 @@ are supported:
 
 ## Gradle toolchains detection
 
-Gradle can automatically detect toolchains installed by some tools (see [toolchain | auto-detection](https://docs.gradle.org/current/userguide/toolchains.html#sec:auto_detection)).
+Run Gradle through mise so it inherits the selected `JAVA_HOME`:
 
-At the moment, `Gradle` does not support auto-detecting Java installations by `mise` (see [gradle/issues/29508](https://github.com/gradle/gradle/issues/29508) and [gradle/issues/29355](https://github.com/gradle/gradle/issues/29355)). A workaround is to leverage the fact that the `mise` install layout is [similar to the one used by `asdf`](/ide-integration.html#sdk-selection-using-asdf-layout).
-
-```shell
-mkdir -p ~/.asdf/installs/ && ln -s ~/.local/share/mise/installs/java ~/.asdf/installs/
+```sh
+mise exec -- ./gradlew -q javaToolchains
 ```
 
-Otherwise, you can always use the [foojay-resolver-convention](https://plugins.gradle.org/plugin/org.gradle.toolchains.foojay-resolver-convention) plugin to let Gradle automatically install JDKs required by your project.
+This assumes the project has a Gradle wrapper and JVM build configuration. The
+report shows which JDKs Gradle detects and how it found them.
+
+To expose the selected JDK as an explicit toolchain candidate, add:
+
+```properties [gradle.properties]
+org.gradle.java.installations.fromEnv=JAVA_HOME
+```
+
+For multiple JDKs, Gradle also accepts a comma-separated list of installation
+homes in `org.gradle.java.installations.paths`. It does not recursively search
+those directories. Use actual JDK homes, not mise's entire `installs/java`
+directory; see [Gradle's custom toolchain locations](https://docs.gradle.org/current/userguide/toolchains.html#sec:custom_loc).
+
+The build's toolchain requirements still determine which candidate Gradle uses.
+After changing toolchain configuration, stop the existing daemon with
+`mise exec -- ./gradlew --stop` before checking again.
 
 ## Settings
 

--- a/docs/lang/node.md
+++ b/docs/lang/node.md
@@ -1,23 +1,27 @@
-# Node
+# Node.js
 
 Like `nvm` (or `volta`, `fnm`, or `asdf`), `mise` can manage multiple versions of Node.js on the same system.
 
-> The following are instructions for using the node mise core plugin. It is used when no
-> git plugin named "node" is installed. If you want to use [asdf-nodejs](https://github.com/asdf-vm/asdf-nodejs) instead,
-> run `mise plugins install node https://github.com/asdf-vm/asdf-nodejs`.
-
-The code for this is inside the mise repository at [`./src/plugins/core/node.rs`](https://github.com/jdx/mise/blob/main/src/plugins/core/node.rs).
-
 ## Usage
 
-The following installs the latest version of node-26.x and makes it the global
-default:
+Select Node.js for the current project and verify it without depending on shell
+activation:
 
 ```sh
-mise use -g node@26
+mise use node@26
+mise exec -- node --version
 ```
 
+Use `mise use -g node@26` for a personal default. Project versions override that
+default when you enter the project with shell activation, run a task, or use
+`mise exec`. Use `mise upgrade node` to update within the configured request.
+
 See the [Node.js Cookbook](/mise-cookbook/nodejs.html) for common tasks and examples.
+
+These instructions use mise's built-in node support. An installed external
+plugin with the same name can change the behavior; use `mise plugins ls` to
+check for overrides. See the [core implementation](https://github.com/jdx/mise/blob/main/src/plugins/core/node.rs)
+for backend details.
 
 ## Run projects with aube
 
@@ -30,7 +34,7 @@ Install it with mise, then run an existing package script:
 
 ```sh
 mise use aube
-aubr test
+mise exec -- aubr test
 ```
 
 See [aube's security overview](https://aube.jdx.dev/security) for its release-cooling, trust-policy, malicious-package,
@@ -69,16 +73,14 @@ To pin both to exact versions:
 mise use --pin node@lts npm@latest
 ```
 
-This resolves aliases like `lts` and `latest` to exact version numbers in `mise.toml`, e.g.:
+This writes the resolved concrete versions to `mise.toml`. The numbers depend on
+the current releases; inspect the result with `mise ls --current` or read the
+config file.
 
-```toml [mise.toml]
-[tools]
-node = "26.1.0"
-npm = "11.12.1"
-```
-
-The pinned npm version takes precedence over the one bundled with Node, so `npm --version` will
-always return the version specified in `mise.toml`.
+The separately configured npm takes precedence over Node's bundled npm inside
+the mise environment. Check it with `mise exec -- npm --version`. This selects
+the package-manager executable; the project's dependency lockfile still controls
+its npm packages.
 
 ## `.nvmrc`, `.node-version` and `package.json` support
 
@@ -86,7 +88,7 @@ By default, mise uses a `mise.toml` file for auto-switching between software ver
 
 It also supports `.tool-versions` files for asdf compatibility. `.nvmrc`, `.node-version`, and the `devEngines` field in `package.json` are also supported but must be explicitly enabled (see the tip below).
 
-This makes it a drop-in replacement for `nvm`. See [idiomatic version files](/configuration.html#idiomatic-version-files) for more information.
+See [idiomatic version files](/configuration.html#idiomatic-version-files) for more information.
 
 ::: tip
 Idiomatic version files (`.nvmrc`, `.node-version`, `devEngines` field in `package.json`) are disabled by default and must be explicitly enabled:
@@ -139,9 +141,8 @@ version. To use this legacy feature, provide a `$HOME/.default-npm-packages` fil
 package per line, for example:
 
 ```text
-lodash
-request
-express
+typescript
+eslint
 ```
 
 You can specify a different location for this file with the `MISE_NODE_DEFAULT_PACKAGES_FILE` variable.

--- a/docs/lang/python.md
+++ b/docs/lang/python.md
@@ -2,39 +2,39 @@
 
 Like `pyenv`, `mise` can manage multiple versions of Python on the same system. It can also automatically create virtual environments for your projects and integrates with `uv`.
 
-> The following are instructions for using the python mise core plugin. It is used when no
-> plugin named "python" has been installed manually with `mise plugins install python [GIT_URL]`.
-
-The code for this is inside the mise repository
-at [`./src/plugins/core/python.rs`](https://github.com/jdx/mise/blob/main/src/plugins/core/python.rs).
-
 ## Usage
 
-The following installs the latest version of python-3.15.x and makes it the global
-default:
+Select Python for the current project and verify the interpreter:
 
 ```sh
-mise use -g python@3.15
+mise use python@3.14
+mise exec -- python --version
 ```
+
+Use `mise use -g python@3.14` for a personal default. Installing Python supplies
+the runtime; use a project virtualenv for dependencies.
 
 You can also use multiple versions of python at the same time:
 
 ```sh
-$ mise use -g python@3.14 python@3.15
-$ python -V
-3.14.0
-$ python3.15 -V
-3.15.0
+mise use python@3.13 python@3.14
+mise exec -- python --version     # the first configured version, 3.13.x
+mise exec -- python3.14 --version # the versioned executable, 3.14.x
 ```
 
 You can also install a specific python flavour. To get the latest version of a flavour, use the
 flavour prefix alone:
 
 ```sh
-mise use -g python@anaconda         # latest version of anaconda
+mise use python@anaconda         # latest version of anaconda
 ```
 
 See the [Python Cookbook](/mise-cookbook/python.html) for common tasks and examples.
+
+These instructions use mise's built-in python support. An installed external
+plugin with the same name can change the behavior; use `mise plugins ls` to
+check for overrides. See the [core implementation](https://github.com/jdx/mise/blob/main/src/plugins/core/python.rs)
+for backend details.
 
 ## Tool Options
 
@@ -68,7 +68,15 @@ prefer the default unless you need this as an install workaround.
 
 ## `.python-version` support
 
-`.python-version`/`.python-versions` files are supported by mise. See [idiomatic version files](/configuration.html#idiomatic-version-files).
+`.python-version`/`.python-versions` files are supported after you enable discovery:
+
+```sh
+mise settings add idiomatic_version_file_enable_tools python
+```
+
+Keep one authoritative project version source. A conflicting Python declaration
+in `mise.toml` takes precedence over an idiomatic file. See
+[idiomatic version files](/configuration.html#idiomatic-version-files).
 
 ## Automatic virtualenv activation
 
@@ -95,26 +103,35 @@ The legacy `virtualenv` tool option (`python = { version = "3.15", virtualenv = 
 
 Use `_.python.venv` in the `[env]` section of `mise.toml`:
 
-```toml
+```toml [mise.toml]
 [tools]
-python = "3.15" # [optional] will be used for the venv
+python = "3.14"
 
 [env]
-_.python.venv = ".venv" # relative to this file's directory
-_.python.venv = "/root/.venv" # can be absolute
-_.python.venv = "{{env.HOME}}/.cache/venv/myproj" # can use templates
-_.python.venv = { path = ".venv", create = true } # create the venv if it doesn't exist
-_.python.venv = { path = ".venv", create = true, python = "3.15" } # use a specific python version
-_.python.venv = {
-  path = ".venv", create = true,
-  python_create_args = ["--without-pip"], # pass args to python -m venv
-}
-_.python.venv = {
-  path = ".venv", create = true,
-  uv_create_args = ["--system-site-packages"], # pass args to uv venv
-}
-# Install seed packages (pip, setuptools, and wheel) into the virtual environment.
-_.python.venv = { path = ".venv", create = true, uv_create_args = ['--seed'] }
+_.python.venv = { path = ".venv", create = true }
+```
+
+Run `mise exec -- python -c 'import sys; print(sys.executable)'` to verify that
+Python comes from `.venv`. Add `.venv/` to `.gitignore`.
+
+Choose one declaration for the virtualenv. A string such as `_.python.venv =
+".venv"` activates an existing environment; the object form accepts these options:
+
+| Option               | Purpose                                                                         |
+| -------------------- | ------------------------------------------------------------------------------- |
+| `path`               | Environment directory, relative to the config root or an absolute/template path |
+| `create`             | Create the environment when missing                                             |
+| `python`             | Python version to use when creating it                                          |
+| `python_create_args` | Arguments for `python -m venv`, such as `["--without-pip"]`                     |
+| `uv_create_args`     | Arguments for `uv venv`, such as `["--seed"]` or `["--system-site-packages"]`   |
+
+For example, when uv is installed and you need pip inside the virtualenv:
+
+```toml
+[env._.python.venv]
+path = ".venv"
+create = true
+uv_create_args = ["--seed"]
 ```
 
 Unless `create=true` is set, you need to create the venv manually with `python -m venv /path/to/venv`.
@@ -132,7 +149,7 @@ For uv-managed projects (those with a `uv.lock` file), you can use the `python.u
 [settings]
 python.uv_venv_auto = "source"        # activate existing .venv
 # or
-python.uv_venv_auto = "create|source" # create .venv if missing, then activate
+# python.uv_venv_auto = "create|source" # create .venv if missing, then activate
 ```
 
 mise respects uv's `UV_PROJECT_ENVIRONMENT` variable when choosing the environment path. A relative
@@ -284,35 +301,15 @@ try installing Python with the following command:
 ```sh
 CFLAGS="-I$(brew --prefix openssl)/include" \
 LDFLAGS="-L$(brew --prefix openssl)/lib" \
-mise install python@latest;
+MISE_PYTHON_COMPILE=1 mise install python@latest
 ```
 
 Homebrew installs its own OpenSSL version, which may collide with the one the system expects.
-You could add these variables to your
-`.profile`,
-`.bashrc`,
-or `.zshrc`
-to avoid setting them every time.
-
-If you encounter issues with python-build,
-you may also benefit from unlinking pkg-config before installing
-([reason](https://github.com/pyenv/pyenv/issues/2823#issuecomment-1769081965)):
-
-```sh
-brew unlink pkg-config
-mise install python@latest
-brew link pkg-config
-```
-
-The entire script would then look like this:
-
-```sh
-brew unlink pkg-config
-CFLAGS="-I$(brew --prefix openssl)/include" \
-  LDFLAGS="-L$(brew --prefix openssl)/lib" \
-  mise install python@latest
-brew link pkg-config
-```
+Keep compiler flags scoped to the installation command so they do not affect
+unrelated builds. If the failure comes from python-build, inspect its build log
+and consult the [upstream build-environment guidance](https://github.com/pyenv/pyenv/wiki#suggested-build-environment)
+for your macOS and Python versions. Precompiled installs do not use these compiler
+flags; set `MISE_PYTHON_COMPILE=1` when intentionally testing a source build.
 
 ## Settings
 

--- a/docs/lang/ruby.md
+++ b/docs/lang/ruby.md
@@ -2,27 +2,29 @@
 
 Like `rvm`, `rbenv`, or `asdf`, `mise` can manage multiple versions of [Ruby](https://www.ruby-lang.org/) on the same system.
 
-> The following are instructions for using the ruby mise core plugin. It is used when no
-> git plugin named "ruby" is installed. If you want to use [asdf-ruby](https://github.com/asdf-vm/asdf-ruby) instead,
-> run `mise plugins install ruby GIT_URL`.
-
-The code for this is inside the mise repository at
-[`./src/plugins/core/ruby.rs`](https://github.com/jdx/mise/blob/main/src/plugins/core/ruby.rs).
-
 ## Usage
 
-The following installs the latest version of ruby-3.2.x (if some version of 3.2.x is not already
-installed) and makes it the global default:
+Select Ruby for the current project and check its executable:
 
 ```sh
-mise use -g ruby@3.2
+mise use ruby@3.4
+mise exec -- ruby --version
 ```
+
+Use `mise use -g ruby@3.4` for a personal default. For an existing Bundler project,
+run `mise exec -- bundle install`, then prefix application commands with
+`mise exec -- bundle exec`. See the [Ruby cookbook](/mise-cookbook/ruby.html).
 
 By default, mise installs a precompiled Ruby binary when one is available and falls back to
 compiling from source with [`ruby-build`](https://github.com/rbenv/ruby-build). Source builds require
 the necessary [dependencies](https://github.com/rbenv/ruby-build/wiki#suggested-build-environment).
 See the ruby-build [README](https://github.com/rbenv/ruby-build/blob/master/README.md) for additional
 settings and troubleshooting.
+
+These instructions use mise's built-in ruby support. An installed external
+plugin with the same name can change the behavior; use `mise plugins ls` to
+check for overrides. See the [core implementation](https://github.com/jdx/mise/blob/main/src/plugins/core/ruby.rs)
+for backend details.
 
 ## Precompiled Binaries
 
@@ -191,10 +193,11 @@ However, it can also read the ruby-specific version files `.ruby-version` and `G
 Create a `.ruby-version` file for the current version of ruby:
 
 ```sh
-ruby -v > .ruby-version
+mise exec -- ruby -e 'puts RUBY_VERSION' > .ruby-version
 ```
 
-Enable idiomatic version file reading for ruby:
+Write only the version number, not the full `ruby -v` banner. Then enable
+idiomatic version file reading:
 
 ```sh
 mise settings add idiomatic_version_file_enable_tools ruby

--- a/docs/lang/rust.md
+++ b/docs/lang/rust.md
@@ -27,25 +27,30 @@ version, and asks rustup to install any configured components or targets when yo
 
 ## Usage
 
-Use the latest stable version of Rust:
+Install the latest stable toolchain for the current project and verify it:
 
 ```sh
-mise use -g rust
-cargo build
+mise use rust
+mise exec -- rustc --version
+mise exec -- cargo --version
 ```
+
+In a Cargo project, use `mise exec -- cargo build` or a mise task. Add `-g` to
+`mise use` for a personal default. These examples select the toolchain through
+mise; they do not require shell activation.
 
 Use the latest beta version of Rust:
 
 ```sh
-mise use -g rust@beta
-cargo build
+mise use rust@beta
+mise exec -- cargo build
 ```
 
 Use the rolling nightly channel:
 
 ```sh
-mise use -g rust@nightly
-cargo build
+mise use rust@nightly
+mise exec -- cargo build
 ```
 
 The configuration remains `nightly`, while mise resolves the current Rust channel manifest to a concrete
@@ -55,7 +60,7 @@ locked installs reproducible. Run `mise upgrade rust` or `mise lock --bump` to a
 To keep a specific nightly instead, configure its date explicitly:
 
 ```sh
-mise use -g rust@nightly-2026-08-13
+mise use rust@nightly-2026-08-13
 ```
 
 An explicitly dated nightly is an exact pin. Commands using `--bump`, such as `mise upgrade --bump rust`, can replace
@@ -64,9 +69,24 @@ that pin with the current nightly.
 Use a specific version of Rust:
 
 ```sh
-mise use -g rust@1.82
-cargo build
+mise use rust@1.82
+mise exec -- cargo build
 ```
+
+## Existing rustup projects
+
+If the project already uses `rust-toolchain.toml`, enable idiomatic-file discovery
+instead of duplicating a conflicting Rust version in `mise.toml`:
+
+```sh
+mise settings add idiomatic_version_file_enable_tools rust
+mise install
+mise exec -- rustup show active-toolchain
+```
+
+mise sets `RUSTUP_TOOLCHAIN` for its selected toolchain. Use `mise exec` when
+comparing selection with a standalone rustup invocation, since the environment
+can change which override rustup sees.
 
 ## Share Cargo builds with Mr Boxington
 
@@ -147,10 +167,7 @@ be given as an array or as a comma-separated string.
 
 ```toml
 [tools]
-"rust" = {
-  version = "1.83.0",
-  targets = ["wasm32-unknown-unknown", "thumbv7em-none-eabi"],
-}
+rust = { version = "1.83.0", targets = ["wasm32-unknown-unknown", "thumbv7em-none-eabi"] }
 ```
 
 If the Rust toolchain is already installed, `mise install` will still add any missing configured targets.

--- a/docs/lang/swift.md
+++ b/docs/lang/swift.md
@@ -4,12 +4,20 @@
 
 ## Usage
 
-Use the latest stable version of swift:
+Install Swift for the current project and check the selected toolchain:
 
 ```sh
-mise use -g swift
-swift --version
+mise use swift@latest
+mise exec -- swift --version
 ```
+
+Use `mise use -g swift@latest` for a personal default. In an existing Swift package
+with `Package.swift`, run `mise exec -- swift build` to build it.
+
+On Linux, Swift archives target specific distributions and require compatible
+system libraries. mise records the selected distribution in lockfile options;
+use a lock entry built for your target distribution. The Swift core plugin does
+not currently support Windows.
 
 See [a mise guide for Swift developers](https://tuist.dev/blog/2025/02/04/mise) for how to use `mise` with `swift`.
 

--- a/docs/lang/zig.md
+++ b/docs/lang/zig.md
@@ -2,22 +2,26 @@
 
 `mise` can be used to install and manage multiple versions of [zig](https://ziglang.org/) on the same system.
 
-> The following are instructions for using the zig mise core plugin.
-
-The code for this is inside the mise repository at
-[`./src/plugins/core/zig.rs`](https://github.com/jdx/mise/blob/main/src/plugins/core/zig.rs).
-
 ## Usage
 
-The following installs zig and makes it the global default:
+Install the latest stable Zig for the current project:
 
 ```sh
-mise use -g zig@0.14           # install zig 0.14.x
-mise use -g zig@latest         # install latest zig release
-mise use -g zig@master         # install latest nightly from master
-mise use -g zig@2024.11.0-mach # install Mach nominated zig
-mise use -g zig@mach-latest    # install latest Mach nominated zig
+mise use zig@latest
+mise exec -- zig version
 ```
+
+Choose one request for the release stream your project needs:
+
+| Request           | Selects                           |
+| ----------------- | --------------------------------- |
+| `zig@0.14`        | A release in the 0.14 series      |
+| `zig@latest`      | The latest stable release         |
+| `zig@master`      | The moving nightly channel        |
+| `zig@mach-latest` | The latest Mach-nominated version |
+
+Use `mise use -g <request>` for a personal default. A later `mise use zig@...`
+replaces the project's previous Zig request.
 
 See available stable versions with `mise ls-remote zig`.
 
@@ -26,10 +30,10 @@ don't appear in `mise ls-remote zig` because of a workaround for a
 [version ordering bug](https://github.com/jdx/mise/discussions/5232).
 You can still install the Mach versions listed in the
 [Mach version index](https://machengine.org/zig/index.json). The following
-command lists available Mach versions:
+command lists available Mach versions and requires `curl` and `jq`:
 
 ```sh
-curl https://machengine.org/zig/index.json | yq 'keys'
+curl --fail --show-error --silent --location https://machengine.org/zig/index.json | jq 'keys'
 ```
 
 ### `master` (nightly channel)
@@ -41,18 +45,25 @@ newer nightlies — instead of the channel staying pinned to the build it was fi
 installed from. Run `mise upgrade zig` (or `mise install -f zig@master`) to move to
 the current nightly.
 
+These instructions use mise's built-in zig support. An installed external
+plugin with the same name can change the behavior; use `mise plugins ls` to
+check for overrides. See the [core implementation](https://github.com/jdx/mise/blob/main/src/plugins/core/zig.rs)
+for backend details.
+
 ## zig Language Server
 
 The `zig` language server ([zls](https://github.com/zigtools/zls)) needs to be installed separately.
 You can install it with `mise`:
 
 ```sh
-mise use -g zls@0.14   # install zls 0.14.x
-mise use -g zls@latest # install latest zls release
+mise use zig@0.14 zls@0.14
+mise exec -- zls --version
 ```
 
-A tagged release of `zig` should be used with
-the same tagged release of `zls`. There is currently no Mach version of `zls`.
+Choose a ZLS version compatible with your Zig version; see the
+[ZLS installation guide](https://zigtools.org/zls/install/). Installing both at
+`latest` independently is not a compatibility check. There is currently no
+Mach-specific ZLS release.
 
 ## Tool Options
 


### PR DESCRIPTION
Language setup examples often changed global defaults, relied on an activated shell, or implied that selecting a runtime also controlled its package manager's behavior. Review and improve all 13 language guides with project setup, executable checks, and explicit idiomatic-file configuration.

Correct .NET shared SDK selection with `global.json`, provide valid Python virtualenv configurations, and replace Java cache-editing workarounds with supported local installations and Gradle toolchain configuration. Also clarify Go's own toolchain selection, Erlang compilation fallback, Rust channel selection, and Zig/ZLS compatibility.

Validation:
- `mise exec rust@1.95 -- mise run lint-fix` passed, including Cargo check. The checkout's default Rust 1.93 cannot meet its current dependency MSRV.
- Scoped hk Markdown/format checks and `mise run docs:build` passed (333 pages).
- All TOML/JSON examples parse. Isolated runtime checks passed for installed Node, Go, Ruby, Bun, Deno, and Python virtualenv creation; Ruby version-file output was checked.
- Java, .NET, Swift, and Zig behavior was reviewed against implementation and relevant upstream documentation. Their runtimes and the privileged macOS registration commands were not executed.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to language guides; no runtime or CLI behavior changes.
> 
> **Overview**
> **Reframes all 13 language guides** (`bun`, `deno`, `dotnet`, `elixir`, `erlang`, `go`, `java`, `node`, `python`, `ruby`, `rust`, `swift`, `zig`) so quick starts use **project** `mise use` plus **`mise exec`** checks instead of global `-g` defaults and assuming an activated shell.
> 
> **Cross-cutting doc changes:** upgrade via **`mise upgrade`** (not tool-native upgraders), commit **`mise.toml`** for teams, and a shared note that **external plugins** can override built-in backends. Intro blocks that duplicated core-plugin/asdf install text are trimmed; implementation links move to the end.
> 
> **Larger accuracy fixes:** **.NET** explains shared `DOTNET_ROOT` SDK resolution vs **`global.json`** / isolated mode; **Java** drops cache/symlink hacks in favor of **`path`**, **`mise link`**, and Gradle **`JAVA_HOME`** toolchain config; **Python** tightens **`_.python.venv`** examples and idiomatic-file enablement; **Go** and **Rust** add toolchain / **`rust-toolchain.toml`** caveats; **Erlang** documents precompiled vs **`erlang.compile`**; **Zig** documents release requests and **ZLS** pairing. **Node.js** title, npm pinning, and **aube** examples are aligned with the same patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f38a470f1044b6d346e5fb5afed1e847cd1dbca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated language guides for Bun, Deno, .NET, Elixir, Erlang, Go, Java, Node.js, Python, Ruby, Rust, Swift, and Zig.
  - Clarified project-local installations, version selection, verification with `mise exec`, upgrades, global defaults, and plugin overrides.
  - Added guidance for language-specific workflows, including SDK selection, virtual environments, package managers, toolchains, build commands, and platform requirements.
  - Documented idiomatic version-file support and related configuration where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->