### PR TITLE
docs: clarify tool selection, shims, and dependency workflows

### DIFF
--- a/docs/dev-tools/aliases.md
+++ b/docs/dev-tools/aliases.md
@@ -1,79 +1,86 @@
 # Tool Aliases
 
-::: tip
-`[alias]` has been renamed to `[tool_alias]` to distinguish it from `[shell_alias]`.
-The old `[alias]` key still works but is deprecated.
+Use `[tool_alias]` to give a tool a different backend or name a version request.
+Put shared aliases in the project's `mise.toml`; use
+`~/.config/mise/config.toml` for personal defaults. Teammates need the alias
+definition as well as the tool declaration.
 
-For shell command aliases (like `alias ll='ls -la'`), see [Shell Aliases](/shell-aliases).
+::: warning Renamed configuration key
+`[alias]` was renamed to `[tool_alias]`. The old key still works but is deprecated.
+For command shortcuts such as `alias ll='ls -la'`, use
+[Shell Aliases](/shell-aliases.html).
 :::
 
 ## Aliased Backends
 
-Tools can be aliased so that a tool like `node`, which normally maps to `core:node`, points
-to a different backend instead.
+A backend alias changes where mise obtains a tool. For example, explicitly choose
+mise's built-in Node.js backend:
 
-```toml [~/.config/mise/config.toml]
+```toml [mise.toml]
 [tool_alias]
-node = 'github:company/our-custom-node'   # shorthand for https://github.com/company/our-custom-node
-erlang = 'aqua:company/our-custom-erlang' # use an aqua registry entry
+node = "core:node"
+
+[tools]
+node = "24"
 ```
 
-This can also be used to install multiple tools from the same GitHub repository:
+Inspect the result with `mise tool node`, then run `mise install` to install the
+selected version. See [backend selection](/dev-tools/backend_architecture.html#how-backend-selection-works)
+if an installed plugin or environment override selects a different source than expected.
 
-```toml [~/.config/mise/config.toml]
+Aliases can also select separate release assets from the same GitHub repository:
+
+```toml [mise.toml]
 [tool_alias]
-dhall-json = 'github:dhall-lang/dhall-haskell'
-dhall-lsp = 'github:dhall-lang/dhall-haskell'
+dhall-json = "github:dhall-lang/dhall-haskell"
+dhall-lsp = "github:dhall-lang/dhall-haskell"
 
 [tools]
 dhall-json = { version = "v1.42.2", matching = "dhall-json" }
 dhall-lsp = { version = "latest", matching = "dhall-lsp-server" }
 ```
 
