### PR TITLE
docs: deepen and regenerate the CLI reference

### DIFF
--- a/docs/.vitepress/cli-reference.test.ts
+++ b/docs/.vitepress/cli-reference.test.ts
@@ -34,6 +34,14 @@ test("synopses distinguish optional subcommands and dynamic task arguments", () 
     ),
     "mise run [FLAGS] [TASK] [ARGS]…",
   );
+  assert.equal(
+    synopsis(
+      command("run [FLAGS] [TASK] [ARGS]…", {
+        mounts: [{ run: "mise tasks --usage" }],
+      }),
+    ),
+    "mise run [FLAGS] [TASK] [ARGS]…",
+  );
   assert.equal(synopsis(command("use <TOOL>…")), "mise use <TOOL>…");
 });
 

--- a/docs/.vitepress/cli-reference.test.ts
+++ b/docs/.vitepress/cli-reference.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { commandIndex, type Command } from "./cli-reference";
+import {
+  commandIndex,
+  replaceCommandIndex,
+  type Command,
+} from "./cli-reference";
 
 function command(usage: string, overrides: Partial<Command> = {}): Command {
   return {
@@ -26,4 +30,23 @@ test("command index hides compatibility commands and includes uncategorized addi
   assert.ok(output.includes("/cli/future.html"));
   assert.ok(!output.includes("legacy"));
   assert.equal((output.match(/\/cli\/use.html/g) ?? []).length, 1);
+});
+
+test("replacing the command index preserves preceding and following sections", () => {
+  const before = "# mise\n\n## Arguments\n\nTask arguments.\n\n";
+  const after =
+    "## Global Flags\n\nGlobal flags.\n\n## Examples\n\nmise --help\n";
+  const old = "## Subcommands\n\n### Old group\n\n- old command\n\n";
+  const index = commandIndex(
+    command("", { subcommands: { use: command("use") } }),
+  );
+  assert.equal(
+    replaceCommandIndex(before + old + after, index),
+    before + index + "\n\n" + after,
+  );
+  assert.equal(replaceCommandIndex(before + old, index), before + index + "\n");
+  assert.throws(
+    () => replaceCommandIndex(before, index),
+    /Missing Subcommands/,
+  );
 });

--- a/docs/.vitepress/cli-reference.test.ts
+++ b/docs/.vitepress/cli-reference.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import MarkdownIt from "markdown-it";
+import {
+  commandIndex,
+  fenceCodeBlocks,
+  synopsis,
+  type Command,
+} from "./cli-reference";
+
+function command(usage: string, overrides: Partial<Command> = {}): Command {
+  return {
+    full_cmd: [],
+    usage,
+    hide: false,
+    subcommands: {},
+    mounts: [],
+    ...overrides,
+  };
+}
+
+test("synopses distinguish optional subcommands and dynamic task arguments", () => {
+  const config = command("config <SUBCOMMAND>", {
+    subcommands: { ls: command("config ls") },
+  });
+  assert.equal(synopsis(config), "mise config [SUBCOMMAND]");
+  assert.equal(
+    synopsis({ ...config, subcommand_required: true }),
+    "mise config <SUBCOMMAND>",
+  );
+  assert.equal(
+    synopsis(
+      command("run [FLAGS]", { mounts: [{ run: "mise tasks --usage" }] }),
+    ),
+    "mise run [FLAGS] [TASK] [ARGS]…",
+  );
+  assert.equal(synopsis(command("use <TOOL>…")), "mise use <TOOL>…");
+});
+
+test("fencing preserves nested lists and fenced TOML 1.1 and JSON examples", () => {
+  const source = [
+    "- First phase",
+    "  - Nested description",
+    "    continuation of the description",
+    "",
+    "```toml",
+    "node = {",
+    '  version = "22", # TOML 1.1 comment and trailing comma',
+    "}",
+    "```",
+    "",
+    "```json",
+    "{",
+    '  "tags": [',
+    '    {"kind": "path"}',
+    "  ]",
+    "}",
+    "```",
+    "",
+    "    mise run build",
+    "    mise exec -- node -v",
+    "",
+  ].join("\n");
+  const output = fenceCodeBlocks(source);
+  assert.equal(
+    new MarkdownIt().render(output),
+    new MarkdownIt().render(source),
+  );
+  assert.ok(output.includes("```\nmise run build\nmise exec -- node -v\n```"));
+  assert.equal(fenceCodeBlocks(output), output);
+});
+
+test("code nested in a list and literal backtick fences remain code", () => {
+  const source =
+    "- Example:\n\n      literal ``` fence\n      {{ template }}\n\n- Next item\n";
+  const output = fenceCodeBlocks(source);
+  assert.equal(
+    new MarkdownIt().render(output),
+    new MarkdownIt().render(source),
+  );
+  assert.ok(output.includes("````"));
+});
+
+test("command index hides compatibility commands and includes uncategorized additions", () => {
+  const root = command("", {
+    subcommands: {
+      use: command("use <TOOL>", { help: "Install and select tools" }),
+      legacy: command("legacy", { hide: true }),
+      future: command("future", { help: "A new command" }),
+    },
+  });
+  const output = commandIndex(root);
+  assert.ok(output.includes("### Install and inspect tools"));
+  assert.ok(output.includes("### Other commands"));
+  assert.ok(output.includes("/cli/future.html"));
+  assert.ok(!output.includes("legacy"));
+  assert.equal((output.match(/\/cli\/use.html/g) ?? []).length, 1);
+});

--- a/docs/.vitepress/cli-reference.test.ts
+++ b/docs/.vitepress/cli-reference.test.ts
@@ -1,12 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import MarkdownIt from "markdown-it";
-import {
-  commandIndex,
-  fenceCodeBlocks,
-  synopsis,
-  type Command,
-} from "./cli-reference";
+import { commandIndex, type Command } from "./cli-reference";
 
 function command(usage: string, overrides: Partial<Command> = {}): Command {
   return {
@@ -14,95 +8,9 @@ function command(usage: string, overrides: Partial<Command> = {}): Command {
     usage,
     hide: false,
     subcommands: {},
-    mounts: [],
     ...overrides,
   };
 }
-
-test("synopses distinguish optional subcommands and dynamic task arguments", () => {
-  const config = command("config <SUBCOMMAND>", {
-    subcommands: { ls: command("config ls") },
-  });
-  assert.equal(synopsis(config), "mise config [SUBCOMMAND]");
-  assert.equal(
-    synopsis({ ...config, subcommand_required: true }),
-    "mise config <SUBCOMMAND>",
-  );
-  assert.equal(
-    synopsis(
-      command("run [FLAGS]", { mounts: [{ run: "mise tasks --usage" }] }),
-    ),
-    "mise run [FLAGS] [TASK] [ARGS]…",
-  );
-  assert.equal(
-    synopsis(
-      command("run [FLAGS] [TASK] [ARGS]…", {
-        mounts: [{ run: "mise tasks --usage" }],
-      }),
-    ),
-    "mise run [FLAGS] [TASK] [ARGS]…",
-  );
-  assert.equal(synopsis(command("use <TOOL>…")), "mise use <TOOL>…");
-});
-
-test("fencing preserves nested lists and fenced TOML 1.1 and JSON examples", () => {
-  const source = [
-    "- First phase",
-    "  - Nested description",
-    "    continuation of the description",
-    "",
-    "```toml",
-    "node = {",
-    '  version = "22", # TOML 1.1 comment and trailing comma',
-    "}",
-    "```",
-    "",
-    "```json",
-    "{",
-    '  "tags": [',
-    '    {"kind": "path"}',
-    "  ]",
-    "}",
-    "```",
-    "",
-    "    mise run build",
-    "    mise exec -- node -v",
-    "",
-  ].join("\n");
-  const output = fenceCodeBlocks(source);
-  assert.equal(
-    new MarkdownIt().render(output),
-    new MarkdownIt().render(source),
-  );
-  assert.ok(output.includes("```\nmise run build\nmise exec -- node -v\n```"));
-  assert.equal(fenceCodeBlocks(output), output);
-});
-
-test("code nested in a list and literal backtick fences remain code", () => {
-  const source =
-    "- Example:\n\n      literal ``` fence\n      {{ template }}\n\n- Next item\n";
-  const output = fenceCodeBlocks(source);
-  assert.equal(
-    new MarkdownIt().render(output),
-    new MarkdownIt().render(source),
-  );
-  assert.ok(output.includes("````"));
-});
-
-test("nested code preserves blank first lines and intentional indentation", () => {
-  const source =
-    "- Example:\n\n      \n        intentionally indented\n      plain\n\n- Next item\n";
-  const output = fenceCodeBlocks(source);
-  assert.equal(
-    new MarkdownIt().render(output),
-    new MarkdownIt().render(source),
-  );
-  assert.ok(
-    output.includes(
-      "      \n  ```\n    intentionally indented\n  plain\n  ```",
-    ),
-  );
-});
 
 test("command index hides compatibility commands and includes uncategorized additions", () => {
   const root = command("", {

--- a/docs/.vitepress/cli-reference.test.ts
+++ b/docs/.vitepress/cli-reference.test.ts
@@ -81,6 +81,21 @@ test("code nested in a list and literal backtick fences remain code", () => {
   assert.ok(output.includes("````"));
 });
 
+test("nested code preserves blank first lines and intentional indentation", () => {
+  const source =
+    "- Example:\n\n      \n        intentionally indented\n      plain\n\n- Next item\n";
+  const output = fenceCodeBlocks(source);
+  assert.equal(
+    new MarkdownIt().render(output),
+    new MarkdownIt().render(source),
+  );
+  assert.ok(
+    output.includes(
+      "      \n  ```\n    intentionally indented\n  plain\n  ```",
+    ),
+  );
+});
+
 test("command index hides compatibility commands and includes uncategorized additions", () => {
   const root = command("", {
     subcommands: {

--- a/docs/.vitepress/cli-reference.ts
+++ b/docs/.vitepress/cli-reference.ts
@@ -180,8 +180,14 @@ export function fenceCodeBlocks(source: string): string {
   for (const token of blocks.reverse()) {
     const [start, end] = token.map!;
     const content = token.content.replace(/\n$/, "");
-    const first = content.split("\n")[0];
-    const indent = Math.max(0, lines[start].indexOf(first) - 4);
+    const contentLines = content.split("\n");
+    const firstContentLine = contentLines.findIndex((line) => line.trim());
+    const sourceLine = lines[start + Math.max(0, firstContentLine)] ?? "";
+    const sourceIndent = sourceLine.match(/^ */)?.[0].length ?? 0;
+    const contentIndent =
+      contentLines[Math.max(0, firstContentLine)]?.match(/^ */)?.[0].length ??
+      0;
+    const indent = Math.max(0, sourceIndent - 4 - contentIndent);
     const prefix = " ".repeat(indent);
     const longest = Math.max(
       2,
@@ -192,7 +198,7 @@ export function fenceCodeBlocks(source: string): string {
       start,
       end - start,
       prefix + fence,
-      ...content.split("\n").map((line) => prefix + line),
+      ...contentLines.map((line) => prefix + line),
       prefix + fence,
     );
   }

--- a/docs/.vitepress/cli-reference.ts
+++ b/docs/.vitepress/cli-reference.ts
@@ -1,22 +1,18 @@
-// Add website navigation and normalize presentation after usage generates docs/cli.
+// Add mise-specific website navigation after usage generates docs/cli.
 // Command prose, arguments, flags, and visibility still come from mise.usage.kdl.
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import MarkdownIt from "markdown-it";
 
 export interface Command {
   full_cmd: string[];
   usage: string;
   help?: string;
-  subcommand_required?: boolean;
   hide: boolean;
   subcommands: Record<string, Command>;
-  mounts: { run: string }[];
 }
 
-const markdown = new MarkdownIt();
 const docsDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const navigationMarker = "<!-- generated reference navigation -->";
 
@@ -159,55 +155,6 @@ const categories = [
   ["Integrations and community", "mcp skills patrons sponsors"],
 ];
 
-export function synopsis(cmd: Command): string {
-  let usage = cmd.usage;
-  if (Object.keys(cmd.subcommands).length && !cmd.subcommand_required) {
-    usage = usage.replace("<SUBCOMMAND>", "[SUBCOMMAND]");
-  }
-  // The completion spec replaces run's arguments with a dynamic project-task mount.
-  if (
-    cmd.mounts.some((mount) => mount.run === "mise tasks --usage") &&
-    !usage.includes("[TASK]")
-  ) {
-    usage += " [TASK] [ARGS]…";
-  }
-  return `mise ${usage}`.trim();
-}
-
-/** Fence only real indented code tokens, preserving lists and existing fences. */
-export function fenceCodeBlocks(source: string): string {
-  const lines = source.split("\n");
-  const blocks = markdown
-    .parse(source, {})
-    .filter((token) => token.type === "code_block");
-  for (const token of blocks.reverse()) {
-    const [start, end] = token.map!;
-    const content = token.content.replace(/\n$/, "");
-    const contentLines = content.split("\n");
-    const firstContentLine = contentLines.findIndex((line) => line.trim());
-    const sourceLine = lines[start + Math.max(0, firstContentLine)] ?? "";
-    const sourceIndent = sourceLine.match(/^ */)?.[0].length ?? 0;
-    const contentIndent =
-      contentLines[Math.max(0, firstContentLine)]?.match(/^ */)?.[0].length ??
-      0;
-    const indent = Math.max(0, sourceIndent - 4 - contentIndent);
-    const prefix = " ".repeat(indent);
-    const longest = Math.max(
-      2,
-      ...[...content.matchAll(/`+/g)].map((match) => match[0].length),
-    );
-    const fence = "`".repeat(longest + 1);
-    lines.splice(
-      start,
-      end - start,
-      prefix + fence,
-      ...contentLines.map((line) => prefix + line),
-      prefix + fence,
-    );
-  }
-  return lines.join("\n");
-}
-
 export function commandIndex(root: Command): string {
   const remaining = new Map(
     Object.entries(root.subcommands).filter(([, cmd]) => !cmd.hide),
@@ -257,7 +204,7 @@ function main() {
       throw new Error(`Missing guide: ${label} (${url})`);
   }
   let count = 0;
-  for (const [name, cmd] of commands) {
+  for (const name of commands.keys()) {
     const file = resolve(
       docsDir,
       "cli",
@@ -266,17 +213,6 @@ function main() {
     if (!existsSync(file)) continue; // usage excludes hidden commands' own pages.
     let page = readFileSync(file, "utf8").split(navigationMarker)[0].trimEnd();
     if (name) {
-      page = page.replace(
-        /^- \*\*Usage:\*\* `[^\n]+`/m,
-        `- **Usage:** \`${synopsis(cmd)}\``,
-      );
-      // When the first child is hidden, usage omits the subcommand heading.
-      if (!page.includes("## Subcommands")) {
-        page = page.replace(
-          /\n- \[`mise [^\n]+\]\(\/cli\//,
-          (match) => "\n\n## Subcommands\n" + match,
-        );
-      }
       const parts = name.split(" ");
       let guide: [string, string] | undefined;
       for (let i = parts.length; i > 0 && !guide; i--)
@@ -288,8 +224,10 @@ function main() {
         !existsSync(resolve(docsDir, "cli", parent.join("/") + ".md"))
       )
         parent.pop();
+      const parentUsage =
+        commands.get(parent.join(" "))?.usage ?? parent.join(" ");
       const parentLink = parent.length
-        ? `[\`mise ${parent.join(" ")}\`](/cli/${parent.join("/")}.html)`
+        ? `[\`mise ${parentUsage}\`](/cli/${parent.join("/")}.html)`
         : "[All commands](/cli/)";
       const hiddenParent = parts
         .slice(0, -1)
@@ -301,7 +239,7 @@ function main() {
           .replace("bootstrap systemd", "bootstrap linux systemd-units")
           .replace("bootstrap macos-defaults", "bootstrap macos defaults");
         if (canonical !== name && commands.has(canonical))
-          compatibility = `\nThis is a compatibility spelling. Use [\`mise ${canonical}\`](/cli/${canonical.replaceAll(" ", "/")}.html) in new scripts.\n`;
+          compatibility = `\nThis is a compatibility spelling. Use [\`mise ${commands.get(canonical)!.usage}\`](/cli/${canonical.replaceAll(" ", "/")}.html) in new scripts.\n`;
       }
       page += `\n\n${navigationMarker}\n${compatibility}\n## Related documentation\n\n- [${guide[0]}](${guide[1]}).\n- ${parentLink}.\n- [Global flags and argument syntax](/cli/#global-flags).\n`;
     } else {
@@ -323,17 +261,6 @@ function main() {
         "## Global Flags\n\nThese flags provide shared context. A command can define its own flag with the same\nname, so consult that command's page for placement and meaning. Effect labels describe\nthe command's intended operation; configuration evaluation, caches, and required tool\ninstallation can still have side effects. They are not sandbox guarantees.\n",
       );
     }
-    // Keep every linked synopsis consistent with the command's own page.
-    if (name)
-      page = page.replace(
-        /\[`mise [^\n]+?`\]\(\/cli\/([^)]*)\.(?:md|html)\)/g,
-        (match, path: string) => {
-          const child = commands.get(path.replaceAll("/", " "));
-          return child ? `[\`${synopsis(child)}\`](/cli/${path}.html)` : match;
-        },
-      );
-    page = page.replace(/^Examples:\s*$/gm, "## Examples");
-    page = fenceCodeBlocks(page);
     writeFileSync(file, page.trimEnd() + "\n");
     count++;
   }

--- a/docs/.vitepress/cli-reference.ts
+++ b/docs/.vitepress/cli-reference.ts
@@ -165,7 +165,10 @@ export function synopsis(cmd: Command): string {
     usage = usage.replace("<SUBCOMMAND>", "[SUBCOMMAND]");
   }
   // The completion spec replaces run's arguments with a dynamic project-task mount.
-  if (cmd.mounts.some((mount) => mount.run === "mise tasks --usage")) {
+  if (
+    cmd.mounts.some((mount) => mount.run === "mise tasks --usage") &&
+    !usage.includes("[TASK]")
+  ) {
     usage += " [TASK] [ARGS]…";
   }
   return `mise ${usage}`.trim();
@@ -303,7 +306,7 @@ function main() {
       page += `\n\n${navigationMarker}\n${compatibility}\n## Related documentation\n\n- [${guide[0]}](${guide[1]}).\n- ${parentLink}.\n- [Global flags and argument syntax](/cli/#global-flags).\n`;
     } else {
       page = page.replace(
-        /\*\*Usage:\*\* `[^\n]+`/,
+        /^(?:- )?\*\*Usage:\*\* `[^\n]+`/m,
         "**Usage:** `mise [FLAGS] [COMMAND | TASK] [ARGS]…`",
       );
       page = page.replace(/^- \*\*Usage:\*\*[^\n]+\n/m, "");
@@ -321,13 +324,14 @@ function main() {
       );
     }
     // Keep every linked synopsis consistent with the command's own page.
-    page = page.replace(
-      /\[`mise [^\n]+?`\]\(\/cli\/([^)]*)\.md\)/g,
-      (match, path: string) => {
-        const child = commands.get(path.replaceAll("/", " "));
-        return child ? `[\`${synopsis(child)}\`](/cli/${path}.html)` : match;
-      },
-    );
+    if (name)
+      page = page.replace(
+        /\[`mise [^\n]+?`\]\(\/cli\/([^)]*)\.(?:md|html)\)/g,
+        (match, path: string) => {
+          const child = commands.get(path.replaceAll("/", " "));
+          return child ? `[\`${synopsis(child)}\`](/cli/${path}.html)` : match;
+        },
+      );
     page = page.replace(/^Examples:\s*$/gm, "## Examples");
     page = fenceCodeBlocks(page);
     writeFileSync(file, page.trimEnd() + "\n");

--- a/docs/.vitepress/cli-reference.ts
+++ b/docs/.vitepress/cli-reference.ts
@@ -1,0 +1,333 @@
+// Add website navigation and normalize presentation after usage generates docs/cli.
+// Command prose, arguments, flags, and visibility still come from mise.usage.kdl.
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import MarkdownIt from "markdown-it";
+
+export interface Command {
+  full_cmd: string[];
+  usage: string;
+  help?: string;
+  subcommand_required?: boolean;
+  hide: boolean;
+  subcommands: Record<string, Command>;
+  mounts: { run: string }[];
+}
+
+const markdown = new MarkdownIt();
+const docsDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const navigationMarker = "<!-- generated reference navigation -->";
+
+// Longest matching command path wins; descendants share their resource's guide.
+const guides: Record<string, [string, string]> = {
+  activate: ["Shell activation", "/getting-started.html#activate-mise"],
+  deactivate: ["Shell activation", "/getting-started.html#activate-mise"],
+  en: ["Shell activation", "/getting-started.html#activate-mise"],
+  shell: ["Shell activation", "/getting-started.html#activate-mise"],
+  completion: ["Shell completions", "/dev-tools/packslip-resources.html"],
+  "shell-alias": ["Shell aliases", "/shell-aliases.html"],
+  env: ["Environment variables", "/environments/"],
+  set: ["Environment variables", "/environments/"],
+  unset: ["Environment variables", "/environments/"],
+  exec: ["Running tools", "/dev-tools/"],
+  backends: ["Choosing backends", "/dev-tools/backends/"],
+  config: ["Configuration", "/configuration.html"],
+  edit: ["Configuration", "/configuration.html"],
+  fmt: ["Configuration", "/configuration.html"],
+  settings: ["Settings reference", "/configuration/settings.html"],
+  "tool-alias": ["Tool version aliases", "/dev-tools/aliases.html"],
+  bootstrap: ["Bootstrap workflow", "/bootstrap.html"],
+  "bootstrap accounts": ["Users and groups", "/bootstrap/accounts.html"],
+  "bootstrap compose": ["Compose projects", "/bootstrap/compose.html"],
+  "bootstrap dotfiles": ["Dotfile ownership and modes", "/dotfiles.html"],
+  "bootstrap files": [
+    "Privileged files and directories",
+    "/bootstrap/files.html",
+  ],
+  "bootstrap firewall": ["Host firewall", "/bootstrap/firewall.html"],
+  "bootstrap launchd": ["LaunchAgents", "/bootstrap/launchd.html"],
+  "bootstrap linux": ["systemd user units", "/bootstrap/systemd.html"],
+  "bootstrap macos": ["macOS defaults", "/bootstrap/macos-defaults.html"],
+  "bootstrap macos launchd-agents": ["LaunchAgents", "/bootstrap/launchd.html"],
+  "bootstrap macos-defaults": [
+    "macOS defaults",
+    "/bootstrap/macos-defaults.html",
+  ],
+  "bootstrap mise-shell-activate": ["Shell setup", "/bootstrap/shell.html"],
+  "bootstrap packages": ["Host packages", "/bootstrap/packages/"],
+  "bootstrap packages brew": [
+    "Homebrew packages and taps",
+    "/bootstrap/packages/brew.html",
+  ],
+  "bootstrap plugins": ["Package plugins", "/bootstrap/packages/plugins.html"],
+  "bootstrap remote": ["Remote bootstrap", "/bootstrap/remote.html"],
+  "bootstrap repos": ["Repository checkouts", "/bootstrap/repos.html"],
+  "bootstrap secrets": ["Bootstrap secrets", "/bootstrap/secrets.html"],
+  "bootstrap services": ["System services", "/bootstrap/services.html"],
+  "bootstrap systemd": ["systemd user units", "/bootstrap/systemd.html"],
+  "bootstrap user": ["Current-user settings", "/bootstrap/user.html"],
+  cache: ["Cache behavior", "/cache-behavior.html"],
+  "cache task": ["Task output caching", "/tasks/caching.html"],
+  deps: ["Project dependencies", "/dev-tools/deps.html"],
+  doctor: ["Troubleshooting", "/troubleshooting.html"],
+  generate: ["Tasks and automation", "/tasks/"],
+  "generate config": ["Configuration", "/configuration.html"],
+  "generate devcontainer": ["IDE integration", "/ide-integration.html"],
+  "generate github-action": [
+    "Continuous integration",
+    "/continuous-integration.html",
+  ],
+  "generate install-script": ["Project installation scripts", "/dev-tools/"],
+  "generate tool-stub": ["Portable tool stubs", "/dev-tools/tool-stubs.html"],
+  implode: ["Uninstalling mise", "/installing-mise.html"],
+  "install-into": ["Development tools", "/dev-tools/"],
+  install: ["Installing and selecting tools", "/dev-tools/"],
+  latest: ["Version requests", "/dev-tools/"],
+  link: ["Development tools", "/dev-tools/"],
+  lock: ["Lockfiles and strict installation", "/dev-tools/mise-lock.html"],
+  ls: ["Development tools", "/dev-tools/"],
+  "ls-remote": ["Version requests", "/dev-tools/"],
+  mcp: ["MCP integration", "/mcp.html"],
+  oci: ["Building and running OCI images", "/dev-tools/mise-oci.html"],
+  outdated: ["Upgrading tools", "/dev-tools/"],
+  packslip: ["Signer verification", "/dev-tools/packslip-verification.html"],
+  patrons: ["Supporting mise", "/about.html"],
+  plugins: ["Plugin selection and maintenance", "/plugin-usage.html"],
+  "plugins link": ["Developing tool plugins", "/tool-plugin-development.html"],
+  prune: ["Development tools", "/dev-tools/"],
+  registry: ["Registry and explicit backends", "/registry.html"],
+  reshim: ["Shims", "/dev-tools/shims.html"],
+  run: ["Running tasks", "/tasks/running-tasks.html"],
+  search: ["Registry and explicit backends", "/registry.html"],
+  "self-update": ["Installing and updating mise", "/installing-mise.html"],
+  skills: [
+    "Skills and other Packslip resources",
+    "/dev-tools/packslip-resources.html",
+  ],
+  sponsors: ["Supporting mise", "/about.html"],
+  ssh: ["Git provider authentication", "/dev-tools/github-tokens.html"],
+  sync: ["Development tools", "/dev-tools/"],
+  "sync node": ["Node.js", "/lang/node.html"],
+  "sync python": ["Python", "/lang/python.html"],
+  "sync ruby": ["Ruby", "/lang/ruby.html"],
+  tasks: ["Task configuration", "/tasks/task-configuration.html"],
+  "tasks add": ["TOML tasks", "/tasks/toml-tasks.html"],
+  "tasks deps": ["Task dependency graph", "/tasks/architecture.html"],
+  "tasks edit": ["File tasks", "/tasks/file-tasks.html"],
+  "tasks graph": ["Monorepo projects", "/tasks/monorepo.html"],
+  "tasks run": ["Running tasks", "/tasks/running-tasks.html"],
+  "test-tool": [
+    "Contributing and registry tests",
+    "/contributing.html#tool-testing",
+  ],
+  token: ["Git provider authentication", "/dev-tools/github-tokens.html"],
+  tool: ["Development tools", "/dev-tools/"],
+  "bin-paths": ["Shims and executable lookup", "/dev-tools/shims.html"],
+  "tool-stub": ["Portable tool stubs", "/dev-tools/tool-stubs.html"],
+  trust: ["Configuration trust", "/security.html"],
+  untrust: ["Configuration trust", "/security.html"],
+  uninstall: ["Development tools", "/dev-tools/"],
+  unuse: [
+    "Configuration write targets",
+    "/configuration.html#target-file-for-write-operations",
+  ],
+  upgrade: ["Development tools", "/dev-tools/"],
+  use: ["Installing and selecting tools", "/dev-tools/"],
+  version: ["Troubleshooting", "/troubleshooting.html"],
+  watch: ["Watching tasks", "/tasks/running-tasks.html"],
+  where: ["Development tools", "/dev-tools/"],
+  which: ["Shims and executable lookup", "/dev-tools/shims.html"],
+};
+
+const categories = [
+  [
+    "Install and inspect tools",
+    "use install install-into uninstall unuse upgrade outdated lock latest ls ls-remote tool where which bin-paths registry search backends link sync prune reshim tool-stub packslip",
+  ],
+  [
+    "Shell and environment",
+    "activate deactivate completion en env exec shell set unset shell-alias tool-alias ssh",
+  ],
+  ["Tasks and project automation", "run tasks watch deps generate"],
+  ["Machine setup and images", "bootstrap oci"],
+  [
+    "Configuration and diagnostics",
+    "config edit fmt settings trust untrust doctor cache version self-update implode",
+  ],
+  ["Integrations and community", "mcp skills patrons sponsors"],
+];
+
+export function synopsis(cmd: Command): string {
+  let usage = cmd.usage;
+  if (Object.keys(cmd.subcommands).length && !cmd.subcommand_required) {
+    usage = usage.replace("<SUBCOMMAND>", "[SUBCOMMAND]");
+  }
+  // The completion spec replaces run's arguments with a dynamic project-task mount.
+  if (cmd.mounts.some((mount) => mount.run === "mise tasks --usage")) {
+    usage += " [TASK] [ARGS]…";
+  }
+  return `mise ${usage}`.trim();
+}
+
+/** Fence only real indented code tokens, preserving lists and existing fences. */
+export function fenceCodeBlocks(source: string): string {
+  const lines = source.split("\n");
+  const blocks = markdown
+    .parse(source, {})
+    .filter((token) => token.type === "code_block");
+  for (const token of blocks.reverse()) {
+    const [start, end] = token.map!;
+    const content = token.content.replace(/\n$/, "");
+    const first = content.split("\n")[0];
+    const indent = Math.max(0, lines[start].indexOf(first) - 4);
+    const prefix = " ".repeat(indent);
+    const longest = Math.max(
+      2,
+      ...[...content.matchAll(/`+/g)].map((match) => match[0].length),
+    );
+    const fence = "`".repeat(longest + 1);
+    lines.splice(
+      start,
+      end - start,
+      prefix + fence,
+      ...content.split("\n").map((line) => prefix + line),
+      prefix + fence,
+    );
+  }
+  return lines.join("\n");
+}
+
+export function commandIndex(root: Command): string {
+  const remaining = new Map(
+    Object.entries(root.subcommands).filter(([, cmd]) => !cmd.hide),
+  );
+  const sections: string[] = [];
+  for (const [heading, names] of [
+    ...categories,
+    ["Other commands", [...remaining.keys()].join(" ")],
+  ]) {
+    const rows: string[] = [];
+    for (const name of names.split(" ")) {
+      const cmd = remaining.get(name);
+      if (!cmd) continue;
+      remaining.delete(name);
+      rows.push(
+        `- [\`mise ${name}\`](/cli/${name}.html) — ${cmd.help ?? "Command reference"}`,
+      );
+    }
+    if (rows.length) sections.push(`### ${heading}\n\n${rows.join("\n")}`);
+  }
+  return `## Subcommands\n\nChoose a command family below. Its page lists the available subcommands.\n\n${sections.join("\n\n")}`;
+}
+
+function sourcePath(url: string): string {
+  const path = url.split("#")[0];
+  return resolve(
+    docsDir,
+    path.slice(1).replace(/\.html$/, ".md") +
+      (path.endsWith("/") ? "index.md" : ""),
+  );
+}
+
+function main() {
+  const root = JSON.parse(
+    execFileSync("usage", ["generate", "json", "--file", "mise.usage.kdl"], {
+      encoding: "utf8",
+    }),
+  ).cmd as Command;
+  const commands = new Map<string, Command>();
+  function visit(cmd: Command) {
+    commands.set(cmd.full_cmd.join(" "), cmd);
+    Object.values(cmd.subcommands).forEach(visit);
+  }
+  visit(root);
+  for (const [label, url] of Object.values(guides)) {
+    if (!existsSync(sourcePath(url)))
+      throw new Error(`Missing guide: ${label} (${url})`);
+  }
+  let count = 0;
+  for (const [name, cmd] of commands) {
+    const file = resolve(
+      docsDir,
+      "cli",
+      name ? `${name.replaceAll(" ", "/")}.md` : "index.md",
+    );
+    if (!existsSync(file)) continue; // usage excludes hidden commands' own pages.
+    let page = readFileSync(file, "utf8").split(navigationMarker)[0].trimEnd();
+    if (name) {
+      page = page.replace(
+        /^- \*\*Usage:\*\* `[^\n]+`/m,
+        `- **Usage:** \`${synopsis(cmd)}\``,
+      );
+      // When the first child is hidden, usage omits the subcommand heading.
+      if (!page.includes("## Subcommands")) {
+        page = page.replace(
+          /\n- \[`mise [^\n]+\]\(\/cli\//,
+          (match) => "\n\n## Subcommands\n" + match,
+        );
+      }
+      const parts = name.split(" ");
+      let guide: [string, string] | undefined;
+      for (let i = parts.length; i > 0 && !guide; i--)
+        guide = guides[parts.slice(0, i).join(" ")];
+      guide ??= ["Getting started", "/getting-started.html"];
+      let parent = parts.slice(0, -1);
+      while (
+        parent.length &&
+        !existsSync(resolve(docsDir, "cli", parent.join("/") + ".md"))
+      )
+        parent.pop();
+      const parentLink = parent.length
+        ? `[\`mise ${parent.join(" ")}\`](/cli/${parent.join("/")}.html)`
+        : "[All commands](/cli/)";
+      const hiddenParent = parts
+        .slice(0, -1)
+        .some((_, i) => commands.get(parts.slice(0, i + 1).join(" "))?.hide);
+      let compatibility = "";
+      if (hiddenParent) {
+        const canonical = name
+          .replace("bootstrap launchd", "bootstrap macos launchd-agents")
+          .replace("bootstrap systemd", "bootstrap linux systemd-units")
+          .replace("bootstrap macos-defaults", "bootstrap macos defaults");
+        if (canonical !== name && commands.has(canonical))
+          compatibility = `\nThis is a compatibility spelling. Use [\`mise ${canonical}\`](/cli/${canonical.replaceAll(" ", "/")}.html) in new scripts.\n`;
+      }
+      page += `\n\n${navigationMarker}\n${compatibility}\n## Related documentation\n\n- [${guide[0]}](${guide[1]}).\n- ${parentLink}.\n- [Global flags and argument syntax](/cli/#global-flags).\n`;
+    } else {
+      page = page.replace(
+        /\*\*Usage:\*\* `[^\n]+`/,
+        "**Usage:** `mise [FLAGS] [COMMAND | TASK] [ARGS]…`",
+      );
+      page = page.replace(/^- \*\*Usage:\*\*[^\n]+\n/m, "");
+      page =
+        page.slice(0, page.indexOf("## Subcommands")) +
+        commandIndex(root) +
+        "\n";
+      page = page.replace(
+        "## Arguments",
+        "Use `mise COMMAND --help` for the help shipped with your installed version. Put mise\nflags before a task name; arguments after the name are passed to that task.\nSquare brackets mark optional input, angle brackets mark required input, and `…`\nmeans the argument can repeat. Do not type those notation characters.\n\n## Arguments",
+      );
+      page = page.replace(
+        "## Global Flags",
+        "## Global Flags\n\nThese flags provide shared context. A command can define its own flag with the same\nname, so consult that command's page for placement and meaning. Effect labels describe\nthe command's intended operation; configuration evaluation, caches, and required tool\ninstallation can still have side effects. They are not sandbox guarantees.\n",
+      );
+    }
+    // Keep every linked synopsis consistent with the command's own page.
+    page = page.replace(
+      /\[`mise [^\n]+?`\]\(\/cli\/([^)]*)\.md\)/g,
+      (match, path: string) => {
+        const child = commands.get(path.replaceAll("/", " "));
+        return child ? `[\`${synopsis(child)}\`](/cli/${path}.html)` : match;
+      },
+    );
+    page = page.replace(/^Examples:\s*$/gm, "## Examples");
+    page = fenceCodeBlocks(page);
+    writeFileSync(file, page.trimEnd() + "\n");
+    count++;
+  }
+  console.log(`Added reference navigation to ${count} CLI pages`);
+}
+
+if (import.meta.main) main();

--- a/docs/.vitepress/cli-reference.ts
+++ b/docs/.vitepress/cli-reference.ts
@@ -178,6 +178,22 @@ export function commandIndex(root: Command): string {
   return `## Subcommands\n\nChoose a command family below. Its page lists the available subcommands.\n\n${sections.join("\n\n")}`;
 }
 
+export function replaceCommandIndex(page: string, index: string): string {
+  const heading = "## Subcommands";
+  const start = page.search(/^## Subcommands$/m);
+  if (start === -1)
+    throw new Error("Missing Subcommands section in generated CLI index");
+  const bodyStart = start + heading.length;
+  const nextSection = page.slice(bodyStart).search(/^## /m);
+  const suffix = nextSection === -1 ? "" : page.slice(bodyStart + nextSection);
+  return (
+    page.slice(0, start) +
+    index.trimEnd() +
+    "\n" +
+    (suffix ? "\n" + suffix : "")
+  );
+}
+
 function sourcePath(url: string): string {
   const path = url.split("#")[0];
   return resolve(
@@ -248,10 +264,7 @@ function main() {
         "**Usage:** `mise [FLAGS] [COMMAND | TASK] [ARGS]…`",
       );
       page = page.replace(/^- \*\*Usage:\*\*[^\n]+\n/m, "");
-      page =
-        page.slice(0, page.indexOf("## Subcommands")) +
-        commandIndex(root) +
-        "\n";
+      page = replaceCommandIndex(page, commandIndex(root));
       page = page.replace(
         "## Arguments",
         "Use `mise COMMAND --help` for the help shipped with your installed version. Put mise\nflags before a task name; arguments after the name are passed to that task.\nSquare brackets mark optional input, angle brackets mark required input, and `…`\nmeans the argument can repeat. Do not type those notation characters.\n\n## Arguments",

--- a/docs/cli/activate.md
+++ b/docs/cli/activate.md
@@ -5,26 +5,21 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/activate.rs`](https://github.com/jdx/mise/blob/main/src/cli/activate.rs)
 
-Initialize mise in the current shell session
+Print the script to activate mise in an interactive shell
 
-Add this to your shell's rc or profile file so it runs in every new shell.
-Otherwise, it only takes effect in the current session.
-(e.g. ~/.zshrc, ~/.zprofile, ~/.zshenv, ~/.bashrc, ~/.bash_profile, ~/.profile, ~/.config/fish/config.fish, or $PROFILE for powershell)
+Evaluate this command's output with the syntax for your shell; running it alone
+only prints the script. Activation updates tools and environment variables as
+this shell changes directories.
 
-Typically, this can be added with something like the following:
+Add the appropriate example below once to your interactive startup file:
+~/.bashrc for Bash, ~/.zshrc for Zsh, ~/.config/fish/config.fish for Fish,
+or $PROFILE for PowerShell. See the getting-started guide for other shells.
 
-```
-echo 'eval "$(mise activate zsh)"' >> ~/.zshrc
-```
+The mise executable must be on PATH before that line runs. Otherwise use its
+absolute path, for example `eval "$(~/.local/bin/mise activate zsh)"`.
 
-However, this requires that "mise" is in your PATH. If it is not, you need to
-specify the full path like this:
-
-```
-echo 'eval "$(/path/to/mise activate zsh)"' >> ~/.zshrc
-```
-
-Customize status output with `status` settings.
+Use `mise exec -- command` for scripts and CI that do not need interactive hooks.
+Customize status output with the `status` settings.
 
 ## Arguments
 - **`[SHELL_TYPE]`** — Shell type to generate the script for
@@ -79,3 +74,11 @@ Activate mise in PowerShell.
 ```
 (&mise activate pwsh) | Out-String | Invoke-Expression
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Shell activation](/getting-started.html#activate-mise).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/backends.md
+++ b/docs/cli/backends.md
@@ -19,3 +19,11 @@ Deprecation:
 
 The `mise b` alias is deprecated and will be removed in mise 2027.4.0.
 Use `mise backends` instead.
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Choosing backends](/dev-tools/backends/).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/backends/ls.md
+++ b/docs/cli/backends/ls.md
@@ -19,3 +19,11 @@ Installed plugin availability and built-in backends are separate lists
 mise backends ls
 mise plugins ls
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Choosing backends](/dev-tools/backends/).
+- [`mise backends [SUBCOMMAND]`](/cli/backends.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bin-paths.md
+++ b/docs/cli/bin-paths.md
@@ -15,3 +15,11 @@ List all the active runtime bin paths
 - **`--bin-names`** — Output executable names instead of bin directories
 - **`-J --json`** — Output executable entries in JSON format (implies --bin-names)
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Shims and executable lookup](/dev-tools/shims.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap.md
+++ b/docs/cli/bootstrap.md
@@ -6,55 +6,27 @@
 - **Effect:** destructive — may delete or irreversibly overwrite
 - **Source code:** [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
-Set up a machine for the current config in one command
+Set up a machine from the current configuration
 
-Runs the bootstrap steps for the current config in order:
+Runs these phases in order, when configured and selected:
 
-0. `mise bootstrap accounts apply` — converge `[bootstrap.users]` and
-   `[bootstrap.groups]` (Linux)
-1. `mise bootstrap plugins apply` — install `[bootstrap.plugins]`
-   1.7. `[bootstrap.hooks.pre-packages]` — optional setup hook
-2. Install built-in-manager entries from `[bootstrap.packages]`
-3. `mise bootstrap files apply` — converge `[bootstrap.files]` and
-   `[bootstrap.directories]`
-4. `mise bootstrap services apply` — converge `[bootstrap.services]`
-   systemd system services (Linux)
-5. `mise bootstrap firewall apply` — converge `[bootstrap.linux.firewall]`
-   host firewall policy and rules (Linux)
-6. `mise bootstrap compose apply` — converge `[bootstrap.compose]`
-   Docker Compose projects
-7. `mise bootstrap repos apply` — clone/converge `[bootstrap.repos]`
-   surrounded by `pre-repos`/`post-repos` hooks
-8. `mise bootstrap dotfiles apply` — apply dotfiles from `[dotfiles]`
-   surrounded by `pre-dotfiles`/`post-dotfiles` hooks
-9. `mise bootstrap mise-shell-activate apply` — configure shell activation
-   from `[bootstrap.mise_shell_activate]`
-10. `mise bootstrap macos defaults apply` — write
-    `[bootstrap.macos.defaults]` entries (macOS)
-    surrounded by `pre-defaults`/`post-defaults` hooks
-11. `mise bootstrap macos launchd-agents apply` — install/load
-    `[bootstrap.macos.launchd.agents]`
-12. `mise bootstrap linux systemd-units apply` — install/start
-    `[bootstrap.linux.systemd.units]`
-13. `mise bootstrap user apply` — set `[bootstrap.user].login_shell`
-    (Unix)
-    surrounded by `pre-user`/`post-user` hooks
-14. `mise install` — install missing tools from `[tools]`
-    surrounded by `pre-tools`/`post-tools` hooks; package-plugin entries
-    from `[bootstrap.packages]` install afterward, followed by
-    `[bootstrap.hooks.post-packages]`
-15. `mise run bootstrap` — if a task named `bootstrap` is defined
-16. `[bootstrap.hooks.final]` — optional final hook
+1. Linux accounts, then package-manager plugins.
+2. The pre-packages hook, then packages handled by built-in managers.
+3. Privileged files/directories, system services, firewall, and Compose projects.
+4. Git repositories, then dotfiles, each with its pre/post hooks.
+5. Shell activation, macOS defaults and LaunchAgents, Linux user units, and user settings.
+6. The pre-tools hook, versioned tools, and post-tools hook.
+7. Package-plugin packages, then the post-packages hook.
+8. The `bootstrap` task, when defined, then the final hook.
 
-The declarative steps converge — anything already in its desired state
-is skipped, so re-running is safe. The `bootstrap` task runs on every
-invocation; keep it idempotent. Use it for any project-specific setup
-that doesn't fit the declarative sections (seeding databases, auth flows,
-etc.) — it runs with the installed tools on PATH.
+Defaults and user settings also have pre/post hooks. See
+<https://mise.jdx.dev/bootstrap.html> for the complete phase order and configuration.
+Unchanged resource state is skipped, but hooks and the bootstrap task can run again;
+make those commands safe to repeat. Dotfile templates may execute while checking state.
 
-Use `--skip <part>` to skip named parts, or `--only <part>` to run just
-named parts. Both flags can be repeated or comma-separated, but they
-cannot be used together.
+Use `--dry-run` to preview the selected workflow, `bootstrap status` to inspect state,
+or `bootstrap plan` for the declarative-resource plan. `--only` and `--skip` accept
+repeated or comma-separated parts and cannot be combined.
 
 ## Flags
 - **`--from <GIT_URL>`** — Clone a git repository and bootstrap from its configuration
@@ -119,3 +91,11 @@ mise bootstrap user apply --dry-run
 - [`mise bootstrap services <SUBCOMMAND>`](/cli/bootstrap/services.html)
 - [`mise bootstrap status [FLAGS]`](/cli/bootstrap/status.html)
 - [`mise bootstrap user <SUBCOMMAND>`](/cli/bootstrap/user.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Bootstrap workflow](/bootstrap.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/accounts.md
+++ b/docs/cli/bootstrap/accounts.md
@@ -7,6 +7,9 @@
 
 Manage Linux users and groups from `[bootstrap.users]` and `[bootstrap.groups]`
 
+These are system accounts on the target Linux host. Inspect `status` or an apply
+preview before changing user IDs, memberships, or account state.
+
 ## Flags
 - **`-h --help`** — Print help
 
@@ -14,3 +17,11 @@ Manage Linux users and groups from `[bootstrap.users]` and `[bootstrap.groups]`
 
 - [`mise bootstrap accounts apply [-n --dry-run] [-y --yes]`](/cli/bootstrap/accounts/apply.html)
 - [`mise bootstrap accounts status [-J --json] [--missing]`](/cli/bootstrap/accounts/status.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Users and groups](/bootstrap/accounts.html).
+- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/accounts/apply.md
+++ b/docs/cli/bootstrap/accounts/apply.md
@@ -11,3 +11,11 @@ Apply configured Linux users and groups
 - **`-n --dry-run`** — Print what would change without changing anything
 - **`-y --yes`** — Skip the confirmation prompt
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Users and groups](/bootstrap/accounts.html).
+- [`mise bootstrap accounts`](/cli/bootstrap/accounts.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/accounts/apply.md
+++ b/docs/cli/bootstrap/accounts/apply.md
@@ -17,5 +17,5 @@ Apply configured Linux users and groups
 ## Related documentation
 
 - [Users and groups](/bootstrap/accounts.html).
-- [`mise bootstrap accounts`](/cli/bootstrap/accounts.html).
+- [`mise bootstrap accounts <SUBCOMMAND>`](/cli/bootstrap/accounts.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/accounts/status.md
+++ b/docs/cli/bootstrap/accounts/status.md
@@ -11,3 +11,11 @@ Show configured Linux user and group state
 - **`-J --json`** — Output in JSON format
 - **`--missing`** — Exit with code 1 when any account is not converged
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Users and groups](/bootstrap/accounts.html).
+- [`mise bootstrap accounts`](/cli/bootstrap/accounts.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/accounts/status.md
+++ b/docs/cli/bootstrap/accounts/status.md
@@ -17,5 +17,5 @@ Show configured Linux user and group state
 ## Related documentation
 
 - [Users and groups](/bootstrap/accounts.html).
-- [`mise bootstrap accounts`](/cli/bootstrap/accounts.html).
+- [`mise bootstrap accounts <SUBCOMMAND>`](/cli/bootstrap/accounts.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/compose.md
+++ b/docs/cli/bootstrap/compose.md
@@ -7,6 +7,9 @@
 
 Manage Docker Compose projects from `[bootstrap.compose]`
 
+Requires a working Docker engine and Compose command on the target host. `apply`
+reconciles declared project state; `status` inspects the existing projects.
+
 ## Flags
 - **`-h --help`** — Print help
 
@@ -14,3 +17,11 @@ Manage Docker Compose projects from `[bootstrap.compose]`
 
 - [`mise bootstrap compose apply [-n --dry-run] [-y --yes]`](/cli/bootstrap/compose/apply.html)
 - [`mise bootstrap compose status [-J --json] [--missing]`](/cli/bootstrap/compose/status.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Compose projects](/bootstrap/compose.html).
+- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/compose/apply.md
+++ b/docs/cli/bootstrap/compose/apply.md
@@ -17,5 +17,5 @@ Apply configured Docker Compose project state
 ## Related documentation
 
 - [Compose projects](/bootstrap/compose.html).
-- [`mise bootstrap compose`](/cli/bootstrap/compose.html).
+- [`mise bootstrap compose <SUBCOMMAND>`](/cli/bootstrap/compose.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/compose/apply.md
+++ b/docs/cli/bootstrap/compose/apply.md
@@ -11,3 +11,11 @@ Apply configured Docker Compose project state
 - **`-n --dry-run`** — Print what would change without changing anything
 - **`-y --yes`** — Skip the confirmation prompt
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Compose projects](/bootstrap/compose.html).
+- [`mise bootstrap compose`](/cli/bootstrap/compose.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/compose/status.md
+++ b/docs/cli/bootstrap/compose/status.md
@@ -17,5 +17,5 @@ Show configured Docker Compose project state
 ## Related documentation
 
 - [Compose projects](/bootstrap/compose.html).
-- [`mise bootstrap compose`](/cli/bootstrap/compose.html).
+- [`mise bootstrap compose <SUBCOMMAND>`](/cli/bootstrap/compose.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/compose/status.md
+++ b/docs/cli/bootstrap/compose/status.md
@@ -11,3 +11,11 @@ Show configured Docker Compose project state
 - **`-J --json`** — Output in JSON format
 - **`--missing`** — Exit with code 1 when any Compose project is not converged
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Compose projects](/bootstrap/compose.html).
+- [`mise bootstrap compose`](/cli/bootstrap/compose.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/config-roots.md
+++ b/docs/cli/bootstrap/config-roots.md
@@ -7,6 +7,17 @@
 
 Show non-composed bootstrap declarations in each selected configuration root
 
+Use this to locate the origin of declarations before composition. For the
+combined desired state and its changes, use `bootstrap plan`.
+
 ## Flags
 - **`-J --json`** — Output in JSON format
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Bootstrap workflow](/bootstrap.html).
+- [`mise bootstrap`](/cli/bootstrap.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/config-roots.md
+++ b/docs/cli/bootstrap/config-roots.md
@@ -19,5 +19,5 @@ combined desired state and its changes, use `bootstrap plan`.
 ## Related documentation
 
 - [Bootstrap workflow](/bootstrap.html).
-- [`mise bootstrap`](/cli/bootstrap.html).
+- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/dotfiles.md
+++ b/docs/cli/bootstrap/dotfiles.md
@@ -18,3 +18,11 @@ Manage dotfiles from `[dotfiles]`
 - [`mise bootstrap dotfiles edit [FLAGS] <TARGET>`](/cli/bootstrap/dotfiles/edit.html)
 - [`mise bootstrap dotfiles status [-J --json] [--missing] [TARGET]…`](/cli/bootstrap/dotfiles/status.html)
 - [`mise bootstrap dotfiles unapply [FLAGS] [TARGET]…`](/cli/bootstrap/dotfiles/unapply.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Dotfile ownership and modes](/dotfiles.html).
+- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/dotfiles/add.md
+++ b/docs/cli/bootstrap/dotfiles/add.md
@@ -9,7 +9,9 @@ Add or update dotfiles in `[dotfiles]`
 
 If the target is already managed, this updates its source from the live
 target. Otherwise it creates a `[dotfiles]` entry and seeds the source
-under `dotfiles.root` unless `--source` is provided.
+under `dotfiles.root` unless `--source` is provided. Captured entries are
+applied unless `--no-apply` is passed. Use `--dry-run` to preview both the
+source capture and config write without making those changes.
 
 ## Arguments
 - **`[TARGET]…`** — Targets to add or update
@@ -35,3 +37,11 @@ mise bootstrap dotfiles add --mode copy ~/.config/starship.toml
 mise bootstrap dotfiles add --source dotfiles/gitconfig ~/.gitconfig
 mise bootstrap dotfiles add --changed
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Dotfile ownership and modes](/dotfiles.html).
+- [`mise bootstrap dotfiles <SUBCOMMAND>`](/cli/bootstrap/dotfiles.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/dotfiles/apply.md
+++ b/docs/cli/bootstrap/dotfiles/apply.md
@@ -28,3 +28,11 @@ mise bootstrap dotfiles apply
 mise bootstrap dotfiles apply --dry-run
 mise bootstrap dotfiles apply --force --yes
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Dotfile ownership and modes](/dotfiles.html).
+- [`mise bootstrap dotfiles <SUBCOMMAND>`](/cli/bootstrap/dotfiles.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/dotfiles/diff.md
+++ b/docs/cli/bootstrap/dotfiles/diff.md
@@ -19,3 +19,11 @@ Show the changes needed to apply dotfiles from `[dotfiles]`
 mise bootstrap dotfiles diff
 mise bootstrap dotfiles diff ~/.zshrc
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Dotfile ownership and modes](/dotfiles.html).
+- [`mise bootstrap dotfiles <SUBCOMMAND>`](/cli/bootstrap/dotfiles.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/dotfiles/edit.md
+++ b/docs/cli/bootstrap/dotfiles/edit.md
@@ -23,3 +23,11 @@ Edit a managed dotfile source
 mise bootstrap dotfiles edit ~/.zshrc
 mise bootstrap dotfiles edit --apply ~/.config/starship.toml
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Dotfile ownership and modes](/dotfiles.html).
+- [`mise bootstrap dotfiles <SUBCOMMAND>`](/cli/bootstrap/dotfiles.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/dotfiles/status.md
+++ b/docs/cli/bootstrap/dotfiles/status.md
@@ -8,6 +8,9 @@
 
 Show the status of dotfiles from `[dotfiles]`
 
+Template entries are rendered to compare their output; trusted template
+functions may execute. `--missing` changes the exit status, not the listing.
+
 ## Arguments
 - **`[TARGET]…`** — Only show these targets
 
@@ -25,3 +28,11 @@ mise bootstrap dotfiles status ~/.zshrc
 mise bootstrap dotfiles status --json
 mise bootstrap dotfiles status --missing # exit 1 if anything is out of sync
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Dotfile ownership and modes](/dotfiles.html).
+- [`mise bootstrap dotfiles <SUBCOMMAND>`](/cli/bootstrap/dotfiles.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/dotfiles/unapply.md
+++ b/docs/cli/bootstrap/dotfiles/unapply.md
@@ -9,7 +9,8 @@ Remove dotfiles applied from `[dotfiles]`
 
 Removes configured whole-file entries and edits while preserving files
 mise cannot identify as managed. Modified copies, templates, and plain-line
-edits require `--force`.
+edits require `--force`. Source files and configuration entries are retained.
+Run this before deleting a declaration so mise can still identify its targets.
 
 ## Arguments
 - **`[TARGET]…`** — Only unapply these targets
@@ -28,3 +29,11 @@ mise bootstrap dotfiles unapply ~/.zshrc
 mise bootstrap dotfiles unapply --dry-run
 mise bootstrap dotfiles unapply --force --yes
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Dotfile ownership and modes](/dotfiles.html).
+- [`mise bootstrap dotfiles <SUBCOMMAND>`](/cli/bootstrap/dotfiles.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/files.md
+++ b/docs/cli/bootstrap/files.md
@@ -7,6 +7,9 @@
 
 Manage privileged files and directories from `[bootstrap.files]` and `[bootstrap.directories]`
 
+Use these resources for ownership, permissions, and desired presence on a host.
+For personal symlinks, copies, or edits, use `[dotfiles]` and `bootstrap dotfiles`.
+
 ## Flags
 - **`-h --help`** — Print help
 
@@ -14,3 +17,11 @@ Manage privileged files and directories from `[bootstrap.files]` and `[bootstrap
 
 - [`mise bootstrap files apply [FLAGS]`](/cli/bootstrap/files/apply.html)
 - [`mise bootstrap files status [FLAGS]`](/cli/bootstrap/files/status.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Privileged files and directories](/bootstrap/files.html).
+- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/files/apply.md
+++ b/docs/cli/bootstrap/files/apply.md
@@ -12,3 +12,11 @@ Apply configured privileged files and directories
 - **`-y --yes`** — Skip the confirmation prompt
 - **`--prompt-secrets`** — Prompt securely for missing bootstrap secret inputs
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Privileged files and directories](/bootstrap/files.html).
+- [`mise bootstrap files`](/cli/bootstrap/files.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/files/apply.md
+++ b/docs/cli/bootstrap/files/apply.md
@@ -18,5 +18,5 @@ Apply configured privileged files and directories
 ## Related documentation
 
 - [Privileged files and directories](/bootstrap/files.html).
-- [`mise bootstrap files`](/cli/bootstrap/files.html).
+- [`mise bootstrap files <SUBCOMMAND>`](/cli/bootstrap/files.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/files/status.md
+++ b/docs/cli/bootstrap/files/status.md
@@ -12,3 +12,11 @@ Show configured privileged file and directory state
 - **`--missing`** — Exit with code 1 when any resource is not converged
 - **`--prompt-secrets`** — Prompt securely for missing bootstrap secret inputs
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Privileged files and directories](/bootstrap/files.html).
+- [`mise bootstrap files`](/cli/bootstrap/files.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/files/status.md
+++ b/docs/cli/bootstrap/files/status.md
@@ -18,5 +18,5 @@ Show configured privileged file and directory state
 ## Related documentation
 
 - [Privileged files and directories](/bootstrap/files.html).
-- [`mise bootstrap files`](/cli/bootstrap/files.html).
+- [`mise bootstrap files <SUBCOMMAND>`](/cli/bootstrap/files.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/firewall.md
+++ b/docs/cli/bootstrap/firewall.md
@@ -7,6 +7,9 @@
 
 Manage the Linux host firewall from `[bootstrap.linux.firewall]`
 
+This manages host firewall policy and rules. Review `apply --dry-run` before applying
+a policy to a remote machine, including the rule that permits your SSH connection.
+
 ## Flags
 - **`-h --help`** — Print help
 
@@ -14,3 +17,11 @@ Manage the Linux host firewall from `[bootstrap.linux.firewall]`
 
 - [`mise bootstrap firewall apply [-n --dry-run] [-y --yes]`](/cli/bootstrap/firewall/apply.html)
 - [`mise bootstrap firewall status [-J --json] [--missing]`](/cli/bootstrap/firewall/status.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Host firewall](/bootstrap/firewall.html).
+- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/firewall/apply.md
+++ b/docs/cli/bootstrap/firewall/apply.md
@@ -17,5 +17,5 @@ Apply the configured Linux host firewall
 ## Related documentation
 
 - [Host firewall](/bootstrap/firewall.html).
-- [`mise bootstrap firewall`](/cli/bootstrap/firewall.html).
+- [`mise bootstrap firewall <SUBCOMMAND>`](/cli/bootstrap/firewall.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/firewall/apply.md
+++ b/docs/cli/bootstrap/firewall/apply.md
@@ -11,3 +11,11 @@ Apply the configured Linux host firewall
 - **`-n --dry-run`** — Print what would change without changing anything
 - **`-y --yes`** — Skip the confirmation prompt
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Host firewall](/bootstrap/firewall.html).
+- [`mise bootstrap firewall`](/cli/bootstrap/firewall.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/firewall/status.md
+++ b/docs/cli/bootstrap/firewall/status.md
@@ -17,5 +17,5 @@ Show configured Linux host firewall state
 ## Related documentation
 
 - [Host firewall](/bootstrap/firewall.html).
-- [`mise bootstrap firewall`](/cli/bootstrap/firewall.html).
+- [`mise bootstrap firewall <SUBCOMMAND>`](/cli/bootstrap/firewall.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/firewall/status.md
+++ b/docs/cli/bootstrap/firewall/status.md
@@ -11,3 +11,11 @@ Show configured Linux host firewall state
 - **`-J --json`** — Output in JSON format
 - **`--missing`** — Exit with code 1 when the firewall is not converged
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Host firewall](/bootstrap/firewall.html).
+- [`mise bootstrap firewall`](/cli/bootstrap/firewall.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/launchd/apply.md
+++ b/docs/cli/bootstrap/launchd/apply.md
@@ -11,3 +11,13 @@ Install and load LaunchAgents from `[bootstrap.macos.launchd.agents]`
 - **`-n --dry-run`** — Print the commands that would run without running them
 - **`-y --yes`** — Skip the confirmation prompt
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+This is a compatibility spelling. Use [`mise bootstrap macos launchd-agents apply`](/cli/bootstrap/macos/launchd-agents/apply.html) in new scripts.
+
+## Related documentation
+
+- [LaunchAgents](/bootstrap/launchd.html).
+- [`mise bootstrap`](/cli/bootstrap.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/launchd/apply.md
+++ b/docs/cli/bootstrap/launchd/apply.md
@@ -14,10 +14,10 @@ Install and load LaunchAgents from `[bootstrap.macos.launchd.agents]`
 
 <!-- generated reference navigation -->
 
-This is a compatibility spelling. Use [`mise bootstrap macos launchd-agents apply`](/cli/bootstrap/macos/launchd-agents/apply.html) in new scripts.
+This is a compatibility spelling. Use [`mise bootstrap macos launchd-agents apply [-n --dry-run] [-y --yes]`](/cli/bootstrap/macos/launchd-agents/apply.html) in new scripts.
 
 ## Related documentation
 
 - [LaunchAgents](/bootstrap/launchd.html).
-- [`mise bootstrap`](/cli/bootstrap.html).
+- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/launchd/status.md
+++ b/docs/cli/bootstrap/launchd/status.md
@@ -14,10 +14,10 @@ Show the state of LaunchAgents from `[bootstrap.macos.launchd.agents]`
 
 <!-- generated reference navigation -->
 
-This is a compatibility spelling. Use [`mise bootstrap macos launchd-agents status`](/cli/bootstrap/macos/launchd-agents/status.html) in new scripts.
+This is a compatibility spelling. Use [`mise bootstrap macos launchd-agents status [-J --json] [--missing]`](/cli/bootstrap/macos/launchd-agents/status.html) in new scripts.
 
 ## Related documentation
 
 - [LaunchAgents](/bootstrap/launchd.html).
-- [`mise bootstrap`](/cli/bootstrap.html).
+- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/launchd/status.md
+++ b/docs/cli/bootstrap/launchd/status.md
@@ -11,3 +11,13 @@ Show the state of LaunchAgents from `[bootstrap.macos.launchd.agents]`
 - **`-J --json`** — Output in JSON format
 - **`--missing`** — Exit with code 1 if any configured LaunchAgent is not in its desired state
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+This is a compatibility spelling. Use [`mise bootstrap macos launchd-agents status`](/cli/bootstrap/macos/launchd-agents/status.html) in new scripts.
+
+## Related documentation
+
+- [LaunchAgents](/bootstrap/launchd.html).
+- [`mise bootstrap`](/cli/bootstrap.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/linux.md
+++ b/docs/cli/bootstrap/linux.md
@@ -13,3 +13,11 @@ Manage Linux bootstrap config from `[bootstrap.linux]`
 ## Subcommands
 
 - [`mise bootstrap linux systemd-units <SUBCOMMAND>`](/cli/bootstrap/linux/systemd-units.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [systemd user units](/bootstrap/systemd.html).
+- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/linux/systemd-units.md
+++ b/docs/cli/bootstrap/linux/systemd-units.md
@@ -8,6 +8,9 @@
 
 Manage systemd user services from `[bootstrap.linux.systemd.units]`
 
+Installs unit files and reconciles services in the current user manager. This is
+separate from system services declared in `[bootstrap.services]`.
+
 ## Flags
 - **`-h --help`** — Print help
 
@@ -15,3 +18,11 @@ Manage systemd user services from `[bootstrap.linux.systemd.units]`
 
 - [`mise bootstrap linux systemd-units apply [-n --dry-run] [-y --yes]`](/cli/bootstrap/linux/systemd-units/apply.html)
 - [`mise bootstrap linux systemd-units status [-J --json] [--missing]`](/cli/bootstrap/linux/systemd-units/status.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [systemd user units](/bootstrap/systemd.html).
+- [`mise bootstrap linux <SUBCOMMAND>`](/cli/bootstrap/linux.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/linux/systemd-units/apply.md
+++ b/docs/cli/bootstrap/linux/systemd-units/apply.md
@@ -17,5 +17,5 @@ Install and start systemd user services from `[bootstrap.linux.systemd.units]`
 ## Related documentation
 
 - [systemd user units](/bootstrap/systemd.html).
-- [`mise bootstrap linux systemd-units`](/cli/bootstrap/linux/systemd-units.html).
+- [`mise bootstrap linux systemd-units <SUBCOMMAND>`](/cli/bootstrap/linux/systemd-units.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/linux/systemd-units/apply.md
+++ b/docs/cli/bootstrap/linux/systemd-units/apply.md
@@ -11,3 +11,11 @@ Install and start systemd user services from `[bootstrap.linux.systemd.units]`
 - **`-n --dry-run`** — Print the commands that would run without running them
 - **`-y --yes`** — Skip the confirmation prompt
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [systemd user units](/bootstrap/systemd.html).
+- [`mise bootstrap linux systemd-units`](/cli/bootstrap/linux/systemd-units.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/linux/systemd-units/status.md
+++ b/docs/cli/bootstrap/linux/systemd-units/status.md
@@ -17,5 +17,5 @@ Show the state of systemd user services from `[bootstrap.linux.systemd.units]`
 ## Related documentation
 
 - [systemd user units](/bootstrap/systemd.html).
-- [`mise bootstrap linux systemd-units`](/cli/bootstrap/linux/systemd-units.html).
+- [`mise bootstrap linux systemd-units <SUBCOMMAND>`](/cli/bootstrap/linux/systemd-units.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/linux/systemd-units/status.md
+++ b/docs/cli/bootstrap/linux/systemd-units/status.md
@@ -11,3 +11,11 @@ Show the state of systemd user services from `[bootstrap.linux.systemd.units]`
 - **`-J --json`** — Output in JSON format
 - **`--missing`** — Exit with code 1 if any configured systemd user service is not in its desired state
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [systemd user units](/bootstrap/systemd.html).
+- [`mise bootstrap linux systemd-units`](/cli/bootstrap/linux/systemd-units.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/macos-defaults/apply.md
+++ b/docs/cli/bootstrap/macos-defaults/apply.md
@@ -14,10 +14,10 @@ Write macOS defaults from `[bootstrap.macos.defaults]`
 
 <!-- generated reference navigation -->
 
-This is a compatibility spelling. Use [`mise bootstrap macos defaults apply`](/cli/bootstrap/macos/defaults/apply.html) in new scripts.
+This is a compatibility spelling. Use [`mise bootstrap macos defaults apply [-n --dry-run] [-y --yes]`](/cli/bootstrap/macos/defaults/apply.html) in new scripts.
 
 ## Related documentation
 
 - [macOS defaults](/bootstrap/macos-defaults.html).
-- [`mise bootstrap`](/cli/bootstrap.html).
+- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/macos-defaults/apply.md
+++ b/docs/cli/bootstrap/macos-defaults/apply.md
@@ -11,3 +11,13 @@ Write macOS defaults from `[bootstrap.macos.defaults]`
 - **`-n --dry-run`** — Print the commands that would run without running them
 - **`-y --yes`** — Skip the confirmation prompt
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+This is a compatibility spelling. Use [`mise bootstrap macos defaults apply`](/cli/bootstrap/macos/defaults/apply.html) in new scripts.
+
+## Related documentation
+
+- [macOS defaults](/bootstrap/macos-defaults.html).
+- [`mise bootstrap`](/cli/bootstrap.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/macos-defaults/status.md
+++ b/docs/cli/bootstrap/macos-defaults/status.md
@@ -11,3 +11,13 @@ Show whether macOS defaults match `[bootstrap.macos.defaults]`
 - **`-J --json`** — Output in JSON format
 - **`--missing`** — Exit with code 1 if any configured defaults are not in their desired state
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+This is a compatibility spelling. Use [`mise bootstrap macos defaults status`](/cli/bootstrap/macos/defaults/status.html) in new scripts.
+
+## Related documentation
+
+- [macOS defaults](/bootstrap/macos-defaults.html).
+- [`mise bootstrap`](/cli/bootstrap.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/macos-defaults/status.md
+++ b/docs/cli/bootstrap/macos-defaults/status.md
@@ -14,10 +14,10 @@ Show whether macOS defaults match `[bootstrap.macos.defaults]`
 
 <!-- generated reference navigation -->
 
-This is a compatibility spelling. Use [`mise bootstrap macos defaults status`](/cli/bootstrap/macos/defaults/status.html) in new scripts.
+This is a compatibility spelling. Use [`mise bootstrap macos defaults status [-J --json] [--missing]`](/cli/bootstrap/macos/defaults/status.html) in new scripts.
 
 ## Related documentation
 
 - [macOS defaults](/bootstrap/macos-defaults.html).
-- [`mise bootstrap`](/cli/bootstrap.html).
+- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/macos.md
+++ b/docs/cli/bootstrap/macos.md
@@ -14,3 +14,11 @@ Manage macOS bootstrap config from `[bootstrap.macos]`
 
 - [`mise bootstrap macos defaults <SUBCOMMAND>`](/cli/bootstrap/macos/defaults.html)
 - [`mise bootstrap macos launchd-agents <SUBCOMMAND>`](/cli/bootstrap/macos/launchd-agents.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [macOS defaults](/bootstrap/macos-defaults.html).
+- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/macos/defaults.md
+++ b/docs/cli/bootstrap/macos/defaults.md
@@ -7,6 +7,9 @@
 
 Manage macOS defaults from `[bootstrap.macos.defaults]`
 
+Declares typed preferences written with macOS defaults. Application preferences
+may require restarting the affected application before the change becomes visible.
+
 ## Flags
 - **`-h --help`** — Print help
 
@@ -14,3 +17,11 @@ Manage macOS defaults from `[bootstrap.macos.defaults]`
 
 - [`mise bootstrap macos defaults apply [-n --dry-run] [-y --yes]`](/cli/bootstrap/macos/defaults/apply.html)
 - [`mise bootstrap macos defaults status [-J --json] [--missing]`](/cli/bootstrap/macos/defaults/status.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [macOS defaults](/bootstrap/macos-defaults.html).
+- [`mise bootstrap macos <SUBCOMMAND>`](/cli/bootstrap/macos.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/macos/defaults/apply.md
+++ b/docs/cli/bootstrap/macos/defaults/apply.md
@@ -17,5 +17,5 @@ Write macOS defaults from `[bootstrap.macos.defaults]`
 ## Related documentation
 
 - [macOS defaults](/bootstrap/macos-defaults.html).
-- [`mise bootstrap macos defaults`](/cli/bootstrap/macos/defaults.html).
+- [`mise bootstrap macos defaults <SUBCOMMAND>`](/cli/bootstrap/macos/defaults.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/macos/defaults/apply.md
+++ b/docs/cli/bootstrap/macos/defaults/apply.md
@@ -11,3 +11,11 @@ Write macOS defaults from `[bootstrap.macos.defaults]`
 - **`-n --dry-run`** — Print the commands that would run without running them
 - **`-y --yes`** — Skip the confirmation prompt
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [macOS defaults](/bootstrap/macos-defaults.html).
+- [`mise bootstrap macos defaults`](/cli/bootstrap/macos/defaults.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/macos/defaults/status.md
+++ b/docs/cli/bootstrap/macos/defaults/status.md
@@ -11,3 +11,11 @@ Show whether macOS defaults match `[bootstrap.macos.defaults]`
 - **`-J --json`** — Output in JSON format
 - **`--missing`** — Exit with code 1 if any configured defaults are not in their desired state
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [macOS defaults](/bootstrap/macos-defaults.html).
+- [`mise bootstrap macos defaults`](/cli/bootstrap/macos/defaults.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/macos/defaults/status.md
+++ b/docs/cli/bootstrap/macos/defaults/status.md
@@ -17,5 +17,5 @@ Show whether macOS defaults match `[bootstrap.macos.defaults]`
 ## Related documentation
 
 - [macOS defaults](/bootstrap/macos-defaults.html).
-- [`mise bootstrap macos defaults`](/cli/bootstrap/macos/defaults.html).
+- [`mise bootstrap macos defaults <SUBCOMMAND>`](/cli/bootstrap/macos/defaults.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/macos/launchd-agents.md
+++ b/docs/cli/bootstrap/macos/launchd-agents.md
@@ -8,6 +8,9 @@
 
 Manage macOS LaunchAgents from `[bootstrap.macos.launchd.agents]`
 
+Installs plist files and reconciles agents in the current GUI login domain. Run
+from the intended user session; an SSH-only session may not have that domain.
+
 ## Flags
 - **`-h --help`** — Print help
 
@@ -15,3 +18,11 @@ Manage macOS LaunchAgents from `[bootstrap.macos.launchd.agents]`
 
 - [`mise bootstrap macos launchd-agents apply [-n --dry-run] [-y --yes]`](/cli/bootstrap/macos/launchd-agents/apply.html)
 - [`mise bootstrap macos launchd-agents status [-J --json] [--missing]`](/cli/bootstrap/macos/launchd-agents/status.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [LaunchAgents](/bootstrap/launchd.html).
+- [`mise bootstrap macos <SUBCOMMAND>`](/cli/bootstrap/macos.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/macos/launchd-agents/apply.md
+++ b/docs/cli/bootstrap/macos/launchd-agents/apply.md
@@ -11,3 +11,11 @@ Install and load LaunchAgents from `[bootstrap.macos.launchd.agents]`
 - **`-n --dry-run`** — Print the commands that would run without running them
 - **`-y --yes`** — Skip the confirmation prompt
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [LaunchAgents](/bootstrap/launchd.html).
+- [`mise bootstrap macos launchd-agents`](/cli/bootstrap/macos/launchd-agents.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/macos/launchd-agents/apply.md
+++ b/docs/cli/bootstrap/macos/launchd-agents/apply.md
@@ -17,5 +17,5 @@ Install and load LaunchAgents from `[bootstrap.macos.launchd.agents]`
 ## Related documentation
 
 - [LaunchAgents](/bootstrap/launchd.html).
-- [`mise bootstrap macos launchd-agents`](/cli/bootstrap/macos/launchd-agents.html).
+- [`mise bootstrap macos launchd-agents <SUBCOMMAND>`](/cli/bootstrap/macos/launchd-agents.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/macos/launchd-agents/status.md
+++ b/docs/cli/bootstrap/macos/launchd-agents/status.md
@@ -11,3 +11,11 @@ Show the state of LaunchAgents from `[bootstrap.macos.launchd.agents]`
 - **`-J --json`** — Output in JSON format
 - **`--missing`** — Exit with code 1 if any configured LaunchAgent is not in its desired state
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [LaunchAgents](/bootstrap/launchd.html).
+- [`mise bootstrap macos launchd-agents`](/cli/bootstrap/macos/launchd-agents.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/macos/launchd-agents/status.md
+++ b/docs/cli/bootstrap/macos/launchd-agents/status.md
@@ -17,5 +17,5 @@ Show the state of LaunchAgents from `[bootstrap.macos.launchd.agents]`
 ## Related documentation
 
 - [LaunchAgents](/bootstrap/launchd.html).
-- [`mise bootstrap macos launchd-agents`](/cli/bootstrap/macos/launchd-agents.html).
+- [`mise bootstrap macos launchd-agents <SUBCOMMAND>`](/cli/bootstrap/macos/launchd-agents.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/mise-shell-activate.md
+++ b/docs/cli/bootstrap/mise-shell-activate.md
@@ -8,6 +8,9 @@
 
 Manage mise shell activation from `[bootstrap.mise_shell_activate]`
 
+Writes managed activation blocks into the declared shell startup files. The
+current shell is not reactivated by this command; open a new shell afterward.
+
 ## Flags
 - **`-h --help`** — Print help
 
@@ -15,3 +18,11 @@ Manage mise shell activation from `[bootstrap.mise_shell_activate]`
 
 - [`mise bootstrap mise-shell-activate apply [-n --dry-run] [-y --yes]`](/cli/bootstrap/mise-shell-activate/apply.html)
 - [`mise bootstrap mise-shell-activate status [-J --json] [--missing]`](/cli/bootstrap/mise-shell-activate/status.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Shell setup](/bootstrap/shell.html).
+- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/mise-shell-activate/apply.md
+++ b/docs/cli/bootstrap/mise-shell-activate/apply.md
@@ -17,5 +17,5 @@ Configure shell activation from `[bootstrap.mise_shell_activate]`
 ## Related documentation
 
 - [Shell setup](/bootstrap/shell.html).
-- [`mise bootstrap mise-shell-activate`](/cli/bootstrap/mise-shell-activate.html).
+- [`mise bootstrap mise-shell-activate <SUBCOMMAND>`](/cli/bootstrap/mise-shell-activate.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/mise-shell-activate/apply.md
+++ b/docs/cli/bootstrap/mise-shell-activate/apply.md
@@ -11,3 +11,11 @@ Configure shell activation from `[bootstrap.mise_shell_activate]`
 - **`-n --dry-run`** — Print the actions that would run without writing anything
 - **`-y --yes`** — Skip the confirmation prompt
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Shell setup](/bootstrap/shell.html).
+- [`mise bootstrap mise-shell-activate`](/cli/bootstrap/mise-shell-activate.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/mise-shell-activate/status.md
+++ b/docs/cli/bootstrap/mise-shell-activate/status.md
@@ -17,5 +17,5 @@ Show whether shell activation matches `[bootstrap.mise_shell_activate]`
 ## Related documentation
 
 - [Shell setup](/bootstrap/shell.html).
-- [`mise bootstrap mise-shell-activate`](/cli/bootstrap/mise-shell-activate.html).
+- [`mise bootstrap mise-shell-activate <SUBCOMMAND>`](/cli/bootstrap/mise-shell-activate.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/mise-shell-activate/status.md
+++ b/docs/cli/bootstrap/mise-shell-activate/status.md
@@ -11,3 +11,11 @@ Show whether shell activation matches `[bootstrap.mise_shell_activate]`
 - **`-J --json`** — Output in JSON format
 - **`--missing`** — Exit with code 1 if any configured shell activation is not in its desired state
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Shell setup](/bootstrap/shell.html).
+- [`mise bootstrap mise-shell-activate`](/cli/bootstrap/mise-shell-activate.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/packages.md
+++ b/docs/cli/bootstrap/packages.md
@@ -19,3 +19,11 @@ Manage bootstrap system packages from `[bootstrap.packages]`
 - [`mise bootstrap packages status [-J --json] [--missing]`](/cli/bootstrap/packages/status.html)
 - [`mise bootstrap packages upgrade [FLAGS] [PACKAGE]…`](/cli/bootstrap/packages/upgrade.html)
 - [`mise bootstrap packages use [FLAGS] <PACKAGE>…`](/cli/bootstrap/packages/use.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Host packages](/bootstrap/packages/).
+- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/packages/apply.md
+++ b/docs/cli/bootstrap/packages/apply.md
@@ -35,3 +35,11 @@ mise bootstrap packages apply brew:jq brew-cask:firefox
 mise bootstrap packages apply --dry-run
 mise bootstrap packages apply --manager apt --yes
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Host packages](/bootstrap/packages/).
+- [`mise bootstrap packages <SUBCOMMAND>`](/cli/bootstrap/packages.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/packages/brew.md
+++ b/docs/cli/bootstrap/packages/brew.md
@@ -17,3 +17,11 @@ can be fetched directly by mise without a Homebrew installation.
 
 - [`mise bootstrap packages brew tap [FLAGS] <TAP> [URL]`](/cli/bootstrap/packages/brew/tap.html)
 - [`mise bootstrap packages brew untap [FLAGS] <TAPS>…`](/cli/bootstrap/packages/brew/untap.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Homebrew packages and taps](/bootstrap/packages/brew.html).
+- [`mise bootstrap packages <SUBCOMMAND>`](/cli/bootstrap/packages.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/packages/brew/tap.md
+++ b/docs/cli/bootstrap/packages/brew/tap.md
@@ -9,7 +9,7 @@ Add a Homebrew tap URL to [bootstrap.brew.taps]
 
 ## Arguments
 - **`<TAP>`** — Tap name, e.g. `owner/repo`
-- **`[URL]`** — GitHub URL for the tap. Defaults to <https://github.com/&lt;owner>/homebrew-&lt;repo>.git>
+- **`[URL]`** — Repository URL for the tap; defaults to GitHub's owner/homebrew-repo.git naming
 
 ## Flags
 - **`-l --local`** — Write to the local config instead of the global config
@@ -25,3 +25,11 @@ Add a Homebrew tap URL to [bootstrap.brew.taps]
 mise bootstrap packages brew tap railwaycat/emacsmacport
 mise bootstrap packages brew tap acme/tools https://github.com/acme/homebrew-tools.git
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Homebrew packages and taps](/bootstrap/packages/brew.html).
+- [`mise bootstrap packages brew <SUBCOMMAND>`](/cli/bootstrap/packages/brew.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/packages/brew/untap.md
+++ b/docs/cli/bootstrap/packages/brew/untap.md
@@ -24,3 +24,11 @@ Remove Homebrew tap URLs from [bootstrap.brew.taps]
 ```
 mise bootstrap packages brew untap railwaycat/emacsmacport
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Homebrew packages and taps](/bootstrap/packages/brew.html).
+- [`mise bootstrap packages brew <SUBCOMMAND>`](/cli/bootstrap/packages/brew.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/packages/import.md
+++ b/docs/cli/bootstrap/packages/import.md
@@ -34,3 +34,11 @@ mise bootstrap packages import --manager brew --all
 mise bootstrap packages import --manager brew --global
 mise bootstrap packages import --manager brew --dry-run
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Host packages](/bootstrap/packages/).
+- [`mise bootstrap packages <SUBCOMMAND>`](/cli/bootstrap/packages.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/packages/prune.md
+++ b/docs/cli/bootstrap/packages/prune.md
@@ -30,3 +30,11 @@ mise bootstrap packages prune --manager brew --yes
 mise bootstrap packages prune --manager brew-cask --dry-run
 mise bootstrap packages prune --manager vscode --dry-run
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Host packages](/bootstrap/packages/).
+- [`mise bootstrap packages <SUBCOMMAND>`](/cli/bootstrap/packages.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/packages/status.md
+++ b/docs/cli/bootstrap/packages/status.md
@@ -20,3 +20,11 @@ mise bootstrap packages status
 mise bootstrap packages status --json
 mise bootstrap packages status --missing # exit 1 if anything is out of sync
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Host packages](/bootstrap/packages/).
+- [`mise bootstrap packages <SUBCOMMAND>`](/cli/bootstrap/packages.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/packages/upgrade.md
+++ b/docs/cli/bootstrap/packages/upgrade.md
@@ -38,3 +38,11 @@ mise bootstrap packages upgrade --manager mas
 mise bootstrap packages upgrade --manager apt --yes
 mise bootstrap packages upgrade --dry-run
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Host packages](/bootstrap/packages/).
+- [`mise bootstrap packages <SUBCOMMAND>`](/cli/bootstrap/packages.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/packages/use.md
+++ b/docs/cli/bootstrap/packages/use.md
@@ -38,3 +38,11 @@ mise bootstrap packages use brew:jq brew-cask:firefox
 mise bootstrap packages use -g brew:postgresql@17
 mise bootstrap packages use apt:curl@8.5.0-2
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Host packages](/bootstrap/packages/).
+- [`mise bootstrap packages <SUBCOMMAND>`](/cli/bootstrap/packages.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/plan.md
+++ b/docs/cli/bootstrap/plan.md
@@ -22,5 +22,5 @@ full bootstrap run. Use `bootstrap --dry-run` to preview the complete workflow.
 ## Related documentation
 
 - [Bootstrap workflow](/bootstrap.html).
-- [`mise bootstrap`](/cli/bootstrap.html).
+- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/plan.md
+++ b/docs/cli/bootstrap/plan.md
@@ -7,8 +7,20 @@
 
 Show the changes declarative bootstrap resources would make
 
+Covers declarative resources, not every hook, package installation, or task in a
+full bootstrap run. Use `bootstrap --dry-run` to preview the complete workflow.
+`--detailed-exitcode` distinguishes unchanged (0), changes (2), and errors (1).
+
 ## Flags
 - **`-J --json`** — Output a stable machine-readable plan in JSON format
 - **`--detailed-exitcode`** — Exit 2 when the plan contains changes, 0 when unchanged, and 1 on errors
 - **`--prompt-secrets`** — Prompt securely for missing bootstrap secret inputs
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Bootstrap workflow](/bootstrap.html).
+- [`mise bootstrap`](/cli/bootstrap.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/plugins.md
+++ b/docs/cli/bootstrap/plugins.md
@@ -7,6 +7,8 @@
 
 Manage package manager plugins declared in `[bootstrap.plugins]`
 
+Install these plugins before applying packages they manage. Installing a plugin does not itself install the host packages in `[bootstrap.packages]`.
+
 ## Flags
 - **`-h --help`** — Print help
 
@@ -14,3 +16,11 @@ Manage package manager plugins declared in `[bootstrap.plugins]`
 
 - [`mise bootstrap plugins apply [-n --dry-run]`](/cli/bootstrap/plugins/apply.html)
 - [`mise bootstrap plugins status [--missing]`](/cli/bootstrap/plugins/status.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Package plugins](/bootstrap/packages/plugins.html).
+- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/plugins/apply.md
+++ b/docs/cli/bootstrap/plugins/apply.md
@@ -10,3 +10,11 @@ Install package manager plugins declared in `[bootstrap.plugins]`
 ## Flags
 - **`-n --dry-run`** — Print what would happen without installing plugins
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Package plugins](/bootstrap/packages/plugins.html).
+- [`mise bootstrap plugins`](/cli/bootstrap/plugins.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/plugins/apply.md
+++ b/docs/cli/bootstrap/plugins/apply.md
@@ -16,5 +16,5 @@ Install package manager plugins declared in `[bootstrap.plugins]`
 ## Related documentation
 
 - [Package plugins](/bootstrap/packages/plugins.html).
-- [`mise bootstrap plugins`](/cli/bootstrap/plugins.html).
+- [`mise bootstrap plugins <SUBCOMMAND>`](/cli/bootstrap/plugins.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/plugins/status.md
+++ b/docs/cli/bootstrap/plugins/status.md
@@ -16,5 +16,5 @@ Show whether declared package manager plugins are installed
 ## Related documentation
 
 - [Package plugins](/bootstrap/packages/plugins.html).
-- [`mise bootstrap plugins`](/cli/bootstrap/plugins.html).
+- [`mise bootstrap plugins <SUBCOMMAND>`](/cli/bootstrap/plugins.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/plugins/status.md
+++ b/docs/cli/bootstrap/plugins/status.md
@@ -10,3 +10,11 @@ Show whether declared package manager plugins are installed
 ## Flags
 - **`--missing`** — Exit with code 1 if a declared plugin is missing
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Package plugins](/bootstrap/packages/plugins.html).
+- [`mise bootstrap plugins`](/cli/bootstrap/plugins.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/remote.md
+++ b/docs/cli/bootstrap/remote.md
@@ -64,5 +64,5 @@ installs persistent global configuration; preview that choice with `--dry-run`.
 ## Related documentation
 
 - [Remote bootstrap](/bootstrap/remote.html).
-- [`mise bootstrap`](/cli/bootstrap.html).
+- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/remote.md
+++ b/docs/cli/bootstrap/remote.md
@@ -7,6 +7,10 @@
 
 Bootstrap one or more machines over OpenSSH
 
+Select inventory hosts by name, tag, or `--all`, or supply ad-hoc `--host` targets.
+The source is staged on each target and bootstrap runs there. `--from-git` instead
+installs persistent global configuration; preview that choice with `--dry-run`.
+
 ## Arguments
 - **`[TARGET]…`** — Inventory host names from `[bootstrap.remote.hosts]`
 
@@ -54,3 +58,11 @@ Bootstrap one or more machines over OpenSSH
 - **`--update`** — Refresh package manager metadata and update configured repos remotely
 - **`-y --yes`** — Skip remote confirmation prompts
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Remote bootstrap](/bootstrap/remote.html).
+- [`mise bootstrap`](/cli/bootstrap.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/repos.md
+++ b/docs/cli/bootstrap/repos.md
@@ -7,6 +7,10 @@
 
 Manage git repo checkouts from `[bootstrap.repos]`
 
+Use `apply` to clone or reconcile the configured checkout, `update` to refresh it,
+and `exec` to run a command in selected repositories. Existing local changes can
+block convergence; `--skip-dirty` skips those repositories without discarding edits.
+
 ## Flags
 - **`-h --help`** — Print help
 
@@ -16,3 +20,11 @@ Manage git repo checkouts from `[bootstrap.repos]`
 - [`mise bootstrap repos exec [-c --continue-on-error] [-n --dry-run] [PATH]… <-- COMMAND>…`](/cli/bootstrap/repos/exec.html)
 - [`mise bootstrap repos status [-J --json] [--missing]`](/cli/bootstrap/repos/status.html)
 - [`mise bootstrap repos update [FLAGS] [PATH]…`](/cli/bootstrap/repos/update.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Repository checkouts](/bootstrap/repos.html).
+- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/repos/apply.md
+++ b/docs/cli/bootstrap/repos/apply.md
@@ -18,5 +18,5 @@ Clone and converge git repos from `[bootstrap.repos]`
 ## Related documentation
 
 - [Repository checkouts](/bootstrap/repos.html).
-- [`mise bootstrap repos`](/cli/bootstrap/repos.html).
+- [`mise bootstrap repos <SUBCOMMAND>`](/cli/bootstrap/repos.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/repos/apply.md
+++ b/docs/cli/bootstrap/repos/apply.md
@@ -12,3 +12,11 @@ Clone and converge git repos from `[bootstrap.repos]`
 - **`-y --yes`** — Skip the confirmation prompt
 - **`--skip-dirty`** — Skip repos with local changes instead of failing
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Repository checkouts](/bootstrap/repos.html).
+- [`mise bootstrap repos`](/cli/bootstrap/repos.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/repos/exec.md
+++ b/docs/cli/bootstrap/repos/exec.md
@@ -6,6 +6,8 @@
 
 Run a command in each configured git repo
 
+Place the executable and its arguments after `--`, for example `mise bootstrap repos exec -- git status --short`. Arguments before `--` select repository paths; use `--continue-on-error` to visit remaining repos after a failure.
+
 ## Arguments
 - **`[PATH]…`** — Run only in matching configured or expanded paths
 - **`<-- COMMAND>…`** — Command and arguments to run in each repo
@@ -14,3 +16,11 @@ Run a command in each configured git repo
 - **`-c --continue-on-error`** — Continue running in other repos after a command fails
 - **`-n --dry-run`** — Print the commands that would run without running them
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Repository checkouts](/bootstrap/repos.html).
+- [`mise bootstrap repos`](/cli/bootstrap/repos.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/repos/exec.md
+++ b/docs/cli/bootstrap/repos/exec.md
@@ -22,5 +22,5 @@ Place the executable and its arguments after `--`, for example `mise bootstrap r
 ## Related documentation
 
 - [Repository checkouts](/bootstrap/repos.html).
-- [`mise bootstrap repos`](/cli/bootstrap/repos.html).
+- [`mise bootstrap repos <SUBCOMMAND>`](/cli/bootstrap/repos.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/repos/status.md
+++ b/docs/cli/bootstrap/repos/status.md
@@ -11,3 +11,11 @@ Show the state of git repos from `[bootstrap.repos]`
 - **`-J --json`** — Output in JSON format
 - **`--missing`** — Exit with code 1 if any configured repo is not in its desired state
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Repository checkouts](/bootstrap/repos.html).
+- [`mise bootstrap repos`](/cli/bootstrap/repos.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/repos/status.md
+++ b/docs/cli/bootstrap/repos/status.md
@@ -17,5 +17,5 @@ Show the state of git repos from `[bootstrap.repos]`
 ## Related documentation
 
 - [Repository checkouts](/bootstrap/repos.html).
-- [`mise bootstrap repos`](/cli/bootstrap/repos.html).
+- [`mise bootstrap repos <SUBCOMMAND>`](/cli/bootstrap/repos.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/repos/update.md
+++ b/docs/cli/bootstrap/repos/update.md
@@ -15,3 +15,11 @@ Pull the latest changes into configured git repos
 - **`-y --yes`** — Skip the confirmation prompt
 - **`--skip-dirty`** — Skip repos with local changes instead of failing
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Repository checkouts](/bootstrap/repos.html).
+- [`mise bootstrap repos`](/cli/bootstrap/repos.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/repos/update.md
+++ b/docs/cli/bootstrap/repos/update.md
@@ -21,5 +21,5 @@ Pull the latest changes into configured git repos
 ## Related documentation
 
 - [Repository checkouts](/bootstrap/repos.html).
-- [`mise bootstrap repos`](/cli/bootstrap/repos.html).
+- [`mise bootstrap repos <SUBCOMMAND>`](/cli/bootstrap/repos.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/secrets.md
+++ b/docs/cli/bootstrap/secrets.md
@@ -13,3 +13,11 @@ Inspect bootstrap secret inputs without revealing their values
 ## Subcommands
 
 - [`mise bootstrap secrets status [-J --json] [--missing]`](/cli/bootstrap/secrets/status.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Bootstrap secrets](/bootstrap/secrets.html).
+- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/secrets/status.md
+++ b/docs/cli/bootstrap/secrets/status.md
@@ -17,5 +17,5 @@ Show whether declared bootstrap secret inputs are available
 ## Related documentation
 
 - [Bootstrap secrets](/bootstrap/secrets.html).
-- [`mise bootstrap secrets`](/cli/bootstrap/secrets.html).
+- [`mise bootstrap secrets <SUBCOMMAND>`](/cli/bootstrap/secrets.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/secrets/status.md
+++ b/docs/cli/bootstrap/secrets/status.md
@@ -11,3 +11,11 @@ Show whether declared bootstrap secret inputs are available
 - **`-J --json`** — Output in JSON format
 - **`--missing`** — Exit with code 1 if a declared secret input is unavailable
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Bootstrap secrets](/bootstrap/secrets.html).
+- [`mise bootstrap secrets`](/cli/bootstrap/secrets.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/services.md
+++ b/docs/cli/bootstrap/services.md
@@ -7,6 +7,9 @@
 
 Manage Linux system services from `[bootstrap.services]`
 
+These are system-level systemd services. For units in the current user session,
+use `bootstrap linux systemd-units` instead.
+
 ## Flags
 - **`-h --help`** — Print help
 
@@ -14,3 +17,11 @@ Manage Linux system services from `[bootstrap.services]`
 
 - [`mise bootstrap services apply [-n --dry-run] [-y --yes]`](/cli/bootstrap/services/apply.html)
 - [`mise bootstrap services status [-J --json] [--missing]`](/cli/bootstrap/services/status.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [System services](/bootstrap/services.html).
+- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/services/apply.md
+++ b/docs/cli/bootstrap/services/apply.md
@@ -11,3 +11,11 @@ Apply configured Linux system service state
 - **`-n --dry-run`** — Print what would change without changing anything
 - **`-y --yes`** — Skip the confirmation prompt
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [System services](/bootstrap/services.html).
+- [`mise bootstrap services`](/cli/bootstrap/services.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/services/apply.md
+++ b/docs/cli/bootstrap/services/apply.md
@@ -17,5 +17,5 @@ Apply configured Linux system service state
 ## Related documentation
 
 - [System services](/bootstrap/services.html).
-- [`mise bootstrap services`](/cli/bootstrap/services.html).
+- [`mise bootstrap services <SUBCOMMAND>`](/cli/bootstrap/services.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/services/status.md
+++ b/docs/cli/bootstrap/services/status.md
@@ -11,3 +11,11 @@ Show configured Linux system service state
 - **`-J --json`** — Output in JSON format
 - **`--missing`** — Exit with code 1 when any service is not converged
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [System services](/bootstrap/services.html).
+- [`mise bootstrap services`](/cli/bootstrap/services.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/services/status.md
+++ b/docs/cli/bootstrap/services/status.md
@@ -17,5 +17,5 @@ Show configured Linux system service state
 ## Related documentation
 
 - [System services](/bootstrap/services.html).
-- [`mise bootstrap services`](/cli/bootstrap/services.html).
+- [`mise bootstrap services <SUBCOMMAND>`](/cli/bootstrap/services.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/status.md
+++ b/docs/cli/bootstrap/status.md
@@ -8,8 +8,20 @@
 
 Show the aggregate bootstrap status
 
+Inspect configured resource state without applying changes. `--missing` sets a
+nonzero exit status for drift; it does not restrict the listing to missing entries.
+Dotfile status can render trusted templates, including their `exec()` calls.
+
 ## Flags
 - **`-J --json`** — Output in JSON format
 - **`--missing`** — Exit with code 1 if any configured bootstrap state is not in its desired state
 - **`--prompt-secrets`** — Prompt securely for missing bootstrap secret inputs
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Bootstrap workflow](/bootstrap.html).
+- [`mise bootstrap`](/cli/bootstrap.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/status.md
+++ b/docs/cli/bootstrap/status.md
@@ -23,5 +23,5 @@ Dotfile status can render trusted templates, including their `exec()` calls.
 ## Related documentation
 
 - [Bootstrap workflow](/bootstrap.html).
-- [`mise bootstrap`](/cli/bootstrap.html).
+- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/systemd/apply.md
+++ b/docs/cli/bootstrap/systemd/apply.md
@@ -11,3 +11,13 @@ Install and start systemd user services from `[bootstrap.linux.systemd.units]`
 - **`-n --dry-run`** — Print the commands that would run without running them
 - **`-y --yes`** — Skip the confirmation prompt
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+This is a compatibility spelling. Use [`mise bootstrap linux systemd-units apply`](/cli/bootstrap/linux/systemd-units/apply.html) in new scripts.
+
+## Related documentation
+
+- [systemd user units](/bootstrap/systemd.html).
+- [`mise bootstrap`](/cli/bootstrap.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/systemd/apply.md
+++ b/docs/cli/bootstrap/systemd/apply.md
@@ -14,10 +14,10 @@ Install and start systemd user services from `[bootstrap.linux.systemd.units]`
 
 <!-- generated reference navigation -->
 
-This is a compatibility spelling. Use [`mise bootstrap linux systemd-units apply`](/cli/bootstrap/linux/systemd-units/apply.html) in new scripts.
+This is a compatibility spelling. Use [`mise bootstrap linux systemd-units apply [-n --dry-run] [-y --yes]`](/cli/bootstrap/linux/systemd-units/apply.html) in new scripts.
 
 ## Related documentation
 
 - [systemd user units](/bootstrap/systemd.html).
-- [`mise bootstrap`](/cli/bootstrap.html).
+- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/systemd/status.md
+++ b/docs/cli/bootstrap/systemd/status.md
@@ -11,3 +11,13 @@ Show the state of systemd user services from `[bootstrap.linux.systemd.units]`
 - **`-J --json`** — Output in JSON format
 - **`--missing`** — Exit with code 1 if any configured systemd user service is not in its desired state
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+This is a compatibility spelling. Use [`mise bootstrap linux systemd-units status`](/cli/bootstrap/linux/systemd-units/status.html) in new scripts.
+
+## Related documentation
+
+- [systemd user units](/bootstrap/systemd.html).
+- [`mise bootstrap`](/cli/bootstrap.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/systemd/status.md
+++ b/docs/cli/bootstrap/systemd/status.md
@@ -14,10 +14,10 @@ Show the state of systemd user services from `[bootstrap.linux.systemd.units]`
 
 <!-- generated reference navigation -->
 
-This is a compatibility spelling. Use [`mise bootstrap linux systemd-units status`](/cli/bootstrap/linux/systemd-units/status.html) in new scripts.
+This is a compatibility spelling. Use [`mise bootstrap linux systemd-units status [-J --json] [--missing]`](/cli/bootstrap/linux/systemd-units/status.html) in new scripts.
 
 ## Related documentation
 
 - [systemd user units](/bootstrap/systemd.html).
-- [`mise bootstrap`](/cli/bootstrap.html).
+- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/user.md
+++ b/docs/cli/bootstrap/user.md
@@ -7,6 +7,9 @@
 
 Manage current-user bootstrap settings from `[bootstrap.user]`
 
+Currently manages the login shell. Apply as the intended user; changing the login
+shell affects future sessions, not the shell running this command.
+
 ## Flags
 - **`-h --help`** — Print help
 
@@ -14,3 +17,11 @@ Manage current-user bootstrap settings from `[bootstrap.user]`
 
 - [`mise bootstrap user apply [-n --dry-run] [-y --yes]`](/cli/bootstrap/user/apply.html)
 - [`mise bootstrap user status [-J --json] [--missing]`](/cli/bootstrap/user/status.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Current-user settings](/bootstrap/user.html).
+- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/user/apply.md
+++ b/docs/cli/bootstrap/user/apply.md
@@ -17,5 +17,5 @@ Apply current-user settings from `[bootstrap.user]`
 ## Related documentation
 
 - [Current-user settings](/bootstrap/user.html).
-- [`mise bootstrap user`](/cli/bootstrap/user.html).
+- [`mise bootstrap user <SUBCOMMAND>`](/cli/bootstrap/user.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/user/apply.md
+++ b/docs/cli/bootstrap/user/apply.md
@@ -11,3 +11,11 @@ Apply current-user settings from `[bootstrap.user]`
 - **`-n --dry-run`** — Print the commands that would run without running them
 - **`-y --yes`** — Skip the confirmation prompt
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Current-user settings](/bootstrap/user.html).
+- [`mise bootstrap user`](/cli/bootstrap/user.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/user/status.md
+++ b/docs/cli/bootstrap/user/status.md
@@ -11,3 +11,11 @@ Show whether current-user settings match `[bootstrap.user]`
 - **`-J --json`** — Output in JSON format
 - **`--missing`** — Exit with code 1 if any configured user setting is not in its desired state
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Current-user settings](/bootstrap/user.html).
+- [`mise bootstrap user`](/cli/bootstrap/user.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/bootstrap/user/status.md
+++ b/docs/cli/bootstrap/user/status.md
@@ -17,5 +17,5 @@ Show whether current-user settings match `[bootstrap.user]`
 ## Related documentation
 
 - [Current-user settings](/bootstrap/user.html).
-- [`mise bootstrap user`](/cli/bootstrap/user.html).
+- [`mise bootstrap user <SUBCOMMAND>`](/cli/bootstrap/user.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/cache.md
+++ b/docs/cli/cache.md
@@ -18,3 +18,11 @@ Run `mise cache` with no args to view the current cache directory.
 - [`mise cache path`](/cli/cache/path.html)
 - [`mise cache prune [-v --verbose] [--dry-run] [TOOL]…`](/cli/cache/prune.html)
 - [`mise cache task [-J --json] <TASK>`](/cli/cache/task.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Cache behavior](/cache-behavior.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/cache/clear.md
+++ b/docs/cli/cache/clear.md
@@ -14,3 +14,11 @@ Delete all cache files
 ## Flags
 - **`--task <TASK>`** — Clear output cache entries for a task name or pattern
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Cache behavior](/cache-behavior.html).
+- [`mise cache`](/cli/cache.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/cache/clear.md
+++ b/docs/cli/cache/clear.md
@@ -20,5 +20,5 @@ Delete all cache files
 ## Related documentation
 
 - [Cache behavior](/cache-behavior.html).
-- [`mise cache`](/cli/cache.html).
+- [`mise cache [SUBCOMMAND]`](/cli/cache.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/cache/path.md
+++ b/docs/cli/cache/path.md
@@ -10,3 +10,11 @@ Show the cache directory path
 
 ## Flags
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Cache behavior](/cache-behavior.html).
+- [`mise cache`](/cli/cache.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/cache/path.md
+++ b/docs/cli/cache/path.md
@@ -16,5 +16,5 @@ Show the cache directory path
 ## Related documentation
 
 - [Cache behavior](/cache-behavior.html).
-- [`mise cache`](/cli/cache.html).
+- [`mise cache [SUBCOMMAND]`](/cli/cache.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/cache/prune.md
+++ b/docs/cli/cache/prune.md
@@ -24,5 +24,5 @@ Change this with the MISE_CACHE_PRUNE_AGE environment variable.
 ## Related documentation
 
 - [Cache behavior](/cache-behavior.html).
-- [`mise cache`](/cli/cache.html).
+- [`mise cache [SUBCOMMAND]`](/cli/cache.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/cache/prune.md
+++ b/docs/cli/cache/prune.md
@@ -18,3 +18,11 @@ Change this with the MISE_CACHE_PRUNE_AGE environment variable.
 - **`-v --verbose`** — Show pruned files
 - **`--dry-run`** — Show what would be pruned without deleting anything
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Cache behavior](/cache-behavior.html).
+- [`mise cache`](/cli/cache.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/cache/task.md
+++ b/docs/cli/cache/task.md
@@ -13,3 +13,11 @@ Inspect output cache entries for a task
 ## Flags
 - **`-J --json`** — Output in JSON format
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Task output caching](/tasks/caching.html).
+- [`mise cache`](/cli/cache.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/cache/task.md
+++ b/docs/cli/cache/task.md
@@ -19,5 +19,5 @@ Inspect output cache entries for a task
 ## Related documentation
 
 - [Task output caching](/tasks/caching.html).
-- [`mise cache`](/cli/cache.html).
+- [`mise cache [SUBCOMMAND]`](/cli/cache.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/completion.md
+++ b/docs/cli/completion.md
@@ -60,3 +60,11 @@ For a tool installed through Packslip with completion resources
 mise completion zsh --tool rg
 mise completion zsh --tool rg --install
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Shell completions](/dev-tools/packslip-resources.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -19,3 +19,11 @@ Manage config files
 - [`mise config get [FLAGS] [KEY]`](/cli/config/get.html)
 - [`mise config ls [FLAGS]`](/cli/config/ls.html)
 - [`mise config set [FLAGS] <KEY> [VALUE]`](/cli/config/set.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Configuration](/configuration.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/config/get.md
+++ b/docs/cli/config/get.md
@@ -5,7 +5,11 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/config/get.rs`](https://github.com/jdx/mise/blob/main/src/cli/config/get.rs)
 
-Display a value from a mise.toml file
+Display a value from one mise TOML file
+
+Reads the highest-precedence loaded TOML file by default. Select another with
+`--file`, `--global`, or `--system`. This reads stored values, not the merged or
+template-expanded environment; use `mise env` for the resolved environment.
 
 ## Arguments
 - **`[KEY]`** — Dotted key path to display, e.g. `tools.python`; omit to print the whole file
@@ -15,7 +19,7 @@ Display a value from a mise.toml file
 
   Can be a file path or directory. If a directory is provided, the config file in that directory is used.
 
-  If not provided, the nearest mise.toml file will be used
+  If not provided, the highest-precedence loaded TOML file is used
 
   **Aliases:** `--path`
 - **`-g --global`** — Read the global config file.
@@ -28,3 +32,11 @@ Display a value from a mise.toml file
 mise config get tools.python
 3.12
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Configuration](/configuration.html).
+- [`mise config [FLAGS] [SUBCOMMAND]`](/cli/config.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/config/ls.md
+++ b/docs/cli/config/ls.md
@@ -22,3 +22,11 @@ Path                        Tools
 ~/.config/mise/config.toml  pitchfork
 ~/src/mise/mise.toml        actionlint, bun, cargo-binstall, cargo:cargo-insta
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Configuration](/configuration.html).
+- [`mise config [FLAGS] [SUBCOMMAND]`](/cli/config.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/config/set.md
+++ b/docs/cli/config/set.md
@@ -5,7 +5,16 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/config/set.rs`](https://github.com/jdx/mise/blob/main/src/cli/config/set.rs)
 
-Set a value in a mise.toml file
+Set a value in one mise TOML file
+
+Edits the highest-precedence loaded TOML file by default, which may be an
+environment-specific override. Use `--file` to select an existing project file,
+or `--global`/`--system` to edit or create those config files.
+
+This edits configuration without installing tools. Use `mise use` to install and
+select a version together. Known settings use their declared type; other values
+are strings or booleans unless `--type` is given. Use `--type string` when a value
+such as `true` should remain literal text.
 
 ## Arguments
 - **`<KEY>`** — Dotted key path to set, e.g. `tools.python`
@@ -16,7 +25,7 @@ Set a value in a mise.toml file
 
   Can be a file path or directory. If a directory is provided, the config file in that directory is used.
 
-  If not provided, the nearest mise.toml file will be used
+  If not provided, the highest-precedence loaded TOML file is used
 
   **Aliases:** `--path`
 - **`-g --global`** — Edit the global config file.
@@ -46,3 +55,11 @@ Type for `settings` is inferred
 ```
 mise config set settings.jobs 4
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Configuration](/configuration.html).
+- [`mise config [FLAGS] [SUBCOMMAND]`](/cli/config.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/deactivate.md
+++ b/docs/cli/deactivate.md
@@ -5,9 +5,12 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/deactivate.rs`](https://github.com/jdx/mise/blob/main/src/cli/deactivate.rs)
 
-Disable mise for current shell session
+Print the script to disable mise in the current shell session
 
-This can be used to temporarily disable mise in a shell session.
+The shell function installed by activation evaluates this output in supported
+shells. When calling the executable directly, evaluate or source its output
+with the appropriate shell syntax. This does not remove the startup-file line;
+new shells will activate mise again.
 
 ## Flags
 - **`-h --help`** — Print help
@@ -25,3 +28,11 @@ Fish
 ```
 command mise deactivate | source
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Shell activation](/getting-started.html#activate-mise).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/deps.md
+++ b/docs/cli/deps.md
@@ -8,13 +8,13 @@
 
 [experimental] Manage project dependencies
 
-Runs all applicable dependency install steps for the current project.
-This checks if dependency lockfiles are newer than installed outputs
-(e.g., package-lock.json vs node_modules/) and runs install commands
-if needed.
+With no subcommand, runs dependency installation for the current project, the same
+as `mise deps install`. Providers detect their inputs and installed outputs to
+decide whether work is needed; use `--explain PROVIDER` to inspect that decision.
 
-Providers with `auto = true` are automatically invoked before `mise x` and `mise run`
-unless skipped with the --no-deps flag.
+Providers with `auto = true` run before `mise exec` and `mise run` unless `--no-deps`
+is passed. These install project dependencies, such as node_modules, separately
+from versioned tools managed by `mise install`.
 
 ## Arguments
 - **`[PROVIDER]`** — Provider to operate on (runs only this provider, or use with --explain)
@@ -69,3 +69,11 @@ run = "npm run codegen"
 
 # To disable npm instead, add `disable = ["npm"]` under [deps].
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Project dependencies](/dev-tools/deps.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/deps/add.md
+++ b/docs/cli/deps/add.md
@@ -22,5 +22,5 @@ Package specs use the format `ecosystem:package`, e.g., `npm:react` or `npm:@typ
 ## Related documentation
 
 - [Project dependencies](/dev-tools/deps.html).
-- [`mise deps`](/cli/deps.html).
+- [`mise deps [FLAGS] [PROVIDER] [SUBCOMMAND]`](/cli/deps.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/deps/add.md
+++ b/docs/cli/deps/add.md
@@ -16,3 +16,11 @@ Package specs use the format `ecosystem:package`, e.g., `npm:react` or `npm:@typ
 ## Flags
 - **`-D --dev`** — Add as a development dependency
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Project dependencies](/dev-tools/deps.html).
+- [`mise deps`](/cli/deps.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/deps/install.md
+++ b/docs/cli/deps/install.md
@@ -34,5 +34,5 @@ then runs its installation command when needed. `--force` bypasses that check;
 ## Related documentation
 
 - [Project dependencies](/dev-tools/deps.html).
-- [`mise deps`](/cli/deps.html).
+- [`mise deps [FLAGS] [PROVIDER] [SUBCOMMAND]`](/cli/deps.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/deps/install.md
+++ b/docs/cli/deps/install.md
@@ -7,8 +7,9 @@
 
 Install all project dependencies
 
-Checks if dependency lockfiles are newer than installed outputs
-and runs install commands if needed.
+Uses each provider's freshness rules to compare configured inputs and outputs,
+then runs its installation command when needed. `--force` bypasses that check;
+`--explain PROVIDER` shows why a provider is considered fresh or stale.
 
 ## Arguments
 - **`[PROVIDER]`** — Provider to operate on (runs only this provider, or use with --explain)
@@ -27,3 +28,11 @@ and runs install commands if needed.
 - **`--only <ONLY>`** — Run specific deps rule(s) only
 - **`--skip <SKIP>`** — Skip specific deps rule(s)
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Project dependencies](/dev-tools/deps.html).
+- [`mise deps`](/cli/deps.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/deps/remove.md
+++ b/docs/cli/deps/remove.md
@@ -15,3 +15,11 @@ Package specs use the format `ecosystem:package`, e.g., `npm:lodash`.
 
 ## Flags
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Project dependencies](/dev-tools/deps.html).
+- [`mise deps`](/cli/deps.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/deps/remove.md
+++ b/docs/cli/deps/remove.md
@@ -21,5 +21,5 @@ Package specs use the format `ecosystem:package`, e.g., `npm:lodash`.
 ## Related documentation
 
 - [Project dependencies](/dev-tools/deps.html).
-- [`mise deps`](/cli/deps.html).
+- [`mise deps [FLAGS] [PROVIDER] [SUBCOMMAND]`](/cli/deps.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -23,3 +23,11 @@ mise doctor path --full
 ## Subcommands
 
 - [`mise doctor path [-f --full]`](/cli/doctor/path.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Troubleshooting](/troubleshooting.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/doctor/path.md
+++ b/docs/cli/doctor/path.md
@@ -19,3 +19,11 @@ Get the PATH entries mise provides, such as `/home/user/.local/share/mise/instal
 ```
 mise doctor path
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Troubleshooting](/troubleshooting.html).
+- [`mise doctor [-J --json] [SUBCOMMAND]`](/cli/doctor.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/edit.md
+++ b/docs/cli/edit.md
@@ -25,3 +25,11 @@ mise edit -g          # edit the global config file
 mise edit -y          # skip interactive editor
 mise edit -n          # preview without writing
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Configuration](/configuration.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/en.md
+++ b/docs/cli/en.md
@@ -41,3 +41,11 @@ Skip loading zshrc.
 ```
 mise en -s "zsh -f"
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Shell activation](/getting-started.html#activate-mise).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/env.md
+++ b/docs/cli/env.md
@@ -6,10 +6,15 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/env.rs`](https://github.com/jdx/mise/blob/main/src/cli/env.rs)
 
-Export env vars to activate mise a single time
+Print the environment for the current configuration
 
-Use this to load the environment into one shell without adding `mise activate` to
-your shell rc file. It is not needed in shells where mise is already activated.
+Evaluate the shell output to load tools and variables once, without installing
+prompt hooks. Changing directories afterward does not recompute this environment.
+Use `mise exec -- command` to apply it to one child process instead.
+
+JSON, dotenv, and shell output contain actual variable values, including secrets.
+`--redacted` selects variables marked for redaction; it does not mask their values.
+Environment construction may install missing tools according to mise's settings.
 
 ## Arguments
 - **`[TOOL@VERSION]…`** — Tool(s) to include in addition to those in config, e.g. node@20
@@ -21,7 +26,7 @@ your shell rc file. It is not needed in shells where mise is already activated.
 
   **Choices:** `bash`, `elvish`, `fish`, `nu`, `xonsh`, `zsh`, `pwsh`, `powershell`
 - **`--json-extended`** — Output in JSON format with additional information (source, tool)
-- **`--redacted`** — Only show redacted environment variables
+- **`--redacted`** — Only include variables marked for redaction; their values are printed unmasked
 - **`--values`** — Only show values of environment variables
 - **`-h --help`** — Print help
 
@@ -33,3 +38,11 @@ eval "$(mise env -s zsh)"
 mise env -s fish | source
 execx($(mise env -s xonsh))
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Environment variables](/environments/).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/exec.md
+++ b/docs/cli/exec.md
@@ -12,16 +12,16 @@ session, or to run ad-hoc commands with tools that are not in the config.
 
 Tools are loaded from mise.toml and can be overridden with &lt;TOOL@VERSION> args. Only the
 tools you name are overridden: if `mise.toml` includes `node = "20"` and you run
-`mise exec python@3.11`, node@20 is still loaded.
+`mise exec python@3.11 -- python -V`, node@20 is still loaded.
 
 The "--" separates tools from the command to pass along to the subprocess.
 
 ## Arguments
 - **`[TOOL@VERSION]…`** — Tool(s) to load e.g.: node@20 python@3.10
-- **`[-- COMMAND]…`** — Command string to execute (same as --command)
+- **`[-- COMMAND]…`** — Executable and arguments to run directly, after `--`
 
 ## Flags
-- **`-c --command <COMMAND>`** — Command string to execute
+- **`-c --command <COMMAND>`** — Command string to execute through a shell (supports pipes and redirection)
 - **`-j --jobs <JOBS>`** — Number of jobs to run in parallel
   Values below 1 are treated as 1
   Defaults to the `jobs` setting
@@ -30,11 +30,13 @@ The "--" separates tools from the command to pass along to the subprocess.
 - **`--allow-env <VAR>`** — Allow specific env var through (implies --deny-env for everything else)
   Supports wildcards, e.g. --allow-env='MYAPP_*'
 - **`--allow-net <HOST>`** — Allow network to specific host (implies --deny-net for everything else)
-  macOS only in v1; on Linux falls back to allowing all network
+  Per-host filtering is unsupported on Linux and returns an error.
+  See the sandboxing guide for current macOS host-filter limitations.
+  On Windows, sandboxing is unavailable: mise warns and runs without host filtering.
 - **`--allow-read <PATH>`** — Allow reads from specific path (implies --deny-read for everything else)
 - **`--allow-write <PATH>`** — Allow writes to specific path (implies --deny-write for everything else)
 - **`--deny-all`** — Block reads, writes, network, and env vars
-- **`--deny-env`** — Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
+- **`--deny-env`** — Block env var inheritance except PATH, HOME, USER, SHELL, TERM, COLORTERM, LANG
 - **`--deny-net`** — Block all network access
 - **`--deny-read`** — Block filesystem reads (system libs and tool dirs still accessible)
 - **`--deny-write`** — Block all filesystem writes
@@ -63,3 +65,11 @@ Run a command in a different directory:
 ```
 mise x -C /path/to/project node@20 -- node ./app.js
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Running tools](/dev-tools/).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/fmt.md
+++ b/docs/cli/fmt.md
@@ -5,9 +5,12 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/fmt.rs`](https://github.com/jdx/mise/blob/main/src/cli/fmt.rs)
 
-Format mise.toml
+Format mise TOML configuration
 
-Sorts keys and cleans up whitespace in mise.toml
+Sorts keys and normalizes whitespace using TOML 1.1 syntax, including multiline
+inline tables. By default, formats config files in the current directory;
+`--all` includes every loaded config. Use `--check` in CI or `--stdin` to format
+a supplied document without rewriting a file.
 
 ## Flags
 - **`-a --all`** — Format every config file mise currently loads, not just those in the current directory
@@ -22,3 +25,11 @@ mise fmt
 mise fmt --check
 cat mise.toml | mise fmt --stdin
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Configuration](/configuration.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/generate.md
+++ b/docs/cli/generate.md
@@ -21,3 +21,11 @@ Generate files for various tools/services
 - [`mise generate task-docs [FLAGS]`](/cli/generate/task-docs.html)
 - [`mise generate task-stubs [FLAGS]`](/cli/generate/task-stubs.html)
 - [`mise generate tool-stub [FLAGS] <OUTPUT>`](/cli/generate/tool-stub.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Tasks and automation](/tasks/).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/generate/config.md
+++ b/docs/cli/generate/config.md
@@ -25,3 +25,11 @@ mise generate config -g          # generate the global config file
 mise generate config -y          # skip interactive editor
 mise generate config -n          # preview without writing
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Configuration](/configuration.html).
+- [`mise generate <SUBCOMMAND>`](/cli/generate.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/generate/devcontainer.md
+++ b/docs/cli/generate/devcontainer.md
@@ -5,7 +5,10 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/generate/devcontainer.rs`](https://github.com/jdx/mise/blob/main/src/cli/generate/devcontainer.rs)
 
-Generate a devcontainer to execute mise
+Generate devcontainer configuration for mise
+
+Prints JSON by default. `--write` saves .devcontainer/devcontainer.json;
+review the image, mounts, and generated setup commands before opening it.
 
 ## Flags
 - **`-i --image <IMAGE>`** — The image to use for the devcontainer
@@ -19,3 +22,11 @@ Generate a devcontainer to execute mise
 ```
 mise generate devcontainer
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [IDE integration](/ide-integration.html).
+- [`mise generate <SUBCOMMAND>`](/cli/generate.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/generate/git-pre-commit.md
+++ b/docs/cli/generate/git-pre-commit.md
@@ -46,3 +46,11 @@ config lives in a subdirectory, so the hook has to change into it first
 ```
 mise generate git-pre-commit --write -- -C subdir
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Tasks and automation](/tasks/).
+- [`mise generate <SUBCOMMAND>`](/cli/generate.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/generate/github-action.md
+++ b/docs/cli/generate/github-action.md
@@ -8,7 +8,9 @@
 Generate a GitHub Action workflow file
 
 This command generates a GitHub Action workflow file that runs a mise task like `mise run ci`
-when you push changes to your repository.
+on pull requests, tags, manual dispatch, and pushes to the current Git branch.
+Prints YAML by default; `--write` saves it under .github/workflows. Define
+the selected task and review the generated triggers before committing.
 
 ## Flags
 - **`-t --task <TASK>`** — The task to run when the workflow is triggered
@@ -29,3 +31,11 @@ mise generate github-action --task=ci
 mise generate github-action --write --task=ci
 git add .github/workflows/ci.yml
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Continuous integration](/continuous-integration.html).
+- [`mise generate <SUBCOMMAND>`](/cli/generate.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/generate/install-script.md
+++ b/docs/cli/generate/install-script.md
@@ -13,9 +13,10 @@ Renamed from `mise generate bootstrap`, which read as a form of `mise bootstrap`
 setup). The old name still works but is deprecated and will be removed in mise 2027.9.0.
 
 ## Flags
-- **`-l --localize`** — Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a project-local directory (`.mise` by default, set with `--localized-dir`)
+- **`-l --localize`** — Keep mise data and cache in a project-local directory (`.mise` by default)
 
-  This is necessary if users may use a different version of mise outside the project.
+  Use `--localized-dir` to choose its location. This isolates mise state;
+  it is not an OS sandbox for commands the generated script runs.
 - **`-V --version <VERSION>`** — Specify mise version to fetch
 - **`-w --write [WRITE]`** — Write the script to a file and make it executable instead of printing it to stdout
 - **`--localized-dir <LOCALIZED_DIR>`** — Directory to put localized data into
@@ -46,3 +47,11 @@ Write bin/mise.cmd as a launcher for contributors who clone the project on Windo
 mise generate install-script --write ./bin/mise --windows
 .\bin\mise.cmd install
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Project installation scripts](/dev-tools/).
+- [`mise generate <SUBCOMMAND>`](/cli/generate.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/generate/task-docs.md
+++ b/docs/cli/generate/task-docs.md
@@ -5,7 +5,10 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/generate/task_docs.rs`](https://github.com/jdx/mise/blob/main/src/cli/generate/task_docs.rs)
 
-Generate documentation for tasks in a project
+Generate Markdown documentation for project tasks
+
+Prints to stdout by default. Use `--output` to write a file, `--inject`
+to replace a marked section, or `--multi` for one file per task.
 
 ## Flags
 - **`-i --inject`** — Insert the documentation into an existing file
@@ -37,3 +40,11 @@ README.md must already contain both mise-tasks marker comments
 ```
 mise generate task-docs --inject --output README.md
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Tasks and automation](/tasks/).
+- [`mise generate <SUBCOMMAND>`](/cli/generate.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/generate/task-stubs.md
+++ b/docs/cli/generate/task-stubs.md
@@ -48,3 +48,11 @@ mise generate task-stubs
 ./bin/test
 running tests
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Tasks and automation](/tasks/).
+- [`mise generate <SUBCOMMAND>`](/cli/generate.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/generate/tool-stub.md
+++ b/docs/cli/generate/tool-stub.md
@@ -97,3 +97,11 @@ For an existing registry-backed stub, resolve and embed version/platform lock da
 ```
 mise generate tool-stub ./bin/registry-node --lock --version 22
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Portable tool stubs](/dev-tools/tool-stubs.html).
+- [`mise generate <SUBCOMMAND>`](/cli/generate.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/implode.md
+++ b/docs/cli/implode.md
@@ -13,3 +13,11 @@ The config directory is kept unless `--config` is passed.
 - **`-n --dry-run`** — List directories that would be removed without actually removing them
 - **`--config`** — Also remove config directory
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Uninstalling mise](/installing-mise.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,12 @@
 
 **Author:** Jeff Dickey <@jdx>
 
-- **Usage:** `mise [FLAGS] [TASK] [SUBCOMMAND]`
+**Usage:** `mise [FLAGS] [COMMAND | TASK] [ARGS]…`
+
+Use `mise COMMAND --help` for the help shipped with your installed version. Put mise
+flags before a task name; arguments after the name are passed to that task.
+Square brackets mark optional input, angle brackets mark required input, and `…`
+means the argument can repeat. Do not type those notation characters.
 
 ## Arguments
 - **`[TASK]`** — Task to run.
@@ -11,6 +16,12 @@
   Shorthand for `mise tasks run <TASK>`.
 
 ## Global Flags
+
+These flags provide shared context. A command can define its own flag with the same
+name, so consult that command's page for placement and meaning. Effect labels describe
+the command's intended operation; configuration evaluation, caches, and required tool
+installation can still have side effects. They are not sandbox guarantees.
+
 - **`-C --cd <DIR>`** — Change directory before running command
 - **`-E --env <ENV>`** — Set the environment for loading `mise.<ENV>.toml`
 - **`-j --jobs <JOBS>`** — How many jobs to run in parallel; values below 1 are treated as 1 [default: 8]
@@ -43,193 +54,86 @@
 
 ## Subcommands
 
-- [`mise activate [FLAGS] [SHELL_TYPE]`](/cli/activate.html)
-- [`mise tool-alias [-p --tool <TOOL>] [--no-header] [SUBCOMMAND]`](/cli/tool-alias.html)
-- [`mise tool-alias get <TOOL> <ALIAS>`](/cli/tool-alias/get.html)
-- [`mise tool-alias ls [--no-header] [TOOL]`](/cli/tool-alias/ls.html)
-- [`mise tool-alias set <ARGS>…`](/cli/tool-alias/set.html)
-- [`mise tool-alias unset <TOOL> [ALIAS]`](/cli/tool-alias/unset.html)
-- [`mise backends [SUBCOMMAND]`](/cli/backends.html)
-- [`mise backends ls`](/cli/backends/ls.html)
-- [`mise bin-paths [--bin-names] [-J --json] [TOOL@VERSION]…`](/cli/bin-paths.html)
-- [`mise bootstrap [FLAGS] [SUBCOMMAND]`](/cli/bootstrap.html)
-- [`mise bootstrap accounts <SUBCOMMAND>`](/cli/bootstrap/accounts.html)
-- [`mise bootstrap accounts apply [-n --dry-run] [-y --yes]`](/cli/bootstrap/accounts/apply.html)
-- [`mise bootstrap accounts status [-J --json] [--missing]`](/cli/bootstrap/accounts/status.html)
-- [`mise bootstrap config-roots [-J --json]`](/cli/bootstrap/config-roots.html)
-- [`mise bootstrap compose <SUBCOMMAND>`](/cli/bootstrap/compose.html)
-- [`mise bootstrap compose apply [-n --dry-run] [-y --yes]`](/cli/bootstrap/compose/apply.html)
-- [`mise bootstrap compose status [-J --json] [--missing]`](/cli/bootstrap/compose/status.html)
-- [`mise bootstrap dotfiles <SUBCOMMAND>`](/cli/bootstrap/dotfiles.html)
-- [`mise bootstrap dotfiles add [FLAGS] [TARGET]…`](/cli/bootstrap/dotfiles/add.html)
-- [`mise bootstrap dotfiles apply [FLAGS] [TARGET]…`](/cli/bootstrap/dotfiles/apply.html)
-- [`mise bootstrap dotfiles diff [TARGET]…`](/cli/bootstrap/dotfiles/diff.html)
-- [`mise bootstrap dotfiles edit [FLAGS] <TARGET>`](/cli/bootstrap/dotfiles/edit.html)
-- [`mise bootstrap dotfiles status [-J --json] [--missing] [TARGET]…`](/cli/bootstrap/dotfiles/status.html)
-- [`mise bootstrap dotfiles unapply [FLAGS] [TARGET]…`](/cli/bootstrap/dotfiles/unapply.html)
-- [`mise bootstrap files <SUBCOMMAND>`](/cli/bootstrap/files.html)
-- [`mise bootstrap files apply [FLAGS]`](/cli/bootstrap/files/apply.html)
-- [`mise bootstrap files status [FLAGS]`](/cli/bootstrap/files/status.html)
-- [`mise bootstrap firewall <SUBCOMMAND>`](/cli/bootstrap/firewall.html)
-- [`mise bootstrap firewall apply [-n --dry-run] [-y --yes]`](/cli/bootstrap/firewall/apply.html)
-- [`mise bootstrap firewall status [-J --json] [--missing]`](/cli/bootstrap/firewall/status.html)
-- [`mise bootstrap launchd apply [-n --dry-run] [-y --yes]`](/cli/bootstrap/launchd/apply.html)
-- [`mise bootstrap launchd status [-J --json] [--missing]`](/cli/bootstrap/launchd/status.html)
-- [`mise bootstrap linux <SUBCOMMAND>`](/cli/bootstrap/linux.html)
-- [`mise bootstrap linux systemd-units <SUBCOMMAND>`](/cli/bootstrap/linux/systemd-units.html)
-- [`mise bootstrap linux systemd-units apply [-n --dry-run] [-y --yes]`](/cli/bootstrap/linux/systemd-units/apply.html)
-- [`mise bootstrap linux systemd-units status [-J --json] [--missing]`](/cli/bootstrap/linux/systemd-units/status.html)
-- [`mise bootstrap macos <SUBCOMMAND>`](/cli/bootstrap/macos.html)
-- [`mise bootstrap macos defaults <SUBCOMMAND>`](/cli/bootstrap/macos/defaults.html)
-- [`mise bootstrap macos defaults apply [-n --dry-run] [-y --yes]`](/cli/bootstrap/macos/defaults/apply.html)
-- [`mise bootstrap macos defaults status [-J --json] [--missing]`](/cli/bootstrap/macos/defaults/status.html)
-- [`mise bootstrap macos launchd-agents <SUBCOMMAND>`](/cli/bootstrap/macos/launchd-agents.html)
-- [`mise bootstrap macos launchd-agents apply [-n --dry-run] [-y --yes]`](/cli/bootstrap/macos/launchd-agents/apply.html)
-- [`mise bootstrap macos launchd-agents status [-J --json] [--missing]`](/cli/bootstrap/macos/launchd-agents/status.html)
-- [`mise bootstrap macos-defaults apply [-n --dry-run] [-y --yes]`](/cli/bootstrap/macos-defaults/apply.html)
-- [`mise bootstrap macos-defaults status [-J --json] [--missing]`](/cli/bootstrap/macos-defaults/status.html)
-- [`mise bootstrap mise-shell-activate <SUBCOMMAND>`](/cli/bootstrap/mise-shell-activate.html)
-- [`mise bootstrap mise-shell-activate apply [-n --dry-run] [-y --yes]`](/cli/bootstrap/mise-shell-activate/apply.html)
-- [`mise bootstrap mise-shell-activate status [-J --json] [--missing]`](/cli/bootstrap/mise-shell-activate/status.html)
-- [`mise bootstrap packages <SUBCOMMAND>`](/cli/bootstrap/packages.html)
-- [`mise bootstrap packages apply [FLAGS] [PACKAGE]…`](/cli/bootstrap/packages/apply.html)
-- [`mise bootstrap packages brew <SUBCOMMAND>`](/cli/bootstrap/packages/brew.html)
-- [`mise bootstrap packages brew tap [FLAGS] <TAP> [URL]`](/cli/bootstrap/packages/brew/tap.html)
-- [`mise bootstrap packages brew untap [FLAGS] <TAPS>…`](/cli/bootstrap/packages/brew/untap.html)
-- [`mise bootstrap packages import [FLAGS]`](/cli/bootstrap/packages/import.html)
-- [`mise bootstrap packages prune [FLAGS]`](/cli/bootstrap/packages/prune.html)
-- [`mise bootstrap packages status [-J --json] [--missing]`](/cli/bootstrap/packages/status.html)
-- [`mise bootstrap packages upgrade [FLAGS] [PACKAGE]…`](/cli/bootstrap/packages/upgrade.html)
-- [`mise bootstrap packages use [FLAGS] <PACKAGE>…`](/cli/bootstrap/packages/use.html)
-- [`mise bootstrap plan [FLAGS]`](/cli/bootstrap/plan.html)
-- [`mise bootstrap plugins <SUBCOMMAND>`](/cli/bootstrap/plugins.html)
-- [`mise bootstrap plugins apply [-n --dry-run]`](/cli/bootstrap/plugins/apply.html)
-- [`mise bootstrap plugins status [--missing]`](/cli/bootstrap/plugins/status.html)
-- [`mise bootstrap remote [FLAGS] [TARGET]…`](/cli/bootstrap/remote.html)
-- [`mise bootstrap repos <SUBCOMMAND>`](/cli/bootstrap/repos.html)
-- [`mise bootstrap repos apply [FLAGS]`](/cli/bootstrap/repos/apply.html)
-- [`mise bootstrap repos exec [-c --continue-on-error] [-n --dry-run] [PATH]… <-- COMMAND>…`](/cli/bootstrap/repos/exec.html)
-- [`mise bootstrap repos status [-J --json] [--missing]`](/cli/bootstrap/repos/status.html)
-- [`mise bootstrap repos update [FLAGS] [PATH]…`](/cli/bootstrap/repos/update.html)
-- [`mise bootstrap secrets <SUBCOMMAND>`](/cli/bootstrap/secrets.html)
-- [`mise bootstrap secrets status [-J --json] [--missing]`](/cli/bootstrap/secrets/status.html)
-- [`mise bootstrap services <SUBCOMMAND>`](/cli/bootstrap/services.html)
-- [`mise bootstrap services apply [-n --dry-run] [-y --yes]`](/cli/bootstrap/services/apply.html)
-- [`mise bootstrap services status [-J --json] [--missing]`](/cli/bootstrap/services/status.html)
-- [`mise bootstrap status [FLAGS]`](/cli/bootstrap/status.html)
-- [`mise bootstrap systemd apply [-n --dry-run] [-y --yes]`](/cli/bootstrap/systemd/apply.html)
-- [`mise bootstrap systemd status [-J --json] [--missing]`](/cli/bootstrap/systemd/status.html)
-- [`mise bootstrap user <SUBCOMMAND>`](/cli/bootstrap/user.html)
-- [`mise bootstrap user apply [-n --dry-run] [-y --yes]`](/cli/bootstrap/user/apply.html)
-- [`mise bootstrap user status [-J --json] [--missing]`](/cli/bootstrap/user/status.html)
-- [`mise cache [SUBCOMMAND]`](/cli/cache.html)
-- [`mise cache clear [--task <TASK>] [TOOL]…`](/cli/cache/clear.html)
-- [`mise cache path`](/cli/cache/path.html)
-- [`mise cache prune [-v --verbose] [--dry-run] [TOOL]…`](/cli/cache/prune.html)
-- [`mise cache task [-J --json] <TASK>`](/cli/cache/task.html)
-- [`mise completion [FLAGS] [SHELL]`](/cli/completion.html)
-- [`mise config [FLAGS] [SUBCOMMAND]`](/cli/config.html)
-- [`mise config get [FLAGS] [KEY]`](/cli/config/get.html)
-- [`mise config ls [FLAGS]`](/cli/config/ls.html)
-- [`mise config set [FLAGS] <KEY> [VALUE]`](/cli/config/set.html)
-- [`mise deactivate`](/cli/deactivate.html)
-- [`mise doctor [-J --json] [SUBCOMMAND]`](/cli/doctor.html)
-- [`mise doctor path [-f --full]`](/cli/doctor/path.html)
-- [`mise en [-s --shell <SHELL>] [DIR]`](/cli/en.html)
-- [`mise env [FLAGS] [TOOL@VERSION]…`](/cli/env.html)
-- [`mise exec [FLAGS] [TOOL@VERSION]… [-- COMMAND]…`](/cli/exec.html)
-- [`mise fmt [FLAGS]`](/cli/fmt.html)
-- [`mise generate <SUBCOMMAND>`](/cli/generate.html)
-- [`mise generate config [FLAGS] [PATH]`](/cli/generate/config.html)
-- [`mise generate devcontainer [FLAGS]`](/cli/generate/devcontainer.html)
-- [`mise generate git-pre-commit [FLAGS] [-- MISE_ARG]…`](/cli/generate/git-pre-commit.html)
-- [`mise generate github-action [FLAGS]`](/cli/generate/github-action.html)
-- [`mise generate install-script [FLAGS]`](/cli/generate/install-script.html)
-- [`mise generate task-docs [FLAGS]`](/cli/generate/task-docs.html)
-- [`mise generate task-stubs [FLAGS]`](/cli/generate/task-stubs.html)
-- [`mise generate tool-stub [FLAGS] <OUTPUT>`](/cli/generate/tool-stub.html)
-- [`mise implode [-n --dry-run] [--config]`](/cli/implode.html)
-- [`mise edit [FLAGS] [PATH]`](/cli/edit.html)
-- [`mise install [FLAGS] [TOOL@VERSION]…`](/cli/install.html)
-- [`mise install-into <TOOL@VERSION> <PATH>`](/cli/install-into.html)
-- [`mise latest [-i --installed] [--minimum-release-age <MINIMUM_RELEASE_AGE>] <TOOL@VERSION>`](/cli/latest.html)
-- [`mise link [-f --force] <TOOL@VERSION> <PATH>`](/cli/link.html)
-- [`mise lock [FLAGS] [TOOL]…`](/cli/lock.html)
-- [`mise ls [FLAGS] [INSTALLED_TOOL]…`](/cli/ls.html)
-- [`mise ls-remote [FLAGS] [TOOL@VERSION] [PREFIX]`](/cli/ls-remote.html)
-- [`mise mcp`](/cli/mcp.html)
-- [`mise oci <SUBCOMMAND>`](/cli/oci.html)
-- [`mise oci build [FLAGS]`](/cli/oci/build.html)
-- [`mise oci push [FLAGS] <REF>`](/cli/oci/push.html)
-- [`mise oci run [FLAGS] [-- CMD]…`](/cli/oci/run.html)
-- [`mise packslip [SUBCOMMAND]`](/cli/packslip.html)
-- [`mise packslip forget <PROJECT>`](/cli/packslip/forget.html)
-- [`mise packslip pins [-J --json]`](/cli/packslip/pins.html)
-- [`mise outdated [FLAGS] [TOOL@VERSION]…`](/cli/outdated.html)
-- [`mise patrons [-J --json] [--refresh]`](/cli/patrons.html)
-- [`mise plugins [FLAGS] [SUBCOMMAND]`](/cli/plugins.html)
-- [`mise plugins install [FLAGS] [NEW_PLUGIN] [GIT_URL]`](/cli/plugins/install.html)
-- [`mise plugins link [-f --force] <NAME> [DIR]`](/cli/plugins/link.html)
-- [`mise plugins ls [FLAGS]`](/cli/plugins/ls.html)
-- [`mise plugins ls-remote [-u --urls] [--only-names]`](/cli/plugins/ls-remote.html)
-- [`mise plugins uninstall [-a --all] [-p --purge] [PLUGIN]…`](/cli/plugins/uninstall.html)
-- [`mise plugins update [-j --jobs <JOBS>] [PLUGIN]…`](/cli/plugins/update.html)
-- [`mise deps [FLAGS] [PROVIDER] [SUBCOMMAND]`](/cli/deps.html)
-- [`mise deps add [-D --dev] <PACKAGES>…`](/cli/deps/add.html)
-- [`mise deps install [FLAGS] [PROVIDER]`](/cli/deps/install.html)
-- [`mise deps remove <PACKAGES>…`](/cli/deps/remove.html)
-- [`mise prune [FLAGS] [INSTALLED_TOOL]…`](/cli/prune.html)
-- [`mise registry [FLAGS] [NAME]`](/cli/registry.html)
-- [`mise reshim [-f --force] [--system]`](/cli/reshim.html)
-- [`mise run [FLAGS] [TASK] [ARGS]…`](/cli/run.html)
-- [`mise search [FLAGS] [NAME]`](/cli/search.html)
-- [`mise self-update [FLAGS] [VERSION]`](/cli/self-update.html)
-- [`mise set [FLAGS] [ENV_VAR]…`](/cli/set.html)
-- [`mise settings [FLAGS] [SETTING] [VALUE] [SUBCOMMAND]`](/cli/settings.html)
-- [`mise settings add [-l --local] <SETTING> [VALUE]`](/cli/settings/add.html)
-- [`mise settings get [-l --local] <SETTING>`](/cli/settings/get.html)
-- [`mise settings ls [FLAGS] [SETTING]`](/cli/settings/ls.html)
-- [`mise settings set [-l --local] <SETTING> [VALUE]`](/cli/settings/set.html)
-- [`mise settings unset [-l --local] <KEY>`](/cli/settings/unset.html)
-- [`mise shell [FLAGS] <TOOL@VERSION>…`](/cli/shell.html)
-- [`mise ssh [FLAGS] [DESTINATION] [COMMAND]…`](/cli/ssh.html)
-- [`mise shell-alias [--no-header] [SUBCOMMAND]`](/cli/shell-alias.html)
-- [`mise shell-alias get <shell_alias>`](/cli/shell-alias/get.html)
-- [`mise shell-alias ls [--no-header]`](/cli/shell-alias/ls.html)
-- [`mise shell-alias set <shell_alias> [COMMAND]`](/cli/shell-alias/set.html)
-- [`mise shell-alias unset <shell_alias>`](/cli/shell-alias/unset.html)
-- [`mise skills [SUBCOMMAND]`](/cli/skills.html)
-- [`mise skills ls [-J --json]`](/cli/skills/ls.html)
-- [`mise skills sync [FLAGS]`](/cli/skills/sync.html)
-- [`mise sponsors`](/cli/sponsors.html)
-- [`mise sync <SUBCOMMAND>`](/cli/sync.html)
-- [`mise sync node [FLAGS]`](/cli/sync/node.html)
-- [`mise sync python [--pyenv] [--uv]`](/cli/sync/python.html)
-- [`mise sync ruby <--brew>`](/cli/sync/ruby.html)
-- [`mise tasks [FLAGS] [TASK] [SUBCOMMAND]`](/cli/tasks.html)
-- [`mise tasks add [FLAGS] <TASK> [-- RUN]…`](/cli/tasks/add.html)
-- [`mise tasks deps [FLAGS] [TASKS]…`](/cli/tasks/deps.html)
-- [`mise tasks edit [-p --path] <TASK>`](/cli/tasks/edit.html)
-- [`mise tasks graph [FLAGS]`](/cli/tasks/graph.html)
-- [`mise tasks info [-J --json] <TASK>`](/cli/tasks/info.html)
-- [`mise tasks ls [FLAGS]`](/cli/tasks/ls.html)
-- [`mise tasks run [FLAGS] [TASK] [ARGS]…`](/cli/tasks/run.html)
-- [`mise tasks validate [--errors-only] [--json] [TASKS]…`](/cli/tasks/validate.html)
-- [`mise test-tool [FLAGS] [TOOLS]…`](/cli/test-tool.html)
-- [`mise token <SUBCOMMAND>`](/cli/token.html)
-- [`mise token forgejo [--unmask] [HOST]`](/cli/token/forgejo.html)
-- [`mise token github [FLAGS] [HOST]`](/cli/token/github.html)
-- [`mise token gitlab [--unmask] [HOST]`](/cli/token/gitlab.html)
-- [`mise tool [FLAGS] <TOOL>`](/cli/tool.html)
-- [`mise tool-stub <FILE> [ARGS]…`](/cli/tool-stub.html)
-- [`mise trust [FLAGS] [CONFIG_FILE]`](/cli/trust.html)
-- [`mise uninstall [FLAGS] [INSTALLED_TOOL@VERSION]…`](/cli/uninstall.html)
-- [`mise unset [-f --file <FILE>] [-g --global] [ENV_KEY]…`](/cli/unset.html)
-- [`mise untrust [CONFIG_FILE]`](/cli/untrust.html)
-- [`mise unuse [FLAGS] <INSTALLED_TOOL@VERSION>…`](/cli/unuse.html)
-- [`mise upgrade [FLAGS] [INSTALLED_TOOL@VERSION]…`](/cli/upgrade.html)
-- [`mise use [FLAGS] [TOOL@VERSION]…`](/cli/use.html)
-- [`mise version [-J --json]`](/cli/version.html)
-- [`mise watch [FLAGS] [TASK] [ARGS]…`](/cli/watch.html)
-- [`mise where <TOOL@VERSION>`](/cli/where.html)
-- [`mise which [FLAGS] [BIN_NAME]`](/cli/which.html)
+Choose a command family below. Its page lists the available subcommands.
+
+### Install and inspect tools
+
+- [`mise use`](/cli/use.html) — Install a tool and add it to configuration
+- [`mise install`](/cli/install.html) — Install a tool version
+- [`mise install-into`](/cli/install-into.html) — Install a tool version to a specific path
+- [`mise uninstall`](/cli/uninstall.html) — Remove installed tool versions
+- [`mise unuse`](/cli/unuse.html) — Remove tool requests from configuration and prune unused installations
+- [`mise upgrade`](/cli/upgrade.html) — Upgrade outdated tools
+- [`mise outdated`](/cli/outdated.html) — Show outdated tool versions
+- [`mise lock`](/cli/lock.html) — Create or refresh lockfile versions, checksums, and download URLs
+- [`mise latest`](/cli/latest.html) — Resolve the latest matching version request for a tool
+- [`mise ls`](/cli/ls.html) — List installed and active tool versions
+- [`mise ls-remote`](/cli/ls-remote.html) — List tool versions available to install
+- [`mise tool`](/cli/tool.html) — Show information about a tool
+- [`mise where`](/cli/where.html) — Display the installation path for a tool
+- [`mise which`](/cli/which.html) — Show the path a tool's executable resolves to
+- [`mise bin-paths`](/cli/bin-paths.html) — List all the active runtime bin paths
+- [`mise registry`](/cli/registry.html) — List registry shorthand names and their backends
+- [`mise search`](/cli/search.html) — Search for tools in the registry
+- [`mise backends`](/cli/backends.html) — Manage backends
+- [`mise link`](/cli/link.html) — Symlink a tool version into mise
+- [`mise sync`](/cli/sync.html) — Synchronize tools from other version managers with mise
+- [`mise prune`](/cli/prune.html) — Delete unused versions of tools
+- [`mise reshim`](/cli/reshim.html) — Create shims for executables provided by installed tools
+- [`mise tool-stub`](/cli/tool-stub.html) — Execute a tool stub
+- [`mise packslip`](/cli/packslip.html) — The signers mise accepts packslips from
+
+### Shell and environment
+
+- [`mise activate`](/cli/activate.html) — Print the script to activate mise in an interactive shell
+- [`mise deactivate`](/cli/deactivate.html) — Print the script to disable mise in the current shell session
+- [`mise completion`](/cli/completion.html) — Generate shell completions
+- [`mise en`](/cli/en.html) — Start a new shell with the mise environment built from the current configuration
+- [`mise env`](/cli/env.html) — Print the environment for the current configuration
+- [`mise exec`](/cli/exec.html) — Execute a command with tool(s) set
+- [`mise shell`](/cli/shell.html) — Set a tool version for the current shell session
+- [`mise set`](/cli/set.html) — Set environment variables in mise.toml
+- [`mise unset`](/cli/unset.html) — Remove environment variable(s) from the config file
+- [`mise shell-alias`](/cli/shell-alias.html) — Manage shell aliases
+- [`mise tool-alias`](/cli/tool-alias.html) — Manage tool version aliases
+- [`mise ssh`](/cli/ssh.html) — Open an SSH session, optionally borrowing read-only GitHub access
+
+### Tasks and project automation
+
+- [`mise run`](/cli/run.html) — Run tasks and their dependencies
+- [`mise tasks`](/cli/tasks.html) — Manage tasks
+- [`mise watch`](/cli/watch.html) — Run task(s) and rerun them when files change
+- [`mise deps`](/cli/deps.html) — [experimental] Manage project dependencies
+- [`mise generate`](/cli/generate.html) — Generate files for various tools/services
+
+### Machine setup and images
+
+- [`mise bootstrap`](/cli/bootstrap.html) — Set up a machine from the current configuration
+- [`mise oci`](/cli/oci.html) — [experimental] Build OCI container images from a mise.toml
+
+### Configuration and diagnostics
+
+- [`mise config`](/cli/config.html) — Manage config files
+- [`mise edit`](/cli/edit.html) — Edit mise.toml interactively
+- [`mise fmt`](/cli/fmt.html) — Format mise TOML configuration
+- [`mise settings`](/cli/settings.html) — Manage settings
+- [`mise trust`](/cli/trust.html) — Mark a config file as trusted
+- [`mise untrust`](/cli/untrust.html) — Remove explicit trust for a config
+- [`mise doctor`](/cli/doctor.html) — Check mise installation for possible problems
+- [`mise cache`](/cli/cache.html) — Manage the mise cache
+- [`mise version`](/cli/version.html) — Display the version of mise
+- [`mise self-update`](/cli/self-update.html) — Update mise itself
+- [`mise implode`](/cli/implode.html) — Remove the mise CLI and all related data
+
+### Integrations and community
+
+- [`mise mcp`](/cli/mcp.html) — Run the Model Context Protocol server over stdin/stdout
+- [`mise skills`](/cli/skills.html) — Agent skills the active tools ship, from their packslips
+- [`mise patrons`](/cli/patrons.html) — Show the individuals supporting mise as Patron-tier members
+- [`mise sponsors`](/cli/sponsors.html) — Show the companies sponsoring mise and the jdx.dev open source tools
+
+### Other commands
+
+- [`mise plugins`](/cli/plugins.html) — Manage plugins
+- [`mise test-tool`](/cli/test-tool.html) — Test that a tool installs and runs
+- [`mise token`](/cli/token.html) — Display git provider tokens mise will use

--- a/docs/cli/install-into.md
+++ b/docs/cli/install-into.md
@@ -24,3 +24,11 @@ install node@20.0.0 into ./mynode
 mise install-into node@20.0.0 ./mynode && ./mynode/bin/node -v
 v20.0.0
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Development tools](/dev-tools/).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -13,7 +13,7 @@ Installs a tool version under the mise data directory, by default
 Installing alone does not add the tool to your config, so a tool that is not
 already configured will not be on PATH.
 To install and activate in one command, use `mise use`, which also writes the version to
-`mise.toml` in the current directory so the tool is active inside it.
+the selected project config so the tool is active in that configuration scope.
 To run a tool once without touching any config, use `mise exec <TOOL>@<VERSION> -- <COMMAND>`.
 
 Tools are installed in parallel. To disable, set `--jobs=1` or `MISE_JOBS=1`.
@@ -73,3 +73,11 @@ mise install              # install everything specified in mise.toml
 mise install --include-lazy # also install tools configured for lazy installation
 mise install --include-task-tools # also install tools required by tasks
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Installing and selecting tools](/dev-tools/).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/latest.md
+++ b/docs/cli/latest.md
@@ -5,9 +5,11 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/latest.rs`](https://github.com/jdx/mise/blob/main/src/cli/latest.rs)
 
-Get the latest available version of a tool
+Resolve the latest matching version request for a tool
 
-Supports prefixes such as `node@20` to get the latest version of node 20.
+Supports prefixes such as `node@20`. The selected backend decides how channels,
+refs, and non-SemVer versions resolve; "latest" is not a generic sort of strings.
+This prints a version without installing it or changing configuration.
 
 ## Arguments
 - **`<TOOL@VERSION>`** — Tool to get the latest version of
@@ -40,3 +42,11 @@ Exclude releases newer than the requested age
 ```
 mise latest node --minimum-release-age 30d
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Version requests](/dev-tools/).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/link.md
+++ b/docs/cli/link.md
@@ -35,3 +35,11 @@ brew install node
 mise link node@brew "$(brew --prefix node)"
 mise use node@brew
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Development tools](/dev-tools/).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/lock.md
+++ b/docs/cli/lock.md
@@ -5,13 +5,15 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/lock.rs`](https://github.com/jdx/mise/blob/main/src/cli/lock.rs)
 
-Update lockfile checksums and URLs for all specified platforms
+Create or refresh lockfile versions, checksums, and download URLs
 
-Updates checksums and download URLs for all platforms already specified in the lockfile.
-If no lockfile exists, shows what would be created based on the current configuration,
-including tools declared by tasks.
-This allows you to refresh lockfile data for platforms other than the one you're currently on.
-Operates on the lockfile in the current config root. Use TOOL arguments to target specific tools.
+Operates on the current config root, including tools declared by tasks. Existing
+matching locked versions are preserved unless `--bump` re-resolves their selectors.
+This command writes lockfiles without installing tools; `--dry-run` previews changes.
+
+Use `--platform` for explicit targets. Otherwise mise uses `lockfile_platforms`
+plus the current platform when that setting is configured, existing lockfile
+platforms when available, or the common platform defaults for a new lockfile.
 
 ## Arguments
 - **`[TOOL]…`** — Tool(s) to update in lockfile
@@ -28,7 +30,7 @@ Operates on the lockfile in the current config root. Use TOOL arguments to targe
 - **`-n --dry-run`** — Show what would be updated without making changes
 - **`-p --platform <PLATFORM>`** — Comma-separated list of platforms to target
   e.g.: linux-x64,macos-arm64,windows-x64
-  If not specified, all platforms already in lockfile will be updated
+  If omitted, use lockfile_platforms, existing platforms, or common defaults
 - **`--bump`** — Re-resolve fuzzy version selectors against the latest available versions
 
   By default, `mise lock` refreshes metadata for the currently locked versions.
@@ -119,3 +121,11 @@ update only global config lockfiles
 ```
 mise lock --global
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Lockfiles and strict installation](/dev-tools/mise-lock.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/ls-remote.md
+++ b/docs/cli/ls-remote.md
@@ -8,15 +8,16 @@
 
 List tool versions available to install
 
-Results may be cached; run `mise cache clear` to fetch fresh results.
+Results may be cached; run `mise cache clear TOOL` to refresh one tool
+before querying it again. Version formats and ordering are backend-specific.
 
 ## Arguments
 - **`[TOOL@VERSION]`** — Tool to get versions for
-- **`[PREFIX]`** — The version prefix to use when querying the latest version
-  same as the first argument after the "@"
+- **`[PREFIX]`** — Filter the available versions by this prefix
+  Equivalent to the version selector after `@` in the first argument
 
 ## Flags
-- **`--all`** — Show all installed plugins and versions
+- **`--all`** — List available versions for every backend/tool currently known to mise
 - **`--minimum-release-age <MINIMUM_RELEASE_AGE>`** — Only show versions released before this age or date
 
   Supports absolute dates like "2024-06-01" and relative durations like "90d" or "1y".
@@ -43,3 +44,11 @@ mise ls-remote node 20
 mise ls-remote node --minimum-release-age 30d
 mise ls-remote github:cli/cli --json
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Version requests](/dev-tools/).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/ls.md
+++ b/docs/cli/ls.md
@@ -71,3 +71,11 @@ Include references from every tracked configuration file
 ```
 mise ls --all-sources
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Development tools](/dev-tools/).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -4,17 +4,16 @@
 - **Usage:** `mise mcp`
 - **Source code:** [`src/cli/mcp.rs`](https://github.com/jdx/mise/blob/main/src/cli/mcp.rs)
 
-Run Model Context Protocol (MCP) server
+Run the Model Context Protocol server over stdin/stdout
 
-This command starts an MCP server that exposes mise functionality
-to AI assistants over stdin/stdout using JSON-RPC protocol.
+Exposes project tools, tasks, environment, and configuration to an MCP client.
+Resources use `mise://tools`, `mise://tasks`, `mise://env`, and `mise://config`.
+`mise://tools?include_inactive=true` also includes inactive installations.
 
-The MCP server provides access to:
-- Installed and available tools
-- Task definitions and execution
-- Environment variables
-- Configuration information
-- Task execution via the run_task tool
+The `list_commands` tool describes commands and their declared effects. `run_task`
+executes project tasks with the user's permissions and can change files or invoke
+external services. `install_tool` is advertised but currently returns an error.
+Environment resources contain real values, including secrets.
 
 Resources available:
 - mise://tools - List all tools (use ?include_inactive=true to include inactive tools)
@@ -41,3 +40,11 @@ Start from the project directory; an MCP client handles the protocol exchange
 ```
 mise -C /path/to/project mcp
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [MCP integration](/mcp.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/oci.md
+++ b/docs/cli/oci.md
@@ -23,3 +23,11 @@ in future releases.
 - [`mise oci build [FLAGS]`](/cli/oci/build.html)
 - [`mise oci push [FLAGS] <REF>`](/cli/oci/push.html)
 - [`mise oci run [FLAGS] [-- CMD]…`](/cli/oci/run.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Building and running OCI images](/dev-tools/mise-oci.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/oci/build.md
+++ b/docs/cli/oci/build.md
@@ -10,8 +10,12 @@
 Each tool version becomes its own content-addressable OCI layer. Bumping a
 tool version only invalidates that tool's layer — other tools, the base
 image, and config are reused unchanged. The output directory conforms to
-the OCI image-layout spec and can be consumed by `skopeo`, `crane`, or
-`podman load`.
+the OCI image-layout spec. Use `skopeo inspect oci:./mise-oci` to inspect it
+or `mise oci run --image-dir ./mise-oci -- command` to load and run it.
+
+Build on Linux with the target architecture: this packages host tool installs
+and, by default, the running mise binary. `--no-mise` omits that binary but does
+not cross-compile tools installed for another OS. asdf/vfox tools are unsupported.
 
 Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).
 
@@ -55,3 +59,11 @@ Notes:
 - The host mise binary is embedded at /usr/local/bin/mise by default;
   build on the same OS/arch as your target image (or pass --no-mise).
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Building and running OCI images](/dev-tools/mise-oci.html).
+- [`mise oci <SUBCOMMAND>`](/cli/oci.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/oci/push.md
+++ b/docs/cli/oci/push.md
@@ -73,3 +73,11 @@ $REGISTRY_AUTH_FILE, $XDG_RUNTIME_DIR/containers/auth.json,
 $ docker login ghcr.io
 $ podman login ghcr.io
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Building and running OCI images](/dev-tools/mise-oci.html).
+- [`mise oci <SUBCOMMAND>`](/cli/oci.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/oci/run.md
+++ b/docs/cli/oci/run.md
@@ -71,3 +71,11 @@ Engines:
 Prefers podman (loads OCI layouts natively). Falls back to docker
 (loaded via docker load). Pass --engine podman or --engine docker to override.
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Building and running OCI images](/dev-tools/mise-oci.html).
+- [`mise oci <SUBCOMMAND>`](/cli/oci.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/outdated.md
+++ b/docs/cli/outdated.md
@@ -61,3 +61,11 @@ Deprecation:
 
 The `-l` shorthand for `--bump` is deprecated and will be removed in mise 2027.8.5.
 After removal, `-l` will become shorthand for `--local`. Use `-b` or `--bump` instead.
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Upgrading tools](/dev-tools/).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/packslip.md
+++ b/docs/cli/packslip.md
@@ -20,3 +20,11 @@ one that drops build provenance is refused until a person says so.
 
 - [`mise packslip forget <PROJECT>`](/cli/packslip/forget.html)
 - [`mise packslip pins [-J --json]`](/cli/packslip/pins.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Signer verification](/dev-tools/packslip-verification.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/packslip/forget.md
+++ b/docs/cli/packslip/forget.md
@@ -17,3 +17,11 @@ project is named as the packslip backend names it: `github.com/owner/repo`,
 
 ## Flags
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Signer verification](/dev-tools/packslip-verification.html).
+- [`mise packslip`](/cli/packslip.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/packslip/forget.md
+++ b/docs/cli/packslip/forget.md
@@ -23,5 +23,5 @@ project is named as the packslip backend names it: `github.com/owner/repo`,
 ## Related documentation
 
 - [Signer verification](/dev-tools/packslip-verification.html).
-- [`mise packslip`](/cli/packslip.html).
+- [`mise packslip [SUBCOMMAND]`](/cli/packslip.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/packslip/pins.md
+++ b/docs/cli/packslip/pins.md
@@ -11,3 +11,11 @@ List the signers mise has accepted packslips from
 ## Flags
 - **`-J --json`** — Output in JSON format
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Signer verification](/dev-tools/packslip-verification.html).
+- [`mise packslip`](/cli/packslip.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/packslip/pins.md
+++ b/docs/cli/packslip/pins.md
@@ -17,5 +17,5 @@ List the signers mise has accepted packslips from
 ## Related documentation
 
 - [Signer verification](/dev-tools/packslip-verification.html).
-- [`mise packslip`](/cli/packslip.html).
+- [`mise packslip [SUBCOMMAND]`](/cli/packslip.html).
 - [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/patrons.md
+++ b/docs/cli/patrons.md
@@ -7,11 +7,11 @@
 
 Show the individuals supporting mise as Patron-tier members
 
-Lists the individuals on the Patron tier from &lt;<https://jdx.dev/patrons.json>>.
+Lists the individuals on the Patron tier from <https://jdx.dev/patrons.json>.
 The list refreshes daily; supporting terminals will render each patron's
 name as a clickable link via OSC 8 hyperlinks.
 
-To appear here, become a patron at &lt;<https://jdx.dev/sponsors.html>>.
+To appear here, become a patron at <https://jdx.dev/sponsors.html>.
 
 ## Flags
 - **`-J --json`** — Output in JSON format
@@ -25,3 +25,11 @@ mise patrons
 mise patrons -J
 mise patrons --refresh
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Supporting mise](/about.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -27,3 +27,11 @@ Manage plugins
 - [`mise plugins ls-remote [-u --urls] [--only-names]`](/cli/plugins/ls-remote.html)
 - [`mise plugins uninstall [-a --all] [-p --purge] [PLUGIN]…`](/cli/plugins/uninstall.html)
 - [`mise plugins update [-j --jobs <JOBS>] [PLUGIN]…`](/cli/plugins/update.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Plugin selection and maintenance](/plugin-usage.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/plugins/install.md
+++ b/docs/cli/plugins/install.md
@@ -6,16 +6,18 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/plugins/install.rs`](https://github.com/jdx/mise/blob/main/src/cli/plugins/install.rs)
 
-Install a plugin
+Install a plugin from a configured source, Git URL, or supported archive
 
-Note that mise installs plugins automatically when you install a tool that needs one,
-e.g.: `mise install cmake@3.30` installs the cmake plugin first. This command is only
-needed to install a plugin ahead of time or from a custom git URL.
+Most registry tools use built-in backends and need no plugin. When a selected
+backend does require a plugin, mise normally installs it with the tool.
+Use this command to install it ahead of time or choose a custom source.
+
+A Git URL may end in `#ref` to select a plugin commit, tag, or branch. This selects
+the plugin implementation, separately from the tool version installed by `mise use`.
 
 ## Arguments
 - **`[NEW_PLUGIN]`** — The name of the plugin to install
-  e.g.: cmake, poetry
-  Can specify multiple plugins: `mise plugins install cmake poetry`
+  Use a configured plugin name, or supply a source URL below
 - **`[GIT_URL]`** — The git url of the plugin
 
 ## Flags
@@ -47,3 +49,11 @@ Install missing plugins that have configured shorthands
 ```
 mise plugins install --all
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Plugin selection and maintenance](/plugin-usage.html).
+- [`mise plugins [FLAGS] [SUBCOMMAND]`](/cli/plugins.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/plugins/link.md
+++ b/docs/cli/plugins/link.md
@@ -6,15 +6,17 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/plugins/link.rs`](https://github.com/jdx/mise/blob/main/src/cli/plugins/link.rs)
 
-Symlink a plugin into mise
+Link a local plugin directory into mise for development
 
-This is used for developing a plugin.
+Edits in the source directory take effect without reinstalling the plugin. Pass
+both a name and directory, or only a directory to infer the name after stripping
+a known prefix such as `mise-` or `vfox-`. This does not install a tool version.
 
 ## Arguments
 - **`<NAME>`** — The name of the plugin
-  e.g.: cmake, poetry
+  With one argument, this is the plugin directory and the name is inferred
 - **`[DIR]`** — The local path to the plugin
-  e.g.: ./vfox-cmake
+  e.g.: ./mise-my-tool
 
 ## Flags
 - **`-f --force`** — Overwrite existing plugin
@@ -37,3 +39,11 @@ List versions through the linked plugin
 ```
 mise ls-remote my-tool
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Developing tool plugins](/tool-plugin-development.html).
+- [`mise plugins [FLAGS] [SUBCOMMAND]`](/cli/plugins.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/plugins/ls-remote.md
+++ b/docs/cli/plugins/ls-remote.md
@@ -20,3 +20,11 @@ These are the shorthand names from the registry: <https://github.com/jdx/mise/bl
 ```
 mise plugins ls-remote
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Plugin selection and maintenance](/plugin-usage.html).
+- [`mise plugins [FLAGS] [SUBCOMMAND]`](/cli/plugins.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/plugins/ls.md
+++ b/docs/cli/plugins/ls.md
@@ -6,9 +6,11 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/plugins/ls.rs`](https://github.com/jdx/mise/blob/main/src/cli/plugins/ls.rs)
 
-List installed plugins
+List installed external plugins
 
-Can also show remotely available plugins to install.
+Use `--core` for built-in runtimes or `--core --user` for both groups. `--outdated`
+queries Git remotes for plugin updates; it does not compare installed tool versions.
+Use `mise plugins ls-remote` for registry plugin sources and `mise ls` for tools.
 
 ## Flags
 - **`-c --core`** — Only show built-in (core) plugins
@@ -31,3 +33,11 @@ mise plugins ls --urls
 mise plugins ls --core --user
 mise plugins ls --outdated
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Plugin selection and maintenance](/plugin-usage.html).
+- [`mise plugins [FLAGS] [SUBCOMMAND]`](/cli/plugins.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/plugins/uninstall.md
+++ b/docs/cli/plugins/uninstall.md
@@ -6,7 +6,10 @@
 - **Effect:** destructive — may delete or irreversibly overwrite
 - **Source code:** [`src/cli/plugins/uninstall.rs`](https://github.com/jdx/mise/blob/main/src/cli/plugins/uninstall.rs)
 
-Remove a plugin
+Remove an installed plugin
+
+Tool installations are retained by default. Pass `--purge` to also remove
+installs, downloads, and cache associated with the selected plugins.
 
 ## Arguments
 - **`[PLUGIN]…`** — Plugin(s) to remove
@@ -21,3 +24,11 @@ Remove a plugin
 ```
 mise plugins uninstall my-tool
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Plugin selection and maintenance](/plugin-usage.html).
+- [`mise plugins [FLAGS] [SUBCOMMAND]`](/cli/plugins.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/plugins/update.md
+++ b/docs/cli/plugins/update.md
@@ -8,7 +8,9 @@
 
 Update a plugin to the latest version
 
-Note: this updates the plugin itself, not the tool versions it manages
+With no names, updates every installed plugin. This updates plugin source,
+not the tool versions it manages. Linked local plugins are skipped; archive
+installations cannot be updated with Git.
 
 ## Arguments
 - **`[PLUGIN]…`** — Plugin(s) to update
@@ -26,3 +28,11 @@ mise plugins update              # update all installed plugins
 mise plugins update my-tool      # update one Git plugin
 mise plugins update my-tool#main # select an upstream ref
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Plugin selection and maintenance](/plugin-usage.html).
+- [`mise plugins [FLAGS] [SUBCOMMAND]`](/cli/plugins.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/prune.md
+++ b/docs/cli/prune.md
@@ -37,3 +37,11 @@ Preview unused versions without deleting them. Example output: `rm -rf ~/.local/
 ```
 mise prune --dry-run
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Development tools](/dev-tools/).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/registry.md
+++ b/docs/cli/registry.md
@@ -5,11 +5,14 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/registry.rs`](https://github.com/jdx/mise/blob/main/src/cli/registry.rs)
 
-List available tools to install
+List registry shorthand names and their backends
 
-This command lists the tools available in the registry as shorthand names.
+The registry maps short names to installation backends. For example, `node`
+uses the built-in Node backend. A tool may have multiple candidates; explicit
+backend syntax and configuration can override registry selection.
 
-For example, `poetry` is shorthand for `asdf:mise-plugins/mise-poetry`.
+This is not a list of every tool mise can install. Use an explicit identifier
+such as `github:owner/repo` for a supported source without a registry shorthand.
 
 ## Arguments
 - **`[NAME]`** — Show only the specified tool's full name
@@ -36,3 +39,11 @@ mise registry node
 mise registry --backend aqua
 mise registry --json
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Registry and explicit backends](/registry.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/reshim.md
+++ b/docs/cli/reshim.md
@@ -5,26 +5,15 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/reshim.rs`](https://github.com/jdx/mise/blob/main/src/cli/reshim.rs)
 
-Create shims for the executables of currently installed tools
+Create shims for executables provided by installed tools
 
-This creates shims in the user shim directory for executables that have been added since
-the last reshim. With `--system`, it rebuilds the system shim farm instead.
-mise runs this automatically after commands like `npm i -g`, but other ways of installing
-executables (such as yarn or pnpm for node) are not detected, so call this explicitly then.
+Run this when an executable was added to an existing installation outside mise,
+for example after a language package manager installed a CLI globally. It rebuilds
+the user shim directory by default; `--system` selects the shared system shim farm.
 
-If you think mise should automatically call this for a particular command, please
-open an issue on the mise repo. You can also set up a shell function to reshim
-automatically (it's really fast so you don't need to worry about overhead):
-
-```
-npm() {
-  command npm "$@"
-  mise reshim
-}
-```
-
-Note that this creates shims for _all_ installed tools, not just the ones that are
-currently active in mise.toml.
+Shims are created for all installed versions. The shim resolves which version to
+run from the current configuration when invoked. `--force` rebuilds mise-owned
+shims; it does not turn unrelated files into mise-owned shims.
 
 ## Flags
 - **`-f --force`** — Rebuild all mise-owned shims
@@ -39,3 +28,11 @@ Rebuild shims, then check node. Example output: `v20.0.0`.
 mise reshim
 ~/.local/share/mise/shims/node -v
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Shims](/dev-tools/shims.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -5,34 +5,29 @@
 - **Aliases:** `r`
 - **Source code:** [`src/cli/run.rs`](https://github.com/jdx/mise/blob/main/src/cli/run.rs)
 
-Run task(s)
+Run tasks and their dependencies
 
-Runs one task, or several tasks in parallel.
-Tasks may depend on other tasks and on source files.
-If a task has `sources` configured, it only runs when those files have changed.
+Use `mise run TASK [ARGS...]` for one task, or separate task invocations with `:::`
+to schedule several. Put mise flags before the task name; following arguments are
+passed to that task. With no task, mise runs `default` when defined or opens the
+task selector in an interactive terminal.
 
-Tasks can be defined in mise.toml or as standalone scripts.
-In mise.toml, tasks take this form:
+Tasks are defined in `mise.toml` or task directories. A task with `sources` and
+`outputs` can skip execution when its outputs are fresh. `--force` bypasses
+freshness checks; task output caching has separate `--task-cache` controls.
 
-```
+For a project that already has npm build scripts and its dependencies installed:
+
+```toml
 [tasks.build]
 run = "npm run build"
-sources = ["src/**/*.ts"]
+sources = ["src/**/*.ts", "package.json", "package-lock.json"]
 outputs = ["dist/**/*.js"]
 ```
 
-Alternatively, tasks can be defined as standalone scripts.
-These must be located in `mise-tasks`, `.mise-tasks`, `.mise/tasks`, `mise/tasks` or
-`.config/mise/tasks`.
-The name of the script becomes the name of the task.
-
-```
-$ cat .mise/tasks/build<<EOF
-#!/usr/bin/env bash
-npm run build
-EOF
-$ mise run build
-```
+To create a standalone script task, use `mise tasks add --file hello -- echo hello`.
+Then run `mise run hello`. See <https://mise.jdx.dev/tasks/> for task directories,
+arguments, caching, and dependency configuration.
 
 ## Flags
 - **`--affected`** — Run matching tasks only for projects affected by Git changes
@@ -81,10 +76,13 @@ $ mise run build
 - **`--allow-env <VAR>`** — Allow specific env var through (implies --deny-env for everything else)
   Supports wildcards, e.g. --allow-env='MYAPP_*'
 - **`--allow-net <HOST>`** — Allow network to specific host (implies --deny-net for everything else)
+  Per-host filtering is unsupported on Linux and returns an error.
+  See the sandboxing guide for current macOS host-filter limitations.
+  On Windows, sandboxing is unavailable: mise warns and runs without host filtering.
 - **`--allow-read <PATH>`** — Allow reads from specific path (implies --deny-read for everything else)
 - **`--allow-write <PATH>`** — Allow writes to specific path (implies --deny-write for everything else)
 - **`--deny-all`** — Block reads, writes, network, and env vars
-- **`--deny-env`** — Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
+- **`--deny-env`** — Block env var inheritance except PATH, HOME, USER, SHELL, TERM, COLORTERM, LANG
 - **`--deny-net`** — Block all network access
 - **`--deny-read`** — Block filesystem reads (system libs and tool dirs still accessible)
 - **`--deny-write`** — Block all filesystem writes
@@ -153,3 +151,11 @@ Run multiple tasks, each with its own arguments.
 ```
 mise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Running tasks](/tasks/running-tasks.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/search.md
+++ b/docs/cli/search.md
@@ -47,3 +47,11 @@ Search a tool
 /jq
 esc clear filter • enter confirm
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Registry and explicit backends](/registry.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/self-update.md
+++ b/docs/cli/self-update.md
@@ -23,3 +23,11 @@ package manager instead. See
 - **`-y --yes`** — Skip confirmation prompt
 - **`--no-plugins`** — Disable auto-updating plugins
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Installing and updating mise](/installing-mise.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/set.md
+++ b/docs/cli/set.md
@@ -8,7 +8,8 @@
 
 Set environment variables in mise.toml
 
-By default, this command modifies `mise.toml` in the current directory.
+By default, this command selects the nearest configuration directory and
+modifies its lowest-precedence TOML file, creating `mise.toml` here if none exists.
 If multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),
 the lowest precedence file (`mise.toml`) will be used.
 See <https://mise.jdx.dev/configuration.html#target-file-for-write-operations>
@@ -99,3 +100,11 @@ Prompt with hidden input and encrypt with age (experimental).
 ```
 mise set --age-encrypt --prompt API_KEY
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Environment variables](/environments/).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -54,3 +54,11 @@ mise settings node.mirror_url https://npmmirror.com/mirrors/node/
 - [`mise settings ls [FLAGS] [SETTING]`](/cli/settings/ls.html)
 - [`mise settings set [-l --local] <SETTING> [VALUE]`](/cli/settings/set.html)
 - [`mise settings unset [-l --local] <KEY>`](/cli/settings/unset.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Settings reference](/configuration/settings.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/settings/add.md
+++ b/docs/cli/settings/add.md
@@ -23,3 +23,11 @@ This modifies ~/.config/mise/config.toml by default, or the local config with `-
 ```
 mise settings add disable_hints python_multi
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Settings reference](/configuration/settings.html).
+- [`mise settings [FLAGS] [SETTING] [VALUE] [SUBCOMMAND]`](/cli/settings.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/settings/get.md
+++ b/docs/cli/settings/get.md
@@ -5,12 +5,11 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/settings/get.rs`](https://github.com/jdx/mise/blob/main/src/cli/settings/get.rs)
 
-Show a current setting
+Show the effective value of a setting
 
-This is the contents of a single entry in ~/.config/mise/config.toml
-
-Note that aliases are also stored in this file
-but managed separately with `mise tool-alias get`
+Includes defaults, configuration, and environment overrides. With `--local`,
+read only the selected local config's explicit settings; an unset key is an error.
+Use `mise config get settings.KEY --file path/to/mise.toml` to inspect one file.
 
 ## Arguments
 - **`<SETTING>`** — The setting to show
@@ -25,3 +24,11 @@ but managed separately with `mise tool-alias get`
 mise settings get jobs
 mise settings get python.compile
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Settings reference](/configuration/settings.html).
+- [`mise settings [FLAGS] [SETTING] [VALUE] [SUBCOMMAND]`](/cli/settings.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/settings/ls.md
+++ b/docs/cli/settings/ls.md
@@ -6,12 +6,12 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/settings/ls.rs`](https://github.com/jdx/mise/blob/main/src/cli/settings/ls.rs)
 
-Show current settings
+List configured settings and their sources
 
-This is the contents of ~/.config/mise/config.toml
-
-Note that aliases are also stored in this file
-but managed separately with `mise tool-alias`
+By default, list explicit settings from loaded TOML files. `--all` also includes
+effective defaults. Use `--local` to restrict output to the selected local file,
+and `--json-extended` to include source information in machine-readable output.
+Use `mise settings get KEY` when you need one effective value.
 
 ## Arguments
 - **`[SETTING]`** — Name of setting
@@ -31,3 +31,11 @@ mise settings ls
 mise settings ls --all
 mise settings ls python --json-extended
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Settings reference](/configuration/settings.html).
+- [`mise settings [FLAGS] [SETTING] [VALUE] [SUBCOMMAND]`](/cli/settings.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/settings/set.md
+++ b/docs/cli/settings/set.md
@@ -25,3 +25,11 @@ See <https://mise.jdx.dev/configuration.html#target-file-for-write-operations>
 ```
 mise settings set jobs 4
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Settings reference](/configuration/settings.html).
+- [`mise settings [FLAGS] [SETTING] [VALUE] [SUBCOMMAND]`](/cli/settings.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/settings/unset.md
+++ b/docs/cli/settings/unset.md
@@ -22,3 +22,11 @@ This modifies ~/.config/mise/config.toml by default, or the local config with `-
 ```
 mise settings unset jobs
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Settings reference](/configuration/settings.html).
+- [`mise settings [FLAGS] [SETTING] [VALUE] [SUBCOMMAND]`](/cli/settings.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/shell-alias.md
+++ b/docs/cli/shell-alias.md
@@ -17,3 +17,11 @@ Manage shell aliases
 - [`mise shell-alias ls [--no-header]`](/cli/shell-alias/ls.html)
 - [`mise shell-alias set <shell_alias> [COMMAND]`](/cli/shell-alias/set.html)
 - [`mise shell-alias unset <shell_alias>`](/cli/shell-alias/unset.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Shell aliases](/shell-aliases.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/shell-alias/get.md
+++ b/docs/cli/shell-alias/get.md
@@ -19,3 +19,11 @@ Show the command for a shell alias
 mise shell-alias get ll
 ls -la
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Shell aliases](/shell-aliases.html).
+- [`mise shell-alias [--no-header] [SUBCOMMAND]`](/cli/shell-alias.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/shell-alias/ls.md
+++ b/docs/cli/shell-alias/ls.md
@@ -23,3 +23,11 @@ alias    command
 ll       ls -la
 gs       git status
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Shell aliases](/shell-aliases.html).
+- [`mise shell-alias [--no-header] [SUBCOMMAND]`](/cli/shell-alias.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/shell-alias/set.md
+++ b/docs/cli/shell-alias/set.md
@@ -23,3 +23,11 @@ This modifies the contents of ~/.config/mise/config.toml
 mise shell-alias set ll "ls -la"
 mise shell-alias set gs "git status"
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Shell aliases](/shell-aliases.html).
+- [`mise shell-alias [--no-header] [SUBCOMMAND]`](/cli/shell-alias.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/shell-alias/unset.md
+++ b/docs/cli/shell-alias/unset.md
@@ -21,3 +21,11 @@ This modifies the contents of ~/.config/mise/config.toml
 ```
 mise shell-alias unset ll
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Shell aliases](/shell-aliases.html).
+- [`mise shell-alias [--no-header] [SUBCOMMAND]`](/cli/shell-alias.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/shell.md
+++ b/docs/cli/shell.md
@@ -33,3 +33,11 @@ mise shell node@20
 node -v
 v20.0.0
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Shell activation](/getting-started.html#activate-mise).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -20,3 +20,11 @@ an agent the skill for exactly that version.
 
 - [`mise skills ls [-J --json]`](/cli/skills/ls.html)
 - [`mise skills sync [FLAGS]`](/cli/skills/sync.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Skills and other Packslip resources](/dev-tools/packslip-resources.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/skills/ls.md
+++ b/docs/cli/skills/ls.md
@@ -23,3 +23,11 @@ mise skills ls
 Skill  Tool                        Version  Path
 mise   packslip:github.com/jdx/mise  2026.9.1  ~/.local/share/mise/installs/.../skills/mise
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Skills and other Packslip resources](/dev-tools/packslip-resources.html).
+- [`mise skills [SUBCOMMAND]`](/cli/skills.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/skills/sync.md
+++ b/docs/cli/skills/sync.md
@@ -37,3 +37,11 @@ somewhere else, and drop links for skills that are no longer active
 ```
 mise skills sync --dir .agents/skills --prune
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Skills and other Packslip resources](/dev-tools/packslip-resources.html).
+- [`mise skills [SUBCOMMAND]`](/cli/skills.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/sponsors.md
+++ b/docs/cli/sponsors.md
@@ -9,3 +9,11 @@ Show the companies sponsoring mise and the jdx.dev open source tools
 
 ## Flags
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Supporting mise](/about.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/ssh.md
+++ b/docs/cli/ssh.md
@@ -22,3 +22,11 @@ Open an SSH session, optionally borrowing read-only GitHub access
 - **`--github-relay-log-format <FORMAT>`** — Relay log and summary format: text or jsonl
 - **`--github-relay-max-duration <DURATION>`** — Expire borrowed access after a duration such as 1h (0s: session lifetime)
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Git provider authentication](/dev-tools/github-tokens.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/sync.md
+++ b/docs/cli/sync.md
@@ -15,3 +15,11 @@ Synchronize tools from other version managers with mise
 - [`mise sync node [FLAGS]`](/cli/sync/node.html)
 - [`mise sync python [--pyenv] [--uv]`](/cli/sync/python.html)
 - [`mise sync ruby <--brew>`](/cli/sync/ruby.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Development tools](/dev-tools/).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/sync/node.md
+++ b/docs/cli/sync/node.md
@@ -24,3 +24,11 @@ brew install node@20
 mise sync node --brew
 mise use -g node@20 # uses Homebrew-provided node
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Node.js](/lang/node.html).
+- [`mise sync <SUBCOMMAND>`](/cli/sync.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/sync/python.md
+++ b/docs/cli/sync/python.md
@@ -31,3 +31,11 @@ mise sync python --uv
 mise x python@3.11.0 -- python -V # uses uv-provided python
 uv run -p 3.10.0 -- python -V # uses mise-provided python
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Python](/lang/python.html).
+- [`mise sync <SUBCOMMAND>`](/cli/sync.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/sync/ruby.md
+++ b/docs/cli/sync/ruby.md
@@ -18,3 +18,11 @@ brew install ruby
 mise sync ruby --brew
 mise ls ruby --installed # inspect linked versions, then select one with mise use
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Ruby](/lang/ruby.html).
+- [`mise sync <SUBCOMMAND>`](/cli/sync.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/tasks.md
+++ b/docs/cli/tasks.md
@@ -39,3 +39,11 @@ Manage tasks
 - [`mise tasks ls [FLAGS]`](/cli/tasks/ls.html)
 - [`mise tasks run [FLAGS] [TASK] [ARGS]…`](/cli/tasks/run.html)
 - [`mise tasks validate [--errors-only] [--json] [TASKS]…`](/cli/tasks/validate.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Task configuration](/tasks/task-configuration.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/tasks/add.md
+++ b/docs/cli/tasks/add.md
@@ -37,3 +37,11 @@ See <https://mise.jdx.dev/configuration.html#target-file-for-write-operations>
 ```
 mise tasks add pre-commit --depends "test" --depends "render" -- echo pre-commit
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [TOML tasks](/tasks/toml-tasks.html).
+- [`mise tasks [FLAGS] [TASK] [SUBCOMMAND]`](/cli/tasks.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/tasks/deps.md
+++ b/docs/cli/tasks/deps.md
@@ -49,3 +49,11 @@ Collapse repeated dependencies
 ```
 mise tasks deps --compact
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Task dependency graph](/tasks/architecture.html).
+- [`mise tasks [FLAGS] [TASK] [SUBCOMMAND]`](/cli/tasks.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/tasks/edit.md
+++ b/docs/cli/tasks/edit.md
@@ -22,3 +22,11 @@ The task will be created as a standalone script if it does not already exist.
 mise tasks edit build
 mise tasks edit test
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [File tasks](/tasks/file-tasks.html).
+- [`mise tasks [FLAGS] [TASK] [SUBCOMMAND]`](/cli/tasks.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/tasks/graph.md
+++ b/docs/cli/tasks/graph.md
@@ -32,3 +32,11 @@ Explain where inferred projects and task fields came from
 ```
 mise tasks graph --explain
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Monorepo projects](/tasks/monorepo.html).
+- [`mise tasks [FLAGS] [TASK] [SUBCOMMAND]`](/cli/tasks.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/tasks/info.md
+++ b/docs/cli/tasks/info.md
@@ -27,3 +27,11 @@ Get the full structured task definition
 ```
 mise tasks info test --json
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Task configuration](/tasks/task-configuration.html).
+- [`mise tasks [FLAGS] [TASK] [SUBCOMMAND]`](/cli/tasks.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/tasks/ls.md
+++ b/docs/cli/tasks/ls.md
@@ -37,3 +37,11 @@ tasks will override the global ones if they have the same name.
 ```
 mise tasks ls
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Task configuration](/tasks/task-configuration.html).
+- [`mise tasks [FLAGS] [TASK] [SUBCOMMAND]`](/cli/tasks.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/tasks/run.md
+++ b/docs/cli/tasks/run.md
@@ -5,34 +5,29 @@
 - **Aliases:** `r`
 - **Source code:** [`src/cli/run.rs`](https://github.com/jdx/mise/blob/main/src/cli/run.rs)
 
-Run task(s)
+Run tasks and their dependencies
 
-Runs one task, or several tasks in parallel.
-Tasks may depend on other tasks and on source files.
-If a task has `sources` configured, it only runs when those files have changed.
+Use `mise run TASK [ARGS...]` for one task, or separate task invocations with `:::`
+to schedule several. Put mise flags before the task name; following arguments are
+passed to that task. With no task, mise runs `default` when defined or opens the
+task selector in an interactive terminal.
 
-Tasks can be defined in mise.toml or as standalone scripts.
-In mise.toml, tasks take this form:
+Tasks are defined in `mise.toml` or task directories. A task with `sources` and
+`outputs` can skip execution when its outputs are fresh. `--force` bypasses
+freshness checks; task output caching has separate `--task-cache` controls.
 
-```
+For a project that already has npm build scripts and its dependencies installed:
+
+```toml
 [tasks.build]
 run = "npm run build"
-sources = ["src/**/*.ts"]
+sources = ["src/**/*.ts", "package.json", "package-lock.json"]
 outputs = ["dist/**/*.js"]
 ```
 
-Alternatively, tasks can be defined as standalone scripts.
-These must be located in `mise-tasks`, `.mise-tasks`, `.mise/tasks`, `mise/tasks` or
-`.config/mise/tasks`.
-The name of the script becomes the name of the task.
-
-```
-$ cat .mise/tasks/build<<EOF
-#!/usr/bin/env bash
-npm run build
-EOF
-$ mise run build
-```
+To create a standalone script task, use `mise tasks add --file hello -- echo hello`.
+Then run `mise run hello`. See <https://mise.jdx.dev/tasks/> for task directories,
+arguments, caching, and dependency configuration.
 
 ## Flags
 - **`--affected`** — Run matching tasks only for projects affected by Git changes
@@ -81,10 +76,13 @@ $ mise run build
 - **`--allow-env <VAR>`** — Allow specific env var through (implies --deny-env for everything else)
   Supports wildcards, e.g. --allow-env='MYAPP_*'
 - **`--allow-net <HOST>`** — Allow network to specific host (implies --deny-net for everything else)
+  Per-host filtering is unsupported on Linux and returns an error.
+  See the sandboxing guide for current macOS host-filter limitations.
+  On Windows, sandboxing is unavailable: mise warns and runs without host filtering.
 - **`--allow-read <PATH>`** — Allow reads from specific path (implies --deny-read for everything else)
 - **`--allow-write <PATH>`** — Allow writes to specific path (implies --deny-write for everything else)
 - **`--deny-all`** — Block reads, writes, network, and env vars
-- **`--deny-env`** — Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
+- **`--deny-env`** — Block env var inheritance except PATH, HOME, USER, SHELL, TERM, COLORTERM, LANG
 - **`--deny-net`** — Block all network access
 - **`--deny-read`** — Block filesystem reads (system libs and tool dirs still accessible)
 - **`--deny-write`** — Block all filesystem writes
@@ -153,3 +151,11 @@ Run multiple tasks, each with its own arguments.
 ```
 mise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Running tasks](/tasks/running-tasks.html).
+- [`mise tasks [FLAGS] [TASK] [SUBCOMMAND]`](/cli/tasks.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/tasks/validate.md
+++ b/docs/cli/tasks/validate.md
@@ -56,3 +56,11 @@ The validate command performs the following checks:
   • Shell Commands: Checks shell executables exist
   • Glob Patterns: Validates source and output patterns
   • Run Entries: Ensures tasks reference valid dependencies
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Task configuration](/tasks/task-configuration.html).
+- [`mise tasks [FLAGS] [TASK] [SUBCOMMAND]`](/cli/tasks.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/test-tool.md
+++ b/docs/cli/test-tool.md
@@ -29,3 +29,11 @@ for this command.
 ```
 mise test-tool ripgrep
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Contributing and registry tests](/contributing.html#tool-testing).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/token.md
+++ b/docs/cli/token.md
@@ -15,3 +15,11 @@ Display git provider tokens mise will use
 - [`mise token forgejo [--unmask] [HOST]`](/cli/token/forgejo.html)
 - [`mise token github [FLAGS] [HOST]`](/cli/token/github.html)
 - [`mise token gitlab [--unmask] [HOST]`](/cli/token/gitlab.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Git provider authentication](/dev-tools/github-tokens.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/token/forgejo.md
+++ b/docs/cli/token/forgejo.md
@@ -35,3 +35,11 @@ codeberg.org: a18099ca69064be387fbe37b8ad1d333758361f6 (source: FORGEJO_TOKEN)
 mise token forgejo forgejo.mycompany.com
 forgejo.mycompany.com: (none)
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Git provider authentication](/dev-tools/github-tokens.html).
+- [`mise token <SUBCOMMAND>`](/cli/token.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/token/github.md
+++ b/docs/cli/token/github.md
@@ -43,3 +43,11 @@ github.mycompany.com: (none)
 mise token github --oauth --refresh
 github.com: gho_…xxxx (source: GitHub OAuth)
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Git provider authentication](/dev-tools/github-tokens.html).
+- [`mise token <SUBCOMMAND>`](/cli/token.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/token/gitlab.md
+++ b/docs/cli/token/gitlab.md
@@ -35,3 +35,11 @@ gitlab.com: glpat-xxxxxxxxxxxx (source: GITLAB_TOKEN)
 mise token gitlab gitlab.mycompany.com
 gitlab.mycompany.com: (none)
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Git provider authentication](/dev-tools/github-tokens.html).
+- [`mise token <SUBCOMMAND>`](/cli/token.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/tool-alias.md
+++ b/docs/cli/tool-alias.md
@@ -19,3 +19,11 @@ Manage tool version aliases
 - [`mise tool-alias ls [--no-header] [TOOL]`](/cli/tool-alias/ls.html)
 - [`mise tool-alias set <ARGS>…`](/cli/tool-alias/set.html)
 - [`mise tool-alias unset <TOOL> [ALIAS]`](/cli/tool-alias/unset.html)
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Tool version aliases](/dev-tools/aliases.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/tool-alias/get.md
+++ b/docs/cli/tool-alias/get.md
@@ -5,9 +5,11 @@
 - **Effect:** read-only
 - **Source code:** [`src/cli/tool_alias/get.rs`](https://github.com/jdx/mise/blob/main/src/cli/tool_alias/get.rs)
 
-Show an alias for a tool
+Show a configured version alias for a tool
 
-This is the contents of a tool_alias.&lt;TOOL> entry in ~/.config/mise/config.toml
+Reads the merged `[tool_alias.TOOL.versions]` configuration. This prints the
+stored request, which may itself be a prefix. Backend-provided aliases are listed
+by `mise tool-alias ls`; they are not entries returned by this command.
 
 ## Arguments
 - **`<TOOL>`** — The tool to show the alias for
@@ -23,3 +25,11 @@ mise tool-alias set node project 20
 mise tool-alias get node project
 20
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Tool version aliases](/dev-tools/aliases.html).
+- [`mise tool-alias [-p --tool <TOOL>] [--no-header] [SUBCOMMAND]`](/cli/tool-alias.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/tool-alias/ls.md
+++ b/docs/cli/tool-alias/ls.md
@@ -14,7 +14,7 @@ In user config, aliases are defined like the following in `~/.config/mise/config
 
 ```
 [tool_alias.node.versions]
-lts = "22.0.0"
+project = "20"
 ```
 
 ## Arguments
@@ -30,3 +30,11 @@ lts = "22.0.0"
 mise tool-alias ls
 node  lts-jod      22
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Tool version aliases](/dev-tools/aliases.html).
+- [`mise tool-alias [-p --tool <TOOL>] [--no-header] [SUBCOMMAND]`](/cli/tool-alias.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/tool-alias/set.md
+++ b/docs/cli/tool-alias/set.md
@@ -24,3 +24,11 @@ This modifies the contents of ~/.config/mise/config.toml
 mise tool-alias set ripgrep aqua:BurntSushi/ripgrep
 mise tool-alias set node project 20
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Tool version aliases](/dev-tools/aliases.html).
+- [`mise tool-alias [-p --tool <TOOL>] [--no-header] [SUBCOMMAND]`](/cli/tool-alias.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/tool-alias/unset.md
+++ b/docs/cli/tool-alias/unset.md
@@ -23,3 +23,11 @@ This modifies the contents of ~/.config/mise/config.toml
 mise tool-alias unset ripgrep
 mise tool-alias unset node project
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Tool version aliases](/dev-tools/aliases.html).
+- [`mise tool-alias [-p --tool <TOOL>] [--no-header] [SUBCOMMAND]`](/cli/tool-alias.html).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/tool-stub.md
+++ b/docs/cli/tool-stub.md
@@ -40,3 +40,11 @@ For more information, see: <https://mise.jdx.dev/dev-tools/tool-stubs.html>
 - **`[ARGS]…`** — Arguments to pass to the tool
 
   All arguments after the stub file path will be forwarded to the underlying tool. Use '--' to separate mise arguments from tool arguments if needed.
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Portable tool stubs](/dev-tools/tool-stubs.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/tool.md
+++ b/docs/cli/tool.md
@@ -32,3 +32,11 @@ Requested Version:  20
 Config Source:      ~/.config/mise/mise.toml
 Tool Options:       [none]
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Development tools](/dev-tools/).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/trust.md
+++ b/docs/cli/trust.md
@@ -53,3 +53,11 @@ trusts mise.toml in the current or parent directory
 ```
 mise trust
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Configuration trust](/security.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/uninstall.md
+++ b/docs/cli/uninstall.md
@@ -40,3 +40,11 @@ uninstall every installed version of node
 ```
 mise uninstall --all node
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Development tools](/dev-tools/).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/unset.md
+++ b/docs/cli/unset.md
@@ -7,7 +7,8 @@
 
 Remove environment variable(s) from the config file
 
-By default, this command modifies `mise.toml` in the current directory.
+By default, this command selects the nearest configuration directory and
+modifies its lowest-precedence TOML file, creating `mise.toml` here if none exists.
 
 ## Arguments
 - **`[ENV_KEY]…`** — Environment variable(s) to remove
@@ -37,3 +38,11 @@ Remove NODE_ENV from the global config
 ```
 mise unset NODE_ENV -g
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Environment variables](/environments/).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/untrust.md
+++ b/docs/cli/untrust.md
@@ -12,3 +12,11 @@ Remove explicit trust for a config
 
 ## Flags
 - **`-h --help`** — Print help
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Configuration trust](/security.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/unuse.md
+++ b/docs/cli/unuse.md
@@ -6,34 +6,27 @@
 - **Effect:** destructive — may delete or irreversibly overwrite
 - **Source code:** [`src/cli/unuse.rs`](https://github.com/jdx/mise/blob/main/src/cli/unuse.rs)
 
-Remove tool versions from mise.toml and uninstall them
+Remove tool requests from configuration and prune unused installations
 
-By default, this will use the `mise.toml` file that has the tool defined.
-If multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),
-the lowest precedence file (`mise.toml`) will be used.
-See <https://mise.jdx.dev/configuration.html#target-file-for-write-operations>
+Without a selector, mise edits the first loaded config that declares one of the
+requested tools. Use `--path`, `--global`, or `--env` to choose a specific file.
+A version argument matches the configured request literally: to remove `node = "20"`,
+use `mise unuse node@20`, not the concrete installed version it resolved to.
+Omit the version to remove all requests for that tool from the selected file.
 
-In the following order:
-- If `--global` is set, it will use the global config file.
-- If `--path` is set, it will use the config file at the given path.
-- If `--env` is set, it will use `mise.<env>.toml`.
-- If [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) is set, it will use that instead.
-- If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will use the first from that list.
-- Otherwise just "mise.toml" or global config if cwd is home directory.
-
-Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
-
-The installed version is also removed unless another config still uses it or `--no-prune` is passed.
+Versions are pruned only when no remaining tracked config or tool stub needs them.
+Pass `--no-prune` to edit configuration while keeping installations. To remove an
+installation without editing configuration, use `mise uninstall`.
 
 ## Arguments
 - **`<INSTALLED_TOOL@VERSION>…`** — Tool(s) to remove
 
 ## Flags
-- **`-e --env <ENV>`** — Create/modify an environment-specific config file like mise.&lt;env>.toml
+- **`-e --env <ENV>`** — Modify `.mise.<env>.toml` when it exists, otherwise `mise.<env>.toml`
 - **`-g --global`** — Use the global config file (`~/.config/mise/config.toml`) instead of the local one
 - **`-p --path <PATH>`** — Specify a path to a config file or directory
 
-  If a directory is specified, it will look for a config file in that directory following the rules above.
+  If a directory is specified, it will look for a config file in that directory following the target-file selection rules.
 
   **Aliases:** `--file`
 - **`--no-prune`** — Do not also prune the installed version
@@ -64,3 +57,11 @@ remove the literal node@20 request from mise.staging.toml
 ```
 mise unuse --env staging node@20
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Configuration write targets](/configuration.html#target-file-for-write-operations).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/upgrade.md
+++ b/docs/cli/upgrade.md
@@ -125,3 +125,11 @@ Deprecation:
 
 The `-l` shorthand for `--bump` is deprecated and will be removed in mise 2027.8.5.
 After removal, `-l` will become shorthand for `--local`. Use `-b` or `--bump` instead.
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Development tools](/dev-tools/).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/use.md
+++ b/docs/cli/use.md
@@ -6,23 +6,21 @@
 - **Effect:** modifies state
 - **Source code:** [`src/cli/use.rs`](https://github.com/jdx/mise/blob/main/src/cli/use.rs)
 
-Install a tool and add it to mise.toml
+Install a tool and add it to configuration
 
-Installs the tool version if it is not already installed, then writes it to a config file.
-By default, this is `mise.toml` in the current directory.
-If multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),
-the lowest precedence file (`mise.toml`) will be used.
+Installs missing tool versions and records the requests in a config file.
+By default, mise selects the nearest directory with a supported config and writes
+to its lowest-precedence file, such as `mise.toml` rather than `mise.local.toml`.
+If no project config exists, it creates one in the current directory. Running from
+your home directory targets global configuration.
+
+Use `--path` for an explicit file/directory, `--global` for personal defaults, or
+`--env` to write `mise.ENV.toml` in the current directory (preserving an existing
+`.mise.ENV.toml`). These selectors override one another; use one per command.
+
 See <https://mise.jdx.dev/configuration.html#target-file-for-write-operations>
-
-In the following order:
-- If `--global` is set, it will use the global config file.
-- If `--path` is set, it will use the config file at the given path.
-- If `--env` is set, it will use `mise.<env>.toml`.
-- If [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) is set, it will use that instead.
-- If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will use the first from that list.
-- Otherwise just "mise.toml" or global config if cwd is home directory.
-
-Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
+for filename overrides and configuration precedence. Selection takes effect in
+an activated shell on its next prompt, or immediately in `mise exec` commands.
 
 ## Arguments
 - **`<TOOL@VERSION>`** — Tool to add to config file
@@ -48,7 +46,7 @@ Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_glo
 - **`-n --dry-run`** — Perform a dry run, showing what would be installed and modified without making changes
 - **`-p --path <PATH>`** — Specify a path to a config file or directory
 
-  If a directory is specified, it will look for a config file in that directory following the rules above.
+  If a directory is specified, it will look for a config file in that directory following the target-file selection rules.
 - **`--dry-run-code`** — Like --dry-run but exits with code 1 if there are changes to make
 
   This is useful for scripts to check if tools need to be added or removed.
@@ -116,3 +114,11 @@ writes mise.staging.toml (loaded with MISE_ENV=staging)
 ```
 mise use --env staging node@20
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Installing and selecting tools](/dev-tools/).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/version.md
+++ b/docs/cli/version.md
@@ -24,3 +24,11 @@ mise --version
 mise -v
 mise -V
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Troubleshooting](/troubleshooting.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/watch.md
+++ b/docs/cli/watch.md
@@ -7,7 +7,11 @@
 
 Run task(s) and rerun them when files change
 
-Uses `watchexec` to watch for file changes and rerun the given task(s).
+Uses `watchexec` to watch task sources and rerun the selected tasks.
+Sources from dependencies are included unless `--skip-deps` is set. With no
+sources, watchexec watches the current directory. Use `--watch` and `--exts`
+for explicit watched paths and filters, and `--print-events` to diagnose them.
+The default task is `default`; define it or pass a task name.
 watchexec must be installed; `mise use -g watchexec@latest` installs it.
 
 For more advanced process management (daemon management, auto-restart, readiness checks,
@@ -43,7 +47,7 @@ cron scheduling), see mise's sister project: https://pitchfork.jdx.dev
   Signals are not supported on Windows at the moment, and will always be overridden to 'kill'. See '--stop-signal' for more on Windows "signals".
 - **`--stop-signal <SIGNAL>`** — Signal to send to stop the command
 
-  This is used by 'restart' and 'signal' modes of '--on-busy-update' (unless '--signal' is provided). The restart behaviour is to send the signal, wait for the command to exit, and if it hasn't exited after some time (see '--timeout-stop'), forcefully terminate it.
+  This is used by 'restart' and 'signal' modes of '--on-busy-update' (unless '--signal' is provided). The restart behaviour is to send the signal, wait for the command to exit, and if it hasn't exited after some time (see '--stop-timeout'), forcefully terminate it.
 
   The default on unix is "SIGTERM".
 
@@ -134,7 +138,7 @@ cron scheduling), see mise's sister project: https://pitchfork.jdx.dev
 
   For more complex uses (like watching non-recursively), use the argfile capability: build a file containing command-line options and pass it to watchexec with `@path/to/argfile`.
 
-  The special value '-' will read from STDIN; this in incompatible with '--stdin-quit'.
+  The special value '-' will read from STDIN; this is incompatible with '--stdin-quit'.
 - **`--no-vcs-ignore`** — Don't load gitignores
 
   Among other VCS exclude files, like for Mercurial, Subversion, Bazaar, DARCS, Fossil. Note that Watchexec will detect which of these is in use, if any, and only load the relevant files. Both global (like '~/.gitignore') and local (like '.gitignore') files are considered.
@@ -204,7 +208,9 @@ cron scheduling), see mise's sister project: https://pitchfork.jdx.dev
 
   /!\ This option is EXPERIMENTAL and may change and/or vanish without notice.
 
-  Provide your own custom filter programs in jaq (similar to jq) syntax. Programs are given an event in the same format as described in '--emit-events-to' and must return a boolean. Invalid programs will make watchexec fail to start; use '-v' to see program runtime errors.
+  Provide your own custom filter programs in jaq (similar to jq) syntax. Programs are given
+  an event in the same format as described in '--emit-events-to' and must return a boolean.
+  Invalid programs will make watchexec fail to start; use '-v' to see program runtime errors.
 
   In addition to the jaq stdlib, watchexec adds some custom filter definitions:
 
@@ -226,13 +232,20 @@ cron scheduling), see mise's sister project: https://pitchfork.jdx.dev
       value to stdout, stderr, or the log (levels = error, warn, info, debug, trace), and
       pass the value through (so '[1] | log("debug") | .[]' will produce a '1' and log '[1]').
 
-  All filtering done with such programs, and especially those using kv or filesystem access, is much slower than the other filtering methods. If filtering is too slow, events will back up and stall watchexec. Take care when designing your filters.
+  All filtering done with such programs, and especially those using kv or filesystem access,
+  is much slower than the other filtering methods. If filtering is too slow, events will back
+  up and stall watchexec. Take care when designing your filters.
 
-  If the argument to this option starts with an '@', the rest of the argument is taken to be the path to a file containing a jaq program.
+  If the argument to this option starts with an '@', the rest of the argument is taken to be
+  the path to a file containing a jaq program.
 
-  Jaq programs are run in order, after all other filters, and short-circuit: if a filter (jaq or not) rejects an event, execution stops there, and no other filters are run. Additionally, they stop after outputting the first value, so you'll want to use 'any' or 'all' when iterating, otherwise only the first item will be processed, which can be quite confusing!
+  Jaq programs are run in order, after all other filters, and short-circuit: if a filter (jaq
+  or not) rejects an event, execution stops there, and no other filters are run. Additionally,
+  they stop after outputting the first value, so you'll want to use 'any' or 'all' when
+  iterating, otherwise only the first item will be processed, which can be quite confusing!
 
-  Find user-contributed programs or submit your own useful ones at &lt;https://github.com/watchexec/watchexec/discussions/592>.
+  Find user-contributed programs or submit your own useful ones at
+  &lt;https://github.com/watchexec/watchexec/discussions/592>.
 
   ## Examples:
 
@@ -246,11 +259,11 @@ cron scheduling), see mise's sister project: https://pitchfork.jdx.dev
 
   Pass events that touch executable files:
 
-    'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | metadata | .executable)'
+    'any(.tags[] | select(.kind == "path" and .filetype == "file"); .absolute | file_meta | .executable)'
 
   Ignore files that start with shebangs:
 
-    'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | read(2) == "#!") | not'
+    'any(.tags[] | select(.kind == "path" and .filetype == "file"); .absolute | file_read(2) == "#!") | not'
 - **`-i --ignore <PATTERN>`** — Filename patterns to filter out
 
   Provide a glob-like filter pattern, and events for files matching the pattern will be excluded. Multiple patterns can be given by repeating the option. Events that are not from files (e.g. signals, keyboard events) will pass through untouched.
@@ -381,7 +394,7 @@ cron scheduling), see mise's sister project: https://pitchfork.jdx.dev
         },
         {
           "kind": "source",
-          "source": "filesystem",
+          "source": "filesystem"
         }
       ],
       "metadata": {
@@ -494,3 +507,11 @@ Start an API server and restart it when Rust files in ./src change.
 ```
 mise watch serve --watch src --exts rs --restart
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Watching tasks](/tasks/running-tasks.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/where.md
+++ b/docs/cli/where.md
@@ -33,3 +33,11 @@ Show the install directory of the active node, or of the latest installed versio
 mise where node
 /home/jdx/.local/share/mise/installs/node/20.0.0
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Development tools](/dev-tools/).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/cli/which.md
+++ b/docs/cli/which.md
@@ -35,3 +35,11 @@ node
 mise which node --version
 20.0.0
 ```
+
+<!-- generated reference navigation -->
+
+## Related documentation
+
+- [Shims and executable lookup](/dev-tools/shims.html).
+- [All commands](/cli/).
+- [Global flags and argument syntax](/cli/#global-flags).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -634,7 +634,7 @@ Use this when you want global writes, such as `mise use` or `mise set` run from
 `$HOME`, to target a different config file. [`MISE_DEFAULT_CONFIG_FILENAME`](#mise-default-config-filename)
 customizes the default local config filename, not the global config path.
 
-### `MISE_DEFAULT_CONFIG_FILENAME`
+### `MISE_DEFAULT_CONFIG_FILENAME` {#mise-default-config-filename}
 
 Default: `mise.toml`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,7 +165,7 @@ Run `mise config` to see what files mise has loaded in order of precedence.
 
 ### Target File for Write Operations
 
-When commands like [`mise use`](/cli/use), [`mise set`](/cli/set), or [`mise unuse`](/cli/unuse) need to write to a config file, they use the **lowest precedence file in the highest precedence directory**. This means:
+When commands like [`mise use`](/cli/use), [`mise set`](/cli/set), or [`mise unset`](/cli/unset) need to write to a config file, they use the **lowest precedence file in the highest precedence directory**. This means:
 
 - If both `mise.toml` and `mise.local.toml` exist, writes go to `mise.toml`
 - If both `mise.toml` and `mise.production.toml` exist, writes go to `mise.toml`
@@ -183,6 +183,11 @@ $ mise set NODE_ENV=production  # writes to mise.toml
 ```
 
 :::
+
+Other commands select files differently:
+
+- [`mise config get`](/cli/config/get) and [`mise config set`](/cli/config/set) default to the **highest-precedence loaded TOML file**, which can be `mise.local.toml`. Use `--file` to choose an existing project file explicitly.
+- [`mise unuse`](/cli/unuse) defaults to the first loaded config that declares any requested tool. A version-qualified argument matches the literal configured request: `node@20` matches `node = "20"`, not `node = "20.0.0"`. Use `--path` to choose the file.
 
 ### `[tools]` - Dev tools
 
@@ -494,7 +499,7 @@ in both mise and nvm. Here are some of the supported idiomatic version files:
 
 Registry-backed tools can also describe how mise should extract versions from structured
 idiomatic files. Registry entries may use the same `version_regex`, `version_json_path`, and
-`version_expr` parsers as the [HTTP backend](/dev-tools/backends/http.html#version-listing).
+`version_expr` parsers as the [HTTP backend](/dev-tools/backends/http.html#version-list-url).
 This lets tools installed through backends such as `aqua:` and `github:` support JSON manifests
 and other tool-specific version files without requiring an asdf or vfox plugin.
 
@@ -626,7 +631,7 @@ Default: `$MISE_CONFIG_DIR/config.toml` (usually `~/.config/mise/config.toml`)
 This is the path to the global config file.
 
 Use this when you want global writes, such as `mise use` or `mise set` run from
-`$HOME`, to target a different config file. [`MISE_DEFAULT_CONFIG_FILENAME`](#mise_default_config_filename)
+`$HOME`, to target a different config file. [`MISE_DEFAULT_CONFIG_FILENAME`](#mise-default-config-filename)
 customizes the default local config filename, not the global config path.
 
 ### `MISE_DEFAULT_CONFIG_FILENAME`

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -164,12 +164,12 @@
 
 ## CLI Reference
 
-- [CLI Overview](https://mise.jdx.dev/cli/)
-- [mise activate](https://mise.jdx.dev/cli/activate.html): Initialize mise in the current shell session
+- [CLI Overview](https://mise.jdx.dev/cli/): Usage: mise [FLAGS] [COMMAND | TASK] [ARGS]…
+- [mise activate](https://mise.jdx.dev/cli/activate.html): Print the script to activate mise in an interactive shell
 - [mise backends](https://mise.jdx.dev/cli/backends.html): Manage backends
 - [mise backends ls](https://mise.jdx.dev/cli/backends/ls.html): List built-in backends
 - [mise bin-paths](https://mise.jdx.dev/cli/bin-paths.html): List all the active runtime bin paths
-- [mise bootstrap](https://mise.jdx.dev/cli/bootstrap.html): Set up a machine for the current config in one command
+- [mise bootstrap](https://mise.jdx.dev/cli/bootstrap.html): Set up a machine from the current configuration
 - [mise bootstrap accounts](https://mise.jdx.dev/cli/bootstrap/accounts.html): Manage Linux users and groups from [bootstrap.users] and [bootstrap.groups]
 - [mise bootstrap compose](https://mise.jdx.dev/cli/bootstrap/compose.html): Manage Docker Compose projects from [bootstrap.compose]
 - [mise bootstrap config-roots](https://mise.jdx.dev/cli/bootstrap/config-roots.html): Show non-composed bootstrap declarations in each selected configuration root
@@ -195,10 +195,10 @@
 - [mise cache task](https://mise.jdx.dev/cli/cache/task.html): Inspect output cache entries for a task
 - [mise completion](https://mise.jdx.dev/cli/completion.html): Generate shell completions
 - [mise config](https://mise.jdx.dev/cli/config.html): Manage config files
-- [mise config get](https://mise.jdx.dev/cli/config/get.html): Display a value from a mise.toml file
+- [mise config get](https://mise.jdx.dev/cli/config/get.html): Display a value from one mise TOML file
 - [mise config ls](https://mise.jdx.dev/cli/config/ls.html): List config files currently in use
-- [mise config set](https://mise.jdx.dev/cli/config/set.html): Set a value in a mise.toml file
-- [mise deactivate](https://mise.jdx.dev/cli/deactivate.html): Disable mise for current shell session
+- [mise config set](https://mise.jdx.dev/cli/config/set.html): Set a value in one mise TOML file
+- [mise deactivate](https://mise.jdx.dev/cli/deactivate.html): Print the script to disable mise in the current shell session
 - [mise deps](https://mise.jdx.dev/cli/deps.html): [experimental] Manage project dependencies
 - [mise deps add](https://mise.jdx.dev/cli/deps/add.html): Add a dependency
 - [mise deps install](https://mise.jdx.dev/cli/deps/install.html): Install all project dependencies
@@ -207,27 +207,27 @@
 - [mise doctor path](https://mise.jdx.dev/cli/doctor/path.html): Print the current PATH entries mise is providing
 - [mise edit](https://mise.jdx.dev/cli/edit.html): Edit mise.toml interactively
 - [mise en](https://mise.jdx.dev/cli/en.html): Start a new shell with the mise environment built from the current configuration
-- [mise env](https://mise.jdx.dev/cli/env.html): Export env vars to activate mise a single time
+- [mise env](https://mise.jdx.dev/cli/env.html): Print the environment for the current configuration
 - [mise exec](https://mise.jdx.dev/cli/exec.html): Execute a command with tool(s) set
-- [mise fmt](https://mise.jdx.dev/cli/fmt.html): Format mise.toml
+- [mise fmt](https://mise.jdx.dev/cli/fmt.html): Format mise TOML configuration
 - [mise generate](https://mise.jdx.dev/cli/generate.html): Generate files for various tools/services
 - [mise generate config](https://mise.jdx.dev/cli/generate/config.html): Generate a mise.toml file
-- [mise generate devcontainer](https://mise.jdx.dev/cli/generate/devcontainer.html): Generate a devcontainer to execute mise
+- [mise generate devcontainer](https://mise.jdx.dev/cli/generate/devcontainer.html): Generate devcontainer configuration for mise
 - [mise generate git-pre-commit](https://mise.jdx.dev/cli/generate/git-pre-commit.html): Generate a git pre-commit hook
 - [mise generate github-action](https://mise.jdx.dev/cli/generate/github-action.html): Generate a GitHub Action workflow file
 - [mise generate install-script](https://mise.jdx.dev/cli/generate/install-script.html): Generate a script to download+execute mise
-- [mise generate task-docs](https://mise.jdx.dev/cli/generate/task-docs.html): Generate documentation for tasks in a project
+- [mise generate task-docs](https://mise.jdx.dev/cli/generate/task-docs.html): Generate Markdown documentation for project tasks
 - [mise generate task-stubs](https://mise.jdx.dev/cli/generate/task-stubs.html): Generate shims to run mise tasks
 - [mise generate tool-stub](https://mise.jdx.dev/cli/generate/tool-stub.html): Generate a tool stub for HTTP-based tools
 - [mise implode](https://mise.jdx.dev/cli/implode.html): Remove the mise CLI and all related data
 - [mise install](https://mise.jdx.dev/cli/install.html): Install a tool version
 - [mise install-into](https://mise.jdx.dev/cli/install-into.html): Install a tool version to a specific path
-- [mise latest](https://mise.jdx.dev/cli/latest.html): Get the latest available version of a tool
+- [mise latest](https://mise.jdx.dev/cli/latest.html): Resolve the latest matching version request for a tool
 - [mise link](https://mise.jdx.dev/cli/link.html): Symlink a tool version into mise
-- [mise lock](https://mise.jdx.dev/cli/lock.html): Update lockfile checksums and URLs for all specified platforms
+- [mise lock](https://mise.jdx.dev/cli/lock.html): Create or refresh lockfile versions, checksums, and download URLs
 - [mise ls](https://mise.jdx.dev/cli/ls.html): List installed and active tool versions
 - [mise ls-remote](https://mise.jdx.dev/cli/ls-remote.html): List tool versions available to install
-- [mise mcp](https://mise.jdx.dev/cli/mcp.html): Run Model Context Protocol (MCP) server
+- [mise mcp](https://mise.jdx.dev/cli/mcp.html): Run the Model Context Protocol server over stdin/stdout
 - [mise oci](https://mise.jdx.dev/cli/oci.html): [experimental] Build OCI container images from a mise.toml
 - [mise oci build](https://mise.jdx.dev/cli/oci/build.html): [experimental] Build an OCI image from the current mise.toml
 - [mise oci push](https://mise.jdx.dev/cli/oci/push.html): [experimental] Build an OCI image and push it to a registry
@@ -238,23 +238,23 @@
 - [mise packslip pins](https://mise.jdx.dev/cli/packslip/pins.html): List the signers mise has accepted packslips from
 - [mise patrons](https://mise.jdx.dev/cli/patrons.html): Show the individuals supporting mise as Patron-tier members
 - [mise plugins](https://mise.jdx.dev/cli/plugins.html): Manage plugins
-- [mise plugins install](https://mise.jdx.dev/cli/plugins/install.html): Install a plugin
-- [mise plugins link](https://mise.jdx.dev/cli/plugins/link.html): Symlink a plugin into mise
-- [mise plugins ls](https://mise.jdx.dev/cli/plugins/ls.html): List installed plugins
+- [mise plugins install](https://mise.jdx.dev/cli/plugins/install.html): Install a plugin from a configured source, Git URL, or supported archive
+- [mise plugins link](https://mise.jdx.dev/cli/plugins/link.html): Link a local plugin directory into mise for development
+- [mise plugins ls](https://mise.jdx.dev/cli/plugins/ls.html): List installed external plugins
 - [mise plugins ls-remote](https://mise.jdx.dev/cli/plugins/ls-remote.html): List all available remote plugins
-- [mise plugins uninstall](https://mise.jdx.dev/cli/plugins/uninstall.html): Remove a plugin
+- [mise plugins uninstall](https://mise.jdx.dev/cli/plugins/uninstall.html): Remove an installed plugin
 - [mise plugins update](https://mise.jdx.dev/cli/plugins/update.html): Update a plugin to the latest version
 - [mise prune](https://mise.jdx.dev/cli/prune.html): Delete unused versions of tools
-- [mise registry](https://mise.jdx.dev/cli/registry.html): List available tools to install
-- [mise reshim](https://mise.jdx.dev/cli/reshim.html): Create shims for the executables of currently installed tools
-- [mise run](https://mise.jdx.dev/cli/run.html): Run task(s)
+- [mise registry](https://mise.jdx.dev/cli/registry.html): List registry shorthand names and their backends
+- [mise reshim](https://mise.jdx.dev/cli/reshim.html): Create shims for executables provided by installed tools
+- [mise run](https://mise.jdx.dev/cli/run.html): Run tasks and their dependencies
 - [mise search](https://mise.jdx.dev/cli/search.html): Search for tools in the registry
 - [mise self-update](https://mise.jdx.dev/cli/self-update.html): Update mise itself
 - [mise set](https://mise.jdx.dev/cli/set.html): Set environment variables in mise.toml
 - [mise settings](https://mise.jdx.dev/cli/settings.html): Manage settings
 - [mise settings add](https://mise.jdx.dev/cli/settings/add.html): Append a value to an array setting
-- [mise settings get](https://mise.jdx.dev/cli/settings/get.html): Show a current setting
-- [mise settings ls](https://mise.jdx.dev/cli/settings/ls.html): Show current settings
+- [mise settings get](https://mise.jdx.dev/cli/settings/get.html): Show the effective value of a setting
+- [mise settings ls](https://mise.jdx.dev/cli/settings/ls.html): List configured settings and their sources
 - [mise settings set](https://mise.jdx.dev/cli/settings/set.html): Add/update a setting
 - [mise settings unset](https://mise.jdx.dev/cli/settings/unset.html): Clear a setting
 - [mise shell](https://mise.jdx.dev/cli/shell.html): Set a tool version for the current shell session
@@ -279,7 +279,7 @@
 - [mise tasks graph](https://mise.jdx.dev/cli/tasks/graph.html): [experimental] Inspect the workspace project graph
 - [mise tasks info](https://mise.jdx.dev/cli/tasks/info.html): Get information about a task
 - [mise tasks ls](https://mise.jdx.dev/cli/tasks/ls.html): List available tasks
-- [mise tasks run](https://mise.jdx.dev/cli/tasks/run.html): Run task(s)
+- [mise tasks run](https://mise.jdx.dev/cli/tasks/run.html): Run tasks and their dependencies
 - [mise tasks validate](https://mise.jdx.dev/cli/tasks/validate.html): Validate tasks for common errors and issues
 - [mise test-tool](https://mise.jdx.dev/cli/test-tool.html): Test that a tool installs and runs
 - [mise token](https://mise.jdx.dev/cli/token.html): Display git provider tokens mise will use
@@ -288,7 +288,7 @@
 - [mise token gitlab](https://mise.jdx.dev/cli/token/gitlab.html): Display the GitLab token mise will use for a given host
 - [mise tool](https://mise.jdx.dev/cli/tool.html): Show information about a tool
 - [mise tool-alias](https://mise.jdx.dev/cli/tool-alias.html): Manage tool version aliases
-- [mise tool-alias get](https://mise.jdx.dev/cli/tool-alias/get.html): Show an alias for a tool
+- [mise tool-alias get](https://mise.jdx.dev/cli/tool-alias/get.html): Show a configured version alias for a tool
 - [mise tool-alias ls](https://mise.jdx.dev/cli/tool-alias/ls.html): List tool version aliases
 - [mise tool-alias set](https://mise.jdx.dev/cli/tool-alias/set.html): Add/update an alias for a tool/backend
 - [mise tool-alias unset](https://mise.jdx.dev/cli/tool-alias/unset.html): Clear an alias for a tool/backend
@@ -297,9 +297,9 @@
 - [mise uninstall](https://mise.jdx.dev/cli/uninstall.html): Remove installed tool versions
 - [mise unset](https://mise.jdx.dev/cli/unset.html): Remove environment variable(s) from the config file
 - [mise untrust](https://mise.jdx.dev/cli/untrust.html): Remove explicit trust for a config
-- [mise unuse](https://mise.jdx.dev/cli/unuse.html): Remove tool versions from mise.toml and uninstall them
+- [mise unuse](https://mise.jdx.dev/cli/unuse.html): Remove tool requests from configuration and prune unused installations
 - [mise upgrade](https://mise.jdx.dev/cli/upgrade.html): Upgrade outdated tools
-- [mise use](https://mise.jdx.dev/cli/use.html): Install a tool and add it to mise.toml
+- [mise use](https://mise.jdx.dev/cli/use.html): Install a tool and add it to configuration
 - [mise version](https://mise.jdx.dev/cli/version.html): Display the version of mise
 - [mise watch](https://mise.jdx.dev/cli/watch.html): Run task(s) and rerun them when files change
 - [mise where](https://mise.jdx.dev/cli/where.html): Display the installation path for a tool

--- a/e2e/cli/test_lock
+++ b/e2e/cli/test_lock
@@ -216,7 +216,7 @@ assert_contains "echo '$output'" "Dry run - would update"
 assert_not_contains "echo '$output'" "Dry run - would prune"
 
 echo "=== Testing help output ==="
-assert_contains "mise lock --help" "Update lockfile checksums and URLs"
+assert_contains "mise lock --help" "Create or refresh lockfile versions, checksums, and download URLs"
 assert_contains "mise lock --help" "--platform"
 assert_contains "mise lock --help" "--dry-run"
 assert_contains "mise lock --help" "--jobs"

--- a/e2e/cli/test_mcp
+++ b/e2e/cli/test_mcp
@@ -3,9 +3,9 @@
 # Test mise mcp command
 
 # Test that mcp command exists and shows help
-assert_contains "mise mcp --help" "Run Model Context Protocol (MCP) server"
-assert_contains "mise mcp --help" "This command starts an MCP server that exposes mise functionality"
-assert_contains "mise mcp --help" "to AI assistants over stdin/stdout using JSON-RPC protocol."
+assert_contains "mise mcp --help" "Run the Model Context Protocol server over stdin/stdout"
+assert_contains "mise mcp --help" "Exposes project tools, tasks, environment, and configuration to an MCP client."
+assert_contains "mise mcp --help" "Environment resources contain real values, including secrets."
 
 # Test that mcp server can be invoked (even if it errors without proper initialization)
 # The server requires proper initialization sequence, so we just test that the command exists

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -116,7 +116,7 @@ Task arguments
 .SH COMMANDS
 .TP
 \fBactivate\fR
-Initialize mise in the current shell session
+Print the script to activate mise in an interactive shell
 .TP
 \fBtool\-alias\fR
 Manage tool version aliases
@@ -125,7 +125,7 @@ Manage tool version aliases
 .RE
 .TP
 \fBtool\-alias get\fR
-Show an alias for a tool
+Show a configured version alias for a tool
 .TP
 \fBtool\-alias ls\fR
 List tool version aliases
@@ -161,7 +161,7 @@ List built\-in backends
 List all the active runtime bin paths
 .TP
 \fBbootstrap\fR
-Set up a machine for the current config in one command
+Set up a machine from the current configuration
 .RS
 \fIAliases: \fRbs
 .RE
@@ -422,7 +422,7 @@ Manage config files
 .RE
 .TP
 \fBconfig get\fR
-Display a value from a mise.toml file
+Display a value from one mise TOML file
 .TP
 \fBconfig ls\fR
 List config files currently in use
@@ -431,10 +431,10 @@ List config files currently in use
 .RE
 .TP
 \fBconfig set\fR
-Set a value in a mise.toml file
+Set a value in one mise TOML file
 .TP
 \fBdeactivate\fR
-Disable mise for current shell session
+Print the script to disable mise in the current shell session
 .TP
 \fBdoctor\fR
 Check mise installation for possible problems
@@ -452,7 +452,7 @@ Print the current PATH entries mise is providing
 Start a new shell with the mise environment built from the current configuration
 .TP
 \fBenv\fR
-Export env vars to activate mise a single time
+Print the environment for the current configuration
 .RS
 \fIAliases: \fRe
 .RE
@@ -464,7 +464,7 @@ Execute a command with tool(s) set
 .RE
 .TP
 \fBfmt\fR
-Format mise.toml
+Format mise TOML configuration
 .TP
 \fBgenerate\fR
 Generate files for various tools/services
@@ -476,7 +476,7 @@ Generate files for various tools/services
 Generate a mise.toml file
 .TP
 \fBgenerate devcontainer\fR
-Generate a devcontainer to execute mise
+Generate devcontainer configuration for mise
 .TP
 \fBgenerate git\-pre\-commit\fR
 Generate a git pre\-commit hook
@@ -491,7 +491,7 @@ Generate a GitHub Action workflow file
 Generate a script to download+execute mise
 .TP
 \fBgenerate task\-docs\fR
-Generate documentation for tasks in a project
+Generate Markdown documentation for project tasks
 .TP
 \fBgenerate task\-stubs\fR
 Generate shims to run mise tasks
@@ -515,7 +515,7 @@ Install a tool version
 Install a tool version to a specific path
 .TP
 \fBlatest\fR
-Get the latest available version of a tool
+Resolve the latest matching version request for a tool
 .TP
 \fBlink\fR
 Symlink a tool version into mise
@@ -524,7 +524,7 @@ Symlink a tool version into mise
 .RE
 .TP
 \fBlock\fR
-Update lockfile checksums and URLs for all specified platforms
+Create or refresh lockfile versions, checksums, and download URLs
 .TP
 \fBls\fR
 List installed and active tool versions
@@ -539,7 +539,7 @@ List tool versions available to install
 .RE
 .TP
 \fBmcp\fR
-Run Model Context Protocol (MCP) server
+Run the Model Context Protocol server over stdin/stdout
 .TP
 \fBoci\fR
 [experimental] Build OCI container images from a mise.toml
@@ -578,19 +578,19 @@ Manage plugins
 .RE
 .TP
 \fBplugins install\fR
-Install a plugin
+Install a plugin from a configured source, Git URL, or supported archive
 .RS
 \fIAliases: \fRi, a, add
 .RE
 .TP
 \fBplugins link\fR
-Symlink a plugin into mise
+Link a local plugin directory into mise for development
 .RS
 \fIAliases: \fRln
 .RE
 .TP
 \fBplugins ls\fR
-List installed plugins
+List installed external plugins
 .RS
 \fIAliases: \fRlist
 .RE
@@ -602,7 +602,7 @@ List all available remote plugins
 .RE
 .TP
 \fBplugins uninstall\fR
-Remove a plugin
+Remove an installed plugin
 .RS
 \fIAliases: \fRremove, rm
 .RE
@@ -632,13 +632,13 @@ Remove a dependency
 Delete unused versions of tools
 .TP
 \fBregistry\fR
-List available tools to install
+List registry shorthand names and their backends
 .TP
 \fBreshim\fR
-Create shims for the executables of currently installed tools
+Create shims for executables provided by installed tools
 .TP
 \fBrun\fR
-Run task(s)
+Run tasks and their dependencies
 .RS
 \fIAliases: \fRr
 .RE
@@ -662,10 +662,10 @@ Manage settings
 Append a value to an array setting
 .TP
 \fBsettings get\fR
-Show a current setting
+Show the effective value of a setting
 .TP
 \fBsettings ls\fR
-Show current settings
+List configured settings and their sources
 .RS
 \fIAliases: \fRlist
 .RE
@@ -770,7 +770,7 @@ Get information about a task
 List available tasks
 .TP
 \fBtasks run\fR
-Run task(s)
+Run tasks and their dependencies
 .RS
 \fIAliases: \fRr
 .RE
@@ -812,7 +812,7 @@ Remove environment variable(s) from the config file
 Remove explicit trust for a config
 .TP
 \fBunuse\fR
-Remove tool versions from mise.toml and uninstall them
+Remove tool requests from configuration and prune unused installations
 .RS
 \fIAliases: \fRrm, remove
 .RE
@@ -824,7 +824,7 @@ Upgrade outdated tools
 .RE
 .TP
 \fBuse\fR
-Install a tool and add it to mise.toml
+Install a tool and add it to configuration
 .RS
 \fIAliases: \fRu
 .RE
@@ -847,22 +847,21 @@ Display the installation path for a tool
 \fBwhich\fR
 Show the path a tool's executable resolves to
 .SH "MISE ACTIVATE"
-Initialize mise in the current shell session
+Print the script to activate mise in an interactive shell
 
-Add this to your shell's rc or profile file so it runs in every new shell.
-Otherwise, it only takes effect in the current session.
-(e.g. ~/.zshrc, ~/.zprofile, ~/.zshenv, ~/.bashrc, ~/.bash_profile, ~/.profile, ~/.config/fish/config.fish, or $PROFILE for powershell)
+Evaluate this command's output with the syntax for your shell; running it alone
+only prints the script. Activation updates tools and environment variables as
+this shell changes directories.
 
-Typically, this can be added with something like the following:
+Add the appropriate example below once to your interactive startup file:
+~/.bashrc for Bash, ~/.zshrc for Zsh, ~/.config/fish/config.fish for Fish,
+or $PROFILE for PowerShell. See the getting\-started guide for other shells.
 
-    echo 'eval "$(mise activate zsh)"' >> ~/.zshrc
+The mise executable must be on PATH before that line runs. Otherwise use its
+absolute path, for example `eval "$(~/.local/bin/mise activate zsh)"`.
 
-However, this requires that "mise" is in your PATH. If it is not, you need to
-specify the full path like this:
-
-    echo 'eval "$(/path/to/mise activate zsh)"' >> ~/.zshrc
-
-Customize status output with `status` settings.
+Use `mise exec \-\- command` for scripts and CI that do not need interactive hooks.
+Customize status output with the `status` settings.
 .PP
 \fBUsage:\fR mise activate [OPTIONS] [<SHELL_TYPE>]
 .PP
@@ -948,9 +947,11 @@ Don't show table header
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE TOOL-ALIAS GET"
-Show an alias for a tool
+Show a configured version alias for a tool
 
-This is the contents of a tool_alias.<TOOL> entry in ~/.config/mise/config.toml
+Reads the merged `[tool_alias.TOOL.versions]` configuration. This prints the
+stored request, which may itself be a prefix. Backend\-provided aliases are listed
+by `mise tool\-alias ls`; they are not entries returned by this command.
 .PP
 \fBUsage:\fR mise tool\-alias get [OPTIONS] <TOOL> <ALIAS>
 .PP
@@ -983,7 +984,7 @@ Aliases can be defined in user config or provided by plugins via `bin/list\-alia
 In user config, aliases are defined like the following in `~/.config/mise/config.toml`:
 
     [tool_alias.node.versions]
-    lts = "22.0.0"
+    project = "20"
 .PP
 \fBUsage:\fR mise tool\-alias ls [OPTIONS] [<TOOL>]
 .PP
@@ -1115,55 +1116,27 @@ Print help
 Tool(s) to look up
 e.g.: ruby@3
 .SH "MISE BOOTSTRAP"
-Set up a machine for the current config in one command
+Set up a machine from the current configuration
 
-Runs the bootstrap steps for the current config in order:
+Runs these phases in order, when configured and selected:
 
-0. `mise bootstrap accounts apply` — converge `[bootstrap.users]` and
-   `[bootstrap.groups]` (Linux)
-1. `mise bootstrap plugins apply` — install `[bootstrap.plugins]`
-   1.7. `[bootstrap.hooks.pre\-packages]` — optional setup hook
-2. Install built\-in\-manager entries from `[bootstrap.packages]`
-3. `mise bootstrap files apply` — converge `[bootstrap.files]` and
-   `[bootstrap.directories]`
-4. `mise bootstrap services apply` — converge `[bootstrap.services]`
-   systemd system services (Linux)
-5. `mise bootstrap firewall apply` — converge `[bootstrap.linux.firewall]`
-   host firewall policy and rules (Linux)
-6. `mise bootstrap compose apply` — converge `[bootstrap.compose]`
-   Docker Compose projects
-7. `mise bootstrap repos apply` — clone/converge `[bootstrap.repos]`
-   surrounded by `pre\-repos`/`post\-repos` hooks
-8. `mise bootstrap dotfiles apply` — apply dotfiles from `[dotfiles]`
-   surrounded by `pre\-dotfiles`/`post\-dotfiles` hooks
-9. `mise bootstrap mise\-shell\-activate apply` — configure shell activation
-   from `[bootstrap.mise_shell_activate]`
-10. `mise bootstrap macos defaults apply` — write
-    `[bootstrap.macos.defaults]` entries (macOS)
-    surrounded by `pre\-defaults`/`post\-defaults` hooks
-11. `mise bootstrap macos launchd\-agents apply` — install/load
-    `[bootstrap.macos.launchd.agents]`
-12. `mise bootstrap linux systemd\-units apply` — install/start
-    `[bootstrap.linux.systemd.units]`
-13. `mise bootstrap user apply` — set `[bootstrap.user].login_shell`
-    (Unix)
-    surrounded by `pre\-user`/`post\-user` hooks
-14. `mise install` — install missing tools from `[tools]`
-    surrounded by `pre\-tools`/`post\-tools` hooks; package\-plugin entries
-    from `[bootstrap.packages]` install afterward, followed by
-    `[bootstrap.hooks.post\-packages]`
-15. `mise run bootstrap` — if a task named `bootstrap` is defined
-16. `[bootstrap.hooks.final]` — optional final hook
+1. Linux accounts, then package\-manager plugins.
+2. The pre\-packages hook, then packages handled by built\-in managers.
+3. Privileged files/directories, system services, firewall, and Compose projects.
+4. Git repositories, then dotfiles, each with its pre/post hooks.
+5. Shell activation, macOS defaults and LaunchAgents, Linux user units, and user settings.
+6. The pre\-tools hook, versioned tools, and post\-tools hook.
+7. Package\-plugin packages, then the post\-packages hook.
+8. The `bootstrap` task, when defined, then the final hook.
 
-The declarative steps converge — anything already in its desired state
-is skipped, so re\-running is safe. The `bootstrap` task runs on every
-invocation; keep it idempotent. Use it for any project\-specific setup
-that doesn't fit the declarative sections (seeding databases, auth flows,
-etc.) — it runs with the installed tools on PATH.
+Defaults and user settings also have pre/post hooks. See
+https://mise.jdx.dev/bootstrap.html for the complete phase order and configuration.
+Unchanged resource state is skipped, but hooks and the bootstrap task can run again;
+make those commands safe to repeat. Dotfile templates may execute while checking state.
 
-Use `\-\-skip <part>` to skip named parts, or `\-\-only <part>` to run just
-named parts. Both flags can be repeated or comma\-separated, but they
-cannot be used together.
+Use `\-\-dry\-run` to preview the selected workflow, `bootstrap status` to inspect state,
+or `bootstrap plan` for the declarative\-resource plan. `\-\-only` and `\-\-skip` accept
+repeated or comma\-separated parts and cannot be combined.
 .PP
 \fBUsage:\fR mise bootstrap [OPTIONS] [COMMAND]
 .PP
@@ -1232,6 +1205,9 @@ mise bootstrap user apply \-\-dry\-run
 .RE
 .SH "MISE BOOTSTRAP ACCOUNTS"
 Manage Linux users and groups from `[bootstrap.users]` and `[bootstrap.groups]`
+
+These are system accounts on the target Linux host. Inspect `status` or an apply
+preview before changing user IDs, memberships, or account state.
 .PP
 \fBUsage:\fR mise bootstrap accounts [OPTIONS] <COMMAND>
 .PP
@@ -1274,6 +1250,9 @@ Exit with code 1 when any account is not converged
 Print help
 .SH "MISE BOOTSTRAP CONFIG-ROOTS"
 Show non\-composed bootstrap declarations in each selected configuration root
+
+Use this to locate the origin of declarations before composition. For the
+combined desired state and its changes, use `bootstrap plan`.
 .PP
 \fBUsage:\fR mise bootstrap config\-roots [OPTIONS]
 .PP
@@ -1287,6 +1266,9 @@ Output in JSON format
 Print help
 .SH "MISE BOOTSTRAP COMPOSE"
 Manage Docker Compose projects from `[bootstrap.compose]`
+
+Requires a working Docker engine and Compose command on the target host. `apply`
+reconciles declared project state; `status` inspects the existing projects.
 .PP
 \fBUsage:\fR mise bootstrap compose [OPTIONS] <COMMAND>
 .PP
@@ -1342,7 +1324,9 @@ Add or update dotfiles in `[dotfiles]`
 
 If the target is already managed, this updates its source from the live
 target. Otherwise it creates a `[dotfiles]` entry and seeds the source
-under `dotfiles.root` unless `\-\-source` is provided.
+under `dotfiles.root` unless `\-\-source` is provided. Captured entries are
+applied unless `\-\-no\-apply` is passed. Use `\-\-dry\-run` to preview both the
+source capture and config write without making those changes.
 .PP
 \fBUsage:\fR mise bootstrap dotfiles add [OPTIONS] [<TARGET>] ...
 .PP
@@ -1490,6 +1474,9 @@ mise bootstrap dotfiles edit \-\-apply ~/.config/starship.toml
 .RE
 .SH "MISE BOOTSTRAP DOTFILES STATUS"
 Show the status of dotfiles from `[dotfiles]`
+
+Template entries are rendered to compare their output; trusted template
+functions may execute. `\-\-missing` changes the exit status, not the listing.
 .PP
 \fBUsage:\fR mise bootstrap dotfiles status [OPTIONS] [<TARGET>] ...
 .PP
@@ -1524,7 +1511,8 @@ Remove dotfiles applied from `[dotfiles]`
 
 Removes configured whole\-file entries and edits while preserving files
 mise cannot identify as managed. Modified copies, templates, and plain\-line
-edits require `\-\-force`.
+edits require `\-\-force`. Source files and configuration entries are retained.
+Run this before deleting a declaration so mise can still identify its targets.
 .PP
 \fBUsage:\fR mise bootstrap dotfiles unapply [OPTIONS] [<TARGET>] ...
 .PP
@@ -1558,6 +1546,9 @@ mise bootstrap dotfiles unapply \-\-force \-\-yes
 .RE
 .SH "MISE BOOTSTRAP FILES"
 Manage privileged files and directories from `[bootstrap.files]` and `[bootstrap.directories]`
+
+Use these resources for ownership, permissions, and desired presence on a host.
+For personal symlinks, copies, or edits, use `[dotfiles]` and `bootstrap dotfiles`.
 .PP
 \fBUsage:\fR mise bootstrap files [OPTIONS] <COMMAND>
 .PP
@@ -1606,6 +1597,9 @@ Prompt securely for missing bootstrap secret inputs
 Print help
 .SH "MISE BOOTSTRAP FIREWALL"
 Manage the Linux host firewall from `[bootstrap.linux.firewall]`
+
+This manages host firewall policy and rules. Review `apply \-\-dry\-run` before applying
+a policy to a remote machine, including the rule that permits your SSH connection.
 .PP
 \fBUsage:\fR mise bootstrap firewall [OPTIONS] <COMMAND>
 .PP
@@ -1658,6 +1652,9 @@ Manage Linux bootstrap config from `[bootstrap.linux]`
 Print help
 .SH "MISE BOOTSTRAP LINUX SYSTEMD-UNITS"
 Manage systemd user services from `[bootstrap.linux.systemd.units]`
+
+Installs unit files and reconciles services in the current user manager. This is
+separate from system services declared in `[bootstrap.services]`.
 .PP
 \fBUsage:\fR mise bootstrap linux systemd\-units [OPTIONS] <COMMAND>
 .PP
@@ -1710,6 +1707,9 @@ Manage macOS bootstrap config from `[bootstrap.macos]`
 Print help
 .SH "MISE BOOTSTRAP MACOS DEFAULTS"
 Manage macOS defaults from `[bootstrap.macos.defaults]`
+
+Declares typed preferences written with macOS defaults. Application preferences
+may require restarting the affected application before the change becomes visible.
 .PP
 \fBUsage:\fR mise bootstrap macos defaults [OPTIONS] <COMMAND>
 .PP
@@ -1752,6 +1752,9 @@ Exit with code 1 if any configured defaults are not in their desired state
 Print help
 .SH "MISE BOOTSTRAP MACOS LAUNCHD-AGENTS"
 Manage macOS LaunchAgents from `[bootstrap.macos.launchd.agents]`
+
+Installs plist files and reconciles agents in the current GUI login domain. Run
+from the intended user session; an SSH\-only session may not have that domain.
 .PP
 \fBUsage:\fR mise bootstrap macos launchd\-agents [OPTIONS] <COMMAND>
 .PP
@@ -1794,6 +1797,9 @@ Exit with code 1 if any configured LaunchAgent is not in its desired state
 Print help
 .SH "MISE BOOTSTRAP MISE-SHELL-ACTIVATE"
 Manage mise shell activation from `[bootstrap.mise_shell_activate]`
+
+Writes managed activation blocks into the declared shell startup files. The
+current shell is not reactivated by this command; open a new shell afterward.
 .PP
 \fBUsage:\fR mise bootstrap mise\-shell\-activate [OPTIONS] <COMMAND>
 .PP
@@ -1928,7 +1934,7 @@ Print help
 Tap name, e.g. `owner/repo`
 .TP
 \fB<URL>\fR
-GitHub URL for the tap. Defaults to https://github.com/<owner>/homebrew\-<repo>.git
+Repository URL for the tap; defaults to GitHub's owner/homebrew\-repo.git naming
 \fBExamples:\fR
 .PP
 .PP
@@ -2168,6 +2174,10 @@ mise bootstrap packages use apt:curl@8.5.0\-2
 .RE
 .SH "MISE BOOTSTRAP PLAN"
 Show the changes declarative bootstrap resources would make
+
+Covers declarative resources, not every hook, package installation, or task in a
+full bootstrap run. Use `bootstrap \-\-dry\-run` to preview the complete workflow.
+`\-\-detailed\-exitcode` distinguishes unchanged (0), changes (2), and errors (1).
 .PP
 \fBUsage:\fR mise bootstrap plan [OPTIONS]
 .PP
@@ -2187,6 +2197,8 @@ Prompt securely for missing bootstrap secret inputs
 Print help
 .SH "MISE BOOTSTRAP PLUGINS"
 Manage package manager plugins declared in `[bootstrap.plugins]`
+
+Install these plugins before applying packages they manage. Installing a plugin does not itself install the host packages in `[bootstrap.packages]`.
 .PP
 \fBUsage:\fR mise bootstrap plugins [OPTIONS] <COMMAND>
 .PP
@@ -2223,6 +2235,10 @@ Exit with code 1 if a declared plugin is missing
 Print help
 .SH "MISE BOOTSTRAP REMOTE"
 Bootstrap one or more machines over OpenSSH
+
+Select inventory hosts by name, tag, or `\-\-all`, or supply ad\-hoc `\-\-host` targets.
+The source is staged on each target and bootstrap runs there. `\-\-from\-git` instead
+installs persistent global configuration; preview that choice with `\-\-dry\-run`.
 .PP
 \fBUsage:\fR mise bootstrap remote [OPTIONS] [<TARGET>] ...
 .PP
@@ -2345,6 +2361,10 @@ Print help
 Inventory host names from `[bootstrap.remote.hosts]`
 .SH "MISE BOOTSTRAP REPOS"
 Manage git repo checkouts from `[bootstrap.repos]`
+
+Use `apply` to clone or reconcile the configured checkout, `update` to refresh it,
+and `exec` to run a command in selected repositories. Existing local changes can
+block convergence; `\-\-skip\-dirty` skips those repositories without discarding edits.
 .PP
 \fBUsage:\fR mise bootstrap repos [OPTIONS] <COMMAND>
 .PP
@@ -2374,6 +2394,8 @@ Skip repos with local changes instead of failing
 Print help
 .SH "MISE BOOTSTRAP REPOS EXEC"
 Run a command in each configured git repo
+
+Place the executable and its arguments after `\-\-`, for example `mise bootstrap repos exec \-\- git status \-\-short`. Arguments before `\-\-` select repository paths; use `\-\-continue\-on\-error` to visit remaining repos after a failure.
 .PP
 \fBUsage:\fR mise bootstrap repos exec [OPTIONS] [<PATH>] ... <COMMAND> ...
 .PP
@@ -2464,6 +2486,9 @@ Exit with code 1 if a declared secret input is unavailable
 Print help
 .SH "MISE BOOTSTRAP SERVICES"
 Manage Linux system services from `[bootstrap.services]`
+
+These are system\-level systemd services. For units in the current user session,
+use `bootstrap linux systemd\-units` instead.
 .PP
 \fBUsage:\fR mise bootstrap services [OPTIONS] <COMMAND>
 .PP
@@ -2506,6 +2531,10 @@ Exit with code 1 when any service is not converged
 Print help
 .SH "MISE BOOTSTRAP STATUS"
 Show the aggregate bootstrap status
+
+Inspect configured resource state without applying changes. `\-\-missing` sets a
+nonzero exit status for drift; it does not restrict the listing to missing entries.
+Dotfile status can render trusted templates, including their `exec()` calls.
 .PP
 \fBUsage:\fR mise bootstrap status [OPTIONS]
 .PP
@@ -2525,6 +2554,9 @@ Prompt securely for missing bootstrap secret inputs
 Print help
 .SH "MISE BOOTSTRAP USER"
 Manage current\-user bootstrap settings from `[bootstrap.user]`
+
+Currently manages the login shell. Apply as the intended user; changing the login
+shell affects future sessions, not the shell running this command.
 .PP
 \fBUsage:\fR mise bootstrap user [OPTIONS] <COMMAND>
 .PP
@@ -2741,7 +2773,11 @@ List all tracked config files
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE CONFIG GET"
-Display a value from a mise.toml file
+Display a value from one mise TOML file
+
+Reads the highest\-precedence loaded TOML file by default. Select another with
+`\-\-file`, `\-\-global`, or `\-\-system`. This reads stored values, not the merged or
+template\-expanded environment; use `mise env` for the resolved environment.
 .PP
 \fBUsage:\fR mise config get [OPTIONS] [<KEY>]
 .PP
@@ -2753,7 +2789,7 @@ The path to the mise.toml file to read
 
 Can be a file path or directory. If a directory is provided, the config file in that directory is used.
 
-If not provided, the nearest mise.toml file will be used
+If not provided, the highest\-precedence loaded TOML file is used
 .TP
 \fB\-g, \-\-global\fR
 Read the global config file.
@@ -2804,7 +2840,16 @@ Path                        Tools
 ~/src/mise/mise.toml        actionlint, bun, cargo\-binstall, cargo:cargo\-insta
 .RE
 .SH "MISE CONFIG SET"
-Set a value in a mise.toml file
+Set a value in one mise TOML file
+
+Edits the highest\-precedence loaded TOML file by default, which may be an
+environment\-specific override. Use `\-\-file` to select an existing project file,
+or `\-\-global`/`\-\-system` to edit or create those config files.
+
+This edits configuration without installing tools. Use `mise use` to install and
+select a version together. Known settings use their declared type; other values
+are strings or booleans unless `\-\-type` is given. Use `\-\-type string` when a value
+such as `true` should remain literal text.
 .PP
 \fBUsage:\fR mise config set [OPTIONS] <KEY> [<VALUE>]
 .PP
@@ -2816,7 +2861,7 @@ The path to the mise.toml file to edit
 
 Can be a file path or directory. If a directory is provided, the config file in that directory is used.
 
-If not provided, the nearest mise.toml file will be used
+If not provided, the highest\-precedence loaded TOML file is used
 .TP
 \fB\-g, \-\-global\fR
 Edit the global config file.
@@ -2864,9 +2909,12 @@ Type for `settings` is inferred
 mise config set settings.jobs 4
 .RE
 .SH "MISE DEACTIVATE"
-Disable mise for current shell session
+Print the script to disable mise in the current shell session
 
-This can be used to temporarily disable mise in a shell session.
+The shell function installed by activation evaluates this output in supported
+shells. When calling the executable directly, evaluate or source its output
+with the appropriate shell syntax. This does not remove the startup\-file line;
+new shells will activate mise again.
 .PP
 \fBUsage:\fR mise deactivate [OPTIONS]
 .PP
@@ -2977,10 +3025,15 @@ Skip loading zshrc.
 mise en \-s "zsh \-f"
 .RE
 .SH "MISE ENV"
-Export env vars to activate mise a single time
+Print the environment for the current configuration
 
-Use this to load the environment into one shell without adding `mise activate` to
-your shell rc file. It is not needed in shells where mise is already activated.
+Evaluate the shell output to load tools and variables once, without installing
+prompt hooks. Changing directories afterward does not recompute this environment.
+Use `mise exec \-\- command` to apply it to one child process instead.
+
+JSON, dotenv, and shell output contain actual variable values, including secrets.
+`\-\-redacted` selects variables marked for redaction; it does not mask their values.
+Environment construction may install missing tools according to mise's settings.
 .PP
 \fBUsage:\fR mise env [OPTIONS] [<TOOL@VERSION>] ...
 .PP
@@ -3000,7 +3053,7 @@ Shell type to generate environment variables for
 Output in JSON format with additional information (source, tool)
 .TP
 \fB\-\-redacted\fR
-Only show redacted environment variables
+Only include variables marked for redaction; their values are printed unmasked
 .TP
 \fB\-\-values\fR
 Only show values of environment variables
@@ -3029,7 +3082,7 @@ session, or to run ad\-hoc commands with tools that are not in the config.
 
 Tools are loaded from mise.toml and can be overridden with <TOOL@VERSION> args. Only the
 tools you name are overridden: if `mise.toml` includes `node = "20"` and you run
-`mise exec python@3.11`, node@20 is still loaded.
+`mise exec python@3.11 \-\- python \-V`, node@20 is still loaded.
 
 The "\-\-" separates tools from the command to pass along to the subprocess.
 .PP
@@ -3039,7 +3092,7 @@ The "\-\-" separates tools from the command to pass along to the subprocess.
 .PP
 .TP
 \fB\-c, \-\-command\fR \fI<COMMAND>\fR
-Command string to execute
+Command string to execute through a shell (supports pipes and redirection)
 .TP
 \fB\-j, \-\-jobs\fR \fI<JOBS>\fR
 Number of jobs to run in parallel
@@ -3055,7 +3108,9 @@ Supports wildcards, e.g. \-\-allow\-env='MYAPP_*'
 .TP
 \fB\-\-allow\-net\fR \fI<HOST>\fR
 Allow network to specific host (implies \-\-deny\-net for everything else)
-macOS only in v1; on Linux falls back to allowing all network
+Per\-host filtering is unsupported on Linux and returns an error.
+See the sandboxing guide for current macOS host\-filter limitations.
+On Windows, sandboxing is unavailable: mise warns and runs without host filtering.
 .TP
 \fB\-\-allow\-read\fR \fI<PATH>\fR
 Allow reads from specific path (implies \-\-deny\-read for everything else)
@@ -3067,7 +3122,7 @@ Allow writes to specific path (implies \-\-deny\-write for everything else)
 Block reads, writes, network, and env vars
 .TP
 \fB\-\-deny\-env\fR
-Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
+Block env var inheritance except PATH, HOME, USER, SHELL, TERM, COLORTERM, LANG
 .TP
 \fB\-\-deny\-net\fR
 Block all network access
@@ -3096,7 +3151,7 @@ Print help
 Tool(s) to load e.g.: node@20 python@3.10
 .TP
 \fB<COMMAND>\fR
-Command string to execute (same as \-\-command)
+Executable and arguments to run directly, after `\-\-`
 \fBExamples:\fR
 .PP
 Launch app.js using node\-20.x, with the full command or its shorter alias.
@@ -3118,9 +3173,12 @@ Run a command in a different directory:
 mise x \-C /path/to/project node@20 \-\- node ./app.js
 .RE
 .SH "MISE FMT"
-Format mise.toml
+Format mise TOML configuration
 
-Sorts keys and cleans up whitespace in mise.toml
+Sorts keys and normalizes whitespace using TOML 1.1 syntax, including multiline
+inline tables. By default, formats config files in the current directory;
+`\-\-all` includes every loaded config. Use `\-\-check` in CI or `\-\-stdin` to format
+a supplied document without rewriting a file.
 .PP
 \fBUsage:\fR mise fmt [OPTIONS]
 .PP
@@ -3191,7 +3249,10 @@ mise generate config \-y          # skip interactive editor
 mise generate config \-n          # preview without writing
 .RE
 .SH "MISE GENERATE DEVCONTAINER"
-Generate a devcontainer to execute mise
+Generate devcontainer configuration for mise
+
+Prints JSON by default. `\-\-write` saves .devcontainer/devcontainer.json;
+review the image, mounts, and generated setup commands before opening it.
 .PP
 \fBUsage:\fR mise generate devcontainer [OPTIONS]
 .PP
@@ -3277,7 +3338,9 @@ mise generate git\-pre\-commit \-\-write \-\- \-C subdir
 Generate a GitHub Action workflow file
 
 This command generates a GitHub Action workflow file that runs a mise task like `mise run ci`
-when you push changes to your repository.
+on pull requests, tags, manual dispatch, and pushes to the current Git branch.
+Prints YAML by default; `\-\-write` saves it under .github/workflows. Define
+the selected task and review the generated triggers before committing.
 .PP
 \fBUsage:\fR mise generate github\-action [OPTIONS]
 .PP
@@ -3324,9 +3387,10 @@ setup). The old name still works but is deprecated and will be removed in mise 2
 .PP
 .TP
 \fB\-l, \-\-localize\fR
-Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a project\-local directory (`.mise` by default, set with `\-\-localized\-dir`)
+Keep mise data and cache in a project\-local directory (`.mise` by default)
 
-This is necessary if users may use a different version of mise outside the project.
+Use `\-\-localized\-dir` to choose its location. This isolates mise state;
+it is not an OS sandbox for commands the generated script runs.
 .TP
 \fB\-V, \-\-version\fR \fI<VERSION>\fR
 Specify mise version to fetch
@@ -3368,7 +3432,10 @@ mise generate install\-script \-\-write ./bin/mise \-\-windows
 \&.\\bin\\mise.cmd install
 .RE
 .SH "MISE GENERATE TASK-DOCS"
-Generate documentation for tasks in a project
+Generate Markdown documentation for project tasks
+
+Prints to stdout by default. Use `\-\-output` to write a file, `\-\-inject`
+to replace a marked section, or `\-\-multi` for one file per task.
 .PP
 \fBUsage:\fR mise generate task\-docs [OPTIONS]
 .PP
@@ -3656,7 +3723,7 @@ Installs a tool version under the mise data directory, by default
 Installing alone does not add the tool to your config, so a tool that is not
 already configured will not be on PATH.
 To install and activate in one command, use `mise use`, which also writes the version to
-`mise.toml` in the current directory so the tool is active inside it.
+the selected project config so the tool is active in that configuration scope.
 To run a tool once without touching any config, use `mise exec <TOOL>@<VERSION> \-\- <COMMAND>`.
 
 Tools are installed in parallel. To disable, set `\-\-jobs=1` or `MISE_JOBS=1`.
@@ -3778,9 +3845,11 @@ mise install\-into node@20.0.0 ./mynode && ./mynode/bin/node \-v
 v20.0.0
 .RE
 .SH "MISE LATEST"
-Get the latest available version of a tool
+Resolve the latest matching version request for a tool
 
-Supports prefixes such as `node@20` to get the latest version of node 20.
+Supports prefixes such as `node@20`. The selected backend decides how channels,
+refs, and non\-SemVer versions resolve; "latest" is not a generic sort of strings.
+This prints a version without installing it or changing configuration.
 .PP
 \fBUsage:\fR mise latest [OPTIONS] <TOOL@VERSION> [<ASDF_VERSION>]
 .PP
@@ -3867,13 +3936,15 @@ mise link node@brew "$(brew \-\-prefix node)"
 mise use node@brew
 .RE
 .SH "MISE LOCK"
-Update lockfile checksums and URLs for all specified platforms
+Create or refresh lockfile versions, checksums, and download URLs
 
-Updates checksums and download URLs for all platforms already specified in the lockfile.
-If no lockfile exists, shows what would be created based on the current configuration,
-including tools declared by tasks.
-This allows you to refresh lockfile data for platforms other than the one you're currently on.
-Operates on the lockfile in the current config root. Use TOOL arguments to target specific tools.
+Operates on the current config root, including tools declared by tasks. Existing
+matching locked versions are preserved unless `\-\-bump` re\-resolves their selectors.
+This command writes lockfiles without installing tools; `\-\-dry\-run` previews changes.
+
+Use `\-\-platform` for explicit targets. Otherwise mise uses `lockfile_platforms`
+plus the current platform when that setting is configured, existing lockfile
+platforms when available, or the common platform defaults for a new lockfile.
 .PP
 \fBUsage:\fR mise lock [OPTIONS] [<TOOL>] ...
 .PP
@@ -3897,7 +3968,7 @@ Show what would be updated without making changes
 \fB\-p, \-\-platform\fR \fI<PLATFORM>\fR
 Comma\-separated list of platforms to target
 e.g.: linux\-x64,macos\-arm64,windows\-x64
-If not specified, all platforms already in lockfile will be updated
+If omitted, use lockfile_platforms, existing platforms, or common defaults
 .TP
 \fB\-\-bump\fR
 Re\-resolve fuzzy version selectors against the latest available versions
@@ -4111,7 +4182,8 @@ mise ls \-\-all\-sources
 .SH "MISE LS-REMOTE"
 List tool versions available to install
 
-Results may be cached; run `mise cache clear` to fetch fresh results.
+Results may be cached; run `mise cache clear TOOL` to refresh one tool
+before querying it again. Version formats and ordering are backend\-specific.
 .PP
 \fBUsage:\fR mise ls\-remote [OPTIONS] [<TOOL@VERSION>] [<PREFIX>]
 .PP
@@ -4119,7 +4191,7 @@ Results may be cached; run `mise cache clear` to fetch fresh results.
 .PP
 .TP
 \fB\-\-all\fR
-Show all installed plugins and versions
+List available versions for every backend/tool currently known to mise
 .TP
 \fB\-\-minimum\-release\-age\fR \fI<MINIMUM_RELEASE_AGE>\fR
 Only show versions released before this age or date
@@ -4155,8 +4227,8 @@ Print help
 Tool to get versions for
 .TP
 \fB<PREFIX>\fR
-The version prefix to use when querying the latest version
-same as the first argument after the "@"
+Filter the available versions by this prefix
+Equivalent to the version selector after `@` in the first argument
 \fBExamples:\fR
 .PP
 .PP
@@ -4168,17 +4240,16 @@ mise ls\-remote node \-\-minimum\-release\-age 30d
 mise ls\-remote github:cli/cli \-\-json
 .RE
 .SH "MISE MCP"
-Run Model Context Protocol (MCP) server
+Run the Model Context Protocol server over stdin/stdout
 
-This command starts an MCP server that exposes mise functionality
-to AI assistants over stdin/stdout using JSON\-RPC protocol.
+Exposes project tools, tasks, environment, and configuration to an MCP client.
+Resources use `mise://tools`, `mise://tasks`, `mise://env`, and `mise://config`.
+`mise://tools?include_inactive=true` also includes inactive installations.
 
-The MCP server provides access to:
-\- Installed and available tools
-\- Task definitions and execution
-\- Environment variables
-\- Configuration information
-\- Task execution via the run_task tool
+The `list_commands` tool describes commands and their declared effects. `run_task`
+executes project tasks with the user's permissions and can change files or invoke
+external services. `install_tool` is advertised but currently returns an error.
+Environment resources contain real values, including secrets.
 
 Resources available:
 \- mise://tools \- List all tools (use ?include_inactive=true to include inactive tools)
@@ -4233,8 +4304,12 @@ Print help
 Each tool version becomes its own content\-addressable OCI layer. Bumping a
 tool version only invalidates that tool's layer — other tools, the base
 image, and config are reused unchanged. The output directory conforms to
-the OCI image\-layout spec and can be consumed by `skopeo`, `crane`, or
-`podman load`.
+the OCI image\-layout spec. Use `skopeo inspect oci:./mise\-oci` to inspect it
+or `mise oci run \-\-image\-dir ./mise\-oci \-\- command` to load and run it.
+
+Build on Linux with the target architecture: this packages host tool installs
+and, by default, the running mise binary. `\-\-no\-mise` omits that binary but does
+not cross\-compile tools installed for another OS. asdf/vfox tools are unsupported.
 
 Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).
 .PP
@@ -4589,11 +4664,11 @@ node    20         20.0.0   20.1.0
 .SH "MISE PATRONS"
 Show the individuals supporting mise as Patron\-tier members
 
-Lists the individuals on the Patron tier from <https://jdx.dev/patrons.json>.
+Lists the individuals on the Patron tier from https://jdx.dev/patrons.json.
 The list refreshes daily; supporting terminals will render each patron's
 name as a clickable link via OSC 8 hyperlinks.
 
-To appear here, become a patron at <https://jdx.dev/sponsors.html>.
+To appear here, become a patron at https://jdx.dev/sponsors.html.
 .PP
 \fBUsage:\fR mise patrons [OPTIONS]
 .PP
@@ -4650,11 +4725,14 @@ to show core and user plugins
 \fB\-h, \-\-help\fR
 Print help
 .SH "MISE PLUGINS INSTALL"
-Install a plugin
+Install a plugin from a configured source, Git URL, or supported archive
 
-Note that mise installs plugins automatically when you install a tool that needs one,
-e.g.: `mise install cmake@3.30` installs the cmake plugin first. This command is only
-needed to install a plugin ahead of time or from a custom git URL.
+Most registry tools use built\-in backends and need no plugin. When a selected
+backend does require a plugin, mise normally installs it with the tool.
+Use this command to install it ahead of time or choose a custom source.
+
+A Git URL may end in `#ref` to select a plugin commit, tag, or branch. This selects
+the plugin implementation, separately from the tool version installed by `mise use`.
 .PP
 \fBUsage:\fR mise plugins install [OPTIONS] [<NEW_PLUGIN>] [<GIT_URL>] [<REST>] ...
 .PP
@@ -4683,8 +4761,7 @@ Print help
 .TP
 \fB<NEW_PLUGIN>\fR
 The name of the plugin to install
-e.g.: cmake, poetry
-Can specify multiple plugins: `mise plugins install cmake poetry`
+Use a configured plugin name, or supply a source URL below
 .TP
 \fB<GIT_URL>\fR
 The git url of the plugin
@@ -4708,9 +4785,11 @@ Install missing plugins that have configured shorthands
 mise plugins install \-\-all
 .RE
 .SH "MISE PLUGINS LINK"
-Symlink a plugin into mise
+Link a local plugin directory into mise for development
 
-This is used for developing a plugin.
+Edits in the source directory take effect without reinstalling the plugin. Pass
+both a name and directory, or only a directory to infer the name after stripping
+a known prefix such as `mise\-` or `vfox\-`. This does not install a tool version.
 .PP
 \fBUsage:\fR mise plugins link [OPTIONS] <NAME> [<DIR>]
 .PP
@@ -4727,11 +4806,11 @@ Print help
 .TP
 \fB<NAME>\fR
 The name of the plugin
-e.g.: cmake, poetry
+With one argument, this is the plugin directory and the name is inferred
 .TP
 \fB<DIR>\fR
 The local path to the plugin
-e.g.: ./vfox\-cmake
+e.g.: ./mise\-my\-tool
 \fBExamples:\fR
 .PP
 .PP
@@ -4751,9 +4830,11 @@ List versions through the linked plugin
 mise ls\-remote my\-tool
 .RE
 .SH "MISE PLUGINS LS"
-List installed plugins
+List installed external plugins
 
-Can also show remotely available plugins to install.
+Use `\-\-core` for built\-in runtimes or `\-\-core \-\-user` for both groups. `\-\-outdated`
+queries Git remotes for plugin updates; it does not compare installed tool versions.
+Use `mise plugins ls\-remote` for registry plugin sources and `mise ls` for tools.
 .PP
 \fBUsage:\fR mise plugins ls [OPTIONS]
 .PP
@@ -4822,7 +4903,10 @@ Print help
 mise plugins ls\-remote
 .RE
 .SH "MISE PLUGINS UNINSTALL"
-Remove a plugin
+Remove an installed plugin
+
+Tool installations are retained by default. Pass `\-\-purge` to also remove
+installs, downloads, and cache associated with the selected plugins.
 .PP
 \fBUsage:\fR mise plugins uninstall [OPTIONS] [<PLUGIN>] ...
 .PP
@@ -4851,7 +4935,9 @@ mise plugins uninstall my\-tool
 .SH "MISE PLUGINS UPDATE"
 Update a plugin to the latest version
 
-Note: this updates the plugin itself, not the tool versions it manages
+With no names, updates every installed plugin. This updates plugin source,
+not the tool versions it manages. Linked local plugins are skipped; archive
+installations cannot be updated with Git.
 .PP
 \fBUsage:\fR mise plugins update [OPTIONS] [<PLUGIN>] ...
 .PP
@@ -4881,13 +4967,13 @@ mise plugins update my\-tool#main # select an upstream ref
 .SH "MISE DEPS"
 [experimental] Manage project dependencies
 
-Runs all applicable dependency install steps for the current project.
-This checks if dependency lockfiles are newer than installed outputs
-(e.g., package\-lock.json vs node_modules/) and runs install commands
-if needed.
+With no subcommand, runs dependency installation for the current project, the same
+as `mise deps install`. Providers detect their inputs and installed outputs to
+decide whether work is needed; use `\-\-explain PROVIDER` to inspect that decision.
 
-Providers with `auto = true` are automatically invoked before `mise x` and `mise run`
-unless skipped with the \-\-no\-deps flag.
+Providers with `auto = true` run before `mise exec` and `mise run` unless `\-\-no\-deps`
+is passed. These install project dependencies, such as node_modules, separately
+from versioned tools managed by `mise install`.
 .PP
 \fBUsage:\fR mise deps [OPTIONS] [<PROVIDER>] [COMMAND]
 .PP
@@ -4965,8 +5051,9 @@ Package(s) to add (e.g., npm:react, npm:@types/react@19)
 .SH "MISE DEPS INSTALL"
 Install all project dependencies
 
-Checks if dependency lockfiles are newer than installed outputs
-and runs install commands if needed.
+Uses each provider's freshness rules to compare configured inputs and outputs,
+then runs its installation command when needed. `\-\-force` bypasses that check;
+`\-\-explain PROVIDER` shows why a provider is considered fresh or stale.
 .PP
 \fBUsage:\fR mise deps install [OPTIONS] [<PROVIDER>]
 .PP
@@ -5075,11 +5162,14 @@ Preview unused versions without deleting them. Example output: `rm \-rf ~/.local
 mise prune \-\-dry\-run
 .RE
 .SH "MISE REGISTRY"
-List available tools to install
+List registry shorthand names and their backends
 
-This command lists the tools available in the registry as shorthand names.
+The registry maps short names to installation backends. For example, `node`
+uses the built\-in Node backend. A tool may have multiple candidates; explicit
+backend syntax and configuration can override registry selection.
 
-For example, `poetry` is shorthand for `asdf:mise\-plugins/mise\-poetry`.
+This is not a list of every tool mise can install. Use an explicit identifier
+such as `github:owner/repo` for a supported source without a registry shorthand.
 .PP
 \fBUsage:\fR mise registry [OPTIONS] [<NAME>]
 .PP
@@ -5125,24 +5215,15 @@ mise registry \-\-backend aqua
 mise registry \-\-json
 .RE
 .SH "MISE RESHIM"
-Create shims for the executables of currently installed tools
+Create shims for executables provided by installed tools
 
-This creates shims in the user shim directory for executables that have been added since
-the last reshim. With `\-\-system`, it rebuilds the system shim farm instead.
-mise runs this automatically after commands like `npm i \-g`, but other ways of installing
-executables (such as yarn or pnpm for node) are not detected, so call this explicitly then.
+Run this when an executable was added to an existing installation outside mise,
+for example after a language package manager installed a CLI globally. It rebuilds
+the user shim directory by default; `\-\-system` selects the shared system shim farm.
 
-If you think mise should automatically call this for a particular command, please
-open an issue on the mise repo. You can also set up a shell function to reshim
-automatically (it's really fast so you don't need to worry about overhead):
-
-    npm() {
-      command npm "$@"
-      mise reshim
-    }
-
-Note that this creates shims for _all_ installed tools, not just the ones that are
-currently active in mise.toml.
+Shims are created for all installed versions. The shim resolves which version to
+run from the current configuration when invoked. `\-\-force` rebuilds mise\-owned
+shims; it does not turn unrelated files into mise\-owned shims.
 .PP
 \fBUsage:\fR mise reshim [OPTIONS] [<TOOL>] [<VERSION>]
 .PP
@@ -5166,30 +5247,29 @@ mise reshim
 ~/.local/share/mise/shims/node \-v
 .RE
 .SH "MISE RUN"
-Run task(s)
+Run tasks and their dependencies
 
-Runs one task, or several tasks in parallel.
-Tasks may depend on other tasks and on source files.
-If a task has `sources` configured, it only runs when those files have changed.
+Use `mise run TASK [ARGS...]` for one task, or separate task invocations with `:::`
+to schedule several. Put mise flags before the task name; following arguments are
+passed to that task. With no task, mise runs `default` when defined or opens the
+task selector in an interactive terminal.
 
-Tasks can be defined in mise.toml or as standalone scripts.
-In mise.toml, tasks take this form:
+Tasks are defined in `mise.toml` or task directories. A task with `sources` and
+`outputs` can skip execution when its outputs are fresh. `\-\-force` bypasses
+freshness checks; task output caching has separate `\-\-task\-cache` controls.
 
-    [tasks.build]
-    run = "npm run build"
-    sources = ["src/**/*.ts"]
-    outputs = ["dist/**/*.js"]
+For a project that already has npm build scripts and its dependencies installed:
 
-Alternatively, tasks can be defined as standalone scripts.
-These must be located in `mise\-tasks`, `.mise\-tasks`, `.mise/tasks`, `mise/tasks` or
-`.config/mise/tasks`.
-The name of the script becomes the name of the task.
+```toml
+[tasks.build]
+run = "npm run build"
+sources = ["src/**/*.ts", "package.json", "package\-lock.json"]
+outputs = ["dist/**/*.js"]
+```
 
-    $ cat .mise/tasks/build<<EOF
-    #!/usr/bin/env bash
-    npm run build
-    EOF
-    $ mise run build
+To create a standalone script task, use `mise tasks add \-\-file hello \-\- echo hello`.
+Then run `mise run hello`. See https://mise.jdx.dev/tasks/ for task directories,
+arguments, caching, and dependency configuration.
 .PP
 \fBUsage:\fR mise run [OPTIONS] [TASK] [ARGS]…
 .PP
@@ -5283,6 +5363,9 @@ Supports wildcards, e.g. \-\-allow\-env='MYAPP_*'
 .TP
 \fB\-\-allow\-net\fR \fI<HOST>\fR
 Allow network to specific host (implies \-\-deny\-net for everything else)
+Per\-host filtering is unsupported on Linux and returns an error.
+See the sandboxing guide for current macOS host\-filter limitations.
+On Windows, sandboxing is unavailable: mise warns and runs without host filtering.
 .TP
 \fB\-\-allow\-read\fR \fI<PATH>\fR
 Allow reads from specific path (implies \-\-deny\-read for everything else)
@@ -5294,7 +5377,7 @@ Allow writes to specific path (implies \-\-deny\-write for everything else)
 Block reads, writes, network, and env vars
 .TP
 \fB\-\-deny\-env\fR
-Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
+Block env var inheritance except PATH, HOME, USER, SHELL, TERM, COLORTERM, LANG
 .TP
 \fB\-\-deny\-net\fR
 Block all network access
@@ -5488,7 +5571,8 @@ Update to a specific version
 .SH "MISE SET"
 Set environment variables in mise.toml
 
-By default, this command modifies `mise.toml` in the current directory.
+By default, this command selects the nearest configuration directory and
+modifies its lowest\-precedence TOML file, creating `mise.toml` here if none exists.
 If multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),
 the lowest precedence file (`mise.toml`) will be used.
 See https://mise.jdx.dev/configuration.html#target\-file\-for\-write\-operations
@@ -5704,12 +5788,11 @@ The value to set (optional if provided as KEY=VALUE)
 mise settings add disable_hints python_multi
 .RE
 .SH "MISE SETTINGS GET"
-Show a current setting
+Show the effective value of a setting
 
-This is the contents of a single entry in ~/.config/mise/config.toml
-
-Note that aliases are also stored in this file
-but managed separately with `mise tool\-alias get`
+Includes defaults, configuration, and environment overrides. With `\-\-local`,
+read only the selected local config's explicit settings; an unset key is an error.
+Use `mise config get settings.KEY \-\-file path/to/mise.toml` to inspect one file.
 .PP
 \fBUsage:\fR mise settings get [OPTIONS] <SETTING>
 .PP
@@ -5734,12 +5817,12 @@ mise settings get jobs
 mise settings get python.compile
 .RE
 .SH "MISE SETTINGS LS"
-Show current settings
+List configured settings and their sources
 
-This is the contents of ~/.config/mise/config.toml
-
-Note that aliases are also stored in this file
-but managed separately with `mise tool\-alias`
+By default, list explicit settings from loaded TOML files. `\-\-all` also includes
+effective defaults. Use `\-\-local` to restrict output to the selected local file,
+and `\-\-json\-extended` to include source information in machine\-readable output.
+Use `mise settings get KEY` when you need one effective value.
 .PP
 \fBUsage:\fR mise settings ls [OPTIONS] [<SETTING>]
 .PP
@@ -6579,30 +6662,29 @@ Print help
 mise tasks ls
 .RE
 .SH "MISE TASKS RUN"
-Run task(s)
+Run tasks and their dependencies
 
-Runs one task, or several tasks in parallel.
-Tasks may depend on other tasks and on source files.
-If a task has `sources` configured, it only runs when those files have changed.
+Use `mise run TASK [ARGS...]` for one task, or separate task invocations with `:::`
+to schedule several. Put mise flags before the task name; following arguments are
+passed to that task. With no task, mise runs `default` when defined or opens the
+task selector in an interactive terminal.
 
-Tasks can be defined in mise.toml or as standalone scripts.
-In mise.toml, tasks take this form:
+Tasks are defined in `mise.toml` or task directories. A task with `sources` and
+`outputs` can skip execution when its outputs are fresh. `\-\-force` bypasses
+freshness checks; task output caching has separate `\-\-task\-cache` controls.
 
-    [tasks.build]
-    run = "npm run build"
-    sources = ["src/**/*.ts"]
-    outputs = ["dist/**/*.js"]
+For a project that already has npm build scripts and its dependencies installed:
 
-Alternatively, tasks can be defined as standalone scripts.
-These must be located in `mise\-tasks`, `.mise\-tasks`, `.mise/tasks`, `mise/tasks` or
-`.config/mise/tasks`.
-The name of the script becomes the name of the task.
+```toml
+[tasks.build]
+run = "npm run build"
+sources = ["src/**/*.ts", "package.json", "package\-lock.json"]
+outputs = ["dist/**/*.js"]
+```
 
-    $ cat .mise/tasks/build<<EOF
-    #!/usr/bin/env bash
-    npm run build
-    EOF
-    $ mise run build
+To create a standalone script task, use `mise tasks add \-\-file hello \-\- echo hello`.
+Then run `mise run hello`. See https://mise.jdx.dev/tasks/ for task directories,
+arguments, caching, and dependency configuration.
 .PP
 \fBUsage:\fR mise tasks run [OPTIONS] [TASK] [ARGS]…
 .PP
@@ -6696,6 +6778,9 @@ Supports wildcards, e.g. \-\-allow\-env='MYAPP_*'
 .TP
 \fB\-\-allow\-net\fR \fI<HOST>\fR
 Allow network to specific host (implies \-\-deny\-net for everything else)
+Per\-host filtering is unsupported on Linux and returns an error.
+See the sandboxing guide for current macOS host\-filter limitations.
+On Windows, sandboxing is unavailable: mise warns and runs without host filtering.
 .TP
 \fB\-\-allow\-read\fR \fI<PATH>\fR
 Allow reads from specific path (implies \-\-deny\-read for everything else)
@@ -6707,7 +6792,7 @@ Allow writes to specific path (implies \-\-deny\-write for everything else)
 Block reads, writes, network, and env vars
 .TP
 \fB\-\-deny\-env\fR
-Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
+Block env var inheritance except PATH, HOME, USER, SHELL, TERM, COLORTERM, LANG
 .TP
 \fB\-\-deny\-net\fR
 Block all network access
@@ -7264,7 +7349,8 @@ mise uninstall \-\-all node
 .SH "MISE UNSET"
 Remove environment variable(s) from the config file
 
-By default, this command modifies `mise.toml` in the current directory.
+By default, this command selects the nearest configuration directory and
+modifies its lowest\-precedence TOML file, creating `mise.toml` here if none exists.
 .PP
 \fBUsage:\fR mise unset [OPTIONS] [<ENV_KEY>] ...
 .PP
@@ -7318,24 +7404,17 @@ Print help
 \fB<CONFIG_FILE>\fR
 The config file to untrust
 .SH "MISE UNUSE"
-Remove tool versions from mise.toml and uninstall them
+Remove tool requests from configuration and prune unused installations
 
-By default, this will use the `mise.toml` file that has the tool defined.
-If multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),
-the lowest precedence file (`mise.toml`) will be used.
-See https://mise.jdx.dev/configuration.html#target\-file\-for\-write\-operations
+Without a selector, mise edits the first loaded config that declares one of the
+requested tools. Use `\-\-path`, `\-\-global`, or `\-\-env` to choose a specific file.
+A version argument matches the configured request literally: to remove `node = "20"`,
+use `mise unuse node@20`, not the concrete installed version it resolved to.
+Omit the version to remove all requests for that tool from the selected file.
 
-In the following order:
-  \- If `\-\-global` is set, it will use the global config file.
-  \- If `\-\-path` is set, it will use the config file at the given path.
-  \- If `\-\-env` is set, it will use `mise.<env>.toml`.
-  \- If [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) is set, it will use that instead.
-  \- If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will use the first from that list.
-  \- Otherwise just "mise.toml" or global config if cwd is home directory.
-
-Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
-
-The installed version is also removed unless another config still uses it or `\-\-no\-prune` is passed.
+Versions are pruned only when no remaining tracked config or tool stub needs them.
+Pass `\-\-no\-prune` to edit configuration while keeping installations. To remove an
+installation without editing configuration, use `mise uninstall`.
 .PP
 \fBUsage:\fR mise unuse [OPTIONS] <INSTALLED_TOOL@VERSION> ...
 .PP
@@ -7343,7 +7422,7 @@ The installed version is also removed unless another config still uses it or `\-
 .PP
 .TP
 \fB\-e, \-\-env\fR \fI<ENV>\fR
-Create/modify an environment\-specific config file like mise.<env>.toml
+Modify `.mise.<env>.toml` when it exists, otherwise `mise.<env>.toml`
 .TP
 \fB\-g, \-\-global\fR
 Use the global config file (`~/.config/mise/config.toml`) instead of the local one
@@ -7351,7 +7430,7 @@ Use the global config file (`~/.config/mise/config.toml`) instead of the local o
 \fB\-p, \-\-path, \-\-file\fR \fI<PATH>\fR
 Specify a path to a config file or directory
 
-If a directory is specified, it will look for a config file in that directory following the rules above.
+If a directory is specified, it will look for a config file in that directory following the target\-file selection rules.
 .TP
 \fB\-\-no\-prune\fR
 Do not also prune the installed version
@@ -7540,23 +7619,21 @@ Only upgrade tools defined in local mise.toml, not global ones
 mise upgrade \-\-local
 .RE
 .SH "MISE USE"
-Install a tool and add it to mise.toml
+Install a tool and add it to configuration
 
-Installs the tool version if it is not already installed, then writes it to a config file.
-By default, this is `mise.toml` in the current directory.
-If multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),
-the lowest precedence file (`mise.toml`) will be used.
+Installs missing tool versions and records the requests in a config file.
+By default, mise selects the nearest directory with a supported config and writes
+to its lowest\-precedence file, such as `mise.toml` rather than `mise.local.toml`.
+If no project config exists, it creates one in the current directory. Running from
+your home directory targets global configuration.
+
+Use `\-\-path` for an explicit file/directory, `\-\-global` for personal defaults, or
+`\-\-env` to write `mise.ENV.toml` in the current directory (preserving an existing
+`.mise.ENV.toml`). These selectors override one another; use one per command.
+
 See https://mise.jdx.dev/configuration.html#target\-file\-for\-write\-operations
-
-In the following order:
-  \- If `\-\-global` is set, it will use the global config file.
-  \- If `\-\-path` is set, it will use the config file at the given path.
-  \- If `\-\-env` is set, it will use `mise.<env>.toml`.
-  \- If [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) is set, it will use that instead.
-  \- If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will use the first from that list.
-  \- Otherwise just "mise.toml" or global config if cwd is home directory.
-
-Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
+for filename overrides and configuration precedence. Selection takes effect in
+an activated shell on its next prompt, or immediately in `mise exec` commands.
 .PP
 \fBUsage:\fR mise use [OPTIONS] [TOOL@VERSION]…
 .PP
@@ -7586,7 +7663,7 @@ Perform a dry run, showing what would be installed and modified without making c
 \fB\-p, \-\-path\fR \fI<PATH>\fR
 Specify a path to a config file or directory
 
-If a directory is specified, it will look for a config file in that directory following the rules above.
+If a directory is specified, it will look for a config file in that directory following the target\-file selection rules.
 .TP
 \fB\-\-dry\-run\-code\fR
 Like \-\-dry\-run but exits with code 1 if there are changes to make
@@ -7710,7 +7787,11 @@ mise \-V
 .SH "MISE WATCH"
 Run task(s) and rerun them when files change
 
-Uses `watchexec` to watch for file changes and rerun the given task(s).
+Uses `watchexec` to watch task sources and rerun the selected tasks.
+Sources from dependencies are included unless `\-\-skip\-deps` is set. With no
+sources, watchexec watches the current directory. Use `\-\-watch` and `\-\-exts`
+for explicit watched paths and filters, and `\-\-print\-events` to diagnose them.
+The default task is `default`; define it or pass a task name.
 watchexec must be installed; `mise use \-g watchexec@latest` installs it.
 
 For more advanced process management (daemon management, auto\-restart, readiness checks,
@@ -7758,7 +7839,7 @@ Each line in the file will be interpreted as if given to '\-w'.
 
 For more complex uses (like watching non\-recursively), use the argfile capability: build a file containing command\-line options and pass it to watchexec with `@path/to/argfile`.
 
-The special value '\-' will read from STDIN; this in incompatible with '\-\-stdin\-quit'.
+The special value '\-' will read from STDIN; this is incompatible with '\-\-stdin\-quit'.
 .TP
 \fB\-c, \-\-clear\fR \fI<MODE>\fR
 Clear screen before running command
@@ -7792,7 +7873,7 @@ Signals are not supported on Windows at the moment, and will always be overridde
 \fB\-\-stop\-signal\fR \fI<SIGNAL>\fR
 Signal to send to stop the command
 
-This is used by 'restart' and 'signal' modes of '\-\-on\-busy\-update' (unless '\-\-signal' is provided). The restart behaviour is to send the signal, wait for the command to exit, and if it hasn't exited after some time (see '\-\-timeout\-stop'), forcefully terminate it.
+This is used by 'restart' and 'signal' modes of '\-\-on\-busy\-update' (unless '\-\-signal' is provided). The restart behaviour is to send the signal, wait for the command to exit, and if it hasn't exited after some time (see '\-\-stop\-timeout'), forcefully terminate it.
 
 The default on unix is "SIGTERM".
 
@@ -8011,7 +8092,7 @@ set of events Watchexec handles. Here's an example of a folder being created on 
       },
       {
         "kind": "source",
-        "source": "filesystem",
+        "source": "filesystem"
       }
     ],
     "metadata": {
@@ -8162,7 +8243,9 @@ This can also be used via the $WATCHEXEC_FILTER_FILES environment variable.
 
 /!\\ This option is EXPERIMENTAL and may change and/or vanish without notice.
 
-Provide your own custom filter programs in jaq (similar to jq) syntax. Programs are given an event in the same format as described in '\-\-emit\-events\-to' and must return a boolean. Invalid programs will make watchexec fail to start; use '\-v' to see program runtime errors.
+Provide your own custom filter programs in jaq (similar to jq) syntax. Programs are given
+an event in the same format as described in '\-\-emit\-events\-to' and must return a boolean.
+Invalid programs will make watchexec fail to start; use '\-v' to see program runtime errors.
 
 In addition to the jaq stdlib, watchexec adds some custom filter definitions:
 
@@ -8184,13 +8267,20 @@ In addition to the jaq stdlib, watchexec adds some custom filter definitions:
     value to stdout, stderr, or the log (levels = error, warn, info, debug, trace), and
     pass the value through (so '[1] | log("debug") | .[]' will produce a '1' and log '[1]').
 
-All filtering done with such programs, and especially those using kv or filesystem access, is much slower than the other filtering methods. If filtering is too slow, events will back up and stall watchexec. Take care when designing your filters.
+All filtering done with such programs, and especially those using kv or filesystem access,
+is much slower than the other filtering methods. If filtering is too slow, events will back
+up and stall watchexec. Take care when designing your filters.
 
-If the argument to this option starts with an '@', the rest of the argument is taken to be the path to a file containing a jaq program.
+If the argument to this option starts with an '@', the rest of the argument is taken to be
+the path to a file containing a jaq program.
 
-Jaq programs are run in order, after all other filters, and short\-circuit: if a filter (jaq or not) rejects an event, execution stops there, and no other filters are run. Additionally, they stop after outputting the first value, so you'll want to use 'any' or 'all' when iterating, otherwise only the first item will be processed, which can be quite confusing!
+Jaq programs are run in order, after all other filters, and short\-circuit: if a filter (jaq
+or not) rejects an event, execution stops there, and no other filters are run. Additionally,
+they stop after outputting the first value, so you'll want to use 'any' or 'all' when
+iterating, otherwise only the first item will be processed, which can be quite confusing!
 
-Find user\-contributed programs or submit your own useful ones at <https://github.com/watchexec/watchexec/discussions/592>.
+Find user\-contributed programs or submit your own useful ones at
+<https://github.com/watchexec/watchexec/discussions/592>.
 
 ## Examples:
 
@@ -8204,11 +8294,11 @@ Pass any event that creates a file:
 
 Pass events that touch executable files:
 
-  'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | metadata | .executable)'
+  'any(.tags[] | select(.kind == "path" and .filetype == "file"); .absolute | file_meta | .executable)'
 
 Ignore files that start with shebangs:
 
-  'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | read(2) == "#!") | not'
+  'any(.tags[] | select(.kind == "path" and .filetype == "file"); .absolute | file_read(2) == "#!") | not'
 .TP
 \fB\-i, \-\-ignore\fR \fI<PATTERN>\fR
 Filename patterns to filter out

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -232,24 +232,23 @@ case $cur in
     ;;
 esac
 """#
-cmd activate help="Initialize mise in the current shell session" effect=read {
+cmd activate help="Print the script to activate mise in an interactive shell" effect=read {
     long_help #"""
-Initialize mise in the current shell session
+Print the script to activate mise in an interactive shell
 
-Add this to your shell's rc or profile file so it runs in every new shell.
-Otherwise, it only takes effect in the current session.
-(e.g. ~/.zshrc, ~/.zprofile, ~/.zshenv, ~/.bashrc, ~/.bash_profile, ~/.profile, ~/.config/fish/config.fish, or $PROFILE for powershell)
+Evaluate this command's output with the syntax for your shell; running it alone
+only prints the script. Activation updates tools and environment variables as
+this shell changes directories.
 
-Typically, this can be added with something like the following:
+Add the appropriate example below once to your interactive startup file:
+~/.bashrc for Bash, ~/.zshrc for Zsh, ~/.config/fish/config.fish for Fish,
+or $PROFILE for PowerShell. See the getting-started guide for other shells.
 
-    echo 'eval "$(mise activate zsh)"' >> ~/.zshrc
+The mise executable must be on PATH before that line runs. Otherwise use its
+absolute path, for example `eval "$(~/.local/bin/mise activate zsh)"`.
 
-However, this requires that "mise" is in your PATH. If it is not, you need to
-specify the full path like this:
-
-    echo 'eval "$(/path/to/mise activate zsh)"' >> ~/.zshrc
-
-Customize status output with `status` settings.
+Use `mise exec -- command` for scripts and CI that do not need interactive hooks.
+Customize status output with the `status` settings.
 """#
     flag "-q --quiet" help="Suppress non-error messages"
     flag "-s --shell" help="Shell type to generate the script for" hide=#true {
@@ -315,11 +314,13 @@ cmd tool-alias help="Manage tool version aliases" effect=read {
     }
     flag --no-header help="Don't show table header"
     flag "-h --help" help="Print help" action=help builtin=#true
-    cmd get help="Show an alias for a tool" effect=read {
+    cmd get help="Show a configured version alias for a tool" effect=read {
         long_help #"""
-Show an alias for a tool
+Show a configured version alias for a tool
 
-This is the contents of a tool_alias.<TOOL> entry in ~/.config/mise/config.toml
+Reads the merged `[tool_alias.TOOL.versions]` configuration. This prints the
+stored request, which may itself be a prefix. Backend-provided aliases are listed
+by `mise tool-alias ls`; they are not entries returned by this command.
 """#
         flag "-h --help" help="Print help" action=help builtin=#true
         arg <TOOL> help="The tool to show the alias for"
@@ -340,7 +341,7 @@ Aliases can be defined in user config or provided by plugins via `bin/list-alias
 In user config, aliases are defined like the following in `~/.config/mise/config.toml`:
 
     [tool_alias.node.versions]
-    lts = "22.0.0"
+    project = "20"
 """#
         flag --no-header help="Don't show table header"
         flag "-h --help" help="Print help" action=help builtin=#true
@@ -409,58 +410,30 @@ Tool(s) to look up
 e.g.: ruby@3
 """# required=#false var=#true
 }
-cmd bootstrap help="Set up a machine for the current config in one command" effect=destructive {
+cmd bootstrap help="Set up a machine from the current configuration" effect=destructive {
     alias bs
     long_help #"""
-Set up a machine for the current config in one command
+Set up a machine from the current configuration
 
-Runs the bootstrap steps for the current config in order:
+Runs these phases in order, when configured and selected:
 
-0. `mise bootstrap accounts apply` — converge `[bootstrap.users]` and
-   `[bootstrap.groups]` (Linux)
-1. `mise bootstrap plugins apply` — install `[bootstrap.plugins]`
-   1.7. `[bootstrap.hooks.pre-packages]` — optional setup hook
-2. Install built-in-manager entries from `[bootstrap.packages]`
-3. `mise bootstrap files apply` — converge `[bootstrap.files]` and
-   `[bootstrap.directories]`
-4. `mise bootstrap services apply` — converge `[bootstrap.services]`
-   systemd system services (Linux)
-5. `mise bootstrap firewall apply` — converge `[bootstrap.linux.firewall]`
-   host firewall policy and rules (Linux)
-6. `mise bootstrap compose apply` — converge `[bootstrap.compose]`
-   Docker Compose projects
-7. `mise bootstrap repos apply` — clone/converge `[bootstrap.repos]`
-   surrounded by `pre-repos`/`post-repos` hooks
-8. `mise bootstrap dotfiles apply` — apply dotfiles from `[dotfiles]`
-   surrounded by `pre-dotfiles`/`post-dotfiles` hooks
-9. `mise bootstrap mise-shell-activate apply` — configure shell activation
-   from `[bootstrap.mise_shell_activate]`
-10. `mise bootstrap macos defaults apply` — write
-    `[bootstrap.macos.defaults]` entries (macOS)
-    surrounded by `pre-defaults`/`post-defaults` hooks
-11. `mise bootstrap macos launchd-agents apply` — install/load
-    `[bootstrap.macos.launchd.agents]`
-12. `mise bootstrap linux systemd-units apply` — install/start
-    `[bootstrap.linux.systemd.units]`
-13. `mise bootstrap user apply` — set `[bootstrap.user].login_shell`
-    (Unix)
-    surrounded by `pre-user`/`post-user` hooks
-14. `mise install` — install missing tools from `[tools]`
-    surrounded by `pre-tools`/`post-tools` hooks; package-plugin entries
-    from `[bootstrap.packages]` install afterward, followed by
-    `[bootstrap.hooks.post-packages]`
-15. `mise run bootstrap` — if a task named `bootstrap` is defined
-16. `[bootstrap.hooks.final]` — optional final hook
+1. Linux accounts, then package-manager plugins.
+2. The pre-packages hook, then packages handled by built-in managers.
+3. Privileged files/directories, system services, firewall, and Compose projects.
+4. Git repositories, then dotfiles, each with its pre/post hooks.
+5. Shell activation, macOS defaults and LaunchAgents, Linux user units, and user settings.
+6. The pre-tools hook, versioned tools, and post-tools hook.
+7. Package-plugin packages, then the post-packages hook.
+8. The `bootstrap` task, when defined, then the final hook.
 
-The declarative steps converge — anything already in its desired state
-is skipped, so re-running is safe. The `bootstrap` task runs on every
-invocation; keep it idempotent. Use it for any project-specific setup
-that doesn't fit the declarative sections (seeding databases, auth flows,
-etc.) — it runs with the installed tools on PATH.
+Defaults and user settings also have pre/post hooks. See
+https://mise.jdx.dev/bootstrap.html for the complete phase order and configuration.
+Unchanged resource state is skipped, but hooks and the bootstrap task can run again;
+make those commands safe to repeat. Dotfile templates may execute while checking state.
 
-Use `--skip <part>` to skip named parts, or `--only <part>` to run just
-named parts. Both flags can be repeated or comma-separated, but they
-cannot be used together.
+Use `--dry-run` to preview the selected workflow, `bootstrap status` to inspect state,
+or `bootstrap plan` for the declarative-resource plan. `--only` and `--skip` accept
+repeated or comma-separated parts and cannot be combined.
 """#
     flag --from help="Clone a git repository and bootstrap from its configuration" {
         arg <GIT_URL>
@@ -569,6 +542,12 @@ Can be passed multiple times or as a comma-separated list.
         flag "-h --help" help="Print help" action=help builtin=#true
     }
     cmd accounts subcommand_required=#true help="Manage Linux users and groups from `[bootstrap.users]` and `[bootstrap.groups]`" effect=read {
+        long_help #"""
+Manage Linux users and groups from `[bootstrap.users]` and `[bootstrap.groups]`
+
+These are system accounts on the target Linux host. Inspect `status` or an apply
+preview before changing user IDs, memberships, or account state.
+"""#
         flag "-h --help" help="Print help" action=help builtin=#true
         cmd apply help="Apply configured Linux users and groups" effect=destructive {
             flag "-n --dry-run" help="Print what would change without changing anything"
@@ -582,10 +561,22 @@ Can be passed multiple times or as a comma-separated list.
         }
     }
     cmd config-roots help="Show non-composed bootstrap declarations in each selected configuration root" effect=read {
+        long_help #"""
+Show non-composed bootstrap declarations in each selected configuration root
+
+Use this to locate the origin of declarations before composition. For the
+combined desired state and its changes, use `bootstrap plan`.
+"""#
         flag "-J --json" help="Output in JSON format"
         flag "-h --help" help="Print help" action=help builtin=#true
     }
     cmd compose subcommand_required=#true help="Manage Docker Compose projects from `[bootstrap.compose]`" effect=read {
+        long_help #"""
+Manage Docker Compose projects from `[bootstrap.compose]`
+
+Requires a working Docker engine and Compose command on the target host. `apply`
+reconciles declared project state; `status` inspects the existing projects.
+"""#
         flag "-h --help" help="Print help" action=help builtin=#true
         cmd apply help="Apply configured Docker Compose project state" effect=destructive {
             flag "-n --dry-run" help="Print what would change without changing anything"
@@ -606,7 +597,9 @@ Add or update dotfiles in `[dotfiles]`
 
 If the target is already managed, this updates its source from the live
 target. Otherwise it creates a `[dotfiles]` entry and seeds the source
-under `dotfiles.root` unless `--source` is provided.
+under `dotfiles.root` unless `--source` is provided. Captured entries are
+applied unless `--no-apply` is passed. Use `--dry-run` to preview both the
+source capture and config write without making those changes.
 """#
             flag --changed help="Update the sources of every changed file managed in copy mode"
             flag "-f --force" help="Overwrite existing sources without prompting"
@@ -684,6 +677,12 @@ mise bootstrap dotfiles edit --apply ~/.config/starship.toml
         }
         cmd status help="Show the status of dotfiles from `[dotfiles]`" effect=read {
             alias ls
+            long_help #"""
+Show the status of dotfiles from `[dotfiles]`
+
+Template entries are rendered to compare their output; trusted template
+functions may execute. `--missing` changes the exit status, not the listing.
+"""#
             flag "-J --json" help="Output in JSON format"
             flag --missing help=#"""
 Exit with code 1 if any configured dotfiles are not in their desired
@@ -704,7 +703,8 @@ Remove dotfiles applied from `[dotfiles]`
 
 Removes configured whole-file entries and edits while preserving files
 mise cannot identify as managed. Modified copies, templates, and plain-line
-edits require `--force`.
+edits require `--force`. Source files and configuration entries are retained.
+Run this before deleting a declaration so mise can still identify its targets.
 """#
             flag "-f --force" help="Remove modified or otherwise ambiguous managed files and lines"
             flag "-n --dry-run" help="Print the actions that would run without writing anything"
@@ -720,6 +720,12 @@ mise bootstrap dotfiles unapply --force --yes
         }
     }
     cmd files subcommand_required=#true help="Manage privileged files and directories from `[bootstrap.files]` and `[bootstrap.directories]`" effect=read {
+        long_help #"""
+Manage privileged files and directories from `[bootstrap.files]` and `[bootstrap.directories]`
+
+Use these resources for ownership, permissions, and desired presence on a host.
+For personal symlinks, copies, or edits, use `[dotfiles]` and `bootstrap dotfiles`.
+"""#
         flag "-h --help" help="Print help" action=help builtin=#true
         cmd apply help="Apply configured privileged files and directories" effect=destructive {
             flag "-n --dry-run" help="Print what would change without changing anything"
@@ -735,6 +741,12 @@ mise bootstrap dotfiles unapply --force --yes
         }
     }
     cmd firewall subcommand_required=#true help="Manage the Linux host firewall from `[bootstrap.linux.firewall]`" effect=read {
+        long_help #"""
+Manage the Linux host firewall from `[bootstrap.linux.firewall]`
+
+This manages host firewall policy and rules. Review `apply --dry-run` before applying
+a policy to a remote machine, including the rule that permits your SSH connection.
+"""#
         flag "-h --help" help="Print help" action=help builtin=#true
         cmd apply help="Apply the configured Linux host firewall" effect=destructive {
             flag "-n --dry-run" help="Print what would change without changing anything"
@@ -748,6 +760,12 @@ mise bootstrap dotfiles unapply --force --yes
         }
     }
     cmd launchd hide=#true subcommand_required=#true help="Manage macOS LaunchAgents from `[bootstrap.macos.launchd.agents]`" effect=read {
+        long_help #"""
+Manage macOS LaunchAgents from `[bootstrap.macos.launchd.agents]`
+
+Installs plist files and reconciles agents in the current GUI login domain. Run
+from the intended user session; an SSH-only session may not have that domain.
+"""#
         flag "-h --help" help="Print help" action=help builtin=#true
         cmd apply help="Install and load LaunchAgents from `[bootstrap.macos.launchd.agents]`" effect=write {
             flag "-n --dry-run" help="Print the commands that would run without running them"
@@ -764,6 +782,12 @@ mise bootstrap dotfiles unapply --force --yes
         flag "-h --help" help="Print help" action=help builtin=#true
         cmd systemd-units subcommand_required=#true help="Manage systemd user services from `[bootstrap.linux.systemd.units]`" effect=read {
             alias systemd
+            long_help #"""
+Manage systemd user services from `[bootstrap.linux.systemd.units]`
+
+Installs unit files and reconciles services in the current user manager. This is
+separate from system services declared in `[bootstrap.services]`.
+"""#
             flag "-h --help" help="Print help" action=help builtin=#true
             cmd apply help="Install and start systemd user services from `[bootstrap.linux.systemd.units]`" effect=write {
                 flag "-n --dry-run" help="Print the commands that would run without running them"
@@ -780,6 +804,12 @@ mise bootstrap dotfiles unapply --force --yes
     cmd macos subcommand_required=#true help="Manage macOS bootstrap config from `[bootstrap.macos]`" effect=read {
         flag "-h --help" help="Print help" action=help builtin=#true
         cmd defaults subcommand_required=#true help="Manage macOS defaults from `[bootstrap.macos.defaults]`" effect=read {
+            long_help #"""
+Manage macOS defaults from `[bootstrap.macos.defaults]`
+
+Declares typed preferences written with macOS defaults. Application preferences
+may require restarting the affected application before the change becomes visible.
+"""#
             flag "-h --help" help="Print help" action=help builtin=#true
             cmd apply help="Write macOS defaults from `[bootstrap.macos.defaults]`" effect=write {
                 flag "-n --dry-run" help="Print the commands that would run without running them"
@@ -794,6 +824,12 @@ mise bootstrap dotfiles unapply --force --yes
         }
         cmd launchd-agents subcommand_required=#true help="Manage macOS LaunchAgents from `[bootstrap.macos.launchd.agents]`" effect=read {
             alias launchd
+            long_help #"""
+Manage macOS LaunchAgents from `[bootstrap.macos.launchd.agents]`
+
+Installs plist files and reconciles agents in the current GUI login domain. Run
+from the intended user session; an SSH-only session may not have that domain.
+"""#
             flag "-h --help" help="Print help" action=help builtin=#true
             cmd apply help="Install and load LaunchAgents from `[bootstrap.macos.launchd.agents]`" effect=write {
                 flag "-n --dry-run" help="Print the commands that would run without running them"
@@ -808,6 +844,12 @@ mise bootstrap dotfiles unapply --force --yes
         }
     }
     cmd macos-defaults hide=#true subcommand_required=#true help="Manage macOS defaults from `[bootstrap.macos.defaults]`" effect=read {
+        long_help #"""
+Manage macOS defaults from `[bootstrap.macos.defaults]`
+
+Declares typed preferences written with macOS defaults. Application preferences
+may require restarting the affected application before the change becomes visible.
+"""#
         flag "-h --help" help="Print help" action=help builtin=#true
         cmd apply help="Write macOS defaults from `[bootstrap.macos.defaults]`" effect=write {
             flag "-n --dry-run" help="Print the commands that would run without running them"
@@ -822,6 +864,12 @@ mise bootstrap dotfiles unapply --force --yes
     }
     cmd mise-shell-activate subcommand_required=#true help="Manage mise shell activation from `[bootstrap.mise_shell_activate]`" effect=read {
         alias shell
+        long_help #"""
+Manage mise shell activation from `[bootstrap.mise_shell_activate]`
+
+Writes managed activation blocks into the declared shell startup files. The
+current shell is not reactivated by this command; open a new shell afterward.
+"""#
         flag "-h --help" help="Print help" action=help builtin=#true
         cmd apply help="Configure shell activation from `[bootstrap.mise_shell_activate]`" effect=write {
             flag "-n --dry-run" help="Print the actions that would run without writing anything"
@@ -881,7 +929,7 @@ can be fetched directly by mise without a Homebrew installation.
                 }
                 flag "-h --help" help="Print help" action=help builtin=#true
                 arg <TAP> help="Tap name, e.g. `owner/repo`"
-                arg "[URL]" help="GitHub URL for the tap. Defaults to https://github.com/<owner>/homebrew-<repo>.git" required=#false
+                arg "[URL]" help="Repository URL for the tap; defaults to GitHub's owner/homebrew-repo.git naming" required=#false
                 example #"""
 mise bootstrap packages brew tap railwaycat/emacsmacport
 mise bootstrap packages brew tap acme/tools https://github.com/acme/homebrew-tools.git
@@ -1035,12 +1083,24 @@ mise bootstrap packages use apt:curl@8.5.0-2
         }
     }
     cmd plan help="Show the changes declarative bootstrap resources would make" effect=read {
+        long_help #"""
+Show the changes declarative bootstrap resources would make
+
+Covers declarative resources, not every hook, package installation, or task in a
+full bootstrap run. Use `bootstrap --dry-run` to preview the complete workflow.
+`--detailed-exitcode` distinguishes unchanged (0), changes (2), and errors (1).
+"""#
         flag "-J --json" help="Output a stable machine-readable plan in JSON format"
         flag --detailed-exitcode help="Exit 2 when the plan contains changes, 0 when unchanged, and 1 on errors"
         flag --prompt-secrets help="Prompt securely for missing bootstrap secret inputs"
         flag "-h --help" help="Print help" action=help builtin=#true
     }
     cmd plugins subcommand_required=#true help="Manage package manager plugins declared in `[bootstrap.plugins]`" effect=read {
+        long_help #"""
+Manage package manager plugins declared in `[bootstrap.plugins]`
+
+Install these plugins before applying packages they manage. Installing a plugin does not itself install the host packages in `[bootstrap.packages]`.
+"""#
         flag "-h --help" help="Print help" action=help builtin=#true
         cmd apply help="Install package manager plugins declared in `[bootstrap.plugins]`" effect=write {
             flag "-n --dry-run" help="Print what would happen without installing plugins"
@@ -1052,6 +1112,13 @@ mise bootstrap packages use apt:curl@8.5.0-2
         }
     }
     cmd remote help="Bootstrap one or more machines over OpenSSH" effect=destructive {
+        long_help #"""
+Bootstrap one or more machines over OpenSSH
+
+Select inventory hosts by name, tag, or `--all`, or supply ad-hoc `--host` targets.
+The source is staged on each target and bootstrap runs there. `--from-git` instead
+installs persistent global configuration; preview that choice with `--dry-run`.
+"""#
         flag --from-git help="Install a Git repository as persistent global configuration on each target" {
             conflicts "--source" "--copy-link" "--copy-links" "--exclude"
             arg "<GIT_URL|OWNER/REPO>"
@@ -1200,6 +1267,13 @@ Defaults to `~/.local/bin/mise`; pass `--install-mise=<PATH>` for another path.
         complete source type=dir
     }
     cmd repos subcommand_required=#true help="Manage git repo checkouts from `[bootstrap.repos]`" effect=read {
+        long_help #"""
+Manage git repo checkouts from `[bootstrap.repos]`
+
+Use `apply` to clone or reconcile the configured checkout, `update` to refresh it,
+and `exec` to run a command in selected repositories. Existing local changes can
+block convergence; `--skip-dirty` skips those repositories without discarding edits.
+"""#
         flag "-h --help" help="Print help" action=help builtin=#true
         cmd apply help="Clone and converge git repos from `[bootstrap.repos]`" effect=write {
             flag "-n --dry-run" help="Print the commands that would run without running them"
@@ -1208,6 +1282,11 @@ Defaults to `~/.local/bin/mise`; pass `--install-mise=<PATH>` for another path.
             flag "-h --help" help="Print help" action=help builtin=#true
         }
         cmd exec help="Run a command in each configured git repo" {
+            long_help #"""
+Run a command in each configured git repo
+
+Place the executable and its arguments after `--`, for example `mise bootstrap repos exec -- git status --short`. Arguments before `--` select repository paths; use `--continue-on-error` to visit remaining repos after a failure.
+"""#
             flag "-c --continue-on-error" help="Continue running in other repos after a command fails"
             flag "-n --dry-run" help="Print the commands that would run without running them"
             flag "-h --help" help="Print help" action=help builtin=#true
@@ -1236,6 +1315,12 @@ Defaults to `~/.local/bin/mise`; pass `--install-mise=<PATH>` for another path.
         }
     }
     cmd services subcommand_required=#true help="Manage Linux system services from `[bootstrap.services]`" effect=read {
+        long_help #"""
+Manage Linux system services from `[bootstrap.services]`
+
+These are system-level systemd services. For units in the current user session,
+use `bootstrap linux systemd-units` instead.
+"""#
         flag "-h --help" help="Print help" action=help builtin=#true
         cmd apply help="Apply configured Linux system service state" effect=destructive {
             flag "-n --dry-run" help="Print what would change without changing anything"
@@ -1250,12 +1335,25 @@ Defaults to `~/.local/bin/mise`; pass `--install-mise=<PATH>` for another path.
     }
     cmd status help="Show the aggregate bootstrap status" effect=read {
         alias ls
+        long_help #"""
+Show the aggregate bootstrap status
+
+Inspect configured resource state without applying changes. `--missing` sets a
+nonzero exit status for drift; it does not restrict the listing to missing entries.
+Dotfile status can render trusted templates, including their `exec()` calls.
+"""#
         flag "-J --json" help="Output in JSON format"
         flag --missing help="Exit with code 1 if any configured bootstrap state is not in its desired state"
         flag --prompt-secrets help="Prompt securely for missing bootstrap secret inputs"
         flag "-h --help" help="Print help" action=help builtin=#true
     }
     cmd systemd hide=#true subcommand_required=#true help="Manage systemd user services from `[bootstrap.linux.systemd.units]`" effect=read {
+        long_help #"""
+Manage systemd user services from `[bootstrap.linux.systemd.units]`
+
+Installs unit files and reconciles services in the current user manager. This is
+separate from system services declared in `[bootstrap.services]`.
+"""#
         flag "-h --help" help="Print help" action=help builtin=#true
         cmd apply help="Install and start systemd user services from `[bootstrap.linux.systemd.units]`" effect=write {
             flag "-n --dry-run" help="Print the commands that would run without running them"
@@ -1269,6 +1367,12 @@ Defaults to `~/.local/bin/mise`; pass `--install-mise=<PATH>` for another path.
         }
     }
     cmd user subcommand_required=#true help="Manage current-user bootstrap settings from `[bootstrap.user]`" effect=read {
+        long_help #"""
+Manage current-user bootstrap settings from `[bootstrap.user]`
+
+Currently manages the login shell. Apply as the intended user; changing the login
+shell affects future sessions, not the shell running this command.
+"""#
         flag "-h --help" help="Print help" action=help builtin=#true
         cmd apply help="Apply current-user settings from `[bootstrap.user]`" effect=write {
             flag "-n --dry-run" help="Print the commands that would run without running them"
@@ -1422,14 +1526,21 @@ cmd config help="Manage config files" effect=read {
     }
     flag --tracked-configs help="List all tracked config files"
     flag "-h --help" help="Print help" action=help builtin=#true
-    cmd get help="Display a value from a mise.toml file" effect=read {
+    cmd get help="Display a value from one mise TOML file" effect=read {
+        long_help #"""
+Display a value from one mise TOML file
+
+Reads the highest-precedence loaded TOML file by default. Select another with
+`--file`, `--global`, or `--system`. This reads stored values, not the merged or
+template-expanded environment; use `mise env` for the resolved environment.
+"""#
         flag "-f --file --path" help="The path to the mise.toml file to read" {
             long_help #"""
 The path to the mise.toml file to read
 
 Can be a file path or directory. If a directory is provided, the config file in that directory is used.
 
-If not provided, the nearest mise.toml file will be used
+If not provided, the highest-precedence loaded TOML file is used
 """#
             arg <FILE>
         }
@@ -1462,14 +1573,26 @@ Path                        Tools
 ~/src/mise/mise.toml        actionlint, bun, cargo-binstall, cargo:cargo-insta
 """#
     }
-    cmd set help="Set a value in a mise.toml file" effect=write {
+    cmd set help="Set a value in one mise TOML file" effect=write {
+        long_help #"""
+Set a value in one mise TOML file
+
+Edits the highest-precedence loaded TOML file by default, which may be an
+environment-specific override. Use `--file` to select an existing project file,
+or `--global`/`--system` to edit or create those config files.
+
+This edits configuration without installing tools. Use `mise use` to install and
+select a version together. Known settings use their declared type; other values
+are strings or booleans unless `--type` is given. Use `--type string` when a value
+such as `true` should remain literal text.
+"""#
         flag "-f --file --path" help="The path to the mise.toml file to edit" {
             long_help #"""
 The path to the mise.toml file to edit
 
 Can be a file path or directory. If a directory is provided, the config file in that directory is used.
 
-If not provided, the nearest mise.toml file will be used
+If not provided, the highest-precedence loaded TOML file is used
 """#
             arg <FILE>
         }
@@ -1534,11 +1657,14 @@ mise current python
 3.11.0 3.10.0
 """# help="can output multiple versions"
 }
-cmd deactivate help="Disable mise for current shell session" effect=read {
+cmd deactivate help="Print the script to disable mise in the current shell session" effect=read {
     long_help #"""
-Disable mise for current shell session
+Print the script to disable mise in the current shell session
 
-This can be used to temporarily disable mise in a shell session.
+The shell function installed by activation evaluates this output in supported
+shells. When calling the executable directly, evaluate or source its output
+with the appropriate shell syntax. This does not remove the startup-file line;
+new shells will activate mise again.
 """#
     flag "-h --help" help="Print help" action=help builtin=#true
     example "eval \"$(command mise deactivate)\"" help="Bash or Zsh, calling the executable rather than the activation function"
@@ -1598,7 +1724,9 @@ Add or update dotfiles in `[dotfiles]`
 
 If the target is already managed, this updates its source from the live
 target. Otherwise it creates a `[dotfiles]` entry and seeds the source
-under `dotfiles.root` unless `--source` is provided.
+under `dotfiles.root` unless `--source` is provided. Captured entries are
+applied unless `--no-apply` is passed. Use `--dry-run` to preview both the
+source capture and config write without making those changes.
 """#
         flag --changed help="Update the sources of every changed file managed in copy mode"
         flag "-f --force" help="Overwrite existing sources without prompting"
@@ -1676,6 +1804,13 @@ mise bootstrap dotfiles edit --apply ~/.config/starship.toml
     }
     cmd status hide=#true help="Show the status of dotfiles from `[dotfiles]`" effect=read {
         alias ls
+        long_help #"""
+Show the status of dotfiles from `[dotfiles]`
+
+Template entries are rendered to compare their output; trusted template
+functions may execute. JSON includes each entry's origin and uses the states
+`applied`, `missing`, `differs`, and `source_missing`.
+"""#
         flag "-J --json" help="Output in JSON format"
         flag --missing help=#"""
 Exit with code 1 if any configured dotfiles are not in their desired
@@ -1696,7 +1831,8 @@ Remove dotfiles applied from `[dotfiles]`
 
 Removes configured whole-file entries and edits while preserving files
 mise cannot identify as managed. Modified copies, templates, and plain-line
-edits require `--force`.
+edits require `--force`. Source files and configuration entries are retained.
+Run this before deleting a declaration so mise can still identify its targets.
 """#
         flag "-f --force" help="Remove modified or otherwise ambiguous managed files and lines"
         flag "-n --dry-run" help="Print the actions that would run without writing anything"
@@ -1753,13 +1889,18 @@ node -v
     example "mise en -s \"zsh -f\"" help="Skip loading zshrc."
     complete dir type=dir
 }
-cmd env help="Export env vars to activate mise a single time" effect=read {
+cmd env help="Print the environment for the current configuration" effect=read {
     alias e
     long_help #"""
-Export env vars to activate mise a single time
+Print the environment for the current configuration
 
-Use this to load the environment into one shell without adding `mise activate` to
-your shell rc file. It is not needed in shells where mise is already activated.
+Evaluate the shell output to load tools and variables once, without installing
+prompt hooks. Changing directories afterward does not recompute this environment.
+Use `mise exec -- command` to apply it to one child process instead.
+
+JSON, dotenv, and shell output contain actual variable values, including secrets.
+`--redacted` selects variables marked for redaction; it does not mask their values.
+Environment construction may install missing tools according to mise's settings.
 """#
     flag "-D --dotenv" help="Output in dotenv format" overrides=--shell
     flag "-J --json" help="Output in JSON format" overrides=--shell
@@ -1779,7 +1920,7 @@ your shell rc file. It is not needed in shells where mise is already activated.
         }
     }
     flag --json-extended help="Output in JSON format with additional information (source, tool)" overrides=--shell
-    flag --redacted help="Only show redacted environment variables"
+    flag --redacted help="Only include variables marked for redaction; their values are printed unmasked"
     flag --values help="Only show values of environment variables"
     flag "-h --help" help="Print help" action=help builtin=#true
     arg "[TOOL@VERSION]…" help="Tool(s) to include in addition to those in config, e.g. node@20" required=#false var=#true
@@ -1800,11 +1941,11 @@ session, or to run ad-hoc commands with tools that are not in the config.
 
 Tools are loaded from mise.toml and can be overridden with <TOOL@VERSION> args. Only the
 tools you name are overridden: if `mise.toml` includes `node = "20"` and you run
-`mise exec python@3.11`, node@20 is still loaded.
+`mise exec python@3.11 -- python -V`, node@20 is still loaded.
 
 The "--" separates tools from the command to pass along to the subprocess.
 """#
-    flag "-c --command" help="Command string to execute" conflicts=COMMAND {
+    flag "-c --command" help="Command string to execute through a shell (supports pipes and redirection)" conflicts=COMMAND {
         arg <COMMAND>
     }
     flag "-j --jobs" help=#"""
@@ -1822,7 +1963,9 @@ Supports wildcards, e.g. --allow-env='MYAPP_*'
     }
     flag --allow-net help=#"""
 Allow network to specific host (implies --deny-net for everything else)
-macOS only in v1; on Linux falls back to allowing all network
+Per-host filtering is unsupported on Linux and returns an error.
+See the sandboxing guide for current macOS host-filter limitations.
+On Windows, sandboxing is unavailable: mise warns and runs without host filtering.
 """# var=#true {
         arg <HOST>
     }
@@ -1833,7 +1976,7 @@ macOS only in v1; on Linux falls back to allowing all network
         arg <PATH>
     }
     flag --deny-all help="Block reads, writes, network, and env vars"
-    flag --deny-env help="Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)"
+    flag --deny-env help="Block env var inheritance except PATH, HOME, USER, SHELL, TERM, COLORTERM, LANG"
     flag --deny-net help="Block all network access"
     flag --deny-read help="Block filesystem reads (system libs and tool dirs still accessible)"
     flag --deny-write help="Block all filesystem writes"
@@ -1842,7 +1985,7 @@ macOS only in v1; on Linux falls back to allowing all network
     flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal. Implies `--jobs=1`" overrides=--jobs
     flag "-h --help" help="Print help" action=help builtin=#true
     arg "[TOOL@VERSION]…" help="Tool(s) to load e.g.: node@20 python@3.10" required=#false var=#true
-    arg "[-- COMMAND]…" help="Command string to execute (same as --command)" required=#false var=#true conflicts=--command required_unless=--command
+    arg "[-- COMMAND]…" help="Executable and arguments to run directly, after `--`" required=#false var=#true conflicts=--command required_unless=--command
     example #"""
 mise exec node@20 -- node ./app.js
 mise x node@20 -- node ./app.js
@@ -1851,11 +1994,14 @@ mise x node@20 -- node ./app.js
     example "mise x -C /path/to/project node@20 -- node ./app.js" help="Run a command in a different directory:"
     complete command type=command
 }
-cmd fmt help="Format mise.toml" effect=write {
+cmd fmt help="Format mise TOML configuration" effect=write {
     long_help #"""
-Format mise.toml
+Format mise TOML configuration
 
-Sorts keys and cleans up whitespace in mise.toml
+Sorts keys and normalizes whitespace using TOML 1.1 syntax, including multiline
+inline tables. By default, formats config files in the current directory;
+`--all` includes every loaded config. Use `--check` in CI or `--stdin` to format
+a supplied document without rewriting a file.
 """#
     flag "-a --all" help="Format every config file mise currently loads, not just those in the current directory"
     flag "-c --check" help="Check whether the configs are formatted without rewriting them; exits 1 if any are not"
@@ -1879,11 +2025,12 @@ This is designed to be used in a project where contributors may not have mise in
 Renamed from `mise generate bootstrap`, which read as a form of `mise bootstrap` (machine
 setup). The old name still works but is deprecated and will be removed in mise 2027.9.0.
 """#
-        flag "-l --localize" help="Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a project-local directory (`.mise` by default, set with `--localized-dir`)" {
+        flag "-l --localize" help="Keep mise data and cache in a project-local directory (`.mise` by default)" {
             long_help #"""
-Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a project-local directory (`.mise` by default, set with `--localized-dir`)
+Keep mise data and cache in a project-local directory (`.mise` by default)
 
-This is necessary if users may use a different version of mise outside the project.
+Use `--localized-dir` to choose its location. This isolates mise state;
+it is not an OS sandbox for commands the generated script runs.
 """#
         }
         flag "-V --version" help="Specify mise version to fetch" {
@@ -1936,7 +2083,13 @@ mise generate config -n          # preview without writing
         complete path type=path
         complete tool_versions type=path
     }
-    cmd devcontainer help="Generate a devcontainer to execute mise" effect=write {
+    cmd devcontainer help="Generate devcontainer configuration for mise" effect=write {
+        long_help #"""
+Generate devcontainer configuration for mise
+
+Prints JSON by default. `--write` saves .devcontainer/devcontainer.json;
+review the image, mounts, and generated setup commands before opening it.
+"""#
         flag "-i --image" help="The image to use for the devcontainer" {
             arg <IMAGE>
         }
@@ -1986,7 +2139,9 @@ git commit -m "feat: add new feature"
 Generate a GitHub Action workflow file
 
 This command generates a GitHub Action workflow file that runs a mise task like `mise run ci`
-when you push changes to your repository.
+on pull requests, tags, manual dispatch, and pushes to the current Git branch.
+Prints YAML by default; `--write` saves it under .github/workflows. Define
+the selected task and review the generated triggers before committing.
 """#
         flag "-t --task" help="The task to run when the workflow is triggered" default=ci {
             arg <TASK>
@@ -2011,11 +2166,12 @@ This is designed to be used in a project where contributors may not have mise in
 Renamed from `mise generate bootstrap`, which read as a form of `mise bootstrap` (machine
 setup). The old name still works but is deprecated and will be removed in mise 2027.9.0.
 """#
-        flag "-l --localize" help="Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a project-local directory (`.mise` by default, set with `--localized-dir`)" {
+        flag "-l --localize" help="Keep mise data and cache in a project-local directory (`.mise` by default)" {
             long_help #"""
-Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a project-local directory (`.mise` by default, set with `--localized-dir`)
+Keep mise data and cache in a project-local directory (`.mise` by default)
 
-This is necessary if users may use a different version of mise outside the project.
+Use `--localized-dir` to choose its location. This isolates mise state;
+it is not an OS sandbox for commands the generated script runs.
 """#
         }
         flag "-V --version" help="Specify mise version to fetch" {
@@ -2050,7 +2206,13 @@ mise generate install-script --write ./bin/mise --windows
 """# help="Write bin/mise.cmd as a launcher for contributors who clone the project on Windows."
         complete localized_dir type=dir
     }
-    cmd task-docs help="Generate documentation for tasks in a project" effect=write {
+    cmd task-docs help="Generate Markdown documentation for project tasks" effect=write {
+        long_help #"""
+Generate Markdown documentation for project tasks
+
+Prints to stdout by default. Use `--output` to write a file, `--inject`
+to replace a marked section, or `--multi` for one file per task.
+"""#
         flag "-i --inject" help="Insert the documentation into an existing file" {
             long_help #"""
 Insert the documentation into an existing file
@@ -2405,7 +2567,7 @@ Installs a tool version under the mise data directory, by default
 Installing alone does not add the tool to your config, so a tool that is not
 already configured will not be on PATH.
 To install and activate in one command, use `mise use`, which also writes the version to
-`mise.toml` in the current directory so the tool is active inside it.
+the selected project config so the tool is active in that configuration scope.
 To run a tool once without touching any config, use `mise exec <TOOL>@<VERSION> -- <COMMAND>`.
 
 Tools are installed in parallel. To disable, set `--jobs=1` or `MISE_JOBS=1`.
@@ -2513,11 +2675,13 @@ v20.0.0
 """# help="install node@20.0.0 into ./mynode"
     complete path type=dir
 }
-cmd latest help="Get the latest available version of a tool" effect=read {
+cmd latest help="Resolve the latest matching version request for a tool" effect=read {
     long_help #"""
-Get the latest available version of a tool
+Resolve the latest matching version request for a tool
 
-Supports prefixes such as `node@20` to get the latest version of node 20.
+Supports prefixes such as `node@20`. The selected backend decides how channels,
+refs, and non-SemVer versions resolve; "latest" is not a generic sort of strings.
+This prints a version without installing it or changing configuration.
 """#
     flag "-i --installed" help="Show latest installed instead of available version"
     flag --minimum-release-age help="Only consider versions released before this date or older than this duration" conflicts=--installed {
@@ -2602,15 +2766,17 @@ the current value of .tool-versions/mise.toml will be displayed
     example "mise local --remove=node" help="removes node from .tool-versions"
     example "mise local node" help="show the current version of node in .tool-versions; example output: `20.0.0`"
 }
-cmd lock help="Update lockfile checksums and URLs for all specified platforms" effect=write {
+cmd lock help="Create or refresh lockfile versions, checksums, and download URLs" effect=write {
     long_help #"""
-Update lockfile checksums and URLs for all specified platforms
+Create or refresh lockfile versions, checksums, and download URLs
 
-Updates checksums and download URLs for all platforms already specified in the lockfile.
-If no lockfile exists, shows what would be created based on the current configuration,
-including tools declared by tasks.
-This allows you to refresh lockfile data for platforms other than the one you're currently on.
-Operates on the lockfile in the current config root. Use TOOL arguments to target specific tools.
+Operates on the current config root, including tools declared by tasks. Existing
+matching locked versions are preserved unless `--bump` re-resolves their selectors.
+This command writes lockfiles without installing tools; `--dry-run` previews changes.
+
+Use `--platform` for explicit targets. Otherwise mise uses `lockfile_platforms`
+plus the current platform when that setting is configured, existing lockfile
+platforms when available, or the common platform defaults for a new lockfile.
 """#
     flag "-g --global" help=#"""
 Target only global config lockfiles (~/.config/mise/mise.lock and system config)
@@ -2626,7 +2792,7 @@ Values below 1 are treated as 1
     flag "-p --platform" help=#"""
 Comma-separated list of platforms to target
 e.g.: linux-x64,macos-arm64,windows-x64
-If not specified, all platforms already in lockfile will be updated
+If omitted, use lockfile_platforms, existing platforms, or common defaults
 """# var=#true {
         arg <PLATFORM> delimiter=,
     }
@@ -2751,9 +2917,10 @@ cmd ls-remote help="List tool versions available to install" effect=read {
     long_help #"""
 List tool versions available to install
 
-Results may be cached; run `mise cache clear` to fetch fresh results.
+Results may be cached; run `mise cache clear TOOL` to refresh one tool
+before querying it again. Version formats and ordering are backend-specific.
 """#
-    flag --all help="Show all installed plugins and versions" {
+    flag --all help="List available versions for every backend/tool currently known to mise" {
         conflicts TOOL@VERSION PREFIX
     }
     flag --minimum-release-age help="Only show versions released before this age or date" {
@@ -2787,8 +2954,8 @@ when a backend's metadata-producing upstream request fails.
     flag "-h --help" help="Print help" action=help builtin=#true
     arg "[TOOL@VERSION]" help="Tool to get versions for" required=#false required_unless=--all
     arg "[PREFIX]" help=#"""
-The version prefix to use when querying the latest version
-same as the first argument after the "@"
+Filter the available versions by this prefix
+Equivalent to the version selector after `@` in the first argument
 """# required=#false
     example #"""
 mise ls-remote node
@@ -2798,19 +2965,18 @@ mise ls-remote node --minimum-release-age 30d
 mise ls-remote github:cli/cli --json
 """#
 }
-cmd mcp help="Run Model Context Protocol (MCP) server" {
+cmd mcp help="Run the Model Context Protocol server over stdin/stdout" {
     long_help #"""
-Run Model Context Protocol (MCP) server
+Run the Model Context Protocol server over stdin/stdout
 
-This command starts an MCP server that exposes mise functionality
-to AI assistants over stdin/stdout using JSON-RPC protocol.
+Exposes project tools, tasks, environment, and configuration to an MCP client.
+Resources use `mise://tools`, `mise://tasks`, `mise://env`, and `mise://config`.
+`mise://tools?include_inactive=true` also includes inactive installations.
 
-The MCP server provides access to:
-- Installed and available tools
-- Task definitions and execution
-- Environment variables
-- Configuration information
-- Task execution via the run_task tool
+The `list_commands` tool describes commands and their declared effects. `run_task`
+executes project tasks with the user's permissions and can change files or invoke
+external services. `install_tool` is advertised but currently returns an error.
+Environment resources contain real values, including secrets.
 
 Resources available:
 - mise://tools - List all tools (use ?include_inactive=true to include inactive tools)
@@ -2850,8 +3016,12 @@ in future releases.
 Each tool version becomes its own content-addressable OCI layer. Bumping a
 tool version only invalidates that tool's layer — other tools, the base
 image, and config are reused unchanged. The output directory conforms to
-the OCI image-layout spec and can be consumed by `skopeo`, `crane`, or
-`podman load`.
+the OCI image-layout spec. Use `skopeo inspect oci:./mise-oci` to inspect it
+or `mise oci run --image-dir ./mise-oci -- command` to load and run it.
+
+Build on Linux with the target architecture: this packages host tool installs
+and, by default, the running mise binary. `--no-mise` omits that binary but does
+not cross-compile tools installed for another OS. asdf/vfox tools are unsupported.
 
 Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).
 """#
@@ -3145,11 +3315,11 @@ cmd patrons help="Show the individuals supporting mise as Patron-tier members" e
     long_help #"""
 Show the individuals supporting mise as Patron-tier members
 
-Lists the individuals on the Patron tier from <https://jdx.dev/patrons.json>.
+Lists the individuals on the Patron tier from https://jdx.dev/patrons.json.
 The list refreshes daily; supporting terminals will render each patron's
 name as a clickable link via OSC 8 hyperlinks.
 
-To appear here, become a patron at <https://jdx.dev/sponsors.html>.
+To appear here, become a patron at https://jdx.dev/sponsors.html.
 """#
     flag "-J --json" help="Output in JSON format"
     flag --refresh help="Bypass the local cache and re-fetch"
@@ -3192,14 +3362,17 @@ to show core and user plugins
 """#
     }
     flag "-h --help" help="Print help" action=help builtin=#true
-    cmd install help="Install a plugin" effect=write {
+    cmd install help="Install a plugin from a configured source, Git URL, or supported archive" effect=write {
         alias i a add
         long_help #"""
-Install a plugin
+Install a plugin from a configured source, Git URL, or supported archive
 
-Note that mise installs plugins automatically when you install a tool that needs one,
-e.g.: `mise install cmake@3.30` installs the cmake plugin first. This command is only
-needed to install a plugin ahead of time or from a custom git URL.
+Most registry tools use built-in backends and need no plugin. When a selected
+backend does require a plugin, mise normally installs it with the tool.
+Use this command to install it ahead of time or choose a custom source.
+
+A Git URL may end in `#ref` to select a plugin commit, tag, or branch. This selects
+the plugin implementation, separately from the tool version installed by `mise use`.
 """#
         flag "-a --all" help=#"""
 Install all missing plugins
@@ -3219,8 +3392,7 @@ Values below 1 are treated as 1
         flag "-h --help" help="Print help" action=help builtin=#true
         arg "[NEW_PLUGIN]" help=#"""
 The name of the plugin to install
-e.g.: cmake, poetry
-Can specify multiple plugins: `mise plugins install cmake poetry`
+Use a configured plugin name, or supply a source URL below
 """# required=#false required_unless=--all
         arg "[GIT_URL]" help="The git url of the plugin" required=#false
         arg "[REST]…" required=#false var=#true hide=#true
@@ -3229,34 +3401,38 @@ Can specify multiple plugins: `mise plugins install cmake poetry`
         example "mise plugins install --all" help="Install missing plugins that have configured shorthands"
         complete git_url type=url
     }
-    cmd link help="Symlink a plugin into mise" effect=write {
+    cmd link help="Link a local plugin directory into mise for development" effect=write {
         alias ln
         long_help #"""
-Symlink a plugin into mise
+Link a local plugin directory into mise for development
 
-This is used for developing a plugin.
+Edits in the source directory take effect without reinstalling the plugin. Pass
+both a name and directory, or only a directory to infer the name after stripping
+a known prefix such as `mise-` or `vfox-`. This does not install a tool version.
 """#
         flag "-f --force" help="Overwrite existing plugin"
         flag "-h --help" help="Print help" action=help builtin=#true
         arg <NAME> help=#"""
 The name of the plugin
-e.g.: cmake, poetry
+With one argument, this is the plugin directory and the name is inferred
 """#
         arg "[DIR]" help=#"""
 The local path to the plugin
-e.g.: ./vfox-cmake
+e.g.: ./mise-my-tool
 """# required=#false
         example "mise plugins link my-tool ./mise-my-tool"
         example "mise plugins link ./mise-my-tool" help="Alternative: infer the name \"my-tool\""
         example "mise ls-remote my-tool" help="List versions through the linked plugin"
         complete dir type=dir
     }
-    cmd ls help="List installed plugins" effect=read {
+    cmd ls help="List installed external plugins" effect=read {
         alias list
         long_help #"""
-List installed plugins
+List installed external plugins
 
-Can also show remotely available plugins to install.
+Use `--core` for built-in runtimes or `--core --user` for both groups. `--outdated`
+queries Git remotes for plugin updates; it does not compare installed tool versions.
+Use `mise plugins ls-remote` for registry plugin sources and `mise ls` for tools.
 """#
         flag "-a --all" help=#"""
 List all available remote plugins
@@ -3308,8 +3484,14 @@ These are the shorthand names from the registry: https://github.com/jdx/mise/blo
         flag "-h --help" help="Print help" action=help builtin=#true
         example "mise plugins ls-remote"
     }
-    cmd uninstall help="Remove a plugin" effect=destructive {
+    cmd uninstall help="Remove an installed plugin" effect=destructive {
         alias remove rm
+        long_help #"""
+Remove an installed plugin
+
+Tool installations are retained by default. Pass `--purge` to also remove
+installs, downloads, and cache associated with the selected plugins.
+"""#
         flag "-a --all" help="Remove all plugins" conflicts=PLUGIN
         flag "-p --purge" help="Also remove the plugin's installs, downloads, and cache"
         flag "-h --help" help="Print help" action=help builtin=#true
@@ -3321,7 +3503,9 @@ These are the shorthand names from the registry: https://github.com/jdx/mise/blo
         long_help #"""
 Update a plugin to the latest version
 
-Note: this updates the plugin itself, not the tool versions it manages
+With no names, updates every installed plugin. This updates plugin source,
+not the tool versions it manages. Linked local plugins are skipped; archive
+installations cannot be updated with Git.
 """#
         flag "-j --jobs" help=#"""
 Number of jobs to run in parallel
@@ -3344,13 +3528,13 @@ cmd deps help="[experimental] Manage project dependencies" effect=write {
     long_help #"""
 [experimental] Manage project dependencies
 
-Runs all applicable dependency install steps for the current project.
-This checks if dependency lockfiles are newer than installed outputs
-(e.g., package-lock.json vs node_modules/) and runs install commands
-if needed.
+With no subcommand, runs dependency installation for the current project, the same
+as `mise deps install`. Providers detect their inputs and installed outputs to
+decide whether work is needed; use `--explain PROVIDER` to inspect that decision.
 
-Providers with `auto = true` are automatically invoked before `mise x` and `mise run`
-unless skipped with the --no-deps flag.
+Providers with `auto = true` run before `mise exec` and `mise run` unless `--no-deps`
+is passed. These install project dependencies, such as node_modules, separately
+from versioned tools managed by `mise install`.
 """#
     after_long_help "\u{1b}[1m\u{1b}[4mConfiguration:\u{1b}[22m\u{1b}[24m\n\n```toml\n# Built-in npm provider (auto-detects lockfile)\n[deps.npm]\nauto = true              # Auto-run before mise x/run\n\n# Custom provider\n[deps.codegen]\nauto = true\nsources = [\"schema/*.graphql\"]\noutputs = [\"src/generated/\"]\nrun = \"npm run codegen\"\n\n# To disable npm instead, add `disable = [\"npm\"]` under [deps].\n```"
     flag --explain help="Show why a provider is fresh or stale (requires a provider argument)"
@@ -3388,8 +3572,9 @@ Package specs use the format `ecosystem:package`, e.g., `npm:react` or `npm:@typ
         long_help #"""
 Install all project dependencies
 
-Checks if dependency lockfiles are newer than installed outputs
-and runs install commands if needed.
+Uses each provider's freshness rules to compare configured inputs and outputs,
+then runs its installation command when needed. `--force` bypasses that check;
+`--explain PROVIDER` shows why a provider is considered fresh or stale.
 """#
         flag --explain help="Show why a provider is fresh or stale (requires a provider argument)"
         flag "-f --force" help="Force run all deps steps even if outputs are fresh"
@@ -3462,13 +3647,16 @@ This is useful for scripts to check if tools need to be pruned.
     arg "[INSTALLED_TOOL]…" help="Prune only these tools" required=#false var=#true
     example "mise prune --dry-run" help="Preview unused versions without deleting them. Example output: `rm -rf ~/.local/share/mise/installs/node/20.0.0` and `rm -rf ~/.local/share/mise/installs/node/20.0.1`."
 }
-cmd registry help="List available tools to install" effect=read {
+cmd registry help="List registry shorthand names and their backends" effect=read {
     long_help #"""
-List available tools to install
+List registry shorthand names and their backends
 
-This command lists the tools available in the registry as shorthand names.
+The registry maps short names to installation backends. For example, `node`
+uses the built-in Node backend. A tool may have multiple candidates; explicit
+backend syntax and configuration can override registry selection.
 
-For example, `poetry` is shorthand for `asdf:mise-plugins/mise-poetry`.
+This is not a list of every tool mise can install. Use an explicit identifier
+such as `github:owner/repo` for a supported source without a registry shorthand.
 """#
     flag "-b --backend" help="Show only tools for this backend" {
         arg <BACKEND>
@@ -3497,26 +3685,17 @@ mise registry --json
 cmd render-help hide=#true help="internal command to generate markdown from help" effect=write {
     flag "-h --help" help="Print help" action=help builtin=#true
 }
-cmd reshim help="Create shims for the executables of currently installed tools" effect=write {
+cmd reshim help="Create shims for executables provided by installed tools" effect=write {
     long_help #"""
-Create shims for the executables of currently installed tools
+Create shims for executables provided by installed tools
 
-This creates shims in the user shim directory for executables that have been added since
-the last reshim. With `--system`, it rebuilds the system shim farm instead.
-mise runs this automatically after commands like `npm i -g`, but other ways of installing
-executables (such as yarn or pnpm for node) are not detected, so call this explicitly then.
+Run this when an executable was added to an existing installation outside mise,
+for example after a language package manager installed a CLI globally. It rebuilds
+the user shim directory by default; `--system` selects the shared system shim farm.
 
-If you think mise should automatically call this for a particular command, please
-open an issue on the mise repo. You can also set up a shell function to reshim
-automatically (it's really fast so you don't need to worry about overhead):
-
-    npm() {
-      command npm "$@"
-      mise reshim
-    }
-
-Note that this creates shims for _all_ installed tools, not just the ones that are
-currently active in mise.toml.
+Shims are created for all installed versions. The shim resolves which version to
+run from the current configuration when invoked. `--force` rebuilds mise-owned
+shims; it does not turn unrelated files into mise-owned shims.
 """#
     flag "-f --force" help="Rebuild all mise-owned shims"
     flag --system help="Rebuild the system shim farm"
@@ -3528,33 +3707,32 @@ mise reshim
 ~/.local/share/mise/shims/node -v
 """# help="Rebuild shims, then check node. Example output: `v20.0.0`."
 }
-cmd run disable_help_flag=#true restart_token=::: help="Run task(s)" unknown_flags=value {
+cmd run disable_help_flag=#true restart_token=::: help="Run tasks and their dependencies" unknown_flags=value {
     alias r
     long_help #"""
-Run task(s)
+Run tasks and their dependencies
 
-Runs one task, or several tasks in parallel.
-Tasks may depend on other tasks and on source files.
-If a task has `sources` configured, it only runs when those files have changed.
+Use `mise run TASK [ARGS...]` for one task, or separate task invocations with `:::`
+to schedule several. Put mise flags before the task name; following arguments are
+passed to that task. With no task, mise runs `default` when defined or opens the
+task selector in an interactive terminal.
 
-Tasks can be defined in mise.toml or as standalone scripts.
-In mise.toml, tasks take this form:
+Tasks are defined in `mise.toml` or task directories. A task with `sources` and
+`outputs` can skip execution when its outputs are fresh. `--force` bypasses
+freshness checks; task output caching has separate `--task-cache` controls.
 
-    [tasks.build]
-    run = "npm run build"
-    sources = ["src/**/*.ts"]
-    outputs = ["dist/**/*.js"]
+For a project that already has npm build scripts and its dependencies installed:
 
-Alternatively, tasks can be defined as standalone scripts.
-These must be located in `mise-tasks`, `.mise-tasks`, `.mise/tasks`, `mise/tasks` or
-`.config/mise/tasks`.
-The name of the script becomes the name of the task.
+```toml
+[tasks.build]
+run = "npm run build"
+sources = ["src/**/*.ts", "package.json", "package-lock.json"]
+outputs = ["dist/**/*.js"]
+```
 
-    $ cat .mise/tasks/build<<EOF
-    #!/usr/bin/env bash
-    npm run build
-    EOF
-    $ mise run build
+To create a standalone script task, use `mise tasks add --file hello -- echo hello`.
+Then run `mise run hello`. See https://mise.jdx.dev/tasks/ for task directories,
+arguments, caching, and dependency configuration.
 """#
     flag --affected help="Run matching tasks only for projects affected by Git changes"
     flag --affected-base help=#"""
@@ -3625,7 +3803,12 @@ Supports wildcards, e.g. --allow-env='MYAPP_*'
 """# var=#true {
         arg <VAR>
     }
-    flag --allow-net help="Allow network to specific host (implies --deny-net for everything else)" var=#true {
+    flag --allow-net help=#"""
+Allow network to specific host (implies --deny-net for everything else)
+Per-host filtering is unsupported on Linux and returns an error.
+See the sandboxing guide for current macOS host-filter limitations.
+On Windows, sandboxing is unavailable: mise warns and runs without host filtering.
+"""# var=#true {
         arg <HOST>
     }
     flag --allow-read help="Allow reads from specific path (implies --deny-read for everything else)" var=#true {
@@ -3635,7 +3818,7 @@ Supports wildcards, e.g. --allow-env='MYAPP_*'
         arg <PATH>
     }
     flag --deny-all help="Block reads, writes, network, and env vars"
-    flag --deny-env help="Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)"
+    flag --deny-env help="Block env var inheritance except PATH, HOME, USER, SHELL, TERM, COLORTERM, LANG"
     flag --deny-net help="Block all network access"
     flag --deny-read help="Block filesystem reads (system libs and tool dirs still accessible)"
     flag --deny-write help="Block all filesystem writes"
@@ -3773,7 +3956,8 @@ cmd set help="Set environment variables in mise.toml" effect=write {
     long_help #"""
 Set environment variables in mise.toml
 
-By default, this command modifies `mise.toml` in the current directory.
+By default, this command selects the nearest configuration directory and
+modifies its lowest-precedence TOML file, creating `mise.toml` here if none exists.
 If multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),
 the lowest precedence file (`mise.toml`) will be used.
 See https://mise.jdx.dev/configuration.html#target-file-for-write-operations
@@ -3881,14 +4065,13 @@ This modifies ~/.config/mise/config.toml by default, or the local config with `-
         arg "[VALUE]" help="The value to set (optional if provided as KEY=VALUE)" required=#false
         example "mise settings add disable_hints python_multi"
     }
-    cmd get help="Show a current setting" effect=read {
+    cmd get help="Show the effective value of a setting" effect=read {
         long_help #"""
-Show a current setting
+Show the effective value of a setting
 
-This is the contents of a single entry in ~/.config/mise/config.toml
-
-Note that aliases are also stored in this file
-but managed separately with `mise tool-alias get`
+Includes defaults, configuration, and environment overrides. With `--local`,
+read only the selected local config's explicit settings; an unset key is an error.
+Use `mise config get settings.KEY --file path/to/mise.toml` to inspect one file.
 """#
         flag "-l --local" help="Use the local config file instead of the global one"
         flag "-h --help" help="Print help" action=help builtin=#true
@@ -3898,15 +4081,15 @@ mise settings get jobs
 mise settings get python.compile
 """#
     }
-    cmd ls help="Show current settings" effect=read {
+    cmd ls help="List configured settings and their sources" effect=read {
         alias list
         long_help #"""
-Show current settings
+List configured settings and their sources
 
-This is the contents of ~/.config/mise/config.toml
-
-Note that aliases are also stored in this file
-but managed separately with `mise tool-alias`
+By default, list explicit settings from loaded TOML files. `--all` also includes
+effective defaults. Use `--local` to restrict output to the selected local file,
+and `--json-extended` to include source information in machine-readable output.
+Use `mise settings get KEY` when you need one effective value.
 """#
         flag "-a --all" help="List all settings"
         flag "-J --json" help="Output in JSON format"
@@ -4382,33 +4565,32 @@ By default, only tasks from the current directory hierarchy are loaded.
         flag "-h --help" help="Print help" action=help builtin=#true
         example "mise tasks ls"
     }
-    cmd run disable_help_flag=#true restart_token=::: help="Run task(s)" unknown_flags=value {
+    cmd run disable_help_flag=#true restart_token=::: help="Run tasks and their dependencies" unknown_flags=value {
         alias r
         long_help #"""
-Run task(s)
+Run tasks and their dependencies
 
-Runs one task, or several tasks in parallel.
-Tasks may depend on other tasks and on source files.
-If a task has `sources` configured, it only runs when those files have changed.
+Use `mise run TASK [ARGS...]` for one task, or separate task invocations with `:::`
+to schedule several. Put mise flags before the task name; following arguments are
+passed to that task. With no task, mise runs `default` when defined or opens the
+task selector in an interactive terminal.
 
-Tasks can be defined in mise.toml or as standalone scripts.
-In mise.toml, tasks take this form:
+Tasks are defined in `mise.toml` or task directories. A task with `sources` and
+`outputs` can skip execution when its outputs are fresh. `--force` bypasses
+freshness checks; task output caching has separate `--task-cache` controls.
 
-    [tasks.build]
-    run = "npm run build"
-    sources = ["src/**/*.ts"]
-    outputs = ["dist/**/*.js"]
+For a project that already has npm build scripts and its dependencies installed:
 
-Alternatively, tasks can be defined as standalone scripts.
-These must be located in `mise-tasks`, `.mise-tasks`, `.mise/tasks`, `mise/tasks` or
-`.config/mise/tasks`.
-The name of the script becomes the name of the task.
+```toml
+[tasks.build]
+run = "npm run build"
+sources = ["src/**/*.ts", "package.json", "package-lock.json"]
+outputs = ["dist/**/*.js"]
+```
 
-    $ cat .mise/tasks/build<<EOF
-    #!/usr/bin/env bash
-    npm run build
-    EOF
-    $ mise run build
+To create a standalone script task, use `mise tasks add --file hello -- echo hello`.
+Then run `mise run hello`. See https://mise.jdx.dev/tasks/ for task directories,
+arguments, caching, and dependency configuration.
 """#
         flag --affected help="Run matching tasks only for projects affected by Git changes"
         flag --affected-base help=#"""
@@ -4479,7 +4661,12 @@ Supports wildcards, e.g. --allow-env='MYAPP_*'
 """# var=#true {
             arg <VAR>
         }
-        flag --allow-net help="Allow network to specific host (implies --deny-net for everything else)" var=#true {
+        flag --allow-net help=#"""
+Allow network to specific host (implies --deny-net for everything else)
+Per-host filtering is unsupported on Linux and returns an error.
+See the sandboxing guide for current macOS host-filter limitations.
+On Windows, sandboxing is unavailable: mise warns and runs without host filtering.
+"""# var=#true {
             arg <HOST>
         }
         flag --allow-read help="Allow reads from specific path (implies --deny-read for everything else)" var=#true {
@@ -4489,7 +4676,7 @@ Supports wildcards, e.g. --allow-env='MYAPP_*'
             arg <PATH>
         }
         flag --deny-all help="Block reads, writes, network, and env vars"
-        flag --deny-env help="Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)"
+        flag --deny-env help="Block env var inheritance except PATH, HOME, USER, SHELL, TERM, COLORTERM, LANG"
         flag --deny-net help="Block all network access"
         flag --deny-read help="Block filesystem reads (system libs and tool dirs still accessible)"
         flag --deny-write help="Block all filesystem writes"
@@ -4814,7 +5001,8 @@ cmd unset help="Remove environment variable(s) from the config file" effect=writ
     long_help #"""
 Remove environment variable(s) from the config file
 
-By default, this command modifies `mise.toml` in the current directory.
+By default, this command selects the nearest configuration directory and
+modifies its lowest-precedence TOML file, creating `mise.toml` here if none exists.
 """#
     flag "-f --file --path" help="Specify a file to use instead of `mise.toml`" {
         long_help #"""
@@ -4841,29 +5029,22 @@ cmd untrust help="Remove explicit trust for a config" effect=write {
     arg "[CONFIG_FILE]" help="The config file to untrust" required=#false
     complete config_file type=path
 }
-cmd unuse help="Remove tool versions from mise.toml and uninstall them" effect=destructive {
+cmd unuse help="Remove tool requests from configuration and prune unused installations" effect=destructive {
     alias rm remove
     long_help #"""
-Remove tool versions from mise.toml and uninstall them
+Remove tool requests from configuration and prune unused installations
 
-By default, this will use the `mise.toml` file that has the tool defined.
-If multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),
-the lowest precedence file (`mise.toml`) will be used.
-See https://mise.jdx.dev/configuration.html#target-file-for-write-operations
+Without a selector, mise edits the first loaded config that declares one of the
+requested tools. Use `--path`, `--global`, or `--env` to choose a specific file.
+A version argument matches the configured request literally: to remove `node = "20"`,
+use `mise unuse node@20`, not the concrete installed version it resolved to.
+Omit the version to remove all requests for that tool from the selected file.
 
-In the following order:
-  - If `--global` is set, it will use the global config file.
-  - If `--path` is set, it will use the config file at the given path.
-  - If `--env` is set, it will use `mise.<env>.toml`.
-  - If [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) is set, it will use that instead.
-  - If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will use the first from that list.
-  - Otherwise just "mise.toml" or global config if cwd is home directory.
-
-Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
-
-The installed version is also removed unless another config still uses it or `--no-prune` is passed.
+Versions are pruned only when no remaining tracked config or tool stub needs them.
+Pass `--no-prune` to edit configuration while keeping installations. To remove an
+installation without editing configuration, use `mise uninstall`.
 """#
-    flag "-e --env" help="Create/modify an environment-specific config file like mise.<env>.toml" {
+    flag "-e --env" help="Modify `.mise.<env>.toml` when it exists, otherwise `mise.<env>.toml`" {
         overrides "--global" "--path"
         arg <ENV>
     }
@@ -4874,7 +5055,7 @@ The installed version is also removed unless another config still uses it or `--
         long_help #"""
 Specify a path to a config file or directory
 
-If a directory is specified, it will look for a config file in that directory following the rules above.
+If a directory is specified, it will look for a config file in that directory following the target-file selection rules.
 """#
         overrides "--global" "--env"
         arg <PATH>
@@ -5000,26 +5181,24 @@ See https://usage.jdx.dev for more information on this specification.
 """#
     flag "-h --help" help="Print help" action=help builtin=#true
 }
-cmd use help="Install a tool and add it to mise.toml" effect=write {
+cmd use help="Install a tool and add it to configuration" effect=write {
     alias u
     long_help #"""
-Install a tool and add it to mise.toml
+Install a tool and add it to configuration
 
-Installs the tool version if it is not already installed, then writes it to a config file.
-By default, this is `mise.toml` in the current directory.
-If multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),
-the lowest precedence file (`mise.toml`) will be used.
+Installs missing tool versions and records the requests in a config file.
+By default, mise selects the nearest directory with a supported config and writes
+to its lowest-precedence file, such as `mise.toml` rather than `mise.local.toml`.
+If no project config exists, it creates one in the current directory. Running from
+your home directory targets global configuration.
+
+Use `--path` for an explicit file/directory, `--global` for personal defaults, or
+`--env` to write `mise.ENV.toml` in the current directory (preserving an existing
+`.mise.ENV.toml`). These selectors override one another; use one per command.
+
 See https://mise.jdx.dev/configuration.html#target-file-for-write-operations
-
-In the following order:
-  - If `--global` is set, it will use the global config file.
-  - If `--path` is set, it will use the config file at the given path.
-  - If `--env` is set, it will use `mise.<env>.toml`.
-  - If [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) is set, it will use that instead.
-  - If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will use the first from that list.
-  - Otherwise just "mise.toml" or global config if cwd is home directory.
-
-Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
+for filename overrides and configuration precedence. Selection takes effect in
+an activated shell on its next prompt, or immediately in `mise exec` commands.
 """#
     flag "-e --env" help="Create/modify an environment-specific config file like .mise.<env>.toml" {
         overrides "--global" "--path"
@@ -5041,7 +5220,7 @@ Defaults to the `jobs` setting
         long_help #"""
 Specify a path to a config file or directory
 
-If a directory is specified, it will look for a config file in that directory following the rules above.
+If a directory is specified, it will look for a config file in that directory following the target-file selection rules.
 """#
         overrides "--global" "--env"
         arg <PATH>
@@ -5136,7 +5315,11 @@ cmd watch help="Run task(s) and rerun them when files change" unknown_flags=valu
     long_help #"""
 Run task(s) and rerun them when files change
 
-Uses `watchexec` to watch for file changes and rerun the given task(s).
+Uses `watchexec` to watch task sources and rerun the selected tasks.
+Sources from dependencies are included unless `--skip-deps` is set. With no
+sources, watchexec watches the current directory. Use `--watch` and `--exts`
+for explicit watched paths and filters, and `--print-events` to diagnose them.
+The default task is `default`; define it or pass a task name.
 watchexec must be installed; `mise use -g watchexec@latest` installs it.
 
 For more advanced process management (daemon management, auto-restart, readiness checks,
@@ -5186,7 +5369,7 @@ Each line in the file will be interpreted as if given to '-w'.
 
 For more complex uses (like watching non-recursively), use the argfile capability: build a file containing command-line options and pass it to watchexec with `@path/to/argfile`.
 
-The special value '-' will read from STDIN; this in incompatible with '--stdin-quit'.
+The special value '-' will read from STDIN; this is incompatible with '--stdin-quit'.
 """#
         arg <PATH>
     }
@@ -5243,7 +5426,7 @@ Signals are not supported on Windows at the moment, and will always be overridde
         long_help #"""
 Signal to send to stop the command
 
-This is used by 'restart' and 'signal' modes of '--on-busy-update' (unless '--signal' is provided). The restart behaviour is to send the signal, wait for the command to exit, and if it hasn't exited after some time (see '--timeout-stop'), forcefully terminate it.
+This is used by 'restart' and 'signal' modes of '--on-busy-update' (unless '--signal' is provided). The restart behaviour is to send the signal, wait for the command to exit, and if it hasn't exited after some time (see '--stop-timeout'), forcefully terminate it.
 
 The default on unix is "SIGTERM".
 
@@ -5492,7 +5675,7 @@ set of events Watchexec handles. Here's an example of a folder being created on 
       },
       {
         "kind": "source",
-        "source": "filesystem",
+        "source": "filesystem"
       }
     ],
     "metadata": {
@@ -5690,7 +5873,9 @@ This can also be used via the $WATCHEXEC_FILTER_FILES environment variable.
 
 /!\ This option is EXPERIMENTAL and may change and/or vanish without notice.
 
-Provide your own custom filter programs in jaq (similar to jq) syntax. Programs are given an event in the same format as described in '--emit-events-to' and must return a boolean. Invalid programs will make watchexec fail to start; use '-v' to see program runtime errors.
+Provide your own custom filter programs in jaq (similar to jq) syntax. Programs are given
+an event in the same format as described in '--emit-events-to' and must return a boolean.
+Invalid programs will make watchexec fail to start; use '-v' to see program runtime errors.
 
 In addition to the jaq stdlib, watchexec adds some custom filter definitions:
 
@@ -5712,13 +5897,20 @@ In addition to the jaq stdlib, watchexec adds some custom filter definitions:
     value to stdout, stderr, or the log (levels = error, warn, info, debug, trace), and
     pass the value through (so '[1] | log("debug") | .[]' will produce a '1' and log '[1]').
 
-All filtering done with such programs, and especially those using kv or filesystem access, is much slower than the other filtering methods. If filtering is too slow, events will back up and stall watchexec. Take care when designing your filters.
+All filtering done with such programs, and especially those using kv or filesystem access,
+is much slower than the other filtering methods. If filtering is too slow, events will back
+up and stall watchexec. Take care when designing your filters.
 
-If the argument to this option starts with an '@', the rest of the argument is taken to be the path to a file containing a jaq program.
+If the argument to this option starts with an '@', the rest of the argument is taken to be
+the path to a file containing a jaq program.
 
-Jaq programs are run in order, after all other filters, and short-circuit: if a filter (jaq or not) rejects an event, execution stops there, and no other filters are run. Additionally, they stop after outputting the first value, so you'll want to use 'any' or 'all' when iterating, otherwise only the first item will be processed, which can be quite confusing!
+Jaq programs are run in order, after all other filters, and short-circuit: if a filter (jaq
+or not) rejects an event, execution stops there, and no other filters are run. Additionally,
+they stop after outputting the first value, so you'll want to use 'any' or 'all' when
+iterating, otherwise only the first item will be processed, which can be quite confusing!
 
-Find user-contributed programs or submit your own useful ones at <https://github.com/watchexec/watchexec/discussions/592>.
+Find user-contributed programs or submit your own useful ones at
+<https://github.com/watchexec/watchexec/discussions/592>.
 
 ## Examples:
 
@@ -5732,11 +5924,11 @@ Pass any event that creates a file:
 
 Pass events that touch executable files:
 
-  'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | metadata | .executable)'
+  'any(.tags[] | select(.kind == "path" and .filetype == "file"); .absolute | file_meta | .executable)'
 
 Ignore files that start with shebangs:
 
-  'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | read(2) == "#!") | not'
+  'any(.tags[] | select(.kind == "path" and .filetype == "file"); .absolute | file_read(2) == "#!") | not'
 """#
         arg <EXPRESSION>
     }

--- a/src/cli/activate.rs
+++ b/src/cli/activate.rs
@@ -11,22 +11,21 @@ use crate::toolset::env_cache::CachedEnv;
 use crate::{dirs, env};
 use eyre::Result;
 
-/// Initialize mise in the current shell session
+/// Print the script to activate mise in an interactive shell
 ///
-/// Add this to your shell's rc or profile file so it runs in every new shell.
-/// Otherwise, it only takes effect in the current session.
-/// (e.g. ~/.zshrc, ~/.zprofile, ~/.zshenv, ~/.bashrc, ~/.bash_profile, ~/.profile, ~/.config/fish/config.fish, or $PROFILE for powershell)
+/// Evaluate this command's output with the syntax for your shell; running it alone
+/// only prints the script. Activation updates tools and environment variables as
+/// this shell changes directories.
 ///
-/// Typically, this can be added with something like the following:
+/// Add the appropriate example below once to your interactive startup file:
+/// ~/.bashrc for Bash, ~/.zshrc for Zsh, ~/.config/fish/config.fish for Fish,
+/// or $PROFILE for PowerShell. See the getting-started guide for other shells.
 ///
-///     echo 'eval "$(mise activate zsh)"' >> ~/.zshrc
+/// The mise executable must be on PATH before that line runs. Otherwise use its
+/// absolute path, for example `eval "$(~/.local/bin/mise activate zsh)"`.
 ///
-/// However, this requires that "mise" is in your PATH. If it is not, you need to
-/// specify the full path like this:
-///
-///     echo 'eval "$(/path/to/mise activate zsh)"' >> ~/.zshrc
-///
-/// Customize status output with `status` settings.
+/// Use `mise exec -- command` for scripts and CI that do not need interactive hooks.
+/// Customize status output with the `status` settings.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     verbatim_doc_comment,

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -32,55 +32,27 @@ use crate::system::resources::{ResourceAction, ResourceId};
 use crate::system::systemd::SystemdState;
 use crate::toolset::ResolveOptions;
 use crate::ui::table::MiseTable;
-/// Set up a machine for the current config in one command
+/// Set up a machine from the current configuration
 ///
-/// Runs the bootstrap steps for the current config in order:
+/// Runs these phases in order, when configured and selected:
 ///
-/// 0. `mise bootstrap accounts apply` — converge `[bootstrap.users]` and
-///    `[bootstrap.groups]` (Linux)
-/// 1. `mise bootstrap plugins apply` — install `[bootstrap.plugins]`
-///    1.7. `[bootstrap.hooks.pre-packages]` — optional setup hook
-/// 2. Install built-in-manager entries from `[bootstrap.packages]`
-/// 3. `mise bootstrap files apply` — converge `[bootstrap.files]` and
-///    `[bootstrap.directories]`
-/// 4. `mise bootstrap services apply` — converge `[bootstrap.services]`
-///    systemd system services (Linux)
-/// 5. `mise bootstrap firewall apply` — converge `[bootstrap.linux.firewall]`
-///    host firewall policy and rules (Linux)
-/// 6. `mise bootstrap compose apply` — converge `[bootstrap.compose]`
-///    Docker Compose projects
-/// 7. `mise bootstrap repos apply` — clone/converge `[bootstrap.repos]`
-///    surrounded by `pre-repos`/`post-repos` hooks
-/// 8. `mise bootstrap dotfiles apply` — apply dotfiles from `[dotfiles]`
-///    surrounded by `pre-dotfiles`/`post-dotfiles` hooks
-/// 9. `mise bootstrap mise-shell-activate apply` — configure shell activation
-///    from `[bootstrap.mise_shell_activate]`
-/// 10. `mise bootstrap macos defaults apply` — write
-///     `[bootstrap.macos.defaults]` entries (macOS)
-///     surrounded by `pre-defaults`/`post-defaults` hooks
-/// 11. `mise bootstrap macos launchd-agents apply` — install/load
-///     `[bootstrap.macos.launchd.agents]`
-/// 12. `mise bootstrap linux systemd-units apply` — install/start
-///     `[bootstrap.linux.systemd.units]`
-/// 13. `mise bootstrap user apply` — set `[bootstrap.user].login_shell`
-///     (Unix)
-///     surrounded by `pre-user`/`post-user` hooks
-/// 14. `mise install` — install missing tools from `[tools]`
-///     surrounded by `pre-tools`/`post-tools` hooks; package-plugin entries
-///     from `[bootstrap.packages]` install afterward, followed by
-///     `[bootstrap.hooks.post-packages]`
-/// 15. `mise run bootstrap` — if a task named `bootstrap` is defined
-/// 16. `[bootstrap.hooks.final]` — optional final hook
+/// 1. Linux accounts, then package-manager plugins.
+/// 2. The pre-packages hook, then packages handled by built-in managers.
+/// 3. Privileged files/directories, system services, firewall, and Compose projects.
+/// 4. Git repositories, then dotfiles, each with its pre/post hooks.
+/// 5. Shell activation, macOS defaults and LaunchAgents, Linux user units, and user settings.
+/// 6. The pre-tools hook, versioned tools, and post-tools hook.
+/// 7. Package-plugin packages, then the post-packages hook.
+/// 8. The `bootstrap` task, when defined, then the final hook.
 ///
-/// The declarative steps converge — anything already in its desired state
-/// is skipped, so re-running is safe. The `bootstrap` task runs on every
-/// invocation; keep it idempotent. Use it for any project-specific setup
-/// that doesn't fit the declarative sections (seeding databases, auth flows,
-/// etc.) — it runs with the installed tools on PATH.
+/// Defaults and user settings also have pre/post hooks. See
+/// https://mise.jdx.dev/bootstrap.html for the complete phase order and configuration.
+/// Unchanged resource state is skipped, but hooks and the bootstrap task can run again;
+/// make those commands safe to repeat. Dotfile templates may execute while checking state.
 ///
-/// Use `--skip <part>` to skip named parts, or `--only <part>` to run just
-/// named parts. Both flags can be repeated or comma-separated, but they
-/// cannot be used together.
+/// Use `--dry-run` to preview the selected workflow, `bootstrap status` to inspect state,
+/// or `bootstrap plan` for the declarative-resource plan. `--only` and `--skip` accept
+/// repeated or comma-separated parts and cannot be combined.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     verbatim_doc_comment,
@@ -319,6 +291,10 @@ enum Commands {
 }
 
 /// Show the aggregate bootstrap status
+///
+/// Inspect configured resource state without applying changes. `--missing` sets a
+/// nonzero exit status for drift; it does not restrict the listing to missing entries.
+/// Dotfile status can render trusted templates, including their `exec()` calls.
 #[derive(Debug, usage_rs::Args)]
 #[usage(visible_alias = "ls", verbatim_doc_comment)]
 struct BootstrapStatus {
@@ -336,6 +312,10 @@ struct BootstrapStatus {
 }
 
 /// Show the changes declarative bootstrap resources would make
+///
+/// Covers declarative resources, not every hook, package installation, or task in a
+/// full bootstrap run. Use `bootstrap --dry-run` to preview the complete workflow.
+/// `--detailed-exitcode` distinguishes unchanged (0), changes (2), and errors (1).
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment)]
 struct BootstrapPlan {
@@ -353,6 +333,9 @@ struct BootstrapPlan {
 }
 
 /// Show non-composed bootstrap declarations in each selected configuration root
+///
+/// Use this to locate the origin of declarations before composition. For the
+/// combined desired state and its changes, use `bootstrap plan`.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment)]
 struct BootstrapConfigRoots {
@@ -421,6 +404,9 @@ struct BootstrapInspectFirewallPlan {}
 struct BootstrapInspectSystemFiles {}
 
 /// Manage Linux users and groups from `[bootstrap.users]` and `[bootstrap.groups]`
+///
+/// These are system accounts on the target Linux host. Inspect `status` or an apply
+/// preview before changing user IDs, memberships, or account state.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment)]
 struct BootstrapAccounts {
@@ -459,6 +445,9 @@ struct BootstrapAccountsStatus {
 }
 
 /// Manage privileged files and directories from `[bootstrap.files]` and `[bootstrap.directories]`
+///
+/// Use these resources for ownership, permissions, and desired presence on a host.
+/// For personal symlinks, copies, or edits, use `[dotfiles]` and `bootstrap dotfiles`.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment)]
 struct BootstrapFiles {
@@ -505,6 +494,9 @@ struct BootstrapFilesStatus {
 }
 
 /// Manage Linux system services from `[bootstrap.services]`
+///
+/// These are system-level systemd services. For units in the current user session,
+/// use `bootstrap linux systemd-units` instead.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment)]
 struct BootstrapServices {
@@ -543,6 +535,9 @@ struct BootstrapServicesStatus {
 }
 
 /// Manage the Linux host firewall from `[bootstrap.linux.firewall]`
+///
+/// This manages host firewall policy and rules. Review `apply --dry-run` before applying
+/// a policy to a remote machine, including the rule that permits your SSH connection.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment)]
 struct BootstrapFirewall {
@@ -581,6 +576,9 @@ struct BootstrapFirewallStatus {
 }
 
 /// Manage Docker Compose projects from `[bootstrap.compose]`
+///
+/// Requires a working Docker engine and Compose command on the target host. `apply`
+/// reconciles declared project state; `status` inspects the existing projects.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment)]
 struct BootstrapCompose {
@@ -619,6 +617,10 @@ struct BootstrapComposeStatus {
 }
 
 /// Bootstrap one or more machines over OpenSSH
+///
+/// Select inventory hosts by name, tag, or `--all`, or supply ad-hoc `--host` targets.
+/// The source is staged on each target and bootstrap runs there. `--from-git` instead
+/// installs persistent global configuration; preview that choice with `--dry-run`.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment)]
 struct BootstrapRemote {
@@ -841,6 +843,9 @@ struct BootstrapDotfilesApply {
 }
 
 /// Show the status of dotfiles from `[dotfiles]`
+///
+/// Template entries are rendered to compare their output; trusted template
+/// functions may execute. `--missing` changes the exit status, not the listing.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     visible_alias = "ls",
@@ -866,6 +871,9 @@ struct BootstrapPackages {
 }
 
 /// Manage package manager plugins declared in `[bootstrap.plugins]`
+///
+/// Install these plugins before applying packages they manage. Installing a plugin
+/// does not itself install the host packages in `[bootstrap.packages]`.
 #[derive(Debug, usage_rs::Args)]
 struct BootstrapPlugins {
     #[usage(subcommand)]
@@ -908,6 +916,10 @@ enum BootstrapPackagesCommands {
 }
 
 /// Manage git repo checkouts from `[bootstrap.repos]`
+///
+/// Use `apply` to clone or reconcile the configured checkout, `update` to refresh it,
+/// and `exec` to run a command in selected repositories. Existing local changes can
+/// block convergence; `--skip-dirty` skips those repositories without discarding edits.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment)]
 struct BootstrapRepos {
@@ -960,6 +972,10 @@ struct BootstrapReposUpdate {
 }
 
 /// Run a command in each configured git repo
+///
+/// Place the executable and its arguments after `--`, for example
+/// `mise bootstrap repos exec -- git status --short`. Arguments before `--` select
+/// repository paths; use `--continue-on-error` to visit remaining repos after a failure.
 #[derive(Debug, usage_rs::Args)]
 struct BootstrapReposExec {
     /// Run only in matching configured or expanded paths
@@ -1021,6 +1037,9 @@ enum BootstrapLinuxCommands {
 }
 
 /// Manage macOS defaults from `[bootstrap.macos.defaults]`
+///
+/// Declares typed preferences written with macOS defaults. Application preferences
+/// may require restarting the affected application before the change becomes visible.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment)]
 struct BootstrapMacosDefaults {
@@ -1059,6 +1078,9 @@ struct BootstrapMacosDefaultsStatus {
 }
 
 /// Manage macOS LaunchAgents from `[bootstrap.macos.launchd.agents]`
+///
+/// Installs plist files and reconciles agents in the current GUI login domain. Run
+/// from the intended user session; an SSH-only session may not have that domain.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment)]
 struct BootstrapLaunchd {
@@ -1097,6 +1119,9 @@ struct BootstrapLaunchdStatus {
 }
 
 /// Manage systemd user services from `[bootstrap.linux.systemd.units]`
+///
+/// Installs unit files and reconciles services in the current user manager. This is
+/// separate from system services declared in `[bootstrap.services]`.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment)]
 struct BootstrapSystemd {
@@ -1135,6 +1160,9 @@ struct BootstrapSystemdStatus {
 }
 
 /// Manage mise shell activation from `[bootstrap.mise_shell_activate]`
+///
+/// Writes managed activation blocks into the declared shell startup files. The
+/// current shell is not reactivated by this command; open a new shell afterward.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment)]
 struct BootstrapShell {
@@ -1173,6 +1201,9 @@ struct BootstrapShellStatus {
 }
 
 /// Manage current-user bootstrap settings from `[bootstrap.user]`
+///
+/// Currently manages the login shell. Apply as the intended user; changing the login
+/// shell affects future sessions, not the shell running this command.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment)]
 struct BootstrapUser {

--- a/src/cli/config/get.rs
+++ b/src/cli/config/get.rs
@@ -5,7 +5,11 @@ use crate::file::display_path;
 use eyre::bail;
 use std::path::PathBuf;
 
-/// Display a value from a mise.toml file
+/// Display a value from one mise TOML file
+///
+/// Reads the highest-precedence loaded TOML file by default. Select another with
+/// `--file`, `--global`, or `--system`. This reads stored values, not the merged or
+/// template-expanded environment; use `mise env` for the resolved environment.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     example(
@@ -22,7 +26,7 @@ pub(super) struct ConfigGet {
     ///
     /// Can be a file path or directory. If a directory is provided, the config file in that directory is used.
     ///
-    /// If not provided, the nearest mise.toml file will be used
+    /// If not provided, the highest-precedence loaded TOML file is used
     #[usage(short, long, visible_alias = "path", value_hint = usage_rs::ValueHint::AnyPath)]
     pub file: Option<PathBuf>,
 

--- a/src/cli/config/set.rs
+++ b/src/cli/config/set.rs
@@ -8,7 +8,16 @@ use crate::toml::dedup_toml_array;
 use eyre::bail;
 use std::path::PathBuf;
 
-/// Set a value in a mise.toml file
+/// Set a value in one mise TOML file
+///
+/// Edits the highest-precedence loaded TOML file by default, which may be an
+/// environment-specific override. Use `--file` to select an existing project file,
+/// or `--global`/`--system` to edit or create those config files.
+///
+/// This edits configuration without installing tools. Use `mise use` to install and
+/// select a version together. Known settings use their declared type; other values
+/// are strings or booleans unless `--type` is given. Use `--type string` when a value
+/// such as `true` should remain literal text.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     example(
@@ -36,7 +45,7 @@ pub(super) struct ConfigSet {
     ///
     /// Can be a file path or directory. If a directory is provided, the config file in that directory is used.
     ///
-    /// If not provided, the nearest mise.toml file will be used
+    /// If not provided, the highest-precedence loaded TOML file is used
     #[usage(short, long, visible_alias = "path", value_hint = usage_rs::ValueHint::AnyPath)]
     pub file: Option<PathBuf>,
 

--- a/src/cli/deactivate.rs
+++ b/src/cli/deactivate.rs
@@ -3,9 +3,12 @@ use eyre::Result;
 use crate::env;
 use crate::shell::{EXAMPLE_SHELL, build_deactivation_script, require_shell};
 
-/// Disable mise for current shell session
+/// Print the script to disable mise in the current shell session
 ///
-/// This can be used to temporarily disable mise in a shell session.
+/// The shell function installed by activation evaluates this output in supported
+/// shells. When calling the executable directly, evaluate or source its output
+/// with the appropriate shell syntax. This does not remove the startup-file line;
+/// new shells will activate mise again.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     verbatim_doc_comment,

--- a/src/cli/deps/install.rs
+++ b/src/cli/deps/install.rs
@@ -6,8 +6,9 @@ use crate::toolset::{InstallOptions, Toolset, ToolsetBuilder};
 
 /// Install all project dependencies
 ///
-/// Checks if dependency lockfiles are newer than installed outputs
-/// and runs install commands if needed.
+/// Uses each provider's freshness rules to compare configured inputs and outputs,
+/// then runs its installation command when needed. `--force` bypasses that check;
+/// `--explain PROVIDER` shows why a provider is considered fresh or stale.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment)]
 pub(crate) struct DepsInstall {

--- a/src/cli/deps/mod.rs
+++ b/src/cli/deps/mod.rs
@@ -6,13 +6,13 @@ mod remove;
 
 /// [experimental] Manage project dependencies
 ///
-/// Runs all applicable dependency install steps for the current project.
-/// This checks if dependency lockfiles are newer than installed outputs
-/// (e.g., package-lock.json vs node_modules/) and runs install commands
-/// if needed.
+/// With no subcommand, runs dependency installation for the current project, the same
+/// as `mise deps install`. Providers detect their inputs and installed outputs to
+/// decide whether work is needed; use `--explain PROVIDER` to inspect that decision.
 ///
-/// Providers with `auto = true` are automatically invoked before `mise x` and `mise run`
-/// unless skipped with the --no-deps flag.
+/// Providers with `auto = true` run before `mise exec` and `mise run` unless `--no-deps`
+/// is passed. These install project dependencies, such as node_modules, separately
+/// from versioned tools managed by `mise install`.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     visible_alias = "dep",

--- a/src/cli/dotfiles/add.rs
+++ b/src/cli/dotfiles/add.rs
@@ -18,7 +18,9 @@ use crate::ui::prompt;
 ///
 /// If the target is already managed, this updates its source from the live
 /// target. Otherwise it creates a `[dotfiles]` entry and seeds the source
-/// under `dotfiles.root` unless `--source` is provided.
+/// under `dotfiles.root` unless `--source` is provided. Captured entries are
+/// applied unless `--no-apply` is passed. Use `--dry-run` to preview both the
+/// source capture and config write without making those changes.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     verbatim_doc_comment,

--- a/src/cli/dotfiles/status.rs
+++ b/src/cli/dotfiles/status.rs
@@ -8,6 +8,10 @@ use crate::system::files::FileState;
 use crate::ui::table::MiseTable;
 
 /// Show the status of dotfiles from `[dotfiles]`
+///
+/// Template entries are rendered to compare their output; trusted template
+/// functions may execute. JSON includes each entry's origin and uses the states
+/// `applied`, `missing`, `differs`, and `source_missing`.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     visible_alias = "ls",

--- a/src/cli/dotfiles/unapply.rs
+++ b/src/cli/dotfiles/unapply.rs
@@ -8,7 +8,8 @@ use crate::ui::prompt;
 ///
 /// Removes configured whole-file entries and edits while preserving files
 /// mise cannot identify as managed. Modified copies, templates, and plain-line
-/// edits require `--force`.
+/// edits require `--force`. Source files and configuration entries are retained.
+/// Run this before deleting a declaration so mise can still identify its targets.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     verbatim_doc_comment,

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -9,10 +9,15 @@ use crate::toolset::{InstallOptions, Toolset, ToolsetBuilder};
 use crate::wildcard::wildcard_match;
 use indexmap::IndexSet;
 
-/// Export env vars to activate mise a single time
+/// Print the environment for the current configuration
 ///
-/// Use this to load the environment into one shell without adding `mise activate` to
-/// your shell rc file. It is not needed in shells where mise is already activated.
+/// Evaluate the shell output to load tools and variables once, without installing
+/// prompt hooks. Changing directories afterward does not recompute this environment.
+/// Use `mise exec -- command` to apply it to one child process instead.
+///
+/// JSON, dotenv, and shell output contain actual variable values, including secrets.
+/// `--redacted` selects variables marked for redaction; it does not mask their values.
+/// Environment construction may install missing tools according to mise's settings.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     visible_alias = "e",
@@ -45,7 +50,7 @@ pub(crate) struct Env {
     #[usage(long, overrides = "shell")]
     json_extended: bool,
 
-    /// Only show redacted environment variables
+    /// Only include variables marked for redaction; their values are printed unmasked
     #[usage(long)]
     redacted: bool,
 

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -26,7 +26,7 @@ use crate::toolset::{InstallOptions, ResolveOptions, Toolset, ToolsetBuilder};
 ///
 /// Tools are loaded from mise.toml and can be overridden with <TOOL@VERSION> args. Only the
 /// tools you name are overridden: if `mise.toml` includes `node = "20"` and you run
-/// `mise exec python@3.11`, node@20 is still loaded.
+/// `mise exec python@3.11 -- python -V`, node@20 is still loaded.
 ///
 /// The "--" separates tools from the command to pass along to the subprocess.
 #[derive(Debug, usage_rs::Args)]
@@ -53,11 +53,11 @@ pub(crate) struct Exec {
     #[usage(value_name = "TOOL@VERSION")]
     pub tool: Vec<ToolArg>,
 
-    /// Command string to execute (same as --command)
+    /// Executable and arguments to run directly, after `--`
     #[usage(conflicts = "c", required_unless = "c", double_dash = "required")]
     pub command: Option<Vec<String>>,
 
-    /// Command string to execute
+    /// Command string to execute through a shell (supports pipes and redirection)
     #[usage(short, long = "command", value_hint = usage_rs::ValueHint::CommandString, conflicts = "command")]
     pub c: Option<String>,
 
@@ -73,7 +73,8 @@ pub(crate) struct Exec {
     pub allow_env: Vec<String>,
 
     /// Allow network to specific host (implies --deny-net for everything else)
-    /// macOS only in v1; on Linux falls back to allowing all network
+    /// Per-host filtering is unsupported on Linux and returns an error.
+    /// See the sandboxing guide for current macOS host-filter limitations.
     #[usage(long, value_name = "HOST", verbatim_doc_comment)]
     pub allow_net: Vec<String>,
 
@@ -89,7 +90,7 @@ pub(crate) struct Exec {
     #[usage(long, verbatim_doc_comment)]
     pub deny_all: bool,
 
-    /// Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
+    /// Block env var inheritance except PATH, HOME, USER, SHELL, TERM, COLORTERM, LANG
     #[usage(long, verbatim_doc_comment)]
     pub deny_env: bool,
 

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -75,6 +75,7 @@ pub(crate) struct Exec {
     /// Allow network to specific host (implies --deny-net for everything else)
     /// Per-host filtering is unsupported on Linux and returns an error.
     /// See the sandboxing guide for current macOS host-filter limitations.
+    /// On Windows, sandboxing is unavailable: mise warns and runs without host filtering.
     #[usage(long, value_name = "HOST", verbatim_doc_comment)]
     pub allow_net: Vec<String>,
 

--- a/src/cli/fmt.rs
+++ b/src/cli/fmt.rs
@@ -5,9 +5,12 @@ use eyre::bail;
 use std::io::{self, Read, Write};
 use taplo::formatter::Options;
 
-/// Format mise.toml
+/// Format mise TOML configuration
 ///
-/// Sorts keys and cleans up whitespace in mise.toml
+/// Sorts keys and normalizes whitespace using TOML 1.1 syntax, including multiline
+/// inline tables. By default, formats config files in the current directory;
+/// `--all` includes every loaded config. Use `--check` in CI or `--stdin` to format
+/// a supplied document without rewriting a file.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     verbatim_doc_comment,

--- a/src/cli/generate/devcontainer.rs
+++ b/src/cli/generate/devcontainer.rs
@@ -7,7 +7,10 @@ use crate::{
 };
 use serde::Serialize;
 
-/// Generate a devcontainer to execute mise
+/// Generate devcontainer configuration for mise
+///
+/// Prints JSON by default. `--write` saves .devcontainer/devcontainer.json;
+/// review the image, mounts, and generated setup commands before opening it.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, example(r###"mise generate devcontainer"###))]
 pub(super) struct Devcontainer {

--- a/src/cli/generate/github_action.rs
+++ b/src/cli/generate/github_action.rs
@@ -6,7 +6,9 @@ use crate::git::Git;
 /// Generate a GitHub Action workflow file
 ///
 /// This command generates a GitHub Action workflow file that runs a mise task like `mise run ci`
-/// when you push changes to your repository.
+/// on pull requests, tags, manual dispatch, and pushes to the current Git branch.
+/// Prints YAML by default; `--write` saves it under .github/workflows. Define
+/// the selected task and review the generated triggers before committing.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     verbatim_doc_comment,

--- a/src/cli/generate/install_script.rs
+++ b/src/cli/generate/install_script.rs
@@ -27,9 +27,10 @@ use xx::regex;
     )
 )]
 pub(super) struct InstallScript {
-    /// Sandbox mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a project-local directory (`.mise` by default, set with `--localized-dir`)
+    /// Keep mise data and cache in a project-local directory (`.mise` by default)
     ///
-    /// This is necessary if users may use a different version of mise outside the project.
+    /// Use `--localized-dir` to choose its location. This isolates mise state;
+    /// it is not an OS sandbox for commands the generated script runs.
     #[usage(long, short, verbatim_doc_comment)]
     localize: bool,
     /// Specify mise version to fetch

--- a/src/cli/generate/task_docs.rs
+++ b/src/cli/generate/task_docs.rs
@@ -6,7 +6,10 @@ use std::path::{Path, PathBuf};
 const TASK_PLACEHOLDER_START: &str = "<!-- mise-tasks -->";
 const TASK_PLACEHOLDER_END: &str = "<!-- /mise-tasks -->";
 
-/// Generate documentation for tasks in a project
+/// Generate Markdown documentation for project tasks
+///
+/// Prints to stdout by default. Use `--output` to write a file, `--inject`
+/// to replace a marked section, or `--multi` for one file per task.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     verbatim_doc_comment,

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -29,7 +29,7 @@ use std::path::PathBuf;
 /// Installing alone does not add the tool to your config, so a tool that is not
 /// already configured will not be on PATH.
 /// To install and activate in one command, use `mise use`, which also writes the version to
-/// `mise.toml` in the current directory so the tool is active inside it.
+/// the selected project config so the tool is active in that configuration scope.
 /// To run a tool once without touching any config, use `mise exec <TOOL>@<VERSION> -- <COMMAND>`.
 ///
 /// Tools are installed in parallel. To disable, set `--jobs=1` or `MISE_JOBS=1`.

--- a/src/cli/install_into.rs
+++ b/src/cli/install_into.rs
@@ -71,6 +71,20 @@ impl InstallInto {
         tv.install_path = Some(install_path.clone());
         tv.install_path_is_exact = true;
         tv.install_path_is_explicit = true;
+        // Serialize every `install-into` writer targeting this destination,
+        // including different tools or versions whose ordinary tool-version
+        // locks would not overlap. Keep the lock through confirmation and the
+        // backend replacement so no cooperating writer can populate the path
+        // between the occupancy check and deletion.
+        let lock_display_path = install_path.clone();
+        let _destination_lock = crate::lock_file::LockFile::new(&install_path)
+            .with_callback(move |_| {
+                debug!(
+                    "waiting for install-into destination lock on {}",
+                    display_path(&lock_display_path)
+                );
+            })
+            .lock()?;
         // install-into force-reinstalls, which uninstalls (rm -rf) whatever
         // already exists at the install path. Check immediately before the
         // install performs that deletion (rather than at the start of `run`) so

--- a/src/cli/install_into.rs
+++ b/src/cli/install_into.rs
@@ -76,15 +76,19 @@ impl InstallInto {
         // locks would not overlap. Keep the lock through confirmation and the
         // backend replacement so no cooperating writer can populate the path
         // between the occupancy check and deletion.
+        let lock_path = install_path.clone();
         let lock_display_path = install_path.clone();
-        let _destination_lock = crate::lock_file::LockFile::new(&install_path)
-            .with_callback(move |_| {
-                debug!(
-                    "waiting for install-into destination lock on {}",
-                    display_path(&lock_display_path)
-                );
-            })
-            .lock()?;
+        let _destination_lock = tokio::task::spawn_blocking(move || {
+            crate::lock_file::LockFile::new(&lock_path)
+                .with_callback(move |_| {
+                    debug!(
+                        "waiting for install-into destination lock on {}",
+                        display_path(&lock_display_path)
+                    );
+                })
+                .lock()
+        })
+        .await??;
         // install-into force-reinstalls, which uninstalls (rm -rf) whatever
         // already exists at the install path. Check immediately before the
         // install performs that deletion (rather than at the start of `run`) so

--- a/src/cli/install_into.rs
+++ b/src/cli/install_into.rs
@@ -71,24 +71,6 @@ impl InstallInto {
         tv.install_path = Some(install_path.clone());
         tv.install_path_is_exact = true;
         tv.install_path_is_explicit = true;
-        // Serialize every `install-into` writer targeting this destination,
-        // including different tools or versions whose ordinary tool-version
-        // locks would not overlap. Keep the lock through confirmation and the
-        // backend replacement so no cooperating writer can populate the path
-        // between the occupancy check and deletion.
-        let lock_path = install_path.clone();
-        let lock_display_path = install_path.clone();
-        let _destination_lock = tokio::task::spawn_blocking(move || {
-            crate::lock_file::LockFile::new(&lock_path)
-                .with_callback(move |_| {
-                    debug!(
-                        "waiting for install-into destination lock on {}",
-                        display_path(&lock_display_path)
-                    );
-                })
-                .lock()
-        })
-        .await??;
         // install-into force-reinstalls, which uninstalls (rm -rf) whatever
         // already exists at the install path. Check immediately before the
         // install performs that deletion (rather than at the start of `run`) so

--- a/src/cli/latest.rs
+++ b/src/cli/latest.rs
@@ -7,9 +7,11 @@ use crate::install_before::resolve_cli_minimum_release_age;
 use crate::toolset::{ToolRequest, resolve_sub_base};
 use crate::ui::multi_progress_report::MultiProgressReport;
 
-/// Get the latest available version of a tool
+/// Resolve the latest matching version request for a tool
 ///
-/// Supports prefixes such as `node@20` to get the latest version of node 20.
+/// Supports prefixes such as `node@20`. The selected backend decides how channels,
+/// refs, and non-SemVer versions resolve; "latest" is not a generic sort of strings.
+/// This prints a version without installing it or changing configuration.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     verbatim_doc_comment,

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -51,13 +51,15 @@ fn push_unique_lock_tool(tools: &mut Vec<LockTool>, tool: LockTool) {
     }
 }
 
-/// Update lockfile checksums and URLs for all specified platforms
+/// Create or refresh lockfile versions, checksums, and download URLs
 ///
-/// Updates checksums and download URLs for all platforms already specified in the lockfile.
-/// If no lockfile exists, shows what would be created based on the current configuration,
-/// including tools declared by tasks.
-/// This allows you to refresh lockfile data for platforms other than the one you're currently on.
-/// Operates on the lockfile in the current config root. Use TOOL arguments to target specific tools.
+/// Operates on the current config root, including tools declared by tasks. Existing
+/// matching locked versions are preserved unless `--bump` re-resolves their selectors.
+/// This command writes lockfiles without installing tools; `--dry-run` previews changes.
+///
+/// Use `--platform` for explicit targets. Otherwise mise uses `lockfile_platforms`
+/// plus the current platform when that setting is configured, existing lockfile
+/// platforms when available, or the common platform defaults for a new lockfile.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     verbatim_doc_comment,
@@ -106,7 +108,7 @@ pub(crate) struct Lock {
 
     /// Comma-separated list of platforms to target
     /// e.g.: linux-x64,macos-arm64,windows-x64
-    /// If not specified, all platforms already in lockfile will be updated
+    /// If omitted, use lockfile_platforms, existing platforms, or common defaults
     #[usage(long, short, delimiter = ',', verbatim_doc_comment)]
     pub platform: Vec<String>,
 

--- a/src/cli/ls_remote.rs
+++ b/src/cli/ls_remote.rs
@@ -27,7 +27,8 @@ struct VersionOutputAll {
 
 /// List tool versions available to install
 ///
-/// Results may be cached; run `mise cache clear` to fetch fresh results.
+/// Results may be cached; run `mise cache clear TOOL` to refresh one tool
+/// before querying it again. Version formats and ordering are backend-specific.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, example(r###"mise ls-remote node
 mise ls-remote node@20
@@ -40,12 +41,12 @@ pub(crate) struct LsRemote {
     #[usage(value_name = "TOOL@VERSION", required_unless = "all")]
     pub plugin: Option<ToolArg>,
 
-    /// The version prefix to use when querying the latest version
-    /// same as the first argument after the "@"
+    /// Filter the available versions by this prefix
+    /// Equivalent to the version selector after `@` in the first argument
     #[usage(verbatim_doc_comment)]
     pub prefix: Option<String>,
 
-    /// Show all installed plugins and versions
+    /// List available versions for every backend/tool currently known to mise
     #[usage(long, verbatim_doc_comment, conflicts = ["plugin", "prefix"])]
     pub all: bool,
 

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -20,17 +20,16 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-/// Run Model Context Protocol (MCP) server
+/// Run the Model Context Protocol server over stdin/stdout
 ///
-/// This command starts an MCP server that exposes mise functionality
-/// to AI assistants over stdin/stdout using JSON-RPC protocol.
+/// Exposes project tools, tasks, environment, and configuration to an MCP client.
+/// Resources use `mise://tools`, `mise://tasks`, `mise://env`, and `mise://config`.
+/// `mise://tools?include_inactive=true` also includes inactive installations.
 ///
-/// The MCP server provides access to:
-/// - Installed and available tools
-/// - Task definitions and execution
-/// - Environment variables
-/// - Configuration information
-/// - Task execution via the run_task tool
+/// The `list_commands` tool describes commands and their declared effects. `run_task`
+/// executes project tasks with the user's permissions and can change files or invoke
+/// external services. `install_tool` is advertised but currently returns an error.
+/// Environment resources contain real values, including secrets.
 ///
 /// Resources available:
 /// - mise://tools - List all tools (use ?include_inactive=true to include inactive tools)

--- a/src/cli/oci/build.rs
+++ b/src/cli/oci/build.rs
@@ -26,8 +26,12 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 /// Each tool version becomes its own content-addressable OCI layer. Bumping a
 /// tool version only invalidates that tool's layer — other tools, the base
 /// image, and config are reused unchanged. The output directory conforms to
-/// the OCI image-layout spec and can be consumed by `skopeo`, `crane`, or
-/// `podman load`.
+/// the OCI image-layout spec. Use `skopeo inspect oci:./mise-oci` to inspect it
+/// or `mise oci run --image-dir ./mise-oci -- command` to load and run it.
+///
+/// Build on Linux with the target architecture: this packages host tool installs
+/// and, by default, the running mise binary. `--no-mise` omits that binary but does
+/// not cross-compile tools installed for another OS. asdf/vfox tools are unsupported.
 ///
 /// Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).
 #[derive(Debug, usage_rs::Args)]

--- a/src/cli/patrons.rs
+++ b/src/cli/patrons.rs
@@ -9,11 +9,11 @@ use crate::{dirs, duration, file};
 
 /// Show the individuals supporting mise as Patron-tier members
 ///
-/// Lists the individuals on the Patron tier from <https://jdx.dev/patrons.json>.
+/// Lists the individuals on the Patron tier from https://jdx.dev/patrons.json.
 /// The list refreshes daily; supporting terminals will render each patron's
 /// name as a clickable link via OSC 8 hyperlinks.
 ///
-/// To appear here, become a patron at <https://jdx.dev/sponsors.html>.
+/// To appear here, become a patron at https://jdx.dev/sponsors.html.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     verbatim_doc_comment,

--- a/src/cli/plugins/install.rs
+++ b/src/cli/plugins/install.rs
@@ -18,11 +18,14 @@ use crate::{backend::unalias_backend, config::Settings};
 
 use super::{PluginTaskNames, PluginTaskResult, join_plugin_tasks, spawn_plugin_task};
 
-/// Install a plugin
+/// Install a plugin from a configured source, Git URL, or supported archive
 ///
-/// Note that mise installs plugins automatically when you install a tool that needs one,
-/// e.g.: `mise install cmake@3.30` installs the cmake plugin first. This command is only
-/// needed to install a plugin ahead of time or from a custom git URL.
+/// Most registry tools use built-in backends and need no plugin. When a selected
+/// backend does require a plugin, mise normally installs it with the tool.
+/// Use this command to install it ahead of time or choose a custom source.
+///
+/// A Git URL may end in `#ref` to select a plugin commit, tag, or branch. This selects
+/// the plugin implementation, separately from the tool version installed by `mise use`.
 #[derive(Debug, usage_rs::Args)]
 #[usage(visible_aliases = ["i", "a", "add"], verbatim_doc_comment, example(r###"mise plugins install postgres https://github.com/smashedtoatoms/asdf-postgres.git"###, help = r###"Install an asdf-compatible plugin from its upstream repository"###),
     example(r###"mise plugins install my-tool file:///path/to/mise-my-tool#v1.0.0"###, help = r###"Use a local plugin repository at a tag you created"###),
@@ -30,8 +33,7 @@ use super::{PluginTaskNames, PluginTaskResult, join_plugin_tasks, spawn_plugin_t
 )]
 pub(crate) struct PluginsInstall {
     /// The name of the plugin to install
-    /// e.g.: cmake, poetry
-    /// Can specify multiple plugins: `mise plugins install cmake poetry`
+    /// Use a configured plugin name, or supply a source URL below
     #[usage(required_unless = "all", verbatim_doc_comment)]
     new_plugin: Option<String>,
 

--- a/src/cli/plugins/link.rs
+++ b/src/cli/plugins/link.rs
@@ -8,9 +8,11 @@ use crate::backend::unalias_backend;
 use crate::file::{make_symlink, remove_all};
 use crate::{dirs, file};
 
-/// Symlink a plugin into mise
+/// Link a local plugin directory into mise for development
 ///
-/// This is used for developing a plugin.
+/// Edits in the source directory take effect without reinstalling the plugin. Pass
+/// both a name and directory, or only a directory to infer the name after stripping
+/// a known prefix such as `mise-` or `vfox-`. This does not install a tool version.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     visible_alias = "ln",
@@ -27,12 +29,12 @@ use crate::{dirs, file};
 )]
 pub(super) struct PluginsLink {
     /// The name of the plugin
-    /// e.g.: cmake, poetry
+    /// With one argument, this is the plugin directory and the name is inferred
     #[usage(verbatim_doc_comment)]
     name: String,
 
     /// The local path to the plugin
-    /// e.g.: ./vfox-cmake
+    /// e.g.: ./mise-my-tool
     #[usage(value_hint = ValueHint::DirPath, verbatim_doc_comment)]
     dir: Option<PathBuf>,
 

--- a/src/cli/plugins/ls.rs
+++ b/src/cli/plugins/ls.rs
@@ -10,9 +10,11 @@ use crate::registry::full_to_url;
 use crate::toolset::install_state;
 use crate::ui::table;
 
-/// List installed plugins
+/// List installed external plugins
 ///
-/// Can also show remotely available plugins to install.
+/// Use `--core` for built-in runtimes or `--core --user` for both groups. `--outdated`
+/// queries Git remotes for plugin updates; it does not compare installed tool versions.
+/// Use `mise plugins ls-remote` for registry plugin sources and `mise ls` for tools.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     visible_alias = "list",

--- a/src/cli/plugins/uninstall.rs
+++ b/src/cli/plugins/uninstall.rs
@@ -6,7 +6,10 @@ use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::style;
 use crate::{backend, plugins};
 
-/// Remove a plugin
+/// Remove an installed plugin
+///
+/// Tool installations are retained by default. Pass `--purge` to also remove
+/// installs, downloads, and cache associated with the selected plugins.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, visible_aliases = ["remove", "rm"], example(r###"mise plugins uninstall my-tool"###))]
 pub(super) struct PluginsUninstall {

--- a/src/cli/plugins/update.rs
+++ b/src/cli/plugins/update.rs
@@ -13,7 +13,9 @@ use super::{PluginTaskNames, PluginTaskResult, join_plugin_tasks, spawn_plugin_t
 
 /// Update a plugin to the latest version
 ///
-/// Note: this updates the plugin itself, not the tool versions it manages
+/// With no names, updates every installed plugin. This updates plugin source,
+/// not the tool versions it manages. Linked local plugins are skipped; archive
+/// installations cannot be updated with Git.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, visible_aliases = ["up", "upgrade"], example(r###"mise plugins update              # update all installed plugins
 mise plugins update my-tool      # update one Git plugin

--- a/src/cli/registry.rs
+++ b/src/cli/registry.rs
@@ -10,11 +10,14 @@ use serde::Serialize;
 use std::sync::Arc;
 use tokio::{sync::Semaphore, task::JoinSet};
 
-/// List available tools to install
+/// List registry shorthand names and their backends
 ///
-/// This command lists the tools available in the registry as shorthand names.
+/// The registry maps short names to installation backends. For example, `node`
+/// uses the built-in Node backend. A tool may have multiple candidates; explicit
+/// backend syntax and configuration can override registry selection.
 ///
-/// For example, `poetry` is shorthand for `asdf:mise-plugins/mise-poetry`.
+/// This is not a list of every tool mise can install. Use an explicit identifier
+/// such as `github:owner/repo` for a supported source without a registry shorthand.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     example(

--- a/src/cli/reshim.rs
+++ b/src/cli/reshim.rs
@@ -4,24 +4,15 @@ use crate::config::Config;
 use crate::shims;
 use crate::toolset::ToolsetBuilder;
 
-/// Create shims for the executables of currently installed tools
+/// Create shims for executables provided by installed tools
 ///
-/// This creates shims in the user shim directory for executables that have been added since
-/// the last reshim. With `--system`, it rebuilds the system shim farm instead.
-/// mise runs this automatically after commands like `npm i -g`, but other ways of installing
-/// executables (such as yarn or pnpm for node) are not detected, so call this explicitly then.
+/// Run this when an executable was added to an existing installation outside mise,
+/// for example after a language package manager installed a CLI globally. It rebuilds
+/// the user shim directory by default; `--system` selects the shared system shim farm.
 ///
-/// If you think mise should automatically call this for a particular command, please
-/// open an issue on the mise repo. You can also set up a shell function to reshim
-/// automatically (it's really fast so you don't need to worry about overhead):
-///
-///     npm() {
-///       command npm "$@"
-///       mise reshim
-///     }
-///
-/// Note that this creates shims for _all_ installed tools, not just the ones that are
-/// currently active in mise.toml.
+/// Shims are created for all installed versions. The shim resolves which version to
+/// run from the current configuration when invoked. `--force` rebuilds mise-owned
+/// shims; it does not turn unrelated files into mise-owned shims.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     verbatim_doc_comment,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -30,30 +30,29 @@ use serde::Serialize;
 use std::panic::AssertUnwindSafe;
 use tokio::sync::Mutex;
 
-/// Run task(s)
+/// Run tasks and their dependencies
 ///
-/// Runs one task, or several tasks in parallel.
-/// Tasks may depend on other tasks and on source files.
-/// If a task has `sources` configured, it only runs when those files have changed.
+/// Use `mise run TASK [ARGS...]` for one task, or separate task invocations with `:::`
+/// to schedule several. Put mise flags before the task name; following arguments are
+/// passed to that task. With no task, mise runs `default` when defined or opens the
+/// task selector in an interactive terminal.
 ///
-/// Tasks can be defined in mise.toml or as standalone scripts.
-/// In mise.toml, tasks take this form:
+/// Tasks are defined in `mise.toml` or task directories. A task with `sources` and
+/// `outputs` can skip execution when its outputs are fresh. `--force` bypasses
+/// freshness checks; task output caching has separate `--task-cache` controls.
 ///
-///     [tasks.build]
-///     run = "npm run build"
-///     sources = ["src/**/*.ts"]
-///     outputs = ["dist/**/*.js"]
+/// For a project that already has npm build scripts and its dependencies installed:
 ///
-/// Alternatively, tasks can be defined as standalone scripts.
-/// These must be located in `mise-tasks`, `.mise-tasks`, `.mise/tasks`, `mise/tasks` or
-/// `.config/mise/tasks`.
-/// The name of the script becomes the name of the task.
+/// ```toml
+/// [tasks.build]
+/// run = "npm run build"
+/// sources = ["src/**/*.ts", "package.json", "package-lock.json"]
+/// outputs = ["dist/**/*.js"]
+/// ```
 ///
-///     $ cat .mise/tasks/build<<EOF
-///     #!/usr/bin/env bash
-///     npm run build
-///     EOF
-///     $ mise run build
+/// To create a standalone script task, use `mise tasks add --file hello -- echo hello`.
+/// Then run `mise run hello`. See https://mise.jdx.dev/tasks/ for task directories,
+/// arguments, caching, and dependency configuration.
 #[derive(usage_rs::Args)]
 #[usage(
     visible_alias = "r",
@@ -203,6 +202,7 @@ pub(crate) struct Run {
     pub allow_env: Vec<String>,
 
     /// Allow network to specific host (implies --deny-net for everything else)
+    /// Unsupported on Linux; see the sandboxing guide for macOS limitations.
     #[usage(long, value_name = "HOST", verbatim_doc_comment)]
     pub allow_net: Vec<String>,
 
@@ -218,7 +218,7 @@ pub(crate) struct Run {
     #[usage(long, verbatim_doc_comment)]
     pub deny_all: bool,
 
-    /// Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
+    /// Block env var inheritance except PATH, HOME, USER, SHELL, TERM, COLORTERM, LANG
     #[usage(long, verbatim_doc_comment)]
     pub deny_env: bool,
 

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -202,7 +202,9 @@ pub(crate) struct Run {
     pub allow_env: Vec<String>,
 
     /// Allow network to specific host (implies --deny-net for everything else)
-    /// Unsupported on Linux; see the sandboxing guide for macOS limitations.
+    /// Per-host filtering is unsupported on Linux and returns an error.
+    /// See the sandboxing guide for current macOS host-filter limitations.
+    /// On Windows, sandboxing is unavailable: mise warns and runs without host filtering.
     #[usage(long, value_name = "HOST", verbatim_doc_comment)]
     pub allow_net: Vec<String>,
 

--- a/src/cli/set.rs
+++ b/src/cli/set.rs
@@ -17,7 +17,8 @@ use tabled::Tabled;
 
 /// Set environment variables in mise.toml
 ///
-/// By default, this command modifies `mise.toml` in the current directory.
+/// By default, this command selects the nearest configuration directory and
+/// modifies its lowest-precedence TOML file, creating `mise.toml` here if none exists.
 /// If multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),
 /// the lowest precedence file (`mise.toml`) will be used.
 /// See https://mise.jdx.dev/configuration.html#target-file-for-write-operations

--- a/src/cli/settings/get.rs
+++ b/src/cli/settings/get.rs
@@ -3,12 +3,11 @@ use crate::config::Settings;
 use crate::config::settings::SETTINGS_META;
 use eyre::bail;
 
-/// Show a current setting
+/// Show the effective value of a setting
 ///
-/// This is the contents of a single entry in ~/.config/mise/config.toml
-///
-/// Note that aliases are also stored in this file
-/// but managed separately with `mise tool-alias get`
+/// Includes defaults, configuration, and environment overrides. With `--local`,
+/// read only the selected local config's explicit settings; an unset key is an error.
+/// Use `mise config get settings.KEY --file path/to/mise.toml` to inspect one file.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     example(

--- a/src/cli/settings/ls.rs
+++ b/src/cli/settings/ls.rs
@@ -7,12 +7,12 @@ use eyre::Result;
 use std::path::{Path, PathBuf};
 use tabled::{Table, Tabled};
 
-/// Show current settings
+/// List configured settings and their sources
 ///
-/// This is the contents of ~/.config/mise/config.toml
-///
-/// Note that aliases are also stored in this file
-/// but managed separately with `mise tool-alias`
+/// By default, list explicit settings from loaded TOML files. `--all` also includes
+/// effective defaults. Use `--local` to restrict output to the selected local file,
+/// and `--json-extended` to include source information in machine-readable output.
+/// Use `mise settings get KEY` when you need one effective value.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     example(

--- a/src/cli/system/brew/tap.rs
+++ b/src/cli/system/brew/tap.rs
@@ -21,7 +21,7 @@ pub(crate) struct SystemBrewTap {
     /// Tap name, e.g. `owner/repo`
     tap: String,
 
-    /// GitHub URL for the tap. Defaults to https://github.com/<owner>/homebrew-<repo>.git
+    /// Repository URL for the tap; defaults to GitHub's owner/homebrew-repo.git naming
     #[usage(value_hint = usage_rs::ValueHint::Url)]
     url: Option<String>,
 

--- a/src/cli/tool_alias/get.rs
+++ b/src/cli/tool_alias/get.rs
@@ -3,10 +3,11 @@ use color_eyre::eyre::{Result, eyre};
 use crate::cli::args::BackendArg;
 use crate::config::Config;
 
-/// Show an alias for a tool
+/// Show a configured version alias for a tool
 ///
-/// This is the contents of a tool_alias.<TOOL> entry in ~/.config/mise/config.toml
-///
+/// Reads the merged `[tool_alias.TOOL.versions]` configuration. This prints the
+/// stored request, which may itself be a prefix. Backend-provided aliases are listed
+/// by `mise tool-alias ls`; they are not entries returned by this command.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     example(

--- a/src/cli/tool_alias/ls.rs
+++ b/src/cli/tool_alias/ls.rs
@@ -13,7 +13,7 @@ use crate::ui::table;
 /// In user config, aliases are defined like the following in `~/.config/mise/config.toml`:
 ///
 ///     [tool_alias.node.versions]
-///     lts = "22.0.0"
+///     project = "20"
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     visible_alias = "list",

--- a/src/cli/unset.rs
+++ b/src/cli/unset.rs
@@ -8,7 +8,8 @@ use crate::config::{ConfigPathOptions, resolve_target_config_path};
 
 /// Remove environment variable(s) from the config file
 ///
-/// By default, this command modifies `mise.toml` in the current directory.
+/// By default, this command selects the nearest configuration directory and
+/// modifies its lowest-precedence TOML file, creating `mise.toml` here if none exists.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     verbatim_doc_comment,

--- a/src/cli/unuse.rs
+++ b/src/cli/unuse.rs
@@ -10,24 +10,17 @@ use eyre::Result;
 use itertools::Itertools;
 use path_absolutize::Absolutize;
 
-/// Remove tool versions from mise.toml and uninstall them
+/// Remove tool requests from configuration and prune unused installations
 ///
-/// By default, this will use the `mise.toml` file that has the tool defined.
-/// If multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),
-/// the lowest precedence file (`mise.toml`) will be used.
-/// See https://mise.jdx.dev/configuration.html#target-file-for-write-operations
+/// Without a selector, mise edits the first loaded config that declares one of the
+/// requested tools. Use `--path`, `--global`, or `--env` to choose a specific file.
+/// A version argument matches the configured request literally: to remove `node = "20"`,
+/// use `mise unuse node@20`, not the concrete installed version it resolved to.
+/// Omit the version to remove all requests for that tool from the selected file.
 ///
-/// In the following order:
-///   - If `--global` is set, it will use the global config file.
-///   - If `--path` is set, it will use the config file at the given path.
-///   - If `--env` is set, it will use `mise.<env>.toml`.
-///   - If [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) is set, it will use that instead.
-///   - If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will use the first from that list.
-///   - Otherwise just "mise.toml" or global config if cwd is home directory.
-///
-/// Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
-///
-/// The installed version is also removed unless another config still uses it or `--no-prune` is passed.
+/// Versions are pruned only when no remaining tracked config or tool stub needs them.
+/// Pass `--no-prune` to edit configuration while keeping installations. To remove an
+/// installation without editing configuration, use `mise uninstall`.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, visible_aliases = ["rm", "remove"], example(r###"mise unuse node@18.0.0"###, help = r###"remove node@18.0.0 from mise.toml and uninstall it"###),
     example(r###"mise unuse -g node@18.0.0"###, help = r###"remove it from the global config instead"###),
@@ -49,7 +42,7 @@ pub(crate) struct Unuse {
     /// Specify a path to a config file or directory
     ///
     /// If a directory is specified, it will look for a config file in that directory following
-    /// the rules above.
+    /// the target-file selection rules.
     #[usage(short, long, visible_alias = "file", overrides = & ["global", "env"], value_hint = usage_rs::ValueHint::FilePath)]
     path: Option<PathBuf>,
 

--- a/src/cli/unuse.rs
+++ b/src/cli/unuse.rs
@@ -31,7 +31,7 @@ pub(crate) struct Unuse {
     #[usage(value_name = "INSTALLED_TOOL@VERSION", required = true)]
     installed_tool: Vec<ToolArg>,
 
-    /// Create/modify an environment-specific config file like mise.<env>.toml
+    /// Modify `.mise.<env>.toml` when it exists, otherwise `mise.<env>.toml`
     #[usage(long, short, overrides = & ["global", "path"])]
     env: Option<String>,
 

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -21,23 +21,21 @@ use crate::toolset::{
 use crate::ui::ctrlc;
 use crate::{config, env, exit, file};
 
-/// Install a tool and add it to mise.toml
+/// Install a tool and add it to configuration
 ///
-/// Installs the tool version if it is not already installed, then writes it to a config file.
-/// By default, this is `mise.toml` in the current directory.
-/// If multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),
-/// the lowest precedence file (`mise.toml`) will be used.
+/// Installs missing tool versions and records the requests in a config file.
+/// By default, mise selects the nearest directory with a supported config and writes
+/// to its lowest-precedence file, such as `mise.toml` rather than `mise.local.toml`.
+/// If no project config exists, it creates one in the current directory. Running from
+/// your home directory targets global configuration.
+///
+/// Use `--path` for an explicit file/directory, `--global` for personal defaults, or
+/// `--env` to write `mise.ENV.toml` in the current directory (preserving an existing
+/// `.mise.ENV.toml`). These selectors override one another; use one per command.
+///
 /// See https://mise.jdx.dev/configuration.html#target-file-for-write-operations
-///
-/// In the following order:
-///   - If `--global` is set, it will use the global config file.
-///   - If `--path` is set, it will use the config file at the given path.
-///   - If `--env` is set, it will use `mise.<env>.toml`.
-///   - If [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) is set, it will use that instead.
-///   - If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will use the first from that list.
-///   - Otherwise just "mise.toml" or global config if cwd is home directory.
-///
-/// Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
+/// for filename overrides and configuration precedence. Selection takes effect in
+/// an activated shell on its next prompt, or immediately in `mise exec` commands.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     verbatim_doc_comment,
@@ -101,7 +99,7 @@ pub(crate) struct Use {
     /// Specify a path to a config file or directory
     ///
     /// If a directory is specified, it will look for a config file in that directory following
-    /// the rules above.
+    /// the target-file selection rules.
     // No `--file` alias here: `-f` on this command is `--force`, so offering `--file`
     // invites `-f <path>`, which is a different action. See `mise unset --path` for the
     // commands where the short form is free.

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -17,7 +17,11 @@ use std::path::{Path, PathBuf};
 
 /// Run task(s) and rerun them when files change
 ///
-/// Uses `watchexec` to watch for file changes and rerun the given task(s).
+/// Uses `watchexec` to watch task sources and rerun the selected tasks.
+/// Sources from dependencies are included unless `--skip-deps` is set. With no
+/// sources, watchexec watches the current directory. Use `--watch` and `--exts`
+/// for explicit watched paths and filters, and `--print-events` to diagnose them.
+/// The default task is `default`; define it or pass a task name.
 /// watchexec must be installed; `mise use -g watchexec@latest` installs it.
 ///
 /// For more advanced process management (daemon management, auto-restart, readiness checks,
@@ -588,7 +592,7 @@ pub(crate) struct WatchexecArgs {
     /// For more complex uses (like watching non-recursively), use the argfile capability: build a
     /// file containing command-line options and pass it to watchexec with `@path/to/argfile`.
     ///
-    /// The special value '-' will read from STDIN; this in incompatible with '--stdin-quit'.
+    /// The special value '-' will read from STDIN; this is incompatible with '--stdin-quit'.
     #[usage(
 		short = 'F',
 		long,
@@ -664,7 +668,7 @@ pub(crate) struct WatchexecArgs {
     ///
     /// This is used by 'restart' and 'signal' modes of '--on-busy-update' (unless '--signal' is
     /// provided). The restart behaviour is to send the signal, wait for the command to exit, and if
-    /// it hasn't exited after some time (see '--timeout-stop'), forcefully terminate it.
+    /// it hasn't exited after some time (see '--stop-timeout'), forcefully terminate it.
     ///
     /// The default on unix is "SIGTERM".
     ///
@@ -960,7 +964,7 @@ pub(crate) struct WatchexecArgs {
     ///       },
     ///       {
     ///         "kind": "source",
-    ///         "source": "filesystem",
+    ///         "source": "filesystem"
     ///       }
     ///     ],
     ///     "metadata": {
@@ -1234,16 +1238,17 @@ pub(crate) struct WatchexecArgs {
     ///
     /// Pass events that touch executable files:
     ///
-    ///   'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | metadata | .executable)'
+    ///   'any(.tags[] | select(.kind == "path" and .filetype == "file"); .absolute | file_meta | .executable)'
     ///
     /// Ignore files that start with shebangs:
     ///
-    ///   'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | read(2) == "#!") | not'
+    ///   'any(.tags[] | select(.kind == "path" and .filetype == "file"); .absolute | file_read(2) == "#!") | not'
     #[usage(
         long = "filter-prog",
         short = 'J',
         help_heading = "Filtering",
-        value_name = "EXPRESSION"
+        value_name = "EXPRESSION",
+        verbatim_doc_comment
     )]
     pub filter_programs: Vec<String>,
 

--- a/tasks.toml
+++ b/tasks.toml
@@ -69,6 +69,8 @@ run = [
   "mise generate task-docs > tasks.md",
   "rm -rf docs/cli && mkdir -p docs/cli",
   "usage generate markdown -m --out-dir docs/cli --url-prefix /cli --link-extension .html --html-encode --file mise.usage.kdl --replace-pre-with-code-fences",
+  "bun test ./docs/.vitepress/cli-reference.test.ts",
+  "bun docs/.vitepress/cli-reference.ts",
   "markdownlint --fix docs/cli",
 ]
 


### PR DESCRIPTION
The CLI reference had misleading command descriptions, fragmented navigation, and examples that no longer matched the implementation. Correct the Rust help sources and regenerate the reference pages, usage specification, and man page.

- Organize the command index by workflow and connect each command to its guide, parent command, and global flags. Explain compatibility spellings and argument notation.
- Correct documentation for configuration write targets, secret-value output, literal version removal, lockfile creation, bootstrap phases, plugin identities, task execution, and watch filters.
- Use the structured examples and generic rendering supplied by `usage` 6.8. The site postprocessor now handles only mise-specific navigation and explanatory text; redundant fencing, synopsis, subcommand-heading, and link-format workarounds have been removed.

The `install-into` destination locking change has been extracted into #12901. This PR no longer changes that implementation.

Validation: full render and documentation build (333 pages); scoped safe hk checks including Cargo check and formatting; targeted `install-into`, lock, and MCP e2e tests. An additionally matched lock-environment test failed while cloning its test plugin with a server I/O error. For the postprocessor cleanup, `mise run render:usage` and the command-index test pass, and all 191 generated CLI pages are byte-for-byte unchanged from before the cleanup.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and docs-build pipeline only; no application runtime changes in this diff.
> 
> **Overview**
> **Deepens and reorganizes the generated CLI reference** after `usage` emits `docs/cli`, via a new VitePress postprocessor wired into `render:usage`.
> 
> The postprocessor (`cli-reference.ts`) builds a **workflow-grouped command index** on the root CLI page (replacing the flat subcommand list), appends **Related documentation** blocks with guide links, parent command links, and **compatibility spelling** callouts for hidden bootstrap aliases. It validates guide targets exist and is covered by `cli-reference.test.ts`.
> 
> Across **~191 CLI pages**, prose is revised for accuracy (config write targets, `env`/`exec`/`run` behavior, lockfile semantics, bootstrap phases, sandbox flags, MCP caveats, etc.) while keeping flags/args from `mise.usage.kdl`. The PR description notes Rust help sources were corrected upstream of regeneration and redundant markdown workarounds were removed in favor of `usage` 6.8 rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd92ab202088f65de0e70e8c8aad8761081c6d0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->