### PR TITLE
docs: clarify tool stub and OCI distribution workflows

### DIFF
--- a/docs/dev-tools/mise-oci.md
+++ b/docs/dev-tools/mise-oci.md
@@ -3,20 +3,20 @@
 `mise oci build` turns a `mise.toml` into a container image, with one
 [OCI](https://github.com/opencontainers/image-spec) layer per installed tool.
 
-The payoff is that **bumping any single tool version only invalidates one
-content-addressable blob**. With a Dockerfile, each `RUN install_tool` is
-stacked on the one before it — changing an early `RUN` invalidates every
-later layer. mise's on-disk layout (every tool installed in an isolated
-`$MISE_DATA_DIR/installs/<plugin>/<version>/` directory) makes layer ordering
-semantically irrelevant, so swapping a tool's version swaps a single layer
-and everything else (the base image, other tools, mise itself, image config)
-is reused unchanged.
+Tool layers can be reused independently when a version changes. Image config,
+manifests, and layers whose inputs changed still need updating; a Python change
+can also invalidate dependent pipx layers.
+
+Build on a **Linux host with the target architecture**. mise packages the installed
+host binaries; it does not cross-compile or download another OS's tools for the
+image. `mise oci run` also requires Docker or Podman. Building and pushing an OCI
+layout use mise's own image and registry support.
 
 ::: warning Experimental
 `mise oci build` is experimental. Enable it with:
 
 ```sh
-mise settings experimental=true
+mise settings set experimental=true
 # or, per-invocation:
 MISE_EXPERIMENTAL=1 mise oci build …
 ```
@@ -34,21 +34,38 @@ Flags, output layout, and defaults may change in future releases.
 
 ## Quick start
 
-```sh
-# Build an image from the current mise.toml using the default base
-# (debian:bookworm-slim). Output goes to ./mise-oci/.
-mise oci build
+On Linux, start with a project configuration such as:
 
-# Run an interactive shell in the image (uses podman if present, else
-# docker).
-mise oci run -it -- bash
+```toml [mise.toml]
+[settings]
+experimental = true
 
-# Push to a registry with the built-in client (no skopeo/crane needed).
-mise oci push ghcr.io/me/devenv:latest
-
-# The output is a standard OCI image layout, so external tools work too:
-skopeo inspect oci:./mise-oci
+[tools]
+node = "24"
 ```
+
+Build a local image layout, then verify its executable through a container engine:
+
+```sh
+mise oci build -o ./mise-oci
+mise oci run --image-dir ./mise-oci -- node --version
+```
+
+The default base is `debian:bookworm-slim`. Add the generated `mise-oci/` directory
+to `.gitignore`. This creates a tool environment; it does not automatically copy
+your application or install its package dependencies. Use a volume for development
+or [`oci.copy`](/dev-tools/mise-oci.html#oci-section-in-mise-toml) for files that belong in the image.
+
+To inspect the layout with an external tool, install `skopeo` and run
+`skopeo inspect oci:./mise-oci`. To publish it, follow [push authentication](#push-authentication)
+and choose a registry/repository you can write to:
+
+```sh
+mise oci push --image-dir ./mise-oci ghcr.io/OWNER/IMAGE:TAG
+```
+
+Replace the uppercase placeholders. This command publishes the image to that
+registry; it is separate from the local build and run checks.
 
 ## How layering works
 
@@ -75,9 +92,9 @@ jq = "1.8.1"
 6. **Synthesized `/etc/mise/config.toml`** referencing `/mise` as the data
    directory.
 
-Bumping `node` from `20.10` to `20.11` only invalidates the node layer.
-Python, jq, mise, the base, and the synthesized config are reused from
-the previous build (or from the registry, on pull).
+Changing Node.js leaves unrelated tool archives reusable. The generated
+configuration and image manifest still reflect the new version. Reuse also
+depends on the in-image path, file ownership, and any relocation inputs.
 
 ## `mise oci build`
 
@@ -246,9 +263,9 @@ For ghcr.io, the token needs the `write:packages` scope.
 from        = "debian:bookworm-slim"  # base image ref
 tag         = "ghcr.io/me/devenv:v1"  # default tag for the built image
 workdir     = "/workspace"             # WORKDIR
-entrypoint  = ["bash", "-l"]           # ENTRYPOINT
+entrypoint  = []           # ENTRYPOINT
 cmd         = []                        # CMD
-user        = "nonroot"                # USER
+user        = "1000:1000"                # USER
 user_id     = 1000                      # tar layer entry UID (file ownership)
 group_id    = 1000                      # tar layer entry GID (defaults to user_id)
 mount_point = "/mise"                  # where tools install in the image
@@ -270,7 +287,10 @@ NODE_ENV = "production"
 "org.opencontainers.image.source" = "https://github.com/me/my-app"
 ```
 
