### PR TITLE
docs: correct plugin authoring contracts and examples

### DIFF
--- a/docs/backend-plugin-development.md
+++ b/docs/backend-plugin-development.md
@@ -4,14 +4,14 @@
 The [mise-backend-plugin-template](https://github.com/jdx/mise-backend-plugin-template) provides a ready-to-use starting point with LuaCATS type definitions, stylua formatting, and hk linting pre-configured.
 :::
 
-Backend plugins in mise use enhanced backend methods to manage multiple tools with the `plugin:tool` format. They are well suited to package managers, tool families, and custom installations that manage several related tools.
+Backend plugins in mise use dedicated backend hooks to manage multiple tools with the `plugin:tool` format. They are well suited to package managers, tool families, and custom installations that manage several related tools.
 
 ## What are Backend Plugins?
 
-Backend plugins extend the standard vfox plugin system with enhanced backend methods. They support:
+Backend plugins extend the standard vfox plugin system with dedicated backend hooks. They support:
 
 - **Multiple Tools**: One plugin can manage multiple tools. For example, `vfox-npm` can install `prettier`, `eslint`, and other npm packages
-- **Cross-Platform Support**: Works on Windows, macOS, and Linux
+- **Cross-Platform Support**: Lua runs on Windows, macOS, and Linux; your installer must support each target
 - **Flexible Architecture**: A modern plugin system with dedicated backend methods
 
 ## Plugin Architecture
@@ -45,7 +45,9 @@ end
 ```
 
 > [!WARNING]
-> **Version sorting**: The versions returned by `BackendListVersions` should be in ascending order (oldest to newest), sorted semantically (version `3.10.0` should not come before `3.2.0`). mise does not apply any additional sorting to the versions returned by this method.
+> Return versions **oldest to newest**, according to the tool's release policy. mise preserves
+> that order. Do not assume SemVer: versions may be dates, prereleases, or channel names.
+> This is the opposite of a tool plugin's `Available` hook, which returns newest first.
 
 ### BackendInstall
 
@@ -69,7 +71,8 @@ end
 
 ### BackendExecEnv
 
-Sets up environment variables for a tool:
+Returns environment entries for a selected installation. Implement this hook even when
+there are no entries to add; return `{env_vars = {}}` in that case:
 
 ```lua
 function PLUGIN:BackendExecEnv(ctx)
@@ -125,7 +128,7 @@ my-backend-plugin/
 │   ├── backend_list_versions.lua   # BackendListVersions hook
 │   ├── backend_install.lua         # BackendInstall hook
 │   └── backend_exec_env.lua        # BackendExecEnv hook
-└── Injection.lua                   # Runtime injection (auto-generated)
+
 ```
 
 ### 2. Basic metadata.lua
@@ -141,7 +144,13 @@ PLUGIN = {
 
 ## Real-World Example: vfox-npm
 
-Here's the complete implementation of the vfox-npm plugin, which manages npm packages:
+This small teaching implementation uses npm to install packages. It requires a POSIX shell
+and Node/npm on PATH; the commands below are not a Windows implementation. For everyday
+use, prefer the built-in [npm backend](/dev-tools/backends/npm.html), which handles platform
+integration and additional installation options.
+
+The snippets belong in the three hook files shown. They pass package values through quoted
+environment variables instead of concatenating them into shell commands.
 
 ### metadata.lua
 
@@ -150,7 +159,8 @@ PLUGIN = {
     name = "vfox-npm",
     version = "1.0.0",
     description = "Backend plugin for npm packages",
-    author = "jdx"
+    author = "Plugin Author",
+    depends = { "node" },
 }
 ```
 
@@ -158,12 +168,22 @@ PLUGIN = {
 
 ```lua
 function PLUGIN:BackendListVersions(ctx)
+    if RUNTIME.osType == "windows" then
+        error("This example requires a POSIX shell")
+    end
     local cmd = require("cmd")
     local json = require("json")
-
-    local result = cmd.exec("npm view " .. ctx.tool .. " versions --json")
+    local result = cmd.exec('npm view "$MISE_PLUGIN_PACKAGE" versions --json', {
+        env = {MISE_PLUGIN_PACKAGE = ctx.tool},
+    })
     local versions = json.decode(result)
-
+    -- npm can return a single version as a string.
+    if type(versions) == "string" then
+        versions = {versions}
+    end
+    if type(versions) ~= "table" or #versions == 0 then
+        error("No versions returned for " .. ctx.tool)
+    end
     return {versions = versions}
 end
 ```
@@ -172,16 +192,14 @@ end
 
 ```lua
 function PLUGIN:BackendInstall(ctx)
-    local tool = ctx.tool
-    local version = ctx.version
-    local install_path = ctx.install_path
-
-    -- Install the package directly using npm install
+    if RUNTIME.osType == "windows" then
+        error("This example requires a POSIX shell")
+    end
     local cmd = require("cmd")
-    local npm_cmd = "npm install " .. tool .. "@" .. version .. " --no-package-lock --no-save --silent"
-    local result = cmd.exec(npm_cmd, {cwd = install_path})
-
-    -- If we get here, the command succeeded
+    cmd.exec('npm install --no-package-lock --no-save -- "$MISE_PLUGIN_SPEC"', {
+        cwd = ctx.install_path,
+        env = {MISE_PLUGIN_SPEC = ctx.tool .. "@" .. ctx.version},
+    })
     return {}
 end
 ```
@@ -204,8 +222,9 @@ end
 The plugin name doesn't have to match the repository name. The backend prefix is whatever name the plugin was installed under.
 
 ```bash
-# Install the plugin
-mise plugin install vfox-npm https://github.com/jdx/vfox-npm
+# Link the example you created and configure its prerequisite
+mise plugin link vfox-npm /path/to/your/plugin
+mise use node@24
 
 # List available versions
 mise ls-remote vfox-npm:prettier
@@ -220,7 +239,9 @@ mise use vfox-npm:prettier@latest
 mise exec -- prettier --help
 ```
 
-> **Tip**: This naming flexibility lets a plugin behave differently depending on the name it was installed under. For example, you could install the same plugin under different names to configure different behaviors or access different tool registries.
+Use a name that does not collide with a built-in backend. To test different registries or
+behavior, define explicit tool options and read `ctx.options`; the installed name is not a
+substitute for an options contract.
 
 ## Context Variables
 
@@ -288,48 +309,12 @@ mise --debug install my-plugin:some-tool@1.0.0
 
 ### Error Handling
 
-Provide meaningful error messages:
+`cmd.exec` raises an error on a nonzero exit status and includes stderr. Do not hide stderr
+or search successful stdout for an error string. Check HTTP status codes before parsing
+bodies, validate required response fields, and keep credentials out of errors.
 
-```lua
-function PLUGIN:BackendListVersions(ctx)
-    local tool = ctx.tool
-
-    -- Validate tool name
-    if not tool or tool == "" then
-        error("Tool name cannot be empty")
-    end
-
-    -- Execute command with error checking
-    local cmd = require("cmd")
-    local result = cmd.exec("npm view " .. tool .. " versions --json 2>/dev/null")
-    if not result or result:match("npm ERR!") then
-        error("Failed to fetch versions for " .. tool .. ": " .. (result or "no output"))
-    end
-
-    -- Parse JSON response
-    local json = require("json")
-    local success, npm_versions = pcall(json.decode, result)
-    if not success or not npm_versions then
-        error("Failed to parse versions for " .. tool)
-    end
-
-    -- Return versions or error if none found
-    -- `npm view` already returns versions oldest-to-newest, which is the
-    -- order mise expects, so keep them as-is
-    local versions = {}
-    if type(npm_versions) == "table" then
-        for _, v in ipairs(npm_versions) do
-            table.insert(versions, v)
-        end
-    end
-
-    if #versions == 0 then
-        error("No versions found for " .. tool)
-    end
-
-    return {versions = versions}
-end
-```
+The [Lua modules reference](/plugin-lua-modules.html) explains synchronous errors and the
+HTTP `try_*` methods for recoverable transport failures.
 
 ### Regex Parsing
 
@@ -344,64 +329,28 @@ end
 
 ### Path Handling
 
-Use cross-platform path handling:
+Use `file.join_path` for path construction and `cmd.exec`'s `cwd` option for the command's
+working directory. Prefer file operations over shelling out to `mkdir`, `cp`, or `mv`.
+If your installer needs shell commands, document the shell and quote every external value.
 
 ```lua
-local function join_path(...)
-    local sep = package.config:sub(1,1) -- Get OS path separator
-    return table.concat({...}, sep)
-end
-
-local bin_path = join_path(install_path, "bin")
+local file = require("file")
+local bin_path = file.join_path(ctx.install_path, "bin")
 ```
 
 ### Cross-Platform Commands
 
-Handle different operating systems:
-
-```lua
-local function create_dir(path)
-    local cmd = RUNTIME.osType == "windows" and "mkdir" or "mkdir -p"
-    os.execute(cmd .. " " .. path)
-end
-```
+The Lua runtime does not translate a shell command between operating systems. A POSIX
+`mkdir -p`, `$VARIABLE`, or `chmod` example needs a different implementation on Windows.
+Test on each platform you claim to support, including paths containing spaces.
 
 ## Advanced Features
 
 ### Conditional Installation
 
-Use different installation logic depending on the tool or version:
-
-```lua
-function PLUGIN:BackendInstall(ctx)
-    local tool = ctx.tool
-    local version = ctx.version
-    local install_path = ctx.install_path
-
-    -- Create install directory
-    os.execute("mkdir -p " .. install_path)
-
-    if tool == "special-tool" then
-        -- Special installation logic
-        local cmd = require("cmd")
-        local npm_cmd = "cd " .. install_path .. " && npm install " .. tool .. "@" .. version .. " --no-package-lock --no-save --silent 2>/dev/null"
-        local result = cmd.exec(npm_cmd)
-        if result:match("npm ERR!") then
-            error("Failed to install " .. tool .. "@" .. version)
-        end
-    else
-        -- Default installation logic
-        local cmd = require("cmd")
-        local npm_cmd = "cd " .. install_path .. " && npm install " .. tool .. "@" .. version .. " --no-package-lock --no-save --silent 2>/dev/null"
-        local result = cmd.exec(npm_cmd)
-        if result:match("npm ERR!") then
-            error("Failed to install " .. tool .. "@" .. version)
-        end
-    end
-
-    return {}
-end
-```
+Choose installation logic using `ctx.tool`, `ctx.version`, and `RUNTIME`. Validate that the
+tool and platform are supported before downloading or running an installer. Keep shared
+logic in a Lua helper module instead of duplicating the same command in every branch.
 
 ### Environment Detection
 
@@ -441,8 +390,8 @@ function PLUGIN:BackendExecEnv(ctx)
     return {
         env_vars = {
             {key = "PATH", value = bin_path},
-            {key = ctx.tool:upper() .. "_HOME", value = ctx.install_path},
-            {key = ctx.tool:upper() .. "_VERSION", value = ctx.version}
+            {key = "EXAMPLE_TOOL_HOME", value = ctx.install_path},
+            {key = "EXAMPLE_TOOL_VERSION", value = ctx.version}
         }
     }
 end
@@ -452,7 +401,10 @@ end
 
 ### Caching
 
-TODO: We need caching support for [Shared Lua modules](plugin-lua-modules.md).
+mise caches remote version lists and tool environment results. During development, use
+`mise cache clear my-plugin:some-tool` when a cached result hides a hook change. A Lua table
+only caches within that Lua runtime; it does not persist across separate mise invocations.
+See [cache behavior](/cache-behavior.html) and the [Lua modules reference](/plugin-lua-modules.html#caching).
 
 ## Next Steps
 

--- a/docs/env-plugin-development.md
+++ b/docs/env-plugin-development.md
@@ -1,218 +1,186 @@
 # Environment Plugin Development
 
-Environment plugins are a special type of mise plugin that provides environment variables and PATH modifications without managing tool versions. They're ideal for integrating external services, managing secrets, and standardizing environment configuration across teams.
+Environment plugins return variables and PATH entries without installing a versioned tool.
+Use them for an external configuration service, secret manager, or team environment. They
+run while mise constructs an environment, so keep their hooks fast and non-interactive.
+Their execution frequency depends on environment caching and the command being run.
 
-Unlike [tool plugins](tool-plugin-development.md) and [backend plugins](backend-plugin-development.md), environment plugins:
-
-- Don't implement version management (`Available`, `PreInstall`, `PostInstall` hooks)
-- Only implement environment hooks (`MiseEnv`, `MisePath`)
-- Are configured with the `env._.<plugin-name>` syntax
-- Can accept configuration options as TOML values
-- Execute on every environment activation
+For installation lifecycles, use a [tool](/tool-plugin-development.html) or
+[backend](/backend-plugin-development.html) plugin instead.
 
 ## Quick Start
 
-The fastest way to create an environment plugin is to use the [mise-env-plugin-template](https://github.com/jdx/mise-env-plugin-template).
+Start from the [environment plugin template](https://github.com/jdx/mise-env-plugin-template),
+or create the files below. Link the directory before referencing the directive:
 
-::: tip
-The [mise-env-plugin-template](https://github.com/jdx/mise-env-plugin-template) provides a ready-to-use starting point with LuaCATS type definitions, stylua formatting, and hk linting pre-configured.
-:::
-
-To get started:
-
-```bash
-# Clone the template
-git clone https://github.com/jdx/mise-env-plugin-template my-env-plugin
-cd my-env-plugin
-
-# Customize for your use case
-# Edit metadata.lua, hooks/mise_env.lua, hooks/mise_path.lua
+```sh
+mise plugin link my-env-plugin /path/to/my-env-plugin
 ```
+
+```toml
+[env]
+_.my-env-plugin = {
+  api_url = "https://api.example.com",
+  debug = false,
+}
+```
+
+Check the result with `mise env --json` or run a command through `mise exec`. Environment
+output may contain secrets, so inspect it locally and avoid pasting it into logs or issues.
 
 ## Plugin Structure
 
-Environment plugins are implemented in Lua (currently version 5.1). A minimal environment plugin has this structure:
-
-```
+```text
 my-env-plugin/
-├── metadata.lua           # Plugin metadata
+├── metadata.lua
 └── hooks/
-    ├── mise_env.lua      # Returns environment variables (required)
-    └── mise_path.lua     # Returns PATH entries (optional)
+    ├── mise_env.lua   # variables
+    └── mise_path.lua  # optional PATH entries
 ```
+
+Plugins use mise's embedded Lua 5.1 runtime. Environment hooks are mise extensions; do not
+assume an upstream vfox installation will invoke them.
 
 ### metadata.lua
 
-The `metadata.lua` file defines your plugin's basic information:
-
 ```lua
-PLUGIN = {}
-
---- Plugin name (required)
-PLUGIN.name = "my-env-plugin"
-
---- Plugin version (required)
-PLUGIN.version = "1.0.0"
-
---- Plugin description (required)
-PLUGIN.description = "Provides environment variables for my service"
-
---- Plugin homepage (optional)
-PLUGIN.homepage = "https://github.com/username/my-env-plugin"
-
---- Plugin license (optional)
-PLUGIN.license = "MIT"
-
---- Minimum mise/vfox version required (optional)
-PLUGIN.minRuntimeVersion = "0.3.0"
+PLUGIN = {
+    name = "my-env-plugin",
+    version = "1.0.0",
+    description = "Provide service configuration",
+    author = "Plugin Author",
+}
 ```
+
+Keep metadata declarative. Document and test the required mise version in your README and
+CI; a `minRuntimeVersion` field is not a mise-version compatibility check.
 
 ### hooks/mise_env.lua
 
-The `MiseEnv` hook returns environment variables to set:
+A minimal working hook returns an array of key/value entries:
 
 ```lua
 function PLUGIN:MiseEnv(ctx)
-    -- Access configuration from mise.toml via ctx.options
-    local api_url = ctx.options.api_url or "https://api.example.com"
-    local debug = ctx.options.debug or false
-
-    -- Return array of environment variables
     return {
-        {
-            key = "API_URL",
-            value = api_url
-        },
-        {
-            key = "DEBUG",
-            value = tostring(debug)
-        },
-        {
-            key = "SERVICE_TOKEN",
-            value = get_token_from_somewhere()  -- Your custom logic
-        }
+        {key = "API_URL", value = ctx.options.api_url or "https://api.example.com"},
+        {key = "DEBUG", value = tostring(ctx.options.debug or false)},
     }
 end
 ```
 
-::: tip
-When `cmd.exec()` is called from `MiseEnv` or `MisePath` hooks, it inherits the mise-constructed environment — including `_.path` entries and environment variables from preceding directives. If the module directive is configured with `tools = true` (e.g., `_.my-plugin = { tools = true }`), tool installation bin paths are also included, so mise-managed tools are directly callable (e.g., `cmd.exec("node --version")`).
-:::
-
-**Return value**: Either a simple array of env keys or a table with caching metadata.
-
-Simple format - array of tables, each with:
-
-- `key` (string, required): Environment variable name
-- `value` (string, required): Environment variable value
-
-Extended format - table with:
-
-- `env` (array, required): Array of `{key, value}` tables (same as simple format)
-- `cacheable` (boolean, optional): If `true`, mise can cache this plugin's output. Default: `false`
-- `watch_files` (array of strings, optional): File paths to watch for changes. If any file's mtime changes, the cache is invalidated.
-
-Example using extended format with caching:
+Keys and values must be strings. To provide cache and redaction metadata, return a table:
 
 ```lua
 function PLUGIN:MiseEnv(ctx)
-    local config_path = ctx.options.config_file or "config.json"
-    local config = load_config(config_path)
-
+    local file = require("file")
+    local json = require("json")
+    local path = file.join_path(ctx.config_root, ctx.options.config_file or "service.json")
+    local config = json.decode(file.read(path))
+    assert(type(config.api_url) == "string", "service.json must contain a string api_url")
     return {
         cacheable = true,
-        watch_files = {config_path},
-        env = {
-            {key = "API_URL", value = config.api_url},
-            {key = "API_KEY", value = config.api_key}
-        }
+        watch_files = {path},
+        env = {{key = "API_URL", value = config.api_url}},
     }
 end
 ```
 
-When `cacheable = true`, mise caches the environment variables and only re-executes the plugin when:
+This example treats `config_file` as relative to the config root. Define and document a
+separate policy if your plugin also accepts absolute paths.
 
-- Any file in `watch_files` changes
-- The mise configuration changes
-- The cache TTL expires (configured via `env_cache_ttl` setting)
+| Field         | Meaning                                                                                                       |
+| ------------- | ------------------------------------------------------------------------------------------------------------- |
+| `env`         | Array of `{key, value}` entries; omitted means no variables                                                   |
+| `cacheable`   | Whether mise may cache this output; defaults to `false`                                                       |
+| `watch_files` | Files whose modification times participate in cache validation; relative entries resolve from the config root |
+| `redact`      | Request redaction of returned values in mise's processed output; defaults to `false`                          |
 
-::: tip
-For caching to work, users must enable the `env_cache` setting:
+A user's explicit directive-level `redact` option overrides the plugin's preference.
+Redaction does not remove values from the environment and raw task output bypasses it.
+See [redactions](/environments/#redactions).
 
-```toml
-# ~/.config/mise/config.toml
-[settings]
-env_cache = true
-```
-
-:::
+Caching requires the global `env_cache` setting. The cache is session-keyed and has a TTL;
+file watching does not detect a changed value in a remote service. There are also limitations
+when cached environments are inherited by nested mise invocations. Do not promise immediate
+refresh of secrets merely because `cacheable = false` or `watch_files` is present. Use
+`MISE_ENV_CACHE=0` when current values are required; see [cache behavior](/cache-behavior.html).
 
 ### hooks/mise_path.lua
 
-The optional `MisePath` hook returns directories to add to PATH:
+Return an array of directory paths. For project-relative configuration, resolve paths
+against `ctx.config_root`, not the process's current working directory:
 
 ```lua
 function PLUGIN:MisePath(ctx)
-    -- Return array of paths to prepend to PATH
-    local paths = {
-        "/opt/my-service/bin"
-    }
-
-    -- Optionally add user-configured path
-    if ctx.options.custom_bin_path then
-        table.insert(paths, ctx.options.custom_bin_path)
+    local file = require("file")
+    if not ctx.options.bin_dir then
+        return {}
     end
-
-    return paths
+    return {file.join_path(ctx.config_root, ctx.options.bin_dir)}
 end
 ```
 
-**Return value**: Array of strings (directory paths)
+This example accepts a relative `bin_dir`. The hook returns directories to add to PATH,
+not a full PATH string. Return only existing directories your integration needs.
 
 ## Context Object
 
-Both hooks receive a `ctx` parameter with:
+Both hooks receive `ctx.options`, containing directive configuration as typed TOML values,
+and `ctx.config_root`, the root associated with the declaring config file. Resolve local
+input files from that root so invoking mise from a subdirectory produces the same result.
 
-- **`ctx.options`**: TOML table of user configuration from `mise.toml`
+`os.getenv` and `cmd.exec` see the mise-constructed environment, including preceding
+directives and `_.path` entries. To expose configured tool binaries, use `tools = true`:
 
-For environment plugins, `ctx.options` is the primary way to accept user configuration.
+```toml
+[tools]
+node = "24"
+
+[env]
+_.my-env-plugin = { tools = true }
+```
+
+This runs the directive in the tool-aware phase. It does not declare which external programs
+your plugin requires; document those prerequisites for users.
 
 ## Configuration in mise.toml
 
-Users configure environment plugins using the `env._` directive:
-
-Simple activation with no options:
+An empty table invokes a plugin without custom options:
 
 ```toml
 [env]
 _.my-env-plugin = {}
 ```
 
-With configuration options:
+Use a TOML table for options. mise supports TOML 1.1 multiline inline tables, comments, and
+trailing commas:
 
 ```toml
 [env]
 _.my-env-plugin = {
-  api_url = "https://prod.api.example.com",
-  debug = false,
-  custom_bin_path = "/custom/path/bin",
+  # Relative to the file's configuration root.
+  config_file = "service.json",
+  bin_dir = "bin",
 }
 ```
 
-All fields in the TOML table are passed to your hooks as `ctx.options`.
+Reserve mise's directive controls, such as `tools` and `redact`, for their documented
+meaning. Do not repurpose them as unrelated plugin options.
 
 ## Complete Example: Secret Manager Plugin
 
-Here's a complete example of a plugin that fetches secrets from an external service:
+This hook reads string-valued secrets from a [HashiCorp Vault KV v2](https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#read-secret-version) response. It requires
+a preexisting `VAULT_TOKEN` with permission to read the selected path. It does not implement
+token login/renewal, namespaces, or other Vault secret engines.
 
 **metadata.lua**:
 
 ```lua
-PLUGIN = {}
-PLUGIN.name = "vault-secrets"
-PLUGIN.version = "1.0.0"
-PLUGIN.description = "Fetch secrets from HashiCorp Vault"
-PLUGIN.minRuntimeVersion = "0.3.0"
+PLUGIN = {
+    name = "vault-secrets",
+    version = "1.0.0",
+    description = "Read Vault KV v2 secrets",
+}
 ```
 
 **hooks/mise_env.lua**:
@@ -222,39 +190,31 @@ local http = require("http")
 local json = require("json")
 
 function PLUGIN:MiseEnv(ctx)
-    local vault_url = ctx.options.vault_url or error("vault_url required")
-    local secrets_path = ctx.options.secrets_path or error("secrets_path required")
-    local vault_token = os.getenv("VAULT_TOKEN") or error("VAULT_TOKEN not set")
-
-    -- Fetch secrets from Vault
-    local url = vault_url .. "/v1/" .. secrets_path
+    local vault_url = ctx.options.vault_url or error("vault_url is required")
+    local secrets_path = ctx.options.secrets_path or error("secrets_path is required")
+    local token = os.getenv("VAULT_TOKEN") or error("VAULT_TOKEN is not set")
     local response = http.get({
-        url = url,
-        headers = {
-            ["X-Vault-Token"] = vault_token
-        }
+        url = vault_url:gsub("/+$", "") .. "/v1/" .. secrets_path,
+        headers = {["X-Vault-Token"] = token},
     })
-
     if response.status_code ~= 200 then
-        error("Failed to fetch secrets: " .. response.status_code)
+        error("Vault request failed with HTTP " .. response.status_code)
     end
-
-    local data = json.decode(response.body)
-    local env_vars = {}
-
-    -- Convert Vault secrets to environment variables
-    for key, value in pairs(data.data.data) do
-        table.insert(env_vars, {
-            key = key,
-            value = value
-        })
+    local payload = json.decode(response.body)
+    local data = payload.data and payload.data.data
+    assert(type(data) == "table", "Expected a Vault KV v2 data response")
+    local variables = {}
+    for key, value in pairs(data) do
+        assert(key:match("^[%a_][%w_]*$"), "Secret key is not an environment variable name")
+        assert(type(value) == "string", "Secret values must be strings")
+        table.insert(variables, {key = key, value = value})
     end
-
-    return env_vars
+    return {env = variables, cacheable = false, redact = true}
 end
 ```
 
-**Usage in mise.toml**:
+Install or link this plugin as `vault-secrets`, then configure the endpoint and KV v2 API
+path. Use an HTTPS endpoint you trust to receive the token:
 
 ```toml
 [env]
@@ -264,204 +224,76 @@ _.vault-secrets = {
 }
 ```
 
+The hook returns unmasked values to child processes. Redaction only affects supported mise
+output processing. Account for the cache limitations above when defining secret freshness.
+
 ## Available Lua Modules
 
-Environment plugins have access to mise's built-in Lua modules:
-
-- **`http`**: Make HTTP requests
-- **`json`**: Encode/decode JSON
-- **`file`**: Read/write files
-- **`cmd`**: Execute shell commands
-- **`strings`**: String manipulation utilities
-- **`env`**: Access environment variables
-
-See [Plugin Lua Modules](/plugin-lua-modules.html) for complete documentation.
+Use the [Lua modules reference](/plugin-lua-modules.html) for HTTP, JSON, files, commands,
+strings, and logging. `cmd.exec` invokes a shell; prefer direct file/HTTP operations when
+possible and never interpolate an untrusted option into a command string.
 
 ## Best Practices
 
-### 1. Provide Sensible Defaults
+Validate required options before a request and reject malformed responses with a useful
+error that omits credentials and secret values. Provide defaults only when they have a clear
+meaning. Avoid interactive login during shell activation; explain authentication setup in
+the plugin README.
 
-```lua
-function PLUGIN:MiseEnv(ctx)
-    local api_url = ctx.options.api_url or "https://api.example.com"
-    local timeout = ctx.options.timeout or 30
-
-    -- ...
-end
-```
-
-### 2. Validate Required Options
-
-```lua
-function PLUGIN:MiseEnv(ctx)
-    if not ctx.options.api_key then
-        error("api_key is required in mise.toml configuration")
-    end
-
-    -- ...
-end
-```
-
-### 3. Handle Errors Gracefully
-
-```lua
-function PLUGIN:MiseEnv(ctx)
-    local response = http.get({url = ctx.options.api_url})
-
-    if response.status_code ~= 200 then
-        error("API request failed: " .. response.status_code .. " - " .. response.body)
-    end
-
-    -- ...
-end
-```
+Return environment values through the hook. `env.setenv` changes the mise process itself;
+it is not the mechanism for returning variables to the user's shell.
 
 ### 4. Use Built-in Caching for Expensive Operations
 
-For plugins that fetch data from external services, use mise's built-in caching by returning the extended format with `cacheable = true`:
-
-```lua
-function PLUGIN:MiseEnv(ctx)
-    local config_file = ctx.options.config_file or "secrets.json"
-
-    -- Fetch secrets (mise will cache the result)
-    local secrets = fetch_secrets(ctx.options)
-
-    return {
-        cacheable = true,
-        watch_files = {config_file},  -- Re-fetch if config changes
-        env = secrets
-    }
-end
-```
-
-This is preferred over manual caching because:
-
-- mise handles cache invalidation automatically
-- The cache is encrypted with session-scoped keys
-- It integrates with `mise cache clear` and `mise cache prune`
-- It respects the `env_cache_ttl` setting
-
-Users must enable `env_cache = true` in their settings for caching to work.
-
-### 5. Support Multiple Environments
-
-```lua
-function PLUGIN:MiseEnv(ctx)
-    local env_name = ctx.options.environment or "development"
-
-    -- Load different config based on environment
-    local config = load_config(env_name)
-
-    return {
-        {key = "ENV", value = env_name},
-        {key = "API_URL", value = config.api_url},
-        -- ...
-    }
-end
-```
+Opt into caching only when a stale result is acceptable for the configured TTL. List local
+inputs in `watch_files`, and test refresh from an inherited shell session as well as a fresh
+process. A local Lua table is not a persistent cache across mise invocations.
 
 ## Testing Your Plugin
 
 ### Local Testing
 
-1. Link your plugin for development:
+Test from an isolated configuration/data directory, using the workflow in
+[Plugin Publishing](/plugin-publishing.html#testing-before-publication). Cover at least:
 
-```bash
-mise plugin link my-env-plugin /path/to/my-env-plugin
-```
-
-2. Configure it in `mise.toml`:
-
-```toml
-[env]
-_.my-env-plugin = { test_option = "value" }
-```
-
-3. Test the environment:
-
-```bash
-# See environment variables
-mise env | grep MY_
-
-# Run a command with the environment
-mise exec -- env | grep MY_
-
-# Debug with MISE_DEBUG
-MISE_DEBUG=1 mise env
-```
+- A minimal directive and each supported option.
+- Invocation from a subdirectory, including file and PATH resolution.
+- Missing credentials, non-200 HTTP responses, and malformed payloads.
+- The `tools = true` phase if the plugin invokes a configured tool.
+- Fresh and cached environments when cache metadata is returned.
 
 ### Common Issues
 
-**Plugin not found**: Make sure you've installed or linked the plugin:
+Use `mise plugins ls` to confirm the plugin name matches the directive. Check the TOML
+shape: `_.my-plugin = { key = "value" }` is a table; a string value is not the same interface.
+Use `MISE_DEBUG=1 mise env` locally for hook failures, taking care with secret-bearing output.
 
-```bash
-mise plugin ls
-```
-
-**Hook not executing**: Enable debug logging:
-
-```bash
-MISE_DEBUG=1 mise env
-```
-
-**Options not passed**: Verify TOML syntax in `mise.toml`:
-
-```toml
-[env]
-# Correct: TOML table
-_.my-plugin = { key = "value" }
-
-# Wrong: String value
-_.my-plugin = "value"  # This won't work
-```
+If the hook is not running, check for safe mode or a cached environment. If a command is
+missing, confirm its prerequisite and whether the directive needs `tools = true`.
 
 ## Publishing Your Plugin
 
-Once your environment plugin is ready:
-
-1. **Create a GitHub repository** for your plugin
-2. **Add a README** with usage instructions
-3. **Tag releases** following semantic versioning
-4. **Share the repository URL** (optional) so others can install it directly with `mise plugin install`
-
-See [Plugin Publishing](/plugin-publishing.html) for detailed instructions.
+Document the configuration fields, required credentials, API scope, supported platforms,
+and cache/redaction behavior. Publish a Git repository and share its URL; a registry
+shorthand is not required. See [Plugin Publishing](/plugin-publishing.html).
 
 ## Examples
 
-- [mise-env-plugin-template](https://github.com/jdx/mise-env-plugin-template) - Simple example showing basic usage
-- The [mise-plugins](https://github.com/mise-plugins) organization currently hosts tool plugins only. Add your environment plugin there (or share it with the community) so others can learn from more examples
+Start with the [environment template](https://github.com/jdx/mise-env-plugin-template) and
+adapt the working hooks above. Treat a third-party example as code to review, not as an
+assurance that its service or authentication behavior matches your environment.
 
 ## Migration from Tool Plugins
 
-If you have an existing tool plugin that only sets environment variables, you can simplify it to an environment-only plugin:
-
-**Before** (tool plugin with unused hooks):
-
-```
-my-plugin/
-├── metadata.lua
-└── hooks/
-    ├── available.lua        # Returns empty list
-    ├── pre_install.lua      # Not used
-    ├── post_install.lua     # Not used
-    └── env_keys.lua         # Actually sets env vars
-```
-
-**After** (environment plugin):
-
-```
-my-plugin/
-├── metadata.lua
-└── hooks/
-    └── mise_env.lua         # Clean and focused
-```
+Move environment-only behavior from `EnvKeys` into `MiseEnv`, add a directive under `[env]`,
+and remove the artificial tool version/install hooks. Use `MisePath` for PATH entries.
+This changes activation from a selected tool version to an explicit environment directive;
+document the configuration migration for existing users.
 
 ## Related Documentation
 
-- [Plugin Overview](/plugins.html) - Overview of all plugin types
-- [Tool Plugin Development](/tool-plugin-development.html) - For plugins that manage tool versions
-- [Backend Plugin Development](/backend-plugin-development.html) - For multi-tool backends
-- [Plugin Lua Modules](/plugin-lua-modules.html) - Available Lua APIs
-- [Plugin Publishing](/plugin-publishing.html) - Publishing your plugin
-- [Environment Variables](/environments/) - How mise manages environments
+- [Plugin Overview](/plugins.html).
+- [Tool Plugin Development](/tool-plugin-development.html).
+- [Backend Plugin Development](/backend-plugin-development.html).
+- [Plugin Lua Modules](/plugin-lua-modules.html).
+- [Environment Variables](/environments/).

--- a/docs/env-plugin-development.md
+++ b/docs/env-plugin-development.md
@@ -116,7 +116,12 @@ function PLUGIN:MisePath(ctx)
     if not ctx.options.bin_dir then
         return {}
     end
-    return {file.join_path(ctx.config_root, ctx.options.bin_dir)}
+    local path = file.join_path(ctx.config_root, ctx.options.bin_dir)
+    local metadata = file.stat(path)
+    if not metadata or not metadata.is_dir then
+        return {}
+    end
+    return {path}
 end
 ```
 
@@ -191,6 +196,7 @@ local json = require("json")
 
 function PLUGIN:MiseEnv(ctx)
     local vault_url = ctx.options.vault_url or error("vault_url is required")
+    assert(vault_url:match("^https://"), "vault_url must use HTTPS")
     local secrets_path = ctx.options.secrets_path or error("secrets_path is required")
     local token = os.getenv("VAULT_TOKEN") or error("VAULT_TOKEN is not set")
     local response = http.get({

--- a/docs/package-plugin-development.md
+++ b/docs/package-plugin-development.md
@@ -5,6 +5,11 @@ manager for [`[bootstrap.packages]`](/bootstrap/packages/). It wraps state owned
 by a host tool rather than installing versioned tools under mise's data
 directory.
 
+Start with a manager that can report installed state without prompting or making changes.
+The status hook drives previews and action selection, so an inaccurate answer can cause
+unnecessary installations or hide missing packages. See [package plugin usage](/bootstrap/packages/plugins.html)
+for user configuration.
+
 ## Layout
 
 ```text
@@ -23,6 +28,18 @@ identifies the repository as a package plugin. A repository with only one of
 these hooks remains a regular vfox plugin. If `hooks/backend_install.lua` is
 also present, mise treats the repository as a tool backend instead; package
 and tool-backend plugins must be separate repositories.
+
+Provide normal Lua metadata as well as the package-manager declaration:
+
+```lua
+PLUGIN = {
+  name = "vscode-extensions",
+  version = "1.0.0",
+  description = "Manage VS Code extensions",
+}
+```
+
+In `mise.plugin.toml`:
 
 ```toml
 [package-manager]
@@ -54,15 +71,29 @@ Hooks are batch-oriented, but each hook receives the batch for its own phase:
 
 mise does not call an action hook when its action batch is empty.
 
+For example, a VS Code manager can inspect extensions with one host command and return
+only the requested identities:
+
 ```lua
 function PLUGIN:PackageInstalled(ctx)
-  -- ctx.packages: {{ name = "diff", version = "1.3.4" | nil }, ...}
-  return {
-    packages = {
-      { name = "diff", state = "installed", version = "1.3.4" },
-      { name = "s3", state = "missing" },
-    },
-  }
+  local output = require("cmd").exec("code --list-extensions --show-versions")
+  local installed = {}
+  for line in output:gmatch("[^\r\n]+") do
+    local name, version = line:match("^(.+)@([^@]+)$")
+    if name then
+      installed[name:lower()] = version
+    end
+  end
+  local results = {}
+  for _, package in ipairs(ctx.packages) do
+    local version = installed[package.name:lower()]
+    table.insert(results, {
+      name = package.name,
+      state = version and "installed" or "missing",
+      version = version,
+    })
+  end
+  return {packages = results}
 end
 ```
 
@@ -132,5 +163,17 @@ and new removal candidates are never added without another confirmation.
 
 For a VS Code implementation, `PackageInstalled` can parse
 `code --list-extensions --show-versions`, `PackageInstall` can run
-`code --install-extension name[@version]`, and `PackageUpgrade` can run
-`code --update-extensions` or reinstall the requested extensions.
+`code --install-extension name[@version]`, and `PackageUpgrade` can reinstall only the
+requested extensions. Avoid `code --update-extensions` for a selected batch: it updates
+extensions outside that batch too. Keep any profile selection consistent between status
+and action hooks, and quote package arguments for the shell in use.
+
+## Testing
+
+Test against a disposable host profile or a fake host CLI before changing real packages.
+Cover an empty batch, missing and installed packages, exact pin mismatch, failed action,
+and a subset request. Verify that status calls never mutate state and that an action touches
+only `ctx.packages`. Test dry runs and the explicit prune ownership checks separately.
+
+See [Plugin Publishing](/plugin-publishing.html) for isolated mise directories and release
+validation, and [Lua modules](/plugin-lua-modules.html#command-module) for command execution.

--- a/docs/plugin-lua-modules.md
+++ b/docs/plugin-lua-modules.md
@@ -1,6 +1,11 @@
 # Plugin Lua Modules
 
-mise plugins have access to a comprehensive set of built-in Lua modules. These modules are available in both backend plugins and tool plugins, making it easy to perform common operations like HTTP requests, JSON parsing, and file operations.
+mise's embedded Lua 5.1 runtime provides modules for plugin hooks, including backend, tool,
+environment, and package plugins. This reference describes mise's implementations; upstream
+vfox may differ. Load modules with `require` and use `RUNTIME` for the target platform.
+
+Use direct HTTP and file operations when possible. `cmd.exec` runs a shell, so command
+quoting and external prerequisites still depend on the selected platform.
 
 ## Available Modules
 
@@ -12,14 +17,17 @@ mise plugins have access to a comprehensive set of built-in Lua modules. These m
 - **`file`** - File system operations
 - **`env`** - Environment variable operations
 - **`strings`** - String manipulation utilities
-- **`semver`** - Semantic version comparison and sorting
+- **`semver`** - Numeric-component comparison and sorting (not full SemVer precedence)
 - **`html`** - HTML parsing and manipulation
 - **`archiver`** - Archive extraction
 - **`log`** - Structured logging
 
 ## HTTP Module
 
-The HTTP module makes web requests and downloads files.
+The HTTP module makes web requests and downloads files. `get` and `head` return a response
+or raise on a transport failure; a non-2xx HTTP response is still a response, so check
+`status_code`. `download_file` raises on transport and HTTP error status and returns no
+value on success. Use the non-raising `try_*` variants for fallback logic.
 
 ### Basic HTTP Requests
 
@@ -27,7 +35,7 @@ The HTTP module makes web requests and downloads files.
 local http = require("http")
 
 -- GET request
-local resp, err = http.get({
+local resp = http.get({
     url = "https://api.github.com/repos/owner/repo/releases",
     headers = {
         ['User-Agent'] = "mise-plugin",
@@ -35,9 +43,6 @@ local resp, err = http.get({
     }
 })
 
-if err ~= nil then
-    error("Request failed: " .. err)
-end
 
 if resp.status_code ~= 200 then
     error("HTTP error: " .. resp.status_code)
@@ -52,13 +57,10 @@ local body = resp.body
 local http = require("http")
 
 -- HEAD request to check file info
-local resp, err = http.head({
+local resp = http.head({
     url = "https://example.com/file.tar.gz"
 })
 
-if err ~= nil then
-    error("HEAD request failed: " .. err)
-end
 
 local content_length = resp.headers['content-length']
 local content_type = resp.headers['content-type']
@@ -201,32 +203,32 @@ print(strings.has_prefix(text, "hello"))  -- true
 print(strings.has_suffix(text, "world"))  -- true
 print(strings.contains(text, "lo wo"))    -- true
 
--- Trim specific characters
+-- Remove repeated exact suffixes (not a character set)
 local trimmed = strings.trim("hello world", "world")
 print(trimmed)  -- "hello "
 ```
 
 ### Version String Utilities
 
+Use Lua patterns to remove a known publisher prefix. The module has no `trim_prefix`
+function, and stripping a prerelease suffix would change the requested version:
+
 ```lua
-local strings = require("strings")
-
--- Common version string operations
 local function normalize_version(version)
-    -- Remove 'v' prefix if present
-    version = strings.trim_prefix(version, "v")
-
-    -- Remove pre-release suffixes
-    local parts = strings.split(version, "-")
-    return parts[1]
+    return (version:gsub("^v", ""))
 end
-
-local version = normalize_version("v1.2.3-beta.1")  -- "1.2.3"
+local version = normalize_version("v1.2.3-beta.1") -- "1.2.3-beta.1"
 ```
 
 ## Semver Module
 
-The semver module compares and sorts semantic versions. It is useful for sorting the version lists returned by `Available()` hooks.
+Despite its name, this module compares **numeric components extracted from strings**, not
+full Semantic Versioning precedence. It ignores non-digit text and treats missing numeric
+components as zero. For example, `1.0.0-beta` compares equal to `1.0.0`, and `1.0.0-beta.1`
+compares greater. Do not use it to choose the newest arbitrary tool version or order channels.
+
+Use it only when a tool's documented version scheme matches this numeric comparison.
+Otherwise preserve the publisher's order or implement that tool's actual policy.
 
 ### Version Comparison
 
@@ -255,7 +257,7 @@ print(parts[1])  -- 1
 print(parts[2])  -- 2
 print(parts[3])  -- 3
 
--- Works with prefixes and suffixes
+-- Non-digit text is discarded; this is not a SemVer parser
 local parts = semver.parse("v1.2.3-beta")  -- {1, 2, 3}
 ```
 
@@ -287,19 +289,20 @@ local sorted = semver.sort_by(releases, "version")
 
 ### Real-World Example: Available Hook
 
+This sketch applies only to releases made of three numeric components, with no prereleases
+or channels. Prefer a structured release API over scraping text when one is available.
+
 ```lua
 local http = require("http")
 local semver = require("semver")
 
 function PLUGIN:Available(ctx)
-    local resp, err = http.get({
+    local resp = http.get({
         url = "https://example.com/releases/"
     })
 
-    if err ~= nil then
-        error("Failed to fetch versions: " .. err)
-    end
 
+    assert(resp.status_code == 200, "Release request failed")
     local result = {}
     -- Parse versions from response...
     for version in string.gmatch(resp.body, 'v([0-9]+%.[0-9]+%.[0-9]+)') do
@@ -335,7 +338,10 @@ end)
 
 ## HTML Module
 
-The HTML module parses HTML documents.
+The HTML module returns selection objects, not Lua arrays. Use `:each(function(index,
+node) ... end)` to iterate a selection, `:first()` for its first element, and `:eq(0)` for
+its zero-based first position. `:text()` reads the first selected node's inner content
+(which can include markup); `:attr(name)` reads its attribute.
 
 ### Basic HTML Parsing
 
@@ -360,11 +366,10 @@ local version = doc:find("#version"):text()  -- "1.2.3"
 
 -- Extract attributes
 local links = doc:find("a")
-for _, link in ipairs(links) do
+links:each(function(index, link)
     local href = link:attr("href")
-    local text = link:text()
-    print(text .. ": " .. href)
-end
+    print(index, link:text(), href)
+end)
 ```
 
 ### CSS Selectors
@@ -389,25 +394,26 @@ local specific_links = doc:find("ul.downloads a[href$='.tar.gz']")
 
 ### Real-World Example: Scraping Releases
 
+This illustrates selection traversal. Website HTML and duplicate links can change; prefer
+a release API when available and deduplicate identifiers before returning a hook result.
+
 ```lua
 local html = require("html")
 local http = require("http")
 
 function get_github_releases(owner, repo)
-    local resp, err = http.get({
+    local resp = http.get({
         url = "https://github.com/" .. owner .. "/" .. repo .. "/releases"
     })
 
-    if err ~= nil then
-        error("Failed to fetch releases: " .. err)
-    end
 
+    assert(resp.status_code == 200, "Release page request failed")
     local doc = html.parse(resp.body)
     local releases = {}
 
     -- Find all release tags
     local release_elements = doc:find("a[href*='/releases/tag/']")
-    for _, element in ipairs(release_elements) do
+    release_elements:each(function(index, element)
         local href = element:attr("href")
         local version = href:match("/releases/tag/(.+)")
         if version then
@@ -416,7 +422,7 @@ function get_github_releases(owner, repo)
                 url = "https://github.com" .. href
             })
         end
-    end
+    end)
 
     return releases
 end
@@ -424,7 +430,8 @@ end
 
 ## Archiver Module
 
-The archiver module extracts compressed archives.
+The archiver module extracts archives based on their filename suffix. It does not download
+or authenticate the archive; verify the artifact before extracting it.
 
 ### Supported Formats
 
@@ -441,16 +448,13 @@ local archiver = require("archiver")
 -- Extract archive to directory
 archiver.decompress("archive.tar.gz", "extracted/")
 
--- Failures raise Lua errors. Use pcall only when the plugin needs to intercept one.
-local ok, err = pcall(archiver.decompress, "package.zip", "destination/")
-if not ok then
-    error("ZIP extraction failed: " .. err)
-end
+-- Failures raise Lua errors and stop the hook.
+archiver.decompress("package.zip", "destination/")
 ```
 
 To flatten versioned directories at the root of an archive, pass
 `strip_components = 1`. Files already at the archive root are retained, matching
-mise's built-in archive backends.
+mise's built-in archive backends. Only `0` and `1` are supported; higher values raise an error.
 
 ```lua
 archiver.decompress("node-v24.18.1-linux-x64.tar.gz", "destination/", {
@@ -490,10 +494,13 @@ local file = require("file")
 
 -- Join path segments using the OS-specific separator
 local full_path = file.join_path("/foo", "bar", "baz.txt")
-print(full_path)  -- On Unix: /foo/bar/baz.txt, on Windows: \foo\bar\baz.txt
+print(full_path)  -- On Unix: /foo/bar/baz.txt
 ```
 
-The `file.join_path(...)` function joins any number of path segments using the correct separator for the current operating system. This is the recommended way to construct file paths in cross-platform plugins.
+`file.join_path` joins nonempty segments with the host path separator. It does not normalize
+existing separators, resolve `..`, expand `~`, or make an untrusted path safe. Pass relative
+segments after the base directory. For environment plugins, use `ctx.config_root` as the
+base for project-relative options.
 
 ### Read File Contents
 
@@ -501,6 +508,8 @@ The `file.join_path(...)` function joins any number of path segments using the c
 local file = require("file")
 print(file.read("/path/to/file"))
 ```
+
+`file.read` returns UTF-8 text or raises an error; it does not return `nil` for a missing file.
 
 ### Create Symbolic Links
 
@@ -545,9 +554,19 @@ file.move(
 )
 ```
 
+### File Metadata
+
+`file.stat(path)` returns `nil` when the path is missing. Otherwise it returns `size`,
+`is_file`, `is_dir`, `is_symlink`, and available `modified`, `accessed`, and `created` Unix
+timestamps. It inspects the link itself. `mode` is an octal permission string on Unix and
+`nil` on other platforms.
+
 ## Environment Module
 
-The env module provides environment variable operations.
+`env.setenv` changes the mise process environment. It does not return a variable to the
+user's shell, and it does not update an already-constructed hook environment. Prefer
+returning values from `MiseEnv`, `EnvKeys`, or `BackendExecEnv`. For one child command, use
+`cmd.exec(..., {env = {...}})` to avoid process-wide mutations.
 
 ### Set Environment Variable
 
@@ -564,25 +583,20 @@ env.setenv("MY_VAR", "my_value")
 
 ### Path Operations
 
-```lua
-local env = require("env")
-
--- Get current PATH
-local current_path = os.getenv("PATH")
-
--- Add to PATH
-local new_path = "/usr/local/bin:" .. current_path
-env.setenv("PATH", new_path)
-
--- Platform-specific PATH separator
-local separator = package.config:sub(1,1) == '\\' and ";" or ":"
-local paths = {"/usr/local/bin", "/opt/bin", current_path}
-env.setenv("PATH", table.concat(paths, separator))
-```
+Return separate PATH entries from an environment hook. Use `file.join_path` to construct
+paths and let mise merge them using the host's PATH separator. Do not prepend a Unix
+colon-separated string to PATH in code that also runs on Windows.
 
 ## Command Module
 
-The cmd module executes shell commands.
+`cmd.exec` runs a command through mise's configured default inline shell. It returns stdout
+on success and raises an error containing stderr on failure. Successful stderr is not part
+of the returned string. `pcall(cmd.exec, ...)` can intercept the error.
+
+The string is shell code, not an argument array. Use `cwd` for the working directory and
+quote external values for that shell; interpolating tool options into shell text can execute
+unintended commands. `os.execute` streams output and returns the exit status using Lua 5.1
+conventions (`0` for success), with the same mise-constructed environment.
 
 ### Basic Command Execution
 
@@ -625,7 +639,7 @@ The options table supports the following keys:
 
 - **`cwd`** (string): Set the working directory for the command
 - **`env`** (table): Set environment variables for the command. These are merged on top of the inherited environment (see below).
-- **`timeout`** (number): Set a timeout for command execution (future feature)
+- **`timeout`**: Currently ignored. Do not rely on it to terminate a command.
 
 ### Environment Inheritance in Env Module Hooks
 
@@ -640,6 +654,7 @@ _.my-plugin = { tools = true }
 
 ```lua
 function PLUGIN:MiseEnv(ctx)
+    local cmd = require("cmd")
     -- With tools=true, mise-managed tools are on PATH
     local version = cmd.exec("node --version")
     return {
@@ -678,22 +693,23 @@ print("OS Info:", os_info)
 
 ### Version Fetching from API
 
+This helper collects version identifiers. An unordered JSON object does not establish
+oldest/newest order, and lexicographic sorting misorders `1.10.0` and `1.2.0`.
+
 ```lua
 local http = require("http")
 local json = require("json")
 
 function fetch_npm_versions(package_name)
-    local resp, err = http.get({
+    local resp = http.get({
         url = "https://registry.npmjs.org/" .. package_name,
         headers = {
             ['User-Agent'] = "mise-plugin"
         }
     })
 
-    if err ~= nil then
-        error("Failed to fetch package info: " .. err)
-    end
 
+    assert(resp.status_code == 200, "Package metadata request failed")
     local package_info = json.decode(resp.body)
     local versions = {}
 
@@ -701,42 +717,19 @@ function fetch_npm_versions(package_name)
         table.insert(versions, version)
     end
 
-    -- Sort versions (simple string sort)
-    table.sort(versions)
-
+    -- The JSON object has no release order. Return the collected identifiers;
+    -- callers must apply npm's actual release policy before using this as a hook.
     return versions
 end
 ```
 
-### File Download with Progress
+### Download and Verification {#file-download-with-progress}
 
-```lua
-local http = require("http")
-local file = require("file")
-
-function download_with_verification(url, dest_path, expected_sha256)
-    -- Download file
-    local err = http.download_file({
-        url = url,
-        headers = {
-            ['User-Agent'] = "mise-plugin"
-        }
-    }, dest_path)
-
-    if err ~= nil then
-        error("Download failed: " .. err)
-    end
-
-    -- Verify file exists
-    if not file.exists(dest_path) then
-        error("Downloaded file not found")
-    end
-
-    -- Note: SHA256 verification would need additional implementation
-    -- This is a simplified example
-    print("Downloaded successfully to: " .. dest_path)
-end
-```
+`http.download_file` downloads bytes; checking that the destination exists is not checksum
+verification. A tool plugin should return the trusted digest in `PreInstall.sha256` or
+`PreInstall.sha512` so mise verifies before extraction. A backend plugin performing its own
+download must implement verification explicitly. Do not accept an `expected_sha256` argument
+and then ignore it.
 
 ### Configuration File Parsing
 
@@ -751,11 +744,7 @@ function parse_config_file(config_path)
     end
 
     local content = file.read(config_path)
-    if not content then
-        error("Failed to read config file: " .. config_path)
-    end
-
-    -- Trim whitespace
+        -- Trim whitespace
     content = strings.trim_space(content)
 
     -- Parse JSON
@@ -776,25 +765,23 @@ local html = require("html")
 local strings = require("strings")
 
 function scrape_versions_from_releases(base_url)
-    local resp, err = http.get({
+    local resp = http.get({
         url = base_url .. "/releases"
     })
 
-    if err ~= nil then
-        error("Failed to fetch releases page: " .. err)
-    end
 
+    assert(resp.status_code == 200, "Release page request failed")
     local doc = html.parse(resp.body)
     local versions = {}
 
     -- Find version tags
     local version_elements = doc:find("h2 a[href*='/releases/tag/']")
-    for _, element in ipairs(version_elements) do
+    version_elements:each(function(index, element)
         local version_text = element:text()
         local version = strings.trim_space(version_text)
 
         -- Remove 'v' prefix if present
-        version = strings.trim_prefix(version, "v")
+        version = version:gsub("^v", "")
 
         if version and version ~= "" then
             table.insert(versions, {
@@ -802,7 +789,7 @@ function scrape_versions_from_releases(base_url)
                 url = base_url .. element:attr("href")
             })
         end
-    end
+    end)
 
     return versions
 end
@@ -875,14 +862,11 @@ local http = require("http")
 local json = require("json")
 
 function safe_api_call(url)
-    local resp, err = http.get({url = url})
+    local resp = http.get({url = url})
 
-    if err ~= nil then
-        error("HTTP request failed: " .. err)
-    end
 
     if resp.status_code ~= 200 then
-        error("API returned error: " .. resp.status_code .. " " .. resp.body)
+        error("API returned error: " .. resp.status_code)
     end
 
     local success, data = pcall(json.decode, resp.body)
@@ -896,7 +880,10 @@ end
 
 ### Caching
 
-Cache expensive operations:
+A local Lua table can avoid repeated work within one runtime. It does not persist between
+separate mise invocations. mise already caches tool version and environment results;
+environment plugins can also return [cache metadata](/env-plugin-development.html#hooks-mise-env-lua).
+The example below is only an in-memory cache:
 
 ```lua
 local cache = {}
@@ -913,12 +900,10 @@ function cached_http_get(url)
 
     -- Fetch fresh data
     local http = require("http")
-    local resp, err = http.get({url = url})
+    local resp = http.get({url = url})
 
-    if err ~= nil then
-        error("HTTP request failed: " .. err)
-    end
 
+    assert(resp.status_code == 200, "Request failed")
     -- Cache the result
     cache[cache_key] = {
         data = resp,
@@ -931,33 +916,18 @@ end
 
 ### Platform Detection
 
-Handle cross-platform differences:
+Use runtime metadata instead of subprocesses or ambient host variables:
 
 ```lua
-local function get_platform_info()
-    local is_windows = package.config:sub(1,1) == '\\'
-    local cmd = require("cmd")
-
-    if is_windows then
-        return {
-            os = "windows",
-            arch = os.getenv("PROCESSOR_ARCHITECTURE") or "x64",
-            path_sep = "\\",
-            env_sep = ";"
-        }
-    else
-        local uname = cmd.exec("uname -s"):lower()
-        local arch = cmd.exec("uname -m")
-
-        return {
-            os = uname,
-            arch = arch,
-            path_sep = "/",
-            env_sep = ":"
-        }
-    end
-end
+local platform = {
+    os = RUNTIME.osType,
+    arch = RUNTIME.archType,
+    libc = RUNTIME.envType,
+}
 ```
+
+`RUNTIME` may describe another target during lockfile generation. Shelling out to `uname`
+would report the host and can produce the wrong artifact URL for that target.
 
 ## Next Steps
 

--- a/docs/plugin-publishing.md
+++ b/docs/plugin-publishing.md
@@ -1,279 +1,187 @@
 # Plugin Publishing
 
-This guide shows how to publish and distribute backend plugins and tool plugins. Publishing makes your plugins available to other users and keeps them easy to install and maintain.
+Publish a plugin as a Git repository or release archive, with a tested installation command
+and documentation for its actual interface. Users can install it directly by URL; adding a
+mise registry shorthand is a separate process, and new asdf/vfox tool entries are not accepted.
+
+This guide applies to Lua tool, backend, environment, and package plugins. Choose the
+[plugin type](/plugins.html) before adapting a test or release workflow.
 
 ## Publishing Checklist
 
-Before publishing your plugin, ensure you have:
-
 ### Essential Files
 
-- **`metadata.lua`** - Plugin metadata with name, version, description, and author
-- **Plugin implementation** - Either backend methods or hook functions
-- **Test coverage** - Automated tests to verify functionality
+Include `metadata.lua`, the hook files for your interface, and a README with installation,
+configuration, prerequisites, supported platforms, and a working verification command.
+Keep credentials and machine-specific configuration out of the repository.
 
 ### Optional but Recommended
 
-- **`README.md`** - Basic usage instructions and examples
-- **`test/`** directory - Test scripts for verification
-- **Version control** - Git repository with proper versioning
+Add a license, automated tests, a changelog or release notes, and formatting/lint tasks.
+Document the minimum tested mise version, particularly for mise-specific hooks and modules.
+Plugin metadata's version describes the plugin release, not the version of a managed tool.
 
 ## Repository Setup
 
 ### 1. Initialize Repository
 
-The easiest way to start is with the [mise-tool-plugin-template](https://github.com/jdx/mise-tool-plugin-template):
+Use the template matching your interface:
 
-```bash
-# Clone the template
-git clone https://github.com/jdx/mise-tool-plugin-template my-plugin
-cd my-plugin
+- [Tool plugin template](https://github.com/jdx/mise-tool-plugin-template).
+- [Backend plugin template](https://github.com/jdx/mise-backend-plugin-template).
+- [Environment plugin template](https://github.com/jdx/mise-env-plugin-template).
 
-# Remove template history and set up your own repository
-rm -rf .git
-git init
-git remote add origin https://github.com/username/my-plugin.git
+Create a new repository from the template, or initialize a fresh directory:
 
-# Customize for your plugin
-# Edit metadata.lua, hooks/*.lua, README.md, etc.
-```
-
-Alternatively, create a repository from scratch:
-
-```bash
-# Create plugin directory
+```sh
 mkdir my-plugin
 cd my-plugin
-
-# Initialize git repository
-git init
-git remote add origin https://github.com/username/my-plugin.git
-
-# Create initial structure
-touch metadata.lua
-mkdir -p test
-echo "# My Plugin" > README.md
+git init -b main
+mkdir hooks
 ```
+
+Add your implementation before testing. Empty metadata and hooks are not an installable plugin.
 
 ### 2. Basic Directory Structure
 
-Organize your plugin with this structure:
-
-```
+```text
 my-plugin/
-├── metadata.lua          # Plugin metadata
-├── README.md            # Basic documentation
-├── test/                # Test scripts
-│   └── test.sh
-├── .gitignore           # Git ignore rules
-└── [implementation files]
-```
-
-For backend plugins:
-
-```
-backend-plugin/
-├── metadata.lua          # Backend methods implementation
+├── metadata.lua
 ├── README.md
+├── LICENSE
+├── hooks/
 └── test/
-    └── test.sh
 ```
 
-For tool plugins:
+The files inside `hooks/` identify the interface:
 
-```
-tool-plugin/
-├── metadata.lua          # Plugin metadata
-├── hooks/               # Hook implementations
-│   ├── available.lua
-│   ├── pre_install.lua
-│   └── env_keys.lua
-├── lib/                 # Helper libraries
-│   └── helper.lua
-├── README.md
-└── test/
-    └── test.sh
-```
+| Plugin type | Hook files |
+| --- | --- |
+| Tool | `available.lua`, `pre_install.lua`, `env_keys.lua`; optional lifecycle hooks |
+| Backend | `backend_list_versions.lua`, `backend_install.lua`, `backend_exec_env.lua` |
+| Environment | `mise_env.lua`, optional `mise_path.lua` |
+| Package | `package_installed.lua`, `package_install.lua`; optional upgrade/uninstall hooks |
+
+Backend hook implementations belong under `hooks/`, not in `metadata.lua`. Package plugins
+also use `mise.plugin.toml` for manager capabilities; see [package development](/package-plugin-development.html).
 
 ### 3. Git Ignore Configuration
 
-Create a `.gitignore` file:
-
-```gitignore
-# Temporary files
-*.tmp
-*.temp
-.DS_Store
-Thumbs.db
-
-# Test artifacts
-test/tmp/
-test/output/
-
-# IDE files
-.vscode/
-.idea/
-*.swp
-*.swo
-
-# OS files
-*.log
-```
+Ignore test output and local credentials using paths specific to your workflow. Do not
+accidentally exclude files the plugin needs at runtime. Check the release tree with
+`git ls-tree -r --name-only HEAD` and test the resulting archive or checkout.
 
 ## Versioning Strategy
 
 ### Semantic Versioning
 
-Use semantic versioning (SemVer) for your plugin releases:
-
-- **Major version** (1.0.0 → 2.0.0): Breaking changes
-- **Minor version** (1.0.0 → 1.1.0): New features, backward compatible
-- **Patch version** (1.0.0 → 1.0.1): Bug fixes, backward compatible
+SemVer is a useful convention for **plugin releases**: increase the major version for a
+breaking configuration or behavior change, minor for compatible additions, and patch for
+fixes. This does not imply that the **tools managed by the plugin** use SemVer.
 
 ### Version Management
 
-Update the version in `metadata.lua`:
+Update `PLUGIN.version` and the release notes together:
 
 ```lua
 PLUGIN = {
     name = "my-plugin",
-    version = "1.2.3",  -- Update this for each release
-    description = "My awesome plugin",
-    author = "Your Name"
+    version = "1.2.3",
+    description = "Manage Example Tool",
+    author = "Plugin Author",
 }
 ```
 
-Create git tags for releases:
-
-```bash
-# Tag the current commit
-git tag -a v1.2.3 -m "Release version 1.2.3"
-
-# Push tags to repository
-git push origin --tags
-```
+Use a Git tag for that release. A metadata version does not itself select a Git revision
+when a user installs the repository.
 
 ## Testing Before Publication
 
 ### Automated Testing
 
-Create comprehensive test scripts:
+Run tests with isolated mise directories so a local plugin cannot replace the developer's
+installed plugin or edit their usual global configuration. This POSIX setup creates a
+disposable test project. Save your plugin path before changing directories:
 
-```bash
-#!/bin/bash
-# test/test.sh
-set -e
-
-echo "Testing plugin functionality..."
-
-# Install plugin locally
-mise plugin install my-plugin .
-
-# Test basic functionality
-if [[ "$(mise ls-remote my-plugin)" == "" ]]; then
-    echo "ERROR: No versions available"
-    exit 1
-fi
-
-# Test installation
-mise install my-plugin@latest
-
-# Test execution
-mise exec my-plugin:tool -- --version
-
-# Clean up
-mise plugin remove my-plugin
-
-echo "All tests passed!"
+```sh
+plugin_dir="$PWD"
+test_dir="$(mktemp -d)"
+export MISE_CONFIG_DIR="$test_dir/config"
+export MISE_SYSTEM_CONFIG_DIR="$test_dir/system"
+export MISE_GLOBAL_CONFIG_FILE="$test_dir/global.toml"
+export MISE_DATA_DIR="$test_dir/data"
+export MISE_CACHE_DIR="$test_dir/cache"
+export MISE_STATE_DIR="$test_dir/state"
+export MISE_ENV_CACHE=0
+export MISE_YES=1
+mkdir -p "$test_dir/project"
+cd "$test_dir/project"
+mise plugin link test-plugin "$plugin_dir"
 ```
+
+Run this in a disposable shell/subshell and remove the temporary directory afterwards.
+Clear any inherited `MISE_*` settings that affect your test, especially safe mode, forced
+config paths, or disabled backends. These directories isolate mise's own state; package
+plugins and external installers can still modify their host-managed state.
+
+Then test the interface your plugin implements. The following names are placeholders:
+
+| Type | Verification |
+| --- | --- |
+| Tool | `mise ls-remote test-plugin`, `mise use test-plugin@1.0.0`, `mise exec -- example --version` |
+| Backend | `mise ls-remote test-plugin:example`, `mise use test-plugin:example@1.0.0`, `mise exec -- example --version` |
+| Environment | Declare `_.test-plugin` under `[env]`, then assert the expected environment in a child process |
+| Package | Use a disposable host profile or fake CLI; test status, selected batches, dry run, and ownership-aware prune |
+
+The command after `mise exec --` must include the actual executable. Test a concrete tool
+version rather than `latest` so an unrelated upstream release does not change the fixture.
 
 ### Manual Testing
 
-Test your plugin manually:
-
-```bash
-# Link for development
-mise plugin link my-plugin /path/to/plugin
-
-# Test all functionality
-mise ls-remote my-plugin
-mise install my-plugin@latest
-mise use my-plugin@latest
-
-# Test in different environments
-docker run --rm -it ubuntu:latest bash -c "
-    curl -fsSL https://mise.jdx.dev/install.sh | sh
-    mise plugin install my-plugin https://github.com/username/my-plugin
-    mise install my-plugin@latest
-"
-```
+Test the published Git ref or archive in a fresh test directory as well as a local symlink.
+A symlink sees uncommitted and untracked files that may be absent from a release. Verify
+paths containing spaces, required external programs, and every supported OS in CI. An
+empty Linux container needs host prerequisites and an absolute mise executable path before
+it can run your installer.
 
 ## Publishing Process
 
 ### 1. Prepare for Release
 
-Before publishing, ensure everything is ready:
-
-```bash
-# Run tests
-./test/test.sh
-
-# Check git status
-git status
-
-# Update version in metadata.lua
-vim metadata.lua
-
-# Commit changes
-git add .
-git commit -m "Prepare release v1.2.3"
-```
+Run the plugin's documented checks, inspect the diff and release tree, update metadata and
+notes, and commit only the intended release files. Verify that installation instructions
+use your own repository URL and supported tool versions.
 
 ### 2. Create Release
 
-Create a tagged release:
+From the reviewed release commit, create and push one tag:
 
-```bash
-# Create and push tag
-git tag -a v1.2.3 -m "Release version 1.2.3"
-git push origin v1.2.3
+```sh
+git tag -a v1.2.3 -m "Release v1.2.3"
 git push origin main
+git push origin v1.2.3
 ```
+
+Push the branch that actually contains the release if it is not `main`. Avoid `git push
+--tags`, which can publish unrelated local tags.
 
 ### 3. GitHub Releases (Recommended)
 
-Create a GitHub release for better discoverability:
-
-1. Go to your repository on GitHub
-2. Click "Releases" → "Create a new release"
-3. Choose your tag (v1.2.3)
-4. Write release notes describing changes
-5. Publish the release
+Create a release for the existing tag with installation instructions, supported mise versions,
+and behavior changes. Test the exact revision users will receive. Published signatures are
+useful only when consumers verify them; do not imply that every plugin install validates
+a Git tag signature.
 
 ### 4. Release Notes Template
 
 ````markdown
-## Changes in v1.2.3
+## v1.2.3
 
-### Added
+Describe the concrete behavior change, required mise version, and any migration steps.
+List supported platforms and changed external prerequisites.
 
-- New feature X
-- Support for Y
-
-### Changed
-
-- Improved performance of Z
-- Updated dependencies
-
-### Fixed
-
-- Fixed issue with A
-- Resolved bug in B
-
-### Installation
-
-```bash
-mise plugin install my-plugin https://github.com/username/my-plugin
+```sh
+mise plugin install my-plugin 'https://github.com/your-org/my-plugin#v1.2.3'
 ```
 ````
 
@@ -281,210 +189,113 @@ mise plugin install my-plugin https://github.com/username/my-plugin
 
 ### 1. Direct Git Installation
 
-Users can install directly from your repository:
-
-```bash
-# Install from GitHub
-mise plugin install my-plugin https://github.com/username/my-plugin
-
-# Install specific version
-mise plugin install my-plugin https://github.com/username/my-plugin@v1.2.3
-
-# Install from other Git providers
-mise plugin install my-plugin https://gitlab.com/username/my-plugin
+```sh
+mise plugin install my-plugin https://github.com/your-org/my-plugin
+mise plugin install my-plugin 'https://github.com/your-org/my-plugin#v1.2.3'
 ```
+
+Git refs use `#`, not the `@version` syntax used for tool requests. A tag or branch can move;
+a commit ID identifies a fixed source revision. Existing installations require an explicit
+update or replacement; sharing a new URL does not update users automatically.
 
 ### 2. Private Repository Access
 
-For private repositories, users need access:
+Use the user's Git authentication setup, for example SSH:
 
-```bash
-# SSH access (recommended)
-mise plugin install my-plugin git@github.com:username/private-plugin.git
-
-# HTTPS with token
-mise plugin install my-plugin https://username:token@github.com/username/private-plugin.git
+```sh
+mise plugin install my-plugin git@github.com:your-org/private-plugin.git
 ```
+
+HTTPS repositories can use Git's credential helper. Do not put a token directly in a command
+URL: it can be retained in shell history, configuration, process arguments, or Git remotes.
+Verify access with `git ls-remote <repository-url>` before debugging plugin hooks.
 
 ### 3. Archive Distribution
 
-You can also distribute plugins as archives:
+Create an archive from the exact release ref, with a top-level directory:
 
-```bash
-# Create release archive
-git archive --format=zip --output=my-plugin-v1.2.3.zip v1.2.3
-
-# Users can install from archive
-mise plugin install my-plugin https://github.com/username/my-plugin/releases/download/v1.2.3/my-plugin-v1.2.3.zip
+```sh
+git archive --format=zip --prefix=my-plugin/ --output=my-plugin-v1.2.3.zip v1.2.3
 ```
+
+Publish it, then test its URL from a fresh mise data directory:
+
+```sh
+mise plugin install my-plugin https://github.com/your-org/my-plugin/releases/download/v1.2.3/my-plugin-v1.2.3.zip
+```
+
+An archive installation has no Git history. `mise plugin update` cannot fetch a new Git ref
+for it; users must explicitly install the replacement archive.
 
 ## Maintenance and Updates
 
 ### 1. Update Workflow
 
-Establish a regular update process:
+Test changes, publish a new revision, and document how users update:
 
-```bash
-# Development workflow
-git checkout -b feature/new-feature
-# ... make changes ...
-git commit -m "Add new feature"
-git push origin feature/new-feature
-
-# After review and merge
-git checkout main
-git pull origin main
-git tag -a v1.3.0 -m "Release v1.3.0"
-git push origin v1.3.0
+```sh
+mise plugin update my-plugin#v1.3.0
 ```
+
+Updating plugin code and upgrading installed tool versions are separate actions. Test both
+new installations and existing installs when changing executable paths or environment hooks.
 
 ### 2. Backward Compatibility
 
-Maintain backward compatibility when possible:
-
-- Keep the existing plugin interface unchanged
-- Make new features optional
-- Deprecate old features gradually
-- Document breaking changes clearly
+Document renamed options, changed defaults, required external tools, and removed platforms.
+Keep old configurations working when practical, and provide a complete replacement example
+when a migration is necessary.
 
 ### 3. User Communication
 
-Keep users informed about updates:
-
-- Use clear release notes
-- Announce major changes
-- Provide migration guides for breaking changes
-- Maintain documentation
+Release notes should explain observable changes and the commands needed to adopt them.
+State known limitations and how to report a reproducible failure without including secrets.
 
 ## Security Considerations
 
-### 1. Code Review
+Review the code and dependencies you distribute. Treat tool names, paths, versions, and
+configuration options as inputs when constructing commands. Keep downloads verified and
+fail on missing required checksums. Do not print credentials or secret response bodies.
 
-- Review all code changes before publishing
-- Check for security vulnerabilities
-- Validate external dependencies
-- Test with untrusted inputs
-
-### 2. Dependency Management
-
-- Pin dependency versions where possible
-- Regularly update dependencies
-- Monitor for security advisories
-- Use trusted sources only
-
-### 3. Access Control
-
-- Limit repository access appropriately
-- Use strong authentication
-- Regularly audit access permissions
-- Consider signed releases for sensitive plugins
+A plugin is executable code with the user's permissions. An archive, a tag, a tool lockfile,
+and configuration trust each cover different things; avoid claiming that one secures all
+of them. See [Security](/security.html) and [Using Plugins](/plugin-usage.html).
 
 ## Best Practices
 
-### 1. Documentation
-
-- Keep README.md concise but complete
-- Include usage examples
-- Document configuration options
-- Provide a troubleshooting guide
-
-### 2. Testing
-
-- Test on multiple platforms
-- Include edge cases
-- Test upgrade scenarios
-- Automate testing where possible
-
-### 3. Community
-
-- Respond to issues promptly
-- Accept contributions gracefully
-- Maintain consistent code style
-- Be helpful and respectful
-
-### 4. Release Management
-
-- Follow semantic versioning
-- Create clear release notes
-- Test releases thoroughly
-- Maintain stable branches
+Make the README sufficient to install, configure, run, update, and remove the integration.
+Test from the release artifact, automate supported-platform checks, and keep fixtures
+independent of personal settings and credentials.
 
 ## Troubleshooting
 
 ### Common Issues
 
-**Plugin not installing:**
+If a plugin works as a local link but fails after publication, compare `git ls-tree` or
+archive contents with the working directory. Check hook filenames and Lua syntax, and
+confirm the published revision includes helper files.
 
-```bash
-# Check repository URL
-git clone https://github.com/username/my-plugin.git
-
-# Verify metadata.lua exists
-ls -la my-plugin/metadata.lua
-
-# Test locally
-mise plugin link my-plugin ./my-plugin
-```
-
-**Version conflicts:**
-
-```bash
-# Check version in metadata.lua
-grep version my-plugin/metadata.lua
-
-# Verify git tags
-git tag -l
-```
-
-**Permission issues:**
-
-```bash
-# Check repository permissions
-git ls-remote https://github.com/username/my-plugin.git
-
-# For private repos, verify access
-ssh -T git@github.com
-```
+If a version appears wrong, distinguish `PLUGIN.version`, the repository ref, and the
+managed tool's version. Inspect `mise plugins ls --urls` and `mise ls --current` separately.
+For authentication failures, first check repository access using Git itself.
 
 ## Next Steps
 
-- [Backend Plugin Development](backend-plugin-development.md)
-- [Tool Plugin Development](tool-plugin-development.md)
-- [Plugin Lua Modules](plugin-lua-modules.md)
+- [Backend Plugin Development](/backend-plugin-development.html).
+- [Tool Plugin Development](/tool-plugin-development.html).
+- [Environment Plugin Development](/env-plugin-development.html).
+- [Package Plugin Development](/package-plugin-development.html).
+- [Plugin Lua Modules](/plugin-lua-modules.html).
 
 ## Examples
 
 ### Simple Backend Plugin Release
 
-```bash
-# 1. Prepare plugin
-cd my-backend-plugin
-# ... edit metadata.lua and hooks/*.lua ...
-
-# 2. Test locally
-mise plugin link my-plugin .
-mise ls-remote my-plugin:tool
-
-# 3. Release
-git add .
-git commit -m "v1.0.0: Initial release"
-git tag -a v1.0.0 -m "Initial release"
-git push origin v1.0.0
-```
+Test `test-plugin:example` through all three backend hooks, then install the tagged repository
+in a new data directory and repeat the same checks. This catches missing helper files and
+incorrectly packaged hook directories.
 
 ### Tool Plugin with Hooks
 
-```bash
-# 1. Prepare plugin
-cd my-tool-plugin
-./test/test.sh  # Run tests
-
-# 2. Update version
-sed -i 's/version = "1.0.0"/version = "1.1.0"/' metadata.lua
-
-# 3. Release
-git add .
-git commit -m "v1.1.0: Add new hook functionality"
-git tag -a v1.1.0 -m "Add new hook functionality"
-git push origin v1.1.0
-```
+Test version listing, artifact verification, extraction, `PostInstall` if present, and
+`EnvKeys`. Include a version-file test in a project without a competing `[tools]` entry.

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -123,11 +123,11 @@
 - [Plugin Overview](https://mise.jdx.dev/plugins.html): Plugins extend mise with new functionality, such as extra tools or environment variable management.
 - [Using Plugins](https://mise.jdx.dev/plugin-usage.html): mise supports plugins that extend its functionality, allowing you to install tools that aren't available in the standard registry. This is particularly useful for.
 - [Backend Plugin Development](https://mise.jdx.dev/backend-plugin-development.html): The mise-backend-plugin-template provides a ready-to-use starting point with LuaCATS type definitions, stylua formatting, and hk linting pre-configured.
-- [Tool Plugin Development](https://mise.jdx.dev/tool-plugin-development.html): The mise-tool-plugin-template provides a ready-to-use starting point with LuaCATS type definitions, stylua formatting, and hk linting pre-configured.
-- [Environment Plugin Development](https://mise.jdx.dev/env-plugin-development.html): Environment plugins are a special type of mise plugin that provides environment variables and PATH modifications without managing tool versions.
+- [Tool Plugin Development](https://mise.jdx.dev/tool-plugin-development.html): A tool plugin manages one versioned tool using Lua lifecycle hooks. Use a backend plugin for an integration that manages several tools, or an environment plugin for variables without an installation.
+- [Environment Plugin Development](https://mise.jdx.dev/env-plugin-development.html): Environment plugins return variables and PATH entries without installing a versioned tool. Use them for an external configuration service, secret manager, or team environment.
 - [Package Plugin Development](https://mise.jdx.dev/package-plugin-development.html): A package plugin is a Lua-based vfox plugin that implements a machine-global manager for [bootstrap.packages].
-- [Plugin Lua Modules](https://mise.jdx.dev/plugin-lua-modules.html): mise plugins have access to a comprehensive set of built-in Lua modules. These modules are available in both backend plugins and tool plugins, making it easy to perform common operations like HTTP…
-- [Plugin Publishing](https://mise.jdx.dev/plugin-publishing.html): This guide shows how to publish and distribute backend plugins and tool plugins. Publishing makes your plugins available to other users and keeps them easy to install and maintain.
+- [Plugin Lua Modules](https://mise.jdx.dev/plugin-lua-modules.html): mise's embedded Lua 5.1 runtime provides modules for plugin hooks, including backend, tool, environment, and package plugins.
+- [Plugin Publishing](https://mise.jdx.dev/plugin-publishing.html): Publish a plugin as a Git repository or release archive, with a tested installation command and documentation for its actual interface.
 - [asdf (Legacy) Plugins](https://mise.jdx.dev/asdf-legacy-plugins.html): asdf plugins are considered legacy. New asdf and vfox plugins are not accepted into the mise registry for supply-chain security reasons — for registry submissions use packslip (preferred when the…
 
 ## About

--- a/docs/tool-plugin-development.md
+++ b/docs/tool-plugin-development.md
@@ -301,8 +301,10 @@ platforms the publisher actually supports and reject others explicitly.
 -- lib/platform.lua
 local M = {}
 function M.archive_platform()
-    local os_name = RUNTIME.osType == "darwin" and "macos" or RUNTIME.osType
-    local arch = RUNTIME.archType == "amd64" and "x64" or RUNTIME.archType
+    local os_names = {darwin = "macos", linux = "linux", windows = "windows"}
+    local arches = {amd64 = "x64", arm64 = "arm64"}
+    local os_name = os_names[RUNTIME.osType] or error("Unsupported OS: " .. RUNTIME.osType)
+    local arch = arches[RUNTIME.archType] or error("Unsupported architecture: " .. RUNTIME.archType)
     return os_name .. "-" .. arch
 end
 return M

--- a/docs/tool-plugin-development.md
+++ b/docs/tool-plugin-development.md
@@ -1,337 +1,240 @@
 # Tool Plugin Development
 
-::: tip
-The [mise-tool-plugin-template](https://github.com/jdx/mise-tool-plugin-template) provides a ready-to-use starting point with LuaCATS type definitions, stylua formatting, and hk linting pre-configured.
-:::
+A tool plugin manages one versioned tool using Lua lifecycle hooks. Use a
+[backend plugin](/backend-plugin-development.html) for an integration that manages several
+tools, or an [environment plugin](/env-plugin-development.html) for variables without an
+installation. Check the built-in [backends](/dev-tools/backends/) before writing an installer.
 
-Tool plugins use a hook-based architecture to manage individual tools. They are compatible with the standard vfox ecosystem and are perfect for tools that need complex installation logic, environment configuration, or legacy file parsing.
+The [tool plugin template](https://github.com/jdx/mise-tool-plugin-template) supplies a
+starting layout and development tooling. mise embeds Lua 5.1; its supported vfox hooks
+and extensions are described here. Sharing a plugin with upstream vfox requires testing
+there as well, particularly when using mise-specific modules or metadata.
 
 ## What are Tool Plugins?
 
-Tool plugins use traditional hook functions to manage a single tool. They provide:
+Tool plugins can download archives, compile sources, return environment entries, and parse
+idiomatic version files. The Lua runtime runs on Windows, macOS, and Linux; each plugin
+must implement the artifact selection and external commands needed for those targets.
 
-- **Standard vfox Compatibility**: Works with both mise and vfox
-- **Complex Installation Logic**: Handles source compilation, custom builds, and complex setups
-- **Environment Configuration**: Sets up complex environment variables beyond PATH
-- **Legacy File Support**: Parses version files from other tools (`.nvmrc`, `.tool-version`, etc.)
-- **Cross-Platform Support**: Works on Windows, macOS, and Linux
+Plugins run with the user's permissions. Keep metadata free of host probes and avoid
+changing global package-manager configuration from an installation hook.
 
 ## Plugin Architecture
 
-Tool plugins are implemented in Lua (currently version 5.1). They use a hook-based architecture with specific functions for different lifecycle events:
-
 ```mermaid
-graph TD
-    A[User Request] --> B[mise CLI]
-    B --> C[Tool Plugin]
-
-    C --> D[Available Hook<br/>List Versions]
-    C --> E[PreInstall Hook<br/>Download]
-    C --> F[PostInstall Hook<br/>Setup]
-    C --> G[EnvKeys Hook<br/>Configure]
-
-    subgraph "Plugin Files"
-        H[metadata.lua]
-        I[hooks/available.lua]
-        J[hooks/pre_install.lua]
-        K[hooks/env_keys.lua]
-        L[hooks/post_install.lua]
-    end
-
-    style C fill:#e1f5fe
-    style D fill:#e8f5e8
-    style E fill:#e8f5e8
-    style F fill:#e8f5e8
-    style G fill:#e8f5e8
+flowchart LR
+    A[Available: list versions] --> B[Resolve a version]
+    B --> C[PreInstall: describe artifact]
+    C --> D[mise: download, verify, extract]
+    D --> E[PostInstall: optional setup]
+    E --> F[EnvKeys: return environment]
 ```
+
+A pinned or already-installed version can skip parts of this flow. Environment construction
+can happen again on later invocations; it is not a one-time installation callback.
 
 ## Hook Functions
 
 ### Required Hooks
 
-A functional plugin must implement these hooks:
-
 #### Available Hook
 
-Lists all available versions of the tool:
+Return an array **newest first**, ordered by the publisher's release policy. mise reverses
+this list for its internal oldest-first version listing. This differs from
+`BackendListVersions`, which already returns oldest first.
 
 ```lua
 -- hooks/available.lua
 function PLUGIN:Available(ctx)
-    local args = ctx.args  -- User arguments
-
-    -- Return array of available versions
     return {
-        {
-            version = "20.0.0",
-            note = "Latest"
-        },
-        {
-            version = "18.18.0",
-            note = "LTS",
-            addition = {
-                {
-                    name = "npm",
-                    version = "9.8.1"
-                }
-            }
-        }
+        {version = "1.10.0", note = "Current stable release"},
+        {version = "1.2.0"},
     }
 end
 ```
 
+Do not discard prerelease suffixes or sort arbitrary versions with a shared SemVer parser.
+`ctx.args` is available but mise does not supply interactive vfox arguments here.
+
 ##### Rolling Releases
 
-For tools with rolling releases such as "nightly" or "stable", where the version string stays the same but the content changes, mark the version as rolling and provide a checksum so mise can detect updates:
+For a channel whose contents change without changing its name, return `rolling = true`
+and an asset checksum that changes with the channel's artifact:
 
 ```lua
 function PLUGIN:Available(ctx)
     return {
         {
             version = "nightly",
-            note = "Latest development build",
-            rolling = true,  -- Mark as rolling release
-            checksum = "abc123..."  -- SHA256 of the release asset
-        },
-        {
-            version = "stable",
-            note = "Latest stable release",
             rolling = true,
-            checksum = "def456..."
+            checksum = "REPLACE_WITH_CURRENT_PLATFORM_ASSET_SHA256",
         },
-        {
-            version = "1.0.0",
-            note = "Fixed release"
-            -- No rolling or checksum needed for fixed versions
-        }
     }
 end
 ```
 
-When `rolling = true` is set:
-
-- `mise upgrade` checks whether the checksum has changed to detect updates
-- `mise upgrade --bump` preserves the version name (e.g., "nightly") instead of converting it to a semver version
-
-The checksum should be the SHA256 hash of the release asset for the user's platform. See the [vfox-neovim plugin](https://github.com/mise-plugins/vfox-neovim) for a complete example.
+The checksum above is a placeholder. Fetch the actual checksum for the selected platform.
+`mise upgrade` compares rolling checksums, and `mise upgrade --bump` preserves the channel
+name. This update marker is separate from the artifact checksum returned by `PreInstall`.
 
 #### PreInstall Hook
 
-Handles pre-installation logic and returns download information:
+Return the URL and verification metadata for `ctx.version`. mise downloads and extracts
+the main artifact. `ctx.options` contains typed tool options; use `RUNTIME` for platform
+information, including when mise asks for another platform's lockfile entry.
 
 ```lua
--- hooks/pre_install.lua
+-- hooks/pre_install.lua: an illustrative Linux x64 release layout
 function PLUGIN:PreInstall(ctx)
-    local version = ctx.version
-    local runtimeVersion = ctx.runtimeVersion
-
-    -- Determine download URL and checksums
-    local url = "https://nodejs.org/dist/v" .. version .. "/node-v" .. version .. "-linux-x64.tar.gz"
-
+    if RUNTIME.osType ~= "linux" or RUNTIME.archType ~= "amd64" then
+        error("This example artifact supports Linux x64 only")
+    end
+    local filename = "example-" .. ctx.version .. "-linux-x64.tar.gz"
     return {
-        version = version,
-        url = url,
-        sha256 = "abc123...",  -- Optional checksum
-        note = "Installing Node.js " .. version,
-        -- Optional attestation metadata, choose a verification type
-        attestation = {
-            -- GitHub
-            github_owner = "ownername"
-            github_repo = "reponame"
-            -- Cosign
-            cosign_sig_or_bundle_path = "/path/to/sig/or/bundle/file"
-            -- SLSA
-            slsa_provenance_path = "/path/to/provenance/file"
-        },
-        -- Additional files can be specified
-        addition = {
-            {
-                name = "npm",
-                url = "https://registry.npmjs.org/npm/-/npm-" .. npm_version .. ".tgz"
-            }
-        }
+        version = ctx.version,
+        url = "https://downloads.example.com/" .. filename,
+        sha256 = ctx.options.sha256 or error("sha256 option is required"),
     }
 end
 ```
 
+Replace the publisher URL and provide its trusted SHA-256 digest. Never put an ellipsis or
+dummy checksum in a working installer. A URL with no strong checksum or supported
+attestation does not establish artifact integrity. SHA-256 and SHA-512 are supported;
+legacy SHA-1/MD5 do not satisfy strong-verification requirements.
+
+For supported attestations, return an `attestation` table. For example:
+
+```lua
+local attestation = {
+    github_owner = "your-org",
+    github_repo = "your-tool",
+    -- Optional: constrain the publishing workflow.
+    github_signer_workflow = "your-org/your-tool/.github/workflows/release.yml",
+}
+```
+
+Assign this table to the `attestation` field in `PreInstall`'s response. Other supported
+fields include `cosign_sig_or_bundle_path` with optional `cosign_public_key_path`, and
+`slsa_provenance_path` with optional `slsa_min_level`. Supply real verification inputs for
+the chosen method. Do not combine unrelated placeholder methods into one example.
+
+mise's lifecycle processes the main artifact; do not rely on upstream vfox `addition`
+entries to install a second SDK. Use tool dependencies or implement the additional work
+explicitly when needed.
+
 #### EnvKeys Hook
 
-Configures environment variables for the installed tool:
+Return `{key, value}` entries. `ctx.path` is the installation path and `ctx.version` is the
+selected version. `ctx.main`, `ctx.sdkInfo`, and typed `ctx.options` are also available;
+`ctx.runtimeVersion` is not part of this hook's context.
 
 ```lua
 -- hooks/env_keys.lua
 function PLUGIN:EnvKeys(ctx)
-    local mainPath = ctx.path
-    local runtimeVersion = ctx.runtimeVersion
-    local sdkInfo = ctx.sdkInfo['nodejs']
-    local path = sdkInfo.path
-    local version = sdkInfo.version
-    local name = sdkInfo.name
-
+    local file = require("file")
     return {
-        {
-            key = "NODE_HOME",
-            value = mainPath
-        },
-        {
-            key = "PATH",
-            value = mainPath .. "/bin"
-        },
-        -- Multiple PATH entries are automatically merged
-        {
-            key = "PATH",
-            value = mainPath .. "/lib/node_modules/.bin"
-        }
+        {key = "EXAMPLE_HOME", value = ctx.path},
+        {key = "PATH", value = file.join_path(ctx.path, "bin")},
     }
 end
 ```
 
-### Optional Hooks
+Multiple PATH entries are merged. Return directories, not a replacement containing the
+entire inherited PATH. Avoid network access or other expensive work in this hook.
 
-These hooks provide additional functionality:
+### Optional Hooks
 
 #### PostInstall Hook
 
-Performs additional setup after installation:
+Use `ctx.rootPath` for the extracted installation directory. `ctx.sdkInfo` describes the
+main SDK, and `ctx.options` contains tool options. The compatibility field
+`ctx.runtimeVersion` holds the requested tool version, not the mise application version.
 
 ```lua
 -- hooks/post_install.lua
 function PLUGIN:PostInstall(ctx)
-    local rootPath = ctx.rootPath
-    local runtimeVersion = ctx.runtimeVersion
-    local sdkInfo = ctx.sdkInfo['nodejs']
-    local path = sdkInfo.path
-    local version = sdkInfo.version
-
-    -- Compile native modules, set permissions, etc.
-    local result = os.execute("chmod +x " .. path .. "/bin/*")
-    if result ~= 0 then
-        error("Failed to set permissions")
+    local file = require("file")
+    if not file.exists(file.join_path(ctx.rootPath, "bin", "example")) then
+        error("Expected bin/example in the extracted archive")
     end
-
-    -- No return value needed
 end
 ```
+
+The check above assumes a Unix executable layout. Archives normally carry executable
+permissions; only change them when the actual distribution requires it.
 
 #### PreUse Hook
 
-Modifies the version before use:
-
-```lua
--- hooks/pre_use.lua
-function PLUGIN:PreUse(ctx)
-    local version = ctx.version
-    local previousVersion = ctx.previousVersion
-    local installedSdks = ctx.installedSdks
-    local cwd = ctx.cwd
-    local scope = ctx.scope  -- global/project/session
-
-    -- Optionally modify the version
-    if version == "latest" then
-        version = "20.0.0"  -- Resolve to specific version
-    end
-
-    return {
-        version = version
-    }
-end
-```
+mise does not implement the upstream vfox `PreUse` hook. Do not rely on it to rewrite a
+version, observe shell changes, or perform activation work. Resolve version requests using
+supported version listing/aliases and return environment entries through `EnvKeys`.
 
 #### ParseLegacyFile Hook
 
-Parses version files from other tools:
+Declare filenames in `metadata.lua`, implement the parser, and ask users to enable
+[`idiomatic_version_file_enable_tools`](/configuration/settings.html#idiomatic_version_file_enable_tools)
+for the plugin's installed name. Return a version request without changing its meaning:
 
 ```lua
 -- hooks/parse_legacy_file.lua
 function PLUGIN:ParseLegacyFile(ctx)
-    local filename = ctx.filename
-    local filepath = ctx.filepath
-    local versions = ctx:getInstalledVersions()
-
-    -- Read and parse the file
     local file = require("file")
-    local content = file.read(filepath)
-    local version = content:match("v?([%d%.]+)")
-
-    return {
-        version = version
-    }
+    local contents = file.read(ctx.filepath)
+    local version = contents:match("^%s*([^\r\n]+)")
+    if version then
+        version = version:match("^%s*(.-)%s*$")
+    end
+    return {version = version}
 end
 ```
+
+This parser supports a single-line version request, including channels and prereleases.
+Adapt it to the file's real format. `ctx.filename` is the basename and `ctx.filepath` is the
+full path. Despite its name, the compatibility method `ctx:getInstalledVersions()` calls
+`Available`; it is not an inventory of installed versions and can perform network requests.
 
 ## Creating a Tool Plugin
 
 ### Using the Template Repository
 
-The easiest way to create a new tool plugin is to use the [mise-tool-plugin-template](https://github.com/jdx/mise-tool-plugin-template) repository as a starting point:
-
-```bash
-# Clone the template
-git clone https://github.com/jdx/mise-tool-plugin-template my-tool-plugin
-cd my-tool-plugin
-
-# Remove the template's git history and start fresh
-rm -rf .git
-git init
-
-# Customize the plugin for your tool
-# Edit metadata.lua, hooks/*.lua files, etc.
-```
-
-The template includes:
-
-- Pre-configured plugin structure with all required hooks
-- Example implementations with comments
-- Linting configuration (`.luacheckrc`, `stylua.toml`)
-- Testing setup with mise tasks
-- GitHub Actions workflow for CI
+Create a repository from the [tool template](https://github.com/jdx/mise-tool-plugin-template),
+or clone it to inspect and customize its files. Choose a plugin name that does not collide
+with a core tool or an existing plugin while testing.
 
 ### 1. Plugin Structure
 
-Create a directory with this structure (or use the template above):
-
-```
+```text
 my-tool-plugin/
-├── metadata.lua          # Plugin metadata and configuration
-├── hooks/               # Hook functions directory
-│   ├── available.lua    # List available versions [required]
-│   ├── pre_install.lua  # Pre-installation hook [required]
-│   ├── env_keys.lua     # Environment configuration [required]
-│   ├── post_install.lua # Post-installation hook [optional]
-│   ├── pre_use.lua      # Pre-use hook [optional]
-│   └── parse_legacy_file.lua # Legacy file parser [optional]
-├── lib/                 # Shared library code [optional]
-│   └── helper.lua       # Helper functions
-└── test/               # Test scripts [optional]
-    └── test.sh
+├── metadata.lua
+├── hooks/
+│   ├── available.lua
+│   ├── pre_install.lua
+│   ├── env_keys.lua
+│   ├── post_install.lua       # optional
+│   └── parse_legacy_file.lua  # optional
+└── lib/
+    └── helper.lua            # optional shared code
 ```
 
 ### 2. metadata.lua
 
-Configure plugin metadata and legacy file support:
-
 ```lua
--- metadata.lua
 PLUGIN = {
-    name = "nodejs",
-    version = "1.0.0",
-    description = "Node.js runtime environment",
+    name = "my-tool",
+    version = "1.0.0", -- plugin release, separate from the tool version
+    description = "Install Example Tool",
     author = "Plugin Author",
-
-    -- Legacy version files this plugin can parse
-    legacyFilenames = {
-        '.nvmrc',
-        '.node-version'
-    },
-
-    -- Tools whose bin paths should be available during install hooks
-    depends = { "node" },
+    legacyFilenames = {".example-version"},
+    -- Add only real installation prerequisites, if any:
+    -- depends = {"go", "make"},
 }
 ```
 
-Add `depends` to the `PLUGIN` table when install hooks need other mise-managed tools on `PATH`. Use tool names as they would appear in `mise.toml`, for example `depends = { "go", "make" }`. Omit it if hooks do not shell out to other tools.
-
-This is separate from `depends` in `[tools]`, which only makes one configured tool wait for another in the install graph. The `depends` field in vfox `metadata.lua` is plugin metadata; when matching tools are configured, mise uses it to order the current install jobs and to build the hook environment.
+`depends` exposes matching configured tools to installation hooks and orders their install
+jobs. Users must configure those tools; the metadata does not choose their versions. Avoid
+self-dependencies. This differs from a tool's `[tools]` `depends` option, which orders the
+configured install graph.
 
 #### System Dependencies
 
@@ -390,507 +293,180 @@ These declarations are inert on older mise versions and on upstream vfox (both i
 
 ### 3. Helper Libraries
 
-Create shared functions in the `lib/` directory:
+Use Lua helpers for publisher-specific platform naming. The runtime reports `darwin` for
+macOS and `amd64` for x64; an upstream archive may spell those differently. Map only the
+platforms the publisher actually supports and reject others explicitly.
 
 ```lua
--- lib/helper.lua
+-- lib/platform.lua
 local M = {}
-
-function M.get_arch()
-    -- Use the RUNTIME object provided by vfox/mise
-    return (RUNTIME.archType == "amd64") and "x64" or RUNTIME.archType  -- return as-is for other architectures
+function M.archive_platform()
+    local os_name = RUNTIME.osType == "darwin" and "macos" or RUNTIME.osType
+    local arch = RUNTIME.archType == "amd64" and "x64" or RUNTIME.archType
+    return os_name .. "-" .. arch
 end
-
-function M.get_os()
-    -- Use the RUNTIME object provided by vfox/mise
-    return (RUNTIME.osType == "windows") and "win" or RUNTIME.osType
-end
-
-function M.get_platform()
-    return M.get_os() .. "-" .. M.get_arch()
-end
-
 return M
 ```
 
 ## Real-World Example: vfox-nodejs
 
-Here is a complete example, based on the vfox-nodejs plugin, that demonstrates all of these concepts:
+Study [vfox-nodejs](https://github.com/version-fox/vfox-nodejs) for an upstream implementation.
+For normal Node use, prefer mise's [core Node backend](/lang/node.html). A Node plugin must
+handle the following details rather than copying a fixed Linux archive URL.
 
 ### Available Hook Example
 
-```lua
--- hooks/available.lua
-function PLUGIN:Available(ctx)
-    local http = require("http")
-    local json = require("json")
-
-    -- Fetch versions from Node.js API
-    local resp, err = http.get({
-        url = "https://nodejs.org/dist/index.json"
-    })
-
-    if err ~= nil then
-        error("Failed to fetch versions: " .. err)
-    end
-
-    local versions = json.decode(resp.body)
-    local result = {}
-
-    for i, v in ipairs(versions) do
-        local version = v.version:gsub("^v", "")  -- Remove 'v' prefix
-        local note = nil
-
-        if v.lts then
-            note = "LTS"
-        end
-
-        table.insert(result, {
-            version = version,
-            note = note,
-            addition = {
-                {
-                    name = "npm",
-                    version = v.npm
-                }
-            }
-        })
-    end
-
-    return result
-end
-```
+Node's release index contains version strings and release metadata. Check the HTTP status
+before decoding it, preserve the index's release order, and remove only its known leading
+`v`. Keep prerelease identifiers intact. The [HTTP and JSON modules](/plugin-lua-modules.html)
+provide the request and decoding APIs.
 
 ### PreInstall Hook Example
 
+Select the exact archive for the target OS/architecture, then match its filename exactly
+in `SHASUMS256.txt`. A filename contains Lua pattern characters such as `.` and `-`, so
+`line:match(filename)` is not an exact filename check. For example:
+
 ```lua
--- hooks/pre_install.lua
-function PLUGIN:PreInstall(ctx)
-    local version = ctx.version
-
-    -- Determine platform using RUNTIME object
-    local arch_token = (RUNTIME.archType == "amd64") and "x64" or RUNTIME.archType
-    local os_token = (RUNTIME.osType == "windows") and "win" or RUNTIME.osType
-    local platform = os_token .. "-" .. arch_token
-    local extension = (RUNTIME.osType == "windows") and "zip" or "tar.gz"
-
-    -- Build download URL
-    local filename = "node-v" .. version .. "-" .. platform .. "." .. extension
-    local url = "https://nodejs.org/dist/v" .. version .. "/" .. filename
-
-    -- Fetch checksum
-    local http = require("http")
-    local shasums_url = "https://nodejs.org/dist/v" .. version .. "/SHASUMS256.txt"
-    local resp, err = http.get({ url = shasums_url })
-
-    local sha256 = nil
-    if err == nil then
-        -- Extract SHA256 for our file
-        for line in resp.body:gmatch("[^\n]+") do
-            if line:match(filename) then
-                sha256 = line:match("^(%w+)")
-                break
-            end
+local function find_checksum(body, filename)
+    for line in body:gmatch("[^\r\n]+") do
+        local digest, name = line:match("^(%x+)%s+%*?(.+)$")
+        if name == filename and #digest == 64 then
+            return digest
         end
     end
-
-    return {
-        version = version,
-        url = url,
-        sha256 = sha256,
-        note = "Installing Node.js " .. version .. " (" .. platform .. ")"
-    }
+    error("No SHA-256 entry for " .. filename)
 end
 ```
 
+Fail if the checksum is missing. Do not silently continue with `sha256 = nil` after a
+failed request. Obtaining a checksum from the same server is an integrity check, not the
+same guarantee as verifying Node's signed checksum manifest.
+
 ### EnvKeys Hook Example
 
+Node archives place executables in `bin` on Unix and at the installation root on Windows.
+Use the correct directory:
+
 ```lua
--- hooks/env_keys.lua
 function PLUGIN:EnvKeys(ctx)
-    local mainPath = ctx.path
-    local os_type = RUNTIME.osType
-
-    local env_vars = {
-        {
-            key = "NODE_HOME",
-            value = mainPath
-        },
-        {
-            key = "PATH",
-            value = mainPath .. "/bin"
-        }
+    local file = require("file")
+    local bin = RUNTIME.osType == "windows" and ctx.path or file.join_path(ctx.path, "bin")
+    return {
+        {key = "NODE_HOME", value = ctx.path},
+        {key = "PATH", value = bin},
     }
-
-    -- Add npm global modules to PATH
-    local npm_global_path = mainPath .. "/lib/node_modules/.bin"
-    if os_type == "windows" then
-        npm_global_path = mainPath .. "/node_modules/.bin"
-    end
-
-    table.insert(env_vars, {
-        key = "PATH",
-        value = npm_global_path
-    })
-
-    return env_vars
 end
 ```
 
 ### PostInstall Hook Example
 
-```lua
--- hooks/post_install.lua
-function PLUGIN:PostInstall(ctx)
-    local sdkInfo = ctx.sdkInfo['nodejs']
-    local path = sdkInfo.path
-    -- Set executable permissions on Unix systems
-    if RUNTIME.osType ~= "windows" then
-        os.execute("chmod +x " .. path .. "/bin/*")
-    end
-
-    -- Create npm cache directory
-    local npm_cache_dir = path .. "/.npm"
-    os.execute("mkdir -p " .. npm_cache_dir)
-
-    -- Configure npm to use local cache
-    local npm_cmd = path .. "/bin/npm"
-    if RUNTIME.osType == "windows" then
-        npm_cmd = path .. "/npm.cmd"
-    end
-
-    os.execute(npm_cmd .. " config set cache " .. npm_cache_dir)
-    os.execute(npm_cmd .. " config set prefix " .. path)
-end
-```
+Avoid running `npm config set` without a deliberate configuration scope: it can change the
+user's npm configuration outside the tool installation. Prefer returning environment
+entries if the plugin needs a specific npm prefix or cache. Test the actual archive layout
+before adding permission changes or setup commands.
 
 ### Legacy File Support
 
-```lua
--- hooks/parse_legacy_file.lua
-function PLUGIN:ParseLegacyFile(ctx)
-    local filename = ctx.filename
-    local filepath = ctx.filepath
-    local file = require("file")
-
-    -- Read file content
-    local content = file.read(filepath)
-    if not content then
-        error("Failed to read " .. filepath)
-    end
-
-    -- Parse version from different file formats
-    local version = nil
-
-    if filename == ".nvmrc" then
-        -- .nvmrc can contain version with or without 'v' prefix
-        version = content:match("v?([%d%.]+)")
-    elseif filename == ".node-version" then
-        -- .node-version typically contains just the version number
-        version = content:match("([%d%.]+)")
-    end
-
-    -- Remove any whitespace
-    if version then
-        version = version:gsub("%s+", "")
-    end
-
-    return {
-        version = version
-    }
-end
-```
+Node version files can contain aliases such as `lts/*`, prefixes, and prereleases. Do not
+extract only digits and dots. A parser must preserve the request and the plugin must support
+resolving it; otherwise report the unsupported value instead of selecting a different release.
 
 ## Testing Your Plugin
 
 ### Local Development
 
-```bash
-# Link your plugin for development
+Use a separate test project and a plugin name that will not replace your normal tools:
+
+```sh
 mise plugin link my-tool /path/to/my-tool-plugin
-
-# Test listing versions
 mise ls-remote my-tool
-
-# Test installation
-mise install my-tool@1.0.0
-
-# Test environment setup
 mise use my-tool@1.0.0
-my-tool --version
-
-# Test legacy file parsing (if applicable)
-echo "2.0.0" > .my-tool-version
-mise use my-tool
+mise exec -- example --version
 ```
 
-If you're using the template repository, you can run the included tests:
+Replace `1.0.0` with a published test version and `example` with the executable it provides.
+For version-file tests, use another empty project with no competing `[tools]` pin:
 
-```bash
-# Run linting
-mise run lint
-
-# Run tests
-mise run test
+```toml
+[settings]
+idiomatic_version_file_enable_tools = ["my-tool"]
 ```
+
+Write a supported request to `.example-version`, run `mise install`, and verify
+`mise exec -- example --version`. `mise use my-tool` would write a tool selection, so it
+is not a test of whether the version file controls resolution.
 
 ### Debug Mode
 
-Use debug mode to see detailed plugin execution:
-
-```bash
-mise --debug install nodejs@20.0.0
+```sh
+MISE_DEBUG=1 mise install my-tool@1.0.0
+mise cache clear my-tool
 ```
+
+Clear the tool's cache when cached metadata or version results hide a local hook edit.
 
 ### Plugin Test Script
 
-Create a comprehensive test script:
-
-```bash
-#!/bin/bash
-# test/test.sh
-set -e
-
-echo "Testing nodejs plugin..."
-
-# Install the plugin
-mise plugin install nodejs .
-
-# Test basic functionality
-mise install nodejs@18.18.0
-mise use nodejs@18.18.0
-
-# Verify installation
-node --version | grep "18.18.0"
-npm --version
-
-# Test legacy file support
-echo "20.0.0" > .nvmrc
-mise use nodejs
-node --version | grep "20.0.0"
-
-# Clean up
-rm -f .nvmrc
-mise plugin remove nodejs
-
-echo "All tests passed!"
-```
+Use the isolated [publishing test workflow](/plugin-publishing.html#testing-before-publication).
+Exercise version listing, a concrete install, executable lookup, and environment values.
+Also test unsupported platforms, missing checksums, malformed metadata, paths with spaces,
+and idiomatic files if supported. Run each advertised OS in CI.
 
 ## Best Practices
 
 ### Error Handling
 
-Always provide meaningful error messages:
-
-```lua
-function PLUGIN:Available(ctx)
-    local http = require("http")
-    local resp, err = http.get({
-        url = "https://api.example.com/versions"
-    })
-
-    if err ~= nil then
-        error("Failed to fetch versions from API: " .. err)
-    end
-
-    if resp.status_code ~= 200 then
-        error("API returned status " .. resp.status_code .. ": " .. resp.body)
-    end
-
-    -- Process response...
-end
-```
+Use `http.try_get` for a recoverable transport failure, and check HTTP status before parsing.
+Synchronous operations such as `json.decode` and `cmd.exec` raise catchable Lua errors.
+Never log tokens or a secret-bearing response body just to explain a failed request.
 
 ### Platform Detection
 
-Handle different operating systems using the `RUNTIME` object:
+Use the injected runtime instead of spawning `uname`:
 
-```lua
--- lib/platform.lua
-local M = {}
-
-function M.is_windows()
-    return RUNTIME.osType == "windows"
-end
-
-function M.get_exe_extension()
-    return M.is_windows() and ".exe" or ""
-end
-
-function M.get_path_separator()
-    return M.is_windows() and "\\" or "/"
-end
-
-return M
-```
-
-The `RUNTIME` object is available in all plugin hooks and provides:
-
-- `RUNTIME.osType`: Operating system type ("windows", "linux", "darwin")
-- `RUNTIME.archType`: Architecture ("amd64", "arm64", "x86", etc.)
-- `RUNTIME.envType`: libc environment type (`"gnu"` on glibc Linux, `"musl"` on musl Linux, `nil` on Windows/macOS and undetected systems)
-- `RUNTIME.version`: vfox runtime version
-- `RUNTIME.pluginDirPath`: Plugin directory path
+| Field                   | Values or meaning                                          |
+| ----------------------- | ---------------------------------------------------------- |
+| `RUNTIME.osType`        | `windows`, `linux`, `darwin`                               |
+| `RUNTIME.archType`      | `amd64`, `arm64`, `x86`, and other supported architectures |
+| `RUNTIME.envType`       | `gnu` or `musl` on detected Linux systems; otherwise `nil` |
+| `RUNTIME.version`       | Embedded vfox runtime version                              |
+| `RUNTIME.pluginDirPath` | Plugin source directory                                    |
 
 ### Version Normalization
 
-Normalize versions consistently:
-
-```lua
-local function normalize_version(version)
-    -- Remove 'v' prefix if present
-    version = version:gsub("^v", "")
-
-    -- Remove pre-release suffixes
-    version = version:gsub("%-.*", "")
-
-    return version
-end
-```
+Normalize only a documented publisher convention, such as a leading `v`. Treat the rest
+of the version as opaque. Removing `-beta.1` changes a prerelease into a different request.
 
 ### Caching
 
-Cache expensive operations:
-
-```lua
--- Cache versions for 12 hours
-local cache = {}
-local cache_ttl = 12 * 60 * 60  -- 12 hours in seconds
-
-function PLUGIN:Available(ctx)
-    local now = os.time()
-
-    -- Check cache first
-    if cache.versions and cache.timestamp and (now - cache.timestamp) < cache_ttl then
-        return cache.versions
-    end
-
-    -- Fetch fresh data
-    local versions = fetch_versions_from_api()
-
-    -- Update cache
-    cache.versions = versions
-    cache.timestamp = now
-
-    return versions
-end
-```
+mise caches remote version lists and environment results. A module-level Lua table only
+lasts for that runtime and cannot provide a cache shared by separate mise invocations.
+Keep metadata declarative and see [cache behavior](/cache-behavior.html) for refresh controls.
 
 ## Advanced Features
 
 ### Conditional Installation
 
-Use different installation logic depending on the platform or version:
-
-```lua
-function PLUGIN:PreInstall(ctx)
-    local version = ctx.version
-
-    -- Different logic for different platforms using RUNTIME object
-    if RUNTIME.osType == "windows" then
-        -- Windows-specific installation
-        return install_windows(version)
-    elseif RUNTIME.osType == "darwin" then
-        -- macOS-specific installation
-        return install_macos(version)
-    else
-        -- Linux installation
-        return install_linux(version)
-    end
-end
-```
+Choose the archive using `RUNTIME` and the exact requested version. `PreInstall` can be
+called for lockfile generation on another target platform; avoid probing the host or
+installing dependencies just to calculate an artifact URL.
 
 ### Source Compilation
 
-For plugins that need to compile from source:
-
-```lua
--- hooks/post_install.lua
-function PLUGIN:PostInstall(ctx)
-    local sdkInfo = ctx.sdkInfo['tool-name']
-    local path = sdkInfo.path
-    local version = sdkInfo.version
-
-    -- Change to source directory
-    local build_dir = path .. "/src"
-
-    -- Configure build
-    local configure_result = os.execute("cd " .. build_dir .. " && ./configure --prefix=" .. path)
-    if configure_result ~= 0 then
-        error("Configure failed")
-    end
-
-    -- Compile
-    local make_result = os.execute("cd " .. build_dir .. " && make -j$(nproc)")
-    if make_result ~= 0 then
-        error("Compilation failed")
-    end
-
-    -- Install
-    local install_result = os.execute("cd " .. build_dir .. " && make install")
-    if install_result ~= 0 then
-        error("Installation failed")
-    end
-end
-```
+Compile only in the installation phase. Declare prerequisites, use `cmd.exec` with a `cwd`
+option, and pass paths through correctly quoted arguments or environment variables.
+Document whether the build needs a POSIX shell. Commands such as `nproc`, `chmod`, and
+`./configure` do not form a portable Windows build recipe.
 
 ### Environment Configuration
 
-A more complex environment variable setup:
-
-```lua
-function PLUGIN:EnvKeys(ctx)
-    local mainPath = ctx.path
-    local version = ctx.sdkInfo['tool-name'].version
-
-    local env_vars = {
-        -- Standard environment variables
-        {
-            key = "TOOL_HOME",
-            value = mainPath
-        },
-        {
-            key = "TOOL_VERSION",
-            value = version
-        },
-
-        -- PATH entries
-        {
-            key = "PATH",
-            value = mainPath .. "/bin"
-        },
-        {
-            key = "PATH",
-            value = mainPath .. "/scripts"
-        },
-
-        -- Library paths
-        {
-            key = "LD_LIBRARY_PATH",
-            value = mainPath .. "/lib"
-        },
-        {
-            key = "PKG_CONFIG_PATH",
-            value = mainPath .. "/lib/pkgconfig"
-        }
-    }
-
-    -- Platform-specific additions
-    if RUNTIME.osType == "darwin" then
-        table.insert(env_vars, {
-            key = "DYLD_LIBRARY_PATH",
-            value = mainPath .. "/lib"
-        })
-    end
-
-    return env_vars
-end
-```
+Return only the variables the tool needs. PATH entries are directories; setting unrelated
+variables such as `LD_LIBRARY_PATH` can affect every process launched in the environment.
+For variables unrelated to a tool version, use an [environment plugin](/env-plugin-development.html).
 
 ## Next Steps
 
-- [Start with the plugin template](https://github.com/jdx/mise-tool-plugin-template)
-- [Learn about Backend Plugin Development](backend-plugin-development.md)
-- [Explore available Lua modules](plugin-lua-modules.md)
-- [Publish your plugin](plugin-publishing.md)
-- [View the vfox-nodejs plugin source](https://github.com/version-fox/vfox-nodejs)
+- [Backend Plugin Development](/backend-plugin-development.html).
+- [Plugin Lua Modules](/plugin-lua-modules.html).
+- [Plugin Publishing](/plugin-publishing.html).


### PR DESCRIPTION
Correct the plugin authoring guides against the embedded Lua runtime and mise's lifecycle. Explain hook contexts and version ordering, remove unsupported PreUse behavior and ignored SDK additions, preserve opaque versions, and replace broken shell, HTML, string, checksum, and installation examples.

The environment guide now includes configuration-root-relative paths, a complete Vault KV v2 hook, cache limitations, and redaction scope. Package guidance reports only requested identities and avoids manager-wide upgrades for a selected batch. Publishing distinguishes plugin revisions from tool versions and tests isolated Git/archive installations. The Lua reference documents numeric comparison limitations, selection traversal, process environment mutation, and the ignored command timeout.

Validation: 78 Lua snippets compiled through mise's Lua 5.1 runtime; eight TOML 1.1 snippets parsed; full lint-fix with Rust 1.95, scoped safe hk checks, docs build, and rendered links. Isolated fixtures exercise module APIs, HTTP failures, archives, environment paths, Vault responses, tool listing/install/env hooks, exact checksum rejection, the POSIX npm backend, selected package status batches, prefixed archives, and #tag Git installs. Windows implementations and real Vault/VS Code services were not exercised. Rebased on main and rebuilt docs/public/llms.txt.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime behavior; risk is limited to authors following outdated guidance if any new inaccuracy slipped in.
> 
> **Overview**
> This PR **realigns the plugin authoring docs** with mise’s embedded Lua runtime and real hook contracts, replacing misleading examples and trimming duplicated tutorial code.
> 
> **Tool, backend, and Lua reference** pages now spell out **version list ordering** (`Available` newest-first vs `BackendListVersions` oldest-first), **opaque version strings** (no blanket SemVer sorting), **artifact verification** expectations, and that **`PreUse` and vfox `addition` installs are not supported** in mise’s lifecycle. Examples favor **`file.join_path`**, **`RUNTIME`**, quoted **`cmd.exec` env vars**, HTTP **`status_code` checks**, and corrected **HTML module** iteration.
> 
> **Environment plugins** are rewritten around **`ctx.config_root`**, cache/redaction limits, **`tools = true`**, and a complete **Vault KV v2** hook. **Package plugins** add accurate **status-batch** behavior and warn against manager-wide upgrades. **Publishing** distinguishes plugin refs from tool versions and documents **isolated `MISE_*` test directories** and Git `#tag` installs. **`docs/public/llms.txt`** blurbs are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e54958db75bbe929de0b06694c347490973bdb17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reworked plugin development guides for tool, backend, environment, and package plugins with clearer mise-specific guidance and updated examples.
  * Added guidance on plugin hooks, lifecycle behavior, caching, platform compatibility, security, testing, and error handling.
  * Rewrote plugin publishing documentation to cover all supported plugin types, distribution methods, versioning, and maintenance.
  * Updated the public documentation index with refreshed plugin guide descriptions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->