### PR TITLE
security(http): prevent credential downgrade in URL replacements

### DIFF
--- a/docs/paranoid.md
+++ b/docs/paranoid.md
@@ -1,9 +1,9 @@
 # Paranoid
 
-Paranoid mode requires explicit content-bound trust for non-global configuration and rechecks supported
-provenance during installation. Use it when you want configuration edits to require renewed
-approval. It does not sandbox a command after you approve it; see [Security](/security.html)
-for the scope of each control.
+Paranoid mode disables automatic and CI trust, binds direct file approvals to configuration content,
+and rechecks supported provenance during installation. Configurations accepted through
+`trusted_config_paths` or inherited monorepo-root trust remain path-based exceptions. It does not
+sandbox a command after you approve it; see [Security](/security.html) for the scope of each control.
 
 Enable it for one invocation with `MISE_PARANOID=1`, or persist it globally:
 
@@ -21,10 +21,10 @@ as `mise run`, `mise install`, and `mise exec` automatically trust their active 
 Other commands may prompt, fail, or skip an untrusted file depending on how they discover it.
 See [`mise trust`](/cli/trust.html) for normal-mode rules.
 
-Paranoid mode requires explicit trust for every non-global config file, including formats
-that normally do not need it. It hashes the contents, so editing a file requires renewed
-trust. Automatic trust for execution commands and the usual CI trust exemption are disabled.
-Trust is not shared between Git worktrees in this mode.
+Paranoid mode requires explicit trust for non-global config files, including formats that normally
+do not need it. Direct file approval hashes the contents, so editing the file requires renewed trust.
+Automatic trust for execution commands and the usual CI trust exemption are disabled. Trust is not
+shared between Git worktrees in this mode.
 
 Inspect the file before accepting it:
 
@@ -33,9 +33,10 @@ mise trust --show
 mise trust path/to/mise.toml
 ```
 
-Replace the path with the configuration you reviewed. Trusting a broad directory is not a
-substitute for content-bound approval in paranoid mode. Global and system configuration is
-operator-owned and remains exempt, allowing paranoid mode itself to be set globally.
+Replace the path with the configuration you reviewed. Paths allowed by the global
+`trusted_config_paths` setting and descendants covered by trusted monorepo roots bypass the
+content-hash check, so changes there do not require renewed approval. Global and system
+configuration is operator-owned and remains exempt, allowing paranoid mode itself to be set globally.
 
 [Safe mode](/security.html#safe-mode) takes precedence if both modes are enabled. It suppresses
 project execution and environment injection, so the configuration can load without a trust

--- a/docs/paranoid.md
+++ b/docs/paranoid.md
@@ -1,54 +1,46 @@
 # Paranoid
 
-Paranoid mode is an optional behavior that locks mise down further to make it
-harder for a bad actor to compromise your system. I do not use these settings
-on my own system because I find them too restrictive for the benefits.
+Paranoid mode requires explicit trust for non-global configuration and rechecks supported
+provenance during installation. Use it when you want configuration edits to require renewed
+approval. It does not sandbox a command after you approve it; see [Security](/security.html)
+for the scope of each control.
 
-Paranoid mode can be enabled with either `MISE_PARANOID=1` or a global setting:
+Enable it for one invocation with `MISE_PARANOID=1`, or persist it globally:
 
 ```sh
-mise settings paranoid=1
+mise settings set paranoid true
 ```
 
-The setting is global-only, so a project config cannot enable or disable paranoid
-mode for itself.
+To restore normal mode, run `mise settings set paranoid false`. The setting is global-only;
+a project cannot enable or disable it for itself.
 
 ## Config files
 
-Normally, `mise` makes sure some config files are "trusted" before loading
-them. It may prompt you to confirm that you want to load the file, e.g.:
+In normal mode, simple configuration can load without trust, and execution commands such
+as `mise run`, `mise install`, and `mise exec` automatically trust their active configuration.
+Other commands may prompt, fail, or skip an untrusted file depending on how they discover it.
+See [`mise trust`](/cli/trust.html) for normal-mode rules.
+
+Paranoid mode requires explicit trust for every non-global config file, including formats
+that normally do not need it. It hashes the contents, so editing a file requires renewed
+trust. Automatic trust for execution commands and the usual CI trust exemption are disabled.
+Trust is not shared between Git worktrees in this mode.
+
+Inspect the file before accepting it:
 
 ```sh
-$ mise env
-mise ~/src/mise/mise.toml is not trusted. Trust it [y/n]?
+mise trust --show
+mise trust path/to/mise.toml
 ```
 
-In normal mode, `mise run`, naked task invocations such as `mise <TASK>`,
-`mise install`, `mise exec`, and `mise watch` automatically trust their active
-config because they explicitly execute project-defined behavior. Automatic shell
-activation through `hook-env` does not.
+Replace the path with the configuration you reviewed. Trusting a broad directory is not a
+substitute for content-bound approval in paranoid mode. Global and system configuration is
+operator-owned and remains exempt, allowing paranoid mode itself to be set globally.
 
-Other commands check trust before parsing `mise.toml` files because they can
-contain behavior that executes code or affects the environment. Some discovery
-paths that look at previously tracked configs may skip untrusted files instead
-of prompting. Commands that directly need an untrusted config can fail with an
-untrusted-config error when mise cannot prompt. When mise detects that it is
-running in CI, configs are assumed to be trusted unless paranoid mode is enabled.
-
-Under paranoid mode, all config files must be trusted first, including formats
-that normally do not require trust, and automatic trust for execution commands is
-disabled. In normal mode, a config file only needs to be trusted once. In paranoid
-mode, the file's contents are hashed to detect changes, so if you change your
-config file, you'll need to trust it again.
-
-Global and system config files (e.g., `~/.config/mise/config.toml`) are implicitly trusted and exempt from this check, so paranoid mode can be enabled in a global config without a trust prompt for that file itself.
-
-[Safe mode](/security.html#safe-mode) takes precedence when both modes are enabled.
-Safe mode disables project-defined code execution and environment injection while
-retaining non-executable configuration such as tool definitions, task metadata,
-plugin declarations, and tool aliases. It therefore loads untrusted config without
-a trust prompt or untrusted-config error. Other configuration errors are still
-reported.
+[Safe mode](/security.html#safe-mode) takes precedence if both modes are enabled. It suppresses
+project execution and environment injection, so the configuration can load without a trust
+prompt; syntax errors and refused operations still fail. Loading in safe mode does not grant
+trust for a later normal or paranoid-mode invocation.
 
 ## Community plugins
 
@@ -71,27 +63,21 @@ an untrusted community plugin by short name.
 
 ## Provenance re-verification
 
-Normally, when a lockfile contains both a checksum and a provenance entry for a tool,
-`mise install` trusts the lockfile and skips provenance re-verification to avoid
-redundant API calls (e.g., to GitHub). This is safe when you trust that the lockfile
-was generated correctly.
+A supported backend can reuse a lockfile's recorded provenance when installing an artifact
+whose checksum matches. This avoids repeating checks and API calls, and relies on the
+lockfile having been generated correctly.
 
-In paranoid mode, `mise install` always re-verifies provenance (SLSA, cosign, minisign,
-GitHub artifact attestations) at install time, even when the lockfile already has a
-provenance entry. This ensures that cryptographic verification happens on every install,
-not just when the lockfile is first generated.
+In paranoid mode, supported and enabled provenance methods (such as SLSA, Cosign, Minisign,
+and GitHub attestations) run again during installation instead of being skipped because a
+provenance entry exists. This can require network access. It does not add verification that
+the backend does not support, or rescan an already-installed tool that mise skips.
 
 This behavior can also be enabled independently via the
 [`locked_verify_provenance`](/configuration/settings.html#locked_verify_provenance) setting.
 
 ## See also
 
-[Safe mode](/security.html#safe-mode) (`MISE_SAFE=1`) is a related but distinct
-control: paranoid tightens _trust_ (which configs are loaded and re-verified),
-while safe mode is a hard boundary on _code execution_ for running mise against
-configuration you do not control.
-
-## More?
-
-If you have suggestions for more that could be added to paranoid mode, please
-let me know.
+- [Safe mode](/security.html#safe-mode) for processing untrusted project metadata.
+- [Sandboxing](/sandboxing.html) for restrictions on executed commands.
+- [Lockfiles](/dev-tools/mise-lock.html) for checksums, provenance, and backend coverage.
+- [Contact](/contact.html) to suggest improvements or report unexpected behavior.

--- a/docs/paranoid.md
+++ b/docs/paranoid.md
@@ -1,6 +1,6 @@
 # Paranoid
 
-Paranoid mode requires explicit trust for non-global configuration and rechecks supported
+Paranoid mode requires explicit content-bound trust for non-global configuration and rechecks supported
 provenance during installation. Use it when you want configuration edits to require renewed
 approval. It does not sandbox a command after you approve it; see [Security](/security.html)
 for the scope of each control.

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -28,7 +28,7 @@
 - [Registry](https://mise.jdx.dev/registry.html): The registry maps short tool names to one or more installation backends. Search the tool list below, or inspect the registry bundled with your installed mise.
 - [GitHub Tokens](https://mise.jdx.dev/dev-tools/github-tokens.html): Many tools in mise are hosted on GitHub. For public releases, mise uses mise-versions by default as a shared cache for version lists, release metadata, and GitHub artifact attestations.
 - [mise.lock Lockfile](https://mise.jdx.dev/dev-tools/mise-lock.html): mise.toml records the versions a project accepts; mise.lock records the concrete versions those requests resolved to.
-- [Security](https://mise.jdx.dev/security.html): mise includes several supply-chain controls for installing and managing tools. These controls have different coverage depending on the backend and the metadata available from upstream.
+- [Security](https://mise.jdx.dev/security.html): mise provides controls for different parts of a development workflow. Choose the control that addresses the operation you are running.
 - [Packslip Completions and Skills](https://mise.jdx.dev/dev-tools/packslip-resources.html): Tools installed with the Packslip backend can provide shell completions and agent skills that match the version active in your project. The publisher declares these resources in the release manifest.
 - [Packslip Verification and Policy](https://mise.jdx.dev/dev-tools/packslip-verification.html): mise uses Packslip's signed metadata to discover releases, verify publishers, and select compatible builds. This guide describes the discovery and policy rules behind the Packslip backend.
 - [OCI Images (experimental)](https://mise.jdx.dev/dev-tools/mise-oci.html): mise oci build turns a mise.toml into a container image, with one OCI layer per installed tool.
@@ -116,7 +116,7 @@
 - [Remote Cache Protocol](https://mise.jdx.dev/tasks/remote-cache-protocol.html): [!WARNING] Remote build caching is experimental. This document defines protocol version 1 for mise task artifact caching.
 - [Task Templates](https://mise.jdx.dev/tasks/templates.html): Task templates let you define reusable task definitions that multiple tasks can extend. They are particularly useful in monorepos or projects with similar task patterns across components.
 - [Monorepo Tasks](https://mise.jdx.dev/tasks/monorepo.html): mise supports monorepo-style task organization with target path syntax. This lets you manage tasks across multiple projects in a single repository, where each project can have its own mise.toml with…
-- [Sandboxing](https://mise.jdx.dev/sandboxing.html): mise supports lightweight process sandboxing for mise exec and mise run, inspired by zerobox. Sandboxing restricts filesystem, network, and environment variable access with granular controls.
+- [Sandboxing](https://mise.jdx.dev/sandboxing.html): mise can restrict filesystem, network, and environment access for commands launched by mise exec and mise run. Restrictions use the host operating system, with different support on Linux and macOS.
 
 ## Plugins
 
@@ -155,9 +155,9 @@
 ## Advanced
 
 - [Architecture](https://mise.jdx.dev/architecture.html): This map is for contributors deciding where a behavior belongs. Start with the command that exposes the behavior, then follow configuration, tool resolution, or task execution into the owning…
-- [Paranoid](https://mise.jdx.dev/paranoid.html): Paranoid mode is an optional behavior that locks mise down further to make it harder for a bad actor to compromise your system.
+- [Paranoid](https://mise.jdx.dev/paranoid.html): Paranoid mode disables automatic and CI trust, binds direct file approvals to configuration content, and rechecks supported provenance during installation.
 - [Templates](https://mise.jdx.dev/templates.html): Use Tera expressions to derive configuration values from the project directory, environment, or [vars]. mise renders those expressions when it resolves configuration or prepares a task.
-- [URL Replacements](https://mise.jdx.dev/url-replacements.html): mise does not include a built-in registry for downloading artifacts. Instead, it retrieves remote registry manifests, which specify the URLs for downloading tools.
+- [URL Replacements](https://mise.jdx.dev/url-replacements.html): Use url_replacements to route requests made by mise's HTTP client through an internal mirror or proxy. This can cover release metadata and artifact downloads, including Conda channel metadata.
 - [Model Context Protocol](https://mise.jdx.dev/mcp.html): The mise MCP server lets an AI assistant inspect a project's tools, tasks, environment, and configuration, and run mise tasks. It uses the Model Context Protocol over stdin/stdout.
 - [Directory Structure](https://mise.jdx.dev/directories.html): mise separates configuration, installed tools, disposable metadata, and machine-local state. Use the table to locate files, then see the sections below for what is safe to share or remove.
 - [Cache Behavior](https://mise.jdx.dev/cache-behavior.html): mise caches version metadata, computed environments, and task results separately. Start with the cache related to the symptom: clearing a version list does not reinstall a tool, and clearing an…

--- a/docs/sandboxing.md
+++ b/docs/sandboxing.md
@@ -1,24 +1,35 @@
 # Sandboxing
 
-mise supports lightweight process sandboxing for `mise exec` and `mise run`, inspired by [zerobox](https://github.com/afshinm/zerobox). Sandboxing restricts filesystem, network, and environment variable access with granular controls. No Docker required, minimal overhead.
+mise can restrict filesystem, network, and environment access for commands launched by
+`mise exec` and `mise run`. Restrictions use the host operating system, with different support
+on Linux and macOS. Read [platform support](#platform-support) before relying on a policy;
+Windows does not enforce filesystem or network restrictions.
+
+The sandbox applies to the child command. Configuration evaluation, tool installation, and
+other preparation by mise happen outside that command's sandbox. For untrusted configuration,
+see [safe mode](/security.html#safe-mode).
 
 ## Quick Start
 
-Any `--deny-*` or `--allow-*` flag implicitly enables sandboxing:
+Any `--deny-*` or `--allow-*` flag enables the corresponding restriction. In a project that
+has Node installed:
 
-```bash
-# Full lockdown — no writes, no network, no env vars
-mise x --deny-all -- node script.js
+```sh
+# Block network access for a local build
+mise exec --deny-net -- npm run build
 
-# Block network only
-mise x --deny-net -- npm run build
+# Restrict writes to an existing output directory, plus implicit system exceptions
+mkdir -p dist
+mise exec --allow-write=./dist -- npm run build
 
-# Block writes except to ./dist
-mise x --allow-write=./dist -- npm run build
-
-# Block everything, allow specific exceptions
-mise x --deny-all --allow-read=. --allow-write=./dist --allow-net=registry.npmjs.org -- npm install
+# Deny reads, writes, network, and nonessential environment variables,
+# then allow reading this project and writing its output
+mise exec --deny-all --allow-read=. --allow-write=./dist -- node build.js
 ```
