### PR TITLE
docs: clarify plugin selection and maintenance

### DIFF
--- a/docs/asdf-legacy-plugins.md
+++ b/docs/asdf-legacy-plugins.md
@@ -16,11 +16,12 @@ asdf plugins are shell script-based plugins that follow the asdf plugin specific
 
 asdf plugins have several limitations compared to mise's modern plugin system:
 
-- **Platform Support**: Only work on Linux and macOS (no Windows support)
+- **Platform Support**: Require Unix shell utilities; the asdf backend is disabled by default on Windows
 - **Performance**: Shell script execution is slower than mise's native backends
 - **Features**: Limited compared to modern backends like aqua, github, or tool/backend plugins
 - **Maintenance**: Harder to maintain and debug
-- **Security**: Less secure than sandboxed modern backends
+- **Execution scope**: Plugin scripts run with your permissions. Lua plugins can also run
+  commands and access files; neither plugin format is an OS sandbox.
 
 ## When to Use asdf (Legacy) Plugins
 
@@ -44,14 +45,15 @@ Only use asdf plugins when:
 
 ### From the Registry
 
-Most popular asdf plugins are available through mise's registry:
+Some registry entries retain asdf alternatives, but a shorthand may prefer another backend.
+Select asdf explicitly when you need to test or maintain that implementation:
 
 ```bash
-# Install from registry shorthand
-mise use postgres@15
+# Select the asdf implementation explicitly
+mise use asdf:mise-plugins/mise-postgres@17
 
-# This is equivalent to
-mise use asdf:mise-plugins/mise-postgres@15
+# The postgres shorthand currently prefers vfox instead
+mise registry postgres
 ```
 
 ### From Git Repository
@@ -71,11 +73,15 @@ mise plugin install postgres https://github.com/mise-plugins/mise-postgres
 mise plugin add postgres https://github.com/mise-plugins/mise-postgres
 
 # Install tool version
-mise install postgres@15.0.0
+mise install postgres@17.0
 
 # Use the tool
-mise use postgres@15.0.0
+mise use postgres@17.0
 ```
+
+An installed plugin with that name takes precedence over the registry shorthand when its
+backend is enabled. Use the full `asdf:owner/repo` identifier above to select an implementation
+without relying on an installed short-name plugin.
 
 ## Plugin Structure
 
@@ -85,7 +91,7 @@ asdf plugins follow this directory structure:
 plugin-name/
 ├── bin/
 │   ├── list-all          # List all available versions
-│   ├── download          # Download source code/binary
+│   ├── download          # Separate download phase [optional]
 │   ├── install           # Install the tool
 │   ├── latest-stable     # Get latest stable version [optional]
 │   ├── help.overview     # Plugin description [optional]
@@ -104,18 +110,24 @@ plugin-name/
 
 ## Required Scripts
 
+Provide `bin/list-all` and `bin/install`. The separate `bin/download` hook is optional;
+without it, the install hook is responsible for obtaining the source or binary. Mark
+scripts executable and write diagnostics to stderr so version output stays machine-readable.
+
 ### bin/list-all
 
 Lists all available versions of the tool:
 
 ```bash
 #!/usr/bin/env bash
-# List all available versions
-curl -s https://api.github.com/repos/owner/repo/releases |
-  grep '"tag_name":' |
-  sed -E 's/.*"([^"]+)".*/\1/' |
-  sort -V
+set -euo pipefail
+# Illustrative version list, ordered oldest to newest by the publisher's rules.
+printf '%s\n' 1.0.0 1.1.0 1.10.0
 ```
+
+For real plugins, query the publisher's release source and parse structured metadata with
+a suitable parser. Do not scrape JSON with `grep` or assume every tool uses SemVer. Preserve
+meaningful release order; `sort -V` is not portable to macOS and does not understand channels.
 
 ### bin/download
 
@@ -123,7 +135,7 @@ Downloads the tool source/binary:
 
 ```bash
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 # Input variables from mise
 # ASDF_INSTALL_TYPE (version or ref)
@@ -135,17 +147,19 @@ version="$ASDF_INSTALL_VERSION"
 download_path="$ASDF_DOWNLOAD_PATH"
 
 # Download logic here
-curl -Lo "$download_path/archive.tar.gz" \
+mkdir -p "$download_path"
+curl -fSL -o "$download_path/archive.tar.gz" \
   "https://github.com/owner/repo/archive/v${version}.tar.gz"
 ```
 
 ### bin/install
 
-Installs the tool:
+Installs the tool. This source-build sketch assumes the archive contains a Makefile with
+an `install` target accepting `PREFIX`, and that build dependencies are already available:
 
 ```bash
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 # Input variables from mise
 # ASDF_INSTALL_TYPE (version or ref)
@@ -182,9 +196,8 @@ Gets the latest stable version:
 
 ```bash
 #!/usr/bin/env bash
-curl -s https://api.github.com/repos/owner/repo/releases/latest |
-  grep '"tag_name":' |
-  sed -E 's/.*"([^"]+)".*/\1/'
+# Return a version from bin/list-all according to this tool's stable-release policy.
+printf '%s\n' 1.10.0
 ```
 
 ### bin/list-legacy-filenames
@@ -193,9 +206,12 @@ Lists legacy version file names:
 
 ```bash
 #!/usr/bin/env bash
-echo ".tool-version"
-echo ".tool-versions"
+echo ".example-version"
 ```
+
+Enable idiomatic version files for the tool through
+[`idiomatic_version_file_enable_tools`](/configuration/settings.html#idiomatic_version_file_enable_tools).
+Do not return `.tool-versions`: mise already parses that multi-tool format itself.
 
 ### bin/parse-legacy-file
 
@@ -203,12 +219,13 @@ Parses a legacy version file:
 
 ```bash
 #!/usr/bin/env bash
-cat "$1" | head -n 1
+head -n 1 "$1"
 ```
 
 ## Environment Variables
 
-asdf plugins have access to these environment variables:
+Hook inputs depend on the phase. Installation hooks receive the version and path values;
+update hooks receive the previous and new Git refs:
 
 - `ASDF_INSTALL_TYPE` - `version` or `ref`
 - `ASDF_INSTALL_VERSION` - Version number or git ref
@@ -217,7 +234,6 @@ asdf plugins have access to these environment variables:
 - `ASDF_PLUGIN_PATH` - Plugin directory
 - `ASDF_PLUGIN_PREV_REF` - Previous git ref (for updates)
 - `ASDF_PLUGIN_POST_REF` - New git ref (for updates)
-- `ASDF_CMD_FILE` - Path to executable being run
 
 ## Best Practices
 
@@ -248,17 +264,20 @@ esac
 
 case "$(uname -m)" in
   x86_64) arch="amd64" ;;
