### PR TITLE
docs: improve bootstrap workflows and resource examples

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -1,15 +1,46 @@
 # Bootstrap
 
-`mise bootstrap` sets up a machine for the current config in one command: Linux
-users and groups, OS packages, privileged files and directories, system services,
-Linux host firewall policy, Docker Compose projects, git repos, dotfiles, mise shell
-activation, macOS defaults, macOS LaunchAgents, Linux systemd user services,
-the user's login shell, tools, and any final project-specific task. It can
-consume declared secret inputs without storing their values in mise config. You
-can also add hooks that run at named points in the bootstrap sequence.
+`mise bootstrap` applies the machine setup declared in your mise configuration:
+packages, files, services, repositories, shell setup, tools, and a final task.
+Use it for workstation or server setup that needs more than installing
+`[tools]`. Run it explicitly when you want to apply that configuration.
 
-The same configuration can be applied to named inventory hosts or ad-hoc SSH
-destinations with [`mise bootstrap remote`](/bootstrap/remote.html).
+Start with the parts your machine needs, preview them, and add more resources
+as the configuration grows. Each section has its own status and apply commands.
+For SSH targets, see [remote bootstrap](/bootstrap/remote.html).
+
+## Example
+
+This small `mise.toml` configures zsh activation, installs Node.js, and verifies
+it in a final task. Choose the [shell entries](/bootstrap/shell.html) for the
+shell you actually use:
+
+```toml
+[bootstrap.mise_shell_activate]
+zprofile = "shims"
+zshrc = "activate"
+
+[tools]
+node = "24"
+
+[tasks.bootstrap]
+run = "node --version"
+```
+
+Review the configuration before trusting it, then preview and apply it:
+
+```sh
+mise trust
+mise bootstrap --dry-run
+mise bootstrap
+mise bootstrap status
+```
+
+`--yes` skips confirmation prompts for an unattended apply. A dry run inspects
+state and prints proposed actions; hooks and the final task are not executed.
+Open a new shell after activation files change.
+
+## Starting from a repository
 
 On a new machine, mise can clone the repository containing that configuration
 before it starts:
@@ -43,59 +74,6 @@ is cloned into that file's parent directory instead and that file is loaded.
 As with `--from`, an existing non-empty destination must be a git checkout
 whose `origin` exactly matches the requested URL; pass `--update` to
 fast-forward it before bootstrap.
-
-Use bootstrap for things that are needed before a project or workstation is
-ready, but that do not belong in `[tools]`: native libraries, Homebrew
-formulae, dotfile repositories, shell rc files, editor config, macOS
-preferences, user services, and one-time machine setup.
-
-## Composing configuration roots
-
-`[bootstrap].config_roots` composes declarative resources from independent
-configuration roots into the current bootstrap operation:
-
-```toml
-[bootstrap]
-config_roots = ["bundles/*"]
-```
-
-Entries are relative to the declaring config root and may use single-level `*`
-globs. Each matched directory is loaded with the normal active configuration
-environments. Relative resource sources and template `config_root` values remain
-relative to the config that declared them. Variables declared by a selected root
-are available to that root's dotfile templates without leaking into sibling
-roots.
-
-Composition includes `[dotfiles]`, `[bootstrap.files]`,
-`[bootstrap.directories]`, `[bootstrap.services]`, and `[bootstrap.compose]`.
-Equivalent declarations are deduplicated. Different declarations for the same
-dotfile target, edit `(path, id)`, managed file, managed directory, service, or
-Compose project are errors that identify both declaring configs. Independent
-roots never acquire precedence from their order in `config_roots`.
-Same-target `symlink-each` declarations are the exception: their source trees
-compose when their leaf paths are disjoint, while overlapping leaves or
-file/directory collisions are reported with both declaring configs.
-Directory `copy` and `symlink-each` footprints are also checked against nested
-dotfile declarations. Disjoint leaves may share directories, but two entries
-cannot own the same leaf or place a file where another entry needs a directory.
-
-Other configuration such as tools, tasks, packages, hooks, and repos is not
-collected from these roots. Use their existing explicit workflows when those
-resources need aggregate behavior.
-
-Use `mise bootstrap config-roots` to inspect the active non-composed bootstrap
-declarations before running those workflows:
-
-```sh
-mise bootstrap config-roots
-mise bootstrap config-roots --json
-```
-
-The command reports package, repo, account, and hook declarations separately
-for every matched configuration root. JSON output includes the declaring config
-and its active configuration environment. Counts describe active TOML entries;
-the command does not inspect the host, resolve resource state, or run bootstrap
-hooks.
 
 ## How it runs
 
@@ -150,7 +128,9 @@ same part names and can be repeated or comma-separated, for example
 exclusive.
 
 Use `mise bootstrap --update` to refresh system package manager metadata
-before installing packages (apk: `--update-cache`, apt: `apt-get update`).
+before installing packages (apk: `--update-cache`, apt: `apt-get update`) and
+update declared repositories. Check the [repo update rules](/bootstrap/repos.html)
+for clean-worktree and fast-forward requirements.
 
 Hook phases can also run before and after the built-in steps:
 `pre-packages`, `post-packages`, `pre-repos`, `post-repos`, `pre-dotfiles`,
@@ -160,129 +140,24 @@ using the declaring config's context, including values such as
 <code v-pre>{{ config_root }}</code>, <code v-pre>{{ xdg_config_home }}</code>,
 and <code v-pre>{{ vars.name }}</code>.
 
-The declarative steps converge: if a package is already installed, a repo is
-already at the requested ref, a dotfile already matches, or a default is already
-set, mise skips it. The `bootstrap` task runs every time, so keep it idempotent.
+The declarative steps compare the requested state with the host and apply
+needed changes. Hooks and the `bootstrap` task run on every selected apply, so
+make them safe to repeat. Bootstrap is a sequence, not a transaction: if a later
+phase fails, earlier successful changes remain. Fix the reported failure and
+run bootstrap again.
 
-## Example
+## Previewing changes
 
