### PR TITLE
feat(dotfiles): automatic synchronization and fresh-machine bootstrap from a setup repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6458,6 +6458,7 @@ dependencies = [
  "bytesize",
  "bzip2",
  "calm_io",
+ "cc",
  "cfg_aliases",
  "chacha20poly1305 0.11.0",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ include = [
   "/README.md",
   "/build.rs",
   "/completions/*",
+  "/docs/public/apple-touch-icon.png",
   "/minisign.pub",
   "/registry/*.toml",
   "/settings.toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -303,6 +303,7 @@ windows-sys = { version = "0.61", features = [
 [build-dependencies]
 aqua-registry = { path = "crates/aqua-registry" }
 built = { version = "0.8", features = ["chrono"] }
+cc = "1"
 cfg_aliases = "0.2"
 eyre = "0.6"
 heck = "0.5"

--- a/build.rs
+++ b/build.rs
@@ -24,11 +24,41 @@ fn main() -> Result<()> {
         vfox: { any(feature = "vfox", target_os = "windows") },
     }
     built::write_built_file()?;
+    build_notification_helper()?;
 
     let aqua_registry = load_aqua_registry()?;
     codegen_settings();
     codegen_registry(&aqua_registry.packages);
     codegen_aqua_standard_registry(&aqua_registry)?;
+    Ok(())
+}
+
+fn build_notification_helper() -> Result<()> {
+    let source = "src/system/history/notify/macos.m";
+    println!("cargo:rerun-if-changed={source}");
+    if env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("macos") {
+        return Ok(());
+    }
+    let output = PathBuf::from(env::var_os("OUT_DIR").unwrap()).join("mise-notify");
+    let status = cc::Build::new()
+        .get_compiler()
+        .to_command()
+        .args(["-fobjc-arc", "-O2", "-mmacosx-version-min=10.14"])
+        .args([
+            "-framework",
+            "AppKit",
+            "-framework",
+            "UserNotifications",
+            "-framework",
+            "CoreServices",
+        ])
+        .arg(source)
+        .arg("-o")
+        .arg(output)
+        .status()?;
+    if !status.success() {
+        return Err(eyre!("failed to build the macOS notification helper"));
+    }
     Ok(())
 }
 

--- a/docs/.vitepress/sidebar.ts
+++ b/docs/.vitepress/sidebar.ts
@@ -112,6 +112,7 @@ export const sidebar: SidebarItem[] = [
     text: "Bootstrap",
     items: [
       { text: "Overview", link: "/bootstrap" },
+      { text: "Set Up a Machine", link: "/bootstrap/setup" },
       {
         text: "Remote Hosts",
         link: "/bootstrap/remote",

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -75,6 +75,19 @@ As with `--from`, an existing non-empty destination must be a git checkout
 whose `origin` exactly matches the requested URL; pass `--update` to
 fast-forward it before bootstrap.
 
+If the repository is a mise **setup repository** (one connected with
+`mise bootstrap dotfiles origin set`, recognizable by its
+`.mise-history/format.toml`), `--from-git` sets the machine up from it
+instead of cloning it: the branch is fetched into mise's own history store,
+the shared configuration, the sources it references, and this machine's
+tracked files are written by the same recoverable pull as any other incoming
+change (a file that already exists and differs is held for a decision, never
+overwritten; `--dry-run` shows the plan), the connection is remembered for
+the history watcher, and the ordinary bootstrap then runs from the
+configuration that arrived. Nothing is cloned into `$MISE_CONFIG_DIR`, and an
+existing checkout there is not converted. See [history](/history.html) for
+what happens next.
+
 ## How it runs
 
 `mise bootstrap` runs the steps below in order.

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -315,6 +315,10 @@ The `pre-dotfiles` and `post-dotfiles` phases also wrap
 
 ## Common workflows
 
+The whole path from installing mise to a second machine that shares the
+same setup, with the output each step prints, is
+[Set up a machine](/bootstrap/setup.html).
+
 ### New machine
 
 ```sh

--- a/docs/bootstrap/remote.md
+++ b/docs/bootstrap/remote.md
@@ -340,6 +340,25 @@ changes.
 copy-link settings. Explicit `--source`, `--copy-link`, `--copy-links`, and
 `--exclude` flags cannot be combined with it.
 
+A **setup repository** (one connected with `mise bootstrap dotfiles origin set`,
+carrying `.mise-history/format.toml`) is set up from rather than checked out:
+the remote host fetches the transferred branch into its own history store,
+writes the shared configuration and this machine's tracked files with a
+recoverable pull, records the connection, and the bootstrap that follows
+installs the history watcher like any other user service:
+
+```sh
+mise bootstrap remote --host devbox --install-mise --from-git jdx/dotfiles \
+  --github-relay-read-only --github-relay-repo jdx/dotfiles
+```
+
+The borrowed GitHub access is read-only and ends with the session: the remote
+host can fetch through it but never publish. When the setup succeeded but the
+host cannot reach the repository on its own afterwards, the bootstrap says
+so; give the host credentials of its own for ongoing synchronization
+(`mise x gh -- gh auth login` and `mise x gh -- gh auth setup-git` there, or
+an SSH url through `mise bootstrap dotfiles origin set`).
+
 The relay is separate from this initial transfer. Enable it when bootstrap needs
 additional private GitHub content, authorizing each required repository with a
 repeated `--github-relay-repo`. Shorthand never enables or expands relay access.

--- a/docs/bootstrap/remote.md
+++ b/docs/bootstrap/remote.md
@@ -358,6 +358,10 @@ so its watcher can keep running. Dry runs do not persist it. Enabling experiment
 locally alone does not opt in the remote host. Ordinary repository-based bootstrap
 does not require the flag.
 
+The target must allow machine-local configuration discovery. If it sets
+`MISE_GLOBAL_CONFIG_FILE` to a different file, unset that override before setup;
+mise refuses to save an opt-in in a file that subsequent sessions would ignore.
+
 ```sh
 mise bootstrap remote --experimental --host devbox --install-mise --from-git jdx/dotfiles \
   --github-relay-read-only --github-relay-repo jdx/dotfiles

--- a/docs/bootstrap/remote.md
+++ b/docs/bootstrap/remote.md
@@ -305,7 +305,7 @@ mise configuration directory:
 
 ```sh
 # Authenticate on this machine first (for example, using gh auth login).
-mise bootstrap remote --host devbox --from-git jdx/dotfiles \
+mise bootstrap remote --experimental --host devbox --from-git jdx/dotfiles \
   --github-relay-read-only --github-relay-repo jdx/dotfiles
 ```
 
@@ -351,13 +351,15 @@ installs the history watcher like any other user service. With `--dry-run` the
 target shows that plan (the files it would write, and any held for a decision),
 records no connection, and keeps no fetched branch:
 
-Tracking-enabled setup repositories are experimental. Before using one,
-install mise on the target if necessary and run `mise settings experimental=true`
-there. Enabling experimental locally does not enable it on the remote host.
-Ordinary repository-based bootstrap does not require this opt-in.
+Tracking-enabled setup repositories require `--experimental`. This explicitly
+enables experimental features for the remote invocation and, after successful
+tracking setup, saves the opt-in in the target's machine-local mise configuration
+so its watcher can keep running. Dry runs do not persist it. Enabling experimental
+locally alone does not opt in the remote host. Ordinary repository-based bootstrap
+does not require the flag.
 
 ```sh
-mise bootstrap remote --host devbox --install-mise --from-git jdx/dotfiles \
+mise bootstrap remote --experimental --host devbox --install-mise --from-git jdx/dotfiles \
   --github-relay-read-only --github-relay-repo jdx/dotfiles
 ```
 
@@ -429,7 +431,7 @@ mise ssh devbox --github-relay-read-only --github-relay-repo jdx/dotfiles \
   --github-relay-log-requests --github-relay-max-duration 1h
 
 # Structured relay events for troubleshooting or auditing:
-mise bootstrap remote --host devbox --from-git jdx/dotfiles \
+mise bootstrap remote --experimental --host devbox --from-git jdx/dotfiles \
   --github-relay-read-only --github-relay-repo jdx/dotfiles \
   --github-relay-log-requests --github-relay-log-format jsonl
 ```

--- a/docs/bootstrap/remote.md
+++ b/docs/bootstrap/remote.md
@@ -351,6 +351,11 @@ installs the history watcher like any other user service. With `--dry-run` the
 target shows that plan (the files it would write, and any held for a decision),
 records no connection, and keeps no fetched branch:
 
+Tracking-enabled setup repositories are experimental. Before using one,
+install mise on the target if necessary and run `mise settings experimental=true`
+there. Enabling experimental locally does not enable it on the remote host.
+Ordinary repository-based bootstrap does not require this opt-in.
+
 ```sh
 mise bootstrap remote --host devbox --install-mise --from-git jdx/dotfiles \
   --github-relay-read-only --github-relay-repo jdx/dotfiles

--- a/docs/bootstrap/remote.md
+++ b/docs/bootstrap/remote.md
@@ -329,12 +329,14 @@ An existing matching checkout is reused unless `--update` requests a safe
 fast-forward. Dirty checkouts, mismatched origins, conflicting files, and source
 files ending in `.local.toml` require manual resolution. A nonempty non-Git
 directory can be adopted after confirmation: existing files and local overrides
-are preserved. With `--from-git`, `--dry-run` only reports the proposed operation;
-it does not fetch the source, open an SSH session, inspect the target, or create
-temporary staging. Dirty checkouts, mismatched origins, and adoption conflicts
-are therefore detected only during a real apply. By contrast, `--source .
---dry-run` connects to and inspects the target without applying persistent
-changes.
+are preserved. With `--from-git`, `--dry-run` previews the whole operation the
+way `--source . --dry-run` does: the revision is fetched locally, the target is
+connected to, mise and the bundle are staged, and the target runs every check
+(dirty checkout, mismatched origin, adoption conflicts, `.local.toml` files) and
+says what it would do: clone, fast-forward, or adopt with the number of new
+files. When a global configuration already exists on the target, the bootstrap
+that follows is previewed with `--dry-run` too. Nothing persistent is written
+and the staging directory is removed.
 
 `--from-git` uses the repository instead of the inventory's archive source and
 copy-link settings. Explicit `--source`, `--copy-link`, `--copy-links`, and
@@ -345,7 +347,9 @@ carrying `.mise-history/format.toml`) is set up from rather than checked out:
 the remote host fetches the transferred branch into its own history store,
 writes the shared configuration and this machine's tracked files with a
 recoverable pull, records the connection, and the bootstrap that follows
-installs the history watcher like any other user service:
+installs the history watcher like any other user service. With `--dry-run` the
+target shows that plan (the files it would write, and any held for a decision),
+records no connection, and keeps no fetched branch:
 
 ```sh
 mise bootstrap remote --host devbox --install-mise --from-git jdx/dotfiles \

--- a/docs/bootstrap/setup.md
+++ b/docs/bootstrap/setup.md
@@ -1,0 +1,224 @@
+# Set up a machine with mise
+
+The recommended way to run mise on a workstation: keep editing your
+configuration files where they are, let mise save every change and share the
+ones you choose, and recreate the whole setup on the next machine with one
+command. Symlink, copy, and template workflows keep working as before and mix
+with this freely; tracking files in place is simply the default worth reaching
+for first.
+
+This page is one path through the whole thing. Each step shows the commands
+and what they print (identifiers and times differ on your machine); the
+details live in [dotfiles](/dotfiles.html), [history](/history.html),
+[services](/bootstrap/services.html), and [remote bootstrap](/bootstrap/remote.html).
+
+## 1. Install mise and sign in to your repository host
+
+```sh
+curl https://mise.run | sh
+export PATH="$HOME/.local/bin:$PATH"
+mise use -g gh
+gh auth login --hostname github.com --git-protocol https --web
+gh auth setup-git --hostname github.com
+```
+
+`gh auth setup-git` makes git use the GitHub CLI as its credential helper,
+so background synchronization can reach a private repository without a
+terminal. An SSH remote works too when the history watcher can reach an
+agent or an unencrypted key.
+
+## 2. Track a file you already have
+
+```sh
+$ mise bootstrap dotfiles track ~/.zshrc ~/.config/hypr
+mise history: saved baseline checkpoint 1
+mise WARN automatic capture is inactive: declare `[bootstrap.services.mise-history] builtin = "history-watch"` and run `mise bootstrap`; until then edits are saved by `mise bootstrap dotfiles save` or `mise bootstrap dotfiles watch --once`
+```
+
+The files stay exactly where they are. The declaration is one line per
+destination in `~/.config/mise/config.toml`:
+
+```toml
+[dotfiles]
+"~/.zshrc" = { mode = "track" }
+"~/.config/hypr" = { mode = "track" }
+```
+
+## 3. Let a service save your edits
+
+```toml
+[bootstrap.services.mise-history]
+builtin = "history-watch"
+```
+
+```sh
+$ mise bootstrap
+...
+mise user services: applied mise-history
+```
+
+The same declaration installs a systemd user unit on Linux, a LaunchAgent
+on macOS, and a Scheduled Task on Windows. `mise bootstrap dotfiles status`
+reports `automatic capture: running`.
+
+## 4. Connect a repository and pick a mode
+
+```sh
+$ mise bootstrap dotfiles origin set https://github.com/you/setup.git --name laptop
+Setup repository: https://github.com/you/setup.git (branch main)
+Machine: laptop (0192f3a4-…)
+Sync mode sync: the watcher publishes this machine's shared files and configuration after each save, fetches the repository periodically, and applies nonconflicting incoming changes to tracked files and configuration (with a protective checkpoint first; a conflict or an unsaved edit holds the path, nothing else waits). It never runs `mise bootstrap`, installs or removes packages, or renders templates; when incoming configuration changes declarations, `mise bootstrap dotfiles status` says to run `mise bootstrap`. `mise bootstrap dotfiles sync` and `pull` do the same on request.
+The repository is empty: the first publication creates `main` with the mise marker.
+Published from this machine:
+  configuration: 1 file(s)
+  tracked (home): 4 file(s)
+Not shared:
+  ~/.config/mise/config.local.toml: machine-local configuration (private unless explicitly overridden)
+Machine backups: 5 of 6 captured file(s) are backed up in plain form under refs/mise-history/0192f3a4-…/ — anyone who can read this repository can read every file in these snapshots. The setup branch is always plaintext; use a private repository.
+Existing checkpoints: not uploaded; only checkpoints from now on (pass --include-existing to upload them too)
+Connect this setup repository? [y/N] y
+mise history: connected https://github.com/you/setup.git (sync); [history.origin] written to ~/.config/mise/config.local.toml
+mise history: published 3f2a1c9
+```
+
+`sync` is the default: the watcher publishes shortly after a save, fetches
+periodically, and writes nonconflicting incoming changes with a protective
+checkpoint first. `fetch-only` never publishes and never changes a file
+until you run `pull`; `manual` does nothing on the network by itself
+(`--sync <mode>` chooses; `mise settings set history.sync <mode>` changes it
+later). `sync` and `pull` are different commands on purpose: `sync` moves
+saved changes between the machine and the repository, `pull` writes what
+arrived into your files; in `sync` mode the watcher does both. Everything
+the disclosure lists leaves the machine in plain text, so use a private
+repository.
+
+## 5. Edit a file and look at its history
+
+Edit `~/.config/hypr/bindings.lua` in your editor. Once it has been quiet
+for two seconds the watcher saves it:
+
+```sh
+$ mise bootstrap dotfiles history --path ~/.config/hypr/bindings.lua
+ID  When              Trigger   Description                                Files
+7   2026-09-06 09:41  edit      edited hypr/bindings.lua                   1
+4   2026-09-05 18:02  edit      edited hypr/bindings.lua, hypr/monitors.lua 2
+1   2026-09-03 08:15  baseline  tracked ~/.zshrc, ~/.config/hypr           5
+$ mise bootstrap dotfiles history diff 4 --path ~/.config/hypr/bindings.lua --patch
+-bind = SUPER, Q, exec, kitty
++bind = SUPER, Q, exec, alacritty
+```
+
+A file that keeps changing (a state file an application rewrites every
+second) is saved ever more rarely rather than flooding the history, and
+never delays the others; `mise bootstrap dotfiles paths --noisy` names it,
+and `mise bootstrap dotfiles exclude '<glob>'` leaves it out.
+
+## 6. Restore one file
+
+```sh
+$ mise bootstrap dotfiles rollback ~/.config/hypr/bindings.lua
+Path                         Action  From          To
+~/.config/hypr/bindings.lua  write   file 9c1e2d4  file 51ab7f0
+history: apply this plan? [y/N] y
+mise history: rolled back ~/.config/hypr/bindings.lua to 4
+$ mise bootstrap dotfiles undo
+```
+
+A rollback saves a protective checkpoint first, touches only the paths in
+its plan, and is a new change like any other: with a repository connected
+it is published and other machines receive it; `undo` reverses it.
+
+## 7. Resolve a conflict
+
+Two machines edited the same lines of `~/.zshrc` before either synced. Both
+versions are kept, the file on each machine is untouched, and every other
+file keeps syncing:
+
+```sh
+$ mise bootstrap dotfiles status
+...
+Setup repository: https://github.com/you/setup.git (branch main, mode sync, machine desktop).
+  last publish 2026-09-06 09:41, last fetch 2026-09-06 09:55, last pull 2026-09-06 09:41; 0 checkpoint(s) pending upload.
+  conflict: ~/.zshrc: both sides changed the same lines; your local file is unchanged, other files continue syncing (`mise bootstrap dotfiles pull --take-remote|--keep-local ~/.zshrc`)
+$ mise bootstrap dotfiles pull --take-remote ~/.zshrc
+```
+
+`--keep-local` publishes this machine's version instead. `mise doctor` names
+a held path too, and `settings.history.notify = true` shows a desktop
+notification the first time a conflict needs a decision (Linux and macOS).
+
+## 8. Set up the next machine
+
+```sh
+curl https://mise.run | sh
+gh auth login --hostname github.com --git-protocol https --web
+gh auth setup-git --hostname github.com
+mise bootstrap --from-git you/setup
+```
+
+```
+https://github.com/you/setup.git is a mise setup repository (format 1); branch main.
+Sync mode sync: ...
+Path                         Action  Group
+~/.config/mise/config.toml   create  configuration
+~/.zshrc                     create  tracked/home/.zshrc
+~/.config/hypr/bindings.lua  create  tracked/home/.config/hypr/bindings.lua
+Set this machine up from the repository? [y/N] y
+Wrote 3 file(s) from https://github.com/you/setup.git.
+...
+mise user services: applied mise-history
+```
+
+The branch goes into mise's own store (nothing is cloned into
+`~/.config/mise`), the configuration and the tracked files are written by a
+recoverable pull, the watcher service comes up with the rest of the
+bootstrap, and from then on the machine syncs like the first one. A file
+that already exists and differs is held for a decision; when that file is
+the configuration itself, the command stops there and names the `pull
+--take-remote|--keep-local` that decides it. Over SSH:
+
+```sh
+mise bootstrap remote --host devbox --install-mise --from-git you/setup \
+  --github-relay-read-only --github-relay-repo you/setup
+```
+
+The borrowed GitHub access is read-only and ends with the session; give the
+host credentials of its own (step 1, there) for ongoing synchronization.
+
+## Templates next to tracked files
+
+A tracked file is shared as it is. A file that must differ per machine is
+rendered from a template source, and only the source is shared:
+
+```toml
+[vars]
+email = "you@example.com"
+
+[dotfiles]
+"~/.gitconfig" = { source = "templates/gitconfig.tera", mode = "template" }
+```
+
+`~/.config/mise/templates/gitconfig.tera` (the source) is captured, shared,
+and set up on the next machine like any configuration file. `~/.gitconfig`
+(the output) is rendered by `mise bootstrap` with this machine's `[vars]`,
+kept in local history so an edit to it can be recovered, and never shared as
+its own file.
+
+## Platform notes
+
+- **Omarchy**: track `~/.config/hypr`, `~/.config/omarchy`, and
+  `~/.config/waybar`; leave the git clones under `~/.config/omarchy/themes`
+  and `~/.config/omarchy/plugins` to Omarchy (they are nested repositories
+  and are never descended into); exclude `~/.config/omarchy/backgrounds`.
+  `omarchy-update` keeps running as it does; add
+  `mise bootstrap dotfiles save --best-effort` before it to mark the state it
+  starts from.
+- **Ubuntu**: the watcher is a systemd user unit
+  (`systemctl --user status mise-history`); `apt` packages go in
+  `[bootstrap.packages]` and are installed by `mise bootstrap` like tools.
+- **macOS**: the watcher is a LaunchAgent (`launchctl list | grep dev.mise`);
+  a tracked file can carry a macOS variant
+  (`track ~/.zshrc --os macos`) that evolves apart from the Linux one.
+- **Windows**: tracking, checkpoints, rollback, sync, and the Scheduled Task
+  watcher work; symlink modes need Developer Mode, copy and template modes
+  do not. Desktop notifications for conflicts are not available yet.

--- a/docs/bootstrap/setup.md
+++ b/docs/bootstrap/setup.md
@@ -193,7 +193,7 @@ the configuration itself, the command stops there and names the `pull
 --take-remote|--keep-local` that decides it. Over SSH:
 
 ```sh
-mise bootstrap remote --host devbox --install-mise --from-git you/setup \
+mise bootstrap remote --experimental --host devbox --install-mise --from-git you/setup \
   --github-relay-read-only --github-relay-repo you/setup
 ```
 

--- a/docs/bootstrap/setup.md
+++ b/docs/bootstrap/setup.md
@@ -1,5 +1,11 @@
 # Set up a machine with mise
 
+> [!WARNING]
+> This guide uses experimental dotfile tracking and synchronization. Enable
+> them on each machine with `mise settings experimental=true`. Interfaces
+> and storage formats may change. Existing source-managed dotfiles do not
+> require experimental mode.
+
 The recommended way to run mise on a workstation: keep editing your
 configuration files where they are, let mise save every change and share the
 ones you choose, and recreate the whole setup on the next machine with one
@@ -30,6 +36,7 @@ agent or an unencrypted key.
 ## 2. Track a file you already have
 
 ```sh
+$ mise settings experimental=true
 $ mise bootstrap dotfiles track ~/.zshrc ~/.config/hypr
 mise history: saved baseline checkpoint 1
 mise WARN automatic capture is inactive: declare `[bootstrap.services.mise-history] builtin = "history-watch"` and run `mise bootstrap`; until then edits are saved by `mise bootstrap dotfiles save` or `mise bootstrap dotfiles watch --once`

--- a/docs/bootstrap/setup.md
+++ b/docs/bootstrap/setup.md
@@ -1,211 +1,213 @@
 # Set up a machine with mise
 
 > [!WARNING]
-> This guide uses experimental dotfile tracking and synchronization. Enable
-> them on each machine with `mise settings experimental=true`. Interfaces
-> and storage formats may change. Existing source-managed dotfiles do not
-> require experimental mode.
+> Dotfile tracking and synchronization are experimental. Enable them with
+> `mise settings experimental=true`. Interfaces and storage formats may change.
+> Existing source-managed dotfiles do not require experimental mode.
 
-The recommended way to run mise on a workstation: keep editing your
-configuration files where they are, let mise save every change and share the
-ones you choose, and recreate the whole setup on the next machine with one
-command. Symlink, copy, and template workflows keep working as before and mix
-with this freely; tracking files in place is simply the default worth reaching
-for first.
+Keep editing your dotfiles where they are. This guide shows how to save local
+history, restore a file, and optionally share your setup through a Git repository.
+Start with one file; add more once you have tried restoring a change.
 
-This page is one path through the whole thing. Each step shows the commands
-and what they print (identifiers and times differ on your machine); the
-details live in [dotfiles](/dotfiles.html), [history](/history.html),
-[services](/bootstrap/services.html), and [remote bootstrap](/bootstrap/remote.html).
+## Install mise
 
-## 1. Install mise and sign in to your repository host
+You need Git installed. If mise is already installed, skip the first two commands.
 
 ```sh
 curl https://mise.run | sh
 export PATH="$HOME/.local/bin:$PATH"
-mise use -g gh
-gh auth login --hostname github.com --git-protocol https --web
-gh auth setup-git --hostname github.com
+mise settings experimental=true
 ```
 
-`gh auth setup-git` makes git use the GitHub CLI as its credential helper,
-so background synchronization can reach a private repository without a
-terminal. An SSH remote works too when the history watcher can reach an
-SSH agent with an encrypted key. For unattended file-based credentials,
-use a repository-scoped deploy key and restrict its file permissions.
+## Track a file
 
-## 2. Track a file you already have
+On macOS with zsh:
 
 ```sh
-$ mise settings experimental=true
-$ mise bootstrap dotfiles track ~/.zshrc ~/.config/hypr
-mise history: saved baseline checkpoint 1
-mise WARN automatic capture is inactive: declare `[bootstrap.services.mise-history] builtin = "history-watch"` and run `mise bootstrap`; until then edits are saved by `mise bootstrap dotfiles save` or `mise bootstrap dotfiles watch --once`
+mise bootstrap dotfiles track ~/.zshrc
 ```
 
-The files stay exactly where they are. The declaration is one line per
-destination in `~/.config/mise/config.toml`:
+On Omarchy with Bash, use `~/.bashrc` instead. Choose a file that already exists;
+the remaining examples use `~/.zshrc`.
+
+Tracking saves a baseline and adds a declaration to `~/.config/mise/config.toml`.
+The file stays in place:
 
 ```toml
 [dotfiles]
 "~/.zshrc" = { mode = "track" }
-"~/.config/hypr" = { mode = "track" }
 ```
 
-## 3. Let a service save your edits
+## Save edits automatically
+
+Add this table to `~/.config/mise/config.toml`:
 
 ```toml
 [bootstrap.services.mise-history]
 builtin = "history-watch"
 ```
 
-```sh
-$ mise bootstrap
-...
-mise user services: applied mise-history
-```
-
-The same declaration installs a systemd user unit on Linux, a LaunchAgent
-on macOS, and a Scheduled Task on Windows. `mise bootstrap dotfiles status`
-reports `automatic capture: running`.
-
-## 4. Connect a repository and pick a mode
+Install the service and check that it is running:
 
 ```sh
-$ mise bootstrap dotfiles origin set https://github.com/you/setup.git --name laptop
-Setup repository: https://github.com/you/setup.git (branch main)
-Machine: laptop (0192f3a4-…)
-Sync mode sync: the watcher publishes saved changes and fetches periodically. Any conflict pauses publication and incoming application for the entire setup; local history, fetching, and eligible machine backups continue. Incoming changes are preflighted together and applied with a protective checkpoint and recovery journal. Applying never runs `mise bootstrap` or renders templates. Run `mise bootstrap` when the new declarations need to be applied.
-The repository is empty: the first publication creates `main` with the mise marker.
-Published from this machine:
-  configuration: 1 file(s)
-  tracked (home): 4 file(s)
-Not shared:
-  ~/.config/mise/config.local.toml: machine-local configuration (private unless explicitly overridden)
-Machine backups: 5 of 6 captured file(s) are backed up in plain form under refs/mise-history/0192f3a4-…/ — anyone who can read this repository can read every file in these snapshots. The setup branch is always plaintext; use a private repository.
-Existing checkpoints: not uploaded; only checkpoints from now on (pass --include-existing to upload them too)
-Connect this setup repository? [y/N] y
-mise history: connected https://github.com/you/setup.git (sync); [history.origin] written to ~/.config/mise/config.local.toml
-mise history: published 3f2a1c9
+mise bootstrap
+mise bootstrap dotfiles status
 ```
 
-`sync` is the default: the watcher publishes shortly after a save, fetches
-periodically, and applies incoming changes with a protective checkpoint first.
-Any conflict pauses publication and incoming application for the entire setup.
-Local history, fetching, and eligible backups continue. `fetch-only` never publishes and never changes a file
-until you run `pull`; `manual` does nothing on the network by itself
-(`--sync <mode>` chooses; `mise settings set history.sync <mode>` changes it
-later). `sync` and `pull` are different commands on purpose: `sync` moves
-saved changes between the machine and the repository, `pull` writes what
-arrived into your files; in `sync` mode the watcher does both. Everything
-the disclosure lists leaves the machine in plain text, so use a private
-repository.
+The watcher runs as a systemd user service on Linux or a LaunchAgent on macOS.
+It saves edits to local history. No repository connection is needed.
 
-## 5. Edit a file and look at its history
+If you prefer to save manually, skip the service and run
+`mise bootstrap dotfiles save` after editing.
 
-Edit `~/.config/hypr/bindings.lua` in your editor. Once it has been quiet
-for two seconds the watcher saves it:
+## Inspect and restore a change
+
+Edit your tracked file, then save a checkpoint explicitly so you can inspect it
+without waiting for the watcher:
 
 ```sh
-$ mise bootstrap dotfiles history --path ~/.config/hypr/bindings.lua
-ID  When              Trigger   Description                                Files
-7   2026-09-06 09:41  edit      edited hypr/bindings.lua                   1
-4   2026-09-05 18:02  edit      edited hypr/bindings.lua, hypr/monitors.lua 2
-1   2026-09-03 08:15  baseline  tracked ~/.zshrc, ~/.config/hypr           5
-$ mise bootstrap dotfiles history diff 4 --path ~/.config/hypr/bindings.lua --patch
--bind = SUPER, Q, exec, kitty
-+bind = SUPER, Q, exec, alacritty
+mise bootstrap dotfiles save
+mise bootstrap dotfiles history --path ~/.zshrc
 ```
 
-A file that keeps changing (a state file an application rewrites every
-second) is saved ever more rarely rather than flooding the history, and
-never delays the others; `mise bootstrap dotfiles paths --noisy` names it,
-and `mise bootstrap dotfiles exclude '<glob>'` leaves it out.
-
-## 6. Restore one file
+To see a checkpoint's changes, replace `CHECKPOINT_ID` with an ID from that list:
 
 ```sh
-$ mise bootstrap dotfiles rollback ~/.config/hypr/bindings.lua
-Path                         Action  From          To
-~/.config/hypr/bindings.lua  write   file 9c1e2d4  file 51ab7f0
-history: apply this plan? [y/N] y
-mise history: rolled back ~/.config/hypr/bindings.lua to 4
-$ mise bootstrap dotfiles undo
+mise bootstrap dotfiles history diff CHECKPOINT_ID --path ~/.zshrc --patch
 ```
 
-A rollback saves a protective checkpoint first, touches only the paths in
-its plan, and is a new change like any other: with a repository connected
-it is published and other machines receive it; `undo` reverses it.
-
-## 7. Resolve a conflict
-
-Two machines edited the same lines of `~/.zshrc` before either synced. Both
-versions are kept, the file on each machine is untouched, and sharing pauses
-for the entire setup until the conflict is decided; local history, fetching,
-and eligible machine backups continue:
+To restore the previous version:
 
 ```sh
-$ mise bootstrap dotfiles status
-...
-Setup repository: https://github.com/you/setup.git (branch main, mode sync, machine desktop).
-  last publish 2026-09-06 09:41, last fetch 2026-09-06 09:55, last pull 2026-09-06 09:41; 0 checkpoint(s) pending upload.
-  sync paused: ~/.zshrc: both sides changed the same lines; sharing is paused for the entire setup; local history continues (`mise bootstrap dotfiles pull --take-remote|--keep-local ~/.zshrc`)
-$ mise bootstrap dotfiles pull --take-remote ~/.zshrc
+mise bootstrap dotfiles rollback ~/.zshrc
 ```
 
-`--keep-local` selects this machine's version instead. Choices are recorded
-per file, but publication and incoming application wait until every conflict
-is resolved and the current versions have been rechecked. Local history,
-fetching, and eligible machine backups continue while sharing is paused.
-`mise doctor` names the blocking paths too. Desktop notifications are enabled
-by default on Linux and macOS, once per pause; set
-`settings.history.notify = false` to opt out.
+Review the proposed changes before confirming. Rollback saves a protective
+checkpoint first. To reverse the rollback:
 
-## 8. Set up the next machine
+```sh
+mise bootstrap dotfiles undo
+```
+
+A rollback becomes a new change in local history. If the file is shared, that
+change can also be published according to your sync mode.
+
+## Share your setup (optional)
+
+Create an empty private GitHub repository, then authenticate on this machine:
+
+```sh
+mise use -g gh
+mise x gh -- gh auth login --hostname github.com --git-protocol https --web
+mise x gh -- gh auth setup-git --hostname github.com
+```
+
+The credential helper lets background synchronization authenticate without an
+interactive prompt. You can also use an SSH remote with credentials available
+to the watcher.
+
+Replace `you/setup` with your repository. This example chooses manual sync:
+
+```sh
+mise bootstrap dotfiles origin set https://github.com/you/setup.git --name laptop --sync manual
+```
+
+Before confirming, review the files that will be shared and backed up. By default,
+shared files and machine backups are stored in plaintext. A file excluded from sharing
+may still be included in machine backups; do not assume it stays on this machine.
+Existing checkpoints are not uploaded unless you select `--include-existing`.
+
+Choose the mode that fits your workflow:
+
+| Mode         | Watcher behavior                                                |
+| ------------ | --------------------------------------------------------------- |
+| `manual`     | Saves locally; does not use the network automatically.          |
+| `fetch-only` | Fetches remote changes; does not publish or apply them.         |
+| `sync`       | Publishes saved changes, fetches, and applies incoming changes. |
+
+Change modes with `mise settings set history.sync MODE`.
+
+In manual mode, save and exchange checkpoints, then apply fetched changes:
+
+```sh
+mise bootstrap dotfiles save
+mise bootstrap dotfiles sync
+mise bootstrap dotfiles pull
+```
+
+`sync` exchanges saved changes with the repository; `pull` applies fetched
+changes to your files. Applying changes does not run bootstrap tasks or render
+templates. Run `mise bootstrap` when updated declarations need to be applied.
+
+## Set up another machine
+
+Install Git first. Then install mise, enable tracking, and authenticate with the
+same repository host:
 
 ```sh
 curl https://mise.run | sh
+export PATH="$HOME/.local/bin:$PATH"
 mise settings experimental=true
-gh auth login --hostname github.com --git-protocol https --web
-gh auth setup-git --hostname github.com
+mise use -g gh
+mise x gh -- gh auth login --hostname github.com --git-protocol https --web
+mise x gh -- gh auth setup-git --hostname github.com
 mise bootstrap --from-git you/setup
 ```
 
-```
-https://github.com/you/setup.git is a mise setup repository (format 1); branch main.
-Sync mode sync: ...
-Path                         Action  Group
-~/.config/mise/config.toml   create  configuration
-~/.zshrc                     create  tracked/home/.zshrc
-~/.config/hypr/bindings.lua  create  tracked/home/.config/hypr/bindings.lua
-Set this machine up from the repository? [y/N] y
-Wrote 3 file(s) from https://github.com/you/setup.git.
-...
-mise user services: applied mise-history
-```
+Review the proposed files before confirming. Bootstrap restores the shared
+configuration and tracked files, then applies the configuration, including the
+watcher declaration added earlier.
 
-The branch goes into mise's own store (nothing is cloned into
-`~/.config/mise`), the configuration and the tracked files are written by a
-recoverable pull, the watcher service comes up with the rest of the
-bootstrap, and from then on the machine syncs like the first one. A file
-that already exists and differs is held for a decision; when that file is
-the configuration itself, the command stops there and names the `pull
---take-remote|--keep-local` that decides it. Over SSH:
+If an existing file differs, mise holds it for a decision instead of silently
+overwriting it. Follow the reported conflict instructions. Check this machine's
+sync mode with `mise bootstrap dotfiles status` and choose its mode explicitly
+with `mise settings set history.sync MODE`.
+
+For setup over SSH, see [remote bootstrap](/bootstrap/remote.html). Tracked setups
+require explicit target opt-in:
 
 ```sh
 mise bootstrap remote --experimental --host devbox --install-mise --from-git you/setup \
   --github-relay-read-only --github-relay-repo you/setup
 ```
 
-The borrowed GitHub access is read-only and ends with the session; give the
-host credentials of its own (step 1, there) for ongoing synchronization.
-`--dry-run` previews on the host without persisting setup state; it removes
-the temporary mise and bundle staging afterwards.
+GitHub access is borrowed read-only for this run. The target needs its own
+credentials for ongoing synchronization.
 
-## Templates next to tracked files
+## Resolve a conflict
 
-A tracked file is shared as it is. A file that must differ per machine is
-rendered from a template source, and only the source is shared:
+If two machines change the same lines, mise preserves both versions and pauses
+publication and incoming application for the entire setup. Local history
+continues.
+
+Inspect the conflict:
+
+```sh
+mise bootstrap dotfiles status
+```
+
+Choose the repository's version of a file:
+
+```sh
+mise bootstrap dotfiles pull --take-remote ~/.zshrc
+```
+
+Or keep this machine's version:
+
+```sh
+mise bootstrap dotfiles pull --keep-local ~/.zshrc
+```
+
+Resolve every reported conflict before sharing can resume. In manual mode, run
+`mise bootstrap dotfiles sync` to publish your resolution.
+
+## Use a template (optional)
+
+Use tracking for files you edit directly. Use a template when you want mise to
+render a file from configuration values.
+
+Add these entries to `~/.config/mise/config.toml`, merging them into any existing
+`[vars]` and `[dotfiles]` tables:
 
 ```toml
 [vars]
@@ -215,28 +217,45 @@ email = "you@example.com"
 "~/.gitconfig" = { source = "templates/gitconfig.tera", mode = "template" }
 ```
 
-`~/.config/mise/templates/gitconfig.tera` (the source) is captured, shared,
-and set up on the next machine like any configuration file. `~/.gitconfig`
-(the output) is rendered by `mise bootstrap` with this machine's `[vars]`,
-kept in local history so an edit to it can be recovered, and never shared as
-its own file.
+Create `~/.config/mise/templates/gitconfig.tera`:
 
-## Platform notes
+```ini
+[user]
+    email = {{ vars.email }}
+```
 
-- **Omarchy**: track `~/.config/hypr`, `~/.config/omarchy`, and
-  `~/.config/waybar`; leave the git clones under `~/.config/omarchy/themes`
-  and `~/.config/omarchy/plugins` to Omarchy (they are nested repositories
-  and are never descended into); exclude `~/.config/omarchy/backgrounds`.
-  `omarchy-update` keeps running as it does; add
-  `mise bootstrap dotfiles save --best-effort` before it to mark the state it
-  starts from.
-- **Ubuntu**: the watcher is a systemd user unit
-  (`systemctl --user status mise-history`); `apt` packages go in
-  `[bootstrap.packages]` and are installed by `mise bootstrap` like tools.
-- **macOS**: the watcher is a LaunchAgent (`launchctl list | grep dev.mise`);
-  a tracked file can carry a macOS variant
-  (`track ~/.zshrc --os macos`) that evolves apart from the Linux one.
-- **Windows**: tracking, checkpoints, rollback, sync, and the Scheduled Task
-  watcher work; symlink modes need Developer Mode, copy and template modes
-  do not. Desktop notifications are Linux and macOS only for now: on Windows,
-  `mise bootstrap dotfiles status` and `mise doctor` show a paused setup.
+Run `mise bootstrap` to render `~/.gitconfig`. Edit the template or its variables
+for future changes. The template source is shared; the rendered file is kept in
+local history but is not shared as a separate file.
+
+See [dotfiles](/dotfiles.html) for templates and OS-specific variants.
+
+## Add more files
+
+On Omarchy, start with individual configuration files you edit. Inspect a
+directory before tracking it: themes, plugins, backgrounds, and application state
+may not belong in your dotfile history. Nested Git repositories are skipped.
+
+Before an update, save the current tracked files:
+
+```sh
+mise bootstrap dotfiles save --best-effort
+```
+
+This saves dotfiles, not installed packages or the rest of the operating system.
+
+On macOS, you can keep a tracked file separate from its Linux counterpart:
+
+```sh
+mise bootstrap dotfiles track ~/.zshrc --os macos
+```
+
+On either platform, check tracking and watcher status with:
+
+```sh
+mise bootstrap dotfiles status
+```
+
+For directory exclusions and capture policies, see [dotfiles](/dotfiles.html).
+For service management and other platforms, see
+[user services](/bootstrap/services.html).

--- a/docs/bootstrap/setup.md
+++ b/docs/bootstrap/setup.md
@@ -67,7 +67,7 @@ reports `automatic capture: running`.
 $ mise bootstrap dotfiles origin set https://github.com/you/setup.git --name laptop
 Setup repository: https://github.com/you/setup.git (branch main)
 Machine: laptop (0192f3a4-…)
-Sync mode sync: the watcher publishes this machine's shared files and configuration after each save, fetches the repository periodically, and applies nonconflicting incoming changes to tracked files and configuration (with a protective checkpoint first; a conflict or an unsaved edit holds the path, nothing else waits). It never runs `mise bootstrap`, installs or removes packages, or renders templates; when incoming configuration changes declarations, `mise bootstrap dotfiles status` says to run `mise bootstrap`. `mise bootstrap dotfiles sync` and `pull` do the same on request.
+Sync mode sync: the watcher publishes saved changes and fetches periodically. Any conflict pauses publication and incoming application for the entire setup; local history, fetching, and eligible machine backups continue. Incoming changes are preflighted together and applied with a protective checkpoint and recovery journal. Applying never runs `mise bootstrap` or renders templates. Run `mise bootstrap` when the new declarations need to be applied.
 The repository is empty: the first publication creates `main` with the mise marker.
 Published from this machine:
   configuration: 1 file(s)
@@ -82,8 +82,9 @@ mise history: published 3f2a1c9
 ```
 
 `sync` is the default: the watcher publishes shortly after a save, fetches
-periodically, and writes nonconflicting incoming changes with a protective
-checkpoint first. `fetch-only` never publishes and never changes a file
+periodically, and applies incoming changes with a protective checkpoint first.
+Any conflict pauses publication and incoming application for the entire setup.
+Local history, fetching, and eligible backups continue. `fetch-only` never publishes and never changes a file
 until you run `pull`; `manual` does nothing on the network by itself
 (`--sync <mode>` chooses; `mise settings set history.sync <mode>` changes it
 later). `sync` and `pull` are different commands on purpose: `sync` moves
@@ -139,13 +140,17 @@ $ mise bootstrap dotfiles status
 ...
 Setup repository: https://github.com/you/setup.git (branch main, mode sync, machine desktop).
   last publish 2026-09-06 09:41, last fetch 2026-09-06 09:55, last pull 2026-09-06 09:41; 0 checkpoint(s) pending upload.
-  conflict: ~/.zshrc: both sides changed the same lines; your local file is unchanged, other files continue syncing (`mise bootstrap dotfiles pull --take-remote|--keep-local ~/.zshrc`)
+  sync paused: ~/.zshrc: both sides changed the same lines; sharing is paused for the entire setup; local history continues (`mise bootstrap dotfiles pull --take-remote|--keep-local ~/.zshrc`)
 $ mise bootstrap dotfiles pull --take-remote ~/.zshrc
 ```
 
-`--keep-local` publishes this machine's version instead. `mise doctor` names
-a held path too, and `settings.history.notify = true` shows a desktop
-notification the first time a conflict needs a decision (Linux and macOS).
+`--keep-local` selects this machine's version instead. Choices are recorded
+per file, but publication and incoming application wait until every conflict
+is resolved and the current versions have been rechecked. Local history,
+fetching, and eligible machine backups continue while sharing is paused.
+`mise doctor` names the blocking paths too. Desktop notifications are enabled
+by default on Linux and macOS, once per pause; set
+`settings.history.notify = false` to opt out.
 
 ## 8. Set up the next machine
 

--- a/docs/bootstrap/setup.md
+++ b/docs/bootstrap/setup.md
@@ -132,8 +132,9 @@ it is published and other machines receive it; `undo` reverses it.
 ## 7. Resolve a conflict
 
 Two machines edited the same lines of `~/.zshrc` before either synced. Both
-versions are kept, the file on each machine is untouched, and every other
-file keeps syncing:
+versions are kept, the file on each machine is untouched, and sharing pauses
+for the entire setup until the conflict is decided; local history, fetching,
+and eligible machine backups continue:
 
 ```sh
 $ mise bootstrap dotfiles status
@@ -189,6 +190,7 @@ mise bootstrap remote --host devbox --install-mise --from-git you/setup \
 
 The borrowed GitHub access is read-only and ends with the session; give the
 host credentials of its own (step 1, there) for ongoing synchronization.
+`--dry-run` shows the same plan on the host without writing anything there.
 
 ## Templates next to tracked files
 
@@ -226,4 +228,5 @@ its own file.
   (`track ~/.zshrc --os macos`) that evolves apart from the Linux one.
 - **Windows**: tracking, checkpoints, rollback, sync, and the Scheduled Task
   watcher work; symlink modes need Developer Mode, copy and template modes
-  do not. Desktop notifications for conflicts are not available yet.
+  do not. Desktop notifications are Linux and macOS only for now: on Windows,
+  `mise bootstrap dotfiles status` and `mise doctor` show a paused setup.

--- a/docs/bootstrap/setup.md
+++ b/docs/bootstrap/setup.md
@@ -165,6 +165,7 @@ by default on Linux and macOS, once per pause; set
 
 ```sh
 curl https://mise.run | sh
+mise settings experimental=true
 gh auth login --hostname github.com --git-protocol https --web
 gh auth setup-git --hostname github.com
 mise bootstrap --from-git you/setup
@@ -198,7 +199,8 @@ mise bootstrap remote --host devbox --install-mise --from-git you/setup \
 
 The borrowed GitHub access is read-only and ends with the session; give the
 host credentials of its own (step 1, there) for ongoing synchronization.
-`--dry-run` shows the same plan on the host without writing anything there.
+`--dry-run` previews on the host without persisting setup state; it removes
+the temporary mise and bundle staging afterwards.
 
 ## Templates next to tracked files
 

--- a/docs/bootstrap/setup.md
+++ b/docs/bootstrap/setup.md
@@ -31,7 +31,8 @@ gh auth setup-git --hostname github.com
 `gh auth setup-git` makes git use the GitHub CLI as its credential helper,
 so background synchronization can reach a private repository without a
 terminal. An SSH remote works too when the history watcher can reach an
-agent or an unencrypted key.
+SSH agent with an encrypted key. For unattended file-based credentials,
+use a repository-scoped deploy key and restrict its file permissions.
 
 ## 2. Track a file you already have
 

--- a/docs/cli/bootstrap/dotfiles/pull.md
+++ b/docs/cli/bootstrap/dotfiles/pull.md
@@ -21,7 +21,7 @@ local history and fetching continue. Decisions are recorded per path
 with `--take-remote` or `--keep-local`; sharing resumes only after all
 conflicts are resolved and the plan has been recomputed.
 
-In `sync` mode the history watcher pulls nonconflicting changes on its
+In `sync` mode the watcher pulls conflict-free setups on its
 own; this command writes what is pending right now and decides
 conflicts. When an incoming configuration declares more tracked files,
 their shared versions follow in the same run.

--- a/docs/cli/bootstrap/dotfiles/pull.md
+++ b/docs/cli/bootstrap/dotfiles/pull.md
@@ -21,6 +21,11 @@ local history and fetching continue. Decisions are recorded per path
 with `--take-remote` or `--keep-local`; sharing resumes only after all
 conflicts are resolved and the plan has been recomputed.
 
+In `sync` mode the history watcher pulls nonconflicting changes on its
+own; this command writes what is pending right now and decides
+conflicts. When an incoming configuration declares more tracked files,
+their shared versions follow in the same run.
+
 ## Arguments
 - **`[PATH]…`** — Paths must cover the complete pending setup; partial pulls are rejected
 

--- a/docs/cli/bootstrap/dotfiles/sync.md
+++ b/docs/cli/bootstrap/dotfiles/sync.md
@@ -14,6 +14,9 @@ checkpoints, and records incoming changes to apply and conflicts to
 decide. Live files are never changed here: `mise bootstrap dotfiles pull` does
 that. In `fetch-only` mode nothing is published.
 
+The history watcher does this on its own in `sync` and `fetch-only` mode
+(`settings.history.sync`); this command is for right now.
+
 ## Flags
 - **`--fetch-only`** — Fetch without publishing
 - **`--best-effort`** — Warn instead of failing when the origin is unreachable

--- a/docs/cli/bootstrap/dotfiles/watch.md
+++ b/docs/cli/bootstrap/dotfiles/watch.md
@@ -18,7 +18,7 @@ watched.
 With a connected setup repository the watcher also synchronizes per
 `settings.history.sync`: in `sync` mode it publishes within
 `history.sync_interval` after a save, fetches every
-`history.fetch_interval`, and applies nonconflicting incoming changes;
+`history.fetch_interval`, and applies incoming changes once the complete setup is conflict-free;
 in `fetch-only` mode it only fetches; in `manual` mode it does nothing
 on the network. A failed sync backs off and is retried while saving
 continues. `--once` runs one reconcile and one such synchronization.

--- a/docs/cli/bootstrap/dotfiles/watch.md
+++ b/docs/cli/bootstrap/dotfiles/watch.md
@@ -15,6 +15,14 @@ reconciles the whole set at startup, every `history.watch.reconcile`,
 and when the configuration changes. Manual-save entries are never
 watched.
 
+With a connected setup repository the watcher also synchronizes per
+`settings.history.sync`: in `sync` mode it publishes within
+`history.sync_interval` after a save, fetches every
+`history.fetch_interval`, and applies nonconflicting incoming changes;
+in `fetch-only` mode it only fetches; in `manual` mode it does nothing
+on the network. A failed sync backs off and is retried while saving
+continues. `--once` runs one reconcile and one such synchronization.
+
 The `history-watch` built-in service runs this for you:
 
 ```
@@ -29,7 +37,7 @@ the pending changes; one that would overlap another history operation
 is deferred.
 
 ## Flags
-- **`--once`** — Reconcile once and exit (for timers and cron)
+- **`--once`** — Reconcile and synchronize once and exit (for timers and cron)
 - **`-J --json`** — One JSON object per line instead of log lines
 - **`-h --help`** — Print help
 

--- a/docs/cli/bootstrap/remote.md
+++ b/docs/cli/bootstrap/remote.md
@@ -15,6 +15,7 @@ installs persistent global configuration; preview that choice with `--dry-run`.
 - **`[TARGET]…`** — Inventory host names from `[bootstrap.remote.hosts]`
 
 ## Flags
+- **`--experimental`** — Enable experimental features on the target; retain opt-in after tracking setup
 - **`--from-git <GIT_URL|OWNER/REPO>`** — Install a Git repository as persistent global configuration on each target
 - **`--github-relay-read-only`** — Borrow read-only GitHub access for this invocation
 - **`--github-relay-repo <OWNER/REPO>`** — Approved GitHub repository; repeat for multiple repositories

--- a/docs/history.md
+++ b/docs/history.md
@@ -252,9 +252,11 @@ per store: a second one exits 0 immediately.
 
 ### Health
 
-The watcher never notifies you. It persists its health (`health.json` in
-the history store) and two commands read it, without starting a sync,
-applying anything, or prompting:
+The watcher speaks up only when sharing pauses for a conflict (a desktop
+notification on Linux and macOS, on by default; see
+[Sharing across machines](#sharing-across-machines) below). Otherwise it persists its
+health (`health.json` in the history store) and two commands read it, without
+starting a sync, applying anything, or prompting:
 
 - `mise doctor` prints a concise `dotfiles` section: a watcher that is
   declared but not running (with the command that starts it), repeated

--- a/docs/history.md
+++ b/docs/history.md
@@ -295,6 +295,18 @@ git. A history-enabled repository carries
 repository (its `--from`/`--from-git` behaviour is unchanged) until you
 confirm its adoption, and a newer format stops with an upgrade message.
 
+**Another machine.** `mise bootstrap --from-git <url>` on a machine that has
+nothing yet recognizes the marker and sets the machine up from the
+repository: the branch goes into mise's own store (no checkout in
+`~/.config/mise`), the shared configuration, its sources, and this machine's
+tracked files are written by one recoverable pull (the configuration first,
+then what it declares; a file that already exists and differs is held for a
+decision), the connection is remembered, and the ordinary bootstrap runs:
+packages, tools, templates rendered from the sources that just arrived, the
+watcher service. From then on the machine syncs like any other. Over SSH the
+same happens through `mise bootstrap remote`; see
+[remote bootstrap](/bootstrap/remote.html).
+
 **How a sync decides.** For every path the saved version here (ours is
 always the saved version, never a live edit in progress), the fetched
 upstream version, and the recorded acknowledged/reconciled/applied versions

--- a/docs/history.md
+++ b/docs/history.md
@@ -271,7 +271,8 @@ applying anything, or prompting:
 
 One setup repository holds the shared setup and every machine's recovery
 refs. Connect it once per machine; nothing else is ever done with git by
-hand:
+hand ([Set up a machine](/bootstrap/setup.html) walks through connecting,
+editing, resolving a conflict, and setting up the next machine):
 
 ```sh
 mise bootstrap dotfiles origin set https://github.com/you/setup.git --name laptop

--- a/docs/history.md
+++ b/docs/history.md
@@ -388,11 +388,16 @@ changes declarations, `mise bootstrap dotfiles status` says to run
 `mise bootstrap`.
 
 **Conflict notifications** are on by default. A desktop notification
-(`notify-send` on Linux, `osascript` on macOS) reports when sharing pauses
+(`notify-send` on Linux, `terminal-notifier` or `osascript` on macOS) reports when sharing pauses
 for the setup. Retries and additional conflicts during the same pause stay
 silent; a later pause can notify again after recovery. Set
 `settings.history.notify = false` to opt out. Missing or failing notifiers
 never hold up history or sync.
+
+Linux notifications use the mise logo as their icon. On macOS, an optional
+`terminal-notifier` installation includes the logo as an image in the notification;
+without it, mise uses the built-in text-only `osascript` notification. No logo
+download is needed, and an unavailable logo cache never prevents notification.
 
 **Applying.** `mise bootstrap dotfiles pull` writes pending changes as one recoverable
 transaction (a protective checkpoint first, each file journaled, reload

--- a/docs/history.md
+++ b/docs/history.md
@@ -364,7 +364,7 @@ unrelated files survive. Repeating a sync changes nothing.
 
 - `sync` (the default, recommended): after a save the watcher publishes
   within `history.sync_interval` (5 minutes); every `history.fetch_interval`
-  (15 minutes) it fetches and applies nonconflicting incoming changes, with
+  (15 minutes) it fetches and applies incoming changes, with
   a protective checkpoint first. A conflict or an unsaved edit pauses
   publication and incoming application for the complete setup.
 - `fetch-only`: the watcher fetches; nothing is ever published and no live
@@ -384,11 +384,12 @@ or removes packages, or renders templates: when incoming configuration
 changes declarations, `mise bootstrap dotfiles status` says to run
 `mise bootstrap`.
 
-**Conflict notifications** are off by default. With
-`settings.history.notify = true`, a desktop notification (`notify-send` on
-Linux, `osascript` on macOS) names each conflict once, the first time it
-needs a decision; retries of the same sync stay silent, and a notifier that
-is missing or failing never holds up history or sync.
+**Conflict notifications** are on by default. A desktop notification
+(`notify-send` on Linux, `osascript` on macOS) reports when sharing pauses
+for the setup. Retries and additional conflicts during the same pause stay
+silent; a later pause can notify again after recovery. Set
+`settings.history.notify = false` to opt out. Missing or failing notifiers
+never hold up history or sync.
 
 **Applying.** `mise bootstrap dotfiles pull` writes pending changes as one recoverable
 transaction (a protective checkpoint first, each file journaled, reload

--- a/docs/history.md
+++ b/docs/history.md
@@ -272,7 +272,10 @@ default; `--include-existing`), names that look like secrets with the
 `track … --no-share --no-backup` line for each, and private content already
 committed in the repository's history, which stops the connection unless
 `--allow-committed-private` is passed (rewriting history is your decision).
-The declaration goes to `[history.origin]` in the global config, the mode
+The declaration goes to `[history.origin]` in `config.local.toml` next to the
+global config (machine-local, never published: each machine names the
+repository the way it reaches it, and a fresh machine's own declaration
+never conflicts with the configuration it pulls), the mode
 to `settings.history.sync`.
 
 **What is synchronized.** The setup branch mirrors the global configuration
@@ -305,15 +308,35 @@ mise's own bare repository and pushed with a lease; a rejection fetches and
 retries; nothing is ever force-pushed or reset, so your own commits and
 unrelated files survive. Repeating a sync changes nothing.
 
-**Modes** (`settings.history.sync`): `sync` (default) publishes, fetches, and
-queues incoming changes for application; `fetch-only` only
-downloads; `manual` publishes and fetches but never applies by itself. In
-this release `mise bootstrap dotfiles sync` publishes and fetches and
-`mise bootstrap dotfiles pull` writes what is queued; the watcher's automatic
-publication and application follow in the next release. Applying never runs
-`mise bootstrap`, installs or removes packages, or renders templates: when
-incoming configuration changes declarations, `mise bootstrap dotfiles status`
-says to run `mise bootstrap`.
+**Modes** (`settings.history.sync`) say what the watcher does on its own:
+
+- `sync` (the default, recommended): after a save the watcher publishes
+  within `history.sync_interval` (5 minutes); every `history.fetch_interval`
+  (15 minutes) it fetches and applies nonconflicting incoming changes, with
+  a protective checkpoint first. A conflict or an unsaved edit pauses
+  publication and incoming application for the complete setup.
+- `fetch-only`: the watcher fetches; nothing is ever published and no live
+  file changes until you run `mise bootstrap dotfiles pull`.
+- `manual`: no automatic network activity at all.
+
+`mise bootstrap dotfiles sync` (publish and fetch now) and `mise bootstrap
+dotfiles pull` (write what is pending now, decide conflicts) work on request
+in every mode: they are for when you do not want to wait, not something the
+background mode needs you to run. A failed sync (the repository unreachable,
+credentials missing) backs off from a minute to an hour and is retried;
+saving continues meanwhile, and `mise bootstrap dotfiles status` and
+`mise doctor` show the last error. The watcher never publishes a throttled
+file's unsaved churn or a manual-save entry's unsaved edits: what it
+publishes is what it saved. Applying never runs `mise bootstrap`, installs
+or removes packages, or renders templates: when incoming configuration
+changes declarations, `mise bootstrap dotfiles status` says to run
+`mise bootstrap`.
+
+**Conflict notifications** are off by default. With
+`settings.history.notify = true`, a desktop notification (`notify-send` on
+Linux, `osascript` on macOS) names each conflict once, the first time it
+needs a decision; retries of the same sync stay silent, and a notifier that
+is missing or failing never holds up history or sync.
 
 **Applying.** `mise bootstrap dotfiles pull` writes pending changes as one recoverable
 transaction (a protective checkpoint first, each file journaled, reload

--- a/docs/history.md
+++ b/docs/history.md
@@ -388,16 +388,18 @@ changes declarations, `mise bootstrap dotfiles status` says to run
 `mise bootstrap`.
 
 **Conflict notifications** are on by default. A desktop notification
-(`notify-send` on Linux, `terminal-notifier` or `osascript` on macOS) reports when sharing pauses
+(`notify-send` on Linux, a bundled mise helper app on macOS) reports when sharing pauses
 for the setup. Retries and additional conflicts during the same pause stay
 silent; a later pause can notify again after recovery. Set
 `settings.history.notify = false` to opt out. Missing or failing notifiers
 never hold up history or sync.
 
-Linux notifications use the mise logo as their icon. On macOS, an optional
-`terminal-notifier` installation includes the logo as an image in the notification;
-without it, mise uses the built-in text-only `osascript` notification. No logo
-download is needed, and an unavailable logo cache never prevents notification.
+Linux and macOS notifications use the mise logo. On macOS, allow notifications
+for mise when asked on first use; you can change that permission in System
+Settings > Notifications > mise. The helper is included in mise: no compiler,
+extra notifier, or logo download is needed. Denied permissions never block sync.
+Alerts name the conflicting file, explain that local saves still work, and
+point to `mise bootstrap dotfiles status` for resolution steps.
 
 **Applying.** `mise bootstrap dotfiles pull` writes pending changes as one recoverable
 transaction (a protective checkpoint first, each file journaled, reload

--- a/docs/history.md
+++ b/docs/history.md
@@ -309,7 +309,8 @@ tracked entry, per its policies) and this machine's recovery refs
 from the snapshot, the metadata, and the descriptions). `share = false`
 keeps a file out of the setup branch and out of other machines;
 `backup = false` keeps it out of the recovery refs; `*.local.toml` and
-credential stores are both unless a per-file declaration says otherwise.
+credential stores default to both `share = false` and `backup = false`
+unless a per-file declaration says otherwise.
 Everything else stays on this machine. Encrypted recovery refs are not
 implemented yet: `--encrypt-backups` and `encrypt_backups = true` are refused
 rather than silently uploading in plain text, so a file you would only back

--- a/docs/history.md
+++ b/docs/history.md
@@ -44,7 +44,8 @@ Every checkpoint carries:
   that was never covered.
 - **What changed** since the previous checkpoint, and a description computed
   from it (`edited hypr/bindings.lua; added omarchy/hooks/post-theme`).
-  `mise bootstrap dotfiles history describe <ref> "…"` replaces the description.
+  `mise bootstrap dotfiles history describe <ref> "…"` replaces the description,
+  and so can a command of yours (below).
 - **The trigger**: `save`, `baseline` (a newly tracked path), or the two halves
   of an operation: `bootstrap-before` (the protective checkpoint taken before
   a bootstrap command changes anything) and `bootstrap` (the outcome, with a
@@ -52,6 +53,29 @@ Every checkpoint carries:
 
 `mise bootstrap dotfiles history show <ref>` prints all of it; `--files` lists the snapshot,
 `--json` gives the record.
+
+### Descriptions from an agent
+
+`settings.history.describe_command` names a command that describes the
+checkpoints the watcher saves. It gets one JSON object on stdin, `uuid`,
+`trigger`, the computed `description`, the changed paths that are not
+private (`added`, `modified`, `removed`), and `diff`, a unified diff of the
+changed files that are backed up (at most 64 KiB, `diff_truncated` says
+when it was cut), and prints one line of at most 200 characters, which
+becomes the description (`description_source: command`). With Claude Code:
+
+```toml
+[settings]
+history.describe_command = "claude -p --output-format text --no-session-persistence 'Describe this change to my configuration files in one line of at most 120 characters, plain text, no quotes.'"
+```
+
+The checkpoint is saved before the command runs and keeps its computed
+description when the command fails, prints nothing, or takes longer than 30
+seconds. The command runs once per checkpoint the watcher saved, one at a
+time, never per filesystem event or retry, and never with a shell
+interpolation of file contents (the JSON is its stdin). A private file
+(`*.local.toml`, a credential store) is never named, and a file tracked with
+`backup = false` never has its contents sent.
 
 ## Referring to checkpoints
 
@@ -272,6 +296,21 @@ default; `--include-existing`), names that look like secrets with the
 `track … --no-share --no-backup` line for each, and private content already
 committed in the repository's history, which stops the connection unless
 `--allow-committed-private` is passed (rewriting history is your decision).
+
+**What leaves the machine, in plain text.** Two things, both readable by
+anyone who can read the repository: the setup branch (the shared
+configuration, the sources it references, and the shared version of every
+tracked entry, per its policies) and this machine's recovery refs
+(`refs/mise-history/<machine>/…`: a snapshot of every tracked file with
+`backup = true`, with private paths and paths with `backup = false` removed
+from the snapshot, the metadata, and the descriptions). `share = false`
+keeps a file out of the setup branch and out of other machines;
+`backup = false` keeps it out of the recovery refs; `*.local.toml` and
+credential stores are both unless a per-file declaration says otherwise.
+Everything else stays on this machine. Encrypted recovery refs are not
+implemented yet: `--encrypt-backups` and `encrypt_backups = true` are refused
+rather than silently uploading in plain text, so a file you would only back
+up encrypted is a file to track with `--no-backup` for now.
 The declaration goes to `[history.origin]` in `config.local.toml` next to the
 global config (machine-local, never published: each machine names the
 repository the way it reaches it, and a fresh machine's own declaration

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -70,6 +70,7 @@
 ## Bootstrap
 
 - [Overview](https://mise.jdx.dev/bootstrap.html): mise bootstrap applies the machine setup declared in your mise configuration: packages, files, services, repositories, shell setup, tools, and a final task.
+- [Set Up a Machine](https://mise.jdx.dev/bootstrap/setup.html): The recommended way to run mise on a workstation: keep editing your configuration files where they are, let mise save every change and share the ones you choose, and recreate the whole setup on the…
 - [Remote Hosts](https://mise.jdx.dev/bootstrap/remote.html): mise bootstrap remote applies a bootstrap project to one or more machines through the locally installed OpenSSH client.
 - [Bootstrap Packages](https://mise.jdx.dev/bootstrap/packages/): Declare shared host packages in [bootstrap.packages], then apply them with mise bootstrap packages apply or the full bootstrap.
 - [apk](https://mise.jdx.dev/bootstrap/packages/apk.html): System packages for Alpine Linux.

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -70,7 +70,7 @@
 ## Bootstrap
 
 - [Overview](https://mise.jdx.dev/bootstrap.html): mise bootstrap applies the machine setup declared in your mise configuration: packages, files, services, repositories, shell setup, tools, and a final task.
-- [Set Up a Machine](https://mise.jdx.dev/bootstrap/setup.html): The recommended way to run mise on a workstation: keep editing your configuration files where they are, let mise save every change and share the ones you choose, and recreate the whole setup on the…
+- [Set Up a Machine](https://mise.jdx.dev/bootstrap/setup.html): [!WARNING] This guide uses experimental dotfile tracking and synchronization. Enable them on each machine with mise settings experimental=true. Interfaces and storage formats may change.
 - [Remote Hosts](https://mise.jdx.dev/bootstrap/remote.html): mise bootstrap remote applies a bootstrap project to one or more machines through the locally installed OpenSSH client.
 - [Bootstrap Packages](https://mise.jdx.dev/bootstrap/packages/): Declare shared host packages in [bootstrap.packages], then apply them with mise bootstrap packages apply or the full bootstrap.
 - [apk](https://mise.jdx.dev/bootstrap/packages/apk.html): System packages for Alpine Linux.

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -70,7 +70,7 @@
 ## Bootstrap
 
 - [Overview](https://mise.jdx.dev/bootstrap.html): mise bootstrap applies the machine setup declared in your mise configuration: packages, files, services, repositories, shell setup, tools, and a final task.
-- [Set Up a Machine](https://mise.jdx.dev/bootstrap/setup.html): [!WARNING] This guide uses experimental dotfile tracking and synchronization. Enable them on each machine with mise settings experimental=true. Interfaces and storage formats may change.
+- [Set Up a Machine](https://mise.jdx.dev/bootstrap/setup.html): [!WARNING] Dotfile tracking and synchronization are experimental. Enable them with mise settings experimental=true. Interfaces and storage formats may change.
 - [Remote Hosts](https://mise.jdx.dev/bootstrap/remote.html): mise bootstrap remote applies a bootstrap project to one or more machines through the locally installed OpenSSH client.
 - [Bootstrap Packages](https://mise.jdx.dev/bootstrap/packages/): Declare shared host packages in [bootstrap.packages], then apply them with mise bootstrap packages apply or the full bootstrap.
 - [apk](https://mise.jdx.dev/bootstrap/packages/apk.html): System packages for Alpine Linux.

--- a/e2e/cli/test_bootstrap_remote_git
+++ b/e2e/cli/test_bootstrap_remote_git
@@ -56,7 +56,10 @@ while test "$#" -gt 0; do
       esac
       export HOME="$FAKE_REMOTE_BASE/$destination"
       export MISE_CONFIG_DIR="$HOME/.config/mise"
-      export MISE_GLOBAL_CONFIG_FILE="$MISE_CONFIG_DIR/config.toml"
+      unset MISE_GLOBAL_CONFIG_FILE
+      if test "$destination" = explicit-global; then
+        export MISE_GLOBAL_CONFIG_FILE="$MISE_CONFIG_DIR/config.toml"
+      fi
       export MISE_DATA_DIR="$HOME/.local/share/mise"
       export MISE_CACHE_DIR="$HOME/.cache/mise"
       export XDG_STATE_HOME="$HOME/.local/state"
@@ -64,6 +67,7 @@ while test "$#" -gt 0; do
       unset MISE_GITHUB_TOKEN MISE_GITHUB_API_TOKEN GITHUB_TOKEN GH_TOKEN
       unset MISE_EXPERIMENTAL MISE_BOOTSTRAP_REMOTE_EXPERIMENTAL
       mkdir -p "$MISE_CONFIG_DIR"
+      cd "$HOME" || exit 1
       exec sh -c "$1"
       ;;
   esac
@@ -209,6 +213,8 @@ printf 'tracked contents\n' >~/.remote-tracked
 assert_succeed 'mise bootstrap dotfiles track ~/.remote-tracked'
 assert_succeed "mise bootstrap dotfiles origin set file://$PWD/tracked-origin.git --sync manual --yes"
 assert_succeed 'mise bootstrap dotfiles sync'
+# Local tracked files must not make an unrelated source archive experimental.
+assert_succeed "mise bootstrap remote --host ordinary-source --source seed --remote-mise '$binary' --only dotfiles --yes"
 calls=$(wc -l <"$SSH_LOG" | tr -d ' ')
 assert_fail "mise bootstrap remote --host tracked --from-git file://$PWD/tracked-origin.git --remote-mise '$binary' --only dotfiles --yes" '--experimental'
 assert "wc -l <'$SSH_LOG' | tr -d ' '" "$calls"
@@ -219,6 +225,8 @@ assert_contains 'cat remotes/tracked/.config/mise/config.local.toml' 'experiment
 assert 'cat remotes/tracked/.remote-tracked' 'tracked contents'
 assert_contains 'cat remotes/tracked/.config/mise/config.local.toml' '[history.origin]'
 assert "ssh tracked '$binary settings get experimental'" 'true'
+assert_fail "mise bootstrap remote --experimental --host explicit-global --from-git file://$PWD/tracked-origin.git --remote-mise '$binary' --only dotfiles --yes" 'MISE_GLOBAL_CONFIG_FILE bypasses'
+assert_not_contains 'cat remotes/explicit-global/.config/mise/config.local.toml' 'experimental = true'
 mkdir -p remotes/conflicted
 printf 'keep my edit\n' >remotes/conflicted/.remote-tracked
 assert_fail "mise bootstrap remote --experimental --host conflicted --from-git file://$PWD/tracked-origin.git --remote-mise '$binary' --only dotfiles --yes"

--- a/e2e/cli/test_bootstrap_remote_git
+++ b/e2e/cli/test_bootstrap_remote_git
@@ -59,6 +59,8 @@ while test "$#" -gt 0; do
       export MISE_GLOBAL_CONFIG_FILE="$MISE_CONFIG_DIR/config.toml"
       export MISE_DATA_DIR="$HOME/.local/share/mise"
       export MISE_CACHE_DIR="$HOME/.cache/mise"
+      export XDG_STATE_HOME="$HOME/.local/state"
+      export MISE_STATE_DIR="$HOME/.local/state/mise"
       unset MISE_GITHUB_TOKEN MISE_GITHUB_API_TOKEN GITHUB_TOKEN GH_TOKEN
       mkdir -p "$MISE_CONFIG_DIR"
       exec sh -c "$1"
@@ -71,6 +73,16 @@ export PATH="$PWD/fakebin:$PATH"
 
 mkdir -p remotes/one/.config/mise
 echo '# machine local' >remotes/one/.config/mise/config.local.toml
+# A dry run connects, inspects, and says what it would do without writing the
+# checkout (a clone on an empty host, an adoption on one with files already);
+# the bootstrap that follows is previewed too.
+assert_contains "mise bootstrap remote --host two --from-git '$source_repo' --remote-mise '$binary' --only dotfiles --dry-run 2>&1" 'Would clone'
+assert_contains "cat '$SSH_LOG'" '--repository-dry-run'
+assert_contains "cat '$SSH_LOG'" 'bootstrap --dry-run'
+test ! -e remotes/two/.config/mise/.git
+assert_contains "mise bootstrap remote --host one --from-git '$source_repo' --remote-mise '$binary' --only dotfiles --dry-run 2>&1" 'Would adopt'
+test ! -e remotes/one/.config/mise/.git
+assert "cat remotes/one/.config/mise/config.local.toml" '# machine local'
 mise bootstrap remote --host one --host two --from-git "$source_repo" --remote-mise "$binary" --only dotfiles --yes
 assert "git -C remotes/one/.config/mise rev-parse HEAD" "$first_revision"
 assert "git -C remotes/two/.config/mise rev-parse HEAD" "$first_revision"
@@ -85,12 +97,17 @@ git -C seed -c core.hooksPath=/dev/null commit -m second
 second_revision=$(git -C seed rev-parse HEAD)
 mise bootstrap remote --host one --from-git "$source_repo" --remote-mise "$binary" --only dotfiles --yes
 assert "git -C remotes/one/.config/mise rev-parse HEAD" "$first_revision"
+# an update is previewed against the existing checkout without moving it
+assert_contains "mise bootstrap remote --host one --from-git '$source_repo' --remote-mise '$binary' --only dotfiles --yes --update --dry-run 2>&1" 'Would fast-forward'
+assert "git -C remotes/one/.config/mise rev-parse HEAD" "$first_revision"
+assert_fail "git -C remotes/one/.config/mise cat-file -e $second_revision^{commit}"
 mise bootstrap remote --host one --from-git "$source_repo" --remote-mise "$binary" --only dotfiles --yes --update
 assert "git -C remotes/one/.config/mise rev-parse HEAD" "$second_revision"
 assert "git -C remotes/one/.config/mise rev-parse '@{upstream}'" "$second_revision"
 assert "cat remotes/one/.config/mise/config.local.toml" '# machine local'
 echo '# dirty' >>remotes/one/.config/mise/config.toml
 assert_fail "mise bootstrap remote --host one --from-git '$source_repo' --remote-mise '$binary' --only dotfiles --yes --update" 'uncommitted changes'
+assert_fail "mise bootstrap remote --host one --from-git '$source_repo' --remote-mise '$binary' --only dotfiles --yes --update --dry-run" 'uncommitted changes'
 
 # A failed forwarding request must prevent bootstrap and close the owned master.
 assert_fail "MISE_GITHUB_TOKEN=fake-local-relay-token mise bootstrap remote --host two --from-git '$source_repo' --remote-mise '$binary' --only dotfiles --yes --github-relay-read-only --github-relay-repo owner/repo" 'forwarding failed'

--- a/e2e/cli/test_bootstrap_remote_git
+++ b/e2e/cli/test_bootstrap_remote_git
@@ -62,6 +62,7 @@ while test "$#" -gt 0; do
       export XDG_STATE_HOME="$HOME/.local/state"
       export MISE_STATE_DIR="$HOME/.local/state/mise"
       unset MISE_GITHUB_TOKEN MISE_GITHUB_API_TOKEN GITHUB_TOKEN GH_TOKEN
+      unset MISE_EXPERIMENTAL MISE_BOOTSTRAP_REMOTE_EXPERIMENTAL
       mkdir -p "$MISE_CONFIG_DIR"
       exec sh -c "$1"
       ;;
@@ -200,6 +201,28 @@ trap 'kill "$redirect_pid" 2>/dev/null || true' EXIT
 wait_for_file redirect-port 'HTTPS redirect fixture' 10 "$redirect_pid"
 # This test certificate is self-signed; disable verification only for this fixture.
 assert_fail "GIT_SSL_NO_VERIFY=1 mise bootstrap remote --host redirect --from-git 'https://127.0.0.1:$(cat redirect-port)/repo' --remote-mise '$binary' --yes" 'could not fetch setup repository'
+
+# Explicit remote opt-in survives the session only after tracking setup.
+export MISE_EXPERIMENTAL=1
+git init -q --bare -b main "$PWD/tracked-origin.git"
+printf 'tracked contents\n' >~/.remote-tracked
+assert_succeed 'mise bootstrap dotfiles track ~/.remote-tracked'
+assert_succeed "mise bootstrap dotfiles origin set file://$PWD/tracked-origin.git --sync manual --yes"
+assert_succeed 'mise bootstrap dotfiles sync'
+calls=$(wc -l <"$SSH_LOG" | tr -d ' ')
+assert_fail "mise bootstrap remote --host tracked --from-git file://$PWD/tracked-origin.git --remote-mise '$binary' --only dotfiles --yes" '--experimental'
+assert "wc -l <'$SSH_LOG' | tr -d ' '" "$calls"
+assert_succeed "mise bootstrap remote --experimental --host tracked --from-git file://$PWD/tracked-origin.git --remote-mise '$binary' --only dotfiles --dry-run"
+assert_fail 'test -f remotes/tracked/.config/mise/config.local.toml'
+assert_succeed "MISE_EXPERIMENTAL=0 mise bootstrap remote --experimental --host tracked --from-git file://$PWD/tracked-origin.git --remote-mise '$binary' --only dotfiles --yes"
+assert_contains 'cat remotes/tracked/.config/mise/config.local.toml' 'experimental = true'
+assert 'cat remotes/tracked/.remote-tracked' 'tracked contents'
+assert_contains 'cat remotes/tracked/.config/mise/config.local.toml' '[history.origin]'
+assert "ssh tracked '$binary settings get experimental'" 'true'
+mkdir -p remotes/conflicted
+printf 'keep my edit\n' >remotes/conflicted/.remote-tracked
+assert_fail "mise bootstrap remote --experimental --host conflicted --from-git file://$PWD/tracked-origin.git --remote-mise '$binary' --only dotfiles --yes"
+assert_not_contains 'cat remotes/conflicted/.config/mise/config.local.toml' 'experimental = true'
 test -f redirect-requested
 test ! -e redirect-followed
 kill "$redirect_pid"

--- a/e2e/cli/test_bootstrap_remote_setup_repository
+++ b/e2e/cli/test_bootstrap_remote_setup_repository
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# `mise bootstrap remote --from-git` on a history-managed setup repository sets
+# the target up from it over the transferred bundle. A dry run connects,
+# inspects the target and the repository, and shows the plan without writing
+# configuration, recording a connection, or keeping the fetched branch; the
+# real run writes what the dry run showed.
+# shellcheck disable=SC2016
+
+require_cmd git
+
+binary=$(command -v mise)
+mkdir -p fakebin remotes
+export FAKE_REMOTE_BASE="$PWD/remotes"
+export SSH_LOG="$PWD/ssh.log"
+# the fake ssh runs the remote command locally under a per-host HOME
+cat >fakebin/ssh <<'EOF2'
+#!/bin/sh
+printf '%s\n' "$*" >>"$SSH_LOG"
+while test "$#" -gt 0; do
+  case "$1" in
+    -o|-p|-i|-S) shift 2 ;;
+    -tt) shift ;;
+    -O) exit 0 ;;
+    *)
+      destination=$1
+      shift
+      export HOME="$FAKE_REMOTE_BASE/$destination"
+      export XDG_CONFIG_HOME="$HOME/.config" XDG_STATE_HOME="$HOME/.local/state"
+      export MISE_CONFIG_DIR="$HOME/.config/mise"
+      export MISE_GLOBAL_CONFIG_FILE="$MISE_CONFIG_DIR/config.toml"
+      export MISE_DATA_DIR="$HOME/.local/share/mise"
+      export MISE_CACHE_DIR="$HOME/.cache/mise"
+      export MISE_STATE_DIR="$HOME/.local/state/mise"
+      unset MISE_GITHUB_TOKEN MISE_GITHUB_API_TOKEN GITHUB_TOKEN GH_TOKEN
+      mkdir -p "$HOME"
+      exec sh -c "$1"
+      ;;
+  esac
+done
+EOF2
+chmod +x fakebin/ssh
+export PATH="$PWD/fakebin:$PATH"
+
+# ---- this machine publishes its setup: a tracked directory
+origin="$PWD/origin.git"
+git init -q --bare -b main "$origin"
+mkdir -p ~/.config/hypr
+echo 'bind = SUPER, Q, exec, kitty' >~/.config/hypr/bindings.lua
+assert_succeed "mise bootstrap dotfiles track ~/.config/hypr"
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --name laptop --yes"
+assert_contains "git --git-dir=$origin ls-tree -r --name-only main" "tracked/home/.config/hypr/bindings.lua"
+
+# ---- a dry run on a fresh host previews and leaves no trace
+out="$(mise bootstrap remote --host fresh --from-git "file://$origin" --remote-mise "$binary" --only dotfiles --dry-run 2>&1)"
+assert_contains "echo \"$out\"" "is a mise setup repository"
+assert_contains "echo \"$out\"" "bindings.lua"
+assert_contains "echo \"$out\"" "Dry run: nothing was changed"
+assert_contains "echo \"$out\"" "once the configuration exists there"
+assert_contains "cat '$SSH_LOG'" '--repository-dry-run'
+assert_not_contains "cat '$SSH_LOG'" '/.config/mise bootstrap'
+assert_fail "test -e remotes/fresh/.config/mise/config.toml"
+assert_fail "test -e remotes/fresh/.config/hypr/bindings.lua"
+assert "find remotes/fresh -name sync.json | wc -l | tr -d ' '" "0"
+assert "find remotes/fresh -path '*/refs/setup/*' | wc -l | tr -d ' '" "0"
+assert "find remotes/fresh -name config.local.toml | wc -l | tr -d ' '" "0"
+
+# ---- the real run writes what the dry run showed
+assert_succeed "mise bootstrap remote --host fresh --from-git file://$origin --remote-mise '$binary' --only dotfiles --yes"
+assert_fail "test -e remotes/fresh/.config/mise/.git"
+assert "cat remotes/fresh/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, kitty"
+assert_contains "cat remotes/fresh/.config/mise/config.toml" '"~/.config/hypr" = { mode = "track" }'
+assert_contains "cat remotes/fresh/.config/mise/config.local.toml" "file://$origin"
+assert "find remotes/fresh -name sync.json | wc -l | tr -d ' '" "1"
+assert_contains "cat '$SSH_LOG'" '/.config/mise bootstrap'
+
+# ---- a dry run on a set-up host previews the bootstrap against its configuration
+out="$(mise bootstrap remote --host fresh --from-git "file://$origin" --remote-mise "$binary" --only dotfiles --dry-run 2>&1)"
+assert_contains "echo \"$out\"" "Dry run: nothing was changed"
+assert_contains "cat '$SSH_LOG'" 'bootstrap --dry-run'
+assert "cat remotes/fresh/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, kitty"

--- a/e2e/cli/test_bootstrap_remote_setup_repository
+++ b/e2e/cli/test_bootstrap_remote_setup_repository
@@ -27,12 +27,13 @@ while test "$#" -gt 0; do
       export HOME="$FAKE_REMOTE_BASE/$destination"
       export XDG_CONFIG_HOME="$HOME/.config" XDG_STATE_HOME="$HOME/.local/state"
       export MISE_CONFIG_DIR="$HOME/.config/mise"
-      export MISE_GLOBAL_CONFIG_FILE="$MISE_CONFIG_DIR/config.toml"
+      unset MISE_GLOBAL_CONFIG_FILE
       export MISE_DATA_DIR="$HOME/.local/share/mise"
       export MISE_CACHE_DIR="$HOME/.cache/mise"
       export MISE_STATE_DIR="$HOME/.local/state/mise"
       unset MISE_GITHUB_TOKEN MISE_GITHUB_API_TOKEN GITHUB_TOKEN GH_TOKEN
       mkdir -p "$HOME"
+      cd "$HOME" || exit 1
       exec sh -c "$1"
       ;;
   esac
@@ -51,11 +52,12 @@ assert_succeed "mise bootstrap dotfiles origin set file://$origin --name laptop 
 assert_contains "git --git-dir=$origin ls-tree -r --name-only main" "tracked/home/.config/hypr/bindings.lua"
 
 # ---- a dry run on a fresh host previews and leaves no trace
-out="$(mise bootstrap remote --host fresh --from-git "file://$origin" --remote-mise "$binary" --only dotfiles --dry-run 2>&1)"
-assert_contains "echo \"$out\"" "is a mise setup repository"
-assert_contains "echo \"$out\"" "bindings.lua"
-assert_contains "echo \"$out\"" "Dry run: nothing was changed"
-assert_contains "echo \"$out\"" "once the configuration exists there"
+out="$(mise bootstrap remote --experimental --host fresh --from-git "file://$origin" --remote-mise "$binary" --only dotfiles --dry-run 2>&1)"
+export out
+assert_contains 'printf "%s\n" "$out"' "is a mise setup repository"
+assert_contains 'printf "%s\n" "$out"' "bindings.lua"
+assert_contains 'printf "%s\n" "$out"' "Dry run: nothing was changed"
+assert_contains 'printf "%s\n" "$out"' "once the configuration exists there"
 assert_contains "cat '$SSH_LOG'" '--repository-dry-run'
 assert_not_contains "cat '$SSH_LOG'" '/.config/mise bootstrap'
 assert_fail "test -e remotes/fresh/.config/mise/config.toml"
@@ -65,7 +67,7 @@ assert "find remotes/fresh -path '*/refs/setup/*' | wc -l | tr -d ' '" "0"
 assert "find remotes/fresh -name config.local.toml | wc -l | tr -d ' '" "0"
 
 # ---- the real run writes what the dry run showed
-assert_succeed "mise bootstrap remote --host fresh --from-git file://$origin --remote-mise '$binary' --only dotfiles --yes"
+assert_succeed "mise bootstrap remote --experimental --host fresh --from-git file://$origin --remote-mise '$binary' --only dotfiles --yes"
 assert_fail "test -e remotes/fresh/.config/mise/.git"
 assert "cat remotes/fresh/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, kitty"
 assert_contains "cat remotes/fresh/.config/mise/config.toml" '"~/.config/hypr" = { mode = "track" }'
@@ -74,7 +76,7 @@ assert "find remotes/fresh -name sync.json | wc -l | tr -d ' '" "1"
 assert_contains "cat '$SSH_LOG'" '/.config/mise bootstrap'
 
 # ---- a dry run on a set-up host previews the bootstrap against its configuration
-out="$(mise bootstrap remote --host fresh --from-git "file://$origin" --remote-mise "$binary" --only dotfiles --dry-run 2>&1)"
-assert_contains "echo \"$out\"" "Dry run: nothing was changed"
+out="$(mise bootstrap remote --experimental --host fresh --from-git "file://$origin" --remote-mise "$binary" --only dotfiles --dry-run 2>&1)"
+assert_contains 'printf "%s\n" "$out"' "Dry run: nothing was changed"
 assert_contains "cat '$SSH_LOG'" 'bootstrap --dry-run'
 assert "cat remotes/fresh/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, kitty"

--- a/e2e/cli/test_bootstrap_remote_setup_repository
+++ b/e2e/cli/test_bootstrap_remote_setup_repository
@@ -48,16 +48,22 @@ git init -q --bare -b main "$origin"
 mkdir -p ~/.config/hypr
 echo 'bind = SUPER, Q, exec, kitty' >~/.config/hypr/bindings.lua
 assert_succeed "mise bootstrap dotfiles track ~/.config/hypr"
+cat >>"$MISE_CONFIG_DIR/config.toml" <<'EOF'
+
+[bootstrap.repos]
+"~/preview-only-repo" = { url = "https://example.invalid/preview-only.git" }
+EOF
 assert_succeed "mise bootstrap dotfiles origin set file://$origin --name laptop --yes"
 assert_contains "git --git-dir=$origin ls-tree -r --name-only main" "tracked/home/.config/hypr/bindings.lua"
 
 # ---- a dry run on a fresh host previews and leaves no trace
-out="$(mise bootstrap remote --experimental --host fresh --from-git "file://$origin" --remote-mise "$binary" --only dotfiles --dry-run 2>&1)"
+out="$(mise bootstrap remote --experimental --host fresh --from-git "file://$origin" --remote-mise "$binary" --only repos --dry-run 2>&1)"
 export out
 assert_contains 'printf "%s\n" "$out"' "is a mise setup repository"
 assert_contains 'printf "%s\n" "$out"' "bindings.lua"
 assert_contains 'printf "%s\n" "$out"' "Dry run: nothing was changed"
-assert_contains 'printf "%s\n" "$out"' "once the configuration exists there"
+assert_contains 'printf "%s\n" "$out"' "git clone https://example.invalid/preview-only.git"
+assert_fail "test -e remotes/fresh/preview-only-repo"
 assert_contains "cat '$SSH_LOG'" '--repository-dry-run'
 assert_not_contains "cat '$SSH_LOG'" '/.config/mise bootstrap'
 assert_fail "test -e remotes/fresh/.config/mise/config.toml"

--- a/e2e/cli/test_dotfiles_bootstrap_from_git
+++ b/e2e/cli/test_dotfiles_bootstrap_from_git
@@ -43,6 +43,17 @@ EOF2
 }
 
 # ---- machine C: a fresh HOME, one command
+preview_home="$(dirname "$HOME")/conflict-preview-home"
+wrapper "$preview_home" "$PWD/conflict-preview"
+mkdir -p "$preview_home/.config/hypr"
+echo local >"$preview_home/.config/hypr/bindings.lua"
+preview="$("$PWD/conflict-preview" bootstrap --from-git "file://$origin" --dry-run 2>&1)"
+assert_contains "echo \"$preview\"" "bindings.lua"
+assert_contains "echo \"$preview\"" "held: unresolved conflict"
+assert_contains "echo \"$preview\"" "config.toml"
+assert "cat $preview_home/.config/hypr/bindings.lua" "local"
+assert_fail "test -e $preview_home/.config/mise/config.toml"
+
 C="$(dirname "$HOME")/c-home"
 wrapper "$C" "$PWD/c"
 c="$PWD/c"

--- a/e2e/cli/test_dotfiles_bootstrap_from_git
+++ b/e2e/cli/test_dotfiles_bootstrap_from_git
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# `mise bootstrap --from-git` on a history-managed setup repository sets a
+# fresh machine up from it with one command: the branch goes into mise's own
+# store (no checkout in the configuration directory), the shared configuration,
+# its sources, and this machine's tracked files are written by a recoverable
+# pull, the connection is remembered for the watcher, and the ordinary
+# bootstrap runs afterwards. An ordinary repository keeps the old clone.
+# shellcheck disable=SC2016
+
+require_cmd git
+
+origin="$PWD/origin.git"
+git init -q --bare -b main "$origin"
+
+# ---- machine A publishes its setup: a tracked directory and a template with
+# its source
+mkdir -p ~/.config/hypr "$MISE_CONFIG_DIR/templates"
+echo 'bind = SUPER, Q, exec, kitty' >~/.config/hypr/bindings.lua
+printf 'name = "{{ vars.name }}"\n' >"$MISE_CONFIG_DIR/templates/gitconfig.tera"
+cat <<'EOF2' >"$MISE_CONFIG_DIR/config.toml"
+[vars]
+name = "shared"
+
+[dotfiles]
+"~/.gitconfig-shared" = { source = "templates/gitconfig.tera", mode = "template" }
+EOF2
+assert_succeed "mise bootstrap dotfiles track ~/.config/hypr"
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --name laptop --yes"
+assert_contains "git --git-dir=$origin ls-tree -r --name-only main" "templates/gitconfig.tera"
+
+# other machines are other HOMEs reached through wrapper scripts
+wrapper() {
+  local home="$1" script="$2"
+  mkdir -p "$home"
+  cat <<EOF2 >"$script"
+#!/usr/bin/env bash
+export HOME="$home" XDG_CONFIG_HOME="$home/.config" MISE_CONFIG_DIR="$home/.config/mise" \\
+  MISE_STATE_DIR="$home/.local/state/mise" MISE_DATA_DIR="$home/.local/share/mise" \\
+  MISE_CACHE_DIR="$home/.cache/mise" MISE_TRUSTED_CONFIG_PATHS="$home"
+cd "\$HOME" && exec mise "\$@"
+EOF2
+  chmod +x "$script"
+}
+
+# ---- machine C: a fresh HOME, one command
+C="$(dirname "$HOME")/c-home"
+wrapper "$C" "$PWD/c"
+c="$PWD/c"
+out="$($c bootstrap --from-git "file://$origin" --dry-run 2>&1)"
+assert_contains "echo \"$out\"" "is a mise setup repository"
+assert_contains "echo \"$out\"" "config.toml"
+assert_contains "echo \"$out\"" "Dry run: nothing was changed"
+assert_fail "test -e $C/.config/mise/config.toml"
+assert_succeed "$c bootstrap --from-git file://$origin --yes --only dotfiles"
+assert_fail "test -e $C/.config/mise/.git"
+assert "cat $C/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, kitty"
+assert_contains "cat $C/.config/mise/config.toml" '"~/.config/hypr" = { mode = "track" }'
+assert "cat $C/.config/mise/templates/gitconfig.tera" 'name = "{{ vars.name }}"'
+# the bootstrap that followed rendered the template on C from the shared source
+assert "cat $C/.gitconfig-shared" 'name = "shared"'
+assert_contains "cat $C/.config/mise/config.local.toml" 'url = "file://'
+assert_contains "$c bootstrap dotfiles status" "mode sync"
+assert_contains "$c bootstrap dotfiles machines" "laptop"
+assert "$c bootstrap dotfiles history --json | jq -r '[.[].trigger] | index(\"apply\") != null'" "true"
+# running it again is a sync, not a second setup
+assert_succeed "$c bootstrap --from-git file://$origin --yes --only dotfiles"
+# C's edits reach A through the usual sync
+echo 'bind = SUPER, Q, exec, foot' >"$C/.config/hypr/bindings.lua"
+assert_contains "$c bootstrap dotfiles sync 2>&1" "published"
+assert_succeed "mise bootstrap dotfiles sync && mise bootstrap dotfiles pull --yes"
+assert "cat ~/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, foot"
+
+# ---- machine D already has a differing configuration: nothing is overwritten
+D="$(dirname "$HOME")/d-home"
+wrapper "$D" "$PWD/d"
+d="$PWD/d"
+mkdir -p "$D/.config/mise"
+printf '[env]\nD_ONLY = "1"\n' >"$D/.config/mise/config.toml"
+assert_contains "$d bootstrap --from-git file://$origin --yes --only dotfiles 2>&1" "need a decision"
+assert "cat $D/.config/mise/config.toml" $'[env]\nD_ONLY = "1"'
+assert_contains "$d bootstrap dotfiles status" "needs adoption"
+assert_succeed "$d bootstrap dotfiles pull --take-remote $D/.config/mise/config.toml --yes"
+assert "cat $D/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, foot"
+
+# ---- an ordinary repository keeps the old behaviour: a checkout in the
+# configuration directory
+plain="$PWD/plain.git"
+git init -q --bare -b main "$plain"
+seed="$PWD/plain-seed"
+git init -q -b main "$seed"
+printf '[env]\nPLAIN = "1"\n' >"$seed/config.toml"
+git -C "$seed" add config.toml
+git -C "$seed" -c user.name=t -c user.email=t@t commit -q -m init
+git -C "$seed" push -q "file://$plain" main
+E="$(dirname "$HOME")/e-home"
+wrapper "$E" "$PWD/e"
+e="$PWD/e"
+assert_succeed "$e bootstrap --from-git file://$plain --yes --only task"
+assert_succeed "test -d $E/.config/mise/.git"
+assert_contains "cat $E/.config/mise/config.toml" 'PLAIN = "1"'
+assert_contains "$e bootstrap dotfiles status" "Setup repository: none"

--- a/e2e/cli/test_dotfiles_bootstrap_from_git
+++ b/e2e/cli/test_dotfiles_bootstrap_from_git
@@ -46,6 +46,9 @@ EOF2
 C="$(dirname "$HOME")/c-home"
 wrapper "$C" "$PWD/c"
 c="$PWD/c"
+assert_fail "MISE_EXPERIMENTAL=0 $c bootstrap --from-git file://$origin --yes --only dotfiles" 'dotfile tracking is experimental'
+assert_directory_not_exists "$C/.local/state/mise/history"
+assert_fail "test -e $C/.config/mise/config.toml"
 out="$($c bootstrap --from-git "file://$origin" --dry-run 2>&1)"
 assert_contains "echo \"$out\"" "is a mise setup repository"
 assert_contains "echo \"$out\"" "config.toml"

--- a/e2e/cli/test_dotfiles_bootstrap_from_git
+++ b/e2e/cli/test_dotfiles_bootstrap_from_git
@@ -104,7 +104,8 @@ git -C "$seed" push -q "file://$plain" main
 E="$(dirname "$HOME")/e-home"
 wrapper "$E" "$PWD/e"
 e="$PWD/e"
-assert_succeed "$e bootstrap --from-git file://$plain --yes --only task"
+assert_succeed "MISE_EXPERIMENTAL=0 $e bootstrap --from-git file://$plain --yes --only task"
+assert_directory_not_exists "$E/.local/state/mise/history"
 assert_succeed "test -d $E/.config/mise/.git"
 assert_contains "cat $E/.config/mise/config.toml" 'PLAIN = "1"'
 assert_contains "$e bootstrap dotfiles status" "Setup repository: none"

--- a/e2e/cli/test_dotfiles_bootstrap_from_git
+++ b/e2e/cli/test_dotfiles_bootstrap_from_git
@@ -51,6 +51,9 @@ assert_contains "echo \"$out\"" "is a mise setup repository"
 assert_contains "echo \"$out\"" "config.toml"
 assert_contains "echo \"$out\"" "Dry run: nothing was changed"
 assert_fail "test -e $C/.config/mise/config.toml"
+# a preview leaves no connection, pending changes, or fetched branch behind
+assert "find $C -name sync.json | wc -l | tr -d ' '" "0"
+assert "find $C -path '*/refs/setup/*' | wc -l | tr -d ' '" "0"
 assert_succeed "$c bootstrap --from-git file://$origin --yes --only dotfiles"
 assert_fail "test -e $C/.config/mise/.git"
 assert "cat $C/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, kitty"
@@ -76,7 +79,10 @@ wrapper "$D" "$PWD/d"
 d="$PWD/d"
 mkdir -p "$D/.config/mise"
 printf '[env]\nD_ONLY = "1"\n' >"$D/.config/mise/config.toml"
-assert_contains "$d bootstrap --from-git file://$origin --yes --only dotfiles 2>&1" "need a decision"
+# the differing configuration is held, so nothing is bootstrapped from the
+# old one: the command says what to decide and fails
+assert_fail "$d bootstrap --from-git file://$origin --yes --only dotfiles 2>&1" "need a decision"
+assert_fail "$d bootstrap --from-git file://$origin --yes --only dotfiles 2>&1" "nothing was bootstrapped"
 assert "cat $D/.config/mise/config.toml" $'[env]\nD_ONLY = "1"'
 assert_contains "$d bootstrap dotfiles status" "needs adoption"
 assert_succeed "$d bootstrap dotfiles pull --take-remote $D/.config/mise/config.toml --yes"
@@ -99,3 +105,15 @@ assert_succeed "$e bootstrap --from-git file://$plain --yes --only task"
 assert_succeed "test -d $E/.config/mise/.git"
 assert_contains "cat $E/.config/mise/config.toml" 'PLAIN = "1"'
 assert_contains "$e bootstrap dotfiles status" "Setup repository: none"
+
+# ---- the repository's default branch is followed, not `main` by its name
+other="$PWD/other.git"
+git clone -q --bare "file://$origin" "$other"
+git --git-dir="$other" branch -q setup main
+git --git-dir="$other" symbolic-ref HEAD refs/heads/setup
+# a stale `main` left behind at the first commit
+git --git-dir="$other" update-ref refs/heads/main "$(git --git-dir="$other" rev-list --max-parents=0 setup | tail -1)"
+F="$(dirname "$HOME")/f-home"
+wrapper "$F" "$PWD/f"
+f="$PWD/f"
+assert_contains "$f bootstrap --from-git file://$other --dry-run 2>&1" "branch setup"

--- a/e2e/cli/test_dotfiles_experimental_stack
+++ b/e2e/cli/test_dotfiles_experimental_stack
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Every mutating entry point must reject use before experimental opt-in.
+export MISE_EXPERIMENTAL=0
+
+assert_fail "mise bootstrap dotfiles rollback latest" 'dotfile tracking is experimental'
+assert_fail "mise bootstrap dotfiles undo" 'dotfile tracking is experimental'
+assert_fail "mise bootstrap dotfiles watch --once" 'dotfile tracking is experimental'
+assert_fail "mise bootstrap dotfiles sync" 'dotfile tracking is experimental'
+assert_fail "mise bootstrap dotfiles pull" 'dotfile tracking is experimental'
+assert_fail "mise bootstrap dotfiles origin set /nonexistent" 'dotfile tracking is experimental'
+assert_fail "mise bootstrap dotfiles origin --remove" 'dotfile tracking is experimental'
+assert_fail "mise bootstrap dotfiles exclude ~/.cache" 'dotfile tracking is experimental'
+assert_directory_not_exists "$MISE_STATE_DIR/history"
+
+mkdir -p "$MISE_CONFIG_DIR"
+cat >"$MISE_CONFIG_DIR/config.toml" <<'EOF'
+[bootstrap.services.history]
+scope = "user"
+builtin = "history-watch"
+EOF
+assert_fail "mise bootstrap services apply --yes" 'dotfile tracking is experimental'
+assert_contains "mise doctor 2>&1" 'tracking is experimental and disabled'

--- a/e2e/cli/test_dotfiles_onboard_review
+++ b/e2e/cli/test_dotfiles_onboard_review
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+require_cmd git
+export MISE_EXPERIMENTAL=1
+printf 'original\n' >~/.onboard-review
+assert_succeed 'mise bootstrap dotfiles track ~/.onboard-review'
+origin="$PWD/origin.git"
+git init -q --bare "$origin"
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --sync fetch-only --yes"
+assert 'mise settings get history.sync' 'fetch-only'
+assert_succeed 'mise settings set history.sync manual'
+assert 'mise settings get history.sync' 'manual'
+assert_contains 'mise bootstrap dotfiles status' 'mode manual'
+assert_succeed 'mise settings set history.sync sync'
+assert 'mise settings get history.sync' 'sync'
+assert_succeed 'mise settings unset history.sync'
+assert 'mise settings get history.sync' 'sync'
+assert_succeed 'mise bootstrap dotfiles sync'
+
+# A broken local store must not turn a marked repository into a plain clone.
+broken="$PWD/broken-state"
+mkdir -p "$broken/history"
+printf 'not a repository\n' >"$broken/history/repo.git"
+assert_fail "MISE_STATE_DIR=$broken mise bootstrap --from-git file://$origin --yes" 'history is unavailable'
+assert_fail 'test -d ~/.config/mise/.git'

--- a/e2e/cli/test_dotfiles_onboard_review
+++ b/e2e/cli/test_dotfiles_onboard_review
@@ -22,3 +22,24 @@ mkdir -p "$broken/history"
 printf 'not a repository\n' >"$broken/history/repo.git"
 assert_fail "MISE_STATE_DIR=$broken mise bootstrap --from-git file://$origin --yes" 'history is unavailable'
 assert_fail 'test -d ~/.config/mise/.git'
+
+# Preview and refusal cannot alter an existing connection's bookkeeping.
+status="$MISE_STATE_DIR/history/sync.json"
+cp "$status" "$PWD/sync-before.json"
+refs="$(git --git-dir="$MISE_STATE_DIR/history/repo.git" for-each-ref --format='%(refname) %(objectname)')"
+assert_succeed "mise bootstrap --from-git file://$origin --dry-run --only dotfiles"
+assert_succeed "cmp '$status' '$PWD/sync-before.json'"
+assert "git --git-dir=$MISE_STATE_DIR/history/repo.git for-each-ref --format='%(refname) %(objectname)'" "$refs"
+assert_fail "MISE_YES=0 mise bootstrap --from-git file://$origin --only dotfiles </dev/null" 'not set up'
+assert_succeed "cmp '$status' '$PWD/sync-before.json'"
+assert "git --git-dir=$MISE_STATE_DIR/history/repo.git for-each-ref --format='%(refname) %(objectname)'" "$refs"
+
+# A validation failure after fetching also leaves the old state untouched.
+git clone -q "$origin" damaged
+printf '[broken\n' >damaged/config.toml
+git -C damaged add config.toml
+git -C damaged -c user.name=test -c user.email=test@example.com commit -qm invalid
+git -C damaged push -q
+assert_fail "mise bootstrap --from-git file://$origin --dry-run --only dotfiles"
+assert_succeed "cmp '$status' '$PWD/sync-before.json'"
+assert "git --git-dir=$MISE_STATE_DIR/history/repo.git for-each-ref --format='%(refname) %(objectname)'" "$refs"

--- a/e2e/cli/test_dotfiles_sync
+++ b/e2e/cli/test_dotfiles_sync
@@ -59,6 +59,14 @@ store="$MISE_STATE_DIR/history/repo.git"
 assert_contains "for ref in \$(git --git-dir=$store for-each-ref --format='%(refname)' refs/checkpoints); do git --git-dir=$store ls-tree -r --name-only \$ref; done" "github_tokens"
 # repeating a sync changes nothing
 assert_contains "mise bootstrap dotfiles sync 2>&1" "nothing new to publish"
+# a lost upload record is reconciled from the origin's refs, not re-pushed:
+# the backups already there are kept, the record fills in again
+status="$MISE_STATE_DIR/history/sync.json"
+jq '.uploaded = []' "$status" >"$status.tmp" && mv "$status.tmp" "$status"
+assert "jq '.uploaded | length' $status" "0"
+assert_succeed "mise bootstrap dotfiles sync"
+assert "git --git-dir=$origin for-each-ref --format='%(refname)' refs/mise-history | grep -c ." "2"
+assert "jq '.uploaded | length' $status" "2"
 assert_contains "mise bootstrap dotfiles origin 2>&1" "mode sync"
 
 # ---- machine B: connect, adopt the differing config, apply the rest

--- a/e2e/cli/test_dotfiles_sync
+++ b/e2e/cli/test_dotfiles_sync
@@ -42,8 +42,10 @@ assert_contains "cat $PWD/connect.log" "machine-local configuration (private unl
 assert_contains "cat $PWD/connect.log" "published"
 assert "git --git-dir=$origin ls-tree -r --name-only main | LC_ALL=C sort | tr '\n' ' '" ".mise-history/format.toml config.toml tracked/home/.config/hypr/bindings.lua "
 assert "git --git-dir=$origin show main:.mise-history/format.toml | grep -c 'format = 1'" "1"
+# the connection is machine-local: never published, never in the way of the
+# configuration a fresh machine pulls
 assert_contains "cat $MISE_CONFIG_DIR/config.local.toml" 'url = "file://'
-assert_contains "cat $MISE_CONFIG_DIR/config.local.toml" 'sync = "sync"'
+assert_not_contains "cat $MISE_CONFIG_DIR/config.toml" 'url = "file://'
 assert_contains "mise bootstrap dotfiles status" "mode sync, machine laptop"
 assert "git --git-dir=$origin for-each-ref --format='%(refname)' refs/mise-history | grep -c ." "2"
 # private files never reach the branch or the machine refs
@@ -72,6 +74,7 @@ assert_contains "$b bootstrap dotfiles status" "needs adoption"
 assert_not_contains "$b bootstrap dotfiles status" "incoming change(s) pending"
 assert_contains "$b bootstrap dotfiles pull --dry-run 2>&1" "sync paused"
 assert_fail "$b bootstrap dotfiles pull --take-remote ~/.config/hypr/bindings.lua --yes 2>&1" "is not a conflict"
+# one pull: the adopted configuration, then the tracked files it declares
 assert_succeed "$b bootstrap dotfiles pull --take-remote $B/.config/mise/config.toml --yes"
 assert "cat $B/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, kitty"
 # the declarations that arrived are applied by a bootstrap, not by pull: said until one ran
@@ -254,9 +257,8 @@ assert_succeed "mise bootstrap dotfiles sync"
 assert "cat ~/.config/hypr/monitors.lua" "monitor=DP-1"
 
 # ---- fetch-only publishes nothing; disconnecting keeps local history
-assert_succeed "MISE_GLOBAL_CONFIG_FILE=$MISE_CONFIG_DIR/config.local.toml mise settings set history.sync fetch-only"
 echo 'monitor=DP-2' >~/.config/hypr/monitors.lua
-assert_contains "mise bootstrap dotfiles sync 2>&1" "nothing new to publish"
+assert_contains "MISE_HISTORY_SYNC=fetch-only mise bootstrap dotfiles sync 2>&1" "nothing new to publish"
 assert "git --git-dir=$origin show main:tracked/home/.config/hypr/monitors.lua" "monitor=DP-1"
 assert_succeed "mise bootstrap dotfiles origin --remove"
 assert_contains "mise bootstrap dotfiles status" "Setup repository: none"
@@ -266,7 +268,6 @@ assert "mise bootstrap dotfiles history --json -n 0 | jq length | awk '{print (\
 # knew is read as a deletion; the local files are published to it
 origin2="$PWD/origin2.git"
 git init -q --bare -b main "$origin2"
-assert_succeed "MISE_GLOBAL_CONFIG_FILE=$MISE_CONFIG_DIR/config.local.toml mise settings set history.sync sync"
 assert_contains "mise bootstrap dotfiles origin set file://$origin2 --name laptop --yes 2>&1" "previous one's sync state is discarded"
 assert "git --git-dir=$origin2 show main:tracked/home/.config/hypr/monitors.lua" "monitor=DP-2"
 assert_not_contains "mise bootstrap dotfiles status" "incoming change(s) pending"

--- a/e2e/cli/test_dotfiles_sync_auto
+++ b/e2e/cli/test_dotfiles_sync_auto
@@ -87,9 +87,15 @@ echo 'bind = SUPER, W, exec, firefox' >>~/.config/hypr/bindings.lua
 wait_until "grep -q '\"event\":\"sync-error\"' a.log"
 assert_contains "mise bootstrap dotfiles history --json | jq -r '.[0].description'" "bindings.lua"
 assert_contains "mise bootstrap dotfiles status 2>&1" "last error"
+# the failure has a start, so an origin that never answered is not "transient"
+# forever: after three fetch intervals doctor escalates
+assert_contains "mise bootstrap dotfiles status 2>&1" "failing since"
+wait_until "(mise doctor 2>&1 || true) | grep -q 'keeps failing'"
+assert "(mise doctor --json 2>/dev/null || true) | jq '.dotfiles.sync_failing_for_secs > 6'" "true"
 mv "$origin.away" "$origin"
 wait_until "grep -q 'firefox' $B/.config/hypr/bindings.lua"
 assert_not_contains "mise bootstrap dotfiles status 2>&1" "last error"
+assert_not_contains "mise bootstrap dotfiles status 2>&1" "failing since"
 
 # ---- a conflict: B changes a line while its watcher is down and A changes the
 # same line; both versions are kept, the entire setup waits, and one

--- a/e2e/cli/test_dotfiles_sync_auto
+++ b/e2e/cli/test_dotfiles_sync_auto
@@ -66,10 +66,10 @@ wait_until "grep -q '\"event\":\"started\"' a.log && grep -q '\"event\":\"starte
 
 # ---- B's watcher applies what A shared without a command on either side: the
 # configuration first, then the tracked files it declares
-wait_until "grep -q '\"event\":\"applied\"' b.log"
+wait_until "grep -q '\"event\":\"replan\"' b.log"
 assert "cat $B/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, kitty"
 assert_contains "cat $B/.config/mise/config.toml" '"~/.config/hypr" = { mode = "track" }'
-assert_contains "cat b.log" '"event":"replan"'
+assert_contains "cat b.log" '"event":"applied"'
 
 # ---- an edit on A is published by its watcher and applied by B's
 echo 'bind = SUPER, Q, exec, alacritty' >~/.config/hypr/bindings.lua

--- a/e2e/cli/test_dotfiles_sync_auto
+++ b/e2e/cli/test_dotfiles_sync_auto
@@ -38,6 +38,7 @@ cat <<'EOF2' >"$B/bin/notify-send"
 printf 'CALL %s\n' "$(printf '%s' "$*" | tr '\n' ' ')" >>"$HOME/notifications"
 EOF2
 chmod +x "$B/bin/notify-send"
+cp "$B/bin/notify-send" "$B/bin/osascript"
 cat <<EOF2 >"$PWD/b"
 #!/usr/bin/env bash
 export HOME="$B" XDG_CONFIG_HOME="$B/.config" MISE_CONFIG_DIR="$B/.config/mise" \\
@@ -60,6 +61,8 @@ $b bootstrap dotfiles watch --json >b.log 2>&1 &
 b_watcher=$!
 cleanup() {
   kill "$a_watcher" "$b_watcher" 2>/dev/null || true
+  wait "$a_watcher" 2>/dev/null || true
+  wait "$b_watcher" 2>/dev/null || true
 }
 trap cleanup EXIT
 wait_until "grep -q '\"event\":\"started\"' a.log && grep -q '\"event\":\"started\"' b.log"
@@ -89,14 +92,14 @@ wait_until "grep -q 'firefox' $B/.config/hypr/bindings.lua"
 assert_not_contains "mise bootstrap dotfiles status 2>&1" "last error"
 
 # ---- a conflict: B changes a line while its watcher is down and A changes the
-# same line; both versions are kept, B's file is untouched, unrelated syncing
-# goes on, and one notification is shown however often the sync retries
+# same line; both versions are kept, the entire setup waits, and one
+# notification is shown by default however often the sync retries
 kill "$b_watcher"
 wait "$b_watcher" 2>/dev/null || true
 printf 'bind = SUPER, Q, exec, wezterm\nbind = SUPER, W, exec, firefox\n' >"$B/.config/hypr/bindings.lua"
 printf 'bind = SUPER, Q, exec, foot\nbind = SUPER, W, exec, firefox\n' >~/.config/hypr/bindings.lua
 wait_until "git --git-dir=$origin show main:tracked/home/.config/hypr/bindings.lua | grep -q foot"
-MISE_HISTORY_NOTIFY=1 $b bootstrap dotfiles watch --json >b.log 2>&1 &
+$b bootstrap dotfiles watch --json >b.log 2>&1 &
 b_watcher=$!
 wait_until "grep -q '\"conflicts\":1' b.log"
 assert_contains "cat $B/.config/hypr/bindings.lua" "wezterm"
@@ -104,11 +107,14 @@ assert_contains "$b bootstrap dotfiles status 2>&1" "both sides changed the same
 assert_contains "$b bootstrap dotfiles status 2>&1" "mise bootstrap dotfiles pull"
 assert_contains "$b doctor 2>&1 || true" "sync conflict"
 echo 'monitor=DP-1' >~/.config/hypr/monitors.lua
-wait_until "test -e $B/.config/hypr/monitors.lua"
+wait_until "git --git-dir=$origin show main:tracked/home/.config/hypr/monitors.lua | grep -q DP-1"
+wait_until "grep -c '\"conflicts\":1' b.log | awk '{exit !(\$1 > 1)}'"
+assert_fail "test -e $B/.config/hypr/monitors.lua"
 assert "grep -c '\"conflicts\":1' b.log | awk '{print (\$1 > 1)}'" "1"
 assert "grep -c '^CALL' $B/notifications" "1"
 assert_contains "cat $B/notifications" "bindings.lua"
 assert_succeed "$b bootstrap dotfiles pull --take-remote $B/.config/hypr/bindings.lua --yes"
+wait_until "test -e $B/.config/hypr/monitors.lua"
 assert "cat $B/.config/hypr/bindings.lua" $'bind = SUPER, Q, exec, foot\nbind = SUPER, W, exec, firefox'
 assert_not_contains "$b bootstrap dotfiles status 2>&1" "both sides changed"
 assert_not_contains "$b doctor 2>&1 || true" "sync conflict"

--- a/e2e/cli/test_dotfiles_sync_auto
+++ b/e2e/cli/test_dotfiles_sync_auto
@@ -28,18 +28,10 @@ git init -q --bare -b main "$origin"
 export MISE_HISTORY_SYNC_INTERVAL=1s MISE_HISTORY_FETCH_INTERVAL=2s
 export MISE_HISTORY_WATCH_DEBOUNCE=2s MISE_HISTORY_WATCH_RECONCILE=0
 
-# machine B is a second HOME reached through a wrapper script; a fake
-# notifier on its PATH records every desktop notification
+# machine B is a second HOME reached through a wrapper script.
 # outside A's home, so none of A's files is discovered as a project config of B
 B="$(dirname "$HOME")/b-home"
 mkdir -p "$B/.config/mise" "$B/.config/hypr" "$B/bin"
-cat <<'EOF2' >"$B/bin/notify-send"
-#!/usr/bin/env bash
-printf 'CALL %s\n' "$(printf '%s' "$*" | tr '\n' ' ')" >>"$HOME/notifications"
-EOF2
-chmod +x "$B/bin/notify-send"
-cp "$B/bin/notify-send" "$B/bin/osascript"
-cp "$B/bin/notify-send" "$B/bin/terminal-notifier"
 cat <<EOF2 >"$PWD/b"
 #!/usr/bin/env bash
 export HOME="$B" XDG_CONFIG_HOME="$B/.config" MISE_CONFIG_DIR="$B/.config/mise" \\
@@ -118,10 +110,8 @@ wait_until "git --git-dir=$origin show main:tracked/home/.config/hypr/monitors.l
 wait_until "grep -c '\"conflicts\":1' b.log | awk '{exit !(\$1 > 1)}'"
 assert_fail "test -e $B/.config/hypr/monitors.lua"
 assert "grep -c '\"conflicts\":1' b.log | awk '{print (\$1 > 1)}'" "1"
-assert "grep -c '^CALL' $B/notifications" "1"
-assert_contains "cat $B/notifications" "bindings.lua"
-assert_contains "cat $B/notifications" "$B/.cache/mise/notifications/mise.png"
-assert_succeed "test -s $B/.cache/mise/notifications/mise.png"
+# Notification delivery and deduplication are unit-tested without sending
+# real desktop alerts from the isolated test homes.
 assert_succeed "$b bootstrap dotfiles pull --take-remote $B/.config/hypr/bindings.lua --yes"
 wait_until "test -e $B/.config/hypr/monitors.lua"
 assert "cat $B/.config/hypr/bindings.lua" $'bind = SUPER, Q, exec, foot\nbind = SUPER, W, exec, firefox'

--- a/e2e/cli/test_dotfiles_sync_auto
+++ b/e2e/cli/test_dotfiles_sync_auto
@@ -39,6 +39,7 @@ printf 'CALL %s\n' "$(printf '%s' "$*" | tr '\n' ' ')" >>"$HOME/notifications"
 EOF2
 chmod +x "$B/bin/notify-send"
 cp "$B/bin/notify-send" "$B/bin/osascript"
+cp "$B/bin/notify-send" "$B/bin/terminal-notifier"
 cat <<EOF2 >"$PWD/b"
 #!/usr/bin/env bash
 export HOME="$B" XDG_CONFIG_HOME="$B/.config" MISE_CONFIG_DIR="$B/.config/mise" \\
@@ -119,6 +120,8 @@ assert_fail "test -e $B/.config/hypr/monitors.lua"
 assert "grep -c '\"conflicts\":1' b.log | awk '{print (\$1 > 1)}'" "1"
 assert "grep -c '^CALL' $B/notifications" "1"
 assert_contains "cat $B/notifications" "bindings.lua"
+assert_contains "cat $B/notifications" "$B/.cache/mise/notifications/mise.png"
+assert_succeed "test -s $B/.cache/mise/notifications/mise.png"
 assert_succeed "$b bootstrap dotfiles pull --take-remote $B/.config/hypr/bindings.lua --yes"
 wait_until "test -e $B/.config/hypr/monitors.lua"
 assert "cat $B/.config/hypr/bindings.lua" $'bind = SUPER, Q, exec, foot\nbind = SUPER, W, exec, firefox'

--- a/e2e/cli/test_dotfiles_sync_auto
+++ b/e2e/cli/test_dotfiles_sync_auto
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Automatic synchronization by the watcher: A's saves are published without a
+# command on either side and B's watcher fetches and applies them; an
+# unreachable origin only backs off while saving continues; a conflict is
+# held with both versions kept, B's file untouched, and notified once; a
+# rollback travels like any other change; fetch-only never publishes or
+# writes by itself; manual does nothing by itself.
+# shellcheck disable=SC2016
+
+require_cmd git
+
+wait_until() {
+  for _ in $(seq 1 150); do
+    if eval "$1" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  echo "timed out waiting for: $1" >&2
+  cat a.log b.log >&2 2>/dev/null
+  return 1
+}
+
+origin="$PWD/origin.git"
+git init -q --bare -b main "$origin"
+
+# short intervals; the same environment reaches machine B through its wrapper
+export MISE_HISTORY_SYNC_INTERVAL=1s MISE_HISTORY_FETCH_INTERVAL=2s
+export MISE_HISTORY_WATCH_DEBOUNCE=2s MISE_HISTORY_WATCH_RECONCILE=0
+
+# machine B is a second HOME reached through a wrapper script; a fake
+# notifier on its PATH records every desktop notification
+# outside A's home, so none of A's files is discovered as a project config of B
+B="$(dirname "$HOME")/b-home"
+mkdir -p "$B/.config/mise" "$B/.config/hypr" "$B/bin"
+cat <<'EOF2' >"$B/bin/notify-send"
+#!/usr/bin/env bash
+printf 'CALL %s\n' "$(printf '%s' "$*" | tr '\n' ' ')" >>"$HOME/notifications"
+EOF2
+chmod +x "$B/bin/notify-send"
+cat <<EOF2 >"$PWD/b"
+#!/usr/bin/env bash
+export HOME="$B" XDG_CONFIG_HOME="$B/.config" MISE_CONFIG_DIR="$B/.config/mise" \\
+  MISE_STATE_DIR="$B/.local/state/mise" MISE_DATA_DIR="$B/.local/share/mise" \\
+  MISE_CACHE_DIR="$B/.cache/mise" MISE_TRUSTED_CONFIG_PATHS="$B" PATH="$B/bin:\$PATH"
+cd "\$HOME" && exec mise "\$@"
+EOF2
+chmod +x "$PWD/b"
+b="$PWD/b"
+
+# ---- A tracks a directory and connects; both watchers start
+mkdir -p ~/.config/hypr
+echo 'bind = SUPER, Q, exec, kitty' >~/.config/hypr/bindings.lua
+assert_succeed "mise bootstrap dotfiles track ~/.config/hypr"
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --name laptop --yes"
+assert_succeed "$b bootstrap dotfiles origin set file://$origin --name desktop --yes"
+mise bootstrap dotfiles watch --json >a.log 2>&1 &
+a_watcher=$!
+$b bootstrap dotfiles watch --json >b.log 2>&1 &
+b_watcher=$!
+cleanup() {
+  kill "$a_watcher" "$b_watcher" 2>/dev/null || true
+}
+trap cleanup EXIT
+wait_until "grep -q '\"event\":\"started\"' a.log && grep -q '\"event\":\"started\"' b.log"
+
+# ---- B's watcher applies what A shared without a command on either side: the
+# configuration first, then the tracked files it declares
+wait_until "grep -q '\"event\":\"applied\"' b.log"
+assert "cat $B/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, kitty"
+assert_contains "cat $B/.config/mise/config.toml" '"~/.config/hypr" = { mode = "track" }'
+assert_contains "cat b.log" '"event":"replan"'
+
+# ---- an edit on A is published by its watcher and applied by B's
+echo 'bind = SUPER, Q, exec, alacritty' >~/.config/hypr/bindings.lua
+wait_until "grep -q 'alacritty' $B/.config/hypr/bindings.lua"
+assert "git --git-dir=$origin show main:tracked/home/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, alacritty"
+assert_contains "cat a.log" '"published":"'
+
+# ---- the origin becomes unreachable: saving continues, syncing backs off and
+# says so, and everything converges once it is back
+mv "$origin" "$origin.away"
+echo 'bind = SUPER, W, exec, firefox' >>~/.config/hypr/bindings.lua
+wait_until "grep -q '\"event\":\"sync-error\"' a.log"
+assert_contains "mise bootstrap dotfiles history --json | jq -r '.[0].description'" "bindings.lua"
+assert_contains "mise bootstrap dotfiles status 2>&1" "last error"
+mv "$origin.away" "$origin"
+wait_until "grep -q 'firefox' $B/.config/hypr/bindings.lua"
+assert_not_contains "mise bootstrap dotfiles status 2>&1" "last error"
+
+# ---- a conflict: B changes a line while its watcher is down and A changes the
+# same line; both versions are kept, B's file is untouched, unrelated syncing
+# goes on, and one notification is shown however often the sync retries
+kill "$b_watcher"
+wait "$b_watcher" 2>/dev/null || true
+printf 'bind = SUPER, Q, exec, wezterm\nbind = SUPER, W, exec, firefox\n' >"$B/.config/hypr/bindings.lua"
+printf 'bind = SUPER, Q, exec, foot\nbind = SUPER, W, exec, firefox\n' >~/.config/hypr/bindings.lua
+wait_until "git --git-dir=$origin show main:tracked/home/.config/hypr/bindings.lua | grep -q foot"
+MISE_HISTORY_NOTIFY=1 $b bootstrap dotfiles watch --json >b.log 2>&1 &
+b_watcher=$!
+wait_until "grep -q '\"conflicts\":1' b.log"
+assert_contains "cat $B/.config/hypr/bindings.lua" "wezterm"
+assert_contains "$b bootstrap dotfiles status 2>&1" "both sides changed the same lines"
+assert_contains "$b bootstrap dotfiles status 2>&1" "mise bootstrap dotfiles pull"
+assert_contains "$b doctor 2>&1 || true" "sync conflict"
+echo 'monitor=DP-1' >~/.config/hypr/monitors.lua
+wait_until "test -e $B/.config/hypr/monitors.lua"
+assert "grep -c '\"conflicts\":1' b.log | awk '{print (\$1 > 1)}'" "1"
+assert "grep -c '^CALL' $B/notifications" "1"
+assert_contains "cat $B/notifications" "bindings.lua"
+assert_succeed "$b bootstrap dotfiles pull --take-remote $B/.config/hypr/bindings.lua --yes"
+assert "cat $B/.config/hypr/bindings.lua" $'bind = SUPER, Q, exec, foot\nbind = SUPER, W, exec, firefox'
+assert_not_contains "$b bootstrap dotfiles status 2>&1" "both sides changed"
+assert_not_contains "$b doctor 2>&1 || true" "sync conflict"
+
+# ---- a rollback is a new shared change, received like any other: the
+# branch grows, nothing is rewritten
+commits="$(git --git-dir="$origin" rev-list --count main)"
+head_before="$(git --git-dir="$origin" rev-parse main)"
+assert_succeed "mise bootstrap dotfiles rollback ~/.config/hypr/bindings.lua --yes"
+assert_contains "cat ~/.config/hypr/bindings.lua" "alacritty"
+wait_until "grep -q 'alacritty' $B/.config/hypr/bindings.lua"
+assert "git --git-dir=$origin rev-list --count main | awk -v n=$commits '{print (\$1 > n)}'" "1"
+assert_succeed "git --git-dir=$origin merge-base --is-ancestor $head_before main"
+
+# ---- fetch-only: B's watcher fetches, never publishes, never writes a file
+kill "$b_watcher"
+wait "$b_watcher" 2>/dev/null || true
+MISE_HISTORY_SYNC=fetch-only $b bootstrap dotfiles watch --json >b.log 2>&1 &
+b_watcher=$!
+echo '# only on B' >>"$B/.config/hypr/monitors.lua"
+echo 'bind = SUPER, E, exec, thunar' >>~/.config/hypr/bindings.lua
+wait_until "grep '\"event\":\"synced\"' b.log | grep -q '\"pending\":1'"
+assert_not_contains "cat $B/.config/hypr/bindings.lua" "thunar"
+assert_not_contains "git --git-dir=$origin show main:tracked/home/.config/hypr/monitors.lua" "only on B"
+assert_succeed "MISE_HISTORY_SYNC=fetch-only $b bootstrap dotfiles pull --yes"
+assert_contains "cat $B/.config/hypr/bindings.lua" "thunar"
+
+# ---- manual: nothing happens on its own
+kill "$b_watcher"
+wait "$b_watcher" 2>/dev/null || true
+MISE_HISTORY_SYNC=manual $b bootstrap dotfiles watch --json >b.log 2>&1 &
+b_watcher=$!
+wait_until "grep -q '\"event\":\"started\"' b.log"
+echo 'bind = SUPER, R, exec, rofi' >>~/.config/hypr/bindings.lua
+wait_until "git --git-dir=$origin show main:tracked/home/.config/hypr/bindings.lua | grep -q rofi"
+sleep 3
+assert_fail "grep -q '\"event\":\"sync\"' b.log"
+assert_not_contains "cat $B/.config/hypr/bindings.lua" "rofi"

--- a/e2e/cli/test_dotfiles_sync_auto_reconcile
+++ b/e2e/cli/test_dotfiles_sync_auto_reconcile
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# A reload of the watcher's configuration (here: the periodic reconcile, every
+# second) keeps the pending publication and fetch deadlines instead of
+# rebuilding the plan, so a save is published within its sync interval even
+# though reconciliation runs more often than that.
+# shellcheck disable=SC2016
+
+require_cmd git
+
+wait_until() {
+  local tries=$1
+  shift
+  for _ in $(seq 1 "$tries"); do
+    if eval "$1" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  echo "timed out waiting for: $1" >&2
+  cat a.log >&2 2>/dev/null
+  return 1
+}
+
+origin="$PWD/origin.git"
+git init -q --bare -b main "$origin"
+
+# reconcile far more often than the publication delay; the first fetch would
+# only come after 15 seconds, so a publication seen sooner is the save's own
+export MISE_HISTORY_SYNC_INTERVAL=3s MISE_HISTORY_FETCH_INTERVAL=30s
+export MISE_HISTORY_WATCH_DEBOUNCE=1s MISE_HISTORY_WATCH_RECONCILE=1s
+
+mkdir -p ~/.config/hypr
+echo 'bind = SUPER, Q, exec, kitty' >~/.config/hypr/bindings.lua
+assert_succeed "mise bootstrap dotfiles track ~/.config/hypr"
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --name laptop --yes"
+mise bootstrap dotfiles watch --json >a.log 2>&1 &
+a_watcher=$!
+cleanup() {
+  kill "$a_watcher" 2>/dev/null || true
+  wait "$a_watcher" 2>/dev/null || true
+}
+trap cleanup EXIT
+wait_until 150 "grep -q '\"event\":\"started\"' a.log"
+
+# the edit is saved after the debounce and published within the sync
+# interval: well under the 15-second first fetch, reconcile ticks or not
+echo 'bind = SUPER, Q, exec, alacritty' >~/.config/hypr/bindings.lua
+wait_until 50 "git --git-dir=$origin show main:tracked/home/.config/hypr/bindings.lua | grep -q alacritty"
+assert_contains "cat a.log" '"published":"'
+# reconciliation did run meanwhile (each tick reloads the configuration)
+assert "grep -c '\"reason\":\"reconcile\"' a.log | awk '{print (\$1 >= 2) ? \"yes\" : \"no\"}'" "yes"

--- a/e2e/cli/test_dotfiles_sync_auto_reconcile
+++ b/e2e/cli/test_dotfiles_sync_auto_reconcile
@@ -46,6 +46,8 @@ wait_until 150 "grep -q '\"event\":\"started\"' a.log"
 # interval: well under the 15-second first fetch, reconcile ticks or not
 echo 'bind = SUPER, Q, exec, alacritty' >~/.config/hypr/bindings.lua
 wait_until 50 "git --git-dir=$origin show main:tracked/home/.config/hypr/bindings.lua | grep -q alacritty"
-assert_contains "cat a.log" '"published":"'
+# The remote ref becomes visible before the sync's remaining work and its
+# completion event finish. Wait for the event rather than racing that work.
+wait_until 50 "grep -q '\"published\":\"' a.log"
 # reconciliation did run meanwhile (each tick reloads the configuration)
 assert "grep -c '\"reason\":\"reconcile\"' a.log | awk '{print (\$1 >= 2) ? \"yes\" : \"no\"}'" "yes"

--- a/e2e/cli/test_dotfiles_sync_experimental
+++ b/e2e/cli/test_dotfiles_sync_experimental
@@ -19,4 +19,5 @@ scope = "user"
 builtin = "history-watch"
 EOF
 assert_fail "mise bootstrap services apply --yes" 'dotfile tracking is experimental'
-assert_contains "mise doctor 2>&1" 'tracking is experimental and disabled'
+# Doctor may also report missing tools in this isolated HOME.
+assert_contains "mise doctor 2>&1 || true" 'tracking is experimental and disabled'

--- a/e2e/cli/test_dotfiles_sync_experimental
+++ b/e2e/cli/test_dotfiles_sync_experimental
@@ -6,6 +6,7 @@ assert_fail "mise bootstrap dotfiles rollback latest" 'dotfile tracking is exper
 assert_fail "mise bootstrap dotfiles undo" 'dotfile tracking is experimental'
 assert_fail "mise bootstrap dotfiles watch --once" 'dotfile tracking is experimental'
 assert_fail "mise bootstrap dotfiles sync" 'dotfile tracking is experimental'
+assert_fail "mise bootstrap dotfiles machines" 'dotfile tracking is experimental'
 assert_fail "mise bootstrap dotfiles pull" 'dotfile tracking is experimental'
 assert_fail "mise bootstrap dotfiles origin set /nonexistent" 'dotfile tracking is experimental'
 assert_fail "mise bootstrap dotfiles origin --remove" 'dotfile tracking is experimental'

--- a/e2e/cli/test_dotfiles_sync_experimental
+++ b/e2e/cli/test_dotfiles_sync_experimental
@@ -19,6 +19,10 @@ cat >"$MISE_CONFIG_DIR/config.toml" <<'EOF'
 scope = "user"
 builtin = "history-watch"
 EOF
-assert_fail "mise bootstrap services apply --yes" 'dotfile tracking is experimental'
+if mise bootstrap services status --json | jq -e '.[] | select(.action == "unknown")' >/dev/null; then
+  assert_contains "mise bootstrap services apply --yes 2>&1" 'skipped'
+else
+  assert_fail "mise bootstrap services apply --yes" 'dotfile tracking is experimental'
+fi
 # Doctor may also report missing tools in this isolated HOME.
 assert_contains "mise doctor 2>&1 || true" 'tracking is experimental and disabled'

--- a/e2e/cli/test_dotfiles_sync_permissions
+++ b/e2e/cli/test_dotfiles_sync_permissions
@@ -50,3 +50,11 @@ assert "cat $B/.script" $'local\nmiddle\nremote'
 assert_fail "test -x ~/.script"
 assert_fail "test -x $B/.script"
 assert_contains "git --git-dir=$origin ls-tree main tracked/home/.script" "100644"
+
+# Purge holds the sync lock through deletion and disconnection; it must not
+# try to reacquire its own lock or leave the connection active afterwards.
+machine="$(jq -r '.id' "$MISE_STATE_DIR/history/machine.json")"
+assert_succeed "mise bootstrap dotfiles origin --purge --yes"
+assert_contains "mise bootstrap dotfiles status" "Setup repository: none"
+assert "git --git-dir=$origin for-each-ref --format='%(refname)' refs/mise-history/$machine/" ""
+assert_succeed "git --git-dir=$origin rev-parse refs/heads/main"

--- a/e2e/cli/test_dotfiles_sync_permissions
+++ b/e2e/cli/test_dotfiles_sync_permissions
@@ -21,7 +21,7 @@ chmod 644 ~/.script
 assert_succeed "mise bootstrap dotfiles track ~/.script"
 assert_succeed "mise bootstrap dotfiles origin set file://$origin --yes"
 assert_succeed "$b bootstrap dotfiles origin set file://$origin --yes"
-assert_succeed "$b bootstrap dotfiles pull --take-remote $B/.config/mise/config.toml --yes"
+assert_succeed "$b bootstrap dotfiles pull --yes"
 assert_fail "test -x $B/.script"
 
 # Identical bytes, different mode: publish and apply the mode-only edit.

--- a/e2e/cli/test_dotfiles_watch
+++ b/e2e/cli/test_dotfiles_watch
@@ -24,6 +24,18 @@ wait_for_count() {
   return 1
 }
 
+wait_until() {
+  for _ in $(seq 1 100); do
+    if eval "$1" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  echo "timed out waiting for: $1" >&2
+  [[ -f watch.log ]] && cat watch.log >&2
+  return 1
+}
+
 mkdir -p ~/.config/hypr
 echo 'monitor=DP-1' >~/.config/hypr/monitors.lua
 assert_succeed "mise bootstrap dotfiles track ~/.config/hypr"
@@ -88,6 +100,36 @@ assert_succeed "mise bootstrap dotfiles rollback ~/.config/hypr/monitors.lua --y
 sleep 2.5
 assert "cat ~/.config/hypr/monitors.lua" "monitor=DP-3"
 assert "$count" "$((n + 2))"
+
+# a description command names the checkpoints the watcher saves from what it
+# is told: the changed paths that are not private and a diff of the files
+# that are backed up; the checkpoint is saved before it runs
+cat <<'EOF' >"$PWD/describe"
+#!/usr/bin/env bash
+input="$(cat)"
+printf '%s\n' "$input" >>"$HOME/describe-input"
+printf 'agent: %s\n' "$(printf '%s' "$input" | jq -r '(.added + .modified + .removed) | join(",")')"
+EOF
+chmod +x "$PWD/describe"
+cat <<EOF >>"$MISE_CONFIG_DIR/config.toml"
+
+[settings]
+history.describe_command = "$PWD/describe"
+EOF
+wait_until "grep -q 'configuration changed' watch.log"
+echo 'token = "s3cret"' >"$MISE_CONFIG_DIR/github_tokens.toml"
+echo 'monitor=DP-4' >~/.config/hypr/monitors.lua
+wait_until "mise bootstrap dotfiles history --json | jq -e '.[0].description_source == \"command\" and (.[0].description | test(\"^agent: .*monitors.lua\"))'"
+assert_contains "cat ~/describe-input" "monitors.lua"
+assert_contains "cat ~/describe-input" "DP-4"
+assert_not_contains "cat ~/describe-input" "github_tokens"
+assert_not_contains "cat ~/describe-input" "s3cret"
+# a failing command keeps the computed description
+printf '#!/usr/bin/env bash\nexit 3\n' >"$PWD/describe"
+echo 'monitor=DP-5' >~/.config/hypr/monitors.lua
+wait_until "grep -q '\"event\":\"describe-error\"' watch.log"
+assert "mise bootstrap dotfiles history --json | jq -r '.[0].description'" "edited hypr/monitors.lua"
+assert "mise bootstrap dotfiles history --json | jq -r '.[0].description_source'" "computed"
 
 # stopping saves what is still pending
 echo 'monitor=DP-5' >~/.config/hypr/monitors.lua

--- a/e2e/cli/test_ssh
+++ b/e2e/cli/test_ssh
@@ -13,7 +13,9 @@ assert_fail "mise ssh devbox --github-relay-read-only --github-relay-all-repos -
 assert_fail "mise bootstrap remote --host devbox --from-git owner/repo --source ."
 assert_fail "mise bootstrap remote --from-git owner/repo"
 assert_fail "mise bootstrap remote --host devbox --from-git not/a/repository --dry-run"
-assert_contains "mise bootstrap remote --host devbox --from-git owner/repo --dry-run" "https://github.com/owner/repo.git"
+# a dry run fetches the repository like a real run; an unreachable one fails
+# before any connection is made
+assert_fail "mise bootstrap remote --host devbox --from-git file://$PWD/missing.git --dry-run" "could not fetch setup repository"
 
 mkdir -p fakebin
 cat >fakebin/ssh <<'EOF'

--- a/e2e/run_test
+++ b/e2e/run_test
@@ -105,6 +105,7 @@ within_isolated_env() {
         LLVM_PROFILE_FILE="${LLVM_PROFILE_FILE:-}" \
         ${proxy_vars[@]+"${proxy_vars[@]}"} \
         MISE_CACHE_DIR="$MISE_CACHE_DIR" \
+        MISE_HISTORY_NOTIFY=0 \
         MISE_URL_REPLACEMENTS="${MISE_URL_REPLACEMENTS:-}" \
         MISE_CACHE_PRUNE_AGE="0" \
         MISE_CONFIG_DIR="$MISE_CONFIG_DIR" \

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -6665,6 +6665,9 @@ Internal session adapter
 .TP
 \fB\-\-repository\-yes\fR
 .TP
+\fB\-\-repository\-dry\-run\fR
+Preview the transferred repository's installation without writing it
+.TP
 \fB\-\-global\-config\-directory\fR
 .TP
 \fB\-h, \-\-help\fR

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -6671,6 +6671,8 @@ Internal session adapter
 \fB\-\-repository\-dry\-run\fR
 Preview the transferred repository's installation without writing it
 .TP
+\fB\-\-repository\-preview\-directory\fR \fI<REPOSITORY_PREVIEW_DIRECTORY>\fR
+.TP
 \fB\-\-global\-config\-directory\fR
 .TP
 \fB\-h, \-\-help\fR

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1834,11 +1834,13 @@ file written and journaled one at a time, reload hooks only afterwards,
 and `mise bootstrap dotfiles undo` to reverse it. Configuration and the sources it
 references apply together; an incoming configuration file that does not
 parse, a path with unsaved local edits, staged git changes in your own
-checkout, or a genuine local edit pauses the complete application.
-Conflicts pause both publication and application for the whole setup;
-local history and fetching continue. Decisions are recorded per path
-with `\-\-take\-remote` or `\-\-keep\-local`; sharing resumes only after all
-conflicts are resolved and the plan has been recomputed.
+checkout, or a genuine local edit is held with its group. Conflicts
+are decided per path with `\-\-take\-remote` or `\-\-keep\-local`.
+
+In `sync` mode the history watcher pulls nonconflicting changes on its
+own; this command writes what is pending right now and decides
+conflicts. When an incoming configuration declares more tracked files,
+their shared versions follow in the same run.
 .PP
 \fBUsage:\fR mise bootstrap dotfiles pull [OPTIONS] [<PATH>] ...
 .PP
@@ -1981,6 +1983,9 @@ head; a rejection fetches again and retries), uploads eligible
 checkpoints, and records incoming changes to apply and conflicts to
 decide. Live files are never changed here: `mise bootstrap dotfiles pull` does
 that. In `fetch\-only` mode nothing is published.
+
+The history watcher does this on its own in `sync` and `fetch\-only` mode
+(`settings.history.sync`); this command is for right now.
 .PP
 \fBUsage:\fR mise bootstrap dotfiles sync [OPTIONS]
 .PP
@@ -2133,6 +2138,14 @@ reconciles the whole set at startup, every `history.watch.reconcile`,
 and when the configuration changes. Manual\-save entries are never
 watched.
 
+With a connected setup repository the watcher also synchronizes per
+`settings.history.sync`: in `sync` mode it publishes within
+`history.sync_interval` after a save, fetches every
+`history.fetch_interval`, and applies nonconflicting incoming changes;
+in `fetch\-only` mode it only fetches; in `manual` mode it does nothing
+on the network. A failed sync backs off and is retried while saving
+continues. `\-\-once` runs one reconcile and one such synchronization.
+
 The `history\-watch` built\-in service runs this for you:
 
     [bootstrap.services.mise\-history]
@@ -2150,7 +2163,7 @@ is deferred.
 .PP
 .TP
 \fB\-\-once\fR
-Reconcile once and exit (for timers and cron)
+Reconcile and synchronize once and exit (for timers and cron)
 .TP
 \fB\-J, \-\-json\fR
 One JSON object per line instead of log lines

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2874,6 +2874,9 @@ installs persistent global configuration; preview that choice with `\-\-dry\-run
 \fBOptions:\fR
 .PP
 .TP
+\fB\-\-experimental\fR
+Enable experimental features on the target; retain opt\-in after tracking setup
+.TP
 \fB\-\-from\-git\fR \fI<GIT_URL|OWNER/REPO>\fR
 Install a Git repository as persistent global configuration on each target
 .TP

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1834,10 +1834,13 @@ file written and journaled one at a time, reload hooks only afterwards,
 and `mise bootstrap dotfiles undo` to reverse it. Configuration and the sources it
 references apply together; an incoming configuration file that does not
 parse, a path with unsaved local edits, staged git changes in your own
-checkout, or a genuine local edit is held with its group. Conflicts
-are decided per path with `\-\-take\-remote` or `\-\-keep\-local`.
+checkout, or a genuine local edit pauses the complete application.
+Conflicts pause both publication and application for the whole setup;
+local history and fetching continue. Decisions are recorded per path
+with `\-\-take\-remote` or `\-\-keep\-local`; sharing resumes only after all
+conflicts are resolved and the plan has been recomputed.
 
-In `sync` mode the history watcher pulls nonconflicting changes on its
+In `sync` mode the watcher pulls conflict\-free setups on its
 own; this command writes what is pending right now and decides
 conflicts. When an incoming configuration declares more tracked files,
 their shared versions follow in the same run.

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2144,7 +2144,7 @@ watched.
 With a connected setup repository the watcher also synchronizes per
 `settings.history.sync`: in `sync` mode it publishes within
 `history.sync_interval` after a save, fetches every
-`history.fetch_interval`, and applies nonconflicting incoming changes;
+`history.fetch_interval`, and applies incoming changes once the complete setup is conflict\-free;
 in `fetch\-only` mode it only fetches; in `manual` mode it does nothing
 on the network. A failed sync backs off and is retried while saving
 continues. `\-\-once` runs one reconcile and one such synchronization.

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -879,6 +879,11 @@ Conflicts pause both publication and application for the whole setup;
 local history and fetching continue. Decisions are recorded per path
 with `--take-remote` or `--keep-local`; sharing resumes only after all
 conflicts are resolved and the plan has been recomputed.
+
+In `sync` mode the watcher pulls conflict-free setups on its
+own; this command writes what is pending right now and decides
+conflicts. When an incoming configuration declares more tracked files,
+their shared versions follow in the same run.
 """#
             after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap dotfiles pull --dry-run\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles pull --yes\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles pull ~/.config/hypr\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles pull --take-remote ~/.zshrc\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles pull --keep-local ~/.zshrc\u{1b}[22m\n"
             flag "-n --dry-run" help="Show the plan without changing anything"
@@ -970,6 +975,9 @@ head; a rejection fetches again and retries), uploads eligible
 checkpoints, and records incoming changes to apply and conflicts to
 decide. Live files are never changed here: `mise bootstrap dotfiles pull` does
 that. In `fetch-only` mode nothing is published.
+
+The history watcher does this on its own in `sync` and `fetch-only` mode
+(`settings.history.sync`); this command is for right now.
 """#
             flag --fetch-only help="Fetch without publishing"
             flag --best-effort help="Warn instead of failing when the origin is unreachable"
@@ -1061,6 +1069,14 @@ reconciles the whole set at startup, every `history.watch.reconcile`,
 and when the configuration changes. Manual-save entries are never
 watched.
 
+With a connected setup repository the watcher also synchronizes per
+`settings.history.sync`: in `sync` mode it publishes within
+`history.sync_interval` after a save, fetches every
+`history.fetch_interval`, and applies nonconflicting incoming changes;
+in `fetch-only` mode it only fetches; in `manual` mode it does nothing
+on the network. A failed sync backs off and is retried while saving
+continues. `--once` runs one reconcile and one such synchronization.
+
 The `history-watch` built-in service runs this for you:
 
     [bootstrap.services.mise-history]
@@ -1073,7 +1089,7 @@ the pending changes; one that would overlap another history operation
 is deferred.
 """#
             after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap dotfiles watch\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles watch --once\u{1b}[22m      # one reconcile, for a timer\n    $ \u{1b}[1mmise bootstrap dotfiles watch --json\u{1b}[22m\n"
-            flag --once help="Reconcile once and exit (for timers and cron)"
+            flag --once help="Reconcile and synchronize once and exit (for timers and cron)"
             flag "-J --json" help="One JSON object per line instead of log lines"
             flag "-h --help" help="Print help" action=help builtin=#true
         }

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -4596,6 +4596,7 @@ cmd ssh help="Open an SSH session, optionally borrowing read-only GitHub access"
     }
     flag --repository-update hide=#true
     flag --repository-yes hide=#true
+    flag --repository-dry-run help="Preview the transferred repository's installation without writing it" hide=#true
     flag --global-config-directory hide=#true
     flag "-h --help" help="Print help" action=help builtin=#true
     arg "[DESTINATION]" help="OpenSSH destination or SSH-config alias" required=#false

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1494,6 +1494,7 @@ Select inventory hosts by name, tag, or `--all`, or supply ad-hoc `--host` targe
 The source is staged on each target and bootstrap runs there. `--from-git` instead
 installs persistent global configuration; preview that choice with `--dry-run`.
 """#
+        flag --experimental help="Enable experimental features on the target; retain opt-in after tracking setup"
         flag --from-git help="Install a Git repository as persistent global configuration on each target" {
             conflicts "--source" "--copy-link" "--copy-links" "--exclude"
             arg "<GIT_URL|OWNER/REPO>"

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1072,7 +1072,7 @@ watched.
 With a connected setup repository the watcher also synchronizes per
 `settings.history.sync`: in `sync` mode it publishes within
 `history.sync_interval` after a save, fetches every
-`history.fetch_interval`, and applies nonconflicting incoming changes;
+`history.fetch_interval`, and applies incoming changes once the complete setup is conflict-free;
 in `fetch-only` mode it only fetches; in `manual` mode it does nothing
 on the network. A failed sync backs off and is retried while saving
 continues. `--once` runs one reconcile and one such synchronization.

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -4598,6 +4598,9 @@ cmd ssh help="Open an SSH session, optionally borrowing read-only GitHub access"
     flag --repository-update hide=#true
     flag --repository-yes hide=#true
     flag --repository-dry-run help="Preview the transferred repository's installation without writing it" hide=#true
+    flag --repository-preview-directory hide=#true {
+        arg <REPOSITORY_PREVIEW_DIRECTORY>
+    }
     flag --global-config-directory hide=#true
     flag "-h --help" help="Print help" action=help builtin=#true
     arg "[DESTINATION]" help="OpenSSH destination or SSH-config alias" required=#false

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1154,8 +1154,8 @@
               }
             },
             "notify": {
-              "default": false,
-              "description": "Show a desktop notification when a sync conflict newly needs a decision. Off by default; each conflict notifies once, and a notifier that is missing or failing never holds up history or sync.",
+              "default": true,
+              "description": "Show a desktop notification when conflicts pause sharing for the setup. Enabled by default; retries stay silent until sharing recovers, and a notifier that is missing or failing never holds up history or sync.",
               "type": "boolean"
             },
             "sync": {

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1121,6 +1121,11 @@
           "type": "object",
           "unevaluatedProperties": false,
           "properties": {
+            "describe_command": {
+              "default": "",
+              "description": "A command that names checkpoints the watcher saves (an agent, say): it gets one JSON object on stdin (uuid, trigger, the computed description, the changed paths that are not private, and a unified diff of the changed files that are backed up, at most 64 KiB) and prints one line of at most 200 characters, which becomes the description. Empty: computed descriptions only.",
+              "type": "string"
+            },
             "enabled": {
               "default": true,
               "description": "Record experimental configuration history: a checkpoint of the tracked files before and after every mutating bootstrap command, and on every explicit save. Requires experimental = true.",

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1160,7 +1160,7 @@
             },
             "sync": {
               "default": "sync",
-              "description": "What the history watcher does with a connected setup repository on its own: `sync` publishes after saves, fetches periodically, and applies nonconflicting incoming changes; `fetch-only` only fetches; `manual` does nothing automatically. `mise bootstrap dotfiles sync` and `pull` work on request in every mode.",
+              "description": "What the history watcher does with a connected setup repository on its own: `sync` publishes after saves, fetches periodically, and applies incoming changes. Any conflict pauses publication and incoming application for the entire setup; local history, fetching, and eligible backups continue. `fetch-only` only fetches; `manual` does nothing automatically. `mise bootstrap dotfiles sync` and `pull` work on request in every mode.",
               "type": "string",
               "enum": ["sync", "fetch-only", "manual"]
             },

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1148,9 +1148,14 @@
                 }
               }
             },
+            "notify": {
+              "default": false,
+              "description": "Show a desktop notification when a sync conflict newly needs a decision. Off by default; each conflict notifies once, and a notifier that is missing or failing never holds up history or sync.",
+              "type": "boolean"
+            },
             "sync": {
               "default": "sync",
-              "description": "How a connected setup repository is used: `sync` publishes, fetches, and queues nonconflicting incoming changes for application; `fetch-only` only downloads; `manual` publishes and fetches but never applies by itself. `mise bootstrap dotfiles pull` writes queued changes.",
+              "description": "What the history watcher does with a connected setup repository on its own: `sync` publishes after saves, fetches periodically, and applies nonconflicting incoming changes; `fetch-only` only fetches; `manual` does nothing automatically. `mise bootstrap dotfiles sync` and `pull` work on request in every mode.",
               "type": "string",
               "enum": ["sync", "fetch-only", "manual"]
             },

--- a/settings.toml
+++ b/settings.toml
@@ -1244,6 +1244,18 @@ env = "MISE_GPG_VERIFY"
 optional = true
 type = "Bool"
 
+[history.describe_command]
+default = ""
+description = "A command that names checkpoints the watcher saves (an agent, say): it gets one JSON object on stdin (uuid, trigger, the computed description, the changed paths that are not private, and a unified diff of the changed files that are backed up, at most 64 KiB) and prints one line of at most 200 characters, which becomes the description. Empty: computed descriptions only."
+docs = """
+The checkpoint is saved before the command runs and keeps its computed description when the
+command fails, prints nothing, or takes longer than 30 seconds. It runs once per checkpoint the
+watcher saved, never per filesystem event or retry, one at a time. Private files (`*.local.toml`,
+credential stores) are never named, and a file with `backup = false` never has its contents sent.
+"""
+env = "MISE_HISTORY_DESCRIBE_COMMAND"
+type = "String"
+
 [history.enabled]
 default = true
 description = "Record experimental configuration history: a checkpoint of the tracked files before and after every mutating bootstrap command, and on every explicit save. Requires experimental = true."

--- a/settings.toml
+++ b/settings.toml
@@ -1291,8 +1291,8 @@ rust_type = "usize"
 type = "Integer"
 
 [history.notify]
-default = false
-description = "Show a desktop notification when a sync conflict newly needs a decision. Off by default; each conflict notifies once, and a notifier that is missing or failing never holds up history or sync."
+default = true
+description = "Show a desktop notification when conflicts pause sharing for the setup. Enabled by default; retries stay silent until sharing recovers, and a notifier that is missing or failing never holds up history or sync."
 docs = """
 Linux uses `notify-send`, macOS `osascript`; other platforms log the conflict only.
 `mise bootstrap dotfiles status` and `mise doctor` show the same conflicts without notifications.
@@ -1302,7 +1302,7 @@ type = "Bool"
 
 [history.sync]
 default = "sync"
-description = "What the history watcher does with a connected setup repository on its own: `sync` publishes after saves, fetches periodically, and applies nonconflicting incoming changes; `fetch-only` only fetches; `manual` does nothing automatically. `mise bootstrap dotfiles sync` and `pull` work on request in every mode."
+description = "What the history watcher does with a connected setup repository on its own: `sync` publishes after saves, fetches periodically, and applies incoming changes. Any conflict pauses publication and incoming application for the entire setup; local history, fetching, and eligible backups continue. `fetch-only` only fetches; `manual` does nothing automatically. `mise bootstrap dotfiles sync` and `pull` work on request in every mode."
 docs = """
 Chosen and disclosed by `mise bootstrap dotfiles origin set`. Publication happens at most every
 `history.sync_interval` after a save, fetching every `history.fetch_interval`; failures back

--- a/settings.toml
+++ b/settings.toml
@@ -1278,13 +1278,23 @@ env = "MISE_HISTORY_KEEP_COUNT"
 rust_type = "usize"
 type = "Integer"
 
+[history.notify]
+default = false
+description = "Show a desktop notification when a sync conflict newly needs a decision. Off by default; each conflict notifies once, and a notifier that is missing or failing never holds up history or sync."
+docs = """
+Linux uses `notify-send`, macOS `osascript`; other platforms log the conflict only.
+`mise bootstrap dotfiles status` and `mise doctor` show the same conflicts without notifications.
+"""
+env = "MISE_HISTORY_NOTIFY"
+type = "Bool"
+
 [history.sync]
 default = "sync"
-description = "How a connected setup repository is used: `sync` publishes, fetches, and queues nonconflicting incoming changes for application; `fetch-only` only downloads; `manual` publishes and fetches but never applies by itself. `mise bootstrap dotfiles pull` writes queued changes."
+description = "What the history watcher does with a connected setup repository on its own: `sync` publishes after saves, fetches periodically, and applies nonconflicting incoming changes; `fetch-only` only fetches; `manual` does nothing automatically. `mise bootstrap dotfiles sync` and `pull` work on request in every mode."
 docs = """
-Chosen and disclosed by `mise bootstrap dotfiles origin set`. In this release `mise bootstrap
-dotfiles sync` publishes and fetches and `mise bootstrap dotfiles pull` writes what is queued;
-the watcher's automatic publication and application follow. Applying never runs
+Chosen and disclosed by `mise bootstrap dotfiles origin set`. Publication happens at most every
+`history.sync_interval` after a save, fetching every `history.fetch_interval`; failures back
+off (one minute doubling to an hour) and local saves continue meanwhile. Applying never runs
 `mise bootstrap`, installs packages, or renders templates: when incoming configuration
 changes declarations, `mise bootstrap dotfiles status` says to run `mise bootstrap`.
 """

--- a/settings.toml
+++ b/settings.toml
@@ -1294,7 +1294,10 @@ type = "Integer"
 default = true
 description = "Show a desktop notification when conflicts pause sharing for the setup. Enabled by default; retries stay silent until sharing recovers, and a notifier that is missing or failing never holds up history or sync."
 docs = """
-Linux uses `notify-send`, macOS `osascript`; other platforms log the conflict only.
+Linux uses `notify-send`. macOS uses a bundled mise helper app with the mise icon;
+allow notifications for mise when macOS asks on first use. Permission can be
+changed later in System Settings > Notifications > mise. No extra notifier is
+required. Other platforms log the conflict only.
 `mise bootstrap dotfiles status` and `mise doctor` show the same conflicts without notifications.
 """
 env = "MISE_HISTORY_NOTIFY"

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -3116,16 +3116,9 @@ impl BootstrapRemote {
             .transpose()?;
         if let Some(origin) = &repository {
             system::remote_repository::validate_origin(origin)?;
-            if self.dry_run {
-                for host in selected.values() {
-                    miseprintln!(
-                        "Would fetch one revision of {origin} locally, transfer it to {}, preview adoption/update of the persistent global configuration, and bootstrap there",
-                        host.name
-                    );
-                }
-                return Ok(());
-            }
         }
+        // a dry run fetches and transfers like a real one: the preview comes
+        // from the target, which inspects itself and the repository
         let repository = if let Some(origin) = repository {
             Some(
                 system::remote::interruptible(system::remote_repository::Source::fetch(origin))

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -1864,6 +1864,25 @@ impl Bootstrap {
             .as_deref()
             .map(crate::github_relay::expand_repository)
             .transpose()?;
+        // a history-managed setup repository is not cloned into the
+        // configuration directory: its branch goes into mise's own store and
+        // its files are written by the same recoverable pull as any other
+        // incoming change; the ordinary bootstrap then runs from them
+        if let Some(url) = expanded.as_deref()
+            && config::Settings::get().history.enabled
+            && let Some(outcome) =
+                system::history::sync::onboard::from_git(url, self.yes, self.dry_run).await?
+        {
+            if self.dry_run {
+                return Ok(());
+            }
+            let config_dir = system::history::tracked::global_config_dir();
+            self.run_child_bootstrap(config_dir).await?;
+            if !outcome.durable_access {
+                warn!("ongoing synchronization still needs credentials on this host (see above)");
+            }
+            return Ok(());
+        }
         let (url, checkout) = if let Some(url) = expanded.as_deref() {
             let checkout = crate::env::MISE_GLOBAL_CONFIG_FILE
                 .as_deref()
@@ -1921,6 +1940,12 @@ impl Bootstrap {
             return Ok(());
         }
 
+        self.run_child_bootstrap(checkout).await
+    }
+
+    /// Runs the bootstrap itself as a child process from `checkout` (the
+    /// global configuration directory for `--from-git`), trusted for it.
+    async fn run_child_bootstrap(&self, checkout: PathBuf) -> Result<()> {
         let checkout = dunce::canonicalize(&checkout)?;
         let mut command = Command::new(std::env::current_exe()?);
         command.args(bootstrap_from_child_args(

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -1883,6 +1883,10 @@ impl Bootstrap {
                 system::history::sync::onboard::from_git(url, self.yes, self.dry_run).await?
         {
             if self.dry_run {
+                if let Some(preview) = outcome.preview_config.as_ref() {
+                    self.run_child_bootstrap(preview.path().to_path_buf())
+                        .await?;
+                }
                 return Ok(());
             }
             // the configuration that arrived is what to bootstrap from; one
@@ -1970,19 +1974,28 @@ impl Bootstrap {
             &crate::env::ARGS.read().unwrap(),
         ));
         if self.from_git.is_some() {
-            let config_dir = crate::env::MISE_CONFIG_DIR.as_path();
-            let config_dir = if config_dir.is_absolute() {
-                config_dir.to_path_buf()
+            if self.dry_run {
+                command.env("MISE_CONFIG_DIR", &checkout);
+                let name = crate::env::MISE_GLOBAL_CONFIG_FILE
+                    .as_deref()
+                    .and_then(Path::file_name)
+                    .unwrap_or(std::ffi::OsStr::new("config.toml"));
+                command.env("MISE_GLOBAL_CONFIG_FILE", checkout.join(name));
             } else {
-                std::env::current_dir()?.join(config_dir)
-            };
-            command.env("MISE_CONFIG_DIR", config_dir);
+                let config_dir = crate::env::MISE_CONFIG_DIR.as_path();
+                let config_dir = if config_dir.is_absolute() {
+                    config_dir.to_path_buf()
+                } else {
+                    std::env::current_dir()?.join(config_dir)
+                };
+                command.env("MISE_CONFIG_DIR", config_dir);
 
-            if let Some(file_name) = crate::env::MISE_GLOBAL_CONFIG_FILE
-                .as_deref()
-                .and_then(Path::file_name)
-            {
-                command.env("MISE_GLOBAL_CONFIG_FILE", checkout.join(file_name));
+                if let Some(file_name) = crate::env::MISE_GLOBAL_CONFIG_FILE
+                    .as_deref()
+                    .and_then(Path::file_name)
+                {
+                    command.env("MISE_GLOBAL_CONFIG_FILE", checkout.join(file_name));
+                }
             }
         }
 

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -1876,6 +1876,14 @@ impl Bootstrap {
             if self.dry_run {
                 return Ok(());
             }
+            // the configuration that arrived is what to bootstrap from; one
+            // held for a decision leaves the existing one, whose tasks and
+            // installations are not what was asked for
+            if outcome.configuration_held {
+                bail!(
+                    "the configuration from {url} waits for a decision (a differing one is here already); nothing was bootstrapped. `mise bootstrap dotfiles status` lists it, `mise bootstrap dotfiles pull --take-remote|--keep-local <path>` decides, then run `mise bootstrap`"
+                );
+            }
             let config_dir = system::history::tracked::global_config_dir();
             self.run_child_bootstrap(config_dir).await?;
             if !outcome.durable_access {

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -1869,7 +1869,6 @@ impl Bootstrap {
         // its files are written by the same recoverable pull as any other
         // incoming change; the ordinary bootstrap then runs from them
         if let Some(url) = expanded.as_deref()
-            && config::Settings::get().history.enabled
             && let Some(outcome) =
                 system::history::sync::onboard::from_git(url, self.yes, self.dry_run).await?
         {

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -649,6 +649,9 @@ struct BootstrapComposeStatus {
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment)]
 struct BootstrapRemote {
+    /// Enable experimental features on the target; retain opt-in after tracking setup
+    #[usage(long)]
+    experimental: bool,
     /// Install a Git repository as persistent global configuration on each target
     #[usage(long, value_name = "GIT_URL|OWNER/REPO", conflicts = ["source", "copy_link", "copy_links", "exclude"])]
     from_git: Option<String>,
@@ -1654,6 +1657,13 @@ impl Bootstrap {
             }
             self.run_hooks(&config, &hooks, BootstrapHookPhase::PostDotfiles)
                 .await?;
+            if !self.dry_run
+                && files
+                    .iter()
+                    .any(|file| file.mode == system::files::FileMode::Track)
+            {
+                system::remote::persist_experimental_opt_in()?;
+            }
         }
 
         if skip.contains(&BootstrapPart::Shell) {
@@ -3083,6 +3093,7 @@ impl BootstrapRemote {
             bootstrap_command: self.bootstrap_command,
         };
         let options = system::remote::RemoteRunOptions {
+            experimental: self.experimental,
             relay,
             dry_run: self.dry_run,
             yes: self.yes,
@@ -3127,6 +3138,21 @@ impl BootstrapRemote {
             None
         };
         let mut artifacts = system::remote::RemoteArtifactResolver::default();
+        if !options.experimental {
+            let tracking = if let Some(repository) = &repository {
+                system::remote_repository::history_branch(&repository.bundle, &repository.revision)?
+                    .is_some()
+            } else {
+                system::files::files_from_config(&config)?
+                    .iter()
+                    .any(|file| file.mode == system::files::FileMode::Track)
+            };
+            if tracking {
+                bail!(
+                    "remote dotfile tracking requires explicit opt-in: pass `mise bootstrap remote --experimental`"
+                );
+            }
+        }
         for host in selected.values() {
             if let Err(error) =
                 system::remote::run(host, &options, &mut artifacts, repository.as_ref()).await

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -3138,20 +3138,14 @@ impl BootstrapRemote {
             None
         };
         let mut artifacts = system::remote::RemoteArtifactResolver::default();
-        if !options.experimental {
-            let tracking = if let Some(repository) = &repository {
-                system::remote_repository::history_branch(&repository.bundle, &repository.revision)?
-                    .is_some()
-            } else {
-                system::files::files_from_config(&config)?
-                    .iter()
-                    .any(|file| file.mode == system::files::FileMode::Track)
-            };
-            if tracking {
-                bail!(
-                    "remote dotfile tracking requires explicit opt-in: pass `mise bootstrap remote --experimental`"
-                );
-            }
+        if !options.experimental
+            && let Some(repository) = &repository
+            && system::remote_repository::history_branch(&repository.bundle, &repository.revision)?
+                .is_some()
+        {
+            bail!(
+                "remote dotfile tracking requires explicit opt-in: pass `mise bootstrap remote --experimental`"
+            );
         }
         for host in selected.values() {
             if let Err(error) =

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -90,6 +90,33 @@ struct DotfilesDiagnosis {
     /// is longer than a few fetch intervals (a transient error is not).
     sync_error: Option<String>,
     sync_failing_for_secs: Option<u64>,
+    /// Failed syncs in a row, since the last success.
+    sync_failures: u32,
+}
+
+/// How long syncs have been failing: since the current run of failures
+/// began, or, for a record from before that was kept, since the last
+/// success. `None` when nothing is known.
+fn sync_failure_duration(
+    status: &crate::system::history::sync::run::SyncStatus,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Option<u64> {
+    let since = status
+        .failing_since
+        .as_deref()
+        .and_then(|at| chrono::DateTime::parse_from_rfc3339(at).ok())
+        .or_else(|| {
+            [&status.last_fetch, &status.last_publish]
+                .into_iter()
+                .flatten()
+                .filter_map(|at| chrono::DateTime::parse_from_rfc3339(at).ok())
+                .max()
+        })?;
+    Some(
+        (now - since.with_timezone(&chrono::Utc))
+            .num_seconds()
+            .max(0) as u64,
+    )
 }
 
 enum SystemLoginShellDiagnosis {
@@ -730,6 +757,7 @@ impl Doctor {
             sync_conflicts: vec![],
             sync_error: None,
             sync_failing_for_secs: None,
+            sync_failures: 0,
         };
         if let Some(reason) = unavailable {
             self.errors.push(format!(
@@ -798,27 +826,20 @@ impl Doctor {
             }
             if let Some(error) = &status.last_error {
                 diagnosis.sync_error = Some(error.clone());
+                diagnosis.sync_failures = status.consecutive_failures;
                 let fetch_interval = crate::duration::parse_duration(
                     &crate::config::Settings::get().history.fetch_interval,
                 )
                 .map(|d| d.as_secs())
                 .unwrap_or(900);
-                let last_success = [&status.last_fetch, &status.last_publish]
-                    .into_iter()
-                    .flatten()
-                    .filter_map(|at| chrono::DateTime::parse_from_rfc3339(at).ok())
-                    .max();
-                let failing_for = last_success.map(|at| {
-                    (chrono::Utc::now() - at.with_timezone(&chrono::Utc))
-                        .num_seconds()
-                        .max(0) as u64
-                });
+                let failing_for = sync_failure_duration(&status, chrono::Utc::now());
                 // a single failed attempt is transient; a repository that has
                 // not answered for a few fetch intervals is a problem
                 if failing_for.is_some_and(|secs| secs > fetch_interval.saturating_mul(3)) {
                     diagnosis.sync_failing_for_secs = failing_for;
                     self.warnings.push(format!(
-                        "dotfiles: syncing with the setup repository keeps failing ({error}).\n     Local checkpoints continue; nothing is published or pulled until it succeeds.\n     Inspect with: mise bootstrap dotfiles status"
+                        "dotfiles: syncing with the setup repository keeps failing ({error}; {} attempt(s)).\n     Local checkpoints continue; nothing is published or pulled until it succeeds.\n     Inspect with: mise bootstrap dotfiles status",
+                        status.consecutive_failures
                     ));
                 }
             }
@@ -877,10 +898,11 @@ impl Doctor {
         if let Some(error) = &diagnosis.sync_error {
             match diagnosis.sync_failing_for_secs {
                 Some(secs) => lines.push(format!(
-                    "sync failing for {}: {error}",
+                    "sync failing for {} ({} attempt(s)): {error}",
                     crate::system::history::watch::runtime::humantime(
                         std::time::Duration::from_secs(secs)
-                    )
+                    ),
+                    diagnosis.sync_failures
                 )),
                 None if diagnosis.sync_conflicts.is_empty() => {
                     lines.push(format!("last sync error (transient): {error}"))
@@ -1566,7 +1588,47 @@ fn install_dir_is_empty(path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::install_dir_is_empty;
+    use super::{install_dir_is_empty, sync_failure_duration};
+    use crate::system::history::sync::run::SyncStatus;
+
+    fn ago(now: chrono::DateTime<chrono::Utc>, secs: i64) -> Option<String> {
+        Some((now - chrono::Duration::seconds(secs)).to_rfc3339())
+    }
+
+    #[test]
+    fn a_failure_run_is_measured_from_its_start() {
+        // the fetch is stamped before a publication can fail, so a repository
+        // whose publications keep failing still has a recent fetch
+        let now = chrono::Utc::now();
+        let status = SyncStatus {
+            failing_since: ago(now, 100),
+            last_fetch: ago(now, 10),
+            ..Default::default()
+        };
+        assert_eq!(sync_failure_duration(&status, now), Some(100));
+    }
+
+    #[test]
+    fn an_origin_that_never_worked_still_counts() {
+        let now = chrono::Utc::now();
+        let status = SyncStatus {
+            failing_since: ago(now, 30),
+            ..Default::default()
+        };
+        assert_eq!(sync_failure_duration(&status, now), Some(30));
+    }
+
+    #[test]
+    fn an_older_record_falls_back_to_the_last_success() {
+        let now = chrono::Utc::now();
+        let status = SyncStatus {
+            last_publish: ago(now, 50),
+            last_fetch: ago(now, 80),
+            ..Default::default()
+        };
+        assert_eq!(sync_failure_duration(&status, now), Some(50));
+        assert_eq!(sync_failure_duration(&SyncStatus::default(), now), None);
+    }
 
     #[test]
     fn empty_directory_is_reported() {

--- a/src/cli/dotfiles/history_status.rs
+++ b/src/cli/dotfiles/history_status.rs
@@ -38,6 +38,9 @@ pub(crate) struct SyncReport {
     pub conflicts: Vec<(String, String)>,
     pub declarations_changed: bool,
     pub last_error: Option<String>,
+    /// When the current run of failed syncs began, and how many so far.
+    pub failing_since: Option<String>,
+    pub consecutive_failures: u32,
     pub application_failure: Option<String>,
     pub validation_error: Option<String>,
 }
@@ -89,6 +92,8 @@ pub(crate) fn sync_report(
         conflicts: apply::describe_conflicts(&status.conflicts),
         declarations_changed: status.declarations_changed,
         last_error: status.last_error.clone(),
+        failing_since: status.failing_since.clone(),
+        consecutive_failures: status.consecutive_failures,
         application_failure: status.application_failure.clone(),
         validation_error: status.validation_error.clone(),
     }))
@@ -227,7 +232,14 @@ pub(crate) fn print(report: &HistoryReport) -> Result<()> {
                 miseprintln!("  declarations changed: run `mise bootstrap` (dry-run available)");
             }
             if let Some(error) = &sync.last_error {
-                miseprintln!("  last error: {error}");
+                match &sync.failing_since {
+                    Some(since) => miseprintln!(
+                        "  last error: {error} (failing since {}, {} attempt(s))",
+                        local_time(since),
+                        sync.consecutive_failures
+                    ),
+                    None => miseprintln!("  last error: {error}"),
+                }
             }
             if let Some(error) = &sync.application_failure {
                 miseprintln!("  sync paused: {error}");

--- a/src/cli/dotfiles/pull.rs
+++ b/src/cli/dotfiles/pull.rs
@@ -19,6 +19,11 @@ use crate::system::history::sync::apply::{self, ApplyRequest};
 /// local history and fetching continue. Decisions are recorded per path
 /// with `--take-remote` or `--keep-local`; sharing resumes only after all
 /// conflicts are resolved and the plan has been recomputed.
+///
+/// In `sync` mode the watcher pulls conflict-free setups on its
+/// own; this command writes what is pending right now and decides
+/// conflicts. When an incoming configuration declares more tracked files,
+/// their shared versions follow in the same run.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(crate) struct DotfilesPull {
@@ -62,9 +67,11 @@ impl DotfilesPull {
                 yes: self.yes,
                 take_remote: self.take_remote.clone(),
                 keep_local: self.keep_local.clone(),
+                automatic: false,
             },
         )
-        .await
+        .await?;
+        Ok(())
     }
 }
 

--- a/src/cli/dotfiles/pull.rs
+++ b/src/cli/dotfiles/pull.rs
@@ -68,6 +68,7 @@ impl DotfilesPull {
                 take_remote: self.take_remote.clone(),
                 keep_local: self.keep_local.clone(),
                 automatic: false,
+                plan_only: false,
             },
         )
         .await?;

--- a/src/cli/dotfiles/sync.rs
+++ b/src/cli/dotfiles/sync.rs
@@ -10,6 +10,9 @@ use crate::system::history::sync::run::{self, SyncRequest};
 /// checkpoints, and records incoming changes to apply and conflicts to
 /// decide. Live files are never changed here: `mise bootstrap dotfiles pull` does
 /// that. In `fetch-only` mode nothing is published.
+///
+/// The history watcher does this on its own in `sync` and `fetch-only` mode
+/// (`settings.history.sync`); this command is for right now.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment)]
 pub(crate) struct DotfilesSync {
@@ -43,13 +46,7 @@ impl DotfilesSync {
         if let Some(reason) = store.unavailable() {
             bail!("cannot synchronize: {reason}");
         }
-        let outcome = run::sync(
-            &store,
-            &tracked,
-            &SyncRequest {
-                fetch_only: self.fetch_only,
-            },
-        )?;
+        let outcome = run::sync(&store, &tracked, &SyncRequest::new(self.fetch_only))?;
         crate::system::history::sync::origin::report(&outcome);
         Ok(())
     }

--- a/src/cli/dotfiles/watch.rs
+++ b/src/cli/dotfiles/watch.rs
@@ -12,6 +12,14 @@ use crate::system::history::watch::runtime::{self, WatchOptions};
 /// and when the configuration changes. Manual-save entries are never
 /// watched.
 ///
+/// With a connected setup repository the watcher also synchronizes per
+/// `settings.history.sync`: in `sync` mode it publishes within
+/// `history.sync_interval` after a save, fetches every
+/// `history.fetch_interval`, and applies nonconflicting incoming changes;
+/// in `fetch-only` mode it only fetches; in `manual` mode it does nothing
+/// on the network. A failed sync backs off and is retried while saving
+/// continues. `--once` runs one reconcile and one such synchronization.
+///
 /// The `history-watch` built-in service runs this for you:
 ///
 ///     [bootstrap.services.mise-history]
@@ -25,7 +33,7 @@ use crate::system::history::watch::runtime::{self, WatchOptions};
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(crate) struct DotfilesWatch {
-    /// Reconcile once and exit (for timers and cron)
+    /// Reconcile and synchronize once and exit (for timers and cron)
     #[usage(long)]
     once: bool,
 

--- a/src/cli/dotfiles/watch.rs
+++ b/src/cli/dotfiles/watch.rs
@@ -15,7 +15,7 @@ use crate::system::history::watch::runtime::{self, WatchOptions};
 /// With a connected setup repository the watcher also synchronizes per
 /// `settings.history.sync`: in `sync` mode it publishes within
 /// `history.sync_interval` after a save, fetches every
-/// `history.fetch_interval`, and applies nonconflicting incoming changes;
+/// `history.fetch_interval`, and applies incoming changes once the complete setup is conflict-free;
 /// in `fetch-only` mode it only fetches; in `manual` mode it does nothing
 /// on the network. A failed sync backs off and is retried while saving
 /// continues. `--once` runs one reconcile and one such synchronization.

--- a/src/cli/settings/set.rs
+++ b/src/cli/settings/set.rs
@@ -72,6 +72,8 @@ pub(super) fn set(mut key: &str, value: &str, add: bool, local: bool) -> Result<
 
     let path = if local {
         config::local_toml_config_path()
+    } else if key == "history.sync" && crate::env::MISE_GLOBAL_CONFIG_FILE.is_none() {
+        crate::cli::dotfiles::track::declaration_file(true)?
     } else {
         config::global_config_path()
     };

--- a/src/cli/settings/unset.rs
+++ b/src/cli/settings/unset.rs
@@ -27,6 +27,8 @@ impl SettingsUnset {
 pub(super) fn unset(mut key: &str, local: bool) -> Result<()> {
     let path = if local {
         config::local_toml_config_path()
+    } else if key == "history.sync" && crate::env::MISE_GLOBAL_CONFIG_FILE.is_none() {
+        crate::cli::dotfiles::track::declaration_file(true)?
     } else {
         config::global_config_path()
     };

--- a/src/cli/ssh.rs
+++ b/src/cli/ssh.rs
@@ -76,6 +76,31 @@ impl Ssh {
             let revision = self
                 .repository_revision
                 .ok_or_else(|| eyre::eyre!("missing repository revision"))?;
+            // a history-managed setup repository is set up from, never
+            // checked out into the configuration directory
+            if let Some(branch) =
+                crate::system::remote_repository::history_branch(&bundle, &revision)?
+            {
+                use crate::system::history::sync::onboard;
+                let store = crate::system::history::checkpoint::Store::open()?;
+                if let Some(reason) = store.unavailable() {
+                    bail!("cannot set up from a setup repository: {reason}");
+                }
+                let fetch_from = bundle.to_string_lossy().into_owned();
+                onboard::probe(&store, &fetch_from, &branch)?;
+                onboard::run(
+                    &store,
+                    &onboard::Onboarding {
+                        fetch_from,
+                        origin,
+                        branch,
+                        yes: self.repository_yes,
+                        dry_run: false,
+                    },
+                )
+                .await?;
+                return Ok(());
+            }
             crate::system::remote_repository::install(
                 &bundle,
                 &origin,

--- a/src/cli/ssh.rs
+++ b/src/cli/ssh.rs
@@ -92,7 +92,7 @@ impl Ssh {
                 }
                 let fetch_from = bundle.to_string_lossy().into_owned();
                 onboard::probe(&store, &fetch_from, &branch)?;
-                onboard::run(
+                let outcome = onboard::run(
                     &store,
                     &onboard::Onboarding {
                         fetch_from,
@@ -103,6 +103,16 @@ impl Ssh {
                     },
                 )
                 .await?;
+                if !self.repository_dry_run
+                    && (outcome.configuration_held
+                        || !crate::system::history::sync::run::read_status(store.state_dir())?
+                            .conflicts
+                            .is_empty())
+                {
+                    bail!(
+                        "setup has conflicts; nothing was bootstrapped; use `mise bootstrap dotfiles status` to resolve them"
+                    );
+                }
                 return Ok(());
             }
             crate::system::remote_repository::install(

--- a/src/cli/ssh.rs
+++ b/src/cli/ssh.rs
@@ -85,6 +85,7 @@ impl Ssh {
                 crate::system::remote_repository::history_branch(&bundle, &revision)?
             {
                 use crate::system::history::sync::onboard;
+                crate::config::Settings::get().ensure_experimental("dotfile tracking")?;
                 let store = crate::system::history::checkpoint::Store::open()?;
                 if let Some(reason) = store.unavailable() {
                     bail!("cannot set up from a setup repository: {reason}");

--- a/src/cli/ssh.rs
+++ b/src/cli/ssh.rs
@@ -53,6 +53,8 @@ pub(crate) struct Ssh {
     #[usage(long, hide = true)]
     repository_dry_run: bool,
     #[usage(long, hide = true)]
+    repository_preview_directory: Option<PathBuf>,
+    #[usage(long, hide = true)]
     global_config_directory: bool,
     /// Command to execute after --; omit for an interactive shell
     #[usage(trailing_var_arg = true, allow_hyphen_values = true)]
@@ -91,7 +93,6 @@ impl Ssh {
                     bail!("cannot set up from a setup repository: {reason}");
                 }
                 let fetch_from = bundle.to_string_lossy().into_owned();
-                onboard::probe(&store, &fetch_from, &branch)?;
                 let outcome = onboard::run(
                     &store,
                     &onboard::Onboarding {
@@ -103,6 +104,19 @@ impl Ssh {
                     },
                 )
                 .await?;
+                if let Some(directory) = &self.repository_preview_directory {
+                    if !self.repository_dry_run {
+                        bail!("a repository preview directory requires a dry run");
+                    }
+                    let preview = outcome
+                        .preview_config
+                        .as_ref()
+                        .ok_or_else(|| eyre::eyre!("missing setup configuration preview"))?;
+                    // The remote runner supplies a new directory inside its
+                    // private staging area; never overwrite an existing tree.
+                    std::fs::create_dir(directory)?;
+                    crate::file::copy_dir_all_preserve_symlinks(preview.path(), directory)?;
+                }
                 if !self.repository_dry_run
                     && (outcome.configuration_held
                         || !crate::system::history::sync::run::read_status(store.state_dir())?

--- a/src/cli/ssh.rs
+++ b/src/cli/ssh.rs
@@ -49,6 +49,9 @@ pub(crate) struct Ssh {
     repository_update: bool,
     #[usage(long, hide = true)]
     repository_yes: bool,
+    /// Preview the transferred repository's installation without writing it
+    #[usage(long, hide = true)]
+    repository_dry_run: bool,
     #[usage(long, hide = true)]
     global_config_directory: bool,
     /// Command to execute after --; omit for an interactive shell
@@ -95,7 +98,7 @@ impl Ssh {
                         origin,
                         branch,
                         yes: self.repository_yes,
-                        dry_run: false,
+                        dry_run: self.repository_dry_run,
                     },
                 )
                 .await?;
@@ -107,6 +110,7 @@ impl Ssh {
                 &revision,
                 self.repository_update,
                 self.repository_yes,
+                self.repository_dry_run,
             )?;
             return Ok(());
         }

--- a/src/system/history/checkpoint.rs
+++ b/src/system/history/checkpoint.rs
@@ -986,7 +986,7 @@ pub(crate) fn describe(
     truncate(describe_changes(changes))
 }
 
-fn describe_changes(changes: &Changes) -> String {
+pub(crate) fn describe_changes(changes: &Changes) -> String {
     let mut budget = DESCRIPTION_PATHS;
     let mut groups = vec![];
     let mut more = 0usize;

--- a/src/system/history/describe_command.rs
+++ b/src/system/history/describe_command.rs
@@ -1,0 +1,262 @@
+//! An optional command that names checkpoints (`history.describe_command`):
+//! an agent, say. It receives one JSON object on stdin (the checkpoint's
+//! uuid, trigger, and computed description, the changed paths that are not
+//! private, and a unified diff of the changed files that are backed up, at
+//! most 64 KiB) and prints one line, which becomes the description. The
+//! checkpoint is durable before the command runs and stays as it is when
+//! the command fails, prints nothing, or takes longer than 30 seconds; the
+//! watcher runs it once per checkpoint it saved, never per event or retry.
+
+use std::collections::BTreeSet;
+use std::io::{Read, Write};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use eyre::{Result, bail};
+use serde::Serialize;
+
+use super::checkpoint::{Store, annotate, describe_changes};
+use super::shadow::DiffOpts;
+use super::store::{self, Annotation, Changes, DescriptionSource, Entry};
+
+/// How long the command may take, how much diff it is given, and how long a
+/// description it may print.
+pub(crate) const TIMEOUT: Duration = Duration::from_secs(30);
+const DIFF_LIMIT: usize = 64 * 1024;
+const DESCRIPTION_LIMIT: usize = 200;
+
+#[derive(Serialize)]
+struct Input<'a> {
+    uuid: &'a str,
+    trigger: &'a str,
+    /// The computed description, with private paths counted, not named.
+    description: String,
+    added: Vec<&'a str>,
+    modified: Vec<&'a str>,
+    removed: Vec<&'a str>,
+    /// A unified diff of the changed files that are backed up (never a
+    /// private file, never one with `backup = false`), cut at the limit.
+    diff: String,
+    diff_truncated: bool,
+}
+
+/// The configured command, if any.
+pub(crate) fn configured() -> Option<String> {
+    let command = crate::config::Settings::get()
+        .history
+        .describe_command
+        .trim()
+        .to_string();
+    (!command.is_empty()).then_some(command)
+}
+
+/// Runs the command for `entry` and records what it printed. `Ok(None)`
+/// when it printed nothing usable; an error when it could not run, timed
+/// out, or failed. The checkpoint is unchanged in every case but success.
+pub(crate) fn run(store: &Store, entry: &Entry, command: &str) -> Result<Option<String>> {
+    let input = serde_json::to_vec(&input(store, entry)?)?;
+    let mut child = shell(command)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()?;
+    // stdin is written and closed on its own thread: a command that answers
+    // before reading everything must not block us
+    let mut stdin = child.stdin.take().expect("piped");
+    std::thread::spawn(move || {
+        let _ = stdin.write_all(&input);
+    });
+    let mut stdout = child.stdout.take().expect("piped");
+    let reader = std::thread::spawn(move || {
+        let mut out = Vec::new();
+        let _ = stdout.read_to_end(&mut out);
+        out
+    });
+    let started = Instant::now();
+    let status = loop {
+        if let Some(status) = child.try_wait()? {
+            break status;
+        }
+        if started.elapsed() >= TIMEOUT {
+            let _ = child.kill();
+            let _ = child.wait();
+            bail!("took longer than {}s", TIMEOUT.as_secs());
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    };
+    let output = reader.join().unwrap_or_default();
+    if !status.success() {
+        bail!("exited with {status}");
+    }
+    let Some(line) = first_line(&output) else {
+        return Ok(None);
+    };
+    annotate(
+        store,
+        entry,
+        Annotation {
+            description: Some(line.clone()),
+            description_source: Some(DescriptionSource::Command),
+            pinned: None,
+            labels: None,
+            updated_at: store::now_rfc3339(),
+        },
+    )?;
+    Ok(Some(line))
+}
+
+/// The first non-empty line, trimmed, cut at the limit.
+fn first_line(output: &[u8]) -> Option<String> {
+    let text = String::from_utf8_lossy(output);
+    let line = text.lines().map(str::trim).find(|line| !line.is_empty())?;
+    Some(line.chars().take(DESCRIPTION_LIMIT).collect())
+}
+
+fn shell(command: &str) -> Command {
+    if cfg!(windows) {
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/C", command]);
+        cmd
+    } else {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", command]);
+        cmd
+    }
+}
+
+/// What the command is told: never a private path, never the contents of a
+/// file that is not backed up.
+fn input<'a>(store: &Store, entry: &'a Entry) -> Result<Input<'a>> {
+    let checkpoint = &entry.checkpoint;
+    let mut withheld: BTreeSet<&str> = BTreeSet::new();
+    let mut unbacked: BTreeSet<&str> = BTreeSet::new();
+    for coverage in &checkpoint.tree.coverage.entries {
+        if coverage.private.is_some() || coverage.mode == "private" {
+            withheld.insert(coverage.path.as_str());
+        } else if !coverage.backup {
+            unbacked.insert(coverage.path.as_str());
+        }
+    }
+    let under = |path: &str, roots: &BTreeSet<&str>| {
+        roots.iter().any(|root| {
+            path == *root
+                || path
+                    .strip_prefix(root)
+                    .is_some_and(|rest| rest.starts_with('/'))
+        })
+    };
+    let visible = |paths: &'a [String]| -> Vec<&'a str> {
+        paths
+            .iter()
+            .map(String::as_str)
+            .filter(|path| !under(path, &withheld))
+            .collect()
+    };
+    let added = visible(&checkpoint.changes.added);
+    let modified = visible(&checkpoint.changes.modified);
+    let removed = visible(&checkpoint.changes.removed);
+    let hidden = checkpoint.changes.added.len()
+        + checkpoint.changes.modified.len()
+        + checkpoint.changes.removed.len()
+        - added.len()
+        - modified.len()
+        - removed.len();
+    let visible_changes = Changes {
+        since: checkpoint.changes.since.clone(),
+        added: added.iter().map(|path| path.to_string()).collect(),
+        modified: modified.iter().map(|path| path.to_string()).collect(),
+        removed: removed.iter().map(|path| path.to_string()).collect(),
+        truncated: checkpoint.changes.truncated,
+    };
+    let mut description = if hidden == 0 {
+        checkpoint.description.clone()
+    } else {
+        describe_changes(&visible_changes)
+    };
+    if hidden > 0 {
+        if !description.is_empty() {
+            description.push_str("; ");
+        }
+        description.push_str(&format!(
+            "{hidden} private file{} changed",
+            if hidden == 1 { "" } else { "s" }
+        ));
+    }
+    let (diff, diff_truncated) = match (
+        store.repo(),
+        &checkpoint.tree.snapshot,
+        checkpoint
+            .changes
+            .since
+            .as_deref()
+            .and_then(|since| {
+                store::read_meta_cache_in(store.state_dir(), since)
+                    .ok()
+                    .flatten()
+            })
+            .and_then(|previous| previous.tree.snapshot),
+    ) {
+        (Some(repo), Some(snapshot), Some(previous)) => {
+            let mut text = String::new();
+            for path in added.iter().chain(&modified).chain(&removed) {
+                if under(path, &unbacked) {
+                    continue;
+                }
+                let tree_path = super::tracked::display_to_tree_path(path);
+                let result = repo.diff(
+                    &previous,
+                    snapshot,
+                    &DiffOpts {
+                        patch: true,
+                        stream: false,
+                        color: false,
+                        paths: Some((tree_path.clone(), tree_path)),
+                    },
+                )?;
+                text.push_str(&String::from_utf8_lossy(&result.output));
+                if text.len() > DIFF_LIMIT {
+                    break;
+                }
+            }
+            let truncated = text.len() > DIFF_LIMIT;
+            if truncated {
+                let mut cut = DIFF_LIMIT;
+                while !text.is_char_boundary(cut) {
+                    cut -= 1;
+                }
+                text.truncate(cut);
+            }
+            (text, truncated)
+        }
+        _ => (String::new(), false),
+    };
+    Ok(Input {
+        uuid: &checkpoint.uuid,
+        trigger: checkpoint.trigger.as_str(),
+        description,
+        added,
+        modified,
+        removed,
+        diff,
+        diff_truncated,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_first_line_is_the_description() {
+        assert_eq!(
+            first_line(b"\n  tidy zsh aliases  \nmore\n").as_deref(),
+            Some("tidy zsh aliases")
+        );
+        assert_eq!(first_line(b"   \n"), None);
+        let long = "x".repeat(300);
+        assert_eq!(
+            first_line(long.as_bytes()).unwrap().len(),
+            DESCRIPTION_LIMIT
+        );
+    }
+}

--- a/src/system/history/describe_command.rs
+++ b/src/system/history/describe_command.rs
@@ -10,6 +10,7 @@
 use std::collections::BTreeSet;
 use std::io::{Read, Write};
 use std::process::{Command, Stdio};
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use eyre::{Result, bail};
@@ -22,6 +23,8 @@ use super::store::{self, Annotation, Changes, DescriptionSource, Entry};
 /// How long the command may take, how much diff it is given, and how long a
 /// description it may print.
 pub(crate) const TIMEOUT: Duration = Duration::from_secs(30);
+/// How long the output is waited for after the shell exited.
+const OUTPUT_GRACE: Duration = Duration::from_secs(2);
 const DIFF_LIMIT: usize = 64 * 1024;
 const DESCRIPTION_LIMIT: usize = 200;
 
@@ -40,6 +43,38 @@ struct Input<'a> {
     diff_truncated: bool,
 }
 
+/// The command running right now, so a shutdown can end it.
+static RUNNING: Mutex<Option<u32>> = Mutex::new(None);
+
+/// Ends the running command and everything it started, if any.
+pub(crate) fn abort_running() {
+    let pid = RUNNING.lock().ok().and_then(|mut running| running.take());
+    if let Some(pid) = pid {
+        kill_tree(pid);
+    }
+}
+
+/// Ends the command's whole process tree: the shell is its own process
+/// group on Unix, and Task Scheduler's tree kill covers Windows.
+fn kill_tree(pid: u32) {
+    #[cfg(unix)]
+    {
+        let _ = nix::sys::signal::killpg(
+            nix::unistd::Pid::from_raw(pid as i32),
+            nix::sys::signal::Signal::SIGKILL,
+        );
+    }
+    #[cfg(windows)]
+    {
+        let _ = Command::new("taskkill")
+            .args(["/T", "/F", "/PID", &pid.to_string()])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+}
+
 /// The configured command, if any.
 pub(crate) fn configured() -> Option<String> {
     let command = crate::config::Settings::get()
@@ -55,11 +90,21 @@ pub(crate) fn configured() -> Option<String> {
 /// out, or failed. The checkpoint is unchanged in every case but success.
 pub(crate) fn run(store: &Store, entry: &Entry, command: &str) -> Result<Option<String>> {
     let input = serde_json::to_vec(&input(store, entry)?)?;
-    let mut child = shell(command)
+    let mut shell = shell(command);
+    shell
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()?;
+        .stderr(Stdio::null());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // its own process group: a timeout ends what the shell started too
+        shell.process_group(0);
+    }
+    let mut child = shell.spawn()?;
+    if let Ok(mut running) = RUNNING.lock() {
+        *running = Some(child.id());
+    }
     // stdin is written and closed on its own thread: a command that answers
     // before reading everything must not block us
     let mut stdin = child.stdin.take().expect("piped");
@@ -67,10 +112,11 @@ pub(crate) fn run(store: &Store, entry: &Entry, command: &str) -> Result<Option<
         let _ = stdin.write_all(&input);
     });
     let mut stdout = child.stdout.take().expect("piped");
-    let reader = std::thread::spawn(move || {
+    let (sender, receiver) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
         let mut out = Vec::new();
         let _ = stdout.read_to_end(&mut out);
-        out
+        let _ = sender.send(out);
     });
     let started = Instant::now();
     let status = loop {
@@ -78,13 +124,26 @@ pub(crate) fn run(store: &Store, entry: &Entry, command: &str) -> Result<Option<
             break status;
         }
         if started.elapsed() >= TIMEOUT {
+            // the shell and whatever it started; the reader thread ends
+            // with the last writer of the pipe, so it is not waited for
+            kill_tree(child.id());
             let _ = child.kill();
             let _ = child.wait();
+            if let Ok(mut running) = RUNNING.lock() {
+                *running = None;
+            }
             bail!("took longer than {}s", TIMEOUT.as_secs());
         }
         std::thread::sleep(Duration::from_millis(100));
     };
-    let output = reader.join().unwrap_or_default();
+    if let Ok(mut running) = RUNNING.lock() {
+        *running = None;
+    }
+    // a descendant that outlived the shell and kept the pipe is not the
+    // shell's answer: the output is waited for a moment, not forever
+    let Ok(output) = receiver.recv_timeout(OUTPUT_GRACE) else {
+        bail!("a process it started kept its output open");
+    };
     if !status.success() {
         bail!("exited with {status}");
     }

--- a/src/system/history/mod.rs
+++ b/src/system/history/mod.rs
@@ -11,6 +11,7 @@
 
 pub(crate) mod checkpoint;
 pub(crate) mod config;
+pub(crate) mod describe_command;
 pub(crate) mod health;
 pub(crate) mod journal;
 pub(crate) mod notify;

--- a/src/system/history/mod.rs
+++ b/src/system/history/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod checkpoint;
 pub(crate) mod config;
 pub(crate) mod health;
 pub(crate) mod journal;
+pub(crate) mod notify;
 pub(crate) mod replay;
 pub(crate) mod retention;
 pub(crate) mod scope;

--- a/src/system/history/notify.rs
+++ b/src/system/history/notify.rs
@@ -1,5 +1,5 @@
 //! Optional desktop notifications for sync conflicts that newly need a
-//! decision (`settings.history.notify`, off by default). Best effort: the
+//! decision (`settings.history.notify`, on by default). Best effort: the
 //! notifier is started and not waited for, a missing desktop or tool is a
 //! debug line, and nothing here ever holds up a capture or a sync.
 

--- a/src/system/history/notify.rs
+++ b/src/system/history/notify.rs
@@ -5,6 +5,32 @@
 
 use std::process::{Command, Stdio};
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+const LOGO: &[u8] = include_bytes!("../../../docs/public/apple-touch-icon.png");
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn logo() -> Option<std::path::PathBuf> {
+    let path = crate::dirs::CACHE.join("notifications/mise.png");
+    match cache_logo(&path) {
+        Ok(()) => Some(path),
+        Err(err) => {
+            debug!("history: could not cache notification logo: {err}");
+            None
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn cache_logo(path: &std::path::Path) -> eyre::Result<()> {
+    if std::fs::read(path).ok().as_deref() != Some(LOGO) {
+        if let Some(parent) = path.parent() {
+            crate::file::create_dir_all(parent)?;
+        }
+        crate::file::write_atomic(path, LOGO)?;
+    }
+    Ok(())
+}
+
 /// Shows a notification with `title` and `body`, if a notifier is available.
 pub(crate) fn send(title: &str, body: &str) {
     let mut command = match notifier(title, body) {
@@ -27,16 +53,36 @@ pub(crate) fn send(title: &str, body: &str) {
 #[cfg(target_os = "linux")]
 fn notifier(title: &str, body: &str) -> Option<Command> {
     let bin = crate::file::which_spawnable("notify-send")?;
+    Some(linux_notification(&bin, title, body, logo().as_deref()))
+}
+
+#[cfg(any(target_os = "linux", all(test, target_os = "macos")))]
+fn linux_notification(
+    bin: &std::path::Path,
+    title: &str,
+    body: &str,
+    icon: Option<&std::path::Path>,
+) -> Command {
     let mut command = Command::new(bin);
+    command.args(["--app-name", "mise", "--urgency", "normal"]);
+    if let Some(icon) = icon {
+        command.arg("--icon").arg(icon);
+    }
+    command.arg("--").arg(title).arg(body);
     command
-        .args(["--app-name", "mise", "--urgency", "normal", "--"])
-        .arg(title)
-        .arg(body);
-    Some(command)
 }
 
 #[cfg(target_os = "macos")]
 fn notifier(title: &str, body: &str) -> Option<Command> {
+    if let Some(bin) = crate::file::which_spawnable("terminal-notifier") {
+        let mut command = terminal_notification(&bin, title, body);
+        if let Some(icon) = logo() {
+            // Modern macOS fixes the sender icon to its application bundle;
+            // contentImage displays the logo without impersonating another app.
+            command.arg("-contentImage").arg(icon);
+        }
+        return Some(command);
+    }
     let bin = crate::file::which_spawnable("osascript")?;
     let escape = |text: &str| text.replace('\\', "\\\\").replace('"', "\\\"");
     let mut command = Command::new(bin);
@@ -48,7 +94,104 @@ fn notifier(title: &str, body: &str) -> Option<Command> {
     Some(command)
 }
 
+#[cfg(target_os = "macos")]
+fn terminal_notification(bin: &std::path::Path, title: &str, body: &str) -> Command {
+    let mut command = Command::new(bin);
+    // terminal-notifier reads values through NSUserDefaults. Escape the first
+    // character so leading brackets/quotes are not parsed as property lists.
+    command.args([
+        "-title",
+        &format!("\\{title}"),
+        "-message",
+        &format!("\\{body}"),
+    ]);
+    command
+}
+
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 fn notifier(_title: &str, _body: &str) -> Option<Command> {
     None
+}
+
+#[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn notification_logo_is_cached_and_repaired() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("notifications/mise.png");
+        cache_logo(&path).unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), LOGO);
+        let modified = std::fs::metadata(&path).unwrap().modified().unwrap();
+        cache_logo(&path).unwrap();
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().modified().unwrap(),
+            modified
+        );
+        std::fs::write(&path, b"stale").unwrap();
+        cache_logo(&path).unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), LOGO);
+    }
+
+    #[test]
+    fn notification_logo_cache_failure_is_reported() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("not-a-directory");
+        std::fs::write(&parent, b"").unwrap();
+        assert!(cache_logo(&parent.join("mise.png")).is_err());
+    }
+
+    #[test]
+    fn linux_notification_logo_is_optional_and_paths_are_literal() {
+        let bin = std::path::Path::new("notify-send");
+        let icon = std::path::Path::new("/cache with spaces/mise.png");
+        let with_logo = linux_notification(bin, "--title", "body", Some(icon));
+        assert_eq!(
+            with_logo.get_args().collect::<Vec<_>>(),
+            [
+                "--app-name",
+                "mise",
+                "--urgency",
+                "normal",
+                "--icon",
+                "/cache with spaces/mise.png",
+                "--",
+                "--title",
+                "body"
+            ]
+        );
+        let without_logo = linux_notification(bin, "--title", "body", None);
+        assert_eq!(
+            without_logo.get_args().collect::<Vec<_>>(),
+            [
+                "--app-name",
+                "mise",
+                "--urgency",
+                "normal",
+                "--",
+                "--title",
+                "body"
+            ]
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn terminal_notification_preserves_literal_text() {
+        let command = terminal_notification(
+            std::path::Path::new("terminal-notifier"),
+            "[mise]",
+            "\"file\"; $(touch unwanted)",
+        );
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            [
+                "-title",
+                "\\[mise]",
+                "-message",
+                "\\\"file\"; $(touch unwanted)"
+            ]
+        );
+    }
 }

--- a/src/system/history/notify.rs
+++ b/src/system/history/notify.rs
@@ -1,6 +1,6 @@
 //! Optional desktop notifications for sync conflicts that newly need a
 //! decision (`settings.history.notify`, on by default). Best effort: the
-//! notifier is started and not waited for, a missing desktop or tool is a
+//! notifier runs and is reaped on a worker thread, a missing desktop or tool is a
 //! debug line, and nothing here ever holds up a capture or a sync.
 
 use std::process::{Command, Stdio};
@@ -44,10 +44,28 @@ pub(crate) fn send(title: &str, body: &str) {
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());
-    match command.spawn() {
-        Ok(_child) => debug!("history: notified: {title}"),
+    match dispatch(command) {
+        Ok(_worker) => debug!("history: notification dispatched: {title}"),
         Err(err) => debug!("history: could not notify ({title}): {err}"),
     }
+}
+
+fn dispatch(
+    mut command: Command,
+) -> std::io::Result<std::thread::JoinHandle<std::io::Result<std::process::ExitStatus>>> {
+    // Start the process inside the thread, so a thread-creation failure cannot
+    // strand an unreaped child. Waiting here never blocks the watcher.
+    std::thread::Builder::new()
+        .name("mise-notification".into())
+        .spawn(move || {
+            let result = command.status();
+            match &result {
+                Ok(status) if status.success() => debug!("history: notifier completed"),
+                Ok(status) => debug!("history: notifier exited with {status}"),
+                Err(err) => debug!("history: could not run notifier: {err}"),
+            }
+            result
+        })
 }
 
 #[cfg(target_os = "linux")]
@@ -116,6 +134,22 @@ fn notifier(_title: &str, _body: &str) -> Option<Command> {
 #[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
 mod tests {
     use super::*;
+
+    #[test]
+    fn notification_worker_reaps_the_child_and_reports_spawn_errors() {
+        let mut command = Command::new("/bin/sh");
+        command.args(["-c", "exit 7"]);
+        let status = dispatch(command).unwrap().join().unwrap().unwrap();
+        assert_eq!(status.code(), Some(7));
+        let missing = tempfile::tempdir().unwrap().path().join("missing-notifier");
+        assert!(
+            dispatch(Command::new(missing))
+                .unwrap()
+                .join()
+                .unwrap()
+                .is_err()
+        );
+    }
 
     #[test]
     fn notification_logo_is_cached_and_repaired() {

--- a/src/system/history/notify.rs
+++ b/src/system/history/notify.rs
@@ -5,10 +5,13 @@
 
 use std::process::{Command, Stdio};
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(target_os = "macos")]
+mod macos;
+
+#[cfg(any(target_os = "linux", all(test, target_os = "macos")))]
 const LOGO: &[u8] = include_bytes!("../../../docs/public/apple-touch-icon.png");
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(target_os = "linux")]
 fn logo() -> Option<std::path::PathBuf> {
     let path = crate::dirs::CACHE.join("notifications/mise.png");
     match cache_logo(&path) {
@@ -20,7 +23,7 @@ fn logo() -> Option<std::path::PathBuf> {
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", all(test, target_os = "macos")))]
 fn cache_logo(path: &std::path::Path) -> eyre::Result<()> {
     if std::fs::read(path).ok().as_deref() != Some(LOGO) {
         if let Some(parent) = path.parent() {
@@ -33,32 +36,29 @@ fn cache_logo(path: &std::path::Path) -> eyre::Result<()> {
 
 /// Shows a notification with `title` and `body`, if a notifier is available.
 pub(crate) fn send(title: &str, body: &str) {
-    let mut command = match notifier(title, body) {
-        Some(command) => command,
-        None => {
-            debug!("history: no desktop notifier on this platform; not notifying: {title}");
-            return;
-        }
-    };
-    command
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
-    match dispatch(command) {
-        Ok(_worker) => debug!("history: notification dispatched: {title}"),
-        Err(err) => debug!("history: could not notify ({title}): {err}"),
+    let title = title.to_owned();
+    let body = body.to_owned();
+    if let Err(err) = dispatch(move || {
+        notifier(&title, &body).ok_or_else(|| std::io::Error::other("desktop notifier unavailable"))
+    }) {
+        debug!("history: could not start notification worker: {err}");
     }
 }
 
 fn dispatch(
-    mut command: Command,
+    prepare: impl FnOnce() -> std::io::Result<Command> + Send + 'static,
 ) -> std::io::Result<std::thread::JoinHandle<std::io::Result<std::process::ExitStatus>>> {
-    // Start the process inside the thread, so a thread-creation failure cannot
-    // strand an unreaped child. Waiting here never blocks the watcher.
+    // Prepare the bundle and reap the child off the watcher thread.
     std::thread::Builder::new()
         .name("mise-notification".into())
         .spawn(move || {
-            let result = command.status();
+            let result = prepare().and_then(|mut command| {
+                command
+                    .stdin(Stdio::null())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .status()
+            });
             match &result {
                 Ok(status) if status.success() => debug!("history: notifier completed"),
                 Ok(status) => debug!("history: notifier exited with {status}"),
@@ -92,38 +92,9 @@ fn linux_notification(
 
 #[cfg(target_os = "macos")]
 fn notifier(title: &str, body: &str) -> Option<Command> {
-    if let Some(bin) = crate::file::which_spawnable("terminal-notifier") {
-        let mut command = terminal_notification(&bin, title, body);
-        if let Some(icon) = logo() {
-            // Modern macOS fixes the sender icon to its application bundle;
-            // contentImage displays the logo without impersonating another app.
-            command.arg("-contentImage").arg(icon);
-        }
-        return Some(command);
-    }
-    let bin = crate::file::which_spawnable("osascript")?;
-    let escape = |text: &str| text.replace('\\', "\\\\").replace('"', "\\\"");
-    let mut command = Command::new(bin);
-    command.arg("-e").arg(format!(
-        "display notification \"{}\" with title \"{}\"",
-        escape(body),
-        escape(title)
-    ));
-    Some(command)
-}
-
-#[cfg(target_os = "macos")]
-fn terminal_notification(bin: &std::path::Path, title: &str, body: &str) -> Command {
-    let mut command = Command::new(bin);
-    // terminal-notifier reads values through NSUserDefaults. Escape the first
-    // character so leading brackets/quotes are not parsed as property lists.
-    command.args([
-        "-title",
-        &format!("\\{title}"),
-        "-message",
-        &format!("\\{body}"),
-    ]);
-    command
+    macos::notification(title, body)
+        .map_err(|err| debug!("history: could not prepare notification helper: {err:#}"))
+        .ok()
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
@@ -139,11 +110,15 @@ mod tests {
     fn notification_worker_reaps_the_child_and_reports_spawn_errors() {
         let mut command = Command::new("/bin/sh");
         command.args(["-c", "exit 7"]);
-        let status = dispatch(command).unwrap().join().unwrap().unwrap();
+        let status = dispatch(move || Ok(command))
+            .unwrap()
+            .join()
+            .unwrap()
+            .unwrap();
         assert_eq!(status.code(), Some(7));
         let missing = tempfile::tempdir().unwrap().path().join("missing-notifier");
         assert!(
-            dispatch(Command::new(missing))
+            dispatch(move || Ok(Command::new(missing)))
                 .unwrap()
                 .join()
                 .unwrap()
@@ -206,25 +181,6 @@ mod tests {
                 "--",
                 "--title",
                 "body"
-            ]
-        );
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn terminal_notification_preserves_literal_text() {
-        let command = terminal_notification(
-            std::path::Path::new("terminal-notifier"),
-            "[mise]",
-            "\"file\"; $(touch unwanted)",
-        );
-        assert_eq!(
-            command.get_args().collect::<Vec<_>>(),
-            [
-                "-title",
-                "\\[mise]",
-                "-message",
-                "\\\"file\"; $(touch unwanted)"
             ]
         );
     }

--- a/src/system/history/notify.rs
+++ b/src/system/history/notify.rs
@@ -1,0 +1,54 @@
+//! Optional desktop notifications for sync conflicts that newly need a
+//! decision (`settings.history.notify`, off by default). Best effort: the
+//! notifier is started and not waited for, a missing desktop or tool is a
+//! debug line, and nothing here ever holds up a capture or a sync.
+
+use std::process::{Command, Stdio};
+
+/// Shows a notification with `title` and `body`, if a notifier is available.
+pub(crate) fn send(title: &str, body: &str) {
+    let mut command = match notifier(title, body) {
+        Some(command) => command,
+        None => {
+            debug!("history: no desktop notifier on this platform; not notifying: {title}");
+            return;
+        }
+    };
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    match command.spawn() {
+        Ok(_child) => debug!("history: notified: {title}"),
+        Err(err) => debug!("history: could not notify ({title}): {err}"),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn notifier(title: &str, body: &str) -> Option<Command> {
+    let bin = crate::file::which_spawnable("notify-send")?;
+    let mut command = Command::new(bin);
+    command
+        .args(["--app-name", "mise", "--urgency", "normal", "--"])
+        .arg(title)
+        .arg(body);
+    Some(command)
+}
+
+#[cfg(target_os = "macos")]
+fn notifier(title: &str, body: &str) -> Option<Command> {
+    let bin = crate::file::which_spawnable("osascript")?;
+    let escape = |text: &str| text.replace('\\', "\\\\").replace('"', "\\\"");
+    let mut command = Command::new(bin);
+    command.arg("-e").arg(format!(
+        "display notification \"{}\" with title \"{}\"",
+        escape(body),
+        escape(title)
+    ));
+    Some(command)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn notifier(_title: &str, _body: &str) -> Option<Command> {
+    None
+}

--- a/src/system/history/notify/macos.m
+++ b/src/system/history/notify/macos.m
@@ -1,0 +1,68 @@
+// Embedded at build time: users need no compiler or third-party notifier.
+#import <AppKit/AppKit.h>
+#import <CoreServices/CoreServices.h>
+#import <UserNotifications/UserNotifications.h>
+#include <string.h>
+
+static NSString *const notificationID = @"mise.dotfiles.sync";
+
+@interface MiseNotificationDelegate : NSObject <UNUserNotificationCenterDelegate>
+@end
+
+@implementation MiseNotificationDelegate
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+      willPresentNotification:(UNNotification *)notification
+        withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completion {
+    completion(UNNotificationPresentationOptionAlert);
+}
+@end
+
+int main(int argc, const char *argv[]) {
+    @autoreleasepool {
+        // Clicking an old alert may relaunch the app. Never send it again.
+        if (argc == 1) return 0;
+        NSBundle *bundle = NSBundle.mainBundle;
+        if (argc == 2 && strcmp(argv[1], "--check") == 0) {
+            NSString *icon = [bundle pathForResource:@"mise" ofType:@"icns"];
+            return [bundle.bundleIdentifier isEqualToString:@"dev.jdx.mise.notifications"] &&
+                [[NSImage alloc] initWithContentsOfFile:icon] != nil ? 0 : 2;
+        }
+        if (argc != 3) return 2;
+        // Register our own bundle so Notification Center can resolve its name
+        // and icon even when mise invokes the embedded executable directly.
+        if (LSRegisterURL((__bridge CFURLRef)bundle.bundleURL, true) != noErr) return 6;
+        [NSApplication sharedApplication];
+        [NSApp setActivationPolicy:NSApplicationActivationPolicyProhibited];
+        UNUserNotificationCenter *center = UNUserNotificationCenter.currentNotificationCenter;
+        NSString *title = [NSString stringWithUTF8String:argv[1]];
+        NSString *body = [NSString stringWithUTF8String:argv[2]];
+        if (title == nil || body == nil) return 2;
+        MiseNotificationDelegate *delegate = [MiseNotificationDelegate new];
+        center.delegate = delegate;
+        dispatch_semaphore_t done = dispatch_semaphore_create(0);
+        __block int result = 4;
+        [center requestAuthorizationWithOptions:UNAuthorizationOptionAlert
+            completionHandler:^(BOOL granted, NSError *error) {
+                if (!granted || error != nil) {
+                    result = 3;
+                    dispatch_semaphore_signal(done);
+                    return;
+                }
+                UNMutableNotificationContent *content = [UNMutableNotificationContent new];
+                content.title = title;
+                content.body = body;
+                UNNotificationRequest *request = [UNNotificationRequest
+                    requestWithIdentifier:notificationID content:content trigger:nil];
+                [center addNotificationRequest:request withCompletionHandler:^(NSError *failure) {
+                    result = failure == nil ? 0 : 5;
+                    dispatch_semaphore_signal(done);
+                }];
+            }];
+        NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:30];
+        while (dispatch_semaphore_wait(done, DISPATCH_TIME_NOW) != 0) {
+            if (deadline.timeIntervalSinceNow <= 0) return 4;
+            [NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+        }
+        return result;
+    }
+}

--- a/src/system/history/notify/macos.rs
+++ b/src/system/history/notify/macos.rs
@@ -1,0 +1,137 @@
+//! A real application identity is required for a custom notification icon.
+//! The small native helper is embedded in mise, not compiled on the user's Mac.
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use eyre::{Result, bail};
+
+const HELPER: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/mise-notify"));
+const ICON: &[u8] = include_bytes!("../../../../docs/public/android-chrome-512x512.png");
+const INFO: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>CFBundleIdentifier</key><string>dev.jdx.mise.notifications</string>
+<key>CFBundleName</key><string>mise</string>
+<key>CFBundleDisplayName</key><string>mise</string>
+<key>CFBundleExecutable</key><string>mise-notify</string>
+<key>CFBundleIconFile</key><string>mise.icns</string>
+<key>CFBundlePackageType</key><string>APPL</string>
+<key>CFBundleVersion</key><string>1</string>
+<key>LSUIElement</key><true/>
+<key>LSMinimumSystemVersion</key><string>10.14</string>
+</dict></plist>"#;
+
+fn app_path(root: &Path) -> PathBuf {
+    // A versioned directory permits safe replacement without modifying a
+    // running helper. The bundle identifier remains stable across versions.
+    let fingerprint = crate::hash::hash_to_str(&(HELPER, ICON, INFO));
+    root.join(fingerprint).join("mise.app")
+}
+
+fn executable(app: &Path) -> PathBuf {
+    app.join("Contents/MacOS/mise-notify")
+}
+
+pub(super) fn notification(title: &str, body: &str) -> Result<Command> {
+    let app = ensure_app(&crate::dirs::DATA.join("notifications"))?;
+    Ok(notification_command(&app, title, body))
+}
+
+fn notification_command(app: &Path, title: &str, body: &str) -> Command {
+    let mut command = Command::new(executable(app));
+    command.args([title, body]);
+    command
+}
+
+fn ensure_app(root: &Path) -> Result<PathBuf> {
+    let app = app_path(root);
+    if executable(&app).is_file() {
+        return Ok(app);
+    }
+    crate::file::create_dir_all(root)?;
+    let mut lock = fslock::LockFile::open(&root.join("install.lock"))?;
+    lock.lock()?;
+    if executable(&app).is_file() {
+        return Ok(app);
+    }
+    let staging = tempfile::tempdir_in(root)?;
+    let staged = staging.path().join("mise.app");
+    let contents = staged.join("Contents");
+    std::fs::create_dir_all(contents.join("MacOS"))?;
+    std::fs::create_dir_all(contents.join("Resources"))?;
+    std::fs::write(executable(&staged), HELPER)?;
+    std::fs::set_permissions(executable(&staged), std::fs::Permissions::from_mode(0o755))?;
+    std::fs::write(contents.join("Info.plist"), INFO)?;
+    // ICNS container with one lossless 512x512 PNG representation (ic09).
+    let mut icon = Vec::with_capacity(ICON.len() + 16);
+    icon.extend_from_slice(b"icns");
+    icon.extend_from_slice(&u32::try_from(ICON.len() + 16)?.to_be_bytes());
+    icon.extend_from_slice(b"ic09");
+    icon.extend_from_slice(&u32::try_from(ICON.len() + 8)?.to_be_bytes());
+    icon.extend_from_slice(ICON);
+    std::fs::write(contents.join("Resources/mise.icns"), icon)?;
+    // Ad-hoc sign this mise-owned bundle, never another installed app.
+    let signed = Command::new("/usr/bin/codesign")
+        .args([
+            "--force",
+            "--sign",
+            "-",
+            "--identifier",
+            "dev.jdx.mise.notifications",
+        ])
+        .arg(&staged)
+        .output()?;
+    if !signed.status.success() {
+        bail!("could not sign the mise notification helper");
+    }
+    std::fs::create_dir_all(app.parent().unwrap())?;
+    std::fs::rename(staged, &app)?;
+    Ok(app)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn notification_helper_has_its_own_identity_and_decodable_icon_without_notifying() {
+        let temp = tempfile::tempdir().unwrap();
+        let app = ensure_app(temp.path()).unwrap();
+        assert!(
+            Command::new(executable(&app))
+                .arg("--check")
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert!(
+            Command::new("/usr/bin/codesign")
+                .args(["--verify", "--strict"])
+                .arg(&app)
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert_eq!(ensure_app(temp.path()).unwrap(), app);
+        assert!(Command::new(executable(&app)).status().unwrap().success());
+    }
+
+    #[test]
+    fn notification_text_is_literal_and_install_failure_is_reported() {
+        let command = notification_command(
+            Path::new("/app with spaces/mise.app"),
+            "[mise]",
+            "\"file\"; $(touch unwanted)",
+        );
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            ["[mise]", "\"file\"; $(touch unwanted)"]
+        );
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("not-a-directory");
+        std::fs::write(&root, b"").unwrap();
+        assert!(ensure_app(&root).is_err());
+    }
+}

--- a/src/system/history/scope.rs
+++ b/src/system/history/scope.rs
@@ -100,6 +100,26 @@ impl OperationScope {
         command: &str,
         dry_run: bool,
     ) -> Result<Self> {
+        Self::begin_with_wait(kind, command, dry_run, OPERATION_LOCK_WAIT).await
+    }
+
+    /// The watcher retries contention later rather than delaying its event loop.
+    pub(crate) async fn begin_automatic_apply() -> Result<Self> {
+        Self::begin_with_wait(
+            OperationKind::Apply,
+            "dotfiles pull",
+            false,
+            std::time::Duration::ZERO,
+        )
+        .await
+    }
+
+    async fn begin_with_wait(
+        kind: OperationKind,
+        command: &str,
+        dry_run: bool,
+        wait: std::time::Duration,
+    ) -> Result<Self> {
         if dry_run || !Settings::get().experimental {
             return Ok(Self(None));
         }
@@ -119,7 +139,7 @@ impl OperationScope {
         let tracked = TrackedSet::effective().await?;
         let command = command.to_owned();
         let writer = tokio::task::spawn_blocking(move || {
-            Writer::begin(&dirs::STATE, kind, &command, tracked)
+            Writer::begin(&dirs::STATE, kind, &command, tracked, wait)
         })
         .await??;
         let uuid = writer.pending.checkpoint.uuid.clone();
@@ -263,9 +283,10 @@ impl Writer {
         kind: OperationKind,
         command: &str,
         tracked: TrackedSet,
+        wait: std::time::Duration,
     ) -> Result<Self> {
         let store = Store::open_in(state_dir)?;
-        let lock = take_operation_lock(&store, &tracked)?;
+        let lock = take_operation_lock_with_wait(&store, &tracked, wait)?;
         let argv: Vec<String> = env::ARGS.read().unwrap().iter().skip(1).cloned().collect();
         // What the user typed is the better label; the caller's name is the
         // fallback for in-process callers with no argv (tests).
@@ -515,11 +536,19 @@ impl Writer {
 /// own (an explicit save) holds this for its duration too, so it never
 /// interleaves with a bootstrap, rollback, or undo.
 pub(crate) fn take_operation_lock(store: &Store, tracked: &TrackedSet) -> Result<fslock::LockFile> {
+    take_operation_lock_with_wait(store, tracked, OPERATION_LOCK_WAIT)
+}
+
+fn take_operation_lock_with_wait(
+    store: &Store,
+    tracked: &TrackedSet,
+    wait: std::time::Duration,
+) -> Result<fslock::LockFile> {
     let state_dir = store.state_dir();
     let path = store::operation_lock_in(state_dir);
     // a running operation (the watcher applying incoming changes, say) is
     // usually over in moments: wait for it a bounded while before failing
-    let deadline = std::time::Instant::now() + OPERATION_LOCK_WAIT;
+    let deadline = std::time::Instant::now() + wait;
     let mut announced = false;
     let lock = loop {
         if let Some(lock) = LockFile::new(&path).try_lock()? {
@@ -623,5 +652,37 @@ fn outcome_trigger(kind: OperationKind) -> Trigger {
         OperationKind::Rollback | OperationKind::BootstrapRollback => Trigger::Rollback,
         OperationKind::Undo => Trigger::Undo,
         OperationKind::Apply => Trigger::Apply,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn automatic_operation_lock_does_not_wait() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = Store::open_in(temp.path()).unwrap();
+        let held = LockFile::new(&store::operation_lock_in(temp.path()))
+            .try_lock()
+            .unwrap()
+            .unwrap();
+        let started = std::time::Instant::now();
+        let result = take_operation_lock_with_wait(
+            &store,
+            &TrackedSet::default(),
+            std::time::Duration::ZERO,
+        );
+        assert!(result.is_err());
+        assert!(started.elapsed() < std::time::Duration::from_secs(2));
+        drop(held);
+        assert!(
+            take_operation_lock_with_wait(
+                &store,
+                &TrackedSet::default(),
+                std::time::Duration::ZERO,
+            )
+            .is_ok()
+        );
     }
 }

--- a/src/system/history/scope.rs
+++ b/src/system/history/scope.rs
@@ -516,22 +516,45 @@ impl Writer {
 /// interleaves with a bootstrap, rollback, or undo.
 pub(crate) fn take_operation_lock(store: &Store, tracked: &TrackedSet) -> Result<fslock::LockFile> {
     let state_dir = store.state_dir();
-    let lock = LockFile::new(&store::operation_lock_in(state_dir)).try_lock()?;
-    let Some(lock) = lock else {
-        let marker = store::read_marker_in(state_dir)?;
-        match marker {
-            Some(marker) => bail!(
-                "another history operation is running: {} since {} ({})",
-                marker.kind.as_str(),
-                marker.started_at,
-                marker.command
-            ),
-            None => bail!("another history operation is running"),
+    let path = store::operation_lock_in(state_dir);
+    // a running operation (the watcher applying incoming changes, say) is
+    // usually over in moments: wait for it a bounded while before failing
+    let deadline = std::time::Instant::now() + OPERATION_LOCK_WAIT;
+    let mut announced = false;
+    let lock = loop {
+        if let Some(lock) = LockFile::new(&path).try_lock()? {
+            break lock;
         }
+        let marker = store::read_marker_in(state_dir)?;
+        if std::time::Instant::now() >= deadline {
+            match marker {
+                Some(marker) => bail!(
+                    "another history operation is running: {} since {} ({})",
+                    marker.kind.as_str(),
+                    marker.started_at,
+                    marker.command
+                ),
+                None => bail!("another history operation is running"),
+            }
+        }
+        if !announced {
+            announced = true;
+            info!(
+                "history: waiting for another history operation to finish{}",
+                marker
+                    .map(|marker| format!(": {} ({})", marker.kind.as_str(), marker.command))
+                    .unwrap_or_default()
+            );
+        }
+        std::thread::sleep(OPERATION_LOCK_POLL);
     };
     recover_stale(store, tracked)?;
     Ok(lock)
 }
+
+/// How long an operation waits for a running one, and how often it looks.
+const OPERATION_LOCK_WAIT: std::time::Duration = std::time::Duration::from_secs(30);
+const OPERATION_LOCK_POLL: std::time::Duration = std::time::Duration::from_millis(200);
 
 /// Closes the pending records of operations that died. Only the holder of
 /// the operation lock may call this: a pending record whose operation is

--- a/src/system/history/shadow.rs
+++ b/src/system/history/shadow.rs
@@ -194,7 +194,7 @@ impl HistoryRepo {
         tree
     }
 
-    fn mktree(&self, listing: &str) -> Result<String> {
+    pub(crate) fn mktree(&self, listing: &str) -> Result<String> {
         self.output_str(PlumbingCall::new(["mktree"]).stdin(listing.as_bytes()))
     }
 

--- a/src/system/history/sync/apply.rs
+++ b/src/system/history/sync/apply.rs
@@ -38,6 +38,9 @@ pub(crate) struct ApplyRequest {
     /// The watcher applying in the background: no prompt, no plan on
     /// stdout, and held paths are a count, not a failure.
     pub automatic: bool,
+    /// With `dry_run`: the plan is shown before a question, so no
+    /// "nothing was changed" note.
+    pub plan_only: bool,
 }
 
 impl ApplyRequest {
@@ -49,6 +52,7 @@ impl ApplyRequest {
             take_remote: vec![],
             keep_local: vec![],
             automatic: true,
+            plan_only: false,
         }
     }
 }
@@ -272,7 +276,9 @@ pub(crate) async fn apply(
         table.print()?;
     }
     if req.dry_run {
-        miseprintln!("history: dry run; nothing was changed");
+        if !req.plan_only {
+            miseprintln!("history: dry run; nothing was changed");
+        }
         return Ok(ApplyOutcome::default());
     }
     if ready.is_empty() {

--- a/src/system/history/sync/apply.rs
+++ b/src/system/history/sync/apply.rs
@@ -323,7 +323,11 @@ pub(crate) async fn apply(
 
     // the transaction
     let reload = crate::system::history::config::reload_commands()?;
-    let scope = OperationScope::begin_kind(OperationKind::Apply, "dotfiles pull", false).await?;
+    let scope = if req.automatic {
+        OperationScope::begin_automatic_apply().await?
+    } else {
+        OperationScope::begin_kind(OperationKind::Apply, "dotfiles pull", false).await?
+    };
     scope.with_operation(|op| {
         op.applied = status.upstream_commit.clone();
     });

--- a/src/system/history/sync/apply.rs
+++ b/src/system/history/sync/apply.rs
@@ -370,7 +370,7 @@ pub(crate) async fn apply(
                 message: Some("apply failed; recovery attempted".into()),
             }),
         );
-        return result;
+        return result.map(|()| ApplyOutcome::default());
     }
     let (error, summary) = match &result {
         Ok(()) => {

--- a/src/system/history/sync/apply.rs
+++ b/src/system/history/sync/apply.rs
@@ -169,6 +169,30 @@ pub(crate) async fn apply(
         run::write_status(state_dir, &status)?;
     }
     if !status.conflicts.is_empty() {
+        if req.dry_run {
+            // Preview the whole paused setup even when reconciliation
+            // cannot yet produce an applicable write set.
+            let mut table = MiseTable::new(false, &["Path", "Action", "Group"]);
+            for conflict in &status.conflicts {
+                if let Some(path) = roots.locate(&conflict.branch_path).path() {
+                    table.add_row(vec![
+                        display_path(path),
+                        "held: unresolved conflict".to_string(),
+                        conflict.branch_path.clone(),
+                    ]);
+                }
+            }
+            for pending in &status.pending_applications {
+                if let Some(path) = roots.locate(&pending.branch_path).path() {
+                    table.add_row(vec![
+                        display_path(path),
+                        "held: sharing paused for the entire setup".to_string(),
+                        pending.branch_path.clone(),
+                    ]);
+                }
+            }
+            table.print()?;
+        }
         if take_remote.is_empty() && keep_local.is_empty() && !req.dry_run && !req.automatic {
             bail!(
                 "sync paused: resolve all {} conflict(s) before sharing resumes",

--- a/src/system/history/sync/apply.rs
+++ b/src/system/history/sync/apply.rs
@@ -25,6 +25,7 @@ use crate::system::history::store::{OperationKind, Summary};
 use crate::system::history::tracked::{TrackedSet, normalize_target};
 use crate::ui::table::MiseTable;
 
+#[derive(Clone, Debug)]
 pub(crate) struct ApplyRequest {
     /// Only these local paths (empty: everything pending).
     pub paths: Vec<PathBuf>,
@@ -34,6 +35,33 @@ pub(crate) struct ApplyRequest {
     pub take_remote: Vec<PathBuf>,
     /// Resolve these conflicts by publishing the local version next.
     pub keep_local: Vec<PathBuf>,
+    /// The watcher applying in the background: no prompt, no plan on
+    /// stdout, and held paths are a count, not a failure.
+    pub automatic: bool,
+}
+
+impl ApplyRequest {
+    pub(crate) fn automatic() -> Self {
+        Self {
+            paths: vec![],
+            dry_run: false,
+            yes: true,
+            take_remote: vec![],
+            keep_local: vec![],
+            automatic: true,
+        }
+    }
+}
+
+/// What an application did.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct ApplyOutcome {
+    /// Files written or removed.
+    pub written: usize,
+    /// Paths held for a decision (with their groups).
+    pub held: usize,
+    /// A configuration file was written: declarations may have changed.
+    pub configuration: bool,
 }
 
 /// Why a pending application is not written now.
@@ -53,13 +81,23 @@ struct Step {
     permissions: Option<std::fs::Permissions>,
 }
 
-pub(crate) async fn apply(store: &Store, tracked: &TrackedSet, req: &ApplyRequest) -> Result<()> {
+pub(crate) async fn apply(
+    store: &Store,
+    tracked: &TrackedSet,
+    req: &ApplyRequest,
+) -> Result<ApplyOutcome> {
     let _sync_lock = run::lock(store)?;
     let repo = store
         .repo()
         .ok_or_else(|| eyre::eyre!("applying requires git"))?;
     let state_dir = store.state_dir();
     let mut status = run::read_status(state_dir)?;
+    if req.automatic && status.application_failure.is_some() {
+        return Ok(ApplyOutcome {
+            held: status.pending_applications.len().max(1),
+            ..Default::default()
+        });
+    }
     run::refresh(store, tracked, &mut status)?;
     let roots = Roots::current();
     let filter: BTreeSet<PathBuf> = req
@@ -127,7 +165,7 @@ pub(crate) async fn apply(store: &Store, tracked: &TrackedSet, req: &ApplyReques
         run::write_status(state_dir, &status)?;
     }
     if !status.conflicts.is_empty() {
-        if take_remote.is_empty() && keep_local.is_empty() && !req.dry_run {
+        if take_remote.is_empty() && keep_local.is_empty() && !req.dry_run && !req.automatic {
             bail!(
                 "sync paused: resolve all {} conflict(s) before sharing resumes",
                 status.conflicts.len()
@@ -137,7 +175,10 @@ pub(crate) async fn apply(store: &Store, tracked: &TrackedSet, req: &ApplyReques
             "sync paused: {} conflict(s) remain; no files applied or published",
             status.conflicts.len()
         );
-        return Ok(());
+        return Ok(ApplyOutcome {
+            held: status.conflicts.len(),
+            ..Default::default()
+        });
     }
 
     // the write set
@@ -173,12 +214,14 @@ pub(crate) async fn apply(store: &Store, tracked: &TrackedSet, req: &ApplyReques
         });
     }
     if steps.is_empty() {
-        if !req.dry_run {
+        if !req.dry_run && !req.automatic {
             status.application_failure = None;
             run::write_status(state_dir, &status)?;
         }
-        info!("history: nothing to apply");
-        return Ok(());
+        if !req.automatic {
+            info!("history: nothing to apply");
+        }
+        return Ok(ApplyOutcome::default());
     }
 
     // validation and holds, per group
@@ -225,17 +268,27 @@ pub(crate) async fn apply(store: &Store, tracked: &TrackedSet, req: &ApplyReques
             step.group.clone(),
         ]);
     }
-    table.print()?;
+    if !req.automatic {
+        table.print()?;
+    }
     if req.dry_run {
         miseprintln!("history: dry run; nothing was changed");
-        return Ok(());
+        return Ok(ApplyOutcome::default());
     }
     if ready.is_empty() {
+        if req.automatic {
+            return Ok(ApplyOutcome {
+                held: held.len(),
+                ..Default::default()
+            });
+        }
         bail!("nothing can be applied until the held paths are decided");
     }
-    if !super::origin::confirmed(req.yes, "history: apply these incoming changes?")? {
+    if !req.automatic
+        && !super::origin::confirmed(req.yes, "history: apply these incoming changes?")?
+    {
         info!("history: skipped");
-        return Ok(());
+        return Ok(ApplyOutcome::default());
     }
 
     // the transaction
@@ -341,6 +394,7 @@ pub(crate) async fn apply(store: &Store, tracked: &TrackedSet, req: &ApplyReques
         .retain(|pending| !applied.contains(&pending.branch_path));
     status.resolutions.retain(|path, _| !applied.contains(path));
     status.application_failure = None;
+    status.notified_conflicts.clear();
     // the live declarations changed now: said until `mise bootstrap` ran
     let configuration_written = ready
         .iter()
@@ -358,13 +412,21 @@ pub(crate) async fn apply(store: &Store, tracked: &TrackedSet, req: &ApplyReques
     scope.finish(error, Some(summary));
     result?;
     replay::run_reload(&reload, &touched);
-    if ready.iter().any(|step| step.pending.configuration) {
+    let configuration = ready.iter().any(|step| step.pending.configuration);
+    if configuration && !req.automatic {
         info!(
             "history: configuration changed; declarations may differ from the applied setup: run `mise bootstrap --dry-run`"
         );
     }
-    info!("history: applied {} incoming change(s)", touched.len());
-    Ok(())
+    if !req.automatic {
+        info!("history: applied {} incoming change(s)", touched.len());
+    }
+    let outcome = ApplyOutcome {
+        written: touched.len(),
+        held: held.len(),
+        configuration,
+    };
+    Ok(outcome)
 }
 
 fn recover_step(repo: &crate::system::history::shadow::HistoryRepo, step: &Step) -> Result<()> {

--- a/src/system/history/sync/apply.rs
+++ b/src/system/history/sync/apply.rs
@@ -400,7 +400,7 @@ pub(crate) async fn apply(
         .retain(|pending| !applied.contains(&pending.branch_path));
     status.resolutions.retain(|path, _| !applied.contains(path));
     status.application_failure = None;
-    status.notified_conflicts.clear();
+    status.conflict_pause_observed = false;
     // the live declarations changed now: said until `mise bootstrap` ran
     let configuration_written = ready
         .iter()

--- a/src/system/history/sync/backup.rs
+++ b/src/system/history/sync/backup.rs
@@ -9,7 +9,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use eyre::Result;
 
-use super::network::{PushOutcome, REMOTE_MACHINES_PREFIX, Remote};
+use super::network::{MACHINES_PREFIX, PushOutcome, REMOTE_MACHINES_PREFIX, Remote};
 use super::privacy::mask_checkpoint;
 use crate::system::history::shadow::{HistoryRepo, Overlay};
 use crate::system::history::store::{Entry, OperationStatus};
@@ -69,7 +69,19 @@ pub(crate) fn remote_ref(machine_id: &str, uuid: &str) -> String {
     format!("{REMOTE_MACHINES_PREFIX}{machine_id}/{uuid}")
 }
 
-/// Uploads every eligible checkpoint not yet uploaded. Returns how many.
+/// The mirrored remote ref of one of this machine's checkpoints, as the
+/// sync's fetch left it: present means the origin holds the backup, whatever
+/// the local record remembers.
+fn mirrored(repo: &HistoryRepo, machine_id: &str, uuid: &str) -> Result<Option<String>> {
+    repo.ref_oid(&format!("{MACHINES_PREFIX}{machine_id}/{uuid}"))
+}
+
+/// Uploads every eligible checkpoint the origin does not hold yet. Returns
+/// how many were pushed. The origin's refs decide, not only the local record
+/// (a lost `sync.json` must not re-push, and a backup already there is never
+/// replaced): a checkpoint mirrored by the fetch is recorded as uploaded, and
+/// one the origin refuses (a differing backup under the same name) is left as
+/// it is on the origin and reported, while the others go on.
 pub(crate) fn upload(
     remote: &Remote<'_>,
     repo: &HistoryRepo,
@@ -79,21 +91,25 @@ pub(crate) fn upload(
 ) -> Result<usize> {
     let mut count = 0;
     for entry in entries {
-        if uploaded.contains(&entry.checkpoint.uuid) || !eligible(entry) {
+        let uuid = &entry.checkpoint.uuid;
+        if uploaded.contains(uuid) || !eligible(entry) {
+            continue;
+        }
+        if mirrored(repo, machine_id, uuid)?.is_some() {
+            uploaded.insert(uuid.clone());
             continue;
         }
         let commit = filtered_commit(repo, entry)?;
-        let refspec = format!(
-            "{commit}:{}",
-            remote_ref(machine_id, &entry.checkpoint.uuid)
-        );
+        let refspec = format!("{commit}:{}", remote_ref(machine_id, uuid));
         match remote.push(&[refspec], None)? {
             PushOutcome::Done => {
-                uploaded.insert(entry.checkpoint.uuid.clone());
+                uploaded.insert(uuid.clone());
                 count += 1;
             }
             PushOutcome::Rejected(reason) => {
-                eyre::bail!("uploading checkpoint {}: {reason}", entry.checkpoint.uuid)
+                warn!(
+                    "history sync: the origin already holds a different backup of checkpoint {uuid}; keeping the origin's ({reason})"
+                );
             }
         }
     }
@@ -139,4 +155,162 @@ pub(crate) fn remote_refs(remote: &Remote<'_>, machine_id: &str) -> Result<Vec<S
         .filter(|(_, name)| name.starts_with(&prefix))
         .map(|(_, name)| name)
         .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use super::*;
+    use crate::system::history::checkpoint::test_checkpoint;
+    use crate::system::history::store::CoverageEntry;
+
+    fn repo(tmp: &std::path::Path) -> HistoryRepo {
+        HistoryRepo::open_or_init_in(&tmp.join("state"))
+            .unwrap()
+            .expect("git is required for these tests")
+    }
+
+    fn origin(tmp: &std::path::Path) -> String {
+        let path = tmp.join("origin.git");
+        let status = Command::new("git")
+            .args(["init", "-q", "--bare", "-b", "main"])
+            .arg(&path)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        format!("file://{}", path.display())
+    }
+
+    fn origin_refs(url: &str) -> Vec<String> {
+        let output = Command::new("git")
+            .args(["ls-remote", "--quiet", url])
+            .output()
+            .unwrap();
+        String::from_utf8(output.stdout)
+            .unwrap()
+            .lines()
+            .filter_map(|line| line.split('\t').nth(1).map(str::to_string))
+            .collect()
+    }
+
+    /// An eligible checkpoint: content, and one entry with `backup = true`.
+    fn entry(repo: &HistoryRepo, uuid: &str) -> Entry {
+        let blob = repo.hash_blob(b"alias ll='ls -l'\n").unwrap();
+        let tree = repo
+            .mktree(&format!("100644 blob {blob}\t.zshrc\n"))
+            .unwrap();
+        let mut checkpoint = test_checkpoint(uuid, Some(&tree));
+        checkpoint.tree.coverage.entries.push(CoverageEntry {
+            path: "~/.zshrc".into(),
+            mode: "track".into(),
+            variant: None,
+            source: None,
+            autosave: true,
+            share: true,
+            backup: true,
+            state: "live".into(),
+            promotion: None,
+            private: None,
+            declared_in: None,
+        });
+        let commit = repo
+            .write_checkpoint_commit(Some(&tree), &checkpoint, &BTreeMap::new())
+            .unwrap();
+        Entry {
+            id: 1,
+            commit,
+            checkpoint,
+        }
+    }
+
+    #[test]
+    fn a_backup_the_fetch_mirrored_is_recorded_not_pushed() {
+        if crate::git::plumbing_binary().is_none() {
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = repo(tmp.path());
+        let url = origin(tmp.path());
+        let remote = Remote::new(&repo, &url);
+        let entry = entry(&repo, "u1");
+        repo.update_ref(&format!("{MACHINES_PREFIX}m/u1"), &entry.commit, None)
+            .unwrap();
+        let mut uploaded = BTreeSet::new();
+        assert_eq!(
+            upload(&remote, &repo, &[entry], "m", &mut uploaded).unwrap(),
+            0
+        );
+        assert_eq!(uploaded, BTreeSet::from(["u1".to_string()]));
+        assert!(origin_refs(&url).is_empty());
+    }
+
+    #[test]
+    fn a_forgotten_upload_is_found_on_the_origin_instead_of_pushed_again() {
+        if crate::git::plumbing_binary().is_none() {
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = repo(tmp.path());
+        let url = origin(tmp.path());
+        let remote = Remote::new(&repo, &url);
+        let entry = entry(&repo, "u1");
+        let mut uploaded = BTreeSet::new();
+        assert_eq!(
+            upload(
+                &remote,
+                &repo,
+                std::slice::from_ref(&entry),
+                "m",
+                &mut uploaded
+            )
+            .unwrap(),
+            1
+        );
+        assert_eq!(origin_refs(&url), vec![remote_ref("m", "u1")]);
+        // the local record is lost; the next sync's fetch mirrors the ref
+        uploaded.clear();
+        remote.fetch("main").unwrap();
+        assert_eq!(
+            upload(&remote, &repo, &[entry], "m", &mut uploaded).unwrap(),
+            0
+        );
+        assert_eq!(uploaded, BTreeSet::from(["u1".to_string()]));
+        assert_eq!(origin_refs(&url), vec![remote_ref("m", "u1")]);
+    }
+
+    #[test]
+    fn a_differing_backup_on_the_origin_is_kept() {
+        if crate::git::plumbing_binary().is_none() {
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = repo(tmp.path());
+        let url = origin(tmp.path());
+        let remote = Remote::new(&repo, &url);
+        // another build of the same checkpoint is on the origin already
+        let other = entry(&repo, "u1");
+        let refspec = format!("{}:{}", other.commit, remote_ref("m", "u1"));
+        assert_eq!(remote.push(&[refspec], None).unwrap(), PushOutcome::Done);
+        let mut entry = entry(&repo, "u1");
+        entry.checkpoint.description = "rebuilt".into();
+        let mut uploaded = BTreeSet::new();
+        assert_eq!(
+            upload(
+                &remote,
+                &repo,
+                std::slice::from_ref(&entry),
+                "m",
+                &mut uploaded
+            )
+            .unwrap(),
+            0
+        );
+        assert!(uploaded.is_empty());
+        let output = Command::new("git")
+            .args(["ls-remote", "--quiet", &url, &remote_ref("m", "u1")])
+            .output()
+            .unwrap();
+        assert!(String::from_utf8_lossy(&output.stdout).starts_with(&other.commit));
+    }
 }

--- a/src/system/history/sync/mod.rs
+++ b/src/system/history/sync/mod.rs
@@ -24,15 +24,27 @@ pub(crate) mod run;
 pub(crate) mod share;
 pub(crate) mod state;
 
-/// `settings.history.sync`.
+/// `settings.history.sync`: what the watcher does on its own. Explicit
+/// commands (`sync`, `pull`) work the same in every mode except that
+/// `fetch-only` never publishes.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum SyncMode {
-    /// Publish and fetch; any conflict pauses publication and incoming application for the setup.
+    /// The watcher publishes after saves, fetches periodically, and applies
+    /// nonconflicting incoming changes.
     Sync,
-    /// Download only: never publish, never change live files.
+    /// The watcher fetches periodically; nothing is ever published and no
+    /// live file changes without `pull`.
     FetchOnly,
-    /// Publish and fetch; apply only on `mise bootstrap dotfiles pull`.
+    /// No automatic network activity: `sync` and `pull` on request only.
     Manual,
+}
+
+/// What a mode does in the background.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct Automatic {
+    pub publish: bool,
+    pub fetch: bool,
+    pub apply: bool,
 }
 
 impl SyncMode {
@@ -61,17 +73,37 @@ impl SyncMode {
         self != Self::FetchOnly
     }
 
+    pub(crate) fn automatic(self) -> Automatic {
+        match self {
+            Self::Sync => Automatic {
+                publish: true,
+                fetch: true,
+                apply: true,
+            },
+            Self::FetchOnly => Automatic {
+                publish: false,
+                fetch: true,
+                apply: false,
+            },
+            Self::Manual => Automatic {
+                publish: false,
+                fetch: false,
+                apply: false,
+            },
+        }
+    }
+
     /// What the mode does and does not do, disclosed when connecting.
     pub(crate) fn disclosure(self) -> &'static str {
         match self {
             Self::Sync => {
-                "sync: this machine publishes its shared files and configuration and fetches the repository. Any conflict pauses publication and incoming application for the entire setup; local history, fetching, and eligible machine backups continue. Once all conflicts are resolved, `mise bootstrap dotfiles pull` applies the complete incoming batch with a protective checkpoint and recovery journal. Applying never runs `mise bootstrap`, installs or removes packages, or renders templates; when incoming configuration changes declarations, `mise bootstrap dotfiles status` says to run `mise bootstrap`."
+                "sync: the watcher publishes this machine's shared files and configuration after each save, fetches the repository periodically, and applies nonconflicting incoming changes to tracked files and configuration (with a protective checkpoint first; a conflict or an unsaved edit holds the path, nothing else waits). It never runs `mise bootstrap`, installs or removes packages, or renders templates; when incoming configuration changes declarations, `mise bootstrap dotfiles status` says to run `mise bootstrap`. `mise bootstrap dotfiles sync` and `pull` do the same on request."
             }
             Self::FetchOnly => {
-                "fetch-only: this machine only downloads the repository and other machines' recovery refs. Nothing is published, no live file changes."
+                "fetch-only: the watcher only downloads the repository and other machines' recovery refs. Nothing is ever published, and no live file changes unless you run `mise bootstrap dotfiles pull`."
             }
             Self::Manual => {
-                "manual: this machine publishes and fetches automatically; incoming changes are applied only by `mise bootstrap dotfiles pull`."
+                "manual: no automatic network activity. `mise bootstrap dotfiles sync` publishes and fetches, and `mise bootstrap dotfiles pull` applies, when you run them."
             }
         }
     }

--- a/src/system/history/sync/mod.rs
+++ b/src/system/history/sync/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod format;
 pub(crate) mod layout;
 pub(crate) mod machines;
 pub(crate) mod network;
+pub(crate) mod onboard;
 pub(crate) mod origin;
 mod preflight;
 pub(crate) mod privacy;

--- a/src/system/history/sync/mod.rs
+++ b/src/system/history/sync/mod.rs
@@ -31,7 +31,7 @@ pub(crate) mod state;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum SyncMode {
     /// The watcher publishes after saves, fetches periodically, and applies
-    /// nonconflicting incoming changes.
+    /// incoming changes once the complete setup is free of conflicts.
     Sync,
     /// The watcher fetches periodically; nothing is ever published and no
     /// live file changes without `pull`.
@@ -98,7 +98,7 @@ impl SyncMode {
     pub(crate) fn disclosure(self) -> &'static str {
         match self {
             Self::Sync => {
-                "sync: the watcher publishes this machine's shared files and configuration after each save, fetches the repository periodically, and applies nonconflicting incoming changes to tracked files and configuration (with a protective checkpoint first; a conflict or an unsaved edit holds the path, nothing else waits). It never runs `mise bootstrap`, installs or removes packages, or renders templates; when incoming configuration changes declarations, `mise bootstrap dotfiles status` says to run `mise bootstrap`. `mise bootstrap dotfiles sync` and `pull` do the same on request."
+                "sync: the watcher publishes saved changes and fetches periodically. Any conflict pauses publication and incoming application for the entire setup; local history, fetching, and eligible machine backups continue. Incoming changes are preflighted together and applied with a protective checkpoint and recovery journal. Applying never runs `mise bootstrap` or renders templates. Run `mise bootstrap` when the new declarations need to be applied."
             }
             Self::FetchOnly => {
                 "fetch-only: the watcher only downloads the repository and other machines' recovery refs. Nothing is ever published, and no live file changes unless you run `mise bootstrap dotfiles pull`."

--- a/src/system/history/sync/network.rs
+++ b/src/system/history/sync/network.rs
@@ -178,6 +178,30 @@ impl<'a> Remote<'a> {
     }
 
     /// The remote's refs: `(oid, name)`.
+    /// The branch the repository's `HEAD` points at, when it says.
+    pub(crate) fn symbolic_head(&self) -> Result<Option<String>> {
+        let output = self
+            .repo
+            .network(["ls-remote", "--quiet", "--symref", &self.url, "HEAD"])?;
+        if !output.status.success() {
+            bail!(
+                "listing {}: {}",
+                self.url,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        Ok(String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .find_map(|line| {
+                let rest = line.strip_prefix("ref: ")?;
+                let (target, name) = rest.split_once('\t')?;
+                (name == "HEAD")
+                    .then(|| target.strip_prefix("refs/heads/"))
+                    .flatten()
+                    .map(str::to_string)
+            }))
+    }
+
     pub(crate) fn ls_remote(&self) -> Result<Vec<(String, String)>> {
         let output = self.repo.network(["ls-remote", "--quiet", &self.url])?;
         if !output.status.success() {

--- a/src/system/history/sync/onboard.rs
+++ b/src/system/history/sync/onboard.rs
@@ -39,6 +39,9 @@ pub(crate) struct Outcome {
     /// The repository can be reached without this session's borrowed
     /// GitHub access.
     pub durable_access: bool,
+    /// The shared configuration was not written: it waits for a decision
+    /// (a differing configuration is here already), so no bootstrap ran.
+    pub configuration_held: bool,
 }
 
 /// `mise bootstrap --from-git <url>`: `Some` when the repository is
@@ -74,9 +77,13 @@ pub(crate) async fn from_git(url: &str, yes: bool, dry_run: bool) -> Result<Opti
     Ok(Some(outcome))
 }
 
-/// The branch a fresh machine takes: `main`, else `master`, else the first
-/// head; `None` when the repository lists none (unreachable, empty).
+/// The branch a fresh machine takes: the repository's default branch (its
+/// `HEAD`), else `main`, else `master`, else the first head; `None` when the
+/// repository lists none (unreachable, empty).
 fn default_branch(remote: &Remote<'_>) -> Result<Option<String>> {
+    if let Ok(Some(head)) = remote.symbolic_head() {
+        return Ok(Some(head));
+    }
     let Ok(refs) = remote.ls_remote() else {
         return Ok(None);
     };
@@ -160,18 +167,43 @@ pub(crate) async fn run(store: &Store, onboarding: &Onboarding) -> Result<Outcom
         encrypt_backups: false,
     });
     request.capture = !onboarding.dry_run;
+    request.dry_run = onboarding.dry_run;
+    // a dry run records what is pending only for the plan below and puts
+    // everything back afterwards: the previous sync state, and no fetched
+    // branch on a machine that was not connected
+    let recorded = run::status_path(state_dir);
+    let recorded_before = onboarding
+        .dry_run
+        .then(|| std::fs::read(&recorded).ok())
+        .flatten();
+    let connected_before = {
+        let status = run::read_status(state_dir);
+        status.origin_url.is_some() && !status.disconnected
+    };
     let synced = run::sync(store, &tracked, &request)?;
     let mut preview = ApplyRequest::automatic();
     preview.automatic = false;
     preview.dry_run = true;
     preview.plan_only = true;
-    apply::apply(store, &tracked, &preview).await?;
+    let previewed = apply::apply(store, &tracked, &preview).await;
     if onboarding.dry_run {
+        match recorded_before {
+            Some(bytes) => crate::file::write(&recorded, bytes)?,
+            None => {
+                let _ = std::fs::remove_file(&recorded);
+            }
+        }
+        if !connected_before && let Some(repo) = store.repo() {
+            repo.delete_ref(UPSTREAM_REF)?;
+        }
+        previewed?;
         miseprintln!("Dry run: nothing was changed.");
         return Ok(Outcome {
             durable_access: true,
+            configuration_held: false,
         });
     }
+    previewed?;
     if !super::origin::confirmed(onboarding.yes, "Set this machine up from the repository?")? {
         bail!("not set up");
     }
@@ -196,6 +228,18 @@ pub(crate) async fn run(store: &Store, onboarding: &Onboarding) -> Result<Outcom
     // a conflict (a file that exists here and differs) is not pending: it
     // waits for a decision, like a path held with its group
     let undecided = applied.held + synced.conflicts;
+    // configuration among them: nothing to bootstrap from yet
+    let configuration_held = {
+        let status = run::read_status(state_dir);
+        status
+            .pending_applications
+            .iter()
+            .any(|pending| pending.configuration)
+            || status
+                .conflicts
+                .iter()
+                .any(|conflict| super::layout::is_configuration(&conflict.branch_path))
+    };
     miseprintln!(
         "Wrote {} file(s) from {}{}.",
         applied.written,
@@ -214,7 +258,10 @@ pub(crate) async fn run(store: &Store, onboarding: &Onboarding) -> Result<Outcom
             "setup complete, but ongoing synchronization needs credentials on this host: the borrowed GitHub access ends with this session. Run `mise x gh -- gh auth login` and `mise x gh -- gh auth setup-git` here, or connect an SSH url with `mise bootstrap dotfiles origin set <url>`"
         );
     }
-    Ok(Outcome { durable_access })
+    Ok(Outcome {
+        durable_access,
+        configuration_held,
+    })
 }
 
 /// Whether this host reaches the repository on its own: with the

--- a/src/system/history/sync/onboard.rs
+++ b/src/system/history/sync/onboard.rs
@@ -48,7 +48,15 @@ pub(crate) struct Outcome {
 /// history-managed and this machine was set up from it (or would be, on a
 /// dry run); `None` leaves the ordinary clone to the caller.
 pub(crate) async fn from_git(url: &str, yes: bool, dry_run: bool) -> Result<Option<Outcome>> {
-    let store = Store::open()?;
+    // Detect marked repositories without creating persistent tracking state
+    // for users of the released, ordinary --from-git workflow.
+    let probe_dir = (!crate::config::Settings::get().experimental)
+        .then(tempfile::tempdir)
+        .transpose()?;
+    let store = match &probe_dir {
+        Some(dir) => Store::open_in(dir.path())?,
+        None => Store::open()?,
+    };
     if let Some(reason) = store.unavailable() {
         debug!("history: {url} is not probed for a setup repository: {reason}");
         return Ok(None);
@@ -63,6 +71,7 @@ pub(crate) async fn from_git(url: &str, yes: bool, dry_run: bool) -> Result<Opti
     if !matches!(probe(&store, url, &branch)?, RepoState::Marked(_)) {
         return Ok(None);
     }
+    crate::config::Settings::get().ensure_experimental("dotfile tracking")?;
     let outcome = run(
         &store,
         &Onboarding {
@@ -135,6 +144,7 @@ pub(crate) fn probe(store: &Store, fetch_from: &str, branch: &str) -> Result<Rep
 /// the connection, and pulls (the configuration first, then what it
 /// declares, like any pull).
 pub(crate) async fn run(store: &Store, onboarding: &Onboarding) -> Result<Outcome> {
+    crate::config::Settings::get().ensure_experimental("dotfile tracking")?;
     let state_dir = store.state_dir();
     let mode = SyncMode::current()?;
     let config_dir = global_config_dir();

--- a/src/system/history/sync/onboard.rs
+++ b/src/system/history/sync/onboard.rs
@@ -209,19 +209,19 @@ pub(crate) async fn run(store: &Store, onboarding: &Onboarding) -> Result<Outcom
     }
 
     // the connection: declared machine-locally, recorded for the watcher
-    let mut status = run::read_status(state_dir);
-    status.origin_url = Some(onboarding.origin.clone());
-    status.origin_branch = Some(onboarding.branch.clone());
-    status.disconnected = false;
-    if status.upload_since.is_none() {
-        let newest = store
-            .list()?
-            .into_iter()
-            .last()
-            .map(|entry| entry.checkpoint.created_at);
-        status.upload_since = Some(newest.unwrap_or_else(hstore::now_rfc3339));
-    }
-    run::write_status(state_dir, &status)?;
+    let newest = store
+        .list()?
+        .into_iter()
+        .last()
+        .map(|entry| entry.checkpoint.created_at);
+    run::update_status(state_dir, run::STATUS_LOCK_WAIT, |status| {
+        status.origin_url = Some(onboarding.origin.clone());
+        status.origin_branch = Some(onboarding.branch.clone());
+        status.disconnected = false;
+        if status.upload_since.is_none() {
+            status.upload_since = Some(newest.unwrap_or_else(hstore::now_rfc3339));
+        }
+    })?;
     super::origin::write_config(&onboarding.origin, &onboarding.branch, None)?;
 
     let applied = apply::apply(store, &tracked, &ApplyRequest::automatic()).await?;

--- a/src/system/history/sync/onboard.rs
+++ b/src/system/history/sync/onboard.rs
@@ -263,6 +263,9 @@ pub(crate) async fn run(store: &Store, onboarding: &Onboarding) -> Result<Outcom
         }
     );
     let durable_access = durable_access(&onboarding.origin, &onboarding.branch);
+    if applied.held == 0 && synced.conflicts == 0 && !configuration_held {
+        crate::system::remote::persist_experimental_opt_in()?;
+    }
     if !durable_access {
         warn!(
             "setup complete, but ongoing synchronization needs credentials on this host: the borrowed GitHub access ends with this session. Run `mise x gh -- gh auth login` and `mise x gh -- gh auth setup-git` here, or connect an SSH url with `mise bootstrap dotfiles origin set <url>`"

--- a/src/system/history/sync/onboard.rs
+++ b/src/system/history/sync/onboard.rs
@@ -36,12 +36,77 @@ pub(crate) struct Onboarding {
 }
 
 pub(crate) struct Outcome {
+    /// Incoming configuration staged privately for the ordinary bootstrap
+    /// preview. The caller owns its lifetime; live configuration is untouched.
+    pub preview_config: Option<tempfile::TempDir>,
     /// The repository can be reached without this session's borrowed
     /// GitHub access.
     pub durable_access: bool,
     /// The shared configuration was not written: it waits for a decision
     /// (a differing configuration is here already), so no bootstrap ran.
     pub configuration_held: bool,
+}
+
+/// Snapshot only the state needed for planning while its writers are locked.
+/// All fetches, reconciliation, and preview status writes then target this
+/// private store, so cancellation never needs to roll back live bookkeeping.
+fn preview_store(store: &Store) -> Result<(tempfile::TempDir, Store)> {
+    let _sync = run::lock(store)?;
+    let _capture = store.lock()?;
+    let temp = tempfile::tempdir()?;
+    hstore::ensure_store_dir_in(temp.path())?;
+    std::fs::copy(
+        hstore::machine_file_in(store.state_dir()),
+        hstore::machine_file_in(temp.path()),
+    )?;
+    let preview = Store::open_in(temp.path())?;
+    let source = store
+        .repo()
+        .ok_or_else(|| eyre::eyre!("preview requires git"))?;
+    let destination = preview
+        .repo()
+        .ok_or_else(|| eyre::eyre!("preview requires git"))?;
+    let url = url::Url::from_file_path(source.dir())
+        .map_err(|_| eyre::eyre!("cannot address the local history repository"))?;
+    let copied = destination.network(["fetch", "--no-tags", url.as_str(), "+refs/*:refs/*"])?;
+    if !copied.status.success() {
+        bail!("could not snapshot the local history repository for preview");
+    }
+    run::write_status(temp.path(), &run::read_status(store.state_dir())?)?;
+    // Reopen to rebuild checkpoint and promotion indexes from the copied refs.
+    let preview = Store::open_in(temp.path())?;
+    Ok((temp, preview))
+}
+
+fn preview_configuration(store: &Store) -> Result<tempfile::TempDir> {
+    let temp = tempfile::tempdir()?;
+    let repo = store
+        .repo()
+        .ok_or_else(|| eyre::eyre!("preview requires git"))?;
+    let head = repo
+        .ref_oid(UPSTREAM_REF)?
+        .ok_or_else(|| eyre::eyre!("setup preview has no fetched branch"))?;
+    for entry in repo.ls_tree(&head)? {
+        if super::layout::is_configuration(&entry.path)
+            && super::layout::is_safe_branch_path(&entry.path)
+        {
+            let Some((mode, oid)) = repo.object_at(&head, &entry.path)? else {
+                bail!("configuration disappeared from preview commit");
+            };
+            crate::system::history::replay::write_path(
+                repo,
+                &temp.path().join(&entry.path),
+                &mode,
+                &oid,
+            )?;
+        }
+    }
+    // Machine-local inputs are not published, but affect the real bootstrap.
+    let local = global_config_dir().join("config.local.toml");
+    if local.is_file() {
+        std::fs::copy(local, temp.path().join("config.local.toml"))?;
+    }
+    Ok(temp)
 }
 
 /// `mise bootstrap --from-git <url>`: `Some` when the repository is
@@ -166,7 +231,8 @@ pub(crate) async fn run(store: &Store, onboarding: &Onboarding) -> Result<Outcom
         );
     }
 
-    // what is pending, then the plan
+    // Preview in an isolated store, never in the live sync state.
+    let (_preview_dir, planning_store) = preview_store(store)?;
     let tracked = TrackedSet::effective().await?;
     let mut request = SyncRequest::new(true);
     request.origin = Some(OriginTomlConfig {
@@ -174,47 +240,34 @@ pub(crate) async fn run(store: &Store, onboarding: &Onboarding) -> Result<Outcom
         branch: onboarding.branch.clone(),
         encrypt_backups: false,
     });
-    request.capture = !onboarding.dry_run;
-    request.dry_run = onboarding.dry_run;
-    // a dry run records what is pending only for the plan below and puts
-    // everything back afterwards: the previous sync state, and no fetched
-    // branch on a machine that was not connected
-    let recorded = run::status_path(state_dir);
-    let recorded_before = onboarding
-        .dry_run
-        .then(|| std::fs::read(&recorded).ok())
-        .flatten();
-    let connected_before = {
-        let status = run::read_status(state_dir)?;
-        status.origin_url.is_some() && !status.disconnected
-    };
-    let synced = run::sync(store, &tracked, &request)?;
+    request.capture = false;
+    request.dry_run = true;
+    // Pending decisions belong only to this preview store.
+    run::sync(&planning_store, &tracked, &request)?;
     let mut preview = ApplyRequest::automatic();
     preview.automatic = false;
     preview.dry_run = true;
     preview.plan_only = true;
-    let previewed = apply::apply(store, &tracked, &preview).await;
+    apply::apply(&planning_store, &tracked, &preview).await?;
     if onboarding.dry_run {
-        match recorded_before {
-            Some(bytes) => crate::file::write(&recorded, bytes)?,
-            None => {
-                let _ = std::fs::remove_file(&recorded);
-            }
-        }
-        if !connected_before && let Some(repo) = store.repo() {
-            repo.delete_ref(UPSTREAM_REF)?;
-        }
-        previewed?;
+        let preview_config = Some(preview_configuration(&planning_store)?);
         miseprintln!("Dry run: nothing was changed.");
         return Ok(Outcome {
+            preview_config,
             durable_access: true,
             configuration_held: false,
         });
     }
-    previewed?;
     if !super::origin::confirmed(onboarding.yes, "Set this machine up from the repository?")? {
         bail!("not set up");
     }
+
+    // Recompute after confirmation against current local files and remote
+    // refs; never apply a stale preview or restore over a watcher's new state.
+    refuse_other_connection(store, &onboarding.origin, &onboarding.branch)?;
+    request.capture = true;
+    request.dry_run = false;
+    let synced = run::sync(store, &tracked, &request)?;
 
     // the connection: declared machine-locally, recorded for the watcher
     let newest = store
@@ -273,6 +326,7 @@ pub(crate) async fn run(store: &Store, onboarding: &Onboarding) -> Result<Outcom
         );
     }
     Ok(Outcome {
+        preview_config: None,
         durable_access,
         configuration_held,
     })

--- a/src/system/history/sync/onboard.rs
+++ b/src/system/history/sync/onboard.rs
@@ -110,7 +110,7 @@ fn default_branch(remote: &Remote<'_>) -> Result<Option<String>> {
 
 /// A machine connected to another repository is not silently moved.
 fn refuse_other_connection(store: &Store, origin: &str, branch: &str) -> Result<()> {
-    let status = run::read_status(store.state_dir());
+    let status = run::read_status(store.state_dir())?;
     if let Some(url) = &status.origin_url
         && !status.disconnected
         && (url != origin || status.origin_branch.as_deref() != Some(branch))
@@ -187,7 +187,7 @@ pub(crate) async fn run(store: &Store, onboarding: &Onboarding) -> Result<Outcom
         .then(|| std::fs::read(&recorded).ok())
         .flatten();
     let connected_before = {
-        let status = run::read_status(state_dir);
+        let status = run::read_status(state_dir)?;
         status.origin_url.is_some() && !status.disconnected
     };
     let synced = run::sync(store, &tracked, &request)?;
@@ -240,7 +240,7 @@ pub(crate) async fn run(store: &Store, onboarding: &Onboarding) -> Result<Outcom
     let undecided = applied.held + synced.conflicts;
     // configuration among them: nothing to bootstrap from yet
     let configuration_held = {
-        let status = run::read_status(state_dir);
+        let status = run::read_status(state_dir)?;
         status
             .pending_applications
             .iter()

--- a/src/system/history/sync/onboard.rs
+++ b/src/system/history/sync/onboard.rs
@@ -1,0 +1,249 @@
+//! Setting a machine up from a history-managed setup repository:
+//! `mise bootstrap --from-git <url>` on a repository that carries the
+//! `.mise-history/format.toml` marker, locally or on a remote host through
+//! the bundle `mise bootstrap remote --from-git` transfers. The branch is
+//! fetched into mise's own bare store, never cloned into the configuration
+//! directory; the shared configuration, the sources it references, and this
+//! machine's tracked streams are written by the same recoverable pull as any
+//! other incoming change (a file that differs is held for a decision, never
+//! overwritten); the connection is declared machine-locally and recorded
+//! for the watcher. An ordinary repository (no marker) is left to the
+//! ordinary `--from-git`.
+
+use std::process::{Command, Stdio};
+
+use eyre::{Result, bail};
+
+use super::SyncMode;
+use super::apply::{self, ApplyRequest};
+use super::format::{self, RepoState};
+use super::network::{Remote, UPSTREAM_REF};
+use super::run::{self, SyncRequest};
+use crate::file::display_path;
+use crate::system::history::checkpoint::Store;
+use crate::system::history::config::OriginTomlConfig;
+use crate::system::history::store as hstore;
+use crate::system::history::tracked::{TrackedSet, global_config_dir};
+
+pub(crate) struct Onboarding {
+    /// Where the branch is fetched from: the url, or a transferred bundle.
+    pub fetch_from: String,
+    /// The repository as this machine keeps reaching it.
+    pub origin: String,
+    pub branch: String,
+    pub yes: bool,
+    pub dry_run: bool,
+}
+
+pub(crate) struct Outcome {
+    /// The repository can be reached without this session's borrowed
+    /// GitHub access.
+    pub durable_access: bool,
+}
+
+/// `mise bootstrap --from-git <url>`: `Some` when the repository is
+/// history-managed and this machine was set up from it (or would be, on a
+/// dry run); `None` leaves the ordinary clone to the caller.
+pub(crate) async fn from_git(url: &str, yes: bool, dry_run: bool) -> Result<Option<Outcome>> {
+    let store = Store::open()?;
+    if let Some(reason) = store.unavailable() {
+        debug!("history: {url} is not probed for a setup repository: {reason}");
+        return Ok(None);
+    }
+    let repo = store
+        .repo()
+        .ok_or_else(|| eyre::eyre!("probing a setup repository requires git"))?;
+    let Some(branch) = default_branch(&Remote::new(repo, url))? else {
+        return Ok(None);
+    };
+    refuse_other_connection(&store, url, &branch)?;
+    if !matches!(probe(&store, url, &branch)?, RepoState::Marked(_)) {
+        return Ok(None);
+    }
+    let outcome = run(
+        &store,
+        &Onboarding {
+            fetch_from: url.to_string(),
+            origin: url.to_string(),
+            branch,
+            yes,
+            dry_run,
+        },
+    )
+    .await?;
+    Ok(Some(outcome))
+}
+
+/// The branch a fresh machine takes: `main`, else `master`, else the first
+/// head; `None` when the repository lists none (unreachable, empty).
+fn default_branch(remote: &Remote<'_>) -> Result<Option<String>> {
+    let Ok(refs) = remote.ls_remote() else {
+        return Ok(None);
+    };
+    for candidate in ["refs/heads/main", "refs/heads/master"] {
+        if refs.iter().any(|(_, name)| name == candidate) {
+            return Ok(Some(
+                candidate.trim_start_matches("refs/heads/").to_string(),
+            ));
+        }
+    }
+    Ok(refs
+        .iter()
+        .find_map(|(_, name)| name.strip_prefix("refs/heads/").map(str::to_string)))
+}
+
+/// A machine connected to another repository is not silently moved.
+fn refuse_other_connection(store: &Store, origin: &str, branch: &str) -> Result<()> {
+    let status = run::read_status(store.state_dir());
+    if let Some(url) = &status.origin_url
+        && !status.disconnected
+        && (url != origin || status.origin_branch.as_deref() != Some(branch))
+    {
+        bail!(
+            "this machine is connected to {url}; `mise bootstrap dotfiles origin --remove` disconnects it, or `mise bootstrap dotfiles origin set {origin}` moves it"
+        );
+    }
+    Ok(())
+}
+
+/// Fetches the branch into the store and says what the repository is. A
+/// format this mise does not understand is an error; an ordinary
+/// repository leaves nothing behind.
+pub(crate) fn probe(store: &Store, fetch_from: &str, branch: &str) -> Result<RepoState> {
+    let repo = store
+        .repo()
+        .ok_or_else(|| eyre::eyre!("probing a setup repository requires git"))?;
+    Remote::new(repo, fetch_from).fetch(branch)?;
+    let upstream = repo.ref_oid(UPSTREAM_REF)?;
+    let state = format::detect(repo, upstream.as_deref())?;
+    state.check()?;
+    if !matches!(state, RepoState::Marked(_)) && upstream.is_some() {
+        repo.delete_ref(UPSTREAM_REF)?;
+    }
+    Ok(state)
+}
+
+/// Sets this machine up from a repository already found to be
+/// history-managed: says what will happen, shows the plan, confirms, records
+/// the connection, and pulls (the configuration first, then what it
+/// declares, like any pull).
+pub(crate) async fn run(store: &Store, onboarding: &Onboarding) -> Result<Outcome> {
+    let state_dir = store.state_dir();
+    let mode = SyncMode::current()?;
+    let config_dir = global_config_dir();
+    refuse_other_connection(store, &onboarding.origin, &onboarding.branch)?;
+    miseprintln!(
+        "{} is a mise setup repository (format {}); branch {}.",
+        onboarding.origin,
+        format::FORMAT,
+        onboarding.branch
+    );
+    miseprintln!("Sync mode {}", mode.disclosure());
+    miseprintln!(
+        "The shared configuration goes to {}, sources to where that configuration puts them, and this machine's tracked files to their places under {}. A file that already exists and differs is held for a decision, never overwritten.",
+        display_path(&config_dir),
+        display_path(*crate::dirs::HOME)
+    );
+    if config_dir.join(".git").exists() {
+        miseprintln!(
+            "{} is a git checkout: it is not converted or committed to; files written there appear as ordinary working-tree changes.",
+            display_path(&config_dir)
+        );
+    }
+
+    // what is pending, then the plan
+    let tracked = TrackedSet::effective().await?;
+    let mut request = SyncRequest::new(true);
+    request.origin = Some(OriginTomlConfig {
+        url: onboarding.fetch_from.clone(),
+        branch: onboarding.branch.clone(),
+        encrypt_backups: false,
+    });
+    request.capture = !onboarding.dry_run;
+    let synced = run::sync(store, &tracked, &request)?;
+    let mut preview = ApplyRequest::automatic();
+    preview.automatic = false;
+    preview.dry_run = true;
+    preview.plan_only = true;
+    apply::apply(store, &tracked, &preview).await?;
+    if onboarding.dry_run {
+        miseprintln!("Dry run: nothing was changed.");
+        return Ok(Outcome {
+            durable_access: true,
+        });
+    }
+    if !super::origin::confirmed(onboarding.yes, "Set this machine up from the repository?")? {
+        bail!("not set up");
+    }
+
+    // the connection: declared machine-locally, recorded for the watcher
+    let mut status = run::read_status(state_dir);
+    status.origin_url = Some(onboarding.origin.clone());
+    status.origin_branch = Some(onboarding.branch.clone());
+    status.disconnected = false;
+    if status.upload_since.is_none() {
+        let newest = store
+            .list()?
+            .into_iter()
+            .last()
+            .map(|entry| entry.checkpoint.created_at);
+        status.upload_since = Some(newest.unwrap_or_else(hstore::now_rfc3339));
+    }
+    run::write_status(state_dir, &status)?;
+    super::origin::write_config(&onboarding.origin, &onboarding.branch, None)?;
+
+    let applied = apply::apply(store, &tracked, &ApplyRequest::automatic()).await?;
+    // a conflict (a file that exists here and differs) is not pending: it
+    // waits for a decision, like a path held with its group
+    let undecided = applied.held + synced.conflicts;
+    miseprintln!(
+        "Wrote {} file(s) from {}{}.",
+        applied.written,
+        onboarding.origin,
+        if undecided > 0 {
+            format!(
+                "; {undecided} path(s) need a decision (`mise bootstrap dotfiles status` lists them, `mise bootstrap dotfiles pull --take-remote|--keep-local <path>` decides)"
+            )
+        } else {
+            String::new()
+        }
+    );
+    let durable_access = durable_access(&onboarding.origin, &onboarding.branch);
+    if !durable_access {
+        warn!(
+            "setup complete, but ongoing synchronization needs credentials on this host: the borrowed GitHub access ends with this session. Run `mise x gh -- gh auth login` and `mise x gh -- gh auth setup-git` here, or connect an SSH url with `mise bootstrap dotfiles origin set <url>`"
+        );
+    }
+    Ok(Outcome { durable_access })
+}
+
+/// Whether this host reaches the repository on its own: with the
+/// session's GitHub relay (its `url.<relay>.insteadOf` rewrites travel as
+/// `GIT_CONFIG_KEY_n`/`GIT_CONFIG_VALUE_n`) taken out of the environment.
+/// Without a relay, whatever works now keeps working.
+fn durable_access(url: &str, branch: &str) -> bool {
+    if std::env::var_os("MISE_GITHUB_RELAY_SOCKET").is_none() {
+        return true;
+    }
+    let Some(git) = crate::file::which_spawnable("git") else {
+        return true;
+    };
+    let mut command = Command::new(git);
+    command
+        .args(["ls-remote", "--exit-code", "--heads", url, branch])
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env_remove("MISE_GITHUB_RELAY_SOCKET")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    for (key, _) in std::env::vars_os() {
+        let name = key.to_string_lossy();
+        if name == "GIT_CONFIG_COUNT"
+            || name.starts_with("GIT_CONFIG_KEY_")
+            || name.starts_with("GIT_CONFIG_VALUE_")
+        {
+            command.env_remove(&key);
+        }
+    }
+    command.status().is_ok_and(|status| status.success())
+}

--- a/src/system/history/sync/onboard.rs
+++ b/src/system/history/sync/onboard.rs
@@ -50,16 +50,10 @@ pub(crate) struct Outcome {
 pub(crate) async fn from_git(url: &str, yes: bool, dry_run: bool) -> Result<Option<Outcome>> {
     // Detect marked repositories without creating persistent tracking state
     // for users of the released, ordinary --from-git workflow.
-    let probe_dir = (!crate::config::Settings::get().experimental)
-        .then(tempfile::tempdir)
-        .transpose()?;
-    let store = match &probe_dir {
-        Some(dir) => Store::open_in(dir.path())?,
-        None => Store::open()?,
-    };
+    let probe_dir = tempfile::tempdir()?;
+    let store = Store::open_in(probe_dir.path())?;
     if let Some(reason) = store.unavailable() {
-        debug!("history: {url} is not probed for a setup repository: {reason}");
-        return Ok(None);
+        bail!("cannot determine whether {url} is a setup repository: {reason}");
     }
     let repo = store
         .repo()
@@ -67,11 +61,15 @@ pub(crate) async fn from_git(url: &str, yes: bool, dry_run: bool) -> Result<Opti
     let Some(branch) = default_branch(&Remote::new(repo, url))? else {
         return Ok(None);
     };
-    refuse_other_connection(&store, url, &branch)?;
     if !matches!(probe(&store, url, &branch)?, RepoState::Marked(_)) {
         return Ok(None);
     }
     crate::config::Settings::get().ensure_experimental("dotfile tracking")?;
+    let store = Store::open()?;
+    if let Some(reason) = store.unavailable() {
+        bail!("cannot onboard this setup repository: history is unavailable: {reason}");
+    }
+    refuse_other_connection(&store, url, &branch)?;
     let outcome = run(
         &store,
         &Onboarding {
@@ -237,7 +235,10 @@ pub(crate) async fn run(store: &Store, onboarding: &Onboarding) -> Result<Outcom
     let applied = apply::apply(store, &tracked, &ApplyRequest::automatic()).await?;
     // a conflict (a file that exists here and differs) is not pending: it
     // waits for a decision, like a path held with its group
-    let undecided = applied.held + synced.conflicts;
+    let undecided = run::read_status(store.state_dir())?
+        .conflicts
+        .len()
+        .max(applied.held);
     // configuration among them: nothing to bootstrap from yet
     let configuration_held = {
         let status = run::read_status(state_dir)?;

--- a/src/system/history/sync/origin.rs
+++ b/src/system/history/sync/origin.rs
@@ -498,6 +498,14 @@ fn reset_sync_state(
 /// Disconnects: the declaration is removed; local refs, state, and
 /// checkpoints stay.
 pub(crate) fn remove() -> Result<()> {
+    let state_dir: &std::path::Path = &crate::dirs::STATE;
+    let _sync_lock = run::lock_in(state_dir)?;
+    let mut status = run::read_status(state_dir)?;
+    remove_locked(state_dir, &mut status)
+}
+
+/// The caller holds the sync lock across both configuration and state writes.
+fn remove_locked(state_dir: &std::path::Path, status: &mut run::SyncStatus) -> Result<()> {
     let mut removed = vec![];
     // the machine-local file, and the shared one for a declaration written
     // there by hand or by an earlier mise
@@ -516,14 +524,12 @@ pub(crate) fn remove() -> Result<()> {
         }
     }
     // the recorded connection no longer stands in for a declaration
-    let state_dir: &std::path::Path = &crate::dirs::STATE;
     let mut disconnected = false;
-    run::update_status(state_dir, run::STATUS_LOCK_WAIT, |status| {
-        if status.origin_url.is_some() && !status.disconnected {
-            status.disconnected = true;
-            disconnected = true;
-        }
-    })?;
+    if status.origin_url.is_some() && !status.disconnected {
+        status.disconnected = true;
+        disconnected = true;
+    }
+    run::write_status(state_dir, status)?;
     if disconnected && removed.is_empty() {
         removed.push("the recorded connection".to_string());
     }
@@ -564,5 +570,5 @@ pub(crate) fn purge(store: &Store, yes: bool) -> Result<()> {
     status.uploaded.clear();
     run::write_status(state_dir, &status)?;
     info!("history: deleted {} ref(s) from {}", refs.len(), origin.url);
-    remove()
+    remove_locked(state_dir, &mut status)
 }

--- a/src/system/history/sync/origin.rs
+++ b/src/system/history/sync/origin.rs
@@ -499,7 +499,7 @@ fn reset_sync_state(
 /// checkpoints stay.
 pub(crate) fn remove() -> Result<()> {
     let state_dir: &std::path::Path = &crate::dirs::STATE;
-    let _sync_lock = run::lock_in(state_dir)?;
+    let _sync_lock = run::lock_wait(state_dir, run::STATUS_LOCK_WAIT)?;
     let mut status = run::read_status(state_dir)?;
     remove_locked(state_dir, &mut status)
 }

--- a/src/system/history/sync/origin.rs
+++ b/src/system/history/sync/origin.rs
@@ -517,13 +517,15 @@ pub(crate) fn remove() -> Result<()> {
     }
     // the recorded connection no longer stands in for a declaration
     let state_dir: &std::path::Path = &crate::dirs::STATE;
-    let mut status = run::read_status(state_dir);
-    if status.origin_url.is_some() && !status.disconnected {
-        status.disconnected = true;
-        run::write_status(state_dir, &status)?;
-        if removed.is_empty() {
-            removed.push("the recorded connection".to_string());
+    let mut disconnected = false;
+    run::update_status(state_dir, run::STATUS_LOCK_WAIT, |status| {
+        if status.origin_url.is_some() && !status.disconnected {
+            status.disconnected = true;
+            disconnected = true;
         }
+    })?;
+    if disconnected && removed.is_empty() {
+        removed.push("the recorded connection".to_string());
     }
     if removed.is_empty() {
         info!("history: no setup repository was connected");

--- a/src/system/history/sync/origin.rs
+++ b/src/system/history/sync/origin.rs
@@ -425,8 +425,11 @@ fn origin_file() -> Result<PathBuf> {
     crate::cli::dotfiles::track::declaration_file(true)
 }
 
-fn write_config(url: &str, branch: &str, mode: Option<SyncMode>) -> Result<()> {
+pub(super) fn write_config(url: &str, branch: &str, mode: Option<SyncMode>) -> Result<()> {
     let global = origin_file()?;
+    if let Some(parent) = global.parent() {
+        crate::file::create_dir_all(parent)?;
+    }
     let mut doc = crate::cli::dotfiles::track::read_document(&global)?;
     let history = doc
         .entry("history")

--- a/src/system/history/sync/origin.rs
+++ b/src/system/history/sync/origin.rs
@@ -292,7 +292,11 @@ async fn set_inner(
     if opts.name.is_some() {
         hstore::write_json(&hstore::machine_file_in(state_dir), &machine)?;
     }
-    write_config(&opts.url, &opts.branch, opts.mode)?;
+    // the mode is recorded only when it differs from what the settings
+    // say, so `mise settings set history.sync …` keeps working afterwards
+    let mode =
+        (opts.mode.as_str() != crate::config::Settings::get().history.sync).then_some(opts.mode);
+    write_config(&opts.url, &opts.branch, mode)?;
     // another repository or branch starts from a clean slate: the previous
     // one's per-path state, pending changes, and conflicts would read its
     // absence of a file as a deletion
@@ -308,6 +312,7 @@ async fn set_inner(
     }
     status.origin_url = Some(opts.url.clone());
     status.origin_branch = Some(opts.branch.clone());
+    status.disconnected = false;
     status.adopted = repo_state == RepoState::Unmarked || status.adopted;
     // from now on: the checkpoint holding the current state (taken above)
     // is included, not only what changes later
@@ -326,7 +331,7 @@ async fn set_inner(
         "history: connected {} ({}); [history.origin] written to {}",
         opts.url,
         opts.mode.as_str(),
-        display_path(crate::cli::dotfiles::track::declaration_file(true)?)
+        display_path(origin_file()?)
     );
 
     // the first synchronization
@@ -336,13 +341,7 @@ async fn set_inner(
     let store = Store::open_in(state_dir)?;
     // the mode just chosen decides, not the settings loaded before it was
     // written: fetch-only connects without publishing anything
-    let outcome = run::sync(
-        &store,
-        &tracked,
-        &SyncRequest {
-            fetch_only: !opts.mode.publishes(),
-        },
-    )?;
+    let outcome = run::sync(&store, &tracked, &SyncRequest::new(!opts.mode.publishes()))?;
     report(&outcome);
     Ok(())
 }
@@ -417,8 +416,17 @@ fn unshared_destinations(shared: &share::ShareReport, tracked: &TrackedSet) -> V
     out
 }
 
-fn write_config(url: &str, branch: &str, mode: SyncMode) -> Result<()> {
-    let global = crate::cli::dotfiles::track::declaration_file(true)?;
+/// Where the connection is declared: `config.local.toml` next to the
+/// global configuration. Machine-local, so it is never published (each
+/// machine names the repository the way it reaches it) and a fresh
+/// machine's own declaration never conflicts with the configuration it
+/// pulls.
+fn origin_file() -> Result<PathBuf> {
+    crate::cli::dotfiles::track::declaration_file(true)
+}
+
+fn write_config(url: &str, branch: &str, mode: Option<SyncMode>) -> Result<()> {
+    let global = origin_file()?;
     let mut doc = crate::cli::dotfiles::track::read_document(&global)?;
     let history = doc
         .entry("history")
@@ -439,6 +447,10 @@ fn write_config(url: &str, branch: &str, mode: SyncMode) -> Result<()> {
     origin.set_implicit(false);
     origin.insert("url", Item::Value(Value::from(url)));
     origin.insert("branch", Item::Value(Value::from(branch)));
+    let Some(mode) = mode else {
+        crate::file::write(&global, doc.to_string())?;
+        return Ok(());
+    };
     let settings = doc
         .entry("settings")
         .or_insert(Item::Table(toml_edit::Table::new()));
@@ -483,22 +495,39 @@ fn reset_sync_state(
 /// Disconnects: the declaration is removed; local refs, state, and
 /// checkpoints stay.
 pub(crate) fn remove() -> Result<()> {
-    let global = crate::cli::dotfiles::track::declaration_file(true)?;
-    let mut doc = crate::cli::dotfiles::track::read_document(&global)?;
-    let mut removed = false;
-    if let Some(history) = doc.get_mut("history").and_then(Item::as_table_mut) {
-        removed = history.remove("origin").is_some();
+    let mut removed = vec![];
+    // the machine-local file, and the shared one for a declaration written
+    // there by hand or by an earlier mise
+    for file in [origin_file()?, crate::config::global_shared_config_path()] {
+        if !file.exists() {
+            continue;
+        }
+        let mut doc = crate::cli::dotfiles::track::read_document(&file)?;
+        let mut changed = false;
+        if let Some(history) = doc.get_mut("history").and_then(Item::as_table_mut) {
+            changed = history.remove("origin").is_some();
+        }
+        if changed {
+            crate::file::write(&file, doc.to_string())?;
+            removed.push(display_path(&file));
+        }
     }
-    if removed {
-        crate::file::write(&global, doc.to_string())?;
-        info!(
-            "history: disconnected; [history.origin] removed from {} (local checkpoints and fetched refs are kept)",
-            display_path(&global)
-        );
+    // the recorded connection no longer stands in for a declaration
+    let state_dir: &std::path::Path = &crate::dirs::STATE;
+    let mut status = run::read_status(state_dir);
+    if status.origin_url.is_some() && !status.disconnected {
+        status.disconnected = true;
+        run::write_status(state_dir, &status)?;
+        if removed.is_empty() {
+            removed.push("the recorded connection".to_string());
+        }
+    }
+    if removed.is_empty() {
+        info!("history: no setup repository was connected");
     } else {
         info!(
-            "history: no setup repository was connected in {}",
-            display_path(&global)
+            "history: disconnected; [history.origin] removed from {} (local checkpoints and fetched refs are kept)",
+            removed.join(" and ")
         );
     }
     Ok(())

--- a/src/system/history/sync/run.rs
+++ b/src/system/history/sync/run.rs
@@ -783,6 +783,9 @@ pub(super) fn eligible(roots: &Roots, tracked: &TrackedSet, branch_path: &str) -
 /// A bootstrap finished: the declarations that arrived through sync are
 /// applied now, so `status` stops asking for one.
 pub(crate) fn bootstrap_completed() {
+    if !crate::config::Settings::get().experimental {
+        return;
+    }
     let state_dir: &Path = &crate::dirs::STATE;
     let status = match read_status(state_dir) {
         Ok(status) => status,

--- a/src/system/history/sync/run.rs
+++ b/src/system/history/sync/run.rs
@@ -106,11 +106,9 @@ pub(crate) struct SyncStatus {
     pub origin_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub origin_branch: Option<String>,
-    /// Nonempty while a conflict-paused episode has been observed. Kept as
-    /// paths for compatibility with older status records; new conflicts
-    /// during the same pause do not trigger more notifications.
+    /// Whether this conflict-paused episode has already been observed.
     #[serde(default)]
-    pub notified_conflicts: Vec<String>,
+    pub conflict_pause_observed: bool,
     /// `origin --remove` was run: the recorded repository no longer stands
     /// in for a declaration.
     #[serde(default)]
@@ -505,7 +503,7 @@ fn notify_conflicts_with(status: &mut SyncStatus, enabled: bool, send: impl FnOn
         .iter()
         .map(|conflict| conflict.branch_path.clone())
         .collect();
-    if !current.is_empty() && status.notified_conflicts.is_empty() && enabled {
+    if !current.is_empty() && !status.conflict_pause_observed && enabled {
         let roots = Roots::current();
         let lines: Vec<String> = status
             .conflicts
@@ -531,7 +529,7 @@ fn notify_conflicts_with(status: &mut SyncStatus, enabled: bool, send: impl FnOn
             &format!("{body}\nInspect with: mise bootstrap dotfiles status"),
         );
     }
-    status.notified_conflicts = current.into_iter().collect();
+    status.conflict_pause_observed = !current.is_empty();
 }
 
 /// Saves the tracked set now (deduplicated against the newest checkpoint),
@@ -878,7 +876,7 @@ mod notification_tests {
         assert_eq!(calls, 1);
         status.conflicts.clear();
         notify_conflicts_with(&mut status, true, |_, _| calls += 1);
-        assert!(status.notified_conflicts.is_empty());
+        assert!(!status.conflict_pause_observed);
         status.conflicts.push(conflict("tracked/home/.gitconfig"));
         notify_conflicts_with(&mut status, true, |_, _| calls += 1);
         assert_eq!(calls, 2);
@@ -891,7 +889,7 @@ mod notification_tests {
             ..Default::default()
         };
         notify_conflicts_with(&mut status, false, |_, _| panic!("notifications disabled"));
-        assert_eq!(status.notified_conflicts.len(), 1);
+        assert!(status.conflict_pause_observed);
     }
 }
 

--- a/src/system/history/sync/run.rs
+++ b/src/system/history/sync/run.rs
@@ -512,25 +512,33 @@ fn notify_conflicts_with(status: &mut SyncStatus, enabled: bool, send: impl FnOn
         let lines: Vec<String> = status
             .conflicts
             .iter()
-            .take(3)
+            .take(1)
             .map(|conflict| {
                 let path = roots
                     .locate(&conflict.branch_path)
                     .path()
                     .map(display_path)
                     .unwrap_or_else(|| conflict.branch_path.clone());
-                format!("{path}: {}", conflict.kind.describe())
+                let mut chars = path.chars().filter(|ch| !ch.is_control());
+                let mut path: String = chars.by_ref().take(80).collect();
+                if chars.next().is_some() {
+                    path.push('…');
+                }
+                path
             })
             .collect();
-        let more = current.len().saturating_sub(3);
+        let more = current.len().saturating_sub(1);
         let body = if more > 0 {
-            format!("{}\n+{more} more", lines.join("\n"))
+            let noun = if more == 1 { "file" } else { "files" };
+            format!("{} and {more} other {noun}", lines.join(""))
         } else {
             lines.join("\n")
         };
         send(
-            "mise: setup sharing paused",
-            &format!("{body}\nInspect with: mise bootstrap dotfiles status"),
+            "mise: dotfile sync paused",
+            &format!(
+                "Conflicting changes in {body}.\nLocal saves still work. For resolution steps, run:\nmise bootstrap dotfiles status"
+            ),
         );
     }
     status.conflict_pause_observed = !current.is_empty();
@@ -872,7 +880,7 @@ mod notification_tests {
         };
         let mut calls = 0;
         notify_conflicts_with(&mut status, true, |title, body| {
-            assert!(title.contains("sharing paused"));
+            assert!(title.contains("dotfile sync paused"));
             assert!(body.contains(".zshrc"));
             calls += 1;
         });
@@ -887,6 +895,24 @@ mod notification_tests {
         status.conflicts.push(conflict("tracked/home/.gitconfig"));
         notify_conflicts_with(&mut status, true, |_, _| calls += 1);
         assert_eq!(calls, 2);
+    }
+
+    #[test]
+    fn notification_keeps_the_action_visible_for_long_or_unusual_paths() {
+        let mut status = SyncStatus {
+            conflicts: vec![
+                conflict(&format!("tracked/home/\n{}", "x".repeat(200))),
+                conflict("tracked/home/.gitconfig"),
+            ],
+            ..Default::default()
+        };
+        notify_conflicts_with(&mut status, true, |_, body| {
+            assert!(body.contains("… and 1 other file"));
+            assert!(body.contains("Local saves still work."));
+            assert!(body.ends_with("mise bootstrap dotfiles status"));
+            assert_eq!(body.lines().count(), 3);
+            assert!(body.chars().count() < 250);
+        });
     }
 
     #[test]

--- a/src/system/history/sync/run.rs
+++ b/src/system/history/sync/run.rs
@@ -138,7 +138,7 @@ pub(crate) fn write_status(state_dir: &Path, status: &SyncStatus) -> Result<()> 
 }
 
 #[cfg(test)]
-mod status_tests {
+mod status_read_tests {
     use super::*;
 
     #[test]
@@ -218,7 +218,7 @@ pub(crate) fn origin() -> Result<OriginTomlConfig> {
     }
     // recorded when it was connected: a fresh machine's declaration may
     // still be on its way in the configuration being pulled
-    let status = read_status(&crate::dirs::STATE);
+    let status = read_status(&crate::dirs::STATE)?;
     if let (Some(url), Some(branch), false) =
         (status.origin_url, status.origin_branch, status.disconnected)
     {
@@ -481,7 +481,7 @@ pub(crate) fn update_status(
         }
         std::thread::sleep(STATUS_LOCK_POLL);
     };
-    let mut status = read_status(state_dir);
+    let mut status = read_status(state_dir)?;
     mutate(&mut status);
     write_status(state_dir, &status)
 }
@@ -937,7 +937,7 @@ mod status_tests {
             status.declarations_changed = false;
         })
         .unwrap();
-        let current = read_status(state_dir);
+        let current = read_status(state_dir).unwrap();
         assert!(!current.declarations_changed);
         assert_eq!(current.conflicts.len(), 1);
         assert_eq!(current.last_error.as_deref(), Some("unreachable"));

--- a/src/system/history/sync/run.rs
+++ b/src/system/history/sync/run.rs
@@ -98,6 +98,14 @@ pub(crate) struct SyncStatus {
     pub origin_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub origin_branch: Option<String>,
+    /// Conflicts a desktop notification was shown for, so a retry of the
+    /// same conflict never notifies again.
+    #[serde(default)]
+    pub notified_conflicts: Vec<String>,
+    /// `origin --remove` was run: the recorded repository no longer stands
+    /// in for a declaration.
+    #[serde(default)]
+    pub disconnected: bool,
 }
 
 pub(crate) fn status_path(state_dir: &Path) -> PathBuf {
@@ -164,16 +172,50 @@ pub(crate) struct SyncOutcome {
 
 pub(crate) struct SyncRequest {
     pub fetch_only: bool,
+    /// Save the tracked set first, so what is published is what is on
+    /// disk. The watcher passes `false`: it saves on its own schedule, and a
+    /// throttled file's held version or a manual-save entry's unsaved edits
+    /// must not reach the repository through a sync.
+    pub capture: bool,
+    /// The repository to use instead of `[history.origin]` (onboarding,
+    /// before the configuration that declares it is in place).
+    pub origin: Option<OriginTomlConfig>,
+    /// No network: reconcile against the branch as last fetched and record
+    /// what is pending (after an incoming configuration declared more).
+    pub offline: bool,
+}
+
+impl SyncRequest {
+    pub(crate) fn new(fetch_only: bool) -> Self {
+        Self {
+            fetch_only,
+            capture: true,
+            origin: None,
+            offline: false,
+        }
+    }
 }
 
 /// The connected origin, or why there is none.
 pub(crate) fn origin() -> Result<OriginTomlConfig> {
-    match crate::system::history::config::origin()? {
-        Some((_, origin)) => Ok(origin),
-        None => bail!(
-            "no setup repository is connected; `mise bootstrap dotfiles origin set <url>` connects one"
-        ),
+    if let Some((_, origin)) = crate::system::history::config::origin()? {
+        return Ok(origin);
     }
+    // recorded when it was connected: a fresh machine's declaration may
+    // still be on its way in the configuration being pulled
+    let status = read_status(&crate::dirs::STATE);
+    if let (Some(url), Some(branch), false) =
+        (status.origin_url, status.origin_branch, status.disconnected)
+    {
+        return Ok(OriginTomlConfig {
+            url,
+            branch,
+            encrypt_backups: false,
+        });
+    }
+    bail!(
+        "no setup repository is connected; `mise bootstrap dotfiles origin set <url>` connects one"
+    )
 }
 
 /// Runs one synchronization.
@@ -184,7 +226,10 @@ pub(crate) fn sync(
 ) -> Result<SyncOutcome> {
     crate::config::Settings::get().ensure_experimental("dotfile tracking")?;
     let _sync_lock = lock(store)?;
-    let origin = origin()?;
+    let origin = match &request.origin {
+        Some(origin) => origin.clone(),
+        None => origin()?,
+    };
     if origin.encrypt_backups {
         bail!("[history.origin] encrypt_backups is not supported yet; set it to false");
     }
@@ -199,22 +244,24 @@ pub(crate) fn sync(
     let mut outcome = SyncOutcome::default();
 
     let result = (|| -> Result<()> {
-        // a branch that vanished from a repository this machine had synced
-        // with is not an empty upstream: reading it as one would queue the
-        // deletion of every file it held
-        let found = remote.fetch_pruning(&origin.branch)?;
-        if !found && status.upstream_commit.is_some() {
-            bail!(
-                "the setup branch `{}` is not at {} any more (renamed, or deleted?); nothing was changed. `mise bootstrap dotfiles origin set {} --branch <name>` follows a renamed branch",
-                origin.branch,
-                origin.url,
-                origin.url
-            );
+        if !request.offline {
+            // a branch that vanished from a repository this machine had
+            // synced with is not an empty upstream: reading it as one would
+            // queue the deletion of every file it held
+            let found = remote.fetch_pruning(&origin.branch)?;
+            if !found && status.upstream_commit.is_some() {
+                bail!(
+                    "the setup branch `{}` is not at {} any more (renamed, or deleted?); nothing was changed. `mise bootstrap dotfiles origin set {} --branch <name>` follows a renamed branch",
+                    origin.branch,
+                    origin.url,
+                    origin.url
+                );
+            }
+            if !found && repo.ref_oid(UPSTREAM_REF)?.is_some() {
+                repo.delete_ref(UPSTREAM_REF)?;
+            }
+            status.last_fetch = Some(hstore::now_rfc3339());
         }
-        if !found && repo.ref_oid(UPSTREAM_REF)?.is_some() {
-            repo.delete_ref(UPSTREAM_REF)?;
-        }
-        status.last_fetch = Some(hstore::now_rfc3339());
         let mut upstream_commit = repo.ref_oid(UPSTREAM_REF)?;
         outcome.fetched_upstream = upstream_commit.clone();
         let repo_state = format::detect(repo, upstream_commit.as_deref())?;
@@ -228,11 +275,13 @@ pub(crate) fn sync(
         }
         // ours is the saved version: save what is live first, so a fresh
         // machine's existing files take part in adoption
-        capture_now(store, tracked);
+        if request.capture {
+            capture_now(store, tracked);
+        }
         let entries = store.list()?;
         let shared = share::current(repo, store, tracked)?;
         let unsaved = unsaved_paths(repo, tracked, &shared)?;
-        let publish = mode.publishes() && !request.fetch_only;
+        let publish = mode.publishes() && !request.fetch_only && !request.offline;
         let mut plans;
         let mut attempts = 0;
         loop {
@@ -354,6 +403,7 @@ pub(crate) fn sync(
         outcome.conflicts = status.conflicts.len();
         status.last_error = None;
         status.backoff_until = None;
+        notify_new_conflicts(&mut status);
         Ok(())
     })();
     if let Err(err) = &result {
@@ -374,6 +424,55 @@ pub(crate) fn lock(store: &Store) -> Result<fslock::LockFile> {
     crate::lock_file::LockFile::new(&hstore::store_dir_in(store.state_dir()).join("sync.lock"))
         .try_lock()?
         .ok_or_else(|| eyre::eyre!("another setup sync or pull is running; retry shortly"))
+}
+
+/// A desktop notification for conflicts that newly need a decision, when
+/// `history.notify` is on. Each conflict notifies once: a retry of the same
+/// sync is silent, and a resolved conflict is forgotten so it notifies
+/// again should it come back. Never blocks; a failure is only logged.
+fn notify_new_conflicts(status: &mut SyncStatus) {
+    let current: BTreeSet<String> = status
+        .conflicts
+        .iter()
+        .map(|conflict| conflict.branch_path.clone())
+        .collect();
+    let notified: BTreeSet<String> = status.notified_conflicts.iter().cloned().collect();
+    let new: Vec<&Conflict> = status
+        .conflicts
+        .iter()
+        .filter(|conflict| !notified.contains(&conflict.branch_path))
+        .collect();
+    if !new.is_empty() && crate::config::Settings::get().history.notify {
+        let roots = Roots::current();
+        let lines: Vec<String> = new
+            .iter()
+            .take(3)
+            .map(|conflict| {
+                let path = roots
+                    .locate(&conflict.branch_path)
+                    .path()
+                    .map(display_path)
+                    .unwrap_or_else(|| conflict.branch_path.clone());
+                format!("{path}: {}", conflict.kind.describe())
+            })
+            .collect();
+        let more = new.len().saturating_sub(3);
+        let body = if more > 0 {
+            format!("{}\n+{more} more", lines.join("\n"))
+        } else {
+            lines.join("\n")
+        };
+        crate::system::history::notify::send(
+            &format!(
+                "{} sync conflict{} need{} a decision",
+                new.len(),
+                if new.len() == 1 { "" } else { "s" },
+                if new.len() == 1 { "s" } else { "" }
+            ),
+            &format!("{body}\nInspect with: mise bootstrap dotfiles status"),
+        );
+    }
+    status.notified_conflicts = current.into_iter().collect();
 }
 
 /// Saves the tracked set now (deduplicated against the newest checkpoint),

--- a/src/system/history/sync/run.rs
+++ b/src/system/history/sync/run.rs
@@ -8,6 +8,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 use eyre::{Result, WrapErr, bail};
 use serde::{Deserialize, Serialize};
@@ -82,6 +83,13 @@ pub(crate) struct SyncStatus {
     pub declarations_changed: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_error: Option<String>,
+    /// When the current run of failed syncs began; a success clears it. An
+    /// origin that has never answered has no last success to measure from,
+    /// so `mise doctor` measures the failure from here.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failing_since: Option<String>,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub consecutive_failures: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub backoff_until: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -107,6 +115,10 @@ pub(crate) struct SyncStatus {
     /// in for a declaration.
     #[serde(default)]
     pub disconnected: bool,
+}
+
+fn is_zero(value: &u32) -> bool {
+    *value == 0
 }
 
 pub(crate) fn status_path(state_dir: &Path) -> PathBuf {
@@ -407,6 +419,8 @@ pub(crate) fn sync(
         outcome.pending = status.pending_applications.len();
         outcome.conflicts = status.conflicts.len();
         status.last_error = None;
+        status.failing_since = None;
+        status.consecutive_failures = 0;
         status.backoff_until = None;
         if !request.dry_run {
             notify_new_conflicts(&mut status);
@@ -415,6 +429,8 @@ pub(crate) fn sync(
     })();
     if let Err(err) = &result {
         status.last_error = Some(format!("{err:#}"));
+        status.failing_since.get_or_insert_with(hstore::now_rfc3339);
+        status.consecutive_failures = status.consecutive_failures.saturating_add(1);
     }
     if let Err(write_error) = write_status(state_dir, &status) {
         return match result {
@@ -427,10 +443,49 @@ pub(crate) fn sync(
     result.map(|()| outcome)
 }
 
+/// How long a status update waits for a running sync or pull to finish.
+pub(crate) const STATUS_LOCK_WAIT: Duration = Duration::from_secs(5);
+const STATUS_LOCK_POLL: Duration = Duration::from_millis(100);
+
+fn lock_path(state_dir: &Path) -> PathBuf {
+    hstore::store_dir_in(state_dir).join("sync.lock")
+}
+
+/// The sync lock: every reader-then-writer of `sync.json` holds it. A sync
+/// or pull takes it for its whole duration and fails at once when another
+/// holds it.
 pub(crate) fn lock(store: &Store) -> Result<fslock::LockFile> {
-    crate::lock_file::LockFile::new(&hstore::store_dir_in(store.state_dir()).join("sync.lock"))
+    lock_in(store.state_dir())
+}
+
+pub(crate) fn lock_in(state_dir: &Path) -> Result<fslock::LockFile> {
+    crate::lock_file::LockFile::new(&lock_path(state_dir))
         .try_lock()?
         .ok_or_else(|| eyre::eyre!("another setup sync or pull is running; retry shortly"))
+}
+
+/// Changes one thing in `sync.json` under the sync lock, reading the record
+/// again first, so a sync or pull that finished meanwhile is not written
+/// over with an older copy. Waits up to `wait` for a running one;
+/// `Duration::ZERO` tries once.
+pub(crate) fn update_status(
+    state_dir: &Path,
+    wait: Duration,
+    mutate: impl FnOnce(&mut SyncStatus),
+) -> Result<()> {
+    let deadline = Instant::now() + wait;
+    let _lock = loop {
+        if let Some(lock) = crate::lock_file::LockFile::new(&lock_path(state_dir)).try_lock()? {
+            break lock;
+        }
+        if Instant::now() >= deadline {
+            bail!("another setup sync or pull is running; retry shortly");
+        }
+        std::thread::sleep(STATUS_LOCK_POLL);
+    };
+    let mut status = read_status(state_dir);
+    mutate(&mut status);
+    write_status(state_dir, &status)
 }
 
 /// A desktop notification for conflicts that newly need a decision, when
@@ -731,18 +786,22 @@ pub(super) fn eligible(roots: &Roots, tracked: &TrackedSet, branch_path: &str) -
 /// applied now, so `status` stops asking for one.
 pub(crate) fn bootstrap_completed() {
     let state_dir: &Path = &crate::dirs::STATE;
-    let mut status = match read_status(state_dir) {
+    let status = match read_status(state_dir) {
         Ok(status) => status,
         Err(err) => {
             warn!("history: could not record that the bootstrap ran: {err:#}");
             return;
         }
     };
-    if status.declarations_changed {
+    if !status.declarations_changed {
+        return;
+    }
+    // under the sync lock, changing only this: a sync that finished during
+    // the bootstrap keeps its conflicts, pending changes, and uploads
+    if let Err(err) = update_status(state_dir, STATUS_LOCK_WAIT, |status| {
         status.declarations_changed = false;
-        if let Err(err) = write_status(state_dir, &status) {
-            debug!("history: could not record that the bootstrap ran: {err}");
-        }
+    }) {
+        debug!("history: could not record that the bootstrap ran: {err}");
     }
 }
 
@@ -833,5 +892,71 @@ mod notification_tests {
         };
         notify_conflicts_with(&mut status, false, |_, _| panic!("notifications disabled"));
         assert_eq!(status.notified_conflicts.len(), 1);
+    }
+}
+
+#[cfg(test)]
+mod status_tests {
+    use super::*;
+
+    fn conflict() -> Conflict {
+        Conflict {
+            branch_path: "tracked/home/.zshrc".to_string(),
+            kind: reconcile::ConflictKind::SameHunk,
+            local: None,
+            remote: None,
+            base: None,
+        }
+    }
+
+    #[test]
+    fn an_older_record_loads_without_the_failure_run() {
+        let status: SyncStatus = serde_json::from_str("{}").unwrap();
+        assert_eq!(status.failing_since, None);
+        assert_eq!(status.consecutive_failures, 0);
+        let text = serde_json::to_string(&status).unwrap();
+        assert!(!text.contains("consecutive_failures"));
+    }
+
+    #[test]
+    fn an_update_changes_only_its_field_in_the_current_record() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state_dir = tmp.path();
+        let mut status = SyncStatus {
+            declarations_changed: true,
+            last_error: Some("unreachable".to_string()),
+            ..Default::default()
+        };
+        write_status(state_dir, &status).unwrap();
+        // a sync finishes meanwhile and records a conflict: the update reads
+        // that record, not the one it started from
+        status.conflicts.push(conflict());
+        write_status(state_dir, &status).unwrap();
+        update_status(state_dir, Duration::ZERO, |status| {
+            status.declarations_changed = false;
+        })
+        .unwrap();
+        let current = read_status(state_dir);
+        assert!(!current.declarations_changed);
+        assert_eq!(current.conflicts.len(), 1);
+        assert_eq!(current.last_error.as_deref(), Some("unreachable"));
+    }
+
+    #[test]
+    fn an_update_gives_way_to_a_running_sync() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state_dir = tmp.path();
+        std::fs::create_dir_all(hstore::store_dir_in(state_dir)).unwrap();
+        let held = lock_in(state_dir).unwrap();
+        let err = update_status(state_dir, Duration::ZERO, |status| {
+            status.declarations_changed = false;
+        })
+        .unwrap_err();
+        assert!(err.to_string().contains("another setup sync or pull"));
+        drop(held);
+        update_status(state_dir, Duration::ZERO, |status| {
+            status.declarations_changed = false;
+        })
+        .unwrap();
     }
 }

--- a/src/system/history/sync/run.rs
+++ b/src/system/history/sync/run.rs
@@ -98,8 +98,9 @@ pub(crate) struct SyncStatus {
     pub origin_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub origin_branch: Option<String>,
-    /// Conflicts a desktop notification was shown for, so a retry of the
-    /// same conflict never notifies again.
+    /// Nonempty while a conflict-paused episode has been observed. Kept as
+    /// paths for compatibility with older status records; new conflicts
+    /// during the same pause do not trigger more notifications.
     #[serde(default)]
     pub notified_conflicts: Vec<String>,
     /// `origin --remove` was run: the recorded repository no longer stands
@@ -433,24 +434,26 @@ pub(crate) fn lock(store: &Store) -> Result<fslock::LockFile> {
 }
 
 /// A desktop notification for conflicts that newly need a decision, when
-/// `history.notify` is on. Each conflict notifies once: a retry of the same
-/// sync is silent, and a resolved conflict is forgotten so it notifies
-/// again should it come back. Never blocks; a failure is only logged.
+/// `history.notify` is on. Notify once per whole-setup pause, not per path.
+/// Never blocks; a failure is only logged.
 fn notify_new_conflicts(status: &mut SyncStatus) {
+    notify_conflicts_with(
+        status,
+        crate::config::Settings::get().history.notify,
+        crate::system::history::notify::send,
+    );
+}
+
+fn notify_conflicts_with(status: &mut SyncStatus, enabled: bool, send: impl FnOnce(&str, &str)) {
     let current: BTreeSet<String> = status
         .conflicts
         .iter()
         .map(|conflict| conflict.branch_path.clone())
         .collect();
-    let notified: BTreeSet<String> = status.notified_conflicts.iter().cloned().collect();
-    let new: Vec<&Conflict> = status
-        .conflicts
-        .iter()
-        .filter(|conflict| !notified.contains(&conflict.branch_path))
-        .collect();
-    if !new.is_empty() && crate::config::Settings::get().history.notify {
+    if !current.is_empty() && status.notified_conflicts.is_empty() && enabled {
         let roots = Roots::current();
-        let lines: Vec<String> = new
+        let lines: Vec<String> = status
+            .conflicts
             .iter()
             .take(3)
             .map(|conflict| {
@@ -462,19 +465,14 @@ fn notify_new_conflicts(status: &mut SyncStatus) {
                 format!("{path}: {}", conflict.kind.describe())
             })
             .collect();
-        let more = new.len().saturating_sub(3);
+        let more = current.len().saturating_sub(3);
         let body = if more > 0 {
             format!("{}\n+{more} more", lines.join("\n"))
         } else {
             lines.join("\n")
         };
-        crate::system::history::notify::send(
-            &format!(
-                "{} sync conflict{} need{} a decision",
-                new.len(),
-                if new.len() == 1 { "" } else { "s" },
-                if new.len() == 1 { "s" } else { "" }
-            ),
+        send(
+            "mise: setup sharing paused",
             &format!("{body}\nInspect with: mise bootstrap dotfiles status"),
         );
     }
@@ -786,4 +784,54 @@ fn unsaved_paths(
         }
     }
     Ok(unsaved)
+}
+
+#[cfg(test)]
+mod notification_tests {
+    use super::*;
+
+    fn conflict(path: &str) -> Conflict {
+        Conflict {
+            branch_path: path.into(),
+            kind: reconcile::ConflictKind::SameHunk,
+            local: None,
+            remote: None,
+            base: None,
+        }
+    }
+
+    #[test]
+    fn one_notification_per_pause_and_another_after_recovery() {
+        let mut status = SyncStatus {
+            conflicts: vec![conflict("tracked/home/.zshrc")],
+            ..Default::default()
+        };
+        let mut calls = 0;
+        notify_conflicts_with(&mut status, true, |title, body| {
+            assert!(title.contains("sharing paused"));
+            assert!(body.contains(".zshrc"));
+            calls += 1;
+        });
+        status.conflicts.push(conflict("tracked/home/.gitconfig"));
+        notify_conflicts_with(&mut status, true, |_, _| calls += 1);
+        status.conflicts.remove(0);
+        notify_conflicts_with(&mut status, true, |_, _| calls += 1);
+        assert_eq!(calls, 1);
+        status.conflicts.clear();
+        notify_conflicts_with(&mut status, true, |_, _| calls += 1);
+        assert!(status.notified_conflicts.is_empty());
+        status.conflicts.push(conflict("tracked/home/.gitconfig"));
+        notify_conflicts_with(&mut status, true, |_, _| calls += 1);
+        assert_eq!(calls, 2);
+    }
+
+    #[test]
+    fn explicit_opt_out_is_preserved() {
+        let mut status = SyncStatus {
+            conflicts: vec![conflict("tracked/home/.zshrc")],
+            ..Default::default()
+        };
+        notify_conflicts_with(&mut status, false, |_, _| panic!("notifications disabled"));
+        assert_eq!(status.notified_conflicts.len(), 1);
+    }
 }

--- a/src/system/history/sync/run.rs
+++ b/src/system/history/sync/run.rs
@@ -471,19 +471,23 @@ pub(crate) fn update_status(
     wait: Duration,
     mutate: impl FnOnce(&mut SyncStatus),
 ) -> Result<()> {
+    let _lock = lock_wait(state_dir, wait)?;
+    let mut status = read_status(state_dir)?;
+    mutate(&mut status);
+    write_status(state_dir, &status)
+}
+
+pub(crate) fn lock_wait(state_dir: &Path, wait: Duration) -> Result<fslock::LockFile> {
     let deadline = Instant::now() + wait;
-    let _lock = loop {
+    loop {
         if let Some(lock) = crate::lock_file::LockFile::new(&lock_path(state_dir)).try_lock()? {
-            break lock;
+            return Ok(lock);
         }
         if Instant::now() >= deadline {
             bail!("another setup sync or pull is running; retry shortly");
         }
         std::thread::sleep(STATUS_LOCK_POLL);
-    };
-    let mut status = read_status(state_dir)?;
-    mutate(&mut status);
-    write_status(state_dir, &status)
+    }
 }
 
 /// A desktop notification for conflicts that newly need a decision, when

--- a/src/system/history/sync/run.rs
+++ b/src/system/history/sync/run.rs
@@ -183,6 +183,9 @@ pub(crate) struct SyncRequest {
     /// No network: reconcile against the branch as last fetched and record
     /// what is pending (after an incoming configuration declared more).
     pub offline: bool,
+    /// A preview: nothing is announced (the caller puts the recorded state
+    /// back afterwards).
+    pub dry_run: bool,
 }
 
 impl SyncRequest {
@@ -192,6 +195,7 @@ impl SyncRequest {
             capture: true,
             origin: None,
             offline: false,
+            dry_run: false,
         }
     }
 }
@@ -403,7 +407,9 @@ pub(crate) fn sync(
         outcome.conflicts = status.conflicts.len();
         status.last_error = None;
         status.backoff_until = None;
-        notify_new_conflicts(&mut status);
+        if !request.dry_run {
+            notify_new_conflicts(&mut status);
+        }
         Ok(())
     })();
     if let Err(err) = &result {

--- a/src/system/history/sync/run.rs
+++ b/src/system/history/sync/run.rs
@@ -911,7 +911,7 @@ mod status_tests {
     }
 
     #[test]
-    fn an_older_record_loads_without_the_failure_run() {
+    fn omitted_failure_fields_default_to_no_failures() {
         let status: SyncStatus = serde_json::from_str("{}").unwrap();
         assert_eq!(status.failing_since, None);
         assert_eq!(status.consecutive_failures, 0);

--- a/src/system/history/tracked.rs
+++ b/src/system/history/tracked.rs
@@ -841,6 +841,12 @@ pub(crate) fn hard_exclusions() -> Vec<PathBuf> {
     .map(normalize)
     .collect();
     dirs.push(normalize(&super::store::store_dir_in(&dirs::STATE)));
+    // the setup branch's reserved directories, should a checkout of it sit
+    // in the configuration directory: never captured, never republished
+    let config_dir = normalize(&global_config_dir());
+    for reserved in ["tracked", "sources", ".mise-history"] {
+        dirs.push(config_dir.join(reserved));
+    }
     dirs.sort();
     dirs.dedup();
     dirs

--- a/src/system/history/watch/runtime.rs
+++ b/src/system/history/watch/runtime.rs
@@ -652,7 +652,7 @@ pub(crate) async fn run(opts: WatchOptions) -> Result<i32> {
                             installed = match install(&mut debouncer, &installed, &state.plan.anchors, &mut capture) {
                                 Ok(installed) => installed,
                                 Err(err) => {
-                                    stop_after_install_failure(&mut capture, &state.tracked, &err).await;
+                                    stop_after_install_failure(&mut capture, &state.tracked, &err, "re-installed").await;
                                     debouncer.stop();
                                     return Ok(1);
                                 }

--- a/src/system/history/watch/runtime.rs
+++ b/src/system/history/watch/runtime.rs
@@ -23,6 +23,7 @@ use crate::config::{Config, Settings};
 use crate::file::display_path;
 use crate::lock_file::LockFile;
 use crate::system::history::checkpoint::{Draft, Outcome, Store};
+use crate::system::history::describe_command;
 use crate::system::history::health::{self, Health, ThrottledPath};
 use crate::system::history::store::{self, Trigger};
 use crate::system::history::sync::apply::{self, ApplyRequest};
@@ -142,6 +143,23 @@ pub(crate) async fn run(opts: WatchOptions) -> Result<i32> {
         let outcome = capture.reconcile(&state.tracked, "startup reconcile");
         capture.write_health();
         let synced = once_sync(&mut capture, &state).await;
+        if let Some(task) = start_describe(&mut capture)
+            && let Ok((id, result)) = task.await
+        {
+            match result {
+                Ok(Some(description)) => capture.out.emit(
+                    "described",
+                    &format!("checkpoint {id} described by history.describe_command: {description}"),
+                    json!({ "id": id, "description": description }),
+                ),
+                Ok(None) => {}
+                Err(err) => capture.out.emit(
+                    "describe-error",
+                    &format!("history.describe_command failed for checkpoint {id}: {err:#}; keeping the computed description"),
+                    json!({ "id": id, "message": format!("{err:#}") }),
+                ),
+            }
+        }
         return Ok(match outcome {
             Attempt::Done if synced => 0,
             Attempt::Done => 1,
@@ -225,7 +243,12 @@ pub(crate) async fn run(opts: WatchOptions) -> Result<i32> {
     // the network runs on a blocking task of its own: a slow origin never
     // delays a capture
     let mut sync_task: Option<tokio::task::JoinHandle<Result<SyncOutcome>>> = None;
+    // the description command runs one checkpoint at a time, off the loop
+    let mut describe_task: Option<tokio::task::JoinHandle<(u64, Result<Option<String>>)>> = None;
     loop {
+        if describe_task.is_none() {
+            describe_task = start_describe(&mut capture);
+        }
         // the next save, or the retry of a deferred or failed capture,
         // whichever comes first
         let flush_at = match (
@@ -260,6 +283,12 @@ pub(crate) async fn run(opts: WatchOptions) -> Result<i32> {
         };
         let sync_done = async {
             match &mut sync_task {
+                Some(task) => task.await,
+                None => std::future::pending().await,
+            }
+        };
+        let describe_done = async {
+            match &mut describe_task {
                 Some(task) => task.await,
                 None => std::future::pending().await,
             }
@@ -580,6 +609,31 @@ pub(crate) async fn run(opts: WatchOptions) -> Result<i32> {
             _ = sync_tick => {
                 sync_task = start_sync(&mut capture, &state.tracked);
             }
+            joined = describe_done => {
+                describe_task = None;
+                match joined {
+                    Ok((id, Ok(Some(description)))) => capture.out.emit(
+                        "described",
+                        &format!("checkpoint {id} described by history.describe_command: {description}"),
+                        json!({ "id": id, "description": description }),
+                    ),
+                    Ok((id, Ok(None))) => capture.out.emit(
+                        "described",
+                        &format!("history.describe_command printed nothing for checkpoint {id}; keeping the computed description"),
+                        json!({ "id": id, "description": null }),
+                    ),
+                    Ok((id, Err(err))) => capture.out.emit(
+                        "describe-error",
+                        &format!("history.describe_command failed for checkpoint {id}: {err:#}; keeping the computed description"),
+                        json!({ "id": id, "message": format!("{err:#}") }),
+                    ),
+                    Err(err) => capture.out.emit(
+                        "describe-error",
+                        &format!("history.describe_command stopped unexpectedly: {err}"),
+                        json!({ "message": err.to_string() }),
+                    ),
+                }
+            }
             joined = sync_done => {
                 sync_task = None;
                 let outcome = match joined {
@@ -633,6 +687,23 @@ pub(crate) async fn run(opts: WatchOptions) -> Result<i32> {
     }
     debouncer.stop();
     Ok(0)
+}
+
+/// Starts the description command for the newest checkpoint waiting for
+/// one, on a blocking task of its own. The checkpoint is saved already;
+/// whatever the command does, history is not held up.
+fn start_describe(
+    capture: &mut Capture,
+) -> Option<tokio::task::JoinHandle<(u64, Result<Option<String>>)>> {
+    let entry = capture.describe_next.take()?;
+    let command = describe_command::configured()?;
+    let state_dir = capture.store.state_dir().to_path_buf();
+    Some(tokio::task::spawn_blocking(move || {
+        let id = entry.id;
+        let result = Store::open_in(&state_dir)
+            .and_then(|store| describe_command::run(&store, &entry, &command));
+        (id, result)
+    }))
 }
 
 /// Starts one synchronization on a blocking task, per the mode: the
@@ -1356,6 +1427,9 @@ struct Capture {
     /// Automatic synchronization, when an origin is connected and the mode
     /// allows any.
     sync: Option<SyncPlan>,
+    /// Checkpoints waiting for `history.describe_command`: at most one,
+    /// the newest (a name for an older one is not worth a queue).
+    describe_next: Option<store::Entry>,
     backoff: Duration,
     retry_at: Option<Instant>,
     /// Why the last attempt did not run, while a retry is pending.
@@ -1404,6 +1478,7 @@ impl Capture {
             retry_kind: None,
             anchor_ids: Default::default(),
             sync: SyncPlan::from_settings(&Settings::get(), Instant::now()),
+            describe_next: None,
         }
     }
 
@@ -1476,6 +1551,9 @@ impl Capture {
                 self.recovered();
                 if let Some(plan) = &mut self.sync {
                     plan.saved(Instant::now());
+                }
+                if describe_command::configured().is_some() {
+                    self.describe_next = Some((*entry).clone());
                 }
                 self.health.watcher.last_capture = Some(store::now_rfc3339());
                 self.out.emit(

--- a/src/system/history/watch/runtime.rs
+++ b/src/system/history/watch/runtime.rs
@@ -25,6 +25,9 @@ use crate::lock_file::LockFile;
 use crate::system::history::checkpoint::{Draft, Outcome, Store};
 use crate::system::history::health::{self, Health, ThrottledPath};
 use crate::system::history::store::{self, Trigger};
+use crate::system::history::sync::apply::{self, ApplyRequest};
+use crate::system::history::sync::run::{self as sync_run, SyncOutcome, SyncRequest};
+use crate::system::history::sync::{Automatic, SyncMode};
 use crate::system::history::tracked::{
     self, ExcludeSet, TrackedSet, hard_exclusions, normalize, normalize_target,
 };
@@ -52,6 +55,13 @@ const WATCH_LOCK_RETRY: Duration = Duration::from_millis(200);
 /// history operation to finish before giving up.
 const SHUTDOWN_RETRY_EVERY: Duration = Duration::from_secs(1);
 const SHUTDOWN_RETRIES: usize = 10;
+/// Automatic synchronization: the first fetch after a start, the follow-up
+/// after an incoming configuration changed the tracked set, and the
+/// backoff after a failed sync (local saves continue meanwhile).
+const SYNC_FIRST_FETCH: Duration = Duration::from_secs(15);
+const SYNC_FOLLOW_UP: Duration = Duration::from_secs(5);
+const SYNC_BACKOFF_MIN: Duration = Duration::from_secs(60);
+const SYNC_BACKOFF_MAX: Duration = Duration::from_secs(3600);
 
 /// What became of a capture attempt.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -131,8 +141,10 @@ pub(crate) async fn run(opts: WatchOptions) -> Result<i32> {
         // file whose save is not due is held, not read live
         let outcome = capture.reconcile(&state.tracked, "startup reconcile");
         capture.write_health();
+        let synced = once_sync(&mut capture, &state).await;
         return Ok(match outcome {
-            Attempt::Done => 0,
+            Attempt::Done if synced => 0,
+            Attempt::Done => 1,
             Attempt::Deferred => {
                 capture.out.emit(
                     "unsaved",
@@ -210,6 +222,9 @@ pub(crate) async fn run(opts: WatchOptions) -> Result<i32> {
     let mut next_reconcile = intervals
         .reconcile
         .map(|every| tokio::time::Instant::now() + every);
+    // the network runs on a blocking task of its own: a slow origin never
+    // delays a capture
+    let mut sync_task: Option<tokio::task::JoinHandle<Result<SyncOutcome>>> = None;
     loop {
         // the next save, or the retry of a deferred or failed capture,
         // whichever comes first
@@ -230,6 +245,23 @@ pub(crate) async fn run(opts: WatchOptions) -> Result<i32> {
             match next_reconcile {
                 Some(at) => tokio::time::sleep_until(at).await,
                 None => std::future::pending::<()>().await,
+            }
+        };
+        let sync_at = if sync_task.is_none() {
+            capture.sync.as_ref().and_then(SyncPlan::deadline)
+        } else {
+            None
+        };
+        let sync_tick = async {
+            match sync_at {
+                Some(at) => tokio::time::sleep_until(tokio::time::Instant::from_std(at)).await,
+                None => std::future::pending::<()>().await,
+            }
+        };
+        let sync_done = async {
+            match &mut sync_task {
+                Some(task) => task.await,
+                None => std::future::pending().await,
             }
         };
         tokio::select! {
@@ -334,6 +366,8 @@ pub(crate) async fn run(opts: WatchOptions) -> Result<i32> {
                     };
                             // the timing settings may have changed with it
                             apply_intervals(&mut capture, &mut intervals, &mut next_reconcile);
+                            // the origin or the mode may have changed with it
+                            refresh_sync_plan(&mut capture, now);
                             capture.out.emit(
                                 "replan",
                                 &format!("configuration changed; watching {} anchor(s)", installed.len()),
@@ -399,6 +433,7 @@ pub(crate) async fn run(opts: WatchOptions) -> Result<i32> {
                                 }
                             };
                             apply_intervals(&mut capture, &mut intervals, &mut next_reconcile);
+                            refresh_sync_plan(&mut capture, Instant::now());
                             prune_schedule(&mut capture, &state);
                         }
                         Ok(false) => {
@@ -432,6 +467,7 @@ pub(crate) async fn run(opts: WatchOptions) -> Result<i32> {
                         }
                     }
                     apply_intervals(&mut capture, &mut intervals, &mut next_reconcile);
+                    refresh_sync_plan(&mut capture, Instant::now());
                     // a replaced directory keeps its path but not its
                     // watch: an anchor that changed is watched anew
                     installed = match if anchor_changed {
@@ -524,6 +560,7 @@ pub(crate) async fn run(opts: WatchOptions) -> Result<i32> {
                             }
                         };
                         apply_intervals(&mut capture, &mut intervals, &mut next_reconcile);
+                        refresh_sync_plan(&mut capture, Instant::now());
                         prune_schedule(&mut capture, &state);
                     }
                     Ok(false) => {
@@ -540,7 +577,55 @@ pub(crate) async fn run(opts: WatchOptions) -> Result<i32> {
                 capture.reconcile(&state.tracked, "reconcile");
                 capture.write_health();
             }
+            _ = sync_tick => {
+                sync_task = start_sync(&mut capture, &state.tracked);
+            }
+            joined = sync_done => {
+                sync_task = None;
+                let outcome = match joined {
+                    Ok(outcome) => outcome,
+                    Err(err) => Err(eyre::eyre!("the sync task stopped unexpectedly: {err}")),
+                };
+                if finish_sync(&mut capture, &state.tracked, outcome).await == Some(true) {
+                    // the configuration that arrived may declare more:
+                    // replan, and fetch again soon for what it declares
+                    match state.reload().await {
+                        Ok(true) => {
+                            installed = match install(&mut debouncer, &installed, &state.plan.anchors, &mut capture) {
+                                Ok(installed) => installed,
+                                Err(err) => {
+                                    stop_after_install_failure(&mut capture, &state.tracked, &err).await;
+                                    debouncer.stop();
+                                    return Ok(1);
+                                }
+                            };
+                            capture.out.emit(
+                                "replan",
+                                &format!("incoming configuration applied; watching {} anchor(s)", installed.len()),
+                                json!({ "anchors": installed.len() }),
+                            );
+                            if let Some(plan) = &mut capture.sync {
+                                plan.follow_up(Instant::now());
+                            }
+                        }
+                        Ok(false) => {
+                            capture.out.emit("disabled", "history was disabled; stopping", json!({}));
+                            return Ok(0);
+                        }
+                        Err(err) => capture.out.emit(
+                            "error",
+                            &format!("configuration could not be reloaded; keeping the previous tracked set: {err:#}"),
+                            json!({ "message": format!("{err:#}") }),
+                        ),
+                    }
+                }
+            }
             _ = shutdown.wait() => {
+                if let Some(task) = sync_task.take() {
+                    // a publication in flight finishes; nothing is started after
+                    let outcome = task.await.unwrap_or_else(|err| Err(eyre::eyre!("the sync task stopped unexpectedly: {err}")));
+                    finish_sync(&mut capture, &state.tracked, outcome).await;
+                }
                 finish(&mut capture, &state.tracked, Restart::Final).await;
                 break;
             }
@@ -548,6 +633,233 @@ pub(crate) async fn run(opts: WatchOptions) -> Result<i32> {
     }
     debouncer.stop();
     Ok(0)
+}
+
+/// Starts one synchronization on a blocking task, per the mode: the
+/// watcher's own captures decide what is saved, so the sync never captures
+/// (a throttled file's held version and a manual-save entry's unsaved edits
+/// stay on this machine).
+fn start_sync(
+    capture: &mut Capture,
+    tracked: &TrackedSet,
+) -> Option<tokio::task::JoinHandle<Result<SyncOutcome>>> {
+    let plan = capture.sync.as_mut()?;
+    let fetch_only = !plan.automatic.publish;
+    plan.next_publish = None;
+    plan.next_fetch = None;
+    capture.out.emit(
+        "sync",
+        if fetch_only {
+            "fetching the setup repository"
+        } else {
+            "publishing to and fetching the setup repository"
+        },
+        json!({ "fetch_only": fetch_only }),
+    );
+    let tracked = tracked.clone();
+    let state_dir = capture.store.state_dir().to_path_buf();
+    Some(tokio::task::spawn_blocking(move || {
+        let store = Store::open_in(&state_dir)?;
+        let mut request = SyncRequest::new(fetch_only);
+        request.capture = false;
+        sync_run::sync(&store, &tracked, &request)
+    }))
+}
+
+/// Records a sync's outcome and, in `sync` mode, applies what it recorded
+/// as pending. `None` after a failure (retried after the backoff), else
+/// whether a configuration file was written.
+async fn finish_sync(
+    capture: &mut Capture,
+    tracked: &TrackedSet,
+    outcome: Result<SyncOutcome>,
+) -> Option<bool> {
+    let now = Instant::now();
+    let outcome = match outcome {
+        Ok(outcome) => outcome,
+        Err(err) => {
+            let retry_in = capture.sync_failed(now);
+            capture.out.emit(
+                "sync-error",
+                &format!(
+                    "could not synchronize: {err:#}; retrying in {} (saving continues meanwhile)",
+                    humantime(retry_in)
+                ),
+                json!({ "message": format!("{err:#}"), "retry_in_secs": retry_in.as_secs() }),
+            );
+            return None;
+        }
+    };
+    capture.sync_succeeded(now);
+    capture.out.emit(
+        "synced",
+        &format!(
+            "synchronized: {}, {} incoming change(s) pending, {} conflict(s)",
+            match &outcome.published {
+                Some(commit) =>
+                    format!("published {}", crate::cli::dotfiles::history::short(commit)),
+                None => "nothing new to publish".to_string(),
+            },
+            outcome.pending,
+            outcome.conflicts
+        ),
+        json!({
+            "published": outcome.published,
+            "uploaded": outcome.uploaded,
+            "pending": outcome.pending,
+            "conflicts": outcome.conflicts,
+        }),
+    );
+    let applies = capture
+        .sync
+        .as_ref()
+        .is_some_and(|plan| plan.automatic.apply);
+    if !applies || outcome.pending == 0 {
+        return Some(false);
+    }
+    match apply::apply(&capture.store, tracked, &ApplyRequest::automatic()).await {
+        Ok(applied) => {
+            capture.out.emit(
+                "applied",
+                &format!(
+                    "applied {} incoming change(s); {} path(s) held for a decision{}",
+                    applied.written,
+                    applied.held,
+                    if applied.configuration {
+                        "; configuration changed: run `mise bootstrap` when its declarations should take effect"
+                    } else {
+                        ""
+                    }
+                ),
+                json!({ "written": applied.written, "held": applied.held, "configuration": applied.configuration }),
+            );
+            Some(applied.configuration)
+        }
+        Err(err) => {
+            let retry_in = capture.sync_failed(now);
+            capture.out.emit(
+                "error",
+                &format!(
+                    "could not apply incoming changes: {err:#}; retrying in {}",
+                    humantime(retry_in)
+                ),
+                json!({ "message": format!("{err:#}"), "retry_in_secs": retry_in.as_secs() }),
+            );
+            Some(false)
+        }
+    }
+}
+
+/// `--once`: one synchronization per the mode, waited for. Whether it (and
+/// the application it may include) succeeded; `true` when nothing is due.
+async fn once_sync(capture: &mut Capture, state: &State) -> bool {
+    let Some(task) = start_sync(capture, &state.tracked) else {
+        return true;
+    };
+    let outcome = task
+        .await
+        .unwrap_or_else(|err| Err(eyre::eyre!("the sync task stopped unexpectedly: {err}")));
+    finish_sync(capture, &state.tracked, outcome)
+        .await
+        .is_some()
+}
+
+/// What the watcher does with the setup repository on its own, per
+/// `settings.history.sync`: when the next publication (at most
+/// `sync_interval` after a save) and the next fetch (every
+/// `fetch_interval`) are due, and the backoff after a failure.
+struct SyncPlan {
+    automatic: Automatic,
+    publish_after: Duration,
+    fetch_every: Duration,
+    next_publish: Option<Instant>,
+    next_fetch: Option<Instant>,
+    backoff: Duration,
+}
+
+impl SyncPlan {
+    /// `None` without a connected origin, or in `manual` mode.
+    fn from_settings(settings: &Settings, now: Instant) -> Option<Self> {
+        if !crate::system::history::config::origin()
+            .ok()
+            .flatten()
+            .is_some()
+        {
+            return None;
+        }
+        let automatic = SyncMode::parse(&settings.history.sync).ok()?.automatic();
+        if !automatic.publish && !automatic.fetch {
+            return None;
+        }
+        let parse = |name: &str, value: &str, default: Duration| {
+            crate::duration::parse_duration(value).unwrap_or_else(|err| {
+                warn!("history.{name}: {err}; using {default:?}");
+                default
+            })
+        };
+        let fetch_every = parse(
+            "fetch_interval",
+            &settings.history.fetch_interval,
+            Duration::from_secs(900),
+        );
+        Some(Self {
+            automatic,
+            publish_after: parse(
+                "sync_interval",
+                &settings.history.sync_interval,
+                Duration::from_secs(300),
+            ),
+            fetch_every,
+            next_publish: None,
+            next_fetch: automatic
+                .fetch
+                .then(|| now + SYNC_FIRST_FETCH.min(fetch_every)),
+            backoff: SYNC_BACKOFF_MIN.min(fetch_every),
+        })
+    }
+
+    /// The shortest backoff: a minute, or the fetch interval when that is
+    /// shorter (a test's, say).
+    fn backoff_floor(&self) -> Duration {
+        SYNC_BACKOFF_MIN.min(self.fetch_every)
+    }
+
+    fn deadline(&self) -> Option<Instant> {
+        match (self.next_publish, self.next_fetch) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (a, b) => a.or(b),
+        }
+    }
+
+    /// A checkpoint was saved: publish it soon, unless a publication is
+    /// already due sooner.
+    fn saved(&mut self, now: Instant) {
+        if !self.automatic.publish {
+            return;
+        }
+        let at = now + self.publish_after;
+        self.next_publish = Some(self.next_publish.map_or(at, |due| due.min(at)));
+    }
+
+    /// An incoming configuration changed the tracked set: fetch again soon.
+    fn follow_up(&mut self, now: Instant) {
+        let at = now + SYNC_FOLLOW_UP;
+        self.next_fetch = Some(self.next_fetch.map_or(at, |due| due.min(at)));
+    }
+
+    fn failed(&mut self, now: Instant) -> Duration {
+        let retry_in = self.backoff;
+        self.next_publish = None;
+        self.next_fetch = Some(now + retry_in);
+        self.backoff = (self.backoff * 2).min(SYNC_BACKOFF_MAX);
+        retry_in
+    }
+
+    fn succeeded(&mut self, now: Instant) {
+        self.backoff = self.backoff_floor();
+        self.next_publish = None;
+        self.next_fetch = self.automatic.fetch.then(|| now + self.fetch_every);
+    }
 }
 
 /// The final capture before the process ends: a full capture, not only the
@@ -911,6 +1223,18 @@ fn apply_intervals(
     *intervals = fresh;
 }
 
+/// The synchronization plan as the configuration says now (the origin or
+/// the mode may have changed), keeping the backoff of the previous one.
+fn refresh_sync_plan(capture: &mut Capture, now: Instant) {
+    let previous = capture.sync.take();
+    capture.sync = SyncPlan::from_settings(&Settings::get(), now).map(|mut plan| {
+        if let Some(previous) = previous {
+            plan.backoff = previous.backoff;
+        }
+        plan
+    });
+}
+
 /// Drops from the schedule what the tracked set no longer covers (excluded,
 /// untracked, switched to manual saving, a link's old target): no capture
 /// from now on holds it or carries its old version forward. A path that is
@@ -1029,6 +1353,9 @@ struct Capture {
     out: Output,
     schedule: Schedule,
     health: Health,
+    /// Automatic synchronization, when an origin is connected and the mode
+    /// allows any.
+    sync: Option<SyncPlan>,
     backoff: Duration,
     retry_at: Option<Instant>,
     /// Why the last attempt did not run, while a retry is pending.
@@ -1076,6 +1403,7 @@ impl Capture {
             retry_at: None,
             retry_kind: None,
             anchor_ids: Default::default(),
+            sync: SyncPlan::from_settings(&Settings::get(), Instant::now()),
         }
     }
 
@@ -1146,6 +1474,9 @@ impl Capture {
         match result {
             Ok(Outcome::Created(entry)) => {
                 self.recovered();
+                if let Some(plan) = &mut self.sync {
+                    plan.saved(Instant::now());
+                }
                 self.health.watcher.last_capture = Some(store::now_rfc3339());
                 self.out.emit(
                     "captured",
@@ -1177,6 +1508,28 @@ impl Capture {
                 self.fail(reason, &format!("{err:#}"));
                 Attempt::Failed
             }
+        }
+    }
+
+    /// A sync failed: the next attempt after the backoff, recorded for
+    /// `mise doctor` and `mise bootstrap dotfiles status`.
+    fn sync_failed(&mut self, now: Instant) -> Duration {
+        let Some(plan) = &mut self.sync else {
+            return SYNC_BACKOFF_MIN;
+        };
+        let retry_in = plan.failed(now);
+        let state_dir = self.store.state_dir();
+        let mut status = sync_run::read_status(state_dir);
+        status.backoff_until = Some(rfc3339_in(retry_in));
+        if let Err(err) = sync_run::write_status(state_dir, &status) {
+            debug!("history watch: could not record the sync backoff: {err}");
+        }
+        retry_in
+    }
+
+    fn sync_succeeded(&mut self, now: Instant) {
+        if let Some(plan) = &mut self.sync {
+            plan.succeeded(now);
         }
     }
 
@@ -1261,6 +1614,11 @@ fn epoch_secs() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0)
+}
+
+fn rfc3339_in(from_now: Duration) -> String {
+    let at = chrono::Utc::now() + chrono::Duration::from_std(from_now).unwrap_or_default();
+    at.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
 }
 
 fn rfc3339_ago(ago: Duration) -> String {

--- a/src/system/history/watch/runtime.rs
+++ b/src/system/history/watch/runtime.rs
@@ -52,6 +52,10 @@ enum Restart {
 const WATCH_LOCK_TRIES: u32 = 5;
 const WATCH_LOCK_RETRY: Duration = Duration::from_millis(200);
 
+/// How many checkpoints may wait for `history.describe_command` before the
+/// oldest keeps its computed description.
+const DESCRIBE_QUEUE: usize = 8;
+
 /// How often, and how many times, the shutdown capture waits for a running
 /// history operation to finish before giving up.
 const SHUTDOWN_RETRY_EVERY: Duration = Duration::from_secs(1);
@@ -695,7 +699,7 @@ pub(crate) async fn run(opts: WatchOptions) -> Result<i32> {
 fn start_describe(
     capture: &mut Capture,
 ) -> Option<tokio::task::JoinHandle<(u64, Result<Option<String>>)>> {
-    let entry = capture.describe_next.take()?;
+    let entry = capture.describe_next.pop_front()?;
     let command = describe_command::configured()?;
     let state_dir = capture.store.state_dir().to_path_buf();
     Some(tokio::task::spawn_blocking(move || {
@@ -1018,6 +1022,9 @@ async fn finish(capture: &mut Capture, tracked: &TrackedSet, restart: Restart) -
         );
     }
     capture.persist_schedule();
+    // a description command still running is not waited for: its
+    // checkpoint keeps the computed description
+    describe_command::abort_running();
     capture.out.emit("stopped", "stopping", json!({}));
     capture.write_health();
     outcome
@@ -1427,9 +1434,9 @@ struct Capture {
     /// Automatic synchronization, when an origin is connected and the mode
     /// allows any.
     sync: Option<SyncPlan>,
-    /// Checkpoints waiting for `history.describe_command`: at most one,
-    /// the newest (a name for an older one is not worth a queue).
-    describe_next: Option<store::Entry>,
+    /// Checkpoints waiting for `history.describe_command`, oldest first;
+    /// past the bound the oldest is skipped, and said so.
+    describe_next: std::collections::VecDeque<store::Entry>,
     backoff: Duration,
     retry_at: Option<Instant>,
     /// Why the last attempt did not run, while a retry is pending.
@@ -1478,7 +1485,7 @@ impl Capture {
             retry_kind: None,
             anchor_ids: Default::default(),
             sync: SyncPlan::from_settings(&Settings::get(), Instant::now()),
-            describe_next: None,
+            describe_next: std::collections::VecDeque::new(),
         }
     }
 
@@ -1553,7 +1560,19 @@ impl Capture {
                     plan.saved(Instant::now());
                 }
                 if describe_command::configured().is_some() {
-                    self.describe_next = Some((*entry).clone());
+                    self.describe_next.push_back((*entry).clone());
+                    if self.describe_next.len() > DESCRIBE_QUEUE
+                        && let Some(skipped) = self.describe_next.pop_front()
+                    {
+                        self.out.emit(
+                            "describe-skipped",
+                            &format!(
+                                "history.describe_command is behind; checkpoint {} keeps its computed description",
+                                skipped.id
+                            ),
+                            json!({ "id": skipped.id }),
+                        );
+                    }
                 }
                 self.health.watcher.last_capture = Some(store::now_rfc3339());
                 self.out.emit(

--- a/src/system/history/watch/runtime.rs
+++ b/src/system/history/watch/runtime.rs
@@ -719,7 +719,7 @@ fn start_sync(
     tracked: &TrackedSet,
 ) -> Option<tokio::task::JoinHandle<Result<SyncOutcome>>> {
     let plan = capture.sync.as_mut()?;
-    let fetch_only = !plan.automatic.publish;
+    let fetch_only = !plan.config.automatic.publish;
     plan.next_publish = None;
     plan.next_fetch = None;
     capture.out.emit(
@@ -788,7 +788,7 @@ async fn finish_sync(
     let applies = capture
         .sync
         .as_ref()
-        .is_some_and(|plan| plan.automatic.apply);
+        .is_some_and(|plan| plan.config.automatic.apply);
     if !applies || outcome.pending == 0 {
         return Some(false);
     }
@@ -844,24 +844,28 @@ async fn once_sync(capture: &mut Capture, state: &State) -> bool {
 /// `sync_interval` after a save) and the next fetch (every
 /// `fetch_interval`) are due, and the backoff after a failure.
 struct SyncPlan {
-    automatic: Automatic,
-    publish_after: Duration,
-    fetch_every: Duration,
+    config: SyncConfig,
     next_publish: Option<Instant>,
     next_fetch: Option<Instant>,
     backoff: Duration,
 }
 
-impl SyncPlan {
+/// What `settings.history.sync` and `[history.origin]` say. Compared after a
+/// reload of the configuration, so a pending deadline survives an edit to
+/// something else.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SyncConfig {
+    automatic: Automatic,
+    publish_after: Duration,
+    fetch_every: Duration,
+    /// The repository's url and branch: another one starts afresh.
+    origin: (String, String),
+}
+
+impl SyncConfig {
     /// `None` without a connected origin, or in `manual` mode.
-    fn from_settings(settings: &Settings, now: Instant) -> Option<Self> {
-        if !crate::system::history::config::origin()
-            .ok()
-            .flatten()
-            .is_some()
-        {
-            return None;
-        }
+    fn from_settings(settings: &Settings) -> Option<Self> {
+        let (_, origin) = crate::system::history::config::origin().ok().flatten()?;
         let automatic = SyncMode::parse(&settings.history.sync).ok()?.automatic();
         if !automatic.publish && !automatic.fetch {
             return None;
@@ -872,11 +876,6 @@ impl SyncPlan {
                 default
             })
         };
-        let fetch_every = parse(
-            "fetch_interval",
-            &settings.history.fetch_interval,
-            Duration::from_secs(900),
-        );
         Some(Self {
             automatic,
             publish_after: parse(
@@ -884,19 +883,73 @@ impl SyncPlan {
                 &settings.history.sync_interval,
                 Duration::from_secs(300),
             ),
-            fetch_every,
-            next_publish: None,
-            next_fetch: automatic
-                .fetch
-                .then(|| now + SYNC_FIRST_FETCH.min(fetch_every)),
-            backoff: SYNC_BACKOFF_MIN.min(fetch_every),
+            fetch_every: parse(
+                "fetch_interval",
+                &settings.history.fetch_interval,
+                Duration::from_secs(900),
+            ),
+            origin: (origin.url, origin.branch),
         })
+    }
+}
+
+impl SyncPlan {
+    /// `None` without a connected origin, or in `manual` mode.
+    fn from_settings(settings: &Settings, now: Instant) -> Option<Self> {
+        SyncConfig::from_settings(settings).map(|config| Self::new(config, now))
+    }
+
+    /// A fresh plan: the first fetch soon, no publication pending.
+    fn new(config: SyncConfig, now: Instant) -> Self {
+        Self {
+            next_publish: None,
+            next_fetch: config
+                .automatic
+                .fetch
+                .then(|| now + SYNC_FIRST_FETCH.min(config.fetch_every)),
+            backoff: SYNC_BACKOFF_MIN.min(config.fetch_every),
+            config,
+        }
+    }
+
+    /// The configuration was reloaded. Another origin starts afresh;
+    /// otherwise what is pending stays, moved only by what changed: a
+    /// disabled activity loses its deadline, a newly enabled fetch gets its
+    /// first one, and a shorter interval brings a deadline forward, never
+    /// back. A reload that changes nothing changes nothing here, so a
+    /// reconcile tick or an edit elsewhere never postpones what is due.
+    fn reconfigure(&mut self, fresh: SyncConfig, now: Instant) {
+        if fresh == self.config {
+            return;
+        }
+        if fresh.origin != self.config.origin {
+            *self = Self::new(fresh, now);
+            return;
+        }
+        let previous = std::mem::replace(&mut self.config, fresh);
+        let config = &self.config;
+        if !config.automatic.publish {
+            self.next_publish = None;
+        } else if config.publish_after != previous.publish_after {
+            // nothing saved, nothing to bring forward
+            let at = now + config.publish_after;
+            self.next_publish = self.next_publish.map(|due| due.min(at));
+        }
+        if !config.automatic.fetch {
+            self.next_fetch = None;
+        } else if !previous.automatic.fetch {
+            self.next_fetch = Some(now + SYNC_FIRST_FETCH.min(config.fetch_every));
+        } else if config.fetch_every != previous.fetch_every {
+            let at = now + config.fetch_every;
+            self.next_fetch = Some(self.next_fetch.map_or(at, |due| due.min(at)));
+        }
+        self.backoff = self.backoff.min(SYNC_BACKOFF_MAX).max(self.backoff_floor());
     }
 
     /// The shortest backoff: a minute, or the fetch interval when that is
     /// shorter (a test's, say).
     fn backoff_floor(&self) -> Duration {
-        SYNC_BACKOFF_MIN.min(self.fetch_every)
+        SYNC_BACKOFF_MIN.min(self.config.fetch_every)
     }
 
     fn deadline(&self) -> Option<Instant> {
@@ -909,10 +962,10 @@ impl SyncPlan {
     /// A checkpoint was saved: publish it soon, unless a publication is
     /// already due sooner.
     fn saved(&mut self, now: Instant) {
-        if !self.automatic.publish {
+        if !self.config.automatic.publish {
             return;
         }
-        let at = now + self.publish_after;
+        let at = now + self.config.publish_after;
         self.next_publish = Some(self.next_publish.map_or(at, |due| due.min(at)));
     }
 
@@ -933,7 +986,11 @@ impl SyncPlan {
     fn succeeded(&mut self, now: Instant) {
         self.backoff = self.backoff_floor();
         self.next_publish = None;
-        self.next_fetch = self.automatic.fetch.then(|| now + self.fetch_every);
+        self.next_fetch = self
+            .config
+            .automatic
+            .fetch
+            .then(|| now + self.config.fetch_every);
     }
 }
 
@@ -1302,15 +1359,17 @@ fn apply_intervals(
 }
 
 /// The synchronization plan as the configuration says now (the origin or
-/// the mode may have changed), keeping the backoff of the previous one.
+/// the mode may have changed), adjusted rather than rebuilt: a pending
+/// publication or fetch keeps its deadline unless what it depends on changed.
 fn refresh_sync_plan(capture: &mut Capture, now: Instant) {
-    let previous = capture.sync.take();
-    capture.sync = SyncPlan::from_settings(&Settings::get(), now).map(|mut plan| {
-        if let Some(previous) = previous {
-            plan.backoff = previous.backoff;
+    let fresh = SyncConfig::from_settings(&Settings::get());
+    capture.sync = match (capture.sync.take(), fresh) {
+        (Some(mut plan), Some(fresh)) => {
+            plan.reconfigure(fresh, now);
+            Some(plan)
         }
-        plan
-    });
+        (_, fresh) => fresh.map(|config| SyncPlan::new(config, now)),
+    };
 }
 
 /// Drops from the schedule what the tracked set no longer covers (excluded,
@@ -1615,10 +1674,15 @@ impl Capture {
             return SYNC_BACKOFF_MIN;
         };
         let retry_in = plan.failed(now);
-        let state_dir = self.store.state_dir();
-        let mut status = sync_run::read_status(state_dir);
-        status.backoff_until = Some(rfc3339_in(retry_in));
-        if let Err(err) = sync_run::write_status(state_dir, &status) {
+        // under the sync lock, changing only this; no wait: this is the event
+        // loop, and an explicit sync or pull holding the lock writes its own
+        // fresh record
+        let until = rfc3339_in(retry_in);
+        if let Err(err) =
+            sync_run::update_status(self.store.state_dir(), Duration::ZERO, |status| {
+                status.backoff_until = Some(until);
+            })
+        {
             debug!("history watch: could not record the sync backoff: {err}");
         }
         retry_in
@@ -1954,5 +2018,107 @@ mod tests {
         let state = state_of(tracked, root.join("mise"));
         assert!(!state.may_cover_missing(&hypr.join("bindings.lua")));
         assert!(!state.may_cover_missing(&root.join("elsewhere/target")));
+    }
+}
+
+#[cfg(test)]
+mod sync_plan_tests {
+    use super::*;
+
+    fn secs(n: u64) -> Duration {
+        Duration::from_secs(n)
+    }
+
+    fn config(mode: SyncMode, publish_after: u64, fetch_every: u64) -> SyncConfig {
+        SyncConfig {
+            automatic: mode.automatic(),
+            publish_after: secs(publish_after),
+            fetch_every: secs(fetch_every),
+            origin: ("file:///setup.git".to_string(), "main".to_string()),
+        }
+    }
+
+    #[test]
+    fn a_reload_that_changes_nothing_keeps_the_deadlines() {
+        let start = Instant::now();
+        let mut plan = SyncPlan::new(config(SyncMode::Sync, 300, 900), start);
+        plan.saved(start);
+        let retry = plan.failed(start + secs(1));
+        let (publish, fetch, backoff) = (plan.next_publish, plan.next_fetch, plan.backoff);
+        assert_eq!(fetch, Some(start + secs(1) + retry));
+        plan.reconfigure(config(SyncMode::Sync, 300, 900), start + secs(5));
+        assert_eq!(plan.next_publish, publish);
+        assert_eq!(plan.next_fetch, fetch);
+        assert_eq!(plan.backoff, backoff);
+    }
+
+    #[test]
+    fn fetch_only_drops_the_pending_publication() {
+        let start = Instant::now();
+        let mut plan = SyncPlan::new(config(SyncMode::Sync, 300, 900), start);
+        plan.saved(start);
+        let fetch = plan.next_fetch;
+        plan.reconfigure(config(SyncMode::FetchOnly, 300, 900), start + secs(5));
+        assert_eq!(plan.next_publish, None);
+        assert_eq!(plan.next_fetch, fetch);
+        // and a save in fetch-only mode schedules nothing
+        plan.saved(start + secs(6));
+        assert_eq!(plan.next_publish, None);
+    }
+
+    #[test]
+    fn a_shorter_fetch_interval_brings_the_next_fetch_forward_a_longer_one_does_not_delay_it() {
+        let start = Instant::now();
+        let mut plan = SyncPlan::new(config(SyncMode::Sync, 300, 900), start);
+        plan.succeeded(start);
+        assert_eq!(plan.next_fetch, Some(start + secs(900)));
+        plan.reconfigure(config(SyncMode::Sync, 300, 2), start + secs(5));
+        assert_eq!(plan.next_fetch, Some(start + secs(7)));
+        plan.reconfigure(config(SyncMode::Sync, 300, 900), start + secs(6));
+        assert_eq!(plan.next_fetch, Some(start + secs(7)));
+    }
+
+    #[test]
+    fn a_shorter_publish_delay_brings_a_pending_publication_forward() {
+        let start = Instant::now();
+        let mut plan = SyncPlan::new(config(SyncMode::Sync, 300, 900), start);
+        plan.reconfigure(config(SyncMode::Sync, 1, 900), start + secs(1));
+        // nothing saved: a new delay arms nothing
+        assert_eq!(plan.next_publish, None);
+        plan.saved(start + secs(2));
+        assert_eq!(plan.next_publish, Some(start + secs(3)));
+        plan.reconfigure(config(SyncMode::Sync, 300, 900), start + secs(2));
+        assert_eq!(plan.next_publish, Some(start + secs(3)));
+        let mut plan = SyncPlan::new(config(SyncMode::Sync, 300, 900), start);
+        plan.saved(start);
+        plan.reconfigure(config(SyncMode::Sync, 1, 900), start + secs(2));
+        assert_eq!(plan.next_publish, Some(start + secs(3)));
+    }
+
+    #[test]
+    fn enabling_fetch_arms_the_first_fetch() {
+        let start = Instant::now();
+        let mut publish_only = config(SyncMode::Sync, 300, 900);
+        publish_only.automatic.fetch = false;
+        let mut plan = SyncPlan::new(publish_only, start);
+        assert_eq!(plan.next_fetch, None);
+        plan.reconfigure(config(SyncMode::Sync, 300, 900), start + secs(5));
+        assert_eq!(plan.next_fetch, Some(start + secs(5) + SYNC_FIRST_FETCH));
+    }
+
+    #[test]
+    fn another_origin_starts_afresh() {
+        let start = Instant::now();
+        let mut plan = SyncPlan::new(config(SyncMode::Sync, 300, 900), start);
+        plan.saved(start);
+        plan.failed(start);
+        plan.failed(start + secs(60));
+        assert!(plan.backoff > plan.backoff_floor());
+        let mut moved = config(SyncMode::Sync, 300, 900);
+        moved.origin.1 = "work".to_string();
+        plan.reconfigure(moved, start + secs(100));
+        assert_eq!(plan.backoff, plan.backoff_floor());
+        assert_eq!(plan.next_publish, None);
+        assert_eq!(plan.next_fetch, Some(start + secs(100) + SYNC_FIRST_FETCH));
     }
 }

--- a/src/system/remote.rs
+++ b/src/system/remote.rs
@@ -586,6 +586,15 @@ async fn run_staged(
     repository: Option<&super::remote_repository::Source>,
 ) -> Result<()> {
     let project = format!("{staging}/project");
+    let preview_setup = options.dry_run
+        && match repository {
+            Some(repository) => {
+                super::remote_repository::history_branch(&repository.bundle, &repository.revision)?
+                    .is_some()
+            }
+            None => false,
+        };
+    let preview_directory = format!("{staging}/preview");
     session
         .status_async(&["mkdir", "-p", &project], false)
         .await?;
@@ -637,6 +646,9 @@ async fn run_staged(
         if options.dry_run {
             install.push("--repository-dry-run");
         }
+        if preview_setup {
+            install.extend(["--repository-preview-directory", &preview_directory]);
+        }
         // The helper uses the target's XDG/global-config environment. Only its
         // absolute result, never the staging directory, becomes trusted config.
         let path = session
@@ -648,7 +660,7 @@ async fn run_staged(
             bail!("invalid remote global configuration path");
         }
         session.status_async(&install, true).await?;
-        if options.dry_run && !remote_directory_exists(session, &path).await? {
+        if options.dry_run && !preview_setup && !remote_directory_exists(session, &path).await? {
             // nothing was written, so there is no configuration to preview the
             // bootstrap against yet
             miseprintln!(
@@ -662,7 +674,11 @@ async fn run_staged(
             }
             return Ok(());
         }
-        path
+        if preview_setup {
+            preview_directory
+        } else {
+            path
+        }
     } else {
         project
     };
@@ -671,6 +687,10 @@ async fn run_staged(
         format!("MISE_TRUSTED_CONFIG_PATHS={project}"),
     ];
     argv.push(format!("MISE_ENV={}", session.host.mise_env.join(",")));
+    if preview_setup {
+        argv.push(format!("MISE_CONFIG_DIR={project}"));
+        argv.push(format!("MISE_GLOBAL_CONFIG_FILE={project}/config.toml"));
+    }
     if options.experimental {
         argv.extend([
             "MISE_EXPERIMENTAL=1".into(),

--- a/src/system/remote.rs
+++ b/src/system/remote.rs
@@ -518,6 +518,19 @@ async fn finish_session(
     result
 }
 
+/// Whether a directory exists on the target (a dry run wrote nothing, so the
+/// configuration directory the helper reported may not be there).
+async fn remote_directory_exists(session: &SshSession<'_>, path: &str) -> Result<bool> {
+    let output = session
+        .output_async(&[
+            "sh",
+            "-c",
+            &format!("test -d {} && echo yes || echo no", shell_quote(path)),
+        ])
+        .await?;
+    Ok(output.trim() == "yes")
+}
+
 fn staging_creation_script() -> &'static str {
     r#"set -eu
 staging=$(mktemp -d /tmp/mise-bootstrap.XXXXXXXXXX)
@@ -579,6 +592,11 @@ async fn run_staged(
         if options.yes {
             install.push("--repository-yes");
         }
+        // the whole operation previews: the helper inspects the target and the
+        // repository and says what it would write, before the bootstrap preview
+        if options.dry_run {
+            install.push("--repository-dry-run");
+        }
         // The helper uses the target's XDG/global-config environment. Only its
         // absolute result, never the staging directory, becomes trusted config.
         let path = session
@@ -590,6 +608,20 @@ async fn run_staged(
             bail!("invalid remote global configuration path");
         }
         session.status_async(&install, true).await?;
+        if options.dry_run && !remote_directory_exists(session, &path).await? {
+            // nothing was written, so there is no configuration to preview the
+            // bootstrap against yet
+            miseprintln!(
+                "Would then run `mise bootstrap --dry-run` in {path} on {} once the configuration exists there",
+                session.host.name
+            );
+            if options.relay.is_some() {
+                info!(
+                    "borrowed GitHub access has ended; future private updates require remote credentials or another relay-enabled session"
+                );
+            }
+            return Ok(());
+        }
         path
     } else {
         project

--- a/src/system/remote.rs
+++ b/src/system/remote.rs
@@ -115,6 +115,7 @@ pub(crate) struct RemoteOverrides {
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct RemoteRunOptions {
+    pub experimental: bool,
     pub relay: Option<crate::github_relay::Scope>,
     pub dry_run: bool,
     pub yes: bool,
@@ -133,6 +134,28 @@ pub(crate) struct RemoteArtifactResolver {
     manifest: Option<ReleaseManifest>,
     artifacts: IndexMap<String, PathBuf>,
     official_local_verified: bool,
+}
+
+/// Retain an explicitly forwarded opt-in only after tracked setup succeeds.
+/// The machine-local file is not part of the shared setup configuration.
+pub(crate) fn persist_experimental_opt_in() -> Result<()> {
+    if std::env::var("MISE_BOOTSTRAP_REMOTE_EXPERIMENTAL").as_deref() != Ok("1") {
+        return Ok(());
+    }
+    let path = crate::cli::dotfiles::track::declaration_file(true)?;
+    let mut document = crate::cli::dotfiles::track::read_document(&path)?;
+    let settings = document
+        .entry("settings")
+        .or_insert(toml_edit::Item::Table(toml_edit::Table::new()));
+    let settings = settings
+        .as_table_mut()
+        .ok_or_else(|| eyre::eyre!("[settings] must be a table in {}", path.display()))?;
+    settings.insert("experimental", toml_edit::value(true));
+    if let Some(parent) = path.parent() {
+        crate::file::create_dir_all(parent)?;
+    }
+    crate::file::write(&path, document.to_string())?;
+    Ok(())
 }
 
 #[derive(Clone, Debug)]
@@ -577,6 +600,7 @@ async fn run_staged(
             )
             .await?;
         let mut install = vec![
+            "env",
             mise.as_str(),
             "ssh",
             "--repository-bundle",
@@ -586,6 +610,15 @@ async fn run_staged(
             "--repository-revision",
             &repository.revision,
         ];
+        if options.experimental {
+            install.splice(
+                1..1,
+                [
+                    "MISE_EXPERIMENTAL=1",
+                    "MISE_BOOTSTRAP_REMOTE_EXPERIMENTAL=1",
+                ],
+            );
+        }
         if options.update {
             install.push("--repository-update");
         }
@@ -631,6 +664,12 @@ async fn run_staged(
         format!("MISE_TRUSTED_CONFIG_PATHS={project}"),
     ];
     argv.push(format!("MISE_ENV={}", session.host.mise_env.join(",")));
+    if options.experimental {
+        argv.extend([
+            "MISE_EXPERIMENTAL=1".into(),
+            "MISE_BOOTSTRAP_REMOTE_EXPERIMENTAL=1".into(),
+        ]);
+    }
     #[cfg(unix)]
     if relay.is_some() {
         argv.extend([

--- a/src/system/remote.rs
+++ b/src/system/remote.rs
@@ -143,6 +143,13 @@ pub(crate) fn persist_experimental_opt_in() -> Result<()> {
         return Ok(());
     }
     let path = crate::cli::dotfiles::track::declaration_file(true)?;
+    if let Some(selected) = std::env::var_os("MISE_GLOBAL_CONFIG_FILE")
+        && Path::new(&selected) != path
+    {
+        bail!(
+            "cannot retain remote experimental opt-in: MISE_GLOBAL_CONFIG_FILE bypasses config.local.toml; unset it on the target and rerun with --experimental"
+        );
+    }
     let mut document = crate::cli::dotfiles::track::read_document(&path)?;
     let settings = document
         .entry("settings")

--- a/src/system/remote_repository.rs
+++ b/src/system/remote_repository.rs
@@ -150,14 +150,26 @@ pub(crate) fn history_branch(bundle: &Path, revision: &str) -> Result<Option<Str
     Ok(Some(git(&checkout, &["symbolic-ref", "--short", "HEAD"])?))
 }
 
+/// Installs the transferred revision as the global configuration checkout.
+/// A dry run runs every check and says what it would do (clone, fast-forward,
+/// adopt) without writing anything persistent.
 pub(crate) fn install(
     bundle: &Path,
     origin: &str,
     revision: &str,
     update: bool,
     yes: bool,
+    dry_run: bool,
 ) -> Result<PathBuf> {
-    install_at(bundle, origin, revision, update, yes, &global_directory())
+    install_at(
+        bundle,
+        origin,
+        revision,
+        update,
+        yes,
+        dry_run,
+        &global_directory(),
+    )
 }
 
 fn install_at(
@@ -166,6 +178,7 @@ fn install_at(
     revision: &str,
     update: bool,
     yes: bool,
+    dry_run: bool,
     destination: &Path,
 ) -> Result<PathBuf> {
     validate_origin(origin)?;
@@ -178,10 +191,19 @@ fn install_at(
     let parent = destination
         .parent()
         .ok_or_else(|| eyre::eyre!("missing parent directory"))?;
-    std::fs::create_dir_all(parent)?;
+    if !dry_run {
+        std::fs::create_dir_all(parent)?;
+    }
     let _lock = crate::lock_file::LockFile::new(destination).lock()?;
-    let temporary = tempfile::tempdir_in(parent)?;
+    // the checkout is renamed into place, so it is staged next to the
+    // destination; a dry run never renames and leaves the parent alone
+    let temporary = if dry_run {
+        tempfile::tempdir()?
+    } else {
+        tempfile::tempdir_in(parent)?
+    };
     let checkout = temporary.path().join("checkout");
+    let shown = crate::file::display_path(destination);
     let mut command = Command::new("git");
     crate::git::sanitize_git_command(&mut command);
     let output = command
@@ -233,6 +255,25 @@ fn install_at(
             if git(destination, &["symbolic-ref", "--short", "HEAD"])? != branch {
                 bail!("global configuration branch differs from the transferred branch");
             }
+            if dry_run {
+                // the bundle holds the history from the checkout's commit on,
+                // so the fast-forward is checked there without fetching into
+                // the destination
+                let head = git(destination, &["rev-parse", "HEAD"])?;
+                if head == revision {
+                    miseprintln!(
+                        "Would keep {shown} at {revision}, already the transferred revision"
+                    );
+                } else if git(&checkout, &["merge-base", "--is-ancestor", &head, revision]).is_ok()
+                {
+                    miseprintln!("Would fast-forward {shown} from {head} to {revision}");
+                } else {
+                    bail!(
+                        "global configuration at {shown} cannot be fast-forwarded to the transferred revision"
+                    );
+                }
+                return Ok(destination.to_path_buf());
+            }
             git(
                 destination,
                 &[
@@ -266,6 +307,10 @@ fn install_at(
                     revision,
                 ],
             )?;
+        } else if dry_run {
+            miseprintln!(
+                "Would keep the existing checkout of {origin} at {shown}; --update fast-forwards it"
+            );
         }
         return Ok(destination.to_path_buf());
     }
@@ -287,6 +332,17 @@ fn install_at(
             {
                 bail!("existing file conflicts with adoption: {entry}");
             }
+        }
+        if dry_run {
+            let new_files = entries
+                .split('\0')
+                .filter(|s| !s.is_empty())
+                .filter(|entry| !destination.join(entry).exists())
+                .count();
+            miseprintln!(
+                "Would adopt {shown} as the global configuration repository ({new_files} new file(s); existing files and local overrides preserved)"
+            );
+            return Ok(destination.to_path_buf());
         }
         eprintln!(
             "Adopt existing global configuration at {} (preserving existing files and local overrides)",
@@ -310,6 +366,8 @@ fn install_at(
             }
         }
         std::fs::rename(checkout.join(".git"), destination.join(".git"))?;
+    } else if dry_run {
+        miseprintln!("Would clone {origin} at {revision} into {shown}");
     } else {
         if destination.exists() {
             std::fs::remove_dir(destination)?;
@@ -352,8 +410,65 @@ mod tests {
             &source.revision,
             update,
             true,
+            false,
             dest,
         )
+    }
+    fn preview_source(source: &Source, dest: &Path, update: bool) -> Result<PathBuf> {
+        install_at(
+            &source.bundle,
+            &source.origin,
+            &source.revision,
+            update,
+            true,
+            true,
+            dest,
+        )
+    }
+    #[tokio::test]
+    async fn dry_run_previews_without_writing() {
+        let repo = repository();
+        let source = Source::fetch(repo.path().to_str().unwrap().into())
+            .await
+            .unwrap();
+        let target = tempfile::tempdir().unwrap();
+        // a fresh destination, its parent missing too: neither is created
+        let dest = target.path().join("missing").join("mise");
+        preview_source(&source, &dest, false).unwrap();
+        assert!(!dest.exists());
+        assert!(!target.path().join("missing").exists());
+        // an existing checkout is inspected, not moved
+        let dest = target.path().join("mise");
+        install_source(&source, &dest, false).unwrap();
+        commit(
+            repo.path(),
+            "config.toml",
+            "[settings]\nexperimental = true\n",
+        );
+        let next = Source::fetch(source.origin.clone()).await.unwrap();
+        preview_source(&next, &dest, false).unwrap();
+        preview_source(&next, &dest, true).unwrap();
+        assert_eq!(git(&dest, &["rev-parse", "HEAD"]).unwrap(), source.revision);
+        // and nothing was fetched into it: the new revision is not there
+        assert!(
+            git(
+                &dest,
+                &["cat-file", "-e", &format!("{}^{{commit}}", next.revision)]
+            )
+            .is_err()
+        );
+        std::fs::write(dest.join("config.toml"), "dirty").unwrap();
+        assert!(preview_source(&next, &dest, true).is_err());
+        // adoption is previewed without writing git metadata; a conflict
+        // still refuses
+        let adopt = tempfile::tempdir().unwrap();
+        std::fs::write(adopt.path().join("config.local.toml"), "private").unwrap();
+        std::fs::write(adopt.path().join("config.toml"), "conflict").unwrap();
+        assert!(preview_source(&source, adopt.path(), false).is_err());
+        std::fs::write(adopt.path().join("config.toml"), "[tools]\n").unwrap();
+        preview_source(&source, adopt.path(), false).unwrap();
+        assert!(!adopt.path().join(".git").exists());
+        assert!(!adopt.path().join(".gitattributes").exists());
     }
     #[tokio::test]
     async fn pinned_install_and_safe_updates() {

--- a/src/system/remote_repository.rs
+++ b/src/system/remote_repository.rs
@@ -127,6 +127,29 @@ pub(crate) fn global_directory() -> PathBuf {
         .to_path_buf()
 }
 
+/// The branch of a transferred bundle whose tree carries the setup
+/// repository marker (`.mise-history/format.toml`); `None` for an ordinary
+/// repository.
+pub(crate) fn history_branch(bundle: &Path, revision: &str) -> Result<Option<String>> {
+    let temporary = tempfile::tempdir()?;
+    let checkout = temporary.path().join("checkout");
+    let mut command = Command::new("git");
+    crate::git::sanitize_git_command(&mut command);
+    let output = command
+        .args(["clone", "--no-checkout", "--"])
+        .arg(bundle)
+        .arg(&checkout)
+        .output()?;
+    if !output.status.success() {
+        bail!("invalid transferred repository bundle");
+    }
+    let marker = format!("{revision}:.mise-history/format.toml");
+    if git(&checkout, &["cat-file", "-e", &marker]).is_err() {
+        return Ok(None);
+    }
+    Ok(Some(git(&checkout, &["symbolic-ref", "--short", "HEAD"])?))
+}
+
 pub(crate) fn install(
     bundle: &Path,
     origin: &str,


### PR DESCRIPTION
## Release contract

Tracking, history, rollback, watching, synchronization, and encrypted dotfiles ship without experimental opt-in. The integrated removal of the earlier gates is in #12905; this stack ships together. Remote bootstrap does not need an experimental flag or persist an experimental setting. Existing source-managed dotfile workflows remain supported.

Compatibility is measured against the last published release, `v2026.9.1`, not intermediate revisions of this unreleased stack.

Stacked on #12865 (`bootstrap/9-origin`). Completes native-file configuration history and sharing through `mise bootstrap dotfiles`, automatic synchronization, and fresh-machine bootstrap.

## Automatic synchronization

- `sync` is the default: the watcher publishes saved changes and periodically fetches and applies incoming changes.
- Any conflict pauses publication and incoming application for the **entire setup**. Local checkpoints, fetching, and eligible machine backups continue.
- Per-file choices accumulate without partially applying anything. The complete plan is revalidated against current local and remote versions before resuming.
- `fetch-only` downloads without publishing or applying; `manual` performs no automatic network operations.
- Offline failures back off without delaying local capture. Throttled and manual-save files publish only saved contents, not ongoing unsaved churn.

## Notifications and health

`settings.history.notify` defaults to **true**, with explicit false respected. Notifications occur once when sharing enters a conflict pause, not on every retry or every newly conflicting path. Recovery resets deduplication for the next episode. Missing notifiers and headless environments never block operations.

`mise bootstrap dotfiles status` and `mise doctor` report the whole-setup pause, conflicting paths, resolution commands, last successful application, and distinct local-history/backup health.

## Onboarding

`mise bootstrap --from-git jdx/dotfiles` recognizes setup repositories by their marker, fetches into mise's bare store, preflights the complete incoming configuration, selected platform streams, and required sources, and applies them before ordinary bootstrap. No second apply round is needed to discover newly declared files. Existing differing files require a decision; the command does not silently bootstrap using an unrelated active configuration. Dry runs do not retain connection state.

Ordinary repositories retain the existing clone behavior. Existing symlink, copy, managed-edit, and template workflows remain compatible. Templates travel as sources and render during bootstrap, not sync.

The remote path uses the landed relay:

```sh
mise bootstrap remote --host devbox --install-mise --from-git jdx/dotfiles --github-relay-read-only --github-relay-repo jdx/dotfiles
```

Borrowed read-only GitHub access ends with the session. A host that will push later needs its own write authentication. The connection declaration stays machine-local in `config.local.toml`.

## Verification

Locally passed: `test_dotfiles_sync_auto`, `test_dotfiles_bootstrap_from_git`, `test_dotfiles_sync_preflight`, `test_dotfiles_sync`, notification deduplication/opt-out unit tests, complete documentation rendering, and lint-fix. CI is being checked on each updated head.

Docs and the launch blog now describe whole-setup pauses and default-on notifications, without claiming unrelated files continue syncing during a conflict.

## Follow-ups from the launch-post review

- **Remote dry run.** `mise bootstrap remote --host <h> --from-git <repo> --dry-run` connects, transfers the pinned revision, and the target previews the whole operation before anything is written: the helper runs every check and says what it would clone, fast-forward, or adopt (hidden `mise ssh --repository-dry-run`); a setup repository shows its plan and leaves no connection or fetched branch; the bootstrap is previewed when a configuration exists on the target. Previously the local command printed one line and returned, and the helper would have installed before `--dry-run` reached the bootstrap. New e2e: `test_bootstrap_remote_setup_repository`; the fake `ssh` in `test_bootstrap_remote_git` gives each host its own state directory.
- **Automatic sync scheduling.** A configuration reload adjusts the watcher's sync plan instead of rebuilding it (`SyncPlan::reconfigure`): pending publish/fetch deadlines survive unless the mode, an interval, or the origin changed. Unit tests plus `test_dotfiles_sync_auto_reconcile` (reconcile every second, publication still within the sync interval).
- **Backup retries.** Uploads consult the mirrored `refs/machines/<id>/<uuid>` the fetch left, so a lost `sync.json` records what the origin already holds rather than re-pushing; a backup the origin refuses is kept as it is there and the other uploads continue. Unit tests in `backup.rs`; `test_dotfiles_sync` empties the upload record and syncs again.
- **Concurrent status updates.** Every writer of `sync.json` outside `sync`/`pull`/`origin set` goes through `run::update_status` (sync lock, fresh read, one field). The bootstrap no longer clears "declarations changed" by writing an old copy over a sync that finished meanwhile.
- **Persistent failures.** `SyncStatus` records `failing_since` and `consecutive_failures`; `mise doctor` measures the failure from there (falling back to the last success for older records), so an origin that never answered escalates instead of reading as transient forever; status prints the same.

Deferred: deterministic backup wrapper commits (`GIT_*_DATE` from `created_at`), and a staged preview checkout so a remote ordinary-repository dry run can also preview the bootstrap on a host without a configuration yet.

## Limitations

Application is all-or-nothing with preflight and recovery, not an atomic multi-file filesystem operation. Desktop notifications currently support Linux/macOS and are best-effort. Encrypted backups are deferred and rejected when requested; the setup branch and eligible recovery backups are plaintext.

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core bootstrap, remote SSH provisioning, and multi-machine dotfile sync/apply with conflict handling and persisted remote experimental settings; mistakes could affect live configuration on targets.
> 
> **Overview**
> This PR completes the experimental dotfile **history/sync** story: the **history watcher** now drives network sync per `settings.history.sync` (publish after saves, periodic fetch, and automatic **pull** when the setup is conflict-free), with backoff on failures and reconcile/`--once` doing a full sync cycle—not just filesystem capture.
> 
> **Fresh machines** and **remote bootstrap** treat repos with `.mise-history/format.toml` as **setup repositories**: `mise bootstrap --from-git` and the remote `mise ssh` repository path fetch into mise’s bare store, run the same recoverable **onboard/pull** flow (held files need a decision; dry runs leave no connection), then continue normal bootstrap—instead of cloning into `~/.config/mise`. Ordinary git repos keep the old checkout behavior. Remote tracked setups require **`mise bootstrap remote --experimental`**, which can persist experimental opt-in on the target; **`--dry-run`** now previews clone/adopt/setup plans on the target (including follow-on bootstrap).
> 
> New **`history.describe_command`** lets a user command name watcher checkpoints from JSON stdin (private paths and non-backed-up content excluded). **`history.notify`** (default on) sends one desktop alert per conflict pause (`notify-send` on Linux; a **bundled macOS helper** built via `build.rs`/`cc`). Doctor and dotfiles status report **`failing_since`** and consecutive sync failures.
> 
> Docs add **Set up a machine**, expand bootstrap/remote/history/CLI reference, and ship extensive e2e coverage for auto-sync, onboarding, and remote setup repos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fa4f0bf67332d84c2fa5f877d543f09f42756de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->