-`[oci].user` sets the image `USER` directive. `[oci].user_id` and
+The copy examples require `dist/my-app` and `assets` to exist.
+`[oci].user` sets the image `USER` directive; it does not create an account, home
+directory, or writable workspace. Use a numeric UID/GID or a user already
+provided by the base image. `[oci].user_id` and
 `[oci].group_id` set layer file ownership; if no `group_id` is configured,
 it defaults to the resolved `user_id`.
 
@@ -339,10 +359,10 @@ container-specific startup work belongs in the image entrypoint or command.
 | `oci.default_from`        | `debian:bookworm-slim` | Default base image when none is specified. |
 | `oci.default_mount_point` | `/mise`                | Where tools install inside the image.      |
 
-The default base is **glibc-based on purpose**. Alpine / musl would break
-most mise-installed prebuilt binaries (Node, Python wheels, Ruby gems).
-If you know your tools are statically linked you can opt in with
-`--from alpine:…` — expect trouble otherwise.
+Choose a base compatible with the packaged binaries and their shared libraries.
+The default uses glibc. An Alpine/musl base requires musl-compatible or suitable
+static binaries; changing `--from` does not rebuild the installed tools for a
+different libc. System libraries required at runtime must be present in the image.
 
 ## Environment variables in the image
 
@@ -372,16 +392,16 @@ mise emits a warning with the number of `[env]` vars it baked in.
 
 ## Supported backends
 
-All of mise's first-party backends install entirely under their
-per-version install directory, so they work as per-tool layers:
+The builder accepts built-in backends and packages each selected tool's install
+directory. It also relocates supported executable paths and shebangs. Acceptance
+by the builder does not guarantee that a tool is self-contained: system libraries,
+external runtimes, or paths outside its installation may still be needed.
+Declare required runtimes alongside their tools and verify the resulting image
+with the commands your project actually runs.
 
-`core`, `aqua`, `cargo`, `npm`, `go`, `pipx`, `github`, `gitlab`,
-`forgejo`, `ubi`, `spm`, `http`, `s3`, `gem`, `conda`, `dotnet`.
-
-**Not supported in v1:** `asdf` and `vfox` plugins (including third-party
-vfox plugins). Their install scripts can write outside the per-version
-directory, breaking the one-layer-per-tool invariant. Using them fails
-with a clear error message.
+asdf and vfox plugins, including custom vfox backend plugins, are rejected. Their
+installation hooks can write outside the per-version directory, which the
+per-tool layer model cannot capture reliably.
 
 ## Registry base-image support
 
@@ -394,8 +414,12 @@ private base images work too.
 Digest references are supported:
 
 ```sh
-mise oci build --from ubuntu@sha256:e3b0c44298fc...
+mise oci build --from "REGISTRY/IMAGE@sha256:FULL_DIGEST"
 ```
+
+Replace the placeholders with an actual image reference and its complete
+SHA256 digest. A digest pins the base image; a mutable tag can resolve to a new
+base on a later build.
 
 ## Reproducibility
 
@@ -418,9 +442,11 @@ image whose `os` field is `linux`, but any embedded binaries (mise and
 every tool layer) are still host-native — they will fail with
 `Exec format error` when executed inside the container.
 
-For a working image, run `mise oci build` on a Linux host (or inside a
-Linux container — `docker run -v $PWD:/src -w /src debian mise oci build`
-works). mise prints a warning when this mismatch is detected.
+Build on a Linux host or in a Linux development container that already has mise
+and the required tool-installation dependencies. A stock `debian` image does
+not contain mise. Do not mount macOS or Windows tool installations into that
+container as substitutes for Linux installations. mise warns when host and image
+platforms do not match.
 
 ### Multi-arch images
 
@@ -430,15 +456,42 @@ tag: each push uploads its platform manifest by digest and points the
 tag at an OCI **image index** that preserves the entries other
 platforms pushed.
 