-```toml
-[bootstrap.packages]
-"apk:build-base" = "latest"
-"apt:build-essential" = "latest"
-"brew:postgresql@17" = "latest"
-
-[bootstrap.secrets]
-service_token = "EXAMPLE_SERVICE_TOKEN"
-
-[bootstrap.groups.example]
-system = true
-
-[bootstrap.users.example]
-system = true
-group = "example"
-home = "/var/lib/example"
-create_home = true
-
-[bootstrap.directories."/opt/example"]
-owner = "root"
-group = "root"
-mode = "0755"
-
-[bootstrap.files."/etc/example.conf"]
-content = 'token={{ secret(name="service_token") }}'
-template = true
-owner = "root"
-group = "root"
-mode = "0644"
-notify = ["example"]
-
-[bootstrap.services.example]
-state = "running"
-enabled = true
-on_change = "reload_or_restart"
-
-[bootstrap.linux.firewall]
-backend = "auto"
-state = "enabled"
-default_incoming = "deny"
-default_outgoing = "allow"
-
-[[bootstrap.linux.firewall.rules]]
-name = "https"
-port = 443
-protocol = "tcp"
-action = "allow"
-
-[bootstrap.repos]
-"~/src/dotfiles" = { url = "git@github.com:jdx/dotfiles.git", ref = "main" }
-
-[dotfiles]
-"~/.config/mise/config.toml" = { source = "config.toml", mode = "symlink" }
-"~/.gitconfig" = { mode = "symlink" }
-"~/.config/nvim" = { mode = "symlink" }
-
-[bootstrap.mise_shell_activate]
-zprofile = "shims"
-zshrc = "activate"
-fish = "activate"
-
-[bootstrap.macos.dock]
-autohide = true
-orientation = "left"
-tilesize = 48
-
-[bootstrap.macos.finder]
-show_pathbar = true
-
-[bootstrap.macos.keyboard]
-key_repeat = 2
-initial_key_repeat = 15
-
-[bootstrap.macos.trackpad]
-tap_to_click = true
-
-[bootstrap.macos.defaults]
-"com.apple.finder" = { AppleShowAllFiles = true }
-
-[bootstrap.macos.launchd.agents.my-sync]
-program = "~/.local/bin/my-sync"
-args = ["--watch"]
-run_at_load = true
-
-[bootstrap.linux.systemd.units.my-sync]
-description = "sync files"
-exec_start = "~/.local/bin/my-sync --watch"
-restart = "on-failure"
-
-[bootstrap.user]
-login_shell = "/bin/zsh"
-
-[bootstrap.hooks.pre-packages]
-run = "softwareupdate --install-rosetta --agree-to-license"
-
-[bootstrap.hooks.post-defaults]
-run = "killall Dock || true"
-
-[tools]
-node = "lts"
-python = "3.12"
-
-[tasks.bootstrap]
-run = "gh auth status || gh auth login"
-```
-
-Then converge the whole machine (`--yes` skips the confirmation prompts):
+Use `mise bootstrap --dry-run` to preview the selected phases. To narrow an
+apply while developing a configuration, for example:
 
 ```sh
-mise bootstrap --yes
+mise bootstrap --only dotfiles,tools --dry-run
+mise bootstrap --only dotfiles,tools
 ```
 
-To preview what would change without touching anything:
-
-```sh
-mise bootstrap --dry-run
-```
+Select every prerequisite your changes need. `--only services` does not install
+the packages or unit files that supply those services.
 
 For a structured resource plan, use `mise bootstrap plan`. The provisioning
 planner reports accounts, system packages, privileged files and directories,
@@ -347,26 +222,32 @@ want to check one part without installing anything.
 
 ## What goes where
 
-| Config                                                         | Use for                                                       |
-| -------------------------------------------------------------- | ------------------------------------------------------------- |
-| [`[bootstrap.packages]`](/bootstrap/packages/)                 | OS packages from apk, apt, dnf, pacman, brew, flatpak, or mas |
-| [`[bootstrap.repos]`](/bootstrap/repos.html)                   | Git repos cloned before dotfiles are applied                  |
-| [`[dotfiles]`](/dotfiles.html)                                 | Whole-file dotfiles and small managed edits to existing files |
-| [`[bootstrap.mise_shell_activate]`](/bootstrap/shell.html)     | mise activation snippets in shell startup files               |
-| [`[bootstrap.macos.*]`](/bootstrap/macos-defaults.html)        | Curated macOS preferences for Dock/Finder/keyboard/trackpad   |
-| [`[bootstrap.macos.defaults]`](/bootstrap/macos-defaults.html) | macOS user preferences written through `defaults write`       |
-| [`[bootstrap.macos.launchd.agents]`](/bootstrap/launchd.html)  | macOS user LaunchAgents written and loaded with `launchctl`   |
-| [`[bootstrap.linux.systemd.units]`](/bootstrap/systemd.html)   | Linux systemd user services managed with `systemctl --user`   |
-| [`[bootstrap.linux.firewall]`](/bootstrap/firewall.html)       | Linux host firewall policy and managed rules                  |
-| [`[bootstrap.user]`](/bootstrap/user.html)                     | Current-user settings such as `login_shell`                   |
-| `[bootstrap.hooks]`                                            | Commands that run at named bootstrap phases                   |
-| `[tools]`                                                      | Versioned dev tools managed by mise                           |
-| `[tasks.bootstrap]`                                            | Anything custom that should run after tools are installed     |
+| Config                                                                  | Use for                                                       |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------- |
+| [`[bootstrap.secrets]`](/bootstrap/secrets.html)                        | Names of secret inputs consumed by managed file templates     |
+| [`[bootstrap.users]`, `[bootstrap.groups]`](/bootstrap/accounts.html)   | Linux service accounts and groups                             |
+| [`[bootstrap.files]`, `[bootstrap.directories]`](/bootstrap/files.html) | Managed system paths, content, ownership, and permissions     |
+| [`[bootstrap.services]`](/bootstrap/services.html)                      | Existing Linux systemd system units and file-change handlers  |
+| [`[bootstrap.compose]`](/bootstrap/compose.html)                        | Docker Compose project lifecycle                              |
+| [`[bootstrap.plugins]`](/bootstrap/packages/plugins.html)               | Package manager plugins                                       |
+| [`[bootstrap.packages]`](/bootstrap/packages/)                          | OS packages from apk, apt, dnf, pacman, brew, flatpak, or mas |
+| [`[bootstrap.repos]`](/bootstrap/repos.html)                            | Git repos cloned before dotfiles are applied                  |
+| [`[dotfiles]`](/dotfiles.html)                                          | Whole-file dotfiles and small managed edits to existing files |
+| [`[bootstrap.mise_shell_activate]`](/bootstrap/shell.html)              | mise activation snippets in shell startup files               |
+| [`[bootstrap.macos.*]`](/bootstrap/macos-defaults.html)                 | Curated macOS preferences for Dock/Finder/keyboard/trackpad   |
+| [`[bootstrap.macos.defaults]`](/bootstrap/macos-defaults.html)          | macOS user preferences written through `defaults write`       |
+| [`[bootstrap.macos.launchd.agents]`](/bootstrap/launchd.html)           | macOS user LaunchAgents written and loaded with `launchctl`   |
+| [`[bootstrap.linux.systemd.units]`](/bootstrap/systemd.html)            | Linux systemd user services managed with `systemctl --user`   |
+| [`[bootstrap.linux.firewall]`](/bootstrap/firewall.html)                | Linux host firewall policy and managed rules                  |
+| [`[bootstrap.user]`](/bootstrap/user.html)                              | Current-user settings such as `login_shell`                   |
+| `[bootstrap.hooks]`                                                     | Commands that run at named bootstrap phases                   |
+| `[tools]`                                                               | Versioned dev tools managed by mise                           |
+| `[tasks.bootstrap]`                                                     | Anything custom that should run after tools are installed     |
 
 Use declarative sections when mise can inspect and converge the state. Use
 `[tasks.bootstrap]` for imperative setup that does not fit those sections,
-such as running an auth flow, seeding local data, or other one-off project
-setup.
+such as checking authentication or seeding local data. The task runs again on
+every bootstrap, so guard operations that should happen only once.
 
 ## Hooks
 
