### PR TITLE
fix: finish cache compression before publishing files

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -304,6 +304,8 @@ where
             .with_extension(format!("part-{}", random_string(8)));
         let mut zlib = ZlibEncoder::new(File::create(&partial_path)?, Compression::fast());
         zlib.write_all(&rmp_serde::to_vec_named(&val)?[..])?;
+        // Finish compression and close the file before publishing it to readers.
+        drop(zlib.finish()?);
         file::rename(&partial_path, &self.cache_file_path)?;
 
         Ok(())


### PR DESCRIPTION
Cache writes currently rename the temporary file into place while the zlib encoder is still open. A concurrent reader can see an unfinished stream, and process termination in that window can leave an incomplete cache at the published path. Finalization errors are also lost when the encoder is dropped.

Finish compression explicitly, propagate errors, and close the file before renaming it into place.

Found while investigating https://github.com/jdx/mise/discussions/12893. This fixes the publication window; it is not a confirmed fix for the reported persistent hang. Tests with corrupt caches on the reported release recovered without hanging.

Validation (Rust 1.95.0):
- `mise run lint-fix` passed, including `cargo check --all-features`.
- `mise exec -- cargo test --all-features --bin mise cache::tests -- --test-threads=1`: 29 passed.
- `git diff --check` passed.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to on-disk cache publication ordering with clearer error handling; no auth or data-model changes.
> 
> **Overview**
> **Cache writes now finalize and close the compressed partial file before it is renamed into the published cache path.**
> 
> Previously `CacheManager::write` could `rename` the `.part-*` file while the `ZlibEncoder` was still open, so concurrent readers might see an incomplete zlib stream and abrupt shutdown could leave a truncated file at the final path. The writer now calls `zlib.finish()?` and drops the encoder before `file::rename`, so compression errors propagate and readers only see fully written entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65d0fe8ffd87b9435c96390298a9daea60007bcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache reliability by ensuring compressed cache files are fully finalized and closed before becoming available to readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->