### PR TITLE
docs: ground contributor workflows in current implementation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,405 +1,224 @@
 ---
-outline: [1, 3]
+outline: [2, 3]
 ---
 
 # mise Architecture
 
-This document gives an overview of mise's architecture. It is aimed at contributors and anyone interested in how mise works internally.
-
-For practical development guidance, see the [Contributing Guide](contributing.md).
+This map is for contributors deciding where a behavior belongs. Start with the command
+that exposes the behavior, then follow configuration, tool resolution, or task execution
+into the owning subsystem. The [contributing guide](/contributing.html) covers setup,
+checks, and generated files.
 
 ## System Overview
 
-mise is a Rust-based tool with a modular architecture centered on three core concepts:
+mise combines versioned development tools, environment construction, task execution, and
+explicit machine setup through [bootstrap](/bootstrap.html). These features share configuration
+and execution helpers, but have different state and side effects. Installing a versioned
+tool is not the same operation as applying a host package or dotfile declaration.
 
-1. **Tool Version Management** - Installing and managing different versions of [development tools](dev-tools/)
-2. **Environment Management** - Setting up [environment variables](environments/) and project contexts
-3. **Task Running** - Executing [project tasks](tasks/) with dependency management
-
-These three pillars work together to provide unified development environment management.
+```mermaid
+flowchart TD
+    CLI[CLI command] --> Config[Configuration and settings]
+    Config --> Tools[Tool requests and backend resolution]
+    Tools --> Env[Environment and PATH]
+    Env --> Exec[Child command or shell output]
+    Config --> Tasks[Task discovery and dependency graph]
+    Tasks --> Env
+    Config --> Bootstrap[Bootstrap plan and explicit apply]
+```
 
 ## Core Architecture Components
 
-### Command Layer ([`src/cli/`](https://github.com/jdx/mise/tree/main/src/cli/))
+### Command Layer
 