@@ -378,18 +259,17 @@ bootstrap if they fail, and print the command instead of running it during
 `mise exec -- ...` inside a hook, or use `[tasks.bootstrap]`, when the command
 needs tools from `[tools]` on PATH.
 
-```toml
-[bootstrap.hooks.pre-packages]
-run = "softwareupdate --install-rosetta --agree-to-license"
+The following hooks assume `node`, `python`, and `gh` are declared in `[tools]`.
 
+```toml
 [bootstrap.hooks.post-tools]
 run = [
-  "mise exec -- corepack enable",
-  "mise exec -- rustup component add rustfmt clippy",
+  "mise exec -- node --version",
+  "mise exec -- python --version",
 ]
 
 [bootstrap.hooks.final]
-run = "gh auth status || gh auth login"
+run = "mise exec -- gh auth status"
 ```
 
 As shorthand, a hook phase can also be set directly:
@@ -440,6 +320,54 @@ mise bootstrap dotfiles apply ~/.zshrc
 
 For symlinked dotfiles, `edit` opens the managed source, so it works with the
 default `symlink` mode.
+
+## Composing configuration roots
+
+`[bootstrap].config_roots` composes declarative resources from independent
+configuration roots into the current bootstrap operation:
+
+```toml
+[bootstrap]
+config_roots = ["bundles/*"]
+```
+
+Entries are relative to the declaring config root and may use single-level `*`
+globs. Each matched directory is loaded with the normal active configuration
+environments. Relative resource sources and template `config_root` values remain
+relative to the config that declared them. Variables declared by a selected root
+are available to that root's dotfile templates without leaking into sibling
+roots.
+
+Composition includes `[dotfiles]`, `[bootstrap.files]`,
+`[bootstrap.directories]`, `[bootstrap.services]`, and `[bootstrap.compose]`.
+Equivalent declarations are deduplicated. Different declarations for the same
+dotfile target, edit `(path, id)`, managed file, managed directory, service, or
+Compose project are errors that identify both declaring configs. Independent
+roots never acquire precedence from their order in `config_roots`.
+Same-target `symlink-each` declarations are the exception: their source trees
+compose when their leaf paths are disjoint, while overlapping leaves or
+file/directory collisions are reported with both declaring configs.
+Directory `copy` and `symlink-each` footprints are also checked against nested
+dotfile declarations. Disjoint leaves may share directories, but two entries
+cannot own the same leaf or place a file where another entry needs a directory.
+
+Other configuration such as tools, tasks, packages, hooks, and repos is not
+collected from these roots. Use their existing explicit workflows when those
+resources need aggregate behavior.
+
+Use `mise bootstrap config-roots` to inspect the active non-composed bootstrap
+declarations before running those workflows:
+
+```sh
+mise bootstrap config-roots
+mise bootstrap config-roots --json
+```
+
+The command reports package, repo, account, and hook declarations separately
+for every matched configuration root. JSON output includes the declaring config
+and its active configuration environment. Counts describe active TOML entries;
+the command does not inspect the host, resolve resource state, or run bootstrap
+hooks.
 
 ## Advanced: self-managing config
 

--- a/docs/bootstrap/accounts.md
+++ b/docs/bootstrap/accounts.md
@@ -56,6 +56,17 @@ When a managed file or directory names one of these ignored declarations as
 its owner or group, that ownership field is ignored with a warning too. Its
 content, mode, and any unrelated local owner or group still converge normally.
 
+## Preview and apply
+
+Run `mise bootstrap accounts apply --dry-run` before changing existing users.
+Inspect any UID/GID and supplementary-group changes: these affect the account
+database even when the user's files are outside this configuration. To use a
+new account as a file owner, apply the full bootstrap or include both
+`accounts` and `files` in `--only`.
+
+Removing an account declaration leaves the account in place. Use the explicit
+removal state below when it should be deleted.
+
 ## Removal
 
 Removal is explicit and ordered users-before-groups:

--- a/docs/bootstrap/compose.md
+++ b/docs/bootstrap/compose.md
@@ -6,7 +6,17 @@ have converged. This makes it suitable for self-hosted services whose Compose
 file, environment file, Docker installation, and daemon lifecycle are all
 managed by the same bootstrap configuration.
 
+The example below targets a Debian/Ubuntu host whose repositories provide the
+listed Docker packages. Create `infra/mise-cache/compose.yaml` with your
+service's Compose model, and provide both declared secret inputs before apply.
+The environment-file template assumes single-line values valid in Compose's
+`.env` format; encode other values for that format.
+
 ```toml
+[bootstrap.secrets]
+s3_access_key = "EXAMPLE_S3_ACCESS_KEY"
+s3_secret_key = "EXAMPLE_S3_SECRET_KEY"
+
 [bootstrap.packages]
 "apt:docker.io" = "latest"
 "apt:docker-compose-v2" = "latest"
@@ -27,6 +37,9 @@ content = """
 S3_ACCESS_KEY={{ secret(name="s3_access_key") }}
 S3_SECRET_KEY={{ secret(name="s3_secret_key") }}
 """
+template = true
+owner = "root"
+group = "root"
 mode = "0600"
 
 [bootstrap.compose.mise-cache]
@@ -43,6 +56,19 @@ depends_on = ["package:apt:docker.io", "service:docker"]
 and `env_files` resolve from it. With no `files`, Compose performs its normal
 project-directory discovery. mise passes multiple files and environment files
 in declaration order, so later entries retain Compose's override semantics.
+
+## Preview the whole setup
+
+```sh
+mise bootstrap plan
+mise bootstrap --only packages,files,services,compose --dry-run
+```
+
+Use the full bootstrap, or include the required phases as above, when mise must
+create the files and install Docker first. `mise bootstrap compose apply` only
+converges Compose projects; it does not apply their package and file prerequisites.
+A dry run cannot prove that an image will start successfully or pass its health
+check on the target.
 
 ## Lifecycle and convergence
 
@@ -118,7 +144,8 @@ command = ["podman", "compose"]
 engine_command = ["podman"]
 ```
 
-The engine command is used only to inspect container config-hash labels. Set
+The engine command inspects container config-hash labels and removes orphaned
+containers when converging a stopped project with `remove_orphans = true`. Set
 `sudo = true` when the project belongs to the system Docker daemon and the
 bootstrap user does not have socket access. mise authenticates before capturing
 status output, never hides an interactive sudo prompt, and honors the existing

--- a/docs/bootstrap/files.md
+++ b/docs/bootstrap/files.md
@@ -17,6 +17,11 @@ group = "root"
 mode = "0644"
 ```
 
+Create `files/example.conf` beside the declaring configuration before applying
+this example. The source is read by mise; `/etc/example.conf` is its destination.
+For file templates containing credentials, use mode `"0600"` and ownership that
+allows only the intended service account or root to read them.
+
 File content may come from `source` or inline `content`. Relative source paths
 are resolved from the configuration file that declares them, and source paths
 beginning with `~/` are resolved from the user's home directory. Present files