-  arm64)  arch="arm64" ;;
+  arm64|aarch64) arch="arm64" ;;
   *)      echo "Unsupported architecture" >&2; exit 1 ;;
 esac
 ```
 
 ### Version Parsing
 
+Normalize a publisher prefix only when it is part of that tool's convention. Keep
+non-numeric versions and channels intact; a shared SemVer parser is not appropriate.
+
 ```bash
 #!/usr/bin/env bash
 
-# Parse semantic version
+# Remove this example publisher's prefix
 parse_version() {
   local version="$1"
   # Remove 'v' prefix if present
@@ -273,12 +292,12 @@ parse_version() {
 
 ```bash
 # Link plugin for development
-mise plugin add my-plugin /path/to/local/plugin
+mise plugin link my-plugin /path/to/local/plugin
 
 # Test basic functionality
 mise ls-remote my-plugin
-mise install my-plugin@1.0.0
-mise which my-plugin
+mise use my-plugin@1.0.0
+mise exec -- my-plugin --version
 ```
 
 ### Debugging
@@ -293,44 +312,46 @@ mise install --verbose my-plugin@1.0.0
 
 ## Example Plugin
 
-Here's a minimal example for a fictional tool:
+This self-contained local fixture demonstrates the minimum interface without network
+requests or a compiler. Create these two executable files under `my-plugin/bin/`:
 
 ```bash
 #!/usr/bin/env bash
 # bin/list-all
-curl -s "https://api.github.com/repos/example/tool/releases" |
-  grep '"tag_name":' |
-  sed -E 's/.*"v([^"]+)".*/\1/' |
-  sort -V
-```
-
-```bash
-#!/usr/bin/env bash
-# bin/download
-set -e
-version="$ASDF_INSTALL_VERSION"
-platform=$(uname -s | tr '[:upper:]' '[:lower:]')
-arch=$(uname -m)
-
-url="https://github.com/example/tool/releases/download/v${version}/tool-${platform}-${arch}.tar.gz"
-curl -fSL "$url" -o "$ASDF_DOWNLOAD_PATH/tool.tar.gz"
+set -euo pipefail
+printf '%s\n' 1.0.0
 ```
 
 ```bash
 #!/usr/bin/env bash
 # bin/install
-set -e
-cd "$ASDF_DOWNLOAD_PATH"
-tar -xzf tool.tar.gz
-cp tool "$ASDF_INSTALL_PATH/bin/"
-chmod +x "$ASDF_INSTALL_PATH/bin/tool"
+set -euo pipefail
+mkdir -p "$ASDF_INSTALL_PATH/bin"
+cat > "$ASDF_INSTALL_PATH/bin/my-plugin" <<'SCRIPT'
+#!/usr/bin/env sh
+printf '%s\n' 'my-plugin 1.0.0'
+SCRIPT
+chmod +x "$ASDF_INSTALL_PATH/bin/my-plugin"
 ```
+
+Test from a separate project directory:
+
+```sh
+chmod +x /path/to/my-plugin/bin/list-all /path/to/my-plugin/bin/install
+mise plugin link my-plugin /path/to/my-plugin
+mise ls-remote my-plugin
+mise use my-plugin@1.0.0
+mise exec -- my-plugin --version
+```
+
+Replace the fixture installer with your real download, verification, extraction, or build
+steps. Keep `bin/exec-env` cheap: it can run while constructing the shell environment.
 
 ## Migration Path
 
 Consider migrating from asdf plugins to modern alternatives:
 
-1. **Check if tool is available in [aqua registry](https://github.com/aquaproj/aqua-registry)**
+1. **Check for [signed packslip releases](/dev-tools/backends/packslip.html), then whether the tool is available in [aqua registry](https://github.com/aquaproj/aqua-registry)**
 2. **Use [github backend](dev-tools/backends/github.md) for simple GitHub releases**
 3. **Create a [mise plugin](tool-plugin-development.md) for complex tools** - use the [mise-tool-plugin-template](https://github.com/jdx/mise-tool-plugin-template) for a quick start
 4. **Use language-specific package managers** (npm, pipx, cargo, gem)

--- a/docs/plugin-usage.md
+++ b/docs/plugin-usage.md
@@ -1,65 +1,60 @@
 # Using Plugins
 
-mise supports plugins that extend its functionality, allowing you to install tools that aren't available in the standard registry. This is particularly useful for:
-
-- Installing tools from private repositories
-- Using experimental or niche tools
-- Creating custom tool installations for your team
+Use a plugin when an integration needs custom installation logic, environment directives,
+or a host package manager. A tool does not need a registry shorthand or a plugin to be
+installable: first check whether a built-in [backend](/dev-tools/backends/) accepts it directly.
+For example, `mise use npm:prettier` uses the built-in npm backend.
 
 ## What Are Plugins?
 
-Plugins are extensions that can install and manage tools not included in mise's built-in registry. They are written in Lua and come in two main types:
+Lua plugins support several interfaces. The [plugin overview](/plugins.html#choose-a-plugin-type)
+compares backend, tool, environment, and package plugins. This page covers installing and
+maintaining them; [asdf plugins](/asdf-legacy-plugins.html) have a separate compatibility guide.
 
 ### Backend Plugins
 
-Backend plugins use enhanced backend methods and support the `plugin:tool` format:
-
-- **Multiple Tools**: A single plugin can manage multiple tools
-- **Enhanced Methods**: Backend methods for listing, installing, and environment setup
-- **Format**: Use the `plugin:tool` format (e.g., `vfox-npm:prettier`)
+A backend plugin manages one or more tools using `plugin-name:tool`. For example,
+`vfox-npm:prettier` selects `prettier` through a plugin installed as `vfox-npm`.
 
 ### Tool Plugins
 
-Tool plugins use the traditional hook-based approach:
-
-- **Single Tool**: Each plugin manages one tool
-- **Hook-based**: Use hooks like `PreInstall`, `PostInstall`, `Available`, etc.
-- **Format**: Use the tool name directly (e.g., `my-tool`)
-
-Both types:
-
-- Install tools from any source (npm packages, GitHub releases, custom builds)
-- Set up environment variables and PATH entries
-- Handle version management and listing
-- Work across all platforms (Windows, macOS, Linux)
+A tool plugin manages one tool. Use the name under which it was installed, such as
+`my-tool`. Lua runs on Windows, macOS, and Linux, but the plugin's own dependencies and
+installation logic determine which platforms it supports.
 
 ## Installing Plugins
 
 ### From a Git Repository
 
-```bash
-# Install a plugin from a repository
-mise plugin install <plugin-name> <repository-url>
-
-# Example: Installing the vfox-npm plugin
-mise plugin install vfox-npm https://github.com/jdx/vfox-npm
+```sh
+# Substitute your plugin's name and repository URL.
+mise plugin install my-plugin https://github.com/your-org/my-plugin
 ```
+
+For a specific Git revision, append `#<ref>` to the URL:
+
+```sh
+mise plugin install my-plugin 'https://github.com/your-org/my-plugin#v1.0.0'
+```
+
+Use a commit ID when you need an immutable source revision. A tag or branch can move.
+Review updates before changing the revision; a tool version pin is a separate choice.
 
 ### From Zip File
 
-```bash
-# Install a plugin from a zip file over HTTPS
-mise plugin install <plugin-name> <zip-url>
+For an HTTPS archive, provide its URL instead of a Git URL:
 
-# Example: Installing a plugin from a zip file
-mise plugin install tiny https://github.com/mise-plugins/mise-tiny/archive/refs/heads/main.zip
+```sh
+mise plugin install my-plugin https://github.com/your-org/my-plugin/archive/refs/tags/v1.0.0.zip
 ```
+
+The archive must contain a valid plugin. An unpacked archive has no Git checkout for
+`mise plugin update`; install a new archive explicitly when updating it.
 
 ### From Local Directory
 
-```bash
-# Link a local plugin for development
-mise plugin link <plugin-name> /path/to/plugin/directory
+```sh
+mise plugin link my-plugin /path/to/plugin/directory
 ```
 
 Local plugins can also be declared in `mise.toml`:
@@ -69,193 +64,164 @@ Local plugins can also be declared in `mise.toml`:
 my-plugin = "./plugins/my-plugin"
 ```
 
-Absolute paths and `~/...` are supported. Explicit relative paths beginning with
-`./` or `../` are resolved from the config root of the file containing the
-declaration. mise symlinks the directory just like `mise plugins link`, so local
-edits are reflected immediately. Existing plugin installations are not replaced
-automatically; use `mise plugins install --force my-plugin` to switch an
-existing installation to a local source.
+Absolute paths and `~/...` are supported. Explicit relative paths beginning with `./` or
+`../` resolve from the config root of the declaring file. mise symlinks the directory,
+so local edits take effect immediately. Existing installations are not replaced
+automatically: use `mise plugins install --force my-plugin` to apply a changed local source,
+or `mise plugins link --force my-plugin /path/to/plugin` when linking explicitly.
 
 ## Using Plugins (Advanced)
 
-Once a plugin is installed, you can use it with the `plugin:tool` format:
+After installing a backend plugin, select a tool and then invoke its executable:
 
-```bash
-# Install a specific tool using the plugin
-mise install vfox-npm:prettier@latest
-
-# Use the tool
-mise use vfox-npm:prettier@3.0.0
-
-# Execute the tool
-mise exec vfox-npm:prettier -- --version
-
-# List available versions
-mise ls-remote vfox-npm:prettier
+```sh
+mise ls-remote my-backend:some-tool
+mise use my-backend:some-tool@1.0.0
+mise exec -- some-tool --version
 ```
+
+To use a version for just one command without writing configuration:
+
+```sh
+mise exec my-backend:some-tool@1.0.0 -- some-tool --version
+```
+
+Replace the names with the plugin's documented identifiers. The argument after `--` is
+an executable, which may differ from the tool name: a TypeScript package provides `tsc`,
+for example. `mise install` alone installs a version; `mise use` also selects it in configuration.
 
 ## Plugin:Tool Format
 
-The `plugin:tool` format allows a single plugin to manage multiple tools. This is particularly useful for:
+The prefix is the installed backend plugin name, and the suffix identifies a tool within
+that backend. It is not the syntax for an ordinary single-tool plugin. Use:
 
-- **Package managers**: Install different npm packages, Python packages, etc.
-- **Tool families**: Manage related tools from the same ecosystem
-- **Custom builds**: Install different variants of the same tool
+```toml
+[plugins]
+my-backend = "https://github.com/your-org/my-backend"
+my-tool = "https://github.com/your-org/my-tool-plugin"
 
-### Example: npm packages
-
-```bash
-# Install different npm packages using the same plugin
-mise install vfox-npm:prettier@latest
-mise install vfox-npm:eslint@8.0.0
-mise install vfox-npm:typescript@latest
-
-# Use them in your project
-mise use vfox-npm:prettier@latest vfox-npm:eslint@8.0.0
+[tools]
+"my-backend:some-tool" = "1.0.0"
+my-tool = "2.0.0"
 ```
+
+The repository and version values are illustrative; choose versions returned by the plugin.
 
 ## Managing Plugins
 
 ### List installed plugins
 
-```bash
-# Show all plugins
+```sh
 mise plugins ls
-
-# Show plugin URLs
 mise plugins ls --urls
 ```
 
 ### Update plugins
 
-```bash
-# Update a specific plugin
-mise plugin update vfox-npm
-
-# Update all plugins
-mise plugin update --all
+```sh
+mise plugin update my-plugin
+mise plugin update my-plugin#v1.1.0
+mise plugin update  # all installed Git plugins
 ```
+
+This updates plugin code, not the versions of tools it has installed. Local links are
+skipped. Check the resulting revision with `mise plugins ls --urls`.
 
 ### Remove plugins
 
-```bash
-# Remove a plugin
-mise plugin remove vfox-npm
-
-# This will also remove all tools installed by the plugin
+```sh
+mise plugin remove my-plugin
 ```
+
+By default this removes plugin code and retains installed tools. Those tools may still
+need the plugin to resolve their executable paths or environment. Remove unneeded tool
+versions with `mise uninstall` before removing the plugin. For a single-tool plugin,
+`mise plugin remove --purge my-plugin` also removes its installs, downloads, and cache.
+Remove corresponding `[plugins]` and `[tools]` entries if you no longer want the integration.
 
 ## Configuration
 
-Plugins can be configured in your `mise.toml` file:
-
-```toml
-[plugins]
-vfox-npm = "https://github.com/jdx/vfox-npm"
-
-[tools]
-"vfox-npm:prettier" = "latest"
-"vfox-npm:eslint" = "8.0.0"
-```
+Declare plugin sources in `[plugins]` and tool versions in `[tools]`, as shown above.
+Environment plugins use `[env]`; package plugins use `[bootstrap.packages]`. Configuration
+options belong to the plugin's own interface, so consult its README before copying options
+from another plugin.
 
 ## Finding Plugins
 
-mise doesn't have a centralized registry for community plugins, but you can find them in a few places:
-
-- **GitHub**: Search for repositories with the "vfox-" prefix
-- **Community**: Check mise community discussions and Discord
-- **Company internal**: Your organization may have private plugins
+Check the [mise-plugins organization](https://github.com/mise-plugins), the
+[mise discussions](https://github.com/jdx/mise/discussions), or your organization's repositories.
+The [registry](/registry.html) contains some existing plugin-backed tool shorthands, but it
+is not a general catalog of plugins and does not accept new asdf or vfox tool entries.
 
 ## Plugin Examples
 
 ### vfox-npm (Example Plugin)
 
-The `vfox-npm` plugin demonstrates how to create a plugin that installs npm packages:
+[vfox-npm](https://github.com/jdx/vfox-npm) demonstrates a multi-tool backend. It is an example
+for plugin development; use mise's built-in [npm backend](/dev-tools/backends/npm.html) for
+normal npm tool installation:
 
-```bash
-# Install the plugin
-mise plugin install vfox-npm https://github.com/jdx/vfox-npm
-
-# Install tools
-mise install vfox-npm:prettier@latest
-mise install vfox-npm:eslint@latest
-
-# Use them
-mise use vfox-npm:prettier@latest
-mise exec vfox-npm:prettier -- --check .
+```sh
+mise use npm:prettier
+mise exec -- prettier --check .
 ```
-
-::: info
-This is only an example plugin for testing. mise has built-in npm support, which you should use instead: `mise install npm:prettier@latest`
-:::
 
 ## Backend Plugins (Advanced)
 
-Backend plugins use enhanced backend methods that provide better performance and support for the `plugin:tool` format:
-
-- **BackendListVersions**: Lists available versions of a tool
-- **BackendInstall**: Installs a specific version
-- **BackendExecEnv**: Sets up environment variables
-
-This architecture allows plugins to manage multiple tools efficiently while providing a consistent interface.
+Backend plugins implement `BackendListVersions`, `BackendInstall`, and optionally
+`BackendExecEnv`. See [Backend Plugin Development](/backend-plugin-development.html) for
+context fields and typed tool options.
 
 ## Tool Plugins (Advanced)
 
-Tool plugins use the traditional hook-based approach:
-
-- **Available**: Lists available versions
-- **PreInstall/PostInstall**: Installation hooks
-- **EnvKeys**: Environment variable setup
-- **ParseLegacyFile**: Parses version files from other tools (e.g. `.nvmrc`)
-
-Both architectures provide a flexible plugin system that can handle diverse installation and management needs.
+Tool plugins use hooks such as `Available`, `PreInstall`, `PostInstall`, and `EnvKeys`.
+See [Tool Plugin Development](/tool-plugin-development.html) for lifecycle ordering and
+idiomatic version-file support.
 
 ## Security Considerations
 
-::: danger
-When using plugins, be aware that:
+Plugin code runs with your permissions during installation and use. Inspect its source
+and revisions before installing or updating it. Plugins can invoke external commands;
+Lua does not provide an OS sandbox for those operations.
 
-- **Plugins execute arbitrary code** during installation and use
-- **Only install plugins from trusted sources**
-- **Review plugin code** before installation when possible
-- **Use version pinning**, such as [`mise.lock`](/dev-tools/mise-lock.md), to avoid unexpected updates
-:::
+A tool pin in `mise.toml` or `mise.lock` does not pin plugin code. Pin the plugin repository
+revision separately, and check which [lockfile guarantees](/dev-tools/mise-lock.html) its
+backend supports. See [Security](/security.html) for safe mode and trust boundaries.
 
 ## Troubleshooting
 
 ### Plugin installation fails
 
-```bash
-# Check if the repository URL is correct
-mise plugin install vfox-npm https://github.com/jdx/vfox-npm
-
-# Check plugin directory
-ls ~/.local/share/mise/plugins/
-```
+Check the repository URL, revision, Git credentials, and `mise plugins ls --urls` output.
+A local directory must have the plugin's expected files and hooks. To replace an existing
+plugin, use `--force` only after checking the intended source.
 
 ### Tool installation fails
 
-```bash
-# Check plugin logs
-mise install vfox-npm:prettier@latest --verbose
-
-# Verify plugin is installed
-mise plugins ls
+```sh
+mise ls-remote my-backend:some-tool
+mise install --verbose my-backend:some-tool@1.0.0
 ```
+
+Confirm the plugin supports the host platform and that its required external programs are
+available. Verbose output shows the underlying error; avoid publishing credentials from logs.
 
 ### Environment issues
 
-```bash
-# Check if PATH is set correctly
-mise exec vfox-npm:prettier env | grep PATH
-
-# Verify tool is installed
-ls ~/.local/share/mise/installs/vfox-npm/prettier/
+```sh
+mise ls --current
+mise where my-backend:some-tool
+mise exec my-backend:some-tool@1.0.0 -- some-tool --version
 ```
+
+Use `mise where` instead of guessing an installation path. For environment plugins, check
+`mise env --json` locally; its output may contain secrets. A successful installation alone
+does not activate a tool in the current shell.
 
 ## Next Steps
 
-- [Learn how to create backend plugins](backend-plugin-development.md)
-- [Learn how to create tool plugins](tool-plugin-development.md)
-- [Explore built-in backends](dev-tools/backends/)
-- [Check the community registry](registry.md)
+- [Create a backend plugin](/backend-plugin-development.html).
+- [Create a tool plugin](/tool-plugin-development.html).
+- [Create an environment plugin](/env-plugin-development.html).
+- [Create a package plugin](/package-plugin-development.html).
+- [Publish a plugin](/plugin-publishing.html).

--- a/docs/plugin-usage.md
+++ b/docs/plugin-usage.md
@@ -142,7 +142,9 @@ Remove corresponding `[plugins]` and `[tools]` entries if you no longer want the
 ## Configuration
 
 Declare plugin sources in `[plugins]` and tool versions in `[tools]`, as shown above.
-Environment plugins use `[env]`; package plugins use `[bootstrap.packages]`. Configuration
+Environment plugins use `[env]`. Register package managers in `[bootstrap.plugins]` or
+install them as `package:<name>`, then declare package requests in `[bootstrap.packages]`;
+see [package plugin setup](/bootstrap/packages/plugins.html). Configuration
 options belong to the plugin's own interface, so consult its README before copying options
 from another plugin.
 

--- a/docs/plugin-usage.md
+++ b/docs/plugin-usage.md
@@ -168,7 +168,7 @@ mise exec -- prettier --check .
 
 ## Backend Plugins (Advanced)
 
-Backend plugins implement `BackendListVersions`, `BackendInstall`, and optionally
+Backend plugins implement `BackendListVersions`, `BackendInstall`, and
 `BackendExecEnv`. See [Backend Plugin Development](/backend-plugin-development.html) for
 context fields and typed tool options.
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,151 +1,136 @@
 # Plugins
 
-Plugins extend mise with new functionality, such as extra tools or environment variable management.
+Plugins add installation logic, environment directives, or bootstrap package managers to
+mise. Most tools can use a built-in [backend](/dev-tools/backends/) directly, even when they
+have no [registry](/registry.html) shorthand. Start there before installing a plugin.
 
-Historically, plugins were the only way to add new tools, since the only backend was [asdf](/dev-tools/backends/asdf.html).
+For release binaries, prefer [packslip](/dev-tools/backends/packslip.html) when the publisher
+provides signed manifests, then [aqua](/dev-tools/backends/aqua.html),
+[github](/dev-tools/backends/github.html), or [gitlab](/dev-tools/backends/gitlab.html).
+Use a plugin when your integration needs custom behavior those backends cannot provide.
 
-With that backend, every tool has its own plugin, which must be installed manually. Now, with [core tools](/core-tools.html)
-and backends like [aqua](/dev-tools/backends/aqua.html)/[github](/dev-tools/backends/github.html), plugins are no longer necessary to run most tools in mise.
+Plugin code can read files, make requests, and run processes with your permissions. Lua's
+cross-platform runtime does not make a plugin an OS sandbox. Review the source and its
+updates; new asdf and vfox tool plugins are not accepted into the mise registry.
 
-Tool plugins should be avoided for security reasons. New tools built with asdf/plugins will not be accepted into mise unless they are very popular and
-aqua/github is not an option for some reason.
+## Choose a plugin type
 
-The exception is a tool that needs to set env vars or has a complex installation process: plugins can provide functionality like [setting env vars globally](/environments/#plugin-provided-env-directives) without relying on a tool being installed. They can also provide [aliases for versions](/dev-tools/aliases.html#aliased-versions).
+| Type        | Use it for                                            | Configuration                        | Author guide                                            |
+| ----------- | ----------------------------------------------------- | ------------------------------------ | ------------------------------------------------------- |
+| Backend     | Several versioned tools managed by one integration    | `[tools]`, `my-backend:tool`         | [Backend development](/backend-plugin-development.html) |
+| Tool        | One versioned tool with download/install hooks        | `[tools]`, the installed plugin name | [Tool development](/tool-plugin-development.html)       |
+| Environment | Variables or PATH entries without a tool installation | `[env]`, `_.my-plugin`               | [Environment development](/env-plugin-development.html) |
+| Package     | Host-managed packages for machine bootstrap           | `[bootstrap.packages]`               | [Package development](/package-plugin-development.html) |
+| asdf        | An existing shell-based tool integration              | `[tools]`, an asdf backend           | [Legacy plugins](/asdf-legacy-plugins.html)             |
 
-To integrate a new tool into mise, prefer [packslip](/dev-tools/backends/packslip.html)
-when the project publishes signed release manifests. Otherwise, get it into the
-[aqua registry](/dev-tools/backends/aqua.html) or check whether it can be installed
-with [github](/dev-tools/backends/github.html) or [gitlab](/dev-tools/backends/gitlab.html).
-Aqua is preferred over github: it has better UX and more features, such as SLSA verification and the ability to use different logic for older versions.
-
-You can manage all installed plugins in `mise` with [`mise plugins`](/cli/plugins.html).
-
-```shell
-mise plugins ls --urls
-# Plugin                          Url                                                     Ref  Sha
-# 1password                       https://github.com/mise-plugins/mise-1password-cli.git  HEAD f5d5aab
-# vfox-mise-plugins-vfox-dart     https://github.com/mise-plugins/vfox-dart               HEAD 1424253
-# ...
-```
+The Lua runtime is available on Windows, macOS, and Linux. Each plugin must still support
+the selected platform and any external programs it invokes. asdf plugins use shell scripts
+and are disabled by default on Windows.
 
 ## Backend Plugins
 
-Backend plugins provide enhanced functionality with modern backend methods. These plugins use the `plugin:tool` format and offer advantages over traditional plugins:
+A backend plugin implements `BackendListVersions`, `BackendInstall`, and optionally
+`BackendExecEnv`. The prefix is the name under which you install the plugin:
 
-- **Multiple Tools**: A single plugin can manage multiple tools
-- **Enhanced Methods**: Backend methods for listing versions, installing, and setting environment variables
-- **Cross-platform**: Work on Windows, macOS, and Linux
-- **Performance**: Faster execution than shell-based plugins
-
-Example usage:
-
-```bash
-# Install a backend plugin
-mise plugin install my-plugin https://github.com/username/my-plugin
-
-# Use the plugin:tool format
-mise install my-plugin:some-tool@1.0.0
-mise use my-plugin:some-tool@latest
+```sh
+# Replace this example repository and tool with your plugin's values.
+mise plugin install my-backend https://github.com/your-org/my-backend
+mise use my-backend:some-tool@1.0.0
+mise exec -- some-tool --version
 ```
 
-See [Backend Plugin Development](backend-plugin-development.md) for creating backend plugins. You can start quickly with the [mise-backend-plugin-template](https://github.com/jdx/mise-backend-plugin-template).
+See [Using Plugins](/plugin-usage.html) for installation, local development, and updates.
+The [backend template](https://github.com/jdx/mise-backend-plugin-template) provides a starting point.
 
 ## Tool Plugins
 
-Tool plugins use the traditional hook-based approach with Lua scripts. These plugins provide:
+A tool plugin manages one tool through hooks such as `Available`, `PreInstall`, and
+`EnvKeys`. Use its installed name as the tool name:
 
-- **Hook-based**: Use hooks like `PreInstall`, `PostInstall`, `Available`, etc.
-- **Single Tool**: Each plugin manages one tool
-- **Cross-platform**: Work on Windows, macOS, and Linux
-- **Flexible**: Full control over installation and environment setup
-
-Example usage:
-
-```bash
-# Install a tool plugin
-mise plugin install my-tool https://github.com/username/my-tool-plugin
-
-# Use the tool directly
-mise install my-tool@1.0.0
-mise use my-tool@latest
+```sh
+mise plugin install my-tool https://github.com/your-org/my-tool-plugin
+mise use my-tool@1.0.0
+mise exec -- my-tool --version
 ```
 
-See [Tool Plugin Development](tool-plugin-development.md) for creating tool plugins. The [mise-tool-plugin-template](https://github.com/jdx/mise-tool-plugin-template) provides a ready-to-use starting point.
+These repository and executable names are placeholders. Start with the
+[tool template](https://github.com/jdx/mise-tool-plugin-template) when writing your own.
 
 ## Environment Plugins
 
-Environment plugins provide environment variables and PATH modifications without managing tool versions. They're ideal for integrating with secret managers, setting dynamic configurations, and standardizing team environments.
+An environment plugin implements `MiseEnv` and optionally `MisePath`. Install it before
+using its directive:
 
-Example usage:
-
-```bash
-# Install an environment plugin
-mise plugin install my-env-plugin https://github.com/username/my-env-plugin
+```sh
+mise plugin install my-env-plugin https://github.com/your-org/my-env-plugin
 ```
 
 ```toml
-# Configure in mise.toml
 [env]
-_.my-env-plugin = { api_url = "https://api.example.com", debug = true }
+_.my-env-plugin = {
+  api_url = "https://api.example.com",
+  debug = true,
+}
 ```
 
-Unlike tool plugins, environment plugins:
+The fields are defined by the plugin. See [environment plugin development](/env-plugin-development.html)
+for return values, cache behavior, and the [environment template](https://github.com/jdx/mise-env-plugin-template).
 
-- Only implement environment hooks (`MiseEnv`, `MisePath`)
-- Are activated via `env._.<plugin-name>` syntax
-- Don't manage tool versions or installations
+## Package plugins
 
-See [Environment Plugin Development](env-plugin-development.md) for creating environment plugins. The [mise-env-plugin-template](https://github.com/jdx/mise-env-plugin-template) repository provides a ready-to-use starting point.
+Package plugins implement a host package manager for [bootstrap packages](/bootstrap/packages/plugins.html).
+They operate on batches of package requests and report installed state. Their installations
+belong to the host manager, unlike versioned tools stored under mise's data directory.
+See [Package Plugin Development](/package-plugin-development.html) for the hook contract.
 
 ## General Plugin Usage
 
-For end-user documentation on installing and using both backend and tool plugins, see [Using Plugins](plugin-usage.md).
+[Using Plugins](/plugin-usage.html) explains repository URLs, archive installation, local
+links, pinning plugin revisions, and diagnostics. List what is already installed with:
+
+```sh
+mise plugins ls --urls
+```
 
 ## asdf (Legacy) Plugins
 
-mise can use asdf's plugin ecosystem under the hood for backward compatibility. These plugins contain shell scripts like
-`bin/install` (for installing) and `bin/list-all` (for listing all available versions).
-
-asdf plugins have limitations compared to modern backends and should only be used when necessary. They only work on Linux/macOS and are slower than native backends.
-
-See [asdf (Legacy) Plugins](asdf-legacy-plugins.md) for comprehensive documentation on using and creating these plugins.
+mise can run existing asdf plugins with scripts such as `bin/list-all`, `bin/install`, and
+`bin/exec-env`. Use the [legacy guide](/asdf-legacy-plugins.html) to maintain one, or the
+[hook migration table](/dev-tools/backends/asdf.html#hook-migration-asdf-to-vfox) to port it to Lua.
 
 ## Plugin Authors
 
-<https://github.com/mise-plugins> is a GitHub organization for community-developed plugins.
-See [SECURITY.md](https://github.com/jdx/mise/blob/main/SECURITY.md) for more details on how plugins here are treated differently.
-
-If you'd like your plugin to be hosted here, let me know (a GH discussion or Discord message is fine)
-and I'd be happy to host it for you.
+The [mise-plugins organization](https://github.com/mise-plugins) hosts community plugins.
+Contact the maintainers through a [GitHub discussion](https://github.com/jdx/mise/discussions)
+to discuss hosting. Hosting a plugin and adding a registry shorthand are separate decisions;
+see the [publishing guide](/plugin-publishing.html).
 
 ## Tool Options
 
-mise supports "tool options": configuration specified in `mise.toml` that changes the behavior
-of tools. One example is virtualenv for Python:
+Plugins define custom options in their tool configuration. For example, a plugin that
+supports a `mirror` option could accept:
 
 ```toml
 [tools]
-python = { version='3.11', virtualenv='.venv' }
+my-tool = {
+  version = "1.0.0",
+  mirror = "https://mirror.example.com",
+}
 ```
 
-::: warning
-The python `virtualenv` tool option is deprecated and will be removed in a future release.
-Use [`_.python.venv`](/lang/python.html#automatic-virtualenv-activation) in the `[env]` section instead.
-:::
-
-For asdf plugins and version-specific vfox lifecycle hooks, this is passed as
-`MISE_TOOL_OPTS__VIRTUALENV=.venv`. These variables are scoped to the plugin hook environment; mise
-does not export them to the user's shell. Custom backend options are passed to the plugin in that
-format; mise-managed fields such as `depends`, `install_env`, and `os` are not exported.
-
-Currently, this only supports simple strings, but we can make it compatible with more complex types
-(arrays, tables) fairly easily if there is a need for it.
+For asdf and version-specific vfox lifecycle hooks, that option is exposed as
+`MISE_TOOL_OPTS__MIRROR`. These variables are scoped to hook execution, not exported into
+your shell. mise-managed fields such as `depends`, `install_env`, and `os` are handled by
+mise instead. Backend plugin hooks receive typed options through `ctx.options`, including
+arrays and nested tables; see [backend context](/backend-plugin-development.html#context-variables).
 
 ## Templates
 
-Plugin custom repository values can be templates; see [Templates](/templates) for details.
+Repository values in `[plugins]` support [templates](/templates.html). Prefer a normal SSH
+or HTTPS repository URL and your Git credential setup for private repositories; embedding
+credentials in a URL can expose them in configuration or logs.
 
 ```toml
 [plugins]
-"vfox-backend:my-plugin" = "https://{{ get_env(name='GIT_USR', default='empty') }}:{{ get_env(name='GIT_PWD', default='empty') }}@github.com/foo/my-plugin.git"
+my-backend = "git@github.com:your-org/my-backend.git"
 ```

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -29,7 +29,7 @@ and are disabled by default on Windows.
 
 ## Backend Plugins
 
-A backend plugin implements `BackendListVersions`, `BackendInstall`, and optionally
+A backend plugin implements `BackendListVersions`, `BackendInstall`, and
 `BackendExecEnv`. The prefix is the name under which you install the plugin:
 
 ```sh

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -23,6 +23,10 @@ updates; new asdf and vfox tool plugins are not accepted into the mise registry.
 | Package     | Host-managed packages for machine bootstrap           | `[bootstrap.packages]`               | [Package development](/package-plugin-development.html) |
 | asdf        | An existing shell-based tool integration              | `[tools]`, an asdf backend           | [Legacy plugins](/asdf-legacy-plugins.html)             |
 
+Register a package manager in `[bootstrap.plugins]`, or install it as `package:<name>`,
+before declaring its requests in `[bootstrap.packages]`. See the
+[package plugin setup](/bootstrap/packages/plugins.html) for a complete configuration.
+
 The Lua runtime is available on Windows, macOS, and Linux. Each plugin must still support
 the selected platform and any external programs it invokes. asdf plugins use shell scripts
 and are disabled by default on Windows.

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -25,7 +25,7 @@
 - [Shims](https://mise.jdx.dev/dev-tools/shims.html): There are several ways to load the mise context (dev tools, environment variables) into your shell.
 - [Tool Aliases](https://mise.jdx.dev/dev-tools/aliases.html): Use [tool_alias] to give a tool a different backend or name a version request. Put shared aliases in the project's mise.toml; use ~/.config/mise/config.toml for personal defaults.
 - [Tool Stubs](https://mise.jdx.dev/dev-tools/tool-stubs.html): A tool stub is an executable file that records how to obtain and run one tool. Commit it to a repository so a command such as ./bin/py selects the intended runtime and forwards its arguments.
-- [Registry](https://mise.jdx.dev/registry.html): List of all tools aliased by default in mise.
+- [Registry](https://mise.jdx.dev/registry.html): The registry maps short tool names to one or more installation backends. Search the tool list below, or inspect the registry bundled with your installed mise.
 - [GitHub Tokens](https://mise.jdx.dev/dev-tools/github-tokens.html): Many tools in mise are hosted on GitHub. For public releases, mise uses mise-versions by default as a shared cache for version lists, release metadata, and GitHub artifact attestations.
 - [mise.lock Lockfile](https://mise.jdx.dev/dev-tools/mise-lock.html): mise.toml records the versions a project accepts; mise.lock records the concrete versions those requests resolved to.
 - [Security](https://mise.jdx.dev/security.html): mise includes several supply-chain controls for installing and managing tools. These controls have different coverage depending on the backend and the metadata available from upstream.
@@ -120,8 +120,8 @@
 
 ## Plugins
 
-- [Plugin Overview](https://mise.jdx.dev/plugins.html): Plugins extend mise with new functionality, such as extra tools or environment variable management.
-- [Using Plugins](https://mise.jdx.dev/plugin-usage.html): mise supports plugins that extend its functionality, allowing you to install tools that aren't available in the standard registry. This is particularly useful for.
+- [Plugin Overview](https://mise.jdx.dev/plugins.html): Plugins add installation logic, environment directives, or bootstrap package managers to mise. Most tools can use a built-in backend directly, even when they have no registry shorthand.
+- [Using Plugins](https://mise.jdx.dev/plugin-usage.html): Use a plugin when an integration needs custom installation logic, environment directives, or a host package manager.
 - [Backend Plugin Development](https://mise.jdx.dev/backend-plugin-development.html): The mise-backend-plugin-template provides a ready-to-use starting point with LuaCATS type definitions, stylua formatting, and hk linting pre-configured.
 - [Tool Plugin Development](https://mise.jdx.dev/tool-plugin-development.html): The mise-tool-plugin-template provides a ready-to-use starting point with LuaCATS type definitions, stylua formatting, and hk linting pre-configured.
 - [Environment Plugin Development](https://mise.jdx.dev/env-plugin-development.html): Environment plugins are a special type of mise plugin that provides environment variables and PATH modifications without managing tool versions.

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -8,21 +8,23 @@ editLink: false
 import Registry from '/components/registry.vue';
 </script>
 
-List of all [tools](#tools) aliased by default in `mise`.
+The registry maps short tool names to one or more installation backends. Search the
+[tool list](#tools) below, or inspect the registry bundled with your installed mise:
 
-You can use these shorthands with `mise use`. This allows you to use a tool without needing to know the full name. For example, to use the `aws-cli` tool, you can do the following:
-
-```shell
+```sh
+mise registry
+mise registry aws-cli
 mise use aws-cli
 ```
 
-instead of
+A shorthand can carry backend-specific options as well as a backend name. For example,
+`aws-cli` currently selects Aqua with registry-provided executable-link options. Choosing
+`aqua:aws/aws-cli` explicitly selects that backend, but does not mean every shorthand option
+is identical.
 
-```shell
-mise use aqua:aws/aws-cli
-```
-
-If a tool is not available in the registry, you can install it by its full name. [github](./dev-tools/backends/github.html) and [aqua](./dev-tools/backends/aqua.html) give you for example access to almost all programs available on GitHub.
+If a tool has no shorthand, use its full [backend identifier](/dev-tools/backends/), such as
+`github:owner/repo`. The backend must support that project's release layout or package
+format; a repository existing on GitHub is not sufficient by itself.
 
 ## Floating registries
 
@@ -31,7 +33,7 @@ mise release. Users whose system package manager ships mise updates slowly can o
 registry data without replacing the mise executable:
 
 ```shell
-mise settings registry_floating=true
+mise settings set registry_floating true
 ```
 
 With this enabled, mise fetches the shorthand registry published with the latest mise release and
@@ -40,7 +42,7 @@ remote registries cannot be loaded. Fast and offline commands never refresh the 
 use an existing cached copy or the bundled snapshot.
 The mise registry is cached for [`registry_cache_ttl`](/configuration/settings.html#registry_cache_ttl),
 which defaults to one hour; aqua continues to use
-[`aqua.registry_cache_ttl`](/configuration/settings.html#aqua-registry_cache_ttl), which defaults to
+[`aqua.registry_cache_ttl`](/configuration/settings.html#aqua.registry_cache_ttl), which defaults to
 one week. `mise cache clear` forces both to be downloaded again on their next online use.
 
 This behavior is opt-in because a floating registry may contain changes that were made after the
@@ -50,6 +52,11 @@ available.
 ## Backends
 
 In addition to built-in [core tools](/core-tools.html), `mise` supports a variety of [backends](/dev-tools/backends/) to install tools.
+
+These tiers apply to **new registry submissions**, not to backends you may use in your
+own configuration. New entries must already be widely used, normally with thousands of
+GitHub stars, and must list installable versions. See [Contributing](/contributing.html)
+before submitting a shorthand. Backend availability alone does not qualify a tool.
 
 Backends fall into the following acceptance tiers for new registry entries:
 
@@ -69,14 +76,17 @@ Backends fall into the following acceptance tiers for new registry entries:
 
 **Tier 4 — very high bar, rarely accepted:**
 
-- [pipx](./dev-tools/backends/pipx.html) - only for python tools, requires `python` on PATH
+- [pipx](./dev-tools/backends/pipx.html) - Python applications; uses uv by default, which can provision Python
 - [npm](./dev-tools/backends/npm.html) - only for node tools, requires `node` on PATH
 - [gem](./dev-tools/backends/gem.html) - only for ruby tools, requires `ruby` on PATH
 - [go](./dev-tools/backends/go.html) - only for go tools, requires `go` to be installed to compile. Because go tools can be distributed as a single binary, packslip/aqua/github/gitlab are preferred.
 - [cargo](./dev-tools/backends/cargo.html) - only for rust tools, requires `cargo` to be installed to compile. Because rust tools can be distributed as a single binary, packslip/aqua/github/gitlab are preferred.
 - [dotnet](./dev-tools/backends/dotnet.html) - only for dotnet tools, requires `dotnet` to be installed to compile. Because dotnet tools can be distributed as a single binary, packslip/aqua/github/gitlab are preferred.
 
-These all depend on a separately-installed runtime/toolchain on PATH, which is fragile — `npm`/`pipx`/`gem` in particular silently bind tools to whichever `node`/`python`/`ruby` happened to be on PATH at install time.
+These integrations depend on a language runtime or toolchain and can require extra setup.
+For example, npm tools need Node at runtime, and Ruby gems depend on the Ruby installation
+used to install them. Prefer release binaries for registry entries when available; consult
+each backend page for its actual runtime, installer, and binary-download behavior.
 
 **Not accepted:**
 
@@ -87,13 +97,16 @@ Users can still install via any backend themselves with explicit syntax (`mise u
 
 ### Backends Priority
 
-Each tool can define its own priority if it has more than one backend it supports. If you would like to disable a backend, you can do so with the following command:
+An explicitly installed plugin can override its matching shorthand. Otherwise, a shorthand
+lists backends in preference order. Platform support, disabled backends, and
+version boundaries affect which eligible backend is selected. If you would like to disable a backend, you can do so with the following command:
 
 ```shell
-mise settings disable_backends=asdf
+mise settings set disable_backends asdf
 ```
 
-This will disable the [asdf](./dev-tools/backends/asdf.html) backend. See [Aliases](/dev-tools/aliases.html) for a way to set a default backend for a tool. Note that the `asdf` backend is disabled by default on Windows.
+This replaces the configured disabled-backend list with `asdf`; include any other backends
+you want disabled in the same comma-separated value. It disables the [asdf](./dev-tools/backends/asdf.html) backend. See [Aliases](/dev-tools/aliases.html) for a way to set a default backend for a tool. Note that the `asdf` backend is disabled by default on Windows.
 
 You can also specify the full name for a tool using `mise use aqua:1password/cli` if you want to use a specific backend.
 


### PR DESCRIPTION
Make plugin selection and maintenance actionable across backend, tool, environment, package, and legacy asdf integrations. Correct executable invocation, Git revision syntax, update-all syntax, removal versus purge, local development, plugin-code pinning, and the claim that Lua plugins are sandboxed.

Replace broken asdf JSON scraping and installation sketches with a runnable local fixture. Clarify registry shorthand options, installed-plugin precedence, submission requirements, floating registry settings, and explicit backend selection. Preserve TOML 1.1 multiline inline tables.

Validation: five TOML 1.1 examples, full lint-fix with Rust 1.95, scoped safe hk checks, docs build, and rendered links. An isolated smoke test runs the documented asdf plugin, lists and selects its version, verifies execution, updates a local link, checks that ordinary removal retains tools, and confirms explicit purge removes the installation while preserving the source. Registry settings commands were also exercised. Rebased on main and rebuilt docs/public/llms.txt.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security logic modifications; any risk is limited to possible CLI naming or behavior mismatches in examples.
> 
> **Overview**
> This PR **rewrites the plugin and registry docs** so readers pick built-in backends and explicit backend IDs before installing Lua or asdf plugins, with a **plugin-type comparison table** (backend, tool, environment, package, legacy asdf) and clearer security wording that **plugins are not OS-sandboxed**.
> 
> **Using Plugins** and **Plugins overview** now use generic examples for install/link/update flows, **`plugin:tool` vs single-tool naming**, **`mise exec -- <executable>`**, Git **`#ref` pinning** (separate from tool version pins), **remove vs `--purge`**, zip/local **`--force`** behavior, and pointers to package/env plugin setup.
> 
> **Legacy asdf** docs drop brittle JSON-`grep` samples in favor of **`set -euo pipefail`**, optional **`bin/download`**, explicit **`asdf:owner/repo`** selection when shorthands prefer other backends, a **local runnable fixture** for testing, and corrected Windows/asdf-backend limits.
> 
> **Registry** docs explain **`mise registry`**, shorthand backend options, **installed-plugin precedence**, **`mise settings set`** for floating registries and **`disable_backends`**, stricter **submission tier** notes, and updated tier-4 runtime descriptions (e.g. pipx/uv). **`docs/public/llms.txt`** summaries were refreshed to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d97f086da161ad86988a2e82d3e0ed3be0132e5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated plugin documentation with clearer guidance on plugin types, built-in backends, installation, management, security, troubleshooting, and migration.
  - Clarified legacy plugin limitations, script requirements, testing procedures, and version handling.
  - Expanded registry documentation covering backend mappings, compatibility, priorities, caching, and configuration.
  - Improved public reference content describing registries, plugins, and custom installation integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->