+For example, the following GitHub Actions job builds one architecture at a time.
+It assumes the project has `mise.toml`, publishes to GHCR, and grants the workflow
+access to that package:
+
 ```yaml
-# CI sketch: one job per arch, same tag
+name: Publish development image
+on: workflow_dispatch
+permissions:
+  contents: read
+  packages: write
+concurrency:
+  group: mise-development-image
+  cancel-in-progress: false
 jobs:
-  push-amd64: # runs-on: ubuntu-24.04
-    run: mise oci push --update-index ghcr.io/me/dev:latest
-  push-arm64: # runs-on: ubuntu-24.04-arm
-    needs: push-amd64 # sequence to avoid a read-modify-write race
-    run: mise oci push --update-index ghcr.io/me/dev:latest
+  publish:
+    strategy:
+      max-parallel: 1
+      matrix:
+        runner: [ubuntu-24.04, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.runner }}
+    env:
+      MISE_EXPERIMENTAL: "1"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: jdx/mise-action@v2
+      - name: Authenticate to GHCR
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+      - name: Publish this architecture
+        run: mise oci push --update-index "ghcr.io/${GITHUB_REPOSITORY,,}/dev:latest"
 ```
+
+Choose runner labels available to your repository. Matrix serialization prevents
+the two platform pushes from racing, and workflow concurrency prevents overlapping
+runs of this workflow from updating the same tag simultaneously.
 
 Re-pushing the same platform replaces its entry (no duplicates), and a
 previously single-arch tag is upgraded to an index without losing the
@@ -454,7 +507,7 @@ different runners can race — sequence them as above.
 - `asdf` / `vfox` backends are rejected (see above).
 - Cross-platform builds produce broken images (binaries are host-native);
   run the build on a Linux host.
-- Alpine / musl base images will break most tools.
+- The base image must supply a compatible libc and other runtime libraries.
 - `mise oci run` needs a container engine (podman or docker) — mise has
   no built-in container runtime. Pushing needs no external tools.
 

--- a/docs/dev-tools/mise-oci.md
+++ b/docs/dev-tools/mise-oci.md
@@ -480,7 +480,7 @@ jobs:
       MISE_EXPERIMENTAL: "1"
     steps:
       - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@v4
       - name: Authenticate to GHCR
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/dev-tools/tool-stubs.md
+++ b/docs/dev-tools/tool-stubs.md
@@ -1,6 +1,9 @@
 # Tool Stubs
 