@@ -52,6 +57,18 @@ search one of its parent directories, mise compares its metadata and content in
 one privileged batch. Plans and file content are sent to narrowly scoped mise
 helpers over stdin, so file content does not appear in process arguments or
 logs.
+
+## Preview and inspect
+
+```sh
+mise bootstrap files status --json
+mise bootstrap files apply --dry-run
+```
+
+Check source paths, ownership, modes, and any `unknown` states before applying.
+Inspection may need elevated access to read protected targets. A missing source
+must be fixed in the configuration checkout; changing target permissions does
+not supply that source.
 
 ## Removing resources
 

--- a/docs/bootstrap/firewall.md
+++ b/docs/bootstrap/firewall.md
@@ -4,6 +4,11 @@
 supports native nftables, firewalld policies, and UFW while keeping mise-owned
 rules separate from unrelated host rules.
 
+The example allows HTTPS and limits SSH from one administrator address.
+Replace `203.0.113.10/32` with your actual administration network and use the
+host's real SSH port before applying it. Ensure the chosen firewall command is
+installed; `backend = "auto"` selects an available backend rather than installing one.
+
 ```toml
 [bootstrap.linux.firewall]
 backend = "auto"
@@ -97,6 +102,18 @@ Set `exclusive = true` only when the configuration owns the complete firewall.
 It drops undeclared mise rules. With UFW, exclusive mode performs `ufw reset`,
 which also removes unrelated UFW rules, and is therefore always confirmed as a
 destructive operation.
+
+## Preview the target's policy
+
+```sh
+mise bootstrap firewall status --json
+mise bootstrap firewall apply --dry-run
+```
+
+Inspect the selected backend, default policies, rule order, and removals. Other
+firewall systems and container networking can affect the same host; verify the
+resulting reachability from the networks that use the service. A plan describes
+mise's requested changes, not an end-to-end connectivity test.
 
 ## SSH lockout protection
 

--- a/docs/bootstrap/launchd.md
+++ b/docs/bootstrap/launchd.md
@@ -1,16 +1,19 @@
-# launchd
+# macOS LaunchAgents
 
 mise can declare macOS user LaunchAgents in
 `[bootstrap.macos.launchd.agents]` and apply them with
 `mise bootstrap macos launchd-agents apply` or as part of
 [`mise bootstrap`](/bootstrap.html):
 
+Run this as the user who owns the agent in a macOS session with a GUI launchd
+domain. Create the executable and any log directories before applying it.
+The example's `my-sync` is a placeholder for your own program:
+
 ```toml
 [bootstrap.macos.launchd.agents.my-sync]
 program = "~/.local/bin/my-sync"
 args = ["--watch"]
 run_at_load = true
-start_calendar_interval = { hour = 2, minute = 0 }
 environment = { PATH = "/opt/homebrew/bin:/usr/bin:/bin" }
 working_directory = "~"
 stdout_path = "~/Library/Logs/my-sync.log"
@@ -22,6 +25,11 @@ loaded with `launchctl bootstrap gui/$UID
 ~/Library/LaunchAgents/dev.mise.<name>.plist`. Agent names may contain letters,
 numbers, `.`, `_`, and `-`. mise owns only the plist files it creates with the
 `dev.mise.` label prefix.
+
+The agent receives launchd's environment, not your interactive shell's
+activation. Use explicit executable paths and declare required environment
+variables. `program` and `args` form an argument vector; shell expressions such
+as pipes and redirections need an explicitly invoked shell or a wrapper script.
 
 ## Supported keys
 
@@ -51,6 +59,8 @@ launchd calendar keys. For multiple independent calendar schedules, use an
 array of inline tables:
 
 ```toml
+[bootstrap.macos.launchd.agents.daily-sync]
+program = "~/.local/bin/my-sync"
 start_calendar_interval = [{ hour = 3 }, { hour = 12, weekday = 1 }]
 ```
 

--- a/docs/bootstrap/macos-defaults.md
+++ b/docs/bootstrap/macos-defaults.md
@@ -36,6 +36,18 @@ sections. Within the same config file, raw defaults override the raw
 global-to-local precedence still applies, so a local friendly setting can
 override a global raw default for the same pair.
 
+## Preview and apply
+
+```sh
+mise bootstrap macos defaults status
+mise bootstrap macos defaults apply --dry-run
+mise bootstrap macos defaults apply
+```
+
+Apply as the user whose preferences should change. Choose either a friendly key
+or a raw entry for each preference unless you intentionally need an override.
+The example repeats `AppleShowAllFiles` to demonstrate that precedence.
+
 ## Friendly sections
 
 `[bootstrap.macos.dock]` supports:
@@ -114,7 +126,7 @@ newer mise versions still work.
   `mise bootstrap macos defaults apply` ignores them, so a shared config
   authored for both Linux and macOS works as is.
 - **Manual application only** — mise never writes defaults implicitly; only
-  `mise bootstrap macos defaults apply` does, after the usual confirmation
+  `mise bootstrap macos defaults apply` or the full `mise bootstrap` does, after the usual confirmation
   prompt.
 - **Strictly typed** — an existing value only counts as in sync when both
   the value and the plist type match: an integer `1` does not satisfy a
@@ -161,7 +173,10 @@ writes defaults, the follow-up summary reminds you to relaunch; a common
 run = "killall Dock || true"
 ```
 
-Without a relaunch, Dock/Finder preferences can look unset until the next login.
+The stored value may already match while Dock or Finder still displays its
+previous behavior. Check status, then relaunch the affected app when convenient.
+A post-defaults hook runs on every selected bootstrap, even when no preference
+changed; use the manual commands above when that is not desirable.
 
 ## Finding keys
 

--- a/docs/bootstrap/macos-defaults.md
+++ b/docs/bootstrap/macos-defaults.md
@@ -26,7 +26,7 @@ press_and_hold = false
 tap_to_click = true
 
 [bootstrap.macos.defaults]
-"com.apple.finder" = { AppleShowAllFiles = true }
+"com.apple.finder" = { AppleShowAllFiles = false }
 ```
 
 The friendly sections compile to raw defaults entries. Use
@@ -46,7 +46,9 @@ mise bootstrap macos defaults apply
 
 Apply as the user whose preferences should change. Choose either a friendly key
 or a raw entry for each preference unless you intentionally need an override.
-The example repeats `AppleShowAllFiles` to demonstrate that precedence.
+The example sets friendly `show_all_files = true` and raw
+`AppleShowAllFiles = false` to demonstrate that the raw entry wins within the
+same file.
 
 ## Friendly sections
 

--- a/docs/bootstrap/remote.md
+++ b/docs/bootstrap/remote.md
@@ -329,9 +329,12 @@ An existing matching checkout is reused unless `--update` requests a safe
 fast-forward. Dirty checkouts, mismatched origins, conflicting files, and source
 files ending in `.local.toml` require manual resolution. A nonempty non-Git
 directory can be adopted after confirmation: existing files and local overrides
