### PR TITLE
docs: reorganize FAQs and deepen workflow recipes

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,26 +1,182 @@
+---
+outline: [2, 3]
+---
+
 # FAQs
 
-## I don't want to put a `mise.toml`/`.tool-versions` file into my project since git shows it as an untracked file
+Quick answers about daily commands, shell integration, and configuration. For a failed
+command, start with [Troubleshooting](/troubleshooting.html) or [Errors](/errors.html).
 
-Use [`mise.local.toml`](https://mise.jdx.dev/configuration.html#mise-toml) and put that into your global gitignore file. This file should never be committed.
+## Daily commands
 
-If you really want to use a `mise.toml` or `.tool-versions`, here are three ways to make git ignore these files:
+### What is the difference between `mise install` and `mise use`?
 
-- Add `mise.toml` to the project's `.git/info/exclude`. This file is local to your project, so
-  there is no need to commit it.
-- Add `mise.toml` to the project's `.gitignore` file. The downside is that you need to
-  commit the change to the ignore file.
-- Add `mise.toml` to your global gitignore (`core.excludesFile`). Git then ignores
-  `mise.toml` files in all projects. You can still explicitly add one to a project if needed
-  with `git add --force mise.toml`.
+`mise install` installs requested tools without adding tool declarations to configuration.
+`mise use` installs a tool and writes its version request to a config file.
 
-## What is the difference between "nodejs" and "node" (or "golang" and "go")?
+```sh
+mise use node@24       # select Node 24 for the project and install it
+mise install          # install tools already declared by the project
+mise install node@24  # install Node 24 without adding a declaration
+```
 
-These are aliased. For example, `mise install nodejs@14.0` is the same as `mise install node@14.0`. This
+Installation alone does not change your parent shell's environment. Use activation, shims,
+`mise exec`, or `mise run` to run the selected tools. To record a concrete version, add
+`--pin` to `mise use`; to reproduce a project's lockfile, use `mise install --locked`.
+
+`mise install node` uses the configured request when present, otherwise `latest`.
+`mise install` without tool arguments installs the configured toolset.
+
+### Where does `mise use` write to?
+
+By default, mise chooses the lowest-precedence config file in the nearest applicable config
+directory. This can be a parent directory or a `.tool-versions` file, not necessarily a
+`mise.toml` in the current directory. With both `mise.toml` and `mise.local.toml` in that
+directory, shared configuration is preferred. See [write target selection](/configuration.html#target-file-for-write-operations).
+
+Use an explicit target when location matters:
+
+```sh
+mise use --path mise.toml node@24  # this file
+mise use --global node@24          # global configuration
+mise use --env local node@24       # personal local environment
+```
+
+`mise use --dry-run node@24` previews the operation. `mise config` shows the files loaded
+for the current directory.
+
+### Does a partial version select the newest release? {#does-node-20-mean-the-newest-available-version-of-node}
+
+A partial request such as `node@20` restricts the matching versions. For normal execution,
+mise can reuse an installed version that satisfies the request. Installation and upgrade
+commands can resolve a newer available match. A lockfile can pin the resolved result.
+
+```sh
+mise latest --installed node@20  # inspect an installed match
+mise latest node@20              # inspect an available match
+mise install node@20             # install a matching release
+```
+
+Use `mise ls --current node` and `mise which node` to inspect what this project actually uses.
+Do not infer the selected version from a directory name or assume that every tool follows
+Node's version scheme. See [version selection](/dev-tools/) and [lockfiles](/dev-tools/mise-lock.html).
+
+### Does `latest` mean the newest remote version?
+
+`latest` is resolved by the tool's backend. For normal execution it can reuse an installed
+version, so a newly published release does not automatically change your environment.
+A lockfile can constrain the selection further.
+
+To query an available release, run `mise latest node`. An explicit request such as
+`mise install node@latest` or `mise exec node@latest -- node --version` asks for an available
+release rather than only reusing the current installed match, subject to lock policy.
+
+To upgrade within your configured requests, use `mise upgrade node`. To also change the
+request in configuration, use `mise upgrade --bump node`. See [upgrading tools](/dev-tools/)
+and [lockfiles](/dev-tools/mise-lock.html). Different backends define “latest” differently;
+it does not universally mean the largest semantic version or include prereleases.
+
+### How does `mise exec` work?
+
+`mise exec` reads configuration, resolves and installs missing requested tools as needed,
+computes the environment, and runs the command after `--`:
+
+```sh
+mise exec -- node --version
+mise exec node@24 -- node --version
+```
+
+The first command uses the project's configured Node version. The second supplies an
+override for that invocation. You do not need to repeat `node@24` when that is already the
+request in `mise.toml`. The child receives mise's environment; the parent shell is unchanged.
+
+## Shells and editors
+
+### What does `mise activate` do?
+
+`mise activate` prints a shell script. Evaluating it in your shell installs the mise function
+and hooks that refresh tool paths and environment variables. Prompt hooks notice changes to
+configuration; supported shells also have directory-change hooks.
+
+`mise hook-env` computes the assignments needed for the current directory, including removal
+of values from the previous project. It can exit early when nothing relevant changed. It
+prints shell code; running the executable alone does not modify its parent shell.
+
+The shell function lets commands such as `mise shell` and `mise deactivate` update the current
+session. Put activation in your [shell's startup file](/getting-started.html#activate-mise).
+For a script or CI job, use `mise exec -- command` or `mise run task` so execution does not
+depend on a prompt hook. See [shell integration choices](#how-do-mise-activate-shims-mise-exec-and-mise-env-relate).
+
+### How do `mise activate`, shims, `mise exec`, and `mise env` relate?
+
+Each method makes mise tools available at a different boundary:
+
+| Method                  | Environment applies to                            | Typical use                    |
+| ----------------------- | ------------------------------------------------- | ------------------------------ |
+| `mise activate`         | Current shell, refreshed by hooks                 | Interactive terminals          |
+| `mise activate --shims` | Adds a shim directory to the current shell's PATH | Editors and simple shell setup |
+| A tool shim             | The launched tool and its children                | Commands found through PATH    |
+| `mise exec` / `mise x`  | One command and its children                      | Scripts and CI                 |
+| `mise env`              | Prints assignments for another program to consume | Environment integrations       |
+| `mise run`              | A task and its dependencies                       | Named project commands         |
+
+Shims load `[env]` for the tool they launch, but do not export it into the parent shell or
+install prompt hooks there. Use normal activation for shell hooks and automatic shell
+variable updates. See [Shims vs PATH](/dev-tools/shims.html#shims-vs-path).
+
+### Windows support?
+
+mise supports native Windows, including PowerShell activation. Follow the
+[Windows installation instructions](/installing-mise.html#windows-winget) and the
+[shell compatibility table](/getting-started.html#shell-feature-compatibility).
+
+Shims, `mise exec`, and `mise run` are also available. A shim loads the mise environment for
+the tool it launches; it does not update the parent PowerShell session.
+
+Backend and tool support varies by platform. asdf shell plugins require Unix; use a compatible
+core, binary-download, or vfox implementation on Windows. WSL uses Linux tools and should have
+its own Linux mise installation. See [Windows troubleshooting](/troubleshooting.html#windows-problems).
+
+### Why does a Windows editor report `spawn EINVAL`? {#vscode-for-windows-extension-with-error-spawn-einval}
+
+An extension that tries to spawn a `.cmd` shim directly can fail with `spawn EINVAL` after a [Node.js security fix](https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high).
+
+Use the default [`windows_shim_mode = "exe"`](/configuration/settings.html#windows_shim_mode),
+run `mise reshim`, and restart the affected extension or language server. See
+[IDE integration](/ide-integration.html) if it still resolves the old shim path.
+
+### How do I disable/force CLI color output?
+
+Use `NO_COLOR=1` or `MISE_COLOR=0` to disable ANSI color, and `CLICOLOR_FORCE=1` to force it,
+including when piping output. `CLICOLOR_FORCE=1` takes precedence over `NO_COLOR`,
+so remove conflicting overrides when diagnosing unexpected color.
+
+```sh
+NO_COLOR=1 mise ls
+CLICOLOR_FORCE=1 mise ls
+```
+
+These settings control mise's output. Child tools may have their own color options.
+
+## Configuration and networking
+
+### How do I keep personal configuration out of Git? {#i-don-t-want-to-put-a-mise-toml-tool-versions-file-into-my-project-since-git-shows-it-as-an-untracked-file}
+
+Use `mise.local.toml` for personal project settings. Add it to `.git/info/exclude` to ignore it
+in just your checkout, or to your global Git ignore file to ignore it across projects.
+Keep shared tool versions and tasks in a committed `mise.toml`.
+
+If you need to keep `mise.toml` itself private to a checkout, the same ignore mechanisms
+work. A project's `.gitignore` is another option when the team agrees to the policy.
+Ignore rules only affect untracked files; they do not hide changes to a file already in Git.
+
+### What is the difference between "nodejs" and "node" (or "golang" and "go")?
+
+These are aliased. For example, `mise install nodejs@24` is the same as `mise install node@24`. This
 means they cannot be different plugins.
 
 This is for convenience, so you don't need to remember which one is the "official" name. If
-the aliasing misbehaves, submit a ticket or stick to "node" and "go".
+the aliasing misbehaves, use the canonical names `node` and `go`, and [report the mismatch](/contact.html).
 Under the hood, when mise reads a config file or CLI input, it swaps out "nodejs" and
 "golang".
 
@@ -28,224 +184,9 @@ When mise _writes_ to a `mise.toml` (`mise use`, `mise unuse`), it writes the ca
 `nodejs` entry becomes `node`, keeping its comments. `.tool-versions` files are unaffected and still
 use the asdf spellings.
 
-## What does `mise activate` do?
+### My config file is being ignored / `mise trust` issues
 
-It registers a shell hook to run `mise hook-env` every time the shell prompt is displayed.
-`mise hook-env` checks the current env vars (most importantly `PATH`, but also others like
-`GOROOT` or `JAVA_HOME` for some tools) and adds/removes/updates the ones that have changed.
-
-For example, if you `cd` into a different directory that has `java 18` instead of `java 17`
-specified, the shell runs `eval "$(mise hook-env)"` just before the next prompt is displayed,
-which executes something like this in the current shell session:
-
-```sh
-export JAVA_HOME=$HOME/.local/share/installs/java/18
-export PATH=$HOME/.local/share/installs/java/18/bin:$PATH
-```
-
-In reality, updating `PATH` is a bit more complex than that because it also needs to remove java-17,
-but you get the idea.
-
-You may think it is excessive to run `mise hook-env` every time the prompt is displayed
-and that it should only run on `cd`. However, there are plenty of
-situations where it needs to run without the directory changing, for example when `.tool-versions` or
-`mise.toml` was just edited in the current shell.
-
-Because it runs on prompt display, `mise activate` in a
-non-interactive session (like a bash script) never calls `mise hook-env` and so
-never modifies PATH, because no prompt is ever displayed. For this type of setup, either call
-`mise hook-env` manually every time you want to update PATH, or use [shims](/dev-tools/shims.md)
-instead (preferred).
-If you only need mise for certain commands, prefix them with
-[`mise x --`](./cli/exec),
-for example `mise x -- npm test` or `mise x -- ./my_script.sh`.
-
-`mise hook-env` exits early when nothing has changed. This avoids
-adding latency to your shell prompt every time you run a command. You can run `mise hook-env`
-yourself
-to see what it outputs, though it is likely nothing if your shell has already been
-activated.
-
-`mise activate` also creates a shell function (in most shells) called `mise`.
-This is a trick that makes it possible for `mise shell`
-and `mise deactivate` to work without wrapping them in `eval "$(mise shell)"`.
-
-## Windows support?
-
-::: warning
-While mise runs great in WSL, native Windows is also supported, though only via shims until
-someone adds [powershell](https://github.com/jdx/mise/discussions/6733) support.
-
-Because you'll need to use shims, you won't have environment variables from mise.toml unless you run mise via
-[`mise x`](/cli/exec) or [`mise run`](/cli/run).
-:::
-
-## How do I use mise with HTTP proxies?
-
-Short answer: set the `http_proxy` and `https_proxy` environment variables. These should be
-lowercase.
-
-This may not work with plugins that are not configured to use these env vars.
-If you're having a proxy-related issue installing something specific, post an issue on the
-plugin's repository.
-
-## How do the shorthand plugin names map to repositories?
-
-For example, how does `mise plugin install elixir` know to fetch <https://github.com/asdf-vm/asdf-elixir>?
-
-We maintain [an index](https://github.com/mise-plugins/registry) of shorthands that mise uses as a
-base.
-It is updated every time mise has a release. This repository is stored directly
-in
-the codebase in [registry/](https://github.com/jdx/mise/blob/main/registry/).
-
-## Does "node@20" mean the newest available version of node?
-
-It depends on the command. For most commands and inside config files, "node@20"
-points to the latest _installed_ version of node-20.x. You can find this version by running
-`mise latest --installed node@20` or by checking what the `~/.local/share/mise/installs/node/20`
-symlink
-points to:
-
-```sh
-$ ls -l ~/.local/share/mise/installs/node/20
-[...] /home/jdx/.local/share/mise/installs/node/20 -> node-v20.0.0-linux-x64
-```
-
-There are some exceptions, such as:
-
-- `mise install node@20`
-- `mise latest node@20`
-- `mise upgrade node@20`
-
-These use the latest _available_ version of node-20.x. This generally makes sense because you
-wouldn't want to install a version that is already installed.
-
-## How do I migrate from asdf?
-
-- Install mise and set up `mise activate` as described in the [getting started guide](/getting-started)
-- Remove asdf from your shell rc file
-- Run `mise install` in a directory with an asdf `.tool-versions` file; mise will install the tools
-
-::: info
-`mise` does not consider `~/.tool-versions` files to be a global config file like `asdf` does. `mise` uses a
-`~/.config/mise/config.toml` file for global configuration.
-:::
-
-Here is an example script you can use to migrate your global `.tool-versions` file to mise:
-
-```shell
-mv ~/.tool-versions ~/.tool-versions.bak
-cat ~/.tool-versions.bak | tr -s ' ' | tr ' ' '@' | xargs -n2 mise use -g
-```
-
-Once you are comfortable with mise, you can remove the `.tool-versions.bak` file and [uninstall `asdf`](https://asdf-vm.com/manage/core.html#uninstall).
-
-## How compatible is mise with asdf?
-
-mise should be able to read/install any `.tool-versions` file used by asdf. Any asdf plugin
-should be usable in mise. The commands in mise are slightly
-different, such as `mise install node@20.0.0` vs `asdf install node 20.0.0`—this is so
-multiple tools can be specified at once. However, asdf-style syntax is still supported (`mise
-install node 20.0.0`). This is the case for most commands, though the command's help may not
-mention that asdf-style syntax is supported. When in doubt, try asdf syntax and see if it works—it probably does.
-
-::: info
-UPDATE (2025-01-01): mise was designed to be compatible with the asdf written in bash (<=0.15). The new asdf written in go (>=0.16)
-has commands mise does not support, like `asdf set`. `mise set` is an existing command that is completely different from `asdf set`—in mise it sets env vars.
-
-This matters less for usability than for keeping plugins working that
-call asdf commands inside their plugin code.
-:::
-
-Commands like `mise use` may write `.tool-versions` files that are not compatible with asdf,
-such as ones using fuzzy versions. Set `--pin` or `MISE_PIN=1` to make `mise use` write asdf-compatible versions
-to `.tool-versions`. Alternatively, you can keep `mise.toml` and `.tool-versions` side by side; tools in `mise.toml`
-override tools defined in a `.tool-versions` in the same directory.
-
-That said, compatibility with asdf is in general no longer a design goal. There has long been
-no reason to prefer asdf to mise, so users should migrate. While plenty of
-teams use both in tandem, issues with such a setup are unlikely to be prioritized.
-
-## How do I disable/force CLI color output?
-
-mise uses [console.rs](https://docs.rs/console/latest/console/fn.colors_enabled.html) which
-honors the [clicolors spec](https://bixense.com/clicolors/):
-
-- `CLICOLOR != 0`: ANSI colors are supported and should be used when the program isn't piped.
-- `CLICOLOR == 0`: Don't output ANSI color escape codes.
-- `CLICOLOR_FORCE != 0`: ANSI colors should be enabled no matter what.
-
-## Is mise secure?
-
-Providing a secure supply chain is incredibly important. mise already provides a more secure
-experience than asdf. Security-oriented evaluations and contributions are welcome.
-We also urge users to look after the plugins they use, and urge plugin authors to look after
-the users they serve.
-
-For more details see [SECURITY.md](https://github.com/jdx/mise/blob/main/SECURITY.md).
-
-## What is usage?
-
-usage (<https://usage.jdx.dev/>) is a spec and CLI for defining CLI tools.
-
-Arguments, flags, environment variables, and config files can all be defined in a usage spec. Think of it as OpenAPI (Swagger) for CLIs.
-
-mise embeds usage for task argument parsing, help, and autocompletion, so the separate `usage` CLI is not required. See [autocompletion](/installing-mise.html#autocompletion).
-
-You can use usage in file tasks to get autocompletion working; see [file task arguments](/tasks/file-tasks.html#arguments).
-
-## What is pitchfork?
-
-pitchfork (<https://pitchfork.jdx.dev/>) is a process manager for developers.
-
-It handles daemon management with features like automatic restarts on failure, smart readiness checks, shell-based auto-start/stop when entering project directories, and cron-style scheduling for periodic tasks.
-
-## VSCode for windows extension with error `spawn EINVAL`
-
-In VSCode, many extensions throw an "error spawn EINVAL" due to a [Node.js security fix](https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high).
-
-The default `exe` shim mode should resolve this. If you're using an older mode, you can change [windows_shim_mode](https://mise.jdx.dev/configuration/settings.html#windows_shim_mode) to `exe`, `hardlink`, or `symlink`.
-
-## What is the difference between `mise install` and `mise use`?
-
-`mise install` downloads and installs a tool version but does **not** add it to any config file.
-The tool won't be automatically activated in your shell unless it's already listed in a `mise.toml` or `.tool-versions`.
-
-`mise use` installs the tool **and** adds it to `mise.toml` (or `~/.config/mise/config.toml` with `-g`), so it will be activated
-automatically when you enter the directory.
-
-If you want to pin a tool for a project, use `mise use`. If you want to install
-a version that's already listed in config, use `mise install`.
-
-::: tip
-`mise install node` (with no version) installs the **latest** version if node isn't in your config.
-`mise install` (with no arguments) installs only the tools listed in your config files.
-:::
-
-## Does `latest` mean the newest remote version?
-
-It depends on context. In config files and most commands, `latest` resolves to the latest
-**installed** version. This means that if you have node 20.0.0 installed and node 22.0.0 is
-available remotely, `latest` still points to 20.0.0.
-
-However, some commands resolve `latest` to the newest **available** (remote) version:
-
-- `mise install node@latest` — installs the newest available version
-- `mise x node@latest -- node -v` — uses the newest available version
-- `mise latest node` — shows the newest available version
-
-To upgrade to the newest available version and update your config, run:
-
-```sh
-mise upgrade node
-# or to also update mise.toml:
-mise upgrade --bump node
-```
-
-## My config file is being ignored / `mise trust` issues
-
-mise requires you to trust config files that were not created by you. Safe config files —
+Trust depends on the configuration contents and the command, not file authorship. Safe config files —
 those that only contain `min_version`, `[tools]` entries whose values are plain version
 strings or arrays of strings, and `[tasks]` without templates — load without trust. Tool-option
 tables and other top-level settings require trust. In normal mode, `mise run`, naked task
@@ -254,9 +195,8 @@ trust the active config because they explicitly execute project-defined behavior
 config requires trust. Common issues:
 
 - **Accidentally denied trust**: If mise prompted you to trust a file and you said no, it is
-  added to the ignore list. Check the `ignored-configs` directory in your
-  [mise state directory](/directories.html) (default: `~/.local/state/mise/ignored-configs/`)
-  and remove the relevant symlink to un-ignore it.
+  added to the ignore list. Inspect `mise trust --show`, then run
+  `mise trust path/to/mise.toml` to trust the reviewed file again.
 - **Symlinked configs**: If your config is symlinked (e.g., via GNU Stow), mise may track the
   symlink target path. Try `mise trust` pointing to the actual file path.
 - **CI**: In detected CI, mise assumes configs are trusted unless paranoid mode is enabled.
@@ -267,13 +207,16 @@ config requires trust. Common issues:
   configs may skip untrusted entries instead. Either run `mise trust` beforehand or set
   [`trusted_config_paths`](/configuration/settings.html#trusted_config_paths) in your global settings
   for configs you trust.
-- **Global config** (`~/.config/mise/config.toml`) should be auto-trusted. If it's not, run
-  `mise trust ~/.config/mise/config.toml` explicitly.
+- **Global config** is operator-owned and does not need project trust. Check `mise config`
+  if a file you thought was global is being discovered as project configuration.
 
 Run `mise doctor` (`mise dr`) to see if any config files are untrusted — it will
 list them under "problems".
 
-## How do idiomatic version files (`.python-version`, `.node-version`, etc.) work?
+Also check your current directory and selected [configuration environment](/configuration/environments.html).
+A profile file that is not selected is not a trust failure.
+
+### How do idiomatic version files (`.python-version`, `.node-version`, etc.) work?
 
 Idiomatic version files (`.python-version`, `.node-version`, `.ruby-version`, etc.) are
 **disabled by default** in mise. They are only read if you explicitly opt in per tool using
@@ -285,79 +228,87 @@ mise settings add idiomatic_version_file_enable_tools node
 ```
 
 If you previously enabled idiomatic files and now want to stop mise from reading them
-(e.g., because `uv` manages `.python-version`), don't add that tool to the list.
+(e.g., because `uv` manages `.python-version`), remove that tool from the configured list. Unset the setting entirely to restore its empty default.
 
 See [Idiomatic Version Files](/configuration.html#idiomatic-version-files) for more information.
 
-## How do `mise activate`, shims, `mise exec`, and `mise env` relate?
+### How do the shorthand plugin names map to repositories?
 
-These all do the same core thing: they set up your environment (primarily `PATH`) so that
-mise-managed tools are available. The difference is _when_ and _how_:
+The bundled [registry](/registry.html) maps short names to backend specifications, such as
+`aqua:owner/repo` or `vfox:owner/plugin`. It is maintained in the repository's
+[`registry/`](https://github.com/jdx/mise/tree/main/registry) directory and ships with mise.
 
-| Method                              | How it works                                           | Best for                                   |
-| ----------------------------------- | ------------------------------------------------------ | ------------------------------------------ |
-| `mise activate`                     | Hooks into your shell prompt, updates PATH dynamically | Interactive terminal use                   |
-| `mise activate --shims`             | Adds the shims directory to PATH once                  | IDEs, simple setups (no hooks/env support) |
-| `mise exec` / `mise x`              | Sets up env, runs a single command, then exits         | Scripts, CI, one-off commands              |
-| `mise env`                          | Prints env vars you can `eval`                         | Integrating with other tools               |
-| `mise run`                          | Sets up env, then runs a task                          | Task execution                             |
-| Shims (`~/.local/share/mise/shims`) | Wrapper scripts that call mise on each invocation      | Non-interactive shells, IDEs               |
+Most tools do not need an external plugin. Inspect a tool's selected backend with
+`mise tool ripgrep`, or see its available choices with `mise registry ripgrep`.
+For plugin-backed tools, the backend specification identifies the plugin repository.
+See [backend selection](/dev-tools/backend_architecture.html#how-backend-selection-works).
 
-::: warning
-`mise activate --shims` does **not** support hooks, env vars from `[env]`, or `watch_files`.
-It only puts shims on PATH. If you need those features, use `mise activate` (without `--shims`).
-:::
+### How do I use mise with HTTP proxies?
 
-## How does `mise exec` work?
-
-`mise exec` (or `mise x`) reads your config, sets up `PATH` and environment variables, then
-runs the command you specify after `--`:
+Set `http_proxy` and `https_proxy` in the environment that starts mise. For example, replace
+the proxy host and port below with your organization's proxy:
 
 ```sh
-# Uses whatever node version is in your mise.toml
-mise x -- node script.js
-
-# Override with a specific version (useful when it differs from config)
-mise x node@22 -- node script.js
+https_proxy=http://proxy.example.com:8080 mise install
 ```
 
-A common pattern seen on Discord is `mise x node@20 -- node script.js` when node@20 is already
-in `mise.toml`. This works but is redundant — `mise x -- node script.js` is simpler when
-you want the configured version.
+Plugin scripts and package managers may have separate proxy or certificate settings. If a
+single backend fails, identify the subprocess or URL in verbose output and check that tool's
+proxy configuration. See [Errors](/errors.html) for network and authentication failures.
 
-## Where does `mise use` write to?
+## Migration
 
-`mise use` writes to the nearest `mise.toml` in your directory hierarchy. If there's a
-`mise.toml` in a parent directory (including `~/.config/mise/config.toml` for `-g`), it
-updates that file.
+### How do I migrate from asdf?
+
+1. Install mise and [configure shell activation](/getting-started.html#activate-mise).
+2. Remove asdf activation from the shell's startup files, then open a new shell.
+3. Run `mise install` in a project with `.tool-versions`, then verify a configured tool with
+   `mise exec -- node --version` (substitute your project's tool).
+
+mise reads `.tool-versions`, but its global configuration normally lives at
+`~/.config/mise/config.toml`. Review your `~/.tool-versions` and add the defaults you want with
+`mise use --global`. For example, after choosing the versions you need:
 
 ```sh
-mise use node@22           # writes to nearest mise.toml (may be a parent dir!)
-mise use -g node@22        # writes to ~/.config/mise/config.toml
-mise use --path mise.toml node@22  # writes to a specific file
+mise use --global node@24 python@3.14
 ```
 
-Use `mise cfg` to see which config files mise is reading in the current directory.
+This example chooses new defaults; it is not a lossless conversion of an arbitrary asdf file.
+Keep the old file until you have checked every tool, including entries with multiple versions
+or aliases. Do not share the installation directories between asdf and mise. Once verified,
+you can [uninstall asdf](https://asdf-vm.com/manage/core.html#uninstall).
 
-## mise is for dev tools, not applications or system packages
+### How compatible is mise with asdf?
 
-mise manages **development tool versions** (node, python, go, rust, etc.) and CLI utilities.
-It is not a replacement for system package managers like `apt`, `brew`, or `pacman`.
+mise supports `.tool-versions` and the asdf shell-plugin interface on Unix. Compatibility
+with every asdf command or plugin is not guaranteed. Prefer the mise syntax shown in each
+command's help, such as `mise install node@24`.
 
-Things mise does **not** do:
+The asdf Go rewrite introduced commands such as `asdf set`. `mise set` has a different
+purpose: it sets environment variables. Use `mise use` to select tool versions.
 
-- Install system libraries (libssl, zlib, etc.)
-- Manage desktop applications
-- Handle system-level dependencies that tools need to compile
+If a team shares `.tool-versions` between both tools, use concrete versions that asdf accepts.
+`mise use --pin` writes a resolved version instead of a fuzzy request. You can also keep
+`mise.toml` alongside `.tool-versions`; the mise file takes precedence for tools declared in
+both at the same directory level. See [asdf compatibility](/asdf-legacy-plugins.html) and
+[plugin usage](/plugin-usage.html).
 
-If a mise-installed tool needs a system library, install that library with your OS package
-manager first. You can declare those packages in
-[`[bootstrap.packages]`](/bootstrap/packages/) so `mise bootstrap` installs them: through
-apt/dnf/pacman where the platform's package manager owns them, or through mise's built-in
-Homebrew installers for `brew:` and `brew-cask:` entries, which do not require Homebrew
-itself. Either way they are host packages, not `[tools]` entries.
+## Scope and related tools
 
-## How do I install tools other users can run without mise?
+### Can mise manage system packages and desktop applications? {#mise-is-for-dev-tools-not-applications-or-system-packages}
+
+`[tools]` manages versioned development tools and runtimes. Host packages, desktop
+applications, and system libraries belong in [`[bootstrap.packages]`](/bootstrap/packages/).
+
+For example, a compiler may need an OS development-library package before a tool can build.
+Declare that package with the appropriate manager and apply it using `mise bootstrap`.
+Most managers delegate to the OS package manager; mise's built-in Homebrew installers can
+handle `brew:` and `brew-cask:` entries without requiring Homebrew itself.
+
+Host packages share the machine's package database or prefix. They do not gain per-project
+version switching simply because they are declared in `mise.toml`.
+
+### How do I install tools other users can run without mise?
 
 Two features install binaries that work on `PATH` with no mise involved at runtime.
 
@@ -387,13 +338,14 @@ Use [`mise install-into`](/cli/install-into.html) for any backend mise supports.
 one tool version into a directory you pick, for use outside of mise:
 
 ```sh
-mise install-into node@22 /opt/node
-/opt/node/bin/node -v
+mise install-into node@24 "$HOME/standalone-node"
+"$HOME/standalone-node/bin/node" --version
 ```
 
 Point it at a new or empty directory: `install-into` deletes whatever is already at the
 destination, after a confirmation prompt that defaults to no, or without asking under
-`--yes`. It only writes to that directory, so add its `bin` to `PATH` yourself the way you
+`--yes`. The tool installation goes to that directory; backends may also use mise caches and
+install dependencies. Add its `bin` to `PATH` yourself the way you
 would the brew prefix above. Tools that expect environment variables such as `JAVA_HOME`,
 or other configuration mise normally applies at runtime, still need those set up by hand.
 
@@ -403,17 +355,39 @@ with no per-project version selection. When you want that selection, keep the to
 config, and tools in one command — or across many hosts with
 [`mise bootstrap remote`](/bootstrap/remote.html).
 
-## How does mise versioning work?
+### Is mise secure?
 
-mise uses [Calver](https://calver.org/) versioning (`2024.1.0`).
-Breaking changes will be few, but when they do happen,
-they will be communicated in the CLI with as much notice as possible.
+mise supports download verification, configuration trust, and optional restrictions such
+as safe and paranoid modes. Their guarantees depend on the backend and operation. Start with
+[Security](/security.html) for the threat model and available controls. Report vulnerabilities
+through [SECURITY.md](https://github.com/jdx/mise/blob/main/SECURITY.md).
 
-Rather than using SemVer major releases to communicate large changes,
-mise lets new functionality and changes be opted into with settings like `experimental = true`.
-This way, plugin authors and users can
-test new functionality immediately without waiting for a major release.
+### What is usage?
 
-The numbers in Calver (YYYY.MM.RELEASE) represent the date of the release—not compatibility
-or how many new features were added.
-Each release is small and incremental.
+[usage](https://usage.jdx.dev/) is a spec and CLI for defining CLI tools.
+
+Arguments, flags, environment variables, and config files can all be defined in a usage spec. A single definition can drive help text, argument parsing, and completions.
+
+mise embeds usage for task argument parsing, help, and autocompletion, so the separate `usage` CLI is not required. See [autocompletion](/installing-mise.html#autocompletion).
+
+You can use usage in file tasks to get autocompletion working; see [file task arguments](/tasks/file-tasks.html#arguments).
+
+### What is pitchfork?
+
+[pitchfork](https://pitchfork.jdx.dev/) is a process manager for developers.
+
+It handles daemon management with features like automatic restarts on failure, smart readiness checks, shell-based auto-start/stop when entering project directories, and cron-style scheduling for periodic tasks.
+
+Use [mise tasks](/tasks/) for commands and dependency ordering; use a process supervisor when
+a service needs to keep running independently of a task invocation.
+
+### How does mise versioning work?
+
+mise uses calendar versions in the form `YYYY.MONTH.RELEASE`, such as `2026.9.1`.
+The final number is a release counter within the month, not a day of the month or a
+compatibility indicator.
+
+New features can be introduced behind settings such as `experimental = true`. Deprecation
+warnings and [release notes](https://github.com/jdx/mise/releases) describe behavior changes;
+do not infer compatibility from a SemVer-style major version. For a team's required mise
+version, use [`min_version`](/configuration.html).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -45,7 +45,7 @@ mise use --env local node@24       # personal local environment
 `mise use --dry-run node@24` previews the operation. `mise config` shows the files loaded
 for the current directory.
 
-### Does a partial version select the newest release? {#does-node-20-mean-the-newest-available-version-of-node}
+### Does a partial version select the newest release? {#does-node20-mean-the-newest-available-version-of-node}
 
 A partial request such as `node@20` restricts the matching versions. For normal execution,
 mise can reuse an installed version that satisfies the request. Installation and upgrade
@@ -148,8 +148,8 @@ run `mise reshim`, and restart the affected extension or language server. See
 ### How do I disable/force CLI color output?
 
 Use `NO_COLOR=1` or `MISE_COLOR=0` to disable ANSI color, and `CLICOLOR_FORCE=1` to force it,
-including when piping output. `CLICOLOR_FORCE=1` takes precedence over `NO_COLOR`,
-so remove conflicting overrides when diagnosing unexpected color.
+including when piping output. `NO_COLOR=1` and `MISE_COLOR=0` take precedence over
+`CLICOLOR_FORCE=1`; unset the disabling overrides when forcing color.
 
 ```sh
 NO_COLOR=1 mise ls
@@ -189,7 +189,7 @@ use the asdf spellings.
 Trust depends on the configuration contents and the command, not file authorship. Safe config files —
 those that only contain `min_version`, `[tools]` entries whose values are plain version
 strings or arrays of strings, and `[tasks]` without templates — load without trust. Tool-option
-tables and other top-level settings require trust. In normal mode, `mise run`, naked task
+tables and other top-level settings require trust. In normal mode outside CI, `mise run`, naked task
 invocations such as `mise <TASK>`, `mise install`, `mise exec`, and `mise watch` automatically
 trust the active config because they explicitly execute project-defined behavior. Other unsafe
 config requires trust. Common issues:

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,6 +1,7 @@
 # Glossary
 
-This glossary defines key terms and concepts used throughout the mise documentation.
+Definitions for the concepts used in the guides and CLI reference. Follow a term's link for
+configuration syntax and examples.
 
 ## Core Concepts
 
@@ -8,7 +9,7 @@ This glossary defines key terms and concepts used throughout the mise documentat
 : The process of loading mise's context (tools, environment variables, PATH modifications) into your shell session. Typically done via `eval "$(mise activate bash)"` in your shell rc file. See [Installing mise](/installing-mise.html) for setup instructions.
 
 **Backend**
-: A package manager or ecosystem that mise uses to install and manage tools. Each backend knows how to fetch, install, and manage tools from its respective source. See [Backends](#backends) below and [Backend Architecture](/dev-tools/backend_architecture) for details.
+: An implementation that resolves versions and installs tools from a particular source. A backend may download releases directly or use a package manager; it is not necessarily a separate program. See [Backends](#backends) below and [Backend Architecture](/dev-tools/backend_architecture) for details.
 
 **Core Tools**
 : Built-in tool implementations written in Rust that ship with mise. These provide first-class support for popular languages such as Node.js, Python, Ruby, and Go. See [Core tools](/core-tools) for the full list.
@@ -29,32 +30,35 @@ This glossary defines key terms and concepts used throughout the mise documentat
 : A development tool or runtime that mise can install and manage, such as `node`, `python`, `terraform`, or `jq`.
 
 **Tool Request**
-: A user's specification for a tool version, which may be fuzzy or use aliases. Examples: `node@18`, `python@latest`, `go@1.21`. These are resolved to concrete Tool Versions.
+: A user's specification for a tool version, which may be fuzzy or use aliases. Examples: `node@24`, `python@latest`, `go@1.26`. These are resolved to concrete Tool Versions.
 
 **Tool Version**
-: A concrete, resolved version of a tool. For example, `node@18` (tool request) might resolve to `node@18.19.0` (tool version).
+: A concrete, resolved version of a tool. For example, `node@24` (tool request) might resolve to `node@24.0.0` (tool version).
 
 **Toolset**
-: An immutable collection of resolved tools for a specific context, containing all the Tool Versions that should be active for a directory or project.
+: The collection of requested and resolved tools for a specific context, containing all the Tool Versions that should be active for a directory or project.
 
 ## Backends
 
 mise supports multiple backends for installing tools from different sources:
 
 **aqua**
-: Backend using the [aqua](https://aquaproj.github.io/) registry. Supports SLSA provenance verification and provides access to thousands of tools. See [aqua backend](/dev-tools/backends/aqua).
+: Backend using the [aqua](https://aquaproj.github.io/) registry. Supplies release selection and verification metadata for supported tools. See [aqua backend](/dev-tools/backends/aqua).
 
 **asdf**
 : Legacy backend compatible with [asdf](https://asdf-vm.com/) shell-script plugins. Linux and macOS only. Slower than native backends but provides access to the asdf plugin ecosystem. See [asdf backend](/dev-tools/backends/asdf).
 
 **cargo**
-: Installs Rust tools by compiling them with `cargo install`. See [cargo backend](/dev-tools/backends/cargo).
+: Installs Rust CLI tools using `cargo-binstall` when available and enabled, or compiles them with `cargo install`. See [cargo backend](/dev-tools/backends/cargo).
 
 **conda**
-: Installs packages from Conda repositories. See [conda backend](/dev-tools/backends/conda).
+: Downloads and resolves packages from Conda channels directly, without requiring a conda executable. See [conda backend](/dev-tools/backends/conda).
 
 **dotnet**
 : Installs .NET tools. See [dotnet backend](/dev-tools/backends/dotnet).
+
+**forgejo**
+: Installs tools from Forgejo releases. See [Forgejo backend](/dev-tools/backends/forgejo.html).
 
 **gem**
 : Installs Ruby gems as tools. See [gem backend](/dev-tools/backends/gem).
@@ -74,8 +78,17 @@ mise supports multiple backends for installing tools from different sources:
 **npm**
 : Installs Node.js packages and CLI tools from the npm registry. See [npm backend](/dev-tools/backends/npm).
 
+**packslip**
+: Installs releases from signed manifests and verifies artifact digests and the signer. See [packslip backend](/dev-tools/backends/packslip.html).
+
 **pipx**
-: Installs Python CLI tools in isolated environments using pipx. See [pipx backend](/dev-tools/backends/pipx).
+: Installs Python CLI tools in isolated environments using uv by default, or pipx when configured. See [pipx backend](/dev-tools/backends/pipx).
+
+**pkgx**
+: Installs packages through pkgx. See [pkgx backend](/dev-tools/backends/pkgx.html).
+
+**s3**
+: Downloads tool artifacts from S3 or compatible storage. See [S3 backend](/dev-tools/backends/s3.html).
 
 **spm**
 : Installs tools via Swift Package Manager. See [spm backend](/dev-tools/backends/spm).
@@ -98,21 +111,21 @@ mise supports multiple backends for installing tools from different sources:
 : The process of updating the shims directory after tools are installed or removed. Run `mise reshim` if shims get out of sync.
 
 **Shims**
-: Small executable scripts that intercept tool commands and delegate to mise, which loads the appropriate tool context before execution. An alternative to PATH activation. See [Shims](/dev-tools/shims).
+: Executable launchers that intercept tool commands and delegate to mise, which loads the appropriate tool context before execution. An alternative to PATH activation. See [Shims](/dev-tools/shims).
 
 ## Configuration
 
 **config_root**
-: The canonical project root directory that mise uses when resolving relative paths in configuration files. Detected automatically from the location of the configuration file and exposed to tasks and hooks as the `MISE_PROJECT_ROOT` environment variable.
+: The canonical project root directory that mise uses when resolving relative paths in configuration files. Derived from the configuration file's location. An imported file can have a different `config_root` from the active project's `MISE_PROJECT_ROOT`.
 
 **Configuration Environments**
-: Environment-specific configuration files like `mise.dev.toml` or `mise.prod.toml`, activated via the `MISE_ENV` environment variable. See [Configuration Environments](/configuration/environments).
+: Environment-specific configuration files like `mise.dev.toml` or `mise.prod.toml`, selected with `MISE_ENV`, `mise -E`, or `.miserc.toml`. See [Configuration Environments](/configuration/environments).
 
 **Configuration Hierarchy**
 : The system where mise.toml files at different levels (system, global, project) are merged, with files closer to the current directory taking precedence over those in parent directories.
 
 **Settings**
-: Global mise configuration options stored in `~/.config/mise/settings.toml` that define behavior across all projects. See [Settings](/configuration/settings).
+: Options that control mise itself, normally under `[settings]` in a config file. Some can be project-specific; settings marked global-only must be configured globally. See [Settings](/configuration/settings).
 
 **Templates**
 : Dynamic values in configuration using Tera template syntax, like <span v-pre>`{{env.HOME}}`</span> or <span v-pre>`{{arch()}}`</span>. See [Templates](/templates).
@@ -126,16 +139,16 @@ mise supports multiple backends for installing tools from different sources:
 - `env._.path` - Prepend directories to PATH
 - `env._.source` - Source a bash script
 
-**Lazy Evaluation**
-: Environment variables configured with `tools = true` that can access tool-provided environment variables. These are evaluated after tools are loaded.
+**Tool-dependent environment**
+: Directives with `tools = true` run after the tool environment is available. This is evaluation order, not lazy installation or evaluation only when a variable is read.
 
 **Redaction**
-: Marking sensitive environment variables with `redact = true` to hide their values from mise output and logs.
+: Masking selected values in output processed by mise. `redact = true` marks an environment value; raw or interactive child output bypasses this processing. See [redaction](/environments/#redactions).
 
 ## Hooks
 
 **Hooks**
-: Scripts that run automatically at specific events during mise activation. An experimental feature. See [Hooks](/hooks).
+: Commands triggered by events such as entering a project or installing tools. Shell events require normal activation; installation hooks do not. See [Hooks](/hooks).
 
 **cd hook**
 : Runs whenever you change directories while mise is active.
@@ -153,7 +166,7 @@ mise supports multiple backends for installing tools from different sources:
 : Runs before a tool installation begins.
 
 **watch_files hook**
-: Runs when specified files change. Requires `mise activate` for file watching.
+: Runs when an activation hook detects changes to matching files. It is not a background watcher; `mise watch` is a separate command.
 
 ## Tasks
 
@@ -178,10 +191,10 @@ mise supports multiple backends for installing tools from different sources:
 : Directory where mise caches downloaded files and metadata. Defaults to `~/.cache/mise` on Linux, `~/Library/Caches/mise` on macOS.
 
 **MISE_DATA_DIR**
-: Directory where mise stores installed tools and other persistent data. Defaults to `~/.local/share/mise`.
+: Directory where mise stores installed tools and other persistent data. Defaults to `~/.local/share/mise` on Unix and `%LOCALAPPDATA%\mise` on Windows. See [directories](/directories.html).
 
 **MISE_PROJECT_ROOT**
-: Environment variable automatically set to the root directory of the current project (where the mise.toml is located).
+: The active project root passed to tasks and hooks. Nested configuration layouts such as `.config/mise/config.toml` resolve to the owning project directory, not the config file's immediate parent.
 
 ## Other Terms
 
@@ -189,7 +202,7 @@ mise supports multiple backends for installing tools from different sources:
 : Alternative names for tool backends or tool versions, managed via `mise tool-alias` or the `[tool_alias]` config section. Backend aliases let a short name like `node` point to a custom backend. Version aliases let symbolic names like `lts-iron` map to a concrete version number. See [Tool Aliases](/dev-tools/aliases).
 
 **Shell Aliases**
-: Shell command aliases (example: `ll = "ls -la"`) managed via `mise shell-alias` or the `[shell_alias]` config section. They are set dynamically when entering a directory and unset when leaving it, similar to environment variables. Supported in bash, zsh, fish, and xonsh. See [Shell Aliases](/shell-aliases).
+: Shell command aliases (example: `ll = "ls -la"`) managed via `mise shell-alias` or the `[shell_alias]` config section. They are set dynamically when entering a directory and unset when leaving it, similar to environment variables. Support varies by shell; see the [shell compatibility table](/getting-started.html#shell-feature-compatibility). See [Shell Aliases](/shell-aliases).
 
 **direnv**
 : An external tool for environment management that mise can work alongside. See [direnv integration](/direnv).
@@ -198,7 +211,10 @@ mise supports multiple backends for installing tools from different sources:
 : French culinary phrase meaning "everything in its place" - the philosophy behind mise. Chefs prepare all ingredients before cooking; developers should have all tools ready before coding.
 
 **mise.lock**
-: A lockfile that records exact resolved versions for reproducible environments across machines and CI. See [mise.lock](/dev-tools/mise-lock).
+: A file that records concrete versions and supported artifact metadata for selected platforms. It complements `mise.toml`, which records the requested versions. See [mise.lock](/dev-tools/mise-lock).
 
 **Tool Options**
-: Configuration in mise.toml that changes tool behavior, such as setting a Python `virtualenv` path or Node.js `corepack` preferences.
+: Configuration in mise.toml that changes tool behavior, such as an HTTP download URL, asset pattern, or backend-specific installation arguments. Python virtualenv activation is an environment directive, not a generic tool option.
+
+**Bootstrap packages**
+: Host packages declared in `[bootstrap.packages]`, applied during machine setup. They use a shared system package database or prefix, unlike project-selected `[tools]` versions. See [bootstrap packages](/bootstrap/packages/).

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -134,11 +134,11 @@
 
 - [About mise](https://mise.jdx.dev/about.html): mise (pronounced "meez") or "mise-en-place" is a development environment setup tool. The name refers to a French culinary phrase that roughly translates to "setup" or "put in place".
 - [mise-en-place: The Song](https://mise.jdx.dev/mise-en-place.html): I keep a tidy kitchen for the working software engineer, Where every runtime's labeled so the shell can find it bright and clear; I pin the Node and Python, Rust and Go all reproducibly, Then place…
-- [Glossary](https://mise.jdx.dev/glossary.html): This glossary defines key terms and concepts used throughout the mise documentation.
-- [FAQs](https://mise.jdx.dev/faq.html): Use mise.local.toml and put that into your global gitignore file. This file should never be committed.
+- [Glossary](https://mise.jdx.dev/glossary.html): Definitions for the concepts used in the guides and CLI reference. Follow a term's link for configuration syntax and examples.
+- [FAQs](https://mise.jdx.dev/faq.html): Quick answers about daily commands, shell integration, and configuration. For a failed command, start with Troubleshooting or Errors.
 - [Troubleshooting](https://mise.jdx.dev/troubleshooting.html): If you're looking for help with a specific error message, see Errors — this page is organized by symptom instead.
 - [Errors](https://mise.jdx.dev/errors.html): This page lists common error messages mise emits, what causes them, and how to fix them. It complements Troubleshooting, which is organized by symptom (wrong tool version, slow prompts, activation…
-- [Tips & Tricks](https://mise.jdx.dev/tips-and-tricks.html): An assortment of helpful tips for using mise.
+- [Tips & Tricks](https://mise.jdx.dev/tips-and-tricks.html): Short recipes for common workflows. Each section links to the full guide when setup or platform details matter. Start with Getting Started if you have not yet configured a project.
 - [Cookbook](https://mise.jdx.dev/mise-cookbook/): These recipes combine tools, environment variables, and tasks for specific workflows. Start with the recipe closest to your project, then adapt its paths, versions, and application commands.
 - [C++](https://mise.jdx.dev/mise-cookbook/cpp.html): Use mise to install build tools and define the configure/build cycle. A C or C++ compiler must already be available, for example through your operating system's development tools.
 - [Docker](https://mise.jdx.dev/mise-cookbook/docker.html): Install mise inside an image, use it to run project commands, or preinstall tools outside user home directories for shared development containers.

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -1,62 +1,66 @@
 # Tips & Tricks
 
-An assortment of helpful tips for using `mise`.
+Short recipes for common workflows. Each section links to the full guide when setup or
+platform details matter. Start with [Getting Started](/getting-started.html) if you have not
+yet configured a project.
 
 ## macOS Rosetta
 
-If you need to run tools as x86_64 on Apple Silicon, mise can do this, but you'll currently
-need to use the x86_64 version of mise itself. A common reason is to compile node <=14.
-
-You can do this either with the [`MISE_ARCH`](https://mise.jdx.dev/configuration/settings.html#arch)
-setting or with a dedicated Rosetta mise binary, as described below.
-
-First, you'll need a copy of mise that's built for x86_64:
+For precompiled Intel tools on Apple Silicon, set [`MISE_ARCH`](/configuration/settings.html#arch)
+to `x64`. Keep those installations separate from native arm64 tools, and use the same
+directory and architecture overrides for installation and execution:
 
 ```sh
-$ curl https://mise.run | MISE_INSTALL_PATH=~/.local/bin/mise-x64 MISE_INSTALL_ARCH=x64 sh
-$ ~/.local/bin/mise-x64 --version
-mise 2024.x.x
+export MISE_DATA_DIR="$HOME/.local/share/mise-x64"
+export MISE_ARCH=x64
+mise install node@24
+mise exec node@24 -- node --version
 ```
 
-::: warning
-If `~/.local/bin` is not in PATH, you'll need to prefix all commands with `~/.local/bin/mise-x64`.
-:::
+Run this in a dedicated shell session. The overrides remain active until you unset them or
+close that shell. Rosetta must be installed to execute an Intel binary on Apple Silicon;
+source builds may also require an Intel toolchain and dependencies.
 
-Now you can use `mise-x64` to install tools:
+If a backend needs the mise process itself to run as Intel, install a separate binary:
 
 ```sh
-mise-x64 use -g node@20
+curl -fsSL https://mise.run -o /tmp/install-mise.sh
+MISE_INSTALL_PATH="$HOME/.local/bin/mise-x64" MISE_INSTALL_ARCH=x64 sh /tmp/install-mise.sh
+"$HOME/.local/bin/mise-x64" --version
 ```
+
+Keep the separate `MISE_DATA_DIR` when using that executable too. See the relevant
+[language guide](/core-tools.html) for compilation requirements.
 
 ## Shebang
 
 You can specify a tool and its version in a shebang without first setting up
 a `mise.toml`/`.tool-versions` config:
 
-```typescript
-#!/usr/bin/env -S mise x node@20 -- node
+```javascript [script.js]
+#!/usr/bin/env -S mise x node@24 -- node
 // "env -S" allows multiple arguments in a shebang
 console.log(`Running node: ${process.version}`);
 ```
 
-This can also be useful in environments where mise isn't activated
-(such as a non-interactive session).
+Save this as `script.js`, run `chmod +x script.js`, then execute `./script.js`.
+This requires mise on `PATH` and an `env` implementation supporting `-S`; native Windows
+does not execute Unix shebangs. Shell activation is unnecessary. For a committed wrapper
+with additional installation options, see [tool stubs](/dev-tools/tool-stubs.html).
 
 ## Bootstrap script
 
-You can download the <https://mise.run> script to use in a project bootstrap script:
+Generate and commit a wrapper that downloads mise on first use:
 
 ```sh
-curl https://mise.run > setup-mise.sh
-chmod +x setup-mise.sh
-./setup-mise.sh
+mise generate install-script --localize --write bin/mise
+./bin/mise install
 ```
 
-::: tip
-This file contains checksums, so committing it to your project is more secure than
-calling `curl https://mise.run` dynamically—though this means it will only fetch
-the version of mise that was current when the script was created.
-:::
+Commit `bin/mise` and ignore `.mise/`, where the localized wrapper stores its binary, tools,
+and cache. The generated wrapper records a default mise version; regenerate it to update
+that default. See [CI bootstrapping](/continuous-integration.html#bootstrapping) for version
+overrides, cache layout, and an example pipeline.
 
 ## Project-local task entrypoints
 
@@ -66,144 +70,82 @@ If you want contributors to run project tasks without installing mise first, pai
 
 ```sh
 mkdir -p bin
-mise generate install-script --localize --write bin/mise
+mise generate install-script --localize --write bin/mise --windows
 mise generate task-stubs --mise-bin ./bin/mise
 ./bin/test
 ```
 
-The generated task stubs behave like small project commands, while `bin/mise`
+Define a `test` task before running the example. Commit the generated entrypoints and ignore
+`.mise/`. The task stubs behave like small project commands, while `bin/mise`
 downloads and runs the pinned mise binary for the project.
 
-If contributors work on Windows, add `--windows`. Windows cannot execute a shebang script, so
+The example includes `--windows` for contributors on Windows. Windows cannot execute a shebang script, so
 `mise generate install-script --write ./bin/mise --windows` writes `bin/mise.cmd` alongside it, and Windows contributors
 run `.\bin\mise.cmd`. The launcher downloads the standalone `mise.exe` for the release and checks it
 against a checksum embedded when the script was generated, so it needs nothing beyond what Windows
 already ships.
 
 Task stubs get a `.cmd` launcher beside each stub for the same reason, so the Windows form of the
-example above is `.\bin\test.cmd`. Both halves are generated on every platform, so a `bin/`
-committed from Linux or macOS still works for someone who clones the repository on Windows.
+example above is `.\bin\test.cmd`. The default `.cmd` task launcher can be generated on any platform, but `cmd.exe` can alter
+shell metacharacters in arguments. Generate `--windows-launcher exe` on Windows when exact
+argument forwarding is required; see [task stubs](/cli/generate/task-stubs.html).
 
 ## Machine bootstrapping
 
-Beyond `[tools]`, mise can declare the rest of the machine setup needed for
-a project or workstation, and [`mise bootstrap`](/cli/bootstrap.html)
-converges it in one command — system packages, then repos, then dotfiles, then
-shell activation, then macOS defaults, then LaunchAgents, then systemd user
-services, then login shell, then tools, then a `bootstrap` task if you define
-one:
-
-```toml
-[bootstrap.packages]                      # OS packages (apk/apt/dnf/pacman/brew)
-"apk:build-base" = "latest"
-"apt:build-essential" = "latest"
-"brew:postgresql@17" = "latest"
-
-[bootstrap.repos]                         # git repos cloned before dotfiles
-"~/src/dotfiles" = { url = "git@github.com:jdx/dotfiles.git", ref = "main" }
-
-[dotfiles]                             # dotfiles: symlink/copy/template
-"~/.config/mise/config.toml" = { source = "config.toml", mode = "symlink" }
-"~/.gitconfig" = { mode = "symlink" }
-"~/.config/nvim" = { mode = "symlink" }
-
-[bootstrap.mise_shell_activate]       # mise activation in shell startup files
-zprofile = "shims"
-zshrc = "activate"
-fish = "activate"
-
-[bootstrap.macos.dock]                 # friendly macOS defaults
-autohide = true
-orientation = "left"
-
-[bootstrap.macos.finder]
-show_pathbar = true
-
-[bootstrap.macos.launchd.agents.my-sync]      # macOS user LaunchAgents
-program = "~/.local/bin/my-sync"
-run_at_load = true
-
-[bootstrap.linux.systemd.units.my-sync]       # Linux systemd user services
-exec_start = "~/.local/bin/my-sync --watch"
-restart = "on-failure"
-
-[bootstrap.user]                       # current user's login shell
-login_shell = "/bin/zsh"
-
-[bootstrap.hooks.post-defaults]        # optional phase hooks
-run = "killall Dock || true"
-
-[tasks.bootstrap]                      # anything else, with tools on PATH
-run = "gh auth status || gh auth login"
-```
+Use [`mise bootstrap`](/bootstrap.html) to apply machine setup declared in configuration.
+Start with a preview:
 
 ```sh
-mise bootstrap --yes   # new laptop or container -> ready to work
+mise bootstrap --dry-run
+mise bootstrap
+mise bootstrap status
 ```
 
-When taking over an existing Mac that already has Homebrew casks (or a
-nix-darwin brew integration), set `[bootstrap.brew] adopt = true` so mise
-records ownership without replacing `/Applications` bundles — replacing an
-`.app` can revoke macOS Privacy & Security grants. See
-[brew casks / TCC](/bootstrap/packages/brew.html#macos-privacy-security-tcc).
+Choose the parts your machine needs: [packages](/bootstrap/packages/),
+[repositories](/bootstrap/repos.html), [dotfiles](/dotfiles.html),
+[shell activation](/bootstrap/shell.html), [macOS defaults](/bootstrap/macos-defaults.html),
+[launchd](/bootstrap/launchd.html), or [systemd](/bootstrap/systemd.html).
+The full guide explains phase ordering and host selection; do not copy declarations for
+unrelated platforms into a workstation config just to try the command.
 
-After writing macOS defaults, relaunch Dock/Finder (or use a `post-defaults`
-hook); otherwise preferences can look unset until the next restart — see
-[macOS Defaults](/bootstrap/macos-defaults.html#app-restarts).
+Hooks and a `bootstrap` task are ordinary commands and need their own idempotent behavior.
+When adopting existing Homebrew casks, see [ownership and macOS privacy permissions](/bootstrap/packages/brew.html#macos-privacy-security-tcc)
+before replacing application bundles.
 
-Everything is declarative and idempotent: re-running skips whatever is
-already in its desired state, `mise bootstrap packages status --missing` and
-`mise bootstrap dotfiles status --missing` work as CI checks, and nothing is ever
-applied implicitly. The exceptions are `[bootstrap.hooks]` and `[tasks.bootstrap]`,
-which are imperative commands run during `mise bootstrap` and may have side
-effects; treat hook commands as non-idempotent unless they are written to
-converge safely. See
-[Bootstrap](/bootstrap.html), [Bootstrap Packages](/bootstrap/packages/),
-[Repos](/bootstrap/repos.html), [Dotfiles](/dotfiles.html),
-[Shell Activation](/bootstrap/shell.html),
-[macOS Defaults](/bootstrap/macos-defaults.html), [launchd](/bootstrap/launchd.html),
-[systemd](/bootstrap/systemd.html), and [User Login Shell](/bootstrap/user.html).
+## Zsh with Zinit {#installation-via-zsh-zinit}
 
-## Installation via zsh zinit
+If you use [Zinit](https://github.com/zdharma-continuum/zinit), install mise using a supported
+[installation method](/installing-mise.html), then activate it after plugins that modify PATH:
 
-[Zinit](https://github.com/zdharma-continuum/zinit) is a plugin manager for zsh. This snippet installs mise and its shell completion:
-
-```sh
-zinit as="command" lucid from="gh-r" for \
-    id-as="mise" mv="mise* -> mise" \
-    atclone="./mise* completion zsh > _mise" \
-    atpull="%atclone" \
-    atload='eval "$(mise activate zsh)"' \
-    jdx/mise
+```zsh
+# ~/.zshrc, after your Zinit setup
+eval "$(mise activate zsh)"
 ```
+
+This keeps mise updates under its installer or package manager. Follow the
+[Zsh completion instructions](/installing-mise.html#autocompletion) to add completions,
+and avoid initializing `compinit` repeatedly across your plugin and completion setup.
 
 ## CI/CD
 
-Using mise in CI/CD is a great way to keep tool versions in sync between development and builds.
+Commit the project tool configuration and use `mise exec` or `mise run` in CI.
+See [Continuous integration](/continuous-integration.html) for provider examples,
+locked installs, and caching.
 
 ### GitHub Actions
 
-mise is pretty easy to use without an action:
+For a repository that declares Node in `mise.toml`:
 
 ```yaml
+name: tools
+on: [push, pull_request]
 jobs:
-  build:
-    steps:
-      - run: |
-          curl https://mise.run | sh
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-          echo "$HOME/.local/share/mise/shims" >> $GITHUB_PATH
-```
-
-Or you can use the custom action [`jdx/mise-action`](https://github.com/jdx/mise-action):
-
-```yaml
-jobs:
-  lint:
+  check:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
       - uses: jdx/mise-action@v3
-      - run: node -v # will be the node version from `mise.toml`/`.tool-versions`
+      - run: mise exec -- node --version
 ```
 
 ## `mise set`
@@ -222,17 +164,19 @@ For example, to use a `.hvm` file with a plain Hugo version:
 
 ```toml
 [tools]
-hugo = "{{ read_file(path='.hvm') | trim }}"
+hugo = "{{ read_file(path=config_root ~ '/.hvm') | trim }}"
 ```
 
 HVM also supports versions with an `/extended` suffix. In mise, Hugo and Hugo Extended are separate tools, so strip the suffix and use `hugo-extended` instead:
 
 ```toml
 [tools]
-hugo-extended = "{{ read_file(path='.hvm') | trim | replace(from='/extended', to='') }}"
+hugo-extended = "{{ read_file(path=config_root ~ '/.hvm') | trim | replace(from='/extended', to='') }}"
 ```
 
-See [Templates](/templates.html) for more details on Tera functions and filters.
+Create `.hvm` with a version string before evaluating either example. `config_root` keeps
+the path tied to the configuration when you invoke mise from a subdirectory. Choose one
+Hugo variant for the project. See [Templates](/templates.html) for functions and filters.
 
 ## [`mise run`](/cli/run.html) shorthand
 
@@ -267,7 +211,7 @@ mise watch --restart dev
 For projects with a lot of tasks,
 [`task_config.includes`](/tasks/task-configuration.html#task_config.includes)
 can load task definitions from additional directories, `tasks.toml` files, or
-remote git repositories:
+remote git repositories. Replace the example URL with a repository and ref you trust:
 
 ```toml
 [task_config]
@@ -299,13 +243,13 @@ extends = "node:test"
 run = "pnpm test -- --watch=false"
 ```
 
-This is especially useful in monorepos where each package needs similar build,
-test, or lint tasks with small local overrides.
+This assumes `pnpm test -- --watch=false` is accepted by your project's test script.
+Use a template when packages share defaults, then override commands or paths locally.
 
 ## Redact secrets from task output
 
 If a task may echo secrets in CI logs, add `redactions` to the task or config.
-The listed environment variables are replaced with `[redacted]` in task output:
+Values of the listed environment variables are replaced with `[redacted]` in processed task output:
 
 ```toml
 redactions = ["API_KEY", "PASSWORD"]
@@ -316,6 +260,9 @@ Glob patterns are also supported:
 ```toml
 redactions = ["SECRETS_*"]
 ```
+
+Raw or interactive output bypasses redaction, and child programs still receive the original
+values. See [redaction](/environments/#redactions) for supported output and logging boundaries.
 
 ## Software verification
 
@@ -334,8 +281,10 @@ so if you had `node = "24"` and node 26 is the latest, `mise up --bump node` wil
 
 ## cargo-binstall
 
-cargo-binstall is similar to ubi but specific to Rust tools: it fetches prebuilt binaries for cargo releases. mise uses it automatically for `cargo:` tools when it is installed,
-so if you use `cargo:` tools, add it to make `mise i` much faster.
+[cargo-binstall](https://github.com/cargo-bins/cargo-binstall) can download prebuilt Rust CLI
+binaries instead of compiling them. With `cargo.binstall` enabled (the default), mise uses
+it for `cargo:` tools when available. Not every crate has a compatible prebuilt release;
+see the [Cargo backend](/dev-tools/backends/cargo.html) for fallback behavior.
 
 ```sh
 mise use -g cargo-binstall
@@ -343,79 +292,75 @@ mise use -g cargo-binstall
 
 ## [`mise cache clear`](/cli/cache.html)
 
-mise caches things for obvious reasons, but sometimes you want it to use fresh data (maybe it's not noticing a new release). Run `mise cache clear` to remove the cache, which
-is essentially `rm -rf ~/.cache/mise/*`.
+Clear a tool's cached metadata when checking for a new release, for example
+`mise cache clear node`. `mise cache path` shows the active cache directory. A full
+`mise cache clear` also affects environment and task caches; see [Cache Behavior](/cache-behavior.html).
 
 ## [`mise en`](/cli/en.html)
 
-`mise en` is a great alternative to `mise activate` if you don't want mise running all the time. It sets up the mise environment in your current directory
-but doesn't keep updating the env vars after that.
+`mise en` starts a **new shell** with the current project environment. Exit that shell to
+return to your original session. It does not add directory-change updates by itself; your
+new shell's startup files may still activate mise. Use `mise en -s "bash --norc"` when you
+want to skip Bash's rc file.
 
 ## Auto-install when entering a project
 
-Auto-install tools when entering a project by adding the following to `mise.toml`:
+In a normally activated shell, run installation when entering a trusted project:
 
 ```toml
 [hooks]
 enter = "mise i -q"
 ```
 
+The hook can download tools and run installation scripts when you enter the directory.
+Use explicit `mise install` instead if you prefer to choose when that work runs.
+
 ## [`mise tool [TOOL]`](/cli/tool.html)
 
-See which backend a tool uses, along with other information, with `mise tool [TOOL]`:
+Inspect a tool's selected backend, version requests, and installation information:
 
 ```sh
-❯ mise tool ripgrep
-Backend:            aqua:BurntSushi/ripgrep
-Installed Versions: 14.1.1
-Active Version:     14.1.1
-Requested Version:  latest
-Config Source:      ~/src/mise/mise.toml
-Tool Options:       [none]
+mise tool ripgrep
 ```
+
+Use `mise registry ripgrep` to inspect registry choices and `mise which rg` to find the
+executable selected for the current project.
 
 ## [`mise cfg`](/cli/config.html)
 
-List the config files mise is reading in a particular directory with `mise cfg`:
+List loaded configuration files and their tools:
 
 ```sh
-❯ mise cfg
-Path                                    Tools
-~/.config/mise/config.toml              (none)
-~/.mise/config.toml                     (none)
-~/src/mise.toml                         (none)
-~/src/mise/.config/mise/conf.d/foo.toml (none)
-~/src/mise/mise.toml                    actionlint, bun, cargo-binstall, cargo:…
-~/src/mise/mise.local.toml              (none)
+mise config
 ```
 
-This helps you see the order in which config files are loaded and which one is overriding the others.
+Use this when a value comes from an unexpected file. For precedence and the file commands
+write to, see [configuration](/configuration.html). `mise cfg` is an alias.
 
 ## `mise.lock`
 
-When lockfiles are enabled, mise updates `mise.lock` with full versions and tarball checksums (if the backend supports them).
-These can be updated with [`mise up`](/cli/upgrade.html). You need to create the lockfile manually; mise will then add tools to it:
+Resolve configured requests into a committed lockfile:
 
 ```sh
-touch mise.lock
-mise i
+mise lock
+mise install --locked
 ```
 
-The lockfile uses a consolidated format with `[tools.name.assets]` sections to organize asset information under each tool. Asset information includes checksums, file sizes, and optional download URLs. Legacy lockfiles with separate `[tools.name.checksums]` and `[tools.name.sizes]` sections are automatically migrated to the new format.
+Locking records concrete versions and, where the backend supports it, artifact URLs and
+checksums. `mise install --locked` checks that the lockfile can satisfy the configuration.
+Use `mise lock --bump --dry-run` to preview a version refresh before applying it.
 
-When a backend has no published checksum source, mise needs to install the tool to get the tarball
-checksum. Configured sources such as [`checksum_url`](/dev-tools/backends/http.html#checksum_url) let
-`mise lock` resolve the checksum without downloading the artifact. Otherwise, you may need to run
-something like `mise uninstall --all` first to have mise reinstall everything. mise stores the full
-version even when it doesn't know the checksum, so the version is still locked—just without a
-checksum to go with it.
+Backends differ in the metadata they can lock. For a custom HTTP download, configure a
+[checksum source](/dev-tools/backends/http.html#checksum-url) when available. See
+[lockfiles](/dev-tools/mise-lock.html) for platform coverage and strict validation; do not
+uninstall every tool just to regenerate metadata.
 
 ## Lockfile URL Tracking (Avoiding Rate Limits)
 
-When you use a lockfile (`mise.lock`), mise stores the exact download URLs for each tool asset. This means that after the initial install, future `mise install` runs will use the URLs from the lockfile instead of making API calls to GitHub (or other providers). This has several benefits:
+For backends that record artifact URLs, a lockfile can avoid repeated release-asset lookups
+on later installs. It does not contain the artifacts themselves and does not eliminate all
+network or authentication requirements. Downloads, verification, private repositories, and
+backend-specific operations can still require access.
 
-- **Avoids GitHub API rate limits**: No need to make repeated API calls for every install, which can quickly exhaust your rate limit, especially in CI or large teams.
-- **No need for GITHUB_TOKEN**: Since the URLs are already known, you don't need to set up a `GITHUB_TOKEN` for simple installs. See [GitHub Tokens](/dev-tools/github-tokens.html) for more on token configuration.
-- **Faster installs**: Skipping API lookups speeds up repeated installs.
-
-This is especially useful in CI/CD or when working in environments with strict network or authentication requirements.
+See [GitHub Tokens](/dev-tools/github-tokens.html) for credentials and
+[lockfile behavior](/dev-tools/mise-lock.html) for each backend's guarantees.

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -144,7 +144,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v3
+      - uses: jdx/mise-action@v4
       - run: mise exec -- node --version
 ```
 


### PR DESCRIPTION
Organize the FAQ into daily commands, shell/editor setup, configuration, migration, and project scope while preserving existing question anchors. Correct stale claims about Windows activation, shim environments, trust, write targets, system packages, and version selection.

The recipes now provide project-local wrappers with Windows launchers, configuration-root-relative Hugo templates, separate Intel installations on Apple Silicon, current CI setup, explicit lockfile workflows, and accurate cache/redaction boundaries. The glossary adds missing backends and clarifies settings, roots, hooks, tool options, and environment evaluation.

Validation: 8 TOML 1.1 examples; full `mise run lint-fix` with Rust 1.95; scoped safe hk checks; documentation build and rendered links. Isolated smoke checks cover nearest/explicit/local config writes, generated task and Windows wrappers, a localized task entrypoint, executable Node shebangs, and Hugo/Hugo Extended templates evaluated from a subdirectory. Windows launchers were generated but not executed; Rosetta was unavailable, so Intel execution was not tested. Rebased on `main` and regenerated `docs/public/llms.txt`.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to user-facing documentation and the LLM index; they do not modify application code or configuration defaults.
> 
> **Overview**
> **Documentation-only refresh** across the FAQ, glossary, Tips & Tricks, and `llms.txt` index blurbs—no runtime or CLI behavior changes.
> 
> The **FAQ** is restructured into themed sections (daily commands, shells/editors, configuration, migration, scope) while keeping important anchors. Content is rewritten to fix outdated guidance on Windows/PowerShell activation, shim vs PATH boundaries, `mise use` write targets, partial/`latest` version semantics, trust/`mise trust`, proxies, asdf migration, bootstrap vs `[tools]`, security, and Calver-style mise releases.
> 
> The **glossary** tightens definitions (backends, toolset, settings, `config_root`/`MISE_PROJECT_ROOT`, hooks, redaction, lockfiles) and documents additional backends (**forgejo**, **packslip**, **pkgx**, **s3**).
> 
> **Tips & Tricks** drops the long inline bootstrap TOML in favor of linked guides; updates Rosetta/`MISE_ARCH`, generated install/task stubs (including Windows launchers), CI (`mise-action@v4`, `mise exec`), Hugo templates via `config_root`, lockfile workflow (`mise lock`), cache/redaction limits, and Zinit setup (standard install + `eval` instead of a Zinit plugin snippet).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32502519fd4c7bebc57a4b60fbe61fe8efba4bc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Reorganized and updated the FAQ with clearer sections, revised commands, current examples, and expanded guidance on configuration, networking, migration, lockfiles, trust, and versioning.
  - Expanded the glossary with clarified terminology and coverage of additional backends and tools.
  - Updated documentation index descriptions for the Glossary, FAQs, and Tips & Tricks.
  - Revised Tips & Tricks with current workflows for macOS, bootstrapping, shell integration, project tasks, CI/CD, caching, lockfiles, and related commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->