### PR TITLE
docs: clarify bootstrap package ownership and workflows

### DIFF
--- a/docs/bootstrap/packages/apk.md
+++ b/docs/bootstrap/packages/apk.md
@@ -1,4 +1,4 @@
-# apk
+# Alpine packages (apk)
 
 System packages for Alpine Linux.
 
@@ -7,6 +7,19 @@ System packages for Alpine Linux.
 "apk:build-base" = "latest"
 "apk:zlib-dev" = "1.3.1-r2" # version pin
 ```
+
+## Preview and apply
+
+```sh
+mise bootstrap packages status
+mise bootstrap packages apply --manager apk --dry-run
+mise bootstrap packages apply --manager apk
+```
+
+These commands use the active `[bootstrap.packages]` declarations. To add and
+install a package together, use `mise bootstrap packages use apk:build-base`.
+The manager must be available on the host; an explicit `--manager apk` fails
+when it is unavailable.
 
 ## Behavior
 
@@ -20,6 +33,10 @@ System packages for Alpine Linux.
   for the configured packages that are already installed.
 
 ## Version pins
+
+The pinned version above is illustrative. Check `apk policy zlib-dev` on the
+target and select a version available from its configured repositories. A pin
+does not add an old Alpine repository or retrieve archived packages.
 
 A pinned entry (`"apk:zlib-dev" = "1.3.1-r2"`) shows as `version mismatch`
 in `mise bootstrap packages status` when a different version is installed,

--- a/docs/bootstrap/packages/apt.md
+++ b/docs/bootstrap/packages/apt.md
@@ -1,4 +1,4 @@
-# apt
+# Debian and Ubuntu packages (apt)
 
 System packages for Debian-family Linux (Debian, Ubuntu, Mint, ...).
 
@@ -9,6 +9,19 @@ System packages for Debian-family Linux (Debian, Ubuntu, Mint, ...).
 "apt:gcc:arm64" = "latest"     # architecture qualifier
 ```
 
+## Preview and apply
+
+```sh
+mise bootstrap packages status
+mise bootstrap packages apply --manager apt --dry-run
+mise bootstrap packages apply --manager apt
+```
+
+These commands use the active `[bootstrap.packages]` declarations. To add and
+install a package together, use `mise bootstrap packages use apt:libssl-dev`.
+The manager must be available on the host; an explicit `--manager apt` fails
+when it is unavailable.
+
 ## Behavior
 
 - Package state is checked with `dpkg-query` (read-only, never elevates).
@@ -17,10 +30,12 @@ System packages for Debian-family Linux (Debian, Ubuntu, Mint, ...).
 - Version pins are passed to apt as its native `name=version` syntax;
   `name:arch` qualifiers pass through in the package name.
 - `DEBIAN_FRONTEND=noninteractive` is set so installs never block on
-  configuration prompts.
+  debconf configuration prompts. This does not supply sudo credentials or
+  guarantee that every maintainer script is non-interactive.
 - `mise bootstrap packages upgrade` runs `apt-get update` and then
   `apt-get install --only-upgrade` for the configured packages, so nothing
-  that is not already installed gets pulled in.
+  requested package that is not already installed becomes an install target.
+  apt still resolves dependencies required by those upgrades.
 
 ## Metadata refresh
 
@@ -33,7 +48,18 @@ refresh explicitly:
 mise bootstrap packages apply --update
 ```
 
+## Architecture-qualified packages
+
+`gcc:arm64` is a package name with an architecture qualifier. The target's dpkg
+architecture configuration and apt repositories must supply that architecture;
+this declaration does not enable multiarch or add a repository.
+
 ## Version pins
+
+The version above is illustrative and specific to a distribution release. Use
+`apt-cache policy curl` to inspect candidates on the target before pinning it.
+An exact pin must remain available in the configured repositories; mise does
+not turn apt into a historical package archive.
 
 A pinned entry (`"apt:curl" = "8.5.0-2ubuntu10"`) shows as `version mismatch`
 in `mise bootstrap packages status` when a different version is installed, and

--- a/docs/bootstrap/packages/aur.md
+++ b/docs/bootstrap/packages/aur.md
@@ -17,7 +17,10 @@ your AUR helper and does not add an independent trust or verification layer.
 "aur:visual-studio-code-bin" = "latest"
 ```
 
-mise prefers `yay` when both helpers are on `PATH`, matching Omarchy's default,
+Install a working AUR helper and its build prerequisites before applying this
+configuration. Run as a regular user, not root.
+
+mise prefers `yay` when both helpers are on `PATH`,
 and otherwise uses `paru`. The helper runs as the current user because AUR
 packages are built with `makepkg`; the helper requests elevation from pacman
 when it installs the finished package.