-are preserved. `--dry-run` reports the required fetch/adoption work without
-fetching the source or applying the persistent checkout changes. SSH inspection
-and temporary staging can still occur.
+are preserved. With `--from-git`, `--dry-run` only reports the proposed operation;
+it does not fetch the source, open an SSH session, inspect the target, or create
+temporary staging. Dirty checkouts, mismatched origins, and adoption conflicts
+are therefore detected only during a real apply. By contrast, `--source .
+--dry-run` connects to and inspects the target without applying persistent
+changes.
 
 `--from-git` uses the repository instead of the inventory's archive source and
 copy-link settings. Explicit `--source`, `--copy-link`, `--copy-links`, and

--- a/docs/bootstrap/remote.md
+++ b/docs/bootstrap/remote.md
@@ -5,146 +5,28 @@ through the locally installed OpenSSH client. Targets can live in versioned
 configuration or be supplied ad hoc from the command line.
 
 Remote targets must provide a POSIX shell plus `cksum`, `mktemp`, `tar`, and `uname`.
-Linux and macOS hosts satisfy these requirements by default. The orchestrating
+Minimal images may need these utilities installed first. The orchestrating
 machine needs local `ssh` and `tar` commands.
 
-## Private configuration repositories
+## First remote run
 
-Install your configuration repository into the remote user's persistent global
-mise configuration directory:
-
-```sh
-# Authenticate on this machine first (for example, using gh auth login).
-mise bootstrap remote --host devbox --from-git jdx/dotfiles \
-  --github-relay-read-only --github-relay-repo jdx/dotfiles
-```
-
-`OWNER/REPO` expands to `https://github.com/OWNER/REPO.git`. Explicit Git URLs,
-SSH syntax, and local paths also work. Network repositories must use HTTPS or
-SSH; other transports and custom Git helpers are rejected. Source clones do not
-follow HTTP redirects, so use the repository's canonical URL.
-`--from-git` conflicts with `--source`.
-Targets still come from explicit `--host` or inventory selectors, never from the
-downloaded repository's inventory.
-
-mise fetches the repository once using **local Git authentication**, pins that
-commit for every selected target, and transfers a Git bundle over SSH. It does
-not modify the initiating machine's global configuration or copy its Git
-configuration. The remote checkout retains the original credential-free origin,
-its branch, and its upstream. Temporary staging is removed; the installed global
-configuration is not. Use `--install-mise` to also install mise persistently when
-the target does not already have it.
-
-An existing matching checkout is reused unless `--update` requests a safe
-fast-forward. Dirty checkouts, mismatched origins, conflicting files, and source
-files ending in `.local.toml` require manual resolution. A nonempty non-Git
-directory can be adopted after confirmation: existing files and local overrides
-are preserved. `--dry-run` reports the required fetch/adoption work without
-fetching the source or changing the target.
-
-`--from-git` uses the repository instead of the inventory's archive source and
-copy-link settings. Explicit `--source`, `--copy-link`, `--copy-links`, and
-`--exclude` flags cannot be combined with it.
-
-The relay is separate from this initial transfer. Enable it when bootstrap needs
-additional private GitHub content, authorizing each required repository with a
-repeated `--github-relay-repo`. Shorthand never enables or expands relay access.
-
-## Borrowing GitHub access for one session
+Use a project containing reviewed bootstrap configuration and an SSH host you
+can already reach. Replace `devbox` with your SSH host or alias:
 
 ```sh
-mise ssh devbox --github-relay-read-only --github-relay-repo jdx/dotfiles
-mise ssh devbox --github-relay-read-only --github-relay-repo jdx/dotfiles \
-  -- git clone https://github.com/jdx/dotfiles.git
-
-# Deliberately allow every repository your local credential can read:
-mise ssh devbox --github-relay-read-only --github-relay-all-repos
-
-# Ordinary OpenSSH, without provisioning mise or starting a relay:
-mise ssh devbox -i ~/.ssh/devbox -p 2222 -o ServerAliveInterval=30 -- uname -a
+ssh devbox uname -s
+mise bootstrap remote --host devbox --source . --dry-run
+mise bootstrap remote --host devbox --source .
 ```
 
-The same relay flags work with `mise bootstrap remote`. Enabling the relay
-requires either a repository allowlist or explicit all-repository access, not
-both. Credentials are resolved on the initiating machine using mise's existing
-GitHub token resolution; there is no automatic login or new credential store.
+A remote dry run still connects over SSH, transfers the project, stages mise,
+and inspects the target. It suppresses bootstrap resource changes; it is not an
+offline plan. Temporary staging is cleaned up unless `--keep-staging` is set.
 
-The owned SSH connection forwards a private Unix socket. Remote mise requests
-and Git's GitHub HTTPS/SSH transports use session-only adapters. The local broker
-authorizes repository metadata, refs, contents, releases, assets, and smart-HTTP
-clone/fetch. Pushes, API mutations, GraphQL, and other endpoints are denied.
-Only approved GitHub asset redirects are followed, without authentication.
-Requests are limited to 8 MiB and 32 accepted connections; responses are streamed.
-The default concurrency is eight requests and the default total request timeout
-is five minutes. Both limits can be configured on the initiating machine.
+Use `--install-mise` if the target should keep mise after the run. Review archive
+exclusions before transferring a repository with local secrets or generated data.
 