-Tool stubs let you create executable files with embedded TOML configuration for tool execution. They provide a convenient way to define tool versions, backends, and execution parameters directly within executable scripts. They are also a good way to lazy-load some tools, since a stubbed tool is fetched only when it is called, not when you run something like `mise install`.
+A tool stub is an executable file that records how to obtain and run one tool.
+Commit it to a repository so a command such as `./bin/py` selects the intended
+runtime and forwards its arguments. mise installs the tool on first execution;
+a normal project `mise install` does not discover and install arbitrary stub files.
 
 This feature is inspired by [dotslash](https://github.com/facebook/dotslash), which pioneered the concept of executable files with embedded configuration for portable tool execution.
 
@@ -8,27 +11,39 @@ This feature is inspired by [dotslash](https://github.com/facebook/dotslash), wh
 
 A tool stub is an executable file that begins with a shebang line pointing to `mise tool-stub` and contains TOML configuration specifying which tool to execute and how to execute it. When the stub runs, mise installs the specified tool version (if needed) and executes it with the provided arguments.
 
-Tool stubs can use any mise backend, but because they default to the http backend—whose tools have URLs and don't require a version—http stubs look a bit different from non-http stubs.
+A stub requires `mise` on `PATH`, unless generated with the optional bootstrap
+wrapper. It can name a backend or provide HTTP download URLs. A backend stub
+uses that backend's version resolution; an HTTP stub records the artifact location
+directly.
 
 For a machine-wide catalogue of ordinary tools, prefer
 [`lazy = true` in `[tools]`](/dev-tools/shims.html#lazy-tools). Standalone tool
 stub scripts remain useful when the executable file itself should carry a
 portable, self-contained tool definition.
 
-::: tip
-Tool stubs are particularly useful for adding less commonly used tools to your mise setup. Since a tool is installed only when its stub is first executed, you can define many tools without the overhead of installing them all up front. This is ideal for specialized tools, testing utilities, or project-specific binaries that you don't use every day.
-:::
-
 ## Tool (non-http) Stubs
 
-```bash
-#!/usr/bin/env -S mise tool-stub
-# Optional comment describing the tool
+Create a `bin` directory, then save this file as `bin/py`:
 
-version = "1.0.0"
+```toml [bin/py]
+#!/usr/bin/env -S mise tool-stub
+
 tool = "python"
+version = "3.14"
 bin = "python"
 ```
+
+On Unix, make it executable and run it:
+
+```sh
+chmod +x ./bin/py
+./bin/py --version
+./bin/py -c 'import sys; print(sys.executable)'
+```
+
+The stub's name is `py`, but it runs the installed `python` executable. Arguments
+following the stub path are forwarded to Python. For an exact runtime, use a
+concrete version or [lock the stub](#locking-a-stub).
 
 ::: info Why use `env -S`?
 The `-S` flag tells `env` to split the command line on spaces, so multiple arguments can be passed to the interpreter. This is necessary because shebangs on Unix systems traditionally support only a single argument after the interpreter path. `env -S mise tool-stub` makes the shebang work by splitting it into `env` → `mise` → `tool-stub`.
@@ -36,24 +51,29 @@ The `-S` flag tells `env` to split the command line on spaces, so multiple argum
 
 ## Configuration Fields
 
-Tool stub configuration is essentially a subset of a `mise.toml` `[tools]` section, with the addition of a `tool` field to specify which tool to use. All the options available for tool configuration in `mise.toml` are also supported in tool stubs.
+A stub contains a tool declaration, not an entire `mise.toml`. Put fields at the
+top level; do not wrap them in `[tools]`. Backend-specific installation options
+are passed to the selected backend, while `tool`, `version`, `bin`, `os`,
+`install_env`, and embedded `lock` data control the stub itself.
 
 ### Optional Fields
 
-- `tool` - Explicit tool name or backend specification (e.g., "python", "github:cli/cli"). This is the only field unique to tool stubs; it specifies which tool to use. If it is omitted and a `url` field is present, the stub defaults to the HTTP backend.
-- `version` - The version of the tool to use
+- `tool` - Explicit tool name or backend specification (e.g., "python", "github:cli/cli"). If omitted, a top-level or platform-specific URL selects the HTTP backend; otherwise mise uses the stub filename as the tool name.
+- `version` - The version request (defaults to `latest`)
 - `bin` - The binary name to execute within the tool (defaults to the stub filename)
 
 ## HTTP Stubs
 
-For multi-platform tarballs:
+A top-level URL applies to every platform on which the stub is run. Use it only
+for an artifact compatible with all of those machines. The URLs below are
+placeholders; use the generator to record real download metadata:
 
 ```toml
 #!/usr/bin/env -S mise tool-stub
-url = "https://example.com/releases/1.0.0/tool-linux-x64.tar.gz"
+url = "https://example.com/releases/1.0.0/tool.tar.gz"
 ```
 
-For platform-specific tarballs:
+For OS- or architecture-specific binaries, provide a platform table instead:
 
 ```toml
 #!/usr/bin/env -S mise tool-stub
@@ -66,7 +86,11 @@ url = "https://example.com/releases/1.0.0/tool-macos-arm64.tar.gz"
 
 ### Platform-Specific Binary Paths
 
-Different platforms may have different binary structures or names. You can specify platform-specific `bin` fields when the binary path differs between platforms:
+Set `bin` relative to the installed directory, after any archive root directory
+has been stripped. The generator accounts for that extraction layout. An explicit
+`--bin` must name the path that will remain after extraction.
+
+Use platform-specific `bin` fields when layouts or executable names differ:
 
 ```toml
 #!/usr/bin/env -S mise tool-stub
@@ -85,7 +109,8 @@ bin = "tool.exe"  # Platform-specific binary for Windows
 The tool stub generator detects when platforms have different binary paths and generates platform-specific `bin` fields when needed, or a single global `bin` field when all platforms share the same binary structure.
 
 ::: tip
-Tool stubs default to the HTTP backend if no `tool` field is specified and a `url` field is present.
+Tool stubs default to the HTTP backend when download URLs are present and no
+`tool` field selects another backend.
 See the [HTTP backend documentation](/dev-tools/backends/http) for full details on configuring HTTP-based tools.
 :::
 
@@ -107,9 +132,13 @@ mise generate tool-stub ./bin/gh --url "https://github.com/cli/cli/releases/down
 
 This will:
 
-- Download the archive to compute checksums (for security)
+- Download the archive and record a checksum of those bytes
 - Extract it to auto-detect the binary path
-- Generate an executable stub with complete TOML configuration
+- Generate an executable stub with download and execution metadata
+
+A generated checksum detects later changes to the artifact. It does not by itself
+authenticate the publisher of the initial download. Review the URL and obtain it
+from a source you trust before committing the stub.
 
 ### Platform-Specific Generation
 
@@ -149,7 +178,9 @@ mise generate tool-stub ./bin/rg \
   --platform-url https://github.com/BurntSushi/ripgrep/releases/download/14.0.3/ripgrep-14.0.3-x86_64-pc-windows-msvc.zip
 ```
 
-The generator preserves existing configuration and merges new platforms into the `[platforms]` table. If you specify a platform that already exists, its URL is updated.
+The generator merges new platforms into the existing `[platforms]` table.
+Re-specifying a platform updates that entry, so inspect the diff before committing.
+Use explicit platform prefixes when a filename is ambiguous.
 
 ### Generation Options
 
@@ -159,7 +190,7 @@ The generator preserves existing configuration and merges new platforms into the
 - `--platform-url URL` - Add a platform-specific URL, auto-detecting the platform from the URL filename
 - `--platform-bin PLATFORM:PATH` - Set a platform-specific binary path
 - `--checksum-algorithm ALGORITHM` - Generate `blake3` (default) or `sha256` checksums
-- `--skip-download` - Skip downloading for faster generation (no checksums or binary detection)
+- `--skip-download` - Generate without checksums or binary detection; review the binary path and run `--fetch` before relying on integrity checks
 - `--lock` - Resolve and embed lockfile data (pinned version + platform URLs/checksums) into an existing stub
 - `--fetch` - Fetch missing checksums and sizes for an existing stub file
 
@@ -188,90 +219,72 @@ The generator automatically detects and extracts various archive formats:
 
 ### Generated Stub Example
 
-Running the generation command produces an executable stub like this:
+Inspect the generated file rather than entering a checksum or size by hand:
 
-```bash
-#!/usr/bin/env -S mise tool-stub
-
-version = "latest"
-bin = "bin/gh"
-url = "https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_amd64.tar.gz"
-checksum = "blake3:a1b2c3d4e5f6..."
-size = 12345678
+```sh
+cat ./bin/gh
 ```
 
-The generator automatically:
+The file contains the URL, executable path, checksum, and size discovered from
+the archive. `version` may be omitted when it has the default value `latest`.
+For an HTTP stub, that label does not make a versioned URL track newer releases;
+update the URL and regenerate its metadata when upgrading.
 
-- Calculates BLAKE3 checksums by default, or SHA256 when requested
-- Detects file sizes
-- Identifies the correct binary path within archives
-- Uses the output filename as the tool name
+The output filename becomes the tool name. Set `--bin` if auto-detection selects
+the wrong executable, especially when an archive contains several commands.
 
 ## Examples
 
 ### Basic Node.js Stub
 
-```bash
+```toml
 #!/usr/bin/env -S mise tool-stub
-# Node.js v20 tool stub
+# Node.js tool stub
 
 tool = "node"
-version = "20.0.0"
+version = "24"
 bin = "node"
 ```
 
 ### Python with Custom Binary Name
 
-```bash
+```toml
 #!/usr/bin/env -S mise tool-stub
 # Python tool accessible as 'py'
 
 tool = "python"
-version = "3.11"
+version = "3.14"
 bin = "python"
 ```
 
 ### GitHub Release Backend
 
-```bash
+```toml
 #!/usr/bin/env -S mise tool-stub
 # GitHub CLI tool
 
 tool = "github:cli/cli"
 version = "latest"
+bin = "gh"
 ```
 
 ### Locked Tool Stub
 
-```bash
-#!/usr/bin/env -S mise tool-stub
+Lock a backend stub to record a concrete version and the platform download
+metadata its backend can provide. The generator writes this under `[lock]`;
+the top-level `tool` still selects the backend, and `version` becomes the
+resolved version.
 
-tool = "node"
-version = "20.18.1"
-bin = "node"
-
-[lock.platforms.linux-x64]
-url = "https://nodejs.org/dist/v20.18.1/node-v20.18.1-linux-x64.tar.xz"
-checksum = "sha256:abc123..."
-
-[lock.platforms.macos-arm64]
-url = "https://nodejs.org/dist/v20.18.1/node-v20.18.1-darwin-arm64.tar.gz"
-checksum = "sha256:def456..."
-```
-
-The `[lock]` section is generated by `mise generate tool-stub --lock` and provides
-reproducible downloads with checksum verification. The `tool` and `version` fields are still
-used for backend resolution, while the lock data provides download shortcuts.
-
-::: tip
-Locking is especially useful for avoiding GitHub API rate limits when users don't have a `GITHUB_TOKEN` set. With locked stubs, tools can be installed without any API calls at runtime.
-:::
+Stored URLs can avoid release discovery on later installs. They do not remove
+private-download authentication or every backend's verification and policy
+requests. Review the generated platforms and checksums; a backend that cannot
+provide a URL cannot supply the same download shortcut.
 
 #### Locking a Stub
 
 ```bash
 # Create a stub with a fuzzy version
-mise generate tool-stub ./bin/node --version 20
+mise generate tool-stub ./bin/node --version 24
 
 # Lock it to pin the exact version and add platform URLs/checksums
 mise generate tool-stub ./bin/node --lock
@@ -284,13 +297,13 @@ This resolves the version, fetches URLs for all common platforms (linux-x64, lin
 To bump the version of a locked stub, pass `--version` along with `--lock`:
 
 ```bash
-# Bump to the latest node 22.x and re-lock
-mise generate tool-stub ./bin/node --lock --version 22
+# Select Node.js 26 and regenerate the locked metadata
+mise generate tool-stub ./bin/node --lock --version 26
 ```
 
 ### HTTP Backend with Platform Support
 
-```bash
+```toml
 #!/usr/bin/env -S mise tool-stub
 # Custom HTTP tool with platform-specific downloads
 
@@ -352,7 +365,9 @@ Tool stubs cache lookups to reduce the overhead mise adds when running them:
 - The cache is invalidated automatically when the stub file changes
 - Missing binaries trigger cache cleanup automatically
 
-Cached stubs have ~4ms of overhead.
+Each invocation still passes through mise. For repeated calls inside a script,
+consider preparing the environment once with `mise exec` and calling the tool
+directly from that script.
 
 ## Pruning
 
@@ -376,16 +391,19 @@ mkdir -p ./bin
 # Create a simple Node.js stub
 cat > ./bin/node << 'EOF'
 #!/usr/bin/env bash
-exec mise x node@20 -- "$@"
+exec mise x node@24 -- node "$@"
 EOF
 chmod +x ./bin/node
 
 # Create a Python stub with specific version
 cat > ./bin/python << 'EOF'
 #!/usr/bin/env bash
-exec mise x python@3.11 -- "$@"
+exec mise x python@3.14 -- python "$@"
 EOF
 chmod +x ./bin/python
 ```
 
-This approach is ideal for simple tool execution that needs no custom options, environment variables, or platform-specific settings. For more complex configurations, use the TOML format described above.
+The command after `--` is essential: `mise x node@24` selects the runtime,
+and `node "$@"` names the executable and preserves the caller's arguments.
+These wrappers require Bash and mise and do not embed artifact metadata. Use
+the TOML stub format when you need platform mappings or embedded lock data.

--- a/docs/dev-tools/tool-stubs.md
+++ b/docs/dev-tools/tool-stubs.md
@@ -290,7 +290,7 @@ mise generate tool-stub ./bin/node --version 24
 mise generate tool-stub ./bin/node --lock
 ```
 
-This resolves the version, fetches URLs for all common platforms (linux-x64, linux-arm64, macos-x64, macos-arm64, windows-x64), and writes them into a `[lock]` section in the stub.
+By default, this resolves the version and fetches URLs for all common platforms (linux-x64, linux-x64-musl, linux-arm64, linux-arm64-musl, macos-x64, macos-arm64, and windows-x64). If `lockfile_platforms` is configured, it uses those platforms plus the current platform instead. The generated metadata is written into a `[lock]` section in the stub.
 
 #### Bumping a Locked Version
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -24,7 +24,7 @@
 - [Comparison to asdf](https://mise.jdx.dev/dev-tools/comparison-to-asdf.html): mise reads .tool-versions and supports legacy asdf plugins. You can start with an existing project's version declarations, then adopt mise.toml for environment variables and tasks.
 - [Shims](https://mise.jdx.dev/dev-tools/shims.html): There are several ways to load the mise context (dev tools, environment variables) into your shell.
 - [Tool Aliases](https://mise.jdx.dev/dev-tools/aliases.html): Use [tool_alias] to give a tool a different backend or name a version request. Put shared aliases in the project's mise.toml; use ~/.config/mise/config.toml for personal defaults.
-- [Tool Stubs](https://mise.jdx.dev/dev-tools/tool-stubs.html): Tool stubs let you create executable files with embedded TOML configuration for tool execution. They provide a convenient way to define tool versions, backends, and execution parameters directly…
+- [Tool Stubs](https://mise.jdx.dev/dev-tools/tool-stubs.html): A tool stub is an executable file that records how to obtain and run one tool. Commit it to a repository so a command such as ./bin/py selects the intended runtime and forwards its arguments.
 - [Registry](https://mise.jdx.dev/registry.html): List of all tools aliased by default in mise.
 - [GitHub Tokens](https://mise.jdx.dev/dev-tools/github-tokens.html): Many tools in mise are hosted on GitHub. For public releases, mise uses mise-versions by default as a shared cache for version lists, release metadata, and GitHub artifact attestations.
 - [mise.lock Lockfile](https://mise.jdx.dev/dev-tools/mise-lock.html): mise.toml records the versions a project accepts; mise.lock records the concrete versions those requests resolved to.


### PR DESCRIPTION
Tool stubs and OCI images need different prerequisites and verification steps. This reviews both guides and replaces examples that could produce unusable executables or containers.

- Add runnable Python stubs and correct Bash wrappers to invoke the installed executable and forward arguments. Explain archive-root stripping, checksums, locked URLs, and platform selection.
- Start OCI setup with its Linux and architecture requirements. Correct entrypoint and user examples, separate application setup from tool layers, explain runtime dependencies, and provide a valid serialized multi-architecture publishing workflow.

Validation: full `mise exec rust@1.95 -- mise run lint-fix`, production docs build, scoped hk checks, rendered links and anchors, TOML parsing, and actionlint passed. Smoke tests against the current source build covered stub execution, quoted arguments, generated checksums, and incremental platform generation. OCI container execution was not tested on this macOS host.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are documentation and index text only; no runtime or security behavior changes in application code.
> 
> **Overview**
> **Documentation-only** refresh of the experimental **OCI images** and **tool stubs** guides, plus an updated **Tool Stubs** blurb in `llms.txt`.
> 
> The **OCI** page now leads with Linux/architecture requirements and more accurate layer-reuse limits (config/manifest updates, pipx dependencies). Quick start uses `mise settings set experimental=true`, explicit build/run/push flows, and separates tool layers from app copy/`oci.copy`. `[oci]` examples fix **entrypoint**/`user` (numeric UID, empty entrypoint), document that `user` does not create accounts, and soften Alpine guidance to libc/runtime compatibility. Backend support is reframed around install-dir packaging vs runtime deps; digest and cross-platform sections drop misleading `debian mise oci build` hints. Multi-arch publishing gets a full **GitHub Actions** workflow (matrix serialization, GHCR login, `mise-action`).
> 
> The **tool stubs** page reframes install-on-first-run vs `mise install`, adds a runnable `bin/py` walkthrough, clarifies stub TOML shape vs `[tools]`, HTTP/platform `bin` paths after archive stripping, checksum trust limits, `--skip-download`, locking platforms (`lockfile_platforms`), and fixes **`mise x` wrappers** to invoke the real binary (`node "$@"`). Examples bump to Node/Python 24/3.14.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7efac83fc06476d44440c3198786411fba7ab0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified OCI image requirements, layer reuse, contents, limitations, compatibility, runtime dependencies, digest pinning, and multi-architecture publishing.
  - Updated OCI configuration examples, including entrypoint, user settings, and the GitHub Actions setup.
  - Expanded tool-stub guidance for executable setup, backend selection, URLs, platform-specific binaries, generators, checksums, locking, metadata, caching, and version updates.
  - Improved examples for executable wrappers, argument forwarding, binary detection, platform merging, and lock regeneration.
  - Updated the public tool-stub description to clarify runtime selection and argument forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->