@@ -37,10 +40,13 @@ versions, so version pins are status-only. Use `"latest"` for entries mise can
 install automatically.
 
 ```sh
-mise bootstrap packages status --manager aur
+mise bootstrap packages status
+mise bootstrap packages apply --manager aur --dry-run
 mise bootstrap packages apply --manager aur
 mise bootstrap packages upgrade --manager aur
 ```
 
 `upgrade` rebuilds only the configured AUR packages. It does not upgrade every
-foreign package on the machine.
+foreign package on the machine. The helper can still resolve dependencies while
+building those packages. A dry run shows the helper invocation; it does not
+fetch and review the PKGBUILD for you.

--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -1,4 +1,4 @@
-# brew
+# Homebrew formulae and casks
 
 Homebrew formulae and casks — **without requiring Homebrew to be installed**.
 
@@ -19,6 +19,24 @@ same relocation, code-signing, and linking work `brew` does when pouring a
 bottle. Formulae without a usable bottle are built from source, also without
 Homebrew (see [Source formulae](#source-formulae)). mise never shells out to
 `brew` for homebrew/core formulae.
+
+## First install
+
+Use this manager when you want software in the shared Homebrew prefix. For a
+CLI that needs project-specific version switching, use a [tool backend](/dev-tools/backends/).
+These package declarations do not create mise shims or modify the current shell's PATH.
+
+```sh
+mise bootstrap packages status
+mise bootstrap packages apply --manager brew --dry-run
+mise bootstrap packages apply --manager brew
+```
+
+Check [platform support](#supported-platforms) first. Source builds need a
+compiler and build tools, and some casks need permission to write system-owned
+paths. An installation can include the package's dependencies.
+
+## Third-party taps
 
 Third-party taps are supported with the same fully-qualified name you would
 pass to Homebrew:
@@ -69,7 +87,7 @@ Casks use the `brew-cask:` manager. mise fetches cask metadata directly from
 the Homebrew cask API (or from tap API metadata), downloads the artifact,
 verifies its sha256 when the cask provides one, extracts the archive, and
 installs app bundles into `/Applications` while recording the version under
-`<prefix>/Caskroom`. Like Homebrew, mise moves each app bundle into
+`<prefix>/Caskroom`. For an ordinary managed app artifact, mise moves the bundle into
 `/Applications` and leaves a symlink at its versioned Caskroom path instead of
 retaining a second copy of the application.
 
@@ -167,7 +185,9 @@ mise prints a warning whenever it replaces an existing `.app`. Version
 upgrades still replace the bundle when upstream publishes a new cask version —
 expect to re-confirm TCC prompts after those upgrades, just as with Homebrew.
 
-On Linux, initial cask support is limited to font-only casks without lifecycle
+### Linux font casks
+
+On Linux, cask support is limited to font-only casks without lifecycle
 hooks or structured `preflight_steps` or `postflight_steps` — concepts from
 Homebrew's cask DSL, documented in the
 [Homebrew Cask Cookbook](https://docs.brew.sh/Cask-Cookbook). Fonts are
@@ -184,6 +204,8 @@ explicit request such as `mise bootstrap packages apply brew-cask:firefox`
 still fails with a clear unsupported-platform error. You can also mark macOS
 casks explicitly with `{ os = "macos" }`. This boundary will expand as mise
 gains portable implementations for more cask artifact types.
+
+### Supported artifacts and lifecycle actions
 
 `brew-cask` currently supports app-bundle casks (`app` artifacts), binary and
 generated command-wrapper casks (`binary` and `command_wrapper` artifacts),
@@ -214,6 +236,8 @@ require custom installer choices, services, unsupported hook DSL, unsupported
 structured lifecycle steps, or other cask artifact types fail with a clear
 unsupported artifact error instead of delegating to Homebrew.
 
+### Ownership and installed state
+
 Direct cask pours remain mise-owned. Their completed state is recorded in
 `.mise-cask.toml`; mise does not synthesize Homebrew's private `.metadata`
 receipts. A Homebrew-owned cask with `.metadata` and exactly one Caskroom version
@@ -238,12 +262,6 @@ reported as unhealthy so the next apply can reconcile them. Version upgrades
 and an explicit remove + apply still replace the app when you want a fresh
 pour.
 
-The `brew` manager exists because shared-library packages — postgres, ffmpeg,
-imagemagick, php — fundamentally can't be served by mise's per-project backends like
-`aqua:` or `github:`: their bottles are built against fixed install paths and
-a shared dependency tree. Installing them at Homebrew's canonical prefix is
-what makes them work.
-
 ## Supported platforms
 
 | Platform                    | Prefix                       |
@@ -259,10 +277,25 @@ source instead.
 
 ## The prefix
 
-If the prefix doesn't exist, mise creates it with the standard layout. This is
-the only time the brew manager uses sudo, mirroring what Homebrew's own
-installer does (`mkdir` + `chown` to your user). After that, installs are plain
-file operations as your user; nothing runs as root.
+If the prefix doesn't exist, mise creates it with the standard layout.
+Formula installation may elevate for prefix creation and ownership setup
+(`mkdir` + `chown`), then writes formulae as the prefix owner. Cask installation
+can also require elevation for package installers or lifecycle steps. Run mise
+as the intended owner and let it request the privileges needed for each step.
+
+Linked commands need `<prefix>/bin` on `PATH`. For example, in the appropriate
+shell startup file:
+
+```sh
+# Apple Silicon macOS
+export PATH="/opt/homebrew/bin:$PATH"
+
+# Linux
+# export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+```
+
+Keg-only formulae are not linked there. Use their `<prefix>/opt/<formula>` path
+when configuring compilers or services that need them.
 
 ## Coexistence with a real Homebrew
 
@@ -414,6 +447,14 @@ linked keg — the new keg replaces the old one and the links are repointed,
 the same dance `brew upgrade` does. Since bottles only exist for a formula's
 current version, "upgrade" and "install the current bottle" are the same
 operation.
+
+## Troubleshooting
+
+- **Link conflict:** inspect the paths mise lists and identify their owner before changing them. Repeated apply does not authorize overwriting unrelated files.
+- **Unsupported formula DSL or cask artifact:** read the named unsupported operation. mise's built-in installer has its own coverage; an upstream Homebrew recipe is not a guarantee of support.
+- **Installed but command missing:** check the prefix's `bin` directory and whether the formula is keg-only.
+- **Existing app differs:** decide whether to keep managing it outside mise or use the documented adoption workflow. `adopt` is not permission to overwrite a different app.
+- **App replaced successfully but permissions changed:** check macOS Privacy & Security grants for that app.
 
 ## Limitations
 

--- a/docs/bootstrap/packages/dnf.md
+++ b/docs/bootstrap/packages/dnf.md
@@ -1,4 +1,4 @@
-# dnf
+# RPM packages (dnf)
 
 System packages for Red Hat-family Linux (Fedora, RHEL, CentOS Stream, Rocky,
 Alma, ...).
@@ -9,6 +9,19 @@ Alma, ...).
 "dnf:postgresql-server" = "latest"
 "dnf:bash" = "5.2.26-3.fc40" # version or version-release pin
 ```
+
+## Preview and apply
+
+```sh
+mise bootstrap packages status
+mise bootstrap packages apply --manager dnf --dry-run
+mise bootstrap packages apply --manager dnf
+```
+
+These commands use the active `[bootstrap.packages]` declarations. To add and
+install a package together, use `mise bootstrap packages use dnf:openssl-devel`.
+The manager must be available on the host; an explicit `--manager dnf` fails
+when it is unavailable.
 
 ## Behavior
 
@@ -22,6 +35,16 @@ Alma, ...).
   refresh; otherwise dnf manages its own metadata expiry.
 - `mise bootstrap packages upgrade` runs `dnf upgrade -y --refresh` for the configured
   packages — only already-installed packages are touched.
+
+## Version selection
+
+The Fedora version-release above illustrates syntax; it is not portable across
+RPM distributions or releases. Select a version available in the target's
+enabled repositories. mise passes the constraint to dnf and does not add a
+repository or fetch an archived RPM to satisfy it.
+
+`"latest"` accepts an installed package. Use `upgrade` to request an update;
+source packages and native dependency resolution remain dnf's responsibility.
 
 ::: info
 Only `dnf` is supported — not legacy `yum`-only systems. On RHEL/CentOS 8+

--- a/docs/bootstrap/packages/flatpak.md
+++ b/docs/bootstrap/packages/flatpak.md
@@ -20,17 +20,29 @@ mise does not install Flatpak or configure remotes implicitly. Install the
 the config:
 
 ```sh
+# Choose the scope you intend to manage:
 flatpak remote-add --system --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 mise bootstrap packages use flatpak:org.mozilla.firefox
 mise bootstrap packages use flatpak-user:org.gnome.Builder
 ```
 
+Check remote configuration in the same scope before installing:
+
+```sh
+flatpak remotes --system
+flatpak remotes --user
+```
+
+Adding Flathub in user scope does not make it available to `flatpak:` system
+entries. When multiple remotes provide an ID, resolve the ambiguity in Flatpak's
+configuration; a mise declaration does not choose a remote by name.
+
 ## Commands
 
 ```sh
-mise bootstrap packages status --manager flatpak
-mise bootstrap packages status --manager flatpak-user
+mise bootstrap packages status
+mise bootstrap packages apply --manager flatpak --dry-run
 mise bootstrap packages apply --manager flatpak
 mise bootstrap packages apply --manager flatpak-user
 mise bootstrap packages upgrade --manager flatpak
@@ -47,3 +59,5 @@ these commands, so version pins are not supported. Use `"latest"` in config.
 
 The manager is Linux-only and requires `flatpak` on `PATH`. On other platforms,
 or when the command is missing, shared configs list Flatpak entries as skipped.
+Installing an app does not create a mise shim; launch it through the desktop or
+`flatpak run org.mozilla.firefox` in the scope where it is installed.

--- a/docs/bootstrap/packages/index.md
+++ b/docs/bootstrap/packages/index.md
@@ -1,28 +1,30 @@
 # Bootstrap Packages
 
-mise can ensure host packages are installed via the
-`[bootstrap.packages]` section of `mise.toml`, applied by
-`mise bootstrap packages apply` or as part of
-[`mise bootstrap`](/bootstrap.html):
+Declare shared host packages in `[bootstrap.packages]`, then apply them with
+`mise bootstrap packages apply` or the full [bootstrap](/bootstrap.html).
+Use this for native libraries, build dependencies, and host applications.
+
+Start with the manager used by your machine. For a Debian or Ubuntu host:
 
 ```toml
 [bootstrap.packages]
-"apk:build-base" = "latest"
 "apt:libssl-dev" = "latest"
 "apt:build-essential" = "latest"
-"aur:google-chrome" = "latest"
-"brew:postgresql@17" = "latest"
-"brew:ffmpeg" = "latest"
-"brew-cask:firefox" = "latest"
-"flatpak:org.mozilla.firefox" = "latest"
-"flatpak-user:org.gnome.Builder" = "latest"
-"mas:497799835" = "latest"
+```
+
+Preview and apply the configured packages:
+
+```sh
+mise bootstrap packages status
+mise bootstrap packages apply --dry-run
+mise bootstrap packages apply
 ```
 
 Each entry is keyed `"manager:package"` — the manager prefix is required —
 and the value is a version: `"latest"` for whatever the manager installs, or
 a pin in the manager's native format where supported (see the per-manager
-pages).
+pages). **`"latest"` accepts an already-installed version.** It does not trigger
+an upgrade on every apply; use `mise bootstrap packages upgrade` for that.
 
 Use the table form to restrict an individual package by operating system or
 OS/architecture. `os` accepts one value or a list and uses the same names and
@@ -48,28 +50,17 @@ to make adoption the default for all casks, with per-cask `adopt = false`
 overrides. See the
 [brew cask documentation](/bootstrap/packages/brew.html#casks).
 
-Host packages are intentionally separate from [`[tools]`](/configuration.html):
-they are not version-pinned per project, do not get shims, and are managed
-outside the project by the platform's package manager — or, for `brew` and
-`brew-cask`, by mise's built-in Homebrew installers, which don't require
-Homebrew itself. Use them for shared libraries, build dependencies, and host
-GUI apps (`libssl-dev`, `postgresql`, `ffmpeg`, `firefox`), not for project dev
-tools — those belong in `[tools]`.
+## Host packages or mise tools
 
-The manager list is extensible through [package manager plugins](./plugins.md),
-which cover host-owned state such as VS Code extensions, Helm plugins, krew
-plugins, and GitHub CLI extensions.
+Host package declarations can include version constraints where the manager
+supports them, but installations are shared outside the project. Changing
+directories does not switch them, and mise does not create shims for them.
+Use [`[tools]`](/dev-tools/) when you need isolated versions selected by each
+project. Use `[bootstrap.packages]` when the software belongs in the host's
+package database or shared prefix.
 
-Packages are one part of [mise bootstrap](/bootstrap.html). The other
-declarative sections work the same way:
-
-- [Repos](/bootstrap/repos.html) — `[bootstrap.repos]`
-- [Dotfiles](/dotfiles.html) — `[dotfiles]`
-- [Shell Activation](/bootstrap/shell.html) — `[bootstrap.mise_shell_activate]`
-- [macOS Defaults](/bootstrap/macos-defaults.html) — `[bootstrap.macos.defaults]`
-- [launchd](/bootstrap/launchd.html) — `[bootstrap.macos.launchd.agents]`
-- [systemd](/bootstrap/systemd.html) — `[bootstrap.linux.systemd.units]`
-- [User Login Shell](/bootstrap/user.html) — `[bootstrap.user].login_shell`
+The manager list is extensible through [package manager plugins](./plugins.md)
+for host-owned state such as editor extensions and other applications' plugins.
 
 ## Supported package managers
 
@@ -110,57 +101,32 @@ declarative sections work the same way:
   still list unavailable managers so nothing is silently hidden.
 - **Manual installation only** — mise never installs system packages
   implicitly. `mise install` prints a one-time hint when packages are
-  missing, but only `mise bootstrap packages apply` ever installs anything.
+  missing. Explicit `packages apply`, `packages use`, and the full
+  `mise bootstrap` perform installation; `packages upgrade` updates installed
+  packages.
 - **Unknown managers are ignored with a warning** and a package-plugin install
   hint, so configs using managers from newer mise versions still parse.
 
-To set the current user's login shell, use `[bootstrap.user].login_shell`:
-
-```toml
-[bootstrap.user]
-login_shell = "/bin/zsh"
-```
-
-See [User Login Shell](/bootstrap/user.html) for details.
-
 ## Commands
 
+### Apply or record packages
+
 ```sh
-mise bootstrap packages status            # table of requested vs installed packages
-mise bootstrap packages status --json     # machine-readable
-mise bootstrap packages status --missing  # exit 1 if anything is out of sync (CI check)
-
-mise bootstrap packages apply           # install whatever is missing (prompts first)
-mise bootstrap packages apply apt:curl  # install specific packages (configured or not)
-mise bootstrap packages apply --dry-run # print the commands without running them
-mise bootstrap packages apply --yes     # skip the confirmation prompt
+mise bootstrap packages status --json
+mise bootstrap packages status --missing
+mise bootstrap packages apply --manager apt --dry-run
 mise bootstrap packages apply --manager apt
-mise bootstrap packages apply --update  # refresh package manager metadata first
+mise bootstrap packages apply --update
 
-mise bootstrap packages use apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox flatpak-user:org.gnome.Builder mas:497799835
-mise bootstrap packages use -g brew:ffmpeg     # write globally
-mise bootstrap packages use apt:curl@8.5.0-2   # pin a version
-    # (brew pins via the formula name instead: brew:postgresql@17)
-
-mise bootstrap packages import --manager brew   # add installed requested brew formulae
-mise bootstrap packages import --manager brew --all
-mise bootstrap packages import --manager brew --dry-run
-
-mise bootstrap packages prune --manager brew    # remove unneeded linked brew formulae
-mise bootstrap packages prune --manager brew --dry-run
-mise bootstrap packages prune --manager brew --yes
-mise bootstrap packages prune --manager brew-cask # remove safely prunable mise casks
-mise bootstrap packages prune --manager brew-cask --dry-run
-mise bootstrap packages prune --manager vscode # remove mise-owned plugin packages
-mise bootstrap packages prune --manager vscode --dry-run
-
-mise bootstrap packages upgrade           # upgrade installed packages to current versions
-mise bootstrap packages upgrade --manager brew
-mise bootstrap packages upgrade --manager brew-cask
-mise bootstrap packages upgrade --manager flatpak
-mise bootstrap packages upgrade --manager flatpak-user
-mise bootstrap packages upgrade --manager mas
+mise bootstrap packages use apt:curl
+mise bootstrap packages use -g brew:ffmpeg
 ```
+
+`apply` without package arguments reads the active configuration. An explicit
+request such as `mise bootstrap packages apply apt:curl` can install a package
+without recording it. Use `use` when the package should remain declared.
+`--update` refreshes metadata according to the manager; `--yes` skips mise's
+confirmation prompt but does not provide sudo credentials.
 
 `mise bootstrap packages use` is `mise use` for system packages: it writes
 `"manager:package" = "version"` entries to `mise.toml` (the local file by
@@ -168,6 +134,17 @@ default, the global one with `-g`) and installs whatever is missing. Entries
 for managers that aren't available on the current machine are written without
 installing — that's how a shared config picks up `apt:` lines authored on a
 Mac.
+
+### Import and prune
+
+```sh
+mise bootstrap packages import --manager brew --dry-run
+mise bootstrap packages import --manager brew
+mise bootstrap packages prune --manager brew --dry-run
+```
+
+Inspect the prune plan before running without `--dry-run`. Formula pruning can
+include software installed by Homebrew itself, not just by mise.
 
 `mise bootstrap packages import --manager brew` is the inverse for Homebrew
 formulae: it reads the active Homebrew `opt` links and writes requested
@@ -197,6 +174,13 @@ manually installed packages are never adopted. The plugin must implement
 the hook, and mise verifies removals with `PackageInstalled` before updating its
 ownership state.
 
+### Upgrade installed packages
+
+```sh
+mise bootstrap packages upgrade --manager apt --dry-run
+mise bootstrap packages upgrade --manager apt
+```
+
 `mise bootstrap packages upgrade` refreshes package manager metadata and upgrades the
 configured packages that are already installed to the newest available
 version — apk, apt, and dnf also honor a version pinned in config
@@ -215,13 +199,13 @@ missing.
 ## Choosing which managers run
 
 By default, mise acts on every configured manager that is available on the
-current machine. Since availability implies the OS (`apt` only exists on
-Debian-family systems, `brew` wherever a bottle exists), this usually does the right
-thing without configuration.
+current machine. Availability checks the supported platform and required
+commands; it is not a choice of one preferred manager. For example, a Linux host
+can use both apt and mise's built-in Homebrew manager if both have declarations.
 
 If more than one manager could apply — several package managers installed on
 one machine, or a shared config listing managers you don't want here — pick a
-subset with the [`system_packages.managers`](/configuration/settings.html)
+subset with the [`system_packages.managers`](/configuration/settings.html#system_packages.managers)
 setting:
 
 ```toml
@@ -229,16 +213,18 @@ setting:
 system_packages.managers = ["apt"]
 ```
 
-This composes with [platform-specific config files](/configuration.html)
-(`mise.macos.toml`, `mise.linux.toml`) when you want different selections per
-OS.
+You can also use the per-package `os` selector shown above. To put selections
+in `mise.macos.toml` or `mise.linux.toml`, activate that configuration environment
+with `-E`/`MISE_ENV` or enable
+[`auto_env`](/configuration/environments.html#platform-environments); the filename
+alone does not currently activate it.
 
 ## sudo
 
-The Linux package managers require root. When not running as root, mise
-elevates with `sudo`, which prompts for your password as usual. The same
-sudo path is used when `[bootstrap.user].login_shell` needs to add a shell to
-`/etc/shells`, and it only happens during an explicit `mise bootstrap`:
+The apk, apt, dnf, and pacman managers need root for package changes. mise
+uses sudo when necessary. AUR helpers build as the current user and handle their
+own package-install elevation; Flatpak user installations do not need root.
+The same mise sudo path is used when login-shell setup must edit `/etc/shells`:
 
 - already root (containers, CI): no sudo, commands run directly
 - interactive terminal: e.g. `sudo apt-get install ...` with a normal sudo
@@ -247,10 +233,11 @@ sudo path is used when `[bootstrap.user].login_shell` needs to add a shell to
   command to run manually — it never hangs waiting for a password
 - in every case, the full command line is logged before it runs
 
-Set [`system_packages.sudo = false`](/configuration/settings.html) to forbid
+Set [`system_packages.sudo = false`](/configuration/settings.html#system_packages.sudo) to forbid
 elevation entirely; mise prints the command for you to run yourself
-instead. The `brew` manager never needs sudo except once to create
-`/opt/homebrew` (see [brew](/bootstrap/packages/brew.html)).
+instead. Homebrew formula installation may need elevation to create its
+canonical prefix; cask installers can also need elevation for their artifacts
+(see [brew](/bootstrap/packages/brew.html)).
 Package plugins never use mise's sudo path and must never elevate themselves.
 
 ## CI usage
@@ -267,4 +254,6 @@ named `bootstrap` afterwards, if one is defined) — one command to set up a
 fresh machine or container.
 
 `mise bootstrap packages status --missing` exits 1 when packages are missing, which makes
-for a convenient CI check without installing anything.
+for a convenient CI check without installing anything. Inspect JSON status as
+well when a required manager may be unavailable: skipped declarations are not
+proof that their packages are installed.

--- a/docs/bootstrap/packages/mas.md
+++ b/docs/bootstrap/packages/mas.md
@@ -1,10 +1,9 @@
-# mas
+# Mac App Store applications (mas)
 
 Mac App Store apps via the [`mas`](https://github.com/mas-cli/mas) CLI.
 
 ```toml
 [bootstrap.packages]
-"brew:mas" = "latest"
 "mas:497799835" = "latest"       # Xcode
 ```
 
@@ -12,20 +11,31 @@ Mac App Store apps via the [`mas`](https://github.com/mas-cli/mas) CLI.
 Homebrew formulae, and casks. The package name is the App Store app ID:
 a numeric ADAM ID accepted by `mas install` and `mas upgrade`.
 
-mise does not install `mas` implicitly. Install it yourself first — the
-`"brew:mas"` entry in the example above does this with the built-in
-[brew manager](/bootstrap/packages/brew.html) — or install it as a normal
-mise tool:
+mise needs the `mas` CLI before it can inspect or install these apps. Install
+it as a mise tool:
 
 ```sh
 mise use -g mas
 ```
+
+Or install it through the built-in [brew manager](/bootstrap/packages/brew.html)
+and ensure the Homebrew prefix's `bin` directory is on `PATH`:
+
+```sh
+mise bootstrap packages use brew:mas
+```
+
+Declaring `mas` in `[tools]` alone does not make a fresh full bootstrap install
+it before the built-in packages phase. Install the CLI first, then apply the App
+Store declarations. Confirm `mas` can see the current user's App Store state
+with `mise exec -- mas list`.
 
 ## Commands
 
 ```sh
 mise bootstrap packages use mas:497799835
 mise bootstrap packages status
+mise bootstrap packages apply --manager mas --dry-run
 mise bootstrap packages apply --manager mas
 mise bootstrap packages upgrade --manager mas
 ```
@@ -47,6 +57,11 @@ Mac App Store operations may require an Apple Account signed in to the App
 Store, macOS authentication, prior purchase/claiming for paid apps, and valid
 Spotlight indexing. mise surfaces errors from `mas` rather than trying to
 purchase or claim apps itself.
+
+App Store version pins are not supported by these commands. `"latest"` accepts
+an installed app; use `mise bootstrap packages upgrade --manager mas` when you
+want mise to request an update. App installation does not by itself accept
+Xcode's license or complete its first-launch setup.
 
 ## Finding IDs
 

--- a/docs/bootstrap/packages/pacman.md
+++ b/docs/bootstrap/packages/pacman.md
@@ -1,4 +1,4 @@
-# pacman
+# Arch packages (pacman)
 
 System packages for Arch-family Linux (Arch, Manjaro, EndeavourOS, ...).
 
@@ -8,6 +8,24 @@ System packages for Arch-family Linux (Arch, Manjaro, EndeavourOS, ...).
 "pacman:base-devel" = "latest"
 "pacman:libreoffice-fresh" = { state = "absent" }
 ```
+
+For a rolling-release workstation, keep the whole system current using Arch's
+supported full-system upgrade workflow before adding packages. mise's scoped
+`upgrade` command is not a replacement for that workflow; see the partial-upgrade
+limitation below.
+
+## Preview and apply
+
+```sh
+mise bootstrap packages status
+mise bootstrap packages apply --manager pacman --dry-run
+mise bootstrap packages apply --manager pacman
+```
+
+These commands use the active `[bootstrap.packages]` declarations. To add and
+install a package together, use `mise bootstrap packages use pacman:openssl`.
+The manager must be available on the host; an explicit `--manager pacman` fails
+when it is unavailable.
 
 ## Behavior
 

--- a/docs/bootstrap/packages/plugins.md
+++ b/docs/bootstrap/packages/plugins.md
@@ -22,7 +22,14 @@ krew = "https://github.com/example/mise-krew" # placeholder
 `mise bootstrap` installs declared package plugins first, applies built-in
 package managers, installs `[tools]`, then applies plugin managers. This lets a
 plugin declare a host command such as `code`, `helm`, `kubectl`, or `gh` that is
-provided by the same config's global `[tools]` entries.
+provided by global `[tools]` entries. Package-plugin hooks include the process
+PATH, mise shims, and global tool paths; project-only tool paths are not added
+as a separate dependency toolset. Install the host tool globally or ensure it
+is on the hook's PATH. Installing an extension is separate from installing its host.
+
+For an existing configuration, start with `mise bootstrap --dry-run` to inspect
+the phase order. The narrower `plugins apply` installs plugins themselves;
+`packages apply` expects the plugin and its host dependencies to be ready.
 
 The narrower commands are also available:
 
@@ -39,8 +46,12 @@ You can install a plugin without declaring it:
 
 ```sh
 # placeholder URL — replace with a real package-plugin repository
-mise plugin install package:vscode https://github.com/example/mise-vscode-extensions
+mise plugins install package:vscode https://github.com/example/mise-vscode-extensions
 ```
+
+Run as the user whose application state should change. A successful install in
+one user's VS Code, Helm, or GitHub CLI profile does not configure every user's
+profile on the host.
 
 Package plugins install into the host application's own state directory. They
 do not create mise installs or shims, never elevate with `sudo`, and are not

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -71,7 +71,7 @@
 
 - [Overview](https://mise.jdx.dev/bootstrap.html): mise bootstrap sets up a machine for the current config in one command: Linux users and groups, OS packages, privileged files and directories, system services, Linux host firewall policy, Docker…
 - [Remote Hosts](https://mise.jdx.dev/bootstrap/remote.html): mise bootstrap remote applies a bootstrap project to one or more machines through the locally installed OpenSSH client.
-- [Bootstrap Packages](https://mise.jdx.dev/bootstrap/packages/): mise can ensure host packages are installed via the [bootstrap.packages] section of mise.toml, applied by mise bootstrap packages apply or as part of mise bootstrap.
+- [Bootstrap Packages](https://mise.jdx.dev/bootstrap/packages/): Declare shared host packages in [bootstrap.packages], then apply them with mise bootstrap packages apply or the full bootstrap.
 - [apk](https://mise.jdx.dev/bootstrap/packages/apk.html): System packages for Alpine Linux.
 - [apt](https://mise.jdx.dev/bootstrap/packages/apt.html): System packages for Debian-family Linux (Debian, Ubuntu, Mint, ...).
 - [AUR](https://mise.jdx.dev/bootstrap/packages/aur.html): The aur manager installs packages from the Arch User Repository with yay or paru.


### PR DESCRIPTION
Review and improve all ten bootstrap package pages. The overview now separates declaring/installing, importing/pruning, and upgrading shared host packages, and distinguishes host version constraints from per-project tool switching.

Correct `latest` behavior, unsupported status flags, platform-environment activation, package-plugin dependency scope, and prerequisites for App Store installs. Add native-version availability guidance, scoped previews, multiarch requirements, and clearer AUR/Flatpak behavior. Reorganize the Homebrew guide around installation, cask types, ownership, PATH, and troubleshooting without changing installer behavior.

Validation: 23 TOML snippets parse with the current TOML 1.1 parser. Isolated smoke checks cover writing unavailable-manager declarations, status JSON and explicit-manager errors, explicit and automatic platform environments, and command flag syntax. Full Rust 1.95 `lint-fix` and the docs build pass; all local links in the ten rendered pages resolve. Host package mutation commands were checked against source and were not applied to the workstation. Rebased on main and rebuilt `llms.txt` before publishing.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown documentation and `llms.txt` only; no runtime, auth, or package-install logic changes.
> 
> **Overview**
> **Documentation-only** refresh of all ten bootstrap package guides plus the packages overview and `llms.txt` index blurb—no installer or CLI behavior changes.
> 
> The **overview** is restructured around declare/apply, import/prune, and upgrade; it narrows the opening example to apt, adds preview/apply snippets, and spells out that **`"latest"` does not re-upgrade on every apply** (use `upgrade` instead). It also separates **host `[bootstrap.packages]` from per-project `[tools]`**, documents when multiple managers can run together, fixes **platform config activation** (`-E`/`MISE_ENV`/`auto_env` vs filename alone), and expands CI guidance on **skipped managers in JSON status**.
> 
> **Per-manager pages** get clearer titles, shared **Preview and apply** sections (`status`, `--dry-run`, explicit `--manager`), and tighter semantics: version pins are illustrative and **won’t fetch archived repos**; apt covers **multiarch qualifiers** and upgrade vs install; AUR/Flatpak add prerequisites and dry-run limits; **mas** documents installing the `mas` CLI before App Store declarations; **pacman** warns about full-system upgrades.
> 
> The **Homebrew** page is reorganized with **First install**, PATH/keg-only notes, cask subsection headings, **ownership** vs Homebrew-managed casks, a **Troubleshooting** list, and more precise sudo/elevation wording. **Package plugins** clarifies bootstrap phase order, PATH scope for hooks, per-user installs, and corrects the example to **`mise plugins install`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6e81a9ef0eee68d9e7dd157abc9aa63bd5b3279. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded package manager documentation with clearer setup, prerequisites, platform support, availability checks, and troubleshooting guidance.
  * Added examples for previewing, applying, upgrading, and using packages across supported managers.
  * Clarified version pins, architecture qualifiers, scopes, ownership, elevation, and installation behavior.
  * Documented limitations for Flatpak, Mac App Store applications, Homebrew, and AUR workflows.
  * Updated plugin guidance, including host dependencies, PATH requirements, dry runs, and per-user configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->