-Borrowed access ends when the session ends, including failures and disconnects.
-No GitHub token or persistent transport rewrite is installed on the target.
-Future independent private-repository updates need that machine's own
-credentials or another relay-enabled session. Without the relay, existing remote
-authentication works as before.
-
-::: warning Trust the target with the content you authorize
-A compromised target can read authorized private content during the session.
-Keeping credentials local limits credential exposure; it does not make the
-target trustworthy. Use narrowly scoped repository allowlists.
-:::
-
-Relay support is initially limited to Linux/macOS clients and POSIX Linux/macOS
-targets running a compatible mise. Windows, GitHub Enterprise, remote `gh`, write
-operations, and unattended/persistent relay access are not supported.
-
-Read-only access includes Git clone/fetch, repository metadata, contents, refs,
-releases, release assets, and tar/zip source archives. Archive and asset redirects
-are restricted to approved GitHub download hosts and never carry your credential.
-Resume requests retain their range headers, and denied downloads fail rather than
-being saved as artifacts.
-
-### Observing and limiting borrowed access
-
-```sh
-mise ssh devbox --github-relay-read-only --github-relay-repo jdx/dotfiles \
-  --github-relay-log-requests --github-relay-max-duration 1h
-
-# Structured relay events for troubleshooting or auditing:
-mise bootstrap remote --host devbox --from-git jdx/dotfiles \
-  --github-relay-read-only --github-relay-repo jdx/dotfiles \
-  --github-relay-log-requests --github-relay-log-format jsonl
-```
-
-Request logs are off by default. Enable them per invocation or save preferences
-in your **local global** mise configuration:
-
-```toml
-[settings.github_relay]
-log_requests = true
-log_format = "text" # or "jsonl"
-max_duration = "1h" # default "0s": until the session ends
-request_timeout = "5m"
-concurrency = 8 # 1-32; excess requests fail closed rather than queue
-```
-
-`--github-relay-no-log-requests` overrides a saved logging preference. The format
-and duration flags also override their respective settings. These preferences
-never enable the relay or authorize repositories: access and scope still require
-explicit flags on every invocation.
-
-Events go to the initiating machine's stderr, not the remote command's stdout.
-They show the method, repository and fixed operation name, status, and time to
-response headers. Approved download redirects are identified by host only. Query
-values, refs, filenames, headers, credentials, bodies, and signed download URLs
-are omitted; rejected paths appear as `unapproved operation`. JSONL applies to
-relay events; other mise diagnostics can still appear on stderr.
-
-Every relay prints a session-end summary, even when request logging is off:
-requests received (excluding heartbeat probes), denied/unavailable requests,
-upstream response bytes received, and up to 128 authorized repositories requested.
-Redirects are separate log events but do not add to the incoming request count.
-
-The duration limit starts when the local relay is created. Expiration immediately
-revokes borrowed access and cancels active transfers; the remote adapter then
-ends its command after detecting failed heartbeat probes. No credentials are
-installed to extend access beyond this limit.
+## Inventory configuration
 
 ```toml
 [bootstrap.remote]
@@ -371,8 +253,8 @@ and it is what runs the bootstrap, so the host converges with the mise version
 that orchestrated it. mise writes a temporary file beside the target and renames
 it into place, so replacing a mise that is currently running cannot truncate it.
 When the target already holds a byte-identical executable, nothing is uploaded.
-A dry run never writes to the host: `--dry-run` reports the path it would
-install to and stages the executable as usual.
+A dry run does not write the persistent install path: `--dry-run` reports that
+path and uses a temporary staged executable for inspection.
 
 `install_mise` composes with `mise_bin`, which installs a locally built
 executable. It cannot be combined with `remote_mise` or `bootstrap_command`,
@@ -415,3 +297,142 @@ explicitly configured `mise_env` is remote orchestration metadata rather than
 an inherited local environment. Use `--prompt-secrets` for an attended run.
 Provider-backed secret environment transport can be layered on separately
 without putting values in config, archives, process arguments, plans, or logs.
+
+## Private configuration repositories
+
+Install your configuration repository into the remote user's persistent global
+mise configuration directory:
+
+```sh
+# Authenticate on this machine first (for example, using gh auth login).
+mise bootstrap remote --host devbox --from-git jdx/dotfiles \
+  --github-relay-read-only --github-relay-repo jdx/dotfiles
+```
+
+`OWNER/REPO` expands to `https://github.com/OWNER/REPO.git`. Explicit Git URLs,
+SSH syntax, and local paths on the initiating machine also work. Network repositories must use HTTPS or
+SSH; other transports and custom Git helpers are rejected. Source clones do not
+follow HTTP redirects, so use the repository's canonical URL.
+`--from-git` conflicts with `--source`.
+Targets still come from explicit `--host` or inventory selectors, never from the
+downloaded repository's inventory.
+
+mise fetches the repository once using **local Git authentication**, pins that
+commit for every selected target, and transfers a Git bundle over SSH. It does
+not modify the initiating machine's global configuration or copy its Git
+configuration. The remote checkout retains the original credential-free origin,
+its branch, and its upstream. Temporary staging is removed; the installed global
+configuration is not. Use `--install-mise` to also install mise persistently when
+the target does not already have it.
+
+An existing matching checkout is reused unless `--update` requests a safe
+fast-forward. Dirty checkouts, mismatched origins, conflicting files, and source
+files ending in `.local.toml` require manual resolution. A nonempty non-Git
+directory can be adopted after confirmation: existing files and local overrides
+are preserved. `--dry-run` reports the required fetch/adoption work without
+fetching the source or applying the persistent checkout changes. SSH inspection
+and temporary staging can still occur.
+
+`--from-git` uses the repository instead of the inventory's archive source and
+copy-link settings. Explicit `--source`, `--copy-link`, `--copy-links`, and
+`--exclude` flags cannot be combined with it.
+
+The relay is separate from this initial transfer. Enable it when bootstrap needs
+additional private GitHub content, authorizing each required repository with a
+repeated `--github-relay-repo`. Shorthand never enables or expands relay access.
+
+## Borrowing GitHub access for one session
+
+```sh
+mise ssh devbox --github-relay-read-only --github-relay-repo jdx/dotfiles
+mise ssh devbox --github-relay-read-only --github-relay-repo jdx/dotfiles \
+  -- git clone https://github.com/jdx/dotfiles.git
+
+# Deliberately allow every repository your local credential can read:
+mise ssh devbox --github-relay-read-only --github-relay-all-repos
+
+# Ordinary OpenSSH, without provisioning mise or starting a relay:
+mise ssh devbox -i ~/.ssh/devbox -p 2222 -o ServerAliveInterval=30 -- uname -a
+```
+
+The same relay flags work with `mise bootstrap remote`. Enabling the relay
+requires either a repository allowlist or explicit all-repository access, not
+both. Credentials are resolved on the initiating machine using mise's existing
+GitHub token resolution; there is no automatic login or new credential store.
+
+The owned SSH connection forwards a private Unix socket. Remote mise requests
+and Git's GitHub HTTPS/SSH transports use session-only adapters. The local broker
+authorizes repository metadata, refs, contents, releases, assets, and smart-HTTP
+clone/fetch. Pushes, API mutations, GraphQL, and other endpoints are denied.
+Only approved GitHub asset redirects are followed, without authentication.
+Requests are limited to 8 MiB and 32 accepted connections; responses are streamed.
+The default concurrency is eight requests and the default total request timeout
+is five minutes. Both limits can be configured on the initiating machine.
+
+Borrowed access ends when the session ends, including failures and disconnects.
+No GitHub token or persistent transport rewrite is installed on the target.
+Future independent private-repository updates need that machine's own
+credentials or another relay-enabled session. Without the relay, existing remote
+authentication works as before.
+
+::: warning Trust the target with the content you authorize
+A compromised target can read authorized private content during the session.
+Keeping credentials local limits credential exposure; it does not make the
+target trustworthy. Use narrowly scoped repository allowlists.
+:::
+
+Relay support is initially limited to Linux/macOS clients and POSIX Linux/macOS
+targets running a compatible mise. Windows, GitHub Enterprise, remote `gh`, write
+operations, and unattended/persistent relay access are not supported.
+
+Read-only access includes Git clone/fetch, repository metadata, contents, refs,
+releases, release assets, and tar/zip source archives. Archive and asset redirects
+are restricted to approved GitHub download hosts and never carry your credential.
+Resume requests retain their range headers, and denied downloads fail rather than
+being saved as artifacts.
+
+### Observing and limiting borrowed access
+
+```sh
+mise ssh devbox --github-relay-read-only --github-relay-repo jdx/dotfiles \
+  --github-relay-log-requests --github-relay-max-duration 1h
+
+# Structured relay events for troubleshooting or auditing:
+mise bootstrap remote --host devbox --from-git jdx/dotfiles \
+  --github-relay-read-only --github-relay-repo jdx/dotfiles \
+  --github-relay-log-requests --github-relay-log-format jsonl
+```
+
+Request logs are off by default. Enable them per invocation or save preferences
+in your **local global** mise configuration:
+
+```toml
+[settings.github_relay]
+log_requests = true
+log_format = "text" # or "jsonl"
+max_duration = "1h" # default "0s": until the session ends
+request_timeout = "5m"
+concurrency = 8 # 1-32; excess requests fail closed rather than queue
+```
+
+`--github-relay-no-log-requests` overrides a saved logging preference. The format
+and duration flags also override their respective settings. These preferences
+never enable the relay or authorize repositories: access and scope still require
+explicit flags on every invocation.
+
+Events go to the initiating machine's stderr, not the remote command's stdout.
+They show the method, repository and fixed operation name, status, and time to
+response headers. Approved download redirects are identified by host only. Query
+values, refs, filenames, headers, credentials, bodies, and signed download URLs
+are omitted; rejected paths appear as `unapproved operation`. JSONL applies to
+relay events; other mise diagnostics can still appear on stderr.
+
+Every relay prints a session-end summary, even when request logging is off:
+requests received (excluding heartbeat probes), denied/unavailable requests,
+upstream response bytes received, and up to 128 authorized repositories requested.
+Redirects are separate log events but do not add to the incoming request count.
+
+The duration limit starts when the local relay is created. Expiration immediately
+revokes borrowed access and cancels active transfers; the remote adapter then
+ends its command after detecting failed heartbeat probes. No credentials are
+installed to extend access beyond this limit.