-The CLI layer provides the user interface and delegates to core functionality:
+[`src/cli`](https://github.com/jdx/mise/tree/main/src/cli) defines commands with `usage_rs`
+derives and dispatches them from `src/cli/mod.rs`. The same usage specification feeds
+help, completions, and generated CLI documentation. Change command descriptions at their
+source and regenerate the outputs; do not edit generated reference pages by hand.
 
-- **Modular Commands**: Each command is a separate module ([`install.rs`](https://github.com/jdx/mise/blob/main/src/cli/install.rs), [`use.rs`](https://github.com/jdx/mise/blob/main/src/cli/use.rs), [`run.rs`](https://github.com/jdx/mise/blob/main/src/cli/run.rs), etc.)
-- **Argument Parsing**: Uses [`clap`](https://docs.rs/clap) for CLI parsing and validation
-- **Async Command Execution**: All commands support concurrent operations
-- **Unified Error Handling**: Consistent error reporting across all commands
+Commands delegate to subsystem code. Some are synchronous local queries; others perform
+asynchronous requests or coordinate concurrent work. Avoid adding installation or network
+side effects to a path intended to inspect local state.
 
-**Key Commands Architecture:**
+Useful entry points are `use.rs` for install-and-select behavior, `install.rs` for installation,
+`exec.rs` for a child environment, `run.rs` for tasks, and `bootstrap.rs` for machine setup.
+`activate.rs` emits shell integration, while `shell.rs` sets session-specific tool requests.
 
-- [`install`](cli/install.md) - Tool installation coordination
-- [`use`](cli/use.md) - Tool activation and configuration management
-- [`run`](cli/run.md) - Task execution with dependency resolution
-- [`env`](cli/env.md) - Environment variable management
-- [`shell`](cli/shell.md) - Shell integration and activation
+### Backend System
 
-### Backend System ([`src/backend/`](https://github.com/jdx/mise/tree/main/src/backend/))
+The [`Backend` trait](https://github.com/jdx/mise/blob/main/src/backend/mod.rs) separates
+shared policy from backend-specific metadata, installation, and environment logic. Public
+wrapper methods handle common work such as caching and resolution; implementation hooks
+such as `_list_remote_versions` and `install_version_` supply backend behavior.
 
-The backend system is mise's core abstraction for tool management, built on a trait-based architecture:
+Choose the implementation family that matches the source:
 
-```rust
-pub trait Backend: Debug + Send + Sync {
-    async fn list_remote_versions(&self, config: &Arc<Config>) -> Result<Vec<String>>;
-    async fn install_version(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion>;
-    async fn uninstall_version(&self, tv: &ToolVersion) -> Result<()>;
-    // ... additional methods for lifecycle management
-}
-```
+- Native core runtimes live under `src/plugins/core`.
+- Release and registry integrations, including packslip, Aqua, GitHub, GitLab, and HTTP,
+  live under `src/backend`.
+- Language package integrations include npm, pipx, cargo, gem, and Go.
+- asdf and vfox adapters bridge external plugin interfaces.
 
-**Backend Categories:**
+Backend choice can depend on registry metadata, explicit overrides, the requested version,
+and a matching lock entry. It is not a one-time choice made after a generic version sorter.
+Versions are opaque requests: use backend resolution methods rather than assuming SemVer
+or sorting arbitrary installed versions at a new call site.
 
-- **Core Backends**: Native Rust implementations for maximum performance
-- **Language Package Managers**: npm, pipx, cargo, gem, go modules
-- **Universal Installers**: github (GitHub releases), aqua (comprehensive package management)
-- **Plugin Systems**: [backend plugins](backend-plugin-development.md) (enhanced methods), [tool plugins](tool-plugin-development.md) (hook-based), [asdf plugins](asdf-legacy-plugins.md) (legacy)
+See [Backend Architecture](/dev-tools/backend_architecture.html) and
+[Adding Backends](/contributing.html#adding-backends).
 
-For guidance on implementing new backends, see the [Contributing Guide](contributing.md#adding-backends). For detailed backend system design, see [Backend Architecture](dev-tools/backend_architecture.md).
+### Configuration System
 
-### Configuration System ([`src/config/`](https://github.com/jdx/mise/tree/main/src/config/))
+[`src/config`](https://github.com/jdx/mise/tree/main/src/config) discovers, loads, and merges
+configuration. `ConfigFile` implementations include `MiseToml`, `ToolVersions`, and
+`IdiomaticVersionFile`. The full precedence rules belong in [Configuration](/configuration.html).
 
-A hierarchical configuration system that merges settings from multiple config files:
+Keep three decisions distinct: which files are discovered, whether they may be trusted or
+executed, and how each field merges. Settings, tools, environment directives, tasks, and
+bootstrap entries do not all use the same merge strategy. A write command also has its own
+[target-file selection](/configuration.html#target-file-for-write-operations).
 
-**Config Trait Architecture:**
+`settings.toml` defines setting metadata and documentation. TOML examples use TOML 1.1,
+including multiline inline tables; a TOML 1.0-only validator will reject valid examples.
 
-```rust
-pub trait ConfigFile: Debug + Send + Sync {
-    fn get_path(&self) -> &Path;
-    fn to_tool_request_set(&self) -> Result<ToolRequestSet>;
-    fn env_entries(&self) -> Result<Vec<EnvDirective>>;
-    fn tasks(&self) -> Vec<&Task>;
-    // ... additional configuration methods
-}
-```
+### Toolset Management
 
-**Concrete Implementations:**
+[`src/toolset`](https://github.com/jdx/mise/tree/main/src/toolset) connects requests to selected
+versions and installation state:
 
-- `MiseToml` - Primary configuration format with full feature support
-- `ToolVersions` - asdf compatibility layer
-- `IdiomaticVersion` - Language-specific version files (`.node-version`, etc.)
+| Type             | Role                                                                                  |
+| ---------------- | ------------------------------------------------------------------------------------- |
+| `ToolRequest`    | A request such as `node@24`, a channel, or a ref, with backend/options context        |
+| `ToolVersion`    | A resolved version and its installation metadata                                      |
+| `Toolset`        | Requests and resolved versions for the current context                                |
+| `ToolsetBuilder` | Combines config, runtime environment overrides, and explicit arguments, then resolves |
 
-**Configuration Hierarchy:** See [Configuration Documentation](configuration.md) for the complete hierarchy and precedence rules.
+Resolution, dependency ordering, installation, and environment construction are related but
+separate operations. A read-only listing need not install missing tools. An execution command
+may install them according to its settings. Preserve lockfile backend and checksum information
+when a request is resolved from a lock entry.
 
-### Toolset Management ([`src/toolset/`](https://github.com/jdx/mise/tree/main/src/toolset/))
+### Task System
 
-Coordinates tool resolution, installation, and environment setup:
+[`src/task`](https://github.com/jdx/mise/tree/main/src/task) handles discovery, dependencies,
+freshness/cache decisions, and execution. `Task` stores the definition; task file providers
+load local and remote sources; `Deps` represents the dependency graph; the executor runs
+ready tasks under the configured concurrency and output policy.
 
-**Core Components:**
+`depends` selects prerequisites, `depends_post` selects follow-up tasks, and `wait_for`
+orders tasks only when they are already part of the selected graph. Task identity also
+includes arguments, environment, and execution phase. Check [Task Architecture](/tasks/architecture.html)
+before changing graph construction, duplicate handling, or completion propagation.
 
-- `Toolset` - Immutable collection of resolved tools for a context
-- `ToolVersion` - Represents a specific, resolved tool version (e.g., `node@latest` becomes `node@18.17.0`)
-- `ToolRequest` - User's tool specification (e.g., `node@18`, `python@latest`)
-- `ToolsetBuilder` - Constructs toolsets from configuration with dependency resolution
+### Plugin System
 
-**Tool Resolution Pipeline:**
+[`src/plugins`](https://github.com/jdx/mise/tree/main/src/plugins) manages plugin sources and
+installation metadata. [`crates/vfox`](https://github.com/jdx/mise/tree/main/crates/vfox)
+provides the embedded Lua runtime and hook/module interfaces.
 
-1. **Configuration Parsing**: Extract tool requirements from config files
-2. **Version Resolution**: Resolve version specifications (`latest`, `prefix:1.2`, `sub-1:latest`, etc.) to concrete versions
-3. **Backend Selection**: Choose the appropriate backend for each tool
-4. **Dependency Analysis**: Resolve tool dependencies (e.g., npm requires Node.js)
-5. **Installation Coordination**: Install missing tools in dependency order
-6. **Environment Configuration**: Set up PATH and environment variables
+Tool hooks manage one SDK, backend hooks manage `plugin:tool` requests, environment hooks
+return variables/PATH, and package hooks manage host package batches. asdf adapters execute
+legacy shell scripts. Plugin source installation and tool-version installation have separate
+state and update operations. See [Plugins](/plugins.html).
 
-### Task System ([`src/task/`](https://github.com/jdx/mise/tree/main/src/task/))
+### Shell Integration
 
-Task execution with dependency graph management:
+[`src/shell`](https://github.com/jdx/mise/tree/main/src/shell) emits shell-specific activation
+and environment assignments. `mise activate` registers prompt/directory hooks; hook execution
+computes an environment diff so mise can undo its previous changes before applying a new
+context. `mise exec` constructs a child environment directly and does not need activation.
 
-**Architecture Components:**
+Preserve native Windows PATH inside mise and child processes. Translation belongs only at
+a positively identified shell-output boundary; see the repository's
+[agent guide](https://github.com/jdx/mise/blob/main/AGENTS.md) for implementation constraints.
 
-- `Task` - Task definition with metadata, dependencies, and execution configuration
-- `Deps` - Dependency graph manager using `petgraph` for DAG operations
-- `TaskFileProvider` - Discovers tasks from files and configuration
-- Parallel execution engine with configurable concurrency
+### Environment Management
 
-**Task Discovery:**
+`src/config/env_directive` evaluates environment directives, `EnvDiff` tracks changes, and
+`PathEnv` handles PATH entries. Tool-independent and tool-aware directives run at different
+stages. Use the mise-constructed environment when invoking subprocesses; inheriting a stale
+process environment can lose preceding directives or use the wrong runtime.
 
-1. [File-based tasks](tasks/file-tasks.md) from configured directories
-2. [TOML-defined tasks](tasks/toml-tasks.md) in configuration files
-3. Inherited tasks from parent directories
+See [Environment Variables](/environments/) and [Templates](/templates.html).
 
-**Dependency Resolution:**
+### Bootstrap and host state
 
-- Uses a directed acyclic graph (DAG) to model dependencies
-- Supports multiple dependency types: `depends`, `depends_post`, `wait_for`
-- Parallel execution within dependency constraints
-- Circular dependency detection and prevention
+`src/cli/bootstrap.rs` coordinates plans and selected phases. Implementations under
+`src/system` handle packages, files, edits, repositories, and platform-specific resources.
+Status, preview, apply, and prune have distinct contracts. For example, package status must
+not install anything, and a selected package batch is not a complete desired-state snapshot.
 
-See the [Task Documentation](tasks/) for complete usage details and configuration options, and [Task Architecture](tasks/architecture.md) for detailed system design.
+Read the relevant [bootstrap resource guide](/bootstrap.html) before changing ownership,
+confirmation, rollback, or removal behavior. Host-managed state is not generally contained
+in a versioned tool's installation directory.
 
-### Plugin System ([`src/plugins/`](https://github.com/jdx/mise/tree/main/src/plugins/))
+### Caching System
 
-Extensibility layer supporting multiple plugin architectures:
+[`src/cache.rs`](https://github.com/jdx/mise/blob/main/src/cache.rs) provides `CacheManager<T>`
+with freshness policies and atomic writes. Its serialized cache uses MessagePack with zlib
+compression. Other subsystems have their own formats and invalidation rules, including
+session-keyed environment caching and local/remote task caches.
 
-**Plugin Trait:**
-
-```rust
-pub trait Plugin: Debug + Send {
-    fn name(&self) -> &str;
-    fn path(&self) -> PathBuf;
-    async fn install(&self, config: &Arc<Config>, pr: &dyn SingleReport) -> Result<()>;
-    async fn update(&self, pr: &dyn SingleReport, gitref: Option<String>) -> Result<()>;
-    // ... lifecycle management methods
-}
-```
-
-**Plugin Types:**
-
-- **Backend Plugins**: Enhanced plugins with backend methods for managing multiple tools
-- **Tool Plugins**: Hook-based plugins using the traditional vfox format
-- **asdf Plugins**: Legacy plugins compatible with the asdf plugin ecosystem (Linux/macOS only)
-
-For complete plugin documentation, see [Plugin Guide](plugins.md).
-
-### Shell Integration ([`src/shell/`](https://github.com/jdx/mise/tree/main/src/shell/))
-
-Shell-specific code generation that abstracts commands like `mise env` and contains all shell differences in one place:
-
-**Shell Trait:**
-
-```rust
-pub trait Shell: Display {
-    fn activate(&self, opts: ActivateOptions) -> String;
-    fn set_env(&self, k: &str, v: &str) -> String;
-    fn unset_env(&self, k: &str) -> String;
-    // ... shell-specific methods
-}
-```
-
-**Supported Shells:** See [`mise activate`](cli/activate.md) documentation for the complete list
-
-**Shell Abstractions:** Environment variable setting, PATH modification, command execution
-
-### Environment Management ([`src/env*.rs`](https://github.com/jdx/mise/tree/main/src/))
-
-Helpers for working with environment variables:
-
-- `EnvDiff` - Tracks and applies environment changes
-- `EnvDirective` - Configuration-based environment variable management
-- `PathEnv` - PATH manipulation with precedence rules
-- Context-aware resolution with config layering
-
-For environment setup and configuration, see [Environment Documentation](environments/).
-
-### Caching System ([`src/cache.rs`](https://github.com/jdx/mise/blob/main/src/cache.rs))
-
-Generic caching backed by files, using msgpack serialization with zstd compression:
-
-- `CacheManager<T>` - Generic caching with TTL support
-- Data serialized with msgpack and compressed with zstd for efficient storage
-- Automatic cache invalidation based on file timestamps
-- Per-backend cache isolation for data integrity
+A cache key must include every input that changes the result, including relevant options,
+environment, and source metadata. See [cache behavior](/cache-behavior.html) for user-visible
+refresh controls and limitations.
 
 ## Test Architecture
 
-mise uses a multi-layered testing strategy that combines several approaches for thorough validation across its feature set.
+Use the smallest test layer that demonstrates the behavior. Pure resolution or parsing
+logic fits a unit test; shell boundaries, installation, and task execution often need an
+end-to-end test. Network and host-package tests have prerequisites beyond a Rust compiler.
 
-**Testing Strategy Overview:**
+### Unit Tests
 
-1. **Unit Tests** - Rust `#[test]` functions embedded in source files
-2. **End-to-End (E2E) Tests** - Bash-based integration tests with complete environment isolation
-3. **Snapshot Tests** - `insta`-based tests for complex output validation
+Tests live beside source modules and in workspace crates. The main binary's `src/test.rs`
+initializes shared fixture directories and process environment. Tests are configured to run
+single-threaded; this is not a fresh process or HOME per individual Rust test. Use existing
+guards for temporary environment/current-directory changes and restore them on failure.
 
-::: tip Testing Philosophy
-**Most tests in mise are end-to-end tests, and this is generally the preferred approach** for new functionality. E2E tests validate real-world usage and catch integration issues that unit tests might miss. However, **E2E tests can be challenging to run locally** because of environment dependencies and setup complexity. It is often easier to run them on GitHub Actions, where the environment is consistent and properly configured.
+### End-to-End Tests
 
-See the [Contributing Guide](contributing.md#testing) for detailed testing setup and guidelines.
-:::
+The `e2e` harness runs Bash tests with isolated mise configuration/data/state and temporary
+working directories. Start it through `mise run test:e2e`, which builds mise and selects
+files through the repository's task wrapper. Host programs and services are still external
+prerequisites; isolation does not install Docker, a JDK, or every shell for you.
 
-### Unit Tests ([`src/` modules](https://github.com/jdx/mise/tree/main/src/))
-
-**Structure and Characteristics:**
-
-- **Location**: Embedded within source files using `mod tests` blocks
-- **Test Runner**: Standard Rust `cargo test`
-- **Dependencies**: `pretty_assertions`, `insta`, `test-log`, `ctor`
-- **Coverage**: Over 50 test modules covering all major functionality
-
-```rust
-mod tests {
-    use insta::assert_snapshot;
-    use pretty_assertions::assert_eq;
-    use crate::config::Config;
-    use super::*;
-
-    #[tokio::test]
-    async fn test_hash_to_str() {
-        let _config = Config::get().await.unwrap();
-        assert_eq!(hash_to_str(&"foo"), "e1b19adfb2e348a2");
-    }
-}
+```sh
+mise run test:e2e e2e/cli/test_version
+mise run test:e2e '^test_task_'
+mise run test:e2e --all
 ```
 
-**Test Environment Setup:**
+The wrapper matches test **basenames**, not directory prefixes. Inspect its current source
+with `mise tasks info test:e2e` before changing test-selection instructions.
 
-- **Global Setup**: Uses `ctor::ctor` in [`src/test.rs`](https://github.com/jdx/mise/blob/main/src/test.rs) for test environment initialization
-- **Isolated Environment**: Each test gets a clean environment with custom `HOME`, cache, and config directories
-- **Async Support**: Extensive use of `#[tokio::test]` for async testing
-
-### End-to-End Tests ([`e2e/`](https://github.com/jdx/mise/tree/main/e2e/))
-
-**Architecture:**
-
-```
-e2e/
-├── run_test          # Single test executor with environment isolation
-├── run_all_tests     # Test orchestrator with parallel execution
-├── assert.sh         # Rich assertion library
-├── cli/              # CLI command tests
-│   ├── test_use      # Testing tool activation and configuration
-│   ├── test_install  # Testing tool installation
-│   ├── test_upgrade  # Testing tool upgrades
-│   ├── test_uninstall # Testing tool removal
-│   └── test_version  # Testing version commands
-├── backend/          # Backend-specific tests
-│   ├── test_aqua     # Testing aqua package manager
-│   ├── test_asdf     # Testing asdf plugin compatibility
-│   └── test_npm      # Testing npm backend
-├── tasks/            # Task system tests
-│   ├── test_task_deps # Testing task dependencies
-│   ├── test_task_run_depends # Testing task execution order
-│   ├── test_task_ls  # Testing task listing
-│   └── test_task_info # Testing task metadata
-├── config/           # Configuration tests
-│   ├── test_config_ls # Testing configuration listing
-│   └── test_config_set # Testing configuration updates
-└── [other domains]/  # Additional test categories
-```
-
-**Environment Isolation System:**
-
-Each test runs in complete isolation with temporary directories:
-
-```bash
-setup_isolated_env() {
-  TEST_ISOLATED_DIR="$(mktemp --tmpdir --directory "$(basename "$TEST").XXXXXX")"
-  TEST_HOME="$TEST_ISOLATED_DIR/home"
-  MISE_DATA_DIR="$TEST_HOME/.local/share/mise"
-  MISE_CACHE_DIR="$TEST_HOME/.cache/mise"
-  # ... complete environment isolation
-}
-```
-
-**Rich Assertion Framework:**
-
-[`assert.sh`](https://github.com/jdx/mise/blob/main/e2e/assert.sh) provides rich test utilities:
-
-```bash
-# Basic assertions
-assert "command" "expected_output"
-assert_contains "command" "substring"
-assert_fail "command" "error_message"
-
-# JSON testing
-assert_json "command" '{"key": "value"}'
-assert_json_partial_object "command" "field1,field2" '{"field1": "value1"}'
-
-# File system assertions
-assert_directory_exists "path"
-assert_directory_empty "path"
-```
-
-**Test Categories:**
-
-- **CLI Tests**: Validate all command-line interfaces and argument parsing
-- **Backend Tests**: Test tool installation, version resolution, and backend integration
-- **Task Tests**: Validate task execution, dependency resolution, and parallel execution
-- **Configuration Tests**: Test configuration parsing, hierarchy, and environment variable handling
+Use helpers in `e2e/assert.sh` and let the harness manage cleanup. Do not execute test files
+directly or add executable permissions just to run them.
 
 ### Windows Testing
 
-**Windows-Specific Tests ([`e2e-win/`](https://github.com/jdx/mise/tree/main/e2e-win/)):**
+`e2e-win` uses PowerShell and Pester. Tests should run the emitted commands and check real
+child-process behavior, particularly for PATH and activation, rather than only comparing
+output strings. See [Windows E2E setup](/contributing.html#windows-e2e-tests).
 
-- **Language**: PowerShell scripts (`.ps1`)
-- **Focus**: Windows-specific functionality and cross-platform compatibility
-- **Coverage**: Core tools like Go, Java, Node.js, Python, Rust
+### Snapshot Testing
 
-```powershell
-Describe "go" {
-    It "installs go" {
-        mise install go@latest
-        go version | Should -Match "go version"
-    }
-}
-```
-
-### Snapshot Testing ([`src/snapshots/`](https://github.com/jdx/mise/tree/main/src/snapshots/))
-
-**Implementation:**
-
-- **Crate**: Uses `insta` for snapshot testing
-- **Format**: Stores expected outputs as `.snap` files
-- **Coverage**: Complex outputs like directory listings, configuration parsing, environment diffs
-
-```rust
-#[tokio::test]
-async fn test_parse() {
-    let diff = DirenvDiff::parse(input).unwrap();
-    assert_snapshot!(diff);  // Creates/validates snapshot
-}
-```
+`insta` snapshots record structured or user-visible output. Review each changed snapshot
+as part of the behavior change; accepting all snapshots is not evidence that the new output
+is correct. `mise run snapshots` updates snapshots using the project's task configuration.
 
 ### Test Infrastructure Features
 
-**Performance and Utility Tests ([`xtasks/test/`](https://github.com/jdx/mise/tree/main/xtasks/test/)):**
+The repository has file tasks under `xtasks/test` for E2E selection and performance work.
+Slow E2E files end in `_slow` and require `TEST_ALL=1`. The full runner can partition work
+with `TEST_TRANCHE` and `TEST_TRANCHE_COUNT`. CI supplies platform dependencies and instrumentation;
+a task named `coverage` does not by itself instrument a local binary.
 
-- **Performance Testing**: `perf` script for benchmarking
-- **Coverage Testing**: `coverage` script for test coverage analysis
-- **E2E Runner**: `e2e` script with filtering capabilities
-
-**Test Data Management ([`test/`](https://github.com/jdx/mise/tree/main/test/)):**
-
-```
-test/
-├── config/           # Test-specific configs
-├── cwd/              # Test working directories
-├── data/             # Test plugins and mock data
-├── fixtures/         # Sample configuration files
-├── plugins/          # Test plugin definitions
-└── state/            # Test state directory
-```
-
-**Test Execution Modes:**
-
-- **Fast Tests**: Regular tests that run in CI
-- **Slow Tests**: Marked with `_slow` suffix, skipped unless `TEST_ALL=1`
-- **Tranche Support**: Tests can be split across parallel runners using `TEST_TRANCHE_COUNT`
-
-**Developer Experience Features:**
-
-- **Environment Safety**: Complete isolation prevents tests from affecting the user's actual mise installation
-- **Parallel Execution**: E2E tests support parallel execution with proper isolation
-- **Rich Reporting**: Detailed test timing and environment preservation on failure for debugging
-- **Cross-Platform Validation**: Automated testing on multiple operating systems
-
-**Running Tests:**
-
-```bash
-# Run all unit tests
-cargo test
-
-# Run all E2E tests
-mise run test:e2e
-
-# Run specific E2E test
-mise run test:e2e '^test_install$'
-
-# Run with coverage
-./xtasks/test/coverage
-
-# Performance testing
-./xtasks/test/perf
-```
-
-For complete development setup and testing procedures, see the [Contributing Guide](contributing.md).
-
-This test architecture ensures mise's reliability across tool management, environment configuration, task execution, and multi-platform support.
+See [Testing](/contributing.html#testing) for exact commands and prerequisites.
 
 ## Related Architecture Documentation
 
-For deeper understanding of specific subsystems:
-
-- **[Task Architecture](tasks/architecture.md)** - Detailed design of the task dependency system, parallel execution engine, and task discovery mechanisms
-- **[Backend Architecture](dev-tools/backend_architecture.md)** - In-depth guide to backend types, the trait system, and how different installation methods work
+- [Task Architecture](/tasks/architecture.html).
+- [Backend Architecture](/dev-tools/backend_architecture.html).
+- [Configuration](/configuration.html).
+- [Contributing](/contributing.html).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,5 +1,5 @@
 ---
-outline: [1, 3]
+outline: [2, 3]
 ---
 
 # Contributing
@@ -8,7 +8,7 @@ outline: [1, 3]
 
 mise has a specific scope and design taste. Unless the change is obvious,
 start a [discussion](https://github.com/jdx/mise/discussions) or mention what
-you plan to do in [Discord](https://discord.gg/UBa7pJUN7Z) before opening a PR.
+you plan to do in [Discord](https://discord.gg/mABnUDvP57) before opening a PR.
 The important part is to settle the direction before much implementation or
 review happens. PRs are often rejected or need to change significantly after
 submission, so make sure the idea fits before you invest too much time.
@@ -27,6 +27,56 @@ contributors.
 I get hundreds of PRs per week across my projects, so I do not have time to
 respond to every PR with detailed context. A rejection may be brief.
 
+## Development Setup
+
+### Prerequisites
+
+- A Rust toolchain meeting the `rust-version` in the root `Cargo.toml`; the project does
+  not declare Rust under `[tools]`, so your selected toolchain must already be suitable.
+- A working mise installation meeting `min_version` in `mise.toml`.
+- Git and the host dependencies required by the checks you plan to run.
+
+### Getting Started
+
+```bash
+# Clone the repository
+git clone https://github.com/jdx/mise.git
+cd mise
+
+# Install dependencies
+mise install
+
+# Build and verify the development binary
+mise run build
+target/debug/mise --version
+```
+
+### Development Shim
+
+The repository adds `target/debug` and `node_modules/.bin` to its task environment. Use
+`target/debug/mise` directly to check which binary you are testing. For a recompiling wrapper,
+see [Running the CLI](#running-the-cli).
+
+### Cargo build cache
+
+`mise install` installs the mbx version selected by the project. `mise run` activates its
+transparent Cargo wrapper, so build and lint tasks invoke ordinary Cargo commands through
+the cache. Standalone Cargo commands need an activated mise shell.
+
+If the wrapper fails, run the equivalent Cargo check with `MBX_DISABLE=1`; this bypasses
+the cache without skipping validation:
+
+```sh
+MBX_DISABLE=1 cargo build --all-features
+MBX_DISABLE=1 cargo test --all-features
+MBX_DISABLE=1 cargo check --all-features
+```
+
+If bypassed Cargo succeeds, report the mismatch in a
+[mr-boxington discussion](https://github.com/jdx/mr-boxington/discussions) with repository and
+commit, OS, `mbx --version`, `mbx doctor`, and both commands/output. Redact secrets, absolute
+cache paths, remote URLs, namespaces, and identifying details before posting.
+
 ## Pull Request Checklist
 
 1. **Discuss first**: Use GitHub Discussions or Discord for non-obvious changes
@@ -40,329 +90,10 @@ respond to every PR with detailed context. A rejection may be brief.
 
 ### Development Tips
 
-1. **Disable mise during development**: If you use mise in your shell, disable
-   it when running tests to avoid conflicts
-2. **Test specific features**: Use `cargo test test_name` for targeted testing
-3. **Update snapshots**: Use `mise run snapshots` when changing test outputs
-4. **Rate limiting**: Set `MISE_GITHUB_TOKEN` to avoid GitHub API rate limits
-   during development
-
-## Packaging and Self-Update Instructions
-
-When mise is installed via a package manager, `mise self-update` should not replace the binary the package manager owns; users should update through the package manager instead. This is opt-in: a package that does none of the following keeps self-update fully enabled. Packagers have three ways to turn it off, and any of them makes `mise doctor` report `self_update_available: no`.
-
-The paths below are relative to the install prefix, which mise derives from its own binary: the path is canonicalized (symlinks resolved) and then taken two levels up, so `/usr/bin/mise` gives `/usr`.
-
-### Disable at build time
-
-Build without the `self_update` Cargo feature, as the Arch Linux package does:
-
-```bash
-cargo build --release --no-default-features --features native-tls
-```
-
-The subcommand still exists, so scripts that call it get a clear error rather than "unknown command", but it always fails with `mise's self-update feature has been disabled at build time, cannot update`.
-
-### Disable with a marker file
-
-Install an empty `.disable-self-update` file at any one of:
-
-- `lib/.disable-self-update` (used by Homebrew)
-- `lib/mise/.disable-self-update` (used by the AUR `mise-bin` package)
-- `lib64/mise/.disable-self-update`
-
-### Ship update instructions
-
-Installing a TOML file with platform-specific instructions also disables self-update; mise prints the file's message when `mise self-update` runs and when it detects a newer release. Install it at any one of:
-
-- `lib/mise-self-update-instructions.toml`
-- `lib/mise/mise-self-update-instructions.toml`
-- `lib64/mise/mise-self-update-instructions.toml`
-
-Example contents:
-
-```toml
-# Debian/Ubuntu (APT)
-message = "To update mise from the APT repository, run:\n\n  sudo apt update && sudo apt install --only-upgrade mise\n"
-```
-
-```toml
-# Fedora/CentOS Stream (DNF)
-message = "To update mise from COPR, run:\n\n  sudo dnf upgrade mise\n"
-```
-
-Setting `MISE_SELF_UPDATE_INSTRUCTIONS` to a file path overrides the search.
-
-### Overriding the outcome
-
-`MISE_SELF_UPDATE_AVAILABLE=false` disables self-update without installing anything, and `MISE_SELF_UPDATE_AVAILABLE=true` re-enables it even when a marker or instructions file is present. Both are useful for testing a package build. Neither has any effect on a binary built without the `self_update` feature, where self-update is always unavailable.
-
-`mise self-update --force` also bypasses the availability check, so a user who passes it updates the binary in place even when a marker file, an instructions file, or `MISE_SELF_UPDATE_AVAILABLE=false` is in effect. Treat the runtime mechanisms as "do not update by default" rather than a hard block. A build without the `self_update` feature is the only variant `--force` cannot get past.
-
-## Testing
-
-mise has a comprehensive test suite with several types of tests that check
-reliability and functionality across platforms and scenarios.
-
-### Unit Tests
-
-Unit tests are fast, focused tests for individual components and functions:
-
-```bash
-# Run all unit tests
-cargo test --all-features
-
-# Run specific unit tests
-cargo test <test_name>
-```
-
-**Unit test structure:**
-
-- Located in `src/` directory alongside source code
-- Use Rust's built-in test framework
-- Test individual functions and modules
-- Fast execution (used for quick feedback during development)
-
-### E2E Tests
-
-End-to-end tests validate the complete functionality of mise in realistic
-scenarios:
-
-```bash
-# Run all E2E tests
-mise run test:e2e
-
-# Run specific E2E tests (preferred; always use this mise task)
-mise run test:e2e e2e/cli/test_version
-
-# Run E2E tests under a feature directory
-mise run test:e2e e2e/tasks
-
-# Run all tests including slow ones (`*_slow`)
-TEST_ALL=1 mise run test:e2e
-```
-
-**E2E test structure:**
-
-- Located in `e2e/` directory
-- Organized by functionality:
-  - `e2e/cli/` - Command-line interface tests
-  - `e2e/core/` - Core functionality tests
-  - `e2e/env/` - Environment variable tests
-  - `e2e/tasks/` - Task runner tests
-  - `e2e/config/` - Configuration tests
-  - `e2e/tools/` - Tool management tests
-  - `e2e/shell/` - Shell integration tests
-  - `e2e/backend/` - Backend tests
-  - `e2e/plugins/` - Plugin tests
-
-**E2E test categories:**
-
-- **Fast tests** (`test_*`): Run in normal test suites
-- **Slow tests** (`test_*_slow`): Only run when `TEST_ALL=1` is set
-- **Isolated environment**: Each test runs in a clean, isolated environment
-
-Do not execute files under `e2e/` directly; `mise run test:e2e` is the supported entry point (it depends on `build` and uses `e2e/run_all_tests`). Set `MISE_GITHUB_TOKEN` (or `GITHUB_TOKEN`) to avoid GitHub API rate limits.
-
-### Coverage Tests
-
-Coverage tests measure how much of the codebase is covered by tests:
-
-```bash
-# Run coverage tests
-mise run test:coverage
-
-# Coverage tests run in parallel tranches for CI
-TEST_TRANCHE=0 TEST_TRANCHE_COUNT=8 mise run test:coverage
-```
-
-### Windows E2E Tests
-
-Windows has its own test suite written in PowerShell:
-
-```powershell
-# Run all Windows E2E tests
-pwsh e2e-win\run.ps1
-
-# Run specific Windows tests
-pwsh e2e-win\run.ps1 task  # run tests matching *task*
-```
-
-### Plugin Tests
-
-Test plugin functionality across different backends:
-
-```bash
-# Test specific plugin
-mise test-tool ripgrep
-
-# Test all plugins in registry
-mise test-tool --all
-
-# Test all plugins in config files
-mise test-tool --all-config
-
-# Test with parallel jobs
-mise test-tool --all --jobs 4
-```
-
-### Test Environment Setup
-
-Tests run in isolated environments to avoid conflicts:
-
-```bash
-# Disable mise during development testing
-export MISE_DISABLE_TOOLS=1
-
-# Run tests with specific environment
-MISE_TRUSTED_CONFIG_PATHS=$PWD cargo test
-```
-
-### Test Assertions
-
-The E2E tests use a custom assertion framework (`e2e/assert.sh`):
-
-```bash
-# Basic assertions
-assert "command" "expected_output"
-assert_contains "command" "substring"
-assert_fail "command" "expected_error"
-
-# JSON assertions
-assert_json "command" '{"key": "value"}'
-assert_json_partial_array "command" "fields" '[{...}]'
-
-# File/directory assertions
-assert_directory_exists "/path/to/dir"
-assert_directory_not_exists "/path/to/dir"
-assert_empty "command"
-```
-
-### Running Specific Test Categories
-
-```bash
-# Run all tests (unit + e2e)
-mise run test
-
-# Run only unit tests
-mise run test:unit
-
-# Run only e2e tests
-mise run test:e2e
-
-# Run tests with shuffle (for detecting order dependencies)
-mise run test:shuffle
-
-# Run nightly tests (with bleeding edge Rust)
-rustup default nightly && mise run test
-```
-
-### Running Individual Tests
-
-#### Running Single Unit Tests
-
-```bash
-# Run a specific unit test by name
-cargo test test_name
-
-# Run tests matching a pattern
-cargo test pattern
-
-# Run tests in a specific module
-cargo test module_name
-
-# Run a single test with output
-cargo test test_name -- --nocapture
-```
-
-#### Running Focused E2E Tests
-
-```bash
-# Run a specific E2E test with an anchored filename pattern
-mise run test:e2e '^test_name$'
-
-# Run E2E tests matching a pattern
-mise run test:e2e pattern
-
-# Examples:
-mise run test:e2e '^test_use$'             # Run one specific test
-mise run test:e2e '^test_config_set$'       # Run one config-related test
-mise run test:e2e task                     # Run all tests matching "task"
-```
-
-#### Testing Individual Plugins
-
-```bash
-# Test a specific plugin
-mise test-tool ripgrep
-
-# Test a plugin with verbose output
-mise test-tool ripgrep --raw
-
-# Test multiple plugins
-mise test-tool ripgrep jq terraform
-```
-
-### Performance Testing
-
-```bash
-# Run performance benchmarks
-mise run test:perf
-
-# Build performance test workspace
-mise run test:build-perf-workspace
-```
-
-### Snapshot Testing
-
-Used for testing output consistency:
-
-```bash
-# Update test snapshots when output changes
-mise run snapshots
-
-# Use cargo-insta for snapshot testing
-cargo insta test --accept --unreferenced delete
-```
-
-## Development Setup
-
-### Prerequisites
-
-- [Rust](https://www.rust-lang.org/) (latest stable; we don't use mise to
-  manage Rust)
-- mise
-
-### Getting Started
-
-```bash
-# Clone the repository
-git clone https://github.com/jdx/mise.git
-cd mise
-
-# Install dependencies
-mise install
-
-# Build the project
-mise run build
-```
-
-### Development Shim
-
-Create a development shim to run mise easily during development:
-
-```bash
-# Create ~/.local/bin/@mise
-#!/bin/sh
-exec cargo run -q --all-features --manifest-path ~/src/mise/Cargo.toml -- "$@"
-```
-
-Then use `@mise` to run the development version:
-
-```bash
-@mise --help
-eval "$(@mise activate zsh)"
-```
+Use the project tasks for the supported environment and the development binary at
+`target/debug/mise` when verifying a change. Read [Development Setup](#development-setup)
+first, then run focused checks for the feature you changed. Set `MISE_DEBUG=1` or
+`MISE_TRACE=1` when diagnosing CLI behavior.
 
 ## Project Structure
 
@@ -379,14 +110,16 @@ mise/
 
 ## Available Development Tasks
 
-Use `mise tasks` to see all available development tasks.
+Use `mise tasks ls` to list tasks and `mise tasks info <name>` to see their resolved source.
+This repository loads both `tasks.toml` and file tasks under `xtasks`; a file task can replace
+a same-named TOML task, so inspect the resolved task when behavior is surprising.
 
 ### Common Tasks
 
 - `mise run build` - Build the project
-- `mise run test` - Run all tests (unit + E2E)
+- `mise run test:unit` followed by `mise run test:e2e --all` - Explicitly run unit and E2E suites
 - `mise run test:unit` - Run unit tests only
-- `mise run test:e2e` - Run E2E tests only
+- `mise run test:e2e <test-pattern>` - Run selected E2E tests
 - `mise run lint` - Run linting
 - `mise run lint-fix` - Run linting with fixes
 - `mise run format` - Format code
@@ -398,79 +131,18 @@ Use `mise tasks` to see all available development tasks.
 
 - `mise run docs` - Start documentation development server
 - `mise run docs:build` - Build documentation
-- `mise run render:help` - Generate help documentation
+- `mise run render:usage` - Generate CLI reference documentation
 - `mise run render:completions` - Generate shell completions
 
 ### Release Tasks
 
-- `mise run release-plz` - Create a release
+- `mise run release-plz` - CI-only release automation; do not run locally
 - `mise run ci` - Run CI tasks (format, build, test)
 
 ## Setup
 
-Nothing special should be required, but `mise run build` is a good sanity
-check that everything is working.
-
-## Pre-commit Hooks & Code Quality
-
-mise uses [hk](https://hk.jdx.dev) as its git hook manager for
-linting and code quality checks. hk is a modern alternative to lefthook written
-by the same author as mise.
-
-### hk Configuration
-
-The project uses `hk.pkl` (written in the Pkl configuration language) to define
-linting rules:
-
-```bash
-# Run all linting checks
-hk check --all
-
-# Run linting with fixes
-hk fix --all
-
-# Run specific linter
-hk check --step shellcheck
-```
-
-### Available Linters in hk
-
-- **prettier**: Code formatting for multiple languages
-- **clippy**: Rust linting with `cargo clippy`
-- **shellcheck**: Shell script linting
-- **shfmt**: Shell script formatting
-- **pkl**: Pkl configuration file validation
-
-### Using hk in Development
-
-`hk.pkl` currently defines `check` and `fix` steps only (no git `pre-commit` hook).
-`hk install --mise` may report that nothing is installed; that is expected. Use
-the mise tasks:
-
-```bash
-# Run linting (used in CI)
-mise run lint  # This runs hk check --all
-
-# Run linting with fixes
-mise run lint-fix
-
-# Check specific file types
-hk check --step prettier
-hk check --step shellcheck
-```
-
-### Running Checks Manually
-
-```bash
-# Run all checks
-hk check --all
-
-# Run checks with fixes
-hk fix --all
-
-# Run checks on specific files
-hk check --files="src/**/*.rs"
-```
+After installing prerequisites, `mise run build` and `target/debug/mise --version` establish
+that the selected toolchain can build and run the checkout. Run feature-specific tests next.
 
 ## Running the CLI
 
@@ -478,14 +150,16 @@ I use the following shim in `~/.local/bin/@mise`:
 
 ```sh
 #!/bin/sh
-exec cargo run -q --all-features --manifest-path ~/src/mise/Cargo.toml -- "$@"
+exec cargo run -q --all-features --manifest-path "$HOME/src/mise/Cargo.toml" -- "$@"
 ```
 
 ::: info
 Don't forget to change the manifest path to the correct path for your setup.
 :::
 
-If that directory is on PATH, `@mise` runs mise, compiling it on the fly.
+Make the wrapper executable and put its directory on PATH. `@mise` recompiles the checkout
+when needed. Use a disposable shell when testing development activation so a broken hook
+does not interfere with your normal shell.
 
 ```sh
 @mise --help
@@ -493,21 +167,199 @@ eval "$(@mise activate zsh)"
 @mise activate fish | source
 ```
 
-## Releasing
+## Pre-commit Hooks & Code Quality
 
-Releases are cut automatically by the `release-plz` GitHub Actions workflow
-(`mise run release-plz` in CI). Do not run that task locally.
+### hk Configuration
 
-## Linting
+[`hk.pkl`](https://github.com/jdx/mise/blob/main/hk.pkl) defines `check` and `fix` workflows.
+It currently has no Git `pre-commit` hook, so `hk install --mise` may report that there is
+nothing to install. Run the checks explicitly before committing.
 
-- Lint codebase: `mise run lint`
-- Lint and fix codebase: `mise run lint-fix`
+### Available Linters in hk
+
+The configured steps include Prettier, Markdown linting, Cargo formatting/checking,
+ShellCheck, shfmt, Pkl, TOML/schema validation, Lua checks, and actionlint. The Clippy block
+in `hk.pkl` is disabled; CI runs Clippy separately. Read the current configuration rather
+than assuming a successful hk run includes every Rust lint.
+
+### Using hk in Development
+
+```sh
+mise run lint
+mise run lint-fix
+```
+
+Review and stage the fixes before committing. Do not add Clippy exclusions to make a check
+pass; refactor the code so the applicable lint succeeds.
+
+### Running Checks Manually
+
+For an effect-aware check scoped to changed files:
+
+```sh
+mise exec hk -- hk run check --safe --format json
+```
+
+To check an exact file list, pass NUL-delimited paths with `--files0-from`. Check hk's reported
+results: a skipped step is not a passed step. The project tasks remain the normal entry point
+for the full configured workflows.
+
+## Testing
+
+Choose checks that demonstrate the changed behavior. Use unit tests for local parsing and
+resolution, E2E tests for commands and shell boundaries, and snapshots for output that
+needs a stable contract. Avoid live downloads when a local fixture can cover the behavior.
+
+### Unit Tests
+
+```sh
+mise run test:unit
+cargo test --all-features test_name
+cargo test --all-features module_name -- --nocapture
+```
+
+Standalone Cargo commands need the activated development environment described in
+[Cargo build cache](#cargo-build-cache).
+The main binary's test initialization sets fixture paths and shared process state;
+`.cargo/config.toml` and the task configure `RUST_TEST_THREADS=1`. Use existing environment
+and current-directory guards when changing shared state in a test.
+
+For the Lua runtime crate, use `mise --cd crates/vfox run test`. Tests and fixtures there
+exercise hook return values and built-in modules independently of the CLI adapter.
+
+### E2E Tests
+
+Always use the mise task, which builds the project and invokes the test wrapper:
+
+```sh
+# A concrete test path or a regex matching test basenames
+mise run test:e2e e2e/cli/test_version
+mise run test:e2e '^test_use$'
+mise run test:e2e '^test_task_'
+
+# Inspect available files or run the complete suite
+mise run test:e2e --list
+mise run test:e2e --all
+TEST_ALL=1 mise run test:e2e --all
+```
+
+The wrapper matches **basenames** after stripping a supplied path. A directory such as
+`e2e/tasks` is not a directory filter. Use a concrete test file or a filename pattern and
+check which tests ran. With no arguments, the current wrapper selects no files; use
+`--all` explicitly for the full suite. `*_slow` files require `TEST_ALL=1`.
+
+The harness creates isolated mise configuration, data, state, and working directories.
+It still needs host prerequisites such as the shell under test, compilers, or a running
+service. Let the harness handle cleanup. Do not execute files under `e2e/` directly or
+change their executable bit to run them.
+
+Supply `MISE_GITHUB_TOKEN` or `GITHUB_TOKEN` when a test needs GitHub API access. Avoid
+printing credentials in debug output or failure reports.
+
+### Coverage Tests
+
+`mise run test:coverage` is the CI-oriented setup/E2E runner in `xtasks/test/coverage`.
+Coverage instrumentation is supplied by its environment; running it locally by itself does
+not create an instrumented build. The full runner supports `TEST_TRANCHE` and
+`TEST_TRANCHE_COUNT` for partitioning tests.
+
+### Windows E2E Tests
+
+Install the Pester module in PowerShell and build the Windows binary first. The runner adds
+`target/debug` to PATH:
+
+```powershell
+pwsh -File e2e-win/run.ps1
+pwsh -File e2e-win/run.ps1 -TestName '*task*'
+```
+
+The filter matches Pester test names. Tests for activation and PATH should execute a child
+command and verify its behavior, including a native Windows grandchild where relevant.
+
+### Plugin Tests
+
+`mise test-tool` tests **registry tools**, including tools using built-in backends; it is not
+limited to plugins. It performs real installations and runs the entry's configured test:
+
+```sh
+mise test-tool ripgrep
+mise test-tool ripgrep jq
+mise test-tool ripgrep --raw
+```
+
+Use `--all` only when you intend to test the whole registry, and `--all-config` for configured
+tools. These can involve many downloads, host dependencies, and long builds. Plugin authors
+should also read [Plugin Publishing](/plugin-publishing.html#testing-before-publication).
+
+### Test Environment Setup
+
+Use the supported task/harness instead of setting `MISE_DISABLE_TOOLS=1` or broad trust
+paths in your normal shell. Those settings can hide the very integration the test should
+exercise. A test that invokes a host package manager must isolate its host-managed state
+separately from mise's directories.
+
+### Test Assertions
+
+`e2e/assert.sh` provides exact-output, substring, failure, JSON, and filesystem helpers.
+For example, inside an E2E test:
+
+```sh
+assert "mise exec -- printf '%s' hello" "hello"
+assert_contains "mise --version" "mise"
+assert_fail "mise definitely-not-a-command"
+```
+
+`assert_fail "command" "substring"` checks both failure status and an output substring.
+`assert_fail_contains` requires a message to check; `assert_fail_matches` checks a regular
+expression. Choose the helper that expresses the behavior you need to verify.
+
+### Running Specific Test Categories
+
+Run `mise run test:unit` and a focused E2E selection while developing. For an explicit full
+local run, use `mise run test:unit` followed by `mise run test:e2e --all`. The aggregate
+`test` task currently invokes the E2E wrapper without a selection, so do not infer E2E
+coverage from that task's success alone.
+
+`mise run test:shuffle` requires nightly Rust and tests order sensitivity. Use a command-local
+toolchain selection; do not change your global Rust default just to run one check.
+
+### Running Individual Tests
+
+Use Cargo's name filter for a unit test and the E2E basename patterns shown above for a CLI
+test. Confirm the output reports the intended test count; a successful command with zero
+matching tests has not verified the change.
+
+### Performance Testing
+
+`mise run test:perf` prepares a workspace and runs the performance scripts. Read the script's
+host-tool requirements before using it on macOS. The separate `mise run perf` task uses tak;
+keep the build profile and runner class consistent when comparing results.
+
+### Snapshot Testing
+
+Run `mise run snapshots` when expected output intentionally changes. Review the resulting
+`.snap` diff, including removed snapshots; do not accept snapshots as a substitute for
+checking the behavior that produced them.
 
 ## Generating readme and shell completion files
 
-```sh
-mise run render
-```
+Edit source inputs, then regenerate the outputs affected by your change:
+
+| Change | Source and generation |
+| --- | --- |
+| CLI help or arguments | `src/cli` → `mise run render:usage`; regenerate completions when command structure changes |
+| Settings | `settings.toml` → `mise run render:schema` |
+| All generated docs and completions | `mise run render` |
+| Docs website | Edit Markdown/Vue sources; run `mise run docs:build` |
+| Documentation index for agents | `mise exec bun -- bun docs/.vitepress/llms.ts` after the final docs changes |
+
+CLI pages under `docs/cli` are generated. Do not patch those files without changing their
+source or generator. Docs examples use **TOML 1.1**; multiline inline tables, comments, and
+trailing commas are valid. Use a compatible parser when validating examples.
+
+Before opening a docs PR, rebase on the current `main`, resolve source conflicts, and rebuild
+`docs/public/llms.txt` from the rebased tree. Build the website to catch Markdown/Vue and
+link errors. Commit required generated changes with the source changes that produced them.
 
 ## Dependency Management
 
@@ -518,10 +370,13 @@ mise uses several tools to validate dependencies and code quality:
 - **cargo-msrv**: Verifies minimum supported Rust version compatibility
 - **cargo-machete**: Detects unused dependencies in Cargo.toml
 
-These checks run automatically in CI; run them locally with:
+CI installs these tools separately; they are not all declared in the project's `mise.toml`.
+Install the required tool before running its check locally. Consult the
+[test workflow](https://github.com/jdx/mise/blob/main/.github/workflows/test-impl.yml) for
+the exact CI environment and flags:
 
 ```bash
-# Run checks (tools are automatically available via mise.toml)
+# Run the installed dependency-check tools
 cargo deny check
 cargo msrv verify
 cargo machete --with-metadata
@@ -530,11 +385,11 @@ cargo machete --with-metadata
 ## Conventional Commits
 
 mise uses [Conventional Commits](https://www.conventionalcommits.org/) for
-consistent commit messages and automated changelog generation. All commits
-should follow this format:
+PR titles and automated changelog generation. PR titles **must** use this format;
+intermediate commit subjects should follow it too:
 
 ```text
-<type>[optional scope]: <description>
+<type>[optional scope][optional !]: <description>
 
 [optional body]
 
@@ -551,11 +406,14 @@ should follow this format:
 - **perf**: Performance improvements (⚡ Performance)
 - **test**: Testing changes (🧪 Testing)
 - **chore**: Maintenance tasks, dependency updates
+- **ci**: CI and automation changes
+- **security**: Security-related changes
+- **registry**: Registry changes (without a scope)
 - **revert**: Reverting previous changes (◀️ Revert)
 
 ### Examples
 
-```bash
+```text
 feat(cli): add new command for listing plugins
 fix(parser): handle edge case in version parsing
 refactor(config): simplify configuration loading logic
@@ -563,6 +421,9 @@ docs(readme): update installation instructions
 test(e2e): add tests for new plugin functionality
 chore(deps): update dependencies to latest versions
 ```
+
+Start the description with a lowercase character and use an imperative verb. Use `docs:`
+for documentation changes and `fix:` for CLI behavior fixes, not CI or infrastructure.
 
 ### Scopes
 
@@ -585,15 +446,18 @@ Breaking changes are rarely accepted into mise and are only performed in
 exceptional situations where there is no better alternative. When a breaking
 change is necessary, the process includes:
 
-1. **CLI warnings**: Users receive deprecation warnings in the CLI
-2. **Migration period**: Several months are provided for users to migrate
-3. **Documentation**: Clear migration guides are provided
-4. **Community notice**: Announcements in Discord and GitHub discussions
+1. Mark the feature deprecated in documentation immediately and normally add a CLI warning
+   with `deprecated_at!` in the same release.
+2. Allow 12 months after the warning before removal.
+3. Delay the warning by up to 6 months only when migration requires a new setting, syntax,
+   or replacement that older supported clients reject. Removal remains 12 months after
+   the warning, not after the initial documentation notice.
+4. Provide a working migration path and explain the affected behavior.
 
 For breaking changes, add `!` after the type or include `BREAKING CHANGE:` in
 the footer:
 
-```bash
+```text
 feat(api)!: remove deprecated configuration options
 # OR
 feat(api): remove deprecated configuration options
@@ -616,7 +480,7 @@ development:
 ### PR Title Validation
 
 - **semantic-pr-lint**: Validates that PR titles follow the conventional commit format
-- PR titles must match: `<type>[optional scope]: <description>`
+- PR titles must match: `<type>[optional scope][optional !]: <description>`
 - Example: `feat(cli): add new command for listing plugins`
 
 ### Continuous Integration
@@ -653,6 +517,10 @@ of the full backend specification.
 
 ### Quick Start
 
+First check the popularity requirements below. A new shorthand is for an already widely
+used tool, not a way to make a personal or niche project installable. Explicit backend
+syntax works without a registry entry.
+
 1. **Choose the right backend** for your tool:
 
    - **[packslip](dev-tools/backends/packslip.md)** - Preferred when the project
@@ -677,7 +545,9 @@ of the full backend specification.
    test = { cmd = "your-tool --version", expected = "{{version}}" }
    ```
 
-3. **Test the tool** with `mise test-tool your-tool` to confirm it works
+3. **Verify version listing** with `mise ls-remote <backend:identifier>`. A backend that can
+   install only an explicitly pinned version is insufficient.
+4. **Test the tool** with `mise test-tool your-tool` to confirm installation and execution.
 
 ### Guidelines and Requirements
 
@@ -687,12 +557,13 @@ When adding a new tool, the following requirements apply:
   verify installation. This is automatically enforced by the
   [`validate-new-tools` job](https://github.com/jdx/mise/blob/main/.github/workflows/registry.yml)
   in the registry workflow.
-- **Tools may be rejected if they are not notable** - The tool should be
-  reasonably popular and well-maintained. Notability is decided by maintainer
-  review (not CI). There are no specific guidelines for this; many factors are
-  taken into account. @jdx won't explain why a given tool wasn't accepted.
-  Include a brief popularity summary (stars, downloads, recent release date) in
-  the PR description so the policy can be applied without re-doing the research.
+- **New tools must already be widely used** - The bar is normally thousands of GitHub stars,
+  active maintenance, and real use outside the author's projects. Personal, internal, niche,
+  and low-popularity tools do not meet it. A working installer or passing test is not enough.
+  @jdx won't explain why a given tool wasn't accepted.
+- **Include popularity evidence** - Put current stars/forks, release activity, relevant
+  package downloads, and examples of third-party use in the PR description. Check the actual
+  numbers before proposing an entry; do not submit speculatively.
 
 #### Backend acceptance tiers
 
@@ -722,13 +593,12 @@ user's PATH. The tool still needs to be popular and well-maintained.
 
 **Tier 4 — very high bar, rarely accepted:** `npm`, `pipx`, `gem`, `cargo`, `go`, `dotnet`.
 
-These all depend on a separately installed runtime or toolchain being present on
-the user's PATH (`node`, `python`, `ruby`, `cargo`, `go`, `dotnet`), which is
-fragile. `npm`/`pipx`/`gem` in particular silently bind tools to whichever
-`node`/`python`/`ruby` happened to be on PATH at install time, which breaks when
-versions change or the runtime isn't installed. These backends are accepted only
-when no packslip/aqua/github/gitlab option exists and the tool is widely used. Discuss with @jdx
-before submitting.
+Runtime and toolchain dependencies add setup and reproducibility constraints. For example,
+npm requires Node, and gems depend on their Ruby installation. Requirements differ by
+backend: pipx's default uv mode can provision Python, so consult the backend's guide rather
+than assuming every dependency must already be on PATH. These backends are accepted only
+when no packslip/aqua/github/gitlab option exists and the tool is widely used. Get explicit
+agreement from @jdx before submitting an entry using one of these backends.
 
 **Not accepted:** `asdf`, `vfox`, `ubi`.
 
@@ -818,7 +688,7 @@ idiomatic_files = [".your-tool-version"]
 ```
 
 For structured or tool-specific files, use a table with the same parsing options supported by the
-[HTTP backend's version listing](/dev-tools/backends/http.html#version-listing):
+[HTTP backend's version listing](/dev-tools/backends/http.html#version-list-url):
 
 ```toml
 idiomatic_files = [
@@ -874,8 +744,10 @@ All tools must include a test to verify proper installation:
 test = { cmd = "command-to-run", expected = "expected-output-pattern" }
 ```
 
-The test command should be reliable, and the output pattern should use
-<code v-pre>{{version}}</code> to match any version number.
+The test command should be reliable and verify the installed executable. The template
+<code v-pre>{{version}}</code> expands to the selected tool version; it is not a wildcard
+matching any version. Use it when the command prints that version, or choose another stable
+output check appropriate for the tool.
 
 If `test.cmd` needs extra mise-managed tools on PATH, declare them with
 `test.tools`. This is used only by `mise test-tool`; it does not affect normal
@@ -887,9 +759,9 @@ test = { cmd = "gradle -V", expected = "Gradle", tools = ["java"] }
 
 ### Registry Examples
 
-Recent tool additions:
+Examples of registry shapes (consult the current files for all fields):
 
-- **DuckDB**: Simple github backend ([#4248](https://github.com/jdx/mise/pull/4248))
+- **DuckDB**: Aqua backend ([#4248](https://github.com/jdx/mise/pull/4248))
 
   ```toml
   # registry/duckdb.toml
@@ -926,7 +798,7 @@ or tool that would greatly enhance mise's capabilities.
 
 If you need a custom backend:
 
-1. **Discuss with jdx first** in [Discord](https://discord.gg/UBa7pJUN7Z) or by
+1. **Discuss with jdx first** in [Discord](https://discord.gg/mABnUDvP57) or by
    creating a [discussion](https://github.com/jdx/mise/discussions)
 2. **Consider whether existing backends** (github, aqua, npm, pipx, etc.) can meet
    your needs
@@ -955,36 +827,12 @@ across different installation systems.
 
 1. **Create the backend module** in `src/backend/` (e.g., `my_backend.rs`)
 
-2. **Implement the Backend trait**:
-
-   ```rust
-   use crate::backend::{Backend, BackendType};
-   use crate::install_context::InstallContext;
-
-   #[derive(Debug)]
-   pub struct MyBackend {
-       // backend-specific fields
-   }
-
-   impl Backend for MyBackend {
-       fn get_type(&self) -> BackendType { BackendType::MyBackend }
-
-       async fn list_remote_versions(&self) -> Result<Vec<String>> {
-           // Implementation for listing available versions
-       }
-
-       async fn install_version(&self, ctx: &InstallContext,
-                                 tv: &ToolVersion) -> Result<()> {
-           // Implementation for installing a specific version
-       }
-
-       async fn uninstall_version(&self, tv: &ToolVersion) -> Result<()> {
-           // Implementation for uninstalling a version
-       }
-
-       // ... other required methods
-   }
-   ```
+2. **Implement the current Backend trait** in
+   [`src/backend/mod.rs`](https://github.com/jdx/mise/blob/main/src/backend/mod.rs).
+   Follow a nearby backend with the same installation model. Shared wrapper methods handle
+   caching and policy; implement the appropriate hooks, such as `_list_remote_versions`
+   (which returns `VersionInfo` entries) and `install_version_`, rather than duplicating the
+   wrapper logic. Preserve opaque versions and delegate resolution to the backend.
 
 3. **Register the backend** in `src/backend/mod.rs`:
 
@@ -1020,37 +868,112 @@ Look at existing backends for patterns:
 For detailed architecture information, see
 [Backend Architecture](dev-tools/backend_architecture.md).
 
+## Packaging and Self-Update Instructions
+
+When mise is installed via a package manager, `mise self-update` should not replace the binary the package manager owns; users should update through the package manager instead. This is opt-in: a package that does none of the following keeps self-update fully enabled. Packagers have three ways to turn it off, and any of them makes `mise doctor` report `self_update_available: no`.
+
+The paths below are relative to the install prefix, which mise derives from its own binary: the path is canonicalized (symlinks resolved) and then taken two levels up, so `/usr/bin/mise` gives `/usr`.
+
+### Disable at build time
+
+Build without the `self_update` Cargo feature. This example retains native TLS and bundled
+Lua; a package using system Lua should choose its features and build dependencies accordingly:
+
+```bash
+cargo build --release --no-default-features --features native-tls,vfox/vendored-lua
+```
+
+The subcommand still exists, so scripts that call it get a clear error rather than "unknown command", but it always fails with `mise's self-update feature has been disabled at build time, cannot update`.
+
+### Disable with a marker file
+
+Install an empty `.disable-self-update` file at any one of:
+
+- `lib/.disable-self-update` (used by Homebrew)
+- `lib/mise/.disable-self-update` (used by the AUR `mise-bin` package)
+- `lib64/mise/.disable-self-update`
+
+### Ship update instructions
+
+Installing a TOML file with platform-specific instructions also disables self-update; mise prints the file's message when `mise self-update` runs and when it detects a newer release. Install it at any one of:
+
+- `lib/mise-self-update-instructions.toml`
+- `lib/mise/mise-self-update-instructions.toml`
+- `lib64/mise/mise-self-update-instructions.toml`
+
+Example contents:
+
+```toml
+# Debian/Ubuntu (APT)
+message = "To update mise from the APT repository, run:\n\n  sudo apt update && sudo apt install --only-upgrade mise\n"
+```
+
+```toml
+# Fedora/CentOS Stream (DNF)
+message = "To update mise from COPR, run:\n\n  sudo dnf upgrade mise\n"
+```
+
+Setting `MISE_SELF_UPDATE_INSTRUCTIONS` to a file path overrides the search.
+
+### Overriding the outcome
+
+`MISE_SELF_UPDATE_AVAILABLE=false` disables self-update without installing anything, and `MISE_SELF_UPDATE_AVAILABLE=true` re-enables it even when a marker or instructions file is present. Both are useful for testing a package build. Neither has any effect on a binary built without the `self_update` feature, where self-update is always unavailable.
+
+`mise self-update --force` also bypasses the availability check, so a user who passes it updates the binary in place even when a marker file, an instructions file, or `MISE_SELF_UPDATE_AVAILABLE=false` is in effect. Treat the runtime mechanisms as "do not update by default" rather than a hard block. A build without the `self_update` feature is the only variant `--force` cannot get past.
+
 ## Testing packaging
 
-This is only necessary when changing the packaging setup.
+Test packaging changes in a disposable container or machine for the target distribution.
+A running Docker engine is required for the examples below. Start the container from your
+host shell, then run the installation commands **inside** it as root. These checks exercise
+the published repository; testing an unpublished package also requires copying that artifact
+into the container and installing it there.
 
 ### Ubuntu (apt)
 
-This example is for arm64; change the arch to amd64 if needed.
+```sh
+docker run -ti --rm ubuntu bash
+```
+
+Inside the container:
 
 ```sh
-docker run -ti --rm ubuntu
 apt update -y
-apt install -y curl
+apt install -y curl ca-certificates
 install -dm 755 /etc/apt/keyrings
-curl -fSso /etc/apt/keyrings/mise-archive-keyring.pub https://mise.jdx.dev/gpg-key.pub
-echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.pub arch=arm64] \
+curl -fSso /etc/apt/keyrings/mise-archive-keyring.asc https://mise.jdx.dev/gpg-key.pub
+echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.asc arch=$(dpkg --print-architecture)] \
 https://mise.jdx.dev/deb stable main" >/etc/apt/sources.list.d/mise.list
 apt update -y
 apt install -y mise
-mise -V
+mise --version
 ```
 
 ### Fedora (dnf)
 
 ```sh
-docker run -ti --rm fedora
-dnf copr enable -y jdxcode/mise && dnf install -y mise && mise -v
+docker run -ti --rm fedora bash
 ```
+
+Inside the container, follow the [Fedora installation instructions](/installing-mise.html#dnf),
+then run `mise --version`. Minimal images may require the distribution's DNF COPR plugin first.
 
 ### RHEL (dnf)
 
 ```sh
-docker run -ti --rm registry.access.redhat.com/ubi9/ubi:latest
-dnf copr enable -y jdxcode/mise && dnf install -y mise && mise -v
+docker run -ti --rm registry.access.redhat.com/ubi9/ubi:latest bash
 ```
+
+Inside the container, follow the [RHEL installation instructions](/installing-mise.html#dnf),
+then run `mise --version`. RHEL 9 uses the `centos-stream+epel-next-9` COPR target; do not
+assume that a generic COPR enable command selects an available build for every release.
+
+## Linting
+
+- Lint codebase: `mise run lint`
+- Lint and fix codebase: `mise run lint-fix`
+
+## Releasing
+
+Releases are cut automatically by the `release-plz` GitHub Actions workflow
+(`mise run release-plz` in CI). Do not run that task locally.

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -154,7 +154,7 @@
 
 ## Advanced
 
-- [Architecture](https://mise.jdx.dev/architecture.html): This document gives an overview of mise's architecture. It is aimed at contributors and anyone interested in how mise works internally.
+- [Architecture](https://mise.jdx.dev/architecture.html): This map is for contributors deciding where a behavior belongs. Start with the command that exposes the behavior, then follow configuration, tool resolution, or task execution into the owning…
 - [Paranoid](https://mise.jdx.dev/paranoid.html): Paranoid mode is an optional behavior that locks mise down further to make it harder for a bad actor to compromise your system.
 - [Templates](https://mise.jdx.dev/templates.html): Use Tera expressions to derive configuration values from the project directory, environment, or [vars]. mise renders those expressions when it resolves configuration or prepares a task.
 - [URL Replacements](https://mise.jdx.dev/url-replacements.html): mise does not include a built-in registry for downloading artifacts. Instead, it retrieves remote registry manifests, which specify the URLs for downloading tools.


### PR DESCRIPTION
The contributor guide included E2E commands that can select no tests, stale build and lint assumptions, and packaging examples that mixed host and container commands. Document the resolved task wrapper, current toolchain requirements, assertion helpers, generated-file workflow, and actual checks. Rework the architecture page around current subsystem boundaries and source entry points.

Preserve the registry acceptance policy while clarifying backend prerequisites and version ordering. Document TOML 1.1 examples and regeneration of llms.txt after rebasing.

Validation: rebased on main and rebuilt llms.txt; docs build (334 pages), scoped hk checks, eight TOML snippets parsed by the current TOML 1.1 parser, and rendered local links pass. Ran the documented `mise run test:e2e e2e/cli/test_version` selection with Rust 1.95; it also selected matching version-range tests, all passing. Container recipes were reviewed against the installation guide; Docker is unavailable locally.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; no application code, auth, or data paths are modified.
> 
> **Overview**
> **Reworks contributor-facing docs** so they match how the repo actually builds, tests, and generates artifacts—without changing runtime code.
> 
> The **architecture** page is reframed as a contributor routing map: a Mermaid flowchart, bootstrap as a first-class subsystem, and shorter guidance on CLI (`usage_rs`), backend hooks, config merge semantics, toolset types, caching (MessagePack/zlib), and test layering. Long Rust trait excerpts and outdated cache details are removed.
> 
> The **contributing** guide is reorganized and corrected: prerequisites (`rust-version`, `min_version`, mbx/Cargo cache), E2E selection via `mise run test:e2e` (**basename** patterns, `--all`, empty default), hk/Clippy split, generated-docs workflow (including TOML 1.1 and `llms.txt` regeneration), stricter registry notability and backend-tier wording, formalized breaking-change timeline (`deprecated_at!`, 12-month removal), packaging/self-update moved and updated (Docker host vs container, apt keyring path), and Discord link updates.
> 
> **`docs/public/llms.txt`** picks up the new architecture blurb for agent indexing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c6e7a31916927f12bb550519b3a375e1b363f27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Reworked the architecture guide into a contributor-focused map covering major subsystems and test areas.
  - Rewrote contributing guidance, including development setup, testing, packaging, release practices, backend contributions, and breaking-change policy.
  - Updated contribution requirements for adding tools, quick-start verification, commit conventions, and backend acceptance.
  - Refreshed architecture documentation references in the public LLM guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->