### PR TITLE
docs: clarify download backend setup and verification

### DIFF
--- a/docs/dev-tools/backends/aqua.md
+++ b/docs/dev-tools/backends/aqua.md
@@ -2,7 +2,7 @@
 
 [Aqua](https://aquaproj.github.io/) tools can be used natively in mise. aqua is a Tier 2 backend
 for tools without [packslip manifests](/dev-tools/backends/packslip.html): it does not require plugins, it works on Windows, and it offers security features
-beyond checksums. aqua installs also show more progress bars, which is nice.
+beyond checksums. Verification depends on the metadata provided for each package.
 
 You do not need to install aqua separately. mise does not use the aqua CLI at all; it uses the
 [aqua registry](https://github.com/aquaproj/aqua-registry), which is compiled into the mise binary on release.
@@ -15,21 +15,18 @@ official aqua registry first while retaining the bundled snapshot as a fallback.
 mise's shorthand registry; see [Floating registries](/registry.html#floating-registries) for the
 tradeoffs and cache behavior.
 
-Some aqua tool configurations may need tightening up. Common issues are listed below;
-if you notice problems, I strongly recommend contributing fixes back to the aqua registry. The
-maintainer is very responsive and great to work with.
+If an entry has incorrect platform names, URLs, or verification metadata, report
+it to the aqua registry or contribute a correction. A mise release contains a
+snapshot, so a fix upstream may require a newer mise release or a custom registry.
 
-If all else fails, you can disable aqua entirely with [`MISE_DISABLE_BACKENDS=aqua`](/configuration/settings.html#disable_backends).
-
-Currently, aqua tools cannot set environment variables or do more than download binaries (and I'm
-not sure this functionality will ever be added), so some tools will likely always require asdf or
-vfox plugins.
+Aqua recipes primarily download and extract published artifacts. Tools that need
+custom installation steps or environment setup may require another backend.
 
 The code for this backend is in the mise repository at [`./src/backend/aqua.rs`](https://github.com/jdx/mise/blob/main/src/backend/aqua.rs).
 
 ## Custom Registry
 
-Set [`aqua.registries`](/configuration/settings.html#aqua-registries) to check custom aqua
+Set [`aqua.registries`](/configuration/settings.html#aqua.registries) to check custom aqua
 registry sources before the baked-in registry:
 
 ```toml
@@ -61,7 +58,7 @@ aqua.registries = [
 
 For repository and directory sources, mise loads `registry.yaml` from the source root, falling back
 to `registry.yml` if needed. Remote registry sources are cached under `MISE_CACHE_DIR` for
-[`aqua.registry_cache_ttl`](/configuration/settings.html#aqua-registry_cache_ttl), which defaults
+[`aqua.registry_cache_ttl`](/configuration/settings.html#aqua.registry_cache_ttl), which defaults
 to one week. Local `file://` sources bypass the downloaded source cache, so changes are read the
 next time the registry is loaded. In `MISE_AQUA_REGISTRIES`, separate multiple registry URLs with
 commas.
@@ -76,28 +73,28 @@ registries. Aqua registry aliases are local to the registry that defines them; u
 [`[tool_alias]`](/dev-tools/aliases) when you want a mise shorthand or alias to point at an aqua
 package from another registry.
 
-The legacy [`aqua.registry_url`](/configuration/settings.html#aqua-registry_url) setting is still
+The legacy [`aqua.registry_url`](/configuration/settings.html#aqua.registry_url) setting is still
 supported for a single registry URL, but `aqua.registries` takes precedence when both are set.
 
 ## Usage
 
-The following installs the latest version of ripgrep and sets it as the active version on PATH:
+Install ripgrep in your project and verify the executable without requiring shell
+activation:
 
 ```sh
-$ mise use -g aqua:BurntSushi/ripgrep
-$ rg --version
-ripgrep 14.1.1
+mise use aqua:BurntSushi/ripgrep
+mise exec -- rg --version
 ```
 
-The version is set in `~/.config/mise/config.toml` with the following format:
+This writes the following to `mise.toml`. Add `-g` to `mise use` for a global tool.
 
 ```toml
 [tools]
 "aqua:BurntSushi/ripgrep" = "latest"
 ```
 
-Some tools default to aqua because they are configured in [registry/](https://github.com/jdx/mise/blob/main/registry/)
-to use the aqua backend. To see these tools, run `mise registry | grep aqua:`.
+Use `mise ls-remote aqua:BurntSushi/ripgrep` to inspect available versions.
+`mise registry ripgrep` shows the backends configured for its shorthand.
 
 ## Tool Options
 
@@ -155,127 +152,70 @@ import Settings from '/components/settings.vue';
 
 ## Security Verification
 
-The aqua backend supports multiple verification methods to ensure the integrity and authenticity of downloaded tools. mise provides a **native Rust implementation** of every method, so no external CLI tools such as `cosign`, `slsa-verifier`, or `gh` are needed.
+<span id="github-artifact-attestations"></span>
+<span id="cosign-verification"></span>
+<span id="slsa-provenance-verification"></span>
+<span id="other-security-methods"></span>
+<span id="verification-process"></span>
 
-### GitHub Artifact Attestations
+mise implements checksum, GitHub artifact attestation, Cosign, SLSA, and Minisign
+verification natively. You do not need their separate CLI tools. **Support in the
+backend does not mean that every package supplies all of these checks.**
 
-GitHub Artifact Attestations provide cryptographic proof that artifacts were built by specific GitHub Actions workflows. mise verifies these attestations natively to ensure the authenticity and integrity of downloaded tools.
+| Method                       | Required publisher or registry metadata                                                                    |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Checksums                    | An expected digest from registry metadata, a checksum file, the release API, or a lockfile.                |
+| GitHub artifact attestations | A registry attestation configuration identifying the expected workflow.                                    |
+| Cosign                       | A supported public-key or signature-bundle configuration; arbitrary Cosign CLI arguments are not executed. |
+| SLSA                         | A registry provenance configuration and the publisher's provenance artifact.                               |
+| Minisign                     | A signature and the expected public key.                                                                   |
 
-**Requirements:**
+The corresponding `aqua.*` verification settings are enabled by default. Some
+checks also have a global setting, such as `github_attestations` or `slsa`.
+See [Settings](#settings) for the complete configuration.
 
-- The tool must have a `github_artifact_attestations` entry in the aqua registry for attestations to be verified
-- No external tools are required - verification is handled natively by mise
-
-**Configuration:**
-
-```bash
-# Enable/disable GitHub artifact attestations verification (default: true)
-export MISE_AQUA_GITHUB_ATTESTATIONS=true
-```
-
-**Registry Configuration Example:**
-
-```yaml
-packages:
-  - type: github_release
-    repo_owner: cli
-    repo_name: cli
-    github_artifact_attestations:
-      signer_workflow: cli/cli/.github/workflows/deployment.yml
-```
-
-### Cosign Verification
-
-mise natively verifies Cosign signatures without requiring the `cosign` CLI tool to be installed.
-
-**Configuration:**
-
-```bash
-# Enable/disable Cosign verification (default: true)
-export MISE_AQUA_COSIGN=true
-```
-
-### SLSA Provenance Verification
-
-mise natively verifies SLSA (Supply-chain Levels for Software Artifacts) provenance without requiring the `slsa-verifier` CLI tool.
-
-**Configuration:**
-
-```bash
-# Enable/disable SLSA verification (default: true)
-export MISE_AQUA_SLSA=true
-```
-
-### Other Security Methods
-
-aqua also supports:
-
-- **Minisign verification**: Uses minisign for signature verification
-- **Checksum verification**: Verifies SHA256/SHA512/SHA1/MD5 checksums (always enabled)
-
-### Verification Process
-
-During tool installation, mise will:
-
-1. Download the tool and any signature/attestation files
-2. Perform native verification using the configured methods
-3. Display verification status with progress indicators
-4. Abort installation if any verification fails
-
-**Example output during installation:**
-
-```
-✓ Downloaded cli/cli v2.50.0
-✓ GitHub artifact attestations verified
-✓ Tool installed successfully
-```
+A verified [lockfile](/dev-tools/mise-lock.html) can reuse a previous provenance
+result while checking the artifact digest. Set
+[`locked_verify_provenance`](/configuration/settings.html#locked_verify_provenance)
+to require provenance verification again during locked installation.
 
 ### Troubleshooting
 
-If verification fails:
+Start with the failing command and its verification error:
 
-1. **Check network connectivity**: Verification requires downloading attestation data
-2. **Verify tool configuration**: Ensure the aqua registry has correct verification settings
-3. **Disable specific verification**: Temporarily disable problematic verification methods
-4. **Enable debug logging**: Use `MISE_DEBUG=1` to see detailed verification logs
-
-**Common issues:**
-
-- **No attestations found**: The tool may not have attestations configured in the registry
-- **Verification timeout**: Network issues or slow attestation services
-- **Certificate validation**: Clock skew or certificate chain issues
-
-To disable all verification temporarily:
-
-```bash
-export MISE_AQUA_GITHUB_ATTESTATIONS=false
-export MISE_AQUA_COSIGN=false
-export MISE_AQUA_SLSA=false
-export MISE_AQUA_MINISIGN=false
+```sh
+MISE_DEBUG=1 mise install aqua:cli/cli
 ```
+
+Check that the release publishes the expected signature or attestation, that the
+registry names the correct artifact and signer, and that your clock and network
+allow certificate and transparency-log verification. For private assets or API
+limits, check [GitHub authentication](/dev-tools/github-tokens.html).
+
+A digest mismatch requires investigating the artifact or expected digest. A
+missing or invalid signature requires checking the publisher and registry
+metadata. Disabling verification changes which artifacts you trust; it does not
+repair either problem. Report the affected version, platform, and verifier error
+with credentials removed.
 
 ## Common aqua issues
 
-Here are some common issues I've seen when working with aqua tools.
+These problems usually require a correction to the package entry in the aqua registry.
 
 ### Supported env missing
 
-The aqua registry defines the supported os/arch envs for each tool. I've noticed that some of these
-are missing os/arch combos that are in fact supported—possibly because support was added after
-the tool's registry entry was created.
-
-The fix is simple: edit the `supported_envs` section of `registry.yaml` for the tool in question.
+Compare the registry entry's `supported_envs` with the publisher's release assets.
+If a matching artifact exists but its platform is absent from the registry, update
+that entry. Adding a platform name alone cannot make an incompatible binary run.
 
 ### Using `version_filter` instead of `version_prefix`
 
-This is a weird one that causes odd issues in mise. In general, mise prefers versions like `1.2.3`
-without decoration such as `v1.2.3` or `cli-v1.2.3`. This consistency not only keeps `mise.toml`
-cleaner, it also helps commands like `mise up` work correctly, because the version can be parsed as
-semver without a bunch of edge cases.
+Use `version_prefix` to remove a known tag prefix from the versions shown to
+users, and `version_filter` to exclude unrelated releases. Preserve the
+publisher's meaningful version identifiers; a version does not need to be a
+three-part semantic version.
 
-If you notice aqua tools giving you versions that aren't simple triplets, it's worth fixing.
-
-One common issue I've seen is registries using a `version_filter` expression like `Version startsWith "atlascli/"`.
+For example, an entry may use a `version_filter` expression like `Version startsWith "atlascli/"`.
 
 This causes the version to be `atlascli/1.2.3`, which is not what we want. The fix is to use
 `version_prefix` instead of `version_filter` and put the prefix (`atlascli/` in this example) in the

--- a/docs/dev-tools/backends/forgejo.md
+++ b/docs/dev-tools/backends/forgejo.md
@@ -8,16 +8,17 @@ The code for this is inside the mise repository at [`src/backend/github.rs`](htt
 
 ## Usage
 
-The following installs the latest version of a tool from Forgejo releases
-and sets it as the active version on PATH:
+On Linux, install Forgejo Runner from its own Forgejo instance and check the
+executable. Its releases publish Linux binaries; choose a project with matching
+assets if you are installing on another operating system:
 
 ```sh
-$ mise use -g forgejo:forgejo/runner[api_url=https://code.forgejo.org/api/v1,bin=forgejo-runner]
-$ forgejo-runner -v
-forgejo-runner version v12.4.0
+mise use 'forgejo:forgejo/runner[api_url=https://code.forgejo.org/api/v1,bin=forgejo-runner]'
+mise exec -- forgejo-runner --version
 ```
 
-The version will be set in `~/.config/mise/config.toml` with the following format:
+Quote the complete tool argument so shell globbing does not interpret its square
+brackets. This writes the following project configuration:
 
 ```toml
 [tools]
@@ -27,6 +28,10 @@ The version will be set in `~/.config/mise/config.toml` with the following forma
   bin = "forgejo-runner",
 }
 ```
+
+Add `-g` to `mise use` for a global tool. This installs the runner executable;
+registering it with a server and running it as a service are separate steps.
+For Codeberg repositories, omit `api_url`.
 
 ## Authentication
 
@@ -69,7 +74,8 @@ token = "forgejo-enterprise-token"
 
 ### `credential_command`
 
-You can provide a shell command that prints a token to stdout:
+Set this in your **global** `~/.config/mise/config.toml`. Project configuration
+cannot set `credential_command`. The command must print only the token to stdout:
 
 ```toml
 [settings.forgejo]
@@ -114,9 +120,11 @@ Use `mise token forgejo` to see which token mise would use for a given host:
 
 ```sh
 mise token forgejo
-mise token forgejo --unmask
 mise token forgejo forgejo.mycompany.com
 ```
+
+Token diagnostics are masked by default. `--unmask` prints the actual credential;
+use it only when you need the secret itself, and keep it out of shared logs.
 
 ## Tool Options
 
@@ -154,7 +162,7 @@ Specifies the pattern to match against release asset names. This is useful when 
 
 ### `matching`
 
-Narrows asset selection to names containing the given substring, **while keeping platform autodetection**. Unlike [`asset_pattern`](#asset_pattern) (which replaces autodetection entirely), `matching` only refines the candidate set — autodetection still chooses the correct OS/arch from the narrowed list, so a single config stays portable across platforms.
+Narrows asset selection to names containing the given substring, **while keeping platform autodetection**. Unlike [`asset_pattern`](/dev-tools/backends/forgejo.html#asset-pattern) (which replaces autodetection entirely), `matching` only refines the candidate set — autodetection still chooses the correct OS/arch from the narrowed list, so a single config stays portable across platforms.
 
 This is the option to reach for when a repository ships **multiple binaries as separate per-platform assets** and autodetection can't tell which one you want.
 
@@ -172,9 +180,9 @@ Tool options can also be passed inline on the command line using `[key=value]` s
 mise use "forgejo:user/repo[matching=mytool-cli]"
 ```
 
-`matching` is a case-sensitive substring test, so a value that is also a substring of another asset's name (e.g. `matching = "tool"` when both `tool-*` and `tool-extras-*` are published) won't uniquely select your binary. Use [`matching_regex`](#matching_regex) with an anchor when you need a precise match.
+`matching` is a case-sensitive substring test, so a value that is also a substring of another asset's name (e.g. `matching = "tool"` when both `tool-*` and `tool-extras-*` are published) won't uniquely select your binary. Use [`matching_regex`](/dev-tools/backends/forgejo.html#matching-regex) with an anchor when you need a precise match.
 
-If [`asset_pattern`](#asset_pattern) is also set, it takes precedence and `matching`/`matching_regex` are ignored — `asset_pattern` replaces autodetection entirely, so there is no candidate set left for them to narrow. They are ignored silently: when `asset_pattern` is set, a `matching_regex` is never consulted and an invalid one is not reported, since mise does not error on a superseded option.
+If [`asset_pattern`](/dev-tools/backends/forgejo.html#asset-pattern) is also set, it takes precedence and `matching`/`matching_regex` are ignored — `asset_pattern` replaces autodetection entirely, so there is no candidate set left for them to narrow. They are ignored silently: when `asset_pattern` is set, a `matching_regex` is never consulted and an invalid one is not reported, since mise does not error on a superseded option.
 
 ### `matching_regex`
 
@@ -253,41 +261,47 @@ macos-arm64 = { asset_pattern = "tool_*_macOS_arm64.tar.gz" }
 
 ### `checksum`
 
-Verify the downloaded file with a checksum:
+Set an expected digest for a **specific version and artifact**. Replace the
+placeholder below with the full SHA-256 digest obtained from a trusted source:
 
 ```toml
 [tools."forgejo:owner/repo"]
 version = "1.0.0"
 asset_pattern = "tool-1.0.0-x64.tar.gz"
-checksum = "sha256:a1b2c3d4e5f6789..."
+checksum = "sha256:REPLACE_WITH_THE_64_HEX_DIGIT_DIGEST"
 ```
 
 _Instead of specifying the checksum here, you can use [mise.lock](/dev-tools/mise-lock) to manage checksums._
 
 ### Platform-specific Checksums
 
+Each platform needs its own digest. These values are placeholders; fill them
+from the publisher before installing, or generate [mise.lock](/dev-tools/mise-lock.html).
+
 ```toml
 [tools."forgejo:user/repo"]
-version = "latest"
+version = "1.0.0"
 
 [tools."forgejo:user/repo".platforms]
 linux-x64 = {
   asset_pattern = "tool_*_linux_x64.tar.gz",
-  checksum = "sha256:a1b2c3d4e5f6789...",
+  checksum = "sha256:REPLACE_WITH_THE_64_HEX_DIGIT_DIGEST",
 }
 macos-arm64 = {
   asset_pattern = "tool_*_macOS_arm64.tar.gz",
-  checksum = "sha256:b2c3d4e5f6789...",
+  checksum = "sha256:REPLACE_WITH_THE_64_HEX_DIGIT_DIGEST",
 }
 ```
 
 ### `size`
 
-Verify the downloaded asset size:
+Optionally check the expected byte count. The number below is illustrative;
+use the selected artifact's actual size and pin its version. A size check does
+not authenticate the publisher or replace a checksum:
 
 ```toml
 [tools]
-"forgejo:user/repo" = { version = "latest", size = "12345678" }
+"forgejo:user/repo" = { version = "1.0.0", size = "12345678" }
 ```
 
 ### `strip_components`
@@ -300,7 +314,7 @@ Number of directory components to strip when extracting archives:
 ```
 
 ::: info
-If `strip_components` is not set, mise automatically applies `strip_components = 1` when the extracted archive contains exactly one directory at the root and no files. This is common with tools like ripgrep that package their binaries in a versioned directory (e.g., `mytool-14.1.0-x86_64-unknown-linux-musl/mytool`). The autodetection ensures the binary is placed directly in the install path where mise expects it.
+When both `strip_components` and `bin_path` are unset, mise automatically applies `strip_components = 1` when the extracted archive contains exactly one directory at the root and no files. This is common with tools like ripgrep that package their binaries in a versioned directory (e.g., `mytool-14.1.0-x86_64-unknown-linux-musl/mytool`). The autodetection ensures the binary is placed directly in the install path where mise expects it.
 :::
 
 ### `bin`
@@ -351,6 +365,12 @@ When `no_app = true`:
 
 ### `bin_path`
 
+Paths are relative to the install directory **after** `strip_components` is
+applied. Setting `bin_path` disables automatic root stripping. For an archive
+shaped like `tool-VERSION/bin/tool`, either retain the outer directory and use
+`bin_path = "tool-{{ version }}/bin"`, or set both `strip_components = 1` and
+`bin_path = "bin"`.
+
 ::: v-pre
 Specify the directory containing binaries within the extracted archive, or where to place the downloaded file. This supports Tera templating with `{{ version }}` and the `{{ os() }}` / `{{ arch() }}` functions:
 :::
@@ -358,7 +378,8 @@ Specify the directory containing binaries within the extracted archive, or where
 ```toml
 [tools."forgejo:user/repo"]
 version = "latest"
-bin_path = "tool-{{ version }}/bin" # expands to tool-1.0.0/bin
+strip_components = 0
+bin_path = "tool-{{ version }}/bin" # retain the outer tool-1.0.0 directory
 ```
 
 Both functions take keyword arguments that remap the value mise would emit (`linux`, `macos`,
@@ -369,6 +390,7 @@ differently:
 [tools."forgejo:user/repo"]
 version = "latest"
 # expands to tool-1.0.0-linux-x86_64/bin
+strip_components = 0
 bin_path = 'tool-{{ version }}-{{ os() }}-{{ arch(x64="x86_64", arm64="aarch64") }}/bin'
 ```
 

--- a/docs/dev-tools/backends/github.md
+++ b/docs/dev-tools/backends/github.md
@@ -6,21 +6,24 @@ The code for this is inside of the mise repository at [`./src/backend/github.rs`
 
 ## Usage
 
-The following installs the latest version of ripgrep from GitHub releases
-and sets it as the active version on PATH:
+Install ripgrep in the current project, then check the selected executable:
 
 ```sh
-$ mise use -g github:BurntSushi/ripgrep
-$ rg --version
-ripgrep 14.1.1
+mise use github:BurntSushi/ripgrep
+mise exec -- rg --version
 ```
 
-The version will be set in `~/.config/mise/config.toml` with the following format:
+This records the following in `mise.toml`. Add `-g` to `mise use` for a global tool.
 
 ```toml
 [tools]
 "github:BurntSushi/ripgrep" = "latest"
 ```
+
+Use `mise ls-remote github:BurntSushi/ripgrep` to choose a version, or
+`mise use github:BurntSushi/ripgrep@VERSION` to select it. Replace `VERSION` with
+an entry from that list. For API limits or private releases, see
+[GitHub tokens](/dev-tools/github-tokens.html).
 
 ## Version Listing
 
@@ -84,11 +87,11 @@ Specifies the pattern to match against release asset names. This is useful when 
 
 ```toml
 [tools]
-"github:cli/cli" = { version = "latest", asset_pattern = "gh_*_linux_x64.tar.gz" }
+"github:cli/cli" = { version = "latest", asset_pattern = "gh_*_linux_amd64.tar.gz" }
 ```
 
 ::: v-pre
-Supports the same templating as [`bin_path`](#bin_path): `{{ version }}` plus the
+Supports the same templating as [`bin_path`](/dev-tools/backends/github.html#bin-path): `{{ version }}` plus the
 `{{ os() }}` / `{{ arch() }}` functions (with optional remap keyword arguments).
 :::
 
@@ -112,7 +115,7 @@ linux-x64 = {
 ```
 
 Each pattern must select exactly one archive. Patterns support the same templating as
-[`asset_pattern`](#asset_pattern). Supplemental assets must be archives; bare binaries
+[`asset_pattern`](/dev-tools/backends/github.html#asset-pattern). Supplemental assets must be archives; bare binaries
 are not supported. They are extracted without applying the primary asset's
 `strip_components`, `bin`, or `rename_exe` options. If a supplemental archive contains
 the same path as an earlier archive, the later archive's file wins.
@@ -125,7 +128,7 @@ recorded artifact list and fail if it is incomplete.
 
 ### `matching`
 
-Narrows asset selection to names containing the given substring, **while keeping platform autodetection**. Unlike [`asset_pattern`](#asset_pattern) (which replaces autodetection entirely), `matching` only refines the candidate set — autodetection still chooses the correct OS/arch from the narrowed list, so a single config stays portable across platforms.
+Narrows asset selection to names containing the given substring, **while keeping platform autodetection**. Unlike [`asset_pattern`](/dev-tools/backends/github.html#asset-pattern) (which replaces autodetection entirely), `matching` only refines the candidate set — autodetection still chooses the correct OS/arch from the narrowed list, so a single config stays portable across platforms.
 
 This is the option to reach for when a repository ships **multiple binaries as separate per-platform assets** and autodetection can't tell which one you want (see [Multiple Assets from the Same Release](#multiple-assets-from-the-same-release)).
 
@@ -144,9 +147,9 @@ Tool options can also be passed inline on the command line using `[key=value]` s
 mise use "github:oxc-project/oxc[matching=oxlint,rename_exe=oxlint]@apps_v1.69.0"
 ```
 
-`matching` is a case-sensitive substring test, so a value that is also a substring of another asset's name (e.g. `matching = "tool"` when both `tool-*` and `tool-extras-*` are published) won't uniquely select your binary. Use [`matching_regex`](#matching_regex) with an anchor when you need a precise match.
+`matching` is a case-sensitive substring test, so a value that is also a substring of another asset's name (e.g. `matching = "tool"` when both `tool-*` and `tool-extras-*` are published) won't uniquely select your binary. Use [`matching_regex`](/dev-tools/backends/github.html#matching-regex) with an anchor when you need a precise match.
 
-If [`asset_pattern`](#asset_pattern) is also set, it takes precedence and `matching`/`matching_regex` are ignored — `asset_pattern` replaces autodetection entirely, so there is no candidate set left for them to narrow. They are ignored silently: when `asset_pattern` is set, a `matching_regex` is never consulted and an invalid one is not reported, since mise does not error on a superseded option.
+If [`asset_pattern`](/dev-tools/backends/github.html#asset-pattern) is also set, it takes precedence and `matching`/`matching_regex` are ignored — `asset_pattern` replaces autodetection entirely, so there is no candidate set left for them to narrow. They are ignored silently: when `asset_pattern` is set, a `matching_regex` is never consulted and an invalid one is not reported, since mise does not error on a superseded option.
 
 The filter also scopes verification: checksums are looked up for the selected asset, and SLSA provenance discovery is narrowed the same way, so a multi-binary release can't verify one binary against another's provenance. A single shared provenance file that attests every artifact in the release (e.g. `multiple.intoto.jsonl`) is still used as a fallback when no per-binary provenance matches.
 
@@ -195,8 +198,8 @@ For different asset patterns per platform:
 version = "latest"
 
 [tools."github:cli/cli".platforms]
-linux-x64 = { asset_pattern = "gh_*_linux_x64.tar.gz" }
-macos-arm64 = { asset_pattern = "gh_*_macOS_arm64.tar.gz" }
+linux-x64 = { asset_pattern = "gh_*_linux_amd64.tar.gz" }
+macos-arm64 = { asset_pattern = "gh_*_macOS_arm64.zip" }
 ```
 
 ### Multiple Assets from the Same Release
@@ -204,13 +207,13 @@ macos-arm64 = { asset_pattern = "gh_*_macOS_arm64.tar.gz" }
 There are two distinct cases:
 
 - If the assets are parts of one installation, use
-  [`additional_asset_patterns`](#additional_asset_patterns). The supplemental archives
+  [`additional_asset_patterns`](/dev-tools/backends/github.html#additional-asset-patterns). The supplemental archives
   are overlaid into the same install directory.
 - If the assets are independent tools that should have separate install directories,
   define one tool alias per binary and point each alias at the same
   `github:owner/repo` backend.
 
-Prefer [`matching`](#matching) (or [`matching_regex`](#matching_regex)): it narrows the
+Prefer [`matching`](#matching) (or [`matching_regex`](/dev-tools/backends/github.html#matching-regex)): it narrows the
 candidate set while **keeping platform autodetection**, so one config works on every
 OS/arch. This is the right choice when the per-platform asset names can't be templated
 portably (e.g. Rust target-triples like `oxlint-aarch64-apple-darwin.tar.gz`).
@@ -218,7 +221,7 @@ portably (e.g. Rust target-triples like `oxlint-aarch64-apple-darwin.tar.gz`).
 The example below installs both `oxlint` and `oxfmt` from the single
 `oxc-project/oxc` release. Each `matching` value must be specific enough to
 select **only** the intended binary — if one binary's name were a substring of the
-other's, use [`matching_regex`](#matching_regex) with an anchor (e.g. `"^oxlint-"`)
+other's, use [`matching_regex`](/dev-tools/backends/github.html#matching-regex) with an anchor (e.g. `"^oxlint-"`)
 instead (see the [`matching`](#matching) caveat).
 
 ```toml
@@ -244,14 +247,18 @@ Use them for independent binaries such as `oxlint` and `oxfmt`; use
 :::
 
 If the binary isn't named the way you want to invoke it, add
-[`rename_exe`](#rename_exe) (renames the executable extracted from an archive) or
+[`rename_exe`](/dev-tools/backends/github.html#rename-exe) (renames the executable extracted from an archive) or
 [`bin`](#bin) (selects/renames the binary, including a single bare non-archive binary).
 
-Use [`asset_pattern`](#asset_pattern) instead only when you need full manual control and
+Use [`asset_pattern`](/dev-tools/backends/github.html#asset-pattern) instead only when you need full manual control and
 can name the asset portably (it replaces autodetection, so any <code v-pre>{{ os() }}</code>/<code v-pre>{{ arch() }}</code>
 templating must cover every platform you target):
 
 ```toml
+[tool_alias]
+tool-a = "github:owner/repo"
+tool-b = "github:owner/repo"
+
 [tools.tool-a]
 version = "latest"
 asset_pattern = "tool-a-*"
@@ -263,41 +270,47 @@ asset_pattern = "tool-b-*"
 
 ### `checksum`
 
-Verify the downloaded file with a checksum:
+Set an expected digest for a **specific version and artifact**. Replace the
+placeholder below with the full SHA-256 digest obtained from a trusted source:
 
 ```toml
 [tools."github:owner/repo"]
 version = "1.0.0"
 asset_pattern = "tool-1.0.0-x64.tar.gz"
-checksum = "sha256:a1b2c3d4e5f6789..."
+checksum = "sha256:REPLACE_WITH_THE_64_HEX_DIGIT_DIGEST"
 ```
 
 _Instead of specifying the checksum here, you can use [mise.lock](/dev-tools/mise-lock) to manage checksums._
 
 ### Platform-specific Checksums
 
+Each platform needs its own digest. These values are placeholders; fill them
+from the publisher before installing, or generate [mise.lock](/dev-tools/mise-lock.html).
+
 ```toml
 [tools."github:cli/cli"]
-version = "latest"
+version = "2.100.0"
 
 [tools."github:cli/cli".platforms]
 linux-x64 = {
-  asset_pattern = "gh_*_linux_x64.tar.gz",
-  checksum = "sha256:a1b2c3d4e5f6789...",
+  asset_pattern = "gh_*_linux_amd64.tar.gz",
+  checksum = "sha256:REPLACE_WITH_THE_64_HEX_DIGIT_DIGEST",
 }
 macos-arm64 = {
-  asset_pattern = "gh_*_macOS_arm64.tar.gz",
-  checksum = "sha256:b2c3d4e5f6789...",
+  asset_pattern = "gh_*_macOS_arm64.zip",
+  checksum = "sha256:REPLACE_WITH_THE_64_HEX_DIGIT_DIGEST",
 }
 ```
 
 ### `size`
 
-Verify the downloaded asset size:
+Optionally check the expected byte count. The number below is illustrative;
+use the selected artifact's actual size and pin its version. A size check does
+not authenticate the publisher or replace a checksum:
 
 ```toml
 [tools]
-"github:cli/cli" = { version = "latest", size = "12345678" }
+"github:owner/repo" = { version = "1.0.0", size = "12345678" }
 ```
 
 ### `strip_components`
@@ -310,7 +323,7 @@ Number of directory components to strip when extracting archives:
 ```
 
 ::: info
-If `strip_components` is not explicitly set, mise automatically detects when to apply `strip_components = 1`. This happens when the extracted archive contains exactly one directory at the root level and no files. This is common with tools like ripgrep that package their binaries in a versioned directory (e.g., `ripgrep-14.1.0-x86_64-unknown-linux-musl/rg`). The auto-detection ensures the binary is placed directly in the install path where mise expects it.
+When both `strip_components` and `bin_path` are unset, mise automatically detects when to apply `strip_components = 1`. This happens when the extracted archive contains exactly one directory at the root level and no files. This is common with tools like ripgrep that package their binaries in a versioned directory (e.g., `ripgrep-14.1.0-x86_64-unknown-linux-musl/rg`). The auto-detection ensures the binary is placed directly in the install path where mise expects it.
 :::
 
 ### `bin`
@@ -377,6 +390,12 @@ Without this option, mise's autodetection might select .app bundles on macOS, wh
 
 ### `bin_path`
 
+Paths are relative to the install directory **after** `strip_components` is
+applied. Setting `bin_path` disables automatic root stripping. For an archive
+shaped like `tool-VERSION/bin/tool`, either retain the outer directory and use
+`bin_path = "tool-{{ version }}/bin"`, or set both `strip_components = 1` and
+`bin_path = "bin"`.
+
 ::: v-pre
 Specify the directory containing binaries within the extracted archive, or where to place the downloaded file. This supports Tera templating with `{{ version }}` and the `{{ os() }}` / `{{ arch() }}` functions:
 :::
@@ -384,7 +403,8 @@ Specify the directory containing binaries within the extracted archive, or where
 ```toml
 [tools."github:cli/cli"]
 version = "latest"
-bin_path = "cli-{{ version }}/bin" # expands to cli-1.0.0/bin
+strip_components = 1
+bin_path = "bin" # after the archive's outer directory is stripped
 ```
 
 Both take keyword arguments that remap the value mise would emit (`linux`, `macos`,
@@ -395,6 +415,7 @@ differently:
 [tools."github:pizlonator/fil-c"]
 version = "latest"
 # expands to filc-0.681-linux-x86_64/build/bin
+strip_components = 0
 bin_path = 'filc-{{ version }}-{{ os() }}-{{ arch(x64="x86_64", arm64="aarch64") }}/build/bin'
 ```
 

--- a/docs/dev-tools/backends/gitlab.md
+++ b/docs/dev-tools/backends/gitlab.md
@@ -6,21 +6,31 @@ The code for this backend is in the mise repository at [`./src/backend/github.rs
 
 ## Usage
 
-The following installs the latest version of gitlab-runner from GitLab releases
-and sets it as the active version on PATH:
+GitLab release links have a display name as well as a download URL.
+`asset_pattern` matches the **display name**, which may differ from the filename.
+For example, GitLab Runner calls its Linux binary `binary: Linux amd64`.
 
-```sh
-$ mise use -g gitlab:gitlab-org/gitlab-runner
-$ gitlab-runner --version
-gitlab-runner 16.8.0
-```
-
-The version is set in `~/.config/mise/config.toml` with the following format:
+Add this to a project's `mise.toml` for Linux x64 or macOS arm64:
 
 ```toml
-[tools]
-"gitlab:gitlab-org/gitlab-runner" = { version = "latest", asset_pattern = "gitlab-runner-linux-x64" }
+[tools."gitlab:gitlab-org/gitlab-runner"]
+version = "19.3.1"
+bin = "gitlab-runner"
+
+[tools."gitlab:gitlab-org/gitlab-runner".platforms]
+linux-x64 = { asset_pattern = "binary: Linux amd64" }
+macos-arm64 = { asset_pattern = "binary: macOS arm64" }
 ```
+
+```sh
+mise install
+mise exec -- gitlab-runner --version
+```
+
+This installs the executable; it does not register a runner or create a service.
+For another platform or release, inspect the project's release links and adjust
+the pattern. Version listing uses releases with attached links, not arbitrary
+Git tags or GitLab's generated source archives.
 
 ## Authentication
 
@@ -63,7 +73,8 @@ token = "glpat-yyyyyyyy"
 
 ### `credential_command`
 
-You can provide a shell command that prints a token to stdout:
+Set this in your **global** `~/.config/mise/config.toml`. Project configuration
+cannot set `credential_command`. The command must print only the token to stdout:
 
 ```toml
 [settings.gitlab]
@@ -112,9 +123,11 @@ Use `mise token gitlab` to see which token mise would use for a given host:
 
 ```sh
 mise token gitlab
-mise token gitlab --unmask
 mise token gitlab gitlab.mycompany.com
 ```
+
+Token diagnostics are masked by default. `--unmask` prints the actual credential;
+use it only when you need the secret itself, and keep it out of shared logs.
 
 ## Tool Options
 
@@ -143,17 +156,18 @@ The autodetection logic is implemented in [`src/backend/asset_matcher.rs`](https
 
 ### `asset_pattern`
 
-Specifies the pattern to match against release asset names. This is useful when there are multiple assets for your OS/arch combination or when you need to override autodetection.
+Specifies a glob matched against the release link's display name. This is useful when there are multiple assets for your OS/arch combination or when you need to override autodetection.
 
 ```toml
 [tools."gitlab:gitlab-org/gitlab-runner"]
 version = "latest"
-asset_pattern = "gitlab-runner-linux-x64"
+bin = "gitlab-runner"
+asset_pattern = "binary: Linux amd64"
 ```
 
 ### `matching`
 
-Narrows asset selection to names containing the given substring, **while keeping platform autodetection**. Unlike [`asset_pattern`](#asset_pattern) (which replaces autodetection entirely), `matching` only refines the candidate set — autodetection still chooses the correct OS/arch from the narrowed list, so a single config stays portable across platforms.
+Narrows asset selection to names containing the given substring, **while keeping platform autodetection**. Unlike [`asset_pattern`](/dev-tools/backends/gitlab.html#asset-pattern) (which replaces autodetection entirely), `matching` only refines the candidate set — autodetection still chooses the correct OS/arch from the narrowed list, so a single config stays portable across platforms.
 
 This is the option to reach for when a repository ships **multiple binaries as separate per-platform assets** and autodetection can't tell which one you want.
 
@@ -171,9 +185,9 @@ Tool options can also be passed inline on the command line using `[key=value]` s
 mise use "gitlab:owner/repo[matching=mytool-cli]"
 ```
 
-`matching` is a case-sensitive substring test, so a value that is also a substring of another asset's name (e.g. `matching = "tool"` when both `tool-*` and `tool-extras-*` are published) won't uniquely select your binary. Use [`matching_regex`](#matching_regex) with an anchor when you need a precise match.
+`matching` is a case-sensitive substring test, so a value that is also a substring of another asset's name (e.g. `matching = "tool"` when both `tool-*` and `tool-extras-*` are published) won't uniquely select your binary. Use [`matching_regex`](/dev-tools/backends/gitlab.html#matching-regex) with an anchor when you need a precise match.
 
-If [`asset_pattern`](#asset_pattern) is also set, it takes precedence and `matching`/`matching_regex` are ignored — `asset_pattern` replaces autodetection entirely, so there is no candidate set left for them to narrow. They are ignored silently: when `asset_pattern` is set, a `matching_regex` is never consulted and an invalid one is not reported, since mise does not error on a superseded option.
+If [`asset_pattern`](/dev-tools/backends/gitlab.html#asset-pattern) is also set, it takes precedence and `matching`/`matching_regex` are ignored — `asset_pattern` replaces autodetection entirely, so there is no candidate set left for them to narrow. They are ignored silently: when `asset_pattern` is set, a `matching_regex` is never consulted and an invalid one is not reported, since mise does not error on a superseded option.
 
 ### `matching_regex`
 
@@ -227,62 +241,71 @@ To use different asset patterns per platform:
 ```toml
 [tools."gitlab:gitlab-org/gitlab-runner"]
 version = "latest"
+bin = "gitlab-runner"
 
 [tools."gitlab:gitlab-org/gitlab-runner".platforms]
-linux-x64 = { asset_pattern = "gitlab-runner-linux-x64" }
-macos-arm64 = { asset_pattern = "gitlab-runner-macos-arm64" }
+linux-x64 = { asset_pattern = "binary: Linux amd64" }
+macos-arm64 = { asset_pattern = "binary: macOS arm64" }
 ```
 
 ### `checksum`
 
-Verify the downloaded file with a checksum:
+Set an expected digest for a **specific version and artifact**. Replace the
+placeholder below with the full SHA-256 digest obtained from a trusted source:
 
 ```toml
 [tools."gitlab:owner/repo"]
 version = "1.0.0"
 asset_pattern = "tool-1.0.0-x64.tar.gz"
-checksum = "sha256:a1b2c3d4e5f6789..."
+checksum = "sha256:REPLACE_WITH_THE_64_HEX_DIGIT_DIGEST"
 ```
 
 _Instead of specifying the checksum here, you can use [mise.lock](/dev-tools/mise-lock) to manage checksums._
 
 ### Platform-specific Checksums
 
+Each platform needs its own digest. These values are placeholders; fill them
+from the publisher before installing, or generate [mise.lock](/dev-tools/mise-lock.html).
+
 ```toml
 [tools."gitlab:gitlab-org/gitlab-runner"]
-version = "latest"
+version = "19.3.1"
+bin = "gitlab-runner"
 
 [tools."gitlab:gitlab-org/gitlab-runner".platforms]
 linux-x64 = {
-  asset_pattern = "gitlab-runner-linux-x64",
-  checksum = "sha256:a1b2c3d4e5f6789...",
+  asset_pattern = "binary: Linux amd64",
+  checksum = "sha256:REPLACE_WITH_THE_64_HEX_DIGIT_DIGEST",
 }
 macos-arm64 = {
-  asset_pattern = "gitlab-runner-macos-arm64",
-  checksum = "sha256:b2c3d4e5f6789...",
+  asset_pattern = "binary: macOS arm64",
+  checksum = "sha256:REPLACE_WITH_THE_64_HEX_DIGIT_DIGEST",
 }
 ```
 
 ### `size`
 
-Verify the downloaded asset size:
+Optionally check the expected byte count. The number below is illustrative;
+use the selected artifact's actual size and pin its version. A size check does
+not authenticate the publisher or replace a checksum:
 
 ```toml
 [tools]
-"gitlab:gitlab-org/gitlab-runner" = { version = "latest", size = "12345678" }
+"gitlab:owner/repo" = { version = "1.0.0", size = "12345678" }
 ```
 
 ### Platform-specific Size
 
-You can specify different sizes for different platforms:
+Use each artifact's actual byte count; the following numbers illustrate the syntax:
 
 ```toml
 [tools."gitlab:gitlab-org/gitlab-runner"]
-version = "latest"
+version = "19.3.1"
+bin = "gitlab-runner"
 
 [tools."gitlab:gitlab-org/gitlab-runner".platforms]
-linux-x64 = { size = "12345678" }
-macos-arm64 = { size = "9876543" }
+linux-x64 = { asset_pattern = "binary: Linux amd64", size = "12345678" }
+macos-arm64 = { asset_pattern = "binary: macOS arm64", size = "9876543" }
 ```
 
 ### `strip_components`
@@ -291,11 +314,11 @@ Number of directory components to strip when extracting archives:
 
 ```toml
 [tools]
-"gitlab:gitlab-org/gitlab-runner" = { version = "latest", strip_components = 1 }
+"gitlab:owner/repo" = { version = "1.0.0", strip_components = 1 }
 ```
 
 ::: info
-If `strip_components` is not set, mise automatically applies `strip_components = 1` when the extracted archive contains exactly one directory at the root level and no files. This is common with tools like ripgrep that package their binaries in a versioned directory (e.g., `ripgrep-14.1.0-x86_64-unknown-linux-musl/rg`). Auto-detection places the binary directly in the install path where mise expects it.
+When both `strip_components` and `bin_path` are unset, mise automatically applies `strip_components = 1` when the extracted archive contains exactly one directory at the root level and no files. This is common with tools like ripgrep that package their binaries in a versioned directory (e.g., `ripgrep-14.1.0-x86_64-unknown-linux-musl/rg`). Auto-detection places the binary directly in the install path where mise expects it.
 :::
 
 ### `bin`
@@ -347,14 +370,21 @@ When `no_app = true`:
 
 ### `bin_path`
 
+Paths are relative to the install directory **after** `strip_components` is
+applied. Setting `bin_path` disables automatic root stripping. For an archive
+shaped like `tool-VERSION/bin/tool`, either retain the outer directory and use
+`bin_path = "tool-{{ version }}/bin"`, or set both `strip_components = 1` and
+`bin_path = "bin"`.
+
 ::: v-pre
 Specify the directory containing binaries within the extracted archive, or where to place the downloaded file. This supports Tera templating with `{{ version }}` and the `{{ os() }}` / `{{ arch() }}` functions:
 :::
 
 ```toml
-[tools."gitlab:gitlab-org/gitlab-runner"]
-version = "latest"
-bin_path = "gitlab-runner-{{ version }}/bin" # expands to gitlab-runner-1.0.0/bin
+[tools."gitlab:owner/repo"]
+version = "1.0.0"
+strip_components = 1
+bin_path = "bin" # for an archive shaped like tool-VERSION/bin/tool
 ```
 
 Both take keyword arguments that remap the value mise would emit (`linux`, `macos`,
@@ -365,6 +395,7 @@ differently:
 [tools."gitlab:owner/repo"]
 version = "latest"
 # expands to tool-1.0.0-linux-x86_64/bin
+strip_components = 0
 bin_path = 'tool-{{ version }}-{{ os() }}-{{ arch(x64="x86_64", arm64="aarch64") }}/bin'
 ```
 

--- a/docs/dev-tools/backends/http.md
+++ b/docs/dev-tools/backends/http.md
@@ -1,23 +1,32 @@
 # HTTP Backend
 
-You may install tools directly from HTTP URLs using the `http` backend. This backend downloads files from any HTTP/HTTPS URL and is ideal for tools that distribute pre-built binaries or archives through direct download links.
+The `http` backend installs a binary, script, or archive from a direct download
+URL. Use it when the publisher has no supported release backend or when you host
+your own artifacts. Prefer HTTPS URLs and record an expected checksum.
 
 The code for this is inside the mise repository at [`./src/backend/http.rs`](https://github.com/jdx/mise/blob/main/src/backend/http.rs).
 
 ## Usage
 
-The following installs a tool from a direct HTTP URL:
+Replace the example URL with an artifact for your platform, then install it in
+the current project:
 
 ```sh
-mise use -g http:my-tool[url=https://example.com/releases/my-tool-v1.0.0.tar.gz]@1.0.0
+mise use 'http:my-tool[url=https://example.com/releases/my-tool-v1.0.0.tar.gz]@1.0.0'
+mise exec -- my-tool --version
 ```
 
-The version will be set in `~/.config/mise/config.toml` with the following format:
+This records the URL and version in `mise.toml`. Add `-g` for a global tool:
 
 ```toml
 [tools]
 "http:my-tool" = { version = "1.0.0", url = "https://example.com/releases/my-tool-v1.0.0.tar.gz" }
 ```
+
+A fixed URL needs a concrete version label. `latest` does not discover releases
+from a download URL: add [`version_list_url`](/dev-tools/backends/http.html#version-list-url) to enable
+`mise ls-remote` and automatic version selection. Updating the version alone does
+not change a static URL; use a URL template for versioned artifacts.
 
 ## Supported HTTP Syntax
 
@@ -59,7 +68,7 @@ The `os()` and `arch()` functions support remapping for tools that use different
 [tools]
 # HashiCorp tools use "darwin" instead of "macos" and "amd64" instead of "x64"
 "http:sentinel" = {
-  version = "latest",
+  version = "0.26.3",
   url = 'https://releases.hashicorp.com/sentinel/{{version}}/sentinel_{{version}}_{{os(macos="darwin")}}_{{arch(x64="amd64")}}.zip',
 }
 ```
@@ -95,18 +104,21 @@ you meant and do the right thing anyway.
 
 ### `checksum`
 
-Verify the downloaded file with a checksum:
+Provide the full expected digest from a trusted source. The following value
+is a placeholder and must be replaced before installation:
 
 ```toml
 [tools."http:my-tool"]
 version = "1.0.0"
 url = "https://example.com/releases/my-tool-v1.0.0.tar.gz"
-checksum = "sha256:a1b2c3d4e5f6789..."
+checksum = "sha256:REPLACE_WITH_THE_64_HEX_DIGIT_DIGEST"
 ```
 
 _Instead of specifying the checksum here, you can use [mise.lock](/dev-tools/mise-lock) to manage checksums._
 
 ### Platform-specific Checksums
+
+Replace each placeholder with the digest for that platform's artifact:
 
 ```toml
 [tools."http:my-tool"]
@@ -115,15 +127,15 @@ version = "1.0.0"
 [tools."http:my-tool".platforms]
 macos-x64 = {
   url = "https://example.com/releases/my-tool-v1.0.0-macos-x64.tar.gz",
-  checksum = "sha256:a1b2c3d4e5f6789...",
+  checksum = "sha256:REPLACE_WITH_THE_64_HEX_DIGIT_DIGEST",
 }
 macos-arm64 = {
   url = "https://example.com/releases/my-tool-v1.0.0-macos-arm64.tar.gz",
-  checksum = "sha256:b2c3d4e5f6789...",
+  checksum = "sha256:REPLACE_WITH_THE_64_HEX_DIGIT_DIGEST",
 }
 linux-x64 = {
   url = "https://example.com/releases/my-tool-v1.0.0-linux-x64.tar.gz",
-  checksum = "sha256:c3d4e5f6789...",
+  checksum = "sha256:REPLACE_WITH_THE_64_HEX_DIGIT_DIGEST",
 }
 ```
 
@@ -195,7 +207,8 @@ the literal key `"version"`.
 
 ### `size`
 
-Verify the downloaded file size:
+Check the expected byte count. These numbers illustrate the syntax; use the
+actual artifact sizes. A size check does not replace a checksum:
 
 ```toml
 [tools."http:my-tool"]
@@ -239,7 +252,7 @@ strip_components = 1
 ```
 
 ::: info
-If `strip_components` is not set, mise automatically applies `strip_components = 1` when the extracted archive contains exactly one directory at the root level and no files. This is common with tools like ripgrep that package their binaries in a versioned directory (e.g., `ripgrep-14.1.0-x86_64-unknown-linux-musl/rg`). Auto-detection ensures the binary is placed directly in the install path where mise expects it.
+When both `strip_components` and `bin_path` are unset, mise automatically applies `strip_components = 1` when the extracted archive contains exactly one directory at the root level and no files. This is common with tools like ripgrep that package their binaries in a versioned directory (e.g., `ripgrep-14.1.0-x86_64-unknown-linux-musl/rg`). Auto-detection ensures the binary is placed directly in the install path where mise expects it.
 :::
 
 ### `bin`
@@ -403,13 +416,19 @@ Examples:
 ```toml
 # GitHub releases API format
 version_json_path = ".[].tag_name"
+```
 
+```toml
 # Nested versions array
 version_json_path = ".data.versions[]"
+```
 
+```toml
 # Release info objects
 version_json_path = ".releases[].info.version"
+```
 
+```toml
 # Filter for stable releases only (e.g., Flutter)
 version_json_path = ".releases[?channel=stable].version"
 ```
@@ -438,14 +457,20 @@ Example expressions:
 ```toml
 # Split newline-separated versions
 version_expr = 'split(body, "\n")'
+```
 
+```toml
 # Split and filter empty lines
 version_expr = 'filter(split(body, "\n"), # != "")'
+```
 
+```toml
 # Parse JSON and extract object keys (useful for HashiCorp-style JSON)
 # e.g., {"versions": {"1.0.0": {}, "2.0.0": {}}}
 version_expr = 'keys(fromJSON(body).versions)'
+```
 
+```toml
 # Sort versions with mise's version-aware comparator
 version_expr = 'fromJSON(body) | map({ trimPrefix(#.tag_name, "v") }) | sortVersions()'
 ```
@@ -475,13 +500,19 @@ list. Use the `versions` variable to post-process values produced by
 
 ### `bin_path`
 
+Use paths relative to the extracted install root. Setting `bin_path` disables
+automatic root stripping. For an archive shaped like
+`my-tool-1.0.0/bin/my-tool`, explicitly strip the outer directory as below, or
+leave it in place and use `bin_path = "my-tool-{{ version }}/bin"`.
+
 Specify the directory containing binaries within the extracted archive, or where to place the downloaded file. This supports templating with <code v-pre>{{version}}</code>:
 
 ```toml
 [tools."http:my-tool"]
 version = "1.0.0"
 url = "https://example.com/releases/my-tool-v1.0.0.tar.gz"
-bin_path = "my-tool-{{version}}/bin" # expands to my-tool-1.0.0/bin
+strip_components = 1
+bin_path = "bin"
 ```
 
 **Binary path lookup order:**
@@ -513,8 +544,8 @@ is self-contained and does not link to the installing user's home directory.
 
 Cache keys are derived from the file content so that identical downloads are shared across tools:
 
-1. **Blake3 hash of file content**: When no checksum is provided, mise calculates a Blake3 hash of the downloaded file
-2. **Extraction options**: `strip_components` is included in the cache key since it affects the extracted structure
+1. **File content**: mise calculates a Blake3 hash of the downloaded file, independently of its expected verification checksum.
+2. **Extraction options**: options that change the extracted result, including root stripping, renaming, and relevant format or launcher choices, also affect the key.
 
 Example cache directory structure:
 
@@ -539,8 +570,8 @@ Normal user installations are symlinks to the cached extracted content:
 This approach provides several benefits:
 
 - **Space efficiency**: Normal user installs share identical tarballs across tools
-- **Faster installations**: Cache hits avoid re-downloading and re-extracting files
-- **Consistency**: Identical file content always uses the same cache entry
+- **Faster installations**: Reusing extracted content avoids repeated extraction; a download may still be needed to identify its content
+- **Consistency**: The same file and extraction options reuse the same cached content
 
 System, shared, and install-into destinations contain real files rather than
 these symlinks. This avoids leaving hidden cache entries behind after an
@@ -554,7 +585,7 @@ Each cache entry includes a `metadata.json` file with information about the cach
 ```json
 {
   "url": "https://example.com/releases/my-tool-v1.0.0.tar.gz",
-  "checksum": "sha256:a1b2c3d4e5f6789...",
+  "checksum": "sha256:REPLACE_WITH_THE_64_HEX_DIGIT_DIGEST",
   "size": 1024000,
   "extracted_at": 1703001234,
   "platform": "macos-arm64"

--- a/docs/dev-tools/backends/index.md
+++ b/docs/dev-tools/backends/index.md
@@ -1,30 +1,50 @@
 # Backends
 
-Backends are package managers or ecosystems that mise uses to install [tools](/dev-tools/index.html) and [plugins](/plugins.html). Each backend can install and manage multiple tools from its ecosystem. For example, the `npm` backend can install tools like `npm:prettier`, and the `pipx` backend can install tools like `pipx:black`. This lets mise support a wide variety of tools and languages by leveraging existing package managers and their ecosystems.
+A backend tells mise where to find a tool's versions and how to install them.
+Use a registry shorthand such as `ripgrep` for the default selection, or specify
+a backend explicitly, such as `github:BurntSushi/ripgrep`.
 
-When you run [`mise use`](/cli/use.html), mise determines the appropriate backend based on the tool you are managing. The backend then handles installation, configuration, and any other steps needed to make the tool ready to use.
+## Choose an installation source
 
-For more details on how backends fit into mise's overall design, see the [backend architecture documentation](/dev-tools/backend_architecture.html).
+Start by checking the [registry](/registry.html):
 
-Below is a list of the available backends in mise:
+```sh
+mise registry ripgrep
+mise ls-remote ripgrep
+mise use ripgrep
+mise exec -- rg --version
+```
 
-- [asdf](/dev-tools/backends/asdf) (provides tools through [plugins](/plugins.html))
-- [aqua](/dev-tools/backends/aqua)
-- [cargo](/dev-tools/backends/cargo)
-- [conda](/dev-tools/backends/conda)
-- [dotnet](/dev-tools/backends/dotnet)
-- [forgejo](/dev-tools/backends/forgejo)
-- [gem](/dev-tools/backends/gem)
-- [github](/dev-tools/backends/github)
-- [gitlab](/dev-tools/backends/gitlab)
-- [go](/dev-tools/backends/go)
-- [http](/dev-tools/backends/http)
-- [npm](/dev-tools/backends/npm)
-- [packslip](/dev-tools/backends/packslip)
-- [pipx](/dev-tools/backends/pipx)
-- [pkgx](/dev-tools/backends/pkgx) <Badge type="warning" text="experimental" />
-- [s3](/dev-tools/backends/s3)
-- [spm](/dev-tools/backends/spm)
-- [ubi](/dev-tools/backends/ubi)
-- [vfox](/dev-tools/backends/vfox) (provides tools through [plugins](/plugins.html))
-- [custom backends](/backend-plugin-development) (build your own backend with a plugin that itself provides many tools)
+`mise use` installs the tool and records it in the project's `mise.toml`.
+Add `-g` for your global configuration. You can use an explicit backend even
+when a tool has no registry shorthand; a registry submission is not required.
+
+| Source                      | Backends                                                                                                                                                      | What to check                                                                            |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Signed publisher manifests  | [Packslip](./packslip.html)                                                                                                                                   | The publisher must provide Packslip releases and a verifiable signer.                    |
+| Curated binary recipes      | [Aqua](./aqua.html)                                                                                                                                           | The aqua registry must have an entry for the tool and platform. No aqua CLI is required. |
+| Release assets              | [GitHub](./github.html), [GitLab](./gitlab.html), [Forgejo](./forgejo.html)                                                                                   | Releases must include an installable asset for your platform.                            |
+| Direct downloads            | [HTTP](./http.html), [S3](./s3.html)                                                                                                                          | Supply download URLs and, for version discovery, a version source.                       |
+| Language packages           | [Cargo](./cargo.html), [Go](./go.html), [npm](./npm.html), [pipx](./pipx.html), [gem](./gem.html), [.NET](./dotnet.html), [Swift Package Manager](./spm.html) | Read the backend's runtime and build prerequisites.                                      |
+| Binary package ecosystems   | [Conda](./conda.html), [pkgx](./pkgx.html) (experimental)                                                                                                     | Packages and their runtime dependencies must support your platform.                      |
+| Plugin-defined installation | [vfox](./vfox.html), [asdf](./asdf.html) (legacy)                                                                                                             | Review the plugin and its dependencies before installation.                              |
+| Legacy release installer    | [ubi](./ubi.html) (deprecated)                                                                                                                                | Migrate existing configurations to the appropriate release backend.                      |
+
+Built-in language support is documented in the [language guides](/lang/node.html).
+Plugin authors can also create [custom backends](/backend-plugin-development.html)
+that manage a family of tools.
+
+## Verify the result
+
+A listed version does not guarantee that its publisher ships an artifact for your
+OS and architecture. Check installation and the actual executable with
+`mise exec -- <command> --version`. If selection fails, the backend's guide
+explains its asset names, authentication, and platform options.
+
+For reproducible installations, record concrete versions and supported-platform
+checksums in [mise.lock](/dev-tools/mise-lock.html). Verification coverage differs
+by backend; see [security](/security.html) and the individual guide before relying
+on a particular signature or provenance check.
+
+See [backend architecture](/dev-tools/backend_architecture.html) for selection,
+installation dependencies, and the implementation lifecycle.

--- a/docs/dev-tools/backends/packslip.md
+++ b/docs/dev-tools/backends/packslip.md
@@ -15,12 +15,12 @@ read [Introducing packslip](https://jdx.dev/posts/2026-09-05-introducing-packsli
 
 ## Quick start {#usage}
 
-With [mise activated](/getting-started.html), install [hk](https://hk.jdx.dev),
+Install [hk](https://hk.jdx.dev),
 a git hook and lint manager, in your project:
 
 ```sh
 mise use packslip:github.com/jdx/hk
-hk --version
+mise exec -- hk --version
 ```
 
 This records hk in the project's `mise.toml`. The equivalent configuration is:
@@ -93,13 +93,28 @@ if the cache is empty. Installation still performs verification. See
 [version resolution](/dev-tools/packslip-verification.html#version-resolution)
 for signed lists, withdrawals, and fallback behavior.
 
+### Reproduce an installation
+
+A `latest` request can resolve differently after the publisher recommends a new
+release. Keep the request in `mise.toml` and commit a generated lockfile when your
+team needs to install the same version:
+
+```sh
+mise lock
+mise install --locked
+```
+
+The lockfile carries version, signer, and artifact commitments. Installation still
+needs the artifacts or usable cached copies and must satisfy current verification
+policy. See [mise.lock](/dev-tools/mise-lock.html) for target platforms and updates.
+
 ## Completions and skills {#completions}
 
 With [mise activated](/getting-started.html#activate-mise), installing hk also
 makes its completions available:
 
 ```sh
-mise use hk
+mise use packslip:github.com/jdx/hk
 ```
 
 Type `hk` and press Tab. mise loads the completion script declared by hk's

--- a/docs/dev-tools/backends/packslip.md
+++ b/docs/dev-tools/backends/packslip.md
@@ -100,13 +100,23 @@ release. Keep the request in `mise.toml` and commit a generated lockfile when yo
 team needs to install the same version:
 
 ```sh
-mise lock
+mise install
+git add mise.toml mise.lock
+```
+
+The first installation records the version, signer, and artifact commitments in
+`mise.lock`; commit that file with `mise.toml`. Teammates and CI can then enforce
+those commitments after checking out the project:
+
+```sh
 mise install --locked
 ```
 
-The lockfile carries version, signer, and artifact commitments. Installation still
-needs the artifacts or usable cached copies and must satisfy current verification
-policy. See [mise.lock](/dev-tools/mise-lock.html) for target platforms and updates.
+`mise lock` can resolve the Packslip version without installing it, but it cannot
+record the selected artifact's commitments before the first installation.
+Installation still needs the artifacts or usable cached copies and must satisfy
+current verification policy. See [mise.lock](/dev-tools/mise-lock.html) for target
+platforms and updates.
 
 ## Completions and skills {#completions}
 

--- a/docs/dev-tools/backends/s3.md
+++ b/docs/dev-tools/backends/s3.md
@@ -1,18 +1,22 @@
 # S3 Backend
 
-You may install tools directly from Amazon S3 or S3-compatible storage (like MinIO) using the `s3` backend. This backend is ideal for enterprise teams hosting proprietary tools in private S3 buckets.
+The `s3` backend installs binaries and archives from Amazon S3 or S3-compatible
+storage such as MinIO. Use it when access should follow your AWS credentials or
+when version discovery needs to list objects in a bucket. No AWS CLI is required.
 
 The code for this is inside of the mise repository at [`./src/backend/s3.rs`](https://github.com/jdx/mise/blob/main/src/backend/s3.rs).
 
 ## Usage
 
-The following installs a tool from an S3 bucket:
+Replace the bucket and object key below with an artifact you can read for your
+platform. Use a concrete version for a fixed object URL:
 
 ```sh
-mise use -g "s3:my-tool[url=s3://my-bucket/tools/my-tool-v1.0.0.tar.gz]@1.0.0"
+mise use "s3:my-tool[url=s3://my-bucket/tools/my-tool-v1.0.0.tar.gz]@1.0.0"
 ```
 
-The version will be set in `~/.config/mise/config.toml` with the following format:
+This writes the following to the project's `mise.toml`. Add `-g` for global
+configuration, and run `mise exec -- my-tool --version` to verify the install:
 
 ```toml
 [tools]
@@ -21,20 +25,25 @@ The version will be set in `~/.config/mise/config.toml` with the following forma
 
 ## Authentication
 
-The S3 backend uses the AWS SDK default credential chain. Credentials are loaded from (in order):
+mise uses the AWS SDK's [default credential provider chain](https://docs.aws.amazon.com/sdk-for-rust/latest/dg/credproviders.html).
+It supports environment credentials, shared AWS profiles, web identity, and
+container or instance roles. Prefer an existing profile or workload role over
+copying long-lived access keys into project configuration.
 
-1. Environment variables: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-2. AWS credentials file: `~/.aws/credentials`
-3. IAM roles (when running on AWS infrastructure)
+For a configured local profile:
 
 ```sh
-# Set credentials via environment variables
-export AWS_ACCESS_KEY_ID="your-access-key"
-export AWS_SECRET_ACCESS_KEY="your-secret-key"
-export AWS_DEFAULT_REGION="us-east-1"
-
-mise install
+AWS_PROFILE=development AWS_REGION=us-east-1 mise install
 ```
+
+Temporary environment credentials require `AWS_SESSION_TOKEN` as well as
+`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. The `region` tool option can
+select the bucket's region explicitly.
+
+Downloading a known object requires `s3:GetObject`. Discovery through an object
+prefix also requires `s3:ListBucket`; discovery through a manifest needs read
+access to that manifest. A successful object download does not prove that
+version listing is permitted.
 
 ## Tool Options
 
@@ -58,7 +67,7 @@ Specify a custom S3-compatible endpoint for services like MinIO, DigitalOcean Sp
 [tools."s3:my-tool"]
 version = "1.0.0"
 url = "s3://my-bucket/tools/my-tool-v{{ version }}.tar.gz"
-endpoint = "http://minio.internal:9000"
+endpoint = "https://minio.example.com"
 ```
 
 ### `region`
@@ -88,20 +97,22 @@ linux-x64 = { url = "s3://my-bucket/tools/my-tool-v1.0.0-linux-x64.tar.gz" }
 
 ### `checksum`
 
-Verify the downloaded file with a checksum:
+Set the expected digest for this version and object. Replace this placeholder
+with a complete digest obtained from a trusted source:
 
 ```toml
 [tools."s3:my-tool"]
 version = "1.0.0"
 url = "s3://my-bucket/tools/my-tool-v1.0.0.tar.gz"
-checksum = "sha256:a1b2c3d4e5f6789..."
+checksum = "sha256:REPLACE_WITH_THE_64_HEX_DIGIT_DIGEST"
 ```
 
 _Instead of specifying the checksum here, you can use [mise.lock](/dev-tools/mise-lock) to manage checksums._
 
 ### `size`
 
-Verify the downloaded object size:
+Check the expected object size in bytes. The numbers below illustrate the
+syntax; replace them with the actual sizes. This does not replace a checksum:
 
 ```toml
 [tools."s3:my-tool"]
@@ -133,7 +144,7 @@ strip_components = 1
 ```
 
 ::: info
-If `strip_components` is not explicitly set, mise automatically detects when to apply `strip_components = 1`. This happens when the extracted archive contains exactly one directory at the root level and no files.
+When both `strip_components` and `bin_path` are unset, mise automatically detects when to apply `strip_components = 1`. This happens when the extracted archive contains exactly one directory at the root level and no files.
 :::
 
 ### `bin`
@@ -168,13 +179,16 @@ Use `rename_exe` for archives where the binary inside has a different name than 
 
 ### `bin_path`
 
-Specify the directory containing binaries within the extracted archive:
+Specify the directory containing binaries within the extracted archive. This
+disables automatic root stripping. For an archive shaped like
+`my-tool-VERSION/bin/my-tool`, set both options explicitly:
 
 ```toml
 [tools."s3:my-tool"]
 version = "1.0.0"
 url = "s3://my-bucket/tools/my-tool-v1.0.0.tar.gz"
-bin_path = "my-tool-{{ version }}/bin"
+strip_components = 1
+bin_path = "bin" # after stripping an outer my-tool-VERSION directory
 ```
 
 ### `format`
@@ -190,7 +204,9 @@ format = "tar.gz"
 
 ## Version Discovery
 
-The S3 backend supports two methods for discovering available versions.
+The S3 backend supports a manifest or object listing. Configure one before
+using `latest`, then check it with `mise ls-remote s3:my-tool`. The examples use
+placeholder buckets that you must replace with your own.
 
 ### Manifest File
 
@@ -250,7 +266,7 @@ Discover versions by listing objects in the S3 bucket:
 version = "latest"
 url = "s3://my-bucket/tools/my-tool-v{{ version }}.tar.gz"
 version_prefix = "tools/my-tool-v"
-version_regex = "my-tool-v([0-9.]+)"
+version_regex = 'my-tool-v(.+)\.tar\.gz$'
 ```
 
 - `version_prefix`: The S3 key prefix to list objects from
@@ -264,25 +280,33 @@ Here's a complete example using MinIO as an S3-compatible backend:
 [tools."s3:my-internal-tool"]
 version = "latest"
 url = "s3://tools-bucket/releases/my-tool-{{ version }}.tar.gz"
-endpoint = "http://minio.internal:9000"
+endpoint = "https://minio.example.com"
 region = "us-east-1"
 version_list_url = "s3://tools-bucket/releases/versions.json"
+strip_components = 1 # assumes one outer directory containing bin/
 bin_path = "bin"
 ```
 
-With environment variables:
-
-```sh
-export AWS_ACCESS_KEY_ID="minio-access-key"
-export AWS_SECRET_ACCESS_KEY="minio-secret-key"
-mise install
-```
+Provide the MinIO access key and secret through an AWS-compatible profile or
+the standard environment variables, then run `mise install`. A custom endpoint
+uses path-style bucket addressing; it must be reachable with a trusted TLS
+certificate.
 
 ## Comparison with HTTP Backend
 
-| Feature           | S3 Backend                                          | HTTP Backend      |
-| ----------------- | --------------------------------------------------- | ----------------- |
-| Authentication    | AWS credentials (env vars, ~/.aws/credentials, IAM) | HTTP auth headers |
-| Version discovery | S3 listing or manifest file                         | HTTP endpoint     |
-| Custom endpoints  | Yes (MinIO, etc.)                                   | N/A               |
-| Use case          | Private/enterprise tools                            | Public downloads  |
+| Feature           | S3 Backend                                          | HTTP Backend                           |
+| ----------------- | --------------------------------------------------- | -------------------------------------- |
+| Authentication    | AWS credentials (env vars, ~/.aws/credentials, IAM) | HTTP auth headers                      |
+| Version discovery | S3 listing or manifest file                         | HTTP endpoint                          |
+| Custom endpoints  | Yes (MinIO, etc.)                                   | N/A                                    |
+| Use case          | AWS-authenticated object storage                    | Public or authenticated HTTP downloads |
+
+## Troubleshooting
+
+| Error                     | Check                                                                                                         |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Access denied             | The selected profile or role, object read permissions, and listing permissions when using `version_prefix`.   |
+| Object not found          | The bucket, full key, concrete version, and rendered platform URL.                                            |
+| Signature mismatch        | Credentials, session token, region, endpoint, and local clock.                                                |
+| No versions               | The manifest format or listing prefix and capture group. A download URL alone does not define a version list. |
+| Installed command missing | The archive structure after root stripping and the `bin` or `bin_path` option.                                |

--- a/docs/dev-tools/backends/ubi.md
+++ b/docs/dev-tools/backends/ubi.md
@@ -3,37 +3,38 @@
 ::: warning
 The ubi backend is **deprecated**. Use the [GitHub backend](/dev-tools/backends/github) instead.
 
-The GitHub backend offers several advantages over ubi, including provenance verification, download progress reports, and fewer dependencies. To migrate, replace `ubi:owner/repo` with `github:owner/repo` in your configuration files. The [`matching`](/dev-tools/backends/github.html#matching) and [`matching_regex`](/dev-tools/backends/github.html#matching_regex) options carry over. One behavioral difference is worth noting: ubi applies the substring `matching` only as a tiebreaker among assets that already match your OS/arch, and skips it when a single asset matches the platform. The GitHub backend applies `matching` as a pre-filter before autodetection, so for multi-binary releases you get the binary your filter names, or a clear error naming the filter if it isn't published for your platform.
+The GitHub backend offers several advantages over ubi, including provenance verification, download progress reports, and fewer dependencies. To migrate, replace `ubi:owner/repo` with `github:owner/repo` in your configuration files. The [`matching`](/dev-tools/backends/github.html#matching) and [`matching_regex`](/dev-tools/backends/github.html#matching-regex) options carry over. One behavioral difference is worth noting: ubi applies the substring `matching` only as a tiebreaker among assets that already match your OS/arch, and skips it when a single asset matches the platform. The GitHub backend applies `matching` as a pre-filter before autodetection, so for multi-binary releases you get the binary your filter names, or a clear error naming the filter if it isn't published for your platform.
 
 One migration gotcha: ubi folds `matching` into the install path, so you can install several binaries from one repo via separate `matching` values on the same `ubi:owner/repo` string. The GitHub backend keeps the install path keyed by tool name + version only, so two `github:owner/repo` entries with different `matching` values resolve to the **same** directory and the second overwrites the first. If you rely on that ubi pattern, give each binary its own [`tool_alias`](/dev-tools/backends/github.html#multiple-assets-from-the-same-release) on GitHub so each gets its own install directory.
 :::
 
-You may install GitHub releases and URL packages directly using the [ubi](https://github.com/houseabsolute/ubi) backend. ubi is compiled into
-mise, so it does not need to be installed separately.
-
-ubi doesn't require plugins or any per-tool configuration. It deduces the proper binary or tarball
-from the GitHub release assets and downloads the right one. As long as the vendor uses a reasonably
-standard naming scheme for their releases, ubi should be able to figure it out.
-
-The code for this is inside of the mise repository at [`./src/backend/ubi.rs`](https://github.com/jdx/mise/blob/main/src/backend/ubi.rs).
+This page documents existing ubi configurations. For new installations, use the
+[GitHub](/dev-tools/backends/github.html), [GitLab](/dev-tools/backends/gitlab.html),
+or [HTTP](/dev-tools/backends/http.html) backend as appropriate.
 
 ## Usage
 
-The following installs the latest version of goreleaser
-and sets it as the active version on PATH:
-
-```sh
-$ mise use -g ubi:goreleaser/goreleaser
-$ goreleaser --version
-1.25.1
-```
-
-The version will be set in `~/.config/mise/config.toml` with the following format:
+Migrate one tool at a time. For a simple release install, change:
 
 ```toml
 [tools]
-"ubi:goreleaser/goreleaser" = "latest"
+"ubi:BurntSushi/ripgrep" = "14.1.1"
 ```
+
+To:
+
+```toml
+[tools]
+"github:BurntSushi/ripgrep" = "14.1.1"
+```
+
+Then run `mise install` and `mise exec -- rg --version`. Check custom options
+against the destination backend: for example, `exe` and `extract_all` are ubi
+options and should not be copied blindly. Regenerate and review any lockfile.
+Keep the old installation until the replacement works.
+
+For multiple binaries, follow the alias migration described above. A direct
+`ubi:https://...` download belongs in an [HTTP tool entry](/dev-tools/backends/http.html#usage).
 
 ## Tool Options
 
@@ -125,10 +126,10 @@ and it only makes sense when `extract_all` is set to `true`.
 
 ```toml
 [tools]
-"ubi:BurntSushi/ripgrep" = {
+"ubi:owner/repo" = {
   version = "latest",
   extract_all = true,
-  bin_path = "target/release",
+  bin_path = "target/release", # match the archive's actual layout
 }
 ```
 
@@ -170,11 +171,12 @@ Sometimes vendors name their releases in ways ubi can't figure out, possibly onl
 OS/arch combination. For example, in [this ticket](https://github.com/houseabsolute/ubi/issues/79) a vendor used
 "mac" instead of the more common "macos" or "darwin" tags.
 
-Try using ubi by itself to see if the issue is related to mise or ubi:
+For an existing ubi install, compare with a separately installed ubi CLI
+if you need to isolate its resolver. Run this in an empty scratch directory:
 
 ```sh
 ubi -p jdx/mise
-./bin/mise -v # yes this technically means you could do `mise use ubi:jdx/mise` though I don't know why you would
+./bin/mise --version
 ```
 
 ### `ubi` picks the wrong tarball
@@ -183,7 +185,7 @@ A GitHub release may have many tarballs, some of which don't contain the CLI you
 `matching` field to specify a string to match against the release filenames.
 
 ```sh
-mise use ubi:tamasfe/taplo[matching=full]
+mise use 'ubi:tamasfe/taplo[matching=full]'
 # or with ubi directly
 ubi -p tamasfe/taplo -m full
 ```
@@ -195,7 +197,7 @@ For example, BurntSushi/ripgrep provides a binary named `rg`, not `ripgrep`. In 
 the binary name with the `exe` field:
 
 ```sh
-mise use ubi:BurntSushi/ripgrep[exe=rg]
+mise use 'ubi:BurntSushi/ripgrep[exe=rg]'
 # or with ubi directly
 ubi -p BurntSushi/ripgrep -e rg
 ```

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -47,7 +47,7 @@
 - [Rust](https://mise.jdx.dev/lang/rust.html): mise can install Rust/cargo using rustup under the hood. It installs rustup if it is not already installed, then installs the requested toolchain, components, and targets.
 - [Swift](https://mise.jdx.dev/lang/swift.html): mise can be used to manage multiple versions of swift on the same system. Swift is supported on macOS and Linux.
 - [Zig](https://mise.jdx.dev/lang/zig.html): mise can be used to install and manage multiple versions of zig on the same system.
-- [Backends](https://mise.jdx.dev/dev-tools/backends/): Backends are package managers or ecosystems that mise uses to install tools and plugins. Each backend can install and manage multiple tools from its ecosystem.
+- [Backends](https://mise.jdx.dev/dev-tools/backends/): A backend tells mise where to find a tool's versions and how to install them. Use a registry shorthand such as ripgrep for the default selection, or specify a backend explicitly, such as…
 - [aqua](https://mise.jdx.dev/dev-tools/backends/aqua.html): Aqua tools can be used natively in mise. aqua is a Tier 2 backend for tools without packslip manifests: it does not require plugins, it works on Windows, and it offers security features beyond…
 - [asdf](https://mise.jdx.dev/dev-tools/backends/asdf.html): asdf plugins are considered legacy. New asdf and vfox plugins are not accepted into the mise registry for supply-chain security reasons — for registry submissions use packslip (preferred when the…
 - [cargo](https://mise.jdx.dev/dev-tools/backends/cargo.html): You can install packages directly from Cargo Crates even if there isn't an asdf plugin for them.
@@ -58,7 +58,7 @@
 - [github](https://mise.jdx.dev/dev-tools/backends/github.html): You may install GitHub release assets directly using the github backend. This backend downloads release assets from GitHub repositories and is ideal for tools that distribute pre-built binaries…
 - [gitlab](https://mise.jdx.dev/dev-tools/backends/gitlab.html): The gitlab backend installs release assets directly from GitLab repositories. It is ideal for tools that distribute pre-built binaries through GitLab releases.
 - [go](https://mise.jdx.dev/dev-tools/backends/go.html): You can install packages directly via go install even if there isn't an asdf plugin for them.
-- [http](https://mise.jdx.dev/dev-tools/backends/http.html): You may install tools directly from HTTP URLs using the http backend. This backend downloads files from any HTTP/HTTPS URL and is ideal for tools that distribute pre-built binaries or archives through…
+- [http](https://mise.jdx.dev/dev-tools/backends/http.html): The http backend installs a binary, script, or archive from a direct download URL. Use it when the publisher has no supported release backend or when you host your own artifacts.
 - [npm](https://mise.jdx.dev/dev-tools/backends/npm.html): You can install packages directly from npmjs.org even if there isn't an asdf plugin for them.
 - [packslip](https://mise.jdx.dev/dev-tools/backends/packslip.html): The Packslip backend installs tools using signed release manifests published by their maintainers. mise verifies the release, selects the build for your platform, and installs its executables.
 - [pipx](https://mise.jdx.dev/dev-tools/backends/pipx.html): pipx is a tool for running Python CLIs in isolated virtualenvs. This isolation helps prevent dependency conflicts between CLIs, or between a CLI and your Python projects.


### PR DESCRIPTION
Review the backend overview and all eight download-backend guides: Aqua, GitHub, GitLab, Forgejo, HTTP, S3, Packslip, and deprecated ubi.

- Replace stale output and incomplete setup steps with project-scoped examples and executable verification. Correct GitHub asset filenames, GitLab release-link display names, and the Linux requirement for the Forgejo Runner example.
- Explain how explicit `bin_path` disables automatic archive-root stripping, distinguish fixed URLs from version discovery, correct HTTP cache guarantees, and clarify expected checksums and artifact sizes.
- Document global credential commands, AWS profiles and temporary credentials, object-read versus listing permissions, backend-specific verification coverage, and staged ubi migration.
- Repair broken option/settings links and preserve TOML 1.1 multiline inline tables.

Validation: 140 TOML snippets pass the current mise parser. Local HTTP smoke tests cover version extractors, manifest checksums, locked installation, extraction paths, and argument forwarding. Global GitLab/Forgejo token commands were tested with fake credentials; asset examples were checked against publisher APIs. Full Rust 1.95 lint, production website build, and rendered link checks pass. S3 production access and Linux runner execution were not tested. Rebased onto current main and regenerated `docs/public/llms.txt`.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime or configuration behavior changes.
> 
> **Overview**
> This PR **reworks backend documentation**—the overview plus Aqua, GitHub, GitLab, Forgejo, HTTP, S3, Packslip, and deprecated ubi—so setup and verification read consistently end to end.
> 
> **Workflow and examples** shift from global `mise use -g` and implicit PATH to **project `mise.toml`**, **`mise exec --` verification**, and clearer notes on registry/version discovery. Examples are corrected where they were wrong (GitHub asset names, GitLab **release link display names**, Forgejo Runner on Linux, quoted inline `[...]` tool args).
> 
> **Installation options** are clarified across release backends: **`bin_path` turns off automatic archive root stripping**, checksum/size samples use explicit placeholders and pinned versions, and HTTP/S3 docs separate **fixed URLs from version listing**, tighten **cache/reuse wording**, and expand **AWS auth, IAM, and S3 troubleshooting**.
> 
> **Aqua security** is condensed into a metadata table (what each verifier needs per package), with lockfile provenance reuse and less “disable everything” troubleshooting. **Packslip** adds a short **lockfile / `mise install --locked`** reproduction flow. **ubi** is reframed as migration guidance to GitHub/GitLab/HTTP.
> 
> Cross-links move to stable `.html#` anchors (including `aqua.*` settings), old Aqua section IDs are preserved via empty spans, and **`docs/public/llms.txt`** blurbs match the new pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72b8cb9c4009b06da079739209568122c54f515d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Reworked backend guides with clearer installation, verification, authentication, version discovery, archive extraction, and path configuration guidance.
  - Added backend comparison guidance to help users choose installation sources and verify results.
  - Documented aqua verification methods, provenance reuse, troubleshooting, and registry metadata requirements.
  - Added lockfile-based instructions for reproducible installations.
  - Added migration guidance from the deprecated ubi backend to GitHub.
  - Updated commands, examples, cross-references, and troubleshooting details across backend documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->