--- a/docs/bootstrap/repos.md
+++ b/docs/bootstrap/repos.md
@@ -1,4 +1,4 @@
-# Repos
+# Git repositories
 
 mise can declare git repositories in `[bootstrap.repos]` and apply them with
 `mise bootstrap repos apply` or as part of [`mise bootstrap`](/bootstrap.html):
@@ -47,6 +47,17 @@ from that checkout.
   `--skip-dirty` to skip dirty repos while applying or updating the rest.
 - **Omitted `ref`** — an existing repo with the expected origin is considered
   current; mise does not fetch or update it.
+
+## Choose apply or update
+
+Use `apply` to establish the declared checkout. With no `ref`, an existing
+matching checkout is left at its current commit. Use `update` when you want
+mise to fetch and fast-forward its current branch. A declared `ref` remains the
+target for both commands; `update` does not override that selection.
+
+Git must be installed and able to authenticate to every configured origin.
+For a dotfiles source in one of these checkouts, apply repos before dotfiles,
+as the full bootstrap does.
 
 ## Commands
 

--- a/docs/bootstrap/secrets.md
+++ b/docs/bootstrap/secrets.md
@@ -32,6 +32,13 @@ inputs are resolved and every template is rendered before any full-bootstrap
 mutation starts, so a missing input cannot leave a partially rendered file or
 allow earlier bootstrap steps to run.
 
+The `.env` example assumes values that can be written as single-line assignments.
+The `secret()` function inserts the value; it does not quote or escape it for
+shell, JSON, TOML, or another target format. Render and encode values according
+to the format consumed by the service, especially for quotes or newlines.
+
+## Supply inputs and check availability
+
 Use fnox to inject provider-backed values into the bootstrap process:
 
 ```sh
@@ -56,6 +63,10 @@ mise bootstrap plan --prompt-secrets
 names, and `available`, `missing`, `empty`, or `invalid_unicode`; it never prints
 values. Add `--json` for machine-readable output or `--missing` to exit 1 when
 an input is unavailable.
+
+For [remote bootstrap](/bootstrap/remote.html), the local environment is not
+copied to the SSH target. Supply inputs on the target or use `--prompt-secrets`
+for an attended run.
 
 mise redacts resolved values from its output. Plans, dry runs, status output,
 and privileged-helper output contain no rendered file content. There is no

--- a/docs/bootstrap/services.md
+++ b/docs/bootstrap/services.md
@@ -17,6 +17,14 @@ enabled = true
 Names without a unit suffix receive `.service`. Explicit unit names such as
 `postgresql@16-main.service`, sockets, and timers are also accepted.
 
+For user-owned units written under `~/.config/systemd/user`, use
+[systemd user units](/bootstrap/systemd.html) instead. This section manages
+system units already supplied by packages or [managed files](/bootstrap/files.html).
+
+Preview with `mise bootstrap services apply --dry-run`. If the unit will be
+created by the same configuration, use the full bootstrap to install its package
+or file before converging the service.
+
 ## Options
 
 - `state`: `"running"` (default) or `"stopped"`
@@ -63,7 +71,9 @@ and `mise bootstrap plan` include the notification consequences of pending
 managed-file changes, while `mise bootstrap files apply` runs those handlers
 only after the causal file operation succeeds.
 
-A masked unit must also be stopped and disabled:
+Removing a service declaration leaves its current state unmanaged. To stop it
+and prevent future starts, keep an explicit declaration. A masked unit must
+also be stopped and disabled:
 
 ```toml
 [bootstrap.services.old-worker]

--- a/docs/bootstrap/shell.md
+++ b/docs/bootstrap/shell.md
@@ -15,7 +15,12 @@ bashrc = "activate"
 fish = "activate"
 ```
 
-Use the inline table form when you want a shape that can accept future options:
+Configure only the shells and startup files you use. `"activate"` enables
+interactive environment updates; `"shims"` makes installed tool commands
+available without a prompt hook. See [shims](/dev-tools/shims.html) for that mode's
+limits. The `mise` executable must already be on the startup file's `PATH`.
+
+The inline table form makes enablement and mode explicit:
 
 ```toml
 [bootstrap.mise_shell_activate]
@@ -69,7 +74,9 @@ other bootstrap sections:
   that shell.
 
 For fully managed rc files or custom activation blocks, use `[dotfiles]`
-directly instead.
+directly instead. Review any existing unmarked activation lines to avoid running
+the hook twice. After applying, open a new shell and check `mise doctor`; editing
+a startup file does not change the shell process already running.
 
 ## Commands
 

--- a/docs/bootstrap/systemd.md
+++ b/docs/bootstrap/systemd.md
@@ -1,9 +1,14 @@
-# systemd
+# Linux systemd user units
 
 mise can declare Linux systemd user services and timers in
 `[bootstrap.linux.systemd.units]` and apply them with
 `mise bootstrap linux systemd-units apply` or as part of
 [`mise bootstrap`](/bootstrap.html):
+
+Use [system services](/bootstrap/services.html) for units managed by the system
+manager. These user units need a reachable user manager and run with the user's
+permissions. Install your executable before applying the example; `my-sync`
+is a placeholder for a program you provide.
 
 ```toml
 [bootstrap.linux.systemd.units.my-sync]
@@ -11,7 +16,6 @@ description = "sync files"
 exec_start = "~/.local/bin/my-sync --watch"
 after = ["network-online.target"]
 wants = ["network-online.target"]
-requires = ["credentials.service"]
 environment = { PATH = "/usr/local/bin:/usr/bin:/bin" }
 environment_file = ["-%h/.config/my-sync.env"]
 nice = 10
@@ -19,7 +23,7 @@ umask = "0007"
 working_directory = "~"
 restart = "on-failure"
 restart_sec = "5s"
-standard_output = "append:%h/.local/state/my-sync.log"
+standard_output = "journal"
 standard_error = "journal"
 ```
 
