### PR TITLE
docs: repair shared reference links and refresh CI examples

### DIFF
--- a/docs/mise-cookbook/python.md
+++ b/docs/mise-cookbook/python.md
@@ -120,7 +120,7 @@ _.python.venv = { path = ".venv" }
 
 ### Syncing python versions installed by mise and uv
 
-Use [`mise sync python --uv`](/cli/sync/python.html#uv) to make existing Python
+Use [`mise sync python --uv`](/cli/sync/python.html) to make existing Python
 installations available across mise and uv. This shares installed runtimes; it
 does not update `.python-version`, select the project version, or sync packages.
 Use `uv sync` for project dependencies.

--- a/docs/tasks/caching.md
+++ b/docs/tasks/caching.md
@@ -209,7 +209,7 @@ jobs:
       MISE_TASK_CACHE_REMOTE_OIDC_AUDIENCE: https://cache.example.com
     steps:
       - uses: actions/checkout@v5
-      - uses: jdx/mise-action@v3
+      - uses: jdx/mise-action@v4
       - run: mise run test
 ```
 

--- a/settings.toml
+++ b/settings.toml
@@ -2490,7 +2490,7 @@ It can be useful on distributions whose mise package updates lag behind registry
 
 The downloaded mise registry is refreshed only for commands that allow network access and is cached
 according to [`registry_cache_ttl`](#registry_cache_ttl). Fast and offline commands never refresh it.
-The downloaded aqua registry uses [`aqua.registry_cache_ttl`](#aqua-registry_cache_ttl).
+The downloaded aqua registry uses [`aqua.registry_cache_ttl`](/configuration/settings.html#aqua.registry_cache_ttl).
 """
 env = "MISE_REGISTRY_FLOATING"
 type = "Bool"
@@ -3103,7 +3103,7 @@ type = "String"
 description = "[experimental] Namespace sent to the remote build cache."
 docs = """
 Opaque repository or organization namespace used to isolate remote build-cache entries. This
-setting is required when [`task.cache.remote_url`](#task-cache-remote-url) is configured.
+setting is required when [`task.cache.remote_url`](/configuration/settings.html#task.cache.remote_url) is configured.
 """
 env = "MISE_TASK_CACHE_REMOTE_NAMESPACE"
 optional = true
@@ -3149,7 +3149,7 @@ type = "Path"
 description = "[experimental] Base URL for the remote build-cache service."
 docs = """
 Enable the versioned HTTP remote build-cache protocol at this base URL. Remote access also requires
-[`task.cache.remote_namespace`](#task-cache-remote-namespace). Leave unset to use only local caches.
+[`task.cache.remote_namespace`](/configuration/settings.html#task.cache.remote_namespace). Leave unset to use only local caches.
 """
 env = "MISE_TASK_CACHE_REMOTE_URL"
 optional = true
@@ -3188,7 +3188,7 @@ description = "[experimental] Maximum age of task output cache entries since the
 docs = """
 Remove task output cache entries that have not been accessed within this duration after a new entry
 is stored. This limit applies only to the task output cache and is independent of
-[`cache_prune_age`](#cache_prune_age). Set to `0s` or leave unset to disable the age limit.
+[`cache_prune_age`](/configuration/settings.html#cache_prune_age). Set to `0s` or leave unset to disable the age limit.
 """
 env = "MISE_TASK_CACHE_MAX_AGE"
 optional = true
@@ -3601,7 +3601,7 @@ default = true
 description = "Schedule the version `mise upgrade` replaced for pruning once the new one has installed."
 docs = """
 `mise upgrade` schedules the version it upgraded away from for removal after
-[`upgrade.prune_after`](#upgrade-prune-after). The install directory stays in place during that
+[`upgrade.prune_after`](/configuration/settings.html#upgrade.prune_after). The install directory stays in place during that
 grace period so long-running processes can continue loading files from it. Set this to `false` when
 something outside of mise resolves through that path permanently — a virtualenv built from a
 mise-managed interpreter, for example — and the old version is left in place without a scheduled


### PR DESCRIPTION
Settings descriptions are rendered both in the settings reference and in task documentation. Relative fragments pointed to missing headings on the latter, and several fragments did not match VitePress's generated IDs. Use absolute settings links with the rendered IDs, fix the Python sync link, and update the task-cache workflow to mise-action v4.

Validation: the combined documentation site builds successfully (334 pages), and all local links and fragments on the 332 scoped website pages resolve. The broader audit also passed formatting checks and validated TOML 1.1 examples. This branch was rebased onto current main and `docs/public/llms.txt` was rebuilt before publication. The landing page is unchanged.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and generated settings copy only; no runtime or configuration behavior changes.
> 
> **Overview**
> Fixes **broken documentation links** so settings cross-references and CLI URLs resolve when content is rendered outside the settings reference page.
> 
> In **`settings.toml`**, several inline `docs` links that used same-page fragments (e.g. `#task-cache-remote-url`) now point to **`/configuration/settings.html#…`** with **VitePress-style IDs** (dotted keys like `task.cache.remote_url`, `aqua.registry_cache_ttl`, `cache_prune_age`, `upgrade.prune_after`). That avoids dead anchors when those descriptions appear in task docs and other guides.
> 
> The **Python cookbook** drops the invalid `#uv` fragment on the `mise sync python --uv` link. The **task caching** GitHub Actions sample bumps **`jdx/mise-action` from v3 to v4**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2d29e3ed7aaecbaa76681db84e63c0f70e70aac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Python synchronization documentation links for improved navigation.
  - Updated the GitHub Actions example to use the current mise action version.
  - Revised settings documentation links to point directly to configuration references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->