+
+The npm commands require a `build` script; the final command requires `build.js`. Adjust
+allowed paths for the files and caches your build actually uses. `--deny-all` retains the
+[implicit access](#implicit-access) described below; it is not a container with an empty filesystem.
 
 ## CLI Flags
 
@@ -26,12 +37,12 @@ mise x --deny-all --allow-read=. --allow-write=./dist --allow-net=registry.npmjs
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `--deny-all`           | Block reads, writes, network, and env vars                                                                             |
 | `--deny-read`          | Block filesystem reads (system libs and tool dirs still accessible)                                                    |
-| `--deny-write`         | Block all filesystem writes (except `/tmp`)                                                                            |
+| `--deny-write`         | Block writes except implicit temporary/device paths                                                                    |
 | `--deny-net`           | Block all network access                                                                                               |
-| `--deny-env`           | Block env var inheritance (only `PATH`, `HOME`, `USER`, `SHELL`, `TERM`, `LANG` pass through)                          |
+| `--deny-env`           | Block env var inheritance (essential variables and explicit exceptions still pass through)                             |
 | `--allow-read=<path>`  | Allow reads from specific path (implies `--deny-read` for everything else)                                             |
 | `--allow-write=<path>` | Allow writes to specific path (implies `--deny-write` for everything else)                                             |
-| `--allow-net=<host>`   | Allow network to specific host (implies `--deny-net` for everything else)                                              |
+| `--allow-net=<host>`   | Request host exceptions on macOS (see platform limitations); rejected on Linux                                         |
 | `--allow-env=<var>`    | Allow specific env var through (implies `--deny-env` for everything else). Supports wildcards: `--allow-env='MYAPP_*'` |
 
 These flags work with both `mise exec` (`mise x`) and `mise run`.
@@ -51,7 +62,8 @@ and `deny_env`. Tasks and CLI flags can still add `allow_read`, `allow_write`, `
 
 ## Task Sandboxing
 
-Tasks defined in `mise.toml` can declare sandbox permissions:
+Tasks can declare restrictions next to the command. This example assumes Node is configured,
+`npm run build` exists, and the output directory has been created:
 
 ```toml
 [tasks.build]
@@ -60,27 +72,30 @@ deny_net = true
 allow_write = ["./dist"]
 
 [tasks.lint]
-run = "eslint ."
-deny_all = true
-allow_read = ["."]
-
-[tasks.install]
-run = "npm install"
-deny_all = true
-allow_read = ["."]
-allow_write = ["./node_modules"]
-allow_net = ["registry.npmjs.org"]
+run = "npm run lint"
+deny_write = true
 ```
 
-CLI flags on `mise run` override task-level config:
-
-```bash
-# Run with task's declared sandbox
+```sh
+mkdir -p dist
 mise run build
+```
 
-# Override: also allow network to a specific host
+Global settings, task deny rules, and CLI deny flags are combined. Task and CLI allow lists
+are combined too; CLI flags add exceptions rather than replacing the task policy. Task paths
+are relative to the task's working directory, while CLI paths are relative to the directory
+where you invoke mise.
+
+The host-exception flag is intended for macOS tasks that need network access:
+
+```sh
 mise run --allow-net=registry.npmjs.org build
 ```
+
+A package manager may contact additional hosts and write a cache or lockfile outside the
+output directory. Allow only the resources required by the actual command. Linux rejects
+`--allow-net`; macOS can also reject the generated profile as described below. Use
+`--deny-net` for a command that needs no internet sockets.
 
 ## Implicit Access
 
@@ -89,8 +104,8 @@ When filesystem restrictions are active, certain paths remain accessible so tool
 ### Always Readable
 
 - **System paths** (Linux): `/usr`, `/lib`, `/lib64`, `/bin`, `/sbin`, `/etc`, `/dev`, `/proc`, `/sys`, `/tmp`, `/nix`, `/snap`, `/home/linuxbrew`
-- **System paths** (macOS): `/System`, `/Library`, `/usr`, `/bin`, `/sbin`, `/dev`, `/etc`, `/var/run`, `/tmp`, `/private`, `/opt/homebrew`, `/nix`
-- **Mise tool dirs**: `~/.local/share/mise/installs/...`
+- **System paths** (macOS): `/System`, `/Library`, `/usr`, `/bin`, `/sbin`, `/dev`, `/etc`, `/var/run`, `/tmp`, `/private/tmp`, `/private/etc`, `/private/var/run`, `/opt/homebrew`, `/nix`
+- **Mise data directory**: the configured `MISE_DATA_DIR`, not just individual tool binaries
 
 ### Always Writable
 
@@ -102,16 +117,20 @@ When filesystem restrictions are active, certain paths remain accessible so tool
 - `--allow-write` paths are implicitly readable
 - `--allow-read` paths include system essentials above
 
+When environment filtering is active, `PATH`, `HOME`, `USER`, `SHELL`, `TERM`, `COLORTERM`,
+and `LANG` remain available, along with explicitly allowed variables and task-specific
+pass-through/cache environment inputs. Unix sockets remain available even with `--deny-net`.
+
 ## Platform Support
 
-| Feature                                 | Linux              | macOS    |
-| --------------------------------------- | ------------------ | -------- |
-| Deny/allow reads                        | Landlock           | Seatbelt |
-| Deny/allow writes                       | Landlock           | Seatbelt |
-| Deny all network                        | seccomp            | Seatbelt |
-| Per-host network (`--allow-net=<host>`) | Not supported (v1) | Seatbelt |
-| Env filtering                           | Built-in           | Built-in |
-| Docker support                          | Yes                | N/A      |
+| Feature                                 | Linux    | macOS    |
+| --------------------------------------- | -------- | -------- |
+| Deny/allow reads                        | Landlock | Seatbelt |
+| Deny/allow writes                       | Landlock | Seatbelt |
+| Deny all network                        | seccomp  | Seatbelt |
+| Per-host network (`--allow-net=<host>`) | Rejected | Seatbelt |
+| Env filtering                           | Built-in | Built-in |
+| Docker support                          | Yes      | N/A      |
 
 ### Linux
 
@@ -119,7 +138,9 @@ Filesystem sandboxing uses [Landlock](https://landlock.io/) (available since Lin
 
 If Landlock is unavailable or cannot apply filesystem restrictions, the command fails.
 
-**Limitation**: Per-host network filtering (`--allow-net=<host>`) is not supported on Linux in v1. On Linux, `--allow-net` falls back to allowing all network access. Per-host filtering works on macOS via Seatbelt.
+**Limitation**: Per-host network filtering (`--allow-net=<host>`) is not supported on Linux.
+mise returns an error before executing the command; it does not silently allow all network
+access. Use `--deny-net` to block internet sockets, or omit network restrictions when needed.
 
 **Limitation**: An allow-list entry has to exist when the sandbox is built. Landlock binds each rule to an open descriptor, so a path that has not been created yet cannot be named by one, and mise warns that the rule was dropped. The task can still reach that path if another rule covers it — an allowed ancestor directory, for instance — but nothing else grants access on the dropped rule's behalf. To let a task create something, allow a directory that already exists and contains it.
 
@@ -135,7 +156,15 @@ Landlock cannot restrict creation to a single name, so allowing the containing d
 
 ### macOS
 
-Sandboxing uses Apple's `sandbox-exec` (Seatbelt) with a generated profile and supports all features, including per-host network filtering.
+Sandboxing uses Apple's `sandbox-exec` (Seatbelt) with a generated profile. Network host
+exceptions resolve hostnames to IP addresses when the profile is built. The intended policy allows those IPs,
+not a particular HTTP hostname or URL path; services sharing an IP may also be reachable.
+
+**Limitation**: `sandbox-exec` can reject the generated host-exception profile with
+`host must be * or localhost in network address`. This prevents the child command from
+starting; it does not fall back to unrestricted network access. If you need network access
+to selected hosts, verify the policy on your macOS version and use an external network
+control when `--allow-net` cannot express it.
 
 When reads are restricted, Seatbelt requires data access to the root directory for process startup.
 Sandboxed processes can enumerate names directly under `/`, but cannot read unallowed entries or
@@ -143,14 +172,16 @@ their descendants.
 
 ### Windows
 
-Sandboxing is not currently supported on Windows. A warning is printed and the command runs unsandboxed.
+Filesystem and network sandboxing is not supported on Windows. mise warns and runs the
+command without those OS restrictions. Do not treat a successful Windows invocation with
+sandbox flags as evidence that the filesystem or network policy was enforced.
 
 ## Examples
 
-### Run untrusted script with no filesystem writes
+### Restrict script writes {#run-untrusted-script-with-no-filesystem-writes}
 
 ```bash
-mise x --deny-write -- bash untrusted-script.sh
+mise x --deny-write -- bash script.sh
 ```
 
 ### Build with network isolation
@@ -162,13 +193,14 @@ mise x --deny-net -- make build
 ### Run tool with minimal permissions
 
 ```bash
-mise x --deny-all --allow-read=./src --allow-write=./dist node@20 -- node build.js
+mkdir -p dist
+mise exec --deny-all --allow-read=. --allow-write=./dist -- node build.js
 ```
 
 ### Restrict env vars to a namespace
 
 ```bash
-# Only pass through env vars starting with MYAPP_
+# Pass MYAPP_* in addition to the essential variables
 mise x --allow-env='MYAPP_*' -- node app.js
 
 # Allow multiple patterns
@@ -176,6 +208,10 @@ mise x --allow-env='MYAPP_*' --allow-env='NODE_*' -- node app.js
 ```
 
 ### Sandboxed task definition
+
+Create `coverage/` and `node_modules/.cache/` before running this task on Linux, and adjust
+the paths for your test runner. Allowing `NODE_*` and `npm_*` also exposes any matching
+credentials or runtime options; list exact variable names if a narrower policy is needed.
 
 ```toml
 [tasks.test]

--- a/docs/security.md
+++ b/docs/security.md
@@ -8,7 +8,7 @@ that addresses the operation you are running:
 | Download verification                  | Supported tool installations                    | Check artifact integrity and available signatures or provenance. |
 | [Configuration trust](/cli/trust.html) | Loading project configuration                   | Decide which configuration mise may execute or apply.            |
 | [Safe mode](#safe-mode)                | Processing untrusted project configuration      | Disable project code execution and environment injection.        |
-| [Paranoid mode](/paranoid.html)        | Trust and supported installation verification   | Require content-bound trust and recheck recorded provenance.     |
+| [Paranoid mode](/paranoid.html)        | Trust and supported installation verification   | Bind direct file trust to content and recheck provenance.        |
 | [Sandboxing](/sandboxing.html)         | Commands launched by `mise exec` and `mise run` | Restrict child-process access on supported platforms.            |
 
 These controls have different scopes. For example, trusting configuration does not verify

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,98 +1,101 @@
 # Security
 
-mise includes several supply-chain controls for installing and managing tools. These controls have
-different coverage depending on the backend and the metadata available from upstream.
+mise provides controls for different parts of a development workflow. Choose the control
+that addresses the operation you are running:
+
+| Control                                | Applies to                                      | Purpose                                                          |
+| -------------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------- |
+| Download verification                  | Supported tool installations                    | Check artifact integrity and available signatures or provenance. |
+| [Configuration trust](/cli/trust.html) | Loading project configuration                   | Decide which configuration mise may execute or apply.            |
+| [Safe mode](#safe-mode)                | Processing untrusted project configuration      | Disable project code execution and environment injection.        |
+| [Paranoid mode](/paranoid.html)        | Trust and supported installation verification   | Require content-bound trust and recheck recorded provenance.     |
+| [Sandboxing](/sandboxing.html)         | Commands launched by `mise exec` and `mise run` | Restrict child-process access on supported platforms.            |
+
+These controls have different scopes. For example, trusting configuration does not verify
+an upstream release, and sandboxing a task does not sandbox mise's configuration evaluation.
+Report vulnerabilities through [SECURITY.md](https://github.com/jdx/mise/blob/main/SECURITY.md).
 
 ## Software verification
 
-mise provides native software verification without requiring external dependencies.
-For aqua tools, Cosign/Minisign signatures, SLSA provenance, and GitHub artifact attestations are
-verified automatically using mise's built-in implementation. OpenPGP signature verification for
-Node.js and Swift downloads is likewise built in and requires no external `gpg` binary.
+Verification depends on the backend and the upstream metadata. A checksum detects whether
+bytes match an expected digest; a signature or provenance check also associates an artifact
+with a signer or build identity. The expected checksum, key, or identity must come from a
+source you trust.
 
-To configure aqua verification, which is enabled by default:
+For aqua tools with the corresponding registry metadata, mise has built-in support for
+Cosign and Minisign signatures, SLSA provenance, and GitHub artifact attestations.
+OpenPGP verification for Node.js and Swift is also built in; it does not need an external
+`gpg` executable. [packslip](/dev-tools/backends/packslip.html) verifies signed manifests and
+artifact digests.
 
-```sh
-# Disable specific verification methods if needed
-export MISE_AQUA_COSIGN=false
-export MISE_AQUA_SLSA=false
-export MISE_AQUA_GITHUB_ATTESTATIONS=false
-export MISE_AQUA_MINISIGN=false
-```
+Aqua's verification methods are enabled by default. See the
+[aqua settings](/dev-tools/backends/aqua.html#settings) for individual controls. If verification
+fails, check the selected artifact and the underlying error before changing those settings;
+see [checksum errors](/errors.html).
 
-For lockfile checksum and provenance behavior, see [mise.lock](/dev-tools/mise-lock.html).
+A [lockfile](/dev-tools/mise-lock.html) can record checksums and provenance. By default, a
+supported installation can reuse recorded provenance instead of repeating its verification.
+Use [`locked_verify_provenance`](/configuration/settings.html#locked_verify_provenance) or
+[paranoid mode](/paranoid.html#provenance-re-verification) when installation should recheck it.
+This does not audit the contents of tools that are already installed and skipped.
 
 ## Safe mode
 
-Safe mode (`MISE_SAFE=1`, or the [`safe`](/configuration/settings.html#safe) setting) is a hard
-boundary against **project configuration executing code**. It is intended for running mise against
-configuration you do not control — most notably automation that refreshes `mise.lock` on pull
-request branches, such as a scheduled `mise lock --bump` job (see
-[Bumping Locked Versions](/dev-tools/mise-lock.html#bumping-locked-versions)).
+Set `MISE_SAFE=1` when automation must process configuration it does not control, such as
+resolving tool versions from a pull request. For example:
 
 ```sh
-# resolve tool versions from untrusted config without executing any of it
 MISE_SAFE=1 mise lock --bump --dry-run --json
 ```
 
-When enabled, mise **refuses with an error** (never a silent fallback) to:
+Remove `--dry-run` when the command should update the lockfile. Safe mode does not itself
+make a command read-only.
 
-- run `exec()` or `read_file()` in config templates
-- run hooks (suppressed like `--no-hooks`, since hooks fire ambiently from `mise env`/`hook-env`)
-- run tool-level `postinstall` hooks or apply tool-level `install_env` during installation
-- run tasks
-- execute asdf plugin scripts
-- install plugins
+### Refused operations
 
-It also **ignores environment and shell configuration from project (non-global) config** — `[env]`
-values, `_.path`, `_.file`, and `[shell_alias]` entries. These would otherwise be applied to your
-shell environment (env vars and aliases are emitted through `hook-env`) and to the
-subprocesses mise spawns during version resolution (for example `go list` or a vfox plugin hook),
-which is an indirect code-execution vector (`PATH`, `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`,
-`NODE_OPTIONS`, …) that safe mode is meant to close. Global and system config (e.g.
-`~/.config/mise/config.toml`) is operator-owned and still applies, mirroring the
-[trust](/cli/trust.html) model.
+Safe mode returns an error for operations that would execute project-selected code:
 
-`_.source` is treated as code execution rather than environment injection, so it is ignored in safe
-mode regardless of where it is defined — including operator-owned global config.
+- Template `exec()` and `read_file()` calls.
+- Task execution.
+- Tool-level `postinstall` hooks and `install_env` during installation.
+- asdf plugin scripts and plugin installation.
 
-`[settings]` from project (non-global) config are also ignored, so an untrusted repo cannot change
-mise's behavior during resolution (for example disabling verification or redirecting a backend).
-Global/system settings still apply. Specific project settings may be allowlisted in the future if
-they are both safe and necessary.
+### Ignored configuration
 
-Because a config loaded in safe mode is inert — it can neither execute code nor inject environment —
-**safe mode does not require configs to be trusted.** mise loads untrusted configs without a
-[trust](/cli/trust.html) prompt or error when `safe` is set, since there is nothing a config can do
-to compromise the host. This is what lets automation run `mise lock` against pull-request config
-without a preceding `mise trust`.
+Some behavior is suppressed so metadata queries can still run:
 
-Version resolution still works for every HTTP-based backend — `core`, `aqua`, `github`, `gitlab`,
-`http`, `cargo`, `pipx`, `gem`, `dotnet`, and `npm` — as well as `go` (which runs with
-`GOTOOLCHAIN=local` so a project `go.mod` cannot trigger a toolchain download). Refreshing
-`mise.lock` and listing installed tools work normally.
+- Shell and installation hooks are skipped, like `--no-hooks`.
+- Project `[env]`, environment directives, and `[shell_alias]` do not affect the environment.
+- Project `[settings]` are ignored, preventing a repository from disabling verification or
+  redirecting a backend through settings.
+- `_.source` is ignored everywhere, including global configuration.
 
-Already-installed and embedded vfox plugins also keep working: their code was chosen by the
-operator, not by the repository being processed, and version resolution short-circuits on
-plugins that are not installed without executing anything.
+Operator-owned global and system configuration still applies, apart from these explicit
+restrictions. Review that configuration and the environment of the process running mise.
+The [`safe`](/configuration/settings.html#safe) setting is global-only, so a project cannot
+turn it off for itself.
 
-::: tip
-Safe mode is a code-execution boundary; it does not replace the [trust](/cli/trust.html)
-system. Untrusted configs still require `mise trust` (or a
-[trusted config path](/configuration/settings.html#trusted_config_paths)). Safe mode limits what a
-config can do; trust limits which configs are loaded.
-:::
+### Trust and backend support
 
-`MISE_SAFE` is `global_only`, so it can only be set via the environment or global config — a project
-`mise.toml` cannot turn it off for itself.
+Safe mode loads otherwise untrusted configuration without a trust prompt or untrusted-config
+error, because the project execution and environment features above are disabled. This also
+applies when paranoid mode is enabled. Syntax errors and unsupported operations still fail;
+a successful load does not mean the configuration has been marked trusted for later normal use.
+
+HTTP-based version resolution continues to work for supported backends. The Go backend uses
+`GOTOOLCHAIN=local` to prevent a project `go.mod` from triggering a toolchain download during
+metadata queries. Already-installed or embedded vfox plugin code can still run; a missing
+plugin cannot be installed in safe mode.
+
+Safe mode controls how mise handles project configuration. It is not an operating-system
+sandbox for the mise process, its network requests, or operator-installed plugins. Use
+[sandboxing](/sandboxing.html) for child-process restrictions, accounting for platform limits.
 
 ## Minimum release age
 
 To limit supply-chain risk, you can restrict mise to only install versions released before a
-certain date or duration. This is similar to Renovate's
-[minimum release age](https://docs.renovatebot.com/key-concepts/minimum-release-age/) concept:
-newly published versions are ignored until they have been available for a configurable amount of
-time.
+certain date or duration. Newly published versions can be held back for a configurable period. This delay gives
+time for problems to be discovered; it is not evidence that an older release is trustworthy.
 
 ```toml
 # mise.toml
@@ -101,8 +104,8 @@ minimum_release_age = "7d"  # only install versions released more than 7 days ag
 ```
 
 The setting supports relative durations (`7d`, `6mo`, `1y`) and absolute dates (`2024-06-01`). For most
-backends, it only affects fuzzy version resolution, such as `node@20` or `latest`.
-Explicitly pinned versions like `node@22.5.0` bypass the filter.
+backends, it only affects fuzzy version resolution, such as `node@24` or `latest`.
+Explicitly pinned versions like `node@24.0.0` bypass the filter.
 During ordinary toolset resolution, already-installed fuzzy matches remain eligible:
 `minimum_release_age` limits remote version selection and does not make an installed version
 inactive. Lockfile generation may re-check fuzzy installed matches against release metadata.

--- a/docs/security.md
+++ b/docs/security.md
@@ -34,7 +34,8 @@ fails, check the selected artifact and the underlying error before changing thos
 see [checksum errors](/errors.html).
 
 A [lockfile](/dev-tools/mise-lock.html) can record checksums and provenance. By default, a
-supported installation can reuse recorded provenance instead of repeating its verification.
+supported installation can reuse recorded provenance instead of repeating its verification
+when the target platform's lockfile entry contains both a checksum and verified provenance.
 Use [`locked_verify_provenance`](/configuration/settings.html#locked_verify_provenance) or
 [paranoid mode](/paranoid.html#provenance-re-verification) when installation should recheck it.
 This does not audit the contents of tools that are already installed and skipped.

--- a/docs/url-replacements.md
+++ b/docs/url-replacements.md
@@ -1,61 +1,50 @@
 # URL Replacements
 
-mise does not include a built-in registry for downloading artifacts.
-Instead, it retrieves remote registry manifests, which specify the URLs for downloading tools.
+Use `url_replacements` to route requests made by mise's HTTP client through an internal
+mirror or proxy. This can cover release metadata and artifact downloads, including Conda
+channel metadata. It does not rewrite requests made independently by a plugin script,
+Git, or an external package manager; configure those clients separately.
 
-In some environments — such as enterprises or DMZs — these URLs may not be directly accessible and must be accessed through a proxy or internal mirror.
-
-URL replacements allow you to modify or redirect any URL that mise attempts to access, making it possible to use internal proxies, mirrors, or alternative sources as needed.
-
-This includes conda channel metadata fetched while resolving packages as well as the package
-artifacts downloaded after resolution. The conda lockfile continues to record the logical
-upstream URLs, and replacements are applied when each request is sent.
+A replacement changes where a request is sent. It does not change which asset a backend
+selects, create a mirror, or generate a new checksum. For Conda, lockfiles retain the logical
+upstream URLs and the replacement is applied when the request is sent.
 
 ## Configuration Examples
 
-In mise.toml (single line):
+Put machine-specific mirror settings in global configuration, or share them in `mise.toml`
+when every user of the project has access to the mirror. For an exact URL prefix:
 
 ```toml
 [settings]
-url_replacements = { "example.com" = "mirror.example.com" }
+url_replacements = { "https://example.com/" = "https://mirror.example.com/" }
 ```
 
-In mise.toml (multiline):
+The table form is convenient for several rules:
 
 ```toml
 [settings.url_replacements]
-"example.com" = "mirror.example.com"
-"releases.hashicorp.com" = "hashicorp.example.com"
+"https://example.com/" = "https://mirror.example.com/"
+"https://releases.hashicorp.com/" = "https://hashicorp.example.com/"
 ```
 
-RegEx example:
-
-```toml
-[settings.url_replacements]
-"regex:^http://(.+)" = "https://$1"
-"regex:^https://github\\.com/([^/]+)/([^/]+)/releases/download/(.+)" = "https://hub.example.com/artifactory/github/$1/$2/$3"
-```
+Replace the example mirror hosts with servers you operate or trust. They must serve the
+paths and metadata expected by the original backend. Inspect `mise settings ls` to confirm
+the settings in effect; use debug logging on the failing command to inspect its request URL.
 
 ## Simple Hostname Replacement
 
-For simple hostname-based mirroring, the key is the original hostname/domain to replace,
-and the value is the replacement string. The replacement happens by searching and replacing
-the pattern anywhere in the full URL string (including protocol, hostname, path, and query parameters).
+Despite often being used for hostnames, a plain key is a **substring match on the full URL**.
+It can match a path or query string as well as a hostname. A key such as `github.com` also
+matches `api.github.com` and `github.com.example.org`.
 
-Examples:
-
-- `github.com` -> `mirror.example.com` replaces GitHub hostnames
-- `https://github.com` -> `https://mirror.example.com` includes the protocol, so it excludes hosts like 'api.github.com'
-- `https://github.com` -> `https://proxy.example.com/github-mirror` replaces GitHub with a corporate proxy
-- `http://example.net` -> `https://example.net` changes the protocol from HTTP to HTTPS
-
-See [Security Considerations](#security-considerations) for important warnings about credential handling.
+Including the scheme and trailing `/`, such as `https://github.com/`, avoids matching those
+hostnames. For a rule that must match only at the start of a URL, use an anchored regex.
 
 ## Advanced Regex Replacement
 
-For more complex URL transformations, you can use regex patterns. When a key starts with `regex:`,
-it is treated as a regular expression pattern that can match and transform any part of the URL.
-The value can use capture groups from the regex pattern.
+Prefix a key with `regex:` to use the Rust regex engine. Capture groups in replacement
+values use `$1`, `$2`, or named captures. The examples below use TOML literal strings for
+regex keys, so backslashes do not need doubling.
 
 ### Regex Examples
 
@@ -64,115 +53,111 @@ The value can use capture groups from the regex pattern.
 ```toml
 [settings]
 url_replacements = {
-  "regex:^http://(.+)" = "https://$1"
+  'regex:^http://(.+)' = "https://$1",
 }
 ```
 
-This converts any HTTP URL to HTTPS by capturing everything after "http://" and replacing it with "https://".
+Use this only when the destination supports HTTPS. A scheme change does not make an
+untrusted server trustworthy.
 
 #### 2. GitHub Release Mirroring with Path Restructuring
 
 ```toml
 [settings]
 url_replacements = {
-  "regex:^https://github\\.com/([^/]+)/([^/]+)/releases/download/(.+)" =
-    "https://hub.example.com/artifactory/github/$1/$2/$3"
+  'regex:^https://github\.com/([^/]+)/([^/]+)/releases/download/(.+)' = "https://hub.example.com/artifactory/github/$1/$2/$3",
 }
 ```
 
-This transforms `https://github.com/owner/repo/releases/download/v1.0.0/file.tar.gz`
-to `https://hub.example.com/artifactory/github/owner/repo/v1.0.0/file.tar.gz`.
+This maps `https://github.com/owner/repo/releases/download/v1.0.0/file.tar.gz` to
+`https://hub.example.com/artifactory/github/owner/repo/v1.0.0/file.tar.gz`.
+It does not rewrite `api.github.com` requests; add a separate rule if release metadata must
+also pass through a mirror.
 
 #### 3. Subdomain to Path Conversion
 
 ```toml
 [settings]
 url_replacements = {
-  "regex:^https://([^.]+)\\.cdn\\.example\\.com/(.+)" =
-    "https://unified-cdn.example.com/$1/$2"
+  'regex:^https://([^.]+)\.cdn\.example\.com/(.+)' = "https://unified-cdn.example.com/$1/$2",
 }
 ```
 
-This converts subdomain-based URLs to path-based URLs on a unified CDN.
+For example, `https://eu.cdn.example.com/tool.tar.gz` becomes
+`https://unified-cdn.example.com/eu/tool.tar.gz`.
 
 #### 4. Multiple Replacement Patterns (processed in order)
 
 ```toml
 [settings]
 url_replacements = {
-  "regex:^https://github\\.com/microsoft/(.+)" =
-    "https://internal.example.org/microsoft/$1",
-  "regex:^https://github\\.com/(.+)" =
-    "https://public.example.org/github/$1",
-  "releases.hashicorp.com" = "hashicorp.example.net"
+  # Put the specific rule before the general GitHub rule.
+  'regex:^https://github\.com/microsoft/(.+)' = "https://internal.example.org/microsoft/$1",
+  'regex:^https://github\.com/(.+)' = "https://public.example.org/github/$1",
+  "https://releases.hashicorp.com/" = "https://hashicorp.example.net/",
 }
 ```
 
-The first regex catches Microsoft repositories specifically, the second catches all other GitHub URLs,
-and the simple replacement handles HashiCorp.
-
-## Use Cases
-
-1. **Corporate Mirrors**: Replace public download URLs with internal corporate mirrors
-2. **Custom Registries**: Redirect package downloads to custom or private registries
-3. **Geographic Optimization**: Route downloads to geographically closer mirrors
-4. **Protocol Changes**: Convert HTTP URLs to HTTPS or vice versa
+These examples use TOML 1.1 multiline inline tables, including comments and trailing commas.
+The first rule handles Microsoft repositories, the second handles other GitHub paths, and
+the last handles HashiCorp downloads.
 
 ## Regex Syntax
 
-mise uses the Rust regex engine, which supports:
+Use `^` to anchor the beginning, `(.+)` for a capture, and `[^/]+` for a path component.
+Escape a literal dot with `\.` in a TOML literal string. In a double-quoted TOML string,
+write `\\.` instead because TOML also processes backslash escapes.
 
-- `^` and `$` for anchors (start/end of string)
-- `(.+)` for capture groups (use `$1`, `$2`, etc. in replacement)
-- `[^/]+` for character classes (matches any character except `/`)
-- `\\.` for escaping special characters (note: double backslash required in TOML)
-- `*`, `+`, `?` for quantifiers
-- `|` for alternation
-
-You can test your regex on regex101.com (see [example](https://regex101.com/r/rmcIE1/1)).
-Full regex syntax documentation: <https://docs.rs/regex/latest/regex/#syntax>
+The [Rust regex documentation](https://docs.rs/regex/latest/regex/#syntax) describes the
+supported syntax. Backreferences inside the pattern and lookaround are not supported.
+When a capture is followed by letters or digits, use braces to separate its name, such as
+`${1}suffix`.
 
 ## Precedence and Matching
 
-- URL replacements are processed in the order they appear in the configuration (IndexMap insertion order)
-- Both regex patterns (keys starting with `regex:`) and simple string replacements are processed in this same order
-- The first matching pattern is used; subsequent patterns are ignored for that URL
-- If no patterns match, the original URL is used unchanged
+Rules run in configuration insertion order. mise uses the first rule that changes the URL
+into another valid URL, then stops; replacements do not chain. Put specific rules before
+broad ones. If a matching rule leaves the URL unchanged or produces an invalid URL, mise
+continues to later rules. Invalid regex patterns produce a warning and are skipped.
+
+If no rule produces a valid changed URL, the original request is used. URL replacements are
+therefore routing rules, not an outbound-host allow list. Use network policy outside mise
+when traffic must never reach an upstream host.
 
 ## Security Considerations
 
-When using regex patterns, ensure your replacement URLs point to trusted sources,
-as this feature can redirect tool downloads to arbitrary locations.
+Authentication headers prepared for the original URL can be sent to the replacement server.
+Only route requests to servers trusted to receive both the artifacts and those credentials.
+A host-changing rewrite can replace those headers with mirror credentials from netrc, as
+described below; a rewrite alone does not remove them.
 
-> [!WARNING]
-> **Credential Leaking**: When using `url_replacements`, any authentication headers (like `Authorization: Bearer <TOKEN>`) generated for the original URL (e.g., `api.github.com`) are **preserved** and sent to the replaced URL.
->
-> This is by design to allow authentication with internal proxies that forward requests to upstream services (GitHub, GitLab, Forgejo, etc.). However, it means you must **only** replace URLs with trusted servers. Redirecting to an untrusted server will leak your credentials to that server.
->
-> **Best Practice**: Use the `^` anchor in your regex patterns to ensure you are matching the start of the URL.
->
-> **Bad**: `"regex:github\\.com"` (matches `evil-github.com`)
-> **Good**: `"regex:^https://github\\.com"` (only matches actual GitHub URLs)
+Use both a start anchor and a hostname boundary for an exact host:
+
+```toml
+[settings.url_replacements]
+'regex:^https://github\.com/' = "https://mirror.example.com/"
+```
+
+The trailing slash matters: `^https://github\.com` by itself also matches
+`https://github.com.example.org/`. Avoid placing credentials directly in replacement URLs,
+which can appear in logs.
 
 ## Authentication
 
-URL replacements can be used with `~/.netrc` (or `~/_netrc` on Windows) to authenticate with the replaced URL.
-Replacements are applied _before_ the netrc lookup, so you should use the hostname of the _replaced_ URL in your netrc file.
-
-For example, if you have this in `mise.toml`:
-
-```toml
-[settings]
-url_replacements = { "regex:^https://github\\.com" = "https://nexus.example.com" }
-```
-
-> [!NOTE]
-> Credentials from `.netrc` take precedence over and will **overwrite** any default authentication headers (such as those from `MISE_GITHUB_TOKEN` or other environment variables).
-
-You should have this in `~/.netrc`:
+mise looks up netrc credentials **after** rewriting the URL. Use the replacement hostname
+in `~/.netrc`, or `~/_netrc` on Windows (`~/.netrc` is a fallback there). The
+[`netrc_file`](/configuration/settings.html#netrc_file) setting can select another file.
 
 ```netrc
-machine nexus.example.com
+machine mirror.example.com
   login myusername
   password mypassword
 ```
+
+Use your mirror credentials and restrict the file's permissions on Unix, for example
+`chmod 600 ~/.netrc`.
+
+Netrc is normally a fallback: an existing Authorization header takes precedence. When a
+replacement changes the hostname, matching netrc credentials for the new host can override
+that header. A rewrite that only changes a path or query on the same host keeps existing
+Authorization. See [GitHub Tokens](/dev-tools/github-tokens.html) for upstream token sources.

--- a/docs/url-replacements.md
+++ b/docs/url-replacements.md
@@ -128,11 +128,20 @@ when traffic must never reach an upstream host.
 
 Authentication headers prepared for the original URL can be sent to the replacement server.
 Only route requests to servers trusted to receive both the artifacts and those credentials.
-When an HTTPS-to-HTTP rewrite would send an authorization header, cookie, API key, other recognized
-credential header, or URL credentials, mise refuses the request rather than exposing them without
-transport encryption. An unauthenticated downgrade is still allowed.
-A host-changing rewrite removes credentials scoped to the original host, then can add mirror
-credentials from netrc as described below. Same-host rewrites retain the existing credentials.
+A host-changing rewrite removes credentials scoped to the original host — an authorization header,
+cookie, API key, other recognized credential header, or userinfo carried over from the original URL
+— and can then add mirror credentials from netrc as described below. Same-host rewrites retain the
+existing credentials.
+
+When an HTTPS-to-HTTP rewrite would still send credentials after that scoping, mise refuses the
+request rather than exposing them without transport encryption. This covers a same-host downgrade
+and credentials written into the replacement rule itself. An unauthenticated downgrade is still
+allowed, as is a downgrade whose credentials come from a netrc entry for the replacement host:
+mise sends those to a plain `http://` URL with no rewrite involved, so a rewrite is not stricter.
+
+Both rules apply to mise's HTTP client, GitHub attestation requests, and Conda channel traffic.
+For Sigstore TUF metadata, an insecure credential-bearing downgrade is ignored and the secure
+default TUF URL remains in use.
 
 Use both a start anchor and a hostname boundary for an exact host:
 

--- a/docs/url-replacements.md
+++ b/docs/url-replacements.md
@@ -79,7 +79,7 @@ also pass through a mirror.
 ```toml
 [settings]
 url_replacements = {
-  'regex:^https://([^.]+)\.cdn\.example\.com/(.+)' = "https://unified-cdn.example.com/$1/$2",
+  'regex:^https://([^./]+)\.cdn\.example\.com/(.+)' = "https://unified-cdn.example.com/$1/$2",
 }
 ```
 
@@ -128,6 +128,8 @@ when traffic must never reach an upstream host.
 
 Authentication headers prepared for the original URL can be sent to the replacement server.
 Only route requests to servers trusted to receive both the artifacts and those credentials.
+Use HTTPS destinations for credential-bearing requests; rewriting to HTTP can send the
+original authentication headers without transport encryption.
 A host-changing rewrite can replace those headers with mirror credentials from netrc, as
 described below; a rewrite alone does not remove them.
 

--- a/docs/url-replacements.md
+++ b/docs/url-replacements.md
@@ -128,11 +128,11 @@ when traffic must never reach an upstream host.
 
 Authentication headers prepared for the original URL can be sent to the replacement server.
 Only route requests to servers trusted to receive both the artifacts and those credentials.
-When an HTTPS-to-HTTP rewrite would send an authorization header or URL credentials, mise refuses
-the request rather than exposing them without transport encryption. An unauthenticated downgrade
-is still allowed.
-A host-changing rewrite can replace those headers with mirror credentials from netrc, as
-described below; a rewrite alone does not remove them.
+When an HTTPS-to-HTTP rewrite would send an authorization header, cookie, API key, other recognized
+credential header, or URL credentials, mise refuses the request rather than exposing them without
+transport encryption. An unauthenticated downgrade is still allowed.
+A host-changing rewrite removes credentials scoped to the original host, then can add mirror
+credentials from netrc as described below. Same-host rewrites retain the existing credentials.
 
 Use both a start anchor and a hostname boundary for an exact host:
 

--- a/docs/url-replacements.md
+++ b/docs/url-replacements.md
@@ -128,8 +128,9 @@ when traffic must never reach an upstream host.
 
 Authentication headers prepared for the original URL can be sent to the replacement server.
 Only route requests to servers trusted to receive both the artifacts and those credentials.
-Use HTTPS destinations for credential-bearing requests; rewriting to HTTP can send the
-original authentication headers without transport encryption.
+When an HTTPS-to-HTTP rewrite would send an authorization header or URL credentials, mise refuses
+the request rather than exposing them without transport encryption. An unauthenticated downgrade
+is still allowed.
 A host-changing rewrite can replace those headers with mirror credentials from netrc, as
 described below; a rewrite alone does not remove them.
 

--- a/src/backend/conda.rs
+++ b/src/backend/conda.rs
@@ -58,8 +58,31 @@ struct CondaOptions<'a> {
 #[derive(Debug)]
 struct UrlReplacementMiddleware;
 
-fn rewrite_request_url(request: &mut reqwest::Request, rewriter: impl FnOnce(&mut url::Url)) {
+/// A `url_replacements` rewrite that [`UrlReplacementMiddleware`] refused to send.
+///
+/// `reqwest_middleware` wants a `std::error::Error`, which `eyre::Report` is not.
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+struct UrlReplacementRefused(String);
+
+/// Apply `url_replacements` to a repodata/package request, applying the same credential
+/// rules [`crate::http::Client`] applies to a rewritten URL: refuse a transport downgrade
+/// that would expose credentials, then drop credentials scoped to the original host.
+///
+/// Rattler drives its own client, so these requests never reach `crate::http::Client` and
+/// would otherwise bypass both rules.
+fn rewrite_request_url(
+    request: &mut reqwest::Request,
+    rewriter: impl FnOnce(&mut url::Url),
+) -> Result<()> {
+    let original = request.url().clone();
     rewriter(request.url_mut());
+    // `headers_mut` and `url_mut` cannot be borrowed at once, so scope the URL through a copy.
+    let mut url = request.url().clone();
+    crate::http::clear_cross_host_credentials(request.headers_mut(), &original, &mut url);
+    crate::http::ensure_secure_replacement_credentials(&original, &url, request.headers())?;
+    *request.url_mut() = url;
+    Ok(())
 }
 
 #[async_trait]
@@ -70,7 +93,9 @@ impl Middleware for UrlReplacementMiddleware {
         extensions: &mut Extensions,
         next: Next<'_>,
     ) -> reqwest_middleware::Result<reqwest::Response> {
-        rewrite_request_url(&mut request, apply_url_replacements);
+        rewrite_request_url(&mut request, apply_url_replacements).map_err(|err| {
+            reqwest_middleware::Error::middleware(UrlReplacementRefused(format!("{err:#}")))
+        })?;
         next.run(request, extensions).await
     }
 }
@@ -1084,7 +1109,8 @@ mod tests {
 
         rewrite_request_url(&mut request, |url| {
             *url = Url::parse("https://mirror.invalid/conda/noarch/repodata.json").unwrap();
-        });
+        })
+        .unwrap();
 
         assert_eq!(
             request.url().as_str(),
@@ -1103,9 +1129,101 @@ mod tests {
         let original = Url::parse("https://upstream.invalid/channel/noarch/repodata.json").unwrap();
         let mut request = reqwest::Request::new(reqwest::Method::GET, original.clone());
 
-        rewrite_request_url(&mut request, |_| {});
+        rewrite_request_url(&mut request, |_| {}).unwrap();
 
         assert_eq!(request.url(), &original);
+    }
+
+    #[test]
+    fn request_url_rewrite_rejects_credential_downgrade() {
+        let original = Url::parse("https://upstream.invalid/channel/noarch/repodata.json").unwrap();
+        let mut request = reqwest::Request::new(reqwest::Method::GET, original);
+        request.headers_mut().insert(
+            reqwest::header::AUTHORIZATION,
+            reqwest::header::HeaderValue::from_static("Bearer channel-token"),
+        );
+
+        let err = rewrite_request_url(&mut request, |url| {
+            *url = Url::parse("http://upstream.invalid/conda/noarch/repodata.json").unwrap();
+        })
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("refusing to send credentials over an HTTPS-to-HTTP URL replacement")
+        );
+    }
+
+    #[test]
+    fn request_url_rewrite_allows_unauthenticated_downgrade() {
+        let original = Url::parse("https://upstream.invalid/channel/noarch/repodata.json").unwrap();
+        let mut request = reqwest::Request::new(reqwest::Method::GET, original);
+
+        rewrite_request_url(&mut request, |url| {
+            *url = Url::parse("http://mirror.invalid/conda/noarch/repodata.json").unwrap();
+        })
+        .unwrap();
+
+        assert_eq!(
+            request.url().as_str(),
+            "http://mirror.invalid/conda/noarch/repodata.json"
+        );
+    }
+
+    #[test]
+    fn request_url_rewrite_scopes_credentials_to_the_original_host() {
+        let original =
+            Url::parse("https://user:password@upstream.invalid/channel/noarch/repodata.json")
+                .unwrap();
+        let mut request = reqwest::Request::new(reqwest::Method::GET, original);
+        request.headers_mut().insert(
+            reqwest::header::AUTHORIZATION,
+            reqwest::header::HeaderValue::from_static("Bearer channel-token"),
+        );
+        request.headers_mut().insert(
+            "x-conda-test",
+            reqwest::header::HeaderValue::from_static("preserved"),
+        );
+
+        rewrite_request_url(&mut request, |url| {
+            url.set_host(Some("mirror.invalid")).unwrap();
+            url.set_scheme("http").unwrap();
+        })
+        .unwrap();
+
+        assert!(
+            !request
+                .headers()
+                .contains_key(reqwest::header::AUTHORIZATION)
+        );
+        assert_eq!(request.headers()["x-conda-test"], "preserved");
+        assert_eq!(request.url().scheme(), "http");
+        assert_eq!(request.url().username(), "");
+        assert_eq!(request.url().password(), None);
+    }
+
+    #[test]
+    fn request_url_rewrite_keeps_credentials_on_the_same_host() {
+        let original =
+            Url::parse("https://user:password@upstream.invalid/channel/noarch/repodata.json")
+                .unwrap();
+        let mut request = reqwest::Request::new(reqwest::Method::GET, original);
+        request.headers_mut().insert(
+            reqwest::header::AUTHORIZATION,
+            reqwest::header::HeaderValue::from_static("Bearer channel-token"),
+        );
+
+        rewrite_request_url(&mut request, |url| {
+            url.set_path("/mirror/noarch/repodata.json");
+        })
+        .unwrap();
+
+        assert_eq!(
+            request.headers()[reqwest::header::AUTHORIZATION],
+            "Bearer channel-token"
+        );
+        assert_eq!(request.url().username(), "user");
+        assert_eq!(request.url().password(), Some("password"));
     }
 
     #[test]

--- a/src/github/sigstore.rs
+++ b/src/github/sigstore.rs
@@ -80,19 +80,21 @@ fn routed_api_url(api_url: &str, has_credentials: bool) -> AttestationResult<Str
 /// otherwise `None` (meaning: keep the sigstore crate's default behavior). The
 /// result is pushed into `mise-sigstore` via [`mise_sigstore::set_tuf_url`] so
 /// the TUF root fetch follows the same mirror as the rest of mise's traffic.
-fn routed_tuf_url() -> AttestationResult<Option<String>> {
+fn routed_tuf_url() -> Option<String> {
     let Ok(mut url) = url::Url::parse(mise_sigstore::DEFAULT_TUF_URL) else {
         debug!(
             "invalid Sigstore TUF URL, skipping url_replacements: {}",
             mise_sigstore::DEFAULT_TUF_URL
         );
-        return Ok(None);
+        return None;
     };
     let original = url.clone();
     crate::http::apply_url_replacements(&mut url);
-    crate::http::ensure_secure_url_replacement(&original, &url, false)
-        .map_err(|err| AttestationError::Verification(err.to_string()))?;
-    Ok((url != original).then(|| url.to_string()))
+    if let Err(err) = crate::http::ensure_secure_url_replacement(&original, &url, false) {
+        warn!("{err}; ignoring insecure Sigstore TUF URL replacement");
+        return None;
+    }
+    (url != original).then(|| url.to_string())
 }
 
 /// Build a [`RetryConfig`] from mise's HTTP settings so attestation requests
@@ -131,7 +133,7 @@ pub(crate) async fn verify_attestation(
     api_url: Option<&str>,
     use_versions_host: bool,
 ) -> AttestationResult<bool> {
-    mise_sigstore::set_tuf_url(routed_tuf_url()?);
+    mise_sigstore::set_tuf_url(routed_tuf_url());
     let mut digest = None;
     if use_versions_host_for_attestations(api_url, use_versions_host) {
         let artifact_digest = mise_sigstore::calculate_file_digest(artifact_path).await?;
@@ -223,7 +225,7 @@ pub(crate) async fn verify_attestation_with_predicate_type(
     api_url: Option<&str>,
     use_versions_host: bool,
 ) -> AttestationResult<bool> {
-    mise_sigstore::set_tuf_url(routed_tuf_url()?);
+    mise_sigstore::set_tuf_url(routed_tuf_url());
     let Some(predicate_type) = predicate_type else {
         return verify_attestation(
             artifact_path,
@@ -378,7 +380,7 @@ pub(crate) async fn verify_slsa_provenance(
     provenance_path: &Path,
     min_level: u8,
 ) -> AttestationResult<bool> {
-    mise_sigstore::set_tuf_url(routed_tuf_url()?);
+    mise_sigstore::set_tuf_url(routed_tuf_url());
     mise_sigstore::verify_slsa_provenance(artifact_path, provenance_path, min_level).await
 }
 
@@ -387,7 +389,7 @@ pub(crate) async fn verify_slsa_provenance_artifacts(
     artifacts: &[SlsaArtifact],
     min_level: u8,
 ) -> AttestationResult<bool> {
-    mise_sigstore::set_tuf_url(routed_tuf_url()?);
+    mise_sigstore::set_tuf_url(routed_tuf_url());
     mise_sigstore::verify_slsa_provenance_artifacts(provenance_path, artifacts, min_level).await
 }
 
@@ -404,7 +406,7 @@ pub(crate) async fn verify_cosign_signature(
     artifact_path: &Path,
     sig_or_bundle_path: &Path,
 ) -> AttestationResult<bool> {
-    mise_sigstore::set_tuf_url(routed_tuf_url()?);
+    mise_sigstore::set_tuf_url(routed_tuf_url());
     mise_sigstore::verify_cosign_signature(artifact_path, sig_or_bundle_path).await
 }
 
@@ -414,7 +416,7 @@ pub(crate) async fn verify_cosign_signature_with_key(
     sig_or_bundle_path: &Path,
     public_key_path: &Path,
 ) -> AttestationResult<bool> {
-    mise_sigstore::set_tuf_url(routed_tuf_url()?);
+    mise_sigstore::set_tuf_url(routed_tuf_url());
     mise_sigstore::verify_cosign_signature_with_key(
         artifact_path,
         sig_or_bundle_path,
@@ -684,7 +686,7 @@ mod tests {
                 => "https://tuf-mirror.example.com".to_string(),
         }));
 
-        let routed = routed_tuf_url().unwrap();
+        let routed = routed_tuf_url();
 
         assert_eq!(routed.as_deref(), Some("https://tuf-mirror.example.com/"));
     }
@@ -693,21 +695,17 @@ mod tests {
     fn test_routed_tuf_url_none_without_replacement() {
         let _settings = SettingsGuard::new(None);
 
-        assert_eq!(routed_tuf_url().unwrap(), None);
+        assert_eq!(routed_tuf_url(), None);
     }
 
     #[test]
-    fn test_routed_tuf_url_rejects_userinfo_downgrade() {
+    fn test_routed_tuf_url_ignores_userinfo_downgrade() {
         let _settings = SettingsGuard::new(Some(indexmap::indexmap! {
             "https://tuf-repo-cdn.sigstore.dev".to_string()
                 => "http://user:password@tuf-mirror.example.com".to_string(),
         }));
 
-        let err = routed_tuf_url().unwrap_err();
-
-        assert!(err.to_string().contains("refusing to send credentials"));
-        assert!(!err.to_string().contains("password"));
-        assert!(!is_api_failure(&err));
+        assert_eq!(routed_tuf_url(), None);
     }
 
     #[test]

--- a/src/github/sigstore.rs
+++ b/src/github/sigstore.rs
@@ -58,17 +58,19 @@ fn resolve_token_for_wrapper(api_url: Option<&str>) -> Option<String> {
     crate::github::resolve_token_for_api_url(url)
 }
 
-fn routed_api_url(api_url: &str) -> String {
+fn routed_api_url(api_url: &str, has_credentials: bool) -> AttestationResult<String> {
     let Ok(mut url) = url::Url::parse(api_url) else {
         debug!("invalid GitHub attestation API URL, skipping url_replacements: {api_url}");
-        return api_url.to_string();
+        return Ok(api_url.to_string());
     };
     let original = url.clone();
     crate::http::apply_url_replacements(&mut url);
+    crate::http::ensure_secure_url_replacement(&original, &url, has_credentials)
+        .map_err(|err| AttestationError::Api(err.to_string()))?;
     if url == original {
-        api_url.to_string()
+        Ok(api_url.to_string())
     } else {
-        url.to_string()
+        Ok(url.to_string())
     }
 }
 
@@ -105,7 +107,7 @@ fn mise_retry_config() -> RetryConfig {
 
 fn attestation_client(api_url: &str) -> AttestationResult<AttestationClient> {
     let token = resolve_token_for_wrapper(Some(api_url));
-    let base_url = routed_api_url(api_url);
+    let base_url = routed_api_url(api_url, token.is_some())?;
     let mut builder = AttestationClient::builder()
         .base_url(&base_url)
         .retry_config(mise_retry_config());
@@ -177,7 +179,7 @@ pub(crate) async fn verify_attestation(
     }
 
     let token = resolve_token_for_wrapper(api_url);
-    let base_url = routed_api_url(api_url.unwrap_or(crate::github::API_URL));
+    let base_url = routed_api_url(api_url.unwrap_or(crate::github::API_URL), token.is_some())?;
     if let Some(digest) = digest {
         mise_sigstore::verify_github_attestation_with_base_url_and_digest(
             mise_sigstore::GithubAttestationRequest {
@@ -310,7 +312,7 @@ pub(crate) async fn detect_attestations(
     }
 
     let token = resolve_token_for_wrapper(Some(api_url));
-    let base_url = routed_api_url(api_url);
+    let base_url = routed_api_url(api_url, token.is_some()).map_err(DetectError::SourceCreation)?;
     let source = GitHubSource::with_base_url(owner, repo, token.as_deref(), &base_url)
         .map_err(DetectError::SourceCreation)?;
     let artifact_ref = ArtifactRef::from_digest(digest);
@@ -622,7 +624,7 @@ mod tests {
             "https://api.github.com".to_string() => "https://github-proxy.example.com".to_string(),
         }));
 
-        let routed = routed_api_url(crate::github::API_URL);
+        let routed = routed_api_url(crate::github::API_URL, true).unwrap();
 
         assert_eq!(routed, "https://github-proxy.example.com/");
     }
@@ -633,7 +635,7 @@ mod tests {
             "regex:^https://api\\.github\\.com".to_string() => "https://github-proxy.example.com/api".to_string(),
         }));
 
-        let routed = routed_api_url(crate::github::API_URL);
+        let routed = routed_api_url(crate::github::API_URL, true).unwrap();
 
         assert_eq!(routed, "https://github-proxy.example.com/api/");
     }
@@ -642,9 +644,20 @@ mod tests {
     fn test_routed_api_url_keeps_original_url_without_replacement() {
         let _settings = SettingsGuard::new(None);
 
-        let routed = routed_api_url(crate::github::API_URL);
+        let routed = routed_api_url(crate::github::API_URL, true).unwrap();
 
         assert_eq!(routed, crate::github::API_URL);
+    }
+
+    #[test]
+    fn test_routed_api_url_rejects_credential_downgrade() {
+        let _settings = SettingsGuard::new(Some(indexmap::indexmap! {
+            "https://api.github.com".to_string() => "http://github-proxy.example.com".to_string(),
+        }));
+
+        let err = routed_api_url(crate::github::API_URL, true).unwrap_err();
+
+        assert!(err.to_string().contains("refusing to send credentials"));
     }
 
     #[test]

--- a/src/github/sigstore.rs
+++ b/src/github/sigstore.rs
@@ -66,7 +66,7 @@ fn routed_api_url(api_url: &str, has_credentials: bool) -> AttestationResult<Str
     let original = url.clone();
     crate::http::apply_url_replacements(&mut url);
     crate::http::ensure_secure_url_replacement(&original, &url, has_credentials)
-        .map_err(|err| AttestationError::Api(err.to_string()))?;
+        .map_err(|err| AttestationError::Verification(err.to_string()))?;
     if url == original {
         Ok(api_url.to_string())
     } else {
@@ -80,17 +80,19 @@ fn routed_api_url(api_url: &str, has_credentials: bool) -> AttestationResult<Str
 /// otherwise `None` (meaning: keep the sigstore crate's default behavior). The
 /// result is pushed into `mise-sigstore` via [`mise_sigstore::set_tuf_url`] so
 /// the TUF root fetch follows the same mirror as the rest of mise's traffic.
-fn routed_tuf_url() -> Option<String> {
+fn routed_tuf_url() -> AttestationResult<Option<String>> {
     let Ok(mut url) = url::Url::parse(mise_sigstore::DEFAULT_TUF_URL) else {
         debug!(
             "invalid Sigstore TUF URL, skipping url_replacements: {}",
             mise_sigstore::DEFAULT_TUF_URL
         );
-        return None;
+        return Ok(None);
     };
     let original = url.clone();
     crate::http::apply_url_replacements(&mut url);
-    (url != original).then(|| url.to_string())
+    crate::http::ensure_secure_url_replacement(&original, &url, false)
+        .map_err(|err| AttestationError::Verification(err.to_string()))?;
+    Ok((url != original).then(|| url.to_string()))
 }
 
 /// Build a [`RetryConfig`] from mise's HTTP settings so attestation requests
@@ -129,7 +131,7 @@ pub(crate) async fn verify_attestation(
     api_url: Option<&str>,
     use_versions_host: bool,
 ) -> AttestationResult<bool> {
-    mise_sigstore::set_tuf_url(routed_tuf_url());
+    mise_sigstore::set_tuf_url(routed_tuf_url()?);
     let mut digest = None;
     if use_versions_host_for_attestations(api_url, use_versions_host) {
         let artifact_digest = mise_sigstore::calculate_file_digest(artifact_path).await?;
@@ -221,7 +223,7 @@ pub(crate) async fn verify_attestation_with_predicate_type(
     api_url: Option<&str>,
     use_versions_host: bool,
 ) -> AttestationResult<bool> {
-    mise_sigstore::set_tuf_url(routed_tuf_url());
+    mise_sigstore::set_tuf_url(routed_tuf_url()?);
     let Some(predicate_type) = predicate_type else {
         return verify_attestation(
             artifact_path,
@@ -376,7 +378,7 @@ pub(crate) async fn verify_slsa_provenance(
     provenance_path: &Path,
     min_level: u8,
 ) -> AttestationResult<bool> {
-    mise_sigstore::set_tuf_url(routed_tuf_url());
+    mise_sigstore::set_tuf_url(routed_tuf_url()?);
     mise_sigstore::verify_slsa_provenance(artifact_path, provenance_path, min_level).await
 }
 
@@ -385,7 +387,7 @@ pub(crate) async fn verify_slsa_provenance_artifacts(
     artifacts: &[SlsaArtifact],
     min_level: u8,
 ) -> AttestationResult<bool> {
-    mise_sigstore::set_tuf_url(routed_tuf_url());
+    mise_sigstore::set_tuf_url(routed_tuf_url()?);
     mise_sigstore::verify_slsa_provenance_artifacts(provenance_path, artifacts, min_level).await
 }
 
@@ -402,7 +404,7 @@ pub(crate) async fn verify_cosign_signature(
     artifact_path: &Path,
     sig_or_bundle_path: &Path,
 ) -> AttestationResult<bool> {
-    mise_sigstore::set_tuf_url(routed_tuf_url());
+    mise_sigstore::set_tuf_url(routed_tuf_url()?);
     mise_sigstore::verify_cosign_signature(artifact_path, sig_or_bundle_path).await
 }
 
@@ -412,7 +414,7 @@ pub(crate) async fn verify_cosign_signature_with_key(
     sig_or_bundle_path: &Path,
     public_key_path: &Path,
 ) -> AttestationResult<bool> {
-    mise_sigstore::set_tuf_url(routed_tuf_url());
+    mise_sigstore::set_tuf_url(routed_tuf_url()?);
     mise_sigstore::verify_cosign_signature_with_key(
         artifact_path,
         sig_or_bundle_path,
@@ -658,6 +660,21 @@ mod tests {
         let err = routed_api_url(crate::github::API_URL, true).unwrap_err();
 
         assert!(err.to_string().contains("refusing to send credentials"));
+        assert!(!is_api_failure(&err));
+    }
+
+    #[test]
+    fn test_routed_api_url_rejects_userinfo_downgrade_without_token() {
+        let _settings = SettingsGuard::new(Some(indexmap::indexmap! {
+            "https://api.github.com".to_string()
+                => "http://user:password@github-proxy.example.com".to_string(),
+        }));
+
+        let err = routed_api_url(crate::github::API_URL, false).unwrap_err();
+
+        assert!(err.to_string().contains("refusing to send credentials"));
+        assert!(!err.to_string().contains("password"));
+        assert!(!is_api_failure(&err));
     }
 
     #[test]
@@ -667,7 +684,7 @@ mod tests {
                 => "https://tuf-mirror.example.com".to_string(),
         }));
 
-        let routed = routed_tuf_url();
+        let routed = routed_tuf_url().unwrap();
 
         assert_eq!(routed.as_deref(), Some("https://tuf-mirror.example.com/"));
     }
@@ -676,7 +693,21 @@ mod tests {
     fn test_routed_tuf_url_none_without_replacement() {
         let _settings = SettingsGuard::new(None);
 
-        assert_eq!(routed_tuf_url(), None);
+        assert_eq!(routed_tuf_url().unwrap(), None);
+    }
+
+    #[test]
+    fn test_routed_tuf_url_rejects_userinfo_downgrade() {
+        let _settings = SettingsGuard::new(Some(indexmap::indexmap! {
+            "https://tuf-repo-cdn.sigstore.dev".to_string()
+                => "http://user:password@tuf-mirror.example.com".to_string(),
+        }));
+
+        let err = routed_tuf_url().unwrap_err();
+
+        assert!(err.to_string().contains("refusing to send credentials"));
+        assert!(!err.to_string().contains("password"));
+        assert!(!is_api_failure(&err));
     }
 
     #[test]

--- a/src/http.rs
+++ b/src/http.rs
@@ -1300,9 +1300,6 @@ impl Client {
             return options.check_response(response);
         }
         apply_url_replacements(&mut url);
-        // Refuse a transport downgrade before cross-host credential scoping can
-        // remove credentials; silently dropping them would mask a bad rule.
-        ensure_secure_replacement_credentials(&original_url, &url, headers)?;
         let host_key = http_host_key(&url);
         if Settings::get().prefer_offline()
             && let Some(host) = &host_key
@@ -1330,11 +1327,18 @@ impl Client {
         // netrc) without clobbering forge tokens on un-redirected requests.
         let mut final_headers = headers.clone();
         clear_cross_host_credentials(&mut final_headers, &original_url, &mut url);
+        // Refuse the downgrade for credentials that survive host scoping: a same-host
+        // rewrite keeps the original Authorization, and userinfo written into the rule
+        // itself is sent as-is. This runs before netrc because netrc credentials are
+        // scoped to the *replacement* host by the user, who already gets them sent to a
+        // plain `http://` URL with no rewrite involved — a rewrite must not be stricter
+        // than the direct request, or an http mirror fronting an https origin (#7164)
+        // becomes unusable.
+        ensure_secure_replacement_credentials(&original_url, &url, &final_headers)?;
         if options.use_netrc {
             final_headers =
                 apply_netrc_credentials(final_headers, &original_url, &url, netrc_headers(&url));
         }
-        ensure_secure_replacement_credentials(&original_url, &url, &final_headers)?;
 
         let request_timeout = self.request_timeout();
         let mut req = self.reqwest()?.request(method.clone(), url.clone());
@@ -1750,7 +1754,11 @@ fn is_credential_header(name: &HeaderName, value: &HeaderValue) -> bool {
 }
 
 /// Drop credentials scoped to the original host before contacting a replacement host.
-fn clear_cross_host_credentials(headers: &mut HeaderMap, original_url: &Url, url: &mut Url) {
+pub(crate) fn clear_cross_host_credentials(
+    headers: &mut HeaderMap,
+    original_url: &Url,
+    url: &mut Url,
+) {
     if url.host() == original_url.host() {
         return;
     }
@@ -1803,7 +1811,7 @@ fn apply_netrc_credentials(
 }
 
 /// Reject credentials when a URL replacement downgrades an HTTPS request to HTTP.
-fn ensure_secure_replacement_credentials(
+pub(crate) fn ensure_secure_replacement_credentials(
     original_url: &Url,
     url: &Url,
     headers: &HeaderMap,
@@ -2252,7 +2260,46 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_request_rejects_custom_credentials_on_https_to_http_replacement() {
+        // Same-host downgrade: host scoping keeps the credential header, so sending it
+        // would expose it in cleartext.
         let server = mockito::Server::new_async().await;
+        let replacement = server.url();
+        let original = replacement.replacen("http://", "https://", 1);
+        let _guard = {
+            let lock = crate::test::lock_ignoring_poison(&TEST_SETTINGS_LOCK);
+            let mut settings = crate::config::settings::SettingsPartial::empty();
+            settings.url_replacements = Some(indexmap::indexmap! {
+                original.clone() => replacement,
+            });
+            crate::config::Settings::reset(Some(settings));
+            SettingsGuard { _lock: lock }
+        };
+        let mut headers = HeaderMap::new();
+        headers.insert("x-api-key", HeaderValue::from_static("secret"));
+        let client = Client::new(Duration::from_secs(1), ClientKind::Http).unwrap();
+
+        let err = client
+            .get_text_request(format!("{original}/file"))
+            .headers(&headers)
+            .send()
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("refusing to send credentials"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_request_scopes_credentials_before_refusing_a_downgrade() {
+        // Host-changing downgrade: the credential header belongs to the original host and
+        // is removed, so the request proceeds without it rather than failing. Refusing
+        // here would break an http mirror fronting an https origin (#7164).
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/file")
+            .match_header("x-api-key", mockito::Matcher::Missing)
+            .with_body("ok")
+            .create_async()
+            .await;
         let replacement = server.url();
         let _guard = {
             let lock = crate::test::lock_ignoring_poison(&TEST_SETTINGS_LOCK);
@@ -2267,14 +2314,15 @@ mod tests {
         headers.insert("x-api-key", HeaderValue::from_static("secret"));
         let client = Client::new(Duration::from_secs(1), ClientKind::Http).unwrap();
 
-        let err = client
+        let body = client
             .get_text_request("https://secure.example.com/file")
             .headers(&headers)
             .send()
             .await
-            .unwrap_err();
+            .unwrap();
 
-        assert!(err.to_string().contains("refusing to send credentials"));
+        assert_eq!(body, "ok");
+        mock.assert_async().await;
     }
 
     #[tokio::test]

--- a/src/http.rs
+++ b/src/http.rs
@@ -1330,6 +1330,7 @@ impl Client {
             final_headers =
                 apply_netrc_credentials(final_headers, &original_url, &url, netrc_headers(&url));
         }
+        ensure_secure_replacement_credentials(&original_url, &url, &final_headers)?;
 
         let request_timeout = self.request_timeout();
         let mut req = self.reqwest()?.request(method.clone(), url.clone());
@@ -1753,6 +1754,23 @@ fn apply_netrc_credentials(
         }
     }
     final_headers
+}
+
+/// Reject credentials when a URL replacement downgrades an HTTPS request to HTTP.
+fn ensure_secure_replacement_credentials(
+    original_url: &Url,
+    url: &Url,
+    headers: &HeaderMap,
+) -> Result<()> {
+    let downgraded = original_url.scheme() == "https" && url.scheme() == "http";
+    let has_credentials = headers.contains_key(AUTHORIZATION)
+        || !url.username().is_empty()
+        || url.password().is_some();
+    ensure!(
+        !downgraded || !has_credentials,
+        "refusing to send credentials over an HTTPS-to-HTTP URL replacement"
+    );
+    Ok(())
 }
 
 /// Get HTTP Basic authentication headers from netrc file for the given URL
@@ -3056,6 +3074,39 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
 
         let out = apply_netrc_credentials(headers, &original, &rewritten, basic_netrc_headers());
         assert_eq!(auth_value(&out), vec!["Bearer forge-token".to_string()]);
+    }
+
+    #[test]
+    fn test_rejects_credentials_on_https_to_http_replacement() {
+        let original: Url = "https://public.example.com/file".parse().unwrap();
+        let rewritten: Url = "http://mirror.internal/file".parse().unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer secret"));
+
+        let err =
+            ensure_secure_replacement_credentials(&original, &rewritten, &headers).unwrap_err();
+        assert!(err.to_string().contains("refusing to send credentials"));
+        let rewritten_with_credentials: Url =
+            "http://user:password@mirror.internal/file".parse().unwrap();
+        assert!(
+            ensure_secure_replacement_credentials(
+                &original,
+                &rewritten_with_credentials,
+                &HeaderMap::new(),
+            )
+            .is_err()
+        );
+        assert!(
+            ensure_secure_replacement_credentials(&original, &rewritten, &HeaderMap::new()).is_ok()
+        );
+        assert!(
+            ensure_secure_replacement_credentials(
+                &"http://public.example.com/file".parse().unwrap(),
+                &rewritten,
+                &headers,
+            )
+            .is_ok()
+        );
     }
 
     #[test]

--- a/src/http.rs
+++ b/src/http.rs
@@ -10,8 +10,8 @@ use eyre::{Report, Result, WrapErr, bail, ensure, eyre};
 use regex::Regex;
 use reqwest::StatusCode;
 use reqwest::header::{
-    ACCEPT_ENCODING, AUTHORIZATION, CONTENT_RANGE, CONTENT_TYPE, DATE, ETAG, HeaderMap,
-    HeaderValue, IF_RANGE, LAST_MODIFIED, RANGE,
+    ACCEPT_ENCODING, AUTHORIZATION, CONTENT_RANGE, CONTENT_TYPE, COOKIE, DATE, ETAG, HeaderMap,
+    HeaderName, HeaderValue, IF_RANGE, LAST_MODIFIED, PROXY_AUTHORIZATION, RANGE,
 };
 use reqwest::{ClientBuilder, IntoUrl, Method, Response};
 use serde::{Deserialize, Serialize};
@@ -1300,6 +1300,9 @@ impl Client {
             return options.check_response(response);
         }
         apply_url_replacements(&mut url);
+        // Refuse a transport downgrade before cross-host credential scoping can
+        // remove credentials; silently dropping them would mask a bad rule.
+        ensure_secure_replacement_credentials(&original_url, &url, headers)?;
         let host_key = http_host_key(&url);
         if Settings::get().prefer_offline()
             && let Some(host) = &host_key
@@ -1320,12 +1323,13 @@ impl Client {
         // `host_auth_headers` from GITHUB_TOKEN/gh/github_tokens.toml) wins
         // over netrc. The one exception is when a URL replacement actually
         // redirected the request to a different URL — in that case the
-        // pre-existing auth header was built for the *original* host and is
-        // likely wrong for the replacement target, so netrc (scoped to the
-        // new host) should override it. This preserves the #7164 use case
+        // pre-existing credentials were built for the *original* host and are
+        // removed before netrc credentials scoped to the new host are applied.
+        // This preserves the #7164 use case
         // (replace a public URL with a private mirror authenticated via
         // netrc) without clobbering forge tokens on un-redirected requests.
         let mut final_headers = headers.clone();
+        clear_cross_host_credentials(&mut final_headers, &original_url, &mut url);
         if options.use_netrc {
             final_headers =
                 apply_netrc_credentials(final_headers, &original_url, &url, netrc_headers(&url));
@@ -1728,13 +1732,55 @@ fn netrc_should_apply(host_changed: bool, has_existing_auth: bool) -> bool {
     host_changed || !has_existing_auth
 }
 
+fn is_credential_header(name: &HeaderName, value: &HeaderValue) -> bool {
+    if value.is_sensitive()
+        || name == AUTHORIZATION
+        || name == PROXY_AUTHORIZATION
+        || name == COOKIE
+    {
+        return true;
+    }
+    let name = name.as_str();
+    name == "api-key"
+        || name == "x-api-key"
+        || name.ends_with("-api-key")
+        || name.contains("token")
+        || name.contains("secret")
+        || name.contains("credential")
+}
+
+/// Drop credentials scoped to the original host before contacting a replacement host.
+fn clear_cross_host_credentials(headers: &mut HeaderMap, original_url: &Url, url: &mut Url) {
+    if url.host() == original_url.host() {
+        return;
+    }
+    let credential_headers = headers
+        .iter()
+        .filter(|(name, value)| is_credential_header(name, value))
+        .map(|(name, _)| name.clone())
+        .collect::<Vec<_>>();
+    for name in credential_headers {
+        headers.remove(name);
+    }
+    let inherited_userinfo = (!original_url.username().is_empty()
+        || original_url.password().is_some())
+        && url.username() == original_url.username()
+        && url.password() == original_url.password();
+    if inherited_userinfo {
+        url.set_password(None)
+            .expect("HTTP URLs support clearing passwords");
+        url.set_username("")
+            .expect("HTTP URLs support clearing usernames");
+    }
+}
+
 /// Merge `netrc` credentials into `final_headers`, honoring the fallback
 /// policy in [`netrc_should_apply`]. `original_url` is the URL before any
 /// `apply_url_replacements` rewrite and `url` is the (possibly rewritten)
 /// URL actually being requested; a change of *host* means the request was
-/// redirected to a different server, which lets netrc override an existing
-/// auth header. Netrc values are `insert`ed (not `extend`ed) so they replace
-/// a pre-existing Authorization rather than appending a duplicate one.
+/// redirected to a different server, which lets netrc supply replacement-host
+/// authentication after original-host credentials have been removed. Netrc
+/// values are `insert`ed so only one Authorization value is present.
 fn apply_netrc_credentials(
     mut final_headers: HeaderMap,
     original_url: &Url,
@@ -1762,9 +1808,9 @@ fn ensure_secure_replacement_credentials(
     url: &Url,
     headers: &HeaderMap,
 ) -> Result<()> {
-    let has_credentials = headers.contains_key(AUTHORIZATION)
-        || !url.username().is_empty()
-        || url.password().is_some();
+    let has_credentials = headers
+        .iter()
+        .any(|(name, value)| is_credential_header(name, value));
     ensure_secure_url_replacement(original_url, url, has_credentials)
 }
 
@@ -1774,6 +1820,7 @@ pub(crate) fn ensure_secure_url_replacement(
     has_credentials: bool,
 ) -> Result<()> {
     let downgraded = original_url.scheme() == "https" && url.scheme() == "http";
+    let has_credentials = has_credentials || !url.username().is_empty() || url.password().is_some();
     ensure!(
         !downgraded || !has_credentials,
         "refusing to send credentials over an HTTPS-to-HTTP URL replacement"
@@ -2201,6 +2248,33 @@ mod tests {
         assert!(client.head("").await.is_err());
         assert!(client.get_text("").await.is_err());
         assert!(client.get_text_request("").send().await.is_err());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_request_rejects_custom_credentials_on_https_to_http_replacement() {
+        let server = mockito::Server::new_async().await;
+        let replacement = server.url();
+        let _guard = {
+            let lock = crate::test::lock_ignoring_poison(&TEST_SETTINGS_LOCK);
+            let mut settings = crate::config::settings::SettingsPartial::empty();
+            settings.url_replacements = Some(indexmap::indexmap! {
+                "https://secure.example.com".to_string() => replacement,
+            });
+            crate::config::Settings::reset(Some(settings));
+            SettingsGuard { _lock: lock }
+        };
+        let mut headers = HeaderMap::new();
+        headers.insert("x-api-key", HeaderValue::from_static("secret"));
+        let client = Client::new(Duration::from_secs(1), ClientKind::Http).unwrap();
+
+        let err = client
+            .get_text_request("https://secure.example.com/file")
+            .headers(&headers)
+            .send()
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("refusing to send credentials"));
     }
 
     #[tokio::test]
@@ -3064,6 +3138,28 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
     }
 
     #[test]
+    fn test_cross_host_replacement_clears_credentials_without_netrc() {
+        let original: Url = "https://user:password@public.example.com/file"
+            .parse()
+            .unwrap();
+        let mut redirected: Url = "https://user:password@mirror.internal/file"
+            .parse()
+            .unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer stale"));
+        headers.insert("x-api-key", HeaderValue::from_static("secret"));
+        headers.insert("x-request-id", HeaderValue::from_static("keep-me"));
+
+        clear_cross_host_credentials(&mut headers, &original, &mut redirected);
+
+        assert!(!headers.contains_key(AUTHORIZATION));
+        assert!(!headers.contains_key("x-api-key"));
+        assert_eq!(headers["x-request-id"], "keep-me");
+        assert!(redirected.username().is_empty());
+        assert!(redirected.password().is_none());
+    }
+
+    #[test]
     fn test_apply_netrc_keeps_forge_token_on_same_host_path_rewrite() {
         // A URL replacement that only rewrites the path/query on the SAME host
         // must not let netrc override the forge token: the token is still valid
@@ -3094,6 +3190,16 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         let err =
             ensure_secure_replacement_credentials(&original, &rewritten, &headers).unwrap_err();
         assert!(err.to_string().contains("refusing to send credentials"));
+        let mut cookie_headers = HeaderMap::new();
+        cookie_headers.insert(COOKIE, HeaderValue::from_static("session=secret"));
+        assert!(
+            ensure_secure_replacement_credentials(&original, &rewritten, &cookie_headers).is_err()
+        );
+        let mut api_key_headers = HeaderMap::new();
+        api_key_headers.insert("x-api-key", HeaderValue::from_static("secret"));
+        assert!(
+            ensure_secure_replacement_credentials(&original, &rewritten, &api_key_headers).is_err()
+        );
         let rewritten_with_credentials: Url =
             "http://user:password@mirror.internal/file".parse().unwrap();
         assert!(

--- a/src/http.rs
+++ b/src/http.rs
@@ -1762,10 +1762,18 @@ fn ensure_secure_replacement_credentials(
     url: &Url,
     headers: &HeaderMap,
 ) -> Result<()> {
-    let downgraded = original_url.scheme() == "https" && url.scheme() == "http";
     let has_credentials = headers.contains_key(AUTHORIZATION)
         || !url.username().is_empty()
         || url.password().is_some();
+    ensure_secure_url_replacement(original_url, url, has_credentials)
+}
+
+pub(crate) fn ensure_secure_url_replacement(
+    original_url: &Url,
+    url: &Url,
+    has_credentials: bool,
+) -> Result<()> {
+    let downgraded = original_url.scheme() == "https" && url.scheme() == "http";
     ensure!(
         !downgraded || !has_credentials,
         "refusing to send credentials over an HTTPS-to-HTTP URL replacement"


### PR DESCRIPTION
Clarify which operations download verification, trust, safe mode, paranoid mode, and sandboxing cover, including the path-based trusted_config_paths and inherited monorepo-root exceptions to paranoid content-bound approval.

Prevent URL replacements from forwarding authorization headers or URL credentials when an HTTPS origin is rewritten to HTTP, including the separate GitHub attestation client. Unauthenticated HTTPS-to-HTTP rewrites remain allowed. Errors intentionally omit URLs so embedded credentials cannot leak through diagnostics.

Also correct sandbox and mirror documentation for combined exceptions, platform behavior, first-valid-rewrite semantics, and netrc/header precedence.

Validation:
- mise exec rust@1.95 -- cargo test --all-features --bin mise http::tests::test_rejects_credentials_on_https_to_http_replacement
- mise exec rust@1.95 -- cargo test --all-features --bin mise github::sigstore::tests::test_routed_api_url_rejects_credential_downgrade
- mise exec rust@1.95 -- cargo check --all-features
- mise exec rust@1.95 -- mise run lint
- mise exec rust@1.95 -- mise run render

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication and credential forwarding for downloads, Conda, and attestations; incorrect behavior could break mirrors or leak tokens, though behavior is covered by new unit/integration tests.
> 
> **Overview**
> **URL replacement security** now strips authorization headers, cookies, API keys, and inherited URL userinfo when a rewrite changes the host, then **refuses HTTPS→HTTP rewrites** that would still send credentials (same-host downgrades that keep the header are blocked; host-changing downgrades drop stale credentials so HTTP mirrors keep working). The same rules apply to **Conda channel traffic** (Rattler middleware) and **GitHub attestation / Sigstore TUF routing**; insecure TUF downgrades with embedded credentials are ignored in favor of the default URL.
> 
> **Documentation** is refreshed across security, paranoid mode, sandboxing, and `url_replacements`—including a controls comparison table, paranoid trust exceptions (`trusted_config_paths`, monorepo roots), sandbox platform limits (Linux rejects `--allow-net`), mirror matching/precedence/netrc behavior, and updated `llms.txt` blurbs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f37af2edb71001d5eac91205acde79d2e97363c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Requests that downgrade HTTPS to HTTP through URL replacements are blocked when credentials are present.
  - Security guidance now clarifies verification, safe mode, paranoid mode, lockfile provenance, and supported controls.

- **Documentation**
  - Sandboxing guidance now explains platform-specific enforcement, access exceptions, command behavior, and task configuration.
  - URL replacement documentation adds matching rules, precedence, configuration examples, authentication behavior, and HTTPS security guidance.
  - Reference pages clarify HTTP routing and paranoid-mode requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->