@@ -45,15 +49,22 @@ An entry containing a timer key is rendered as a `.timer` instead of a
 description = "check daemon health"
 type = "oneshot"
 exec_start = "~/.local/bin/daemon healthcheck"
+start = false
+wanted_by = []
 
 [bootstrap.linux.systemd.units.healthcheck-timer]
 description = "periodically check daemon health"
 on_boot_sec = "2min"
 on_unit_inactive_sec = "5min"
 randomized_delay_sec = "30s"
-persistent = true
 unit = "healthcheck"
 ```
+
+The service is left disabled and stopped during apply so the timer controls its
+execution. `persistent` catches up missed calendar events when used with
+`on_calendar`; it does not add catch-up behavior to monotonic timers such as
+`on_unit_inactive_sec`. See the
+[systemd timer reference](https://www.freedesktop.org/software/systemd/man/latest/systemd.timer.html#Persistent=).
 
 A bare `unit` value (no unit-type suffix) is resolved to the mise-owned service
 `dev.mise.<unit>.service` — so `unit = "healthcheck"` targets the `healthcheck`
@@ -112,7 +123,12 @@ systemd specifiers such as `%h`; prefix a path with `-` to make it optional.
 systemd does not expand `~` or `$HOME` in these paths. Environment variables are
 not appropriate for secrets; use systemd credentials for sensitive values.
 
-`exec_start` and `working_directory` expand bare `~` and `~/` to the current
+Unit commands do not inherit your interactive shell's mise activation. Set an
+explicit executable path and the environment the service needs. `ExecStart`
+uses systemd's command syntax; shell operators need an explicitly invoked shell
+or a wrapper script.
+
+`exec_start`, `exec_stop`, and `working_directory` expand bare `~` and `~/` to the current
 user's home directory before writing the service file. `wanted_by` defaults to
 `["default.target"]` for services and `["timers.target"]` for timers; set
 `wanted_by = []` to write the unit and disable any previous enablement. `start`
@@ -130,8 +146,8 @@ unit running.
   `mise bootstrap linux systemd-units status` lists entries as skipped and
   `mise bootstrap linux systemd-units apply` ignores them.
 - **User units only** — mise writes to `~/.config/systemd/user` and uses
-  `systemctl --user`. System services in `/etc/systemd/system` are not
-  supported.
+  `systemctl --user`. To manage system services in `/etc/systemd/system`, use
+  [managed files](/bootstrap/files.html) and [system services](/bootstrap/services.html).
 - **Target user only** — run mise as the user who owns the services, with a
   reachable systemd user manager. `sudo mise` is skipped because `systemctl --user`
   would target the wrong user manager.

--- a/docs/bootstrap/user.md
+++ b/docs/bootstrap/user.md
@@ -9,6 +9,11 @@ apply it with `mise bootstrap user apply` or as part of
 login_shell = "/bin/zsh"
 ```
 
+Install the shell before applying this declaration and verify that the path
+exists. This setting changes the account's login shell; it does not install a
+shell, configure [mise activation](/bootstrap/shell.html), or replace the current
+shell process.
+
 When the configured shell is not listed in `/etc/shells`, mise appends it
 first. When the configured shell differs from the user's account entry, mise
 runs:

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -69,7 +69,7 @@
 
 ## Bootstrap
 
-- [Overview](https://mise.jdx.dev/bootstrap.html): mise bootstrap sets up a machine for the current config in one command: Linux users and groups, OS packages, privileged files and directories, system services, Linux host firewall policy, Docker…
+- [Overview](https://mise.jdx.dev/bootstrap.html): mise bootstrap applies the machine setup declared in your mise configuration: packages, files, services, repositories, shell setup, tools, and a final task.
 - [Remote Hosts](https://mise.jdx.dev/bootstrap/remote.html): mise bootstrap remote applies a bootstrap project to one or more machines through the locally installed OpenSSH client.
 - [Bootstrap Packages](https://mise.jdx.dev/bootstrap/packages/): mise can ensure host packages are installed via the [bootstrap.packages] section of mise.toml, applied by mise bootstrap packages apply or as part of mise bootstrap.
 - [apk](https://mise.jdx.dev/bootstrap/packages/apk.html): System packages for Alpine Linux.


### PR DESCRIPTION
Bootstrap documentation now starts with a small configuration and a preview/apply/status workflow, with repository composition and advanced setup moved after the core flow. Review all fourteen bootstrap and resource guides, including remote execution, accounts, files, secrets, services, Compose, firewall, repos, shell activation, login shell, macOS preferences, LaunchAgents, and systemd user units.

Fix the Compose example's missing secret declarations and `template = true`, document template escaping and mode/ownership requirements, distinguish resource apply from its prerequisite phases, and correct remote dry-run behavior. Improve service/timer examples, distinguish system and user services, and explain repeatable hooks and recovery after a failed phase.

Validation: 32 TOML examples parse with the current TOML 1.1 parser. Isolated smoke checks cover the overview, phase selection and final task, Compose secret rendering and redaction, 0600 permissions, plan exit codes, and missing-secret preflight. Full Rust 1.95 `lint-fix` and the docs build pass; all local links in the fourteen rendered pages resolve. Rebased on main and rebuilt `llms.txt` before publishing. Host services/firewall and SSH targets were reviewed against source, not applied to this machine.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown documentation updates only; no application code or configuration schema changes in this diff.
> 
> **Overview**
> **Documentation-only** refresh of bootstrap and resource guides—no runtime behavior changes.
> 
> The **bootstrap overview** now leads with a minimal `mise.toml` example and an explicit **trust → dry-run → apply → status** flow, replaces the large all-in-one sample, and adds guidance on **non-transactional** applies, **`--update`** (including repos), and expanded **“what goes where”** (secrets, accounts, files, services, compose, plugins). **`config_roots`** composition is moved after the core workflow.
> 
> Across **accounts, files, secrets, services, compose, firewall, repos, shell, user, macOS defaults, LaunchAgents, and systemd** pages, the docs add **preview/status/dry-run** command blocks, prerequisites (ordering, permissions, template escaping), and clearer distinctions (system vs user services, apply vs update for repos, removal semantics).
> 
> **Remote bootstrap** is reordered with a **“first remote run”** quick start; **`--from-git --dry-run`** is documented as offline/plan-only versus **`--source` dry-run**, which still SSHs and inspects. Examples are tightened (Compose secrets/`template`, firewall SSH caution, timer/service patterns). **`docs/public/llms.txt`** bootstrap blurb matches the new overview.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f015f80724035d63fadd511894dc1ad9abc9dac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded bootstrap guidance for previewing, applying, updating, and checking status.
  - Added instructions for accounts, files, secrets, services, repositories, firewall policies, Compose, macOS defaults, and remote setup.
  - Clarified prerequisites, ordering, authentication, permissions, source resolution, and non-transactional behavior.
  - Documented dry-run limitations, secret handling, remote execution, and repository apply/update choices.
  - Updated examples for shell setup, LaunchAgents, systemd units, hooks, and login shells.
  - Refined the public Bootstrap Overview description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->