### PR TITLE
docs: restore TOML 1.1 inline table examples

### DIFF
--- a/docs/dev-tools/index.md
+++ b/docs/dev-tools/index.md
@@ -87,6 +87,9 @@ Tool options customize installation for a particular backend. Start with the
 backend's reference: a valid option for one backend may not apply to another
 source for the same tool.
 
+Examples use TOML 1.1, which allows multiline inline tables and trailing commas
+inside them. Use that form when splitting an option across lines improves readability.
+
 ### Table Format (Recommended)
 
 Use TOML tables when an option has nested fields. This illustrates the HTTP
@@ -96,11 +99,13 @@ backend's platform mapping; replace the example URLs with your own release asset
 [tools."http:my-tool"]
 version = "1.0.0"
 
-[tools."http:my-tool".platforms.macos-x64]
-url = "https://example.com/my-tool-macos-x64.tar.gz"
-
-[tools."http:my-tool".platforms.linux-x64]
-url = "https://example.com/my-tool-linux-x64.tar.gz"
+[tools."http:my-tool".platforms]
+macos-x64 = {
+  url = "https://example.com/my-tool-macos-x64.tar.gz",
+}
+linux-x64 = {
+  url = "https://example.com/my-tool-linux-x64.tar.gz",
+}
 ```
 
 See the [HTTP backend](/dev-tools/backends/http.html) for checksums, executable
@@ -184,7 +189,11 @@ ripgrep = { version = "latest", os = ["linux", "macos"] }
 "github:PowerShell/PowerShell" = { version = "latest", os = ["windows"] }
 
 # Works with other options
-"cargo:usage-cli" = { version = "latest", os = ["linux", "macos"], locked = false }
+"cargo:usage-cli" = {
+  version = "latest",
+  os = ["linux", "macos"],
+  locked = false,
+}
 ```
 
 The `os` field accepts an array of operating system identifiers:

--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -259,14 +259,16 @@ caller passed in.
 You can also provide help text to guide users on how to set the variable:
 
 ```toml
-[env.DATABASE_URL]
-required = "Set DATABASE_URL to your PostgreSQL connection string"
-
-[env.API_KEY]
-required = "Get your API key from https://example.com/api-keys"
-
-[env.AWS_REGION]
-required = "Set to your AWS region (e.g., us-east-1, eu-west-1)"
+[env]
+DATABASE_URL = {
+  required = "Set DATABASE_URL to your PostgreSQL connection string",
+}
+API_KEY = {
+  required = "Get your API key from https://example.com/api-keys",
+}
+AWS_REGION = {
+  required = "Set to your AWS region (e.g., us-east-1, eu-west-1)",
+}
 ```
 
 When a required variable is missing, mise shows the help text in the error message.
@@ -606,9 +608,11 @@ The configuration options you provide (the TOML table after `=`) are passed to t
 ### Example: Secret Management Plugin
 
 ```toml
-[env._.vault-secrets]
-vault_url = "https://vault.example.com"
-secrets_path = "secret/myapp"
+[env]
+_.vault-secrets = {
+  vault_url = "https://vault.example.com",
+  secrets_path = "secret/myapp",
+}
 ```
 
 The plugin could then fetch secrets from HashiCorp Vault and expose them as environment variables.

--- a/docs/lang/python.md
+++ b/docs/lang/python.md
@@ -125,13 +125,27 @@ Choose one declaration for the virtualenv. A string such as `_.python.venv =
 | `python_create_args` | Arguments for `python -m venv`, such as `["--without-pip"]`                     |
 | `uv_create_args`     | Arguments for `uv venv`, such as `["--seed"]` or `["--system-site-packages"]`   |
 
-For example, when uv is installed and you need pip inside the virtualenv:
+For example, pass arguments to Python's `venv` module with a multiline inline
+table:
 
 ```toml
-[env._.python.venv]
-path = ".venv"
-create = true
-uv_create_args = ["--seed"]
+[env]
+_.python.venv = {
+  path = ".venv",
+  create = true,
+  python_create_args = ["--without-pip"],
+}
+```
+
+Alternatively, when uv is installed and you need pip inside the virtualenv:
+
+```toml
+[env]
+_.python.venv = {
+  path = ".venv",
+  create = true,
+  uv_create_args = ["--seed"],
+}
 ```
 
 Unless `create=true` is set, you need to create the venv manually with `python -m venv /path/to/venv`.

--- a/docs/lang/rust.md
+++ b/docs/lang/rust.md
@@ -167,7 +167,10 @@ be given as an array or as a comma-separated string.
 
 ```toml
 [tools]
-rust = { version = "1.83.0", targets = ["wasm32-unknown-unknown", "thumbv7em-none-eabi"] }
+rust = {
+  version = "1.83.0",
+  targets = ["wasm32-unknown-unknown", "thumbv7em-none-eabi"],
+}
 ```
 
 If the Rust toolchain is already installed, `mise install` will still add any missing configured targets.


### PR DESCRIPTION
Restore ten multiline inline-table examples changed during the documentation reviews in #12862, #12864, and #12866. The docs use TOML 1.1, so line breaks, comments, and trailing commas inside inline tables are valid.

Keep the corrected configuration values and separate alternative Python virtualenv declarations into individual examples. Add a short note about TOML 1.1 in the tool options guide. I audited all nine docs PRs in this series; the other six did not remove TOML 1.1 syntax.

Validation: all 66 TOML snippets on the four affected pages pass the current mise parser, including a TOML 1.1 capability probe. Full `mise exec rust@1.95 -- mise run lint-fix`, the production website build, and rendered link checks passed. Rebased onto current main and regenerated `docs/public/llms.txt`; its output is unchanged.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only formatting and examples; no runtime, auth, or config parsing behavior changes.
> 
> **Overview**
> **Documentation-only:** brings back multiline inline tables (with trailing commas) in mise config examples, matching TOML 1.1 syntax the parser already supports.
> 
> The **Tool Options** guide now states that examples use TOML 1.1 and reformats HTTP `platforms` and `cargo:usage-cli` samples accordingly. **Environments** docs show required-variable help text and the Vault plugin example under `[env]` with multiline inline tables instead of separate `[env.KEY]` sections. **Python** splits virtualenv setup into two examples (`python_create_args` vs `uv_create_args`) using `_.python.venv` inline tables. **Rust** expands the `targets` tool option example to the same style.
> 
> Semantics of the shown config values are unchanged aside from the Python page, which documents `python_create_args` in one example where the prior single block only showed `uv_create_args`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c58ee3ef298e6ec68e761145fb6ab607fb8bd96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated TOML configuration examples across the developer tools, environments, Python, and Rust guides.
  * Added examples using TOML 1.1 multiline inline tables and trailing commas.
  * Clarified configuration for platform mappings, required variables, secret management, Python virtual environments, and Rust targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->