-The example above uses the [GitHub backend's `matching`](backends/github#matching) feature to download
-two distinct binaries from different releases in the same GitHub repository.
+Each alias has its own version request and
+[GitHub asset filter](/dev-tools/backends/github.html#matching). This matters for
+repositories that release several tools independently.
 
 ## Aliased Versions
 
-mise supports aliasing tool versions. One use case for this is to define a stable name
-that points to a specific version, so you can reference it symbolically in
-`mise.toml` or `.tool-versions`. For example, you may want `lts-iron` to map to Node.js 20 so you can
-set it with `node = "lts-iron"`.
+A version alias gives a stable name to a version request. Keep a team's Node.js
+release series in one place:
 
-Create user aliases by adding a `tool_alias.<TOOL>.versions` section to
-`~/.config/mise/config.toml`:
-
-```toml
+```toml [mise.toml]
 [tool_alias.node.versions]
-lts-iron = '20'
-```
+project-lts = "24"
 
-Then reference the alias when pinning the tool:
-
-```toml
 [tools]
-node = "lts-iron"
+node = "project-lts"
 ```
 
-Plugins can also provide aliases via a `bin/list-aliases` script. Here is an example showing Node.js
-versions:
+`project-lts` resolves as a request for Node.js 24. It is not an exact patch pin;
+use [mise.lock](/dev-tools/mise-lock.html) to record the resolved version. Changing
+the alias changes the request for every declaration that uses it.
+
+The built-in Node.js backend already supplies aliases such as `lts` and named
+LTS releases. You don't need to redefine those. Legacy asdf plugin authors can
+provide their own aliases through `bin/list-aliases`, with one alias and version
+per line:
 
 ```bash
 #!/usr/bin/env bash
-
-echo "lts-krypton 24"
-echo "lts-jod 22"
-echo "lts-iron 20"
+printf '%s\n' 'recommended 2.0' 'legacy 1.0'
 ```
-
-(mise's built-in node plugin already ships these LTS aliases; the example above shows the format
-that other plugins can use.)
 
 ## Templates
 
-Alias values can be templates; see [Templates](/templates) for details.
+Alias values support [templates](/templates.html). For example, allow an explicit
+environment override with a default release series:
 
 ```toml
 [tool_alias.node.versions]
-current = "{{exec(command='node --version')}}"
+project-lts = "{{ env.PROJECT_NODE_VERSION | default(value='24') }}"
 ```
+
+Set `PROJECT_NODE_VERSION` before invoking mise. Avoid computing a tool's version
+by invoking that same tool from its alias template: version resolution may happen
+before the tool is available, or re-enter mise through a shim.

--- a/docs/dev-tools/backend_architecture.md
+++ b/docs/dev-tools/backend_architecture.md
@@ -1,248 +1,203 @@
 # Backend Architecture
 
-Understanding how mise's backend system works can help you choose the right backend for your tools and troubleshoot issues when they arise. Most users don't need to choose backends explicitly because the [mise registry](../registry.md) defines sensible defaults, but understanding the system helps when you need specific tools or want to optimize performance.
+A backend resolves a tool's versions, installs it, and supplies its executable
+paths and environment. The [registry](/registry.html) maps short names such as
+`node` and `ripgrep` to backends. Start with those names; choose an explicit
+backend when you need a particular distribution or a tool outside the registry.
 
 ## What are Backends?
 
-Backends are mise's way of supporting different tool installation methods. Each backend knows how to:
+In `github:BurntSushi/ripgrep`, `github` is the backend and
+`BurntSushi/ripgrep` identifies the upstream project. These are separate from
+the version request after `@`:
 
-- List available versions of tools
-- Download and install specific versions
-- Set up the environment for installed tools
-- Manage tool lifecycles (updates, uninstalls)
+```sh
+mise ls-remote github:BurntSushi/ripgrep
+mise use github:BurntSushi/ripgrep@latest
+mise exec -- rg --version
+```
 
-Think of backends as "adapters" that let mise work with different package managers and installation systems.
+Installing a tool through a backend does not add a new entry to mise's registry.
+Explicit backend syntax works directly in your own configuration.
 
 ## The Backend Trait System
 
-All backends implement a common interface (called a "trait" in Rust), which means they all provide the same basic functionality:
+Built-in backends implement the Rust
+[`Backend` trait](https://github.com/jdx/mise/blob/main/src/backend/mod.rs).
+The installation flow uses that interface to:
 
-```rust
-pub trait Backend {
-    async fn list_remote_versions(&self) -> Result<Vec<String>>;
-    async fn install_version(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<()>;
-    async fn uninstall_version(&self, tv: &ToolVersion) -> Result<()>;
-    // ... other methods
-}
-```
+1. List versions or resolve a request such as a prefix or channel.
+2. Identify installation dependencies and tool options.
+3. Download or build the requested version and perform the verification supported
+   by that distribution.
+4. Record the installation and expose executable paths and environment variables.
 
-This design allows mise to treat all backends uniformly while each backend handles the specifics of its installation method.
+Version strings are not necessarily semantic versions. Backends can support date
+releases, vendor prefixes, tags, and rolling channels; the backend determines what
+`latest` means. A lockfile records a concrete resolution. See
+[version ordering](/dev-tools/#version-ordering) and [mise.lock](/dev-tools/mise-lock.html).
+
+For extension APIs, see [tool plugins](/tool-plugin-development.html) and
+[backend plugins](/backend-plugin-development.html). Their hook interfaces are
+separate from the internal Rust trait.
 
 ## Backend Types
 
-### Core Tools
+| Distribution method          | Examples                                            | What to check                                                                  |
+| ---------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Built-in language support    | Node.js, Python, Java, Rust                         | Language-specific options, system libraries, and any build tools required      |
+| Signed release manifests     | `packslip:`                                         | Published manifest, trusted signer, and supported platform                     |
+| Registry-described downloads | `aqua:`                                             | Package entry and its per-version download/verification rules                  |
+| Forge releases               | `github:`, `gitlab:`, `forgejo:`                    | Matching release assets for the target platform                                |
+| Direct artifacts             | `http:`, `s3:`                                      | Artifact location, authentication, platform mapping, and integrity information |
+| Language packages            | `npm:`, `pipx:`, `cargo:`, `gem:`, `go:`, `dotnet:` | Required runtime or toolchain and package-manager behavior                     |
+| Other package sources        | `conda:`, `pkgx:`, `spm:`                           | Backend-specific platform support and dependencies                             |
+| External plugins             | asdf, vfox tool plugins, backend plugins            | Plugin code, prerequisites, and supported platforms                            |
 
-Built directly into mise, written in Rust for performance and reliability:
-
-- **Node.js, Python, Ruby, Go, Java, etc.** - Native implementations
-- **Benefits**: Fastest performance, no external dependencies, best integration
-- **Drawbacks**: Require much more maintenance; new core tool contributions are likely to be rejected unless they're for very popular tools like Node.js, Python, or Go
-
-::: info
-Core tools like Node.js and Java are implemented as backends even though they represent single tools. This consistency lets mise handle all tools uniformly, whether they're complex ecosystems or individual tools.
-:::
-
-### Language Package Managers
-
-These backends use existing language ecosystems:
-
-- **npm** - npm packages (`npm:prettier`, `npm:typescript`)
-- **pipx** - Python packages (`pipx:black`, `pipx:poetry`)
-- **cargo** - Rust crates (`cargo:ripgrep`, `cargo:fd-find`)
-- **gem** - Ruby gems (`gem:bundler`, `gem:rails`)
-- **go** - Go modules (`go:github.com/golangci/golangci-lint/cmd/golangci-lint`)
-
-### Universal Installers
-
-#### aqua - Comprehensive Package Manager
-
-Registry-based package manager with strong security features:
-
-- **Usage**: `aqua:golangci/golangci-lint`
-- **Requirements**: Tools must be available in the [aqua registry](https://github.com/aquaproj/aqua-registry)
-- **Sources**: Primarily GitHub but supports other sources through registry configuration
-- **Security**: Comprehensive checksums, signatures, and verification
-
-#### ubi - Universal Binary Installer (Deprecated)
-
-::: warning
-The ubi backend is deprecated. Use the [github backend](/dev-tools/backends/github) instead.
-:::
-
-Zero-configuration installer that works with any GitHub/GitLab repository following standard conventions:
-
-- **Usage**: `ubi:BurntSushi/ripgrep` → migrate to `github:BurntSushi/ripgrep`
-- **Requirements**: Repository must follow standard release tarball conventions
-- **Sources**: Primarily GitHub releases, with GitLab support (rarely used in mise)
-- **Configuration**: None required - automatically detects and downloads appropriate binaries
-
-### Plugin Systems
-
-Support for external plugin ecosystems:
-
-- **Tool Plugins** - Hook-based plugins for single tools (`my-tool`) - a superset of vfox plugin functionality
-- **asdf Plugins** - Legacy plugin ecosystem (`asdf:postgres`, `asdf:redis`) - generally Linux/macOS only
-- **Backend Plugins** - Enhanced plugins using the `plugin:tool` format (`my-plugin:some-tool`) - enable private/custom tools with backend methods
+The [backend reference](/dev-tools/backends/) lists available backends and their
+options. Built-in language guides are under **Languages** in the sidebar.
 
 ## How Backend Selection Works
 
-When you specify a tool, mise determines the backend using this priority:
+An explicit identifier such as `core:node` expresses a backend choice. A short
+name such as `node` also depends on configuration and local state:
 
-1. **Explicit backend**: `mise use aqua:golangci/golangci-lint`
-2. **Environment variable override**: `MISE_BACKENDS_<TOOL>` (see below)
-3. **Registry lookup**: `mise use golangci-lint` → checks registry for default backend
-4. **Core tools**: `mise use node` → uses built-in core backend
-5. **Fallback**: If not found, suggests available backends
+- `[tool_alias]` and `[plugins]` can select another source.
+- A matching lockfile entry can preserve the backend used for that resolution.
+- An installed external plugin can override a registry shorthand, including a
+  built-in language tool. Disabled backends and existing installations also affect
+  this choice.
+- Otherwise, the registry supplies the preferred available backend, which can
+  depend on the requested version and platform.
 
-The [mise registry](../registry.md) defines a priority order of backends for each tool, so end users typically don't need to choose a backend unless they want a tool that isn't in the registry or want to override the default selection.
+Use `mise tool <name>` to inspect the effective backend instead of inferring it
+from the tool's short name. The
+[resolution implementation](https://github.com/jdx/mise/blob/main/src/cli/args/backend_arg.rs)
+contains the detailed precedence rules.
 
 ### Environment Variable Overrides
 
-You can override the backend for any tool using the `MISE_BACKENDS_<TOOL>` environment variable pattern. The tool name is converted to SHOUTY_SNAKE_CASE (uppercase with underscores replacing hyphens).
+`MISE_BACKENDS_<TOOL>` overrides the backend for that identifier. Convert the
+name to uppercase and replace hyphens with underscores. For example, in a POSIX
+shell:
 
-```bash
-# Use vfox backend for php
-export MISE_BACKENDS_PHP='vfox:mise-plugins/vfox-php'
-mise install php@latest
+```sh
+MISE_BACKENDS_NODE=core:node mise tool node
 ```
+
+An exported override affects subsequent commands and can override configuration
+choices. Check your environment when two machines resolve the same shorthand
+differently.
 
 ### Registry System
 
-The [registry](../registry.md) (`mise registry`) maps short names to full backend specifications with a preferred priority order:
+Inspect a registry mapping with `mise registry node`. To commit a backend choice
+without changing the registry, use an [alias](/dev-tools/aliases.html):
 
-```toml
-# ~/.config/mise/config.toml
+```toml [mise.toml]
 [tool_alias]
-go = "core:go"                    # Use core backend
-terraform = "aqua:hashicorp/terraform"  # Use aqua backend
+node = "core:node"
+
+[tools]
+node = "24"
 ```
 
 ## Backend Capabilities Comparison
 
-| Feature                   | Core | npm/pipx/cargo | aqua | ubi | Backend Plugins | Tool Plugins (vfox) | asdf Plugins (legacy) |
-| ------------------------- | ---- | -------------- | ---- | --- | --------------- | ------------------- | --------------------- |
-| **Speed**                 | ✅   | ⚠️             | ✅   | ✅  | ⚠️              | ⚠️                  | ⚠️                    |
-| **Security**              | ✅   | ⚠️             | ✅   | ⚠️  | ⚠️              | ⚠️                  | ⚠️                    |
-| **Windows Support**       | ✅   | ✅             | ✅   | ✅  | ✅              | ✅                  | ❌                    |
-| **Env Var Support**       | ✅   | ❌             | ❌   | ❌  | ✅              | ✅                  | ✅                    |
-| **Custom Scripts**        | ✅   | ❌             | ❌   | ❌  | ✅              | ✅                  | ✅                    |
-| **Built-in Modules**      | ✅   | ❌             | ❌   | ❌  | ✅              | ✅                  | ❌                    |
-| **Security Attestations** | ❌   | ❌             | ✅   | ❌  | ✅              | ✅                  | ❌                    |
-| **Multi-tool Plugins**    | ❌   | ❌             | ❌   | ❌  | ✅              | ❌                  | ❌                    |
-| **Progress/Logging**      | ✅   | ✅             | ✅   | ✅  | ✅              | ✅                  | ❌                    |
+Verification and platform support depend on both the backend and the particular
+tool. A backend supporting Windows does not imply every package it installs has
+a Windows release. Likewise, downloading a checksum does not establish the
+publisher's identity unless that checksum is authenticated.
+
+Consult each backend's verification options and the
+[security guide](/security.html). For example, packslip verifies signed manifests,
+and aqua can apply the verification methods declared by its registry entry.
+External plugin code runs locally and must be trusted along with the tool itself.
 
 ## When to Use Each Backend
 
-### Use **Core Tools** when
+Start with a registry shorthand for supported tools. For another source:
 
-- Available for your tool (check the [registry](../registry.md))
-- You want the fastest performance
-- You're using major programming languages
+- Use `packslip:` when the publisher provides signed release manifests.
+- Use `aqua:` when its registry describes the required tool and releases.
+- Use a forge backend for release assets, or `http:` or `s3:` for artifacts
+  you distribute directly.
+- Use a language package backend when you need that ecosystem's package and can
+  supply its runtime or build dependencies.
+- Use a plugin when installation or environment setup needs custom logic.
 
-Use core tools whenever they're available; they provide the best performance and integration with mise.
-
-### Use **Language Package Managers** when
-
-- Installing tools specific to that language ecosystem
-- The tool is primarily distributed through that package manager
-- You want automatic dependency management
-
-### Use **aqua** when
-
-- Installing pre-compiled binaries or static packages (no compilation needed)
-- You want comprehensive security features (checksums, signatures)
-- You need Windows support
-- The tool is already available in the [aqua registry](https://github.com/aquaproj/aqua-registry)
-- You're willing to contribute tools that aren't yet in the aqua registry
-
-### Use **github** when
-
-- Installing pre-compiled binaries from GitHub releases
-- The repository follows standard conventions for release tarballs
-- You want zero configuration - no registry setup required
-- You need simple, fast binary installation
-- The tool doesn't require complex build processes or environment setup
-
-::: info
-The `ubi` backend still works but is deprecated in favor of `github`. Replace `ubi:owner/repo` with `github:owner/repo`.
+::: warning Deprecated backend
+`ubi:` is deprecated. Use the corresponding `github:` or `gitlab:` backend and
+review its options when migrating; see the [ubi migration guide](/dev-tools/backends/ubi.html).
 :::
-
-### Use **Backend Plugins** when
-
-- You need to manage multiple tools with one plugin
-- You want enhanced backend methods for better performance
-- You need the `plugin:tool` format for flexibility
-- You're working with custom or private tools
-- You want a modern plugin architecture with backend methods
-
-### Use **Tool Plugins** when
-
-- You're creating traditional single-tool plugins
-- You need fine-grained control over installation hooks
-- You want to use the vfox hook system
-- The tool requires complex installation logic or build processes
-- The tool requires environment variable setup (like `JAVA_HOME`, `GOROOT`, etc.)
-- You need cross-platform support, including Windows
-
-### Use **asdf Plugins** when
-
-- The tool requires compilation from source
-- You need complex installation logic or build processes
-- The tool requires environment variable setup (like `JAVA_HOME`, `GOROOT`, etc.)
-- No other backend supports the tool
-- You're migrating from an existing asdf setup
-- You're working on Linux/macOS (no Windows support)
 
 ## Backend Dependencies
 
-Some backends depend on other tools:
+Backends may need another tool during installation. Declare the required tools
+alongside the package so mise can install them in order:
 
-```mermaid
-graph TD
-    A[npm backend] --> B[Node.js]
-    C[pipx backend] --> D[pipx]
-    E[cargo backend] --> F[Rust]
-    G[gem backend] --> H[Ruby]
+```toml [mise.toml]
+[tools]
+node = "24"
+"npm:prettier" = "3"
 ```
 
-mise automatically handles these dependencies, installing Node.js before npm tools, pipx before pipx tools, etc.
+A dependency relationship does not automatically add missing tools to your
+configuration. A matching configured tool is installed first; an unconfigured
+dependency may be satisfied by a suitable executable on the existing `PATH`.
+Otherwise installation fails. See [tool dependencies](/dev-tools/#tool-dependencies)
+for explicit `depends` declarations.
 
 ## Configuration and Overrides
 
 ### Disable Backends
 
-```toml
-# ~/.config/mise/config.toml
+Use the global settings file to prevent installation through selected backends:
+
+```toml [~/.config/mise/config.toml]
 [settings]
-disable_backends = ["asdf", "vfox"] # Don't use these backends
+disable_backends = ["asdf", "vfox"]
 ```
+
+This is an installation restriction, not an uninstall operation. Existing tools
+can still report the backend that installed them.
 
 ### Force Backend for Tool
 
-```toml
-# mise.toml
+An explicit identifier can be used directly as a tool key:
+
+```toml [mise.toml]
 [tools]
-"core:node" = "20"     # Explicitly use core backend
-"aqua:yarn" = "latest" # Use aqua backend instead of default (vfox)
+"core:node" = "24"
+"aqua:BurntSushi/ripgrep" = "latest"
 ```
 
 ### Backend-Specific Settings
 
-Some backends support additional configuration:
+Read the selected backend's reference before adding options. For example, this
+selects an optional extra from a Python package:
 
-```toml
-# mise.toml
+```toml [mise.toml]
 [tools]
-python = { version = "3.12", virtualenv = ".venv" }  # Core backend options
-black = { version = "latest", python = "3.12" }      # pipx backend options
+python = "3.14"
+uv = "latest"
+"pipx:black" = { version = "latest", extras = ["jupyter"] }
 ```
+
+The [pipx backend](/dev-tools/backends/pipx.html) can use uv or pipx. Backend options
+are not interchangeable with options for another distribution of the same tool.
 
 ## Troubleshooting Backend Issues
 
 ### Debug Backend Selection
 
-```bash
-mise doctor                   # Check backend configuration
-mise tool python              # See which backend is used for a tool
-mise config get tools         # Verify tool configurations
+```sh
+mise tool node       # effective backend and tool information
+mise plugins ls      # external plugins that may override defaults
+mise config ls       # configuration files contributing to this directory
+mise ls --current    # selected versions and their sources
+mise doctor          # installation and activation diagnostics
 ```
+
+If selection is correct but installation fails, check the backend's prerequisites,
+platform support, and authentication requirements. `MISE_DEBUG=1 mise install node` adds diagnostic output; review logs for credentials before sharing them.

--- a/docs/dev-tools/comparison-to-asdf.md
+++ b/docs/dev-tools/comparison-to-asdf.md
@@ -1,177 +1,133 @@
 # Comparison to asdf
 
-mise can be used as a drop-in replacement for asdf. It supports the same `.tool-versions` files that
-you may have used with asdf and can use asdf plugins through
-the [asdf backend](/dev-tools/backends/asdf.html).
-
-It will not, however, reuse existing asdf directories
-(so you'll need to either reinstall them or move them), and 100% compatibility is not a design goal.
-That said, if you're coming from asdf-bash (0.15 and below), mise actually
-has [fewer breaking changes than asdf-go (0.16 and above)](https://asdf-vm.com/guide/upgrading-to-v0-16.html).
-
-Casual users coming from asdf have generally found mise to be a faster, easier-to-use asdf.
-
-:::tip
-Have a look at [environments](/environments/) and [tasks](/tasks/), which
-are major parts of mise with no asdf equivalent.
-:::
+mise reads `.tool-versions` and supports [legacy asdf plugins](/dev-tools/backends/asdf.html).
+You can start with an existing project's version declarations, then adopt
+`mise.toml` for [environment variables](/environments/) and [tasks](/tasks/).
+CLI and plugin compatibility are best-effort; mise has its own commands,
+installation directories, and backend selection.
 
 ## Migrate from asdf to mise
 
-If you're moving from asdf to mise, please
-review [#how-do-i-migrate-from-asdf](/faq.html#how-do-i-migrate-from-asdf) for guidance.
+Start in one project before changing your shell defaults:
+
+1. [Install mise](/installing-mise.html).
+2. From the project directory, run `mise config ls` and `mise ls --current` to
+   inspect how mise reads the existing `.tool-versions`.
+3. Run `mise install`, then verify a project command through mise:
+
+   ```sh
+   mise exec -- node --version
+   ```
+
+   Replace `node --version` with a command from your project's tools. mise uses
+   its own installations; it does not automatically reuse asdf's install directory.
+
+4. Once the project works, remove asdf activation and shim `PATH` entries from
+   your shell startup files and [activate mise](/getting-started.html#activate-mise).
+   Start a new shell and check `mise doctor` and `command -v node`.
+
+Keep shared `.tool-versions` files if teammates still use asdf. To update one
+with mise, specify the file and pin a concrete version:
+
+```sh
+mise use --path .tool-versions --pin node@24
+```
+
+Avoid mise-specific prefixes or backend identifiers in a file that asdf must read.
+A `mise.toml` in the same directory takes precedence for tools it declares, so
+check for conflicting declarations before keeping both files.
+
+For personal defaults, use `mise use -g node@24` or edit
+`~/.config/mise/config.toml`. Inspect `mise config ls` from outside a project to
+see which home/global files are contributing to your environment. Copy the
+versions you need explicitly instead of moving or rewriting your asdf installation.
 
 ## asdf in go (0.16+)
 
-asdf has been rewritten in Go. Because this is quite new as of this writing (2025-01-01),
-I'm keeping information about asdf 0.16+ (which I call "asdf-go", as opposed to "asdf-bash") in
-this section; the rest of this doc applies to asdf-bash (0.15 and below).
-
-In terms of performance, mise is still faster than asdf-go, but the difference is much
-smaller. asdf-go is likely fast enough that you may not even notice the difference in
-overhead—after all, there are plenty of people still using asdf-bash who
-claim they don't even notice how slow it is (don't ask me how):
-
-![asdf vs mise exec performance comparison chart](./asdf-mise-exec-perf.jpg)
-
-Now that asdf-go exists, I don't think performance is a good enough reason to switch. It's
-a reason, but a minor one. mise's improved security, better DX, and lack of reliance on
-shims all matter more than performance.
-
-The fact that they went through the trouble of rewriting asdf also indicates they want to keep
-working on it (which is awesome, by the way). This does mean that some of what's
-written here may go out of date if they address some of asdf's problems.
-
-## Supply chain security
-
-asdf plugins are not secure. This is explained
-in [SECURITY.md](https://github.com/jdx/mise/blob/main/SECURITY.md), but the short version is
-that asdf plugins are shell code that can do essentially anything on your machine. It's
-dangerous code. Worse, asdf plugins are rarely written by the tool vendor (whom you need to
-trust anyway to use the tool), which means that for every asdf plugin you use, you're trusting a random
-developer not to go rogue and not to get hacked and have an exploit published to their plugin.
-
-mise still uses asdf plugins for some tools, but we're actively reducing that count as well as
-moving things into the [mise-plugins org](https://github.com/mise-plugins). It might look like asdf has a
-similar model with its asdf-community org, but it doesn't: asdf gives plugin authors commit access
-to their plugin in [asdf-community](https://github.com/asdf-community) when it moves in, which I
-feel defeats the purpose of having a dedicated org in the first place. By the end of 2025, I
-would like there to be no asdf plugins in the registry that aren't owned by me.
-
-I've also been adopting extra security verification steps when vendors offer them, such as
-GPG verification on node installs and native Cosign/SLSA/Minisign/GitHub attestation verification for aqua tools.
+asdf 0.16 replaced the older Bash implementation with Go and changed parts of
+its CLI. In particular, current asdf uses `asdf set` to write versions. See
+[asdf's version commands](https://asdf-vm.com/manage/versions.html).
+`mise set` has a different purpose: it writes environment variables. Use
+`mise use` for tool versions.
 
 ## UX
 
-![CleanShot 2024-01-28 at 12 36 20@2x](https://github.com/jdx/mise-docs/assets/216188/47f381d7-1566-4b78-9260-3b85a21dd6ec)
-
-Some commands are the same as in asdf, but others have changed. Everything that's possible
-in asdf should be possible in mise but may use slightly different syntax. mise has more forgiving
-commands, such as fuzzy matching, e.g. `mise install node@20`. While in asdf you _can_ run
-`asdf install node latest:20`, you can't use `latest:20` in a `.tool-versions` file or many other
-places. In `mise` you can use fuzzy matching everywhere.
-
-asdf requires several steps to install a new runtime if the plugin isn't installed, e.g.:
+`mise use` combines installation and configuration. For example:
 
 ```sh
-asdf plugin add node
-asdf install node latest:20
-asdf local node latest:20
+mise use node@24 python@3.14
+mise exec -- node --version
 ```
 
-In `mise`, this is a single step that installs the plugin, installs the runtime,
-and sets the version:
-
-```sh
-mise use node@20
-```
-
-If you have an existing `.tool-versions` file, or `.mise.toml`, you can install all plugins
-and runtimes with a single command:
-
-```sh
-mise install
-```
-
-I've found asdf to be particularly rigid and difficult to learn. It also made strange decisions like
-having `asdf list all` but `asdf latest --all` (why is one a flag and one a positional argument?).
-`mise` makes heavy use of aliases so you don't need to remember whether it's `mise plugin add node` or
-`mise plugin install node`. If I can guess what you meant, then I'll try to get mise to respond
-in the right way.
-
-That said, there are a lot of great things about asdf. It's the best multi-runtime manager out there
-and I've really been impressed with the plugin system. Most of the design decisions the authors made
-were very good. I really just have two complaints: the shims and the fact that it's written in Bash.
-
-## Performance
-
-asdf made (what I consider) a poor design decision to use shims that sit between a call to a runtime
-and the runtime itself. For example, when you call `node`, it calls an asdf shim file
-`~/.asdf/shims/node`, which calls `asdf exec`, which then calls the correct version of node.
-
-These shims have terrible performance, adding ~120ms to every runtime call. `mise activate` does not
-use shims; instead it updates `PATH`, so there is no overhead when simply calling binaries. These shims are
-the main reason I wrote mise. This is also why, in the demo GIF at the top of this README,
-`mise` isn't actually used when calling `node -v`: the performance is
-identical to running node without mise.
-
-I don't think it's possible for asdf to fix these issues. The author of asdf did a great writeup
-of [performance problems](https://stratus3d.com/blog/2022/08/11/asdf-performance/). asdf is written
-in Bash, which certainly makes performance challenging, but I think the real problem is the
-shim design, and I don't think that can be fixed without a complete rewrite.
-
-mise does call an internal command, `mise hook-env`, every time the directory changes, but because
-it's written in Rust, this is very quick—around 10ms on my machine: 4ms if there are no changes,
-14ms for a full reload.
-
-tl;dr: asdf adds overhead (~120ms) when calling a runtime; mise adds a small amount of overhead (~5ms)
-when the prompt loads.
-
-## Windows support
-
-asdf does not run on Windows at all. With mise, tools using non-asdf backends can support Windows.
-Of course, the tool vendor must provide Windows binaries, but if they do and the backend isn't asdf,
-the tool should work on Windows.
-
-## Security
-
-asdf plugins are insecure. They are typically written by individuals with no ties to the vendor
-of the underlying tool.
-Where possible, mise avoids asdf plugins in favor of backends like aqua and github, which do
-not require separate plugins.
-
-Aqua tools include native Cosign/SLSA/Minisign/GitHub attestation verification built into mise.
-See [SECURITY](https://github.com/jdx/mise/blob/main/SECURITY.md) for more information.
+This records version requests for both tools and installs them if necessary.
+After cloning a configured project, `mise install` installs its tools without
+changing the declarations. You usually do not need to install plugins separately:
+the registry selects a backend, and many tools use built-in backends.
 
 ## Command Compatibility
 
-In nearly all places, you can use the exact syntax that works in asdf, though this won't
-show up in the help or CLI reference. If you're coming from asdf and are comfortable with that way of
-working, you can almost always use the same syntax with mise, e.g.:
+Prefer mise's documented command syntax in scripts. Some legacy asdf spellings
+are accepted, but compatibility aliases are not a complete emulation of asdf.
 
-```sh
-mise install node 20.0.0
-mise local node 20.0.0
-```
+| Goal                         | asdf command                 | mise command                           |
+| ---------------------------- | ---------------------------- | -------------------------------------- |
+| Install a specific version   | `asdf install nodejs 24.0.0` | `mise install node@24.0.0`             |
+| Select a project version     | `asdf set nodejs 24.0.0`     | `mise use node@24.0.0` (also installs) |
+| Select a personal default    | `asdf set -u nodejs 24.0.0`  | `mise use -g node@24.0.0`              |
+| List available versions      | `asdf list all nodejs`       | `mise ls-remote node`                  |
+| Inspect selected versions    | `asdf current`               | `mise ls --current`                    |
+| Find the selected executable | `asdf which node`            | `mise which node`                      |
+| Rebuild shims                | `asdf reshim`                | `mise reshim`                          |
 
-UPDATE (2025-01-01): asdf-go (0.16+) actually got rid of `asdf global|local` entirely in favor of
-`asdf set`, which we can't support since we already have a command named `mise set`. mise command
-compatibility will likely not be as good with asdf-go 0.16+.
+mise recognizes the legacy tool names `nodejs` and `golang`, while its TOML
+configuration uses the canonical names `node` and `go`.
 
-This isn't recommended, though. You almost always want to modify config files and install things, so
-`mise use node@20` saves an extra command. The "@" syntax is also preferred since it allows
-you to install multiple tools at once: `mise use|install node@20 node@18`. And there are edge cases
-where it's not possible—or at least very challenging—for us to know definitively which syntax is
-being used, so we default to mise-style. While there aren't many of these, asdf compatibility is
-best-effort, meant to make the transition from asdf feel familiar for users who
-rely on their muscle memory. Ensuring asdf syntax works with everything is not a design goal.
+## Performance
+
+The main difference is when version selection runs. With normal `mise activate`,
+mise updates `PATH` and environment variables at the shell prompt or supported
+directory-change hooks. Subsequent tool calls use those executable paths directly.
+asdf resolves a tool through a shim when it is called.
+
+mise also provides shims for programs that need stable executable paths. Their
+cost depends on how often commands pass through mise; use `mise exec -- <script>`
+to prepare the environment once for a script and its child processes. Historical
+benchmarks of Bash-based asdf do not describe current asdf performance. See
+[shims](/dev-tools/shims.html) for the behavioral tradeoffs.
+
+## Windows support
+
+mise supports native Windows for compatible tools and backends. Availability
+still depends on the tool's release artifacts and installation logic. Legacy
+asdf shell plugins generally require a Unix environment; using mise does not
+make those plugins native Windows installers. See [Windows](/installing-mise.html#windows-scoop).
+
+## Supply chain security
+
+An asdf plugin executes shell code during tool management. When using one through
+either manager, you trust the plugin's maintainers in addition to the tool's
+publisher. mise can install many tools through built-in download backends without
+an external plugin.
+
+## Security
+
+Verification varies by distribution. For example, packslip verifies signed
+manifests, and aqua supports verification methods described by its registry
+entries. A tool or backend name alone is not a guarantee that a particular
+artifact has a signature. See the [security guide](/security.html) for trust,
+verification, and configuration controls.
 
 ## Extra backends
 
-mise supports backends other than asdf plugins. For example, you can install CLIs
-directly from cargo and npm:
+Use the registry shorthand when available, or select a package source explicitly:
 
-```sh
-mise use -g cargo:ripgrep@14
-mise use -g npm:prettier@3
+```toml [mise.toml]
+[tools]
+node = "24"
+ripgrep = "latest"
+"npm:prettier" = "3"
 ```
+
+Here the npm backend needs Node.js, so both are declared. Other backends can
+install release binaries, Python CLIs, Rust crates, or private tools. See the
+[backend reference](/dev-tools/backends/) for prerequisites and options.

--- a/docs/dev-tools/deps.md
+++ b/docs/dev-tools/deps.md
@@ -1,77 +1,101 @@
 # Deps <Badge type="warning" text="experimental" />
 
-The `mise deps` command manages project dependencies by hashing source files
-(e.g., `package-lock.json`) and running install commands when changes are detected.
-It can also add and remove individual packages.
+`mise deps` runs project dependency installers when tracked inputs change or
+outputs go missing. It compares source hashes with the last successful run, then
+invokes the configured package manager. Use `[tools]` to install the package
+manager itself; use `[deps]` to install the project's packages.
 
 ## Quick Start
 
-```bash
-# Enable experimental features
-export MISE_EXPERIMENTAL=1
+For an existing npm project with `package.json` and `package-lock.json`, add:
 
-# Install all project dependencies
-mise deps
+```toml [mise.toml]
+[settings]
+experimental = true
 
-# Add a package
-mise deps add npm:react
+[tools]
+node = "24"
 
-# Add a dev dependency
-mise deps add -D npm:vitest
-
-# Remove a package
-mise deps remove npm:lodash
+[deps.npm]
+auto = true
 ```
+
+Inspect the provider, install its dependencies, and explain the freshness result:
+
+```sh
+mise install
+mise deps install --list
+mise deps install npm
+mise deps install npm --explain
+```
+
+With `auto = true`, subsequent `mise exec` and `mise run` commands also check
+this provider. If the project has no lockfile yet, create one with its package
+manager first, for example `mise exec --no-deps -- npm install`.
 
 ## Configuration
 
-Configure deps providers in `mise.toml`:
+Enable only the providers your project uses. An empty table selects a built-in
+provider without making it automatic:
 
 ```toml
-# Built-in npm provider (auto-detects lockfile)
-[deps.npm]
-auto = true  # Auto-run before mise x/run
-
-# Built-in providers for other package managers
-[deps.yarn]
-[deps.pnpm]
-[deps.bun]
-[deps.deno]
-[deps.aube]
-[deps.go]
-[deps.pip]
-[deps.poetry]
 [deps.uv]
-[deps.bundler]
-[deps.composer]
+```
 
-# Disable specific providers
+To disable a provider, for example one inherited from another configuration:
+
+```toml
 [deps]
 disable = ["npm"]
 ```
 
+This prevents the provider from running; it does not remove installed packages.
+Use `mise deps install --list` to inspect the effective providers.
+
 ## Built-in Providers
 
-mise includes built-in providers for common package managers:
+Each provider supplies defaults for sources, outputs, and the install command:
 
-| Provider   | Sources                                                | Outputs               | Command                              |
-| ---------- | ------------------------------------------------------ | --------------------- | ------------------------------------ |
-| `npm`      | `package.json`, `package-lock.json`                    | `node_modules/`       | `npm install`                        |
-| `yarn`     | `package.json`, `yarn.lock`                            | `node_modules/`       | `yarn install`                       |
-| `pnpm`     | `package.json`, `pnpm-lock.yaml`                       | `node_modules/`       | `pnpm install`                       |
-| `bun`      | `package.json`, `bun.lock`, `bun.lockb`                | `node_modules/`       | `bun install`                        |
-| `deno`     | `deno.json`, `deno.jsonc`, `package.json`, `deno.lock` | `node_modules/`       | `deno install`                       |
-| `aube`     | `package.json`, `aube-lock.yaml`                       | `node_modules/`       | `aube install`                       |
-| `go`       | `go.mod`                                               | `vendor/` or `go.sum` | `go mod vendor` or `go mod download` |
-| `pip`      | `requirements.txt`                                     | `.venv/`              | `pip install -r requirements.txt`    |
-| `poetry`   | `pyproject.toml`, `poetry.lock`                        | `.venv/`              | `poetry install`                     |
-| `uv`       | `pyproject.toml`, `uv.lock`                            | `.venv/`              | `uv sync`                            |
-| `bundler`  | `Gemfile`, `Gemfile.lock`                              | `vendor/bundle/`      | `bundle install`                     |
-| `composer` | `composer.json`, `composer.lock`                       | `vendor/`             | `composer install`                   |
-| `dart`     | `pubspec.yaml`, `pubspec.lock`                         | `.dart_tool/`         | `dart pub get`                       |
-| `flutter`  | `pubspec.yaml`, `pubspec.lock`                         | `.dart_tool/`         | `flutter pub get`                    |
+| Provider        | Sources                                                | Tracked output                   | Default command                                                  |
+| --------------- | ------------------------------------------------------ | -------------------------------- | ---------------------------------------------------------------- |
+| `npm`           | `package.json`, `package-lock.json`                    | `node_modules/`                  | `npm install`                                                    |
+| `yarn`          | `package.json`, `yarn.lock`                            | `node_modules/`                  | `yarn install`                                                   |
+| `pnpm`          | `package.json`, `pnpm-lock.yaml`                       | `node_modules/`                  | `pnpm install`                                                   |
+| `bun`           | `package.json`, `bun.lock` or `bun.lockb`              | `node_modules/`                  | `bun install`                                                    |
+| `deno`          | `deno.json`, `deno.jsonc`, `package.json`, `deno.lock` | Optional `node_modules/`         | `deno install`                                                   |
+| `aube`          | `package.json`, `aube-lock.yaml`                       | `node_modules/`                  | `aube install`                                                   |
+| `go`            | `go.mod`, `go.sum`                                     | Optional `vendor/`               | `go mod vendor` if `vendor/` exists, otherwise `go mod download` |
+| `pip`           | `requirements.txt`                                     | Optional `.venv/`                | `pip install -r requirements.txt`                                |
+| `poetry`        | `pyproject.toml`, `poetry.lock`                        | Optional `.venv/`                | `poetry install`                                                 |
+| `uv`            | `pyproject.toml`, `uv.lock`                            | `.venv/`                         | `uv sync`                                                        |
+| `bundler`       | `Gemfile`, `Gemfile.lock`                              | Optional `vendor/bundle/`        | `bundle install`                                                 |
+| `composer`      | `composer.json`, `composer.lock`                       | `vendor/`                        | `composer install`                                               |
+| `dart`          | `pubspec.yaml`, `pubspec.lock`                         | `.dart_tool/package_config.json` | `dart pub get`                                                   |
+| `flutter`       | `pubspec.yaml`, `pubspec.lock`                         | `.dart_tool/package_config.json` | `flutter pub get`                                                |
+| `git-submodule` | `.gitmodules`                                          | Declared submodule directories   | `git submodule update --init --recursive`                        |
 
-Built-in providers are active only when they are explicitly configured in `mise.toml` and their lockfile exists.
+Providers must be configured explicitly and have the required project input.
+Most require their lockfile. The exceptions are `go` (`go.mod`), `pip`
+(`requirements.txt`), Dart/Flutter (`pubspec.yaml`), and `git-submodule`
+(a nonempty `.gitmodules`). Pub workspace members track the workspace's package
+configuration file.
+
+An **optional output** is checked for deletion only after mise has observed it
+following a successful run. This supports package managers that install outside
+the project by default. In particular, the pip provider does not create or select
+a virtualenv: configure [Python virtualenv activation](/lang/python.html#automatic-virtualenv-activation)
+first if pip should install into `.venv`.
+
+These defaults are ordinary install commands, not necessarily frozen-lockfile
+installs. To require npm's clean, lockfile-based installation, override `run`:
+
+```toml
+[deps.npm]
+run = "npm ci"
+```
+
+The freshness check still decides whether to run it. Use `--force` when you need
+the command to execute even if its tracked state is unchanged.
 
 ## Monorepos
 
@@ -89,7 +113,7 @@ config_roots = ["apps/*", "packages/*"]
 mise deps --monorepo
 ```
 
-This requires explicit [`[monorepo].config_roots`](/tasks/monorepo.html#explicit-config-roots);
+This requires explicit [`[monorepo].config_roots`](/tasks/monorepo.html#config-roots);
 mise does not search arbitrary subdirectories for dependency providers.
 Providers in the monorepo root config are also included because that config is
 part of every selected config root's hierarchy, matching the behavior of
@@ -136,7 +160,9 @@ supported for add/remove are `npm`, `yarn`, `pnpm`, `bun`, `deno`, `aube`, `dart
 
 ## Custom Providers
 
-Create custom providers for project-specific build steps:
+Create custom providers for project-specific build steps. These examples assume
+`@graphql-codegen/cli` and `prisma` are already project dependencies and the
+corresponding scripts/configuration exist:
 
 ```toml
 [deps.codegen]
@@ -199,8 +225,11 @@ sources = ["{{ config_root }}/schemas/$SCHEMA_NAME.graphql"]
 outputs = ["{{ config_root }}/generated/${SCHEMA_NAME:-default}/"]
 dir = "{{ config_root }}"
 env = { OUTPUT_PACKAGE = "{{ vars.package }}-$BUILD_MODE" }
-run = "npm run codegen -- $OUTPUT_PACKAGE"
+run = 'npm run codegen -- "$OUTPUT_PACKAGE"'
 ```
+
+Set `SCHEMA_NAME` and `BUILD_MODE` in the environment before running this example.
+Quote shell expansions in `run` when a value should remain one argument.
 
 `$VAR` expressions in `run` are left for the provider's shell to expand at execution time. This
 allows `run` to use values from the provider's `env` table. Tera expressions in `run` are rendered
@@ -223,13 +252,22 @@ and working directory; raw command and environment values are not stored in stat
 3. Compare against stored hashes from the last successful run
 4. Mark the provider stale if a source or the effective command was added, removed, or changed
 
-This means:
+Required outputs must exist. Optional outputs must continue to exist once they
+have been observed. With source tracking, the first run is stale and changes to
+sources or the effective command trigger another run.
 
-- If you modify `package-lock.json`, `node_modules/` is considered stale
-- If `node_modules/` doesn't exist, the provider is always stale
-- If sources don't exist, the provider is considered fresh (nothing to do)
-- On first run (no stored state), the provider is always considered stale
-- State created before command hashing is migrated by running each provider once
+For custom providers with no sources, existing outputs are enough to be fresh;
+command changes alone do not invalidate them. A provider with neither sources
+nor outputs runs every time. Configure real input files when a command's result
+depends on their contents.
+
+Freshness checks do not inspect every installed package, query for newer upstream
+releases, or detect removal of an untracked external package cache. Use
+`mise deps install <provider> --explain` to see the decision, and `--force` to
+repair dependencies whose files changed outside the tracked state.
+
+State created before command hashing is migrated by running source-tracked
+providers once.
 
 ## Auto-Install
 
@@ -238,7 +276,9 @@ When `auto = true` is set on a provider, it runs automatically before:
 - `mise run` (task execution)
 - `mise x` (exec command)
 
-This ensures dependencies are always up to date before running tasks or commands.
+Automatic checks use the same sources and outputs as `mise deps`; they ensure
+tracked changes are handled before execution. They do not upgrade packages to
+the newest upstream versions.
 
 To skip auto-install for a single invocation:
 
@@ -308,7 +348,10 @@ sources = ["requirements.yml"]
 outputs = [".galaxy-installed"]
 ```
 
-In this example, `ansible-galaxy` waits for `uv` to finish before starting.
+This assumes the uv project declares `ansible-core` and its virtualenv is on
+`PATH` (for example through `_.python.venv`). The `ansible-galaxy` provider waits
+for `uv` to finish before starting. A `depends` entry orders configured providers;
+it does not declare a missing provider or install a package manager.
 
 Providers without `depends` run in parallel. If a dependency fails, all providers
 that depend on it are skipped. Circular dependencies are detected and the affected providers
@@ -328,28 +371,40 @@ jobs = 4  # Run up to 4 providers in parallel
 
 ## Example: Full-Stack Project
 
-```toml
-# mise.toml for a project with Node.js frontend and Python backend
+This example assumes a repository with npm and uv projects in its root, both
+lockfiles committed, Prisma installed as a project dependency, and an npm
+`codegen` script:
+
+```toml [mise.toml]
+[settings]
+experimental = true
+
+[tools]
+node = "24"
+python = "3.14"
+uv = "latest"
 
 [deps.npm]
 auto = true
 
-[deps.poetry]
+[deps.uv]
 auto = true
 
 [deps.prisma]
 auto = true
-depends = ["npm"]  # needs node_modules first
-sources = ["prisma/schema.prisma"]
+depends = ["npm"]
+sources = ["prisma/schema.prisma", "package-lock.json"]
 outputs = ["node_modules/.prisma/"]
-run = "npx prisma generate"
+run = "npx --no-install prisma generate"
 
 [deps.frontend-codegen]
-depends = ["npm"]  # needs node_modules first
-sources = ["schema.graphql", "codegen.ts"]
+depends = ["npm"]
+sources = ["schema.graphql", "codegen.ts", "package-lock.json"]
 outputs = ["src/generated/"]
 run = "npm run codegen"
 ```
 
-Running `mise deps` installs npm and poetry dependencies in parallel, then runs prisma
-and frontend-codegen (also in parallel, since they depend only on npm, not on each other).
+`mise deps` runs stale npm and uv providers in parallel. Prisma and frontend
+codegen wait for npm, then can run in parallel with each other. The codegen
+provider has no `auto = true`, so it runs through explicit `mise deps` commands,
+not automatically before every `mise exec` or task invocation.

--- a/docs/dev-tools/deps.md
+++ b/docs/dev-tools/deps.md
@@ -67,7 +67,7 @@ Each provider supplies defaults for sources, outputs, and the install command:
 | `go`            | `go.mod`, `go.sum`                                     | Optional `vendor/`               | `go mod vendor` if `vendor/` exists, otherwise `go mod download` |
 | `pip`           | `requirements.txt`                                     | Optional `.venv/`                | `pip install -r requirements.txt`                                |
 | `poetry`        | `pyproject.toml`, `poetry.lock`                        | Optional `.venv/`                | `poetry install`                                                 |
-| `uv`            | `pyproject.toml`, `uv.lock`                            | `.venv/`                         | `uv sync`                                                        |
+| `uv`            | `pyproject.toml`, `uv.lock`                            | Optional `.venv/`                | `uv sync`                                                        |
 | `bundler`       | `Gemfile`, `Gemfile.lock`                              | Optional `vendor/bundle/`        | `bundle install`                                                 |
 | `composer`      | `composer.json`, `composer.lock`                       | `vendor/`                        | `composer install`                                               |
 | `dart`          | `pubspec.yaml`, `pubspec.lock`                         | `.dart_tool/package_config.json` | `dart pub get`                                                   |

--- a/docs/dev-tools/index.md
+++ b/docs/dev-tools/index.md
@@ -83,57 +83,51 @@ and environment modules. Those values are resolved before tool templates render.
 
 ## Tool Options
 
-Tool options let you customize how tools are installed and configured. They support nested configuration for better organization, which is particularly useful for platform-specific settings.
+Tool options customize installation for a particular backend. Start with the
+backend's reference: a valid option for one backend may not apply to another
+source for the same tool.
 
 ### Table Format (Recommended)
 
-The cleanest way to specify nested options is with TOML tables:
+Use TOML tables when an option has nested fields. This illustrates the HTTP
+backend's platform mapping; replace the example URLs with your own release assets:
 
-```toml
+```toml [mise.toml]
 [tools."http:my-tool"]
 version = "1.0.0"
 
-[tools."http:my-tool".platforms]
-macos-x64 = {
-  url = "https://example.com/my-tool-macos-x64.tar.gz",
-  checksum = "sha256:abc123",
-}
-linux-x64 = {
-  url = "https://example.com/my-tool-linux-x64.tar.gz",
-  checksum = "sha256:def456",
-}
+[tools."http:my-tool".platforms.macos-x64]
+url = "https://example.com/my-tool-macos-x64.tar.gz"
+
+[tools."http:my-tool".platforms.linux-x64]
+url = "https://example.com/my-tool-linux-x64.tar.gz"
 ```
+
+See the [HTTP backend](/dev-tools/backends/http.html) for checksums, executable
+selection, and additional platform mappings.
 
 ### Dotted Notation
 
-You can also use dotted notation for simpler nested configurations:
+The same nested fields can be written with dotted keys:
 
 ```toml
 [tools."http:my-tool"]
 version = "1.0.0"
 platforms.macos-x64.url = "https://example.com/my-tool-macos-x64.tar.gz"
 platforms.linux-x64.url = "https://example.com/my-tool-linux-x64.tar.gz"
-simple_option = "value"
 ```
 
 ### Generic Nested Support
 
-Any backend can use nested options for organizing complex configurations:
+mise accepts nested TOML options, but the selected backend must understand them.
+Nesting is a way to organize documented options; it does not define a new backend
+or add arbitrary capabilities to an existing one. For a short declaration, use a
+single-line inline table:
 
 ```toml
-[tools."custom:my-backend"]
-version = "1.0.0"
-
-[tools."custom:my-backend".database]
-host = "localhost"
-port = 5432
-
-[tools."custom:my-backend".cache.redis]
-host = "redis.example.com"
-port = 6379
+[tools]
+node = { version = "24", postinstall = "node --version" }
 ```
-
-Internally, nested options are flattened to dot notation (e.g., `platforms.macos-x64.url`, `database.host`, `cache.redis.port`) for backend access.
 
 ### Version ordering
 
@@ -187,14 +181,10 @@ You can restrict tools to specific operating systems using the `os` field:
 ripgrep = { version = "latest", os = ["linux", "macos"] }
 
 # Only install on Windows
-"npm:windows-terminal" = { version = "latest", os = ["windows"] }
+"github:PowerShell/PowerShell" = { version = "latest", os = ["windows"] }
 
 # Works with other options
-"cargo:usage-cli" = {
-    version = "latest",
-    os = ["linux", "macos"],
-    locked = false
-}
+"cargo:usage-cli" = { version = "latest", os = ["linux", "macos"], locked = false }
 ```
 
 The `os` field accepts an array of operating system identifiers:
@@ -213,7 +203,7 @@ You can also restrict tools to specific OS and architecture combinations using t
 hk = { version = "latest", os = ["linux", "macos/arm64"] }
 
 # Only install on Linux x86_64
-mytool = { version = "latest", os = ["linux/x64"] }
+jq = { version = "latest", os = ["linux/x64"] }
 ```
 
 Supported architecture identifiers:
@@ -231,7 +221,8 @@ You can declare explicit installation dependencies between tools using the `depe
 
 ```toml
 [tools]
-python = "3.12.11"
+python = "3.14"
+uv = "latest"
 "pipx:ruff" = { version = "latest", depends = ["python"] }
 ```
 
@@ -245,7 +236,7 @@ The `depends` field accepts either a single string or an array of strings:
 "pipx:ruff" = { version = "latest", depends = "python" }
 
 # Multiple dependencies
-"pipx:ruff" = { version = "latest", depends = ["python", "pipx"] }
+# "pipx:ruff" = { version = "latest", depends = ["python", "uv"] }
 ```
 
 User-specified `[tools].depends` adds ordering constraints and makes matching tools available to install hooks. Backend declarations such as vfox `PLUGIN.depends` are combined with these user declarations in the same install dependency context.
@@ -268,27 +259,17 @@ Use tool names as they would appear in `mise.toml`. Users can supplement plugin 
 
 ## Caching and Performance
 
-mise uses intelligent caching to minimize overhead:
+Remote version lists are cached according to
+[`fetch_remote_versions_cache`](/configuration/settings.html#fetch_remote_versions_cache).
+Downloaded artifacts and backend metadata have their own caches. Retention
+and reuse depend on the backend and settings; a cached version list does not
+mean the requested tool is already installed.
 
-- **Version lists**: Cached for 1 hour by default ([`fetch_remote_versions_cache`](/configuration/settings.html#fetch_remote_versions_cache)) to avoid repeated API calls
-- **Installation artifacts**: Cached downloads to speed up reinstalls
-- **Environment resolution**: Cached environment setups for faster shell prompts
-- **Plugin metadata**: Cached plugin information for quicker operations
-
-This ensures that mise adds minimal latency to your daily development workflow.
-
-::: info
-After activating, mise will update env vars like PATH whenever the directory is changed or the prompt is _displayed_.
-See the [FAQ](/faq#what-does-mise-activate-do).
-:::
-
-After activating, every time your prompt is displayed, the shell calls `mise hook-env` to fetch new
-environment variables.
-This should be very fast: it exits early if the directory hasn't changed and no
-`mise.toml`/`.tool-versions` files have been modified.
-
-`mise` modifies `PATH` ahead of time so the tools are called directly. This means that calling a tool has zero overhead, and commands like `which node` return the real path to the binary.
-Other tools like asdf only support shim files, which dynamically locate tools when they're called; this adds a small delay and can cause issues with some commands. See [shims](/dev-tools/shims) for more information.
+Shell activation prepares the tool paths before commands run. `mise hook-env`
+can skip work when tracked configuration and environment inputs are unchanged.
+For slow prompts, use the [troubleshooting guide](/troubleshooting.html#slow-shell-prompts)
+to find the expensive input. See [shims](/dev-tools/shims.html) for the difference
+between resolving at the prompt and resolving each command.
 
 ## Common commands
 
@@ -297,46 +278,34 @@ header to open its reference page, which lists all available flags/options and m
 
 ### [`mise use`](/cli/use)
 
-For some users, `mise use` might be the only command they need to learn. It does the following:
+`mise use` installs a requested version and records the request in configuration:
 
-- Install the tool's plugin if needed
-- Install the specified version
-- Set the version as active (i.e. update the `PATH`)
-- Update the current configuration file (`mise.toml` or `.tool-versions`)
-
-```shell
-> cd my-project
-> mise use node@26
-# download node, verify signature...
-mise node@26.x.x ✓ installed
-mise ~/my-project/mise.toml tools: node@26.x.x # mise.toml created/updated
-
-> which node
-~/.local/share/mise/installs/node/26/bin/node
+```sh
+mise use node@24
+mise exec -- node --version
 ```
 
-`mise use node@26` installs the latest version of node 26 and creates/updates the
-`mise.toml`
-config file in the current directory. The resulting file looks like this:
+By default, it writes to the current project's `mise.toml`:
 
 ```toml [mise.toml]
 [tools]
-node = "26"
+node = "24"
 ```
 
-Whenever you're in that directory, that version of `node` is used.
+Use `--pin` to write a concrete version instead of the request, `--global` to
+set a personal default, or `--path` to choose a configuration file. See
+[write-target rules](/configuration.html#target-file-for-write-operations).
 
-`mise use -g node@26` does the same but updates the [global config](/configuration.html#global-config-config-mise-config-toml) (`~/.config/mise/config.toml`), so
-node 26 is the default version for the user unless a config file in the local directory hierarchy
-overrides it.
-
-You can also edit `mise.toml` directly instead of using `mise use` — the effect is the same. Run `mise install` after editing to install any new tools.
+The command does not directly change its parent shell. Shell activation applies
+the selection at the next prompt or supported directory-change hook; `mise exec`
+and tasks load it explicitly. Editing `mise.toml` also changes the selection;
+run `mise install` afterward to install newly declared tools.
 
 ### [`mise install`](/cli/install)
 
-`mise install` installs tools but does not activate them—it downloads/builds/compiles the tool
-into `~/.local/share/mise/installs`, but you can't use it until you "set" the version
-in a `mise.toml` or `.tool-versions` file.
+`mise install` downloads or builds tools without changing version declarations.
+To select an installed version, declare it in configuration or pass it directly
+to `mise exec`, for example `mise exec node@24 -- node --version`.
 
 ::: tip
 If you're coming from `asdf`, there is no need to run `mise plugin add` first to install
@@ -360,10 +329,10 @@ The last form is useful for warming CI, container, or offline caches before runn
 ### [`mise exec`|`mise x`](/cli/exec)
 
 Use `mise x` for one-off commands with specific tools. For example, to run a script
-with Python 3.12:
+with Python 3.14:
 
 ```sh
-mise x python@3.12 -- ./myscript.py
+mise x python@3.14 -- python myscript.py
 ```
 
 With the default [`auto_install`](/configuration/settings.html#auto_install) and
@@ -374,9 +343,7 @@ commands with
 `mise x --`:
 
 ```sh
-$ mise use node@20
-$ mise x -- node -v
-20.x.x
+mise x -- node --version
 ```
 
 ::: tip
@@ -393,16 +360,16 @@ environment with all of your tools.
 
 ## Auto-Install Mechanisms
 
-mise provides several mechanisms to automatically install missing tools or versions as needed. Below, these are grouped by how and when they are triggered, with relevant settings for each. All mechanisms require the global [auto_install](/configuration/settings.html#auto_install) setting to be enabled (**all auto_install settings are enabled by default**).
+mise provides several mechanisms to automatically install missing tools or versions as needed. Below, these are grouped by how and when they are triggered, with relevant settings for each. The general mechanisms below require [auto_install](/configuration/settings.html#auto_install), with separate controls for execution, tasks, and missing commands. See [lazy tools](/dev-tools/shims.html#lazy-tools) for explicit declarations that defer installation until a command is first used.
 
 ### On-Demand Execution ([`mise x`](/cli/exec), [`mise r`](/cli/run))
 
-When you run a command like [`mise x`](/cli/exec) or [`mise r`](/cli/run), mise automatically installs any missing tool versions required to execute the command.
+By default, [`mise x`](/cli/exec) and [`mise r`](/cli/run) install missing non-lazy tools before execution. Lazy tools are handled on first use.
 
 - **When it triggers:** Whenever you use [`mise x`](/cli/exec) or [`mise r`](/cli/run) with a tool/version that is not yet installed.
 - **How to control:**
   - Setting: [`exec_auto_install`](/configuration/settings.html#exec_auto_install) (default: true)
-  - Setting: [`task_auto_install`](/configuration/settings.html#task_auto_install) (default: true)
+  - Setting: [`task.run_auto_install`](/configuration/settings.html#task.run_auto_install) (default: true)
 
 ### Command Not Found Handler (Shell Integration)
 

--- a/docs/dev-tools/shims.md
+++ b/docs/dev-tools/shims.md
@@ -15,26 +15,30 @@ This page explains the differences between these methods and how to use them. In
 mise's "PATH" activation method updates environment variables every time the prompt is displayed. In particular, it updates the `PATH` environment variable, which your shell uses to search for the programs it can run.
 
 ::: info
-This is the method used when you add the `echo 'eval "$(mise activate bash)"' >> ~/.bashrc` line to your shell rc file (in this case, for bash).
+For Bash, add `eval "$(mise activate bash)"` to `~/.bashrc`. Run an
+`echo ... >> ~/.bashrc` setup command in your terminal only once; do not put that
+append command in the startup file itself.
 :::
 
 For example, by default, your `PATH` variable might look like this:
 
 ```sh
-echo $PATH
+echo "$PATH"
 /usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 ```
 
 With [`mise activate`](/cli/activate.html), `mise` automatically adds the required tools to `PATH`.
 
 ```sh
-PATH="$HOME/.local/share/mise/installs/python/3.15.0/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+PATH="$HOME/.local/share/mise/installs/python/3.14.7/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 ```
 
 In this example, the python `bin` directory was added at the beginning of `PATH`, making it available in the current shell session.
-When a fuzzy version like `python = "3.15"` or `node = "26"` is active, this path may use the requested-version symlink, such as `~/.local/share/mise/installs/python/3.15/bin`, instead of the fully resolved patch version.
+When a fuzzy version like `python = "3.14"` or `node = "26"` is active, this path may use the requested-version symlink, such as `~/.local/share/mise/installs/python/3.14/bin`, instead of the fully resolved patch version.
 
-While `PATH` activation works well in most cases, `shims` are preferable in some situations, such as when you are not using an interactive shell (for example, when using `mise` in an IDE or a script).
+Use shims when a program needs a stable path to a tool, such as an IDE configured
+with a Python executable. For scripts, `mise exec -- <command>` loads both tools
+and environment variables explicitly.
 
 ### Shims {#mise-activate-shims}
 
@@ -53,22 +57,23 @@ ls -l ~/.local/share/mise/shims/node
 By default, the shim directory is located at `~/.local/share/mise/shims` (on Windows: `%LOCALAPPDATA%\mise\shims`). When you install a tool (for example, `node`), `mise` adds an entry to the `shims` directory for every binary the tool provides (for example, `~/.local/share/mise/shims/node`).
 
 ```sh
-mise use -g node@20
-npm install -g prettier@3.1.0
+mise use node@24 npm:prettier@3
 
-~/.local/share/mise/shims/node -v
-# v20.0.0
-~/.local/share/mise/shims/prettier -v
-# 3.1.0
+~/.local/share/mise/shims/node --version
+~/.local/share/mise/shims/prettier --version
 ```
 
-Rather than calling `~/.local/share/mise/shims/node` directly, you can add the `shims` directory to your `PATH`.
+These commands use the versions selected for the current directory. The paths
+above assume the default Unix data directory. To find shims by command name, add
+their directory to the existing `PATH`:
 
 ```sh
-export PATH="$HOME/.local/share/mise/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+export PATH="$HOME/.local/share/mise/shims:$PATH"
 ```
 
-This makes all dev tools available in your current shell session as well as in non-interactive environments.
+Child processes inherit this `PATH`. Independently launched applications, CI jobs,
+and other shells need their own environment setup; editing one shell's profile
+does not configure every process on the machine.
 
 ## Lazy tools
 
@@ -110,38 +115,58 @@ are created first. The task installs the tool the first time it runs one of its
 commands. `mise x -- <command>` installs the provider of a lazy command directly.
 
 ::: tip
-[`mise activate --shims`](/cli/activate.html#shims) is a shorthand for adding the shims directory to PATH.
+[`mise activate --shims`](/cli/activate.html#flags) is a shorthand for adding the shims directory to PATH.
 :::
 
 ## How to add mise shims to PATH
 
-The recommended way to add `shims` to `PATH` is to call [`mise activate --shims`](/cli/activate.html#shims) in one of your shell initialization files. For example:
+Use `mise activate --shims` when `mise` itself is already on `PATH`.
+Add the following lines to the indicated files, preserving existing setup.
+Bash and Zsh profiles run for **login shells**; they are not startup files for
+arbitrary non-interactive scripts.
 
 ::: code-group
 
-```sh [bash]
-# note that bash will read from ~/.profile or ~/.bash_profile if the latter exists
-# ergo, you may want to check to see which is defined on your system and only append to the existing file
-echo 'eval "$(mise activate bash --shims)"' >> ~/.bash_profile # this sets up non-interactive sessions
-echo 'eval "$(mise activate bash)"' >> ~/.bashrc       # this sets up interactive sessions
+```sh [Bash: ~/.bash_profile]
+# Use ~/.profile instead if that is your existing login startup file.
+eval "$(mise activate bash --shims)"
 ```
 
-```sh [zsh]
-echo 'eval "$(mise activate zsh --shims)"' >> ~/.zprofile # this sets up non-interactive sessions
-echo 'eval "$(mise activate zsh)"' >> ~/.zshrc    # this sets up interactive sessions
+```sh [Bash: ~/.bashrc]
+eval "$(mise activate bash)"
 ```
 
-```sh [fish]
-echo 'mise activate fish --shims | source' >> ~/.config/fish/config.fish
-echo 'mise activate fish | source' >> ~/.config/fish/config.fish
+```sh [Zsh: ~/.zprofile]
+eval "$(mise activate zsh --shims)"
+```
+
+```sh [Zsh: ~/.zshrc]
+eval "$(mise activate zsh)"
+```
+
+```fish [Fish: ~/.config/fish/config.fish]
+if status is-interactive
+    mise activate fish | source
+else
+    mise activate fish --shims | source
+end
 ```
 
 :::
 
-In this example, we use [`mise activate --shims`](/cli/activate.html#shims) in the non-interactive shell configuration file (like `.bash_profile` or `.zprofile`) and `mise activate` in the interactive shell configuration file (like `.bashrc` or `.zshrc`).
+Bash login shells read the first available file among `~/.bash_profile`,
+`~/.bash_login`, and `~/.profile`. They read `~/.bashrc` only if the profile sources
+it. Check your existing startup files before adding a new profile that would
+hide the old one. Zsh reads `~/.zprofile` for login shells and `~/.zshrc` for
+interactive shells.
+
+For a script or CI command, prefer `mise exec -- <command>`. A script launched
+from an already configured shell inherits its `PATH`, but a scheduler or IDE
+may not inherit that shell's environment. See [IDE integration](/ide-integration.html)
+and [Windows setup](/installing-mise.html#windows-scoop) for those environments.
 
 ::: info
-It's fine to call [`mise activate --shims`](/cli/activate.html#shims) in your shell profile file and then
+It's fine to call [`mise activate --shims`](/cli/activate.html#flags) in your shell profile file and then
 later call [`mise activate`](/cli/activate.html) in an interactive session. PATH
 activation keeps the user and existing system shim farms behind real tool paths
 when the effective toolset contains a lazy declaration or
@@ -166,7 +191,7 @@ alongside `not_found_auto_install = false`, if you'd rather an unresolvable shim
 :::
 
 - You can also decide to use only `shims` if you prefer, though this comes with some [limitations](/dev-tools/shims.html#shims-vs-path).
-- An alternative to [`mise activate --shims`](/cli/activate.html#shims) is to use `export PATH="$HOME/.local/share/mise/shims:$PATH"`. This can be helpful if `mise` is not yet available at that point.
+- An alternative to [`mise activate --shims`](/cli/activate.html#flags) is to use `export PATH="$HOME/.local/share/mise/shims:$PATH"`. This can be helpful if `mise` is not yet available at that point.
 
 ### mise reshim
 
@@ -176,7 +201,11 @@ Use `mise reshim --system` for the system shim farm. If `shims_dir` and
 `system_shims_dir` resolve to the same physical path, either command reconciles
 one combined farm containing both scopes.
 
-`mise` already reshims whenever a tool is installed, updated, or removed, so you don't need to run it in those cases. A reshim also happens by default when using most tools, such as `npm`.
+mise rebuilds shims when it installs, updates, or removes a tool. If another
+package manager adds executables inside an existing installation, run
+`mise reshim`. The Node.js core plugin can do this after `npm install -g` through
+its [`node.npm_shim`](/configuration/settings.html#node.npm_shim) wrapper; this
+is not a general hook for every package manager.
 
 `mise reshim` only creates and removes shims. Some users treat it as a
 "fix it" button, but it is only necessary when `~/.local/share/mise/shims` doesn't contain something it should.
@@ -283,65 +312,54 @@ Many users find `which` valuable. Shims effectively "break" `which`, causing it 
 
 ```sh
 $ which node
-~/.mise/installs/node/20/bin/node
+~/.local/share/mise/installs/node/24/bin/node
 ```
 
 ### Performance
 
-Truthfully, you're unlikely to notice a performance difference between shims and `mise activate`.
+PATH activation does its work at prompts and supported directory-change hooks.
+Shims resolve the environment when a command is invoked. Which costs less depends
+on how you run commands.
 
-- With `mise activate`, mise runs every time the prompt is displayed, so you pay a few ms
-  every time the prompt is displayed. You pay that penalty every time you run any command, regardless
-  of whether it uses a mise tool. mise has some short-circuiting logic to make it faster
-  when nothing has changed, but it doesn't help much unless you have a very complex setup.
-- Shims have the same performance profile but run when the shim is called. This makes some situations
-  better and some worse.
+For example, a script that repeatedly calls a shim resolves the environment on
+each call:
 
-If you are calling a shim from within a bash script like this:
-
-```sh
+```bash
 for i in {1..500}; do
     node script.js
 done
 ```
 
-You'll pay the mise penalty every time you call it within the loop. However, if you instead
-call a subprocess from within a shim (say, node spawning a node subprocess), you will _not_ pay a new
-penalty. This is because when a shim is called, mise sets up `PATH` for all tools, and
-those `PATH` entries come before the shim directory.
+Run the enclosing script with `mise exec -- bash benchmark.sh` to prepare the
+environment once. Child processes then inherit the real tool directories ahead
+of the shim directory. Similarly, a process launched by a shim passes the resolved
+environment to its children.
 
-In other words, which is faster depends on how you're calling mise. Realistically,
-though, most users will not notice the few ms of lag `mise activate` adds to their terminal.
-See [Troubleshooting: Slow shell prompts](/troubleshooting.html#slow-shell-prompts) for how to diagnose performance issues.
-
-The only difference between `hook-env` and shims is that with `hook-env` you need to call
-it again when you change directories, whereas with shims that isn't necessary. If you use both, `mise activate`
-takes care of the shim farms for you: they are kept behind the tool paths as a fallback. Disabling
-[`not_found_auto_install`](/configuration/settings.html#not_found_auto_install) disables general missing-tool
-installation, but explicit `lazy = true` declarations remain available through their shims.
+See [slow shell prompts](/troubleshooting.html#slow-shell-prompts) to diagnose
+activation overhead. Hook behavior and parent-shell environment updates also
+differ, so choose an activation method based on those requirements as well as
+performance.
 
 ## Neither shims nor PATH {#neither-shims-nor-path}
 
-There are many ways to load the mise environment that don't require either, chiefly:
-[`mise x|exec`](/cli/exec.html), [`mise r|run`](/cli/run.html), or [`mise en`](/cli/en.html).
+[`mise exec`](/cli/exec.html), [`mise run`](/cli/run.html), and
+[`mise en`](/cli/en.html) load tools and environment variables explicitly:
 
-These all load the tools and env vars before executing something. This might
-be ideal because you don't need to modify your shell rc file at all and the environment is always loaded
-explicitly. Some may find this a "clean" way of working.
+```sh
+mise exec -- node --version
+mise run build
+```
 
-The obvious downside is that you need to prefix every command with `mise exec|run`, though you can easily alias these to `mx|mr`.
-
-- This approach suits people who prefer precision over convenience.
-- It also suits those who only want to use mise on a single project because that's what their team uses, and
-  prefer not to manage anything else on their system with it. A shell extension
-  would be overkill for that use case.
+The second command requires a task named `build`. This approach works for CI,
+scripts, and projects where you do not want to change shell startup files. It
+requires `mise` on `PATH`, but no shell activation or shim directory.
 
 ## Hook on `cd` {#hook-on-cd}
 
 For some shells (`bash`, `zsh`, `fish`, `xonsh`), `mise` hooks into the `cd` command, while in others, it only runs when the prompt is displayed. This relies on `chpwd` in `zsh`, a `chpwd` emulation (wrapping `cd`/`pushd`/`popd`) plus `PROMPT_COMMAND` in `bash`, `fish_prompt` in `fish`, and `on_chdir` in `xonsh`.
 
-The upside is that it doesn't run as frequently, but since mise is written in Rust, the cost of executing
-mise is negligible (a few ms).
+Directory-change hooks let those shells apply the new project environment before
+the next command, even if no prompt has appeared yet.
 
 ::: details Running several commands in a single line
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -21,9 +21,9 @@
 ## Dev Tools
 
 - [Dev Tools Overview](https://mise.jdx.dev/dev-tools/): mise installs development tools and selects their versions for each project. Keep multiple versions of Node.js, Python, Ruby, Go, and other tools on the same machine, then declare which ones a project…
-- [Comparison to asdf](https://mise.jdx.dev/dev-tools/comparison-to-asdf.html): mise can be used as a drop-in replacement for asdf. It supports the same .tool-versions files that you may have used with asdf and can use asdf plugins through the asdf backend.
+- [Comparison to asdf](https://mise.jdx.dev/dev-tools/comparison-to-asdf.html): mise reads .tool-versions and supports legacy asdf plugins. You can start with an existing project's version declarations, then adopt mise.toml for environment variables and tasks.
 - [Shims](https://mise.jdx.dev/dev-tools/shims.html): There are several ways to load the mise context (dev tools, environment variables) into your shell.
-- [Tool Aliases](https://mise.jdx.dev/dev-tools/aliases.html): [alias] has been renamed to [tool_alias] to distinguish it from [shell_alias]. The old [alias] key still works but is deprecated.
+- [Tool Aliases](https://mise.jdx.dev/dev-tools/aliases.html): Use [tool_alias] to give a tool a different backend or name a version request. Put shared aliases in the project's mise.toml; use ~/.config/mise/config.toml for personal defaults.
 - [Tool Stubs](https://mise.jdx.dev/dev-tools/tool-stubs.html): Tool stubs let you create executable files with embedded TOML configuration for tool execution. They provide a convenient way to define tool versions, backends, and execution parameters directly…
 - [Registry](https://mise.jdx.dev/registry.html): List of all tools aliased by default in mise.
 - [GitHub Tokens](https://mise.jdx.dev/dev-tools/github-tokens.html): Many tools in mise are hosted on GitHub. For public releases, mise uses mise-versions by default as a shared cache for version lists, release metadata, and GitHub artifact attestations.
@@ -32,8 +32,8 @@
 - [Packslip Completions and Skills](https://mise.jdx.dev/dev-tools/packslip-resources.html): Tools installed with the Packslip backend can provide shell completions and agent skills that match the version active in your project. The publisher declares these resources in the release manifest.
 - [Packslip Verification and Policy](https://mise.jdx.dev/dev-tools/packslip-verification.html): mise uses Packslip's signed metadata to discover releases, verify publishers, and select compatible builds. This guide describes the discovery and policy rules behind the Packslip backend.
 - [OCI Images (experimental)](https://mise.jdx.dev/dev-tools/mise-oci.html): mise oci build turns a mise.toml into a container image, with one OCI layer per installed tool.
-- [Deps](https://mise.jdx.dev/dev-tools/deps.html): The mise deps command manages project dependencies by hashing source files (e.g., package-lock.json) and running install commands when changes are detected.
-- [Backend Architecture](https://mise.jdx.dev/dev-tools/backend_architecture.html): Understanding how mise's backend system works can help you choose the right backend for your tools and troubleshoot issues when they arise.
+- [Deps](https://mise.jdx.dev/dev-tools/deps.html): mise deps runs project dependency installers when tracked inputs change or outputs go missing. It compares source hashes with the last successful run, then invokes the configured package manager.
+- [Backend Architecture](https://mise.jdx.dev/dev-tools/backend_architecture.html): A backend resolves a tool's versions, installs it, and supplies its executable paths and environment. The registry maps short names such as node and ripgrep to backends.
 - [Core tools](https://mise.jdx.dev/core-tools.html): mise comes with some plugins built into the CLI and written in Rust. These are new and will improve over time.
 - [Bun](https://mise.jdx.dev/lang/bun.html): mise can be used to install and manage multiple versions of bun on the same system.
 - [Deno](https://mise.jdx.dev/lang/deno.html): mise can be used to install and manage multiple versions of deno on the same system.


### PR DESCRIPTION
Tool setup guides contained invalid TOML, outdated asdf comparisons, incorrect shell startup advice, and unsupported promises about backend dependencies and freshness checks. Review and improve all six core tool-workflow pages: the tool overview, aliases, backend architecture, asdf migration, shims, and project dependencies.

Provide supported backend examples and explain selection diagnostics, current asdf commands, login versus interactive shell startup, and parent-shell environment behavior. Make the dependency quickstart runnable, document optional outputs and required inputs, and distinguish tracked freshness from package upgrades. Preserve the existing major sections while removing stale performance claims and blanket capability ratings.

Validation:
- `mise exec rust@1.95 -- mise run lint-fix` and scoped hk checks passed.
- `mise run docs:build` passed for 333 pages; all local links and anchors in these six rendered pages were checked.
- All TOML examples parse. Isolated checks passed for version aliases and templates, writing pinned `.tool-versions`, the npm dependency quickstart, source changes and missing-output recovery, and Bash/Zsh/Fish startup syntax.
- Backend resolution, dependency-provider behavior, and npm reshim behavior were checked against the implementation; asdf command mappings were checked against its current documentation.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime or configuration behavior changes.
> 
> **Overview**
> This PR **reworks six dev-tools guides** (overview, aliases, backend architecture, asdf comparison, shims, and `mise deps`) plus **`docs/public/llms.txt` blurbs** so they match current behavior and copy-pasteable config.
> 
> The pages now emphasize **project `mise.toml`**, **`mise tool` / `mise registry` diagnostics**, and **limits** (backend deps do not auto-add tools, deps freshness is not package upgrades, version aliases are not patch pins without **`mise.lock`**). **Backend architecture** drops the old capability matrix and long Rust trait excerpt in favor of selection precedence, verification caveats, and **`ubi:` deprecation** pointers.
> 
> **asdf** content is shortened to a practical migration path, a command mapping table, and **best-effort** compatibility; outdated performance charts and broad security rhetoric are removed. **Shims** fixes shell setup guidance (put **`eval "$(mise activate …)"`** in profile/rc files, login vs interactive), and clarifies when to use **`mise exec`**, reshim, and lazy tools.
> 
> **`mise deps`** gets a runnable npm quickstart, expanded provider table (**`git-submodule`**, optional outputs, Dart/Flutter outputs), **`npm ci`** override, and clearer freshness/`depends` semantics. Examples bump to current tool versions and corrected links (e.g. **`task.run_auto_install`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2ccb344f08d01017d83b83b24361af5a79c8e45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked developer documentation covering aliases, backends, asdf migration, dependencies, tool management, and shims.
  * Added clearer setup guidance, command examples, configuration details, troubleshooting steps, and workflow recommendations.
  * Updated examples for current tool versions, backend selection, lockfiles, provider-based dependencies, and shell integration.
  * Clarified compatibility expectations, dependency behavior, installation workflows, activation methods, and script/CI usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->