### PR TITLE
fix(shims): resolve symlinks when locating the mise-shim.exe template

### DIFF
--- a/src/shims.rs
+++ b/src/shims.rs
@@ -1189,7 +1189,12 @@ fn old_shim_path(path: &Path) -> PathBuf {
 /// --windows-launcher=exe` asks the same question, and on a host where the answer is always `None`
 /// that is the honest answer to report rather than a compile error to route around.
 pub(crate) fn find_mise_shim_bin(mise_bin: &Path) -> Option<PathBuf> {
-    // Look next to the mise binary first
+    // Look next to the mise binary first. The invoked path may be a symlink —
+    // e.g. a winget portable install links `mise.exe` into
+    // `%LOCALAPPDATA%\Microsoft\WinGet\Links`, and the template ships beside the
+    // real payload, not beside the link. Resolve the symlink before searching
+    // (`mise_install_base` canonicalizes MISE_BIN for the same reason).
+    let mise_bin = file::canonicalize_or_self(mise_bin);
     if let Some(parent) = mise_bin.parent() {
         let candidate = parent.join("mise-shim.exe");
         if candidate.is_file() {


### PR DESCRIPTION
## What does this PR do?

`find_mise_shim_bin()` now resolves symlinks in the invoked mise path via the existing `file::canonicalize_or_self()` helper before looking for the `mise-shim.exe` template beside it.

Windows installs that launch mise through a symlink — most notably winget portable installs, which link the declared command aliases into `%LOCALAPPDATA%\Microsoft\WinGet\Links` — can miss the template, warn:

```
mise WARN  mise-shim.exe not found next to ...\WinGet\Links\mise.exe or on PATH, falling back to "file" shim mode
```

and silently degrade to `file` shim mode.

The parent lookup mirrors `mise_install_base()` (`src/env.rs`), which already canonicalizes `MISE_BIN` for exactly this class of problem; the shim template lookup was the one place that didn't. The PATH fallback is unchanged.

Behavior-neutral on Unix (the template never exists there, so the function still returns `None`).

## How has this been tested?

**Important provenance note**: winget has **not published** mise 2026.9.1 (microsoft/winget-pkgs#428215 is pending). The reproduction used a **local manifest install** of the binaries from that PR's manifest, via `winget install --manifest` with `LocalManifestFiles` / `LocalArchiveMalwareScanOverride` enabled on Windows 11 x64. The `--manifest` path accepts local YAML directly, so no published winget release is required for any of the following.

Reproduction setup, in two variants of that local manifest:

1. **Manifest as-submitted in #428215** (aliases: `mise`, `mise-shim`): after install, `Links` contains both `mise.exe` and `mise-shim.exe`, so the PATH fallback in `find_mise_shim_bin()` finds the template and native `exe` shims work — the bug is masked.
2. **Variant with the `mise-shim` alias entry removed** (this is the manifest change one would want for #428215, since a `mise-shim` command always exits 1 — the binary is a template meant to be copied as `<tool>.exe`): `Links` contains only `mise.exe`. Invoking mise through that symlink (`mise reshim`, `mise unuse -g uv`) produces the WARN above, and `shims/.mode` = `file` (tool shims become 700-byte scripts instead of native executables).

A/B verification of the patch (official 2026.9.1 binaries from the release zip vs. this branch's build, each in an isolated directory invoked through a fresh symlink, with the PATH fallback isolated by renaming any `mise-shim.exe` off PATH and reducing `PATH` to `C:\Windows\System32;C:\Windows`):

- Official binary: WARN + `shims/.mode` = `file`.
- Patched build: zero warnings, `shims/.mode` = `exe` — the template resolves beside the real payload through the symlink, proving the fix (not the PATH fallback) finds it.

Note: hardlinks do not reproduce this (canonicalize is a no-op on them); the winget `Links` case uses symbolic links.

## Additional context

The investigation motivation: microsoft/winget-pkgs#428215 has been stuck in `Validation-Executable-Error` since submission, and one suspect was the `mise-shim` portable-command alias, which registers a command that always exits 1. Dropping that alias entry is the cleaner manifest — but as variant 1 above shows, removing it currently also breaks native shim mode for winget installs, because of this template-lookup bug. With this PR merged, the alias entry can be safely dropped and both problems are resolved together.
